### PR TITLE
refactor!: delete the output.links runtime mirror; linkStore is the single source

### DIFF
--- a/docs/architecture/ecs-migration-plan.md
+++ b/docs/architecture/ecs-migration-plan.md
@@ -277,9 +277,14 @@ data is complete and consistent with the class-based graph.
 > `rerouteStore` (PRs 13436, 13449): "what links pass through this reroute" is
 > derived per root graph by a cached reverse index over the links' `parentId`
 > chains, and input-side connectivity is one lookup via
-> `linkStore.isInputSlotConnected()` / `getInputSlotLink()`. Remaining:
-> slot mirrors (`input.link` / `output.links`), output-side queries, and
-> execution order.
+> `linkStore.isInputSlotConnected()` / `getInputSlotLink()`.
+>
+> **Status (2026-07-17):** Output-side queries shipped and the `output.links`
+> mirror is deleted (PR 13479): `linkStore.isOutputSlotConnected()` /
+> `getOutputSlotLinks()`, litegraph internals reading through
+> `node/slotLinks.ts` (see
+> [output slot connectivity](output-slot-connectivity.md)). Remaining: the
+> `input.link` slot mirror and execution order.
 
 **Risk:** Low. Read-only system with equivalence tests.
 
@@ -336,7 +341,8 @@ the system knowing about the callback API.
 > through canonical `LGraph` mutation chokepoints: `_addLink`/`_removeLink` and
 > `_addReroute`/`_removeReroute` pair every map mutation with store
 > (un)registration, and `clear()` / subgraph-definition GC unregister whole
-> graphs. The callback contract above and slot-mirror extraction remain.
+> graphs. The callback contract above and `input.link` slot-mirror extraction
+> remain (`output.links` was deleted in PR 13479).
 
 **Risk:** High. Extensions depend on callback ordering and timing. Must be
 validated against real-world extensions.

--- a/docs/architecture/link-topology-store.md
+++ b/docs/architecture/link-topology-store.md
@@ -105,8 +105,11 @@ subgraph-definition GC unregister whole graphs
 
 This design covers link topology (endpoints, type, chain terminus).
 Link visual state (`color`, path caches) and the layout store's link
-_geometry_ records are out of scope. The `input.link` / `output.links`
-slot mirrors remain the litegraph-native representation un-migrated
-consumers read; extracting them is the `SlotConnection` component work
-in the [ECS migration plan](ecs-migration-plan.md), not part of this
-store.
+_geometry_ records are out of scope. The `output.links` mirror has since
+been deleted — the store is the single source for output-side
+connectivity (see
+[output slot connectivity](output-slot-connectivity.md) Decision 6). The
+`input.link` slot mirror remains the litegraph-native representation
+un-migrated consumers read; extracting it is the `SlotConnection`
+component work in the [ECS migration plan](ecs-migration-plan.md), not
+part of this store.

--- a/docs/architecture/output-slot-connectivity.md
+++ b/docs/architecture/output-slot-connectivity.md
@@ -69,7 +69,7 @@ function outputIndex(graphId: UUID): ComputedRef<OriginIndex> {
   const next = computed(() => {
     const index: OriginIndex = new Map()
     for (const t of graphTopologies(graphId)) {
-      if (t.originNodeId === UNASSIGNED_NODE_ID) continue
+      if (isFloatingTopology(t)) continue
       const key = originKey(t.originNodeId, t.originSlot)
       const links = index.get(key) ?? new Set<LinkTopology>()
       links.add(t)
@@ -83,9 +83,10 @@ function outputIndex(graphId: UUID): ComputedRef<OriginIndex> {
 ```
 
 The index spans both collections that `graphTopologies` yields, the keyed
-targets and the unkeyed side set, so a floating link with an assigned
-origin (one endpoint only) still reports its output as connected. A
-`SUBGRAPH_INPUT_ID` origin indexes like any other id.
+targets and the unkeyed side set. Floating links are skipped
+(`isFloatingTopology`): the queries see fully-assigned links only,
+matching the mirror they replace (Decision 6). A `SUBGRAPH_INPUT_ID`
+origin indexes like any other id.
 
 ## Decision 3: Two public queries, mirroring the input pair
 
@@ -122,6 +123,24 @@ disconnect check (`useSlotLinkInteraction`, where one store query replaces
 a mirror read plus a `slotFloatingLinks` scan), widget value propagation
 (`widgetValuePropagation`), and matchType link revalidation
 (`dynamicWidgets.changeOutputType`).
+
+## Decision 5: Wire connected state into the dots (the payoff)
+
+`NodeSlots.vue` passes `connected` to each slot:
+
+- input: `linkStore.isInputSlotConnected(rootGraphId, nodeId, index)`
+  (already available)
+- output: `linkStore.isOutputSlotConnected(rootGraphId, nodeId, index)`
+  (Decision 3)
+
+`InputSlot` and `OutputSlot` already forward `connected` to the
+`lg-slot--connected` class. `SlotConnectionDot` needs no prop of its own:
+the wrapper class is an ancestor styling hook
+(`.lg-slot--connected .slot-dot`), so the visual is one CSS rule away once
+the design-standards check (open question 3) picks it. Threading a
+`connected` prop into the dot before that would be plumbing with no
+consumer. `compatible` stays driven by the existing drag state
+(`useSlotLinkDragUIState`), which this phase leaves alone.
 
 ## Decision 6: Delete the mirror (implemented)
 
@@ -160,26 +179,10 @@ the pure helpers in `node/slotLinks.ts` (`outputHasLinks`,
 
 Extension migration map: presence → `node.isOutputConnected(slot)` /
 `slot.isConnected`; enumerate targets → `node.getOutputNodes(slot)`;
-mutate → `node.connect(...)` / `node.disconnectOutput(slot, target?)`.
-App/Vue code uses `useLinkStore().getOutputSlotLinks(...)` (reactive).
-
-## Decision 5: Wire connected state into the dots (the payoff)
-
-`NodeSlots.vue` passes `connected` to each slot:
-
-- input: `linkStore.isInputSlotConnected(rootGraphId, nodeId, index)`
-  (already available)
-- output: `linkStore.isOutputSlotConnected(rootGraphId, nodeId, index)`
-  (Decision 3)
-
-`InputSlot` and `OutputSlot` already forward `connected` to the
-`lg-slot--connected` class. `SlotConnectionDot` needs no prop of its own:
-the wrapper class is an ancestor styling hook
-(`.lg-slot--connected .slot-dot`), so the visual is one CSS rule away once
-the design-standards check (open question 3) picks it. Threading a
-`connected` prop into the dot before that would be plumbing with no
-consumer. `compatible` stays driven by the existing drag state
-(`useSlotLinkDragUIState`), which this phase leaves alone.
+enumerate links → `outputLinks(graph, node.id, slot)` / `outputLinkIds`
+(`node/slotLinks.ts`); mutate → `node.connect(...)` /
+`node.disconnectOutput(slot, target?)`. App/Vue code uses
+`useLinkStore().getOutputSlotLinks(...)` (reactive).
 
 ## Scope
 

--- a/docs/architecture/output-slot-connectivity.md
+++ b/docs/architecture/output-slot-connectivity.md
@@ -57,8 +57,8 @@ membership is always derived and cannot drift from the topology.
 
 ```ts
 type OriginIndex = Map<
-  string /* `${originNodeId}:${originSlot}` */,
-  Set<LinkId>
+  OriginSlotKey /* `${originNodeId}:${originSlot}` */,
+  Set<LinkTopology>
 >
 
 const outputIndexes = new Map<UUID, ComputedRef<OriginIndex>>()
@@ -71,7 +71,9 @@ function outputIndex(graphId: UUID): ComputedRef<OriginIndex> {
     for (const t of graphTopologies(graphId)) {
       if (t.originNodeId === UNASSIGNED_NODE_ID) continue
       const key = originKey(t.originNodeId, t.originSlot)
-      ;(index.get(key) ?? index.set(key, new Set()).get(key)!).add(t.id)
+      const links = index.get(key) ?? new Set<LinkTopology>()
+      links.add(t)
+      index.set(key, links)
     }
     return index
   })
@@ -89,14 +91,18 @@ origin (one endpoint only) still reports its output as connected. A
 
 ```ts
 isOutputSlotConnected(graphId, nodeId, slot): boolean
-getOutputSlotLinks(graphId, nodeId, slot): ReadonlySet<LinkId>
+getOutputSlotLinks(graphId, nodeId, slot): ReadonlySet<LinkTopology>
 ```
 
 These match `isInputSlotConnected` / `getInputSlotLink` in name and shape.
 The input side returns a single `LinkTopology`, since at most one link
 targets an input; the output side returns a set, since an output fans out
-to many. Presence is all the renderer needs, and `getOutputSlotLinks`
-covers the readers that currently iterate `output.links`.
+to many. The set holds topologies rather than bare `LinkId`s: floating
+links draw their ids from a separate counter (`_lastFloatingLinkId`), so
+an id alone cannot be resolved safely through `graph.links` — a floating
+id can collide with an unrelated regular link. Topologies carry the
+endpoints most readers want and make floating links identifiable
+(`targetNodeId === UNASSIGNED_NODE_ID`) without resolution.
 
 ## Decision 4: Migrate readers incrementally, keep the mirror written by hand
 
@@ -108,10 +114,26 @@ chokepoints.
 sites, all in `LGraphNode`, `LGraph`, and the subgraph paths. Most of the
 reads are litegraph-internal graph algorithms such as traversal, dedup,
 and serialization. Those can keep reading the mirror indefinitely; they
-are not renderer policy and nothing blocks on them. This phase migrates
-only the reader that drives the payoff, the output dot's connected state,
-plus any renderer or pricing reader that needs mere presence. Migrating
-the rest is opportunistic follow-up rather than a gate.
+are not renderer policy and nothing blocks on them.
+
+Migrated readers: the output dot's connected state (`NodeSlots`), the
+minimap link extraction (`AbstractMinimapDataSource`), the drag-start
+disconnect check (`useSlotLinkInteraction`, where one store query replaces
+a mirror read plus a `slotFloatingLinks` scan), widget value propagation
+(`widgetValuePropagation`), and matchType link revalidation
+(`dynamicWidgets.changeOutputType`).
+
+Readers that stay on the mirror, deliberately:
+
+- `rerouteNode`, `widgetInputs` (PrimitiveNode), and `groupNode` read
+  `output.links` inside `onConnectionsChange` / `onConnectOutput`, where
+  their behavior depends on the mirror's mid-mutation staleness window
+  (during `disconnectOutput`, the store unregisters before the origin's
+  OUTPUT callback while the mirror still holds the ids). They are
+  litegraph-native legacy surfaces owned by the `SlotConnection` phase.
+- `linkFixer`, `migrateReroute`, and `proxyWidgetMigration` operate on
+  the serialized mirror itself — validating or repairing it is their job.
+- `useNodeReplacement` writes the mirror; write sites are out of scope.
 
 Because the mirror field stays written and readable, no extension breaks.
 Deleting `output.links[]` and `input.link` is an extension-visible change
@@ -162,11 +184,10 @@ Out of scope, each a piece of the deferred `SlotConnection` phase:
    fallback is an incrementally maintained `Map` updated in `place` and
    `displace`, which is more code and carries drift risk. Start with the
    derived version and measure before optimizing.
-2. **Return type of `getOutputSlotLinks`.** `ReadonlySet<LinkId>` is
-   cheap and gives presence plus ids; `LinkTopology[]` would match
-   `getInputSlotLink`, which returns topology. Ids suffice for every
-   reader found so far, so prefer the set unless a consumer needs
-   endpoints.
+2. **Return type of `getOutputSlotLinks`.** Resolved: a set of
+   `LinkTopology`, per Decision 3. Bare ids looked sufficient until the
+   reader migration surfaced both the endpoint needs (minimap, widget
+   value propagation) and the floating-id collision hazard.
 3. **Dot visual.** What "connected" looks like on the dot (fill, ring, or
    opacity) is a design-standards question rather than an architecture
    one. Check the Comfy Design Standards before implementing Decision 5.

--- a/docs/architecture/output-slot-connectivity.md
+++ b/docs/architecture/output-slot-connectivity.md
@@ -1,7 +1,7 @@
 # Output Slot Connectivity
 
 Date: 2026-07-06
-Status: Proposed (follow-up to the
+Status: Accepted (follow-up to the
 [link topology store](link-topology-store.md); the minimal, non-breaking
 slice of the deferred `SlotConnection` component work in the
 [ECS migration plan](ecs-migration-plan.md))
@@ -123,22 +123,45 @@ a mirror read plus a `slotFloatingLinks` scan), widget value propagation
 (`widgetValuePropagation`), and matchType link revalidation
 (`dynamicWidgets.changeOutputType`).
 
-Readers that stay on the mirror, deliberately:
+## Decision 6: Delete the mirror (implemented)
 
-- `rerouteNode`, `widgetInputs` (PrimitiveNode), and `groupNode` read
-  `output.links` inside `onConnectionsChange` / `onConnectOutput`, where
-  their behavior depends on the mirror's mid-mutation staleness window
-  (during `disconnectOutput`, the store unregisters before the origin's
-  OUTPUT callback while the mirror still holds the ids). They are
-  litegraph-native legacy surfaces owned by the `SlotConnection` phase.
-- `linkFixer`, `migrateReroute`, and `proxyWidgetMigration` operate on
-  the serialized mirror itself — validating or repairing it is their job.
-- `useNodeReplacement` writes the mirror; write sites are out of scope.
+The runtime `output.links[]` field and all nine of its write sites are
+deleted. The store is the single source; litegraph internals read through
+the pure helpers in `node/slotLinks.ts` (`outputHasLinks`,
+`outputLinkIds`, `outputLinks`), and `NodeOutputSlot.isConnected`,
+`serialize`, and `configure` derive from the store. Details:
 
-Because the mirror field stays written and readable, no extension breaks.
-Deleting `output.links[]` and `input.link` is an extension-visible change
-to litegraph-native surfaces (the 40+ custom-node-repo rule in
-AGENTS.md), so it is a later step, not this one.
+- **Wire format unchanged.** `outputAsSerialisable` / `toJSON` emit the
+  serialized `outputs[].links` array from the store, sorted ascending by
+  id (a determinism choice — equal to push order for organically built
+  graphs) and `null` when empty. `configure` fires its output
+  `onConnectionsChange` callbacks from the serialized argument.
+- **Floating links are never returned by link queries.** They are
+  reroute-chain scaffolding, named by `isFloatingTopology`
+  (`src/types/linkTopology.ts`). `isOutputSlotConnected` /
+  `getOutputSlotLinks` see fully-assigned links only, matching the
+  mirror they replace; the one consumer with legacy floating-aware
+  behavior (the slot-drag disconnect check) keeps its own
+  `slotFloatingLinks` scan.
+- **Extension compat = deprecation telemetry, not compatibility.** A
+  read-only prototype getter on `NodeOutputSlot` returns a fresh
+  store-derived `LinkId[] | null` and fires `warnDeprecated`. There is no
+  setter, so extension writes throw in strict mode. `INodeOutputSlot`
+  keeps `links` as `@deprecated readonly` so `'links' in slot`
+  discriminants still compile and hold at runtime via the prototype.
+- **Serialized-data operators are untouched.** `linkFixer` (serialized
+  branch), `migrateReroute`, and `unpackSubgraph`'s pre-configure strip
+  operate on the wire format, which still carries `links`.
+- **Behavior changes, deliberate:** `PrimitiveNode.onLastDisconnect`
+  fires on disconnect-all (the stale mirror previously suppressed it);
+  `disconnectInput` passes `link_info.origin_slot` — not the old
+  mirror-array index — as the OUTPUT slot in `onConnectionsChange`;
+  serialization emits `null` where a lingering `[]` used to persist.
+
+Extension migration map: presence → `node.isOutputConnected(slot)` /
+`slot.isConnected`; enumerate targets → `node.getOutputNodes(slot)`;
+mutate → `node.connect(...)` / `node.disconnectOutput(slot, target?)`.
+App/Vue code uses `useLinkStore().getOutputSlotLinks(...)` (reactive).
 
 ## Decision 5: Wire connected state into the dots (the payoff)
 
@@ -165,16 +188,20 @@ reader migration, and wiring `connected` from `NodeSlots` into
 `InputSlot` / `OutputSlot` (whose `lg-slot--connected` class reaches the
 dot via CSS).
 
+Since implemented by Decision 6: `output.links` reader migration, write
+sites, and field deletion.
+
 Out of scope, each a piece of the deferred `SlotConnection` phase:
 
-- Deleting the `input.link` / `output.links` mirror fields. This is
-  extension-breaking and needs migration guidance.
-- Removing the `output.links` write sites at the chokepoints.
-- Migrating the remaining ~200 `output.links` readers.
+- Deleting the `input.link` mirror field (same recipe as Decision 6).
 - Slot entity extraction: `SlotIdentity`, `SlotVisual`, and retiring the
   `NodeInputSlot` / `NodeOutputSlot` class instances and their
   `shallowReactive` graft.
 - A `compatible`-state source beyond the current drag UI state.
+- Floating/regular link-id counter unification (mint floating ids from
+  the shared `state.lastLinkId`) — only if the internal wart ever bites;
+  nothing resolves store-returned ids against `graph.links` across the
+  id spaces anymore.
 
 ## Open questions
 

--- a/docs/architecture/output-slot-connectivity.md
+++ b/docs/architecture/output-slot-connectivity.md
@@ -1,0 +1,172 @@
+# Output Slot Connectivity
+
+Date: 2026-07-06
+Status: Proposed (follow-up to the
+[link topology store](link-topology-store.md); the minimal, non-breaking
+slice of the deferred `SlotConnection` component work in the
+[ECS migration plan](ecs-migration-plan.md))
+
+Design record for answering "is this output slot connected, and by what
+links?" from `linkStore` instead of the `output.links[]` mirror. It is
+the output-side counterpart to the input-side migration shipped in
+[node-data-store Decision 3](node-data-store.md) (#13455). Wiring it lets
+`SlotConnectionDot` show connected state and removes the last renderer
+dependency on `output.links[]`.
+
+This phase does not extract a Slot entity, add a store, or delete any
+mirror field. Those stay in the deferred `SlotConnection` phase. What it
+does is the smallest change that clears the reader debt and lets the
+output dot show connection state.
+
+## Motivation
+
+`SlotConnectionDot.vue` colors slots by type only. It carries a
+`//TODO Support connected/disconnected colors?`. `InputSlot` and
+`OutputSlot` already declare `connected` / `compatible` props and apply
+the `lg-slot--connected` / `lg-slot--compatible` classes, but
+`NodeSlots.vue` passes neither, so the styling path is built but unwired.
+
+Input connectivity is already answerable through
+`linkStore.isInputSlotConnected` (shipped in #13455). The matching output
+query does not exist yet, so the output dot cannot be wired and
+`output.links[]` stays the only source. This phase adds that query and
+consumes it.
+
+## Decision 1: Extend `linkStore`, do not add a store or a Slot entity
+
+Output connectivity is link topology: the mirror image of the input side
+the store already owns. It belongs in `linkStore`, not a new `slotStore`.
+A dedicated Slot store (plain `SlotIdentity` / `SlotVisual` rows, retiring
+the slot class instances) is the full `SlotConnection` phase and is out
+of scope here. Introducing it now would be premature per the
+node-data-store record, which keeps the slot arrays class-side.
+
+This phase adds read-only accessors over state the store already holds.
+It needs no new plain-data component, registration trio, chokepoint, or
+class adoption, though each sibling store required all four.
+
+## Decision 2: Output connectivity is a derived reverse index
+
+The store already exposes `graphTopologies(graphId)` over every
+registered `LinkTopology`. "Which links leave output slot _(node, slot)_"
+is a reverse index over origin endpoints. This is the same pattern
+`rerouteStore` uses for link membership
+([reroute store](reroute-chain-store.md)): a per-graph cached `computed`
+that Vue invalidates when link state changes. Nothing is stored, so the
+membership is always derived and cannot drift from the topology.
+
+```ts
+type OriginIndex = Map<
+  string /* `${originNodeId}:${originSlot}` */,
+  Set<LinkId>
+>
+
+const outputIndexes = new Map<UUID, ComputedRef<OriginIndex>>()
+
+function outputIndex(graphId: UUID): ComputedRef<OriginIndex> {
+  const existing = outputIndexes.get(graphId)
+  if (existing) return existing
+  const next = computed(() => {
+    const index: OriginIndex = new Map()
+    for (const t of graphTopologies(graphId)) {
+      if (t.originNodeId === UNASSIGNED_NODE_ID) continue
+      const key = originKey(t.originNodeId, t.originSlot)
+      ;(index.get(key) ?? index.set(key, new Set()).get(key)!).add(t.id)
+    }
+    return index
+  })
+  outputIndexes.set(graphId, next)
+  return next
+}
+```
+
+The index spans both collections that `graphTopologies` yields, the keyed
+targets and the unkeyed side set, so a floating link with an assigned
+origin (one endpoint only) still reports its output as connected. A
+`SUBGRAPH_INPUT_ID` origin indexes like any other id.
+
+## Decision 3: Two public queries, mirroring the input pair
+
+```ts
+isOutputSlotConnected(graphId, nodeId, slot): boolean
+getOutputSlotLinks(graphId, nodeId, slot): ReadonlySet<LinkId>
+```
+
+These match `isInputSlotConnected` / `getInputSlotLink` in name and shape.
+The input side returns a single `LinkTopology`, since at most one link
+targets an input; the output side returns a set, since an output fans out
+to many. Presence is all the renderer needs, and `getOutputSlotLinks`
+covers the readers that currently iterate `output.links`.
+
+## Decision 4: Migrate readers incrementally, keep the mirror written by hand
+
+This follows the #13455 discipline for `input.link`: move the readers to
+the store, leave the field in place, and keep writing it at the
+chokepoints.
+
+`output.links[]` has roughly 200 read sites but only about 12 write
+sites, all in `LGraphNode`, `LGraph`, and the subgraph paths. Most of the
+reads are litegraph-internal graph algorithms such as traversal, dedup,
+and serialization. Those can keep reading the mirror indefinitely; they
+are not renderer policy and nothing blocks on them. This phase migrates
+only the reader that drives the payoff, the output dot's connected state,
+plus any renderer or pricing reader that needs mere presence. Migrating
+the rest is opportunistic follow-up rather than a gate.
+
+Because the mirror field stays written and readable, no extension breaks.
+Deleting `output.links[]` and `input.link` is an extension-visible change
+to litegraph-native surfaces (the 40+ custom-node-repo rule in
+AGENTS.md), so it is a later step, not this one.
+
+## Decision 5: Wire connected state into the dots (the payoff)
+
+`NodeSlots.vue` passes `connected` to each slot:
+
+- input: `linkStore.isInputSlotConnected(rootGraphId, nodeId, index)`
+  (already available)
+- output: `linkStore.isOutputSlotConnected(rootGraphId, nodeId, index)`
+  (Decision 3)
+
+`InputSlot` and `OutputSlot` already forward `connected` to the
+`lg-slot--connected` class. `SlotConnectionDot` needs no prop of its own:
+the wrapper class is an ancestor styling hook
+(`.lg-slot--connected .slot-dot`), so the visual is one CSS rule away once
+the design-standards check (open question 3) picks it. Threading a
+`connected` prop into the dot before that would be plumbing with no
+consumer. `compatible` stays driven by the existing drag state
+(`useSlotLinkDragUIState`), which this phase leaves alone.
+
+## Scope
+
+In scope: the derived output-side index, the two queries, the output-dot
+reader migration, and wiring `connected` from `NodeSlots` into
+`InputSlot` / `OutputSlot` (whose `lg-slot--connected` class reaches the
+dot via CSS).
+
+Out of scope, each a piece of the deferred `SlotConnection` phase:
+
+- Deleting the `input.link` / `output.links` mirror fields. This is
+  extension-breaking and needs migration guidance.
+- Removing the `output.links` write sites at the chokepoints.
+- Migrating the remaining ~200 `output.links` readers.
+- Slot entity extraction: `SlotIdentity`, `SlotVisual`, and retiring the
+  `NodeInputSlot` / `NodeOutputSlot` class instances and their
+  `shallowReactive` graft.
+- A `compatible`-state source beyond the current drag UI state.
+
+## Open questions
+
+1. **Index granularity.** One `computed` per graph rebuilds the whole
+   origin index on any link change in that graph, the same cost model as
+   `rerouteStore`. If profiling on large graphs shows this is hot, the
+   fallback is an incrementally maintained `Map` updated in `place` and
+   `displace`, which is more code and carries drift risk. Start with the
+   derived version and measure before optimizing.
+2. **Return type of `getOutputSlotLinks`.** `ReadonlySet<LinkId>` is
+   cheap and gives presence plus ids; `LinkTopology[]` would match
+   `getInputSlotLink`, which returns topology. Ids suffice for every
+   reader found so far, so prefer the set unless a consumer needs
+   endpoints.
+3. **Dot visual.** What "connected" looks like on the dot (fill, ring, or
+   opacity) is a design-standards question rather than an architecture
+   one. Check the Comfy Design Standards before implementing Decision 5.

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
@@ -20,8 +20,10 @@ import {
   normalizeLegacyProxyWidgetEntry,
   readHostQuarantine
 } from '@/core/graph/subgraph/migration/proxyWidgetMigration'
+import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
@@ -372,10 +374,14 @@ describe('flushProxyWidgetMigration', () => {
 
       const danglingLinkId = toLinkId(999_999)
       expect(host.subgraph.links.has(danglingLinkId)).toBe(false)
-      primitive.outputs[0].links = [
-        ...(primitive.outputs[0].links ?? []),
-        danglingLinkId
-      ]
+      useLinkStore().registerLink(host.subgraph.rootGraph.id, {
+        id: danglingLinkId,
+        originNodeId: primitive.id,
+        originSlot: 0,
+        targetNodeId: toNodeId(999_999),
+        targetSlot: 0,
+        type: '*'
+      })
 
       host.properties.proxyWidgets = [[String(primitive.id), 'value']]
       flushProxyWidgetMigration({ hostNode: host })

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
@@ -27,8 +27,10 @@ import type {
   TWidgetValue
 } from '@/lib/litegraph/src/types/widgets'
 import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { LinkTopology } from '@/types/linkTopology'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 
@@ -265,21 +267,30 @@ function pickHostValue(
   return { value: raw, isHole: false }
 }
 
+function primitiveOutputTopologies(
+  hostNode: SubgraphNode,
+  primitiveNode: LGraphNode
+): LinkTopology[] {
+  return [
+    ...useLinkStore().getOutputSlotLinks(
+      hostNode.subgraph.rootGraph.id,
+      primitiveNode.id,
+      0
+    )
+  ]
+}
+
 function collectTargetsStrict(
   hostNode: SubgraphNode,
   primitiveNode: LGraphNode
 ): PrimitiveBypassTargetRef[] | undefined {
   const subgraph = hostNode.subgraph
-  const output = primitiveNode.outputs?.[0]
-  const linkIds = output?.links ?? []
   const targets: PrimitiveBypassTargetRef[] = []
-  for (const linkId of linkIds) {
-    const link = subgraph.links.get(linkId)
-    if (!link) return undefined
-    if (link.target_id === UNASSIGNED_NODE_ID) return undefined
+  for (const topology of primitiveOutputTopologies(hostNode, primitiveNode)) {
+    if (!subgraph.links.get(topology.id)) return undefined
     targets.push({
-      targetNodeId: link.target_id,
-      targetSlot: link.target_slot
+      targetNodeId: topology.targetNodeId,
+      targetSlot: topology.targetSlot
     })
   }
   return targets
@@ -290,18 +301,12 @@ function collectTargetsSkippingDangling(
   primitiveNode: LGraphNode
 ): PrimitiveBypassTargetRef[] {
   const subgraph = hostNode.subgraph
-  const linkIds = primitiveNode.outputs?.[0]?.links ?? []
-  return linkIds.flatMap((linkId) => {
-    const link = subgraph.links.get(linkId)
-    return link && link.target_id !== UNASSIGNED_NODE_ID
-      ? [
-          {
-            targetNodeId: link.target_id,
-            targetSlot: link.target_slot
-          }
-        ]
-      : []
-  })
+  return primitiveOutputTopologies(hostNode, primitiveNode)
+    .filter((topology) => subgraph.links.get(topology.id))
+    .map((topology) => ({
+      targetNodeId: topology.targetNodeId,
+      targetSlot: topology.targetSlot
+    }))
 }
 
 function cohortDuplicatesPrimitive(

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.ts
@@ -31,7 +31,7 @@ import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { LinkTopology } from '@/types/linkTopology'
-import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 
 interface LegacyProxyEntrySource extends PromotedWidgetSource {
@@ -624,17 +624,14 @@ function repairPrimitive(
   }
 
   const baseName = userRenamedTitle(primitiveNode) ?? validated.sourceWidgetName
-  const snapshot: SnapshotLink[] = (primitiveOutput.links ?? [])
-    .map((id) => subgraph.links.get(id))
-    .filter(
-      (l): l is NonNullable<typeof l> =>
-        l !== undefined && l.target_id !== UNASSIGNED_NODE_ID
-    )
-    .map((l) => ({
-      primitiveSlot: l.origin_slot,
-      targetNodeId: l.target_id,
-      targetSlot: l.target_slot
-    }))
+  const snapshot: SnapshotLink[] = primitiveOutputTopologies(
+    hostNode,
+    primitiveNode
+  ).map((topology) => ({
+    primitiveSlot: topology.originSlot,
+    targetNodeId: topology.targetNodeId,
+    targetSlot: topology.targetSlot
+  }))
 
   let newSubgraphInput: SubgraphInput | undefined
   try {

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -263,7 +263,14 @@ export function promoteValueWidgetViaSubgraphInput(
   const hostInput = subgraphNode.inputs.find(
     (input) => input._subgraphSlot === subgraphInput
   )
-  if (hostInput) hostInput.label = sourceSlot.label
+  if (hostInput) {
+    hostInput.label = sourceSlot.label
+    const promotedState = hostInput.widgetId
+      ? useWidgetValueStore().getWidget(hostInput.widgetId)
+      : undefined
+    if (promotedState && sourceSlot.label)
+      promotedState.label = sourceSlot.label
+  }
 
   seedNestedPromotedInputState(subgraphNode, subgraphInput.name, sourceSlot)
 

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -7,7 +7,7 @@ import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { HasInitialMinSize } from '@/services/litegraphService'
 
-setActivePinia(createTestingPinia())
+setActivePinia(createTestingPinia({ stubActions: false }))
 type DynamicInputs = ('INT' | 'STRING' | 'IMAGE' | DynamicInputs)[][]
 type TestAutogrowNode = LGraphNode & {
   comfyDynamic: { autogrow: Record<string, unknown> }

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -2,11 +2,7 @@ import { remove } from 'es-toolkit'
 import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import type {
-  ISlotType,
-  INodeInputSlot,
-  INodeOutputSlot
-} from '@/lib/litegraph/src/interfaces'
+import type { ISlotType, INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
@@ -26,7 +22,9 @@ import {
 import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
+import { useLinkStore } from '@/stores/linkStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 
 const INLINE_INPUTS = false
@@ -267,16 +265,23 @@ function spliceInputs(
 
 function changeOutputType(
   node: LGraphNode,
-  output: INodeOutputSlot,
+  slot: number,
   combinedType: ISlotType
 ) {
+  const output = node.outputs[slot]
   if (output.type === combinedType) return
   output.type = combinedType
 
   //check and potentially remove links
   if (!node.graph) return
-  for (const link_id of output.links ?? []) {
-    const link = node.graph.links[link_id]
+  const topologies = useLinkStore().getOutputSlotLinks(
+    node.graph.rootGraph.id,
+    node.id,
+    slot
+  )
+  for (const topology of topologies) {
+    if (topology.targetNodeId === UNASSIGNED_NODE_ID) continue
+    const link = node.graph.links[topology.id]
     if (!link) continue
     const { input, inputNode, subgraphOutput } = link.resolve(node.graph)
     const inputType = (input ?? subgraphOutput)?.type
@@ -352,10 +357,10 @@ function withComfyMatchType(node: LGraphNode): asserts node is MatchTypeNode {
       })
       const outputType = commonType(...connectedTypes)
       if (!outputType) throw new Error('invalid connection')
-      this.outputs.forEach((output, idx) => {
+      this.outputs.forEach((_output, idx) => {
         if (!(outputGroups?.[idx] == matchKey)) return
         this.outputs[idx] = shallowReactive(this.outputs[idx])
-        changeOutputType(this, output, outputType)
+        changeOutputType(this, idx, outputType)
       })
       app.canvas?.setDirty(true, true)
     }

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -24,7 +24,6 @@ import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
 import { useLinkStore } from '@/stores/linkStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
-import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 
 const INLINE_INPUTS = false
@@ -280,7 +279,6 @@ function changeOutputType(
     slot
   )
   for (const topology of topologies) {
-    if (topology.targetNodeId === UNASSIGNED_NODE_ID) continue
     const link = node.graph.links[topology.id]
     if (!link) continue
     const { input, inputNode, subgraphOutput } = link.resolve(node.graph)

--- a/src/core/graph/widgets/matchTypeConfiguring.test.ts
+++ b/src/core/graph/widgets/matchTypeConfiguring.test.ts
@@ -8,7 +8,7 @@ import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 
-setActivePinia(createTestingPinia())
+setActivePinia(createTestingPinia({ stubActions: false }))
 
 const { addNodeInput } = useLitegraphService()
 

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -2,6 +2,7 @@ import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { LGraphNodeConstructor } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import { parseNodeId } from '@/types/nodeId'
 import type {
   ComfyNode,
@@ -936,14 +937,10 @@ export class GroupNodeHandler {
         groupOutputId < node.outputs?.length;
         groupOutputId++
       ) {
-        const output = node.outputs[groupOutputId]
-        if (!output.links) continue
-        const links = [...output.links]
-        for (const l of links) {
+        const links = outputLinks(app.rootGraph, node.id, groupOutputId)
+        for (const link of links) {
           const slot = newToOldOutputMap[groupOutputId]
           if (!slot) continue
-          const link = app.rootGraph.links[l]
-          if (!link) continue
           const targetNode = app.rootGraph.getNodeById(link.target_id)
           const selectedId = parseNodeId(selectedIds[slot.node.index ?? 0])
           const newNode = selectedId

--- a/src/extensions/core/rerouteNode.ts
+++ b/src/extensions/core/rerouteNode.ts
@@ -5,6 +5,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import type { ISlotType } from '@/lib/litegraph/src/interfaces'
+import { outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 
 import { app } from '../../scripts/app'
 import { getWidgetConfig, mergeIfValid, setWidgetConfig } from './widgetInputs'
@@ -62,19 +63,13 @@ app.registerExtension({
 
         // Prevent multiple connections to different types when we have no input
         if (connected && type === LiteGraph.OUTPUT) {
+          const links = outputLinks(graph, this.id, 0)
           // Ignore wildcard nodes as these will be updated to real types
           const types = new Set(
-            this.outputs[0].links
-              ?.map((l) => graph.links[l]?.type)
-              ?.filter((t) => t && t !== '*') ?? []
+            links.map((l) => l.type).filter((t) => t && t !== '*')
           )
           if (types.size > 1) {
-            const linksToDisconnect = []
-            for (const linkId of this.outputs[0].links ?? []) {
-              const link = graph.links[linkId]
-              linksToDisconnect.push(link)
-            }
-            linksToDisconnect.pop()
+            const linksToDisconnect = links.slice(0, -1)
             for (const link of linksToDisconnect) {
               const node = graph.getNodeById(link.target_id)
               node?.disconnectInput(link.target_slot)
@@ -122,13 +117,7 @@ app.registerExtension({
         let outputType = null
         while (nodes.length) {
           currentNode = nodes.pop()!
-          const outputs = currentNode.outputs?.[0]?.links ?? []
-          for (const linkId of outputs) {
-            const link = graph.links[linkId]
-
-            // When disconnecting sometimes the link is still registered
-            if (!link) continue
-
+          for (const link of outputLinks(graph, currentNode.id, 0)) {
             const node = graph.getNodeById(link.target_id)
             if (!node) continue
             if (node instanceof RerouteNode) {
@@ -176,9 +165,7 @@ app.registerExtension({
             : ''
           node.setSize(node.computeSize())
 
-          for (const l of node.outputs[0].links || []) {
-            const link = graph.links[l]
-            if (!link) continue
+          for (const link of outputLinks(graph, node.id, 0)) {
             link.color = color
 
             if (app.configuringGraph) continue

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -7,6 +7,7 @@ import type {
   LLink
 } from '@/lib/litegraph/src/litegraph'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
+import { outputHasLinks, outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { assetService } from '@/platform/assets/services/assetService'
 import { createAssetWidget } from '@/platform/assets/utils/createAssetWidget'
@@ -69,7 +70,11 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   override onAfterGraphConfigured() {
-    if (this.outputs[0].links?.length && !this.widgets?.length) {
+    if (
+      this.graph &&
+      outputHasLinks(this.graph, this.id, 0) &&
+      !this.widgets?.length
+    ) {
       this._onFirstConnection()
 
       // Populate widget values from config data
@@ -97,16 +102,16 @@ export class PrimitiveNode extends LGraphNode {
       return
     }
 
-    const links = this.outputs[0].links
+    const hasLinks = this.graph ? outputHasLinks(this.graph, this.id, 0) : false
     if (connected) {
-      if (links?.length && !this.widgets?.length) {
+      if (hasLinks && !this.widgets?.length) {
         this._onFirstConnection()
       }
     } else {
       // We may have removed a link that caused the constraints to change
       this._mergeWidgetConfig()
 
-      if (!links?.length) {
+      if (!hasLinks) {
         this.onLastDisconnect()
       }
     }
@@ -125,7 +130,7 @@ export class PrimitiveNode extends LGraphNode {
       return false
     }
 
-    if (this.outputs[slot].links?.length) {
+    if (this.graph && outputHasLinks(this.graph, this.id, slot)) {
       const valid = this._isValidConnection(input)
       if (valid) {
         // On connect of additional outputs, copy our value to their widget
@@ -139,13 +144,15 @@ export class PrimitiveNode extends LGraphNode {
 
   private _onFirstConnection(recreating?: boolean) {
     // First connection can fire before the graph is ready on initial load so random things can be missing
-    if (!this.outputs[0].links || !this.graph) {
+    if (!this.graph) {
       this.onLastDisconnect()
       return
     }
-    const linkId = this.outputs[0].links[0]
-    const link = this.graph.links[linkId]
-    if (!link) return
+    const [link] = outputLinks(this.graph, this.id, 0)
+    if (!link) {
+      if (!outputHasLinks(this.graph, this.id, 0)) this.onLastDisconnect()
+      return
+    }
 
     const theirNode = this.graph.getNodeById(link.target_id)
     if (!theirNode || !theirNode.inputs) return
@@ -318,14 +325,14 @@ export class PrimitiveNode extends LGraphNode {
   private _mergeWidgetConfig() {
     // Merge widget configs if the node has multiple outputs
     const output = this.outputs[0]
-    const links = output.links ?? []
+    const links = this.graph ? outputLinks(this.graph, this.id, 0) : []
 
     const hasConfig = !!output.widget?.[CONFIG]
     if (hasConfig) {
       delete output.widget?.[CONFIG]
     }
 
-    if (links?.length < 2 && hasConfig) {
+    if (links.length < 2 && hasConfig) {
       // Copy the widget options from the source
       if (links.length) {
         this.recreateWidget()
@@ -338,10 +345,7 @@ export class PrimitiveNode extends LGraphNode {
     const isNumber = config1[0] === 'INT' || config1[0] === 'FLOAT'
     if (!isNumber || !this.graph) return
 
-    for (const linkId of links) {
-      const link = this.graph.links[linkId]
-      if (!link) continue // Can be null when removing a node
-
+    for (const link of links) {
       const theirNode = this.graph.getNodeById(link.target_id)
       if (!theirNode) continue
       const theirInput = theirNode.inputs[link.target_slot]

--- a/src/extensions/core/widgetValuePropagation.test.ts
+++ b/src/extensions/core/widgetValuePropagation.test.ts
@@ -1,15 +1,15 @@
+import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { describe, expect, it, vi } from 'vitest'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type {
-  INodeInputSlot,
-  INodeOutputSlot,
-  LLink
-} from '@/lib/litegraph/src/litegraph'
+import type { INodeInputSlot } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useLinkStore } from '@/stores/linkStore'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
-import { createMockLLink } from '@/utils/__tests__/litegraphTestUtils'
+import type { UUID } from '@/utils/uuid'
 
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -21,7 +21,11 @@ vi.mock('@/scripts/app', () => ({
 
 import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
 
-type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+type SourceNode = Pick<LGraphNode, 'id' | 'graph' | 'widgets'>
+type TargetNode = Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>
+
+const GRAPH_ID: UUID = 'graph-test'
+const SOURCE_NODE_ID = toNodeId(1)
 
 function createWidget(
   name: string,
@@ -35,11 +39,8 @@ function createWidget(
   })
 }
 
-function createTargetNode(
-  widget: IBaseWidget,
-  id = 7
-): Pick<LGraphNode, 'id' | 'inputs' | 'widgets'> {
-  return fromPartial<Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>>({
+function createTargetNode(widget: IBaseWidget, id = 7): TargetNode {
+  return fromPartial<TargetNode>({
     id: toNodeId(id),
     inputs: [
       fromPartial<INodeInputSlot>({
@@ -50,39 +51,40 @@ function createTargetNode(
   })
 }
 
-function createLink(targetId: LLink['target_id'], targetSlot = 0): LLink {
-  return createMockLLink({
-    target_id: targetId,
-    target_slot: targetSlot
-  })
-}
-
 function createSourceNode(options: {
-  link: LLink
-  targetNode: Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>
+  targetNode: TargetNode
   widgets?: IBaseWidget[]
 }): SourceNode {
+  useLinkStore().registerLink(GRAPH_ID, {
+    id: toLinkId(1),
+    originNodeId: SOURCE_NODE_ID,
+    originSlot: 0,
+    targetNodeId: options.targetNode.id,
+    targetSlot: 0,
+    type: 'INT'
+  })
   return {
+    id: SOURCE_NODE_ID,
     graph: {
-      links: { 1: options.link },
-      getNodeById: vi.fn((id: LLink['target_id']) =>
+      rootGraph: { id: GRAPH_ID },
+      getNodeById: vi.fn((id: TargetNode['id']) =>
         id === options.targetNode.id ? options.targetNode : null
       )
     } as unknown as NonNullable<LGraphNode['graph']>,
-    outputs: [{ links: [1] } as INodeOutputSlot],
     widgets: options.widgets ?? []
   }
 }
 
 describe('applyFirstWidgetValueToGraph', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
   it('returns early when the source widget is missing', () => {
     const targetCallback = vi.fn()
     const targetWidget = createWidget('value', 'unchanged', targetCallback)
     const targetNode = createTargetNode(targetWidget)
-    const sourceNode = createSourceNode({
-      link: createLink(targetNode.id),
-      targetNode
-    })
+    const sourceNode = createSourceNode({ targetNode })
 
     expect(() => applyFirstWidgetValueToGraph(sourceNode)).not.toThrow()
     expect(targetWidget.value).toBe('unchanged')
@@ -94,7 +96,6 @@ describe('applyFirstWidgetValueToGraph', () => {
     const targetWidget = createWidget('value', 'old', targetCallback)
     const targetNode = createTargetNode(targetWidget)
     const sourceNode = createSourceNode({
-      link: createLink(targetNode.id),
       targetNode,
       widgets: [createWidget('source', 'new value')]
     })
@@ -116,7 +117,6 @@ describe('applyFirstWidgetValueToGraph', () => {
     const targetWidget = createWidget('value', 'old')
     const targetNode = createTargetNode(targetWidget)
     const sourceNode = createSourceNode({
-      link: createLink(targetNode.id),
       targetNode,
       widgets: [createWidget('source', 'draft')]
     })

--- a/src/extensions/core/widgetValuePropagation.ts
+++ b/src/extensions/core/widgetValuePropagation.ts
@@ -3,17 +3,30 @@ import type { LLink } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { app } from '@/scripts/app'
+import { useLinkStore } from '@/stores/linkStore'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 
-type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+type SourceNode = Pick<LGraphNode, 'id' | 'graph' | 'widgets'>
+
+interface TargetEndpoint {
+  targetNodeId: NodeId
+  targetSlot: number
+}
 
 export function applyFirstWidgetValueToGraph(
   node: SourceNode,
   extraLinks: LLink[] = [],
   transformValue?: (value: WidgetValue) => WidgetValue
 ) {
-  const output = node.outputs[0]
-  if (!output?.links?.length || !node.graph) return
+  const { graph } = node
+  if (!graph) return
+
+  const linked = [
+    ...useLinkStore().getOutputSlotLinks(graph.rootGraph.id, node.id, 0)
+  ].filter((topology) => topology.targetNodeId !== UNASSIGNED_NODE_ID)
+  if (!linked.length) return
 
   const sourceWidget = node.widgets?.[0]
   if (!sourceWidget) return
@@ -25,18 +38,22 @@ export function applyFirstWidgetValueToGraph(
 
   const graphMouse: Point = app.canvas?.graph_mouse ?? [0, 0]
 
-  const links = [
-    ...output.links.map((linkId) => node.graph!.links[linkId]),
-    ...extraLinks
+  const endpoints: TargetEndpoint[] = [
+    ...linked.map(({ targetNodeId, targetSlot }) => ({
+      targetNodeId,
+      targetSlot
+    })),
+    ...extraLinks.map((link) => ({
+      targetNodeId: link.target_id,
+      targetSlot: link.target_slot
+    }))
   ]
 
-  for (const linkInfo of links) {
-    if (!linkInfo) continue
-
-    const targetNode = node.graph.getNodeById(linkInfo.target_id)
-    const input = targetNode?.inputs[linkInfo.target_slot]
+  for (const endpoint of endpoints) {
+    const targetNode = graph.getNodeById(endpoint.targetNodeId)
+    const input = targetNode?.inputs[endpoint.targetSlot]
     if (!targetNode || !input) {
-      console.warn('Unable to resolve node or input for link', linkInfo)
+      console.warn('Unable to resolve node or input for link', endpoint)
       continue
     }
 

--- a/src/extensions/core/widgetValuePropagation.ts
+++ b/src/extensions/core/widgetValuePropagation.ts
@@ -4,7 +4,6 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { app } from '@/scripts/app'
 import { useLinkStore } from '@/stores/linkStore'
-import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { WidgetValue } from '@/types/simplifiedWidget'
 
@@ -25,7 +24,7 @@ export function applyFirstWidgetValueToGraph(
 
   const linked = [
     ...useLinkStore().getOutputSlotLinks(graph.rootGraph.id, node.id, 0)
-  ].filter((topology) => topology.targetNodeId !== UNASSIGNED_NODE_ID)
+  ]
   if (!linked.length) return
 
   const sourceWidget = node.widgets?.[0]

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -937,7 +937,6 @@ describe('_removeDuplicateLinks', () => {
     graph.state.lastLinkId = linkId
     const dup = new LLink(linkId, 'number', source.id, 0, target.id, 0)
     graph._addLink(dup)
-    source.outputs[0].links!.push(dup.id)
     return dup
   }
 
@@ -947,7 +946,8 @@ describe('_removeDuplicateLinks', () => {
     for (let i = 0; i < 3; i++) injectDuplicateLink(graph, source, target)
 
     expect(graph._links.size).toBe(4)
-    expect(source.outputs[0].links).toHaveLength(4)
+    // The derived output.links view never contained the contested duplicates.
+    expect(source.outputs[0].links).toHaveLength(1)
 
     graph._removeDuplicateLinks()
 
@@ -1123,7 +1123,7 @@ describe('Subgraph Unpacking', () => {
     return rootGraph.createSubgraph(createTestSubgraphData())
   }
 
-  function duplicateExistingLink(graph: LGraph, source: LGraphNode) {
+  function duplicateExistingLink(graph: LGraph) {
     const existingLink = graph._links.values().next().value!
     const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
     graph.state.lastLinkId = linkId
@@ -1136,7 +1136,6 @@ describe('Subgraph Unpacking', () => {
       existingLink.target_slot
     )
     graph._links.set(dup.id, dup)
-    source.outputs[0].links!.push(dup.id)
     return dup
   }
 
@@ -1152,7 +1151,7 @@ describe('Subgraph Unpacking', () => {
 
     sourceNode.connect(0, targetNode, 0)
 
-    for (let i = 0; i < 3; i++) duplicateExistingLink(subgraph, sourceNode)
+    for (let i = 0; i < 3; i++) duplicateExistingLink(subgraph)
     expect(subgraph._links.size).toBe(4)
 
     const subgraphNode = createTestSubgraphNode(subgraph, { pos: [100, 100] })
@@ -1175,7 +1174,7 @@ describe('Subgraph Unpacking', () => {
     subgraph.add(targetNode)
 
     sourceNode.connect(0, targetNode, 0)
-    duplicateExistingLink(subgraph, sourceNode)
+    duplicateExistingLink(subgraph)
 
     const subgraphNode = createTestSubgraphNode(subgraph, { pos: [100, 100] })
     rootGraph.add(subgraphNode)

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -15,7 +15,7 @@ import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 import { useLinkStore } from '@/stores/linkStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
-import { outputLinks } from './node/slotLinks'
+import { outputHasLinks, outputLinks } from './node/slotLinks'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { UNASSIGNED_NODE_ID, parseNodeId, toNodeId } from '@/types/nodeId'
@@ -1177,8 +1177,8 @@ export class LGraph
 
     // disconnect outputs
     if (outputs) {
-      for (const [i, slot] of outputs.entries()) {
-        if (slot.links?.length) node.disconnectOutput(i)
+      for (const i of outputs.keys()) {
+        if (outputHasLinks(this, node.id, i)) node.disconnectOutput(i)
       }
     }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -15,6 +15,7 @@ import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 import { useLinkStore } from '@/stores/linkStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
+import { outputLinks } from './node/slotLinks'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { UNASSIGNED_NODE_ID, parseNodeId, toNodeId } from '@/types/nodeId'
@@ -794,16 +795,9 @@ export class LGraph
       if (!node.outputs) continue
 
       // for every output
-      for (const output of node.outputs) {
-        // not connected
-        // TODO: Confirm functionality, clean condition
-        if (output?.links == null || output.links.length == 0) continue
-
+      for (const [slot] of node.outputs.entries()) {
         // for every connection
-        for (const link_id of output.links) {
-          const link = this._links.get(link_id)
-          if (!link) continue
-
+        for (const link of outputLinks(this, node.id, slot)) {
           // already visited link (ignore it)
           if (visited_links[link.id]) continue
 
@@ -2173,9 +2167,11 @@ export class LGraph
         link.origin_id = origin_id
       }
       if (link.target_id === SUBGRAPH_OUTPUT_ID) {
-        for (const linkId of subgraphNode.outputs[link.target_slot].links ??
-          []) {
-          const sublink = this.links[linkId]
+        for (const sublink of outputLinks(
+          this,
+          subgraphNode.id,
+          link.target_slot
+        )) {
           newLinks.push({
             oid: link.origin_id,
             oslot: link.origin_slot,

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -79,9 +79,7 @@ function createTestLink(
     targetNode.id,
     inputSlot
   )
-  graph._links.set(linkId, link)
-  sourceNode.outputs[outputSlot].links ??= []
-  sourceNode.outputs[outputSlot].links!.push(linkId)
+  graph._addLink(link)
   targetNode.inputs[inputSlot].link = linkId
   return link
 }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -27,7 +27,7 @@ import type { NodeProperty } from './LGraphNode'
 import { parseNodeId, serializeNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
 import { LLink, slotFloatingLinks } from './LLink'
-import { outputLinks } from './node/slotLinks'
+import { outputLinkIds, outputLinks } from './node/slotLinks'
 import type { LinkId } from './LLink'
 import { Reroute } from './Reroute'
 import type { RerouteId } from './Reroute'
@@ -4603,9 +4603,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         this.highlighted_links[input.link] = true
       }
     }
-    if (item.outputs) {
-      for (const id of item.outputs.flatMap((x) => x.links)) {
-        if (id == null) continue
+    const { graph } = item
+    if (graph && item.outputs) {
+      for (const id of item.outputs.flatMap((_, i) =>
+        outputLinkIds(graph, item.id, i)
+      )) {
         this.highlighted_links[id] = true
       }
     }
@@ -4663,9 +4665,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       }
     }
     if (item.outputs) {
-      for (const id of item.outputs.flatMap((x) => x.links)) {
-        if (id == null) continue
-
+      for (const id of item.outputs.flatMap((_, i) =>
+        outputLinkIds(graph, item.id, i)
+      )) {
         const node = LLink.getTargetNode(graph, id)
         if (node && this.selectedItems.has(node)) continue
 
@@ -4797,9 +4799,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           this.highlighted_links[input.link] = true
         }
       }
-      if (keepSelected.outputs) {
-        for (const id of keepSelected.outputs.flatMap((x) => x.links)) {
-          if (id == null) continue
+      const { graph } = keepSelected
+      if (graph && keepSelected.outputs) {
+        for (const id of keepSelected.outputs.flatMap((_, i) =>
+          outputLinkIds(graph, keepSelected.id, i)
+        )) {
           this.highlighted_links[id] = true
         }
       }
@@ -8680,7 +8684,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         if (node.getSlotMenuOptions) {
           menu_info = node.getSlotMenuOptions(slot)
         } else {
-          if (slot.output?.links?.length || slot.input?.link != null) {
+          if (
+            (slot.output &&
+              node.isOutputConnected(node.outputs.indexOf(slot.output))) ||
+            slot.input?.link != null
+          ) {
             menu_info.push({ content: 'Disconnect Links', slot })
           }
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -27,6 +27,7 @@ import type { NodeProperty } from './LGraphNode'
 import { parseNodeId, serializeNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
 import { LLink, slotFloatingLinks } from './LLink'
+import { outputLinks } from './node/slotLinks'
 import type { LinkId } from './LLink'
 import { Reroute } from './Reroute'
 import type { RerouteId } from './Reroute'
@@ -62,7 +63,6 @@ import type {
   INodeSlot,
   INodeSlotContextItem,
   ISlotType,
-  LinkNetwork,
   LinkSegment,
   NewNodePosition,
   NullableProperties,
@@ -2780,22 +2780,13 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     } else if (!node.flags.collapsed) {
       const { inputs, outputs } = node
 
-      function hasRelevantOutputLinks(
-        output: INodeOutputSlot,
-        network: LinkNetwork
-      ): boolean {
-        return (output.links ?? []).some(
-          (linkId) => network.getLink(linkId) !== undefined
-        )
-      }
-
       // Outputs
       if (outputs) {
         for (const [i, output] of outputs.entries()) {
           const link_pos = node.getOutputPos(i)
           if (isInRectangle(x, y, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             // Drag multiple output links
-            if (e.shiftKey && hasRelevantOutputLinks(output, graph)) {
+            if (e.shiftKey && outputLinks(graph, node.id, i).length > 0) {
               linkConnector.moveOutputLink(graph, node, output)
               this._linkConnectorDrop()
               return

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -126,7 +126,7 @@ describe('LGraphNode', () => {
       outputs: node.outputs?.map((o) => ({
         name: o.name,
         type: o.type,
-        links: o.links,
+        links: o.links ? [...o.links] : o.links,
         slot_index: o.slot_index
       }))
     }
@@ -165,7 +165,7 @@ describe('LGraphNode', () => {
     expect(node.outputs.length).toEqual(1)
     expect(node.outputs[0].name).toEqual('TestOutput')
     expect(node.outputs[0].type).toEqual('number')
-    expect(node.outputs[0].links).toEqual([])
+    expect(node.outputs[0].links).toBeNull()
     expect(node.outputs[0]).instanceOf(NodeOutputSlot)
 
     // Should not override existing outputs
@@ -215,7 +215,7 @@ describe('LGraphNode', () => {
       const disconnected = node2.disconnectInput(0)
       expect(disconnected).toBe(true)
       expect(node2.inputs[0].link).toBeNull()
-      expect(node1.outputs[0].links?.length).toBe(0)
+      expect(node1.outputs[0].links).toBeNull()
       expect(graph._links.has(link!.id)).toBe(false)
 
       // Test disconnecting by slot name
@@ -291,7 +291,7 @@ describe('LGraphNode', () => {
       )
       expect(disconnectedByName).toBe(true)
       expect(targetNode1.inputs[0].link).toBeNull()
-      expect(sourceNode.outputs[1].links?.length).toBe(0)
+      expect(sourceNode.outputs[1].links).toBeNull()
 
       // Test disconnecting all connections from an output
       const link4 = sourceNode.connect(0, targetNode1, 0)

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1128,13 +1128,8 @@ export class LGraphNode
 
     if (!this.graph) throw new NullGraphError()
 
-    // if there are connections, pass the data to the connections
-    const { links } = outputs[slot]
-    if (links) {
-      for (const id of links) {
-        const link = this.graph._links.get(id)
-        if (link) link.data = data
-      }
+    for (const link of outputLinks(this.graph, this.id, slot)) {
+      link.data = data
     }
   }
 
@@ -1152,13 +1147,8 @@ export class LGraphNode
 
     if (!this.graph) throw new NullGraphError()
 
-    // if there are connections, pass the data to the connections
-    const { links } = outputs[slot]
-    if (links) {
-      for (const id of links) {
-        const link = this.graph._links.get(id)
-        if (link) link.type = type
-      }
+    for (const link of outputLinks(this.graph, this.id, slot)) {
+      link.type = type
     }
   }
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -33,6 +33,7 @@ import { LGraphButton } from './LGraphButton'
 import type { LGraphButtonOptions } from './LGraphButton'
 import { LGraphCanvas } from './LGraphCanvas'
 import { LLink, slotFloatingLinks } from './LLink'
+import { outputHasLinks, outputLinks } from './node/slotLinks'
 import { anchorRerouteChain } from './Reroute'
 import type { Reroute, RerouteId } from './Reroute'
 import { getNodeInputOnPos, getNodeOutputOnPos } from './canvas/measureSlots'
@@ -918,10 +919,11 @@ export class LGraphNode
       toClass(NodeOutputSlot, output, this)
     )
     for (const [i, output] of this.outputs.entries()) {
-      if (!output.links) continue
+      const serialisedLinks = info.outputs?.[i]?.links
+      if (!serialisedLinks) continue
 
-      for (const linkId of output.links) {
-        const link = this.graph ? this.graph._links.get(linkId) : null
+      for (const linkId of serialisedLinks) {
+        const link = this.graph ? this.graph._links.get(toLinkId(linkId)) : null
         this.onConnectionsChange?.(NodeSlotType.OUTPUT, i, true, link, output)
       }
       this.onOutputAdded?.(output)
@@ -993,8 +995,10 @@ export class LGraphNode
     if (this.inputs)
       o.inputs = this.inputs.map((input) => inputAsSerialisable(input))
     if (this.outputs)
-      // @ts-expect-error - Output serialization type mismatch
-      o.outputs = this.outputs.map((output) => outputAsSerialisable(output))
+      o.outputs = this.outputs.map((output, i) =>
+        // @ts-expect-error - Output serialization type mismatch
+        outputAsSerialisable(output, this, i)
+      )
 
     if (this.title && this.title != this.constructor.title) o.title = this.title
 
@@ -1334,9 +1338,9 @@ export class LGraphNode
    * tells you if there is a connection in one output slot
    */
   isOutputConnected(slot: number): boolean {
-    if (!this.outputs) return false
+    if (!this.outputs || !this.graph) return false
     return (
-      slot < this.outputs.length && Number(this.outputs[slot].links?.length) > 0
+      slot < this.outputs.length && outputHasLinks(this.graph, this.id, slot)
     )
   }
 
@@ -1344,13 +1348,10 @@ export class LGraphNode
    * tells you if there is any connection in the output slots
    */
   isAnyOutputConnected(): boolean {
-    const { outputs } = this
-    if (!outputs) return false
+    const { outputs, graph } = this
+    if (!outputs || !graph) return false
 
-    for (const output of outputs) {
-      if (output.links?.length) return true
-    }
-    return false
+    return outputs.some((_, slot) => outputHasLinks(graph, this.id, slot))
   }
 
   /**
@@ -1361,19 +1362,16 @@ export class LGraphNode
     if (!outputs || outputs.length == 0) return null
 
     if (slot >= outputs.length) return null
+    if (!this.graph) return null
 
-    const { links } = outputs[slot]
-    if (!links || links.length == 0) return null
-    if (!this.graph) throw new NullGraphError()
+    const links = outputLinks(this.graph, this.id, slot)
+    if (links.length == 0) return null
 
     const r: LGraphNode[] = []
-    for (const id of links) {
-      const link = this.graph._links.get(id)
-      if (link) {
-        const target_node = this.graph.getNodeById(link.target_id)
-        if (target_node) {
-          r.push(target_node)
-        }
+    for (const link of links) {
+      const target_node = this.graph.getNodeById(link.target_id)
+      if (target_node) {
+        r.push(target_node)
       }
     }
     return r
@@ -1552,20 +1550,16 @@ export class LGraphNode
     const output = this.outputs[slot]
     if (!output) return
 
-    const links = output.links
-    if (!links || !links.length) return
-
     if (!this.graph) throw new NullGraphError()
+    const links = outputLinks(this.graph, this.id, slot)
+    if (!links.length) return
+
     this.graph._last_trigger_time = LiteGraph.getTime()
 
     // for every link attached here
-    for (const id of links) {
+    for (const link_info of links) {
       // to skip links
-      if (link_id != null && link_id != id) continue
-
-      const link_info = this.graph._links.get(id)
-      // not connected
-      if (!link_info) continue
+      if (link_id != null && link_id != link_info.id) continue
 
       link_info._last_time = LiteGraph.getTime()
       const node = this.graph.getNodeById(link_info.target_id)
@@ -1600,19 +1594,12 @@ export class LGraphNode
     const output = this.outputs[slot]
     if (!output) return
 
-    const links = output.links
-    if (!links || !links.length) return
-
     if (!this.graph) throw new NullGraphError()
 
     // for every link attached here
-    for (const id of links) {
+    for (const link_info of outputLinks(this.graph, this.id, slot)) {
       // to skip links
-      if (link_id != null && link_id != id) continue
-
-      const link_info = this.graph._links.get(id)
-      // not connected
-      if (!link_info) continue
+      if (link_id != null && link_id != link_info.id) continue
 
       link_info._last_time = 0
     }
@@ -1696,15 +1683,12 @@ export class LGraphNode
     const { outputs } = this
     outputs.splice(slot, 1)
 
-    for (let i = slot; i < outputs.length; ++i) {
-      const output = outputs[i]
-      if (!output || !output.links) continue
-
-      // Only update link indices if node is part of a graph
-      if (this.graph) {
-        for (const linkId of output.links) {
-          const link = this.graph._links.get(linkId)
-          if (link) link.origin_slot--
+    // Only update link indices if node is part of a graph. Ascending order:
+    // each decrement re-keys the link to an already-processed slot index.
+    if (this.graph) {
+      for (let oldSlot = slot + 1; oldSlot <= outputs.length; ++oldSlot) {
+        for (const link of outputLinks(this.graph, this.id, oldSlot)) {
+          link.origin_slot--
         }
       }
     }
@@ -2455,12 +2439,17 @@ export class LGraphNode
     if (!(length > 0)) return -1
 
     for (let i = 0; i < length; ++i) {
-      const slot: TSlot & IGenericLinkOrLinks = slots[i]
-      if (!slot || slot.link || slot.links?.length) continue
+      const slot: TSlot = slots[i]
+      if (!slot || this.#slotIsConnected(slot, i)) continue
       if (opts.typesNotAccepted?.includes?.(slot.type)) continue
       return !opts.returnObj ? i : slot
     }
     return -1
+  }
+
+  #slotIsConnected(slot: INodeInputSlot | INodeOutputSlot, index: number) {
+    if ('link' in slot) return slot.link != null
+    return this.graph ? outputHasLinks(this.graph, this.id, index) : false
   }
 
   /**
@@ -2619,7 +2608,7 @@ export class LGraphNode
           const dest = destType == '_event_' ? LiteGraph.EVENT : destType
 
           if (source == dest || source === '*' || dest === '*') {
-            if (preferFreeSlot && (slot.links?.length || slot.link != null)) {
+            if (preferFreeSlot && this.#slotIsConnected(slot, i)) {
               // In case we can't find a free slot.
               occupiedSlot ??= returnObj ? slot : i
               continue
@@ -2715,7 +2704,8 @@ export class LGraphNode
     return findFreeSlotOfType(
       this.outputs,
       type,
-      (output) => !output.links?.length
+      (_output, index) =>
+        !this.graph || !outputHasLinks(this.graph, this.id, index)
     )
   }
 
@@ -2913,7 +2903,7 @@ export class LGraphNode
 
     if (!output) return null
 
-    if (output.links?.length) {
+    if (outputHasLinks(graph, this.id, slot)) {
       if (
         output.type === LiteGraph.EVENT &&
         !LiteGraph.allow_multi_output_for_events
@@ -3130,12 +3120,9 @@ export class LGraphNode
       }
     }
 
-    if (!output.links || output.links.length == 0) return false
-    const { links } = output
-
-    // one of the output links in this slot
     const graph = this.graph
-    if (!graph) throw new NullGraphError()
+    if (!graph) return false
+    if (!outputHasLinks(graph, this.id, slot)) return false
 
     if (target_node) {
       const target =
@@ -3144,13 +3131,13 @@ export class LGraphNode
           : target_node
       if (!target) throw 'Target Node not found'
 
-      for (const [i, link_id] of links.entries()) {
-        const link_info = graph._links.get(link_id)
-        if (link_info?.target_id != target.id) continue
+      for (const link_info of outputLinks(graph, this.id, slot)) {
+        if (link_info.target_id != target.id) continue
 
         // is the link we are searching for...
         // remove here
-        links.splice(i, 1)
+        const mirrorIndex = output.links?.indexOf(link_info.id) ?? -1
+        if (mirrorIndex !== -1) output.links!.splice(mirrorIndex, 1)
         const input = target.inputs[link_info.target_slot]
         // remove there
         input.link = null
@@ -3179,9 +3166,7 @@ export class LGraphNode
       }
     } else {
       // all the links in this output slot
-      for (const link_id of links) {
-        const link_info = graph._links.get(link_id)
-        if (!link_info) continue
+      for (const link_info of outputLinks(graph, this.id, slot)) {
         if (
           link_info.target_id === SUBGRAPH_OUTPUT_ID &&
           graph instanceof Subgraph
@@ -3296,19 +3281,14 @@ export class LGraphNode
         }
 
         const output = target_node.outputs[link_info.origin_slot]
-        if (!output?.links?.length) {
+        if (!output) {
           // Output not found - may have been removed
           return false
         }
 
-        // search in the inputs list for this link
-        let i = 0
-        for (const l = output.links.length; i < l; i++) {
-          if (output.links[i] == link_id) {
-            output.links.splice(i, 1)
-            break
-          }
-        }
+        // remove the mirror entry on the origin output
+        const mirrorIndex = output.links?.indexOf(link_id) ?? -1
+        if (mirrorIndex !== -1) output.links!.splice(mirrorIndex, 1)
 
         link_info.disconnect(graph, keepReroutes ? 'output' : undefined)
         if (graph) graph.incrementVersion()
@@ -3322,7 +3302,7 @@ export class LGraphNode
         )
         target_node.onConnectionsChange?.(
           NodeSlotType.OUTPUT,
-          i,
+          link_info.origin_slot,
           false,
           link_info,
           output
@@ -3857,6 +3837,7 @@ export class LGraphNode
     if (!graph) throw new NullGraphError()
 
     const { _links } = graph
+    const nodeId = this.id
     let madeAnyConnections = false
 
     // First pass: only match exactly index-to-index
@@ -3872,7 +3853,7 @@ export class LGraphNode
       const inNode = graph.getNodeById(inLink?.origin_id)
       if (!inNode) continue
 
-      bypassAllLinks(output, inNode, inLink, graph)
+      bypassAllLinks(index, inNode, inLink, graph)
     }
     // Configured to only use index-to-index matching
     if (!(this.flags.keepAllLinksOnBypass ?? LGraphNode.keepAllLinksOnBypass))
@@ -3887,25 +3868,23 @@ export class LGraphNode
       const inNode = graph.getNodeById(inLink?.origin_id)
       if (!inNode) continue
 
-      for (const output of outputs) {
+      for (const [outIndex, output] of outputs.entries()) {
         if (!LiteGraph.isValidConnection(input.type, output.type)) continue
 
-        bypassAllLinks(output, inNode, inLink, graph)
+        bypassAllLinks(outIndex, inNode, inLink, graph)
         break
       }
     }
     return madeAnyConnections
 
     function bypassAllLinks(
-      output: INodeOutputSlot,
+      outputIndex: number,
       inNode: LGraphNode,
       inLink: LLink,
       graph: LGraph
     ) {
-      const outLinks = output.links
-        ?.map((x) => _links.get(x))
-        .filter((x) => !!x)
-      if (!outLinks?.length) return
+      const outLinks = outputLinks(graph, nodeId, outputIndex)
+      if (!outLinks.length) return
 
       for (const outLink of outLinks) {
         const outNode = graph.getNodeById(outLink.target_id)
@@ -4008,7 +3987,7 @@ export class LGraphNode
       }
     }
     for (const slot of this._concreteOutputs) {
-      if (slot.links?.length) {
+      if (slot.isConnected) {
         slot.drawCollapsed(ctx)
         break
       }

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -2998,9 +2998,6 @@ export class LGraphNode
     // add to graph links list
     graph._addLink(link)
 
-    // connect in output
-    output.links ??= []
-    output.links.push(link.id)
     // connect in input
     inputNode.inputs[inputIndex].link = link.id
 
@@ -3135,9 +3132,6 @@ export class LGraphNode
         if (link_info.target_id != target.id) continue
 
         // is the link we are searching for...
-        // remove here
-        const mirrorIndex = output.links?.indexOf(link_info.id) ?? -1
-        if (mirrorIndex !== -1) output.links!.splice(mirrorIndex, 1)
         const input = target.inputs[link_info.target_slot]
         // remove there
         input.link = null
@@ -3207,7 +3201,6 @@ export class LGraphNode
           output
         )
       }
-      output.links = null
     }
 
     this.setDirtyCanvas(false, true)
@@ -3285,10 +3278,6 @@ export class LGraphNode
           // Output not found - may have been removed
           return false
         }
-
-        // remove the mirror entry on the origin output
-        const mirrorIndex = output.links?.indexOf(link_id) ?? -1
-        if (mirrorIndex !== -1) output.links!.splice(mirrorIndex, 1)
 
         link_info.disconnect(graph, keepReroutes ? 'output' : undefined)
         if (graph) graph.incrementVersion()

--- a/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
@@ -175,9 +175,8 @@ describe('LinkConnector', () => {
       sourceNode.addOutput('out', slotType)
       targetNode.addInput('in', slotType)
 
-      const link = new LLink(toLinkId(1), slotType, 1, 0, 2, 0)
-      network.links.set(link.id, link)
-      sourceNode.outputs[0].links = [link.id]
+      const link = sourceNode.connect(0, targetNode, 0)!
+      expect(link).toBeTruthy()
 
       connector.moveOutputLink(network, sourceNode, sourceNode.outputs[0])
 

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -449,7 +449,7 @@ describe('LinkConnector Integration', () => {
       expect(connector.outputLinks.length).toBe(0)
 
       expect(disconnectedNode.outputs[0].links).toEqual(nextLinkIds)
-      expect(hasOutputNode.outputs[0].links).toEqual([])
+      expect(hasOutputNode.outputs[0].links).toBeNull()
 
       const reroutesAfter = disconnectedNode.outputs[0].links
         ?.map((linkId) => graph.links.get(linkId)!)
@@ -593,7 +593,7 @@ describe('LinkConnector Integration', () => {
       connector.dropLinks(graph, floatingRerouteEvent)
       connector.reset()
 
-      expect(manyOutputsNode.outputs[0].links).toEqual([])
+      expect(manyOutputsNode.outputs[0].links).toBeNull()
       expect(floatingReroute.linkIds.size).toBe(4)
 
       validateIntegrityFloatingRemoved()
@@ -614,7 +614,7 @@ describe('LinkConnector Integration', () => {
       const canvasY = reroute7.pos[1]
       const reroute7Event = createMockCanvasPointerEvent(canvasX, canvasY)
 
-      const toSortedRerouteChain = (linkIds: number[]) =>
+      const toSortedRerouteChain = (linkIds: readonly number[]) =>
         linkIds
           .map((x) => graph.links.get(toLinkId(x))!)
           .map((x) => LLink.getReroutes(graph, x))

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -2,6 +2,7 @@ import { remove } from 'es-toolkit'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
+import { outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import {
   SUBGRAPH_INPUT_ID,
@@ -323,11 +324,12 @@ export class LinkConnector {
     }
 
     // Normal links
-    if (output.links?.length) {
-      for (const linkId of output.links) {
-        const link = network.links.get(linkId)
-        if (!link) continue
-
+    if (node.graph) {
+      for (const link of outputLinks(
+        node.graph,
+        node.id,
+        node.outputs.indexOf(output)
+      )) {
         const firstReroute = LLink.getFirstReroute(network, link)
         if (firstReroute) {
           firstReroute._dragging = true

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -376,7 +376,13 @@ export interface IWidgetInputSlot extends INodeInputSlot {
 }
 
 export interface INodeOutputSlot extends INodeSlot {
-  links: LinkId[] | null
+  /**
+   * @deprecated Ids of the links leaving this slot, derived from the link
+   * store by a warning getter. Read via `node.isOutputConnected(slot)` /
+   * `node.getOutputNodes(slot)`; mutate via `node.connect()` /
+   * `node.disconnectOutput()`.
+   */
+  readonly links?: readonly LinkId[] | null
   _data?: unknown
   slot_index?: SlotIndex
 }

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -57,14 +57,6 @@ export function purgeOrphanedLinks(
     const link = graph._links.get(id)
     if (!link) continue
 
-    const originNode = graph.getNodeById(link.origin_id)
-    const output = originNode?.outputs?.[link.origin_slot]
-    if (output?.links) {
-      for (let i = output.links.length - 1; i >= 0; i--) {
-        if (output.links[i] === id) output.links.splice(i, 1)
-      }
-    }
-
     graph._removeLink(id)
   }
 

--- a/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.test.ts
@@ -1,0 +1,81 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LinkId } from '@/lib/litegraph/src/LLink'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+function createConnectedGraph() {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'INT')
+  graph.add(source)
+
+  const target = new LGraphNode('Target')
+  target.addInput('in', 'INT')
+  graph.add(target)
+
+  return { graph, source, target }
+}
+
+describe('NodeOutputSlot deprecated links getter', () => {
+  const onWarning = vi.fn()
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    onWarning.mockClear()
+    LiteGraph.onDeprecationWarning = [onWarning]
+    LiteGraph.alwaysRepeatWarnings = true
+  })
+
+  afterEach(() => {
+    LiteGraph.alwaysRepeatWarnings = false
+  })
+
+  it('fires a deprecation warning on read', () => {
+    const { source } = createConnectedGraph()
+
+    void source.outputs[0].links
+
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.stringContaining('output.links is deprecated'),
+      undefined
+    )
+  })
+
+  it('reflects live link store data across connect and disconnect', () => {
+    const { source, target } = createConnectedGraph()
+
+    const link = source.connect(0, target, 0)
+    expect(source.outputs[0].links).toEqual([link!.id])
+
+    source.disconnectOutput(0)
+    expect(source.outputs[0].links).toBeNull()
+  })
+
+  it('returns null for an unconnected slot and for a graphless node', () => {
+    const { source } = createConnectedGraph()
+    expect(source.outputs[0].links).toBeNull()
+
+    const orphan = new LGraphNode('Orphan')
+    orphan.addOutput('out', 'INT')
+    expect(orphan.outputs[0].links).toBeNull()
+  })
+
+  it('throws on assignment', () => {
+    const { source } = createConnectedGraph()
+    const slot: { links?: unknown } = source.outputs[0]
+
+    expect(() => {
+      slot.links = []
+    }).toThrow(TypeError)
+  })
+
+  it('throws on mutation of the returned array', () => {
+    const { source, target } = createConnectedGraph()
+    source.connect(0, target, 0)
+
+    const links = source.outputs[0].links as LinkId[]
+    expect(() => links.push(links[0])).toThrow(TypeError)
+  })
+})

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -10,6 +10,10 @@ import type {
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
 import type { IDrawOptions } from '@/lib/litegraph/src/node/NodeSlot'
+import {
+  outputHasLinks,
+  outputLinkIds
+} from '@/lib/litegraph/src/node/slotLinks'
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
@@ -55,7 +59,13 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   }
 
   override get isConnected(): boolean {
-    return this.links != null && this.links.length > 0
+    const { graph } = this._node
+    if (!graph) return false
+    return outputHasLinks(
+      graph,
+      this._node.id,
+      this._node.outputs.indexOf(this)
+    )
   }
 
   override draw(
@@ -77,9 +87,13 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   }
 
   override toJSON(): INodeOutputSlot {
+    const { graph } = this._node
+    const ids = graph
+      ? outputLinkIds(graph, this._node.id, this._node.outputs.indexOf(this))
+      : []
     return {
       ...super.toJSON(),
-      links: this.links,
+      links: ids.length ? ids : null,
       slot_index: this.slot_index
     }
   }

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -21,7 +21,7 @@ import { warnDeprecated } from '@/lib/litegraph/src/utils/feedback'
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
   /** @deprecated Derived from the link store via a warning prototype getter; never written. */
-  declare readonly links?: readonly LinkId[] | null
+  declare readonly links: readonly LinkId[] | null
   _data?: unknown
   slot_index?: number
 
@@ -110,7 +110,7 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
  * writes throw in strict mode. First-party code uses the slotLinks helpers.
  */
 Object.defineProperty(NodeOutputSlot.prototype, 'links', {
-  get(this: NodeOutputSlot): LinkId[] | null {
+  get(this: NodeOutputSlot): readonly LinkId[] | null {
     warnDeprecated(
       'output.links is deprecated. Read connectivity via node.isOutputConnected(slot) / node.getOutputNodes(slot); mutate via node.connect() / node.disconnectOutput().'
     )
@@ -121,7 +121,7 @@ Object.defineProperty(NodeOutputSlot.prototype, 'links', {
       this._node.id,
       this._node.outputs.indexOf(this)
     )
-    return ids.length ? ids : null
+    return ids.length ? Object.freeze(ids) : null
   },
   configurable: true,
   enumerable: false

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -17,9 +17,11 @@ import {
 import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
+import { warnDeprecated } from '@/lib/litegraph/src/utils/feedback'
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
-  links: LinkId[] | null
+  /** @deprecated Derived from the link store via a warning prototype getter; never written. */
+  declare readonly links?: readonly LinkId[] | null
   _data?: unknown
   slot_index?: number
 
@@ -38,8 +40,11 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     slot: OptionalProps<INodeOutputSlot, 'boundingRect'>,
     node: LGraphNode
   ) {
-    super(slot, node)
-    this.links = slot.links
+    // Serialized outputs carry a legacy links mirror; strip it so the base
+    // ctor's Object.assign cannot collide with the deprecated prototype
+    // getter (assigning a getter-only property throws in strict mode).
+    const { links: _legacyLinks, ...rest } = slot
+    super(rest, node)
     this._data = slot._data
     this.slot_index = slot.slot_index
   }
@@ -98,3 +103,26 @@ export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
     }
   }
 }
+
+/**
+ * Deprecation telemetry for extensions that still read `output.links`.
+ * Returns a fresh store-derived array; there is deliberately no setter, so
+ * writes throw in strict mode. First-party code uses the slotLinks helpers.
+ */
+Object.defineProperty(NodeOutputSlot.prototype, 'links', {
+  get(this: NodeOutputSlot): LinkId[] | null {
+    warnDeprecated(
+      'output.links is deprecated. Read connectivity via node.isOutputConnected(slot) / node.getOutputNodes(slot); mutate via node.connect() / node.disconnectOutput().'
+    )
+    const { graph } = this._node
+    if (!graph) return null
+    const ids = outputLinkIds(
+      graph,
+      this._node.id,
+      this._node.outputs.indexOf(this)
+    )
+    return ids.length ? ids : null
+  },
+  configurable: true,
+  enumerable: false
+})

--- a/src/lib/litegraph/src/node/NodeSlot.test.ts
+++ b/src/lib/litegraph/src/node/NodeSlot.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type {
   INodeInputSlot,
-  INodeOutputSlot
+  INodeOutputSlot,
+  IWidget
 } from '@/lib/litegraph/src/litegraph'
 import {
+  LGraphNode,
   inputAsSerialisable,
   outputAsSerialisable
 } from '@/lib/litegraph/src/litegraph'
@@ -22,8 +24,12 @@ describe('NodeSlot', () => {
         links: [],
         boundingRect
       }
-      // @ts-expect-error Argument type mismatch for test
-      const serialized = outputAsSerialisable(slot)
+      const node = new LGraphNode('test')
+      const serialized = outputAsSerialisable(
+        slot as INodeOutputSlot & { widget?: IWidget },
+        node,
+        0
+      )
       expect(serialized).not.toHaveProperty('_data')
     })
 

--- a/src/lib/litegraph/src/node/slotLinks.test.ts
+++ b/src/lib/litegraph/src/node/slotLinks.test.ts
@@ -1,0 +1,75 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
+
+import { outputHasLinks, outputLinkIds, outputLinks } from './slotLinks'
+
+function createConnectedGraph(targetCount: number) {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'INT')
+  graph.add(source)
+
+  const targets = Array.from({ length: targetCount }, (_, i) => {
+    const target = new LGraphNode(`Target${i}`)
+    target.addInput('in', 'INT')
+    graph.add(target)
+    source.connect(0, target, 0)
+    return target
+  })
+
+  return { graph, source, targets }
+}
+
+describe('slotLinks', () => {
+  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+  it('reports presence, ids, and resolved links for an output slot', () => {
+    const { graph, source } = createConnectedGraph(2)
+
+    expect(outputHasLinks(graph, source.id, 0)).toBe(true)
+    const ids = outputLinkIds(graph, source.id, 0)
+    expect(ids).toHaveLength(2)
+    expect([...ids]).toEqual([...ids].sort((a, b) => a - b))
+    expect(outputLinks(graph, source.id, 0).map((l) => l.id)).toEqual(ids)
+  })
+
+  it('returns nothing for an unconnected slot', () => {
+    const { graph, source } = createConnectedGraph(0)
+
+    expect(outputHasLinks(graph, source.id, 0)).toBe(false)
+    expect(outputLinkIds(graph, source.id, 0)).toEqual([])
+    expect(outputLinks(graph, source.id, 0)).toEqual([])
+  })
+
+  it('never includes floating links', () => {
+    const { graph, source, targets } = createConnectedGraph(1)
+    const link = graph.getLink(targets[0].inputs[0].link!)!
+    const reroute = graph.createReroute([0, 0], link)!
+    graph.remove(targets[0])
+
+    expect(graph.floatingLinks.size).toBe(1)
+    expect(reroute.floatingLinkIds.size).toBe(1)
+    expect(outputHasLinks(graph, source.id, 0)).toBe(false)
+    expect(outputLinks(graph, source.id, 0)).toEqual([])
+  })
+
+  it('reads empty during the final OUTPUT callback of a disconnect-all', () => {
+    const { graph, source } = createConnectedGraph(2)
+    const seen: boolean[] = []
+    source.onConnectionsChange = vi.fn(
+      (type: NodeSlotType, _slot: number, connected: boolean) => {
+        if (type === NodeSlotType.OUTPUT && !connected) {
+          seen.push(outputHasLinks(graph, source.id, 0))
+        }
+      }
+    )
+
+    source.disconnectOutput(0)
+
+    expect(seen).toEqual([true, false])
+  })
+})

--- a/src/lib/litegraph/src/node/slotLinks.ts
+++ b/src/lib/litegraph/src/node/slotLinks.ts
@@ -1,0 +1,50 @@
+import { useLinkStore } from '@/stores/linkStore'
+import type { LinkId } from '@/types/linkId'
+import type { NodeId } from '@/types/nodeId'
+
+import type { LGraph } from '../LGraph'
+import type { LLink } from '../LLink'
+
+/**
+ * Store-backed reads over the links leaving a node's output slot.
+ * These replace the `output.links[]` mirror: the link store is the source
+ * of truth, and floating links are never included.
+ */
+
+/** True when at least one link leaves the output slot. */
+export function outputHasLinks(
+  graph: Pick<LGraph, 'rootGraph'>,
+  nodeId: NodeId,
+  slot: number
+): boolean {
+  return useLinkStore().isOutputSlotConnected(graph.rootGraph.id, nodeId, slot)
+}
+
+/** Ids of the links leaving an output slot, in ascending id order. */
+export function outputLinkIds(
+  graph: Pick<LGraph, 'rootGraph'>,
+  nodeId: NodeId,
+  slot: number
+): LinkId[] {
+  const ids = [
+    ...useLinkStore().getOutputSlotLinks(graph.rootGraph.id, nodeId, slot)
+  ].map((topology) => topology.id)
+  return ids.sort((a, b) => a - b)
+}
+
+/**
+ * Snapshot of the links leaving an output slot, resolved in the owning
+ * graph. Safe to disconnect links while iterating the result.
+ */
+export function outputLinks(
+  graph: LGraph,
+  nodeId: NodeId,
+  slot: number
+): LLink[] {
+  const links: LLink[] = []
+  for (const id of outputLinkIds(graph, nodeId, slot)) {
+    const link = graph.getLink(id)
+    if (link) links.push(link)
+  }
+  return links
+}

--- a/src/lib/litegraph/src/node/slotUtils.test.ts
+++ b/src/lib/litegraph/src/node/slotUtils.test.ts
@@ -1,36 +1,81 @@
-import { describe, expect, it } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { toLinkId } from '@/types/linkId'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 import { outputAsSerialisable } from './slotUtils'
 
 type OutputSlotParam = INodeOutputSlot & { widget?: IWidget }
 
+function createConnectedGraph(targetCount: number) {
+  const graph = new LGraph()
+  const source = new LGraphNode('Source')
+  source.addOutput('out', 'number')
+  graph.add(source)
+
+  for (let i = 0; i < targetCount; i++) {
+    const target = new LGraphNode(`Target${i}`)
+    target.addInput('in', 'number')
+    graph.add(target)
+    source.connect(0, target, 0)
+  }
+
+  return { graph, source }
+}
+
 describe('outputAsSerialisable', () => {
-  it('clones the links array to prevent shared reference mutation', () => {
-    const node = new LGraphNode('test')
-    const output = node.addOutput('out', 'number')
-    output.links = [toLinkId(1), toLinkId(2), toLinkId(3)]
+  beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
-    const serialised = outputAsSerialisable(output as OutputSlotParam)
+  it('serialises the links leaving the slot, ascending by id', () => {
+    const { source } = createConnectedGraph(3)
 
-    expect(serialised.links).toEqual([1, 2, 3])
-    expect(serialised.links).not.toBe(output.links)
+    const serialised = outputAsSerialisable(
+      source.outputs[0] as OutputSlotParam,
+      source,
+      0
+    )
 
-    // Mutating the live array should NOT affect the serialised copy
-    output.links.push(toLinkId(4))
     expect(serialised.links).toHaveLength(3)
+    expect(serialised.links).toEqual([...serialised.links!].sort())
   })
 
-  it('preserves null links', () => {
-    const node = new LGraphNode('test')
-    const output = node.addOutput('out', 'number')
-    output.links = null
+  it('returns a snapshot unaffected by later graph changes', () => {
+    const { source } = createConnectedGraph(2)
 
-    const serialised = outputAsSerialisable(output as OutputSlotParam)
+    const serialised = outputAsSerialisable(
+      source.outputs[0] as OutputSlotParam,
+      source,
+      0
+    )
+    expect(serialised.links).toHaveLength(2)
+
+    source.disconnectOutput(0)
+    expect(serialised.links).toHaveLength(2)
+  })
+
+  it('serialises null when the slot has no links', () => {
+    const { source } = createConnectedGraph(0)
+
+    const serialised = outputAsSerialisable(
+      source.outputs[0] as OutputSlotParam,
+      source,
+      0
+    )
+    expect(serialised.links).toBeNull()
+  })
+
+  it('serialises null for a node with no graph', () => {
+    const node = new LGraphNode('Detached')
+    node.addOutput('out', 'number')
+
+    const serialised = outputAsSerialisable(
+      node.outputs[0] as OutputSlotParam,
+      node,
+      0
+    )
     expect(serialised.links).toBeNull()
   })
 })

--- a/src/lib/litegraph/src/node/slotUtils.ts
+++ b/src/lib/litegraph/src/node/slotUtils.ts
@@ -1,3 +1,4 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type {
   IWidgetInputSlot,
   SharedIntersection
@@ -8,6 +9,7 @@ import type {
   INodeSlot,
   IWidget
 } from '@/lib/litegraph/src/litegraph'
+import { outputLinkIds } from '@/lib/litegraph/src/node/slotLinks'
 import type {
   ISerialisableNodeInput,
   ISerialisableNodeOutput
@@ -63,18 +65,21 @@ export function inputAsSerialisable(
 }
 
 export function outputAsSerialisable(
-  slot: INodeOutputSlot & { widget?: IWidget }
+  slot: INodeOutputSlot & { widget?: IWidget },
+  node: LGraphNode,
+  slotIndex: number
 ): ISerialisableNodeOutput {
-  const { pos, slot_index, links, widget } = slot
+  const { pos, slot_index, widget } = slot
   // Output widgets do not exist in Litegraph; this is a temporary downstream workaround.
   const outputWidget = widget ? { widget: { name: widget.name } } : null
+  const ids = node.graph ? outputLinkIds(node.graph, node.id, slotIndex) : []
 
   return {
     ...shallowCloneCommonProps(slot),
     ...outputWidget,
     pos,
     slot_index,
-    links: links ? [...links] : links
+    links: ids.length ? ids : null
   }
 }
 

--- a/src/lib/litegraph/src/subgraph/SubgraphIO.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIO.test.ts
@@ -71,7 +71,7 @@ describe('SubgraphIO - Input Slot Dual-Nature Behavior', () => {
 
       // Connection should be cleaned up
       expect(subgraphNode.inputs.length).toBe(0)
-      expect(externalNode.outputs[0].links).toHaveLength(0)
+      expect(externalNode.outputs[0].links).toBeNull()
     }
   )
 
@@ -316,7 +316,7 @@ describe('SubgraphIO - Boundary Connection Management', () => {
       complexSubgraph.removeInput(inputToRemove)
 
       expect(subgraphNode.inputs.findIndex((i) => i.name === 'data')).toBe(-1)
-      expect(externalSource.outputs[0].links).toHaveLength(0)
+      expect(externalSource.outputs[0].links).toBeNull()
 
       const outputToRemove = complexSubgraph.outputs[0]
       complexSubgraph.removeOutput(outputToRemove)

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -1,5 +1,3 @@
-import { pull } from 'es-toolkit/compat'
-
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
 import { toLinkId } from '@/types/linkId'
@@ -60,9 +58,6 @@ export class SubgraphOutput extends SubgraphSlot {
       subgraph.beforeChange()
 
       existingLink.disconnect(subgraph, 'input')
-      const resolved = existingLink.resolve(subgraph)
-      const links = resolved.output?.links
-      if (links) pull(links, existingLink.id)
     }
 
     const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
@@ -83,8 +78,6 @@ export class SubgraphOutput extends SubgraphSlot {
 
     // Set link ID in each slot
     this.linkIds[0] = link.id
-    slot.links ??= []
-    slot.links.push(link.id)
 
     anchorRerouteChain(subgraph, link)
     subgraph.incrementVersion()
@@ -145,9 +138,7 @@ export class SubgraphOutput extends SubgraphSlot {
       const link = subgraph.links[linkId]
       if (!link) continue
       subgraph.removeLink(linkId)
-      const { output, outputNode } = link.resolve(subgraph)
-      if (output)
-        output.links = output.links?.filter((id) => id !== linkId) ?? null
+      const { outputNode } = link.resolve(subgraph)
       outputNode?.onConnectionsChange?.(
         NodeSlotType.OUTPUT,
         link.origin_slot,

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -266,7 +266,14 @@ export function createTestSubgraphNode(
     order: 0
   }
 
-  return new SubgraphNode(parentGraph, subgraph, instanceData)
+  const subgraphNode = new SubgraphNode(parentGraph, subgraph, instanceData)
+  // Reserve the id: the node is not add()ed here, so without this a later
+  // parentGraph.add() would mint a duplicate id.
+  const numericId = Number(subgraphNode.id)
+  if (Number.isInteger(numericId) && numericId > parentGraph.state.lastNodeId) {
+    parentGraph.state.lastNodeId = numericId
+  }
+  return subgraphNode
 }
 
 export function setupComplexPromotionFixture(): {

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -4,6 +4,7 @@ import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import type { ResolvedConnection } from '@/lib/litegraph/src/LLink'
+import { outputLinkIds } from '@/lib/litegraph/src/node/slotLinks'
 import { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import { toLinkId } from '@/types/linkId'
@@ -144,14 +145,15 @@ export function getBoundaryLinks(
 
       // Outputs
       if (node.outputs) {
-        for (const [outputIndex, output] of node.outputs.entries()) {
+        for (const [outputIndex] of node.outputs.entries()) {
           addFloatingLinks(
             slotFloatingLinks(graph, 'output', node.id, outputIndex)
           )
 
-          if (!output.links) continue
+          const linkIds = outputLinkIds(graph, node.id, outputIndex)
+          if (!linkIds.length) continue
 
-          const many = LLink.resolveMany(output.links.map(toLinkId), graph)
+          const many = LLink.resolveMany(linkIds, graph)
           for (const { link, inputNode } of many) {
             if (
               // Subgraph output node

--- a/src/lib/litegraph/src/utils/collections.ts
+++ b/src/lib/litegraph/src/utils/collections.ts
@@ -63,7 +63,7 @@ type FreeSlotResult<T extends { type: ISlotType }> =
 export function findFreeSlotOfType<T extends { type: ISlotType }>(
   slots: T[],
   type: ISlotType,
-  hasNoLinks: (slot: T) => boolean
+  hasNoLinks: (slot: T, index: number) => boolean
 ) {
   if (!slots?.length) return
 
@@ -79,7 +79,7 @@ export function findFreeSlotOfType<T extends { type: ISlotType }>(
     for (const validType of validTypes) {
       for (const slotType of slotTypes) {
         if (slotType === validType) {
-          if (hasNoLinks(slot)) {
+          if (hasNoLinks(slot, index)) {
             // Exact match - short circuit
             return { index, slot }
           }
@@ -87,7 +87,7 @@ export function findFreeSlotOfType<T extends { type: ISlotType }>(
           occupiedSlot ??= { index, slot }
         } else if (!wildSlot && (validType === '*' || slotType === '*')) {
           // Save the first free wildcard slot as a fallback
-          if (hasNoLinks(slot)) {
+          if (hasNoLinks(slot, index)) {
             wildSlot = { index, slot }
           } else {
             occupiedWildSlot ??= { index, slot }

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -310,7 +310,6 @@ describe('useNodeReplacement', () => {
       // Output link should be remapped
       expect(link.origin_id).toBe(1)
       expect(link.origin_slot).toBe(0)
-      expect(newNode.outputs[0].links).toEqual([20])
     })
 
     it('should apply set_value to widget', () => {
@@ -657,7 +656,8 @@ describe('useNodeReplacement', () => {
       // Default mapping transfers connections and widget values by name
       expect(newNode.id).toBe(13)
       expect(newNode.inputs[0].link).toBe(4)
-      expect(newNode.outputs[0].links).toEqual([6])
+      expect(outLink.origin_id).toBe(13)
+      expect(outLink.origin_slot).toBe(0)
       expect(newNode.widgets![0].value).toBe(0.75)
     })
 

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useLinkStore } from '@/stores/linkStore'
 import type { MissingNodeType } from '@/types/comfy'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
 import type { NodeReplacement } from './types'
 
 vi.mock('@/lib/litegraph/src/litegraph', () => ({
@@ -75,15 +79,29 @@ function createMockLink(
   }
 }
 
+const GRAPH_ID: UUID = 'node-replacement-graph'
+
 function createMockGraph(
   nodes: LGraphNode[],
   links: ReturnType<typeof createMockLink>[] = []
 ): LGraph {
   const linksMap = new Map(links.map((l) => [l.id, l]))
+  for (const l of links) {
+    useLinkStore().registerLink(GRAPH_ID, {
+      id: toLinkId(l.id),
+      originNodeId: toNodeId(l.origin_id),
+      originSlot: l.origin_slot,
+      targetNodeId: toNodeId(l.target_id),
+      targetSlot: l.target_slot,
+      type: l.type
+    })
+  }
   return fromAny<LGraph, unknown>({
     _nodes: nodes,
     _nodes_by_id: Object.fromEntries(nodes.map((n) => [n.id, n])),
     links: linksMap,
+    getLink: (id: number) => linksMap.get(id),
+    rootGraph: { id: GRAPH_ID },
     updateExecutionOrder: vi.fn(),
     setDirtyCanvas: vi.fn()
   })
@@ -596,6 +614,7 @@ describe('useNodeReplacement', () => {
 
     it('should transfer ConditioningAverage widget value with real workflow data', () => {
       const link = createMockLink(4, 7, 0, 13, 0)
+      const outLink = createMockLink(6, 13, 0, 20, 0)
       // sanitizeNodeName doesn't strip spaces, so placeholder keeps trailing space
       const placeholder = createPlaceholderNode(
         13,
@@ -608,7 +627,7 @@ describe('useNodeReplacement', () => {
       )
       placeholder.last_serialization!.widgets_values = [0.75]
 
-      const graph = createMockGraph([placeholder], [link])
+      const graph = createMockGraph([placeholder], [link, outLink])
       placeholder.graph = graph
       Object.assign(app, { rootGraph: graph })
 

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -1,5 +1,6 @@
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import { isNodeBindable } from '@/lib/litegraph/src/utils/type'
@@ -61,17 +62,15 @@ function transferOutputConnections(
   newOutputIdx: number,
   graph: LGraph
 ): void {
-  const oldLinks = oldNode.outputs?.[oldOutputIdx]?.links
-  if (!oldLinks?.length) return
+  const links = outputLinks(graph, oldNode.id, oldOutputIdx)
+  if (!links.length) return
   if (!newNode.outputs?.[newOutputIdx]) return
 
-  for (const linkId of oldLinks) {
-    const link = graph.links.get(linkId)
-    if (!link) continue
+  for (const link of links) {
     link.origin_id = newNode.id
     link.origin_slot = newOutputIdx
   }
-  newNode.outputs[newOutputIdx].links = [...oldLinks]
+  newNode.outputs[newOutputIdx].links = links.map((link) => link.id)
   oldNode.outputs[oldOutputIdx].links = []
 }
 

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -70,8 +70,6 @@ function transferOutputConnections(
     link.origin_id = newNode.id
     link.origin_slot = newOutputIdx
   }
-  newNode.outputs[newOutputIdx].links = links.map((link) => link.id)
-  oldNode.outputs[oldOutputIdx].links = []
 }
 
 /** Uses old_widget_ids as name→index lookup into widgets_values. */

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -1,11 +1,17 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 
+import { useLinkStore } from '@/stores/linkStore'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
 import {
   createMockCanvas2DContext,
   createMockMinimapCanvas
 } from '@/utils/__tests__/litegraphTestUtils'
+import type { UUID } from '@/utils/uuid'
 
 interface MockNode {
   id: string
@@ -18,12 +24,26 @@ interface MockNode {
 
 interface MockGraph {
   _nodes: MockNode[]
+  rootGraph: { id: UUID }
   links: Record<string, { id: string; target_id: string }>
   getNodeById: Mock
   setDirtyCanvas: Mock
   onNodeAdded: ((node: MockNode) => void) | null
   onNodeRemoved: ((node: MockNode) => void) | null
   onConnectionChange: ((node: MockNode) => void) | null
+}
+
+const GRAPH_ID: UUID = 'minimap-graph'
+
+function registerMockLink(id: number, targetNodeId: string) {
+  useLinkStore().registerLink(GRAPH_ID, {
+    id: toLinkId(id),
+    originNodeId: toNodeId('node1'),
+    originSlot: 0,
+    targetNodeId: toNodeId(targetNodeId),
+    targetSlot: 0,
+    type: '*'
+  })
 }
 
 interface MockCanvas {
@@ -118,6 +138,7 @@ const setupMocks = () => {
 
   moduleMockGraph = {
     _nodes: mockNodes,
+    rootGraph: { id: GRAPH_ID },
     links: {
       link1: {
         id: 'link1',
@@ -229,6 +250,8 @@ describe('useMinimap', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    registerMockLink(1, 'node2')
 
     mockPause.mockClear()
     mockResume.mockClear()
@@ -282,6 +305,7 @@ describe('useMinimap', () => {
 
     moduleMockGraph = {
       _nodes: mockNodes,
+      rootGraph: { id: GRAPH_ID },
       links: {
         link1: {
           id: 'link1',
@@ -937,7 +961,7 @@ describe('useMinimap', () => {
     })
 
     it('should handle invalid link references', async () => {
-      moduleMockGraph.links.link1.target_id = 'invalid-node'
+      registerMockLink(2, 'invalid-node')
       moduleMockGraph.getNodeById.mockReturnValue(null)
 
       const minimap = await createAndInitializeMinimap()

--- a/src/renderer/extensions/minimap/data/AbstractMinimapDataSource.ts
+++ b/src/renderer/extensions/minimap/data/AbstractMinimapDataSource.ts
@@ -1,6 +1,7 @@
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { calculateNodeBounds } from '@/renderer/core/spatial/boundsCalculator'
 import type { PositionedNode } from '@/renderer/core/spatial/boundsCalculator'
+import { useLinkStore } from '@/stores/linkStore'
 
 import type {
   IMinimapDataSource,
@@ -64,6 +65,8 @@ export abstract class AbstractMinimapDataSource implements IMinimapDataSource {
   }
 
   protected extractLinksFromGraph(graph: LGraph): MinimapLinkData[] {
+    const linkStore = useLinkStore()
+    const rootGraphId = graph.rootGraph.id
     const links: MinimapLinkData[] = []
     const nodeMap = new Map(this.getNodes().map((n) => [n.id, n]))
 
@@ -73,21 +76,20 @@ export abstract class AbstractMinimapDataSource implements IMinimapDataSource {
       const sourceNodeData = nodeMap.get(node.id)
       if (!sourceNodeData) continue
 
-      for (const output of node.outputs) {
-        if (!output.links) continue
-
-        for (const linkId of output.links) {
-          const link = graph.links[linkId]
-          if (!link) continue
-
-          const targetNodeData = nodeMap.get(link.target_id)
+      for (const [slot] of node.outputs.entries()) {
+        for (const topology of linkStore.getOutputSlotLinks(
+          rootGraphId,
+          node.id,
+          slot
+        )) {
+          const targetNodeData = nodeMap.get(topology.targetNodeId)
           if (!targetNodeData) continue
 
           links.push({
             sourceNode: sourceNodeData,
             targetNode: targetNodeData,
-            sourceSlot: link.origin_slot,
-            targetSlot: link.target_slot
+            sourceSlot: topology.originSlot,
+            targetSlot: topology.targetSlot
           })
         }
       }

--- a/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
+++ b/src/renderer/extensions/minimap/data/MinimapDataSource.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
 
+import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import type {
   NodeId as LayoutNodeId,
   NodeLayout
 } from '@/renderer/core/layout/types'
+import { useLinkStore } from '@/stores/linkStore'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId as layoutNodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
 import { MinimapDataSourceFactory } from '@/renderer/extensions/minimap/data/MinimapDataSourceFactory'
 
 // Mock layoutStore
@@ -25,13 +31,36 @@ vi.mock('@/stores/executionStore', () => ({
   })
 }))
 
+const GRAPH_ID: UUID = 'minimap-graph'
+
 // Helper to create mock links that satisfy LGraph['links'] type
 function createMockLinks(): LGraph['links'] {
   const map = new Map<number, LLink>()
   return Object.assign(map, {}) as LGraph['links']
 }
 
+function createMockGraph(nodes: LGraphNode[] = []): LGraph {
+  const graph = {
+    _nodes: nodes,
+    _groups: [],
+    links: createMockLinks(),
+    rootGraph: { id: GRAPH_ID }
+  }
+  return graph as unknown as LGraph
+}
+
+function mockEmptyLayoutStore() {
+  const emptyMap = new Map<LayoutNodeId, NodeLayout>()
+  const computedEmpty: ComputedRef<ReadonlyMap<LayoutNodeId, NodeLayout>> =
+    computed(() => emptyMap)
+  vi.mocked(layoutStore.getAllNodes).mockReturnValue(computedEmpty)
+}
+
 describe('MinimapDataSource', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
   describe('MinimapDataSourceFactory', () => {
     it('should create LayoutStoreDataSource when LayoutStore has data', () => {
       // Arrange
@@ -54,14 +83,8 @@ describe('MinimapDataSource', () => {
         computed(() => mockNodes)
       vi.mocked(layoutStore.getAllNodes).mockReturnValue(computedNodes)
 
-      const mockGraph: Pick<LGraph, '_nodes' | '_groups' | 'links'> = {
-        _nodes: [],
-        _groups: [],
-        links: createMockLinks()
-      }
-
       // Act
-      const dataSource = MinimapDataSourceFactory.create(mockGraph as LGraph)
+      const dataSource = MinimapDataSourceFactory.create(createMockGraph())
 
       // Assert
       expect(dataSource).toBeDefined()
@@ -71,10 +94,7 @@ describe('MinimapDataSource', () => {
 
     it('should create LiteGraphDataSource when LayoutStore is empty', () => {
       // Arrange
-      const emptyMap = new Map<LayoutNodeId, NodeLayout>()
-      const computedEmpty: ComputedRef<ReadonlyMap<LayoutNodeId, NodeLayout>> =
-        computed(() => emptyMap)
-      vi.mocked(layoutStore.getAllNodes).mockReturnValue(computedEmpty)
+      mockEmptyLayoutStore()
 
       const mockNode: Pick<
         LGraphNode,
@@ -89,14 +109,10 @@ describe('MinimapDataSource', () => {
         outputs: []
       }
 
-      const mockGraph: Pick<LGraph, '_nodes' | '_groups' | 'links'> = {
-        _nodes: [mockNode as LGraphNode],
-        _groups: [],
-        links: createMockLinks()
-      }
-
       // Act
-      const dataSource = MinimapDataSourceFactory.create(mockGraph as LGraph)
+      const dataSource = MinimapDataSourceFactory.create(
+        createMockGraph([mockNode as LGraphNode])
+      )
 
       // Assert
       expect(dataSource).toBeDefined()
@@ -116,19 +132,10 @@ describe('MinimapDataSource', () => {
 
     it('should handle empty graph correctly', () => {
       // Arrange
-      const emptyMap = new Map<LayoutNodeId, NodeLayout>()
-      const computedEmpty: ComputedRef<ReadonlyMap<LayoutNodeId, NodeLayout>> =
-        computed(() => emptyMap)
-      vi.mocked(layoutStore.getAllNodes).mockReturnValue(computedEmpty)
-
-      const mockGraph: Pick<LGraph, '_nodes' | '_groups' | 'links'> = {
-        _nodes: [],
-        _groups: [],
-        links: createMockLinks()
-      }
+      mockEmptyLayoutStore()
 
       // Act
-      const dataSource = MinimapDataSourceFactory.create(mockGraph as LGraph)
+      const dataSource = MinimapDataSourceFactory.create(createMockGraph())
 
       // Assert
       expect(dataSource.hasData()).toBe(false)
@@ -139,13 +146,68 @@ describe('MinimapDataSource', () => {
     })
   })
 
+  describe('Link extraction', () => {
+    function createLinkableNode(id: string, outputCount: number): LGraphNode {
+      const node: Pick<LGraphNode, 'id' | 'pos' | 'size' | 'outputs'> = {
+        id: layoutNodeId(id),
+        pos: [0, 0],
+        size: [100, 50],
+        outputs: Array.from(
+          { length: outputCount },
+          () => ({}) as INodeOutputSlot
+        )
+      }
+      return node as LGraphNode
+    }
+
+    it('derives links between visible nodes from the link store', () => {
+      mockEmptyLayoutStore()
+      useLinkStore().registerLink(GRAPH_ID, {
+        id: toLinkId(1),
+        originNodeId: layoutNodeId('node1'),
+        originSlot: 0,
+        targetNodeId: layoutNodeId('node2'),
+        targetSlot: 1,
+        type: 'INT'
+      })
+
+      const dataSource = MinimapDataSourceFactory.create(
+        createMockGraph([
+          createLinkableNode('node1', 1),
+          createLinkableNode('node2', 0)
+        ])
+      )
+
+      const links = dataSource.getLinks()
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ sourceSlot: 0, targetSlot: 1 })
+      expect(links[0].sourceNode.id).toBe(layoutNodeId('node1'))
+      expect(links[0].targetNode.id).toBe(layoutNodeId('node2'))
+    })
+
+    it('omits links whose target is not in the viewed nodes', () => {
+      mockEmptyLayoutStore()
+      useLinkStore().registerLink(GRAPH_ID, {
+        id: toLinkId(1),
+        originNodeId: layoutNodeId('node1'),
+        originSlot: 0,
+        targetNodeId: layoutNodeId('elsewhere'),
+        targetSlot: 0,
+        type: 'INT'
+      })
+
+      const dataSource = MinimapDataSourceFactory.create(
+        createMockGraph([createLinkableNode('node1', 1)])
+      )
+
+      expect(dataSource.getLinks()).toEqual([])
+    })
+  })
+
   describe('Bounds calculation', () => {
     it('should calculate correct bounds from nodes', () => {
       // Arrange
-      const emptyMap = new Map<LayoutNodeId, NodeLayout>()
-      const computedEmpty: ComputedRef<ReadonlyMap<LayoutNodeId, NodeLayout>> =
-        computed(() => emptyMap)
-      vi.mocked(layoutStore.getAllNodes).mockReturnValue(computedEmpty)
+      mockEmptyLayoutStore()
 
       const mockNode1: Pick<LGraphNode, 'id' | 'pos' | 'size' | 'outputs'> = {
         id: layoutNodeId('node1'),
@@ -161,14 +223,10 @@ describe('MinimapDataSource', () => {
         outputs: []
       }
 
-      const mockGraph: Pick<LGraph, '_nodes' | '_groups' | 'links'> = {
-        _nodes: [mockNode1 as LGraphNode, mockNode2 as LGraphNode],
-        _groups: [],
-        links: createMockLinks()
-      }
-
       // Act
-      const dataSource = MinimapDataSourceFactory.create(mockGraph as LGraph)
+      const dataSource = MinimapDataSourceFactory.create(
+        createMockGraph([mockNode1 as LGraphNode, mockNode2 as LGraphNode])
+      )
       const bounds = dataSource.getBounds()
 
       // Assert

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -1,19 +1,21 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
 import { renderMinimapToCanvas } from '@/renderer/extensions/minimap/minimapCanvasRenderer'
 import type { MinimapRenderContext } from '@/renderer/extensions/minimap/types'
+import { useLinkStore } from '@/stores/linkStore'
 import { adjustColor } from '@/utils/colorUtil'
 import {
   createMockLGraph,
   createMockLGraphNode,
-  createMockLinks,
-  createMockLLink,
   createMockNodeOutputSlot
 } from '@/utils/__tests__/litegraphTestUtils'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
 
 const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
 vi.mock('@/stores/workspace/colorPaletteStore', () => ({
@@ -30,6 +32,8 @@ vi.mock('@/stores/executionStore', () => ({
   })
 }))
 
+const GRAPH_ID: UUID = 'renderer-graph'
+
 describe('minimapCanvasRenderer', () => {
   let mockCanvas: HTMLCanvasElement
   let mockContext: CanvasRenderingContext2D
@@ -37,6 +41,7 @@ describe('minimapCanvasRenderer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
 
     mockContext = {
       clearRect: vi.fn(),
@@ -81,7 +86,7 @@ describe('minimapCanvasRenderer', () => {
         })
       ],
       _groups: [],
-      links: {} as typeof mockGraph.links,
+      rootGraph: { id: GRAPH_ID } as LGraph,
       getNodeById: vi.fn()
     })
 
@@ -253,31 +258,22 @@ describe('minimapCanvasRenderer', () => {
   })
 
   it('should render connections when enabled', () => {
-    const targetNode = {
-      id: '2',
-      pos: [300, 200],
-      size: [120, 60]
-    }
-
     mockGraph._nodes[0].outputs = [
       createMockNodeOutputSlot({
         name: 'output',
         type: 'number',
-        links: [toLinkId(1)],
         boundingRect: new Float64Array([0, 0, 10, 10])
       })
     ]
 
-    mockGraph.links = createMockLinks([
-      createMockLLink({
-        id: toLinkId(1),
-        target_id: toNodeId(2),
-        origin_slot: 0,
-        target_slot: 0
-      })
-    ])
-
-    mockGraph.getNodeById = vi.fn().mockReturnValue(targetNode)
+    useLinkStore().registerLink(GRAPH_ID, {
+      id: toLinkId(1),
+      originNodeId: mockGraph._nodes[0].id,
+      originSlot: 0,
+      targetNodeId: toNodeId('2'),
+      targetSlot: 0,
+      type: 'number'
+    })
 
     const context: MinimapRenderContext = {
       bounds: { minX: 0, minY: 0, width: 500, height: 400 },

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
@@ -58,7 +58,8 @@ const STUB_SLOT_PROPS = {
   nodeId: { type: String, required: false, default: '' },
   hasError: { type: Boolean, required: false, default: false },
   index: { type: Number, required: true },
-  readonly: { type: Boolean, required: false, default: false }
+  readonly: { type: Boolean, required: false, default: false },
+  connected: { type: Boolean, required: false, default: false }
 } as const
 
 const InputSlotStub = defineComponent({
@@ -73,6 +74,7 @@ const InputSlotStub = defineComponent({
       :data-node-id="nodeId"
       :data-has-error="hasError ? 'true' : 'false'"
       :data-readonly="readonly ? 'true' : 'false'"
+      :data-connected="connected ? 'true' : 'false'"
     />
   `
 })
@@ -88,6 +90,7 @@ const OutputSlotStub = defineComponent({
       :data-type="slotData && slotData.type ? slotData.type : ''"
       :data-node-id="nodeId"
       :data-readonly="readonly ? 'true' : 'false'"
+      :data-connected="connected ? 'true' : 'false'"
     />
   `
 })
@@ -132,15 +135,38 @@ function createTrackingStub(
 
 function renderSlots(
   nodeData: VueNodeData,
-  stubs: SlotComponentStubs = defaultSlotStubs
+  stubs: SlotComponentStubs = defaultSlotStubs,
+  pinia = createTestingPinia({ stubActions: false })
 ) {
   return render(NodeSlots, {
     global: {
-      plugins: [i18n, createTestingPinia({ stubActions: false })],
+      plugins: [i18n, pinia],
       stubs
     },
     props: { nodeData }
   })
+}
+
+function createConnectedGraph() {
+  const pinia = createTestingPinia({ stubActions: false })
+  setActivePinia(pinia)
+
+  const graph = new LGraph()
+  useCanvasStore().canvas = fromPartial<LGraphCanvas>({ graph })
+
+  const upstream = new LGraphNode('Upstream')
+  upstream.id = toNodeId(1)
+  upstream.addOutput('out', 'FAKE')
+  graph.add(upstream)
+
+  const node = new LGraphNode('Target')
+  node.id = toNodeId(2)
+  node.addInput('plain', 'FAKE')
+  node.addInput('w', 'FAKE')
+  node.inputs[1].widget = { name: 'w' }
+  graph.add(node)
+
+  return { pinia, upstream, node }
 }
 
 function renderSlotsWithTracking(
@@ -277,6 +303,52 @@ describe('NodeSlots.vue', () => {
         readonly: false
       }
     ])
+  })
+
+  it('marks an output connected only while a link leaves it', async () => {
+    const { pinia, upstream, node } = createConnectedGraph()
+    upstream.addOutput('spare', 'FAKE')
+    upstream.connect(0, node, 0)
+
+    const nodeData = makeNodeData({
+      id: toVueNodeId(upstream.id),
+      outputs: upstream.outputs
+    })
+    const { container } = renderSlots(nodeData, defaultSlotStubs, pinia)
+    await nextTick()
+
+    expect(getRenderedSlotElement(container, 'out')).toHaveAttribute(
+      'data-connected',
+      'true'
+    )
+    expect(getRenderedSlotElement(container, 'spare')).toHaveAttribute(
+      'data-connected',
+      'false'
+    )
+
+    node.disconnectInput(0)
+    await nextTick()
+    expect(getRenderedSlotElement(container, 'out')).toHaveAttribute(
+      'data-connected',
+      'false'
+    )
+  })
+
+  it('marks an input connected from the link store', async () => {
+    const { pinia, upstream, node } = createConnectedGraph()
+    upstream.connect(0, node, 0)
+
+    const nodeData = makeNodeData({
+      id: toVueNodeId(node.id),
+      inputs: node.inputs
+    })
+    const { container } = renderSlots(nodeData, defaultSlotStubs, pinia)
+    await nextTick()
+
+    expect(getRenderedSlotElement(container, 'plain')).toHaveAttribute(
+      'data-connected',
+      'true'
+    )
   })
 
   it('passes validation error state to matching input slots', async () => {
@@ -441,28 +513,6 @@ describe('NodeSlots.vue', () => {
         },
         props: { nodeData, unified: true }
       })
-    }
-
-    function createConnectedGraph() {
-      const pinia = createTestingPinia({ stubActions: false })
-      setActivePinia(pinia)
-
-      const graph = new LGraph()
-      useCanvasStore().canvas = fromPartial<LGraphCanvas>({ graph })
-
-      const upstream = new LGraphNode('Upstream')
-      upstream.id = toNodeId(1)
-      upstream.addOutput('out', 'FAKE')
-      graph.add(upstream)
-
-      const node = new LGraphNode('Target')
-      node.id = toNodeId(2)
-      node.addInput('plain', 'FAKE')
-      node.addInput('w', 'FAKE')
-      node.inputs[1].widget = { name: 'w' }
-      graph.add(node)
-
-      return { pinia, upstream, node }
     }
 
     it('reacts to connect and disconnect without a reprojection event', async () => {

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.vue
@@ -15,6 +15,7 @@
         :node-id="nodeData.id"
         :has-error="inputHasError(input)"
         :index="getActualInputIndex(input, index)"
+        :connected="isInputConnected(getActualInputIndex(input, index))"
       />
     </div>
 
@@ -29,6 +30,7 @@
         :node-type="nodeData?.type || ''"
         :node-id="nodeData.id"
         :index="index"
+        :connected="isOutputConnected(index)"
       />
     </div>
   </div>
@@ -47,6 +49,7 @@ import {
   nonWidgetedInputs
 } from '@/renderer/extensions/vueNodes/utils/nodeDataUtils'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useLinkStore } from '@/stores/linkStore'
 import { getLocatorIdFromNodeData } from '@/utils/graphTraversalUtil'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -61,6 +64,7 @@ interface NodeSlotsProps {
 const { nodeData, unified = false } = defineProps<NodeSlotsProps>()
 const canvasStore = useCanvasStore()
 const executionErrorStore = useExecutionErrorStore()
+const linkStore = useLinkStore()
 const nodeLocatorId = computed(() => getLocatorIdFromNodeData(nodeData))
 
 const linkedWidgetInputs = computed(() =>
@@ -68,6 +72,18 @@ const linkedWidgetInputs = computed(() =>
     ? linkedWidgetedInputs(nodeData, canvasStore.rootGraphId)
     : []
 )
+
+function isInputConnected(index: number): boolean {
+  const graphId = canvasStore.rootGraphId
+  if (graphId === undefined) return false
+  return linkStore.isInputSlotConnected(graphId, nodeData.id, index)
+}
+
+function isOutputConnected(index: number): boolean {
+  const graphId = canvasStore.rootGraphId
+  if (graphId === undefined) return false
+  return linkStore.isOutputSlotConnected(graphId, nodeData.id, index)
+}
 
 const filteredInputs = computed(() => [
   ...nonWidgetedInputs(nodeData),

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toNodeId } from '@/types/nodeId'
 
@@ -59,6 +61,7 @@ vi.mock('@/scripts/app', () => ({
     canvas: {
       ds: mockDs,
       graph: {
+        rootGraph: { id: 'autopan-graph' },
         getNodeById: (id: string) => ({
           id,
           inputs: [],
@@ -235,6 +238,7 @@ function startDrag() {
 
 describe('useSlotLinkInteraction auto-pan', () => {
   beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
     capturedOnPan.current = null
     capturedAutoPan.current = null
     for (const k of Object.keys(capturedHandlers)) {

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -32,6 +32,7 @@ import { toPoint } from '@/renderer/core/layout/utils/geometry'
 import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
 import { augmentToCanvasPointerEvent } from '@/renderer/extensions/vueNodes/utils/eventUtils'
 import { app } from '@/scripts/app'
+import { useLinkStore } from '@/stores/linkStore'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import { createRafBatch } from '@/utils/rafBatch'
@@ -635,11 +636,13 @@ export function useSlotLinkInteraction({
       : 0
     const hasExistingInputLink = inputLinkId != null || inputFloatingCount > 0
 
-    const outputLinkCount = outputSlot?.links?.length ?? 0
-    const outputFloatingCount = isOutputSlot
-      ? slotFloatingLinks(graph, 'output', localNodeId, index).length
-      : 0
-    const hasExistingOutputLink = outputLinkCount > 0 || outputFloatingCount > 0
+    const hasExistingOutputLink =
+      isOutputSlot &&
+      useLinkStore().isOutputSlotConnected(
+        graph.rootGraph.id,
+        localNodeId,
+        index
+      )
 
     const shouldBreakExistingInputLink =
       isInputSlot &&

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -638,11 +638,12 @@ export function useSlotLinkInteraction({
 
     const hasExistingOutputLink =
       isOutputSlot &&
-      useLinkStore().isOutputSlotConnected(
+      (useLinkStore().isOutputSlotConnected(
         graph.rootGraph.id,
         localNodeId,
         index
-      )
+      ) ||
+        slotFloatingLinks(graph, 'output', localNodeId, index).length > 0)
 
     const shouldBreakExistingInputLink =
       isInputSlot &&

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -19,13 +19,16 @@ import {
   LiteGraph,
   RenderShape,
   SubgraphNode,
-  createBounds
+  createBounds,
+  outputAsSerialisable
 } from '@/lib/litegraph/src/litegraph'
 import type {
   CreateNodeOptions,
   GraphAddOptions,
   IContextMenuValue,
   INodeInputSlot,
+  INodeOutputSlot,
+  IWidget,
   Point,
   Subgraph
 } from '@/lib/litegraph/src/litegraph'
@@ -461,19 +464,23 @@ export const useLitegraphService = () => {
 
         // Note: output name is not unique, so we cannot lookup output by name.
         // Use index instead.
-        data.outputs = _.zip(this.outputs, data.outputs).map(
-          ([output, outputData]) => {
+        data.outputs = _.zip(this.outputs, data.outputs ?? []).map(
+          ([output, outputData], index) => {
             // If there are extra outputs in the serialised node, use them directly.
             // There are currently custom nodes that dynamically add outputs via
             // js logic.
             if (!output) return outputData as ISerialisableNodeOutput
 
             return outputData
-              ? {
+              ? ({
                   ...outputData,
                   ..._.pick(output, RESERVED_KEYS)
-                }
-              : output
+                } as ISerialisableNodeOutput)
+              : outputAsSerialisable(
+                  output as INodeOutputSlot & { widget?: IWidget },
+                  this,
+                  index
+                )
           }
         )
 
@@ -569,19 +576,23 @@ export const useLitegraphService = () => {
 
         // Note: output name is not unique, so we cannot lookup output by name.
         // Use index instead.
-        data.outputs = _.zip(this.outputs, data.outputs).map(
-          ([output, outputData]) => {
+        data.outputs = _.zip(this.outputs, data.outputs ?? []).map(
+          ([output, outputData], index) => {
             // If there are extra outputs in the serialised node, use them directly.
             // There are currently custom nodes that dynamically add outputs via
             // js logic.
             if (!output) return outputData as ISerialisableNodeOutput
 
             return outputData
-              ? {
+              ? ({
                   ...outputData,
                   ..._.pick(output, RESERVED_KEYS)
-                }
-              : output
+                } as ISerialisableNodeOutput)
+              : outputAsSerialisable(
+                  output as INodeOutputSlot & { widget?: IWidget },
+                  this,
+                  index
+                )
           }
         )
 

--- a/src/stores/linkStore.test.ts
+++ b/src/stores/linkStore.test.ts
@@ -215,7 +215,7 @@ describe('useLinkStore', () => {
     expect(links.size).toBe(0)
   })
 
-  it('reports an output connected when its target endpoint is floating', () => {
+  it('never returns floating links from output queries', () => {
     const store = useLinkStore()
     const outputFloating: LinkTopology = {
       ...link(1, 5, 0, 9, 2),
@@ -224,10 +224,8 @@ describe('useLinkStore', () => {
     }
     expect(store.registerLink(graphA, outputFloating)).toBeDefined()
 
-    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
-    expect(
-      [...store.getOutputSlotLinks(graphA, toNodeId(5), 0)].map((l) => l.id)
-    ).toContain(toLinkId(1))
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(false)
+    expect(store.getOutputSlotLinks(graphA, toNodeId(5), 0).size).toBe(0)
   })
 
   it('scopes output queries by graph', () => {

--- a/src/stores/linkStore.test.ts
+++ b/src/stores/linkStore.test.ts
@@ -199,7 +199,7 @@ describe('useLinkStore', () => {
 
     const links = store.getOutputSlotLinks(graphA, toNodeId(5), 0)
 
-    expect([...links].sort((a, b) => a - b)).toEqual([
+    expect([...links].map((l) => l.id).sort((a, b) => a - b)).toEqual([
       toLinkId(1),
       toLinkId(2),
       toLinkId(3)
@@ -225,9 +225,9 @@ describe('useLinkStore', () => {
     expect(store.registerLink(graphA, outputFloating)).toBeDefined()
 
     expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
-    expect(store.getOutputSlotLinks(graphA, toNodeId(5), 0)).toContain(
-      toLinkId(1)
-    )
+    expect(
+      [...store.getOutputSlotLinks(graphA, toNodeId(5), 0)].map((l) => l.id)
+    ).toContain(toLinkId(1))
   })
 
   it('scopes output queries by graph', () => {

--- a/src/stores/linkStore.test.ts
+++ b/src/stores/linkStore.test.ts
@@ -182,4 +182,72 @@ describe('useLinkStore', () => {
     expect(store.isInputSlotConnected(graphA, toNodeId(9), 2)).toBe(true)
     expect(store.isInputSlotConnected(graphB, toNodeId(9), 2)).toBe(false)
   })
+
+  it('reports an output slot connected only where a link leaves it', () => {
+    const store = useLinkStore()
+    store.registerLink(graphA, link(1, 5, 0, 9, 2))
+
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 1)).toBe(false)
+  })
+
+  it('returns every link fanning out of an output slot', () => {
+    const store = useLinkStore()
+    store.registerLink(graphA, link(1, 5, 0, 9, 2))
+    store.registerLink(graphA, link(2, 5, 0, 8, 1))
+    store.registerLink(graphA, link(3, 5, 0, 7, 0))
+
+    const links = store.getOutputSlotLinks(graphA, toNodeId(5), 0)
+
+    expect([...links].sort((a, b) => a - b)).toEqual([
+      toLinkId(1),
+      toLinkId(2),
+      toLinkId(3)
+    ])
+  })
+
+  it('returns an empty set, never undefined, for an unconnected output', () => {
+    const store = useLinkStore()
+
+    const links = store.getOutputSlotLinks(graphA, toNodeId(5), 0)
+
+    expect(links).toBeInstanceOf(Set)
+    expect(links.size).toBe(0)
+  })
+
+  it('reports an output connected when its target endpoint is floating', () => {
+    const store = useLinkStore()
+    const outputFloating: LinkTopology = {
+      ...link(1, 5, 0, 9, 2),
+      targetNodeId: UNASSIGNED_NODE_ID,
+      targetSlot: -1
+    }
+    expect(store.registerLink(graphA, outputFloating)).toBeDefined()
+
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
+    expect(store.getOutputSlotLinks(graphA, toNodeId(5), 0)).toContain(
+      toLinkId(1)
+    )
+  })
+
+  it('scopes output queries by graph', () => {
+    const store = useLinkStore()
+    store.registerLink(graphA, link(1, 5, 0, 9, 2))
+
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
+    expect(store.isOutputSlotConnected(graphB, toNodeId(5), 0)).toBe(false)
+  })
+
+  it('re-derives the output index across register and delete', () => {
+    const store = useLinkStore()
+    const topology = link(1, 5, 0, 9, 2)
+
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(false)
+
+    store.registerLink(graphA, topology)
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(true)
+
+    store.deleteLink(graphA, topology)
+    expect(store.isOutputSlotConnected(graphA, toNodeId(5), 0)).toBe(false)
+  })
 })

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -1,11 +1,12 @@
 import { defineStore } from 'pinia'
-import { reactive, ref, toRaw } from 'vue'
+import { computed, reactive, ref, toRaw } from 'vue'
+import type { ComputedRef } from 'vue'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
-import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
-
+import type { LinkId } from '@/types/linkId'
 import type { LinkTopology } from '@/types/linkTopology'
 import type { NodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
 
 export type EndpointPatch = Partial<
@@ -15,13 +16,28 @@ export type EndpointPatch = Partial<
   >
 >
 
-type TargetIndex = Map<UUID, Map<string, LinkTopology>>
-type UnkeyedLinks = Map<UUID, Set<LinkTopology>>
+/**
+ * Endpoint slot keys are `${nodeId}:${slot}`; slot is numeric so the
+ * separator is unambiguous for any node id. Target (input side) and origin
+ * (output side) keys are branded separately so a key built for one index
+ * cannot be looked up in the other.
+ */
+type TargetSlotKey = string & { readonly __brand: 'TargetSlotKey' }
+type OriginSlotKey = string & { readonly __brand: 'OriginSlotKey' }
 
-/** Slot is numeric so the last separator is unambiguous for any node id. */
-function targetKey(nodeId: NodeId, slot: number): string {
-  return `${nodeId}:${slot}`
+function targetKey(nodeId: NodeId, slot: number): TargetSlotKey {
+  return `${nodeId}:${slot}` as TargetSlotKey
 }
+
+function originKey(nodeId: NodeId, slot: number): OriginSlotKey {
+  return `${nodeId}:${slot}` as OriginSlotKey
+}
+
+type TargetIndex = Map<UUID, Map<TargetSlotKey, LinkTopology>>
+type UnkeyedLinks = Map<UUID, Set<LinkTopology>>
+type OriginIndex = Map<OriginSlotKey, Set<LinkId>>
+
+const EMPTY_LINKS: ReadonlySet<LinkId> = new Set()
 
 /**
  * A link is keyed by its target input slot only when that slot uniquely
@@ -47,11 +63,12 @@ function hasUniqueTarget(topology: LinkTopology): boolean {
 export const useLinkStore = defineStore('link', () => {
   const targetIndex = ref<TargetIndex>(new Map())
   const unkeyedLinks = ref<UnkeyedLinks>(new Map())
+  const outputIndexes = new Map<UUID, ComputedRef<OriginIndex>>()
 
-  function graphTargets(graphId: UUID): Map<string, LinkTopology> {
+  function graphTargets(graphId: UUID): Map<TargetSlotKey, LinkTopology> {
     const existing = targetIndex.value.get(graphId)
     if (existing) return existing
-    const next = reactive(new Map<string, LinkTopology>())
+    const next = reactive(new Map<TargetSlotKey, LinkTopology>())
     targetIndex.value.set(graphId, next)
     return next
   }
@@ -132,6 +149,50 @@ export const useLinkStore = defineStore('link', () => {
     return targetIndex.value.get(graphId)?.get(targetKey(nodeId, slot))
   }
 
+  /**
+   * Reverse index over origin endpoints, keyed `${originNodeId}:${originSlot}`.
+   * Spans both collections `graphTopologies` yields, so a link whose target is
+   * floating still indexes its assigned origin. Links with an unassigned origin
+   * have no output slot to report and are skipped.
+   */
+  function buildOutputIndex(graphId: UUID): OriginIndex {
+    const index: OriginIndex = new Map()
+    for (const topology of graphTopologies(graphId)) {
+      if (topology.originNodeId === UNASSIGNED_NODE_ID) continue
+      const key = originKey(topology.originNodeId, topology.originSlot)
+      const links = index.get(key) ?? new Set<LinkId>()
+      links.add(topology.id)
+      index.set(key, links)
+    }
+    return index
+  }
+
+  function outputIndex(graphId: UUID): ComputedRef<OriginIndex> {
+    const existing = outputIndexes.get(graphId)
+    if (existing) return existing
+    const next = computed(() => buildOutputIndex(graphId))
+    outputIndexes.set(graphId, next)
+    return next
+  }
+
+  function isOutputSlotConnected(
+    graphId: UUID,
+    nodeId: NodeId,
+    slot: number
+  ): boolean {
+    return outputIndex(graphId).value.has(originKey(nodeId, slot))
+  }
+
+  function getOutputSlotLinks(
+    graphId: UUID,
+    nodeId: NodeId,
+    slot: number
+  ): ReadonlySet<LinkId> {
+    return (
+      outputIndex(graphId).value.get(originKey(nodeId, slot)) ?? EMPTY_LINKS
+    )
+  }
+
   /** Iterates every registered topology in a graph's bucket. */
   function* graphTopologies(graphId: UUID): Generator<LinkTopology> {
     const targets = targetIndex.value.get(graphId)
@@ -143,6 +204,7 @@ export const useLinkStore = defineStore('link', () => {
   function clearGraph(graphId: UUID): void {
     targetIndex.value.delete(graphId)
     unkeyedLinks.value.delete(graphId)
+    outputIndexes.delete(graphId)
   }
 
   return {
@@ -151,6 +213,8 @@ export const useLinkStore = defineStore('link', () => {
     deleteLink: displace,
     isInputSlotConnected,
     getInputSlotLink,
+    isOutputSlotConnected,
+    getOutputSlotLinks,
     graphTopologies,
     clearGraph
   }

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -4,6 +4,7 @@ import type { ComputedRef } from 'vue'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
 import type { LinkTopology } from '@/types/linkTopology'
+import { isFloatingTopology } from '@/types/linkTopology'
 import type { NodeId } from '@/types/nodeId'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import type { UUID } from '@/utils/uuid'
@@ -150,14 +151,14 @@ export const useLinkStore = defineStore('link', () => {
 
   /**
    * Reverse index over origin endpoints, keyed `${originNodeId}:${originSlot}`.
-   * Spans both collections `graphTopologies` yields, so a link whose target is
-   * floating still indexes its assigned origin. Links with an unassigned origin
-   * have no output slot to report and are skipped.
+   * Spans both collections `graphTopologies` yields. Floating links are
+   * skipped: link queries return fully-assigned links only, matching the
+   * `output.links` mirror this index replaces.
    */
   function buildOutputIndex(graphId: UUID): OriginIndex {
     const index: OriginIndex = new Map()
     for (const topology of graphTopologies(graphId)) {
-      if (topology.originNodeId === UNASSIGNED_NODE_ID) continue
+      if (isFloatingTopology(topology)) continue
       const key = originKey(topology.originNodeId, topology.originSlot)
       const links = index.get(key) ?? new Set<LinkTopology>()
       links.add(topology)

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -3,7 +3,6 @@ import { computed, reactive, ref, toRaw } from 'vue'
 import type { ComputedRef } from 'vue'
 
 import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
-import type { LinkId } from '@/types/linkId'
 import type { LinkTopology } from '@/types/linkTopology'
 import type { NodeId } from '@/types/nodeId'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
@@ -35,9 +34,9 @@ function originKey(nodeId: NodeId, slot: number): OriginSlotKey {
 
 type TargetIndex = Map<UUID, Map<TargetSlotKey, LinkTopology>>
 type UnkeyedLinks = Map<UUID, Set<LinkTopology>>
-type OriginIndex = Map<OriginSlotKey, Set<LinkId>>
+type OriginIndex = Map<OriginSlotKey, Set<LinkTopology>>
 
-const EMPTY_LINKS: ReadonlySet<LinkId> = new Set()
+const EMPTY_LINKS: ReadonlySet<LinkTopology> = new Set()
 
 /**
  * A link is keyed by its target input slot only when that slot uniquely
@@ -160,8 +159,8 @@ export const useLinkStore = defineStore('link', () => {
     for (const topology of graphTopologies(graphId)) {
       if (topology.originNodeId === UNASSIGNED_NODE_ID) continue
       const key = originKey(topology.originNodeId, topology.originSlot)
-      const links = index.get(key) ?? new Set<LinkId>()
-      links.add(topology.id)
+      const links = index.get(key) ?? new Set<LinkTopology>()
+      links.add(topology)
       index.set(key, links)
     }
     return index
@@ -187,7 +186,7 @@ export const useLinkStore = defineStore('link', () => {
     graphId: UUID,
     nodeId: NodeId,
     slot: number
-  ): ReadonlySet<LinkId> {
+  ): ReadonlySet<LinkTopology> {
     return (
       outputIndex(graphId).value.get(originKey(nodeId, slot)) ?? EMPTY_LINKS
     )

--- a/src/stores/rerouteStore.ts
+++ b/src/stores/rerouteStore.ts
@@ -4,7 +4,7 @@ import type { ComputedRef } from 'vue'
 
 import { useLinkStore } from '@/stores/linkStore'
 import type { LinkId } from '@/types/linkId'
-import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
+import { isFloatingTopology } from '@/types/linkTopology'
 import type { RerouteChain } from '@/types/rerouteChain'
 import type { RerouteId } from '@/types/rerouteId'
 import type { UUID } from '@/utils/uuid'
@@ -55,9 +55,7 @@ export const useRerouteStore = defineStore('reroute', () => {
       { linkIds: Set<LinkId>; floatingLinkIds: Set<LinkId> }
     >()
     for (const topology of useLinkStore().graphTopologies(graphId)) {
-      const floating =
-        topology.originNodeId === UNASSIGNED_NODE_ID ||
-        topology.targetNodeId === UNASSIGNED_NODE_ID
+      const floating = isFloatingTopology(topology)
       const visited = new Set<RerouteId>()
       let rerouteId = topology.parentId
       while (rerouteId !== undefined && !visited.has(rerouteId)) {

--- a/src/types/linkTopology.ts
+++ b/src/types/linkTopology.ts
@@ -1,6 +1,7 @@
 import type { ISlotType } from '@/lib/litegraph/src/interfaces'
 import type { LinkId } from '@/types/linkId'
 import type { NodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import type { RerouteId } from '@/types/rerouteId'
 
 export interface LinkTopology {
@@ -14,4 +15,17 @@ export interface LinkTopology {
   type: ISlotType
   /** Terminal reroute of the segment chain, when the link routes through one. */
   parentId?: RerouteId
+}
+
+/**
+ * A floating link is not yet a link: it is reroute-chain state kept alive so
+ * the chain survives disconnection, with exactly one assigned endpoint. Link
+ * queries never return floating topologies; only reroute-chain bookkeeping
+ * and slot-drag interactions see them.
+ */
+export function isFloatingTopology(topology: LinkTopology): boolean {
+  return (
+    topology.originNodeId === UNASSIGNED_NODE_ID ||
+    topology.targetNodeId === UNASSIGNED_NODE_ID
+  )
 }

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -326,7 +326,7 @@ describe('fixBadLinks', () => {
 describe('fixBadLinks ↔ linkStore integration', () => {
   beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
-  it('removes deleted zombie links from the link store', () => {
+  it('completes the input mirror for a registered link missing it', () => {
     const graph = new LGraph()
     const a = new LGraphNode('A')
     const b = new LGraphNode('B')
@@ -335,17 +335,20 @@ describe('fixBadLinks ↔ linkStore integration', () => {
     graph.add(a)
     graph.add(b)
 
-    const zombie = new LLink(toLinkId(9), '*', a.id, 0, b.id, 0)
-    graph._addLink(zombie)
+    // Registered via the chokepoint, but the input mirror was never written.
+    const orphan = new LLink(toLinkId(9), '*', a.id, 0, b.id, 0)
+    graph._addLink(orphan)
 
     const store = useLinkStore()
     const graphId = graph.rootGraph.id
     expect(store.isInputSlotConnected(graphId, b.id, 0)).toBe(true)
+    expect(b.inputs[0].link).toBeNull()
 
     const result = fixBadLinks(graph, { fix: true, silent: true })
 
-    expect(result).toMatchObject({ fixed: true, deleted: 1 })
-    expect(graph._links.has(zombie.id)).toBe(false)
-    expect(store.isInputSlotConnected(graphId, b.id, 0)).toBe(false)
+    expect(result).toMatchObject({ fixed: true, patched: 1, deleted: 0 })
+    expect(graph._links.has(orphan.id)).toBe(true)
+    expect(b.inputs[0].link).toBe(orphan.id)
+    expect(store.isInputSlotConnected(graphId, b.id, 0)).toBe(true)
   })
 })

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -25,6 +25,7 @@
  * SOFTWARE.
  */
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
+import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
 import { toLinkId } from '@/types/linkId'
 import { parseNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
@@ -175,13 +176,15 @@ export function fixBadLinks(
           return false
         }
         patchedNode['outputs']![slot]!['links'].push(linkId)
-        if (fix) {
+        // Live NodeOutputSlot mirrors are store-derived and need no repair;
+        // only serialized plain slots carry a writable links array.
+        if (fix && !(node.outputs?.[slot] instanceof NodeOutputSlot)) {
           node.outputs = node.outputs || []
-          node.outputs[slot] =
-            node.outputs[slot] ||
-            ({} satisfies Partial<INodeOutputSlot> as INodeOutputSlot)
-          node.outputs[slot]!.links = node.outputs[slot]!.links || []
-          node.outputs[slot]!.links!.push(toLinkId(linkId))
+          const slotData = (node.outputs[slot] ??=
+            {} satisfies Partial<INodeOutputSlot> as INodeOutputSlot)
+          const writable = slotData as { links?: number[] | null }
+          writable.links = writable.links || []
+          writable.links.push(linkId)
         }
       } else {
         const linkIdIndex =
@@ -193,8 +196,9 @@ export function fixBadLinks(
           return false
         }
         patchedNode['outputs']![slot]!['links'].splice(linkIdIndex, 1)
-        if (fix) {
-          node.outputs?.[slot]!.links!.splice(linkIdIndex, 1)
+        if (fix && !(node.outputs?.[slot] instanceof NodeOutputSlot)) {
+          const writable = node.outputs?.[slot] as { links?: number[] | null }
+          writable.links?.splice(linkIdIndex, 1)
         }
       }
     }


### PR DESCRIPTION
## Summary

Deletes the `output.links[]` runtime mirror: the linkStore is now the single source for output-side connectivity, read through the pure `node/slotLinks.ts` helpers, with a deprecation-telemetry getter for extensions.

## Changes

- **What**: Output connectivity queries (`isOutputSlotConnected` / `getOutputSlotLinks`, now returning `LinkTopology` sets and excluding floating links); all app and litegraph-internal readers migrated off the mirror; the `NodeOutputSlot.links` field and its nine write sites deleted; serialization derives `outputs[].links` from the store (sorted ascending, `null` when empty — wire format unchanged); `SlotConnectionDot` connected state wired via `NodeSlots`.
- **Breaking**: Extensions writing `output.links` now throw (no setter); reads still work via a read-only prototype getter that fires `warnDeprecated`. Migration: read via `node.isOutputConnected(slot)` / `node.getOutputNodes(slot)`, mutate via `node.connect()` / `node.disconnectOutput()`. `PrimitiveNode.onLastDisconnect` now fires on disconnect-all (stale-mirror suppression removed); `disconnectInput` passes the correct origin slot to `onConnectionsChange`.

## Review Focus

- `docs/architecture/output-slot-connectivity.md` (Decision 6) records the design, the accepted behavior changes, and the extension migration map.
- Serialization ordering: ascending-id equals push order for organically built graphs; move-history order was the only divergence.
- Two latent bugs surfaced by the migration: `createTestSubgraphNode` minted duplicate node ids, and promoted widget labels did not inherit the source slot label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)