### PR TITLE
fix: suppress the stray focus ring on the sidebar splitter panel

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -35,7 +35,7 @@
           :class="
             sidebarLocation === 'left'
               ? cn(
-                  'side-bar-panel pointer-events-auto bg-comfy-menu-bg',
+                  'side-bar-panel pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden',
                   sidebarPanelVisible && 'min-w-78'
                 )
               : 'pointer-events-auto bg-comfy-menu-bg'
@@ -95,7 +95,7 @@
           :class="
             sidebarLocation === 'right'
               ? cn(
-                  'side-bar-panel pointer-events-auto bg-comfy-menu-bg',
+                  'side-bar-panel pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden',
                   sidebarPanelVisible && 'min-w-78'
                 )
               : 'pointer-events-auto bg-comfy-menu-bg'

--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -38,7 +38,7 @@
                   'side-bar-panel pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden',
                   sidebarPanelVisible && 'min-w-78'
                 )
-              : 'pointer-events-auto bg-comfy-menu-bg'
+              : 'pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden'
           "
           :min-size="
             sidebarLocation === 'left' ? SIDEBAR_MIN_SIZE : BUILDER_MIN_SIZE
@@ -82,7 +82,7 @@
             </SplitterPanel>
             <SplitterPanel
               v-show="bottomPanelVisible && !focusMode"
-              class="bottom-panel pointer-events-auto max-w-full overflow-x-auto rounded-lg border border-(--p-panel-border-color) bg-comfy-menu-bg"
+              class="bottom-panel pointer-events-auto max-w-full overflow-x-auto rounded-lg border border-(--p-panel-border-color) bg-comfy-menu-bg focus-visible:outline-hidden"
             >
               <slot name="bottom-panel" />
             </SplitterPanel>
@@ -98,7 +98,7 @@
                   'side-bar-panel pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden',
                   sidebarPanelVisible && 'min-w-78'
                 )
-              : 'pointer-events-auto bg-comfy-menu-bg'
+              : 'pointer-events-auto bg-comfy-menu-bg focus-visible:outline-hidden'
           "
           :min-size="
             sidebarLocation === 'right' ? SIDEBAR_MIN_SIZE : BUILDER_MIN_SIZE


### PR DESCRIPTION
Clicking empty space in a workspace panel focuses the whole PrimeVue SplitterPanel (tabindex=-1 makes it click-focusable), and any following non-chord keypress (e.g. Shift) trips the browser focus-visible heuristic, painting the default blue ring around the entire panel.

The wrappers are not Tab-reachable (Tab lands on the controls inside, never the panel box) and nothing focuses them programmatically, so the ring conveys nothing. `focus-visible:outline-hidden` suppresses it while keeping a forced-colors (High Contrast) indicator. Confirmed as noise with design (Alex Tov).

Covers every click-focusable panel in `LiteGraphCanvasSplitterOverlay.vue`: the sidebar panel (both locations), the properties-side panel (both branches), and the bottom panel. The center and graph-canvas panels are left untouched - they inherit `pointer-events-none`, so a click can never focus them.

## Repro / QA

Ring trigger: click an empty, non-interactive spot inside the panel, then press solo Shift. On main the browser paints a blue ring around the whole panel; on this PR nothing appears. (Ctrl+Shift only triggers when Shift lands first, hence the original "sometimes".)

| Panel | How to open | Fixed |
| --- | --- | --- |
| Sidebar (left, default) | Any rail icon, e.g. Assets | yes |
| Sidebar (right) | Settings > Sidebar Location > right | yes |
| Properties-side panel | Toggle properties panel / builder mode | yes |
| Bottom panel | Toggle Logs/Terminal | yes |
| Canvas / center | n/a | untouched - pointer-events-none, cannot be click-focused |

- [ ] Each fixed panel: click empty spot, press Shift, no ring
- [ ] Same steps on main/prod show the ring (before-state)
- [ ] Tab still reaches controls inside each panel and their own focus rings still show
- [ ] Media Assets shortcuts unchanged (Ctrl/Cmd+A, marquee modifiers) - PR is CSS-only

- Surfaced during design review of #13323
