### PR TITLE
fix(ci): remove out-of-rootDir config files from package tsconfig includes

### DIFF
--- a/packages/ingest-types/tsconfig.json
+++ b/packages/ingest-types/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*", "*.config.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/object-info-parser/tsconfig.json
+++ b/packages/object-info-parser/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*", "vitest.config.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

Type-aware oxlint rejects `packages/ingest-types/tsconfig.json` and `packages/object-info-parser/tsconfig.json` as invalid (TS6059): their `include` lists a root-level config file (`openapi-ts.config.ts` / `vitest.config.ts`) that sits outside `rootDir: "src"`. This fails the lint-and-format job with "Invalid tsconfig" on any PR that touches those packages' src files — currently blocking every auto-generated ingest-types sync (e.g. #12777).

## Changes

- **What**: Drop the out-of-`rootDir` config-file entries from the two package tsconfig `include` arrays, matching the other workspace packages. Repro: `pnpm exec oxlint --type-aware packages/ingest-types/src/index.ts` fails before, passes after; the config files themselves still lint clean.

## Review Focus

Neither package emits a build, so `rootDir`/`outDir` are editor/lint-only; excluding the config files from the project has no runtime effect (vitest/openapi-ts load their configs directly).