### PR TITLE
test: canary CodeRabbit test path instructions with PR 13362

### DIFF
--- a/src/base/common/async.test.ts
+++ b/src/base/common/async.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('runWhenGlobalIdle', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('falls back to a timeout when idle callbacks are unavailable', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    const { runWhenGlobalIdle } = await import('./async')
+    const runner = vi.fn()
+
+    const disposable = runWhenGlobalIdle(runner)
+    await vi.runAllTimersAsync()
+
+    expect(runner).toHaveBeenCalledOnce()
+    const deadline = runner.mock.calls[0][0]
+    expect(deadline.didTimeout).toBe(true)
+    expect(deadline.timeRemaining()).toBeGreaterThanOrEqual(0)
+
+    disposable.dispose()
+    disposable.dispose()
+  })
+
+  it('cancels fallback idle work before it runs', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    const { runWhenGlobalIdle } = await import('./async')
+    const runner = vi.fn()
+
+    runWhenGlobalIdle(runner).dispose()
+    await vi.runAllTimersAsync()
+
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('uses native idle callbacks when available', async () => {
+    const requestIdleCallback = vi.fn(() => 42)
+    const cancelIdleCallback = vi.fn()
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback)
+    vi.stubGlobal('cancelIdleCallback', cancelIdleCallback)
+    const { runWhenGlobalIdle } = await import('./async')
+    const runner = vi.fn()
+
+    const disposable = runWhenGlobalIdle(runner, 250)
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(runner, { timeout: 250 })
+
+    disposable.dispose()
+    disposable.dispose()
+
+    expect(cancelIdleCallback).toHaveBeenCalledOnce()
+    expect(cancelIdleCallback).toHaveBeenCalledWith(42)
+  })
+
+  it('omits native idle timeout options when no timeout is supplied', async () => {
+    const requestIdleCallback = vi.fn(() => 7)
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback)
+    vi.stubGlobal('cancelIdleCallback', vi.fn())
+    const { runWhenGlobalIdle } = await import('./async')
+    const runner = vi.fn()
+
+    runWhenGlobalIdle(runner)
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(runner, undefined)
+  })
+})

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -1,4 +1,4 @@
-import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -118,6 +118,22 @@ describe('downloadUtil', () => {
       expect(mockLink.href).toBe(invalidUrl)
       expect(mockLink.download).toBe('download.png')
       expect(mockLink.click).toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(createObjectURLSpy).not.toHaveBeenCalled()
+    })
+
+    it('throws for an empty URL', () => {
+      expect(() => downloadFile('')).toThrow(
+        'Invalid URL provided for download'
+      )
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(createObjectURLSpy).not.toHaveBeenCalled()
+    })
+
+    it('throws for a whitespace URL', () => {
+      expect(() => downloadFile('   ')).toThrow(
+        'Invalid URL provided for download'
+      )
       expect(fetchMock).not.toHaveBeenCalled()
       expect(createObjectURLSpy).not.toHaveBeenCalled()
     })
@@ -339,7 +355,7 @@ describe('downloadUtil', () => {
       const testUrl = 'https://storage.googleapis.com/bucket/image.png'
       const blob = new Blob(['test'], { type: 'image/png' })
       const mockTab = { location: { href: '' }, closed: false, close: vi.fn() }
-      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      windowOpenSpy.mockReturnValue(fromPartial<Window>(mockTab))
       fetchMock.mockResolvedValue(
         fromPartial<Response>({
           ok: true,
@@ -359,7 +375,7 @@ describe('downloadUtil', () => {
       mockIsCloud.value = true
       const blob = new Blob(['test'], { type: 'image/png' })
       const mockTab = { location: { href: '' }, closed: false, close: vi.fn() }
-      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      windowOpenSpy.mockReturnValue(fromPartial<Window>(mockTab))
       fetchMock.mockResolvedValue(
         fromPartial<Response>({
           ok: true,
@@ -379,7 +395,7 @@ describe('downloadUtil', () => {
       const testUrl = 'https://storage.googleapis.com/bucket/missing.png'
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockTab = { location: { href: '' }, closed: false, close: vi.fn() }
-      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      windowOpenSpy.mockReturnValue(fromPartial<Window>(mockTab))
       fetchMock.mockResolvedValue(
         fromPartial<Response>({ ok: false, status: 404 })
       )
@@ -395,7 +411,7 @@ describe('downloadUtil', () => {
       mockIsCloud.value = true
       const blob = new Blob(['test'], { type: 'image/png' })
       const mockTab = { location: { href: '' }, closed: true, close: vi.fn() }
-      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      windowOpenSpy.mockReturnValue(fromPartial<Window>(mockTab))
       fetchMock.mockResolvedValue(
         fromPartial<Response>({
           ok: true,

--- a/src/base/credits/comfyCredits.test.ts
+++ b/src/base/credits/comfyCredits.test.ts
@@ -4,6 +4,7 @@ import {
   CREDITS_PER_USD,
   COMFY_CREDIT_RATE_CENTS,
   centsToCredits,
+  clampUsd,
   creditsToCents,
   creditsToUsd,
   formatCredits,
@@ -42,5 +43,22 @@ describe('comfyCredits helpers', () => {
     expect(formatCreditsFromCents({ cents: 100, locale })).toBe('211.00')
     expect(formatCreditsFromUsd({ usd: 1, locale })).toBe('211.00')
     expect(formatUsd({ value: 4.2, locale })).toBe('4.20')
+  })
+
+  test('formats with compatible fraction digit bounds', () => {
+    expect(
+      formatCredits({
+        value: 12.345,
+        locale: 'en-US',
+        numberOptions: { minimumFractionDigits: 4, maximumFractionDigits: 2 }
+      })
+    ).toBe('12.35')
+  })
+
+  test('clamps USD purchase values into the supported range', () => {
+    expect(clampUsd(Number.NaN)).toBe(0)
+    expect(clampUsd(-5)).toBe(1)
+    expect(clampUsd(42)).toBe(42)
+    expect(clampUsd(5000)).toBe(1000)
   })
 })

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -260,7 +260,6 @@ useExtensionService().registerExtension({
         if (!isLoad3dNode(selectedNode)) return
 
         ComfyApp.copyToClipspace(selectedNode)
-        // @ts-expect-error clipspace_return_node is an extension property added at runtime
         ComfyApp.clipspace_return_node = selectedNode
 
         const props = { node: selectedNode }

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2494,6 +2494,7 @@ export class LGraph
         // Deprecated - old schema version, links are arrays
         if (Array.isArray(data.links)) {
           for (const linkData of data.links) {
+            if (!linkData) continue
             const link = LLink.createFromArray(linkData)
             this._links.set(link.id, link)
           }

--- a/src/lib/litegraph/src/types/serialisation.ts
+++ b/src/lib/litegraph/src/types/serialisation.ts
@@ -133,7 +133,7 @@ export interface ISerialisedGraph extends BaseExportedGraph {
   last_node_id: SerializedNodeId
   last_link_id: number
   nodes: ISerialisedNode[]
-  links: SerialisedLLinkArray[]
+  links: (SerialisedLLinkArray | null)[]
   floatingLinks?: SerialisableLLink[]
   groups: ISerialisedGroup[]
   version: typeof LiteGraph.VERSION

--- a/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
@@ -148,13 +148,13 @@ describe('useWorkflowAutoSave', () => {
 
     const serviceInstance = vi.mocked(useWorkflowService).mock.results[0].value
     const graphChangedCallback = vi.mocked(api.addEventListener).mock
-      .calls[0][1]
+      .calls[0][1] as EventListener | undefined
 
-    graphChangedCallback?.({} as Parameters<typeof graphChangedCallback>[0])
+    graphChangedCallback?.({} as Event)
 
     vi.advanceTimersByTime(500)
 
-    graphChangedCallback?.({} as Parameters<typeof graphChangedCallback>[0])
+    graphChangedCallback?.({} as Event)
 
     vi.advanceTimersByTime(1999)
     expect(serviceInstance.saveWorkflow).not.toHaveBeenCalled()
@@ -221,8 +221,8 @@ describe('useWorkflowAutoSave', () => {
     vi.advanceTimersByTime(1000)
 
     const graphChangedCallback = vi.mocked(api.addEventListener).mock
-      .calls[0][1]
-    graphChangedCallback?.({} as Parameters<typeof graphChangedCallback>[0])
+      .calls[0][1] as EventListener | undefined
+    graphChangedCallback?.({} as Event)
 
     resolveSave!()
     await Promise.resolve()
@@ -269,8 +269,8 @@ describe('useWorkflowAutoSave', () => {
     mockAutoSaveDelay = -500
 
     const graphChangedCallback = vi.mocked(api.addEventListener).mock
-      .calls[0][1]
-    graphChangedCallback?.({} as Parameters<typeof graphChangedCallback>[0])
+      .calls[0][1] as EventListener | undefined
+    graphChangedCallback?.({} as Event)
 
     await vi.runAllTimersAsync()
 

--- a/src/renderer/extensions/linearMode/PartnerNodesList.vue
+++ b/src/renderer/extensions/linearMode/PartnerNodesList.vue
@@ -21,7 +21,7 @@ const { isCreditsBadge } = usePriceBadge()
 const { t } = useI18n()
 
 const creditsBadges = computed(() =>
-  mapAllNodes(app.graph, (node) => {
+  mapAllNodes(app.rootGraph, (node) => {
     if (node.isSubgraphNode()) return
 
     const priceBadge = node.badges.find(isCreditsBadge)

--- a/src/schemas/nodeDefSchema.test.ts
+++ b/src/schemas/nodeDefSchema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getComboSpecComboOptions,
+  getInputSpecType,
+  isComboInputSpec,
+  isComboInputSpecV1,
+  isComboInputSpecV2,
+  isFloatInputSpec,
+  isIntInputSpec,
+  isMediaUploadComboInput
+} from './nodeDefSchema'
+import type {
+  ComboInputSpec,
+  ComboInputSpecV2,
+  InputSpec
+} from './nodeDefSchema'
+
+describe('node definition schema helpers', () => {
+  it('identifies input spec variants', () => {
+    const intSpec: InputSpec = ['INT', {}]
+    const floatSpec: InputSpec = ['FLOAT', {}]
+    const comboV1: ComboInputSpec = [['a', 'b'], {}]
+    const comboV2: ComboInputSpecV2 = ['COMBO', { options: ['a', 'b'] }]
+
+    expect(isIntInputSpec(intSpec)).toBe(true)
+    expect(isFloatInputSpec(floatSpec)).toBe(true)
+    expect(isComboInputSpecV1(comboV1)).toBe(true)
+    expect(isComboInputSpecV2(comboV2)).toBe(true)
+    expect(isComboInputSpec(comboV1)).toBe(true)
+    expect(isComboInputSpec(comboV2)).toBe(true)
+    expect(getInputSpecType(comboV1)).toBe('COMBO')
+    expect(getInputSpecType(intSpec)).toBe('INT')
+  })
+
+  it('reads combo options from legacy and v2 combo specs', () => {
+    expect(getComboSpecComboOptions([['a', 1], {}])).toEqual(['a', 1])
+    expect(
+      getComboSpecComboOptions(['COMBO', { options: ['x', 'y'] }])
+    ).toEqual(['x', 'y'])
+    expect(getComboSpecComboOptions(['COMBO', {}])).toEqual([])
+  })
+
+  it('detects media upload combo inputs', () => {
+    expect(isMediaUploadComboInput([['a'], { image_upload: true }])).toBe(true)
+    expect(
+      isMediaUploadComboInput(['COMBO', { animated_image_upload: true }])
+    ).toBe(true)
+    expect(isMediaUploadComboInput(['COMBO', { video_upload: true }])).toBe(
+      true
+    )
+    expect(isMediaUploadComboInput(['STRING', { image_upload: true }])).toBe(
+      false
+    )
+    expect(isMediaUploadComboInput(['COMBO', undefined])).toBe(false)
+  })
+})

--- a/src/scripts/api.cloud.test.ts
+++ b/src/scripts/api.cloud.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchWithUnifiedRemint,
+  shouldRemintCloudRequest
+} from '@/platform/auth/unified/remintRetry'
+
+const { mockAuthStore } = vi.hoisted(() => ({
+  mockAuthStore: {
+    isInitialized: true,
+    getAuthHeader: vi.fn(),
+    getAuthToken: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore)
+}))
+
+vi.mock('@/platform/auth/unified/remintRetry', () => ({
+  fetchWithUnifiedRemint: vi.fn(),
+  shouldRemintCloudRequest: vi.fn()
+}))
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = []
+
+  binaryType = ''
+  sent: string[] = []
+
+  constructor(readonly url: string) {
+    super()
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.dispatchEvent(new Event('close'))
+  }
+}
+
+const { ComfyApi } = await import('./api')
+
+describe('ComfyApi cloud mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    FakeWebSocket.instances = []
+    window.name = ''
+    sessionStorage.clear()
+    mockAuthStore.isInitialized = true
+    mockAuthStore.getAuthHeader.mockResolvedValue(null)
+    mockAuthStore.getAuthToken.mockResolvedValue(null)
+    vi.mocked(shouldRemintCloudRequest).mockResolvedValue(false)
+    vi.mocked(fetchWithUnifiedRemint).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+  })
+
+  it('adds cloud auth headers and enables unified retry for authenticated requests', async () => {
+    mockAuthStore.getAuthHeader.mockResolvedValue({
+      Authorization: 'Bearer firebase-token'
+    })
+    vi.mocked(shouldRemintCloudRequest).mockResolvedValue(true)
+    const api = new ComfyApi()
+    api.user = 'cloud-user'
+
+    await api.fetchApi('/queue')
+
+    expect(api.api_base).toBe('')
+    expect(fetchWithUnifiedRemint).toHaveBeenCalledWith(
+      '/api/queue',
+      expect.objectContaining({
+        cache: 'no-cache',
+        headers: {
+          Authorization: 'Bearer firebase-token',
+          'Comfy-User': 'cloud-user'
+        }
+      }),
+      true
+    )
+  })
+
+  it('continues cloud fetches when auth header lookup fails', async () => {
+    mockAuthStore.getAuthHeader.mockRejectedValue(new Error('auth unavailable'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const api = new ComfyApi()
+
+    await api.fetchApi('/history', {
+      headers: [['X-Test', '1']]
+    })
+
+    const [, options, retryOn401] = vi.mocked(fetchWithUnifiedRemint).mock
+      .calls[0]
+    expect(options.headers).toEqual([
+      ['X-Test', '1'],
+      ['Comfy-User', '']
+    ])
+    expect(retryOn401).toBe(false)
+    expect(shouldRemintCloudRequest).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to get auth header:',
+      expect.any(Error)
+    )
+  })
+
+  it('adds the cloud auth token to websocket URLs', async () => {
+    mockAuthStore.getAuthToken.mockResolvedValue('socket-token')
+    window.name = 'client-1'
+    const api = new ComfyApi()
+
+    api.init()
+
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    })
+    const socket = FakeWebSocket.instances[0]
+
+    expect(socket.url).toContain('clientId=client-1')
+    expect(socket.url).toContain('token=socket-token')
+  })
+
+  it('opens a cloud websocket without a token when token lookup fails', async () => {
+    mockAuthStore.getAuthToken.mockRejectedValue(new Error('token unavailable'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const api = new ComfyApi()
+
+    api.init()
+
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    })
+    const socket = FakeWebSocket.instances[0]
+
+    expect(socket.url).not.toContain('token=')
+    expect(warn).toHaveBeenCalledWith(
+      'Could not get auth token for WebSocket connection:',
+      expect.any(Error)
+    )
+  })
+})

--- a/src/scripts/api.core.test.ts
+++ b/src/scripts/api.core.test.ts
@@ -1,0 +1,460 @@
+import axios from 'axios'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
+} from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { PromptResponse } from '@/schemas/apiSchema'
+import { api as sharedApi, ComfyApi, PromptExecutionError } from '@/scripts/api'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+
+const fetchJobs = vi.hoisted(() => ({
+  fetchHistory: vi.fn(),
+  fetchJobDetail: vi.fn(),
+  fetchQueue: vi.fn()
+}))
+
+vi.mock('axios')
+vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', () => fetchJobs)
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetAllMocks()
+})
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init
+  })
+}
+
+function promptData(): {
+  output: ComfyApiWorkflow
+  workflow: ComfyWorkflowJSON
+} {
+  return {
+    output: fromPartial<ComfyApiWorkflow>({
+      1: {
+        inputs: {},
+        class_type: 'KSampler',
+        _meta: { title: 'KSampler' }
+      }
+    }),
+    workflow: fromPartial<ComfyWorkflowJSON>({
+      version: 0.4,
+      nodes: [],
+      links: []
+    })
+  }
+}
+
+function requestBody(fetchApi: ReturnType<typeof vi.spyOn>, call = 0) {
+  const init = fetchApi.mock.calls[call][1]
+  return JSON.parse(String(init?.body)) as Record<string, unknown>
+}
+
+describe('PromptExecutionError', () => {
+  it('formats string and node-specific prompt errors', () => {
+    const response = fromPartial<PromptResponse>({
+      error: 'invalid prompt',
+      node_errors: {
+        7: {
+          class_type: 'KSampler',
+          dependent_outputs: [],
+          errors: [{ message: 'bad seed', details: 'seed must be numeric' }]
+        }
+      }
+    })
+
+    expect(new PromptExecutionError(response, 400).toString()).toBe(
+      'invalid prompt\nKSampler:\n    - bad seed: seed must be numeric'
+    )
+  })
+
+  it('formats structured prompt errors without node errors', () => {
+    const response = fromPartial<PromptResponse>({
+      error: {
+        type: 'prompt_outputs_failed_validation',
+        message: 'Validation failed',
+        details: 'missing node'
+      }
+    })
+
+    expect(new PromptExecutionError(response).toString()).toBe(
+      'Validation failed: missing node'
+    )
+  })
+})
+
+describe('ComfyApi queuePrompt', () => {
+  it('sends front queue requests with auth and execution options', async () => {
+    const api = new ComfyApi()
+    api.clientId = 'client-1'
+    api.authToken = 'auth-token'
+    api.apiKey = 'api-key'
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValue(jsonResponse({ prompt_id: 'queued' }))
+
+    await api.queuePrompt(-1, promptData(), {
+      partialExecutionTargets: ['9:10' as NodeExecutionId],
+      previewMethod: 'auto'
+    })
+
+    expect(fetchApi).toHaveBeenCalledWith('/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: fetchApi.mock.calls[0][1]?.body
+    })
+    expect(typeof fetchApi.mock.calls[0][1]?.body).toBe('string')
+    expect(requestBody(fetchApi)).toMatchObject({
+      client_id: 'client-1',
+      front: true,
+      partial_execution_targets: ['9:10'],
+      extra_data: {
+        auth_token_comfy_org: 'auth-token',
+        api_key_comfy_org: 'api-key',
+        comfy_usage_source: 'comfyui-frontend',
+        preview_method: 'auto'
+      }
+    })
+    expect(requestBody(fetchApi)).not.toHaveProperty('number')
+  })
+
+  it('omits default-only queue options and sets explicit queue numbers', async () => {
+    const api = new ComfyApi()
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockImplementation(() =>
+        Promise.resolve(jsonResponse({ prompt_id: 'queued' }))
+      )
+
+    await api.queuePrompt(0, promptData(), { previewMethod: 'default' })
+    await api.queuePrompt(4, promptData())
+
+    expect(requestBody(fetchApi, 0)).toMatchObject({ client_id: '' })
+    expect(requestBody(fetchApi, 0)).not.toHaveProperty('front')
+    expect(requestBody(fetchApi, 0)).not.toHaveProperty('number')
+    expect(
+      requestBody(fetchApi, 0).extra_data as Record<string, unknown>
+    ).not.toHaveProperty('preview_method')
+    expect(requestBody(fetchApi, 1)).toMatchObject({ number: 4 })
+  })
+
+  it('throws parsed prompt errors from non-200 responses', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(api, 'fetchApi').mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            type: 'server_error',
+            message: 'Server rejected prompt',
+            details: 'bad output'
+          }
+        },
+        { status: 400, statusText: 'Bad Request' }
+      )
+    )
+
+    await expect(api.queuePrompt(0, promptData())).rejects.toThrow(
+      'Prompt execution failed'
+    )
+  })
+
+  it('wraps non-json prompt errors with status details', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(api, 'fetchApi').mockResolvedValue(
+      new Response('backend exploded', {
+        status: 500,
+        statusText: 'Server Error'
+      })
+    )
+
+    await expect(api.queuePrompt(0, promptData())).rejects.toMatchObject({
+      status: 500,
+      response: {
+        error: {
+          message: '500 Server Error',
+          details: 'backend exploded'
+        }
+      }
+    })
+  })
+})
+
+describe('ComfyApi read helpers', () => {
+  it('returns localized templates, default templates, and empty non-json responses', async () => {
+    const api = new ComfyApi()
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'application/json' },
+        data: [{ name: 'localized' }]
+      })
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'text/html' },
+        data: '<html></html>'
+      })
+
+    await expect(api.getCoreWorkflowTemplates('fr')).resolves.toEqual([
+      { name: 'localized' }
+    ])
+    await expect(api.getCoreWorkflowTemplates()).resolves.toEqual([])
+    expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+      '/templates/index.fr.json'
+    )
+    expect(vi.mocked(axios.get).mock.calls[1][0]).toContain(
+      '/templates/index.json'
+    )
+  })
+
+  it('falls back from missing localized templates to the default index', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(axios.get)
+      .mockRejectedValueOnce(new Error('missing locale'))
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'application/json' },
+        data: [{ name: 'default' }]
+      })
+
+    await expect(api.getCoreWorkflowTemplates('ja')).resolves.toEqual([
+      { name: 'default' }
+    ])
+    expect(vi.mocked(axios.get).mock.calls[1][0]).toContain(
+      '/templates/index.json'
+    )
+  })
+
+  it('returns empty model lists for 404s and filters internal folders', async () => {
+    const api = new ComfyApi()
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse([], { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { name: 'checkpoints' },
+          { name: 'configs' },
+          { name: 'custom_nodes' }
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse([], { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse(['model.safetensors']))
+
+    await expect(api.getModelFolders()).resolves.toEqual([])
+    await expect(api.getModelFolders()).resolves.toEqual([
+      { name: 'checkpoints' }
+    ])
+    await expect(api.getModels('checkpoints')).resolves.toEqual([])
+    await expect(api.getModels('checkpoints')).resolves.toEqual([
+      'model.safetensors'
+    ])
+    expect(fetchApi).toHaveBeenCalledTimes(4)
+  })
+
+  it('handles model metadata text responses', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(new Response(''))
+      .mockResolvedValueOnce(new Response('{"format":"safetensors"}'))
+      .mockResolvedValueOnce(
+        new Response('not json', { status: 200, statusText: 'OK' })
+      )
+
+    await expect(
+      api.viewMetadata('checkpoints', 'a.safetensors')
+    ).resolves.toBe(null)
+    await expect(
+      api.viewMetadata('checkpoints', 'a.safetensors')
+    ).resolves.toEqual({ format: 'safetensors' })
+    await expect(
+      api.viewMetadata('checkpoints', 'a.safetensors')
+    ).resolves.toBe(null)
+  })
+
+  it('gets fuse options only from json responses', async () => {
+    const api = new ComfyApi()
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'application/json' },
+        data: { keys: ['name'] }
+      })
+      .mockResolvedValueOnce({
+        headers: { 'content-type': 'text/plain' },
+        data: 'nope'
+      })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(api.getFuseOptions()).resolves.toEqual({ keys: ['name'] })
+    await expect(api.getFuseOptions()).resolves.toBeNull()
+    vi.mocked(axios.get).mockRejectedValueOnce(new Error('missing'))
+    await expect(api.getFuseOptions()).resolves.toBeNull()
+  })
+})
+
+describe('ComfyApi queue and data helpers', () => {
+  it('routes item collection requests to queue or history', async () => {
+    const api = new ComfyApi()
+    const queue = vi.spyOn(api, 'getQueue').mockResolvedValue({
+      Running: [],
+      Pending: []
+    })
+    const historyItem = fromPartial<JobListItem>({
+      id: 'history-1',
+      status: 'completed',
+      create_time: 1,
+      priority: 0
+    })
+    const history = vi.spyOn(api, 'getHistory').mockResolvedValue([historyItem])
+
+    await expect(api.getItems('queue')).resolves.toEqual({
+      Running: [],
+      Pending: []
+    })
+    await expect(api.getItems('history')).resolves.toEqual([historyItem])
+    expect(queue).toHaveBeenCalledOnce()
+    expect(history).toHaveBeenCalledOnce()
+  })
+
+  it('returns queue fallbacks unless errors are requested', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchJobs.fetchQueue.mockRejectedValue(new Error('network'))
+
+    await expect(api.getQueue()).resolves.toEqual({ Running: [], Pending: [] })
+    await expect(api.getQueue({ throwOnError: true })).rejects.toThrow(
+      'network'
+    )
+  })
+
+  it('returns empty history when fetchHistory fails', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchJobs.fetchHistory.mockRejectedValue(new Error('history down'))
+
+    await expect(api.getHistory()).resolves.toEqual([])
+  })
+
+  it('posts item mutations with and without request bodies', async () => {
+    const api = new ComfyApi()
+    const fetchApi = vi.spyOn(api, 'fetchApi').mockResolvedValue(new Response())
+
+    await api.deleteItem('history', 'job-1')
+    await api.clearItems('queue')
+    await api.interrupt(null)
+    await api.interrupt('running-1')
+
+    expect(fetchApi.mock.calls.map((call) => call[0])).toEqual([
+      '/history',
+      '/queue',
+      '/interrupt',
+      '/interrupt'
+    ])
+    expect(fetchApi.mock.calls[0][1]?.body).toBe(
+      JSON.stringify({ delete: ['job-1'] })
+    )
+    expect(fetchApi.mock.calls[1][1]?.body).toBe(
+      JSON.stringify({ clear: true })
+    )
+    expect(fetchApi.mock.calls[2][1]?.body).toBeUndefined()
+    expect(fetchApi.mock.calls[3][1]?.body).toBe(
+      JSON.stringify({ prompt_id: 'running-1' })
+    )
+  })
+
+  it('throws unauthorized settings responses', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(api, 'fetchApi').mockResolvedValue(
+      new Response('', { status: 401, statusText: 'Unauthorized' })
+    )
+
+    await expect(api.getSettings()).rejects.toThrow('Unauthorized')
+  })
+
+  it('stores user data with default and raw-body options', async () => {
+    const api = new ComfyApi()
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValue(new Response('', { status: 200 }))
+    const raw = new Blob(['raw'])
+
+    await api.storeUserData('a/b.json', { ok: true })
+    await api.storeUserData('raw.bin', raw, {
+      overwrite: false,
+      stringify: false,
+      throwOnError: false,
+      full_info: true
+    })
+
+    expect(fetchApi.mock.calls[0][0]).toBe(
+      '/userdata/a%2Fb.json?overwrite=true&full_info=false'
+    )
+    expect(fetchApi.mock.calls[0][1]?.body).toBe(JSON.stringify({ ok: true }))
+    expect(fetchApi.mock.calls[1][0]).toBe(
+      '/userdata/raw.bin?overwrite=false&full_info=true'
+    )
+    expect(fetchApi.mock.calls[1][1]?.body).toBe(raw)
+  })
+
+  it('honors storeUserData throwOnError', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(
+        new Response('', { status: 500, statusText: 'Server Error' })
+      )
+      .mockResolvedValueOnce(
+        new Response('', { status: 500, statusText: 'Server Error' })
+      )
+
+    await expect(api.storeUserData('bad.json', {})).rejects.toThrow(
+      "Error storing user data file 'bad.json': 500 Server Error"
+    )
+    await expect(
+      api.storeUserData('bad.json', {}, { throwOnError: false })
+    ).resolves.toHaveProperty('status', 500)
+  })
+
+  it('lists full user data info by status', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse([], { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response('', { status: 500, statusText: 'Server Error' })
+      )
+      .mockResolvedValueOnce(jsonResponse([{ path: 'x' }]))
+
+    await expect(api.listUserDataFullInfo('models/')).resolves.toEqual([])
+    await expect(api.listUserDataFullInfo('models/')).rejects.toThrow(
+      "Error getting user data list 'models': 500 Server Error"
+    )
+    await expect(api.listUserDataFullInfo('models/')).resolves.toEqual([
+      { path: 'x' }
+    ])
+  })
+
+  it('loads global subgraph records and deferred data', async () => {
+    const fetchApi = vi
+      .spyOn(sharedApi, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({}, { status: 500 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ready: { name: 'Ready', info: { node_pack: 'core' }, data: '{}' },
+          lazy: { name: 'Lazy', info: { node_pack: 'core' } }
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: '{"lazy":true}' }))
+
+    await expect(sharedApi.getGlobalSubgraphs()).resolves.toEqual({})
+    const subgraphs = await sharedApi.getGlobalSubgraphs()
+
+    expect(subgraphs.ready.data).toBe('{}')
+    expect(subgraphs.lazy.data).toBeInstanceOf(Promise)
+    await expect(subgraphs.lazy.data).resolves.toBe('{"lazy":true}')
+    expect(fetchApi).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/scripts/api.test.ts
+++ b/src/scripts/api.test.ts
@@ -1,0 +1,827 @@
+import axios from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  api as singletonApi,
+  ComfyApi,
+  PromptExecutionError,
+  UnauthorizedError
+} from '@/scripts/api'
+import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { fetchWithUnifiedRemint } from '@/platform/auth/unified/remintRetry'
+
+const { mockToastStore } = vi.hoisted(() => ({
+  mockToastStore: {
+    add: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/auth/unified/remintRetry', () => ({
+  fetchWithUnifiedRemint: vi.fn(),
+  shouldRemintCloudRequest: vi.fn()
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: vi.fn(() => mockToastStore)
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    patch: vi.fn()
+  }
+}))
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = []
+
+  binaryType = ''
+  sent: string[] = []
+
+  constructor(readonly url: string) {
+    super()
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.dispatchEvent(new Event('close'))
+  }
+}
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init
+  })
+}
+
+function createWorkflow() {
+  return {
+    last_node_id: 0,
+    last_link_id: 0,
+    nodes: [],
+    links: [],
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4
+  }
+}
+
+function binaryMessage(type: number, payload: Uint8Array) {
+  const bytes = new Uint8Array(4 + payload.length)
+  new DataView(bytes.buffer).setUint32(0, type)
+  bytes.set(payload, 4)
+  return bytes.buffer
+}
+
+function uint32(value: number) {
+  const bytes = new Uint8Array(4)
+  new DataView(bytes.buffer).setUint32(0, value)
+  return bytes
+}
+
+function concatBytes(...chunks: Uint8Array[]) {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.length
+  }
+  return result
+}
+
+describe('PromptExecutionError', () => {
+  it('formats string, structured, and node-level errors', () => {
+    expect(
+      new PromptExecutionError({
+        error: 'Queue rejected',
+        node_errors: {}
+      }).toString()
+    ).toBe('Queue rejected')
+
+    expect(
+      new PromptExecutionError({
+        error: {
+          type: 'invalid_prompt',
+          message: 'Invalid prompt',
+          details: 'missing input'
+        },
+        node_errors: {
+          1: {
+            class_type: 'PreviewAny',
+            dependent_outputs: ['1'],
+            errors: [
+              {
+                type: 'required_input_missing',
+                message: 'Required input',
+                details: 'source'
+              }
+            ]
+          }
+        }
+      }).toString()
+    ).toContain('Invalid prompt: missing input\nPreviewAny:')
+  })
+})
+
+describe('ComfyApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    FakeWebSocket.instances = []
+    window.name = ''
+    sessionStorage.clear()
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('builds API, internal, file, and fetch URLs with user headers', async () => {
+    const api = new ComfyApi()
+    api.user = 'reviewer'
+    vi.mocked(fetchWithUnifiedRemint).mockResolvedValue(
+      jsonResponse({ ok: true })
+    )
+
+    await api.fetchApi('/queue', {
+      headers: new Headers([['X-Test', '1']])
+    })
+
+    expect(api.apiURL('/api/custom')).toBe(`${api.api_base}/api/custom`)
+    expect(api.apiURL('/queue')).toBe(`${api.api_base}/api/queue`)
+    expect(api.internalURL('/logs')).toBe(`${api.api_base}/internal/logs`)
+    expect(api.fileURL('/view')).toBe(`${api.api_base}/view`)
+    const [, options] = vi.mocked(fetchWithUnifiedRemint).mock.calls[0]
+    expect(options.headers).toBeInstanceOf(Headers)
+    expect((options.headers as Headers).get('Comfy-User')).toBe('reviewer')
+    expect((options.headers as Headers).get('X-Test')).toBe('1')
+  })
+
+  it('guards event listeners and still allows removing them', async () => {
+    const api = new ComfyApi()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const listener = vi.fn()
+    const throwingListener = vi.fn(() => {
+      throw new Error('listener failed')
+    })
+    const asyncListener = vi.fn(() => Promise.reject(new Error('async failed')))
+    const objectListener = { handleEvent: vi.fn() }
+
+    api.addEventListener('status', null)
+    api.removeEventListener('status', null)
+    api.addEventListener('status', listener)
+    api.addEventListener('status', throwingListener)
+    api.addEventListener('status', asyncListener)
+    api.addEventListener('status', objectListener)
+
+    api.dispatchCustomEvent('status', { exec_info: { queue_remaining: 1 } })
+    await Promise.resolve()
+
+    expect(listener).toHaveBeenCalled()
+    expect(throwingListener).toHaveBeenCalled()
+    expect(asyncListener).toHaveBeenCalled()
+    expect(objectListener.handleEvent).toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledTimes(2)
+
+    api.removeEventListener('status', listener)
+    api.dispatchCustomEvent('status', null)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses guarded listener wrappers and ignores unknown removals', () => {
+    const api = new ComfyApi()
+    const listener = vi.fn()
+    const neverRegistered = vi.fn()
+
+    api.addEventListener('status', listener)
+    api.addEventListener('status', listener)
+    api.removeEventListener('status', neverRegistered)
+    api.dispatchCustomEvent('status', null)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(neverRegistered).not.toHaveBeenCalled()
+  })
+
+  it('supports guarded custom event listeners', () => {
+    const api = new ComfyApi()
+    const listener = vi.fn()
+
+    api.addCustomEventListener('custom-node-event', listener)
+    ;(api as EventTarget).dispatchEvent(
+      new CustomEvent('custom-node-event', { detail: { ok: true } })
+    )
+    api.removeCustomEventListener('custom-node-event', listener)
+    ;(api as EventTarget).dispatchEvent(
+      new CustomEvent('custom-node-event', { detail: { ok: false } })
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes websocket JSON messages and custom registered messages', () => {
+    window.name = 'existing-client'
+    const api = new ComfyApi()
+    const status = vi.fn()
+    const executing = vi.fn()
+    const featureFlags = vi.fn()
+    const custom = vi.fn()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    api.addEventListener('status', status)
+    api.addEventListener('executing', executing)
+    api.addEventListener('feature_flags', featureFlags)
+    api.addCustomEventListener('custom-message', custom)
+    api.init()
+    const socket = FakeWebSocket.instances[0]
+    socket.dispatchEvent(new Event('open'))
+
+    expect(socket.url).toContain('clientId=existing-client')
+    expect(JSON.parse(socket.sent[0])).toMatchObject({
+      type: 'feature_flags'
+    })
+
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'status',
+          data: {
+            sid: 'fresh-client',
+            status: { exec_info: { queue_remaining: 2 } }
+          }
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'executing',
+          data: { node: '12' }
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'feature_flags',
+          data: { supports_progress_text_metadata: true }
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'custom-message',
+          data: { from: 'extension' }
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'unknown-message',
+          data: {}
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'unknown-message',
+          data: {}
+        })
+      })
+    )
+
+    expect(api.clientId).toBe('fresh-client')
+    expect(window.name).toBe('fresh-client')
+    expect(sessionStorage.getItem('clientId')).toBe('fresh-client')
+    expect(status).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { exec_info: { queue_remaining: 2 } }
+      })
+    )
+    expect(executing).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: '12' })
+    )
+    expect(featureFlags).toHaveBeenCalled()
+    expect(api.serverSupportsFeature('supports_progress_text_metadata')).toBe(
+      true
+    )
+    expect(custom).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { from: 'extension' } })
+    )
+    expect(api.reportedUnknownMessageTypes.has('unknown-message')).toBe(true)
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls status when the initial websocket connection fails', async () => {
+    vi.useFakeTimers()
+    const api = new ComfyApi()
+    const status = vi.fn()
+    vi.spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(
+        jsonResponse({ exec_info: { queue_remaining: 4 } })
+      )
+      .mockRejectedValueOnce(new Error('poll failed'))
+    api.addEventListener('status', status)
+
+    api.init()
+    FakeWebSocket.instances[0].dispatchEvent(new Event('error'))
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(status).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { exec_info: { queue_remaining: 4 } }
+      })
+    )
+    expect(status).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: null })
+    )
+  })
+
+  it('emits reconnect lifecycle events after an opened websocket closes', async () => {
+    vi.useFakeTimers()
+    const api = new ComfyApi()
+    const status = vi.fn()
+    const reconnecting = vi.fn()
+    const reconnected = vi.fn()
+    api.addEventListener('status', status)
+    api.addEventListener('reconnecting', reconnecting)
+    api.addEventListener('reconnected', reconnected)
+
+    api.init()
+    const socket = FakeWebSocket.instances[0]
+    socket.dispatchEvent(new Event('open'))
+    socket.close()
+
+    expect(status).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: null })
+    )
+    expect(reconnecting).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(300)
+    const reconnectSocket = FakeWebSocket.instances[1]
+    reconnectSocket.dispatchEvent(new Event('open'))
+
+    expect(reconnected).toHaveBeenCalledOnce()
+  })
+
+  it('routes websocket variants without session ids and display-node fallbacks', () => {
+    const api = new ComfyApi()
+    const status = vi.fn()
+    const executing = vi.fn()
+    api.addEventListener('status', status)
+    api.addEventListener('executing', executing)
+    api.init()
+    const socket = FakeWebSocket.instances[0]
+
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'status',
+          data: { status: undefined }
+        })
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'executing',
+          data: { node: 'real', display_node: 'display' }
+        })
+      })
+    )
+
+    expect(status).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: null })
+    )
+    expect(executing).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: 'display' })
+    )
+  })
+
+  it('routes binary preview and progress websocket messages', () => {
+    const api = new ComfyApi()
+    const preview = vi.fn()
+    const previewWithMetadata = vi.fn()
+    const progressText = vi.fn()
+    const encoder = new TextEncoder()
+    api.serverFeatureFlags.value = {
+      supports_progress_text_metadata: true
+    }
+    api.addEventListener('b_preview', preview)
+    api.addEventListener('b_preview_with_metadata', previewWithMetadata)
+    api.addEventListener('progress_text', progressText)
+    api.init()
+    const socket = FakeWebSocket.instances[0]
+
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(1, concatBytes(uint32(2), new Uint8Array([1, 2])))
+      })
+    )
+
+    const promptId = encoder.encode('prompt-1')
+    const nodeId = encoder.encode('7')
+    const progressPayload = concatBytes(
+      uint32(promptId.length),
+      promptId,
+      uint32(nodeId.length),
+      nodeId,
+      encoder.encode('loading')
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(3, progressPayload)
+      })
+    )
+
+    const metadata = encoder.encode(
+      JSON.stringify({
+        image_type: 'image/webp',
+        node_id: '7',
+        display_node_id: '7',
+        parent_node_id: '4',
+        real_node_id: '7',
+        prompt_id: 'prompt-1'
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(
+          4,
+          concatBytes(uint32(metadata.length), metadata, new Uint8Array([9]))
+        )
+      })
+    )
+
+    expect(preview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ type: 'image/png' })
+      })
+    )
+    expect(progressText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          nodeId: '7',
+          text: 'loading',
+          prompt_id: 'prompt-1'
+        }
+      })
+    )
+    expect(previewWithMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          nodeId: '7',
+          parentNodeId: '4',
+          jobId: 'prompt-1'
+        })
+      })
+    )
+  })
+
+  it('routes binary jpeg/default previews and malformed binary messages defensively', () => {
+    const api = new ComfyApi()
+    const preview = vi.fn()
+    const progressText = vi.fn()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const encoder = new TextEncoder()
+    api.addEventListener('b_preview', preview)
+    api.addEventListener('progress_text', progressText)
+    api.init()
+    const socket = FakeWebSocket.instances[0]
+
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(1, concatBytes(uint32(1), new Uint8Array([1])))
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(1, concatBytes(uint32(99), new Uint8Array([2])))
+      })
+    )
+
+    const nodeId = encoder.encode('node')
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(
+          3,
+          concatBytes(uint32(nodeId.length), nodeId, encoder.encode('ready'))
+        )
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(3, new Uint8Array([1]))
+      })
+    )
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: binaryMessage(99, new Uint8Array())
+      })
+    )
+
+    expect(preview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ type: 'image/jpeg' })
+      })
+    )
+    expect(progressText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { nodeId: 'node', text: 'ready' }
+      })
+    )
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('serializes prompt queue options and surfaces non-200 errors', async () => {
+    const api = new ComfyApi()
+    api.clientId = 'client-1'
+    api.authToken = 'token-1'
+    api.apiKey = 'key-1'
+    const prompt: ComfyApiWorkflow = {
+      1: {
+        class_type: 'PreviewAny',
+        inputs: {},
+        _meta: { title: 'PreviewAny' }
+      }
+    }
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({ prompt_id: 'queued' }))
+      .mockResolvedValueOnce(
+        new Response('backend exploded', {
+          status: 500,
+          statusText: 'Server Error'
+        })
+      )
+
+    await expect(
+      api.queuePrompt(
+        -1,
+        { output: prompt, workflow: createWorkflow() },
+        {
+          partialExecutionTargets: ['7' as NodeExecutionId],
+          previewMethod: 'latent2rgb'
+        }
+      )
+    ).resolves.toEqual({ prompt_id: 'queued' })
+
+    const body = JSON.parse(fetchApi.mock.calls[0][1]?.body as string)
+    expect(body).toMatchObject({
+      client_id: 'client-1',
+      prompt,
+      partial_execution_targets: ['7'],
+      front: true,
+      extra_data: {
+        auth_token_comfy_org: 'token-1',
+        api_key_comfy_org: 'key-1',
+        comfy_usage_source: 'comfyui-frontend',
+        preview_method: 'latent2rgb'
+      }
+    })
+    expect(body.number).toBeUndefined()
+
+    await expect(
+      api.queuePrompt(3, { output: prompt, workflow: createWorkflow() })
+    ).rejects.toMatchObject({ status: 500 })
+  })
+
+  it('omits queue position and default preview method for normal queueing', async () => {
+    const api = new ComfyApi()
+    const prompt: ComfyApiWorkflow = {
+      1: {
+        class_type: 'PreviewAny',
+        inputs: {},
+        _meta: { title: 'PreviewAny' }
+      }
+    }
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValue(jsonResponse({ prompt_id: 'queued' }))
+
+    await api.queuePrompt(
+      0,
+      { output: prompt, workflow: createWorkflow() },
+      {
+        previewMethod: 'default'
+      }
+    )
+
+    const body = JSON.parse(fetchApi.mock.calls[0][1]?.body as string)
+    expect(body.front).toBeUndefined()
+    expect(body.number).toBeUndefined()
+    expect(body.extra_data.preview_method).toBeUndefined()
+  })
+
+  it('handles shareable assets, settings, userdata, subgraphs, and memory APIs', async () => {
+    const api = new ComfyApi()
+    const prompt: ComfyApiWorkflow = {
+      1: {
+        class_type: 'PreviewAny',
+        inputs: {},
+        _meta: { title: 'PreviewAny' }
+      }
+    }
+    vi.spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({ assets: [] }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 500 }))
+      .mockResolvedValueOnce(
+        new Response('', { status: 401, statusText: 'Unauthorized' })
+      )
+      .mockResolvedValueOnce(jsonResponse({}, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse([], { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({}, { status: 500, statusText: 'Server Error' })
+      )
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 500 }))
+    vi.spyOn(singletonApi, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({ data: 'subgraph-data' }))
+      .mockResolvedValueOnce(jsonResponse({ missing: {} }))
+      .mockResolvedValueOnce(jsonResponse({ one: { data: 'inline' } }))
+
+    await expect(
+      api.getShareableAssets(prompt, { owned: false })
+    ).resolves.toEqual({ assets: [] })
+    await expect(api.getShareableAssets(prompt)).rejects.toThrow(
+      'Failed to fetch shareable assets'
+    )
+    await expect(api.getSettings()).rejects.toBeInstanceOf(UnauthorizedError)
+    await expect(
+      api.storeUserData('plain.txt', 'raw', {
+        overwrite: false,
+        stringify: false,
+        throwOnError: false,
+        full_info: true
+      })
+    ).resolves.toHaveProperty('status', 204)
+    await expect(api.listUserDataFullInfo('/missing/')).resolves.toEqual([])
+    await expect(api.listUserDataFullInfo('/broken/')).rejects.toThrow(
+      "Error getting user data list '/broken'"
+    )
+    await expect(api.getGlobalSubgraphData('one')).resolves.toBe(
+      'subgraph-data'
+    )
+    await expect(api.getGlobalSubgraphData('missing')).rejects.toThrow(
+      "Global subgraph 'missing' returned empty data"
+    )
+    await expect(api.getGlobalSubgraphs()).resolves.toEqual({
+      one: { data: 'inline' }
+    })
+    await api.freeMemory({ freeExecutionCache: true })
+    await api.freeMemory({ freeExecutionCache: false })
+    await api.freeMemory({ freeExecutionCache: true })
+    expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'Models and Execution Cache have been cleared.'
+      })
+    )
+    expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: 'Models have been unloaded.' })
+    )
+    expect(mockToastStore.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary:
+          'Unloading of models failed. Installed ComfyUI may be an outdated version.'
+      })
+    )
+  })
+
+  it('rejects non-success global subgraph data responses', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(singletonApi, 'fetchApi').mockResolvedValueOnce(
+      jsonResponse({}, { status: 404, statusText: 'Not Found' })
+    )
+
+    await expect(api.getGlobalSubgraphData('missing')).rejects.toThrow(
+      "Failed to fetch global subgraph 'missing': 404 Not Found"
+    )
+  })
+
+  it('handles successful settings and userdata helper request shapes', async () => {
+    const api = new ComfyApi()
+    const fetchApi = vi
+      .spyOn(api, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({ theme: 'dark' }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 200 }))
+
+    await expect(api.getSettings()).resolves.toEqual({ theme: 'dark' })
+    await expect(api.storeUserData('bad.json', { a: 1 })).rejects.toThrow(
+      "Error storing user data file 'bad.json'"
+    )
+    await api.moveUserData('old/path.json', 'new path.json')
+    await api.deleteUserData('old/path.json')
+
+    expect(fetchApi.mock.calls[2]).toEqual([
+      '/userdata/old%2Fpath.json/move/new%20path.json?overwrite=false',
+      { method: 'POST' }
+    ])
+    expect(fetchApi.mock.calls[3]).toEqual([
+      '/userdata/old%2Fpath.json',
+      { method: 'DELETE' }
+    ])
+  })
+
+  it('handles global subgraph fallbacks and log endpoints', async () => {
+    const api = new ComfyApi()
+    vi.spyOn(singletonApi, 'fetchApi')
+      .mockResolvedValueOnce(jsonResponse({}, { status: 500 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          missing: {
+            name: 'Missing data',
+            info: { node_pack: 'core' }
+          }
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: 'lazy-data' }))
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({ data: 'log text', headers: {} })
+      .mockResolvedValueOnce({ data: { logs: [] }, headers: {} })
+      .mockRejectedValueOnce(new Error('no folders'))
+      .mockResolvedValueOnce({
+        data: { checkpoints: ['/models'] },
+        headers: {}
+      })
+    vi.mocked(axios.patch).mockResolvedValue({ data: undefined })
+
+    await expect(api.getGlobalSubgraphs()).resolves.toEqual({})
+    const subgraphs = await api.getGlobalSubgraphs()
+    await expect(subgraphs.missing.data).resolves.toBe('lazy-data')
+    await expect(api.getLogs()).resolves.toBe('log text')
+    await expect(api.getRawLogs()).resolves.toEqual({ logs: [] })
+    await api.subscribeLogs(true)
+    await expect(api.getFolderPaths()).resolves.toEqual({})
+    await expect(api.getFolderPaths()).resolves.toEqual({
+      checkpoints: ['/models']
+    })
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      api.internalURL('/logs/subscribe'),
+      { enabled: true, clientId: undefined }
+    )
+  })
+
+  it('loads localized template indexes and fuse options defensively', async () => {
+    const api = new ComfyApi()
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: [{ name: 'template' }],
+        headers: { 'content-type': 'application/json' }
+      })
+      .mockResolvedValueOnce({
+        data: '<html></html>',
+        headers: { 'content-type': 'text/html' }
+      })
+      .mockRejectedValueOnce(new Error('missing locale'))
+      .mockResolvedValueOnce({
+        data: [{ name: 'fallback' }],
+        headers: { 'content-type': 'application/json' }
+      })
+      .mockRejectedValueOnce(new Error('default missing'))
+      .mockResolvedValueOnce({
+        data: { keys: ['name'] },
+        headers: { 'content-type': 'application/json' }
+      })
+      .mockResolvedValueOnce({
+        data: '<html></html>',
+        headers: { 'content-type': 'text/html' }
+      })
+      .mockResolvedValueOnce({
+        data: { ignored: true },
+        headers: {}
+      })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(api.getCoreWorkflowTemplates('fr')).resolves.toEqual([
+      { name: 'template' }
+    ])
+    await expect(api.getCoreWorkflowTemplates()).resolves.toEqual([])
+    await expect(api.getCoreWorkflowTemplates('zh')).resolves.toEqual([
+      { name: 'fallback' }
+    ])
+    await expect(api.getCoreWorkflowTemplates('en')).resolves.toEqual([])
+    await expect(api.getFuseOptions()).resolves.toEqual({ keys: ['name'] })
+    await expect(api.getFuseOptions()).resolves.toBeNull()
+    await expect(api.getFuseOptions()).resolves.toBeNull()
+  })
+})

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -277,13 +277,13 @@ function addHeaderEntry(headers: HeadersInit, key: string, value: string) {
 export interface ComfyApi extends EventTarget {
   addEventListener<TEvent extends keyof ApiEvents>(
     type: TEvent,
-    callback: ((event: ApiEvents[TEvent]) => void) | null,
+    callback: ((event: ApiEvents[TEvent]) => void) | EventListenerObject | null,
     options?: AddEventListenerOptions | boolean
   ): void
 
   removeEventListener<TEvent extends keyof ApiEvents>(
     type: TEvent,
-    callback: ((event: ApiEvents[TEvent]) => void) | null,
+    callback: ((event: ApiEvents[TEvent]) => void) | EventListenerObject | null,
     options?: EventListenerOptions | boolean
   ): void
 }
@@ -548,7 +548,7 @@ export class ComfyApi extends EventTarget {
 
   override addEventListener<TEvent extends keyof ApiEvents>(
     type: TEvent,
-    callback: ((event: ApiEvents[TEvent]) => void) | null,
+    callback: ((event: ApiEvents[TEvent]) => void) | EventListenerObject | null,
     options?: AddEventListenerOptions | boolean
   ) {
     // Type assertion: strictFunctionTypes.  So long as we emit events in a type-safe fashion, this is safe.
@@ -562,7 +562,7 @@ export class ComfyApi extends EventTarget {
 
   override removeEventListener<TEvent extends keyof ApiEvents>(
     type: TEvent,
-    callback: ((event: ApiEvents[TEvent]) => void) | null,
+    callback: ((event: ApiEvents[TEvent]) => void) | EventListenerObject | null,
     options?: EventListenerOptions | boolean
   ): void {
     super.removeEventListener(

--- a/src/scripts/app.core.test.ts
+++ b/src/scripts/app.core.test.ts
@@ -1,0 +1,3124 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import type {
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
+} from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
+import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { app as singletonApp, ComfyApp } from './app'
+import { createNode, isImageNode } from '@/utils/litegraphUtil'
+import {
+  pasteAudioNode,
+  pasteAudioNodes,
+  pasteImageNode,
+  pasteImageNodes,
+  pasteVideoNode,
+  pasteVideoNodes
+} from '@/composables/usePaste'
+import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
+import { importA1111 } from '@/scripts/pnginfo'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { api, PromptExecutionError } from '@/scripts/api'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useExecutionStore } from '@/stores/executionStore'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
+import type { NodeError, PromptResponse, ResultItem } from '@/schemas/apiSchema'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import type { ISerialisedGraph } from '@/lib/litegraph/src/types/serialisation'
+import {
+  createMockCanvas as createSharedMockCanvas,
+  createMockLGraph,
+  createMockLGraphNode
+} from '@/utils/__tests__/litegraphTestUtils'
+import { deserialiseAndCreate } from '@/utils/vintageClipboard'
+
+const {
+  mockApiKeyAuthStore,
+  mockAuthStore,
+  mockSettingStore,
+  mockToastStore,
+  mockExtensionService,
+  mockNodeOutputStore,
+  mockWorkspaceWorkflow,
+  mockWorkspaceStore,
+  mockRefreshMissingModelPipeline,
+  mockDeserialiseAndCreate,
+  mockDialogService,
+  mockAccountPreconditionDialog,
+  mockResolveAccountPrecondition,
+  mockRescanAndSurfaceMissingNodes,
+  mockExtractFilesFromDragEvent,
+  mockWorkflowService,
+  mockNodeReplacementStore,
+  mockImportA1111,
+  mockWorkflowValidation,
+  mockSubgraphService,
+  mockLitegraphService,
+  mockTelemetry,
+  mockEnsureCorrectLayoutScale,
+  mockSyncLayoutStoreNodeBoundsFromGraph,
+  mockRunMissingModelPipeline,
+  mockFindLegacyRerouteNodes,
+  mockNoNativeReroutes,
+  mockSubgraphNavigationStore
+} = vi.hoisted(() => ({
+  mockApiKeyAuthStore: {
+    getApiKey: vi.fn()
+  },
+  mockAuthStore: {
+    getAuthToken: vi.fn()
+  },
+  mockSettingStore: {
+    get: vi.fn()
+  },
+  mockToastStore: {
+    addAlert: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn()
+  },
+  mockExtensionService: {
+    invokeExtensions: vi.fn(),
+    invokeExtensionsAsync: vi.fn()
+  },
+  mockNodeOutputStore: {
+    refreshNodeOutputs: vi.fn(),
+    getNodeOutputs: vi.fn(),
+    updateNodeImages: vi.fn(),
+    setNodeOutputsByExecutionId: vi.fn(),
+    setNodePreviewsByExecutionId: vi.fn(),
+    revokePreviewsByExecutionId: vi.fn(),
+    resetAllOutputsAndPreviews: vi.fn()
+  },
+  mockWorkspaceWorkflow: {
+    activeWorkflow: null as ComfyWorkflow | null
+  },
+  mockWorkspaceStore: {
+    workflow: null as { activeWorkflow: ComfyWorkflow | null } | null,
+    spinner: false
+  },
+  mockRefreshMissingModelPipeline: vi.fn(),
+  mockDeserialiseAndCreate: vi.fn(),
+  mockDialogService: {
+    showErrorDialog: vi.fn(),
+    showExecutionErrorDialog: vi.fn()
+  },
+  mockAccountPreconditionDialog: {
+    open: vi.fn()
+  },
+  mockResolveAccountPrecondition: vi.fn(),
+  mockRescanAndSurfaceMissingNodes: vi.fn(),
+  mockExtractFilesFromDragEvent: vi.fn(),
+  mockWorkflowService: {
+    showPendingWarnings: vi.fn(),
+    beforeLoadNewGraph: vi.fn(),
+    afterLoadNewGraph: vi.fn()
+  },
+  mockNodeReplacementStore: {
+    load: vi.fn(),
+    getReplacementFor: vi.fn()
+  },
+  mockImportA1111: vi.fn(),
+  mockWorkflowValidation: {
+    validateWorkflow: vi.fn()
+  },
+  mockSubgraphService: {
+    loadSubgraphs: vi.fn(),
+    registerNewSubgraph: vi.fn()
+  },
+  mockLitegraphService: {
+    fitView: vi.fn(),
+    resetView: vi.fn(),
+    updatePreviews: vi.fn()
+  },
+  mockTelemetry: {
+    trackWorkflowOpened: vi.fn(),
+    trackWorkflowImported: vi.fn()
+  },
+  mockEnsureCorrectLayoutScale: vi.fn(),
+  mockSyncLayoutStoreNodeBoundsFromGraph: vi.fn(),
+  mockRunMissingModelPipeline: vi.fn(),
+  mockFindLegacyRerouteNodes: vi.fn(),
+  mockNoNativeReroutes: vi.fn(),
+  mockSubgraphNavigationStore: {
+    updateHash: vi.fn()
+  }
+}))
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  createNode: vi.fn(),
+  isImageNode: vi.fn(),
+  isVideoNode: vi.fn(),
+  isAudioNode: vi.fn(),
+  executeWidgetsCallback: vi.fn(),
+  fixLinkInputSlots: vi.fn()
+}))
+
+vi.mock('@/stores/apiKeyAuthStore', () => ({
+  useApiKeyAuthStore: vi.fn(() => mockApiKeyAuthStore)
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore)
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => mockSettingStore)
+}))
+
+vi.mock('@/composables/usePaste', () => ({
+  pasteAudioNode: vi.fn(),
+  pasteAudioNodes: vi.fn(),
+  pasteImageNode: vi.fn(),
+  pasteImageNodes: vi.fn(),
+  pasteVideoNode: vi.fn(),
+  pasteVideoNodes: vi.fn()
+}))
+
+vi.mock('@/scripts/metadata/parser', () => ({
+  getWorkflowDataFromFile: vi.fn()
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: vi.fn(() => mockToastStore)
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: vi.fn(() => mockExtensionService)
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: vi.fn(() => mockWorkspaceStore)
+}))
+
+vi.mock('@/platform/missingModel/missingModelPipeline', () => ({
+  refreshMissingModelPipeline: mockRefreshMissingModelPipeline,
+  runMissingModelPipeline: mockRunMissingModelPipeline
+}))
+
+vi.mock('@/utils/vintageClipboard', () => ({
+  deserialiseAndCreate: mockDeserialiseAndCreate
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: vi.fn(() => mockDialogService)
+}))
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useAccountPreconditionDialog',
+  () => ({
+    useAccountPreconditionDialog: vi.fn(() => mockAccountPreconditionDialog)
+  })
+)
+
+vi.mock('@/platform/errorCatalog/accountPreconditionRouting', () => ({
+  resolveAccountPrecondition: mockResolveAccountPrecondition
+}))
+
+vi.mock('@/platform/nodeReplacement/missingNodeScan', () => ({
+  rescanAndSurfaceMissingNodes: mockRescanAndSurfaceMissingNodes
+}))
+
+vi.mock('@/utils/eventUtils', () => ({
+  extractFilesFromDragEvent: mockExtractFilesFromDragEvent,
+  hasImageType: ({ type }: File) => type.startsWith('image'),
+  hasAudioType: ({ type }: File) => type.startsWith('audio'),
+  hasVideoType: ({ type }: File) => type.startsWith('video'),
+  isMediaFile: ({ type }: File) =>
+    type.startsWith('image') ||
+    type.startsWith('audio') ||
+    type.startsWith('video')
+}))
+
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: vi.fn(() => mockWorkflowService)
+}))
+
+vi.mock(
+  '@/platform/workflow/validation/composables/useWorkflowValidation',
+  () => ({
+    useWorkflowValidation: vi.fn(() => mockWorkflowValidation)
+  })
+)
+
+vi.mock('@/services/subgraphService', () => ({
+  useSubgraphService: vi.fn(() => mockSubgraphService)
+}))
+
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: vi.fn(() => mockLitegraphService)
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: vi.fn(() => mockTelemetry)
+}))
+
+vi.mock('@/platform/nodeReplacement/nodeReplacementStore', () => ({
+  useNodeReplacementStore: vi.fn(() => mockNodeReplacementStore)
+}))
+
+vi.mock('@/scripts/pnginfo', () => ({
+  importA1111: mockImportA1111
+}))
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/layout/ensureCorrectLayoutScale',
+  () => ({
+    ensureCorrectLayoutScale: mockEnsureCorrectLayoutScale
+  })
+)
+
+vi.mock('@/renderer/core/layout/sync/syncLayoutStoreFromGraph', () => ({
+  syncLayoutStoreNodeBoundsFromGraph: mockSyncLayoutStoreNodeBoundsFromGraph
+}))
+
+vi.mock('@/utils/migration/migrateReroute', () => ({
+  findLegacyRerouteNodes: mockFindLegacyRerouteNodes,
+  noNativeReroutes: mockNoNativeReroutes
+}))
+
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
+}))
+
+function createMockNode(
+  options: Partial<LGraphNode> | Record<string, unknown> = {}
+) {
+  return createMockLGraphNode({
+    size: [200, 100],
+    type: 'LoadImage',
+    connect: vi.fn(),
+    getBounding: vi.fn(() => new Float64Array([0, 0, 200, 100])),
+    ...options
+  })
+}
+
+function createMockCanvas(): LGraphCanvas {
+  return createSharedMockCanvas({
+    graph: createMockLGraph({ change: vi.fn() }),
+    draw: vi.fn(),
+    selectItems: vi.fn()
+  })
+}
+
+type ComfyAppWithPrivateNodeDefs = {
+  updateVueAppNodeDefs(defs: Record<string, ComfyNodeDef>): void
+}
+
+function exposePrivateNodeDefs(app: ComfyApp): ComfyAppWithPrivateNodeDefs {
+  // eslint-disable-next-line no-restricted-syntax -- intersecting ComfyApp with its private updateVueAppNodeDefs reduces to never, so a double assertion is the only way to spy on the private method
+  return app as unknown as ComfyAppWithPrivateNodeDefs
+}
+
+function attachLoadGraphCanvas(
+  app: ComfyApp,
+  options: { width?: number; height?: number } = {}
+): LGraphCanvas {
+  const canvasEl = document.createElement('canvas')
+  canvasEl.width = options.width ?? 100
+  canvasEl.height = options.height ?? 100
+  app.canvasElRef.value = canvasEl
+
+  const canvas = fromPartial<LGraphCanvas>({
+    ...createMockCanvas(),
+    setGraph: vi.fn(),
+    resize: vi.fn(),
+    graph_mouse: [0, 0],
+    viewport: [0, 0, 100, 100],
+    visible_area: { x: 0, y: 0, width: 100, height: 100 },
+    ds: {
+      offset: [0, 0],
+      scale: 1,
+      computeVisibleArea: vi.fn()
+    }
+  })
+  app.canvas = canvas
+  return canvas
+}
+
+function createTestFile(name: string, type: string): File {
+  return new File([''], name, { type })
+}
+
+async function flushDropHandler() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function createWorkflowGraphData(): ComfyWorkflowJSON {
+  return {
+    last_node_id: 0,
+    last_link_id: 0,
+    nodes: [],
+    links: [],
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4
+  }
+}
+
+function createSerialisedGraph(): ISerialisedGraph {
+  return fromPartial<ISerialisedGraph>({
+    last_node_id: 0,
+    last_link_id: 0,
+    nodes: [],
+    links: [],
+    groups: [],
+    version: 0.4
+  })
+}
+
+describe('ComfyApp', () => {
+  let app: ComfyApp
+  let mockCanvas: LGraphCanvas
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    app = new ComfyApp()
+    mockCanvas = createMockCanvas() as LGraphCanvas
+    app.canvas = mockCanvas as LGraphCanvas
+    mockWorkspaceWorkflow.activeWorkflow = null
+    mockWorkspaceStore.workflow = mockWorkspaceWorkflow
+    mockWorkspaceStore.spinner = false
+    mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
+    mockAuthStore.getAuthToken.mockResolvedValue(undefined)
+    mockExtensionService.invokeExtensions.mockReturnValue([])
+    mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
+    mockSettingStore.get.mockImplementation((key: string) =>
+      key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+    )
+    mockResolveAccountPrecondition.mockReturnValue(undefined)
+    mockNodeOutputStore.getNodeOutputs.mockReturnValue(undefined)
+    mockExtractFilesFromDragEvent.mockResolvedValue([])
+    mockNodeReplacementStore.load.mockResolvedValue(undefined)
+    mockNodeReplacementStore.getReplacementFor.mockReturnValue(null)
+    mockWorkflowValidation.validateWorkflow.mockResolvedValue({
+      graphData: undefined
+    })
+    mockEnsureCorrectLayoutScale.mockReturnValue(false)
+    mockRunMissingModelPipeline.mockResolvedValue(undefined)
+    mockFindLegacyRerouteNodes.mockReturnValue([])
+    mockNoNativeReroutes.mockReturnValue(false)
+    mockSubgraphNavigationStore.updateHash.mockResolvedValue(undefined)
+    localStorage.clear()
+    ComfyApp.clipspace = null
+    ComfyApp.clipspace_return_node = null
+    ComfyApp.clipspace_invalidate_handler = null
+    singletonApp.vueAppReady = false
+    singletonApp.canvas = mockCanvas
+    singletonApp.nodeOutputs = {}
+  })
+
+  describe('queuePrompt', () => {
+    it('queues the request but does not start a second processor while busy', async () => {
+      const dispatchCustomEvent = vi
+        .spyOn(api, 'dispatchCustomEvent')
+        .mockImplementation(() => true)
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+      Reflect.set(app, 'processingQueue', true)
+
+      await expect(app.queuePrompt(2, 3)).resolves.toBe(false)
+
+      expect(dispatchCustomEvent).toHaveBeenCalledWith(
+        'promptQueueing',
+        expect.objectContaining({
+          requestId: expect.any(Number),
+          batchCount: 3
+        })
+      )
+      expect(queuePrompt).not.toHaveBeenCalled()
+    })
+
+    it('queues partial execution batches with auth headers and widget callbacks', async () => {
+      const graph = new LGraph()
+      const node = new LGraphNode('PreviewAny', 'PreviewAny')
+      node.id = toNodeId(1)
+      const beforeQueued = vi.fn()
+      node.addWidget('number', 'seed', 1, () => {})
+      node.widgets![0].beforeQueued = beforeQueued
+      graph.add(node)
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/partial.json',
+        modified: 0,
+        size: 0
+      })
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      mockAuthStore.getAuthToken.mockResolvedValue('token-1')
+      mockApiKeyAuthStore.getApiKey.mockReturnValue('api-key-1')
+      mockSettingStore.get.mockImplementation((key: string) => {
+        if (key === 'Comfy.Execution.PreviewMethod') return 'auto'
+        return key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+      })
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {
+          [node.id]: {
+            class_type: 'PreviewAny',
+            inputs: {},
+            _meta: { title: 'PreviewAny' }
+          }
+        },
+        workflow: createWorkflowGraphData()
+      })
+      const dispatchCustomEvent = vi
+        .spyOn(api, 'dispatchCustomEvent')
+        .mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-ok',
+        node_errors: {},
+        error: ''
+      })
+      vi.spyOn(app.ui.queue, 'update').mockResolvedValue(undefined)
+      const targets = ['1'] as NodeExecutionId[]
+
+      await expect(app.queuePrompt(7, 2, targets)).resolves.toBe(true)
+
+      expect(api.queuePrompt).toHaveBeenCalledTimes(2)
+      expect(api.queuePrompt).toHaveBeenCalledWith(7, expect.any(Object), {
+        partialExecutionTargets: targets,
+        previewMethod: 'auto'
+      })
+      expect(api.authToken).toBeUndefined()
+      expect(api.apiKey).toBeUndefined()
+      expect(beforeQueued).toHaveBeenCalledWith({ isPartialExecution: true })
+      expect(dispatchCustomEvent).toHaveBeenCalledWith(
+        'promptQueued',
+        expect.objectContaining({
+          number: 7,
+          batchCount: 2,
+          requestId: expect.any(Number)
+        })
+      )
+      expect(useExecutionStore().queuedJobs['job-ok']?.workflow?.path).toBe(
+        workflow.path
+      )
+    })
+
+    it('shows the error overlay for successful prompt responses with node errors', async () => {
+      const graph = new LGraph()
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/review.json',
+        modified: 0,
+        size: 0
+      })
+      const promptOutput: ComfyApiWorkflow = {
+        '1': {
+          class_type: 'PreviewAny',
+          inputs: {},
+          _meta: { title: 'PreviewAny' }
+        }
+      }
+      const nodeErrors: Record<string, NodeError> = {
+        '1': {
+          class_type: 'PreviewAny',
+          dependent_outputs: ['1'],
+          errors: [
+            {
+              type: 'required_input_missing',
+              message: 'Required input is missing: source',
+              details: '',
+              extra_info: { input_name: 'source' }
+            }
+          ]
+        }
+      }
+      Reflect.set(app, 'rootGraphInternal', graph)
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: promptOutput,
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        node_errors: nodeErrors,
+        error: ''
+      })
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      const errorStore = useExecutionErrorStore()
+      const executionStore = useExecutionStore()
+      expect(errorStore.lastNodeErrors).toEqual(nodeErrors)
+      expect(errorStore.isErrorOverlayOpen).toBe(true)
+      expect(executionStore.queuedJobs['job-1']?.nodes).toEqual({ '1': false })
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+        'workflows/review.json'
+      )
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+
+    it('keeps node errors without opening the overlay when the errors tab is disabled', async () => {
+      const nodeErrors: Record<string, NodeError> = {
+        '1': {
+          class_type: 'PreviewAny',
+          dependent_outputs: ['1'],
+          errors: []
+        }
+      }
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      mockSettingStore.get.mockImplementation((key: string) =>
+        key === 'Comfy.RightSidePanel.ShowErrorsTab' ? false : undefined
+      )
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-errors-hidden',
+        node_errors: nodeErrors,
+        error: ''
+      })
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      expect(useExecutionErrorStore().lastNodeErrors).toEqual(nodeErrors)
+      expect(useExecutionErrorStore().isErrorOverlayOpen).toBe(false)
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+
+    it('routes access restricted failures through the access dialog', async () => {
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/private.json',
+        modified: 0,
+        size: 0
+      })
+      const error = new PromptExecutionError(
+        {
+          error: {
+            type: 'forbidden',
+            message: 'Not allowed',
+            details: ''
+          }
+        },
+        403
+      )
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(mockDialogService.showErrorDialog).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ reportType: 'accessRestrictedError' })
+      )
+      expect(useExecutionErrorStore().lastPromptError).toEqual({
+        type: 'forbidden',
+        message: 'Not allowed',
+        details: ''
+      })
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+
+    it('uses middleware messages for access restricted prompt failures', async () => {
+      const error = new PromptExecutionError(
+        {
+          message: 'Workspace allowlist required',
+          error: ''
+        } as PromptResponse,
+        403
+      )
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(mockDialogService.showErrorDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Workspace allowlist required'
+        }),
+        expect.objectContaining({ reportType: 'accessRestrictedError' })
+      )
+    })
+
+    it('uses string access errors for access restricted prompt failures', async () => {
+      const error = new PromptExecutionError(
+        {
+          error: 'String access denied'
+        } as PromptResponse,
+        403
+      )
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(mockDialogService.showErrorDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'String access denied'
+        }),
+        expect.objectContaining({ reportType: 'accessRestrictedError' })
+      )
+    })
+
+    it('keeps prompt string errors in the execution error store', async () => {
+      const error = new PromptExecutionError({
+        error: 'No outputs found'
+      } as PromptResponse)
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(useExecutionErrorStore().lastPromptError).toEqual({
+        type: 'error',
+        message: 'No outputs found',
+        details: ''
+      })
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+
+    it('rescans the graph for missing-node prompt failures', async () => {
+      const error = new PromptExecutionError({
+        error: {
+          type: 'missing_node_type',
+          message: 'Unknown node',
+          details: ''
+        }
+      })
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(mockRescanAndSurfaceMissingNodes).toHaveBeenCalledWith(graph)
+      expect(useExecutionErrorStore().lastPromptError).toEqual({
+        type: 'missing_node_type',
+        message: 'Unknown node',
+        details: ''
+      })
+    })
+
+    it('opens account precondition prompts without surfacing prompt errors', async () => {
+      const precondition = { code: 'credits_required' }
+      const error = new PromptExecutionError({
+        error: {
+          type: 'credits_required',
+          message: 'Credits required',
+          details: ''
+        }
+      })
+      mockResolveAccountPrecondition.mockReturnValue(precondition)
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await expect(app.queuePrompt(0)).resolves.toBe(true)
+
+      expect(mockAccountPreconditionDialog.open).toHaveBeenCalledWith(
+        precondition
+      )
+      expect(useExecutionErrorStore().lastPromptError).toBeNull()
+      expect(mockDialogService.showErrorDialog).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('preview params', () => {
+    it('returns the configured preview format query param', () => {
+      mockSettingStore.get.mockImplementation((key: string) =>
+        key === 'Comfy.PreviewFormat' ? 'webp' : undefined
+      )
+
+      expect(app.getPreviewFormatParam()).toBe('&preview=webp')
+    })
+
+    it('omits the preview format query param when unset', () => {
+      expect(app.getPreviewFormatParam()).toBe('')
+    })
+
+    it('adds a random cache-busting query param outside cloud', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.25)
+
+      expect(app.getRandParam()).toBe('&rand=0.25')
+    })
+  })
+
+  describe('nodeOutputs', () => {
+    it('notifies extensions after the Vue app is ready', () => {
+      const outputs = {
+        '1': { images: [{ filename: 'output.png' }] }
+      }
+
+      app.nodeOutputs = outputs
+      expect(mockExtensionService.invokeExtensions).not.toHaveBeenCalled()
+
+      app.vueAppReady = true
+      app.nodeOutputs = outputs
+
+      expect(mockExtensionService.invokeExtensions).toHaveBeenCalledWith(
+        'onNodeOutputsUpdated',
+        outputs
+      )
+    })
+  })
+
+  describe('node definitions', () => {
+    function createNodeDef(
+      overrides: Partial<ComfyNodeDef> = {}
+    ): ComfyNodeDef {
+      return {
+        name: 'TestNode',
+        display_name: 'Test Node',
+        category: 'testing/tools',
+        python_module: 'test.nodes',
+        description: 'A test node',
+        input: { required: {}, optional: {} },
+        output: [],
+        output_name: [],
+        output_tooltips: [],
+        output_node: false,
+        deprecated: false,
+        experimental: false,
+        ...overrides
+      }
+    }
+
+    it('loads and translates node definition fallbacks from the API', async () => {
+      const defs = {
+        TestNode: createNodeDef(),
+        EmptyDescription: createNodeDef({
+          name: 'EmptyDescription',
+          display_name: '',
+          category: 'empty',
+          description: ''
+        })
+      }
+      vi.spyOn(api, 'getNodeDefs').mockResolvedValue(defs)
+
+      const result = await app.getNodeDefs()
+
+      expect(result.TestNode).toMatchObject({
+        display_name: 'Test Node',
+        description: 'A test node',
+        category: 'testing/tools'
+      })
+      expect(result.EmptyDescription).toMatchObject({
+        display_name: 'EmptyDescription',
+        description: '',
+        category: 'empty'
+      })
+    })
+
+    it('registers all fetched backend definitions', async () => {
+      const defs = {
+        First: createNodeDef({ name: 'First' }),
+        Second: createNodeDef({ name: 'Second' })
+      }
+      const registerNodeDef = vi
+        .spyOn(app, 'registerNodeDef')
+        .mockResolvedValue(undefined)
+
+      await app.registerNodesFromDefs(defs)
+
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'addCustomNodeDefs',
+        defs
+      )
+      expect(registerNodeDef).toHaveBeenCalledWith('First', defs.First)
+      expect(registerNodeDef).toHaveBeenCalledWith('Second', defs.Second)
+    })
+
+    it('updates Vue node definitions only after the Vue app is ready', async () => {
+      const defs = {
+        TestNode: createNodeDef()
+      }
+      vi.spyOn(app, 'getNodeDefs').mockResolvedValue(defs)
+      vi.spyOn(app, 'registerNodesFromDefs').mockResolvedValue(undefined)
+      const updateVueAppNodeDefs = vi
+        .spyOn(exposePrivateNodeDefs(app), 'updateVueAppNodeDefs')
+        .mockImplementation(() => undefined)
+
+      app.vueAppReady = false
+      await app.registerNodes()
+      expect(updateVueAppNodeDefs).not.toHaveBeenCalled()
+
+      app.vueAppReady = true
+      await app.registerNodes()
+      expect(updateVueAppNodeDefs).toHaveBeenCalledWith(defs)
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'registerCustomNodes'
+      )
+    })
+
+    it('adds frontend-only node definitions while skipping backend and skip-list nodes', () => {
+      class FrontendOnlyNode extends LGraphNode {}
+      class BackendKnownNode extends LGraphNode {}
+      class SkippedNode extends LGraphNode {}
+
+      LiteGraph.registerNodeType('frontend/Only', FrontendOnlyNode)
+      LiteGraph.registerNodeType('backend/Known', BackendKnownNode)
+      LiteGraph.registerNodeType('frontend/Skipped', SkippedNode)
+      Reflect.set(
+        LiteGraph.registered_node_types['frontend/Skipped'],
+        'skip_list',
+        true
+      )
+
+      try {
+        const defs = {
+          'backend/Known': createNodeDef({
+            name: 'backend/Known',
+            display_name: 'Backend Known',
+            category: 'backend'
+          })
+        }
+
+        exposePrivateNodeDefs(app).updateVueAppNodeDefs(defs)
+
+        const store = useNodeDefStore()
+        expect(store.nodeDefsByName['frontend/Only']).toMatchObject({
+          name: 'frontend/Only',
+          category: 'frontend',
+          description: 'Frontend only node for frontend/Only'
+        })
+        expect(store.nodeDefsByName['backend/Known']).toMatchObject({
+          name: 'backend/Known',
+          display_name: 'Backend Known'
+        })
+        expect(store.nodeDefsByName['frontend/Skipped']).toBeUndefined()
+        expect(mockExtensionService.invokeExtensions).toHaveBeenCalledWith(
+          'beforeRegisterVueAppNodeDefs',
+          expect.arrayContaining([
+            expect.objectContaining({ name: 'frontend/Only' }),
+            expect.objectContaining({ name: 'backend/Known' })
+          ])
+        )
+      } finally {
+        LiteGraph.unregisterNodeType('frontend/Only')
+        LiteGraph.unregisterNodeType('backend/Known')
+        LiteGraph.unregisterNodeType('frontend/Skipped')
+      }
+    })
+  })
+
+  describe('clipspace', () => {
+    it('copies widget values and output-store images into clipspace', () => {
+      const image: ResultItem = {
+        filename: 'result.png',
+        subfolder: 'sub',
+        type: 'output'
+      }
+      const invalidate = vi.fn()
+      ComfyApp.clipspace_invalidate_handler = invalidate
+      mockNodeOutputStore.getNodeOutputs.mockReturnValue({ images: [image] })
+
+      ComfyApp.copyToClipspace(
+        createMockNode({
+          imageIndex: 2,
+          widgets: [
+            { type: 'number', name: 'steps', value: 20 },
+            { type: 'text', name: 'prompt', value: 'positive' }
+          ]
+        })
+      )
+
+      expect(ComfyApp.clipspace?.widgets).toEqual([
+        { type: 'number', name: 'steps', value: 20 },
+        { type: 'text', name: 'prompt', value: 'positive' }
+      ])
+      expect(ComfyApp.clipspace?.images).toEqual([image])
+      expect(ComfyApp.clipspace?.selectedIndex).toBe(2)
+      expect(ComfyApp.clipspace_return_node).toBeNull()
+      expect(invalidate).toHaveBeenCalledTimes(1)
+    })
+
+    it('pastes selected images, widget values, and output metadata', () => {
+      const callback = vi.fn()
+      const sourceA = new Image()
+      const sourceB = new Image()
+      const painted = new Image()
+      const combined = new Image()
+      sourceA.src = 'a.png'
+      sourceB.src = 'b.png'
+      painted.src = 'painted.png'
+      combined.src = 'combined.png'
+      const images: ResultItem[] = [
+        { filename: 'a.png', subfolder: 'sub', type: 'input' },
+        { filename: 'b.png', type: 'output' }
+      ]
+      ComfyApp.clipspace = {
+        widgets: [
+          {
+            type: 'text',
+            name: 'prompt',
+            value: { filename: 'mask.png', subfolder: 'masks', type: 'temp' }
+          },
+          { type: 'button', name: 'skip', value: 'new' },
+          { type: 'number', name: 'steps', value: 12 }
+        ],
+        imgs: [sourceA, sourceB, painted, combined],
+        original_imgs: [],
+        images,
+        selectedIndex: 1,
+        img_paste_mode: 'selected',
+        paintedIndex: 2,
+        combinedIndex: 3
+      }
+      const node = createMockNode({
+        id: 8,
+        imgs: [new Image()],
+        widgets: [
+          { type: 'text', name: 'image', value: '' },
+          { type: 'text', name: 'prompt', value: '' },
+          { type: 'button', name: 'skip', value: 'old', callback },
+          { type: 'number', name: 'steps', value: 0, callback }
+        ]
+      })
+      singletonApp.nodeOutputs = { '8': { images: [] } }
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.images).toEqual([images[1]])
+      expect(node.imgs?.map((img) => img.src)).toEqual([
+        expect.stringContaining('/combined.png')
+      ])
+      expect(node.widgets?.[0].value).toBe('b.png [output]')
+      expect(node.widgets?.[1].value).toBe('masks/mask.png [temp]')
+      expect(node.widgets?.[2].value).toBe('old')
+      expect(node.widgets?.[3].value).toBe(12)
+      expect(callback).toHaveBeenCalledWith(12)
+      expect(singletonApp.nodeOutputs['8'].images).toEqual([images[1]])
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true)
+      expect(mockNodeOutputStore.updateNodeImages).toHaveBeenCalledWith(node)
+    })
+
+    it('pastes all images when clipspace is in all-images mode', () => {
+      const sourceA = new Image()
+      const sourceB = new Image()
+      sourceA.src = 'a.png'
+      sourceB.src = 'b.png'
+      const images: ResultItem[] = [
+        { filename: 'a.png', type: 'input' },
+        { filename: 'b.png', type: 'output' }
+      ]
+      ComfyApp.clipspace = {
+        widgets: null,
+        imgs: [sourceA, sourceB],
+        original_imgs: [],
+        images,
+        selectedIndex: 0,
+        img_paste_mode: 'all',
+        paintedIndex: 10,
+        combinedIndex: 10
+      }
+      const node = createMockNode({ id: 9, imgs: [] })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.images).toEqual(images)
+      expect(node.imgs?.map((img) => img.src)).toEqual([
+        expect.stringContaining('/a.png'),
+        expect.stringContaining('/b.png')
+      ])
+      expect(mockNodeOutputStore.updateNodeImages).toHaveBeenCalledWith(node)
+    })
+
+    it('pastes image elements without output metadata', () => {
+      const selected = new Image()
+      const painted = new Image()
+      const combined = new Image()
+      selected.src = 'selected.png'
+      painted.src = 'painted.png'
+      combined.src = 'combined.png'
+      ComfyApp.clipspace = {
+        widgets: null,
+        imgs: [selected, painted, combined],
+        original_imgs: [],
+        images: null,
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({
+        id: 12,
+        imgs: [new Image()],
+        widgets: [{ type: 'text', name: 'prompt', value: 'old' }]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.images).toBeUndefined()
+      expect(node.imgs?.map((img) => img.src)).toEqual([
+        expect.stringContaining('/combined.png')
+      ])
+      expect(node.widgets?.[0].value).toBe('old')
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true)
+      expect(mockNodeOutputStore.updateNodeImages).toHaveBeenCalledWith(node)
+    })
+
+    it('keeps selected and painted images when no combined image exists', () => {
+      const selected = new Image()
+      const painted = new Image()
+      selected.src = 'selected.png'
+      painted.src = 'painted.png'
+      ComfyApp.clipspace = {
+        widgets: null,
+        imgs: [selected, painted],
+        original_imgs: [],
+        images: null,
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 10
+      }
+      const node = createMockNode({
+        id: 14,
+        imgs: [new Image()]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.imgs?.map((img) => img.src)).toEqual([
+        expect.stringContaining('/selected.png'),
+        expect.stringContaining('/painted.png')
+      ])
+    })
+
+    it('pastes widget callbacks when there are no image elements', () => {
+      const callback = vi.fn()
+      ComfyApp.clipspace = {
+        widgets: [
+          {
+            type: 'number',
+            name: 'steps',
+            value: 30
+          }
+        ],
+        imgs: null,
+        original_imgs: null,
+        images: null,
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({
+        widgets: [{ type: 'number', name: 'steps', value: 10, callback }]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.widgets?.[0].value).toBe(30)
+      expect(callback).toHaveBeenCalledWith(30)
+      expect(mockNodeOutputStore.updateNodeImages).toHaveBeenCalledWith(node)
+    })
+
+    it('pastes back into the return node when the editor saves', () => {
+      const node = createMockNode()
+      const paste = vi.spyOn(ComfyApp, 'pasteFromClipspace')
+      ComfyApp.clipspace_return_node = node
+
+      ComfyApp.onClipspaceEditorSave()
+      ComfyApp.onClipspaceEditorClosed()
+
+      expect(paste).toHaveBeenCalledWith(node)
+      expect(ComfyApp.clipspace_return_node).toBeNull()
+    })
+
+    it('copies image elements without widgets or a selected image index', () => {
+      const image = new Image()
+      image.src = 'copied.png'
+
+      ComfyApp.copyToClipspace(
+        createMockNode({
+          imgs: [image]
+        })
+      )
+
+      expect(ComfyApp.clipspace?.widgets).toBeNull()
+      expect(ComfyApp.clipspace?.imgs?.[0].src).toContain('/copied.png')
+      expect(ComfyApp.clipspace?.original_imgs?.[0]).toBe(
+        ComfyApp.clipspace?.imgs?.[0]
+      )
+      expect(ComfyApp.clipspace?.selectedIndex).toBe(0)
+      expect(ComfyApp.clipspace?.paintedIndex).toBe(2)
+      expect(ComfyApp.clipspace?.combinedIndex).toBe(3)
+    })
+
+    it('pastes clipspace metadata even when the target has no image slots', () => {
+      ComfyApp.clipspace = {
+        widgets: null,
+        imgs: null,
+        original_imgs: null,
+        images: null,
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({ id: 11 })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true)
+      expect(mockNodeOutputStore.updateNodeImages).toHaveBeenCalledWith(node)
+    })
+
+    it('pastes image widget objects when the target widget expects images', () => {
+      const image: ResultItem = {
+        filename: 'image.png',
+        type: 'input'
+      }
+      ComfyApp.clipspace = {
+        widgets: [
+          {
+            type: 'image',
+            name: 'mask',
+            value: { filename: 'mask.png', type: 'temp' }
+          }
+        ],
+        imgs: null,
+        original_imgs: null,
+        images: [image],
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({
+        widgets: [
+          { type: 'image', name: 'image', value: null },
+          { type: 'image', name: 'mask', value: null }
+        ]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.widgets?.[0].value).toBe(image)
+      expect(node.widgets?.[1].value).toEqual({
+        filename: 'mask.png',
+        type: 'temp'
+      })
+    })
+
+    it('formats pasted image widget strings without subfolder or type suffixes', () => {
+      ComfyApp.clipspace = {
+        widgets: [
+          {
+            type: 'text',
+            name: 'image',
+            value: { filename: 'plain.png' }
+          }
+        ],
+        imgs: null,
+        original_imgs: null,
+        images: [{ filename: 'target.png' }],
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({
+        widgets: [{ type: 'text', name: 'image', value: '' }]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.widgets?.[0].value).toBe('plain.png')
+    })
+
+    it('does nothing when saving or pasting without clipspace state', () => {
+      const paste = vi.spyOn(ComfyApp, 'pasteFromClipspace')
+      const node = createMockNode()
+
+      ComfyApp.onClipspaceEditorSave()
+      paste.mockRestore()
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(mockCanvas.setDirty).not.toHaveBeenCalled()
+      expect(mockNodeOutputStore.updateNodeImages).not.toHaveBeenCalled()
+    })
+
+    it('copies direct node images without querying output state', () => {
+      const image = new Image()
+      image.src = 'direct.png'
+      const result: ResultItem = { filename: 'direct.png', type: 'output' }
+
+      ComfyApp.copyToClipspace(
+        createMockNode({
+          imgs: [image],
+          images: [result]
+        })
+      )
+
+      expect(ComfyApp.clipspace?.images).toEqual([result])
+      expect(mockNodeOutputStore.getNodeOutputs).not.toHaveBeenCalled()
+    })
+
+    it('skips missing image widgets and callback-free widget matches', () => {
+      ComfyApp.clipspace = {
+        widgets: [{ type: 'number', name: 'steps', value: 8 }],
+        imgs: null,
+        original_imgs: null,
+        images: [{ filename: 'unused.png', type: 'output' }],
+        selectedIndex: 0,
+        img_paste_mode: 'selected',
+        paintedIndex: 1,
+        combinedIndex: 2
+      }
+      const node = createMockNode({
+        widgets: [
+          { type: 'text', name: 'prompt', value: '' },
+          { type: 'number', name: 'steps', value: 0 }
+        ]
+      })
+
+      ComfyApp.pasteFromClipspace(node)
+
+      expect(node.widgets?.[0].value).toBe('')
+      expect(node.widgets?.[1].value).toBe(8)
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe('loadTemplateData', () => {
+    it('loads vintage and reroute clipboard templates and restores clipboard state', () => {
+      localStorage.setItem('litegrapheditor_clipboard', 'previous')
+      const graphMouse: [number, number] = [0, 0]
+      const selected_nodes = {
+        first: { pos: [10, 20], size: [100, 30] },
+        second: { pos: [20, 80], size: [100, 40] }
+      } as PartialDeep<Record<string, LGraphNode>>
+      const pasteFromClipboard = vi.fn()
+      singletonApp.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: graphMouse,
+        selected_nodes,
+        pasteFromClipboard
+      })
+
+      app.loadTemplateData({
+        templates: [{}, { data: '{"nodes":[]}' }, { data: '{"reroutes":[1]}' }]
+      })
+
+      expect(deserialiseAndCreate).toHaveBeenCalledWith(
+        '{"nodes":[]}',
+        singletonApp.canvas
+      )
+      expect(pasteFromClipboard).toHaveBeenCalledTimes(1)
+      expect(graphMouse[1]).toBe(170)
+      expect(localStorage.getItem('litegrapheditor_clipboard')).toBe('previous')
+    })
+
+    it('ignores empty template payloads', () => {
+      app.loadTemplateData({})
+
+      expect(deserialiseAndCreate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refreshComboInNodes', () => {
+    it('shows success toast and removes the pending toast after node defs reload', async () => {
+      app.vueAppReady = true
+      vi.spyOn(app, 'reloadNodeDefs').mockResolvedValue()
+
+      await app.refreshComboInNodes()
+
+      expect(mockToastStore.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'info' })
+      )
+      expect(mockToastStore.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success' })
+      )
+      expect(mockToastStore.remove).toHaveBeenCalledWith(
+        mockToastStore.add.mock.calls[0][0]
+      )
+    })
+
+    it('shows failure toast, removes the pending toast, and rethrows reload failures', async () => {
+      app.vueAppReady = true
+      const error = new Error('object_info failed')
+      vi.spyOn(app, 'reloadNodeDefs').mockRejectedValue(error)
+
+      await expect(app.refreshComboInNodes()).rejects.toThrow(error)
+
+      expect(mockToastStore.add).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+      expect(mockToastStore.remove).toHaveBeenCalledWith(
+        mockToastStore.add.mock.calls[0][0]
+      )
+    })
+  })
+
+  describe('reloadNodeDefs', () => {
+    it('syncs refreshed combo options into promoted combo host state', async () => {
+      const initialOptions = ['missing.safetensors']
+      const refreshedOptions = ['missing.safetensors', 'present.safetensors']
+
+      const rootGraph = createTestRootGraph()
+      const subgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'ckpt_name', type: '*' }]
+      })
+
+      const interiorNode = new LGraphNode(
+        'CheckpointLoaderSimple',
+        'CheckpointLoaderSimple'
+      )
+      const interiorInput = interiorNode.addInput('ckpt_name', '*')
+      interiorInput.widget = { name: 'ckpt_name' }
+      const interiorWidget = interiorNode.addWidget(
+        'combo',
+        'ckpt_name',
+        'missing.safetensors',
+        () => {},
+        { values: initialOptions }
+      )
+      subgraph.add(interiorNode)
+      subgraph.inputNode.slots[0].connect(interiorNode.inputs[0], interiorNode)
+
+      const host = createTestSubgraphNode(subgraph)
+      rootGraph.add(host)
+
+      const hostWidgetId = host.inputs[0].widgetId
+      if (!hostWidgetId) throw new Error('Expected a promoted host widgetId')
+
+      const widgetValueStore = useWidgetValueStore()
+      expect(widgetValueStore.getWidget(hostWidgetId)?.options).toEqual({
+        values: initialOptions
+      })
+
+      const defs: Record<string, ComfyNodeDef> = {
+        CheckpointLoaderSimple: {
+          name: 'CheckpointLoaderSimple',
+          display_name: 'CheckpointLoaderSimple',
+          category: 'loaders',
+          python_module: 'nodes',
+          description: '',
+          input: {
+            required: {
+              ckpt_name: [refreshedOptions, {}]
+            },
+            optional: {}
+          },
+          output: [],
+          output_name: [],
+          output_tooltips: [],
+          output_node: false,
+          deprecated: false,
+          experimental: false
+        }
+      }
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      vi.spyOn(app, 'getNodeDefs').mockResolvedValue(defs)
+      vi.spyOn(app, 'registerNodeDef').mockResolvedValue(undefined)
+
+      await app.reloadNodeDefs()
+
+      expect(interiorWidget.options.values).toEqual(refreshedOptions)
+      expect(widgetValueStore.getWidget(hostWidgetId)?.options.values).toEqual(
+        refreshedOptions
+      )
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'refreshComboInNodes',
+        defs
+      )
+    })
+
+    it('skips promoted host option sync when inputs do not resolve to combo state', async () => {
+      const rootGraph = createTestRootGraph()
+      rootGraph.add(new LGraphNode('PlainNode', 'PlainNode'))
+
+      const unresolvedSubgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'orphan', type: '*' }]
+      })
+      const unresolvedHost = createTestSubgraphNode(unresolvedSubgraph)
+      unresolvedHost.addInput('manual', '*')
+      rootGraph.add(unresolvedHost)
+
+      const textSubgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'text', type: '*' }]
+      })
+      const textNode = new LGraphNode('TextNode', 'TextNode')
+      const textInput = textNode.addInput('text', '*')
+      textInput.widget = { name: 'text' }
+      textNode.addWidget('text', 'text', 'old text', () => {})
+      textSubgraph.add(textNode)
+      textSubgraph.inputNode.slots[0].connect(textNode.inputs[0], textNode)
+      const textHost = createTestSubgraphNode(textSubgraph)
+      rootGraph.add(textHost)
+
+      const comboSubgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'mode', type: '*' }]
+      })
+      const comboNode = new LGraphNode('ComboNode', 'ComboNode')
+      const comboInput = comboNode.addInput('mode', '*')
+      comboInput.widget = { name: 'mode' }
+      comboNode.addWidget('combo', 'mode', 'first', () => {}, {
+        values: ['first', 'second']
+      })
+      comboSubgraph.add(comboNode)
+      comboSubgraph.inputNode.slots[0].connect(comboNode.inputs[0], comboNode)
+      const comboHost = createTestSubgraphNode(comboSubgraph)
+      rootGraph.add(comboHost)
+
+      const widgetValueStore = useWidgetValueStore()
+      const textWidgetId = textHost.inputs[0].widgetId
+      const comboWidgetId = comboHost.inputs[0].widgetId
+      if (!textWidgetId || !comboWidgetId) {
+        throw new Error('Expected promoted host widget ids')
+      }
+      widgetValueStore.deleteWidget(comboWidgetId)
+
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      vi.spyOn(app, 'getNodeDefs').mockResolvedValue({})
+      vi.spyOn(app, 'registerNodeDef').mockResolvedValue(undefined)
+
+      await app.reloadNodeDefs()
+
+      expect(widgetValueStore.getWidget(textWidgetId)?.value).toBe('old text')
+      expect(widgetValueStore.getWidget(comboWidgetId)).toBeUndefined()
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'refreshComboInNodes',
+        {}
+      )
+    })
+
+    it('refreshes optional V2 combo specs and media node outputs', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const mediaNode = new LGraphNode('MediaNode', 'MediaNode')
+      mediaNode.addWidget('combo', 'mode', 'old', () => {}, {
+        values: ['old']
+      })
+      mediaNode.refreshComboInNode = vi.fn()
+      graph.add(mediaNode)
+      const defs: Record<string, ComfyNodeDef> = {
+        MediaNode: {
+          name: 'MediaNode',
+          display_name: 'MediaNode',
+          category: 'media',
+          python_module: 'nodes',
+          description: '',
+          input: {
+            required: {},
+            optional: {
+              mode: ['COMBO', { options: ['new', 'newer'] }]
+            }
+          },
+          output: [],
+          output_name: [],
+          output_tooltips: [],
+          output_node: false,
+          deprecated: false,
+          experimental: false
+        }
+      }
+      Reflect.set(mediaNode, 'previewMediaType', 'image')
+      vi.mocked(isImageNode).mockReturnValue(true)
+      vi.spyOn(app, 'getNodeDefs').mockResolvedValue(defs)
+      vi.spyOn(app, 'registerNodeDef').mockResolvedValue(undefined)
+
+      await app.reloadNodeDefs()
+
+      expect(mediaNode.widgets?.[0].options.values).toEqual(['new', 'newer'])
+      expect(mediaNode.refreshComboInNode).toHaveBeenCalledWith(defs)
+      expect(mockNodeOutputStore.refreshNodeOutputs).toHaveBeenCalledWith(
+        mediaNode
+      )
+    })
+  })
+
+  describe('refreshMissingModels', () => {
+    it('delegates to the app-independent missing model refresh pipeline', async () => {
+      const graph = {
+        nodes: [],
+        serialize: vi.fn(() => createWorkflowGraphData())
+      }
+      const result = {
+        missingModels: [],
+        confirmedCandidates: []
+      }
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(app, 'reloadNodeDefs').mockResolvedValue()
+      mockRefreshMissingModelPipeline.mockResolvedValue(result)
+
+      await expect(app.refreshMissingModels({ silent: false })).resolves.toBe(
+        result
+      )
+
+      expect(mockRefreshMissingModelPipeline).toHaveBeenCalledWith({
+        graph,
+        reloadNodeDefs: expect.any(Function),
+        missingModelStore: useMissingModelStore(),
+        silent: false
+      })
+
+      await mockRefreshMissingModelPipeline.mock.calls[0][0].reloadNodeDefs()
+      expect(app.reloadNodeDefs).toHaveBeenCalled()
+    })
+  })
+
+  describe('loadGraphData', () => {
+    it('falls back to the default graph and runs asset scans with default options', async () => {
+      const rootGraph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      const canvas = attachLoadGraphCanvas(app, { width: 0, height: 0 })
+      vi.spyOn(rootGraph, 'configure').mockImplementation(() => undefined)
+      vi.spyOn(app, 'clean').mockImplementation(() => undefined)
+      const runMissingMediaPipeline = vi
+        .spyOn(
+          Object.getPrototypeOf(app) as {
+            runMissingMediaPipeline(silent?: boolean): Promise<void>
+          },
+          'runMissingMediaPipeline'
+        )
+        .mockResolvedValue(undefined)
+      const requestAnimationFrame = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+          callback(0)
+          return 1
+        })
+
+      await app.loadGraphData()
+
+      expect(canvas.setGraph).toHaveBeenCalledWith(rootGraph)
+      expect(app.clean).toHaveBeenCalled()
+      expect(mockRunMissingModelPipeline).toHaveBeenCalledWith(
+        expect.objectContaining({
+          graph: rootGraph,
+          silent: false
+        })
+      )
+      expect(runMissingMediaPipeline).toHaveBeenCalledWith(false)
+      expect(mockWorkflowService.showPendingWarnings).toHaveBeenCalledWith(
+        undefined,
+        { silent: false }
+      )
+      expect(canvas.resize).toHaveBeenCalled()
+      expect(requestAnimationFrame).toHaveBeenCalled()
+      expect(mockSubgraphNavigationStore.updateHash).toHaveBeenCalled()
+      expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+        null,
+        expect.any(Object),
+        undefined
+      )
+    })
+
+    it('validates, tracks, normalizes, and defers warning-heavy workflow loads', async () => {
+      const rootGraph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      attachLoadGraphCanvas(app)
+      const sampler = new LGraphNode('KSampler', 'KSampler')
+      sampler.addWidget('combo', 'sampler_name', 'sample_euler', () => {}, {
+        values: ['euler']
+      })
+      const controlAfterGenerate = sampler.addWidget(
+        'combo',
+        'control_after_generate',
+        'fixed',
+        () => {},
+        {
+          values: ['fixed', 'randomize']
+        }
+      )
+      Reflect.set(controlAfterGenerate, 'value', true)
+      const ckptName = sampler.addWidget(
+        'combo',
+        'ckpt_name',
+        'model.safetensors',
+        () => {},
+        {
+          values: ['model.safetensors']
+        }
+      )
+      Reflect.set(ckptName, 'value', null)
+      rootGraph.add(sampler)
+      vi.spyOn(rootGraph, 'configure').mockImplementation(() => undefined)
+      mockSettingStore.get.mockImplementation((key: string) => {
+        if (key === 'Comfy.Validation.Workflows') return true
+        if (key === 'Comfy.EnableWorkflowViewRestore') return true
+        return key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+      })
+      mockWorkflowValidation.validateWorkflow.mockImplementation(
+        async (graphData: ComfyWorkflowJSON) => ({ graphData })
+      )
+      mockFindLegacyRerouteNodes.mockReturnValue([{}])
+      mockNoNativeReroutes.mockReturnValue(true)
+      mockNodeReplacementStore.getReplacementFor.mockReturnValue({
+        node_type: 'ReplacementNode'
+      })
+      mockEnsureCorrectLayoutScale.mockReturnValue(true)
+      const runMissingMediaPipeline = vi
+        .spyOn(
+          Object.getPrototypeOf(app) as {
+            runMissingMediaPipeline(silent?: boolean): Promise<void>
+          },
+          'runMissingMediaPipeline'
+        )
+        .mockResolvedValue(undefined)
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+        (callback: FrameRequestCallback) => {
+          callback(0)
+          return 1
+        }
+      )
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/shared.json',
+        modified: 0,
+        size: 0
+      })
+      workflow.shareId = 'workflow-share'
+      const graphData = fromPartial<ComfyWorkflowJSON>({
+        ...createWorkflowGraphData(),
+        nodes: [
+          {
+            id: 1,
+            type: 'Missing<&>',
+            mode: 0,
+            properties: { cnr_id: 'missing-pack' }
+          },
+          {
+            id: 2,
+            type: 'MutedMissing',
+            mode: LGraphEventMode.NEVER
+          }
+        ],
+        extra: {
+          ds: {
+            offset: [25, 50],
+            scale: 0.5
+          }
+        }
+      })
+
+      await app.loadGraphData(graphData, false, true, workflow, {
+        checkForRerouteMigration: true,
+        openSource: 'template',
+        deferWarnings: true,
+        silentAssetErrors: true
+      })
+
+      expect(mockWorkflowValidation.validateWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ version: 0.4 })
+      )
+      expect(mockToastStore.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          group: 'reroute-migration',
+          severity: 'warn'
+        })
+      )
+      expect(mockSubgraphService.loadSubgraphs).toHaveBeenCalledWith(
+        expect.objectContaining({ version: 0.4 })
+      )
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'beforeConfigureGraph',
+        expect.any(Object),
+        expect.any(Array)
+      )
+      expect(sampler.widgets?.map((widget) => widget.value)).toEqual([
+        'euler',
+        'randomize',
+        'model.safetensors'
+      ])
+      expect(mockSyncLayoutStoreNodeBoundsFromGraph).toHaveBeenCalledWith(
+        rootGraph
+      )
+      expect(mockTelemetry.trackWorkflowOpened).toHaveBeenCalledWith(
+        expect.objectContaining({
+          missing_node_count: 1,
+          missing_node_types: ['Missing<&>'],
+          open_source: 'template',
+          share_id: 'workflow-share'
+        })
+      )
+      expect(mockTelemetry.trackWorkflowImported).toHaveBeenCalledWith(
+        expect.objectContaining({
+          missing_node_count: 1,
+          open_source: 'template'
+        })
+      )
+      expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+        workflow,
+        expect.any(Object),
+        'workflow-share'
+      )
+      expect(mockRunMissingModelPipeline).toHaveBeenCalledWith(
+        expect.objectContaining({
+          graph: rootGraph,
+          silent: true
+        })
+      )
+      expect(runMissingMediaPipeline).toHaveBeenCalledWith(true)
+      expect(mockWorkflowService.showPendingWarnings).not.toHaveBeenCalled()
+      expect(mockLitegraphService.fitView).toHaveBeenCalled()
+    })
+
+    it('skips asset scans, aborts verification, and resets missing asset candidates', async () => {
+      const rootGraph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      attachLoadGraphCanvas(app)
+      vi.spyOn(rootGraph, 'configure').mockImplementation(() => undefined)
+      vi.spyOn(app, 'clean').mockImplementation(() => undefined)
+      const modelStore = useMissingModelStore()
+      const mediaStore = useMissingMediaStore()
+      const modelController = new AbortController()
+      const mediaController = new AbortController()
+      const abortModel = vi.spyOn(modelController, 'abort')
+      const abortMedia = vi.spyOn(mediaController, 'abort')
+      vi.spyOn(modelStore, 'createVerificationAbortController').mockReturnValue(
+        modelController
+      )
+      vi.spyOn(mediaStore, 'createVerificationAbortController').mockReturnValue(
+        mediaController
+      )
+      const setMissingModels = vi.spyOn(modelStore, 'setMissingModels')
+      const setMissingMedia = vi.spyOn(mediaStore, 'setMissingMedia')
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+        (callback: FrameRequestCallback) => {
+          callback(0)
+          return 1
+        }
+      )
+
+      await app.loadGraphData(createWorkflowGraphData(), true, false, null, {
+        skipAssetScans: true
+      })
+
+      expect(abortModel).toHaveBeenCalled()
+      expect(abortMedia).toHaveBeenCalled()
+      expect(setMissingModels).toHaveBeenCalledWith([])
+      expect(setMissingMedia).toHaveBeenCalledWith([])
+      expect(mockRunMissingModelPipeline).not.toHaveBeenCalled()
+      expect(mockWorkflowService.showPendingWarnings).toHaveBeenCalled()
+    })
+
+    it('shows a load error and clears loading state when graph configuration fails', async () => {
+      const rootGraph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      attachLoadGraphCanvas(app)
+      const error = new Error('bad graph')
+      vi.spyOn(rootGraph, 'configure').mockImplementation(() => {
+        throw error
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await app.loadGraphData(createWorkflowGraphData())
+
+      expect(mockDialogService.showErrorDialog).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          reportType: 'loadWorkflowError'
+        })
+      )
+      expect(mockRunMissingModelPipeline).not.toHaveBeenCalled()
+    })
+
+    it('resets invalid combo values and restores saved canvas view when loading malformed graph input', async () => {
+      const rootGraph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      attachLoadGraphCanvas(app)
+      const node = new LGraphNode('PrimitiveNode', 'PrimitiveNode')
+      node.addWidget('combo', 'control_after_generate', 'invalid', () => {}, {
+        values: ['fixed', 'randomize']
+      })
+      rootGraph.add(node)
+      vi.spyOn(rootGraph, 'configure').mockImplementation(() => undefined)
+      vi.spyOn(app, 'clean').mockImplementation(() => undefined)
+      mockSettingStore.get.mockImplementation((key: string) => {
+        if (key === 'Comfy.EnableWorkflowViewRestore') return true
+        return key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+      })
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+        (callback: FrameRequestCallback) => {
+          callback(0)
+          return 1
+        }
+      )
+
+      await app.loadGraphData([], true, true)
+
+      expect(node.widgets?.[0].value).toBe('fixed')
+      expect(mockLitegraphService.fitView).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleFileList', () => {
+    it('should create image nodes for each file in the list', async () => {
+      const mockNode1 = createMockNode({ id: 1 })
+      const mockNode2 = createMockNode({ id: 2 })
+      const mockBatchNode = createMockNode({ id: 3, type: 'BatchImagesNode' })
+
+      vi.mocked(pasteImageNodes).mockResolvedValue([mockNode1, mockNode2])
+      vi.mocked(createNode).mockResolvedValue(mockBatchNode)
+
+      const file1 = createTestFile('test1.png', 'image/png')
+      const file2 = createTestFile('test2.jpg', 'image/jpeg')
+      const files = [file1, file2]
+
+      await app.handleFileList(files)
+
+      expect(pasteImageNodes).toHaveBeenCalledWith(mockCanvas, files)
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'BatchImagesNode')
+      expect(mockCanvas.selectItems).toHaveBeenCalledWith([
+        mockNode1,
+        mockNode2,
+        mockBatchNode
+      ])
+      expect(mockNode1.connect).toHaveBeenCalledWith(0, mockBatchNode, 0)
+      expect(mockNode2.connect).toHaveBeenCalledWith(0, mockBatchNode, 1)
+    })
+
+    it('should select single image node without batch node', async () => {
+      const mockNode1 = createMockNode({ id: 1 })
+      vi.mocked(pasteImageNodes).mockResolvedValue([mockNode1])
+
+      const file = createTestFile('test.png', 'image/png')
+
+      await app.handleFileList([file])
+
+      expect(createNode).not.toHaveBeenCalled()
+      expect(mockCanvas.selectItems).toHaveBeenCalledWith([mockNode1])
+      expect(mockNode1.connect).not.toHaveBeenCalled()
+    })
+
+    it('should handle empty file list', async () => {
+      await app.handleFileList([])
+
+      expect(pasteImageNodes).not.toHaveBeenCalled()
+      expect(createNode).not.toHaveBeenCalled()
+    })
+
+    it('should not process unsupported file types', async () => {
+      const invalidFile = createTestFile('test.pdf', 'application/pdf')
+
+      await app.handleFileList([invalidFile])
+
+      expect(pasteImageNodes).not.toHaveBeenCalled()
+      expect(createNode).not.toHaveBeenCalled()
+    })
+
+    it('should return when image paste creates no nodes', async () => {
+      vi.mocked(pasteImageNodes).mockResolvedValue([])
+
+      await app.handleFileList([createTestFile('empty.png', 'image/png')])
+
+      expect(createNode).not.toHaveBeenCalled()
+      expect(mockCanvas.selectItems).not.toHaveBeenCalled()
+    })
+
+    it('should return when batch node creation fails', async () => {
+      const first = createMockNode({ id: 1 })
+      const second = createMockNode({ id: 2 })
+      vi.mocked(pasteImageNodes).mockResolvedValue([first, second])
+      vi.mocked(createNode).mockResolvedValue(null)
+
+      await app.handleFileList([
+        createTestFile('first.png', 'image/png'),
+        createTestFile('second.png', 'image/png')
+      ])
+
+      expect(mockCanvas.selectItems).not.toHaveBeenCalled()
+      expect(first.connect).not.toHaveBeenCalled()
+      expect(second.connect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleAudioFileList', () => {
+    it('should create audio nodes and select them', async () => {
+      const mockNode1 = createMockNode({ id: 1, type: 'LoadAudio' })
+      const mockNode2 = createMockNode({ id: 2, type: 'LoadAudio' })
+      vi.mocked(pasteAudioNodes).mockResolvedValue([mockNode1, mockNode2])
+
+      const file1 = createTestFile('test1.mp3', 'audio/mpeg')
+      const file2 = createTestFile('test2.wav', 'audio/wav')
+
+      await app.handleAudioFileList([file1, file2])
+
+      expect(pasteAudioNodes).toHaveBeenCalledWith(mockCanvas, [file1, file2])
+      expect(mockCanvas.selectItems).toHaveBeenCalledWith([
+        mockNode1,
+        mockNode2
+      ])
+    })
+
+    it('should not select when no nodes created', async () => {
+      vi.mocked(pasteAudioNodes).mockResolvedValue([])
+
+      await app.handleAudioFileList([createTestFile('test.mp3', 'audio/mpeg')])
+
+      expect(mockCanvas.selectItems).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleVideoFileList', () => {
+    it('should create video nodes and select them', async () => {
+      const mockNode1 = createMockNode({ id: 1, type: 'LoadVideo' })
+      const mockNode2 = createMockNode({ id: 2, type: 'LoadVideo' })
+      vi.mocked(pasteVideoNodes).mockResolvedValue([mockNode1, mockNode2])
+
+      const file1 = createTestFile('test1.mp4', 'video/mp4')
+      const file2 = createTestFile('test2.webm', 'video/webm')
+
+      await app.handleVideoFileList([file1, file2])
+
+      expect(pasteVideoNodes).toHaveBeenCalledWith(mockCanvas, [file1, file2])
+      expect(mockCanvas.selectItems).toHaveBeenCalledWith([
+        mockNode1,
+        mockNode2
+      ])
+    })
+
+    it('should not select when no nodes created', async () => {
+      vi.mocked(pasteVideoNodes).mockResolvedValue([])
+
+      await app.handleVideoFileList([createTestFile('test.mp4', 'video/mp4')])
+
+      expect(mockCanvas.selectItems).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('positionBatchNodes', () => {
+    it('should position batch node to the right of first node', () => {
+      const mockNode1 = createMockNode({
+        pos: [100, 200],
+        getBounding: vi.fn(() => new Float64Array([100, 200, 300, 400]))
+      })
+      const mockBatchNode = createMockNode({ pos: [0, 0] })
+
+      app.positionBatchNodes([mockNode1], mockBatchNode)
+
+      expect(mockBatchNode.pos).toEqual([500, 230])
+    })
+
+    it('should stack multiple image nodes vertically', () => {
+      const mockNode1 = createMockNode({
+        pos: [100, 200],
+        type: 'LoadImage',
+        getBounding: vi.fn(() => new Float64Array([100, 200, 300, 400]))
+      })
+      const mockNode2 = createMockNode({ pos: [0, 0], type: 'LoadImage' })
+      const mockNode3 = createMockNode({ pos: [0, 0], type: 'LoadImage' })
+      const mockBatchNode = createMockNode({ pos: [0, 0] })
+
+      app.positionBatchNodes([mockNode1, mockNode2, mockNode3], mockBatchNode)
+
+      expect(mockNode1.pos).toEqual([100, 200])
+      expect(mockNode2.pos).toEqual([100, 594])
+      expect(mockNode3.pos).toEqual([100, 963])
+    })
+
+    it('should call graph change once for all nodes', () => {
+      const mockNode1 = createMockNode({
+        getBounding: vi.fn(() => new Float64Array([100, 200, 300, 400]))
+      })
+      const mockBatchNode = createMockNode()
+
+      app.positionBatchNodes([mockNode1], mockBatchNode)
+
+      expect(mockCanvas.graph?.change).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not add image spacing for non-image nodes', () => {
+      const first = createMockNode({
+        type: 'LoadAudio',
+        getBounding: vi.fn(() => new Float64Array([10, 20, 30, 40]))
+      })
+      const second = createMockNode({ type: 'LoadAudio', pos: [0, 0] })
+      const batchNode = createMockNode({ pos: [0, 0] })
+
+      app.positionBatchNodes([first, second], batchNode)
+
+      expect(batchNode.pos).toEqual([140, 50])
+      expect(second.pos).toEqual([10, 70])
+    })
+  })
+
+  describe('positionNodes', () => {
+    it('should leave single nodes in place', () => {
+      const node = createMockNode({ pos: [5, 10] })
+
+      app.positionNodes([node])
+
+      expect(node.pos).toEqual([5, 10])
+      expect(mockCanvas.graph?.change).not.toHaveBeenCalled()
+    })
+
+    it('should stack later nodes below the first node', () => {
+      const first = createMockNode({
+        getBounding: vi.fn(() => new Float64Array([10, 20, 30, 40]))
+      })
+      const second = createMockNode({ pos: [0, 0] })
+      const third = createMockNode({ pos: [0, 0] })
+
+      app.positionNodes([first, second, third])
+
+      expect(second.pos).toEqual([10, 220])
+      expect(third.pos).toEqual([10, 395])
+      expect(mockCanvas.graph?.change).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('isApiJson', () => {
+    it('accepts only non-empty API prompt records', () => {
+      expect(app.isApiJson(null)).toBe(false)
+      expect(app.isApiJson([])).toBe(false)
+      expect(app.isApiJson({})).toBe(false)
+      expect(app.isApiJson({ 1: null })).toBe(false)
+      expect(app.isApiJson({ 1: { class_type: 123, inputs: {} } })).toBe(false)
+      expect(
+        app.isApiJson({ 1: { class_type: 'PreviewAny', inputs: [] } })
+      ).toBe(false)
+      expect(
+        app.isApiJson({ 1: { class_type: 'PreviewAny', inputs: {} } })
+      ).toBe(true)
+    })
+  })
+
+  describe('loadApiJson', () => {
+    it('builds graph nodes, assigns metadata titles, and wires inputs', () => {
+      const widgetCallback = vi.fn()
+      class ApiSourceNode extends LGraphNode {
+        constructor(title?: string) {
+          super('ApiSource', title)
+          this.addOutput('out', 'number')
+        }
+      }
+      class ApiTargetNode extends LGraphNode {
+        constructor(title?: string) {
+          super('ApiTarget', title)
+          this.addInput('incoming', 'number')
+          this.addWidget('number', 'strength', 0, widgetCallback)
+        }
+      }
+      LiteGraph.registerNodeType('ApiSource', ApiSourceNode)
+      LiteGraph.registerNodeType('ApiTarget', ApiTargetNode)
+      const graph = new LGraph()
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+
+      try {
+        singletonApp.loadApiJson(
+          {
+            source: {
+              class_type: 'ApiSource',
+              inputs: {},
+              _meta: { title: 'Source title' }
+            },
+            2: {
+              class_type: 'ApiTarget',
+              inputs: {
+                incoming: ['source', 0],
+                strength: 0.75
+              },
+              _meta: { title: 'Target title' }
+            }
+          },
+          'api-prompt'
+        )
+
+        const source = graph.nodes.find((node) => node.type === 'ApiSource')
+        const target = graph.nodes.find((node) => node.type === 'ApiTarget')
+        expect(source?.title).toBe('Source title')
+        expect(target?.title).toBe('Target title')
+        expect(target?.widgets?.[0].value).toBe(0.75)
+        expect(widgetCallback).toHaveBeenCalledWith(0.75)
+        expect(target?.inputs?.[0].link).not.toBeNull()
+        expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+          'api-prompt',
+          expect.any(Object)
+        )
+      } finally {
+        LiteGraph.unregisterNodeType('ApiSource')
+        LiteGraph.unregisterNodeType('ApiTarget')
+      }
+    })
+
+    it('surfaces missing node types and skips nodes that cannot be created', () => {
+      const graph = new LGraph()
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const showMissingNodesError = vi
+        .spyOn(
+          Object.getPrototypeOf(singletonApp) as {
+            showMissingNodesError(types: string[]): void
+          },
+          'showMissingNodesError'
+        )
+        .mockImplementation(() => undefined)
+
+      singletonApp.loadApiJson(
+        {
+          1: {
+            class_type: 'MissingApiNode',
+            inputs: {},
+            _meta: { title: 'MissingApiNode' }
+          }
+        },
+        'missing'
+      )
+
+      expect(showMissingNodesError).toHaveBeenCalledWith(['MissingApiNode'])
+      expect(graph.nodes).toHaveLength(0)
+    })
+
+    it('skips missing link sources and converts widgets into inputs when needed', () => {
+      const widgetCallback = vi.fn()
+      class WidgetInputNode extends LGraphNode {
+        constructor(title?: string) {
+          super('WidgetInputNode', title)
+          this.addWidget('number', 'strength', 0, widgetCallback)
+        }
+
+        convertWidgetToInput = () => {
+          this.addInput('strength', 'number')
+          return true
+        }
+      }
+      class SourceNode extends LGraphNode {
+        constructor(title?: string) {
+          super('SourceNode', title)
+          this.addOutput('value', 'number')
+        }
+      }
+      class NoInputNode extends LGraphNode {
+        constructor(title?: string) {
+          super('NoInputNode', title)
+        }
+      }
+      LiteGraph.registerNodeType('WidgetInputNode', WidgetInputNode)
+      LiteGraph.registerNodeType('SourceNode', SourceNode)
+      LiteGraph.registerNodeType('NoInputNode', NoInputNode)
+      const graph = new LGraph()
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+
+      try {
+        singletonApp.loadApiJson(
+          {
+            1: {
+              class_type: 'WidgetInputNode',
+              inputs: {
+                strength: [3, 0],
+                missing: [404, 0]
+              },
+              _meta: { title: 'WidgetInputNode' }
+            },
+            2: {
+              class_type: 'NoInputNode',
+              inputs: {},
+              _meta: { title: 'NoInputNode' }
+            },
+            3: {
+              class_type: 'SourceNode',
+              inputs: {},
+              _meta: { title: 'SourceNode' }
+            }
+          },
+          'converted'
+        )
+
+        const converted = graph.nodes.find(
+          (node) => node.type === 'WidgetInputNode'
+        )
+        expect(converted?.inputs?.[0].name).toBe('strength')
+        expect(converted?.inputs?.[0].link).not.toBeNull()
+        expect(widgetCallback).not.toHaveBeenCalled()
+      } finally {
+        LiteGraph.unregisterNodeType('WidgetInputNode')
+        LiteGraph.unregisterNodeType('SourceNode')
+        LiteGraph.unregisterNodeType('NoInputNode')
+      }
+    })
+
+    it('continues when widget-to-input conversion throws', () => {
+      class ThrowingWidgetNode extends LGraphNode {
+        constructor(title?: string) {
+          super('ThrowingWidgetNode', title)
+          this.addWidget('number', 'strength', 0, () => {})
+        }
+
+        convertWidgetToInput = () => {
+          throw new Error('cannot convert')
+        }
+      }
+      class SourceNode extends LGraphNode {
+        constructor(title?: string) {
+          super('ThrowingSourceNode', title)
+          this.addOutput('value', 'number')
+        }
+      }
+      LiteGraph.registerNodeType('ThrowingWidgetNode', ThrowingWidgetNode)
+      LiteGraph.registerNodeType('ThrowingSourceNode', SourceNode)
+      const graph = new LGraph()
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+
+      try {
+        singletonApp.loadApiJson(
+          {
+            1: {
+              class_type: 'ThrowingSourceNode',
+              inputs: {},
+              _meta: { title: 'ThrowingSourceNode' }
+            },
+            2: {
+              class_type: 'ThrowingWidgetNode',
+              inputs: {
+                strength: [1, 0]
+              },
+              _meta: { title: 'ThrowingWidgetNode' }
+            }
+          },
+          'conversion-failed'
+        )
+
+        const target = graph.nodes.find(
+          (node) => node.type === 'ThrowingWidgetNode'
+        )
+        expect(target?.inputs).toHaveLength(0)
+      } finally {
+        LiteGraph.unregisterNodeType('ThrowingWidgetNode')
+        LiteGraph.unregisterNodeType('ThrowingSourceNode')
+      }
+    })
+  })
+
+  describe('handleFile', () => {
+    it('should handle image files by creating LoadImage node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({})
+
+      const mockNode = createMockNode()
+      vi.mocked(createNode).mockResolvedValue(mockNode)
+
+      const imageFile = createTestFile('test.png', 'image/png')
+
+      await app.handleFile(imageFile)
+
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'LoadImage')
+      expect(pasteImageNode).toHaveBeenCalledWith(
+        mockCanvas,
+        expect.any(DataTransferItemList),
+        mockNode
+      )
+    })
+
+    it('should handle audio files by creating LoadAudio node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({})
+
+      const mockNode = createMockNode({ type: 'LoadAudio' })
+      vi.mocked(createNode).mockResolvedValue(mockNode)
+
+      const audioFile = createTestFile('test.mp3', 'audio/mpeg')
+
+      await app.handleFile(audioFile)
+
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'LoadAudio')
+      expect(pasteAudioNode).toHaveBeenCalledWith(
+        mockCanvas,
+        expect.any(DataTransferItemList),
+        mockNode
+      )
+    })
+
+    it('should handle video files by creating LoadVideo node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({})
+
+      const mockNode = createMockNode({ type: 'LoadVideo' })
+      vi.mocked(createNode).mockResolvedValue(mockNode)
+
+      const videoFile = createTestFile('test.mp4', 'video/mp4')
+
+      await app.handleFile(videoFile)
+
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'LoadVideo')
+      expect(pasteVideoNode).toHaveBeenCalledWith(
+        mockCanvas,
+        expect.any(DataTransferItemList),
+        mockNode
+      )
+    })
+
+    it('should handle image files with non-workflow metadata by creating LoadImage node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        Software: 'gnome-screenshot'
+      })
+
+      const mockNode = createMockNode()
+      vi.mocked(createNode).mockResolvedValue(mockNode)
+
+      const imageFile = createTestFile('screenshot.png', 'image/png')
+
+      await app.handleFile(imageFile)
+
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'LoadImage')
+      expect(pasteImageNode).toHaveBeenCalledWith(
+        mockCanvas,
+        expect.any(DataTransferItemList),
+        mockNode
+      )
+    })
+
+    it('loads workflow metadata and preserves the open source options', async () => {
+      const workflow = createWorkflowGraphData()
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        workflow: JSON.stringify(workflow)
+      })
+      const loadGraphData = vi
+        .spyOn(app, 'loadGraphData')
+        .mockResolvedValue(undefined)
+
+      await app.handleFile(
+        createTestFile('review.workflow.png', 'image/png'),
+        'file_drop',
+        {
+          deferWarnings: true
+        }
+      )
+
+      expect(loadGraphData).toHaveBeenCalledWith(
+        workflow,
+        true,
+        true,
+        'review.workflow',
+        { openSource: 'file_drop', deferWarnings: true }
+      )
+    })
+
+    it('falls back to parameters when workflow metadata is invalid', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(graph, 'serialize').mockReturnValue(createSerialisedGraph())
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        workflow: '[]',
+        parameters: 'Steps: 12'
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await app.handleFile(createTestFile('invalid-workflow.png', 'image/png'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalled()
+      expect(importA1111).toHaveBeenCalledWith(graph, 'Steps: 12')
+      expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+        'invalid-workflow',
+        expect.any(Object)
+      )
+    })
+
+    it('loads template metadata and object workflow payloads', async () => {
+      const workflow = createWorkflowGraphData()
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        templates: [{ name: 'Starter', data: '{"nodes":[]}' }],
+        workflow
+      })
+      const loadTemplateData = vi.spyOn(app, 'loadTemplateData')
+      const loadGraphData = vi
+        .spyOn(app, 'loadGraphData')
+        .mockResolvedValue(undefined)
+
+      await app.handleFile(createTestFile('template.png', 'image/png'))
+
+      expect(loadTemplateData).toHaveBeenCalledWith({
+        templates: [{ name: 'Starter', data: '{"nodes":[]}' }]
+      })
+      expect(loadGraphData).toHaveBeenCalledWith(
+        workflow,
+        true,
+        true,
+        'template',
+        { openSource: undefined, deferWarnings: undefined }
+      )
+    })
+
+    it('loads API prompt metadata before falling back to parameters', async () => {
+      const prompt: ComfyApiWorkflow = {
+        '1': {
+          class_type: 'PreviewAny',
+          inputs: {},
+          _meta: { title: 'Preview' }
+        }
+      }
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        prompt: JSON.stringify(prompt),
+        parameters: 'ignored fallback'
+      })
+      const loadApiJson = vi
+        .spyOn(app, 'loadApiJson')
+        .mockImplementation(() => undefined)
+
+      await app.handleFile(createTestFile('prompt.png', 'image/png'))
+
+      expect(loadApiJson).toHaveBeenCalledWith(prompt, 'prompt')
+      expect(importA1111).not.toHaveBeenCalled()
+    })
+
+    it('loads object API prompt metadata', async () => {
+      const prompt: ComfyApiWorkflow = {
+        '1': {
+          class_type: 'PreviewAny',
+          inputs: {},
+          _meta: { title: 'PreviewAny' }
+        }
+      }
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ prompt })
+      const loadApiJson = vi
+        .spyOn(app, 'loadApiJson')
+        .mockImplementation(() => undefined)
+
+      await app.handleFile(createTestFile('prompt-object.png', 'image/png'))
+
+      expect(loadApiJson).toHaveBeenCalledWith(prompt, 'prompt-object')
+    })
+
+    it('falls back to parameters when prompt metadata cannot be parsed', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(graph, 'serialize').mockReturnValue(createSerialisedGraph())
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        prompt: '{',
+        parameters: 'Steps: 6'
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      await app.handleFile(createTestFile('bad-prompt.png', 'image/png'))
+
+      expect(importA1111).toHaveBeenCalledWith(graph, 'Steps: 6')
+      expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+        'bad-prompt',
+        expect.any(Object)
+      )
+    })
+
+    it('imports A1111 parameters as the final metadata fallback', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        parameters: 'Steps: 20'
+      })
+
+      await app.handleFile(createTestFile('parameters.png', 'image/png'))
+
+      expect(importA1111).toHaveBeenCalledWith(graph, 'Steps: 20')
+      expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalledWith(
+        'parameters',
+        expect.any(Object)
+      )
+    })
+
+    it('shows a load error for unsupported files without metadata', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({})
+
+      await app.handleFile(createTestFile('notes.pdf', 'application/pdf'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalled()
+      expect(createNode).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drop handler', () => {
+    it('syncs graph_mouse and routes mixed file drops by media type', async () => {
+      const graphMouse: [number, number] = [-999, -999]
+      const adjustMouseEvent = vi.fn((e: DragEvent) => {
+        ;(e as DragEvent & { canvasX: number; canvasY: number }).canvasX = 123
+        ;(e as DragEvent & { canvasX: number; canvasY: number }).canvasY = 456
+      })
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: graphMouse,
+        adjustMouseEvent
+      })
+      const image = createTestFile('image.png', 'image/png')
+      const audio = createTestFile('audio.wav', 'audio/wav')
+      const video = createTestFile('video.mp4', 'video/mp4')
+      const workflow = createTestFile('workflow.json', 'application/json')
+      mockExtractFilesFromDragEvent.mockResolvedValue([
+        image,
+        audio,
+        video,
+        workflow
+      ])
+      vi.spyOn(app, 'handleFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleAudioFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleVideoFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleFile').mockResolvedValue(undefined)
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
+      expect(graphMouse).toEqual([123, 456])
+      expect(app.handleFileList).toHaveBeenCalledWith([image])
+      expect(app.handleAudioFileList).toHaveBeenCalledWith([audio])
+      expect(app.handleVideoFileList).toHaveBeenCalledWith([video])
+      expect(app.handleFile).toHaveBeenCalledWith(workflow, 'file_drop', {
+        deferWarnings: true
+      })
+      expect(mockWorkspaceStore.spinner).toBe(false)
+      expect(mockWorkflowService.showPendingWarnings).toHaveBeenCalled()
+    })
+
+    it('routes multi-image drops without requiring every media type', async () => {
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: [0, 0],
+        adjustMouseEvent: vi.fn((event: DragEvent) => {
+          ;(event as DragEvent & { canvasX: number; canvasY: number }).canvasX =
+            3
+          ;(event as DragEvent & { canvasY: number }).canvasY = 4
+        })
+      })
+      const first = createTestFile('first.png', 'image/png')
+      const second = createTestFile('second.png', 'image/png')
+      const workflow = createTestFile('workflow.json', 'application/json')
+      mockExtractFilesFromDragEvent.mockResolvedValue([first, second, workflow])
+      vi.spyOn(app, 'handleFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleAudioFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleVideoFileList').mockResolvedValue(undefined)
+      vi.spyOn(app, 'handleFile').mockResolvedValue(undefined)
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(app.handleFileList).toHaveBeenCalledWith([first, second])
+      expect(app.handleAudioFileList).not.toHaveBeenCalled()
+      expect(app.handleVideoFileList).not.toHaveBeenCalled()
+      expect(app.handleFile).toHaveBeenCalledWith(workflow, 'file_drop', {
+        deferWarnings: true
+      })
+    })
+
+    it('routes a single dropped file through handleFile', async () => {
+      const workflow = createTestFile('workflow.json', 'application/json')
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: [0, 0],
+        adjustMouseEvent: vi.fn((event: DragEvent) => {
+          ;(event as DragEvent & { canvasX: number; canvasY: number }).canvasX =
+            1
+          ;(event as DragEvent & { canvasY: number }).canvasY = 2
+        })
+      })
+      mockExtractFilesFromDragEvent.mockResolvedValue([workflow])
+      const handleFile = vi.spyOn(app, 'handleFile').mockResolvedValue()
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(handleFile).toHaveBeenCalledWith(workflow, 'file_drop', {
+        deferWarnings: true
+      })
+      expect(mockWorkspaceStore.spinner).toBe(false)
+    })
+
+    it('does not start loading when the drop contains no files', async () => {
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: [0, 0],
+        adjustMouseEvent: vi.fn()
+      })
+      mockExtractFilesFromDragEvent.mockResolvedValue([])
+      const handleFile = vi.spyOn(app, 'handleFile').mockResolvedValue()
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(handleFile).not.toHaveBeenCalled()
+      expect(mockWorkspaceStore.spinner).toBe(false)
+    })
+
+    it('surfaces drop routing failures', async () => {
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: [0, 0],
+        adjustMouseEvent: vi.fn()
+      })
+      mockExtractFilesFromDragEvent.mockRejectedValue(new Error('drop failed'))
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(mockToastStore.addAlert).toHaveBeenLastCalledWith(
+        expect.stringContaining('drop failed')
+      )
+    })
+
+    it('ignores drops that were already handled by nested targets', async () => {
+      const handleFile = vi.spyOn(app, 'handleFile').mockResolvedValue()
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+
+      const event = new DragEvent('drop', { cancelable: true })
+      event.preventDefault()
+      document.dispatchEvent(event)
+      await flushDropHandler()
+
+      expect(handleFile).not.toHaveBeenCalled()
+    })
+
+    it('lets the hovered node consume a file drop before app routing', async () => {
+      const dragOverNode = {
+        id: toNodeId(1),
+        onDragDrop: vi.fn().mockResolvedValue(true)
+      }
+      app.dragOverNode = dragOverNode
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph_mouse: [0, 0],
+        adjustMouseEvent: vi.fn((event: DragEvent) => {
+          ;(event as DragEvent & { canvasX: number; canvasY: number }).canvasX =
+            12
+          ;(event as DragEvent & { canvasY: number }).canvasY = 34
+        })
+      })
+      const handleFile = vi.spyOn(app, 'handleFile').mockResolvedValue()
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      document.dispatchEvent(new DragEvent('drop'))
+      await flushDropHandler()
+
+      expect(dragOverNode.onDragDrop).toHaveBeenCalled()
+      expect(app.dragOverNode).toBeNull()
+      expect(handleFile).not.toHaveBeenCalled()
+    })
+
+    it('clears hover state on drag leave and updates it on drag over', async () => {
+      const canvasEl = document.createElement('canvas')
+      app.canvasElRef.value = canvasEl
+      const hoveredNode = {
+        id: 3,
+        onDragOver: vi.fn(() => true)
+      }
+      const graph = {
+        getNodeOnPos: vi.fn(() => hoveredNode)
+      }
+      const setDirty = vi.fn()
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph,
+        setDirty,
+        adjustMouseEvent: vi.fn((event: DragEvent) => {
+          ;(event as DragEvent & { canvasX: number; canvasY: number }).canvasX =
+            7
+          ;(event as DragEvent & { canvasY: number }).canvasY = 8
+        })
+      })
+      const requestAnimationFrame = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+          callback(0)
+          return 1
+        })
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      canvasEl.dispatchEvent(new DragEvent('dragover'))
+      canvasEl.dispatchEvent(new DragEvent('dragleave'))
+
+      expect(graph.getNodeOnPos).toHaveBeenCalledWith(7, 8)
+      expect(app.dragOverNode).toBeNull()
+      expect(setDirty).toHaveBeenCalledWith(false, true)
+      expect(requestAnimationFrame).toHaveBeenCalled()
+    })
+
+    it('clears hover state when the node rejects drag over', () => {
+      const canvasEl = document.createElement('canvas')
+      app.canvasElRef.value = canvasEl
+      app.dragOverNode = {
+        id: toNodeId(4)
+      }
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        graph: {
+          getNodeOnPos: vi.fn(() => ({
+            id: 5,
+            onDragOver: vi.fn(() => false)
+          }))
+        },
+        adjustMouseEvent: vi.fn((event: DragEvent) => {
+          ;(event as DragEvent & { canvasX: number; canvasY: number }).canvasX =
+            1
+          ;(event as DragEvent & { canvasY: number }).canvasY = 2
+        })
+      })
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      canvasEl.dispatchEvent(new DragEvent('dragover'))
+
+      expect(app.dragOverNode).toBeNull()
+    })
+
+    it('ignores drag leave when no node is hovered', () => {
+      const canvasEl = document.createElement('canvas')
+      app.canvasElRef.value = canvasEl
+      app.dragOverNode = null
+
+      ;(
+        Object.getPrototypeOf(app) as { addDropHandler(): void }
+      ).addDropHandler.call(app)
+      canvasEl.dispatchEvent(new DragEvent('dragleave'))
+
+      expect(mockCanvas.setDirty).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('process key handler', () => {
+    it('ignores events without a graph or from inputs and falls back for unbound keys', () => {
+      const originalProcessKey = LGraphCanvas.prototype.processKey
+      const fallback = vi.fn()
+      LGraphCanvas.prototype.processKey = fallback
+      ;(
+        Object.getPrototypeOf(app) as { addProcessKeyHandler(): void }
+      ).addProcessKeyHandler.call(app)
+      const processKey = LGraphCanvas.prototype.processKey
+      const graph = { change: vi.fn() }
+      const canvas = fromPartial<LGraphCanvas>({ graph })
+      const inputEvent = new KeyboardEvent('keydown', { key: 'a' })
+      Object.defineProperty(inputEvent, 'target', {
+        configurable: true,
+        value: document.createElement('input')
+      })
+      const unboundEvent = new KeyboardEvent('keyup', { key: 'a' })
+
+      try {
+        processKey.call(
+          fromPartial<LGraphCanvas>({ graph: null }),
+          unboundEvent
+        )
+        processKey.call(canvas, inputEvent)
+        processKey.call(canvas, unboundEvent)
+
+        expect(fallback).toHaveBeenCalledTimes(1)
+        expect(graph.change).not.toHaveBeenCalled()
+      } finally {
+        LGraphCanvas.prototype.processKey = originalProcessKey
+      }
+    })
+
+    it('executes graph-canvas keybindings and suppresses litegraph fallback', () => {
+      const originalProcessKey = LGraphCanvas.prototype.processKey
+      const fallback = vi.fn()
+      LGraphCanvas.prototype.processKey = fallback
+      const execute = vi
+        .spyOn(useCommandStore(), 'execute')
+        .mockResolvedValue(undefined)
+      vi.spyOn(useKeybindingStore(), 'getKeybinding').mockReturnValue({
+        commandId: 'test.command',
+        targetElementId: 'graph-canvas-container'
+      } as ReturnType<ReturnType<typeof useKeybindingStore>['getKeybinding']>)
+      ;(
+        Object.getPrototypeOf(app) as { addProcessKeyHandler(): void }
+      ).addProcessKeyHandler.call(app)
+      const event = new KeyboardEvent('keydown', { key: 'a' })
+      const preventDefault = vi.spyOn(event, 'preventDefault')
+      const stopImmediatePropagation = vi.spyOn(
+        event,
+        'stopImmediatePropagation'
+      )
+      const graph = { change: vi.fn() }
+
+      try {
+        LGraphCanvas.prototype.processKey.call(
+          fromPartial<LGraphCanvas>({ graph }),
+          event
+        )
+
+        expect(execute).toHaveBeenCalledWith('test.command')
+        expect(graph.change).toHaveBeenCalled()
+        expect(preventDefault).toHaveBeenCalled()
+        expect(stopImmediatePropagation).toHaveBeenCalled()
+        expect(fallback).not.toHaveBeenCalled()
+      } finally {
+        LGraphCanvas.prototype.processKey = originalProcessKey
+      }
+    })
+  })
+
+  describe('clean and coordinate conversion', () => {
+    it('clears the root graph when the canvas is not inside a subgraph', () => {
+      const rootGraph = new LGraph()
+      const clear = vi.spyOn(rootGraph, 'clear')
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        subgraph: undefined
+      })
+
+      app.clean()
+
+      expect(mockNodeOutputStore.resetAllOutputsAndPreviews).toHaveBeenCalled()
+      expect(useExecutionErrorStore().lastNodeErrors).toBeNull()
+      expect(clear).toHaveBeenCalled()
+    })
+
+    it('preserves the root graph when the canvas is inside a subgraph', () => {
+      const rootGraph = new LGraph()
+      const clear = vi.spyOn(rootGraph, 'clear')
+      Reflect.set(app, 'rootGraphInternal', rootGraph)
+      app.canvas = fromPartial<LGraphCanvas>({
+        ...mockCanvas,
+        subgraph: new LGraph()
+      })
+
+      app.clean()
+
+      expect(clear).not.toHaveBeenCalled()
+    })
+
+    it('throws before coordinate conversion is initialized', () => {
+      expect(() => app.clientPosToCanvasPos([1, 2])).toThrow(
+        'clientPosToCanvasPos called before setup'
+      )
+      expect(() => app.canvasPosToClientPos([1, 2])).toThrow(
+        'canvasPosToClientPos called before setup'
+      )
+    })
+
+    it('delegates coordinate conversion after setup initializes it', () => {
+      Reflect.set(app, 'positionConversion', {
+        clientPosToCanvasPos: vi.fn(() => [3, 4]),
+        canvasPosToClientPos: vi.fn(() => [5, 6])
+      })
+
+      expect(app.clientPosToCanvasPos([1, 2])).toEqual([3, 4])
+      expect(app.canvasPosToClientPos([1, 2])).toEqual([5, 6])
+    })
+  })
+
+  describe('API update handlers', () => {
+    it('routes socket events into app stores, dialogs, and canvas refreshes', () => {
+      vi.restoreAllMocks()
+      vi.spyOn(api, 'init').mockImplementation(() => undefined)
+      const graph = new LGraph()
+      const node = new LGraphNode('PreviewAny', 'PreviewAny')
+      node.id = toNodeId(7)
+      node.onExecuted = vi.fn()
+      graph.add(node)
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const setStatus = vi.spyOn(app.ui, 'setStatus')
+
+      ;(
+        Object.getPrototypeOf(app) as { addApiUpdateHandlers(): void }
+      ).addApiUpdateHandlers.call(app)
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('status', {
+          detail: { exec_info: { queue_remaining: 1 } }
+        })
+      )
+      ;(api as EventTarget).dispatchEvent(new CustomEvent('progress'))
+      ;(api as EventTarget).dispatchEvent(new CustomEvent('executing'))
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('executed', {
+          detail: {
+            display_node: 7,
+            output: { images: [{ filename: 'preview.png' }] },
+            merge: true
+          }
+        })
+      )
+
+      expect(setStatus).toHaveBeenCalledWith({
+        exec_info: { queue_remaining: 1 }
+      })
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, false)
+      expect(mockNodeOutputStore.setNodeOutputsByExecutionId).toHaveBeenCalled()
+      expect(node.onExecuted).toHaveBeenCalledWith({
+        images: [{ filename: 'preview.png' }]
+      })
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('executed', {
+          detail: {
+            node: 7,
+            output: { text: ['fallback'] }
+          }
+        })
+      )
+      expect(
+        mockNodeOutputStore.setNodeOutputsByExecutionId
+      ).toHaveBeenCalledWith('7', { text: ['fallback'] }, { merge: undefined })
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('executed', {
+          detail: {
+            display_node: '',
+            node: '',
+            output: { text: ['ignored'] }
+          }
+        })
+      )
+      expect(
+        mockNodeOutputStore.setNodeOutputsByExecutionId
+      ).not.toHaveBeenCalledWith(
+        expect.anything(),
+        { text: ['ignored'] },
+        expect.anything()
+      )
+
+      const precondition = { code: 'credits_required' }
+      mockResolveAccountPrecondition.mockReturnValueOnce(precondition)
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('execution_error', {
+          detail: {
+            exception_type: 'credits_required',
+            exception_message: 'Credits required',
+            node_type: 'CreditNode'
+          }
+        })
+      )
+      expect(mockAccountPreconditionDialog.open).toHaveBeenCalledWith(
+        precondition,
+        { nodeType: 'CreditNode' }
+      )
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('execution_error', {
+          detail: {
+            exception_type: 'runtime_error',
+            exception_message: 'Failed'
+          }
+        })
+      )
+      expect(useExecutionErrorStore().isErrorOverlayOpen).toBe(true)
+
+      mockSettingStore.get.mockReturnValue(false)
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('execution_error', {
+          detail: {
+            exception_type: 'runtime_error',
+            exception_message: 'Still failed'
+          }
+        })
+      )
+      expect(mockDialogService.showExecutionErrorDialog).toHaveBeenCalledWith({
+        exception_type: 'runtime_error',
+        exception_message: 'Still failed'
+      })
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('execution_error', {
+          detail: {}
+        })
+      )
+      expect(mockDialogService.showExecutionErrorDialog).toHaveBeenCalledWith(
+        {}
+      )
+
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('b_preview_with_metadata', {
+          detail: {
+            blob: new Blob(),
+            displayNodeId: '',
+            jobId: 'job-1'
+          }
+        })
+      )
+      expect(
+        mockNodeOutputStore.revokePreviewsByExecutionId
+      ).not.toHaveBeenCalled()
+
+      const objectUrl = 'blob:preview'
+      vi.spyOn(URL, 'createObjectURL').mockReturnValue(objectUrl)
+      vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+      ;(api as EventTarget).dispatchEvent(
+        new CustomEvent('b_preview_with_metadata', {
+          detail: {
+            blob: new Blob(),
+            displayNodeId: '7',
+            jobId: 'job-2'
+          }
+        })
+      )
+      expect(mockNodeOutputStore.revokePreviewsByExecutionId).toHaveBeenCalled()
+      expect(
+        mockNodeOutputStore.setNodePreviewsByExecutionId
+      ).toHaveBeenCalled()
+
+      ;(api as EventTarget).dispatchEvent(new CustomEvent('feature_flags'))
+      expect(mockNodeReplacementStore.load).toHaveBeenCalled()
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+  })
+})

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -188,6 +188,17 @@ describe('ComfyApp', () => {
     )
   })
 
+  describe('graph (deprecated getter)', () => {
+    it('returns undefined until the root graph is initialized', () => {
+      expect(app.graph).toBeUndefined()
+
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+
+      expect(app.graph).toBe(graph)
+    })
+  })
+
   describe('queuePrompt', () => {
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -244,7 +244,7 @@ export class ComfyApp {
   static clipspace_invalidate_handler: (() => void) | null = null
   static open_maskeditor: (() => void) | null = null
   static maskeditor_is_opended: (() => void) | null = null
-  static clipspace_return_node = null
+  static clipspace_return_node: LGraphNode | null = null
 
   vueAppReady: boolean
   api: ComfyApi
@@ -257,8 +257,8 @@ export class ComfyApp {
 
   // TODO: Migrate internal usage to the
   /** @deprecated Use {@link rootGraph} instead */
-  get graph() {
-    return this.rootGraphInternal!
+  get graph(): LGraph | undefined {
+    return this.rootGraphInternal
   }
 
   get rootGraph(): LGraph {
@@ -1167,7 +1167,7 @@ export class ComfyApp {
   }
 
   async loadGraphData(
-    graphData?: ComfyWorkflowJSON,
+    graphData?: ComfyWorkflowJSON | unknown[],
     clean: boolean = true,
     restore_view: boolean = true,
     workflow: string | null | ComfyWorkflow = null,

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,6 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type {
+  CanvasPointerEvent,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import type { ISerialisedGraph } from '@/lib/litegraph/src/types/serialisation'
+import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 
 const mockAssert = vi.hoisted(() => vi.fn())
 
@@ -14,7 +25,7 @@ const mockNodeOutputStore = vi.hoisted(() => ({
 }))
 
 const mockSubgraphNavigationStore = vi.hoisted(() => ({
-  exportState: vi.fn(() => []),
+  exportState: vi.fn((): string[] => []),
   restoreState: vi.fn()
 }))
 
@@ -23,10 +34,24 @@ const mockWorkflowStore = vi.hoisted(() => ({
   getWorkflowByPath: vi.fn()
 }))
 
+const mockExecutionStore = vi.hoisted(() => ({
+  queuedJobs: {} as Record<string, { workflow: { changeTracker: unknown } }>
+}))
+
+const mockMaskEditorIsOpened = vi.hoisted(() => vi.fn(() => false))
+
 vi.mock('@/scripts/app', () => ({
   app: {
+    constructor: {
+      maskeditor_is_opended: mockMaskEditorIsOpened
+    },
     graph: {},
+    ui: {
+      autoQueueEnabled: false,
+      autoQueueMode: 'instant'
+    },
     rootGraph: {
+      subgraphs: new Map(),
       serialize: vi.fn(() => ({
         nodes: [],
         links: [],
@@ -39,8 +64,10 @@ vi.mock('@/scripts/app', () => ({
       }))
     },
     canvas: {
-      ds: { scale: 1, offset: [0, 0] }
-    }
+      ds: { scale: 1, offset: [0, 0] },
+      setGraph: vi.fn()
+    },
+    loadGraphData: vi.fn()
   }
 }))
 
@@ -65,6 +92,10 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => mockWorkflowStore)
 }))
 
+vi.mock('@/stores/executionStore', () => ({
+  useExecutionStore: vi.fn(() => mockExecutionStore)
+}))
+
 import { app } from '@/scripts/app'
 import { api } from '@/scripts/api'
 import { ChangeTracker } from '@/scripts/changeTracker'
@@ -83,7 +114,7 @@ function createState(nodeCount = 0): ComfyWorkflowJSON {
     outputs: [],
     properties: {}
   }))
-  return {
+  return Object.assign(fromPartial<ComfyWorkflowJSON>({}), {
     nodes,
     links: [],
     groups: [],
@@ -92,19 +123,51 @@ function createState(nodeCount = 0): ComfyWorkflowJSON {
     version: 0.4,
     last_node_id: nodeIdCounter,
     last_link_id: 0
-  } as unknown as ComfyWorkflowJSON
+  })
 }
 
 function createTracker(initialState?: ComfyWorkflowJSON): ChangeTracker {
   const state = initialState ?? createState()
-  const workflow = { path: '/test/workflow.json' } as never
+  const workflow = fromPartial<ComfyWorkflow>({ path: '/test/workflow.json' })
   const tracker = new ChangeTracker(workflow, state)
   mockWorkflowStore.activeWorkflow = { changeTracker: tracker }
   return tracker
 }
 
 function mockCanvasState(state: ComfyWorkflowJSON) {
-  vi.mocked(app.rootGraph.serialize).mockReturnValue(state as never)
+  vi.mocked(app.rootGraph.serialize).mockReturnValue(state as ISerialisedGraph)
+}
+
+type ListenerMap = Record<string, EventListener[]>
+
+function storeListener(
+  listeners: ListenerMap,
+  type: string,
+  listener: EventListenerOrEventListenerObject
+) {
+  if (typeof listener === 'function') {
+    listeners[type] ??= []
+    listeners[type].push(listener)
+  }
+}
+
+function dispatchStored(listeners: ListenerMap, type: string, event: Event) {
+  for (const listener of listeners[type] ?? []) {
+    listener(event)
+  }
+}
+
+async function flushAsyncFrame() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function getApiListener(name: string) {
+  const call = vi
+    .mocked(api.addEventListener)
+    .mock.calls.find(([eventName]) => eventName === name)
+  expect(call).toBeDefined()
+  return call?.[1] as (event: CustomEvent<ExecutedWsMessage>) => void
 }
 
 describe('ChangeTracker', () => {
@@ -112,8 +175,83 @@ describe('ChangeTracker', () => {
     vi.clearAllMocks()
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
+    Reflect.set(ChangeTracker, '_checkStateWarned', false)
     mockWorkflowStore.activeWorkflow = null
     mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
+    mockExecutionStore.queuedJobs = {}
+    mockMaskEditorIsOpened.mockReturnValue(false)
+    app.ui.autoQueueEnabled = false
+    app.ui.autoQueueMode = 'instant'
+    vi.mocked(app.canvas.setGraph).mockClear()
+    vi.mocked(app.loadGraphData).mockResolvedValue(undefined)
+    app.rootGraph.subgraphs.clear()
+    app.canvas.ds.scale = 1
+    app.canvas.ds.offset = [0, 0]
+  })
+
+  describe('reset', () => {
+    it('updates initialState from activeState or an explicit state', () => {
+      const tracker = createTracker(createState(1))
+      const changed = createState(2)
+
+      tracker.activeState = changed
+      tracker.reset()
+
+      expect(tracker.initialState).toEqual(changed)
+      expect(tracker.initialState).not.toBe(changed)
+
+      const explicit = createState(3)
+      tracker.reset(explicit)
+
+      expect(tracker.activeState).toEqual(explicit)
+      expect(tracker.activeState).not.toBe(explicit)
+      expect(tracker.initialState).toEqual(explicit)
+    })
+
+    it('does not reset while restoring state', () => {
+      const tracker = createTracker(createState(1))
+      const original = tracker.initialState
+      tracker._restoringState = true
+
+      tracker.reset(createState(2))
+
+      expect(tracker.initialState).toBe(original)
+    })
+  })
+
+  describe('restore', () => {
+    it('restores viewport, outputs, and root graph navigation', () => {
+      const tracker = createTracker()
+      app.canvas.ds.scale = 2
+      app.canvas.ds.offset = [10, 20]
+      mockNodeOutputStore.snapshotOutputs.mockReturnValue({ 1: { images: [] } })
+      mockSubgraphNavigationStore.exportState.mockReturnValue([])
+
+      tracker.store()
+      app.canvas.ds.scale = 1
+      app.canvas.ds.offset = [0, 0]
+      tracker.restore()
+
+      expect(app.canvas.ds.scale).toBe(2)
+      expect(app.canvas.ds.offset).toEqual([10, 20])
+      expect(mockNodeOutputStore.restoreOutputs).toHaveBeenCalledWith({
+        1: { images: [] }
+      })
+      expect(mockSubgraphNavigationStore.restoreState).toHaveBeenCalledWith([])
+      expect(app.canvas.setGraph).toHaveBeenCalledWith(app.rootGraph)
+    })
+
+    it('restores saved subgraph navigation when the subgraph exists', () => {
+      const tracker = createTracker()
+      const subgraph = fromPartial<Subgraph>({ id: 'subgraph-1' })
+      app.rootGraph.subgraphs.set('subgraph-1', subgraph)
+      mockSubgraphNavigationStore.exportState.mockReturnValue(['subgraph-1'])
+
+      tracker.store()
+      tracker.restore()
+
+      expect(app.canvas.setGraph).toHaveBeenCalledWith(subgraph)
+    })
   })
 
   describe('captureCanvasState', () => {
@@ -122,7 +260,7 @@ describe('ChangeTracker', () => {
         const tracker = createTracker()
         const original = tracker.activeState
 
-        const spy = vi.spyOn(app, 'graph', 'get').mockReturnValue(null as never)
+        const spy = vi.spyOn(app, 'graph', 'get').mockReturnValue(undefined)
         tracker.captureCanvasState()
         spy.mockRestore()
 
@@ -169,9 +307,32 @@ describe('ChangeTracker', () => {
           expect.stringContaining('captureCanvasState')
         )
       })
+
+      it('reports inactive tracker calls only once for the same workflow', () => {
+        const tracker = createTracker()
+        tracker.workflow.path = '/test/dedupe-workflow.json'
+        mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+
+        tracker.captureCanvasState()
+        tracker.captureCanvasState()
+
+        expect(mockAssert).toHaveBeenCalledOnce()
+      })
     })
 
     describe('state capture', () => {
+      it('sets the active state without pushing undo when none exists yet', () => {
+        const tracker = createTracker(createState(1))
+        const changed = createState(2)
+        Reflect.set(tracker, 'activeState', undefined)
+        mockCanvasState(changed)
+
+        tracker.captureCanvasState()
+
+        expect(tracker.activeState).toEqual(changed)
+        expect(tracker.undoQueue).toHaveLength(0)
+      })
+
       it('pushes to undoQueue, updates activeState, and calls updateModified', () => {
         const initial = createState(1)
         const tracker = createTracker(initial)
@@ -238,6 +399,19 @@ describe('ChangeTracker', () => {
 
         expect(tracker.undoQueue).toHaveLength(ChangeTracker.MAX_HISTORY)
       })
+
+      it('does not capture until the outer change transaction finishes', () => {
+        const tracker = createTracker(createState(1))
+        tracker.beforeChange()
+        tracker.beforeChange()
+        mockCanvasState(createState(2))
+
+        tracker.afterChange()
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+
+        tracker.afterChange()
+        expect(app.rootGraph.serialize).toHaveBeenCalledOnce()
+      })
     })
   })
 
@@ -302,6 +476,105 @@ describe('ChangeTracker', () => {
     })
   })
 
+  describe('updateModified', () => {
+    it('updates workflow modified state when the store can find it', () => {
+      const state = createState(1)
+      const tracker = createTracker(state)
+      const workflow = { isModified: true }
+      mockWorkflowStore.getWorkflowByPath.mockReturnValue(workflow)
+
+      tracker.updateModified()
+      expect(workflow.isModified).toBe(false)
+
+      tracker.activeState = createState(2)
+      tracker.updateModified()
+      expect(workflow.isModified).toBe(true)
+    })
+  })
+
+  describe('undo and redo', () => {
+    it('restores previous state and moves the current state to the target queue', async () => {
+      const initial = createState(1)
+      const changed = createState(2)
+      const tracker = createTracker(changed)
+      tracker.undoQueue.push(initial)
+
+      await tracker.undo()
+
+      expect(app.loadGraphData).toHaveBeenCalledWith(
+        initial,
+        false,
+        false,
+        tracker.workflow,
+        {
+          checkForRerouteMigration: false,
+          silentAssetErrors: true
+        }
+      )
+      expect(tracker.activeState).toBe(initial)
+      expect(tracker.redoQueue).toEqual([changed])
+      expect(tracker._restoringState).toBe(false)
+    })
+
+    it('clears restoring state when loading fails', async () => {
+      const tracker = createTracker(createState(2))
+      tracker.undoQueue.push(createState(1))
+      vi.mocked(app.loadGraphData).mockRejectedValueOnce(
+        new Error('load failed')
+      )
+
+      await expect(tracker.undo()).rejects.toThrow('load failed')
+
+      expect(tracker._restoringState).toBe(false)
+    })
+
+    it('does nothing when no previous state exists', async () => {
+      const tracker = createTracker(createState(1))
+
+      await tracker.undo()
+
+      expect(app.loadGraphData).not.toHaveBeenCalled()
+    })
+
+    it('handles keyboard undo and redo shortcuts', async () => {
+      const tracker = createTracker()
+      const undo = vi.spyOn(tracker, 'undo').mockResolvedValue()
+      const redo = vi.spyOn(tracker, 'redo').mockResolvedValue()
+
+      await expect(
+        tracker.undoRedo(
+          new KeyboardEvent('keydown', { key: 'z', ctrlKey: true })
+        )
+      ).resolves.toBe(true)
+      await expect(
+        tracker.undoRedo(
+          new KeyboardEvent('keydown', {
+            key: 'z',
+            ctrlKey: true,
+            shiftKey: true
+          })
+        )
+      ).resolves.toBe(true)
+      await expect(
+        tracker.undoRedo(
+          new KeyboardEvent('keydown', { key: 'y', metaKey: true })
+        )
+      ).resolves.toBe(true)
+      await expect(
+        tracker.undoRedo(
+          new KeyboardEvent('keydown', {
+            key: 'z',
+            ctrlKey: true,
+            altKey: true
+          })
+        )
+      ).resolves.toBeUndefined()
+
+      expect(undo).toHaveBeenCalledOnce()
+      expect(redo).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('checkState (deprecated)', () => {
     it('delegates to captureCanvasState', () => {
       const tracker = createTracker(createState(1))
@@ -311,6 +584,379 @@ describe('ChangeTracker', () => {
       tracker.checkState()
 
       expect(tracker.activeState).toEqual(changed)
+    })
+
+    it('warns only once before delegating', () => {
+      const tracker = createTracker(createState(1))
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+      tracker.checkState()
+      tracker.checkState()
+
+      expect(warn).toHaveBeenCalledOnce()
+      warn.mockRestore()
+    })
+  })
+
+  describe('bindInput', () => {
+    it('returns false for missing canvas or body elements', () => {
+      expect(ChangeTracker.bindInput(null)).toBe(false)
+      expect(ChangeTracker.bindInput(document.createElement('canvas'))).toBe(
+        false
+      )
+      expect(ChangeTracker.bindInput(document.body)).toBe(false)
+    })
+
+    it('captures state once when an input-like element changes', () => {
+      const tracker = createTracker()
+      const capture = vi.spyOn(tracker, 'captureCanvasState')
+      const input = document.createElement('input')
+
+      expect(ChangeTracker.bindInput(input)).toBe(true)
+      input.dispatchEvent(new Event('change'))
+      input.dispatchEvent(new Event('change'))
+
+      expect(capture).toHaveBeenCalledOnce()
+    })
+
+    it('binds textarea-like elements that expose an input handler slot', () => {
+      const tracker = createTracker()
+      const capture = vi.spyOn(tracker, 'captureCanvasState')
+      const element = document.createElement('div') as HTMLElement & {
+        oninput: unknown
+      }
+      element.oninput = null
+
+      expect(ChangeTracker.bindInput(element)).toBe(true)
+      element.dispatchEvent(new Event('change'))
+
+      expect(capture).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('init', () => {
+    let windowListeners: ListenerMap
+    let documentListeners: ListenerMap
+    let windowAddSpy: MockInstance
+    let documentAddSpy: MockInstance
+    let rafSpy: MockInstance
+    let originalProcessMouseUp: typeof LGraphCanvas.prototype.processMouseUp
+    let originalPrompt: typeof LGraphCanvas.prototype.prompt
+    let originalClose: typeof LiteGraph.ContextMenu.prototype.close
+
+    beforeEach(() => {
+      windowListeners = {}
+      documentListeners = {}
+      originalProcessMouseUp = LGraphCanvas.prototype.processMouseUp
+      originalPrompt = LGraphCanvas.prototype.prompt
+      originalClose = LiteGraph.ContextMenu.prototype.close
+      windowAddSpy = vi
+        .spyOn(window, 'addEventListener')
+        .mockImplementation((type, listener) => {
+          storeListener(windowListeners, type, listener)
+        })
+      documentAddSpy = vi
+        .spyOn(document, 'addEventListener')
+        .mockImplementation((type, listener) => {
+          storeListener(documentListeners, type, listener)
+        })
+      rafSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          callback(0)
+          return 1
+        })
+    })
+
+    afterEach(() => {
+      LGraphCanvas.prototype.processMouseUp = originalProcessMouseUp
+      LGraphCanvas.prototype.prompt = originalPrompt
+      LiteGraph.ContextMenu.prototype.close = originalClose
+      windowAddSpy.mockRestore()
+      documentAddSpy.mockRestore()
+      rafSpy.mockRestore()
+    })
+
+    it('captures changes from registered browser, graph, and API events', async () => {
+      const processMouseUp = vi.fn(() => true)
+      const prompt = vi.fn()
+      const close = vi.fn(() => true)
+
+      LGraphCanvas.prototype.processMouseUp = processMouseUp
+      LGraphCanvas.prototype.prompt = prompt
+      LiteGraph.ContextMenu.prototype.close = close
+
+      ChangeTracker.init()
+      const tracker = createTracker()
+      const capture = vi.spyOn(tracker, 'captureCanvasState')
+
+      dispatchStored(windowListeners, 'mouseup', new MouseEvent('mouseup'))
+      getApiListener('promptQueued')(
+        new CustomEvent('promptQueued', {
+          detail: fromPartial<ExecutedWsMessage>({})
+        })
+      )
+      getApiListener('graphCleared')(
+        new CustomEvent('graphCleared', {
+          detail: fromPartial<ExecutedWsMessage>({})
+        })
+      )
+      dispatchStored(
+        documentListeners,
+        'litegraph:canvas',
+        new CustomEvent('litegraph:canvas', {
+          detail: { subType: 'before-change' }
+        })
+      )
+      dispatchStored(
+        documentListeners,
+        'litegraph:canvas',
+        new CustomEvent('litegraph:canvas', {
+          detail: { subType: 'after-change' }
+        })
+      )
+
+      expect(capture).toHaveBeenCalledTimes(4)
+
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'Control' })
+      )
+      await flushAsyncFrame()
+      dispatchStored(windowListeners, 'keyup', new KeyboardEvent('keyup'))
+
+      expect(capture).toHaveBeenCalledTimes(5)
+
+      const undoRedo = vi.spyOn(tracker, 'undoRedo').mockResolvedValue(true)
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'z', ctrlKey: true })
+      )
+      await flushAsyncFrame()
+
+      expect(undoRedo).toHaveBeenCalledOnce()
+      expect(capture).toHaveBeenCalledTimes(5)
+
+      undoRedo.mockResolvedValue(undefined)
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'a' })
+      )
+      await flushAsyncFrame()
+
+      expect(capture).toHaveBeenCalledTimes(6)
+
+      const input = document.createElement('input')
+      document.body.append(input)
+      input.focus()
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'b' })
+      )
+      await flushAsyncFrame()
+      input.remove()
+
+      expect(capture).toHaveBeenCalledTimes(6)
+
+      mockMaskEditorIsOpened.mockReturnValue(true)
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'c' })
+      )
+      await flushAsyncFrame()
+
+      expect(capture).toHaveBeenCalledTimes(6)
+
+      const canvas = {} as LGraphCanvas
+      LGraphCanvas.prototype.processMouseUp.call(
+        canvas,
+        new MouseEvent('mouseup') as CanvasPointerEvent
+      )
+
+      expect(processMouseUp).toHaveBeenCalledOnce()
+      expect(capture).toHaveBeenCalledTimes(7)
+
+      const promptCallback = vi.fn()
+      LGraphCanvas.prototype.prompt.call(
+        canvas,
+        'title',
+        'value',
+        promptCallback,
+        new MouseEvent('mouseup') as CanvasPointerEvent
+      )
+      const extendedCallback = prompt.mock.calls[0]?.[2] as
+        | ((value: string) => void)
+        | undefined
+      extendedCallback?.('updated')
+
+      expect(promptCallback).toHaveBeenCalledWith('updated')
+      expect(capture).toHaveBeenCalledTimes(8)
+
+      LiteGraph.ContextMenu.prototype.close.call(
+        {} as InstanceType<typeof LiteGraph.ContextMenu>,
+        new MouseEvent('mouseup')
+      )
+
+      expect(close).toHaveBeenCalledOnce()
+      expect(capture).toHaveBeenCalledTimes(9)
+    })
+
+    it('ignores repeat keydowns and missing active trackers', async () => {
+      ChangeTracker.init()
+      const tracker = createTracker()
+      const capture = vi.spyOn(tracker, 'captureCanvasState')
+
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'x', repeat: true })
+      )
+      await flushAsyncFrame()
+      expect(capture).not.toHaveBeenCalled()
+
+      mockWorkflowStore.activeWorkflow = null
+      dispatchStored(
+        windowListeners,
+        'keydown',
+        new KeyboardEvent('keydown', { key: 'x' })
+      )
+      await flushAsyncFrame()
+      expect(capture).not.toHaveBeenCalled()
+    })
+
+    it('stores executed outputs for the workflow that owns the prompt', () => {
+      ChangeTracker.init()
+      const tracker = createTracker()
+      const executed = getApiListener('executed')
+      mockExecutionStore.queuedJobs = {
+        promptA: { workflow: { changeTracker: tracker } }
+      }
+
+      executed(
+        new CustomEvent('executed', {
+          detail: fromPartial<ExecutedWsMessage>({
+            prompt_id: 'promptA',
+            node: '1',
+            output: { images: ['first'] }
+          } as PartialDeep<ExecutedWsMessage>)
+        })
+      )
+      executed(
+        new CustomEvent('executed', {
+          detail: fromPartial<ExecutedWsMessage>({
+            prompt_id: 'promptA',
+            node: '1',
+            merge: true,
+            output: { images: ['second'], text: ['caption'] }
+          } as PartialDeep<ExecutedWsMessage>)
+        })
+      )
+      executed(
+        new CustomEvent('executed', {
+          detail: fromPartial<ExecutedWsMessage>({
+            prompt_id: 'missing',
+            node: '2',
+            output: { images: ['ignored'] }
+          } as PartialDeep<ExecutedWsMessage>)
+        })
+      )
+
+      expect(tracker.nodeOutputs).toEqual({
+        1: { images: ['first', 'second'], text: ['caption'] }
+      })
+    })
+
+    it('replaces non-array executed outputs during merge updates', () => {
+      ChangeTracker.init()
+      const tracker = createTracker()
+      const executed = getApiListener('executed')
+      mockExecutionStore.queuedJobs = {
+        promptA: { workflow: { changeTracker: tracker } }
+      }
+
+      executed(
+        new CustomEvent('executed', {
+          detail: fromPartial<ExecutedWsMessage>({
+            prompt_id: 'promptA',
+            node: '1',
+            output: { value: 'old' }
+          } as PartialDeep<ExecutedWsMessage>)
+        })
+      )
+      executed(
+        new CustomEvent('executed', {
+          detail: fromPartial<ExecutedWsMessage>({
+            prompt_id: 'promptA',
+            node: '1',
+            merge: true,
+            output: { value: 'new' }
+          } as PartialDeep<ExecutedWsMessage>)
+        })
+      )
+
+      expect(tracker.nodeOutputs).toEqual({
+        1: { value: 'new' }
+      })
+    })
+  })
+
+  describe('graphEqual', () => {
+    it('compares workflow nodes as an unordered set and ignores extra.ds', () => {
+      const first = createState(2)
+      const second = fromPartial<ComfyWorkflowJSON>({
+        ...createState(),
+        nodes: [...first.nodes].reverse(),
+        links: first.links,
+        groups: first.groups,
+        extra: { ds: { scale: 2 } }
+      } as PartialDeep<ComfyWorkflowJSON>)
+
+      expect(ChangeTracker.graphEqual(first, first)).toBe(true)
+      expect(ChangeTracker.graphEqual(first, second)).toBe(true)
+    })
+
+    it('returns false for non-object values and meaningful graph differences', () => {
+      const first = createState(1)
+      const differentNodes = createState(2)
+      const differentLinks = fromPartial<ComfyWorkflowJSON>({
+        ...first,
+        links: [[1, 1, 0, 2, 0, 'MODEL']]
+      } as PartialDeep<ComfyWorkflowJSON>)
+
+      expect(ChangeTracker.graphEqual(first, null)).toBe(false)
+      expect(ChangeTracker.graphEqual(first, differentNodes)).toBe(false)
+      expect(ChangeTracker.graphEqual(first, differentLinks)).toBe(false)
+    })
+
+    it('returns false for extra properties other than viewport state', () => {
+      const first = createState()
+      const second = fromPartial<ComfyWorkflowJSON>({
+        ...first,
+        extra: { custom: true }
+      } as PartialDeep<ComfyWorkflowJSON>)
+
+      expect(ChangeTracker.graphEqual(first, second)).toBe(false)
+    })
+
+    it.each([
+      'floatingLinks',
+      'reroutes',
+      'groups',
+      'definitions',
+      'subgraphs'
+    ] as const)('returns false when %s differs', (key) => {
+      const first = createState()
+      const second = fromPartial<ComfyWorkflowJSON>({
+        ...first,
+        [key]: [{ id: 1 }]
+      } as PartialDeep<ComfyWorkflowJSON>)
+
+      expect(ChangeTracker.graphEqual(first, second)).toBe(false)
     })
   })
 })

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -439,7 +439,7 @@ export class ChangeTracker {
     return false
   }
 
-  static graphEqual(a: ComfyWorkflowJSON, b: ComfyWorkflowJSON) {
+  static graphEqual(a: ComfyWorkflowJSON | null, b: ComfyWorkflowJSON | null) {
     if (a === b) return true
 
     if (typeof a == 'object' && a && typeof b == 'object' && b) {

--- a/src/scripts/domWidget.test.ts
+++ b/src/scripts/domWidget.test.ts
@@ -1,11 +1,20 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, test, vi } from 'vitest'
 
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { ComponentWidgetImpl, DOMWidgetImpl } from '@/scripts/domWidget'
+import { addWidget, isComponentWidget, isDOMWidget } from '@/scripts/domWidget'
+
+const { registerWidget, unregisterWidget } = vi.hoisted(() => ({
+  registerWidget: vi.fn(),
+  unregisterWidget: vi.fn()
+}))
 
 vi.mock('@/stores/domWidgetStore', () => ({
   useDomWidgetStore: () => ({
-    unregisterWidget: vi.fn()
+    registerWidget,
+    unregisterWidget
   })
 }))
 
@@ -94,5 +103,268 @@ describe('BaseDOMWidgetImpl.isVisible', () => {
     widget.computedDisabled = true
 
     expect(widget.isVisible()).toBe(false)
+  })
+})
+
+describe('DOMWidgetImpl', () => {
+  test('identifies DOM and component widgets', () => {
+    const node = new LGraphNode('test-node')
+    const domWidget = new DOMWidgetImpl({
+      node,
+      name: 'dom',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {}
+    })
+    const componentWidget = new ComponentWidgetImpl({
+      node,
+      name: 'component',
+      component: { template: '<div />' },
+      inputSpec: { name: 'component', type: 'STRING' },
+      options: {}
+    })
+
+    expect(isDOMWidget(domWidget)).toBe(true)
+    expect(isDOMWidget(componentWidget)).toBe(false)
+    expect(isComponentWidget(componentWidget)).toBe(true)
+    expect(isComponentWidget(domWidget)).toBe(false)
+  })
+
+  test('uses option-backed values, callbacks, and margins over defaults', () => {
+    const node = new LGraphNode('test-node')
+    let value = 'initial'
+    const setValue = vi.fn((next: string) => {
+      value = next
+    })
+    const callback = vi.fn()
+    const widget = new DOMWidgetImpl({
+      node,
+      name: 'text',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        getValue: () => value,
+        setValue,
+        margin: 4
+      }
+    })
+    widget.callback = callback
+    const defaultWidget = new DOMWidgetImpl({
+      node,
+      name: 'text-default',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {}
+    })
+
+    widget.value = 'next'
+
+    expect(widget.value).toBe('next')
+    expect(widget.margin).toBe(4)
+    expect(setValue).toHaveBeenCalledWith('next')
+    expect(callback).toHaveBeenCalledWith('next')
+    expect(defaultWidget.value).toBe('')
+    expect(defaultWidget.margin).toBe(10)
+  })
+
+  test('draws zoom placeholders and delegates visible draws', () => {
+    const node = new LGraphNode('test-node')
+    vi.spyOn(node, 'isWidgetVisible').mockReturnValue(true)
+    const onDraw = vi.fn()
+    const widget = new DOMWidgetImpl({
+      node,
+      name: 'text',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        hideOnZoom: true,
+        margin: 5,
+        onDraw
+      }
+    })
+    const ctx = fromPartial<CanvasRenderingContext2D>({
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      fillStyle: '#000',
+      rect: vi.fn()
+    })
+
+    widget.draw(ctx, node, 100, 10, 40, true)
+
+    expect(ctx.rect).toHaveBeenCalledWith(5, 15, 90, 30)
+    expect(ctx.fill).toHaveBeenCalledOnce()
+    expect(ctx.fillStyle).toBe('#000')
+    expect(onDraw).toHaveBeenCalledWith(widget)
+  })
+
+  test('skips placeholder drawing when hidden', () => {
+    const node = new LGraphNode('test-node')
+    vi.spyOn(node, 'isWidgetVisible').mockReturnValue(false)
+    const onDraw = vi.fn()
+    const widget = new DOMWidgetImpl({
+      node,
+      name: 'text',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        hideOnZoom: true,
+        onDraw
+      }
+    })
+    const ctx = fromPartial<CanvasRenderingContext2D>({
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      fillStyle: '#000',
+      rect: vi.fn()
+    })
+
+    widget.draw(ctx, node, 100, 10, 40, true)
+
+    expect(ctx.rect).not.toHaveBeenCalled()
+    expect(onDraw).toHaveBeenCalledWith(widget)
+  })
+
+  test('computes hidden, option, percent, and fallback layout sizes', () => {
+    const node = new LGraphNode('test-node')
+    node.size = [100, 200]
+    const hiddenWidget = new DOMWidgetImpl({
+      node,
+      name: 'hidden',
+      type: 'hidden',
+      element: document.createElement('textarea'),
+      options: {}
+    })
+    const optionWidget = new DOMWidgetImpl({
+      node,
+      name: 'option',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        getMinHeight: () => 11,
+        getMaxHeight: () => 88,
+        getHeight: () => 44
+      }
+    })
+    const percentWidget = new DOMWidgetImpl({
+      node,
+      name: 'percent',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        getMinHeight: () => 10,
+        getMaxHeight: () => 60,
+        getHeight: () => '25%'
+      }
+    })
+    const fallbackWidget = new DOMWidgetImpl({
+      node,
+      name: 'fallback',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        getHeight: () => 40
+      }
+    })
+
+    expect(hiddenWidget.computeLayoutSize(node)).toEqual({
+      minHeight: 0,
+      maxHeight: 0,
+      minWidth: 0
+    })
+    expect(optionWidget.computeLayoutSize(node)).toEqual({
+      minHeight: 11,
+      maxHeight: 88,
+      minWidth: 0
+    })
+    expect(percentWidget.computeLayoutSize(node)).toEqual({
+      minHeight: 10,
+      maxHeight: 60,
+      minWidth: 0
+    })
+    expect(fallbackWidget.computeLayoutSize(node)).toEqual({
+      minHeight: 40,
+      maxHeight: undefined,
+      minWidth: 0
+    })
+  })
+
+  test('registers widgets immediately and through node lifecycle callbacks', () => {
+    registerWidget.mockClear()
+    unregisterWidget.mockClear()
+    const node = new LGraphNode('test-node')
+    node.graph = {} as LGraph
+    const beforeResize = vi.fn()
+    const afterResize = vi.fn()
+    const widget = new DOMWidgetImpl({
+      node,
+      name: 'text',
+      type: 'text',
+      element: document.createElement('textarea'),
+      options: {
+        beforeResize,
+        afterResize
+      }
+    })
+    vi.spyOn(node, 'addCustomWidget')
+
+    addWidget(node, widget)
+    node.onAdded?.(node.graph)
+    node.onResize?.([0, 0])
+    node.onRemoved?.()
+
+    expect(node.addCustomWidget).toHaveBeenCalledWith(widget)
+    expect(registerWidget).toHaveBeenCalledWith(widget)
+    expect(registerWidget).toHaveBeenCalledTimes(2)
+    expect(beforeResize).toHaveBeenCalledWith(node)
+    expect(afterResize).toHaveBeenCalledWith(node)
+    expect(unregisterWidget).toHaveBeenCalledWith(widget.id)
+  })
+
+  test('computes component layout and serializes raw values', () => {
+    const node = new LGraphNode('test-node')
+    const value = { nested: true }
+    const widget = new ComponentWidgetImpl({
+      node,
+      name: 'component',
+      component: { template: '<div />' },
+      inputSpec: { name: 'component', type: 'STRING' },
+      options: {
+        getValue: () => value,
+        getMinHeight: () => 12,
+        getMaxHeight: () => 48
+      }
+    })
+
+    expect(widget.computeLayoutSize()).toEqual({
+      minHeight: 12,
+      maxHeight: 48,
+      minWidth: 0
+    })
+    expect(widget.serializeValue()).toEqual({ nested: true })
+  })
+
+  test('adds DOM widgets through LGraphNode prototype helper', () => {
+    const node = new LGraphNode('test-node')
+    const element = document.createElement('textarea')
+    let value = 'initial'
+    const setValue = vi.fn((next: string) => {
+      value = next
+    })
+    vi.spyOn(node, 'addCustomWidget')
+
+    const widget = node.addDOMWidget('text', 'textarea', element, {
+      getValue: () => value,
+      setValue
+    })
+    const callback = vi.fn()
+    widget.callback = callback
+    widget.value = 'next'
+
+    expect(node.addCustomWidget).toHaveBeenCalledWith(widget)
+    expect(widget.element).toBe(element)
+    expect(widget.options.hideOnZoom).toBe(true)
+    expect(widget.value).toBe('next')
+    expect(setValue).toHaveBeenCalledWith('next')
+    expect(callback).toHaveBeenCalledWith('next')
   })
 })

--- a/src/scripts/errorNodeWidgets.test.ts
+++ b/src/scripts/errorNodeWidgets.test.ts
@@ -1,0 +1,99 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+interface TestWidgetOptions {
+  name: string
+  type: string
+  default?: IBaseWidget['value']
+  multiline?: boolean
+}
+
+function createWidgetFactory() {
+  return (node: LGraphNode, options: TestWidgetOptions): IBaseWidget => {
+    const widget = fromPartial<IBaseWidget>({
+      name: options.name,
+      type: options.type,
+      value: options.default,
+      options: { multiline: options.multiline }
+    })
+    node.widgets = [...(node.widgets ?? []), widget]
+    return widget
+  }
+}
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget',
+  () => ({
+    useStringWidget: () => createWidgetFactory()
+  })
+)
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useFloatWidget',
+  () => ({
+    useFloatWidget: () => createWidgetFactory()
+  })
+)
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useBooleanWidget',
+  () => ({
+    useBooleanWidget: () => createWidgetFactory()
+  })
+)
+
+import './errorNodeWidgets'
+
+describe('errorNodeWidgets', () => {
+  it('restores widgets from serialized values on error nodes', () => {
+    const node = new LGraphNode('BrokenNode')
+    const longText = 'serialized value with more than twenty chars'
+    node.has_errors = true
+
+    node.onConfigure?.(
+      fromPartial({
+        widgets_values: ['short text', longText, 12, true, { nested: 'value' }]
+      })
+    )
+
+    expect(node.widgets).toHaveLength(5)
+    expect(node.widgets?.map((widget) => widget.name)).toEqual([
+      'UNKNOWN',
+      'UNKNOWN_1',
+      'UNKNOWN_2',
+      'UNKNOWN_3',
+      'UNKNOWN_4'
+    ])
+    expect(node.widgets?.map((widget) => widget.label)).toEqual([
+      'UNKNOWN',
+      'UNKNOWN',
+      'UNKNOWN',
+      'UNKNOWN',
+      'UNKNOWN'
+    ])
+    expect(node.widgets?.map((widget) => widget.value)).toEqual([
+      'short text',
+      longText,
+      12,
+      true,
+      '{"nested":"value"}'
+    ])
+    expect(node.serialize_widgets).toBe(true)
+  })
+
+  it('leaves normal nodes unchanged', () => {
+    const node = new LGraphNode('HealthyNode')
+
+    node.onConfigure?.(
+      fromPartial({
+        widgets_values: ['ignored']
+      })
+    )
+
+    expect(node.widgets).toBeUndefined()
+    expect(node.serialize_widgets).toBeUndefined()
+  })
+})

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -7,7 +7,8 @@ import {
   EXPECTED_PROMPT_NAN_COERCED,
   EXPECTED_WORKFLOW,
   mockFileReaderAbort,
-  mockFileReaderError
+  mockFileReaderError,
+  mockFileReaderResult
 } from './__fixtures__/helpers'
 import { getFromAvifFile } from './avif'
 
@@ -83,6 +84,11 @@ describe('AVIF metadata', () => {
       mockFileReaderAbort('readAsArrayBuffer')
       expect(await getFromAvifFile(file)).toEqual({})
     })
+
+    it('resolves empty when the FileReader load has no result', async () => {
+      mockFileReaderResult('readAsArrayBuffer', null)
+      expect(await getFromAvifFile(file)).toEqual({})
+    })
   })
 })
 
@@ -154,6 +160,35 @@ const buildInfeBox = (
   return buf
 }
 
+const buildVersionedInfeBox = (
+  itemId: number,
+  itemType: string,
+  version = 2
+): Uint8Array => {
+  const itemIdSize = version === 2 ? 2 : version >= 3 ? 4 : 0
+  const bodySize = 4 + itemIdSize + (version >= 2 ? 2 + 4 + 1 + 1 : 0)
+  const totalSize = 8 + bodySize
+  const buf = new Uint8Array(totalSize)
+  const dv = new DataView(buf.buffer)
+  setU32BE(dv, 0, totalSize)
+  buf.set(new TextEncoder().encode('infe'), 4)
+  buf[8] = version
+  if (version >= 2) {
+    let p = 12
+    if (version === 2) {
+      setU16BE(dv, p, itemId)
+      p += 2
+    } else {
+      setU32BE(dv, p, itemId)
+      p += 4
+    }
+    setU16BE(dv, p, 0)
+    p += 2
+    buf.set(new TextEncoder().encode(itemType.padEnd(4).slice(0, 4)), p)
+  }
+  return buf
+}
+
 const buildIinfBox = (infeBoxes: Uint8Array[]): Uint8Array => {
   const bodySize = 4 + 2 + infeBoxes.reduce((s, b) => s + b.length, 0)
   const totalSize = 8 + bodySize
@@ -163,6 +198,31 @@ const buildIinfBox = (infeBoxes: Uint8Array[]): Uint8Array => {
   buf.set(new TextEncoder().encode('iinf'), 4)
   setU16BE(dv, 12, infeBoxes.length)
   let off = 14
+  for (const ib of infeBoxes) {
+    buf.set(ib, off)
+    off += ib.length
+  }
+  return buf
+}
+
+const buildVersionedIinfBox = (
+  infeBoxes: Uint8Array[],
+  version = 0
+): Uint8Array => {
+  const countSize = version === 0 ? 2 : 4
+  const bodySize = 4 + countSize + infeBoxes.reduce((s, b) => s + b.length, 0)
+  const totalSize = 8 + bodySize
+  const buf = new Uint8Array(totalSize)
+  const dv = new DataView(buf.buffer)
+  setU32BE(dv, 0, totalSize)
+  buf.set(new TextEncoder().encode('iinf'), 4)
+  buf[8] = version
+  if (version === 0) {
+    setU16BE(dv, 12, infeBoxes.length)
+  } else {
+    setU32BE(dv, 12, infeBoxes.length)
+  }
+  let off = 8 + 4 + countSize
   for (const ib of infeBoxes) {
     buf.set(ib, off)
     off += ib.length
@@ -199,6 +259,95 @@ const buildIlocBox = (
   return buf
 }
 
+interface IlocItem {
+  itemId: number
+  extentOffset: number
+  extentLength: number
+  extents?: Array<{ extentOffset: number; extentLength: number }>
+}
+
+const buildIlocBoxWithOptions = (
+  items: IlocItem[],
+  {
+    version = 0,
+    baseOffsetSize = 0,
+    indexSize = 0
+  }: { version?: number; baseOffsetSize?: number; indexSize?: number } = {}
+): Uint8Array => {
+  const itemCountSize = version < 2 ? 2 : 4
+  const itemIdSize = version < 2 ? 2 : 4
+  const constructionMethodSize = version === 1 || version === 2 ? 2 : 0
+  const itemSizes = items.map((item) => {
+    const extents = item.extents ?? [
+      {
+        extentOffset: item.extentOffset,
+        extentLength: item.extentLength
+      }
+    ]
+    return (
+      itemIdSize +
+      constructionMethodSize +
+      2 +
+      baseOffsetSize +
+      2 +
+      extents.length * (indexSize + 4 + 4)
+    )
+  })
+  const bodySize =
+    4 + 1 + 1 + itemCountSize + itemSizes.reduce((sum, size) => sum + size, 0)
+  const totalSize = 8 + bodySize
+  const buf = new Uint8Array(totalSize)
+  const dv = new DataView(buf.buffer)
+  setU32BE(dv, 0, totalSize)
+  buf.set(new TextEncoder().encode('iloc'), 4)
+  buf[8] = version
+  buf[12] = 0x44
+  buf[13] = (baseOffsetSize << 4) | indexSize
+  let p = 14
+  if (version < 2) {
+    setU16BE(dv, p, items.length)
+    p += 2
+  } else {
+    setU32BE(dv, p, items.length)
+    p += 4
+  }
+  for (const it of items) {
+    if (version < 2) {
+      setU16BE(dv, p, it.itemId)
+      p += 2
+    } else {
+      setU32BE(dv, p, it.itemId)
+      p += 4
+    }
+    if (version === 1 || version === 2) {
+      setU16BE(dv, p, 0)
+      p += 2
+    }
+    setU16BE(dv, p, 0)
+    p += 2
+    if (baseOffsetSize > 0) {
+      setU32BE(dv, p, 0)
+      p += baseOffsetSize
+    }
+    const extents = it.extents ?? [
+      {
+        extentOffset: it.extentOffset,
+        extentLength: it.extentLength
+      }
+    ]
+    setU16BE(dv, p, extents.length)
+    p += 2
+    for (const extent of extents) {
+      p += indexSize
+      setU32BE(dv, p, extent.extentOffset)
+      p += 4
+      setU32BE(dv, p, extent.extentLength)
+      p += 4
+    }
+  }
+  return buf
+}
+
 const buildMetaBox = (boxes: Uint8Array[]): Uint8Array => {
   const bodySize = 4 + boxes.reduce((s, b) => s + b.length, 0)
   const totalSize = 8 + bodySize
@@ -231,7 +380,13 @@ interface BuildAvifOpts {
   ftypBrand?: string
   omitMeta?: boolean
   omitIloc?: boolean
+  iinfVersion?: number
   infeVersion?: number
+  ilocVersion?: number
+  ilocBaseOffsetSize?: number
+  ilocIndexSize?: number
+  ilocExtents?: Array<{ extentOffset: number; extentLength: number }>
+  rawExifData?: Uint8Array
 }
 
 const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
@@ -263,6 +418,79 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
   const finalIloc = buildIlocBox([
     { itemId: 1, extentOffset: exifOffset, extentLength: exifData.length }
   ])
+  const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
+  const meta = buildMetaBox(finalInner)
+
+  const total = ftyp.length + meta.length + exifData.length
+  const buf = new Uint8Array(total)
+  let p = 0
+  buf.set(ftyp, p)
+  p += ftyp.length
+  buf.set(meta, p)
+  p += meta.length
+  buf.set(exifData, p)
+  return buf.slice().buffer as ArrayBuffer
+}
+
+const buildAvifFileWithOptions = (opts: BuildAvifOpts = {}): ArrayBuffer => {
+  const {
+    exifEntries = [],
+    endian = 'II',
+    itemType = 'Exif',
+    ftypBrand = 'avif',
+    omitMeta = false,
+    omitIloc = false,
+    iinfVersion = 0,
+    infeVersion = 2,
+    ilocVersion = 0,
+    ilocBaseOffsetSize = 0,
+    ilocIndexSize = 0,
+    ilocExtents,
+    rawExifData
+  } = opts
+
+  const ftyp = buildFtypBox(ftypBrand)
+  if (omitMeta) {
+    return ftyp.slice().buffer as ArrayBuffer
+  }
+
+  const exifData = rawExifData ?? buildExifBlob(exifEntries, endian)
+  const infe = buildVersionedInfeBox(1, itemType, infeVersion)
+  const iinf = buildVersionedIinfBox([infe], iinfVersion)
+
+  const realIloc = buildIlocBoxWithOptions(
+    [
+      {
+        itemId: 1,
+        extentOffset: 0,
+        extentLength: exifData.length,
+        extents: ilocExtents
+      }
+    ],
+    {
+      version: ilocVersion,
+      baseOffsetSize: ilocBaseOffsetSize,
+      indexSize: ilocIndexSize
+    }
+  )
+  const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : realIloc.length)
+  const exifOffset = ftyp.length + metaSize
+
+  const finalIloc = buildIlocBoxWithOptions(
+    [
+      {
+        itemId: 1,
+        extentOffset: exifOffset,
+        extentLength: exifData.length,
+        extents: ilocExtents
+      }
+    ],
+    {
+      version: ilocVersion,
+      baseOffsetSize: ilocBaseOffsetSize,
+      indexSize: ilocIndexSize
+    }
+  )
   const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
   const meta = buildMetaBox(finalInner)
 
@@ -317,6 +545,52 @@ describe('getFromAvifFile', () => {
     const result = await getFromAvifFile(file)
 
     expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
+  })
+
+  it('extracts EXIF metadata from versioned item info and location boxes', async () => {
+    const workflow = '{"versioned":true}'
+    const file = fileFromBuffer(
+      buildAvifFileWithOptions({
+        exifEntries: [`workflow:${workflow}`],
+        iinfVersion: 1,
+        infeVersion: 3,
+        ilocVersion: 2,
+        ilocBaseOffsetSize: 4,
+        ilocIndexSize: 4
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
+  })
+
+  it('returns {} when the Exif item has no extents', async () => {
+    const file = fileFromBuffer(
+      buildAvifFileWithOptions({
+        exifEntries: ['workflow:{}'],
+        ilocExtents: []
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({})
+  })
+
+  it('returns {} when the Exif payload has no TIFF header', async () => {
+    const file = fileFromBuffer(
+      buildAvifFileWithOptions({
+        rawExifData: new TextEncoder().encode('not tiff data')
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({})
+    expect(console.log).toHaveBeenCalledWith(
+      'Warning: TIFF header not found in EXIF data.'
+    )
   })
 
   it('returns {} when AVIF major brand is not "avif"', async () => {

--- a/src/scripts/metadata/ebml.test.ts
+++ b/src/scripts/metadata/ebml.test.ts
@@ -7,7 +7,8 @@ import {
   EXPECTED_PROMPT_NAN_COERCED,
   EXPECTED_WORKFLOW,
   mockFileReaderAbort,
-  mockFileReaderError
+  mockFileReaderError,
+  mockFileReaderResult
 } from './__fixtures__/helpers'
 import { getFromWebmFile } from './ebml'
 
@@ -16,6 +17,56 @@ const nanFixturePath = path.resolve(
   __dirname,
   '__fixtures__/with_nan_metadata.webm'
 )
+const WEBM_SIGNATURE = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3])
+const SIMPLE_TAG = new Uint8Array([0x67, 0xc8])
+const TAG_NAME = new Uint8Array([0x45, 0xa3])
+const TAG_VALUE = new Uint8Array([0x44, 0x87])
+const encoder = new TextEncoder()
+
+function concatBytes(...chunks: Uint8Array[]) {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return result
+}
+
+function bytes(...values: number[]) {
+  return new Uint8Array(values)
+}
+
+function vint(value: number) {
+  return bytes(0x80 | value)
+}
+
+function element(id: Uint8Array, value: string) {
+  const encoded = encoder.encode(value)
+  return concatBytes(id, vint(encoded.length), encoded)
+}
+
+function simpleTag(name: string, value: string, useTwoByteSize = false) {
+  const payload = concatBytes(
+    element(TAG_NAME, name),
+    element(TAG_VALUE, value)
+  )
+  const size = useTwoByteSize
+    ? bytes(0x40, payload.length)
+    : vint(payload.length)
+  return concatBytes(SIMPLE_TAG, size, payload)
+}
+
+async function readWebm(bytes: Uint8Array) {
+  return getFromWebmFile(
+    new File([bytes as Uint8Array<ArrayBuffer>], 'test.webm', {
+      type: 'video/webm'
+    })
+  )
+}
 
 describe('WebM/EBML metadata', () => {
   it('extracts workflow and prompt from EBML SimpleTag elements', async () => {
@@ -46,6 +97,89 @@ describe('WebM/EBML metadata', () => {
     expect(result).toEqual({})
   })
 
+  it('extracts plain string tags and trims null-terminated values', async () => {
+    const result = await readWebm(
+      concatBytes(
+        WEBM_SIGNATURE,
+        simpleTag('\0Comment', ' hello \0ignored', true)
+      )
+    )
+
+    expect(result.comment).toBe('hello')
+  })
+
+  it('ignores prompt tags whose value is not complete JSON', async () => {
+    const result = await readWebm(
+      concatBytes(WEBM_SIGNATURE, simpleTag('PROMPT', '{not-json'))
+    )
+
+    expect(result.prompt).toBeUndefined()
+  })
+
+  it('ignores prompt tags whose value has no JSON object', async () => {
+    const result = await readWebm(
+      concatBytes(WEBM_SIGNATURE, simpleTag('PROMPT', 'not-json'))
+    )
+
+    expect(result.prompt).toBeUndefined()
+  })
+
+  it('parses the first complete JSON object from a prompt tag', async () => {
+    const result = await readWebm(
+      concatBytes(
+        WEBM_SIGNATURE,
+        simpleTag('PROMPT', 'prefix {"outer":{"inner":1}} trailing')
+      )
+    )
+
+    expect(result.prompt).toEqual({ outer: { inner: 1 } })
+  })
+
+  it('ignores tags whose name has no readable text', async () => {
+    const payload = concatBytes(
+      concatBytes(TAG_NAME, vint(2), bytes(0, 1)),
+      element(TAG_VALUE, 'value')
+    )
+
+    const result = await readWebm(
+      concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, vint(payload.length), payload)
+    )
+
+    expect(result).toEqual({})
+  })
+
+  it('ignores tag elements with zero-sized names', async () => {
+    const payload = concatBytes(TAG_NAME, vint(0), element(TAG_VALUE, 'value'))
+
+    const result = await readWebm(
+      concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, vint(payload.length), payload)
+    )
+
+    expect(result).toEqual({})
+  })
+
+  it('ignores malformed SimpleTag encodings', async () => {
+    const nameOnly = element(TAG_NAME, 'comment')
+
+    await expect(
+      readWebm(concatBytes(WEBM_SIGNATURE, SIMPLE_TAG))
+    ).resolves.toEqual({})
+    await expect(
+      readWebm(concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, bytes(0x00)))
+    ).resolves.toEqual({})
+    await expect(
+      readWebm(concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, bytes(0x7f, 0xff)))
+    ).resolves.toEqual({})
+    await expect(
+      readWebm(concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, vint(10), TAG_NAME))
+    ).resolves.toEqual({})
+    await expect(
+      readWebm(
+        concatBytes(WEBM_SIGNATURE, SIMPLE_TAG, vint(nameOnly.length), nameOnly)
+      )
+    ).resolves.toEqual({})
+  })
+
   describe('FileReader failure modes', () => {
     afterEach(() => vi.restoreAllMocks())
 
@@ -58,6 +192,11 @@ describe('WebM/EBML metadata', () => {
 
     it('resolves empty when the FileReader fires abort', async () => {
       mockFileReaderAbort('readAsArrayBuffer')
+      expect(await getFromWebmFile(file)).toEqual({})
+    })
+
+    it('resolves empty when the FileReader load has no result', async () => {
+      mockFileReaderResult('readAsArrayBuffer', null)
       expect(await getFromWebmFile(file)).toEqual({})
     })
   })

--- a/src/scripts/metadata/gltf.test.ts
+++ b/src/scripts/metadata/gltf.test.ts
@@ -5,7 +5,8 @@ import { ASCII, GltfSizeBytes } from '@/types/metadataTypes'
 import {
   EXPECTED_PROMPT_NAN_COERCED,
   mockFileReaderAbort,
-  mockFileReaderError
+  mockFileReaderError,
+  mockFileReaderResult
 } from './__fixtures__/helpers'
 import { getGltfBinaryMetadata } from './gltf'
 
@@ -21,6 +22,18 @@ describe('GLTF binary metadata parser', () => {
     const chunkView = new DataView(chunkHeader)
     chunkView.setUint32(0, jsonData.byteLength, true)
     chunkView.setUint32(4, ASCII.JSON, true)
+    return chunkHeader
+  }
+
+  const createChunkHeaderWithOptions = (
+    jsonData: ArrayBuffer,
+    chunkType = ASCII.JSON,
+    chunkLength = jsonData.byteLength
+  ) => {
+    const chunkHeader = new ArrayBuffer(GltfSizeBytes.CHUNK_HEADER)
+    const chunkView = new DataView(chunkHeader)
+    chunkView.setUint32(0, chunkLength, true)
+    chunkView.setUint32(4, chunkType, true)
     return chunkHeader
   }
 
@@ -59,6 +72,42 @@ describe('GLTF binary metadata parser', () => {
     setHeaders(headerView, jsonData.buffer)
 
     const chunkHeader = createJSONChunk(jsonData.buffer)
+
+    const fileContent = new Uint8Array(
+      header.byteLength + chunkHeader.byteLength + jsonData.byteLength
+    )
+    fileContent.set(new Uint8Array(header), 0)
+    fileContent.set(new Uint8Array(chunkHeader), header.byteLength)
+    fileContent.set(jsonData, header.byteLength + chunkHeader.byteLength)
+
+    return new File([fileContent], 'test.glb', { type: 'model/gltf-binary' })
+  }
+
+  interface MockGltfFileOptions {
+    chunkLength?: number
+    chunkType?: number
+    magicNumber?: number
+  }
+
+  function createMockGltfFileFromTextWithOptions(
+    jsonText: string,
+    {
+      chunkLength,
+      chunkType = ASCII.JSON,
+      magicNumber = ASCII.GLTF
+    }: MockGltfFileOptions = {}
+  ): File {
+    const jsonData = new TextEncoder().encode(jsonText)
+    const { header, headerView } = createGLTFFileStructure()
+
+    setHeaders(headerView, jsonData.buffer)
+    setTypeHeader(headerView, magicNumber)
+
+    const chunkHeader = createChunkHeaderWithOptions(
+      jsonData.buffer,
+      chunkType,
+      chunkLength
+    )
 
     const fileContent = new Uint8Array(
       header.byteLength + chunkHeader.byteLength + jsonData.byteLength
@@ -179,6 +228,80 @@ describe('GLTF binary metadata parser', () => {
     expect(metadata).toEqual({})
   })
 
+  it('returns empty when the GLB magic number is invalid', async () => {
+    const mockFile = createMockGltfFileFromTextWithOptions('{}', {
+      magicNumber: 0
+    })
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('returns empty when the GLB is missing the first chunk header', async () => {
+    const { header, headerView } = createGLTFFileStructure()
+    setTypeHeader(headerView, ASCII.GLTF)
+    setVersionHeader(headerView, 2)
+    setTotalLengthHeader(headerView, GltfSizeBytes.HEADER)
+    const mockFile = new File([header], 'header-only.glb')
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('returns empty when the first chunk is not JSON', async () => {
+    const mockFile = createMockGltfFileFromTextWithOptions('{}', {
+      chunkType: 0
+    })
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('returns empty when the declared JSON chunk exceeds the buffer', async () => {
+    const mockFile = createMockGltfFileFromTextWithOptions('{}', {
+      chunkLength: 1024
+    })
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('returns empty when the JSON chunk cannot be parsed', async () => {
+    const mockFile = createMockGltfFileFromText('{not json')
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('returns empty when asset extras are missing', async () => {
+    const mockFile = createMockGltfFile({ asset: { version: '2.0' } })
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
+  it('skips string metadata values that are not valid JSON', async () => {
+    const mockFile = createMockGltfFile({
+      asset: {
+        version: '2.0',
+        extras: {
+          prompt: '{not json',
+          workflow: '{not json'
+        }
+      }
+    })
+
+    const metadata = await getGltfBinaryMetadata(mockFile)
+
+    expect(metadata).toEqual({})
+  })
+
   describe('FileReader failure modes', () => {
     afterEach(() => vi.restoreAllMocks())
 
@@ -191,6 +314,16 @@ describe('GLTF binary metadata parser', () => {
 
     it('resolves empty when the FileReader fires abort', async () => {
       mockFileReaderAbort('readAsArrayBuffer')
+      expect(await getGltfBinaryMetadata(file)).toEqual({})
+    })
+
+    it('resolves empty when the FileReader load result is missing', async () => {
+      mockFileReaderResult('readAsArrayBuffer', null)
+      expect(await getGltfBinaryMetadata(file)).toEqual({})
+    })
+
+    it('resolves empty when the FileReader result is not a buffer', async () => {
+      mockFileReaderResult('readAsArrayBuffer', 'not a buffer')
       expect(await getGltfBinaryMetadata(file)).toEqual({})
     })
   })

--- a/src/scripts/metadata/isobmff.test.ts
+++ b/src/scripts/metadata/isobmff.test.ts
@@ -7,7 +7,8 @@ import {
   EXPECTED_PROMPT_NAN_COERCED,
   EXPECTED_WORKFLOW,
   mockFileReaderAbort,
-  mockFileReaderError
+  mockFileReaderError,
+  mockFileReaderResult
 } from './__fixtures__/helpers'
 import { getFromIsobmffFile } from './isobmff'
 
@@ -16,6 +17,82 @@ const nanFixturePath = path.resolve(
   __dirname,
   '__fixtures__/with_nan_metadata.mp4'
 )
+const encoder = new TextEncoder()
+
+function uint32(value: number) {
+  return new Uint8Array([
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff
+  ])
+}
+
+function concatBytes(...chunks: Uint8Array[]) {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return result
+}
+
+function box(type: string, payload = new Uint8Array(), size?: number) {
+  return concatBytes(
+    uint32(size ?? 8 + payload.length),
+    encoder.encode(type),
+    payload
+  )
+}
+
+function keyEntry(name: string) {
+  const encoded = encoder.encode(name)
+  return concatBytes(
+    uint32(8 + encoded.length),
+    encoder.encode('mdta'),
+    encoded
+  )
+}
+
+function keysBox(names: string[]) {
+  return box(
+    'keys',
+    concatBytes(uint32(0), uint32(names.length), ...names.map(keyEntry))
+  )
+}
+
+function dataBox(value: string | Uint8Array) {
+  const payload = typeof value === 'string' ? encoder.encode(value) : value
+  return box('data', concatBytes(uint32(0), uint32(0), payload))
+}
+
+function ilstItem(index: number, payload: Uint8Array) {
+  return concatBytes(uint32(8 + payload.length), uint32(index), payload)
+}
+
+function ilstBox(...items: Uint8Array[]) {
+  return box('ilst', concatBytes(...items))
+}
+
+function metaBox(...children: Uint8Array[]) {
+  return box('meta', concatBytes(uint32(0), ...children))
+}
+
+function udtaWithMeta(...children: Uint8Array[]) {
+  return box('udta', metaBox(...children))
+}
+
+async function readMp4(bytes: Uint8Array) {
+  return getFromIsobmffFile(
+    new File([bytes as Uint8Array<ArrayBuffer>], 'test.mp4', {
+      type: 'video/mp4'
+    })
+  )
+}
 
 describe('ISOBMFF (MP4) metadata', () => {
   it('extracts workflow and prompt from QuickTime keys/ilst boxes', async () => {
@@ -48,6 +125,102 @@ describe('ISOBMFF (MP4) metadata', () => {
     expect(result).toEqual({})
   })
 
+  it('extracts metadata from udta nested inside moov', async () => {
+    const bytes = box(
+      'moov',
+      udtaWithMeta(
+        keysBox(['WORKFLOW']),
+        ilstBox(ilstItem(1, dataBox('xxxx{"nodes":[]}')))
+      )
+    )
+
+    const result = await readMp4(bytes)
+
+    expect(result.workflow).toEqual({ nodes: [] })
+  })
+
+  it('returns empty when a top-level box declares an impossible size', async () => {
+    const result = await readMp4(box('free', new Uint8Array([1, 2]), 100))
+
+    expect(result).toEqual({})
+  })
+
+  it('returns empty when the keys box cannot provide entries', async () => {
+    const tooShortKeys = box('keys', uint32(0))
+    const missingKeyEntry = box(
+      'keys',
+      concatBytes(uint32(0), uint32(1), uint32(8))
+    )
+    const malformedKey = box(
+      'keys',
+      concatBytes(uint32(0), uint32(1), uint32(7), encoder.encode('bad!'))
+    )
+    const oversizedKey = box(
+      'keys',
+      concatBytes(uint32(0), uint32(1), uint32(100), encoder.encode('bad!'))
+    )
+
+    await expect(readMp4(udtaWithMeta(tooShortKeys))).resolves.toEqual({})
+    await expect(readMp4(udtaWithMeta(missingKeyEntry))).resolves.toEqual({})
+    await expect(readMp4(udtaWithMeta(malformedKey))).resolves.toEqual({})
+    await expect(readMp4(udtaWithMeta(oversizedKey))).resolves.toEqual({})
+  })
+
+  it('ignores item entries whose key is unknown or unsupported', async () => {
+    const unknownIndex = udtaWithMeta(
+      keysBox(['PROMPT']),
+      ilstBox(ilstItem(2, dataBox('{"1":{}}')))
+    )
+    const unsupportedKey = udtaWithMeta(
+      keysBox(['DESCRIPTION']),
+      ilstBox(ilstItem(1, dataBox('{"ignored":true}')))
+    )
+
+    await expect(readMp4(unknownIndex)).resolves.toEqual({})
+    await expect(readMp4(unsupportedKey)).resolves.toEqual({})
+  })
+
+  it('ignores metadata items without readable JSON data', async () => {
+    const shortDataBox = box('data')
+    const noJson = dataBox('not-json')
+    const invalidJson = dataBox('prefix {not-json')
+    const noDataBox = box('free', new Uint8Array([1]))
+    const invalidItems = ilstBox(
+      concatBytes(uint32(8), uint32(1)),
+      concatBytes(uint32(100), uint32(1), invalidJson)
+    )
+
+    await expect(
+      readMp4(
+        udtaWithMeta(keysBox(['PROMPT']), ilstBox(ilstItem(1, shortDataBox)))
+      )
+    ).resolves.toEqual({})
+    await expect(
+      readMp4(udtaWithMeta(keysBox(['PROMPT']), ilstBox(ilstItem(1, noJson))))
+    ).resolves.toEqual({})
+    await expect(
+      readMp4(
+        udtaWithMeta(keysBox(['PROMPT']), ilstBox(ilstItem(1, invalidJson)))
+      )
+    ).resolves.toEqual({})
+    await expect(
+      readMp4(
+        udtaWithMeta(keysBox(['PROMPT']), ilstBox(ilstItem(1, noDataBox)))
+      )
+    ).resolves.toEqual({})
+    await expect(
+      readMp4(udtaWithMeta(keysBox(['PROMPT']), invalidItems))
+    ).resolves.toEqual({})
+  })
+
+  it('returns empty when required metadata boxes are absent', async () => {
+    await expect(readMp4(box('udta', box('free')))).resolves.toEqual({})
+    await expect(readMp4(udtaWithMeta(ilstBox()))).resolves.toEqual({})
+    await expect(readMp4(udtaWithMeta(keysBox(['PROMPT'])))).resolves.toEqual(
+      {}
+    )
+  })
+
   describe('FileReader failure modes', () => {
     afterEach(() => vi.restoreAllMocks())
 
@@ -61,6 +234,11 @@ describe('ISOBMFF (MP4) metadata', () => {
 
     it('resolves empty when the FileReader fires abort', async () => {
       mockFileReaderAbort('readAsArrayBuffer')
+      expect(await getFromIsobmffFile(file)).toEqual({})
+    })
+
+    it('resolves empty when the FileReader load has no result', async () => {
+      mockFileReaderResult('readAsArrayBuffer', null)
       expect(await getFromIsobmffFile(file)).toEqual({})
     })
   })

--- a/src/scripts/metadata/parser.test.ts
+++ b/src/scripts/metadata/parser.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getFromWebmFile } from '@/scripts/metadata/ebml'
+import { getGltfBinaryMetadata } from '@/scripts/metadata/gltf'
+import { getFromIsobmffFile } from '@/scripts/metadata/isobmff'
+import { getDataFromJSON } from '@/scripts/metadata/json'
+import { getMp3Metadata } from '@/scripts/metadata/mp3'
+import { getOggMetadata } from '@/scripts/metadata/ogg'
+import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
+import { getSvgMetadata } from '@/scripts/metadata/svg'
+import {
+  getAvifMetadata,
+  getFlacMetadata,
+  getLatentMetadata,
+  getPngMetadata,
+  getWebpMetadata
+} from '@/scripts/pnginfo'
+
+vi.mock('@/scripts/metadata/ebml', () => ({ getFromWebmFile: vi.fn() }))
+vi.mock('@/scripts/metadata/gltf', () => ({ getGltfBinaryMetadata: vi.fn() }))
+vi.mock('@/scripts/metadata/isobmff', () => ({ getFromIsobmffFile: vi.fn() }))
+vi.mock('@/scripts/metadata/json', () => ({ getDataFromJSON: vi.fn() }))
+vi.mock('@/scripts/metadata/mp3', () => ({ getMp3Metadata: vi.fn() }))
+vi.mock('@/scripts/metadata/ogg', () => ({ getOggMetadata: vi.fn() }))
+vi.mock('@/scripts/metadata/svg', () => ({ getSvgMetadata: vi.fn() }))
+vi.mock('@/scripts/pnginfo', () => ({
+  getAvifMetadata: vi.fn(),
+  getFlacMetadata: vi.fn(),
+  getLatentMetadata: vi.fn(),
+  getPngMetadata: vi.fn(),
+  getWebpMetadata: vi.fn()
+}))
+
+function file(type: string, name = 'file') {
+  return new File(['data'], name, { type })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getWorkflowDataFromFile', () => {
+  it('routes png/avif/mp3/ogg/webm to their parsers and returns the result', async () => {
+    vi.mocked(getPngMetadata).mockResolvedValue({ a: '1' })
+    expect(await getWorkflowDataFromFile(file('image/png'))).toEqual({ a: '1' })
+    expect(getPngMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('image/avif'))
+    expect(getAvifMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('audio/mpeg'))
+    expect(getMp3Metadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('audio/ogg'))
+    expect(getOggMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('video/webm'))
+    expect(getFromWebmFile).toHaveBeenCalled()
+  })
+
+  it('extracts workflow/prompt from webp, preferring lowercase keys', async () => {
+    vi.mocked(getWebpMetadata).mockResolvedValue({
+      workflow: 'wf',
+      prompt: 'pr'
+    })
+    expect(await getWorkflowDataFromFile(file('image/webp'))).toEqual({
+      workflow: 'wf',
+      prompt: 'pr'
+    })
+  })
+
+  it('falls back to capitalized webp keys when lowercase are absent', async () => {
+    vi.mocked(getWebpMetadata).mockResolvedValue({
+      Workflow: 'WF',
+      Prompt: 'PR'
+    })
+    expect(await getWorkflowDataFromFile(file('image/webp'))).toEqual({
+      workflow: 'WF',
+      prompt: 'PR'
+    })
+  })
+
+  it('handles both flac mime types and extracts workflow/prompt', async () => {
+    vi.mocked(getFlacMetadata).mockResolvedValue({ workflow: 'w' })
+    expect(await getWorkflowDataFromFile(file('audio/flac'))).toEqual({
+      workflow: 'w',
+      prompt: undefined
+    })
+    expect(await getWorkflowDataFromFile(file('audio/x-flac'))).toEqual({
+      workflow: 'w',
+      prompt: undefined
+    })
+  })
+
+  it('routes isobmff by mime type and by file extension', async () => {
+    await getWorkflowDataFromFile(file('video/mp4'))
+    await getWorkflowDataFromFile(file('', 'clip.mov'))
+    await getWorkflowDataFromFile(file('', 'clip.m4v'))
+    expect(getFromIsobmffFile).toHaveBeenCalledTimes(3)
+  })
+
+  it('routes svg and gltf by mime type or extension', async () => {
+    await getWorkflowDataFromFile(file('image/svg+xml'))
+    await getWorkflowDataFromFile(file('', 'icon.svg'))
+    expect(getSvgMetadata).toHaveBeenCalledTimes(2)
+
+    await getWorkflowDataFromFile(file('model/gltf-binary'))
+    await getWorkflowDataFromFile(file('', 'model.glb'))
+    expect(getGltfBinaryMetadata).toHaveBeenCalledTimes(2)
+  })
+
+  it('routes latent/safetensors and json by extension or mime type', async () => {
+    await getWorkflowDataFromFile(file('', 'x.latent'))
+    await getWorkflowDataFromFile(file('', 'x.safetensors'))
+    expect(getLatentMetadata).toHaveBeenCalledTimes(2)
+
+    await getWorkflowDataFromFile(file('application/json'))
+    await getWorkflowDataFromFile(file('', 'x.json'))
+    expect(getDataFromJSON).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns undefined for an unrecognized file', async () => {
+    expect(
+      await getWorkflowDataFromFile(file('application/zip', 'a.zip'))
+    ).toBe(undefined)
+  })
+})

--- a/src/scripts/metadata/png.test.ts
+++ b/src/scripts/metadata/png.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   mockFileReaderAbort,
-  mockFileReaderError
+  mockFileReaderError,
+  mockFileReaderResult
 } from './__fixtures__/helpers'
 import { getFromPngBuffer, getFromPngFile } from './png'
 
@@ -191,6 +192,27 @@ describe('getFromPngBuffer', () => {
     const result = await getFromPngBuffer(buffer)
     expect(result['workflow']).toBe(workflow)
   })
+
+  it('logs error and skips compressed iTXt with invalid deflate data', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const buffer = createPngWithChunk(
+      'iTXt',
+      'workflow',
+      new Uint8Array([1, 2, 3]),
+      {
+        compressionFlag: 1,
+        compressionMethod: 0
+      }
+    )
+
+    const result = await getFromPngBuffer(buffer)
+
+    expect(result['workflow']).toBeUndefined()
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to decompress iTXt chunk "workflow"'),
+      expect.anything()
+    )
+  })
 })
 
 describe('getFromPngFile', () => {
@@ -227,6 +249,13 @@ describe('getFromPngFile', () => {
     it('rejects when the FileReader fires abort', async () => {
       mockFileReaderAbort('readAsArrayBuffer')
       await expect(getFromPngFile(file)).rejects.toThrow('FileReader aborted')
+    })
+
+    it('rejects when the FileReader load has no ArrayBuffer result', async () => {
+      mockFileReaderResult('readAsArrayBuffer', null)
+      await expect(getFromPngFile(file)).rejects.toThrow(
+        'Failed to read file as ArrayBuffer'
+      )
     })
   })
 })

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -1,13 +1,23 @@
 import fs from 'fs'
 import path from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
 
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { api } from '@/scripts/api'
+import {
+  createMockLGraph,
+  createMockLGraphNode
+} from '@/utils/__tests__/litegraphTestUtils'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
 import {
   getAvifMetadata,
   getFlacMetadata,
+  importA1111,
   getLatentMetadata,
   getPngMetadata,
   getWebpMetadata
@@ -53,6 +63,20 @@ function encodeAsciiIfd(entries: AsciiIfdEntry[]): Uint8Array {
     stringOffset += strings[i].length
   }
 
+  return buf
+}
+
+function encodeNonAsciiIfdEntry(tag: number): Uint8Array {
+  const buf = new Uint8Array(22)
+  const dv = new DataView(buf.buffer)
+  buf.set([0x49, 0x49], 0)
+  dv.setUint16(2, 0x002a, true)
+  dv.setUint32(4, 8, true)
+  dv.setUint16(8, 1, true)
+  dv.setUint16(10, tag, true)
+  dv.setUint16(12, 3, true)
+  dv.setUint32(14, 1, true)
+  dv.setUint32(18, 123, true)
   return buf
 }
 
@@ -157,6 +181,16 @@ describe('getWebpMetadata', () => {
 
     expect(metadata).toEqual({ workflow: '{"a":1}' })
   })
+
+  it('ignores EXIF entries that are not ASCII strings', async () => {
+    const file = wrapInWebp([
+      { type: 'EXIF', payload: encodeNonAsciiIfdEntry(270) }
+    ])
+
+    const metadata = await getWebpMetadata(file)
+
+    expect(metadata).toEqual({})
+  })
 })
 
 describe('getLatentMetadata', () => {
@@ -232,5 +266,315 @@ describe('format-specific metadata wrappers', () => {
 
     expect(getFromAvifFile).toHaveBeenCalledWith(file)
     expect(result).toEqual({ workflow: '{"avif":1}' })
+  })
+})
+
+describe('importA1111', () => {
+  function widget(
+    name: string,
+    options: string[] = []
+  ): IBaseWidget & { value?: string | number } {
+    return fromPartial<IBaseWidget & { value?: string | number }>({
+      name,
+      options: { values: options },
+      value: undefined
+    })
+  }
+
+  function createNode(type: string): LGraphNode {
+    const widgetsByType: Record<string, IBaseWidget[]> = {
+      CheckpointLoaderSimple: [widget('ckpt_name', ['sd15.safetensors'])],
+      CLIPSetLastLayer: [widget('stop_at_clip_layer')],
+      CLIPTextEncode: [widget('text')],
+      EmptyLatentImage: [widget('width'), widget('height')],
+      ImageScale: [widget('width'), widget('height')],
+      ImageUpscaleWithModel: [],
+      KSampler: [
+        widget('cfg'),
+        widget('sampler_name', ['euler_a', 'dpmpp_2m']),
+        widget('scheduler', ['normal', 'karras']),
+        widget('seed'),
+        widget('steps'),
+        widget('denoise')
+      ],
+      LatentUpscale: [
+        widget('upscale_method', ['nearest-exact']),
+        widget('width'),
+        widget('height')
+      ],
+      LoraLoader: [
+        widget('lora_name', ['foo.safetensors']),
+        widget('strength_model'),
+        widget('strength_clip')
+      ],
+      UpscaleModelLoader: [widget('model_name', ['ESRGAN'])],
+      VAEEncodeTiled: [],
+      VAEDecodeTiled: [],
+      SaveImage: [],
+      VAEDecode: []
+    }
+    return createMockLGraphNode({
+      type,
+      widgets: widgetsByType[type] ?? [],
+      connect: vi.fn()
+    })
+  }
+
+  function createGraph(): LGraph {
+    return createMockLGraph({
+      add: vi.fn(),
+      arrange: vi.fn(),
+      clear: vi.fn()
+    })
+  }
+
+  function findWidget(node: LGraphNode, name: string) {
+    return node.widgets?.find((widget) => widget.name === name)
+  }
+
+  it('ignores text without parsed generation settings', async () => {
+    const graph = createGraph()
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+
+    await importA1111(graph, 'positive prompt only')
+    await importA1111(graph, 'positive prompt\nSteps:\n')
+
+    expect(graph.clear).not.toHaveBeenCalled()
+  })
+
+  it('ignores text without a negative prompt section', async () => {
+    const graph = createGraph()
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+
+    await importA1111(
+      graph,
+      ['positive prompt only', 'Steps: 20, Sampler: Euler a'].join('\n')
+    )
+
+    expect(graph.clear).not.toHaveBeenCalled()
+  })
+
+  it('stops when a required base node cannot be created', async () => {
+    const graph = createGraph()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) =>
+      type === 'KSampler' ? null : createNode(type)
+    )
+
+    await importA1111(
+      graph,
+      [
+        'prompt',
+        'Negative prompt: blurry',
+        'Steps: 20, Sampler: Euler a, Size: 512x512'
+      ].join('\n')
+    )
+
+    expect(graph.clear).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to create required nodes for A1111 import'
+    )
+  })
+
+  it('builds a basic graph from A1111 parameters', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue(['easynegative'])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        '<lora:foo:0.7> portrait easynegative',
+        'Negative prompt: blurry <lora:bad:not-number>',
+        'Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 42, Size: 512x512, Model: sd15, Clip skip: 2, Model hash: ignored'
+      ].join('\n')
+    )
+
+    const checkpoint = nodes.find(
+      (node) => node.type === 'CheckpointLoaderSimple'
+    )
+    const clipSkip = nodes.find((node) => node.type === 'CLIPSetLastLayer')
+    const sampler = nodes.find((node) => node.type === 'KSampler')
+    const image = nodes.find((node) => node.type === 'EmptyLatentImage')
+    const lora = nodes.find((node) => node.type === 'LoraLoader')
+    const textNodes = nodes.filter((node) => node.type === 'CLIPTextEncode')
+
+    expect(graph.clear).toHaveBeenCalledOnce()
+    expect(graph.arrange).toHaveBeenCalledOnce()
+    expect(findWidget(checkpoint!, 'ckpt_name')?.value).toBe('sd15.safetensors')
+    expect(findWidget(clipSkip!, 'stop_at_clip_layer')?.value).toBe(-2)
+    expect(findWidget(sampler!, 'cfg')?.value).toBe(7)
+    expect(findWidget(sampler!, 'sampler_name')?.value).toBe('euler_a')
+    expect(findWidget(sampler!, 'scheduler')?.value).toBe('normal')
+    expect(findWidget(sampler!, 'seed')?.value).toBe(42)
+    expect(findWidget(sampler!, 'steps')?.value).toBe(20)
+    expect(findWidget(image!, 'width')?.value).toBe(512)
+    expect(findWidget(image!, 'height')?.value).toBe(512)
+    expect(findWidget(lora!, 'lora_name')?.value).toBe('foo.safetensors')
+    expect(findWidget(lora!, 'strength_model')?.value).toBe(0.7)
+    expect(findWidget(lora!, 'strength_clip')?.value).toBe(0.7)
+    expect(findWidget(textNodes[0], 'text')?.value).toBe(
+      ' portrait embedding:easynegative'
+    )
+    expect(findWidget(textNodes[1], 'text')?.value).toBe('blurry ')
+  })
+
+  it('keeps unknown option-prefix values and logs the mismatch', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        'portrait',
+        'Negative prompt: blurry',
+        'Steps: 20, Sampler: Unknown Sampler, CFG scale: 7, Seed: 42, Size: 512x512, Model: unknown-model'
+      ].join('\n')
+    )
+
+    const checkpoint = nodes.find(
+      (node) => node.type === 'CheckpointLoaderSimple'
+    )
+    expect(findWidget(checkpoint!, 'ckpt_name')?.value).toBe('unknown-model')
+    expect(console.warn).toHaveBeenCalledWith(
+      "Unknown value 'unknown-model' for widget 'ckpt_name'",
+      checkpoint
+    )
+  })
+
+  it('skips missing LoraLoader nodes while keeping prompt text cleaned', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      if (type === 'LoraLoader') return null
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        '<lora:missing:0.5> portrait',
+        'Negative prompt: blurry',
+        'Steps: 20, Sampler: Euler a, Size: 512x512'
+      ].join('\n')
+    )
+
+    const textNodes = nodes.filter((node) => node.type === 'CLIPTextEncode')
+    expect(findWidget(textNodes[0], 'text')?.value).toBe(' portrait')
+  })
+
+  it('returns from latent hires setup when LatentUpscale cannot be created', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      if (type === 'LatentUpscale') return null
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        'portrait',
+        'Negative prompt: blurry',
+        'Steps: 8, Sampler: Euler a, Size: 512x512, Hires upscale: 2, Hires upscaler: Latent'
+      ].join('\n')
+    )
+
+    expect(nodes.some((node) => node.type === 'KSampler')).toBe(true)
+    expect(nodes.some((node) => node.type === 'LatentUpscale')).toBe(false)
+  })
+
+  it('builds a latent hires pass with explicit resize and denoise settings', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        'portrait',
+        'Negative prompt: blurry',
+        'Steps: 12, Sampler: DPM++ 2M Karras, CFG scale: 5, Seed: 1, Size: 513x577, Model: sd15, Hires resize: 1025x1089, Hires steps: 4, Hires upscaler: Latent (nearest-exact), Denoising strength: 0.35'
+      ].join('\n')
+    )
+
+    const image = nodes.find((node) => node.type === 'EmptyLatentImage')
+    const latentUpscale = nodes.find((node) => node.type === 'LatentUpscale')
+    const samplers = nodes.filter((node) => node.type === 'KSampler')
+
+    expect(findWidget(image!, 'width')?.value).toBe(576)
+    expect(findWidget(image!, 'height')?.value).toBe(640)
+    expect(findWidget(latentUpscale!, 'upscale_method')?.value).toBe(
+      'nearest-exact'
+    )
+    expect(findWidget(latentUpscale!, 'width')?.value).toBe(1088)
+    expect(findWidget(latentUpscale!, 'height')?.value).toBe(1152)
+    expect(findWidget(samplers[0], 'scheduler')?.value).toBe('karras')
+    expect(findWidget(samplers[0], 'sampler_name')?.value).toBe('dpmpp_2m')
+    expect(findWidget(samplers[1], 'steps')?.value).toBe(4)
+    expect(findWidget(samplers[1], 'cfg')?.value).toBe(5)
+    expect(findWidget(samplers[1], 'scheduler')?.value).toBe('karras')
+    expect(findWidget(samplers[1], 'sampler_name')?.value).toBe('dpmpp_2m')
+    expect(findWidget(samplers[1], 'denoise')?.value).toBe(0.35)
+  })
+
+  it('builds an image upscaler hires pass with fallback steps and denoise', async () => {
+    const graph = createGraph()
+    const nodes: LGraphNode[] = []
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      const node = createNode(type)
+      nodes.push(node)
+      return node
+    })
+
+    await importA1111(
+      graph,
+      [
+        'portrait',
+        'Negative prompt: blurry',
+        'Steps: 8, Sampler: Euler a, CFG scale: 6, Seed: 2, Size: 512x512, Model: sd15, Hires upscale: 1.5, Hires upscaler: ESRGAN'
+      ].join('\n')
+    )
+
+    const upscaleLoader = nodes.find(
+      (node) => node.type === 'UpscaleModelLoader'
+    )
+    const imageScale = nodes.find((node) => node.type === 'ImageScale')
+    const samplers = nodes.filter((node) => node.type === 'KSampler')
+
+    expect(findWidget(upscaleLoader!, 'model_name')?.value).toBe('ESRGAN')
+    expect(findWidget(imageScale!, 'width')?.value).toBe(768)
+    expect(findWidget(imageScale!, 'height')?.value).toBe(768)
+    expect(findWidget(samplers[1], 'steps')?.value).toBe(8)
+    expect(findWidget(samplers[1], 'denoise')?.value).toBe(1)
   })
 })

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -1,0 +1,472 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSettingStore } = vi.hoisted(() => ({
+  mockSettingStore: {
+    get: vi.fn()
+  }
+}))
+
+vi.mock('@/composables/useRunButtonTelemetry', () => ({
+  useRunButtonTelemetry: () => ({ trackRunButton: vi.fn() })
+}))
+
+vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', () => ({
+  extractWorkflow: vi.fn()
+}))
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({ show: vi.fn() })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => mockSettingStore
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackWorkflowExecution: vi.fn() })
+}))
+
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: () => ({ resetView: vi.fn() })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({ execute: vi.fn() })
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({ focusMode: false })
+}))
+
+vi.mock('./api', () => ({
+  api: {
+    addEventListener: vi.fn(),
+    clearItems: vi.fn(),
+    deleteItem: vi.fn(),
+    dispatchCustomEvent: vi.fn(),
+    getHistory: vi.fn(),
+    getJobDetail: vi.fn(),
+    getQueue: vi.fn(),
+    interrupt: vi.fn()
+  }
+}))
+
+vi.mock('./app', () => ({
+  app: {
+    clean: vi.fn(),
+    handleFile: vi.fn(),
+    loadGraphData: vi.fn(),
+    openClipspace: vi.fn(),
+    queuePrompt: vi.fn(),
+    refreshComboInNodes: vi.fn(() => Promise.resolve())
+  },
+  ComfyApp: class ComfyApp {}
+}))
+
+vi.mock('./ui/dialog', () => ({
+  ComfyDialog: class ComfyDialog {}
+}))
+
+vi.mock('./ui/settings', () => ({
+  ComfySettingsDialog: class ComfySettingsDialog {}
+}))
+
+vi.mock('./ui/toggleSwitch', () => ({
+  toggleSwitch: () => document.createElement('div')
+}))
+
+import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
+import type {
+  JobDetail,
+  JobListItem
+} from '@/platform/remote/comfyui/jobs/jobTypes'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+import { api } from './api'
+import { app } from './app'
+import { $el, ComfyUI } from './ui'
+
+beforeEach(() => {
+  document.body.replaceChildren()
+  localStorage.clear()
+  vi.clearAllMocks()
+  mockSettingStore.get.mockReturnValue(undefined)
+  Object.assign(app, {
+    lastExecutionError: undefined,
+    nodeOutputs: undefined
+  })
+})
+
+async function click(button: HTMLButtonElement) {
+  const handler = button.onclick
+  expect(handler).toBeTypeOf('function')
+  await Promise.resolve(handler?.call(button, new PointerEvent('click')))
+}
+
+function buttonByText(root: ParentNode, text: string): HTMLButtonElement {
+  const button = [...root.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent === text
+  )
+  if (!button) throw new Error(`Missing button: ${text}`)
+  return button
+}
+
+describe('$el', () => {
+  it('creates elements with classes, children, props, and callbacks', () => {
+    const parent = document.createElement('section')
+    const child = document.createElement('span')
+    const callback = vi.fn()
+
+    const element = $el(
+      'label.primary.secondary',
+      {
+        parent,
+        $: callback,
+        dataset: { role: 'name' },
+        for: 'target-input',
+        style: { display: 'block' },
+        title: 'Label'
+      },
+      child
+    )
+
+    expect(element.tagName).toBe('LABEL')
+    expect(element.classList.contains('primary')).toBe(true)
+    expect(element.classList.contains('secondary')).toBe(true)
+    expect(element.dataset.role).toBe('name')
+    expect(element.getAttribute('for')).toBe('target-input')
+    expect(element.style.display).toBe('block')
+    expect(element.title).toBe('Label')
+    expect(element.firstElementChild).toBe(child)
+    expect(parent.firstElementChild).toBe(element)
+    expect(callback).toHaveBeenCalledWith(element)
+  })
+
+  it('accepts string and single-element children shorthands', () => {
+    const textElement = $el('button', 'Run')
+    const child = document.createElement('strong')
+    const wrapper = $el('div', child)
+
+    expect(textElement.textContent).toBe('Run')
+    expect(wrapper.firstElementChild).toBe(child)
+  })
+})
+
+describe('ComfyUI legacy menu', () => {
+  it('loads queue items and runs list actions', async () => {
+    vi.mocked(api.getQueue).mockResolvedValue({
+      Running: [fromPartial<JobListItem>({ id: 'running', priority: 1 })],
+      Pending: [fromPartial<JobListItem>({ id: 'pending', priority: 2 })]
+    })
+    vi.mocked(api.getJobDetail).mockResolvedValue(
+      fromPartial<JobDetail>({
+        outputs: { node: { images: ['image.png'] } }
+      } as PartialDeep<JobDetail>)
+    )
+    vi.mocked(extractWorkflow).mockResolvedValue(
+      fromPartial<ComfyWorkflowJSON>({ nodes: [] })
+    )
+    const ui = new ComfyUI(app)
+
+    await ui.queue.show()
+    await click(buttonByText(ui.queue.element, 'Load'))
+
+    expect(api.getJobDetail).toHaveBeenCalledWith('running')
+    expect(extractWorkflow).toHaveBeenCalled()
+    expect(app.loadGraphData).toHaveBeenCalledWith({ nodes: [] }, true, false)
+    expect(app.nodeOutputs).toEqual({ node: { images: ['image.png'] } })
+
+    await click(buttonByText(ui.queue.element, 'Cancel'))
+    expect(api.interrupt).toHaveBeenCalledWith('running')
+
+    await click(buttonByText(ui.queue.element, 'Delete'))
+    expect(api.deleteItem).toHaveBeenCalledWith('queue', 'pending')
+
+    await click(buttonByText(ui.queue.element, 'Clear Queue'))
+    expect(api.clearItems).toHaveBeenCalledWith('queue')
+
+    await click(buttonByText(ui.queue.element, 'Refresh'))
+    expect(api.getQueue).toHaveBeenCalled()
+  })
+
+  it('skips loading queue items when job details are unavailable', async () => {
+    vi.mocked(api.getQueue).mockResolvedValue({
+      Running: [fromPartial<JobListItem>({ id: 'running', priority: 1 })],
+      Pending: []
+    })
+    vi.mocked(api.getJobDetail).mockResolvedValue(undefined)
+    const ui = new ComfyUI(app)
+
+    await ui.queue.show()
+    await click(buttonByText(ui.queue.element, 'Load'))
+
+    expect(extractWorkflow).not.toHaveBeenCalled()
+    expect(app.loadGraphData).not.toHaveBeenCalled()
+  })
+
+  it('loads queue item workflows without outputs', async () => {
+    vi.mocked(api.getQueue).mockResolvedValue({
+      Running: [fromPartial<JobListItem>({ id: 'running', priority: 1 })],
+      Pending: []
+    })
+    vi.mocked(api.getJobDetail).mockResolvedValue(
+      fromPartial<JobDetail>({ id: 'running' })
+    )
+    vi.mocked(extractWorkflow).mockResolvedValue(
+      fromPartial<ComfyWorkflowJSON>({ nodes: [] })
+    )
+    const ui = new ComfyUI(app)
+
+    await ui.queue.show()
+    await click(buttonByText(ui.queue.element, 'Load'))
+
+    expect(app.loadGraphData).toHaveBeenCalledWith({ nodes: [] }, true, false)
+    expect(app.nodeOutputs).toBeUndefined()
+  })
+
+  it('loads history in reverse order', async () => {
+    vi.mocked(api.getHistory).mockResolvedValue([
+      fromPartial<JobListItem>({ id: 'old', priority: 1 }),
+      fromPartial<JobListItem>({ id: 'new', priority: 2 })
+    ])
+    const ui = new ComfyUI(app)
+
+    await ui.history.show()
+
+    expect(ui.history.element.textContent).toContain('2: LoadDelete')
+    expect(ui.history.element.textContent?.indexOf('2:')).toBeLessThan(
+      ui.history.element.textContent?.indexOf('1:') ?? Number.MAX_SAFE_INTEGER
+    )
+  })
+
+  it('updates queue status and auto-queues when enabled', () => {
+    const ui = new ComfyUI(app)
+    ui.autoQueueEnabled = true
+    ui.autoQueueMode = 'instant'
+    ui.lastQueueSize = 1
+    ui.batchCount = 3
+
+    ui.setStatus({ exec_info: { queue_remaining: 0 } })
+
+    expect(app.queuePrompt).toHaveBeenCalledWith(0, 3)
+    expect(ui.queueSize.textContent).toBe('Queue size: 0')
+    expect(ui.lastQueueSize).toBe(3)
+
+    ui.setStatus(null)
+    expect(ui.queueSize.textContent).toBe('Queue size: ERR')
+  })
+
+  it('does not auto-queue while a prior execution error is present', () => {
+    const ui = new ComfyUI(app)
+    ui.autoQueueEnabled = true
+    ui.autoQueueMode = 'instant'
+    ui.lastQueueSize = 1
+    Object.assign(app, { lastExecutionError: new Error('failed') })
+
+    ui.setStatus({ exec_info: { queue_remaining: 0 } })
+
+    expect(app.queuePrompt).not.toHaveBeenCalled()
+    expect(ui.lastQueueSize).toBe(0)
+  })
+
+  it('tracks graph changes for change-mode auto queueing', () => {
+    const ui = new ComfyUI(app)
+    const graphChanged = vi
+      .mocked(api.addEventListener)
+      .mock.calls.find(([eventName]) => eventName === 'graphChanged')?.[1]
+    if (!graphChanged) throw new Error('Missing graphChanged listener')
+
+    ui.autoQueueEnabled = true
+    ui.autoQueueMode = 'change'
+    ui.lastQueueSize = 1
+    ;(graphChanged as EventListener)(
+      fromPartial<CustomEvent<ComfyWorkflowJSON>>(
+        new CustomEvent('graphChanged')
+      )
+    )
+
+    expect(ui.graphHasChanged).toBe(true)
+
+    ui.lastQueueSize = 0
+    ;(graphChanged as EventListener)(
+      fromPartial<CustomEvent<ComfyWorkflowJSON>>(
+        new CustomEvent('graphChanged')
+      )
+    )
+
+    expect(app.queuePrompt).toHaveBeenCalledWith(0, 1)
+    expect(ui.graphHasChanged).toBe(false)
+  })
+
+  it('wires primary menu buttons to app and command actions', async () => {
+    const ui = new ComfyUI(app)
+
+    await click(buttonByText(document, 'Queue Prompt'))
+    expect(app.queuePrompt).toHaveBeenCalledWith(0, 1)
+
+    await click(buttonByText(document, 'Queue Front'))
+    expect(app.queuePrompt).toHaveBeenCalledWith(-1, 1)
+
+    await click(buttonByText(document, 'Save'))
+    await click(buttonByText(document, 'Save (API Format)'))
+    await click(buttonByText(document, 'Refresh'))
+    await click(buttonByText(document, 'Clipspace'))
+    await click(buttonByText(document, 'Clear'))
+    await click(buttonByText(document, 'Load Default'))
+    await click(buttonByText(document, 'Reset View'))
+
+    expect(app.refreshComboInNodes).toHaveBeenCalled()
+    expect(app.openClipspace).toHaveBeenCalled()
+    expect(app.clean).toHaveBeenCalled()
+    expect(app.loadGraphData).toHaveBeenCalledWith()
+    expect(ui.menuContainer.style.display).toBe('none')
+  })
+
+  it('wires file input and legacy option controls', async () => {
+    const ui = new ComfyUI(app)
+    const file = new File(['{}'], 'workflow.json', {
+      type: 'application/json'
+    })
+    const fileInput = document.getElementById(
+      'comfy-file-input'
+    ) as HTMLInputElement
+    Object.defineProperty(fileInput, 'files', {
+      configurable: true,
+      value: [file]
+    })
+
+    await Promise.resolve(
+      fileInput.onchange?.call(fileInput, new Event('change'))
+    )
+    expect(app.handleFile).toHaveBeenCalledWith(file, 'file_button')
+    expect(fileInput.value).toBe('')
+
+    const range = document.getElementById(
+      'batchCountInputRange'
+    ) as HTMLInputElement
+    const number = document.getElementById(
+      'batchCountInputNumber'
+    ) as HTMLInputElement
+    range.value = '4'
+    const extraOptionsCheckbox = document.querySelector(
+      'label input[type="checkbox"]'
+    ) as HTMLInputElement
+    extraOptionsCheckbox.checked = true
+    extraOptionsCheckbox.onchange?.call(
+      extraOptionsCheckbox,
+      fromPartial({ srcElement: extraOptionsCheckbox })
+    )
+    expect(ui.batchCount).toBe(4)
+    expect(document.getElementById('extraOptions')?.style.display).toBe('block')
+
+    number.value = '7'
+    number.oninput?.call(number, fromPartial({ target: number }))
+    expect(range.value).toBe('7')
+
+    range.value = '9'
+    range.oninput?.call(range, fromPartial({ srcElement: range }))
+    expect(number.value).toBe('9')
+
+    const autoQueueCheckbox = document.getElementById(
+      'autoQueueCheckbox'
+    ) as HTMLInputElement
+    autoQueueCheckbox.checked = true
+    autoQueueCheckbox.onchange?.call(
+      autoQueueCheckbox,
+      fromPartial({ target: autoQueueCheckbox })
+    )
+    expect(ui.autoQueueEnabled).toBe(true)
+
+    extraOptionsCheckbox.checked = false
+    extraOptionsCheckbox.onchange?.call(
+      extraOptionsCheckbox,
+      fromPartial({ srcElement: extraOptionsCheckbox })
+    )
+    expect(ui.batchCount).toBe(1)
+    expect(ui.autoQueueEnabled).toBe(false)
+    expect(document.getElementById('extraOptions')?.style.display).toBe('none')
+  })
+
+  it('toggles queue visibility through the menu button', async () => {
+    vi.mocked(api.getQueue).mockResolvedValue({
+      Running: [],
+      Pending: []
+    })
+    const ui = new ComfyUI(app)
+
+    await click(buttonByText(document, 'View Queue'))
+    expect(ui.queue.visible).toBe(true)
+
+    await click(buttonByText(document, 'Close'))
+    expect(ui.queue.visible).toBe(false)
+  })
+
+  it('does not clear or load defaults when confirmation is declined', async () => {
+    mockSettingStore.get.mockReturnValue(true)
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => false)
+    )
+    try {
+      new ComfyUI(app)
+
+      await click(buttonByText(document, 'Clear'))
+      await click(buttonByText(document, 'Load Default'))
+
+      expect(app.clean).not.toHaveBeenCalled()
+      expect(app.loadGraphData).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('persists manual menu dragging', () => {
+    Object.defineProperty(document.body, 'clientWidth', {
+      configurable: true,
+      value: 1000
+    })
+    Object.defineProperty(document.body, 'clientHeight', {
+      configurable: true,
+      value: 800
+    })
+    const ui = new ComfyUI(app)
+    ui.menuContainer.style.display = 'block'
+    Object.defineProperty(ui.menuContainer, 'clientWidth', {
+      configurable: true,
+      value: 100
+    })
+    Object.defineProperty(ui.menuContainer, 'clientHeight', {
+      configurable: true,
+      value: 80
+    })
+    Object.defineProperty(ui.menuContainer, 'offsetLeft', {
+      configurable: true,
+      get: () => 700
+    })
+    Object.defineProperty(ui.menuContainer, 'offsetTop', {
+      configurable: true,
+      get: () => 20
+    })
+    const handle = ui.menuContainer.querySelector('.drag-handle') as HTMLElement
+
+    handle.onmousedown?.(
+      new MouseEvent('mousedown', { clientX: 10, clientY: 10 })
+    )
+    document.onmousemove?.(
+      new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    )
+    document.onmouseup?.(new MouseEvent('mouseup'))
+
+    expect(ui.menuContainer.classList.contains('comfy-menu-manual-pos')).toBe(
+      true
+    )
+    expect(ui.menuContainer.style.right).toBe('190px')
+    expect(localStorage.getItem('Comfy.MenuPosition')).toBe(
+      JSON.stringify({ x: 700, y: 20 })
+    )
+    expect(document.onmousemove).toBeNull()
+    expect(document.onmouseup).toBeNull()
+  })
+})

--- a/src/scripts/ui/components/button.test.ts
+++ b/src/scripts/ui/components/button.test.ts
@@ -1,0 +1,202 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyApp } from '@/scripts/app'
+import type { ComfyPopup } from '@/scripts/ui/components/popup'
+
+vi.mock('../../ui', () => ({
+  $el: (tag: string, props?: Record<string, unknown>, children?: Node[]) => {
+    const [tagName, ...classes] = tag.split('.')
+    const element = document.createElement(tagName)
+    if (classes.length) element.classList.add(...classes)
+    if (props) {
+      const listeners = Object.entries(props).filter(([key]) =>
+        key.startsWith('on')
+      )
+      for (const [key, listener] of listeners) {
+        if (typeof listener === 'function') {
+          element.addEventListener(key.slice(2), listener as EventListener)
+        }
+      }
+    }
+    if (children) element.append(...children)
+    return element
+  }
+}))
+
+vi.mock('../../utils', () => ({
+  prop: <T>(
+    target: object,
+    name: string,
+    defaultValue: T,
+    onChanged?: (currentValue: T, previousValue: T) => void
+  ) => {
+    let currentValue: T
+    Object.defineProperty(target, name, {
+      get() {
+        return currentValue
+      },
+      set(newValue: T) {
+        const previousValue = currentValue
+        currentValue = newValue
+        onChanged?.(currentValue, previousValue)
+      }
+    })
+    ;(target as Record<string, T>)[name] = defaultValue
+    return defaultValue
+  }
+}))
+
+import { ComfyButton } from './button'
+
+class MockPopup extends EventTarget {
+  element = document.createElement('div')
+  open = false
+  toggle = vi.fn(() => {
+    this.open = !this.open
+    this.dispatchEvent(new CustomEvent('change'))
+  })
+}
+
+function mockApp(settingValue: boolean) {
+  let listener: (() => void) | undefined
+  const app = fromPartial<ComfyApp>({
+    ui: {
+      settings: {
+        getSettingValue: vi.fn(() => settingValue),
+        addEventListener: vi.fn((_event: string, callback: () => void) => {
+          listener = callback
+        })
+      }
+    }
+  })
+  return {
+    app,
+    setSettingValue(value: boolean) {
+      settingValue = value
+      listener?.()
+    }
+  }
+}
+
+describe('ComfyButton', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('renders icon, content, tooltip, enabled state, and click action', () => {
+    const action = vi.fn()
+    const button = new ComfyButton({
+      icon: 'play',
+      overIcon: 'pause',
+      iconSize: 18,
+      content: 'Run',
+      tooltip: 'Queue prompt',
+      enabled: false,
+      classList: { primary: true, hiddenClass: false },
+      action
+    })
+
+    expect(button.iconElement.className).toBe('mdi mdi-play mdi-18px')
+    expect(button.contentElement.textContent).toBe('Run')
+    expect(button.element.title).toBe('Queue prompt')
+    expect(button.element.getAttribute('aria-label')).toBe('Queue prompt')
+    expect(button.element.classList.contains('primary')).toBe(true)
+    expect(button.element.classList.contains('disabled')).toBe(true)
+    expect((button.element as HTMLButtonElement).disabled).toBe(true)
+
+    button.enabled = true
+    button.element.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(button.iconElement.className).toBe('mdi mdi-pause mdi-18px')
+    button.element.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(button.iconElement.className).toBe('mdi mdi-play mdi-18px')
+
+    button.element.dispatchEvent(new MouseEvent('click'))
+    expect(action).toHaveBeenCalledWith(expect.any(MouseEvent), button)
+  })
+
+  it('supports HTMLElement content and removing tooltip text', () => {
+    const button = new ComfyButton({ content: 'Text', tooltip: 'Hint' })
+    const content = document.createElement('strong')
+    content.textContent = 'Element'
+
+    button.content = content
+    button.tooltip = ''
+
+    expect(button.contentElement.firstElementChild).toBe(content)
+    expect(button.element.hasAttribute('title')).toBe(false)
+  })
+
+  it('updates the hover icon when overIcon changes while hovered', () => {
+    const button = new ComfyButton({ icon: 'play' })
+
+    button.element.dispatchEvent(new MouseEvent('mouseenter'))
+    button.overIcon = 'pause'
+
+    expect(button.iconElement.className).toBe('mdi mdi-pause')
+  })
+
+  it('hides and shows from a visibility setting', () => {
+    const settings = mockApp(false)
+    const button = new ComfyButton({
+      app: settings.app,
+      visibilitySetting: {
+        id: 'Comfy.UseNewMenu',
+        showValue: true
+      }
+    })
+
+    expect(button.hidden).toBe(true)
+    expect(button.element.classList.contains('hidden')).toBe(true)
+
+    settings.setSettingValue(true)
+
+    expect(button.hidden).toBe(false)
+    expect(button.element.classList.contains('hidden')).toBe(false)
+  })
+
+  it('toggles click popups and reflects popup open state in classes', () => {
+    const popup = new MockPopup()
+    const button = new ComfyButton({ icon: 'dots' }).withPopup(
+      fromPartial<ComfyPopup>(popup)
+    )
+
+    button.element.dispatchEvent(new MouseEvent('click'))
+
+    expect(popup.toggle).toHaveBeenCalledOnce()
+    expect(button.element.classList.contains('popup-open')).toBe(true)
+
+    popup.toggle()
+
+    expect(button.element.classList.contains('popup-closed')).toBe(true)
+  })
+
+  it('opens hover popups while either the button or popup is hovered', () => {
+    const popup = new MockPopup()
+    const button = new ComfyButton({ icon: 'dots' }).withPopup(
+      fromPartial<ComfyPopup>(popup),
+      'hover'
+    )
+
+    button.element.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(popup.open).toBe(true)
+    popup.element.dispatchEvent(new MouseEvent('mouseenter'))
+    button.element.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(popup.open).toBe(true)
+    popup.element.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(popup.open).toBe(false)
+  })
+
+  it('does not click-toggle a hover popup while hovered', () => {
+    const popup = new MockPopup()
+    const button = new ComfyButton({ icon: 'dots' }).withPopup(
+      fromPartial<ComfyPopup>(popup),
+      'hover'
+    )
+
+    button.element.dispatchEvent(new MouseEvent('mouseenter'))
+    button.element.dispatchEvent(new MouseEvent('click'))
+
+    expect(popup.toggle).not.toHaveBeenCalled()
+  })
+})

--- a/src/scripts/ui/components/buttonGroup.ts
+++ b/src/scripts/ui/components/buttonGroup.ts
@@ -10,7 +10,7 @@ export class ComfyButtonGroup {
     this.buttons = prop(this, 'buttons', buttons, () => this.update())
   }
 
-  insert(button: ComfyButton, index: number) {
+  insert(button: HTMLElement | ComfyButton, index: number) {
     this.buttons.splice(index, 0, button)
     this.update()
   }

--- a/src/scripts/ui/components/popup.test.ts
+++ b/src/scripts/ui/components/popup.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type ElChild = Node | string
+type ElInput = Record<string, unknown> | ElChild | ElChild[]
+
+function appendChildren(element: HTMLElement, children: ElChild | ElChild[]) {
+  const list = Array.isArray(children) ? children : [children]
+  for (const child of list) {
+    element.append(child)
+  }
+}
+
+vi.mock('../../ui', () => ({
+  $el: (tag: string, propsOrChildren?: ElInput, children?: ElChild[]) => {
+    const [tagName, ...classes] = tag.split('.')
+    const element = document.createElement(tagName)
+    if (classes.length) element.classList.add(...classes)
+
+    if (
+      propsOrChildren instanceof Node ||
+      typeof propsOrChildren === 'string' ||
+      Array.isArray(propsOrChildren)
+    ) {
+      appendChildren(element, propsOrChildren)
+    } else if (propsOrChildren) {
+      for (const [key, value] of Object.entries(propsOrChildren)) {
+        if (key === '$' && typeof value === 'function') {
+          value(element)
+        } else if (key === 'parent' && value instanceof HTMLElement) {
+          value.append(element)
+        } else if (key === 'textContent') {
+          element.textContent = String(value)
+        } else if (key === 'ariaLabel') {
+          element.setAttribute('aria-label', String(value))
+        } else if (key === 'ariaHasPopup') {
+          element.setAttribute('aria-haspopup', String(value))
+        } else if (key === 'type') {
+          element.setAttribute('type', String(value))
+        } else if (
+          key.toLowerCase().startsWith('on') &&
+          typeof value === 'function'
+        ) {
+          element.addEventListener(
+            key.slice(2).toLowerCase(),
+            value as EventListener
+          )
+        }
+      }
+    }
+
+    if (children) appendChildren(element, children)
+    return element
+  }
+}))
+
+vi.mock('../../utils', () => ({
+  prop: <T>(
+    target: object,
+    name: string,
+    defaultValue: T,
+    onChanged?: (currentValue: T, previousValue: T) => void
+  ) => {
+    let currentValue: T
+    Object.defineProperty(target, name, {
+      get() {
+        return currentValue
+      },
+      set(newValue: T) {
+        const previousValue = currentValue
+        currentValue = newValue
+        onChanged?.(currentValue, previousValue)
+      }
+    })
+    ;(target as Record<string, T>)[name] = defaultValue
+    return defaultValue
+  }
+}))
+
+vi.mock('../utils', () => ({
+  applyClasses: (
+    element: HTMLElement,
+    classList: string | Record<string, boolean>,
+    ...baseClasses: string[]
+  ) => {
+    element.className = baseClasses.join(' ')
+    if (typeof classList === 'string') {
+      element.classList.add(...classList.split(' ').filter(Boolean))
+    } else {
+      for (const [className, enabled] of Object.entries(classList)) {
+        element.classList.toggle(className, enabled)
+      }
+    }
+  },
+  toggleElement:
+    <T>(
+      element: HTMLElement,
+      {
+        onShow
+      }: {
+        onShow?: (element: HTMLElement, value: T) => void
+      } = {}
+    ) =>
+    (value: T) => {
+      element.hidden = !value
+      if (value) onShow?.(element, value)
+    }
+}))
+
+import { ComfyAsyncDialog } from './asyncDialog'
+import { ComfyButton } from './button'
+import { ComfyButtonGroup } from './buttonGroup'
+import { ComfyPopup } from './popup'
+import { ComfySplitButton } from './splitButton'
+
+function targetWithRect(rect: DOMRect) {
+  const target = document.createElement('button')
+  vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(rect)
+  document.body.append(target)
+  return target
+}
+
+describe('ComfyPopup and related UI components', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('opens, positions, updates children and classes, and closes from escape', () => {
+    const target = targetWithRect(
+      DOMRect.fromRect({ x: 10, y: 20, width: 80, height: 30 })
+    )
+    const child = document.createElement('span')
+    const popup = new ComfyPopup(
+      { target, classList: { menu: true, hidden: false } },
+      child
+    )
+    const open = vi.fn()
+    const close = vi.fn()
+    const change = vi.fn()
+    popup.addEventListener('open', open)
+    popup.addEventListener('close', close)
+    popup.addEventListener('change', change)
+    vi.spyOn(popup.element, 'getBoundingClientRect').mockReturnValue(
+      DOMRect.fromRect({ height: 20 })
+    )
+
+    popup.open = true
+
+    expect(open).toHaveBeenCalledOnce()
+    expect(change).toHaveBeenCalledOnce()
+    expect(popup.element).toHaveClass('open')
+    expect(popup.element.style.getPropertyValue('--left')).toBe('10px')
+    expect(popup.element.style.getPropertyValue('--bottom')).toBe('35px')
+
+    const nextChild = document.createElement('strong')
+    popup.children = [nextChild]
+    popup.classList = 'extra'
+
+    expect(popup.element.firstElementChild).toBe(nextChild)
+    expect(popup.element).toHaveClass('comfyui-popup', 'left', 'extra')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    expect(popup.open).toBe(true)
+
+    const escape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      cancelable: true
+    })
+    window.dispatchEvent(escape)
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(escape.defaultPrevented).toBe(true)
+    expect(popup.open).toBe(false)
+  })
+
+  it('handles outside clicks, target clicks, and relative right positioning', () => {
+    const target = targetWithRect(
+      DOMRect.fromRect({ x: 100, y: 40, width: 60, height: 25 })
+    )
+    const container = document.createElement('section')
+    document.body.append(container)
+    const popup = new ComfyPopup({
+      target,
+      container,
+      position: 'relative',
+      horizontal: 'right'
+    })
+    vi.spyOn(popup.element, 'getBoundingClientRect').mockReturnValue(
+      DOMRect.fromRect({ height: 100 })
+    )
+    Object.defineProperty(popup.element, 'clientWidth', {
+      configurable: true,
+      value: 40
+    })
+
+    popup.open = true
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(popup.open).toBe(true)
+
+    const outside = document.createElement('div')
+    document.body.append(outside)
+    outside.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(popup.open).toBe(false)
+    expect(popup.element.style.getPropertyValue('--left')).toBe('0px')
+    expect(popup.element.style.getPropertyValue('--top')).toBe('25px')
+  })
+
+  it('keeps outside clicks open when target clicks are not ignored', () => {
+    const target = targetWithRect(DOMRect.fromRect({ height: 10 }))
+    const popup = new ComfyPopup({
+      target,
+      ignoreTarget: false,
+      closeOnEscape: false
+    })
+    const outside = document.createElement('div')
+    document.body.append(outside)
+
+    popup.toggle()
+    outside.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    expect(popup.open).toBe(true)
+  })
+
+  it('renders split button popup items and updates button groups', () => {
+    const primary = new ComfyButton({ content: 'Queue' })
+    const itemButton = new ComfyButton({ content: 'Queue front' })
+    const rawItem = document.createElement('button')
+    rawItem.textContent = 'Queue back'
+    const split = new ComfySplitButton(
+      {
+        primary,
+        mode: 'hover',
+        horizontal: 'right',
+        position: 'absolute'
+      },
+      itemButton,
+      rawItem
+    )
+
+    expect(split.element).toHaveClass('comfyui-split-button', 'hover')
+    expect(split.popup.element).toHaveTextContent('Queue front')
+    expect(split.popup.element).toHaveTextContent('Queue back')
+    expect(document.body).toContainElement(split.popup.element)
+
+    const group = new ComfyButtonGroup(primary)
+    group.append(itemButton)
+    group.insert(rawItem, 1)
+
+    expect(group.element.children).toHaveLength(3)
+    expect(group.remove(itemButton)).toEqual([itemButton])
+    expect(group.remove(itemButton)).toBeUndefined()
+    expect(group.element.children).toHaveLength(2)
+  })
+
+  it('resolves async dialogs from buttons, close events, and prompt actions', async () => {
+    const dialog = new ComfyAsyncDialog<number>([
+      { text: 'Seven', value: 7 },
+      'Fallback'
+    ])
+
+    const promise = dialog.show('Pick one')
+    dialog.element.querySelector<HTMLButtonElement>('button')?.click()
+    await expect(promise).resolves.toBe(7)
+
+    const closePromise = dialog.show(document.createElement('em'))
+    dialog.element.dispatchEvent(new Event('close'))
+    await expect(closePromise).resolves.toBeNull()
+
+    const promptPromise = ComfyAsyncDialog.prompt({
+      title: 'Confirm',
+      message: 'Continue?',
+      actions: [{ text: 'Yes', value: 'yes' }]
+    })
+    const prompt = Array.from(document.querySelectorAll('dialog')).at(-1)
+    expect(prompt).toHaveTextContent('Confirm')
+    prompt?.querySelector<HTMLButtonElement>('button')?.click()
+
+    await expect(promptPromise).resolves.toBe('yes')
+    expect(document.body).not.toContainElement(prompt ?? null)
+  })
+})

--- a/src/scripts/ui/dialog.test.ts
+++ b/src/scripts/ui/dialog.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ComfyDialog } from './dialog'
+
+const mocks = vi.hoisted(() => ({
+  $el: (
+    selector: string,
+    propsOrChildren?: Record<string, unknown> | Node[],
+    maybeChildren?: Node[]
+  ) => {
+    const [tag, ...classes] = selector.split('.')
+    const element = document.createElement(tag || 'div')
+    element.classList.add(...classes.filter(Boolean))
+    const children = Array.isArray(propsOrChildren)
+      ? propsOrChildren
+      : maybeChildren
+
+    if (propsOrChildren && !Array.isArray(propsOrChildren)) {
+      for (const [key, value] of Object.entries(propsOrChildren)) {
+        if (key === 'parent' && value instanceof Node) {
+          value.appendChild(element)
+        } else if (key === '$' && typeof value === 'function') {
+          value(element)
+        } else {
+          Reflect.set(element, key, value)
+        }
+      }
+    }
+
+    element.append(...(children ?? []))
+    return element
+  }
+}))
+
+vi.mock('../ui', () => ({
+  $el: mocks.$el
+}))
+
+describe('ComfyDialog', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('shows string and element content and closes through the default button', () => {
+    const dialog = new ComfyDialog()
+
+    dialog.show('<strong>Hello</strong>')
+
+    expect(dialog.element.style.display).toBe('flex')
+    expect(dialog.textElement.innerHTML).toBe('<strong>Hello</strong>')
+
+    dialog.element.querySelector('button')?.click()
+    expect(dialog.element.style.display).toBe('none')
+
+    const first = document.createElement('span')
+    const second = document.createElement('em')
+    dialog.show([first, second])
+
+    expect([...dialog.textElement.children]).toEqual([first, second])
+  })
+
+  it('uses supplied custom buttons', () => {
+    const button = document.createElement('button')
+    const dialog = new ComfyDialog('section', [button])
+
+    expect(dialog.element.tagName).toBe('SECTION')
+    expect(dialog.element.querySelector('button')).toBe(button)
+  })
+})

--- a/src/scripts/ui/draggableList.test.ts
+++ b/src/scripts/ui/draggableList.test.ts
@@ -1,0 +1,213 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DraggableList } from './draggableList'
+
+function createList(itemCount: number) {
+  const container = document.createElement('div')
+  const items = Array.from({ length: itemCount }, (_, index) => {
+    const item = document.createElement('div')
+    item.className = 'item'
+    item.dataset.index = String(index)
+
+    const handle = document.createElement('button')
+    handle.className = 'drag-handle'
+    item.append(handle)
+    container.append(item)
+
+    return item
+  })
+  document.body.append(container)
+  return { container, items }
+}
+
+function setRect(element: Element, top: number, height = 20) {
+  return vi
+    .spyOn(element, 'getBoundingClientRect')
+    .mockReturnValue(new DOMRect(0, top, 100, height))
+}
+
+function defineScrollMetrics(
+  container: HTMLElement,
+  scrollHeight: number,
+  clientHeight: number
+) {
+  Object.defineProperty(container, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight
+  })
+  Object.defineProperty(container, 'clientHeight', {
+    configurable: true,
+    value: clientHeight
+  })
+}
+
+function mouseDragEvent(
+  target: Element,
+  overrides: Partial<MouseEvent> = {}
+): MouseEvent {
+  return {
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    preventDefault: vi.fn(),
+    target,
+    ...overrides
+  } satisfies Partial<MouseEvent> as MouseEvent
+}
+
+describe('DraggableList', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores missing containers and non-primary drag starts', () => {
+    const listWithoutContainer = new DraggableList(null, '.item')
+    const { container, items } = createList(1)
+    const list = new DraggableList(container, '.item')
+
+    list.dragStart(
+      mouseDragEvent(items[0].querySelector('.drag-handle')!, { button: 1 })
+    )
+    list.dragEnd()
+
+    expect(listWithoutContainer.listContainer).toBeNull()
+    expect(list.draggableItem).toBeUndefined()
+  })
+
+  it('starts from a handle, scrolls downward, and reorders upward', () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    const { container, items } = createList(3)
+    const scrollBy = vi.fn((_left: number, top: number) => {
+      container.scrollTop += top
+    })
+    Reflect.set(container, 'scrollBy', scrollBy)
+    defineScrollMetrics(container, 120, 80)
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(0, 0, 100, 80)
+    )
+    setRect(items[0], 0)
+    setRect(items[1], 30)
+    setRect(items[2], 60)
+
+    const list = new DraggableList(container, '.item')
+    const dragStart = vi.fn()
+    const dragEnd = vi.fn()
+    list.addEventListener('dragstart', dragStart)
+    list.addEventListener('dragend', dragEnd)
+
+    list.dragStart(
+      mouseDragEvent(items[2].querySelector('.drag-handle')!, {
+        clientX: 10,
+        clientY: 70
+      })
+    )
+    list.drag(
+      mouseDragEvent(items[2].querySelector('.drag-handle')!, {
+        clientX: 20,
+        clientY: 100
+      })
+    )
+    items[1].dataset.isToggled = ''
+    list.dragEnd()
+
+    expect(dragStart).toHaveBeenCalledOnce()
+    expect(dragEnd).toHaveBeenCalledOnce()
+    expect(scrollBy).toHaveBeenCalledWith(0, 10)
+    expect([...container.children]).toEqual([items[0], items[2], items[1]])
+    expect(items[0].classList.contains('is-idle')).toBe(true)
+    expect(items[1].classList.contains('is-idle')).toBe(true)
+  })
+
+  it('supports touch coordinates, upward scrolling, and downward reorder', () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    const { container, items } = createList(3)
+    const scrollBy = vi.fn((_left: number, top: number) => {
+      container.scrollTop += top
+    })
+    container.scrollTop = 10
+    Reflect.set(container, 'scrollBy', scrollBy)
+    defineScrollMetrics(container, 120, 80)
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(0, 20, 100, 80)
+    )
+    setRect(items[0], 0)
+    setRect(items[1], 30)
+    setRect(items[2], 60)
+
+    const list = new DraggableList(container, '.item')
+    const touchStart = fromPartial<TouchEvent>({
+      preventDefault: vi.fn(),
+      target: items[0].querySelector('.drag-handle')!,
+      touches: fromPartial<TouchList>({
+        0: fromPartial<Touch>({ clientX: 5, clientY: 30 }),
+        length: 1
+      })
+    })
+    const touchMove = fromPartial<TouchEvent>({
+      preventDefault: vi.fn(),
+      target: items[0].querySelector('.drag-handle')!,
+      touches: fromPartial<TouchList>({
+        0: fromPartial<Touch>({ clientX: 8, clientY: 10 }),
+        length: 1
+      })
+    })
+
+    list.dragStart(touchStart)
+    list.drag(touchMove)
+    items[1].dataset.isToggled = ''
+    list.dragEnd()
+
+    expect(scrollBy).toHaveBeenCalledWith(0, -10)
+    expect([...container.children]).toEqual([items[1], items[0], items[2]])
+  })
+
+  it('updates idle item state around the dragged item midpoint', () => {
+    const { container, items } = createList(3)
+    const list = new DraggableList(container, '.item')
+    Reflect.set(list, 'items', items)
+    Reflect.set(list, 'draggableItem', items[1])
+    list.itemsGap = 5
+    items[0].classList.add('is-idle')
+    items[1].classList.add('is-idle')
+    items[2].classList.add('is-idle')
+    items[0].dataset.isAbove = ''
+    const draggedRect = setRect(items[1], -10)
+    setRect(items[0], 0)
+    setRect(items[2], 60)
+
+    list.updateIdleItemsStateAndPosition()
+
+    expect(items[0].dataset.isToggled).toBe('')
+    expect(items[0].style.transform).toBe('translateY(25px)')
+    expect(items[2].style.transform).toBe('')
+
+    draggedRect.mockReturnValue(new DOMRect(0, 100, 100, 20))
+    list.updateIdleItemsStateAndPosition()
+
+    expect(items[0].dataset.isToggled).toBeUndefined()
+    expect(items[2].dataset.isToggled).toBe('')
+    expect(items[2].style.transform).toBe('translateY(-25px)')
+  })
+
+  it('uses zero gap for short lists and disposes listeners', () => {
+    const { container } = createList(1)
+    const list = new DraggableList(container, '.item')
+    const off = vi.fn()
+    Reflect.set(list, 'off', [off])
+
+    list.setItemsGap()
+    list.dispose()
+
+    expect(list.itemsGap).toBe(0)
+    expect(off).toHaveBeenCalledOnce()
+  })
+})

--- a/src/scripts/ui/imagePreview.test.ts
+++ b/src/scripts/ui/imagePreview.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateImageGrid } from './imagePreview'
+
+function createImage(width: number, height: number) {
+  const img = document.createElement('img')
+  Object.defineProperty(img, 'naturalWidth', {
+    configurable: true,
+    value: width
+  })
+  Object.defineProperty(img, 'naturalHeight', {
+    configurable: true,
+    value: height
+  })
+  return img
+}
+
+describe('imagePreview', () => {
+  it('calculates the highest-area grid', () => {
+    const images = [
+      createImage(100, 100),
+      createImage(100, 100),
+      createImage(100, 100)
+    ]
+
+    expect(calculateImageGrid(images, 300, 120)).toMatchObject({
+      cellWidth: 100,
+      cellHeight: 100,
+      cols: 3,
+      rows: 1
+    })
+  })
+})

--- a/src/scripts/ui/toggleSwitch.test.ts
+++ b/src/scripts/ui/toggleSwitch.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { toggleSwitch } from './toggleSwitch'
+
+const mocks = vi.hoisted(() => ({
+  $el: (
+    selector: string,
+    propsOrChildren?: Record<string, unknown> | Node[] | Node,
+    maybeChildren?: Node[] | Node
+  ) => {
+    const [tag, ...classes] = selector.split('.')
+    const element = document.createElement(tag || 'div')
+    element.classList.add(...classes.filter(Boolean))
+    const children = Array.isArray(propsOrChildren)
+      ? propsOrChildren
+      : propsOrChildren instanceof Node
+        ? [propsOrChildren]
+        : Array.isArray(maybeChildren)
+          ? maybeChildren
+          : maybeChildren instanceof Node
+            ? [maybeChildren]
+            : []
+
+    if (
+      propsOrChildren &&
+      !(propsOrChildren instanceof Node) &&
+      !Array.isArray(propsOrChildren)
+    ) {
+      for (const [key, value] of Object.entries(propsOrChildren)) {
+        Reflect.set(element, key, value)
+      }
+    }
+
+    element.append(...children)
+    return element
+  }
+}))
+
+vi.mock('../ui', () => ({
+  $el: mocks.$el
+}))
+
+describe('toggleSwitch', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('selects the first item when none is preselected', () => {
+    const onChange = vi.fn()
+    const container = toggleSwitch('mode', ['first', 'second'], { onChange })
+    const labels = [...container.querySelectorAll('label')]
+    const inputs = [...container.querySelectorAll('input')]
+
+    expect(labels[0].classList.contains('comfy-toggle-selected')).toBe(true)
+    expect((inputs[0] as HTMLInputElement).checked).toBe(true)
+    expect(onChange).toHaveBeenCalledWith({
+      item: 'first',
+      prev: undefined
+    })
+  })
+
+  it('moves selection and reports the previous item', () => {
+    const onChange = vi.fn()
+    const container = toggleSwitch(
+      'mode',
+      [
+        { text: 'first', tooltip: 'First option' },
+        { text: 'second', value: '2' }
+      ],
+      { onChange }
+    )
+    const labels = [...container.querySelectorAll('label')]
+    const secondInput = labels[1].querySelector('input') as HTMLInputElement
+
+    secondInput.onchange?.(new Event('change'))
+
+    expect(labels[0].classList.contains('comfy-toggle-selected')).toBe(false)
+    expect(labels[1].classList.contains('comfy-toggle-selected')).toBe(true)
+    expect(labels[0].title).toBe('First option')
+    expect(secondInput.value).toBe('2')
+    expect(onChange).toHaveBeenLastCalledWith({
+      item: { text: 'second', value: '2' },
+      prev: { text: 'first', tooltip: 'First option', value: 'first' }
+    })
+  })
+})

--- a/src/scripts/ui/utils.test.ts
+++ b/src/scripts/ui/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { applyClasses, toggleElement } from './utils'
+
+describe('ui utils', () => {
+  it('applies string, array, object, and required classes', () => {
+    const element = document.createElement('div')
+
+    applyClasses(element, 'one two', 'required')
+    expect([...element.classList]).toEqual(['one', 'two', 'required'])
+
+    applyClasses(element, ['three', 'four'])
+    expect([...element.classList]).toEqual(['three', 'four'])
+
+    applyClasses(element, { five: true, six: false, seven: true })
+    expect([...element.classList]).toEqual(['five', 'seven'])
+
+    applyClasses(element, null)
+    expect(element.className).toBe('')
+  })
+
+  it('toggles an element through a placeholder', () => {
+    const parent = document.createElement('div')
+    const element = document.createElement('span')
+    const onHide = vi.fn()
+    const onShow = vi.fn()
+    parent.append(element)
+    const toggle = toggleElement(element, { onHide, onShow })
+
+    toggle(false)
+    expect(parent.firstChild).toBeInstanceOf(Comment)
+    expect(onHide).toHaveBeenCalledWith(element)
+
+    toggle(true)
+    expect(parent.firstChild).toBe(element)
+    expect(onShow).toHaveBeenCalledWith(element, true)
+
+    toggle('visible')
+    expect(onShow).toHaveBeenCalledWith(element, 'visible')
+
+    toggle(false)
+    expect(parent.firstChild).toBeInstanceOf(Comment)
+    expect(onHide).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/scripts/ui/utils.ts
+++ b/src/scripts/ui/utils.ts
@@ -2,7 +2,7 @@ export type ClassList = string | string[] | Record<string, boolean>
 
 export function applyClasses(
   element: HTMLElement,
-  classList: ClassList,
+  classList: ClassList | null | undefined,
   ...requiredClasses: string[]
 ) {
   classList ??= ''

--- a/src/scripts/utils.test.ts
+++ b/src/scripts/utils.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  addStylesheet,
+  clone,
+  getStorageValue,
+  prop,
+  setStorageValue
+} from './utils'
+
+interface LinkAttrs {
+  href: string
+  onerror: (error: Event) => void
+  onload: () => void
+  parent: HTMLElement
+  rel: string
+  type: string
+}
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    clientId: null as string | null,
+    initialClientId: null as string | null
+  },
+  $el: vi.fn()
+}))
+
+vi.mock('./api', () => ({
+  api: mocks.api
+}))
+
+vi.mock('./ui', () => ({
+  $el: mocks.$el
+}))
+
+function lastLinkAttrs() {
+  return mocks.$el.mock.calls.at(-1)?.[1] as LinkAttrs
+}
+
+describe('scripts utils', () => {
+  afterEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    mocks.api.clientId = null
+    mocks.api.initialClientId = null
+    mocks.$el.mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  it('clones with structuredClone and falls back to JSON cloning', () => {
+    const source = { nested: { value: 1 } }
+
+    expect(clone(source)).toEqual(source)
+
+    vi.stubGlobal(
+      'structuredClone',
+      vi.fn(() => {
+        throw new Error('unsupported')
+      })
+    )
+
+    const cloned = clone(source)
+    cloned.nested.value = 2
+
+    expect(cloned).toEqual({ nested: { value: 2 } })
+    expect(source).toEqual({ nested: { value: 1 } })
+  })
+
+  it('adds stylesheets from script and relative URLs', async () => {
+    const scriptPromise = addStylesheet('/extensions/example.js')
+    lastLinkAttrs().onload()
+
+    await expect(scriptPromise).resolves.toBeUndefined()
+    expect(lastLinkAttrs()).toMatchObject({
+      href: '/extensions/example.css',
+      parent: document.head,
+      rel: 'stylesheet',
+      type: 'text/css'
+    })
+
+    const cssPromise = addStylesheet('theme.css', 'https://example.com/base/')
+    lastLinkAttrs().onload()
+
+    await expect(cssPromise).resolves.toBeUndefined()
+    expect(lastLinkAttrs().href).toBe('https://example.com/base/theme.css')
+  })
+
+  it('rejects when stylesheet loading fails', async () => {
+    const promise = addStylesheet('missing.css', 'https://example.com/')
+    const error = new Event('error')
+    lastLinkAttrs().onerror(error)
+
+    await expect(promise).rejects.toBe(error)
+  })
+
+  it('defines an observable property with the supplied default', () => {
+    const target = {}
+    const onChanged = vi.fn()
+
+    expect(prop(target, 'mode', 'initial', onChanged)).toBe('initial')
+    Object.assign(target, { mode: 'next' })
+
+    expect((target as { mode: string }).mode).toBe('next')
+    expect(onChanged).toHaveBeenCalledWith('next', undefined, target, 'mode')
+  })
+
+  it('uses client-scoped storage before local fallback', () => {
+    mocks.api.clientId = 'client-1'
+    setStorageValue('setting', 'client-value')
+    sessionStorage.removeItem('setting:client-1')
+
+    expect(getStorageValue('setting')).toBe('client-value')
+    expect(localStorage.getItem('setting')).toBe('client-value')
+
+    sessionStorage.setItem('setting:client-1', 'session-value')
+
+    expect(getStorageValue('setting')).toBe('session-value')
+  })
+
+  it('uses initial client id when the current client id is unavailable', () => {
+    mocks.api.initialClientId = 'initial-1'
+    setStorageValue('setting', 'initial-value')
+
+    expect(sessionStorage.getItem('setting:initial-1')).toBe('initial-value')
+    expect(getStorageValue('setting')).toBe('initial-value')
+  })
+})

--- a/src/scripts/widgets.test.ts
+++ b/src/scripts/widgets.test.ts
@@ -1,0 +1,362 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  IBaseWidget,
+  IComboWidget
+} from '@/lib/litegraph/src/types/widgets'
+import type { ComfyApp } from '@/scripts/app'
+import type { InputSpec } from '@/schemas/nodeDefSchema'
+
+const mockSettingGet = vi.hoisted(() => vi.fn())
+const mockNextValueForLinkedTarget = vi.hoisted(() => vi.fn())
+const mockIsComboWidget = vi.hoisted(() => vi.fn())
+const mockTransformInputSpecV1ToV2 = vi.hoisted(() => vi.fn())
+
+function v2WidgetConstructor(kind: string) {
+  return () => (_node: LGraphNode, inputSpec: { name: string }) => ({
+    name: `${kind}:${inputSpec.name}`,
+    options: { minNodeSize: [20, 30] }
+  })
+}
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => `translated:${key}`
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: mockSettingGet
+  })
+}))
+
+vi.mock('@/lib/litegraph/src/litegraph', () => ({
+  isComboWidget: mockIsComboWidget
+}))
+
+vi.mock('./valueControl', () => ({
+  nextValueForLinkedTarget: mockNextValueForLinkedTarget
+}))
+
+vi.mock('@/schemas/nodeDef/migration', () => ({
+  transformInputSpecV1ToV2: mockTransformInputSpecV1ToV2
+}))
+
+vi.mock('@/core/graph/widgets/dynamicWidgets', () => ({
+  dynamicWidgets: {
+    DYNAMIC: () => ({
+      widget: { name: 'dynamic', options: {} },
+      minWidth: 1,
+      minHeight: 1
+    })
+  }
+}))
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useBooleanWidget',
+  () => ({ useBooleanWidget: v2WidgetConstructor('BOOLEAN') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget',
+  () => ({ useBoundingBoxWidget: v2WidgetConstructor('BOUNDING_BOX') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useCurveWidget',
+  () => ({ useCurveWidget: v2WidgetConstructor('CURVE') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useChartWidget',
+  () => ({ useChartWidget: v2WidgetConstructor('CHART') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useColorWidget',
+  () => ({ useColorWidget: v2WidgetConstructor('COLOR') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useComboWidget',
+  () => ({ useComboWidget: v2WidgetConstructor('COMBO') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useFloatWidget',
+  () => ({ useFloatWidget: v2WidgetConstructor('FLOAT') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useGalleriaWidget',
+  () => ({ useGalleriaWidget: v2WidgetConstructor('GALLERIA') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxesWidget',
+  () => ({ useBoundingBoxesWidget: v2WidgetConstructor('BOUNDING_BOXES') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useColorsWidget',
+  () => ({ useColorsWidget: v2WidgetConstructor('COLORS') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useImageCompareWidget',
+  () => ({ useImageCompareWidget: v2WidgetConstructor('IMAGECOMPARE') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget',
+  () => ({
+    useImageUploadWidget: () => (_node: LGraphNode, inputName: string) => ({
+      widget: { name: `IMAGEUPLOAD:${inputName}`, options: {} },
+      minWidth: 5,
+      minHeight: 6
+    })
+  })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useIntWidget',
+  () => ({ useIntWidget: v2WidgetConstructor('INT') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget',
+  () => ({ useMarkdownWidget: v2WidgetConstructor('MARKDOWN') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/usePainterWidget',
+  () => ({ usePainterWidget: v2WidgetConstructor('PAINTER') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useRangeWidget',
+  () => ({ useRangeWidget: v2WidgetConstructor('RANGE') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget',
+  () => ({ useStringWidget: v2WidgetConstructor('STRING') })
+)
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useTextareaWidget',
+  () => ({ useTextareaWidget: v2WidgetConstructor('TEXTAREA') })
+)
+
+vi.mock('./domWidget', () => ({}))
+vi.mock('./errorNodeWidgets', () => ({}))
+
+import {
+  ComfyWidgets,
+  IS_CONTROL_WIDGET,
+  addValueControlWidget,
+  addValueControlWidgets,
+  isValidWidgetType,
+  updateControlWidgetLabel
+} from './widgets'
+
+// `linkedWidgets`, `beforeQueued`, and `afterQueued` already exist on
+// IBaseWidget (via the litegraph augmentation), so no extra members needed.
+type MockWidget = IBaseWidget
+
+function makeTargetWidget(overrides: Partial<MockWidget> = {}): MockWidget {
+  return {
+    name: 'seed',
+    value: 1,
+    callback: vi.fn(),
+    options: {},
+    linkedWidgets: [],
+    computedDisabled: false,
+    ...overrides
+  } as MockWidget
+}
+
+function makeNode(inputs: LGraphNode['inputs'] = []) {
+  const widgets: MockWidget[] = []
+  const node = Object.assign(fromPartial<LGraphNode>({}), {
+    id: 42,
+    inputs,
+    addWidget: vi.fn(
+      (
+        type: string,
+        name: string,
+        value: string,
+        callback: () => void,
+        options: Record<string, unknown>
+      ) => {
+        const widget: MockWidget = fromPartial<MockWidget>({
+          type,
+          name,
+          value,
+          callback,
+          options,
+          linkedWidgets: [],
+          computedDisabled: false
+        })
+        widgets.push(widget)
+        return widget
+      }
+    )
+  })
+  return { node, widgets }
+}
+
+describe('widgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSettingGet.mockReturnValue('after')
+    mockNextValueForLinkedTarget.mockReturnValue('next')
+    mockIsComboWidget.mockImplementation(
+      (widget: MockWidget) => widget.type === 'combo'
+    )
+    mockTransformInputSpecV1ToV2.mockImplementation(
+      (_inputData: InputSpec, options: { name: string }) => ({
+        name: options.name
+      })
+    )
+  })
+
+  it('updates the control widget label from the configured run mode', () => {
+    const widget = makeTargetWidget()
+
+    mockSettingGet.mockReturnValue('before')
+    updateControlWidgetLabel(widget)
+    expect(widget.label).toBe('translated:g.control_before_generate')
+
+    mockSettingGet.mockReturnValue('after')
+    updateControlWidgetLabel(widget)
+    expect(widget.label).toBe('translated:g.control_after_generate')
+  })
+
+  it('adds control and filter widgets for combo targets', () => {
+    const { node, widgets } = makeNode()
+    const target = makeTargetWidget({ type: 'combo', computedDisabled: true })
+
+    const result = addValueControlWidgets(node, target, '', undefined, [
+      'COMBO',
+      {
+        control_prefix: 'custom'
+      }
+    ] as InputSpec)
+
+    expect(result).toHaveLength(2)
+    expect(widgets[0].name).toBe('custom control_after_generate')
+    expect(widgets[0].value).toBe('randomize')
+    expect((widgets[0] as IComboWidget).options.values).toContain(
+      'increment-wrap'
+    )
+    expect(widgets[0][IS_CONTROL_WIDGET]).toBe(true)
+    expect(widgets[0].disabled).toBe(true)
+    expect(widgets[1].name).toBe('custom control_filter_list')
+    expect(widgets[1].disabled).toBe(true)
+  })
+
+  it('uses explicit option names and can skip the combo filter widget', () => {
+    const { node, widgets } = makeNode()
+    const target = makeTargetWidget({ type: 'combo' })
+
+    addValueControlWidgets(
+      node,
+      target,
+      'fixed',
+      {
+        addFilterList: false,
+        controlAfterGenerateName: 'mode'
+      },
+      ['COMBO', {}] as InputSpec
+    )
+
+    expect(widgets).toHaveLength(1)
+    expect(widgets[0].name).toBe('mode')
+  })
+
+  it('applies linked target values after queueing in after mode', () => {
+    const { node, widgets } = makeNode()
+    const target = makeTargetWidget()
+
+    addValueControlWidgets(node, target)
+    widgets[0].afterQueued?.({ isPartialExecution: true })
+
+    expect(mockNextValueForLinkedTarget).toHaveBeenCalledWith({
+      target,
+      linkedWidgets: target.linkedWidgets,
+      nodeId: 42,
+      isPartialExecution: true
+    })
+    expect(target.value).toBe('next')
+    expect(target.callback).toHaveBeenCalledWith('next')
+  })
+
+  it('waits until the second beforeQueued call in before mode', () => {
+    mockSettingGet.mockReturnValue('before')
+    const { node, widgets } = makeNode()
+    const target = makeTargetWidget()
+
+    addValueControlWidgets(node, target)
+    widgets[0].beforeQueued?.()
+    expect(mockNextValueForLinkedTarget).not.toHaveBeenCalled()
+
+    widgets[0].beforeQueued?.({ isPartialExecution: false })
+    expect(mockNextValueForLinkedTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ isPartialExecution: false })
+    )
+  })
+
+  it('does not change the target when the target has a linked input or no next value', () => {
+    const { node, widgets } = makeNode([
+      { widget: { name: 'seed' }, link: 1 }
+    ] as LGraphNode['inputs'])
+    const target = makeTargetWidget()
+
+    addValueControlWidgets(node, target)
+    widgets[0].afterQueued?.()
+    expect(mockNextValueForLinkedTarget).not.toHaveBeenCalled()
+
+    const unlinked = makeNode()
+    mockNextValueForLinkedTarget.mockReturnValue(undefined)
+    addValueControlWidgets(unlinked.node, target)
+    unlinked.widgets[0].afterQueued?.()
+    expect(target.callback).not.toHaveBeenCalled()
+  })
+
+  it('uses the legacy single control widget name from input data before widgetName', () => {
+    const { node, widgets } = makeNode()
+    const target = makeTargetWidget()
+
+    const result = addValueControlWidget(
+      node,
+      target,
+      'fixed',
+      undefined,
+      'fallback',
+      [
+        'INT',
+        {
+          control_after_generate: 'from_input_data'
+        }
+      ] as InputSpec
+    )
+
+    expect(result).toBe(widgets[0])
+    expect(widgets[0].name).toBe('from_input_data')
+  })
+
+  it('exposes transformed widget constructors and type validation', () => {
+    const { node } = makeNode()
+
+    const intWidget = ComfyWidgets.INT(
+      node,
+      'value',
+      ['INT', {}] as InputSpec,
+      fromPartial<ComfyApp>({})
+    )
+
+    expect(intWidget.widget.name).toBe('INT:value')
+    expect(intWidget.minWidth).toBe(20)
+    expect(intWidget.minHeight).toBe(30)
+    expect(
+      ComfyWidgets.IMAGEUPLOAD(
+        node,
+        'image',
+        ['IMAGE', {}],
+        fromPartial<ComfyApp>({})
+      )
+    ).toMatchObject({
+      widget: { name: 'IMAGEUPLOAD:image' },
+      minWidth: 5,
+      minHeight: 6
+    })
+    expect(isValidWidgetType('INT')).toBe(true)
+    expect(isValidWidgetType('DYNAMIC')).toBe(true)
+    expect(isValidWidgetType('missing')).toBe(false)
+  })
+})

--- a/src/services/audioService.test.ts
+++ b/src/services/audioService.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAudioService } from '@/services/audioService'
@@ -36,6 +37,12 @@ describe('useAudioService', () => {
   const mockBlob = new Blob(['test audio data'], { type: 'audio/wav' })
   const mockUploadResponse = {
     name: 'test-audio-123.wav'
+  }
+
+  async function freshService() {
+    vi.resetModules()
+    const audioServiceModule = await import('@/services/audioService')
+    return audioServiceModule.useAudioService()
   }
 
   beforeEach(() => {
@@ -96,15 +103,44 @@ describe('useAudioService', () => {
       expect(mockRegister).toHaveBeenCalledTimes(0)
       expect(console.error).not.toHaveBeenCalled()
     })
+
+    it('should log encoder registration errors', async () => {
+      const error = new Error('Encoder failed')
+      mockRegister.mockReset()
+      mockRegister.mockRejectedValueOnce(error)
+
+      const isolatedService = await freshService()
+      await isolatedService.registerWavEncoder()
+
+      expect(console.error).toHaveBeenCalledWith(
+        'Audio Service Error (encoder):',
+        'Failed to register WAV encoder',
+        error
+      )
+    })
+
+    it('should log non-Error encoder registration failures', async () => {
+      mockRegister.mockReset()
+      mockRegister.mockRejectedValueOnce('Encoder failed')
+
+      const isolatedService = await freshService()
+      await isolatedService.registerWavEncoder()
+
+      expect(console.error).toHaveBeenCalledWith(
+        'Audio Service Error (encoder):',
+        'Failed to register WAV encoder',
+        'Encoder failed'
+      )
+    })
   })
 
   describe('stopAllTracks', () => {
     it('should stop all tracks in a stream', () => {
       const mockTrack1 = { stop: vi.fn() }
       const mockTrack2 = { stop: vi.fn() }
-      const mockStream = {
+      const mockStream = fromPartial<MediaStream>({
         getTracks: vi.fn().mockReturnValue([mockTrack1, mockTrack2])
-      } as Partial<MediaStream> as MediaStream
+      })
 
       service.stopAllTracks(mockStream)
 
@@ -118,9 +154,9 @@ describe('useAudioService', () => {
     })
 
     it('should handle stream with no tracks', () => {
-      const mockStream = {
+      const mockStream = fromPartial<MediaStream>({
         getTracks: vi.fn().mockReturnValue([])
-      } as Partial<MediaStream> as MediaStream
+      })
 
       expect(() => service.stopAllTracks(mockStream)).not.toThrow()
       expect(mockStream.getTracks).toHaveBeenCalledTimes(1)
@@ -133,9 +169,9 @@ describe('useAudioService', () => {
           throw new Error('Stop failed')
         })
       }
-      const mockStream = {
+      const mockStream = fromPartial<MediaStream>({
         getTracks: vi.fn().mockReturnValue([mockTrack1, mockTrack2])
-      } as Partial<MediaStream> as MediaStream
+      })
 
       expect(() => service.stopAllTracks(mockStream)).toThrow()
       expect(mockTrack1.stop).toHaveBeenCalledTimes(1)

--- a/src/services/autoQueueService.test.ts
+++ b/src/services/autoQueueService.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setupAutoQueueHandler } from '@/services/autoQueueService'
+
+type ApiEvent = 'graphChanged'
+type ApiListener = () => void
+type Subscription = () => Promise<void> | void
+
+const {
+  listeners,
+  queueCountStore,
+  queueSettingsStore,
+  appState,
+  addEventListener,
+  isInstantRunningMode
+} = vi.hoisted(() => ({
+  listeners: new Map<ApiEvent, ApiListener>(),
+  queueCountStore: {
+    count: 0,
+    subscription: undefined as Subscription | undefined,
+    $subscribe: vi.fn((_callback: Subscription) => {
+      queueCountStore.subscription = _callback
+    })
+  },
+  queueSettingsStore: {
+    mode: 'manual',
+    batchCount: 1
+  },
+  appState: {
+    lastExecutionError: null as unknown,
+    queuePrompt: vi.fn()
+  },
+  addEventListener: vi.fn((event: ApiEvent, listener: ApiListener) => {
+    listeners.set(event, listener)
+  }),
+  isInstantRunningMode: vi.fn((mode: string) => mode === 'instant')
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: { addEventListener }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: appState
+}))
+
+vi.mock('@/stores/queueStore', () => ({
+  isInstantRunningMode,
+  useQueuePendingTaskCountStore: () => queueCountStore,
+  useQueueSettingsStore: () => queueSettingsStore
+}))
+
+beforeEach(() => {
+  listeners.clear()
+  queueCountStore.count = 0
+  queueCountStore.subscription = undefined
+  queueCountStore.$subscribe.mockClear()
+  queueSettingsStore.mode = 'manual'
+  queueSettingsStore.batchCount = 1
+  appState.lastExecutionError = null
+  appState.queuePrompt.mockReset().mockResolvedValue(undefined)
+  addEventListener.mockClear()
+  isInstantRunningMode
+    .mockClear()
+    .mockImplementation((mode) => mode === 'instant')
+})
+
+describe('setupAutoQueueHandler', () => {
+  it('queues immediately on graph changes when change mode is idle', () => {
+    queueSettingsStore.mode = 'change'
+    queueSettingsStore.batchCount = 3
+
+    setupAutoQueueHandler()
+    listeners.get('graphChanged')?.()
+
+    expect(appState.queuePrompt).toHaveBeenCalledWith(0, 3)
+  })
+
+  it('queues after pending work drains in instant mode', async () => {
+    queueSettingsStore.mode = 'instant'
+    queueSettingsStore.batchCount = 2
+    queueCountStore.count = 0
+
+    setupAutoQueueHandler()
+    await queueCountStore.subscription?.()
+
+    expect(appState.queuePrompt).toHaveBeenCalledWith(0, 2)
+  })
+
+  it('queues after a changed graph drains from an active queue', async () => {
+    queueSettingsStore.mode = 'change'
+    queueCountStore.count = 1
+
+    setupAutoQueueHandler()
+    await queueCountStore.subscription?.()
+    listeners.get('graphChanged')?.()
+    expect(appState.queuePrompt).not.toHaveBeenCalled()
+
+    queueCountStore.count = 0
+    await queueCountStore.subscription?.()
+
+    expect(appState.queuePrompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not requeue while work remains or the last run failed', async () => {
+    queueSettingsStore.mode = 'instant'
+    queueCountStore.count = 1
+
+    setupAutoQueueHandler()
+    await queueCountStore.subscription?.()
+
+    appState.lastExecutionError = { message: 'failed' }
+    queueCountStore.count = 0
+    await queueCountStore.subscription?.()
+
+    expect(appState.queuePrompt).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/colorPaletteService.test.ts
+++ b/src/services/colorPaletteService.test.ts
@@ -1,0 +1,363 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DEFAULT_DARK_COLOR_PALETTE } from '@/constants/coreColorPalettes'
+import {
+  LGraphCanvas,
+  LiteGraph,
+  RenderShape
+} from '@/lib/litegraph/src/litegraph'
+import type { CompletedPalette, Palette } from '@/schemas/colorPaletteSchema'
+
+const mockCanvas = vi.hoisted(() => ({
+  default_connection_color_byType: {} as Record<string, string>,
+  node_title_color: '',
+  default_link_color: '',
+  background_image: '',
+  clear_background_color: '',
+  _pattern: 'pattern' as string | undefined,
+  setDirty: vi.fn()
+}))
+
+const mockColorPaletteStore = vi.hoisted(() => ({
+  customPalettes: {} as Record<string, unknown>,
+  palettesLookup: {} as Record<string, unknown>,
+  completedActivePalette: undefined as unknown,
+  activePaletteId: 'dark',
+  addCustomPalette: vi.fn(),
+  deleteCustomPalette: vi.fn(),
+  completePalette: vi.fn()
+}))
+
+const mockSettingStore = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn()
+}))
+
+const mockNodeDefStore = vi.hoisted(() => ({
+  nodeDataTypes: new Set(['IMAGE', 'MISSING'])
+}))
+
+const mockDownloadBlob = vi.hoisted(() => vi.fn())
+const mockUploadFile = vi.hoisted(() => vi.fn())
+
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: mockCanvas }
+}))
+
+vi.mock('@/stores/workspace/colorPaletteStore', () => ({
+  useColorPaletteStore: () => mockColorPaletteStore
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => mockSettingStore
+}))
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  useNodeDefStore: () => mockNodeDefStore
+}))
+
+vi.mock('@/base/common/downloadUtil', () => ({
+  downloadBlob: mockDownloadBlob
+}))
+
+vi.mock('@/scripts/utils', () => ({
+  uploadFile: mockUploadFile
+}))
+
+vi.mock('@/composables/useErrorHandling', () => ({
+  useErrorHandling: () => ({
+    wrapWithErrorHandling: <T>(action: T) => action,
+    wrapWithErrorHandlingAsync: <T>(action: T) => action
+  })
+}))
+
+import { useColorPaletteService } from './colorPaletteService'
+
+const validCustomPalette = {
+  id: 'custom',
+  name: 'Custom',
+  colors: {
+    node_slot: {},
+    litegraph_base: {},
+    comfy_base: {}
+  }
+} satisfies Palette
+
+function makeCompletedPalette(id = 'custom'): CompletedPalette {
+  const palette = structuredClone(
+    DEFAULT_DARK_COLOR_PALETTE
+  ) as CompletedPalette
+  palette.id = id
+  palette.name = 'Custom'
+  palette.colors.node_slot.IMAGE = '#123456'
+  palette.colors.litegraph_base.NODE_TITLE_COLOR = '#abcdef'
+  palette.colors.litegraph_base.LINK_COLOR = '#fedcba'
+  palette.colors.litegraph_base.BACKGROUND_IMAGE = 'grid.png'
+  palette.colors.litegraph_base.CLEAR_BACKGROUND_COLOR = '#010203'
+  palette.colors.litegraph_base.NODE_DEFAULT_SHAPE = 'legacy'
+  palette.colors.comfy_base['fg-color'] = '#111111'
+  palette.colors.comfy_base['bg-color'] = '#222222'
+  delete palette.colors.comfy_base['contrast-mix-color']
+  return palette
+}
+
+describe('useColorPaletteService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCanvas.default_connection_color_byType = {}
+    mockCanvas.node_title_color = ''
+    mockCanvas.default_link_color = ''
+    mockCanvas.background_image = ''
+    mockCanvas.clear_background_color = ''
+    mockCanvas._pattern = 'pattern'
+    LGraphCanvas.link_type_colors = {}
+    mockSettingStore.get.mockReturnValue('')
+    mockSettingStore.set.mockResolvedValue(undefined)
+    mockColorPaletteStore.customPalettes = { custom: validCustomPalette }
+    mockColorPaletteStore.palettesLookup = { custom: validCustomPalette }
+    mockColorPaletteStore.completedActivePalette = makeCompletedPalette()
+    mockColorPaletteStore.activePaletteId = 'dark'
+    mockColorPaletteStore.completePalette.mockReturnValue(
+      makeCompletedPalette()
+    )
+    document.documentElement.style.cssText = ''
+    document.documentElement.style.setProperty(
+      '--color-datatype-MISSING',
+      '#ffffff'
+    )
+  })
+
+  it('adds valid custom palettes and persists the custom palette map', async () => {
+    const service = useColorPaletteService()
+
+    await service.addCustomColorPalette(validCustomPalette)
+
+    expect(mockColorPaletteStore.addCustomPalette).toHaveBeenCalledWith(
+      validCustomPalette
+    )
+    expect(mockSettingStore.set).toHaveBeenCalledWith(
+      'Comfy.CustomColorPalettes',
+      mockColorPaletteStore.customPalettes
+    )
+  })
+
+  it('rejects invalid custom palettes before mutating the store', async () => {
+    const service = useColorPaletteService()
+
+    await expect(service.addCustomColorPalette({} as Palette)).rejects.toThrow(
+      'Invalid color palette against zod schema'
+    )
+    expect(mockColorPaletteStore.addCustomPalette).not.toHaveBeenCalled()
+  })
+
+  it('deletes custom palettes and persists the custom palette map', async () => {
+    const service = useColorPaletteService()
+
+    await service.deleteCustomColorPalette('custom')
+
+    expect(mockColorPaletteStore.deleteCustomPalette).toHaveBeenCalledWith(
+      'custom'
+    )
+    expect(mockSettingStore.set).toHaveBeenCalledWith(
+      'Comfy.CustomColorPalettes',
+      mockColorPaletteStore.customPalettes
+    )
+  })
+
+  it('loads palette colors into litegraph, Vue CSS variables, and canvas state', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(mockCanvas.default_connection_color_byType.IMAGE).toBe('#123456')
+    expect(LGraphCanvas.link_type_colors.IMAGE).toBe('#123456')
+    expect(
+      document.documentElement.style.getPropertyValue('--color-datatype-IMAGE')
+    ).toBe('#123456')
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--color-datatype-MISSING'
+      )
+    ).toBe('')
+    expect(mockCanvas.node_title_color).toBe('#abcdef')
+    expect(mockCanvas.default_link_color).toBe('#fedcba')
+    expect(mockCanvas.background_image).toBe('grid.png')
+    expect(mockCanvas.clear_background_color).toBe('#010203')
+    expect(mockCanvas._pattern).toBeUndefined()
+    expect(LiteGraph.NODE_DEFAULT_SHAPE).toBe(RenderShape.ROUND)
+    expect(warn).toHaveBeenCalledWith(
+      `litegraph_base.NODE_DEFAULT_SHAPE only accepts [${[
+        RenderShape.BOX,
+        RenderShape.ROUND,
+        RenderShape.CARD
+      ].join(', ')}] but got legacy`
+    )
+    expect(document.documentElement.style.getPropertyValue('--fg-color')).toBe(
+      '#111111'
+    )
+    expect(
+      document.documentElement.style.getPropertyValue('--contrast-mix-color')
+    ).toBe('var(--palette-contrast-mix-color)')
+    expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+    expect(mockColorPaletteStore.activePaletteId).toBe('custom')
+  })
+
+  it('skips absent palette sections while still activating the palette', async () => {
+    const completedPalette = makeCompletedPalette()
+    mockColorPaletteStore.completePalette.mockReturnValue(
+      fromPartial<CompletedPalette>({
+        ...completedPalette,
+        colors: {
+          node_slot: undefined,
+          litegraph_base: completedPalette.colors.litegraph_base,
+          comfy_base: undefined
+        }
+      })
+    )
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(mockCanvas.node_title_color).toBe('#abcdef')
+    expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+    expect(mockColorPaletteStore.activePaletteId).toBe('custom')
+  })
+
+  it('removes Vue node theme overrides for built-in palettes', async () => {
+    mockColorPaletteStore.palettesLookup = { dark: validCustomPalette }
+    mockColorPaletteStore.completePalette.mockReturnValue(
+      makeCompletedPalette('dark')
+    )
+    document.documentElement.style.setProperty(
+      '--component-node-border',
+      '#ffffff'
+    )
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('dark')
+
+    expect(
+      document.documentElement.style.getPropertyValue('--component-node-border')
+    ).toBe('')
+  })
+
+  it('removes Vue node theme variables when completed palette values are absent', async () => {
+    const completedPalette = makeCompletedPalette()
+    // NODE_BOX_OUTLINE_COLOR is required on the completed palette type; the
+    // test needs it absent, so delete via Reflect to keep the type intact.
+    Reflect.deleteProperty(
+      completedPalette.colors.litegraph_base,
+      'NODE_BOX_OUTLINE_COLOR'
+    )
+    mockColorPaletteStore.completePalette.mockReturnValue(completedPalette)
+    document.documentElement.style.setProperty(
+      '--component-node-border',
+      '#ffffff'
+    )
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(
+      document.documentElement.style.getPropertyValue('--component-node-border')
+    ).toBe('')
+  })
+
+  it('preserves numeric LiteGraph node shapes without warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const completedPalette = makeCompletedPalette()
+    completedPalette.colors.litegraph_base.NODE_DEFAULT_SHAPE = RenderShape.CARD
+    mockColorPaletteStore.completePalette.mockReturnValue(completedPalette)
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(LiteGraph.NODE_DEFAULT_SHAPE).toBe(RenderShape.CARD)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('uses explicit optional comfy color values when present', async () => {
+    const completedPalette = makeCompletedPalette()
+    completedPalette.colors.comfy_base['contrast-mix-color'] = '#333333'
+    mockColorPaletteStore.completePalette.mockReturnValue(completedPalette)
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(
+      document.documentElement.style.getPropertyValue('--contrast-mix-color')
+    ).toBe('#333333')
+  })
+
+  it('uses a white splash background for light themes', async () => {
+    const completedPalette = makeCompletedPalette()
+    completedPalette.light_theme = true
+    mockColorPaletteStore.completePalette.mockReturnValue(completedPalette)
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(localStorage.getItem('comfy-splash-bg')).toBe('#FFFFFF')
+    expect(localStorage.getItem('comfy-splash-fg')).toBe('#111111')
+  })
+
+  it('uses transparent canvas background and bg image CSS when a background image setting exists', async () => {
+    mockSettingStore.get.mockReturnValue('/custom/background.png')
+    const service = useColorPaletteService()
+
+    await service.loadColorPalette('custom')
+
+    expect(mockCanvas.clear_background_color).toBe('transparent')
+    expect(document.documentElement.style.getPropertyValue('--bg-img')).toBe(
+      "url('/custom/background.png')"
+    )
+  })
+
+  it('throws when loading or exporting an unknown palette', async () => {
+    mockColorPaletteStore.palettesLookup = {}
+    const service = useColorPaletteService()
+
+    await expect(service.loadColorPalette('missing')).rejects.toThrow(
+      'Color palette missing not found'
+    )
+    expect(() => service.exportColorPalette('missing')).toThrow(
+      'Color palette missing not found'
+    )
+  })
+
+  it('exports palette JSON by id', async () => {
+    const service = useColorPaletteService()
+
+    service.exportColorPalette('custom')
+
+    expect(mockDownloadBlob).toHaveBeenCalledOnce()
+    const [filename, blob] = mockDownloadBlob.mock.calls[0] as [string, Blob]
+    expect(filename).toBe('custom.json')
+    await expect(blob.text()).resolves.toContain('"id": "custom"')
+  })
+
+  it('imports palette JSON through the custom palette path', async () => {
+    mockUploadFile.mockResolvedValue({
+      text: () => Promise.resolve(JSON.stringify(validCustomPalette))
+    })
+    const service = useColorPaletteService()
+
+    const palette = await service.importColorPalette()
+
+    expect(mockUploadFile).toHaveBeenCalledWith('application/json')
+    expect(palette).toEqual(validCustomPalette)
+    expect(mockColorPaletteStore.addCustomPalette).toHaveBeenCalledWith(
+      validCustomPalette
+    )
+  })
+
+  it('returns the completed active palette from the store', () => {
+    const service = useColorPaletteService()
+
+    expect(service.getActiveColorPalette()).toBe(
+      mockColorPaletteStore.completedActivePalette
+    )
+  })
+})

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -1,0 +1,325 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { toNodeId } from '@/types/nodeId'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { AuthUserInfo } from '@/types/authTypes'
+import type { ComfyExtension } from '@/types/comfy'
+import { useExtensionService } from './extensionService'
+
+const mockLoadDisabledExtensionNames = vi.hoisted(() => vi.fn())
+const mockRegisterExtension = vi.hoisted(() => vi.fn())
+const mockCaptureCoreExtensions = vi.hoisted(() => vi.fn())
+const mockEnabledExtensions = vi.hoisted(() => ({
+  value: [] as ComfyExtension[]
+}))
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({
+    loadDisabledExtensionNames: mockLoadDisabledExtensionNames,
+    registerExtension: mockRegisterExtension,
+    captureCoreExtensions: mockCaptureCoreExtensions,
+    get enabledExtensions() {
+      return mockEnabledExtensions.value
+    }
+  })
+}))
+
+const mockGetSetting = vi.hoisted(() => vi.fn())
+const mockAddSetting = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: mockGetSetting,
+    addSetting: mockAddSetting
+  })
+}))
+
+const mockAddDefaultKeybinding = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/keybindings/keybindingStore', () => ({
+  useKeybindingStore: () => ({
+    addDefaultKeybinding: mockAddDefaultKeybinding
+  })
+}))
+
+vi.mock('@/platform/keybindings/keybinding', () => ({
+  KeybindingImpl: class KeybindingImpl {
+    constructor(readonly source: unknown) {}
+  }
+}))
+
+const mockLoadExtensionCommands = vi.hoisted(() => vi.fn())
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({
+    loadExtensionCommands: mockLoadExtensionCommands
+  })
+}))
+
+const mockLoadExtensionMenuCommands = vi.hoisted(() => vi.fn())
+vi.mock('@/stores/menuItemStore', () => ({
+  useMenuItemStore: () => ({
+    loadExtensionMenuCommands: mockLoadExtensionMenuCommands
+  })
+}))
+
+const mockRegisterBottomPanelTabs = vi.hoisted(() => vi.fn())
+vi.mock('@/stores/workspace/bottomPanelStore', () => ({
+  useBottomPanelStore: () => ({
+    registerExtensionBottomPanelTabs: mockRegisterBottomPanelTabs
+  })
+}))
+
+const mockRegisterCustomWidgets = vi.hoisted(() => vi.fn())
+vi.mock('@/stores/widgetStore', () => ({
+  useWidgetStore: () => ({
+    registerCustomWidgets: mockRegisterCustomWidgets
+  })
+}))
+
+const mockToastErrorHandler = vi.hoisted(() => vi.fn())
+vi.mock('@/composables/useErrorHandling', () => ({
+  useErrorHandling: () => ({
+    wrapWithErrorHandling:
+      <Args extends unknown[], Return>(fn: (...args: Args) => Return) =>
+      (...args: Args) =>
+        fn(...args),
+    wrapWithErrorHandlingAsync:
+      <Args extends unknown[], Return>(
+        fn: (...args: Args) => Return | Promise<Return>,
+        handler: (error: unknown) => void
+      ) =>
+      async (...args: Args) => {
+        try {
+          return await fn(...args)
+        } catch (error) {
+          handler(error)
+        }
+      },
+    toastErrorHandler: mockToastErrorHandler
+  })
+}))
+
+const mockUserResolvedCallbacks = vi.hoisted(() => ({
+  values: [] as Array<(user: AuthUserInfo) => void>
+}))
+const mockTokenRefreshedCallbacks = vi.hoisted(() => ({
+  values: [] as Array<() => void>
+}))
+const mockUserLogoutCallbacks = vi.hoisted(() => ({
+  values: [] as Array<() => void>
+}))
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    onUserResolved: (callback: (user: AuthUserInfo) => void) => {
+      mockUserResolvedCallbacks.values.push(callback)
+    },
+    onTokenRefreshed: (callback: () => void) => {
+      mockTokenRefreshedCallbacks.values.push(callback)
+    },
+    onUserLogout: (callback: () => void) => {
+      mockUserLogoutCallbacks.values.push(callback)
+    }
+  })
+}))
+
+const mockSetCurrentExtension = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/litegraph/src/contextMenuCompat', () => ({
+  legacyMenuCompat: {
+    setCurrentExtension: mockSetCurrentExtension
+  }
+}))
+
+const mockApp = vi.hoisted(() => ({ value: { name: 'app' } }))
+vi.mock('@/scripts/app', () => ({
+  app: mockApp.value
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getExtensions: vi.fn(),
+    fileURL: vi.fn((path: string) => path)
+  }
+}))
+
+describe('useExtensionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnabledExtensions.value = []
+    mockUserResolvedCallbacks.values = []
+    mockTokenRefreshedCallbacks.values = []
+    mockUserLogoutCallbacks.values = []
+  })
+
+  it('registers extension contributions across stores', async () => {
+    const widgets = { CustomWidget: vi.fn() }
+    const extension = Object.assign(fromPartial<ComfyExtension>({}), {
+      name: 'registration-extension',
+      keybindings: [{ commandId: 'command.one', combo: { key: 'K' } }],
+      commands: [{ id: 'command.one', label: 'Command One' }],
+      menuCommands: [{ path: ['File'], commands: ['command.one'] }],
+      settings: [{ id: 'setting.one', name: 'Setting One' }],
+      bottomPanelTabs: [{ id: 'tab.one', title: 'Tab One' }],
+      getCustomWidgets: vi.fn().mockResolvedValue(widgets)
+    })
+    const service = useExtensionService()
+
+    service.registerExtension(extension)
+
+    expect(mockRegisterExtension).toHaveBeenCalledWith(extension)
+    expect(mockAddDefaultKeybinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: { commandId: 'command.one', combo: { key: 'K' } }
+      })
+    )
+    expect(mockLoadExtensionCommands).toHaveBeenCalledWith(extension)
+    expect(mockLoadExtensionMenuCommands).toHaveBeenCalledWith(extension)
+    expect(mockAddSetting.mock.calls[0][0]).toEqual({
+      id: 'setting.one',
+      name: 'Setting One'
+    })
+    expect(mockRegisterBottomPanelTabs).toHaveBeenCalledWith(extension)
+    await vi.waitFor(() => {
+      expect(mockRegisterCustomWidgets).toHaveBeenCalledWith(widgets)
+    })
+  })
+
+  it('invokes auth lifecycle hooks through registered callbacks', async () => {
+    const onAuthUserResolved = vi.fn()
+    const onAuthTokenRefreshed = vi.fn()
+    const onAuthUserLogout = vi.fn()
+    const extension = fromPartial<ComfyExtension>({
+      name: 'auth-extension',
+      onAuthUserResolved,
+      onAuthTokenRefreshed,
+      onAuthUserLogout
+    })
+    const user = fromPartial<AuthUserInfo>({ id: 'user-1' })
+    const service = useExtensionService()
+
+    service.registerExtension(extension)
+    mockUserResolvedCallbacks.values[0](user)
+    mockTokenRefreshedCallbacks.values[0]()
+    mockUserLogoutCallbacks.values[0]()
+
+    await vi.waitFor(() => {
+      expect(onAuthUserResolved).toHaveBeenCalledWith(user, mockApp.value)
+      expect(onAuthTokenRefreshed).toHaveBeenCalled()
+      expect(onAuthUserLogout).toHaveBeenCalled()
+    })
+  })
+
+  it('reports auth hook errors through the toast handler', async () => {
+    const error = new Error('auth failed')
+    const extension = fromPartial<ComfyExtension>({
+      name: 'failing-auth-extension',
+      onAuthUserResolved: vi.fn(() => {
+        throw error
+      })
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const service = useExtensionService()
+
+    service.registerExtension(extension)
+    mockUserResolvedCallbacks.values[0](
+      fromPartial<AuthUserInfo>({ id: 'user-1' })
+    )
+
+    await vi.waitFor(() => {
+      expect(mockToastErrorHandler).toHaveBeenCalledWith(error)
+    })
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Extension Auth Hook Error]',
+      expect.objectContaining({
+        extension: 'failing-auth-extension',
+        hook: 'onAuthUserResolved',
+        error
+      })
+    )
+    consoleError.mockRestore()
+  })
+
+  it('invokes synchronous extension methods and keeps failures isolated', () => {
+    const getSelectionToolboxCommands = vi.fn(() => ['command.one'])
+    const failingGetSelectionToolboxCommands = vi.fn(() => {
+      throw new Error('menu failed')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockEnabledExtensions.value = [
+      fromPartial<ComfyExtension>({
+        name: 'working-extension',
+        getSelectionToolboxCommands
+      }),
+      fromPartial<ComfyExtension>({
+        name: 'non-function-extension',
+        getSelectionToolboxCommands: ['not callable']
+      }),
+      fromPartial<ComfyExtension>({
+        name: 'failing-extension',
+        getSelectionToolboxCommands: failingGetSelectionToolboxCommands
+      }),
+      { name: 'missing-method-extension' }
+    ]
+    const service = useExtensionService()
+
+    const results = service.invokeExtensions(
+      'getSelectionToolboxCommands',
+      Object.assign(fromPartial<LGraphNode>({}), { id: toNodeId(1) })
+    )
+
+    expect(results).toEqual([['command.one']])
+    expect(getSelectionToolboxCommands).toHaveBeenCalledWith(
+      Object.assign(fromPartial<LGraphNode>({}), { id: toNodeId(1) }),
+      mockApp.value
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error calling extension 'failing-extension' method 'getSelectionToolboxCommands'",
+      expect.objectContaining({ error: expect.any(Error) }),
+      expect.objectContaining({
+        extension: expect.objectContaining({ name: 'failing-extension' })
+      }),
+      expect.objectContaining({
+        args: [Object.assign(fromPartial<LGraphNode>({}), { id: toNodeId(1) })]
+      })
+    )
+    consoleError.mockRestore()
+  })
+
+  it('tracks current extension around async setup callbacks', async () => {
+    const setup = vi.fn().mockResolvedValue('setup-result')
+    const failingSetup = vi.fn().mockRejectedValue(new Error('setup failed'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockEnabledExtensions.value = [
+      fromPartial<ComfyExtension>({
+        name: 'setup-extension',
+        setup
+      }),
+      fromPartial<ComfyExtension>({
+        name: 'non-function-extension',
+        setup: true
+      }),
+      fromPartial<ComfyExtension>({
+        name: 'failing-setup-extension',
+        setup: failingSetup
+      }),
+      { name: 'missing-method-extension' }
+    ]
+    const service = useExtensionService()
+
+    const results = await service.invokeExtensionsAsync('setup')
+
+    expect(results).toEqual(['setup-result', undefined, undefined, undefined])
+    expect(mockSetCurrentExtension.mock.calls.map((call) => call[0])).toEqual([
+      'setup-extension',
+      'failing-setup-extension',
+      null,
+      null
+    ])
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error calling extension 'failing-setup-extension' method 'setup'",
+      expect.objectContaining({ error: expect.any(Error) }),
+      expect.objectContaining({
+        extension: expect.objectContaining({ name: 'failing-setup-extension' })
+      }),
+      expect.objectContaining({ args: [] })
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/src/services/litegraphService.core.test.ts
+++ b/src/services/litegraphService.core.test.ts
@@ -1,0 +1,2123 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  IContextMenuValue,
+  SubgraphNode
+} from '@/lib/litegraph/src/litegraph'
+import {
+  LGraphCanvas,
+  LGraphNode,
+  LiteGraph,
+  RenderShape
+} from '@/lib/litegraph/src/litegraph'
+import type { ContextMenuDivElement } from '@/lib/litegraph/src/interfaces'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import type {
+  ComfyNodeDef as ComfyNodeDefV2,
+  InputSpec
+} from '@/schemas/nodeDef/nodeDefSchemaV2'
+
+import {
+  GET_CONFIG,
+  getExtraOptionsForWidget
+} from '@/services/litegraphService'
+import type { HasInitialMinSize } from '@/services/litegraphService'
+
+type WidgetFactory = (
+  node: LGraphNode,
+  inputName: string,
+  inputSpec: unknown,
+  app: unknown
+) =>
+  | {
+      widget?: IBaseWidget
+      minWidth?: number
+      minHeight?: number
+    }
+  | undefined
+
+async function invokeMenuCallback(option: IContextMenuValue): Promise<void> {
+  // Production callbacks under test do not reference `this`; ContextMenuDivElement
+  // is a DOM element decorated with extra fields, not realistic to construct in tests.
+  await option.callback?.call({} as ContextMenuDivElement)
+}
+
+const mockPrompt = vi.fn()
+const mockCanvas = vi.hoisted(() => ({
+  setDirty: vi.fn(),
+  graph_mouse: [100, 200] as [number, number],
+  ds: {
+    scale: 1,
+    offset: [0, 0] as [number, number],
+    visible_area: [0, 0, 800, 600] as
+      | [number, number, number, number]
+      | undefined,
+    fitToBounds: vi.fn()
+  },
+  graph: {
+    nodes: [] as unknown[] | undefined,
+    getNodeById: vi.fn(),
+    add: vi.fn(),
+    setDirtyCanvas: vi.fn(),
+    trigger: vi.fn(),
+    isRootGraph: true
+  },
+  animateToBounds: vi.fn(),
+  startGhostPlacement: vi.fn(),
+  _deserializeItems: vi.fn()
+}))
+
+const mockApp = vi.hoisted(() => ({
+  canvas: undefined as unknown,
+  graph: undefined as unknown,
+  dragOverNode: null as { id: unknown } | null,
+  lastExecutionError: null as { node_id: unknown } | null,
+  rootGraph: {}
+}))
+
+const mockWidgetStore = vi.hoisted(() => ({
+  widgets: new Map<string, WidgetFactory>()
+}))
+
+const mockExecutionStore = vi.hoisted(() => ({
+  nodeLocationProgressStates: {} as Record<string, { state?: string }>
+}))
+
+const mockWorkflowStore = vi.hoisted(() => ({
+  activeSubgraph: null as { add: ReturnType<typeof vi.fn> } | null,
+  nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id))
+}))
+
+const mockSubgraphOperations = vi.hoisted(() => ({
+  unpackSubgraph: vi.fn()
+}))
+
+const mockExtensionService = vi.hoisted(() => ({
+  invokeExtensionsAsync: vi.fn()
+}))
+
+const mockSettingStore = vi.hoisted(() => ({
+  get: vi.fn().mockReturnValue(false)
+}))
+
+const mockFavoritedWidgetsStore = vi.hoisted(() => ({
+  isFavorited: vi.fn().mockReturnValue(false),
+  toggleFavorite: vi.fn()
+}))
+
+const mockToastStore = vi.hoisted(() => ({
+  addAlert: vi.fn()
+}))
+
+const mockSubgraphStore = vi.hoisted(() => ({
+  typePrefix: 'Subgraph::',
+  getBlueprint: vi.fn()
+}))
+
+const mockRightSidePanelStore = vi.hoisted(() => ({
+  openPanel: vi.fn()
+}))
+
+const mockPreviewExposureStore = vi.hoisted(() => ({
+  getExposures: vi.fn().mockReturnValue([]),
+  getExposuresAsPromotionShape: vi.fn().mockReturnValue([]),
+  setExposures: vi.fn()
+}))
+
+const mockAnimatedPreview = vi.hoisted(() => ({
+  showAnimatedPreview: vi.fn(),
+  removeAnimatedPreview: vi.fn()
+}))
+
+const mockCanvasImagePreview = vi.hoisted(() => ({
+  showCanvasImagePreview: vi.fn(),
+  removeCanvasImagePreview: vi.fn()
+}))
+
+const mockNodeImagePreview = vi.hoisted(() => ({
+  showPreview: vi.fn()
+}))
+
+const mockNodeVideoPreview = vi.hoisted(() => ({
+  showPreview: vi.fn()
+}))
+
+vi.mock('@/stores/workspace/favoritedWidgetsStore', () => ({
+  useFavoritedWidgetsStore: () => mockFavoritedWidgetsStore
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    prompt: mockPrompt
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: mockCanvas,
+    getCanvas: () => mockCanvas
+  })
+}))
+
+vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
+  addWidgetPromotionOptions: vi.fn(),
+  isPreviewPseudoWidget: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key,
+  st: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/utils/formatUtil', () => ({
+  normalizeI18nKey: (key: string) => key
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: mockApp,
+  ComfyApp: {
+    clipspace: null,
+    clipspace_return_node: null,
+    copyToClipspace: vi.fn(),
+    pasteFromClipspace: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => mockToastStore
+}))
+
+vi.mock('@/stores/widgetStore', () => ({
+  useWidgetStore: () => mockWidgetStore
+}))
+
+vi.mock('@/stores/executionStore', () => ({
+  useExecutionStore: () => mockExecutionStore
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => mockWorkflowStore
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => mockSettingStore
+}))
+
+vi.mock('@/composables/canvas/useSelectedLiteGraphItems', () => ({
+  useSelectedLiteGraphItems: () => ({
+    toggleSelectedNodesMode: vi.fn()
+  })
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => mockExtensionService
+}))
+
+vi.mock('@/stores/subgraphStore', () => ({
+  useSubgraphStore: () => mockSubgraphStore
+}))
+
+vi.mock('@/stores/previewExposureStore', () => ({
+  usePreviewExposureStore: () => mockPreviewExposureStore
+}))
+
+const mockNodeOutputStore = vi.hoisted(() => ({
+  getNodeOutputs: vi.fn(),
+  getNodePreviews: vi.fn()
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => mockNodeOutputStore
+}))
+
+vi.mock('@/composables/node/useNodeAnimatedImage', () => ({
+  useNodeAnimatedImage: () => mockAnimatedPreview
+}))
+
+vi.mock('@/composables/node/useNodeCanvasImagePreview', () => ({
+  useNodeCanvasImagePreview: () => mockCanvasImagePreview
+}))
+
+vi.mock('@/composables/node/useNodeImage', () => ({
+  useNodeImage: () => mockNodeImagePreview,
+  useNodeVideo: () => mockNodeVideoPreview
+}))
+
+vi.mock('@/composables/graph/useSubgraphOperations', () => ({
+  useSubgraphOperations: () => mockSubgraphOperations
+}))
+
+vi.mock('@/composables/maskeditor/useMaskEditor', () => ({
+  useMaskEditor: () => ({ openMaskEditor: vi.fn() })
+}))
+
+vi.mock('@/stores/domWidgetStore', () => ({
+  useDomWidgetStore: () => ({
+    widgetStates: new Map(),
+    registerWidget: vi.fn(),
+    unregisterWidget: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/promotionStore', () => ({
+  usePromotionStore: () => ({
+    getPromotionsRef: vi.fn().mockReturnValue([])
+  })
+}))
+
+vi.mock('@/services/subgraphPseudoWidgetCache', () => ({
+  resolveSubgraphPseudoWidgetCache: vi.fn().mockReturnValue({
+    cache: { promotions: [], entries: [], nodes: [] },
+    nodes: []
+  })
+}))
+
+vi.mock('@/stores/workspace/rightSidePanelStore', () => ({
+  useRightSidePanelStore: () => mockRightSidePanelStore
+}))
+
+vi.mock('@/base/common/downloadUtil', () => ({
+  downloadFile: vi.fn(),
+  openFileInNewTab: vi.fn()
+}))
+
+vi.mock('@/scripts/domWidget', () => ({
+  isComponentWidget: vi.fn().mockReturnValue(false),
+  isDOMWidget: vi.fn().mockReturnValue(false)
+}))
+
+const mockCreateBounds = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    createBounds: mockCreateBounds
+  }
+})
+
+vi.mock('@/scripts/ui', () => ({
+  $el: vi.fn()
+}))
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  isAnimatedOutput: vi.fn().mockReturnValue(false),
+  isImageNode: vi.fn().mockReturnValue(false),
+  isVideoNode: vi.fn().mockReturnValue(false),
+  isVideoOutput: vi.fn().mockReturnValue(false),
+  migrateWidgetsValues: vi.fn().mockReturnValue([])
+}))
+
+vi.mock('@/core/graph/widgets/dynamicWidgets', () => ({
+  applyDynamicInputs: vi.fn().mockReturnValue(false)
+}))
+
+vi.mock('@/schemas/nodeDef/migration', () => ({
+  transformInputSpecV2ToV1: vi.fn().mockReturnValue([])
+}))
+
+vi.mock('@/workbench/utils/nodeDefOrderingUtil', () => ({
+  getOrderedInputSpecs: vi.fn().mockReturnValue([])
+}))
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  ComfyNodeDefImpl: class {
+    constructor(def: object) {
+      Object.assign(this, def)
+    }
+  }
+}))
+
+function createMockNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  const node = new LGraphNode('TestNode')
+  Object.assign(node, {
+    id: 1,
+    inputs: [],
+    graph: null,
+    getWidgetOnPos: vi.fn()
+  })
+  Object.assign(node, overrides)
+  // Set static nodeData for tests that check constructor.nodeData
+  ;(node.constructor as { nodeData?: { name: string } }).nodeData = {
+    name: 'TestNode'
+  }
+  return node
+}
+
+function createNodeWithInitialSize(): LGraphNode & HasInitialMinSize {
+  const node = createMockNode() as LGraphNode & HasInitialMinSize
+  node._initialMinSize = { width: 1, height: 1 }
+  return node
+}
+
+function createMockWidget(
+  overrides: Record<string, unknown> = {}
+): IBaseWidget {
+  return fromPartial<IBaseWidget>({
+    name: 'test_widget',
+    label: undefined,
+    value: 42,
+    callback: vi.fn(),
+    options: {},
+    ...overrides
+  })
+}
+
+function installClipboard(write: Clipboard['write']) {
+  class TestClipboardItem {
+    constructor(readonly data: Record<string, Blob>) {}
+  }
+
+  vi.stubGlobal('ClipboardItem', TestClipboardItem)
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { write }
+  })
+  return TestClipboardItem
+}
+
+function createInputSpec(overrides: Partial<InputSpec> = {}): InputSpec {
+  return {
+    name: 'prompt',
+    type: 'STRING',
+    display_name: 'Prompt',
+    ...overrides
+  } as InputSpec
+}
+
+function createNodeDef(
+  overrides: Partial<ComfyNodeDefV2> = {}
+): ComfyNodeDefV2 {
+  return {
+    inputs: {},
+    outputs: [],
+    hidden: {},
+    name: 'TestNode',
+    display_name: 'Test Node',
+    description: 'A node used by tests',
+    category: 'test',
+    output_node: false,
+    python_module: 'test.nodes',
+    ...overrides
+  }
+}
+
+async function registerTestNode() {
+  const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+  const registerSpy = vi
+    .spyOn(LiteGraph, 'registerNodeType')
+    .mockImplementation(function () {})
+  const { useLitegraphService } = await import('@/services/litegraphService')
+  const service = useLitegraphService()
+
+  await service.registerNodeDef('TestNode', createNodeDef())
+  const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+  registerSpy.mockRestore()
+  return new NodeCtor('Test Node')
+}
+
+describe('litegraphService', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { ComfyApp } = await import('@/scripts/app')
+    ComfyApp.clipspace = null
+    ComfyApp.clipspace_return_node = null
+    mockFavoritedWidgetsStore.isFavorited.mockReturnValue(false)
+    mockPrompt.mockReset()
+    mockCreateBounds.mockReset()
+    mockWidgetStore.widgets.clear()
+    mockExecutionStore.nodeLocationProgressStates = {}
+    mockWorkflowStore.activeSubgraph = null
+    mockWorkflowStore.nodeIdToNodeLocatorId.mockClear()
+    mockExtensionService.invokeExtensionsAsync.mockClear()
+    mockCanvas.graph.getNodeById.mockReset()
+    mockCanvas.graph.add.mockReset()
+    mockCanvas.graph.trigger = vi.fn()
+    mockCanvas.startGhostPlacement = vi.fn()
+    mockSubgraphOperations.unpackSubgraph.mockReset()
+    mockRightSidePanelStore.openPanel.mockReset()
+    mockPreviewExposureStore.getExposures.mockReturnValue([])
+    mockPreviewExposureStore.getExposuresAsPromotionShape.mockReturnValue([])
+    mockPreviewExposureStore.setExposures.mockReset()
+    mockCanvas.ds.scale = 1
+    mockCanvas.ds.offset = [0, 0]
+    mockCanvas.ds.visible_area = [0, 0, 800, 600]
+    mockCanvas.graph.nodes = []
+    mockApp.canvas = mockCanvas
+    mockApp.graph = mockCanvas.graph
+    mockSettingStore.get.mockReturnValue(false)
+    mockSubgraphStore.getBlueprint.mockReset()
+    mockAnimatedPreview.showAnimatedPreview.mockReset()
+    mockAnimatedPreview.removeAnimatedPreview.mockReset()
+    mockCanvasImagePreview.showCanvasImagePreview.mockReset()
+    mockCanvasImagePreview.removeCanvasImagePreview.mockReset()
+    mockNodeImagePreview.showPreview.mockReset()
+    mockNodeVideoPreview.showPreview.mockReset()
+    mockToastStore.addAlert.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getExtraOptionsForWidget', () => {
+    it('adds favorite option when widget is not favorited', () => {
+      const node = createMockNode()
+      const widget = createMockWidget()
+      mockFavoritedWidgetsStore.isFavorited.mockReturnValue(false)
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      expect(options).toHaveLength(1)
+      expect(options[0].content).toContain('contextMenu.FavoriteWidget')
+      expect(options[0].content).toContain('test_widget')
+    })
+
+    it('adds unfavorite option when widget is already favorited', () => {
+      const node = createMockNode()
+      const widget = createMockWidget()
+      mockFavoritedWidgetsStore.isFavorited.mockReturnValue(true)
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      expect(options[0].content).toContain('contextMenu.UnfavoriteWidget')
+    })
+
+    it('uses widget label when available', () => {
+      const node = createMockNode()
+      const widget = createMockWidget({ label: 'My Label' })
+      mockFavoritedWidgetsStore.isFavorited.mockReturnValue(false)
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      expect(options[0].content).toContain('My Label')
+    })
+
+    it('calls toggleFavorite when favorite option callback is invoked', () => {
+      const node = createMockNode()
+      const widget = createMockWidget()
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      void invokeMenuCallback(options[0])
+      expect(mockFavoritedWidgetsStore.toggleFavorite).toHaveBeenCalledWith(
+        node,
+        'test_widget'
+      )
+    })
+
+    it('adds rename option when input matches widget', () => {
+      const widget = createMockWidget({ name: 'seed' })
+      const node = createMockNode({
+        inputs: [{ widget: { name: 'seed' } }]
+      })
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      // rename is unshifted first, then favorite is unshifted (ends up first)
+      expect(options).toHaveLength(2)
+      const renameOption = options.find((o: IContextMenuValue) =>
+        o.content?.includes('contextMenu.RenameWidget')
+      )
+      expect(renameOption).toBeDefined()
+      expect(renameOption!.content).toContain('seed')
+    })
+
+    it('rename callback updates widget and input labels', async () => {
+      const widget = createMockWidget({ name: 'seed' })
+      const input = { widget: { name: 'seed' }, label: undefined as unknown }
+      const node = createMockNode({ inputs: [input] })
+      mockPrompt.mockResolvedValue('New Name')
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      const renameOption = options.find((o: IContextMenuValue) =>
+        o.content?.includes('contextMenu.RenameWidget')
+      )
+      await invokeMenuCallback(renameOption!)
+
+      expect(widget.label).toBe('New Name')
+      expect(input.label).toBe('New Name')
+      expect(widget.callback).toHaveBeenCalledWith(42)
+      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true)
+    })
+
+    it('rename callback clears label when empty string is returned', async () => {
+      const widget = createMockWidget({ name: 'seed', label: 'Old' })
+      const input = {
+        widget: { name: 'seed' },
+        label: 'Old' as string | undefined
+      }
+      const node = createMockNode({ inputs: [input] })
+      mockPrompt.mockResolvedValue('')
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      const renameOption = options.find((o: IContextMenuValue) =>
+        o.content?.includes('contextMenu.RenameWidget')
+      )
+      await invokeMenuCallback(renameOption!)
+
+      expect(widget.label).toBeUndefined()
+      expect(input.label).toBeUndefined()
+    })
+
+    it('rename callback does nothing when prompt is cancelled', async () => {
+      const widget = createMockWidget({ name: 'seed', label: 'Original' })
+      const input = { widget: { name: 'seed' }, label: 'Original' }
+      const node = createMockNode({ inputs: [input] })
+      mockPrompt.mockResolvedValue(null)
+
+      const options = getExtraOptionsForWidget(node, widget)
+
+      const renameOption = options.find((o: IContextMenuValue) =>
+        o.content?.includes('contextMenu.RenameWidget')
+      )
+      await invokeMenuCallback(renameOption!)
+
+      expect(widget.label).toBe('Original')
+      expect(input.label).toBe('Original')
+    })
+
+    it('adds promotion options when node is in a subgraph', async () => {
+      const { addWidgetPromotionOptions } = vi.mocked(
+        await import('@/core/graph/subgraph/promotionUtils')
+      )
+      const node = createMockNode({
+        graph: { isRootGraph: false }
+      })
+      const widget = createMockWidget()
+
+      getExtraOptionsForWidget(node, widget)
+
+      expect(addWidgetPromotionOptions).toHaveBeenCalled()
+    })
+
+    it('does not add promotion options when node has no graph', async () => {
+      const { addWidgetPromotionOptions } = vi.mocked(
+        await import('@/core/graph/subgraph/promotionUtils')
+      )
+      const node = createMockNode({ graph: null })
+      const widget = createMockWidget()
+
+      getExtraOptionsForWidget(node, widget)
+
+      expect(addWidgetPromotionOptions).not.toHaveBeenCalled()
+    })
+
+    it('does not add promotion options on root graph', async () => {
+      const { addWidgetPromotionOptions } = vi.mocked(
+        await import('@/core/graph/subgraph/promotionUtils')
+      )
+      const node = createMockNode({ graph: { isRootGraph: true } })
+      const widget = createMockWidget()
+
+      getExtraOptionsForWidget(node, widget)
+
+      expect(addWidgetPromotionOptions).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('useLitegraphService', () => {
+    // Lazily import to ensure mocks are in place
+    async function getService() {
+      const { useLitegraphService } =
+        await import('@/services/litegraphService')
+      return useLitegraphService()
+    }
+
+    describe('addNodeInput', () => {
+      it('adds optional socket inputs when no widget constructor is registered', async () => {
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+        const addInputSpy = vi.spyOn(node, 'addInput')
+
+        service.addNodeInput(
+          node,
+          createInputSpec({ type: 'LATENT', isOptional: true })
+        )
+
+        expect(addInputSpy).toHaveBeenCalledWith(
+          'prompt',
+          'LATENT',
+          expect.objectContaining({
+            shape: RenderShape.HollowCircle,
+            localized_name: 'prompt'
+          })
+        )
+      })
+
+      it('uses dynamic inputs instead of adding a socket when applicable', async () => {
+        const { applyDynamicInputs } = vi.mocked(
+          await import('@/core/graph/widgets/dynamicWidgets')
+        )
+        applyDynamicInputs.mockReturnValueOnce(true)
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(node, createInputSpec({ type: 'CUSTOM' }))
+
+        expect(node.inputs).toHaveLength(0)
+      })
+
+      it('creates widgets, config-backed sockets, and initial node sizing', async () => {
+        const widget = createMockWidget()
+        const widgetFactory = vi.fn<WidgetFactory>().mockReturnValue({
+          widget,
+          minWidth: 320,
+          minHeight: 48
+        })
+        mockWidgetStore.widgets.set('STRING', widgetFactory)
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(
+          node,
+          createInputSpec({
+            advanced: true,
+            hidden: true,
+            tooltip: 'Prompt text'
+          })
+        )
+
+        expect(widgetFactory).toHaveBeenCalledWith(node, 'prompt', [], mockApp)
+        expect(widget.label).toBe('Prompt')
+        expect(widget.options).toMatchObject({
+          advanced: true,
+          hidden: true
+        })
+        expect(widget.hidden).toBe(true)
+        expect(widget.tooltip).toBe('Prompt text')
+        expect(node.inputs[0].widget).toMatchObject({ name: 'prompt' })
+        const widgetConfig = node.inputs[0].widget as Record<symbol, unknown>
+        expect(typeof widgetConfig[GET_CONFIG]).toBe('function')
+        expect(node._initialMinSize).toEqual({ width: 320, height: 48 })
+      })
+
+      it('uses widgetType to choose the widget constructor while preserving socket type', async () => {
+        const widget = createMockWidget()
+        const widgetFactory = vi.fn<WidgetFactory>().mockReturnValue({
+          widget
+        })
+        mockWidgetStore.widgets.set('CUSTOM_WIDGET', widgetFactory)
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(
+          node,
+          createInputSpec({
+            type: 'STRING',
+            widgetType: 'CUSTOM_WIDGET'
+          })
+        )
+
+        expect(widgetFactory).toHaveBeenCalled()
+        expect(node.inputs[0]).toMatchObject({
+          name: 'prompt',
+          type: 'STRING'
+        })
+      })
+
+      it('does not add sockets for socketless widgets', async () => {
+        const widget = createMockWidget({ options: { socketless: true } })
+        mockWidgetStore.widgets.set(
+          'STRING',
+          vi.fn<WidgetFactory>().mockReturnValue({ widget })
+        )
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(node, createInputSpec())
+
+        expect(node.inputs).toHaveLength(0)
+      })
+
+      it('keeps forced widget inputs as plain sockets', async () => {
+        const widgetFactory = vi.fn<WidgetFactory>()
+        mockWidgetStore.widgets.set('STRING', widgetFactory)
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(node, createInputSpec({ forceInput: true }))
+
+        expect(widgetFactory).not.toHaveBeenCalled()
+        expect(node.inputs).toHaveLength(1)
+        expect(node.inputs[0].widget).toBeUndefined()
+      })
+
+      it('uses default widget sizing when constructors return no sizing hints', async () => {
+        mockWidgetStore.widgets.set(
+          'STRING',
+          vi.fn<WidgetFactory>().mockReturnValue({
+            widget: undefined
+          })
+        )
+        const service = await getService()
+        const node = createNodeWithInitialSize()
+
+        service.addNodeInput(node, createInputSpec())
+
+        expect(node._initialMinSize).toEqual({ width: 1, height: 1 })
+        expect(node.inputs[0].widget).toMatchObject({ name: 'prompt' })
+      })
+    })
+
+    describe('registerNodeDef', () => {
+      it('registers node classes that preserve node definition sockets and outputs', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const { getOrderedInputSpecs } = vi.mocked(
+          await import('@/workbench/utils/nodeDefOrderingUtil')
+        )
+        const inputSpec = createInputSpec({ type: 'LATENT' })
+        getOrderedInputSpecs.mockReturnValueOnce([inputSpec])
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'TestNode',
+          createNodeDef({
+            inputs: { prompt: inputSpec },
+            outputs: [
+              {
+                index: 0,
+                name: 'result',
+                type: 'COMFY_MATCHTYPE_V3',
+                is_list: true
+              }
+            ],
+            api_node: true
+          })
+        )
+
+        expect(registerSpy).toHaveBeenCalledWith(
+          'TestNode',
+          expect.any(Function)
+        )
+        expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+          'beforeRegisterNodeDef',
+          expect.any(Function),
+          expect.objectContaining({ name: 'TestNode' })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+        const node = new NodeCtor('Test Node')
+
+        expect(node.inputs.map((input) => input.name)).toEqual(['prompt'])
+        expect(node.outputs).toHaveLength(1)
+        expect(node.outputs[0]).toMatchObject({
+          name: 'result',
+          type: '*',
+          shape: LiteGraph.GRID_SHAPE
+        })
+        expect(node.serialize_widgets).toBe(true)
+        expect(node.color).toBe(LGraphCanvas.node_colors.yellow.color)
+        expect(node.bgcolor).toBe(LGraphCanvas.node_colors.yellow.bgcolor)
+        registerSpy.mockRestore()
+      })
+
+      it('installs execution, drag-over, and error stroke styles', async () => {
+        const node = await registerTestNode()
+        mockExecutionStore.nodeLocationProgressStates[String(node.id)] = {
+          state: 'running'
+        }
+        mockApp.dragOverNode = { id: node.id }
+        mockApp.lastExecutionError = { node_id: node.id }
+
+        expect(node.strokeStyles.running.call(node)).toEqual({
+          color: '#0f0',
+          lineWidth: 3
+        })
+        expect(node.strokeStyles.dragOver.call(node)).toEqual({
+          color: 'dodgerblue'
+        })
+        expect(node.strokeStyles.executionError.call(node)).toEqual({
+          color: LiteGraph.NODE_ERROR_COLOUR,
+          lineWidth: 3
+        })
+      })
+
+      it('returns no stroke styles when execution, drag-over, and error states do not match', async () => {
+        const node = await registerTestNode()
+        mockExecutionStore.nodeLocationProgressStates[String(node.id)] = {
+          state: 'pending'
+        }
+        mockApp.dragOverNode = { id: 'other' }
+        mockApp.lastExecutionError = { node_id: 'other' }
+
+        expect(node.strokeStyles.running.call(node)).toBeUndefined()
+        expect(node.strokeStyles.dragOver.call(node)).toBeUndefined()
+        expect(node.strokeStyles.executionError.call(node)).toBeUndefined()
+      })
+
+      it('registers normal outputs without list shape or match-type rewriting', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'OutputNode',
+          createNodeDef({
+            name: 'OutputNode',
+            outputs: [
+              {
+                index: 0,
+                name: 'FLOAT',
+                type: 'FLOAT',
+                is_list: false
+              }
+            ]
+          })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+        const node = new NodeCtor('Output Node')
+        expect(node.outputs[0]).toMatchObject({
+          name: 'FLOAT',
+          type: 'FLOAT'
+        })
+        expect(node.outputs[0].shape).toBeUndefined()
+        registerSpy.mockRestore()
+      })
+
+      it('hides dev-only nodes when dev mode is disabled', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'DevNode',
+          createNodeDef({ name: 'DevNode', dev_only: true })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode & {
+          skip_list: boolean
+        }
+        expect(NodeCtor.skip_list).toBe(true)
+        registerSpy.mockRestore()
+      })
+
+      it('keeps dev-only nodes visible when dev mode is enabled', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        mockSettingStore.get.mockImplementation((key: string) =>
+          key === 'Comfy.DevMode' ? true : false
+        )
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'DevNode',
+          createNodeDef({ name: 'DevNode', dev_only: true })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode & {
+          skip_list: boolean
+        }
+        expect(NodeCtor.skip_list).toBe(false)
+        registerSpy.mockRestore()
+      })
+
+      it('uses the node name as title when display name is empty', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'FallbackTitleNode',
+          createNodeDef({
+            name: 'FallbackTitleNode',
+            display_name: ''
+          })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+        expect(NodeCtor.title).toBe('FallbackTitleNode')
+        registerSpy.mockRestore()
+      })
+
+      it('preserves defined socket metadata while keeping dynamic serialized inputs and outputs', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const { getOrderedInputSpecs } = vi.mocked(
+          await import('@/workbench/utils/nodeDefOrderingUtil')
+        )
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const inputSpec = createInputSpec({ type: 'LATENT' })
+        getOrderedInputSpecs.mockReturnValueOnce([inputSpec])
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'ConfigurableNode',
+          createNodeDef({
+            name: 'ConfigurableNode',
+            inputs: { prompt: inputSpec },
+            outputs: [
+              {
+                index: 0,
+                name: 'IMAGE',
+                type: 'IMAGE',
+                is_list: false
+              }
+            ]
+          })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+        const node = new NodeCtor('Configurable Node')
+        const data = {
+          inputs: [
+            {
+              name: 'prompt',
+              type: 'OLD',
+              label: 'Saved prompt'
+            },
+            {
+              name: 'dynamic',
+              type: 'FLOAT'
+            }
+          ],
+          outputs: [
+            {
+              name: 'Saved output',
+              type: 'OLD'
+            },
+            {
+              name: 'Dynamic output',
+              type: 'FLOAT'
+            }
+          ],
+          widgets_values: ['saved']
+        } as ISerialisedNode
+
+        node.configure(data)
+
+        expect(data.inputs?.map((input) => input.name)).toEqual([
+          'prompt',
+          'dynamic'
+        ])
+        expect(data.inputs?.[0]).toMatchObject({
+          name: 'prompt',
+          type: 'LATENT',
+          label: 'Saved prompt'
+        })
+        expect(data.outputs?.[0]).toMatchObject({
+          name: 'IMAGE',
+          type: 'IMAGE'
+        })
+        expect(data.outputs?.[1]).toMatchObject({
+          name: 'Dynamic output',
+          type: 'FLOAT'
+        })
+        registerSpy.mockRestore()
+      })
+
+      it('restores node-defined sockets when serialized metadata is omitted', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const { getOrderedInputSpecs } = vi.mocked(
+          await import('@/workbench/utils/nodeDefOrderingUtil')
+        )
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation(function () {})
+        const inputSpec = createInputSpec({ type: 'LATENT' })
+        getOrderedInputSpecs.mockReturnValueOnce([inputSpec])
+        const service = await getService()
+
+        await service.registerNodeDef(
+          'SparseConfigNode',
+          createNodeDef({
+            name: 'SparseConfigNode',
+            inputs: { prompt: inputSpec },
+            outputs: [
+              {
+                index: 0,
+                name: 'IMAGE',
+                type: 'IMAGE',
+                is_list: false
+              }
+            ]
+          })
+        )
+
+        const NodeCtor = registerSpy.mock.calls[0][1] as typeof LGraphNode
+        const node = new NodeCtor('Sparse Config Node')
+        const data = {} as ISerialisedNode
+
+        node.configure(data)
+
+        expect(data.inputs?.[0]).toMatchObject({
+          name: 'prompt',
+          type: 'LATENT'
+        })
+        expect(data.outputs?.[0]).toMatchObject({
+          name: 'IMAGE',
+          type: 'IMAGE'
+        })
+        expect(data.widgets_values).toEqual([])
+        registerSpy.mockRestore()
+      })
+    })
+
+    describe('registered node handlers', () => {
+      it('adds image, clipspace, bypass, and widget context menu options', async () => {
+        const { ComfyApp } = await import('@/scripts/app')
+        const { downloadFile, openFileInNewTab } = vi.mocked(
+          await import('@/base/common/downloadUtil')
+        )
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.png&preview=1'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(createMockWidget())
+        })
+        ComfyApp.clipspace = fromPartial({ widgets: [] })
+        ComfyApp.clipspace_return_node = null
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+
+        expect(options.map((option) => option.content)).toEqual(
+          expect.arrayContaining([
+            'Open Image',
+            'Save Image',
+            'Bypass',
+            'Copy (Clipspace)',
+            'Paste (Clipspace)'
+          ])
+        )
+
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Open Image')!
+        )
+        expect(openFileInNewTab).toHaveBeenCalledWith(
+          'https://example.test/view?filename=image.png'
+        )
+
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Save Image')!
+        )
+        expect(downloadFile).toHaveBeenCalledWith(
+          'https://example.test/view?filename=image.png',
+          'image.png'
+        )
+
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Bypass')!
+        )
+        expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+      })
+
+      it('copies non-png images by re-encoding them before retrying clipboard write', async () => {
+        const { $el } = vi.mocked(await import('@/scripts/ui'))
+        const sourceBlob = new Blob(['jpeg'], { type: 'image/jpeg' })
+        const pngBlob = new Blob(['png'], { type: 'image/png' })
+        const write = vi
+          .fn<Clipboard['write']>()
+          .mockRejectedValueOnce(new Error('png only'))
+          .mockResolvedValueOnce(undefined)
+        const drawImage = vi.fn()
+        const bitmap = fromPartial<ImageBitmap>({ close: vi.fn() })
+        const canvas = document.createElement('canvas')
+        vi.spyOn(
+          canvas as { getContext(id: string): CanvasRenderingContext2D | null },
+          'getContext'
+        ).mockReturnValue(fromPartial<CanvasRenderingContext2D>({ drawImage }))
+        vi.spyOn(canvas, 'toBlob').mockImplementation((callback, type) => {
+          expect(type).toBe('image/png')
+          callback(pngBlob)
+        })
+        const TestClipboardItem = installClipboard(write)
+        vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap))
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => {
+            return new Response(sourceBlob, {
+              headers: { 'Content-Type': sourceBlob.type }
+            })
+          })
+        )
+        $el.mockReturnValue(canvas)
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.jpg&preview=1'
+        Object.defineProperty(image, 'naturalWidth', { value: 8 })
+        Object.defineProperty(image, 'naturalHeight', { value: 4 })
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Copy Image')!
+        )
+
+        const fetchMock = vi.mocked(fetch)
+        expect(String(fetchMock.mock.calls[0][0])).toBe(
+          'https://example.test/view?filename=image.jpg'
+        )
+        expect(drawImage).toHaveBeenCalledWith(bitmap, 0, 0)
+        expect(bitmap.close).toHaveBeenCalled()
+        expect(write).toHaveBeenCalledTimes(2)
+        expect(write.mock.calls[0][0][0]).toBeInstanceOf(TestClipboardItem)
+        expect(write.mock.calls[1][0][0]).toMatchObject({
+          data: { 'image/png': pngBlob }
+        })
+      })
+
+      it('copies png images without re-encoding them', async () => {
+        const sourceBlob = new Blob(['png'], { type: 'image/png' })
+        const write = vi.fn<Clipboard['write']>().mockResolvedValue(undefined)
+        const TestClipboardItem = installClipboard(write)
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => {
+            return new Response(sourceBlob, {
+              headers: { 'Content-Type': sourceBlob.type }
+            })
+          })
+        )
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.png&preview=1'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Copy Image')!
+        )
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect(write.mock.calls[0][0][0]).toBeInstanceOf(TestClipboardItem)
+        expect(write.mock.calls[0][0][0]).toMatchObject({
+          data: { 'image/png': sourceBlob }
+        })
+      })
+
+      it('reports png clipboard write failures without re-encoding', async () => {
+        const sourceBlob = new Blob(['png'], { type: 'image/png' })
+        const write = vi
+          .fn<Clipboard['write']>()
+          .mockRejectedValue(new Error('clipboard denied'))
+        installClipboard(write)
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => {
+            return new Response(sourceBlob, {
+              headers: { 'Content-Type': sourceBlob.type }
+            })
+          })
+        )
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.png&preview=1'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Copy Image')!
+        )
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+          'toastMessages.errorCopyImage'
+        )
+      })
+
+      it('reports image copy failures when PNG re-encoding cannot get a canvas context', async () => {
+        const { $el } = vi.mocked(await import('@/scripts/ui'))
+        const sourceBlob = new Blob(['jpeg'], { type: 'image/jpeg' })
+        const write = vi
+          .fn<Clipboard['write']>()
+          .mockRejectedValue(new Error('png only'))
+        const canvas = document.createElement('canvas')
+        vi.spyOn(canvas, 'getContext').mockReturnValue(null)
+        installClipboard(write)
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => {
+            return new Response(sourceBlob, {
+              headers: { 'Content-Type': sourceBlob.type }
+            })
+          })
+        )
+        $el.mockReturnValue(canvas)
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.jpg&preview=1'
+        Object.defineProperty(image, 'naturalWidth', { value: 8 })
+        Object.defineProperty(image, 'naturalHeight', { value: 4 })
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Copy Image')!
+        )
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+          'toastMessages.errorCopyImage'
+        )
+      })
+
+      it('reports image copy failures when PNG re-encoding produces no blob', async () => {
+        const { $el } = vi.mocked(await import('@/scripts/ui'))
+        const sourceBlob = new Blob(['jpeg'], { type: 'image/jpeg' })
+        const write = vi
+          .fn<Clipboard['write']>()
+          .mockRejectedValue(new Error('png only'))
+        const canvas = document.createElement('canvas')
+        vi.spyOn(
+          canvas as { getContext(id: string): CanvasRenderingContext2D | null },
+          'getContext'
+        ).mockReturnValue(
+          fromPartial<CanvasRenderingContext2D>({ drawImage: vi.fn() })
+        )
+        vi.spyOn(canvas, 'toBlob').mockImplementation((callback) => {
+          callback(null)
+        })
+        installClipboard(write)
+        vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue({}))
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => {
+            return new Response(sourceBlob, {
+              headers: { 'Content-Type': sourceBlob.type }
+            })
+          })
+        )
+        $el.mockReturnValue(canvas)
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=image.jpg&preview=1'
+        Object.defineProperty(image, 'naturalWidth', { value: 8 })
+        Object.defineProperty(image, 'naturalHeight', { value: 4 })
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Copy Image')!
+        )
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+          'toastMessages.errorCopyImage'
+        )
+      })
+
+      it('uses hovered images and omits clipspace options while editing clipspace', async () => {
+        const { ComfyApp } = await import('@/scripts/app')
+        const { openFileInNewTab } = vi.mocked(
+          await import('@/base/common/downloadUtil')
+        )
+        vi.stubGlobal('ClipboardItem', undefined)
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=hover.png&preview=1'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: null,
+          overIndex: 0,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        // ComfyApp.clipspace_return_node is inferred as `null` in app.ts; widen for the test.
+        ComfyApp.clipspace_return_node = node
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+
+        expect(options.map((option) => option.content)).not.toContain(
+          'Copy Image'
+        )
+        expect(options.map((option) => option.content)).not.toContain(
+          'Copy (Clipspace)'
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Open Image')!
+        )
+        expect(openFileInNewTab).toHaveBeenCalledWith(
+          'https://example.test/view?filename=hover.png'
+        )
+      })
+
+      it('omits image actions when neither selected nor hovered image resolves', async () => {
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?filename=missing.png'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: null,
+          overIndex: 4,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+
+        expect(options.map((option) => option.content)).not.toContain(
+          'Open Image'
+        )
+        expect(options.map((option) => option.content)).not.toContain(
+          'Save Image'
+        )
+      })
+
+      it('adds mask editor option for image nodes', async () => {
+        const { ComfyApp } = await import('@/scripts/app')
+        const { isImageNode } = vi.mocked(await import('@/utils/litegraphUtil'))
+        isImageNode.mockReturnValueOnce(true)
+        ComfyApp.clipspace_return_node = null
+        ComfyApp.clipspace = null
+        const node = await registerTestNode()
+        Object.assign(node, {
+          imgs: undefined,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+
+        expect(options.map((option) => option.content)).toContain(
+          'Open in MaskEditor | Image Canvas'
+        )
+      })
+
+      it('saves images without a filename query as an unnamed download', async () => {
+        const { downloadFile } = vi.mocked(
+          await import('@/base/common/downloadUtil')
+        )
+        const node = await registerTestNode()
+        const image = document.createElement('img')
+        image.src = 'https://example.test/view?preview=1'
+        Object.assign(node, {
+          imgs: [image],
+          imageIndex: 0,
+          overIndex: null,
+          getWidgetOnPos: vi.fn().mockReturnValue(undefined)
+        })
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Save Image')!
+        )
+
+        expect(downloadFile).toHaveBeenCalledWith(
+          'https://example.test/view',
+          undefined
+        )
+      })
+
+      it('adds subgraph menu actions for subgraph nodes', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const { createTestSubgraph } =
+          await import('@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers')
+        const { useSubgraphOperations } =
+          await import('@/composables/graph/useSubgraphOperations')
+        const { useRightSidePanelStore } =
+          await import('@/stores/workspace/rightSidePanelStore')
+        const openPanel = useRightSidePanelStore().openPanel
+        const unpackSubgraph = useSubgraphOperations().unpackSubgraph
+        const service = await getService()
+        const subgraph = createTestSubgraph({
+          id: '00000000-0000-4000-8000-000000000099',
+          name: 'Subgraph Test'
+        })
+        mockApp.rootGraph = subgraph.rootGraph
+        const capturedCtors: unknown[] = []
+        const registerSpy = vi
+          .spyOn(LiteGraph, 'registerNodeType')
+          .mockImplementation((_name, ctor) => {
+            capturedCtors.push(ctor)
+          })
+        service.registerSubgraphNodeDef(
+          createNodeDef({
+            name: subgraph.id,
+            display_name: 'Subgraph Test'
+          }),
+          subgraph,
+          {
+            id: 1,
+            type: subgraph.id,
+            pos: [100, 100],
+            size: [200, 100],
+            inputs: [],
+            outputs: [],
+            properties: {},
+            flags: {},
+            mode: 0,
+            order: 0
+          }
+        )
+        const NodeCtor = capturedCtors[0] as new () => SubgraphNode
+        const node = new NodeCtor()
+        const options: IContextMenuValue[] = []
+
+        node.getExtraMenuOptions?.(
+          Object.assign(fromPartial<LGraphCanvas>({}), mockCanvas),
+          options
+        )
+
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Edit Subgraph Widgets')!
+        )
+        await invokeMenuCallback(
+          options.find((option) => option.content === 'Unpack Subgraph')!
+        )
+
+        expect(openPanel).toHaveBeenCalledWith('subgraph')
+        expect(unpackSubgraph).toHaveBeenCalled()
+        registerSpy.mockRestore()
+      })
+
+      it('keeps setSizeForImage as a no-op compatibility hook', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const node = await registerTestNode()
+
+        node.setSizeForImage?.()
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          'node.setSizeForImage is deprecated. Now it has no effect. Please remove the call to it.'
+        )
+        warnSpy.mockRestore()
+      })
+
+      it('navigates image previews with keyboard handlers', async () => {
+        const node = await registerTestNode()
+        Object.assign(node, {
+          flags: { collapsed: false },
+          imgs: [{}, {}, {}],
+          imageIndex: 0
+        })
+        const preventDefault = vi.fn()
+        const stopImmediatePropagation = vi.fn()
+
+        expect(
+          node.onKeyDown?.(
+            fromPartial<KeyboardEvent>({
+              key: 'ArrowLeft',
+              preventDefault,
+              stopImmediatePropagation
+            })
+          )
+        ).toBe(false)
+        expect(node.imageIndex).toBe(2)
+
+        node.onKeyDown?.(
+          fromPartial<KeyboardEvent>({
+            key: 'ArrowRight',
+            preventDefault,
+            stopImmediatePropagation
+          })
+        )
+        expect(node.imageIndex).toBe(0)
+
+        node.onKeyDown?.(
+          fromPartial<KeyboardEvent>({
+            key: 'Escape',
+            preventDefault,
+            stopImmediatePropagation
+          })
+        )
+        expect(node.imageIndex).toBeNull()
+        expect(preventDefault).toHaveBeenCalledTimes(3)
+        expect(stopImmediatePropagation).toHaveBeenCalledTimes(3)
+      })
+
+      it('keeps keyboard events untouched when nodes are collapsed or lack images', async () => {
+        const node = await registerTestNode()
+        Object.assign(node, {
+          flags: { collapsed: true },
+          imgs: [{}, {}],
+          imageIndex: 0
+        })
+        const event = fromPartial<KeyboardEvent>({
+          key: 'ArrowLeft',
+          preventDefault: vi.fn(),
+          stopImmediatePropagation: vi.fn()
+        })
+
+        expect(node.onKeyDown?.(event)).toBeUndefined()
+        expect(event.preventDefault).not.toHaveBeenCalled()
+
+        Object.assign(node, {
+          flags: { collapsed: false },
+          imgs: undefined,
+          imageIndex: 0
+        })
+        expect(node.onKeyDown?.(event)).toBeUndefined()
+      })
+    })
+
+    describe('getCanvasCenter', () => {
+      it('returns center of visible area', async () => {
+        const service = await getService()
+        // visible_area = [0, 0, 800, 600], dpi = 1
+        const center = service.getCanvasCenter()
+        expect(center).toEqual([400, 300])
+      })
+
+      it('accounts for visible area offset', async () => {
+        const saved = mockCanvas.ds.visible_area
+        mockCanvas.ds.visible_area = [10, 20, 200, 100]
+
+        const service = await getService()
+        const center = service.getCanvasCenter()
+        expect(center).toEqual([110, 70])
+
+        mockCanvas.ds.visible_area = saved
+      })
+
+      it('returns [0, 0] when no visible area', async () => {
+        const savedVisibleArea = mockCanvas.ds.visible_area
+        mockCanvas.ds.visible_area = undefined
+
+        const service = await getService()
+        const center = service.getCanvasCenter()
+        expect(center).toEqual([0, 0])
+
+        mockCanvas.ds.visible_area = savedVisibleArea
+      })
+
+      it('returns [0, 0] without throwing when app.canvas is undefined', async () => {
+        mockApp.canvas = undefined
+
+        const service = await getService()
+        expect(() => service.getCanvasCenter()).not.toThrow()
+        expect(service.getCanvasCenter()).toEqual([0, 0])
+      })
+
+      it('accounts for device pixel ratio when computing the center', async () => {
+        vi.stubGlobal('devicePixelRatio', 2)
+        mockCanvas.ds.visible_area = [10, 20, 200, 100]
+
+        const service = await getService()
+
+        expect(service.getCanvasCenter()).toEqual([60, 45])
+      })
+
+      it('falls back to a device pixel ratio of one when it is unavailable', async () => {
+        vi.stubGlobal('devicePixelRatio', undefined)
+        mockCanvas.ds.visible_area = [10, 20, 200, 100]
+
+        const service = await getService()
+
+        expect(service.getCanvasCenter()).toEqual([110, 70])
+      })
+    })
+
+    describe('resetView', () => {
+      it('resets canvas scale and offset', async () => {
+        mockCanvas.ds.scale = 2.5
+        mockCanvas.ds.offset = [100, 200]
+        const service = await getService()
+
+        service.resetView()
+
+        expect(mockCanvas.ds.scale).toBe(1)
+        expect(mockCanvas.ds.offset).toEqual([0, 0])
+        expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+      })
+    })
+
+    describe('goToNode', () => {
+      it('animates to node bounds when node exists', async () => {
+        const bounds = [10, 20, 100, 50]
+        const graphNode = { boundingRect: bounds }
+        mockCanvas.graph.getNodeById.mockReturnValue(graphNode)
+
+        const service = await getService()
+        service.goToNode(42)
+
+        expect(mockCanvas.animateToBounds).toHaveBeenCalledWith(bounds)
+      })
+
+      it('does nothing when node does not exist', async () => {
+        mockCanvas.graph.getNodeById.mockReturnValue(null)
+
+        const service = await getService()
+        service.goToNode(999)
+
+        expect(mockCanvas.animateToBounds).not.toHaveBeenCalled()
+      })
+
+      it('does nothing when the serialized node id is invalid', async () => {
+        const service = await getService()
+
+        service.goToNode('')
+
+        expect(mockCanvas.graph.getNodeById).not.toHaveBeenCalled()
+        expect(mockCanvas.animateToBounds).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('addNodeOnGraph', () => {
+      it('creates and adds normal nodes to the active graph', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const node = createMockNode()
+        const createNodeSpy = vi
+          .spyOn(LiteGraph, 'createNode')
+          .mockReturnValue(node)
+        const service = await getService()
+
+        const result = service.addNodeOnGraph(createNodeDef())
+
+        expect(createNodeSpy).toHaveBeenCalledWith('TestNode', 'Test Node', {
+          pos: [400, 300]
+        })
+        expect(mockCanvas.graph.add).toHaveBeenCalledWith(node, undefined)
+        expect(result).toBe(node)
+        createNodeSpy.mockRestore()
+      })
+
+      it('uses a supplied position when creating normal nodes', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const node = createMockNode()
+        const createNodeSpy = vi
+          .spyOn(LiteGraph, 'createNode')
+          .mockReturnValue(node)
+        const service = await getService()
+
+        service.addNodeOnGraph(createNodeDef(), { pos: [12, 34] })
+
+        expect(createNodeSpy).toHaveBeenCalledWith('TestNode', 'Test Node', {
+          pos: [12, 34]
+        })
+        createNodeSpy.mockRestore()
+      })
+
+      it('uses the active subgraph when one is present', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const node = createMockNode()
+        const subgraph = { add: vi.fn() }
+        mockWorkflowStore.activeSubgraph = subgraph
+        const createNodeSpy = vi
+          .spyOn(LiteGraph, 'createNode')
+          .mockReturnValue(node)
+        const service = await getService()
+
+        const result = service.addNodeOnGraph(createNodeDef())
+
+        expect(subgraph.add).toHaveBeenCalledWith(node, undefined)
+        expect(mockCanvas.graph.add).not.toHaveBeenCalled()
+        expect(result).toBe(node)
+        createNodeSpy.mockRestore()
+      })
+
+      it('returns null when LiteGraph cannot create the node', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const createNodeSpy = vi
+          .spyOn(LiteGraph, 'createNode')
+          .mockReturnValue(null)
+        const service = await getService()
+
+        expect(service.addNodeOnGraph(createNodeDef())).toBeNull()
+        expect(mockCanvas.graph.add).not.toHaveBeenCalled()
+        createNodeSpy.mockRestore()
+      })
+
+      it('returns null when there is no graph to receive a created node', async () => {
+        const { LiteGraph } = await import('@/lib/litegraph/src/litegraph')
+        const node = createMockNode()
+        const createNodeSpy = vi
+          .spyOn(LiteGraph, 'createNode')
+          .mockReturnValue(node)
+        mockApp.graph = null
+        const service = await getService()
+
+        expect(service.addNodeOnGraph(createNodeDef())).toBeNull()
+        expect(mockCanvas.graph.add).not.toHaveBeenCalled()
+
+        createNodeSpy.mockRestore()
+      })
+
+      it('deserializes subgraph blueprints at the canvas center', async () => {
+        const node = createMockNode({ flags: {} })
+        const blueprint = {
+          nodes: [{ id: 1 }],
+          definitions: { subgraphs: [{ id: 'subgraph-1' }] }
+        }
+        mockSubgraphStore.getBlueprint.mockReturnValue(blueprint)
+        mockCanvas._deserializeItems.mockReturnValue({
+          nodes: new Map([[node.id, node]])
+        })
+        const service = await getService()
+
+        const result = service.addNodeOnGraph(
+          createNodeDef({ name: 'SubgraphBlueprint.Basic' })
+        )
+
+        expect(mockCanvas._deserializeItems).toHaveBeenCalledWith(
+          {
+            nodes: blueprint.nodes,
+            subgraphs: blueprint.definitions.subgraphs
+          },
+          { position: [400, 300] }
+        )
+        expect(result).toBe(node)
+      })
+
+      it('starts ghost placement for subgraph blueprints when requested', async () => {
+        const dragEvent = new DragEvent('dragstart')
+        const node = createMockNode({ flags: {} })
+        mockSubgraphStore.getBlueprint.mockReturnValue({
+          nodes: [{ id: 1 }]
+        })
+        mockCanvas._deserializeItems.mockReturnValue({
+          nodes: new Map([[node.id, node]])
+        })
+        const service = await getService()
+
+        const result = service.addNodeOnGraph(
+          createNodeDef({ name: 'SubgraphBlueprint.Ghost' }),
+          {},
+          { ghost: true, dragEvent }
+        )
+
+        expect(result).toBe(node)
+        expect(node.flags.ghost).toBe(true)
+        expect(mockCanvas.graph.trigger).toHaveBeenCalledWith(
+          'node:property:changed',
+          {
+            nodeId: node.id,
+            property: 'flags.ghost',
+            oldValue: false,
+            newValue: true
+          }
+        )
+        expect(mockCanvas.startGhostPlacement).toHaveBeenCalledWith(
+          node,
+          dragEvent
+        )
+      })
+
+      it('throws when blueprint deserialization fails', async () => {
+        mockSubgraphStore.getBlueprint.mockReturnValue({ nodes: [] })
+        mockCanvas._deserializeItems.mockReturnValue(null)
+        const service = await getService()
+
+        expect(() =>
+          service.addNodeOnGraph(
+            createNodeDef({ name: 'SubgraphBlueprint.Broken' })
+          )
+        ).toThrow('Failed to add subgraph blueprint')
+      })
+
+      it('throws when blueprint deserialization returns no node', async () => {
+        mockSubgraphStore.getBlueprint.mockReturnValue({ nodes: [] })
+        mockCanvas._deserializeItems.mockReturnValue({
+          nodes: new Map()
+        })
+        const service = await getService()
+
+        expect(() =>
+          service.addNodeOnGraph(
+            createNodeDef({ name: 'SubgraphBlueprint.Empty' })
+          )
+        ).toThrow(
+          'Subgraph blueprint was added, but failed to resolve a subgraph Node'
+        )
+      })
+    })
+
+    describe('fitView', () => {
+      it('calls fitToBounds and setDirty', async () => {
+        const mockBounds = [0, 0, 500, 400]
+        mockCreateBounds.mockReturnValue(mockBounds)
+
+        const nodeObj = {
+          boundingRect: [0, 0, 100, 50],
+          updateArea: vi.fn()
+        }
+        mockCanvas.graph.nodes = [nodeObj]
+
+        const service = await getService()
+        service.fitView()
+
+        expect(mockCanvas.ds.fitToBounds).toHaveBeenCalledWith(mockBounds)
+        expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+      })
+
+      it('calls updateArea for nodes with zero bounds', async () => {
+        mockCreateBounds.mockReturnValue([0, 0, 100, 100])
+
+        const nodeObj = {
+          boundingRect: [0, 0, 0, 0],
+          updateArea: vi.fn()
+        }
+        mockCanvas.graph.nodes = [nodeObj]
+
+        const service = await getService()
+        service.fitView()
+
+        expect(nodeObj.updateArea).toHaveBeenCalled()
+      })
+
+      it('does nothing when createBounds returns null', async () => {
+        mockCreateBounds.mockReturnValue(null)
+        mockCanvas.graph.nodes = []
+
+        const service = await getService()
+        service.fitView()
+
+        expect(mockCanvas.ds.fitToBounds).not.toHaveBeenCalled()
+      })
+
+      it('does nothing when the canvas graph has no nodes collection', async () => {
+        const savedNodes = mockCanvas.graph.nodes
+        mockCanvas.graph.nodes = undefined
+
+        const service = await getService()
+        service.fitView()
+
+        expect(mockCreateBounds).not.toHaveBeenCalled()
+        expect(mockCanvas.ds.fitToBounds).not.toHaveBeenCalled()
+
+        mockCanvas.graph.nodes = savedNodes
+      })
+    })
+
+    describe('updatePreviews', () => {
+      it('routes new image outputs through image and canvas previews', async () => {
+        const { isAnimatedOutput } = vi.mocked(
+          await import('@/utils/litegraphUtil')
+        )
+        const service = await getService()
+        const output = { images: [{ filename: 'image.png' }] }
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: [{}],
+          images: undefined,
+          preview: undefined
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue(output)
+
+        service.updatePreviews(node)
+
+        expect(node.images).toBe(output.images)
+        expect(isAnimatedOutput).toHaveBeenCalledWith(output)
+        expect(mockNodeImagePreview.showPreview).toHaveBeenCalled()
+        expect(mockNodeVideoPreview.showPreview).not.toHaveBeenCalled()
+        expect(mockAnimatedPreview.removeAnimatedPreview).toHaveBeenCalledWith(
+          node
+        )
+        expect(
+          mockCanvasImagePreview.showCanvasImagePreview
+        ).toHaveBeenCalledWith(node)
+      })
+
+      it('routes video outputs through video previews', async () => {
+        const { isVideoOutput } = vi.mocked(
+          await import('@/utils/litegraphUtil')
+        )
+        isVideoOutput.mockReturnValueOnce(true)
+        const service = await getService()
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: [{}],
+          images: undefined
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue({
+          images: [{ filename: 'frame.png' }]
+        })
+
+        service.updatePreviews(node)
+
+        expect(mockNodeVideoPreview.showPreview).toHaveBeenCalled()
+        expect(mockNodeImagePreview.showPreview).not.toHaveBeenCalled()
+      })
+
+      it('routes animated outputs through animated previews', async () => {
+        const { isAnimatedOutput } = vi.mocked(
+          await import('@/utils/litegraphUtil')
+        )
+        isAnimatedOutput.mockReturnValueOnce(true)
+        const service = await getService()
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: [{}],
+          images: undefined
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue({
+          images: [{ filename: 'animated.webp' }]
+        })
+
+        service.updatePreviews(node)
+
+        expect(
+          mockCanvasImagePreview.removeCanvasImagePreview
+        ).toHaveBeenCalledWith(node)
+        expect(mockAnimatedPreview.showAnimatedPreview).toHaveBeenCalledWith(
+          node
+        )
+      })
+
+      it('updates preview-only changes without requiring output metadata', async () => {
+        const preview = { filename: 'preview.png' }
+        const service = await getService()
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: undefined,
+          images: undefined,
+          preview: undefined
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue(undefined)
+        mockNodeOutputStore.getNodePreviews.mockReturnValue(preview)
+
+        service.updatePreviews(node)
+
+        expect(node.preview).toBe(preview)
+        expect(mockNodeImagePreview.showPreview).toHaveBeenCalled()
+        expect(
+          mockCanvasImagePreview.showCanvasImagePreview
+        ).not.toHaveBeenCalled()
+      })
+
+      it('uses video previews for video nodes even when output metadata is not video', async () => {
+        const { isVideoNode } = vi.mocked(await import('@/utils/litegraphUtil'))
+        isVideoNode.mockReturnValueOnce(true)
+        const service = await getService()
+        const output = { images: [{ filename: 'frame.png' }] }
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: [{}],
+          images: undefined
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue(output)
+
+        service.updatePreviews(node)
+
+        expect(mockNodeVideoPreview.showPreview).toHaveBeenCalled()
+        expect(mockNodeImagePreview.showPreview).not.toHaveBeenCalled()
+      })
+
+      it('refreshes existing still-image previews when output metadata is unchanged', async () => {
+        const service = await getService()
+        const images = [{ filename: 'same.png' }]
+        const node = createMockNode({
+          flags: { collapsed: false },
+          imgs: [{}],
+          images,
+          animatedImages: false
+        })
+        mockNodeOutputStore.getNodeOutputs.mockReturnValue({ images })
+        mockNodeOutputStore.getNodePreviews.mockReturnValue(undefined)
+
+        service.updatePreviews(node)
+
+        expect(mockNodeImagePreview.showPreview).not.toHaveBeenCalled()
+        expect(mockAnimatedPreview.removeAnimatedPreview).toHaveBeenCalledWith(
+          node
+        )
+        expect(
+          mockCanvasImagePreview.showCanvasImagePreview
+        ).toHaveBeenCalledWith(node)
+      })
+
+      it('catches errors and logs them', async () => {
+        const consoleSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
+
+        mockNodeOutputStore.getNodeOutputs.mockImplementation(() => {
+          throw new Error('test error')
+        })
+
+        const service = await getService()
+        const badNode = createMockNode({ flags: { collapsed: false } })
+        expect(() => service.updatePreviews(badNode)).not.toThrow()
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Error drawing node background',
+          expect.any(Error)
+        )
+
+        consoleSpy.mockRestore()
+      })
+
+      it('skips collapsed nodes', async () => {
+        const service = await getService()
+        const node = createMockNode({
+          flags: { collapsed: true },
+          imgs: undefined,
+          images: undefined,
+          preview: undefined
+        })
+
+        service.updatePreviews(node)
+
+        expect(mockNodeOutputStore.getNodeOutputs).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/services/mediaCacheService.test.ts
+++ b/src/services/mediaCacheService.test.ts
@@ -1,13 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useMediaCache } from './mediaCacheService'
 
+const NativeURL = URL
+
 // Mock fetch
 global.fetch = vi.fn()
-global.URL = {
+global.URL = fromPartial<typeof URL>({
   createObjectURL: vi.fn(() => 'blob:mock-url'),
   revokeObjectURL: vi.fn()
-} as Partial<typeof URL> as typeof URL
+})
 
 describe('mediaCacheService', () => {
   describe('URL reference counting', () => {
@@ -31,5 +34,182 @@ describe('mediaCacheService', () => {
       expect(typeof cache.acquireUrl).toBe('function')
       expect(typeof cache.releaseUrl).toBe('function')
     })
+  })
+})
+
+type MediaCache = ReturnType<typeof useMediaCache>
+
+const mockFetch = vi.fn()
+const mockCreateObjectURL = vi.fn()
+const mockRevokeObjectURL = vi.fn()
+
+class MockURL extends NativeURL {
+  static override createObjectURL(blob: Blob): string {
+    return mockCreateObjectURL(blob)
+  }
+
+  static override revokeObjectURL(url: string): void {
+    mockRevokeObjectURL(url)
+  }
+}
+
+function response(ok: boolean, blob = new Blob(['image'])): Response {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    blob: () => Promise.resolve(blob)
+  } as Response
+}
+
+async function freshCache(options?: {
+  maxSize?: number
+  maxAge?: number
+}): Promise<MediaCache> {
+  vi.resetModules()
+  const module = await import('./mediaCacheService')
+  return module.useMediaCache(options)
+}
+
+describe('useMediaCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    mockFetch.mockReset()
+    mockCreateObjectURL.mockReset()
+    mockRevokeObjectURL.mockReset()
+    mockCreateObjectURL.mockImplementation(
+      (_blob: Blob) => `blob:${mockCreateObjectURL.mock.calls.length}`
+    )
+    vi.stubGlobal('fetch', mockFetch)
+    vi.stubGlobal('URL', MockURL)
+  })
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('beforeunload'))
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches media once and returns cached entries on later reads', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache()
+
+    const first = await cache.getCachedMedia('/image.png')
+    vi.setSystemTime(100)
+    const second = await cache.getCachedMedia('/image.png')
+
+    expect(first).toMatchObject({
+      src: '/image.png',
+      objectUrl: 'blob:1',
+      isLoading: false
+    })
+    expect(second).toEqual(first)
+    expect(second.lastAccessed).toBe(100)
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(mockFetch).toHaveBeenCalledWith('/image.png', {
+      cache: 'force-cache'
+    })
+  })
+
+  it('stores an error entry when fetch fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockFetch.mockResolvedValue(response(false))
+    const cache = await freshCache()
+
+    const entry = await cache.getCachedMedia('/missing.png')
+
+    expect(entry).toMatchObject({
+      src: '/missing.png',
+      error: true,
+      isLoading: false
+    })
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to cache media:',
+      '/missing.png',
+      expect.any(Error)
+    )
+  })
+
+  it('ref-counts acquired object URLs and removes the cache entry on final release', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache()
+    await cache.getCachedMedia('/image.png')
+
+    expect(cache.acquireUrl('/image.png')).toBe('blob:1')
+    expect(cache.acquireUrl('/image.png')).toBe('blob:1')
+    cache.releaseUrl('/image.png')
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+    expect(cache.cache.has('/image.png')).toBe(true)
+
+    cache.releaseUrl('/image.png')
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:1')
+    expect(cache.cache.has('/image.png')).toBe(false)
+  })
+
+  it('returns undefined when acquiring a URL that is not cached', async () => {
+    const cache = await freshCache()
+
+    expect(cache.acquireUrl('/missing.png')).toBeUndefined()
+    cache.releaseUrl('/missing.png')
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('expires old cache entries during scheduled cleanup', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache({ maxAge: 100 })
+    await cache.getCachedMedia('/old.png')
+
+    vi.setSystemTime(200)
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(cache.cache.has('/old.png')).toBe(false)
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:1')
+  })
+
+  it('keeps expired entries while their object URL is still acquired', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache({ maxAge: 100 })
+    await cache.getCachedMedia('/held.png')
+    cache.acquireUrl('/held.png')
+
+    vi.setSystemTime(200)
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(cache.cache.has('/held.png')).toBe(true)
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('removes the oldest unused entries when the cache is over size', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache({ maxSize: 1, maxAge: 1_000_000 })
+    await cache.getCachedMedia('/old.png')
+    vi.setSystemTime(1)
+    await cache.getCachedMedia('/new.png')
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(cache.cache.has('/old.png')).toBe(false)
+    expect(cache.cache.has('/new.png')).toBe(true)
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:1')
+  })
+
+  it('clears all cached URLs on demand and before unload', async () => {
+    mockFetch.mockResolvedValue(response(true))
+    const cache = await freshCache()
+    await cache.getCachedMedia('/first.png')
+    await cache.getCachedMedia('/second.png')
+
+    cache.clearCache()
+
+    expect(cache.cache.size).toBe(0)
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:1')
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:2')
+
+    await cache.getCachedMedia('/third.png')
+    window.dispatchEvent(new Event('beforeunload'))
+
+    expect(cache.cache.size).toBe(0)
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:3')
   })
 })

--- a/src/services/nodeHelpService.test.ts
+++ b/src/services/nodeHelpService.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+import { nodeHelpService } from '@/services/nodeHelpService'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fileURL: vi.fn((path: string) => `/files${path}`)
+  }
+}))
+
+describe('nodeHelpService', () => {
+  const mockFetch = vi.fn<typeof fetch>()
+
+  function nodeDef(options: {
+    name?: string
+    python_module?: string
+    description?: string
+  }): ComfyNodeDefImpl {
+    return {
+      name: options.name ?? 'TestNode',
+      display_name: options.name ?? 'Test Node',
+      category: 'test',
+      python_module: options.python_module ?? 'nodes',
+      description: options.description ?? ''
+    } as ComfyNodeDefImpl
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch.mockReset()
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  it('returns blueprint descriptions without fetching markdown', async () => {
+    const help = await nodeHelpService.fetchNodeHelp(
+      nodeDef({
+        python_module: 'blueprint',
+        description: 'Saved workflow help'
+      }),
+      'en'
+    )
+
+    expect(help).toBe('Saved workflow help')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches localized core node markdown', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Core help', {
+        headers: { 'content-type': 'text/markdown' }
+      })
+    )
+
+    const help = await nodeHelpService.fetchNodeHelp(
+      nodeDef({ name: 'LoadImage' }),
+      'zh'
+    )
+
+    expect(api.fileURL).toHaveBeenCalledWith('/docs/LoadImage/zh.md')
+    expect(mockFetch).toHaveBeenCalledWith('/files/docs/LoadImage/zh.md')
+    expect(help).toBe('Core help')
+  })
+
+  it('rejects core node HTML fallbacks', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('<html></html>', {
+        headers: { 'content-type': 'text/html' },
+        statusText: 'OK'
+      })
+    )
+
+    await expect(
+      nodeHelpService.fetchNodeHelp(nodeDef({ name: 'PreviewImage' }), 'en')
+    ).rejects.toThrow('OK')
+  })
+
+  it('uses the default missing-help error for empty markdown responses', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(''))
+
+    await expect(
+      nodeHelpService.fetchNodeHelp(nodeDef({ name: 'EmptyHelp' }), 'en')
+    ).rejects.toThrow('Help not found')
+  })
+
+  it('fetches custom node localized markdown before fallback markdown', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('Custom localized help', {
+        headers: { 'content-type': 'text/markdown' }
+      })
+    )
+
+    const help = await nodeHelpService.fetchNodeHelp(
+      nodeDef({
+        name: 'CustomNode',
+        python_module: 'custom_nodes.ComfyUI-TestPack@1.2.3.nodes'
+      }),
+      'ja'
+    )
+
+    expect(api.fileURL).toHaveBeenCalledWith(
+      '/extensions/ComfyUI-TestPack/docs/CustomNode/ja.md'
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(help).toBe('Custom localized help')
+  })
+
+  it('falls back to custom node default markdown after locale miss', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response('Not found', {
+          status: 404,
+          statusText: 'Locale missing'
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('Custom fallback help', {
+          headers: { 'content-type': 'text/markdown' }
+        })
+      )
+
+    const help = await nodeHelpService.fetchNodeHelp(
+      nodeDef({
+        name: 'CustomNode',
+        python_module: 'custom_nodes.TestPack.nodes'
+      }),
+      'fr'
+    )
+
+    expect(api.fileURL).toHaveBeenNthCalledWith(
+      1,
+      '/extensions/TestPack/docs/CustomNode/fr.md'
+    )
+    expect(api.fileURL).toHaveBeenNthCalledWith(
+      2,
+      '/extensions/TestPack/docs/CustomNode.md'
+    )
+    expect(help).toBe('Custom fallback help')
+  })
+
+  it('reports the locale miss when the custom fallback is empty', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response('Not found', {
+          status: 404,
+          statusText: 'Locale missing'
+        })
+      )
+      .mockResolvedValueOnce(new Response(''))
+
+    await expect(
+      nodeHelpService.fetchNodeHelp(
+        nodeDef({
+          name: 'CustomNode',
+          python_module: 'custom_nodes.TestPack.nodes'
+        }),
+        'de'
+      )
+    ).rejects.toThrow('Locale missing')
+  })
+})

--- a/src/services/nodeOrganizationService.test.ts
+++ b/src/services/nodeOrganizationService.test.ts
@@ -124,6 +124,80 @@ describe('nodeOrganizationService', () => {
     })
   })
 
+  describe('organizeNodesTab', () => {
+    it('returns no sections for an empty node list', () => {
+      expect(nodeOrganizationService.organizeNodesTab([])).toEqual([])
+    })
+
+    it('classifies blueprints, partner nodes, Comfy nodes, and extensions', () => {
+      const sections = nodeOrganizationService.organizeNodesTab([
+        createMockNodeDef({
+          name: 'MyBlueprint',
+          nodeSource: {
+            type: NodeSourceType.Blueprint,
+            className: 'blueprint',
+            displayText: 'Blueprint',
+            badgeText: 'B'
+          },
+          isGlobal: false
+        }),
+        createMockNodeDef({
+          name: 'ComfyBlueprint',
+          python_module: 'blueprint.comfy',
+          isGlobal: true
+        }),
+        createMockNodeDef({
+          name: 'PartnerApi',
+          category: 'api node/image'
+        }),
+        createMockNodeDef({
+          name: 'CoreNode',
+          nodeSource: {
+            type: NodeSourceType.Core,
+            className: 'core',
+            displayText: 'Core',
+            badgeText: 'C'
+          }
+        }),
+        createMockNodeDef({
+          name: 'EssentialNode',
+          nodeSource: {
+            type: NodeSourceType.Essentials,
+            className: 'essentials',
+            displayText: 'Essentials',
+            badgeText: 'E'
+          }
+        }),
+        createMockNodeDef({
+          name: 'ExtensionNode'
+        })
+      ])
+
+      expect(sections.map((section) => section.category)).toEqual([
+        'blueprints',
+        'comfyNodes',
+        'partnerNodes',
+        'extensions'
+      ])
+      expect(sections[0].tree.children?.map((child) => child.key)).toEqual([
+        'root/my-blueprints',
+        'root/comfy-blueprints'
+      ])
+    })
+
+    it('omits sections that have no matching nodes', () => {
+      const sections = nodeOrganizationService.organizeNodesTab([
+        createMockNodeDef({
+          name: 'OnlyExtension'
+        })
+      ])
+
+      expect(sections.map((section) => section.category)).toEqual([
+        'extensions'
+      ])
+    })
+  })
+
   describe('getGroupingIcon', () => {
     it('should return strategy icon', () => {
       const icon = nodeOrganizationService.getGroupingIcon('category')
@@ -216,6 +290,12 @@ describe('nodeOrganizationService', () => {
         expect(path).toEqual(['core', 'TestNode'])
       })
 
+      it('should handle custom_nodes without a package segment', () => {
+        const nodeDef = createMockNodeDef({ python_module: 'custom_nodes' })
+        const path = strategy?.getNodePath(nodeDef)
+        expect(path).toEqual(['custom_nodes', 'TestNode'])
+      })
+
       it('should handle non-standard module paths', () => {
         const nodeDef = createMockNodeDef({
           python_module: 'some.other.module.path'
@@ -282,6 +362,19 @@ describe('nodeOrganizationService', () => {
         const path = strategy?.getNodePath(nodeDef)
         expect(path).toEqual(['Unknown', 'TestNode'])
       })
+
+      it('should handle core source type', () => {
+        const nodeDef = createMockNodeDef({
+          nodeSource: {
+            type: NodeSourceType.Core,
+            className: 'core',
+            displayText: 'Core',
+            badgeText: 'C'
+          }
+        })
+        const path = strategy?.getNodePath(nodeDef)
+        expect(path).toEqual(['Core', 'TestNode'])
+      })
     })
 
     describe('node name edge cases', () => {
@@ -325,6 +418,15 @@ describe('nodeOrganizationService', () => {
 
       expect(strategy?.compare(nodeA, nodeB)).toBeGreaterThan(0)
       expect(strategy?.compare(nodeB, nodeA)).toBeLessThan(0)
+    })
+
+    it('alphabetical sort handles missing display names', () => {
+      const strategy =
+        nodeOrganizationService.getSortingStrategy('alphabetical')
+      const nodeA = createMockNodeDef({ display_name: undefined })
+      const nodeB = createMockNodeDef({ display_name: undefined })
+
+      expect(strategy?.compare(nodeA, nodeB)).toBe(0)
     })
   })
 })

--- a/src/services/subgraphService.test.ts
+++ b/src/services/subgraphService.test.ts
@@ -1,0 +1,175 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ExportedSubgraph,
+  ExportedSubgraphInstance,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import { createTestSubgraphData } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+
+const mocks = vi.hoisted(() => ({
+  addNodeDef: vi.fn(),
+  createSubgraph: vi.fn((subgraph: unknown) => ({
+    createdFrom: subgraph
+  })),
+  registerSubgraphNodeDef: vi.fn(),
+  subgraphs: new Map<string, unknown>()
+}))
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  useNodeDefStore: () => ({
+    addNodeDef: mocks.addNodeDef
+  })
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    rootGraph: {
+      subgraphs: mocks.subgraphs,
+      createSubgraph: mocks.createSubgraph
+    }
+  }
+}))
+
+vi.mock('./litegraphService', () => ({
+  useLitegraphService: () => ({
+    registerSubgraphNodeDef: mocks.registerSubgraphNodeDef
+  })
+}))
+
+const { useSubgraphService } = await import('./subgraphService')
+
+function createExportedSubgraph(
+  overrides: Partial<ExportedSubgraph> = {}
+): ExportedSubgraph {
+  return createTestSubgraphData({
+    id: 'subgraph-1',
+    name: 'Test Subgraph',
+    ...overrides
+  })
+}
+
+function createWorkflow(subgraphs?: ExportedSubgraph[]): ComfyWorkflowJSON {
+  return fromPartial<ComfyWorkflowJSON>({
+    definitions: subgraphs
+      ? {
+          subgraphs
+        }
+      : undefined
+  } as PartialDeep<ComfyWorkflowJSON>)
+}
+
+describe('useSubgraphService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.subgraphs.clear()
+  })
+
+  it('registers a new subgraph node definition', () => {
+    const service = useSubgraphService()
+    const subgraph = fromPartial<Subgraph>({ id: 'runtime-subgraph' })
+    const exportedSubgraph = createExportedSubgraph()
+
+    service.registerNewSubgraph(subgraph, exportedSubgraph)
+
+    expect(mocks.addNodeDef).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'subgraph-1',
+        display_name: 'Test Subgraph',
+        description: 'Subgraph node for Test Subgraph',
+        category: 'subgraph',
+        output_node: false,
+        python_module: 'nodes'
+      })
+    )
+
+    const [nodeDef, registeredSubgraph, instanceData] = mocks
+      .registerSubgraphNodeDef.mock.calls[0] as [
+      ComfyNodeDefV1,
+      Subgraph,
+      ExportedSubgraphInstance
+    ]
+
+    expect(nodeDef.name).toBe('subgraph-1')
+    expect(registeredSubgraph).toBe(subgraph)
+    expect(instanceData).toMatchObject({
+      id: -1,
+      type: 'subgraph-1',
+      pos: [0, 0],
+      size: [100, 100],
+      inputs: [],
+      outputs: []
+    })
+  })
+
+  it('uses an exported description when present', () => {
+    const service = useSubgraphService()
+    const subgraph = fromPartial<Subgraph>({ id: 'runtime-subgraph' })
+
+    service.registerNewSubgraph(
+      subgraph,
+      createExportedSubgraph({
+        description: 'Reusable workflow section'
+      })
+    )
+
+    expect(mocks.addNodeDef).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Reusable workflow section'
+      })
+    )
+  })
+
+  it('does nothing when workflow data has no subgraph definitions', () => {
+    const service = useSubgraphService()
+
+    service.loadSubgraphs(createWorkflow())
+
+    expect(mocks.addNodeDef).not.toHaveBeenCalled()
+    expect(mocks.registerSubgraphNodeDef).not.toHaveBeenCalled()
+  })
+
+  it('registers existing root graph subgraphs from workflow data', () => {
+    const service = useSubgraphService()
+    const subgraph = fromPartial<Subgraph>({ id: 'existing-subgraph' })
+    const exportedSubgraph = createExportedSubgraph()
+    mocks.subgraphs.set('subgraph-1', subgraph)
+
+    service.loadSubgraphs(createWorkflow([exportedSubgraph]))
+
+    expect(mocks.createSubgraph).not.toHaveBeenCalled()
+    expect(mocks.registerSubgraphNodeDef).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'subgraph-1'
+      }),
+      subgraph,
+      expect.objectContaining({
+        type: 'subgraph-1'
+      })
+    )
+  })
+
+  it('creates missing root graph subgraphs from workflow data', () => {
+    const service = useSubgraphService()
+    const exportedSubgraph = createExportedSubgraph()
+
+    service.loadSubgraphs(createWorkflow([exportedSubgraph]))
+
+    expect(mocks.createSubgraph).toHaveBeenCalledWith(exportedSubgraph)
+    expect(mocks.registerSubgraphNodeDef).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'subgraph-1'
+      }),
+      expect.objectContaining({
+        createdFrom: exportedSubgraph
+      }),
+      expect.objectContaining({
+        type: 'subgraph-1'
+      })
+    )
+  })
+})

--- a/src/stores/assetExportStore.test.ts
+++ b/src/stores/assetExportStore.test.ts
@@ -1,0 +1,300 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as VueUse from '@vueuse/core'
+
+import type { AssetExportWsMessage } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import type { TaskId } from '@/platform/tasks/services/taskService'
+import { useAssetExportStore } from '@/stores/assetExportStore'
+
+const { getExportDownloadUrl, getTask, toastAdd, intervalState } = vi.hoisted(
+  () => ({
+    getExportDownloadUrl: vi.fn(),
+    getTask: vi.fn(),
+    toastAdd: vi.fn(),
+    intervalState: { cb: null as null | (() => void) }
+  })
+)
+
+vi.mock('@vueuse/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
+  useIntervalFn: (cb: () => void) => {
+    intervalState.cb = cb
+    return { pause: vi.fn(), resume: vi.fn() }
+  }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: { addEventListener: vi.fn() }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: { getExportDownloadUrl }
+}))
+
+vi.mock('@/platform/tasks/services/taskService', () => ({
+  taskService: { getTask }
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: toastAdd })
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+function wsMessage(
+  over: Partial<AssetExportWsMessage> = {}
+): AssetExportWsMessage {
+  return {
+    task_id: 'task-1',
+    export_name: 'export.zip',
+    assets_total: 10,
+    assets_attempted: 5,
+    assets_failed: 0,
+    bytes_total: 1000,
+    bytes_processed: 500,
+    progress: 0.5,
+    status: 'running',
+    ...over
+  }
+}
+
+const taskId = (id: string) => id as TaskId
+
+/**
+ * Build a store and an `emit` bound to the real `asset_export` listener the
+ * store registers on `api`, so tests drive the state machine through its
+ * actual entry point rather than a private method.
+ */
+function setup() {
+  const store = useAssetExportStore()
+  const entry = vi
+    .mocked(api.addEventListener)
+    .mock.calls.find((c) => c[0] === 'asset_export')
+  const handler = entry![1] as (e: { detail: AssetExportWsMessage }) => void
+  const emit = (msg: AssetExportWsMessage) => handler({ detail: msg })
+  // Run the polling tick that `useIntervalFn` would normally fire, and let its
+  // async work settle.
+  const runPoll = async () => {
+    intervalState.cb?.()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  return { store, emit, runPoll }
+}
+
+const STALE_AGO_MS = 20_000
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.mocked(api.addEventListener).mockClear()
+  getExportDownloadUrl
+    .mockReset()
+    .mockResolvedValue({ url: 'https://example.com/export.zip' })
+  getTask.mockReset()
+  toastAdd.mockReset()
+})
+
+describe('assetExportStore', () => {
+  it('tracks a new export as created and is idempotent', () => {
+    const { store } = setup()
+
+    store.trackExport(taskId('t1'))
+    store.trackExport(taskId('t1'))
+
+    expect(store.exportList).toHaveLength(1)
+    expect(store.exportList[0].status).toBe('created')
+    expect(store.hasExports).toBe(true)
+    expect(store.hasActiveExports).toBe(true)
+  })
+
+  it('separates active from finished exports by status', () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ task_id: 'running', status: 'running' }))
+    emit(
+      wsMessage({ task_id: 'failed', status: 'failed', export_name: 'f.zip' })
+    )
+
+    expect(store.activeExports.map((e) => e.taskId)).toEqual(['running'])
+    expect(store.finishedExports.map((e) => e.taskId)).toEqual(['failed'])
+  })
+
+  it('updates an export from successive websocket messages', () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ progress: 0.5, status: 'running' }))
+    emit(wsMessage({ progress: 0.9, status: 'running' }))
+
+    expect(store.exportList).toHaveLength(1)
+    expect(store.exportList[0].progress).toBe(0.9)
+  })
+
+  it('ignores updates for an export already completed and downloaded', async () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ status: 'completed' }))
+    await Promise.resolve()
+    const triggeredCalls = getExportDownloadUrl.mock.calls.length
+
+    // A late 'running' message must not revive a completed+downloaded export
+    emit(wsMessage({ status: 'running', progress: 0.1 }))
+
+    expect(store.exportList[0].status).toBe('completed')
+    expect(getExportDownloadUrl).toHaveBeenCalledTimes(triggeredCalls)
+  })
+
+  it('falls back to the prior export name when a message omits it', async () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ status: 'running', progress: 0.4 }))
+    emit(
+      wsMessage({ status: 'running', export_name: undefined, progress: 0.6 })
+    )
+
+    expect(store.exportList[0].exportName).toBe('export.zip')
+  })
+
+  it('falls back to a blank export name when no message has named it', () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ export_name: undefined, status: 'running' }))
+
+    expect(store.exportList[0].exportName).toBe('')
+  })
+
+  it('triggers a download for a named export and clears prior errors', async () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+
+    await store.triggerDownload(exp)
+
+    expect(getExportDownloadUrl).toHaveBeenCalledWith('export.zip')
+    expect(exp.downloadTriggered).toBe(true)
+    expect(exp.downloadError).toBeUndefined()
+  })
+
+  it('does not re-trigger a download unless forced', async () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+    exp.downloadTriggered = true
+
+    await store.triggerDownload(exp)
+    expect(getExportDownloadUrl).not.toHaveBeenCalled()
+
+    await store.triggerDownload(exp, true)
+    expect(getExportDownloadUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('records a download error and surfaces a toast on failure', async () => {
+    getExportDownloadUrl.mockRejectedValueOnce(new Error('network down'))
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+
+    await store.triggerDownload(exp)
+
+    expect(exp.downloadError).toBe('network down')
+    expect(exp.downloadTriggered).toBe(false)
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+  })
+
+  it('records a string download error', async () => {
+    getExportDownloadUrl.mockRejectedValueOnce('offline')
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+
+    await store.triggerDownload(exp)
+
+    expect(exp.downloadError).toBe('offline')
+  })
+
+  it('clears finished exports while keeping active ones', () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ task_id: 'a', status: 'running' }))
+    emit(wsMessage({ task_id: 'b', status: 'failed', export_name: 'b.zip' }))
+
+    store.clearFinishedExports()
+
+    expect(store.exportList.map((e) => e.taskId)).toEqual(['a'])
+  })
+
+  it('does not poll when no active export is stale', async () => {
+    const { emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+
+    await runPoll()
+
+    expect(getTask).not.toHaveBeenCalled()
+  })
+
+  it('reconciles a stale export from the task service result', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockResolvedValue({
+      status: 'completed',
+      result: { export_name: 'reconciled.zip', assets_total: 10 }
+    })
+
+    await runPoll()
+
+    expect(getTask).toHaveBeenCalledWith('task-1')
+    expect(store.exportList[0].status).toBe('completed')
+    expect(store.exportList[0].exportName).toBe('reconciled.zip')
+  })
+
+  it('leaves a stale export active when the task is still running', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockResolvedValue({ status: 'running' })
+
+    await runPoll()
+
+    expect(store.exportList[0].status).toBe('running')
+  })
+
+  it('reconciles a stale failed export using existing counters', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(
+      wsMessage({
+        assets_attempted: 4,
+        assets_failed: 1,
+        status: 'running'
+      })
+    )
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockResolvedValue({
+      status: 'failed',
+      result: { error: 'failed in result' }
+    })
+
+    await runPoll()
+
+    expect(store.exportList[0]).toMatchObject({
+      assetsAttempted: 4,
+      assetsFailed: 1,
+      error: 'failed in result',
+      status: 'failed'
+    })
+  })
+
+  it('leaves a stale export untouched when the task lookup fails', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockRejectedValue(new Error('task not found'))
+
+    await runPoll()
+
+    expect(store.exportList[0].status).toBe('running')
+  })
+})

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -1,9 +1,15 @@
-import { fromAny } from '@total-typescript/shoehorn'
+import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { MissingNodeType } from '@/types/comfy'
 import { createNodeExecutionId } from '@/types/nodeIdentification'
+import type { ExecutionErrorWsMessage, PromptError } from '@/schemas/apiSchema'
+import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import type { MissingModelCandidate } from '@/platform/missingModel/types'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
 
 // Mock dependencies
 vi.mock('@/i18n', () => ({
@@ -15,6 +21,54 @@ vi.mock('@/platform/distribution/types', () => ({
 }))
 
 const mockShowErrorsTab = vi.hoisted(() => ({ value: false }))
+const {
+  mockApp,
+  mockCanvasStore,
+  mockExecutionIdToNodeLocatorId,
+  mockGetExecutionIdByNode,
+  mockGetNodeByExecutionId,
+  mockWorkflowStore
+} = vi.hoisted(() => ({
+  mockApp: {
+    isGraphReady: true,
+    rootGraph: {}
+  },
+  mockCanvasStore: {
+    currentGraph: undefined as object | undefined
+  },
+  mockExecutionIdToNodeLocatorId: vi.fn(
+    (_rootGraph: unknown, id: string): NodeLocatorId | undefined =>
+      id as NodeLocatorId
+  ),
+  mockGetExecutionIdByNode: vi.fn(),
+  mockGetNodeByExecutionId: vi.fn(),
+  mockWorkflowStore: {
+    nodeLocatorIdToNodeId: vi.fn()
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({ app: mockApp }))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => mockCanvasStore
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => mockWorkflowStore
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  executionIdToNodeLocatorId: (
+    ...args: Parameters<typeof mockExecutionIdToNodeLocatorId>
+  ) => mockExecutionIdToNodeLocatorId(...args),
+  forEachNode: vi.fn(),
+  getExecutionIdByNode: (
+    ...args: Parameters<typeof mockGetExecutionIdByNode>
+  ) => mockGetExecutionIdByNode(...args),
+  getNodeByExecutionId: (
+    ...args: Parameters<typeof mockGetNodeByExecutionId>
+  ) => mockGetNodeByExecutionId(...args)
+}))
 
 vi.mock('@/stores/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
@@ -38,6 +92,25 @@ vi.mock(
 import { useExecutionErrorStore } from './executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { toNodeId } from '@/types/nodeId'
+import {
+  createRequiredInputMissingNodeError,
+  seedRequiredInputMissingNodeError
+} from '@/utils/__tests__/executionErrorTestUtils'
+
+beforeEach(() => {
+  mockShowErrorsTab.value = false
+  mockApp.isGraphReady = true
+  mockCanvasStore.currentGraph = undefined
+  mockExecutionIdToNodeLocatorId.mockImplementation(
+    (_rootGraph: unknown, id: string) => id as NodeLocatorId
+  )
+  mockGetExecutionIdByNode.mockReset()
+  mockGetNodeByExecutionId.mockReset()
+  mockWorkflowStore.nodeLocatorIdToNodeId.mockImplementation(
+    (locator: NodeLocatorId) =>
+      toNodeId(String(locator).split(':').at(-1) ?? locator)
+  )
+})
 
 describe('executionErrorStore — node error operations', () => {
   beforeEach(() => {
@@ -141,6 +214,31 @@ describe('executionErrorStore — node error operations', () => {
       )
 
       // Original error should remain untouched
+      expect(store.lastNodeErrors?.['123'].errors).toHaveLength(1)
+    })
+
+    it('does nothing when the requested slot has no errors', () => {
+      const store = useExecutionErrorStore()
+      store.lastNodeErrors = {
+        '123': {
+          errors: [
+            {
+              type: 'value_bigger_than_max',
+              message: 'Max exceeded',
+              details: '',
+              extra_info: { input_name: 'otherSlot' }
+            }
+          ],
+          dependent_outputs: [],
+          class_type: 'TestNode'
+        }
+      }
+
+      store.clearSimpleNodeErrors(
+        createNodeExecutionId([toNodeId(123)]),
+        'testSlot'
+      )
+
       expect(store.lastNodeErrors?.['123'].errors).toHaveLength(1)
     })
 
@@ -388,6 +486,312 @@ describe('executionErrorStore — node error operations', () => {
       expect(store.lastNodeErrors).not.toBeNull()
       expect(store.lastNodeErrors?.['123'].errors).toHaveLength(1)
     })
+
+    it('keeps numeric range errors when no range options prove them valid', () => {
+      const store = useExecutionErrorStore()
+      store.lastNodeErrors = {
+        '123': {
+          errors: [
+            {
+              type: 'value_bigger_than_max',
+              message: '...',
+              details: '',
+              extra_info: { input_name: 'testWidget' }
+            }
+          ],
+          dependent_outputs: [],
+          class_type: 'TestNode'
+        }
+      }
+
+      store.clearWidgetRelatedErrors(
+        createNodeExecutionId([toNodeId(123)]),
+        'testWidget',
+        'testWidget',
+        15
+      )
+
+      expect(store.lastNodeErrors?.['123'].errors).toHaveLength(1)
+    })
+
+    it('is a no-op when the target execution id has no node error entry', () => {
+      const store = useExecutionErrorStore()
+      store.lastNodeErrors = {
+        '999': {
+          errors: [
+            {
+              type: 'value_bigger_than_max',
+              message: '...',
+              details: '',
+              extra_info: { input_name: 'testWidget' }
+            }
+          ],
+          dependent_outputs: [],
+          class_type: 'TestNode'
+        }
+      }
+
+      store.clearWidgetRelatedErrors(
+        createNodeExecutionId([toNodeId(123)]),
+        'testWidget',
+        'testWidget',
+        15,
+        { max: 10 }
+      )
+
+      expect(store.lastNodeErrors?.['123']).toBeUndefined()
+      expect(store.lastNodeErrors?.['999'].errors).toHaveLength(1)
+    })
+  })
+
+  describe('startup clearing', () => {
+    it('clears execution-start errors and closes the overlay when node errors are empty', () => {
+      const store = useExecutionErrorStore()
+      store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+        node_id: '1'
+      })
+      store.lastPromptError = fromPartial<PromptError>({
+        message: 'prompt failed'
+      })
+      store.lastNodeErrors = {}
+      store.showErrorOverlay()
+
+      store.clearExecutionStartErrors()
+
+      expect(store.lastExecutionError).toBeNull()
+      expect(store.lastPromptError).toBeNull()
+      expect(store.isErrorOverlayOpen).toBe(false)
+    })
+
+    it('keeps the overlay open when node errors remain after execution start', () => {
+      const store = useExecutionErrorStore()
+      store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+        node_id: '1'
+      })
+      store.lastPromptError = fromPartial<PromptError>({
+        message: 'prompt failed'
+      })
+      seedRequiredInputMissingNodeError(
+        store,
+        createNodeExecutionId([toNodeId(1)]),
+        'x'
+      )
+      store.showErrorOverlay()
+
+      store.clearExecutionStartErrors()
+
+      expect(store.isErrorOverlayOpen).toBe(true)
+    })
+  })
+})
+
+describe('executionErrorStore derived graph state', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('derives execution error node ids through locator mapping', () => {
+    const store = useExecutionErrorStore()
+    mockExecutionIdToNodeLocatorId.mockReturnValue('graph:7' as NodeLocatorId)
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '7'
+    })
+
+    expect(store.lastExecutionErrorNodeId).toBe(toNodeId(7))
+  })
+
+  it('returns null when there is no execution error locator', () => {
+    const store = useExecutionErrorStore()
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '7'
+    })
+    mockExecutionIdToNodeLocatorId.mockReturnValue(undefined)
+
+    expect(store.lastExecutionErrorNodeId).toBeNull()
+  })
+
+  it('returns null when there is no execution error', () => {
+    const store = useExecutionErrorStore()
+
+    expect(store.lastExecutionErrorNodeId).toBeNull()
+  })
+
+  it('combines prompt, node, execution, and missing-node error counts', () => {
+    const store = useExecutionErrorStore()
+    const missingNodesStore = useMissingNodesErrorStore()
+    store.lastPromptError = fromPartial<PromptError>({
+      message: 'prompt failed'
+    })
+    Reflect.set(store, 'lastExecutionError', { node_id: null })
+    const nodeError = createRequiredInputMissingNodeError('x')
+    store.lastNodeErrors = {
+      '1': {
+        ...nodeError,
+        errors: [
+          ...nodeError.errors,
+          {
+            type: 'value_bigger_than_max',
+            message: 'Too large',
+            details: '',
+            extra_info: { input_name: 'y' }
+          }
+        ]
+      }
+    }
+    missingNodesStore.setMissingNodeTypes([
+      { type: 'MissingNode', hint: '' }
+    ] as MissingNodeType[])
+
+    expect(store.hasPromptError).toBe(true)
+    expect(store.hasNodeError).toBe(true)
+    expect(store.hasExecutionError).toBe(true)
+    expect(store.hasAnyError).toBe(true)
+    expect(store.allErrorExecutionIds).toEqual(['1'])
+    expect(store.totalErrorCount).toBe(5)
+  })
+
+  it('reports empty derived state when there are no errors', () => {
+    const store = useExecutionErrorStore()
+
+    expect(store.hasNodeError).toBe(false)
+    expect(store.allErrorExecutionIds).toEqual([])
+    expect(store.totalErrorCount).toBe(0)
+  })
+
+  it('includes defined execution node ids in the error id list', () => {
+    const store = useExecutionErrorStore()
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '2'
+    })
+
+    expect(store.allErrorExecutionIds).toEqual(['2'])
+  })
+
+  it('excludes undefined execution node ids from the error id list', () => {
+    const store = useExecutionErrorStore()
+    Reflect.set(store, 'lastExecutionError', { node_id: undefined })
+
+    expect(store.allErrorExecutionIds).toEqual([])
+  })
+
+  it('collects active graph node ids for validation and execution errors', () => {
+    const store = useExecutionErrorStore()
+    const activeGraph = {}
+    mockCanvasStore.currentGraph = activeGraph
+    mockGetNodeByExecutionId.mockImplementation((_rootGraph, id: string) => ({
+      id: toNodeId(id),
+      graph: activeGraph
+    }))
+    seedRequiredInputMissingNodeError(
+      store,
+      createNodeExecutionId([toNodeId(1)]),
+      'x'
+    )
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '2'
+    })
+
+    expect([...store.activeGraphErrorNodeIds].sort()).toEqual(['1', '2'])
+  })
+
+  it('falls back to the root graph when there is no current canvas graph', () => {
+    const store = useExecutionErrorStore()
+    mockCanvasStore.currentGraph = undefined
+    mockGetNodeByExecutionId.mockReturnValue({
+      id: toNodeId(1),
+      graph: mockApp.rootGraph
+    })
+    seedRequiredInputMissingNodeError(
+      store,
+      createNodeExecutionId([toNodeId(1)]),
+      'x'
+    )
+
+    expect([...store.activeGraphErrorNodeIds]).toEqual(['1'])
+  })
+
+  it('ignores graph errors outside the active graph', () => {
+    const store = useExecutionErrorStore()
+    const activeGraph = {}
+    mockCanvasStore.currentGraph = activeGraph
+    mockGetNodeByExecutionId.mockReturnValue({
+      id: toNodeId(1),
+      graph: {}
+    })
+    seedRequiredInputMissingNodeError(
+      store,
+      createNodeExecutionId([toNodeId(1)]),
+      'x'
+    )
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '1'
+    })
+
+    expect(store.activeGraphErrorNodeIds.size).toBe(0)
+  })
+
+  it('returns no active graph node ids before the graph is ready', () => {
+    const store = useExecutionErrorStore()
+    mockApp.isGraphReady = false
+    store.lastExecutionError = fromPartial<ExecutionErrorWsMessage>({
+      node_id: '2'
+    })
+
+    expect(store.activeGraphErrorNodeIds.size).toBe(0)
+  })
+
+  it('maps node errors by locator and checks slots', () => {
+    const store = useExecutionErrorStore()
+    const nodeError = createRequiredInputMissingNodeError('x')
+    mockExecutionIdToNodeLocatorId.mockImplementation((_rootGraph, id) =>
+      id === 'missing' ? undefined : (`locator:${id}` as NodeLocatorId)
+    )
+    store.lastNodeErrors = {
+      '1': nodeError,
+      missing: nodeError
+    }
+
+    const locator = 'locator:1' as NodeLocatorId
+    expect(store.getNodeErrors(locator)).toEqual(nodeError)
+    expect(store.slotHasError(locator, 'x')).toBe(true)
+    expect(store.slotHasError(locator, 'y')).toBe(false)
+    expect(
+      store.getNodeErrors('locator:missing' as NodeLocatorId)
+    ).toBeUndefined()
+  })
+
+  it('returns no slot error when there are no node errors', () => {
+    const store = useExecutionErrorStore()
+
+    expect(store.slotHasError('locator:1' as NodeLocatorId, 'x')).toBe(false)
+  })
+
+  it('detects container nodes with internal errors', () => {
+    const store = useExecutionErrorStore()
+    const node = fromPartial<LGraphNode>({})
+    mockGetExecutionIdByNode.mockReturnValueOnce(undefined)
+
+    expect(store.isContainerWithInternalError(node)).toBe(false)
+
+    seedRequiredInputMissingNodeError(
+      store,
+      createNodeExecutionId([toNodeId(1), toNodeId(2)]),
+      'x'
+    )
+    mockGetExecutionIdByNode.mockReturnValue(
+      createNodeExecutionId([toNodeId(1)])
+    )
+
+    expect(store.isContainerWithInternalError(node)).toBe(true)
+  })
+
+  it('does not report container errors before the graph is ready', () => {
+    const store = useExecutionErrorStore()
+    mockApp.isGraphReady = false
+
+    expect(
+      store.isContainerWithInternalError(fromPartial<LGraphNode>({}))
+    ).toBe(false)
   })
 })
 
@@ -400,7 +804,7 @@ describe('surfaceMissingModels — silent option', () => {
   it('opens error overlay when silent is not specified and setting is enabled', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingModels([
-      fromAny({
+      fromPartial<MissingModelCandidate>({
         name: 'model.safetensors',
         nodeId: toNodeId('1'),
         nodeType: 'Loader',
@@ -417,7 +821,7 @@ describe('surfaceMissingModels — silent option', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingModels(
       [
-        fromAny({
+        fromPartial<MissingModelCandidate>({
           name: 'model.safetensors',
           nodeId: toNodeId('1'),
           nodeType: 'Loader',
@@ -436,7 +840,7 @@ describe('surfaceMissingModels — silent option', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingModels(
       [
-        fromAny({
+        fromPartial<MissingModelCandidate>({
           name: 'model.safetensors',
           nodeId: toNodeId('1'),
           nodeType: 'Loader',
@@ -457,6 +861,23 @@ describe('surfaceMissingModels — silent option', () => {
 
     expect(store.isErrorOverlayOpen).toBe(false)
   })
+
+  it('does NOT open error overlay when the setting is disabled', () => {
+    const store = useExecutionErrorStore()
+    mockShowErrorsTab.value = false
+    store.surfaceMissingModels([
+      fromPartial<MissingModelCandidate>({
+        name: 'model.safetensors',
+        nodeId: toNodeId('1'),
+        nodeType: 'Loader',
+        widgetName: 'ckpt',
+        isMissing: true,
+        isAssetSupported: false
+      })
+    ])
+
+    expect(store.isErrorOverlayOpen).toBe(false)
+  })
 })
 
 describe('surfaceMissingMedia — silent option', () => {
@@ -468,7 +889,7 @@ describe('surfaceMissingMedia — silent option', () => {
   it('opens error overlay when silent is not specified and setting is enabled', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingMedia([
-      fromAny({
+      fromPartial<MissingMediaCandidate>({
         name: 'photo.png',
         nodeId: toNodeId('1'),
         nodeType: 'LoadImage',
@@ -485,7 +906,7 @@ describe('surfaceMissingMedia — silent option', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingMedia(
       [
-        fromAny({
+        fromPartial<MissingMediaCandidate>({
           name: 'photo.png',
           nodeId: toNodeId('1'),
           nodeType: 'LoadImage',
@@ -504,7 +925,7 @@ describe('surfaceMissingMedia — silent option', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingMedia(
       [
-        fromAny({
+        fromPartial<MissingMediaCandidate>({
           name: 'photo.png',
           nodeId: toNodeId('1'),
           nodeType: 'LoadImage',
@@ -522,6 +943,23 @@ describe('surfaceMissingMedia — silent option', () => {
   it('does NOT open error overlay for empty media even without silent', () => {
     const store = useExecutionErrorStore()
     store.surfaceMissingMedia([])
+
+    expect(store.isErrorOverlayOpen).toBe(false)
+  })
+
+  it('does NOT open error overlay when the setting is disabled', () => {
+    const store = useExecutionErrorStore()
+    mockShowErrorsTab.value = false
+    store.surfaceMissingMedia([
+      fromPartial<MissingMediaCandidate>({
+        name: 'photo.png',
+        nodeId: toNodeId('1'),
+        nodeType: 'LoadImage',
+        widgetName: 'image',
+        mediaType: 'image',
+        isMissing: true
+      })
+    ])
 
     expect(store.isErrorOverlayOpen).toBe(false)
   })
@@ -568,9 +1006,9 @@ describe('clearAllErrors', () => {
         class_type: 'Test'
       }
     }
-    missingNodesStore.setMissingNodeTypes(
-      fromAny<MissingNodeType[], unknown>([{ type: 'MissingNode', hint: '' }])
-    )
+    missingNodesStore.setMissingNodeTypes([
+      { type: 'MissingNode', hint: '' }
+    ] as MissingNodeType[])
     executionErrorStore.showErrorOverlay()
 
     executionErrorStore.clearAllErrors()

--- a/src/stores/subgraphNavigationStore.navigateToHash.test.ts
+++ b/src/stores/subgraphNavigationStore.navigateToHash.test.ts
@@ -3,6 +3,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
 
 import type * as VueRouter from 'vue-router'
 
@@ -102,10 +103,22 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
 function makeSubgraph(id: string): Subgraph {
   return fromPartial<Subgraph>({
     id,
+    isRootGraph: false,
     rootGraph: app.rootGraph,
     _nodes: [],
     nodes: []
   })
+}
+
+async function makeDuplicatedNavigationFailure(): Promise<Error> {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: {} }]
+  })
+  await router.push('/')
+  const failure = await router.push('/')
+  if (!failure) throw new Error('Expected duplicated navigation failure')
+  return failure
 }
 
 async function flushHashWatcher() {
@@ -118,6 +131,7 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
+    vi.mocked(app.canvas.setGraph).mockReset()
     app.rootGraph.id = ids.root
     app.rootGraph.subgraphs.clear()
     app.canvas.subgraph = undefined
@@ -230,6 +244,44 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     warnSpy.mockRestore()
   })
 
+  it('does not warn when recovery redirect hits a duplicated navigation', async () => {
+    routerMocks.replace.mockRejectedValueOnce(
+      await makeDuplicatedNavigationFailure()
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    app.canvas.graph = makeSubgraph(ids.deletedSubgraph)
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+    )
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      '[subgraphNavigation] router.replace rejected during recovery',
+      expect.any(Error)
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('recovers to root when canvas is unavailable during redirect cleanup', async () => {
+    const appWithOptionalCanvas = app as {
+      canvas: typeof app.canvas | undefined
+    }
+    const canvas = appWithOptionalCanvas.canvas
+    appWithOptionalCanvas.canvas = undefined
+    useSubgraphNavigationStore()
+
+    try {
+      routeHashRef.value = '#not-a-valid-uuid'
+      await vi.waitFor(() =>
+        expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+      )
+    } finally {
+      appWithOptionalCanvas.canvas = canvas
+    }
+  })
+
   it('redirects when a workflow load resolves but the subgraph is still missing', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     workflowStoreState.openWorkflows = [
@@ -303,5 +355,197 @@ describe('useSubgraphNavigationStore - navigateToHash validation', () => {
     expect(routerMocks.replace).toHaveBeenCalledTimes(1)
     expect(app.canvas.setGraph).toHaveBeenCalledWith(app.rootGraph)
     warnSpy.mockRestore()
+  })
+
+  it('updateHash does nothing on initial load with an empty hash', async () => {
+    const store = useSubgraphNavigationStore()
+
+    await store.updateHash()
+
+    expect(routerMocks.replace).not.toHaveBeenCalled()
+    expect(routerMocks.push).not.toHaveBeenCalled()
+  })
+
+  it('updateHash follows a non-empty initial subgraph hash', async () => {
+    const subgraph = makeSubgraph(ids.validSubgraph)
+    app.rootGraph.subgraphs.set(subgraph.id, subgraph)
+    vi.mocked(app.canvas.setGraph).mockImplementation((graph) => {
+      app.canvas.graph = graph
+    })
+    routeHashRef.value = `#${ids.validSubgraph}`
+    const store = useSubgraphNavigationStore()
+
+    await store.updateHash()
+
+    expect(app.canvas.setGraph).toHaveBeenCalledWith(subgraph)
+  })
+
+  it('updateHash does not treat the initial root hash as a subgraph', async () => {
+    routeHashRef.value = `#${ids.root}`
+    app.canvas.graph = app.rootGraph
+    const store = useSubgraphNavigationStore()
+
+    await store.updateHash()
+
+    expect(workflowStoreState.activeSubgraph).toBeUndefined()
+  })
+
+  it('updateHash replaces an empty hash and pushes the active graph id', async () => {
+    const store = useSubgraphNavigationStore()
+    await store.updateHash()
+    app.canvas.graph = fromPartial<LGraph>({ id: ids.validSubgraph })
+
+    await store.updateHash()
+
+    expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+    expect(routerMocks.push).toHaveBeenCalledWith(`#${ids.validSubgraph}`)
+  })
+
+  it('updateHash skips router push when hash already matches the active graph', async () => {
+    const store = useSubgraphNavigationStore()
+    await store.updateHash()
+    routeHashRef.value = `#${ids.validSubgraph}`
+    app.canvas.graph = fromPartial<LGraph>({ id: ids.validSubgraph })
+
+    await store.updateHash()
+
+    expect(routerMocks.push).not.toHaveBeenCalled()
+  })
+
+  it('updateHash skips router push when the active graph has no id', async () => {
+    const store = useSubgraphNavigationStore()
+    await store.updateHash()
+    routeHashRef.value = '#old'
+    app.canvas.graph = fromPartial<LGraph>({})
+
+    await store.updateHash()
+
+    expect(routerMocks.push).not.toHaveBeenCalled()
+  })
+
+  it('updateHash warns when router push rejects', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    routerMocks.push.mockRejectedValueOnce(new Error('push failed'))
+    const store = useSubgraphNavigationStore()
+    await store.updateHash()
+    routeHashRef.value = '#old'
+    app.canvas.graph = fromPartial<LGraph>({ id: ids.validSubgraph })
+
+    await store.updateHash()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[subgraphNavigation] router.push rejected',
+      expect.any(Error)
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('updateHash ignores duplicated router push failures', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    routerMocks.push.mockRejectedValueOnce(
+      await makeDuplicatedNavigationFailure()
+    )
+    const store = useSubgraphNavigationStore()
+    await store.updateHash()
+    routeHashRef.value = `#${ids.root}`
+    app.canvas.graph = fromPartial<LGraph>({ id: ids.validSubgraph })
+
+    await store.updateHash()
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('skips workflows without active state during hash recovery', async () => {
+    workflowStoreState.openWorkflows = [
+      fromPartial<ComfyWorkflow>({ path: 'inactive.json' })
+    ]
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+    )
+  })
+
+  it('skips workflow states and subgraphs that do not match the hash', async () => {
+    workflowStoreState.openWorkflows = [
+      fromPartial<ComfyWorkflow>({
+        path: 'other-workflow.json',
+        activeState: {
+          id: ids.validSubgraph,
+          definitions: {
+            subgraphs: [{ id: ids.validSubgraph }]
+          }
+        }
+      })
+    ]
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+    )
+  })
+
+  it('handles workflow states with no subgraph definitions during recovery', async () => {
+    workflowStoreState.openWorkflows = [
+      fromPartial<ComfyWorkflow>({
+        path: 'no-definitions.json',
+        activeState: { id: ids.validSubgraph }
+      })
+    ]
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(routerMocks.replace).toHaveBeenCalledWith(`#${app.rootGraph.id}`)
+    )
+  })
+
+  it('opens a workflow and navigates to the loaded root graph', async () => {
+    workflowStoreState.openWorkflows = [
+      fromPartial<ComfyWorkflow>({
+        path: 'root-workflow.json',
+        activeState: {
+          id: ids.deletedSubgraph,
+          definitions: { subgraphs: [] }
+        }
+      })
+    ]
+    workflowServiceMocks.openWorkflow.mockImplementation(async () => {
+      app.rootGraph.id = ids.deletedSubgraph
+      app.canvas.graph = fromPartial<LGraph>({ id: ids.root })
+    })
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(app.canvas.setGraph).toHaveBeenCalledWith(app.rootGraph)
+    )
+  })
+
+  it('does not reset the graph when loaded workflow is already active', async () => {
+    workflowStoreState.openWorkflows = [
+      fromPartial<ComfyWorkflow>({
+        path: 'already-active.json',
+        activeState: {
+          id: ids.deletedSubgraph,
+          definitions: { subgraphs: [] }
+        }
+      })
+    ]
+    workflowServiceMocks.openWorkflow.mockImplementation(async () => {
+      app.rootGraph.id = ids.deletedSubgraph
+      app.canvas.graph = fromPartial<LGraph>({ id: ids.deletedSubgraph })
+    })
+    useSubgraphNavigationStore()
+
+    routeHashRef.value = `#${ids.deletedSubgraph}`
+    await vi.waitFor(() =>
+      expect(workflowServiceMocks.openWorkflow).toHaveBeenCalled()
+    )
+
+    expect(app.canvas.setGraph).not.toHaveBeenCalledWith(app.rootGraph)
   })
 })

--- a/src/stores/subgraphNavigationStore.test.ts
+++ b/src/stores/subgraphNavigationStore.test.ts
@@ -74,7 +74,7 @@ describe('useSubgraphNavigationStore', () => {
     app.canvas.ds.offset = [0, 0]
     app.canvas.ds.state.scale = 1
     app.canvas.ds.state.offset = [0, 0]
-    app.graph.getNodeById = vi.fn()
+    app.rootGraph.getNodeById = vi.fn()
   })
 
   it('should not clear navigation stack when workflow internal state changes', async () => {
@@ -223,7 +223,7 @@ describe('useSubgraphNavigationStore', () => {
 
     const unreachableSubgraph = createMockSubgraph('orphan-subgraph', app.graph)
 
-    app.graph.subgraphs.set(unreachableSubgraph.id, unreachableSubgraph)
+    app.rootGraph.subgraphs.set(unreachableSubgraph.id, unreachableSubgraph)
     vi.mocked(findSubgraphPathById).mockReturnValue(null)
 
     const mockWorkflow = fromPartial<ComfyWorkflow>({
@@ -251,7 +251,7 @@ describe('useSubgraphNavigationStore', () => {
     const mockSubgraph = createMockSubgraph('subgraph-1', app.graph)
 
     // Add the subgraph to the graph's subgraphs map
-    app.graph.subgraphs.set('subgraph-1', mockSubgraph)
+    app.rootGraph.subgraphs.set('subgraph-1', mockSubgraph)
 
     // First set an active workflow
     const mockWorkflow = fromPartial<ComfyWorkflow>({

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -89,7 +90,7 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       return rafCallbacks.length
     })
     mockCanvas.subgraph = undefined
-    mockCanvas.graph = app.graph
+    mockCanvas.graph = app.graph ?? null
     mockCanvas.ds.scale = 1
     mockCanvas.ds.offset = [0, 0]
     mockCanvas.ds.state.scale = 1
@@ -136,6 +137,23 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   })
 
   describe('saveViewport', () => {
+    it('does not save when canvas is unavailable', () => {
+      const store = useSubgraphNavigationStore()
+      const canvas = app.canvas
+      const appWithOptionalCanvas = app as {
+        canvas: typeof app.canvas | undefined
+      }
+      appWithOptionalCanvas.canvas = undefined
+
+      try {
+        store.saveViewport('root')
+
+        expect(store.viewportCache.has(':root')).toBe(false)
+      } finally {
+        appWithOptionalCanvas.canvas = canvas
+      }
+    })
+
     it('saves viewport state for root graph', () => {
       const store = useSubgraphNavigationStore()
       mockCanvas.ds.state.scale = 2
@@ -164,6 +182,42 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   })
 
   describe('restoreViewport', () => {
+    it('does nothing when canvas is unavailable', () => {
+      const store = useSubgraphNavigationStore()
+      const canvas = app.canvas
+      const appWithOptionalCanvas = app as {
+        canvas: typeof app.canvas | undefined
+      }
+      appWithOptionalCanvas.canvas = undefined
+
+      try {
+        store.restoreViewport('root')
+
+        expect(mockSetDirty).not.toHaveBeenCalled()
+        expect(rafCallbacks).toHaveLength(0)
+      } finally {
+        appWithOptionalCanvas.canvas = canvas
+      }
+    })
+
+    it('does not apply cached viewport when canvas disappears', () => {
+      const store = useSubgraphNavigationStore()
+      const canvas = app.canvas
+      const appWithOptionalCanvas = app as {
+        canvas: typeof app.canvas | undefined
+      }
+      store.viewportCache.set(':root', { scale: 2.5, offset: [150, 250] })
+      appWithOptionalCanvas.canvas = undefined
+
+      try {
+        store.restoreViewport('root')
+
+        expect(mockSetDirty).not.toHaveBeenCalled()
+      } finally {
+        appWithOptionalCanvas.canvas = canvas
+      }
+    })
+
     it('restores cached viewport', () => {
       const store = useSubgraphNavigationStore()
       store.viewportCache.set(':root', { scale: 2.5, offset: [150, 250] })
@@ -266,7 +320,7 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       expect(mockFitView).toHaveBeenCalledOnce()
 
       // User navigated away before the inner RAF fired
-      mockCanvas.subgraph = { id: 'different-graph' } as never
+      mockCanvas.subgraph = fromPartial<Subgraph>({ id: 'different-graph' })
       rafCallbacks[1](performance.now())
 
       expect(mockRequestSlotSyncAll).not.toHaveBeenCalled()
@@ -283,7 +337,7 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       expect(rafCallbacks).toHaveLength(1)
 
       // Simulate graph switching away before rAF fires
-      mockCanvas.subgraph = { id: 'different-graph' } as never
+      mockCanvas.subgraph = fromPartial<Subgraph>({ id: 'different-graph' })
 
       rafCallbacks[0](performance.now())
 
@@ -296,12 +350,12 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       const store = useSubgraphNavigationStore()
       const workflowStore = useWorkflowStore()
 
-      const mockRootGraph = {
+      const mockRootGraph = fromPartial<LGraph>({
         _nodes: [],
         nodes: [],
         subgraphs: new Map(),
         getNodeById: vi.fn()
-      } as Partial<LGraph> as LGraph
+      })
       const subgraph1 = {
         id: 'sub1',
         rootGraph: mockRootGraph,
@@ -313,7 +367,7 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       mockCanvas.ds.state.offset = [100, 100]
 
       // Enter subgraph
-      workflowStore.activeSubgraph = subgraph1 as Partial<Subgraph> as Subgraph
+      workflowStore.activeSubgraph = fromPartial<Subgraph>(subgraph1)
       await nextTick()
 
       // Root viewport saved
@@ -339,6 +393,23 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       // Root viewport restored
       expect(mockCanvas.ds.scale).toBe(2)
       expect(mockCanvas.ds.offset).toEqual([100, 100])
+    })
+
+    it('does not save the outgoing viewport while a workflow switch is blocked', async () => {
+      const store = useSubgraphNavigationStore()
+      const workflowStore = useWorkflowStore()
+      const subgraph = fromPartial<Subgraph>({
+        id: 'sub1',
+        isRootGraph: false,
+        rootGraph: app.rootGraph
+      })
+
+      store.saveCurrentViewport()
+      store.viewportCache.clear()
+      workflowStore.activeSubgraph = subgraph
+      await nextTick()
+
+      expect(store.viewportCache.has(':root')).toBe(false)
     })
 
     it('preserves pre-existing cache entries across workflow switches', async () => {

--- a/src/stores/subgraphStore.test.ts
+++ b/src/stores/subgraphStore.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
-import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,9 +10,14 @@ import {
 import type { ExportedSubgraph } from '@/lib/litegraph/src/types/serialisation'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { GlobalSubgraphData } from '@/scripts/api'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
+import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
@@ -36,6 +41,7 @@ vi.mock('@/scripts/api', () => ({
     storeUserData: vi.fn(),
     listUserDataFullInfo: vi.fn(),
     getGlobalSubgraphs: vi.fn(),
+    deleteUserData: vi.fn(),
     apiURL: vi.fn(),
     addEventListener: vi.fn()
   }
@@ -98,6 +104,12 @@ describe('useSubgraphStore', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useSubgraphStore()
     vi.clearAllMocks()
+    vi.mocked(useDialogService).mockReturnValue(
+      fromPartial<ReturnType<typeof useDialogService>>({
+        prompt: vi.fn(() => 'testname'),
+        confirm: vi.fn(() => true)
+      })
+    )
   })
 
   it('should allow publishing of a subgraph', async () => {
@@ -134,6 +146,92 @@ describe('useSubgraphStore', () => {
     await store.publishSubgraph()
     expect(api.storeUserData).toHaveBeenCalled()
   })
+
+  it('rejects publishing when a single subgraph node is not selected', async () => {
+    vi.mocked(comfyApp.canvas).selectedItems = new Set()
+
+    await expect(store.publishSubgraph()).rejects.toThrow(
+      'Must have single SubgraphNode selected to publish'
+    )
+  })
+
+  it('rejects publishing when serialization produces multiple nodes', async () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    vi.mocked(comfyApp.canvas).selectedItems = new Set([subgraphNode])
+    vi.mocked(comfyApp.canvas)._serializeItems = vi.fn(() => ({
+      nodes: [subgraphNode.serialize(), subgraphNode.serialize()],
+      subgraphs: []
+    }))
+
+    await expect(store.publishSubgraph()).rejects.toThrow(
+      'Must have single SubgraphNode selected to publish'
+    )
+  })
+
+  it('rejects publishing when the serialized node is not a subgraph node', async () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    vi.mocked(comfyApp.canvas).selectedItems = new Set([subgraphNode])
+    vi.mocked(comfyApp.canvas).draw = vi.fn()
+    vi.mocked(comfyApp.canvas)._serializeItems = vi.fn(() => ({
+      nodes: [{ ...subgraphNode.serialize(), type: 'missing' }],
+      subgraphs: [
+        Object.assign(fromPartial<ExportedSubgraph>({}), subgraph.serialize())
+      ]
+    }))
+
+    await expect(store.publishSubgraph('invalid')).rejects.toThrow(
+      'Loaded subgraph blueprint does not contain valid subgraph'
+    )
+    expect(api.storeUserData).not.toHaveBeenCalled()
+  })
+
+  it('does not publish when the name prompt is cancelled', async () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    vi.mocked(comfyApp.canvas).selectedItems = new Set([subgraphNode])
+    vi.mocked(comfyApp.canvas)._serializeItems = vi.fn(() => ({
+      nodes: [subgraphNode.serialize()],
+      subgraphs: [
+        Object.assign(fromPartial<ExportedSubgraph>({}), subgraph.serialize())
+      ]
+    }))
+    vi.mocked(useDialogService).mockReturnValue(
+      fromPartial<ReturnType<typeof useDialogService>>({
+        prompt: vi.fn(() => null),
+        confirm: vi.fn(() => true)
+      })
+    )
+
+    await store.publishSubgraph()
+
+    expect(api.storeUserData).not.toHaveBeenCalled()
+  })
+
+  it('does not overwrite an existing blueprint when confirmation is cancelled', async () => {
+    const subgraph = createTestSubgraph()
+    const subgraphNode = createTestSubgraphNode(subgraph)
+    vi.mocked(comfyApp.canvas).selectedItems = new Set([subgraphNode])
+    vi.mocked(comfyApp.canvas)._serializeItems = vi.fn(() => ({
+      nodes: [subgraphNode.serialize()],
+      subgraphs: [
+        Object.assign(fromPartial<ExportedSubgraph>({}), subgraph.serialize())
+      ]
+    }))
+    vi.mocked(useDialogService).mockReturnValue(
+      fromPartial<ReturnType<typeof useDialogService>>({
+        prompt: vi.fn(() => 'test'),
+        confirm: vi.fn(() => false)
+      })
+    )
+    await mockFetch({ 'test.json': mockGraph })
+
+    await store.publishSubgraph('test')
+
+    expect(api.storeUserData).not.toHaveBeenCalled()
+  })
+
   it('should display published nodes in the node library', async () => {
     await mockFetch({ 'test.json': mockGraph })
     expect(
@@ -147,6 +245,28 @@ describe('useSubgraphStore', () => {
     await store.editBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
     //check active graph
     expect(comfyApp.loadGraphData).toHaveBeenCalled()
+  })
+
+  it('switches into the nested subgraph when editing opens a wrapper graph', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const setGraph = vi.fn()
+    const nested = { id: 'nested' }
+    const canvasGraph = fromPartial<NonNullable<typeof comfyApp.canvas.graph>>(
+      {}
+    )
+    Reflect.set(canvasGraph, 'nodes', [{ subgraph: nested }])
+    vi.mocked(comfyApp.canvas).graph = canvasGraph
+    vi.mocked(comfyApp.canvas).setGraph = setGraph
+
+    await store.editBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
+
+    expect(setGraph).toHaveBeenCalledWith(nested)
+  })
+
+  it('throws when editing an unloaded blueprint', async () => {
+    await expect(
+      store.editBlueprint(BLUEPRINT_TYPE_PREFIX + 'missing')
+    ).rejects.toThrow('not yet loaded')
   })
   it('should allow subgraphs to be added to graph', async () => {
     //mock
@@ -165,6 +285,12 @@ describe('useSubgraphStore', () => {
     const second = store.getBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
     expect(second.nodes[0].id).not.toBe(-1)
     expect(second.definitions!.subgraphs![0].id).toBe('123')
+  })
+
+  it('throws when getting an unloaded blueprint', () => {
+    expect(() => store.getBlueprint(BLUEPRINT_TYPE_PREFIX + 'missing')).toThrow(
+      'not yet loaded'
+    )
   })
   it('should identify user blueprints as non-global', async () => {
     await mockFetch({ 'test.json': mockGraph })
@@ -186,6 +312,57 @@ describe('useSubgraphStore', () => {
   it('should return false for non-existent blueprints', async () => {
     await mockFetch({ 'test.json': mockGraph })
     expect(store.isGlobalBlueprint('nonexistent')).toBe(false)
+  })
+
+  describe('deleteBlueprint', () => {
+    it('throws for unloaded blueprints', async () => {
+      await expect(
+        store.deleteBlueprint(BLUEPRINT_TYPE_PREFIX + 'missing')
+      ).rejects.toThrow('not yet loaded')
+    })
+
+    it('does not delete global blueprints', async () => {
+      await mockFetch(
+        {},
+        {
+          global_bp: {
+            name: 'Global Blueprint',
+            info: { node_pack: 'comfy_essentials' },
+            data: JSON.stringify(mockGraph)
+          }
+        }
+      )
+
+      await store.deleteBlueprint(BLUEPRINT_TYPE_PREFIX + 'global_bp')
+
+      expect(api.deleteUserData).not.toHaveBeenCalled()
+    })
+
+    it('does not delete when confirmation is cancelled', async () => {
+      await mockFetch({ 'test.json': mockGraph })
+      vi.mocked(useDialogService).mockReturnValue(
+        fromPartial<ReturnType<typeof useDialogService>>({
+          prompt: vi.fn(() => 'testname'),
+          confirm: vi.fn(() => false)
+        })
+      )
+
+      await store.deleteBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
+
+      expect(api.deleteUserData).not.toHaveBeenCalled()
+    })
+
+    it('deletes user blueprints after confirmation', async () => {
+      await mockFetch({ 'test.json': mockGraph })
+      vi.mocked(api.deleteUserData).mockResolvedValue({
+        status: 204
+      } as Response)
+
+      await store.deleteBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')
+
+      expect(api.deleteUserData).toHaveBeenCalledWith('subgraphs/test.json')
+      expect(store.isUserBlueprint(BLUEPRINT_TYPE_PREFIX + 'test')).toBe(false)
+    })
   })
 
   describe('isUserBlueprint', () => {
@@ -285,6 +462,206 @@ describe('useSubgraphStore', () => {
     consoleSpy.mockRestore()
   })
 
+  it('continues when global blueprint discovery rejects', async () => {
+    vi.mocked(api.listUserDataFullInfo).mockResolvedValue([])
+    vi.mocked(api.getGlobalSubgraphs).mockRejectedValue(
+      new Error('global down')
+    )
+
+    await store.fetchSubgraphs()
+
+    expect(store.subgraphBlueprints).toEqual([])
+  })
+
+  it('reports compact detail when more than three blueprints fail', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await mockFetch(
+      {},
+      {
+        a: { name: 'A', info: { node_pack: 'test' }, data: '' },
+        b: { name: 'B', info: { node_pack: 'test' }, data: '' },
+        c: { name: 'C', info: { node_pack: 'test' }, data: '' },
+        d: { name: 'D', info: { node_pack: 'test' }, data: '' }
+      }
+    )
+
+    expect(consoleSpy).toHaveBeenCalledTimes(4)
+    expect(useToastStore().add).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: 'x4' })
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('ignores invalid user blueprint files during fetch', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await mockFetch({
+      'invalid.json': {
+        nodes: [],
+        definitions: { subgraphs: [] }
+      }
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load subgraph blueprint',
+      expect.any(Error)
+    )
+    expect(store.subgraphBlueprints).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('rejects loaded blueprints whose wrapper node does not reference a subgraph', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await mockFetch({
+      'invalid-ref.json': {
+        nodes: [{ id: 1, type: 'missing' }],
+        definitions: { subgraphs: [{ id: 'present' }] }
+      }
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load subgraph blueprint',
+      expect.any(Error)
+    )
+    expect(store.subgraphBlueprints).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('rejects loaded blueprints without subgraph definitions', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await mockFetch({
+      'missing-definitions.json': {
+        nodes: [{ id: 1, type: 'missing' }]
+      }
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load subgraph blueprint',
+      expect.any(Error)
+    )
+    expect(store.subgraphBlueprints).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('rejects saving a blueprint whose active state has no subgraph definitions', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const blueprint = useWorkflowStore().getWorkflowByPath(
+      'subgraphs/test.json'
+    )
+    if (!blueprint?.changeTracker) throw new Error('Blueprint was not loaded')
+    blueprint.changeTracker!.activeState = fromPartial<ComfyWorkflowJSON>({
+      nodes: [{ id: 1, type: '123' }]
+    })
+
+    await expect(blueprint.save()).rejects.toThrow(
+      'The root graph of a subgraph blueprint must consist of only a single subgraph node'
+    )
+  })
+
+  it('marks non-blueprint root nodes when saving an invalid blueprint', async () => {
+    vi.mocked(comfyApp.canvas).draw = vi.fn()
+    await mockFetch({ 'test.json': mockGraph })
+    const blueprint = useWorkflowStore().getWorkflowByPath(
+      'subgraphs/test.json'
+    )
+    if (!blueprint?.changeTracker) throw new Error('Blueprint was not loaded')
+    blueprint.changeTracker!.activeState = fromPartial<ComfyWorkflowJSON>({
+      nodes: [
+        { id: 1, type: '123' },
+        { id: 2, type: 'OtherNode' }
+      ],
+      definitions: { subgraphs: [{ id: '123' }] }
+    })
+
+    await expect(blueprint.save()).rejects.toThrow(
+      'The root graph of a subgraph blueprint must consist of only a single subgraph node'
+    )
+    expect(comfyApp.canvas.draw).toHaveBeenCalledWith(true, true)
+  })
+
+  it('does not save a loaded blueprint when first-save confirmation is cancelled', async () => {
+    const confirm = vi.fn(() => false)
+    vi.mocked(useDialogService).mockReturnValue(
+      fromPartial<ReturnType<typeof useDialogService>>({
+        prompt: vi.fn(() => 'testname'),
+        confirm
+      })
+    )
+    useSettingStore().settingValues['Comfy.Workflow.WarnBlueprintOverwrite'] =
+      true
+    await mockFetch({ 'test.json': mockGraph })
+    const blueprint = useWorkflowStore().getWorkflowByPath(
+      'subgraphs/test.json'
+    )
+    if (!blueprint) throw new Error('Blueprint was not loaded')
+
+    const result = await blueprint.save()
+
+    expect(result).toBe(blueprint)
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'overwriteBlueprint',
+        itemList: ['test']
+      })
+    )
+    expect(api.storeUserData).not.toHaveBeenCalled()
+  })
+
+  it('saves a loaded blueprint after first-save confirmation', async () => {
+    const confirm = vi.fn(() => true)
+    vi.mocked(useDialogService).mockReturnValue(
+      fromPartial<ReturnType<typeof useDialogService>>({
+        prompt: vi.fn(() => 'testname'),
+        confirm
+      })
+    )
+    useSettingStore().settingValues['Comfy.Workflow.WarnBlueprintOverwrite'] =
+      true
+    vi.mocked(api.storeUserData).mockResolvedValue({
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          path: 'subgraphs/test.json',
+          modified: Date.now(),
+          size: 2
+        })
+    } as Response)
+    await mockFetch({ 'test.json': mockGraph })
+    const blueprint = useWorkflowStore().getWorkflowByPath(
+      'subgraphs/test.json'
+    )
+    if (!blueprint) throw new Error('Blueprint was not loaded')
+
+    await blueprint.save()
+
+    const [path, data, options] = vi.mocked(api.storeUserData).mock.calls[0]
+    if (typeof data !== 'string') throw new Error('Expected saved JSON')
+    expect(path).toBe('subgraphs/test.json')
+    expect(JSON.parse(data)).toMatchObject({
+      nodes: [{ type: '123', title: 'test' }],
+      definitions: { subgraphs: [{ id: '123', name: 'test' }] }
+    })
+    expect(options).toEqual({
+      overwrite: true,
+      throwOnError: true,
+      full_info: true
+    })
+  })
+
+  it('returns an already-loaded blueprint when loading without force', async () => {
+    await mockFetch({ 'test.json': mockGraph })
+    const blueprint = useWorkflowStore().getWorkflowByPath(
+      'subgraphs/test.json'
+    )
+    if (!blueprint) throw new Error('Blueprint was not loaded')
+
+    await blueprint.load()
+
+    expect(api.getUserData).toHaveBeenCalledTimes(1)
+  })
+
   it('should handle global blueprint with rejected data promise gracefully', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     await mockFetch(
@@ -293,9 +670,7 @@ describe('useSubgraphStore', () => {
         failing_blueprint: {
           name: 'Failing Blueprint',
           info: { node_pack: 'test_pack' },
-          data: fromAny<string, unknown>(
-            Promise.reject(new Error('Network error'))
-          )
+          data: Promise.reject(new Error('Network error'))
         }
       }
     )
@@ -406,6 +781,29 @@ describe('useSubgraphStore', () => {
       expect(nodeDef?.description).toBe('This is a test blueprint')
     })
 
+    it('does not copy workflowRendererVersion into subgraph metadata on load', async () => {
+      await mockFetch({
+        'metadata-load.json': {
+          nodes: [{ type: '123' }],
+          definitions: {
+            subgraphs: [{ id: '123', extra: {} }]
+          },
+          extra: {
+            BlueprintDescription: 'Loaded description',
+            workflowRendererVersion: 'Vue'
+          }
+        }
+      })
+
+      const blueprint = store.getBlueprint(
+        BLUEPRINT_TYPE_PREFIX + 'metadata-load'
+      )
+
+      expect(blueprint.definitions!.subgraphs![0].extra).toEqual({
+        BlueprintDescription: 'Loaded description'
+      })
+    })
+
     it('should not duplicate metadata in both workflow extra and subgraph extra when publishing', async () => {
       const subgraph = createTestSubgraph()
       const subgraphNode = createTestSubgraphNode(subgraph)
@@ -464,6 +862,59 @@ describe('useSubgraphStore', () => {
       const subgraphExtra = definitions.subgraphs[0]?.extra
       expect(subgraphExtra?.BlueprintDescription).toBeUndefined()
       expect(subgraphExtra?.BlueprintSearchAliases).toBeUndefined()
+    })
+
+    it('keeps workflowRendererVersion in subgraph extra when publishing', async () => {
+      const subgraph = createTestSubgraph()
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      subgraphNode.graph!.add(subgraphNode)
+
+      subgraph.extra = {
+        BlueprintDescription: 'Test description',
+        workflowRendererVersion: 'Vue'
+      }
+
+      vi.mocked(comfyApp.canvas).selectedItems = new Set([subgraphNode])
+      vi.mocked(comfyApp.canvas)._serializeItems = vi.fn(() => {
+        const serializedSubgraph = fromPartial<ExportedSubgraph>({
+          ...subgraph.serialize(),
+          links: [],
+          groups: [],
+          version: 1
+        })
+        return {
+          nodes: [subgraphNode.serialize()],
+          subgraphs: [serializedSubgraph]
+        }
+      })
+
+      let savedWorkflowData: Record<string, unknown> | null = null
+      vi.mocked(api.storeUserData).mockImplementation(async (_path, data) => {
+        savedWorkflowData = JSON.parse(data as string)
+        return {
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              path: 'subgraphs/testname.json',
+              modified: Date.now(),
+              size: 2
+            })
+        } as Response
+      })
+
+      await mockFetch({ 'testname.json': mockGraph })
+      await store.publishSubgraph()
+
+      expect(savedWorkflowData).not.toBeNull()
+      expect(savedWorkflowData!.extra).toEqual({
+        BlueprintDescription: 'Test description'
+      })
+      const definitions = savedWorkflowData!.definitions as {
+        subgraphs: Array<{ extra?: Record<string, unknown> }>
+      }
+      expect(definitions.subgraphs[0]?.extra?.workflowRendererVersion).toBe(
+        'Vue'
+      )
     })
   })
 

--- a/src/utils/__tests__/executionErrorTestUtils.ts
+++ b/src/utils/__tests__/executionErrorTestUtils.ts
@@ -4,7 +4,9 @@ import type { NodeExecutionId } from '@/types/nodeIdentification'
 
 type ExecutionErrorStore = ReturnType<typeof useExecutionErrorStore>
 
-function createRequiredInputMissingNodeError(inputName: string): NodeError {
+export function createRequiredInputMissingNodeError(
+  inputName: string
+): NodeError {
   return {
     errors: [
       {

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -8,10 +8,12 @@ import {
   hexToRgb,
   hsbToRgb,
   hsvaToHex,
+  isColorFormat,
   isTransparent,
   luminance,
   parseToRgb,
   readableTextColor,
+  rgbToHsl,
   rgbToHex,
   textOnColor,
   toHexFromFormat
@@ -236,6 +238,24 @@ describe('colorUtil conversions', () => {
     it('parses 8-digit hex and ignores the alpha channel in RGB output', () => {
       expect(parseToRgb('#ff000080')).toEqual({ r: 255, g: 0, b: 0 })
     })
+
+    it('covers HSL hue sectors outside primary colors', () => {
+      expect(parseToRgb('hsl(60, 100%, 50%)')).toEqual({
+        r: 255,
+        g: 255,
+        b: 0
+      })
+      expect(parseToRgb('hsl(180, 100%, 50%)')).toEqual({
+        r: 0,
+        g: 255,
+        b: 255
+      })
+      expect(parseToRgb('hsl(300, 100%, 50%)')).toEqual({
+        r: 255,
+        g: 0,
+        b: 255
+      })
+    })
   })
 
   describe('hsbToRgb normalization', () => {
@@ -243,6 +263,24 @@ describe('colorUtil conversions', () => {
       // h = -120 should map to h = 240 (blue) when s and b are both 100.
       expect(hsbToRgb({ h: -120, s: 100, b: 100 })).toEqual({
         r: 0,
+        g: 0,
+        b: 255
+      })
+    })
+
+    it('covers all hue ranges', () => {
+      expect(hsbToRgb({ h: 90, s: 100, b: 100 })).toEqual({
+        r: 127,
+        g: 255,
+        b: 0
+      })
+      expect(hsbToRgb({ h: 180, s: 100, b: 100 })).toEqual({
+        r: 0,
+        g: 255,
+        b: 255
+      })
+      expect(hsbToRgb({ h: 300, s: 100, b: 100 })).toEqual({
+        r: 255,
         g: 0,
         b: 255
       })
@@ -263,12 +301,27 @@ describe('colorUtil conversions', () => {
     })
 
     it('returns false for fully opaque hex colors', () => {
+      expect(isTransparent('red')).toBe(false)
       expect(isTransparent('#ff0000')).toBe(false)
       expect(isTransparent('#ff0000ff')).toBe(false)
     })
   })
 
   describe('toHexFromFormat', () => {
+    it('normalizes supported hex spellings', () => {
+      expect(toHexFromFormat('', 'hex')).toBe('#000000')
+      expect(toHexFromFormat('abc', 'hex')).toBe('#abc')
+      expect(toHexFromFormat('#abc', 'hex')).toBe('#abc')
+      expect(toHexFromFormat('#abcdef', 'hex')).toBe('#abcdef')
+      expect(toHexFromFormat('abcdef12', 'hex')).toBe('#abcdef12')
+      expect(toHexFromFormat('#abcdef12', 'hex')).toBe('#abcdef12')
+    })
+
+    it('converts rgb strings and rejects non-string rgb input', () => {
+      expect(toHexFromFormat('rgb(255, 128, 0)', 'rgb')).toBe('#ff8000')
+      expect(toHexFromFormat({ r: 255, g: 128, b: 0 }, 'rgb')).toBe('#000000')
+    })
+
     it('treats an HSV object (with v field) the same as an HSB object', () => {
       const hsbObject = { h: 120, s: 100, b: 100 }
       const hsvObject = { h: 120, s: 100, v: 100 }
@@ -281,6 +334,7 @@ describe('colorUtil conversions', () => {
 
     it('returns #000000 for unparseable hsb input', () => {
       expect(toHexFromFormat({ h: 0 }, 'hsb')).toBe('#000000')
+      expect(toHexFromFormat('hsb()', 'hsb')).toBe('#000000')
     })
 
     it('prefixes a bare 6-digit hex with #', () => {
@@ -292,6 +346,22 @@ describe('colorUtil conversions', () => {
     it('computes perceptual luminance', () => {
       expect(luminance({ r: 255, g: 0, b: 0 })).toBeCloseTo(76.245, 2)
       expect(luminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(255, 2)
+    })
+  })
+
+  describe('rgbToHsl', () => {
+    it('handles light colors and wrapped red hue', () => {
+      expect(rgbToHsl({ r: 255, g: 128, b: 128 }).s).toBeCloseTo(1)
+      expect(rgbToHsl({ r: 255, g: 0, b: 128 }).h).toBeCloseTo(0.916, 2)
+    })
+  })
+
+  describe('isColorFormat', () => {
+    it('recognizes public color format ids', () => {
+      expect(isColorFormat('hex')).toBe(true)
+      expect(isColorFormat('rgb')).toBe(true)
+      expect(isColorFormat('hsb')).toBe(true)
+      expect(isColorFormat('hsl')).toBe(false)
     })
   })
 
@@ -357,6 +427,10 @@ describe('colorUtil - adjustColor', () => {
       })
       expect(result).toBe(color)
     })
+  })
+
+  it('returns the original value when no adjustments are requested', () => {
+    expect(adjustColor('#123456', {})).toBe('#123456')
   })
 
   it('treats 5-char hex as valid color with alpha', () => {

--- a/src/utils/createAnnotatedPath.test.ts
+++ b/src/utils/createAnnotatedPath.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { createAnnotatedPath } from './createAnnotatedPath'
+
+describe('createAnnotatedPath', () => {
+  it('returns bare input paths for string items by default', () => {
+    expect(createAnnotatedPath('image.png')).toBe('image.png')
+  })
+
+  it('prepends the supplied subfolder for string items', () => {
+    expect(createAnnotatedPath('image.png', { subfolder: 'uploads' })).toBe(
+      'uploads/image.png'
+    )
+  })
+
+  it('annotates string items when the root folder is not input', () => {
+    expect(createAnnotatedPath('image.png', { rootFolder: 'output' })).toBe(
+      'image.png [output]'
+    )
+  })
+
+  it('does not duplicate an existing annotation', () => {
+    expect(
+      createAnnotatedPath('image.png [temp]', { rootFolder: 'temp' })
+    ).toBe('image.png [temp]')
+  })
+
+  it('formats result items with their own subfolder', () => {
+    expect(
+      createAnnotatedPath({
+        filename: 'render.png',
+        subfolder: 'final',
+        type: 'output'
+      })
+    ).toBe('final/render.png [output]')
+  })
+
+  it('omits the result-item annotation when type matches the root folder', () => {
+    expect(
+      createAnnotatedPath(
+        {
+          filename: 'render.png',
+          subfolder: '',
+          type: 'output'
+        },
+        { rootFolder: 'output' }
+      )
+    ).toBe('render.png')
+  })
+
+  it('handles missing result-item filenames', () => {
+    expect(createAnnotatedPath({ subfolder: 'folder', type: 'temp' })).toBe(
+      'folder/ [temp]'
+    )
+  })
+})

--- a/src/utils/envUtil.test.ts
+++ b/src/utils/envUtil.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const distributionState = vi.hoisted(() => ({
+  isDesktop: false
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isDesktop() {
+    return distributionState.isDesktop
+  }
+}))
+
+beforeEach(() => {
+  vi.resetModules()
+  Reflect.deleteProperty(window, 'electronAPI')
+  Object.defineProperty(window.navigator, 'windowControlsOverlay', {
+    configurable: true,
+    value: undefined
+  })
+})
+
+async function importEnvUtil(isDesktop: boolean) {
+  distributionState.isDesktop = isDesktop
+  return await import('@/utils/envUtil')
+}
+
+describe('envUtil', () => {
+  it('returns and uses the Electron API when present', async () => {
+    const showContextMenu = vi.fn()
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { showContextMenu }
+    })
+    const envUtil = await importEnvUtil(true)
+
+    expect(envUtil.electronAPI()).toEqual({ showContextMenu })
+
+    envUtil.showNativeSystemMenu()
+
+    expect(showContextMenu).toHaveBeenCalled()
+  })
+
+  it('detects native windows only in desktop window-control overlays', async () => {
+    Object.defineProperty(window.navigator, 'windowControlsOverlay', {
+      configurable: true,
+      value: { visible: true }
+    })
+
+    expect((await importEnvUtil(true)).isNativeWindow()).toBe(true)
+
+    vi.resetModules()
+    expect((await importEnvUtil(false)).isNativeWindow()).toBe(false)
+  })
+
+  it('tolerates a missing Electron API for native menu calls', async () => {
+    const envUtil = await importEnvUtil(true)
+
+    expect(() => envUtil.showNativeSystemMenu()).not.toThrow()
+  })
+})

--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -1,0 +1,202 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+
+import { graphToPrompt } from './executionUtil'
+
+const mocks = vi.hoisted(() => ({
+  compressWidgetInputSlots: vi.fn()
+}))
+
+vi.mock('./litegraphUtil', () => ({
+  compressWidgetInputSlots: mocks.compressWidgetInputSlots
+}))
+
+vi.mock('@/lib/litegraph/src/litegraph', () => ({
+  LGraphEventMode: {
+    NEVER: 1,
+    BYPASS: 2
+  },
+  ExecutableNodeDTO: vi.fn(function (node: {
+    id: number | string
+    executionId?: number | string
+    isVirtualNode?: boolean
+    mode?: number
+    widgets?: unknown[]
+    inputs?: unknown[]
+    resolveInput?: (index: number) => unknown
+    comfyClass?: string
+    title?: string
+    dtoInnerNodes?: unknown[]
+  }) {
+    return {
+      id: node.executionId ?? node.id,
+      isVirtualNode: node.isVirtualNode ?? false,
+      mode: node.mode ?? 0,
+      widgets: node.widgets,
+      inputs: node.inputs ?? [],
+      resolveInput: node.resolveInput ?? (() => null),
+      comfyClass: node.comfyClass,
+      title: node.title,
+      getInnerNodes: () => node.dtoInnerNodes ?? []
+    }
+  })
+}))
+
+function graphWith(
+  nodes: unknown[],
+  workflowExtra?: Record<string, unknown>,
+  workflowNodes: Array<Record<string, unknown>> = [
+    {
+      inputs: [{ name: 'in', localized_name: 'Input' }],
+      outputs: [{ name: 'out', localized_name: 'Output' }]
+    }
+  ]
+): LGraph {
+  return fromPartial<LGraph>({
+    computeExecutionOrder: vi.fn(() => nodes),
+    serialize: vi.fn(() => ({
+      nodes: workflowNodes,
+      extra: workflowExtra
+    }))
+  })
+}
+
+describe('graphToPrompt', () => {
+  it('serializes widget values, links, virtual setup, and workflow metadata', async () => {
+    const virtualApply = vi.fn()
+    const virtualInner = {
+      id: 'virtual-inner',
+      isVirtualNode: true,
+      applyToGraph: virtualApply
+    }
+    const innerOutputNode = {
+      id: 'inner-output',
+      inputs: [],
+      widgets: [],
+      comfyClass: 'InnerClass',
+      title: 'Inner'
+    }
+    const node = {
+      id: 1,
+      getInnerNodes: vi.fn(() => [virtualInner]),
+      dtoInnerNodes: [innerOutputNode],
+      inputs: [
+        { name: 'missing' },
+        { name: 'widget-array' },
+        { name: 'link' },
+        { name: 'removed' }
+      ],
+      widgets: [
+        { name: '', value: 'ignored' },
+        { name: 'skipped', value: 'ignored', options: { serialize: false } },
+        {
+          name: 'curve',
+          type: 'curve',
+          serializeValue: vi.fn(async () => [1, 2])
+        },
+        { name: 'array', value: [3, 4] },
+        { name: 'plain', value: 'value' }
+      ],
+      resolveInput: vi.fn((index: number) => {
+        if (index === 1) return { widgetInfo: { value: [5, 6] } }
+        if (index === 2) return { origin_id: 'inner-output', origin_slot: '7' }
+        if (index === 3) return { origin_id: 'removed-node', origin_slot: '1' }
+        return null
+      }),
+      comfyClass: 'TestClass',
+      title: 'Test'
+    }
+    const graph = graphWith([node])
+
+    const { workflow, output } = await graphToPrompt(graph, { sortNodes: true })
+
+    expect(virtualApply).toHaveBeenCalledTimes(1)
+    expect(graph.serialize).toHaveBeenCalledWith({ sortNodes: true })
+    expect(mocks.compressWidgetInputSlots).toHaveBeenCalledWith(workflow)
+    expect(workflow.nodes[0].inputs?.[0]).toEqual({ name: 'in' })
+    expect(workflow.nodes[0].outputs?.[0]).toEqual({ name: 'out' })
+    expect(workflow.extra?.frontendVersion).toBeDefined()
+    expect(output['1']).toEqual({
+      inputs: {
+        curve: { __type__: 'CURVE', __value__: [1, 2] },
+        array: { __value__: [3, 4] },
+        plain: 'value',
+        'widget-array': { __value__: [5, 6] },
+        link: ['inner-output', 7]
+      },
+      class_type: 'TestClass',
+      _meta: { title: 'Test' }
+    })
+    expect(output['inner-output']).toEqual({
+      inputs: {},
+      class_type: 'InnerClass',
+      _meta: { title: 'Inner' }
+    })
+  })
+
+  it('skips muted and virtual executable nodes', async () => {
+    const normalNode = {
+      id: 'normal',
+      inputs: [],
+      comfyClass: 'Normal',
+      title: 'Normal'
+    }
+    const mutedNode = {
+      id: 'muted',
+      mode: LGraphEventMode.NEVER,
+      inputs: [],
+      widgets: [{ name: 'value', value: 'ignored' }],
+      comfyClass: 'Muted',
+      title: 'Muted',
+      dtoInnerNodes: [
+        {
+          id: 'muted-inner',
+          inputs: [],
+          comfyClass: 'MutedInner',
+          title: 'MutedInner'
+        }
+      ]
+    }
+    const bypassedNode = {
+      id: 'bypassed',
+      mode: LGraphEventMode.BYPASS,
+      inputs: [],
+      comfyClass: 'Bypassed',
+      title: 'Bypassed'
+    }
+    const virtualNode = {
+      id: 'virtual',
+      isVirtualNode: true,
+      inputs: [],
+      comfyClass: 'Virtual',
+      title: 'Virtual'
+    }
+    const graph = graphWith(
+      [normalNode, mutedNode, bypassedNode, virtualNode],
+      {}
+    )
+
+    const { workflow, output } = await graphToPrompt(graph)
+
+    expect(graph.serialize).toHaveBeenCalledWith({ sortNodes: false })
+    expect(workflow.extra?.frontendVersion).toBeDefined()
+    expect(Object.keys(output)).toEqual(['normal'])
+  })
+
+  it('preserves serialized workflow nodes without slot arrays', async () => {
+    const node = {
+      id: 1,
+      inputs: [],
+      comfyClass: 'NodeClass',
+      title: 'Node'
+    }
+    const graph = graphWith([node], {}, [{ id: 1 }])
+
+    const { workflow } = await graphToPrompt(graph)
+
+    expect(workflow.nodes[0]).toEqual({ id: 1 })
+  })
+})

--- a/src/utils/fuseUtil.test.ts
+++ b/src/utils/fuseUtil.test.ts
@@ -11,8 +11,8 @@ interface FilterItem {
   options: string[]
 }
 
-const makeSearch = <T>(data: T[] = []) =>
-  new FuseSearch<T>(data, {
+function makeSearch<T>(data: T[] = []) {
+  return new FuseSearch<T>(data, {
     fuseOptions: {
       keys: ['name'],
       includeScore: true,
@@ -21,6 +21,7 @@ const makeSearch = <T>(data: T[] = []) =>
     },
     advancedScoring: true
   })
+}
 
 describe('FuseSearch', () => {
   it('assigns stable ranking tiers for exact, prefix, word, substring, and multi-part matches', () => {

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -1,4 +1,5 @@
 // oxlint-disable no-misused-spread
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -9,21 +10,27 @@ import type {
 import {
   collectAllNodes,
   collectFromNodes,
+  executionIdToNodeLocatorId,
   findNodeInHierarchy,
   findSubgraphByUuid,
+  findSubgraphPathById,
+  getActiveGraphNodeIds,
   forEachNode,
   forEachSubgraphNode,
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes,
   getLocalNodeIdFromExecutionId,
+  getLocatorIdFromNodeData,
   getNodeByExecutionId,
   getNodeByLocatorId,
   getRootGraph,
+  getRootParentNode,
   getSubgraphPathFromExecutionId,
   getExecutionIdFromNodeData,
   mapAllNodes,
   mapSubgraphNodes,
   parseExecutionId,
+  reduceAllNodes,
   traverseNodesDepthFirst,
   traverseSubgraphPath,
   triggerCallbackOnAllNodes,
@@ -36,6 +43,7 @@ import {
   isMissingCandidateActive
 } from '@/utils/graphTraversalUtil'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
 import { toNodeId } from '@/types/nodeId'
 
 import { createMockLGraphNode } from './__tests__/litegraphTestUtils'
@@ -97,6 +105,8 @@ describe('graphTraversalUtil', () => {
       expect(findNodeInHierarchy(graph, '')).toBeNull()
       expect(getExecutionIdForNodeInGraph(graph, graph, '')).toBeNull()
       expect(getExecutionIdFromNodeData(graph, { id: '' })).toBeNull()
+      expect(getLocatorIdFromNodeData({ id: '' })).toBeNull()
+      expect(executionIdToNodeLocatorId(graph, '')).toBeUndefined()
     })
   })
 
@@ -214,6 +224,12 @@ describe('graphTraversalUtil', () => {
         const graph = createMockGraph([createMockNode('1')])
         const result = traverseSubgraphPath(graph, ['999'])
         expect(result).toBeNull()
+      })
+
+      it('returns null for an unparseable path segment', () => {
+        const graph = createMockGraph([])
+
+        expect(traverseSubgraphPath(graph, [''])).toBeNull()
       })
     })
   })
@@ -501,6 +517,17 @@ describe('graphTraversalUtil', () => {
     })
 
     describe('findSubgraphByUuid', () => {
+      it('uses the root graph subgraph registry when available', () => {
+        const subgraph = createMockSubgraph('registered-uuid', [])
+        const graph = {
+          ...createMockGraph([]),
+          subgraphs: new Map([[subgraph.id, subgraph]])
+        } satisfies Partial<LGraph> as LGraph
+
+        expect(findSubgraphByUuid(graph, subgraph.id)).toBe(subgraph)
+        expect(findSubgraphByUuid(graph, 'missing-uuid')).toBeNull()
+      })
+
       it('should find subgraph by UUID', () => {
         const targetUuid = 'target-uuid'
         const subgraph = createMockSubgraph(targetUuid, [])
@@ -543,6 +570,60 @@ describe('graphTraversalUtil', () => {
 
         const found = findSubgraphByUuid(graph, 'non-existent-uuid')
         expect(found).toBeNull()
+      })
+    })
+
+    describe('findSubgraphPathById', () => {
+      it('returns the path to a nested subgraph', () => {
+        const targetSubgraph = createMockSubgraph('target-uuid', [])
+        const middleNode = createMockNode('20', {
+          isSubgraph: true,
+          subgraph: targetSubgraph
+        })
+        const middleSubgraph = createMockSubgraph('middle-uuid', [middleNode])
+        const rootNode = createMockNode('10', {
+          isSubgraph: true,
+          subgraph: middleSubgraph
+        })
+        const graph = createMockGraph([rootNode])
+
+        expect(findSubgraphPathById(graph, 'target-uuid')).toEqual([
+          'middle-uuid',
+          'target-uuid'
+        ])
+      })
+
+      it('skips malformed graph entries while searching', () => {
+        const malformedSubgraph = fromPartial<Subgraph>({
+          id: 'malformed',
+          nodes: []
+        })
+        const graph = createMockGraph([
+          createMockNode('10', {
+            isSubgraph: true,
+            subgraph: malformedSubgraph
+          })
+        ])
+
+        expect(findSubgraphPathById(graph, 'missing-uuid')).toBeNull()
+      })
+    })
+
+    describe('getRootParentNode', () => {
+      it('returns null for root-level or invalid execution IDs', () => {
+        const graph = createMockGraph([createMockNode('10')])
+
+        expect(getRootParentNode(graph, '10')).toBeNull()
+        expect(getRootParentNode(graph, '')).toBeNull()
+        expect(getRootParentNode(graph, 'invalid:20')).toBeNull()
+      })
+
+      it('returns the root parent for a nested execution ID', () => {
+        const parent = createMockNode('10')
+        const graph = createMockGraph([parent])
+
+        expect(getRootParentNode(graph, '10:20:30')).toBe(parent)
+        expect(getRootParentNode(graph, '10:20:30')?.id).toBe('10')
       })
     })
 
@@ -616,6 +697,14 @@ describe('graphTraversalUtil', () => {
     })
 
     describe('getExecutionIdByNode', () => {
+      it('returns null when the node has no graph', () => {
+        const node = createMockNode('123')
+        node.graph = null
+        const graph = createMockGraph([])
+
+        expect(getExecutionIdByNode(graph, node)).toBeNull()
+      })
+
       it('should return node id if graph is rootGraph', () => {
         const node = createMockNode('123')
         const graph = createMockGraph([node])
@@ -720,7 +809,7 @@ describe('graphTraversalUtil', () => {
           subgraph
         })
         const rootGraph = createMockGraph([subgraphNode])
-        interior.graph = null as unknown as LGraph
+        interior.graph = null
 
         expect(
           getExecutionIdForNodeInGraph(rootGraph, subgraph, interior.id)
@@ -735,6 +824,21 @@ describe('graphTraversalUtil', () => {
         expect(
           getExecutionIdForNodeInGraph(rootGraph, orphanSubgraph, '63')
         ).toBe('63')
+      })
+
+      it('falls back to local id when the parent path is not parseable', () => {
+        const interior = createMockNode('63')
+        const subgraph = createMockSubgraph('sub-uuid', [interior])
+        const subgraphNode = createMockLGraphNode({
+          id: toNodeId(''),
+          isSubgraphNode: () => true,
+          subgraph
+        }) satisfies Partial<LGraphNode> as LGraphNode
+        const rootGraph = createMockGraph([subgraphNode])
+
+        expect(getExecutionIdForNodeInGraph(rootGraph, subgraph, '63')).toBe(
+          '63'
+        )
       })
     })
 
@@ -808,6 +912,22 @@ describe('graphTraversalUtil', () => {
     })
 
     describe('isExecutionPathActive', () => {
+      it('returns true when the graph is unavailable', () => {
+        expect(isExecutionPathActive(null, '42')).toBe(true)
+        expect(isExecutionPathActive(undefined, '42')).toBe(true)
+      })
+
+      it('returns false when the target node cannot be resolved', () => {
+        expect(isExecutionPathActive(createMockGraph([]), '42')).toBe(false)
+      })
+
+      it('returns true for an active target with active ancestors', () => {
+        const node = createMockNode('42')
+        const rootGraph = createMockGraph([node])
+
+        expect(isExecutionPathActive(rootGraph, '42')).toBe(true)
+      })
+
       it('returns false when the target node itself is bypassed', () => {
         const node = createMockLGraphNode({
           id: 42,
@@ -914,6 +1034,10 @@ describe('graphTraversalUtil', () => {
     })
 
     describe('isCandidateScopeActive', () => {
+      it('treats candidates without a scoped node as active', () => {
+        expect(isCandidateScopeActive(createMockGraph([]), {})).toBe(true)
+      })
+
       it('uses sourceExecutionId before nodeId', () => {
         const rootNode = createMockNode('65')
         const sourceNode = createMockLGraphNode({
@@ -1017,6 +1141,51 @@ describe('graphTraversalUtil', () => {
         const locatorId = 'non-existent-uuid:789'
         const found = getNodeByLocatorId(graph, locatorId)
         expect(found).toBeNull()
+      })
+
+      it('returns null when the root graph is unavailable', () => {
+        expect(getNodeByLocatorId(null, '123')).toBeNull()
+      })
+    })
+
+    describe('executionIdToNodeLocatorId', () => {
+      it('returns a root locator for root execution IDs', () => {
+        const graph = createMockGraph([])
+
+        expect(executionIdToNodeLocatorId(graph, '123')).toBe('123')
+      })
+
+      it('returns a subgraph locator for nested execution IDs', () => {
+        const targetNode = createMockNode('789')
+        const subgraph = createMockSubgraph(
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+          [targetNode]
+        )
+        const graph = createMockGraph([
+          createMockNode('456', { isSubgraph: true, subgraph })
+        ])
+
+        expect(executionIdToNodeLocatorId(graph, '456:789')).toBe(
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890:789'
+        )
+      })
+
+      it('returns undefined when the nested path cannot be resolved', () => {
+        const graph = createMockGraph([createMockNode('456')])
+
+        expect(executionIdToNodeLocatorId(graph, '456:789')).toBeUndefined()
+      })
+
+      it('returns undefined when the nested local id is invalid', () => {
+        const subgraph = createMockSubgraph(
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+          []
+        )
+        const graph = createMockGraph([
+          createMockNode('456', { isSubgraph: true, subgraph })
+        ])
+
+        expect(executionIdToNodeLocatorId(graph, '456:')).toBeUndefined()
       })
     })
 
@@ -1207,7 +1376,27 @@ describe('graphTraversalUtil', () => {
       })
     })
 
+    describe('reduceAllNodes', () => {
+      it('reduces nodes across nested subgraphs', () => {
+        const subgraph = createMockSubgraph('sub-uuid', [createMockNode('10')])
+        const graph = createMockGraph([
+          createMockNode('1'),
+          createMockNode('2', { isSubgraph: true, subgraph })
+        ])
+
+        expect(
+          reduceAllNodes(graph, (sum, node) => sum + Number(node.id), 0)
+        ).toBe(13)
+      })
+    })
+
     describe('traverseNodesDepthFirst', () => {
+      it('handles missing traversal options', () => {
+        const node = createMockNode('1')
+
+        expect(() => traverseNodesDepthFirst([node])).not.toThrow()
+      })
+
       it('should traverse nodes in depth-first order', () => {
         const visited: string[] = []
         const nodes = [
@@ -1299,6 +1488,15 @@ describe('graphTraversalUtil', () => {
     })
 
     describe('collectFromNodes', () => {
+      it('collects nodes with default options', () => {
+        const nodes = [createMockNode('1'), createMockNode('2')]
+
+        expect(collectFromNodes(nodes).map((node) => String(node.id))).toEqual([
+          '2',
+          '1'
+        ])
+      })
+
       it('should collect data from all nodes', () => {
         const nodes = [
           createMockNode('1'),
@@ -1582,6 +1780,44 @@ describe('graphTraversalUtil', () => {
         const executionIds = getExecutionIdsForSelectedNodes(subgraph.nodes)
 
         expect(executionIds).toEqual(['2:10', '2:11'])
+      })
+
+      it('returns an empty list when the starting subgraph is unreachable', () => {
+        const rootGraph = createMockGraph([])
+        const orphanSubgraph = createMockSubgraph('orphan', [], rootGraph)
+        createMockNode('10', { graph: orphanSubgraph })
+
+        expect(
+          getExecutionIdsForSelectedNodes(orphanSubgraph.nodes, orphanSubgraph)
+        ).toEqual([])
+      })
+    })
+
+    describe('getActiveGraphNodeIds', () => {
+      it('returns local ids for execution ids in the active graph', () => {
+        const rootNode = createMockNode('1')
+        const subNode = createMockNode('10')
+        const subgraph = createMockSubgraph('sub-uuid', [subNode])
+        const subgraphNode = createMockNode('2', {
+          isSubgraph: true,
+          subgraph
+        })
+        const graph = createMockGraph([rootNode, subgraphNode])
+        rootNode.graph = graph
+        subgraphNode.graph = graph
+        subNode.graph = subgraph
+        const executionIds = new Set([
+          createNodeExecutionId([toNodeId(1)]),
+          createNodeExecutionId([toNodeId(2), toNodeId(10)]),
+          createNodeExecutionId([toNodeId(999)])
+        ])
+
+        expect(getActiveGraphNodeIds(graph, graph, executionIds)).toEqual(
+          new Set(['1'])
+        )
+        expect(getActiveGraphNodeIds(graph, subgraph, executionIds)).toEqual(
+          new Set(['10'])
+        )
       })
     })
   })

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -549,7 +549,7 @@ export function getExecutionIdFromNodeData(
  * @returns The node if found, null otherwise
  */
 export function getNodeByLocatorId(
-  rootGraph: LGraph,
+  rootGraph: LGraph | null,
   locatorId: string
 ): LGraphNode | null {
   if (!rootGraph) return null

--- a/src/utils/gridUtil.test.ts
+++ b/src/utils/gridUtil.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createGridStyle } from '@/utils/gridUtil'
+
+describe('createGridStyle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses auto-fill columns by default', () => {
+    expect(createGridStyle()).toEqual({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(15rem, 1fr))',
+      padding: '0',
+      gap: '1rem'
+    })
+  })
+
+  it('uses fixed columns when provided', () => {
+    expect(
+      createGridStyle({
+        columns: 3,
+        padding: '8px',
+        gap: '4px'
+      })
+    ).toEqual({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      padding: '8px',
+      gap: '4px'
+    })
+  })
+
+  it('warns and clamps invalid fixed columns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    expect(createGridStyle({ columns: -1 }).gridTemplateColumns).toBe(
+      'repeat(1, 1fr)'
+    )
+    expect(warn).toHaveBeenCalledWith(
+      'createGridStyle: columns must be >= 1, defaulting to 1'
+    )
+  })
+})

--- a/src/utils/imageUtil.test.ts
+++ b/src/utils/imageUtil.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { getGridThumbnailUrl, parseImageWidgetValue } from './imageUtil'
+import {
+  fitDimensionsToNodeWidth,
+  getGridThumbnailUrl,
+  is_all_same_aspect_ratio,
+  parseImageWidgetValue
+} from './imageUtil'
 
 describe('getGridThumbnailUrl', () => {
   it('adds a compact preview format to a full-resolution view URL', () => {
@@ -27,6 +32,20 @@ describe('getGridThumbnailUrl', () => {
   it('leaves non-view URLs (e.g. blob previews) untouched', () => {
     const blob = 'blob:http://localhost/abc-123'
     expect(getGridThumbnailUrl(blob)).toBe(blob)
+  })
+
+  it('leaves empty and malformed URLs untouched', () => {
+    expect(getGridThumbnailUrl('')).toBe('')
+    expect(getGridThumbnailUrl('http://[bad-url')).toBe('http://[bad-url')
+  })
+
+  it('preserves absolute URL shape when adding preview params', () => {
+    const result = getGridThumbnailUrl(
+      'https://comfy.local/api/view?filename=image.png&type=output'
+    )
+
+    expect(result).toMatch(/^https:\/\/comfy\.local\/api\/view\?/)
+    expect(result).toContain('preview=webp')
   })
 })
 
@@ -80,6 +99,55 @@ describe('parseImageWidgetValue', () => {
       filename: '',
       subfolder: '',
       type: 'input'
+    })
+  })
+})
+
+describe('is_all_same_aspect_ratio', () => {
+  function image(width: number, height: number) {
+    const img = document.createElement('img')
+    Object.defineProperty(img, 'naturalWidth', {
+      configurable: true,
+      value: width
+    })
+    Object.defineProperty(img, 'naturalHeight', {
+      configurable: true,
+      value: height
+    })
+    return img
+  }
+
+  it('accepts empty, single, and matching aspect ratio image sets', () => {
+    expect(is_all_same_aspect_ratio([])).toBe(true)
+    expect(is_all_same_aspect_ratio([image(10, 20)])).toBe(true)
+    expect(is_all_same_aspect_ratio([image(10, 20), image(30, 60)])).toBe(true)
+  })
+
+  it('rejects mismatched aspect ratios', () => {
+    expect(is_all_same_aspect_ratio([image(10, 20), image(20, 20)])).toBe(false)
+  })
+})
+
+describe('fitDimensionsToNodeWidth', () => {
+  it('scales image dimensions to the node width with a minimum height', () => {
+    expect(fitDimensionsToNodeWidth(400, 200, 100)).toEqual({
+      minWidth: 100,
+      minHeight: 64
+    })
+    expect(fitDimensionsToNodeWidth(200, 400, 100)).toEqual({
+      minWidth: 100,
+      minHeight: 200
+    })
+  })
+
+  it('returns zero dimensions when the aspect ratio is zero or NaN', () => {
+    expect(fitDimensionsToNodeWidth(0, 100, 200)).toEqual({
+      minWidth: 0,
+      minHeight: 0
+    })
+    expect(fitDimensionsToNodeWidth(0, 0, 200)).toEqual({
+      minWidth: 0,
+      minHeight: 0
     })
   })
 })

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -1,4 +1,5 @@
-import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
@@ -8,6 +9,7 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 
+import type { LinkId } from '@/types/linkId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
@@ -162,6 +164,26 @@ describe('fixBadLinks', () => {
     expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
   })
 
+  it('reports a missing target input link during a dry run', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, inputs: [createInput(null)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph)
+
+    expect(result).toMatchObject({
+      hasBadLinks: true,
+      fixed: false,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBeNull()
+  })
+
   it('removes the origin reference when the target input slot is missing', () => {
     const graph = createGraph({
       nodes: [
@@ -206,6 +228,53 @@ describe('fixBadLinks', () => {
     expect(graph.links).toEqual([])
   })
 
+  it('keeps the later target link when two links target the same input slot', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, outputs: [createOutput([2])] }),
+        createNode({ id: 3, inputs: [createInput(null)] })
+      ],
+      links: [
+        [1, 1, 0, 3, 0, '*'],
+        [2, 2, 0, 3, 0, '*']
+      ]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.nodes[1]?.outputs?.[0]?.links).toEqual([2])
+    expect(graph.nodes[2]?.inputs?.[0]?.link).toBe(2)
+    expect(graph.links).toEqual([[2, 2, 0, 3, 0, '*']])
+  })
+
+  it('reports stale origin references during a dry run', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, inputs: [createInput(2)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph)
+
+    expect(result).toMatchObject({
+      hasBadLinks: true,
+      fixed: false,
+      patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+    expect(graph.links).toEqual([[1, 1, 0, 2, 0, '*']])
+  })
+
   it('cleans dangling references when a linked node is missing', () => {
     const graph = createGraph({
       nodes: [createNode({ id: 2, inputs: [createInput(1)] })],
@@ -224,6 +293,24 @@ describe('fixBadLinks', () => {
     expect(graph.links).toEqual([])
   })
 
+  it('deletes missing-origin links when the target does not reference them', () => {
+    const graph = createGraph({
+      nodes: [createNode({ id: 2, inputs: [createInput(null)] })],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.inputs?.[0]?.link).toBeNull()
+    expect(graph.links).toEqual([])
+  })
+
   it('cleans dangling origin references when the target node is missing', () => {
     const graph = createGraph({
       nodes: [createNode({ id: 1, outputs: [createOutput([1])] })],
@@ -236,6 +323,24 @@ describe('fixBadLinks', () => {
       hasBadLinks: false,
       fixed: true,
       patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.links).toEqual([])
+  })
+
+  it('deletes missing-target links when the origin does not reference them', () => {
+    const graph = createGraph({
+      nodes: [createNode({ id: 1, outputs: [createOutput([])] })],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
       deleted: 1
     })
     expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
@@ -264,10 +369,10 @@ describe('fixBadLinks', () => {
 
   it('deletes stale links from live graph link maps', () => {
     const linkId = toLinkId(1)
-    const originNode = fromAny<LGraphNode, unknown>({
+    const originNode = fromPartial<LGraphNode>({
       id: toNodeId(1),
       outputs: [{ links: [linkId] }]
-    })
+    } as PartialDeep<LGraphNode>)
     const link = fromPartial<LLink>({
       id: linkId,
       origin_id: originNode.id,
@@ -276,13 +381,14 @@ describe('fixBadLinks', () => {
       target_slot: 0,
       type: '*'
     })
-    const links = new Map([[linkId, link]])
-    const graph = fromAny<LGraph, unknown>({
+    const links = new Map([[linkId, link]]) as Map<LinkId, LLink> &
+      Record<LinkId, LLink>
+    const graph = fromPartial<LGraph>({
       links,
       getNodeById: vi.fn((nodeId) =>
         nodeId === originNode.id ? originNode : null
       )
-    })
+    } as PartialDeep<LGraph>)
 
     const result = fixBadLinks(graph, { fix: true, silent: true })
 
@@ -316,5 +422,119 @@ describe('fixBadLinks', () => {
     })
     expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
     expect(logger.log).not.toHaveBeenCalled()
+  })
+
+  it('creates missing origin output slots in fix mode', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1 }),
+        createNode({ id: 2, inputs: [createInput(1)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+  })
+
+  it('deletes links whose serialized endpoints are both missing', () => {
+    const graph = createGraph({
+      nodes: [],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
+      deleted: 1
+    })
+    expect(graph.links).toEqual([])
+  })
+
+  it('ignores null serialized link entries', () => {
+    const graph = {
+      ...createGraph({
+        nodes: [createNode({ id: 1 })],
+        links: []
+      }),
+      links: [null]
+    }
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: false,
+      patched: 0,
+      deleted: 0
+    })
+    expect(graph.links).toEqual([])
+  })
+
+  it('deletes object-shaped serialized links', () => {
+    const objectLink = {
+      id: 1,
+      origin_id: 1,
+      origin_slot: 0,
+      target_id: 2,
+      target_slot: 0,
+      type: '*'
+    }
+    const graph = fromPartial<ISerialisedGraph>({
+      ...createGraph({
+        nodes: [],
+        links: []
+      })
+    } as PartialDeep<ISerialisedGraph>)
+    Reflect.set(graph, 'links', [objectLink])
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
+      deleted: 1
+    })
+    expect(graph.links).toEqual([])
+  })
+
+  it('treats invalid live graph endpoint ids as missing', () => {
+    const linkId = toLinkId(1)
+    const link = fromPartial<LLink>({
+      id: linkId,
+      origin_id: toNodeId(''),
+      origin_slot: 0,
+      target_id: toNodeId(''),
+      target_slot: 0,
+      type: '*'
+    })
+    const links = new Map([[linkId, link]]) as Map<LinkId, LLink> &
+      Record<LinkId, LLink>
+    const graph = fromPartial<LGraph>({
+      links,
+      getNodeById: vi.fn()
+    } as PartialDeep<LGraph>)
+
+    const result = fixBadLinks(graph, { fix: true, silent: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
+      deleted: 1
+    })
+    expect(graph.getNodeById).not.toHaveBeenCalled()
+    expect(links.has(linkId)).toBe(false)
   })
 })

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -283,7 +283,9 @@ export function fixBadLinks(
     return hasAny
   }
 
-  const links: Array<SerialisedLLinkArray | LLink> = Array.isArray(graph.links)
+  const links: Array<SerialisedLLinkArray | LLink | null> = Array.isArray(
+    graph.links
+  )
     ? graph.links
     : Array.from((graph as LGraph).links.values())
 

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,14 +1,56 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 
+import { LLink } from '@/lib/litegraph/src/LLink'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
-import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraph,
+  LGraphGroup,
+  LGraphNode,
+  LiteGraph,
+  Reroute
+} from '@/lib/litegraph/src/litegraph'
 import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import type {
+  ExportedSubgraph,
+  ISerialisedGraph
+} from '@/lib/litegraph/src/types/serialisation'
+import type {
+  IBaseWidget,
+  IComboWidget
+} from '@/lib/litegraph/src/types/widgets'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
 import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
-import { createNode, getWidgetIdForNode, resolveNode } from './litegraphUtil'
+import {
+  addToComboValues,
+  compressWidgetInputSlots,
+  createNode,
+  executeWidgetsCallback,
+  fixLinkInputSlots,
+  getItemsColorOption,
+  getLinkTypeColor,
+  getWidgetIdForNode,
+  isAnimatedOutput,
+  isAudioNode,
+  isImageNode,
+  isLGraphGroup,
+  isLGraphNode,
+  isLoad3dNode,
+  isReroute,
+  isVideoNode,
+  isVideoOutput,
+  migrateWidgetsValues,
+  resolveComboValues,
+  resolveNode,
+  resolveNodeWidget
+} from './litegraphUtil'
 
 const mockBringNodeToFront = vi.fn()
 
@@ -138,7 +180,7 @@ describe('createNode', () => {
     const newNode = new LGraphNode('LoadImage')
     const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(newNode)
     const graph = new LGraph()
-    vi.spyOn(graph, 'add').mockReturnValue(fromAny<LGraphNode, null>(null))
+    vi.spyOn(graph, 'add').mockReturnValue(null)
 
     await createNode(makeCanvas(graph), 'LoadImage')
 
@@ -189,5 +231,389 @@ describe('getWidgetIdForNode', () => {
   it('returns undefined for placeholder node id (-1)', () => {
     const node = fakeNode(-1)
     expect(getWidgetIdForNode(node, { name: 'x' })).toBeUndefined()
+  })
+})
+
+describe('media helpers', () => {
+  it('classifies preview media nodes', () => {
+    expect(isImageNode(undefined)).toBe(false)
+    expect(isVideoNode(undefined)).toBe(false)
+    expect(isAudioNode(undefined)).toBe(false)
+
+    const imageNode = new LGraphNode('Image')
+    imageNode.previewMediaType = 'image'
+    const imageWithImgs = Object.assign(new LGraphNode('Image'), {
+      previewMediaType: 'model' as const,
+      imgs: [document.createElement('img')]
+    })
+    const videoWithImgs = Object.assign(new LGraphNode('Video'), {
+      previewMediaType: 'video' as const,
+      imgs: [document.createElement('img')]
+    })
+    const videoNode = new LGraphNode('Video')
+    videoNode.previewMediaType = 'video'
+    const videoContainerNode = Object.assign(new LGraphNode('Video'), {
+      videoContainer: document.body
+    })
+    const audioNode = new LGraphNode('Audio')
+    audioNode.previewMediaType = 'audio'
+
+    expect(isImageNode(imageNode)).toBe(true)
+    expect(isImageNode(imageWithImgs)).toBe(true)
+    expect(isImageNode(videoWithImgs)).toBe(false)
+    expect(isVideoNode(videoNode)).toBe(true)
+    expect(isVideoNode(videoContainerNode)).toBe(true)
+    expect(isAudioNode(audioNode)).toBe(true)
+  })
+
+  it('distinguishes animated images from video outputs', () => {
+    expect(isAnimatedOutput(undefined)).toBe(false)
+    expect(isVideoOutput(undefined)).toBe(false)
+    expect(isAnimatedOutput({ animated: [false, true] })).toBe(true)
+    expect(isVideoOutput({ animated: [true] })).toBe(true)
+    expect(
+      isVideoOutput({
+        animated: [true],
+        images: [{ filename: 'clip.mp4' }]
+      })
+    ).toBe(true)
+    expect(
+      isVideoOutput({
+        animated: [true],
+        images: [{ filename: 'preview.webp' }]
+      })
+    ).toBe(false)
+    expect(
+      isVideoOutput({
+        animated: [true],
+        images: [{ filename: 'preview.png' }]
+      })
+    ).toBe(false)
+  })
+
+  it('detects 3d loader nodes', () => {
+    const modelNode = new LGraphNode('Load3D')
+    modelNode.type = 'Load3D'
+    const animationNode = new LGraphNode('Load3DAnimation')
+    animationNode.type = 'Load3DAnimation'
+    const imageNode = new LGraphNode('LoadImage')
+    imageNode.type = 'LoadImage'
+
+    expect(isLoad3dNode(modelNode)).toBe(true)
+    expect(isLoad3dNode(animationNode)).toBe(true)
+    expect(isLoad3dNode(imageNode)).toBe(false)
+  })
+})
+
+describe('combo widget helpers', () => {
+  function combo(values: IComboWidget['options']['values']): IComboWidget {
+    return fromPartial<IComboWidget>({
+      name: 'mode',
+      type: 'combo',
+      value: 'a',
+      options: { values }
+    })
+  }
+
+  it('resolves combo values from arrays, records, functions, and missing options', () => {
+    expect(resolveComboValues(combo(['a', 'b']))).toEqual(['a', 'b'])
+    expect(resolveComboValues(combo({ a: 'A', b: 'B' }))).toEqual(['a', 'b'])
+    expect(resolveComboValues(combo(() => ['x']))).toEqual(['x'])
+    expect(
+      resolveComboValues(fromPartial<IComboWidget>({ options: {} }))
+    ).toEqual([])
+  })
+
+  it('adds only missing array combo values', () => {
+    const widget = combo(['a'])
+
+    addToComboValues(widget, 'b')
+    addToComboValues(widget, 'b')
+
+    expect(widget.options.values).toEqual(['a', 'b'])
+  })
+
+  it('initializes missing combo options before adding values', () => {
+    const missingOptions = fromPartial<IComboWidget>({})
+    const missingValues = fromPartial<IComboWidget>({ options: {} })
+
+    addToComboValues(missingOptions, 'first')
+    addToComboValues(missingValues, 'second')
+
+    expect(missingOptions.options.values).toEqual(['first'])
+    expect(missingValues.options.values).toEqual(['second'])
+  })
+})
+
+describe('node utility helpers', () => {
+  it('classifies litegraph canvas item types', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('Node')
+    const group = new LGraphGroup('Group')
+    const reroute = new Reroute(toRerouteId(1), graph)
+
+    expect(isLGraphNode(node)).toBe(true)
+    expect(isLGraphNode(group)).toBe(false)
+    expect(isLGraphGroup(group)).toBe(true)
+    expect(isLGraphGroup(node)).toBe(false)
+    expect(isReroute(reroute)).toBe(true)
+    expect(isReroute(node)).toBe(false)
+  })
+
+  it('returns a shared color option only when all colorable items match', () => {
+    const red = { getColorOption: () => 'red', setColorOption: vi.fn() }
+    const redAgain = { getColorOption: () => 'red', setColorOption: vi.fn() }
+    const blue = { getColorOption: () => 'blue', setColorOption: vi.fn() }
+
+    expect(getItemsColorOption([red, redAgain, {}])).toBe('red')
+    expect(getItemsColorOption([red, blue])).toBeNull()
+    expect(getItemsColorOption([{}])).toBeNull()
+  })
+
+  it('executes matching callbacks on node widgets', () => {
+    const onRemove = vi.fn()
+    const afterQueued = vi.fn()
+    const node = new LGraphNode('Callbacks')
+    node.widgets = [
+      fromPartial<IBaseWidget>({ onRemove }),
+      fromPartial<IBaseWidget>({ afterQueued })
+    ]
+
+    executeWidgetsCallback([node], 'onRemove')
+
+    expect(onRemove).toHaveBeenCalledOnce()
+    expect(afterQueued).not.toHaveBeenCalled()
+  })
+
+  it('returns configured link colors with the default fallback', () => {
+    expect(getLinkTypeColor('missing-type')).toBe(LiteGraph.LINK_COLOR)
+  })
+})
+
+describe('legacy workflow migration helpers', () => {
+  it('repairs root and subgraph link input slots from current input order', () => {
+    const graph = new LGraph()
+    const source = new LGraphNode('Source')
+    source.id = toNodeId(1)
+    const target = new LGraphNode('Target')
+    target.id = toNodeId(2)
+    target.inputs = [
+      fromPartial({ name: 'unlinked', link: null }),
+      fromPartial({ name: 'missing', link: toLinkId(99) }),
+      fromPartial({ name: 'linked', link: toLinkId(7) })
+    ]
+    const link = new LLink(toLinkId(7), 'STRING', source.id, 0, target.id, 10)
+    graph.add(source)
+    graph.add(target)
+    graph.links.set(link.id, link)
+
+    const subgraph = createTestSubgraph({ nodeCount: 0 })
+    const innerSource = new LGraphNode('InnerSource')
+    innerSource.id = toNodeId(3)
+    const innerTarget = new LGraphNode('InnerTarget')
+    innerTarget.id = toNodeId(4)
+    innerTarget.inputs = [
+      fromPartial({ name: 'inner-unlinked', link: null }),
+      fromPartial({ name: 'inner-linked', link: toLinkId(8) })
+    ]
+    const innerLink = new LLink(
+      toLinkId(8),
+      'STRING',
+      innerSource.id,
+      0,
+      innerTarget.id,
+      12
+    )
+    subgraph.add(innerSource)
+    subgraph.add(innerTarget)
+    subgraph.links.set(innerLink.id, innerLink)
+
+    const host = new LGraphNode('Host')
+    host.id = toNodeId(5)
+    vi.spyOn(host, 'isSubgraphNode').mockReturnValue(true)
+    Object.assign(host, { subgraph })
+    graph.add(host)
+
+    fixLinkInputSlots(graph)
+
+    expect(link.target_slot).toBe(2)
+    expect(innerLink.target_slot).toBe(1)
+  })
+
+  it('drops legacy force-input widget values only when lengths match', () => {
+    const inputDefs = {
+      seed: { name: 'seed', type: 'INT', forceInput: true },
+      mode: { name: 'mode', type: 'STRING' },
+      batch: {
+        name: 'batch',
+        type: 'INT',
+        control_after_generate: true
+      }
+    }
+    const widgets = [
+      fromPartial<IBaseWidget>({ name: 'mode' }),
+      fromPartial<IBaseWidget>({ name: 'batch' })
+    ]
+
+    expect(migrateWidgetsValues(inputDefs, widgets, [1, 2, 3, 4])).toEqual([
+      2, 3, 4
+    ])
+    expect(migrateWidgetsValues(inputDefs, widgets, [1, 2])).toEqual([1, 2])
+  })
+
+  it('compresses root and subgraph widget input slots', () => {
+    const graph = fromPartial<ISerialisedGraph>({
+      nodes: [
+        {
+          id: 1,
+          type: 'Node',
+          inputs: [
+            {
+              name: 'widget',
+              type: 'STRING',
+              link: null,
+              widget: { name: 'w' }
+            },
+            { name: 'kept', type: 'STRING', link: 7 }
+          ]
+        }
+      ],
+      links: [[7, 2, 0, 1, 99, 'STRING']],
+      definitions: {
+        subgraphs: [
+          {
+            name: 'Subgraph',
+            nodes: [
+              {
+                id: 3,
+                type: 'Inner',
+                inputs: [
+                  {
+                    name: 'legacy',
+                    type: 'STRING',
+                    link: null,
+                    widget: { name: 'legacy' }
+                  },
+                  { name: 'inner', type: 'STRING', link: 8 }
+                ]
+              }
+            ],
+            links: [
+              {
+                id: 8,
+                origin_id: 4,
+                origin_slot: 0,
+                target_id: 3,
+                target_slot: 42,
+                type: 'STRING'
+              }
+            ]
+          }
+        ]
+      }
+    })
+
+    compressWidgetInputSlots(graph)
+
+    expect(graph.nodes[0].inputs?.map((input) => input.name)).toEqual(['kept'])
+    expect(graph.links[0]?.[4]).toBe(0)
+    const subgraph = graph.definitions?.subgraphs?.[0]
+    expect(subgraph?.nodes?.[0].inputs?.map((input) => input.name)).toEqual([
+      'inner'
+    ])
+    expect(subgraph?.links?.[0].target_slot).toBe(0)
+  })
+
+  it('keeps labeled widget inputs and tolerates missing links', () => {
+    const graph = fromPartial<ISerialisedGraph>({
+      nodes: [
+        {
+          id: 1,
+          type: 'Node',
+          inputs: [
+            {
+              name: 'labeled',
+              type: 'STRING',
+              link: null,
+              label: 'Shown',
+              widget: { name: 'shown' }
+            },
+            { name: 'stale', type: 'STRING', link: 99 }
+          ]
+        },
+        { id: 2, type: 'NoInputs' }
+      ],
+      links: []
+    })
+
+    compressWidgetInputSlots(graph)
+
+    expect(graph.nodes[0].inputs?.map((input) => input.name)).toEqual([
+      'labeled',
+      'stale'
+    ])
+  })
+
+  it('handles subgraphs without nodes or links and detects cycles', () => {
+    const cyclic = fromPartial<ISerialisedGraph>({
+      nodes: [],
+      links: [],
+      definitions: { subgraphs: [] }
+    })
+    const child = fromPartial<ExportedSubgraph>({
+      name: 'child',
+      nodes: [{ id: 1, type: 'Inner' }]
+    })
+    cyclic.definitions?.subgraphs?.push(child)
+
+    expect(() => compressWidgetInputSlots(cyclic)).not.toThrow()
+
+    const loop = fromPartial<ExportedSubgraph>({
+      name: 'loop',
+      nodes: [],
+      definitions: { subgraphs: [] }
+    })
+    loop.definitions?.subgraphs?.push(loop)
+    const graph = fromPartial<ISerialisedGraph>({
+      nodes: [],
+      links: [],
+      definitions: { subgraphs: [loop] }
+    })
+
+    expect(() => compressWidgetInputSlots(graph)).toThrow(
+      'Infinite loop detected'
+    )
+  })
+})
+
+describe('resolveNodeWidget', () => {
+  it('resolves root graph nodes and widgets', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const graph = new LGraph()
+    const node = new LGraphNode('TestNode')
+    const widget = node.addWidget('text', 'prompt', 'hello', () => {})
+    graph.add(node)
+
+    expect(resolveNodeWidget(node.id, undefined, graph)).toEqual([node])
+    expect(resolveNodeWidget(node.id, 'prompt', graph)).toEqual([node, widget])
+    expect(resolveNodeWidget(node.id, 'missing', graph)).toEqual([])
+    expect(resolveNodeWidget('not-a-node-id', 'prompt', graph)).toEqual([])
+  })
+
+  it('resolves widgets exposed by subgraph host locators', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const graph = new LGraph()
+    const host = new LGraphNode('Host')
+    host.id = toNodeId(8)
+    const widget = host.addWidget('text', 'mode', 'fast', () => {})
+    graph.add(host)
+    vi.spyOn(host, 'isSubgraphNode').mockReturnValue(true)
+    const locator = createNodeLocatorId(
+      '00000000-0000-0000-0000-000000000001',
+      host.id
+    )
+
+    expect(resolveNodeWidget(locator, 'mode', graph)).toEqual([host, widget])
+    expect(resolveNodeWidget(locator, 'missing', graph)).toEqual([])
   })
 })

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -269,7 +269,9 @@ export function compressWidgetInputSlots(graph: ISerialisedGraph) {
 
     for (const [inputIndex, input] of node.inputs?.entries() ?? []) {
       if (input.link) {
-        const link = graph.links.find((link) => link[0] === input.link)
+        const link = graph.links.find(
+          (link) => link !== null && link[0] === input.link
+        )
         if (link) {
           link[4] = inputIndex
         }

--- a/src/utils/loaderNodeUtil.test.ts
+++ b/src/utils/loaderNodeUtil.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectNodeTypeFromFilename } from './loaderNodeUtil'
+
+describe('detectNodeTypeFromFilename', () => {
+  it.for([
+    ['image.png', { nodeType: 'LoadImage', widgetName: 'image' }],
+    ['clip.mp4', { nodeType: 'LoadVideo', widgetName: 'file' }],
+    ['sound.mp3', { nodeType: 'LoadAudio', widgetName: 'audio' }],
+    ['mesh.glb', { nodeType: null, widgetName: null }],
+    ['notes.txt', { nodeType: null, widgetName: null }]
+  ] as const)('maps %s to its loader node', ([filename, expected]) => {
+    expect(detectNodeTypeFromFilename(filename)).toEqual(expected)
+  })
+})

--- a/src/utils/mapperUtil.test.ts
+++ b/src/utils/mapperUtil.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import type { components } from '@/types/comfyRegistryTypes'
+import { registryToFrontendV2NodeDef } from '@/utils/mapperUtil'
+
+type RegistryNode = components['schemas']['ComfyNode']
+type RegistryPack = components['schemas']['Node']
+
+function nodeDef(over: Partial<RegistryNode> = {}): RegistryNode {
+  return over as RegistryNode
+}
+
+function pack(over: Partial<RegistryPack> = {}): RegistryPack {
+  return over as RegistryPack
+}
+
+describe('registryToFrontendV2NodeDef', () => {
+  it('maps outputs, defaulting names to types and is_list to false', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({
+        return_types: '["INT","IMAGE"]',
+        return_names: '["count",""]',
+        output_is_list: [true]
+      }),
+      pack()
+    )
+
+    expect(def.outputs).toEqual([
+      { type: 'INT', name: 'count', is_list: true, index: 0 },
+      { type: 'IMAGE', name: 'IMAGE', is_list: false, index: 1 }
+    ])
+  })
+
+  it('returns no outputs when return_types is empty or absent', () => {
+    expect(
+      registryToFrontendV2NodeDef(nodeDef({ return_types: '[]' }), pack())
+        .outputs
+    ).toEqual([])
+    expect(registryToFrontendV2NodeDef(nodeDef(), pack()).outputs).toEqual([])
+  })
+
+  it('maps required and optional inputs into keyed specs', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({
+        input_types: JSON.stringify({
+          required: { seed: ['INT', { default: 0 }] },
+          optional: { label: ['STRING', {}] }
+        })
+      }),
+      pack()
+    )
+
+    expect(Object.keys(def.inputs)).toEqual(['seed', 'label'])
+  })
+
+  it('returns no inputs when input_types is empty or absent', () => {
+    expect(registryToFrontendV2NodeDef(nodeDef(), pack()).inputs).toEqual({})
+    expect(
+      registryToFrontendV2NodeDef(nodeDef({ input_types: '{}' }), pack()).inputs
+    ).toEqual({})
+  })
+
+  it('applies field fallbacks for name, category, and python_module', () => {
+    const def = registryToFrontendV2NodeDef(nodeDef(), pack({ id: 'pack-id' }))
+
+    expect(def.name).toBe('Node Name')
+    expect(def.display_name).toBe('Node Name')
+    expect(def.category).toBe('unknown')
+    expect(def.python_module).toBe('pack-id') // name absent -> falls back to id
+  })
+
+  it('prefers explicit values over fallbacks', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({ comfy_node_name: 'KSampler', category: 'sampling' }),
+      pack({ name: 'comfy-core' })
+    )
+
+    expect(def.name).toBe('KSampler')
+    expect(def.category).toBe('sampling')
+    expect(def.python_module).toBe('comfy-core')
+  })
+})

--- a/src/utils/mouseDownUtil.test.ts
+++ b/src/utils/mouseDownUtil.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { whileMouseDown } from '@/utils/mouseDownUtil'
+
+describe('whileMouseDown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs until the element receives mouseup', () => {
+    const element = document.createElement('button')
+    const callback = vi.fn()
+
+    whileMouseDown(element, callback, 10)
+    vi.advanceTimersByTime(25)
+    element.dispatchEvent(new MouseEvent('mouseup'))
+    vi.advanceTimersByTime(30)
+
+    expect(callback.mock.calls).toEqual([[0], [1]])
+  })
+
+  it('uses the event target and stops on document mouseup', () => {
+    const element = document.createElement('button')
+    const event = new MouseEvent('mousedown')
+    Object.defineProperty(event, 'target', { value: element })
+    const callback = vi.fn()
+
+    whileMouseDown(event, callback, 5)
+    vi.advanceTimersByTime(12)
+    document.dispatchEvent(new MouseEvent('mouseup'))
+    vi.advanceTimersByTime(20)
+
+    expect(callback.mock.calls).toEqual([[0], [1]])
+  })
+})

--- a/src/utils/nodeTitleUtil.test.ts
+++ b/src/utils/nodeTitleUtil.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveNodeDisplayName } from '@/utils/nodeTitleUtil'
+
+const options = {
+  emptyLabel: 'Empty Node',
+  untitledLabel: 'Untitled Node',
+  st: vi.fn((key: string, fallback: string) => `${key}:${fallback}`)
+}
+
+describe('resolveNodeDisplayName', () => {
+  beforeEach(() => {
+    options.st.mockClear()
+  })
+
+  it('uses the empty label when no node is available', () => {
+    expect(resolveNodeDisplayName(null, options)).toBe('Empty Node')
+    expect(resolveNodeDisplayName(undefined, options)).toBe('Empty Node')
+    expect(options.st).not.toHaveBeenCalled()
+  })
+
+  it('prefers a trimmed explicit title', () => {
+    expect(
+      resolveNodeDisplayName(
+        { title: '  KSampler  ', type: 'Ignored' },
+        options
+      )
+    ).toBe('KSampler')
+    expect(options.st).not.toHaveBeenCalled()
+  })
+
+  it('translates the node type when the title is empty', () => {
+    expect(
+      resolveNodeDisplayName({ title: '', type: 'CLIP Text Encode' }, options)
+    ).toBe('nodeDefs.CLIP Text Encode.display_name:CLIP Text Encode')
+  })
+
+  it('falls back to the untitled label when title and type are empty', () => {
+    expect(resolveNodeDisplayName({ title: '', type: '' }, options)).toBe(
+      'nodeDefs.Untitled Node.display_name:Untitled Node'
+    )
+    expect(resolveNodeDisplayName({}, options)).toBe(
+      'nodeDefs.Untitled Node.display_name:Untitled Node'
+    )
+  })
+})

--- a/src/utils/objectUrlUtil.test.ts
+++ b/src/utils/objectUrlUtil.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createSharedObjectUrl,
+  releaseSharedObjectUrl,
+  retainSharedObjectUrl
+} from './objectUrlUtil'
+
+describe('objectUrlUtil', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retains and releases shared blob URLs by reference count', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL')
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+
+    const url = createSharedObjectUrl(new Blob(['data']))
+    retainSharedObjectUrl(url)
+    releaseSharedObjectUrl(url)
+
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    releaseSharedObjectUrl(url)
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(url)
+  })
+
+  it('ignores missing and non-blob URLs', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL')
+
+    retainSharedObjectUrl(undefined)
+    retainSharedObjectUrl('https://example.com/image.png')
+    releaseSharedObjectUrl(undefined)
+    releaseSharedObjectUrl('https://example.com/image.png')
+
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('starts retaining externally supplied blob URLs at zero', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL')
+
+    retainSharedObjectUrl('blob:external')
+    retainSharedObjectUrl('blob:external')
+    releaseSharedObjectUrl('blob:external')
+
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+
+    releaseSharedObjectUrl('blob:external')
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:external')
+  })
+
+  it('revokes unknown blob URLs once', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL')
+
+    releaseSharedObjectUrl('blob:unknown')
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:unknown')
+  })
+})

--- a/src/utils/queueDisplay.test.ts
+++ b/src/utils/queueDisplay.test.ts
@@ -21,21 +21,22 @@ function createJob(
   }
 }
 
-function createTask({
-  job,
-  jobId = 'job-123456',
-  createTime = 1_710_000_000_000,
-  executionTime,
-  executionTimeInSeconds,
-  previewOutput
-}: {
-  job?: Partial<JobListItem>
-  jobId?: string
-  createTime?: number
-  executionTime?: number
-  executionTimeInSeconds?: number
-  previewOutput?: PreviewOutput
-} = {}): QueueDisplayTask {
+function createTask(
+  options: {
+    job?: Partial<JobListItem>
+    jobId?: string | undefined
+    createTime?: number | undefined
+    executionTime?: number
+    executionTimeInSeconds?: number
+    previewOutput?: PreviewOutput
+  } = {}
+): QueueDisplayTask {
+  const { job, executionTime, executionTimeInSeconds, previewOutput } = options
+  const jobId = Object.hasOwn(options, 'jobId') ? options.jobId : 'job-123456'
+  const createTime = Object.hasOwn(options, 'createTime')
+    ? options.createTime
+    : 1_710_000_000_000
+
   return {
     job: createJob(job?.status ?? 'pending', job),
     jobId,
@@ -74,6 +75,12 @@ describe('iconForJobState', () => {
     ['failed', 'icon-[lucide--alert-circle]']
   ])('maps %s to its icon', ([state, icon]) => {
     expect(iconForJobState(state)).toBe(icon)
+  })
+
+  it('uses a neutral icon for unrecognized states', () => {
+    expect(iconForJobState('archived' as JobState)).toBe(
+      'icon-[lucide--circle]'
+    )
   })
 })
 
@@ -131,6 +138,23 @@ describe('buildJobDisplay', () => {
       secondary:
         'KSampler sideToolbar.queueProgressOverlay.colonPercent(percent=0%)',
       showClear: true
+    })
+  })
+
+  it('omits current node progress when the active job has no node name', () => {
+    expect(
+      buildJobDisplay(
+        createTask({ job: { status: 'in_progress' } }),
+        'running',
+        createCtx({
+          isActive: true,
+          totalPercent: 101,
+          currentNodePercent: 50
+        })
+      )
+    ).toMatchObject({
+      primary: 'sideToolbar.queueProgressOverlay.total(percent=100%)',
+      secondary: ''
     })
   })
 
@@ -196,6 +220,26 @@ describe('buildJobDisplay', () => {
     })
   })
 
+  it('shows zero elapsed time for cloud completed jobs without timing', () => {
+    expect(
+      buildJobDisplay(
+        createTask({
+          job: {
+            status: 'completed'
+          }
+        }),
+        'completed',
+        createCtx({ isCloud: true })
+      )
+    ).toEqual({
+      iconName: 'icon-[lucide--check-check]',
+      iconImageUrl: undefined,
+      primary: 'queue.completedIn(duration=0s)',
+      secondary: '',
+      showClear: false
+    })
+  })
+
   it('falls back to job title for completed jobs without a preview filename', () => {
     expect(
       buildJobDisplay(
@@ -216,11 +260,88 @@ describe('buildJobDisplay', () => {
     })
   })
 
+  it('builds completed fallback titles from job id or the generic label', () => {
+    expect(
+      buildJobDisplay(
+        createTask({
+          jobId: 'abcdef-123',
+          job: { status: 'completed', priority: undefined }
+        }),
+        'completed',
+        createCtx()
+      ).primary
+    ).toBe('g.job abcdef')
+
+    expect(
+      buildJobDisplay(
+        createTask({
+          jobId: undefined,
+          job: { status: 'completed', id: '', priority: undefined }
+        }),
+        'completed',
+        createCtx()
+      ).primary
+    ).toBe('g.job')
+  })
+
+  it('leaves completed non-image previews without icon URLs', () => {
+    expect(
+      buildJobDisplay(
+        createTask({
+          job: {
+            status: 'completed'
+          },
+          previewOutput: {
+            filename: 'preview.json',
+            isImage: false,
+            url: '/api/view?filename=preview.json&type=output&subfolder='
+          } as PreviewOutput
+        }),
+        'completed',
+        createCtx()
+      )
+    ).toMatchObject({
+      iconImageUrl: undefined,
+      primary: 'preview.json',
+      secondary: ''
+    })
+  })
+
+  it('uses an empty queued timestamp when create time is unavailable', () => {
+    expect(
+      buildJobDisplay(
+        createTask({ createTime: undefined }),
+        'pending',
+        createCtx()
+      ).secondary
+    ).toBe('')
+  })
+
   it('shows failed jobs as clearable failures', () => {
     expect(buildJobDisplay(createTask(), 'failed', createCtx())).toEqual({
       iconName: 'icon-[lucide--alert-circle]',
       primary: 'g.failed',
       secondary: 'g.failed',
+      showClear: true
+    })
+  })
+
+  it('builds a clearable fallback display for unknown states', () => {
+    expect(
+      buildJobDisplay(
+        createTask({
+          job: {
+            priority: undefined
+          },
+          jobId: 'abcdef-123'
+        }),
+        'archived' as JobState,
+        createCtx()
+      )
+    ).toEqual({
+      iconName: 'icon-[lucide--circle]',
+      primary: 'g.job abcdef',
+      secondary: '',
       showClear: true
     })
   })

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createRafBatch } from './rafBatch'
+
+describe('createRafBatch', () => {
+  const callbacks = new Map<number, FrameRequestCallback>()
+  const cancelAnimationFrame = vi.fn()
+
+  beforeEach(() => {
+    callbacks.clear()
+    cancelAnimationFrame.mockClear()
+    let nextId = 0
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = ++nextId
+        callbacks.set(id, callback)
+        return id
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('coalesces scheduled work into one animation frame', () => {
+    const run = vi.fn()
+    const batch = createRafBatch(run)
+
+    batch.schedule()
+    batch.schedule()
+
+    expect(requestAnimationFrame).toHaveBeenCalledOnce()
+    expect(batch.isScheduled()).toBe(true)
+
+    callbacks.get(1)?.(0)
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(batch.isScheduled()).toBe(false)
+  })
+
+  it('cancels and flushes scheduled work', () => {
+    const run = vi.fn()
+    const batch = createRafBatch(run)
+
+    batch.cancel()
+    batch.flush()
+
+    expect(cancelAnimationFrame).not.toHaveBeenCalled()
+    expect(run).not.toHaveBeenCalled()
+
+    batch.schedule()
+    batch.cancel()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+    expect(batch.isScheduled()).toBe(false)
+
+    batch.schedule()
+    batch.flush()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(2)
+    expect(run).toHaveBeenCalledOnce()
+    expect(batch.isScheduled()).toBe(false)
+  })
+})

--- a/src/utils/searchAndReplace.test.ts
+++ b/src/utils/searchAndReplace.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { PartialDeep } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
 
 import { LGraph } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
+
+function createGraph(nodes: LGraphNode[]) {
+  const graph = new LGraph()
+  for (const node of nodes) {
+    graph.add(node)
+  }
+  return graph
+}
 
 describe('applyTextReplacements', () => {
   // Test specifically the filename sanitization part
@@ -82,5 +92,128 @@ describe('applyTextReplacements', () => {
       const result = applyTextReplacements(mockGraph, '%TestNode.testWidget%')
       expect(result).toBe(validChars)
     })
+  })
+
+  it('uses the node S&R property name before falling back to title', () => {
+    const graph = createGraph([
+      fromPartial<LGraphNode>({
+        title: 'AliasTitle',
+        properties: { 'Node name for S&R': 'Alias' },
+        widgets: [{ name: 'prompt', value: 'from-alias' }]
+      } as PartialDeep<LGraphNode>),
+      {
+        title: 'VisibleTitle',
+        widgets: [{ name: 'prompt', value: 'from-title' }]
+      } as LGraphNode
+    ])
+
+    expect(applyTextReplacements(graph, '%Alias.prompt%')).toBe('from-alias')
+    expect(applyTextReplacements(graph, '%VisibleTitle.prompt%')).toBe(
+      'from-title'
+    )
+  })
+
+  it('formats date replacements using the current date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-02T03:04:05'))
+
+    try {
+      expect(
+        applyTextReplacements(new LGraph(), '%date:yyyy-MM-dd_hh-mm-ss%')
+      ).toBe('2026-07-02_03-04-05')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps unsupported one-part replacements without warning for dimensions', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const graph = new LGraph()
+
+    expect(applyTextReplacements(graph, '%width% %height%')).toBe(
+      '%width% %height%'
+    )
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
+  it('warns and keeps invalid replacement patterns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(applyTextReplacements(new LGraph(), '%too.many.parts%')).toBe(
+      '%too.many.parts%'
+    )
+
+    expect(warn).toHaveBeenCalledWith(
+      'Invalid replacement pattern',
+      'too.many.parts'
+    )
+    warn.mockRestore()
+  })
+
+  it('warns when no node matches the replacement', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(applyTextReplacements(new LGraph(), '%Missing.prompt%')).toBe(
+      '%Missing.prompt%'
+    )
+
+    expect(warn).toHaveBeenCalledWith('Unable to find node', 'Missing')
+    warn.mockRestore()
+  })
+
+  it('warns and uses the first node when multiple nodes match', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const graph = createGraph([
+      {
+        title: 'Duplicate',
+        widgets: [{ name: 'prompt', value: 'first' }]
+      } as LGraphNode,
+      {
+        title: 'Duplicate',
+        widgets: [{ name: 'prompt', value: 'second' }]
+      } as LGraphNode
+    ])
+
+    expect(applyTextReplacements(graph, '%Duplicate.prompt%')).toBe('first')
+    expect(warn).toHaveBeenCalledWith(
+      'Multiple nodes matched',
+      'Duplicate',
+      'using first match'
+    )
+    warn.mockRestore()
+  })
+
+  it('warns when the matched node does not have the requested widget', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const node = {
+      title: 'Node',
+      widgets: [{ name: 'other', value: 'value' }]
+    } as LGraphNode
+    const graph = createGraph([node])
+
+    expect(applyTextReplacements(graph, '%Node.prompt%')).toBe('%Node.prompt%')
+    expect(warn).toHaveBeenCalledWith(
+      'Unable to find widget',
+      'prompt',
+      'on node',
+      'Node',
+      node
+    )
+    warn.mockRestore()
+  })
+
+  it('replaces nullish widget values with an empty string', () => {
+    const graph = createGraph([
+      Object.assign(fromPartial<LGraphNode>({}), {
+        title: 'Node',
+        widgets: [{ name: 'prompt', value: null }]
+      })
+    ])
+
+    expect(applyTextReplacements(graph, 'before%Node.prompt%after')).toBe(
+      'beforeafter'
+    )
   })
 })

--- a/src/utils/treeUtil.test.ts
+++ b/src/utils/treeUtil.test.ts
@@ -1,7 +1,22 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it } from 'vitest'
 
 import type { TreeNode } from '@/types/treeExplorerTypes'
-import { buildTree, sortedTree } from '@/utils/treeUtil'
+import {
+  buildTree,
+  combineTrees,
+  findNodeByKey,
+  flattenTree,
+  sortedTree,
+  unwrapTreeRoot
+} from '@/utils/treeUtil'
+
+const createTreeNode = (label: string, leaf = false): TreeNode => ({
+  key: label,
+  label,
+  leaf,
+  children: []
+})
 
 describe('buildTree', () => {
   it('should handle empty folder items correctly', () => {
@@ -65,6 +80,100 @@ describe('buildTree', () => {
   })
 })
 
+describe('unwrapTreeRoot', () => {
+  it('promotes the single non-leaf folder child', () => {
+    const tree: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [
+        {
+          key: 'root/a',
+          label: 'a',
+          leaf: false,
+          children: [createTreeNode('child', true)]
+        }
+      ]
+    }
+
+    expect(unwrapTreeRoot(tree).children?.map((node) => node.key)).toEqual([
+      'child'
+    ])
+  })
+
+  it('keeps roots with leaf, empty, or multiple children intact', () => {
+    const leafRoot: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [createTreeNode('leaf', true)]
+    }
+    const emptyFolderRoot: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [createTreeNode('folder')]
+    }
+    const multiRoot: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [createTreeNode('a'), createTreeNode('b')]
+    }
+    const childWithoutChildren: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [
+        {
+          key: 'root/a',
+          label: 'a',
+          leaf: false
+        }
+      ]
+    }
+
+    expect(unwrapTreeRoot(leafRoot)).toBe(leafRoot)
+    expect(unwrapTreeRoot(emptyFolderRoot)).toBe(emptyFolderRoot)
+    expect(unwrapTreeRoot(multiRoot)).toBe(multiRoot)
+    expect(unwrapTreeRoot(childWithoutChildren)).toBe(childWithoutChildren)
+  })
+})
+
+describe('flattenTree', () => {
+  it('returns data from leaf nodes only', () => {
+    const tree: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [
+        {
+          key: 'folder',
+          label: 'folder',
+          children: [
+            {
+              key: 'leaf-a',
+              label: 'leaf-a',
+              leaf: true,
+              data: { path: 'a' }
+            },
+            {
+              key: 'leaf-b',
+              label: 'leaf-b',
+              leaf: true
+            }
+          ]
+        },
+        {
+          key: 'leaf-c',
+          label: 'leaf-c',
+          leaf: true,
+          data: { path: 'c' }
+        }
+      ]
+    }
+
+    expect(flattenTree<{ path: string }>(tree)).toEqual([
+      { path: 'c' },
+      { path: 'a' }
+    ])
+  })
+})
+
 describe('sortedTree', () => {
   const createNode = (label: string, leaf = false): TreeNode => ({
     key: label,
@@ -92,6 +201,24 @@ describe('sortedTree', () => {
     expect(result.children?.map((c) => c.label)).toEqual(['a', 'b', 'c'])
   })
 
+  it('sorts children with missing labels by the empty-label fallback', () => {
+    const unlabeled = fromPartial<TreeNode>({
+      key: 'missing',
+      leaf: true
+    })
+    const node: TreeNode = {
+      key: 'root',
+      label: 'root',
+      leaf: false,
+      children: [unlabeled, createNode('a', true)]
+    }
+
+    expect(sortedTree(node).children?.map((c) => c.key)).toEqual([
+      'missing',
+      'a'
+    ])
+  })
+
   describe('with groupLeaf=true', () => {
     it('should group folders before files', () => {
       const node: TreeNode = {
@@ -108,6 +235,33 @@ describe('sortedTree', () => {
       const result = sortedTree(node, { groupLeaf: true })
       const labels = result.children?.map((c) => c.label)
       expect(labels).toEqual(['folder1', 'folder2', 'another.txt', 'file.txt'])
+    })
+
+    it('sorts grouped children with missing labels', () => {
+      const unlabeledFolder = fromPartial<TreeNode>({
+        key: 'folder-missing',
+        leaf: false,
+        children: []
+      })
+      const unlabeledFile = fromPartial<TreeNode>({
+        key: 'file-missing',
+        leaf: true,
+        children: []
+      })
+      const node: TreeNode = {
+        key: 'root',
+        label: 'root',
+        children: [
+          createNode('folder-b'),
+          unlabeledFolder,
+          createNode('file-b', true),
+          unlabeledFile
+        ]
+      }
+
+      expect(
+        sortedTree(node, { groupLeaf: true }).children?.map((c) => c.key)
+      ).toEqual(['folder-missing', 'folder-b', 'file-missing', 'file-b'])
     })
 
     it('should sort recursively', () => {
@@ -143,5 +297,55 @@ describe('sortedTree', () => {
 
     const result = sortedTree(node)
     expect(result).toEqual(node)
+  })
+})
+
+describe('findNodeByKey', () => {
+  it('returns the matching nested node or null', () => {
+    const child = createTreeNode('root/child')
+    const tree: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [child]
+    }
+
+    expect(findNodeByKey(tree, 'root')).toBe(tree)
+    expect(findNodeByKey(tree, 'root/child')).toBe(child)
+    expect(findNodeByKey(tree, 'missing')).toBeNull()
+    expect(findNodeByKey(createTreeNode('root'), 'missing')).toBeNull()
+  })
+})
+
+describe('combineTrees', () => {
+  it('adds a cloned subtree under its matching parent', () => {
+    const root: TreeNode = {
+      key: 'root',
+      label: 'root',
+      children: [{ key: 'root/a', label: 'a', children: [] }]
+    }
+    const subtree: TreeNode = {
+      key: 'root/a/b',
+      label: 'b',
+      leaf: true,
+      data: { path: 'b' }
+    }
+
+    const combined = combineTrees(root, subtree)
+
+    expect(combined).not.toBe(root)
+    expect(combined.children?.[0].children?.[0]).toEqual(subtree)
+    expect(combined.children?.[0].children?.[0]).not.toBe(subtree)
+  })
+
+  it('returns a clone unchanged when the parent key is absent', () => {
+    const root: TreeNode = { key: 'root', label: 'root' }
+    const combined = combineTrees(root, {
+      key: 'root/missing/leaf',
+      label: 'leaf',
+      leaf: true
+    })
+
+    expect(combined).toEqual(root)
+    expect(combined).not.toBe(root)
   })
 })

--- a/src/utils/typeGuardUtil.test.ts
+++ b/src/utils/typeGuardUtil.test.ts
@@ -1,15 +1,57 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { isSubgraphIoNode } from '@/utils/typeGuardUtil'
+import {
+  isAbortError,
+  isNonNullish,
+  isResultItemType,
+  isSlotObject,
+  isSubgraph,
+  isSubgraphIoNode
+} from '@/utils/typeGuardUtil'
 
 type NodeConstructor = { comfyClass?: string }
 
 function createMockNode(nodeConstructor?: NodeConstructor): LGraphNode {
-  return { constructor: nodeConstructor } as Partial<LGraphNode> as LGraphNode
+  return fromPartial<LGraphNode>({ constructor: nodeConstructor })
 }
 
 describe('typeGuardUtil', () => {
+  describe('isAbortError', () => {
+    it('matches AbortError DOMExceptions only', () => {
+      expect(isAbortError(new DOMException('cancelled', 'AbortError'))).toBe(
+        true
+      )
+      expect(isAbortError(new DOMException('failed', 'NetworkError'))).toBe(
+        false
+      )
+      expect(isAbortError({ name: 'AbortError' })).toBe(false)
+    })
+  })
+
+  describe('isSubgraph', () => {
+    it('matches non-root graphs only', () => {
+      const subgraph = {
+        isRootGraph: false
+      } as Parameters<typeof isSubgraph>[0]
+      const rootGraph = {
+        isRootGraph: true
+      } as Parameters<typeof isSubgraph>[0]
+
+      expect(isSubgraph(subgraph)).toBe(true)
+      expect(isSubgraph(rootGraph)).toBe(false)
+      expect(isSubgraph(null)).toBe(false)
+    })
+  })
+
+  describe('isNonNullish', () => {
+    it('filters nullish values without dropping falsy data', () => {
+      const values = [0, '', null, undefined, false, 'ok']
+      expect(values.filter(isNonNullish)).toEqual([0, '', false, 'ok'])
+    })
+  })
+
   describe('isSubgraphIoNode', () => {
     it('should identify SubgraphInputNode as IO node', () => {
       const node = createMockNode({ comfyClass: 'SubgraphInputNode' })
@@ -39,6 +81,24 @@ describe('typeGuardUtil', () => {
       const node = createMockNode({})
 
       expect(isSubgraphIoNode(node)).toBe(false)
+    })
+  })
+
+  describe('isSlotObject', () => {
+    it('requires the slot shape fields', () => {
+      expect(
+        isSlotObject({ name: 'image', type: 'IMAGE', boundingRect: [] })
+      ).toBe(true)
+      expect(isSlotObject(null)).toBe(false)
+      expect(isSlotObject({ name: 'image', type: 'IMAGE' })).toBe(false)
+    })
+  })
+
+  describe('isResultItemType', () => {
+    it('recognizes backend result buckets', () => {
+      expect(['input', 'output', 'temp'].every(isResultItemType)).toBe(true)
+      expect(isResultItemType('cache')).toBe(false)
+      expect(isResultItemType(undefined)).toBe(false)
     })
   })
 })

--- a/src/utils/uuid.test.ts
+++ b/src/utils/uuid.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createUuidv4 } from './uuid'
+
+describe('uuid utilities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses crypto.randomUUID when available', () => {
+    const randomUUID = vi.fn(() => 'native-uuid')
+    const getRandomValues = vi.fn()
+    vi.stubGlobal('crypto', { randomUUID, getRandomValues })
+
+    expect(createUuidv4()).toBe('native-uuid')
+    expect(randomUUID).toHaveBeenCalledOnce()
+    expect(getRandomValues).not.toHaveBeenCalled()
+  })
+
+  it('falls back to crypto.getRandomValues', () => {
+    const getRandomValues = vi.fn((storage: Uint32Array) => storage.fill(0))
+    vi.stubGlobal('crypto', { getRandomValues })
+
+    expect(createUuidv4()).toBe('10000000-1000-4000-8000-100000000000')
+    expect(getRandomValues).toHaveBeenCalledWith(expect.any(Uint32Array))
+  })
+
+  it('falls back to Math.random when crypto is unavailable', () => {
+    vi.stubGlobal('crypto', undefined)
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    expect(createUuidv4()).toBe('10000000-1000-4000-8000-100000000000')
+  })
+})

--- a/src/utils/vintageClipboard.test.ts
+++ b/src/utils/vintageClipboard.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+import {
+  createMockCanvas,
+  createMockLGraph,
+  createMockLGraphNode
+} from '@/utils/__tests__/litegraphTestUtils'
+import { deserialiseAndCreate } from '@/utils/vintageClipboard'
+
+vi.mock('@/platform/telemetry/nodeAdded/nodeAddSource', () => ({
+  withNodeAddSource: (_source: string, callback: () => void) => callback()
+}))
+
+function createNode() {
+  const node = createMockLGraphNode({ connect: vi.fn() })
+  node.configure = vi.fn((info: ISerialisedNode) => {
+    node.pos = [...info.pos]
+  })
+  return node
+}
+
+function createCanvas() {
+  return createMockCanvas({
+    graph: createMockLGraph({
+      beforeChange: vi.fn(),
+      afterChange: vi.fn(),
+      add: vi.fn()
+    }),
+    graph_mouse: [100, 200] as [number, number],
+    emitBeforeChange: vi.fn(),
+    emitAfterChange: vi.fn(),
+    selectNodes: vi.fn()
+  })
+}
+
+describe('deserialiseAndCreate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing for empty clipboard data', () => {
+    const canvas = createCanvas()
+
+    deserialiseAndCreate('', canvas)
+
+    expect(canvas.emitBeforeChange).not.toHaveBeenCalled()
+  })
+
+  it('creates pasted nodes relative to the canvas pointer and connects links', () => {
+    const canvas = createCanvas()
+    const first = createNode()
+    const second = createNode()
+    vi.spyOn(LiteGraph, 'createNode')
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+    const data = JSON.stringify({
+      nodes: [
+        { type: 'First', pos: [10, 20] },
+        { type: 'Second', pos: [30, 40] }
+      ],
+      links: [[0, 0, 1, 0]]
+    })
+
+    deserialiseAndCreate(data, canvas)
+
+    expect(canvas.emitBeforeChange).toHaveBeenCalled()
+    expect(canvas.graph!.beforeChange).toHaveBeenCalled()
+    expect(first.configure).toHaveBeenCalledWith({
+      type: 'First',
+      pos: [10, 20]
+    })
+    expect(second.configure).toHaveBeenCalledWith({
+      type: 'Second',
+      pos: [30, 40]
+    })
+    expect(first.pos).toEqual([100, 200])
+    expect(second.pos).toEqual([120, 220])
+    expect(canvas.graph!.add).toHaveBeenNthCalledWith(1, first, true)
+    expect(canvas.graph!.add).toHaveBeenNthCalledWith(2, second, true)
+    expect(first.connect).toHaveBeenCalledWith(0, second, 0)
+    expect(canvas.selectNodes).toHaveBeenCalledWith([first, second])
+    expect(canvas.graph!.afterChange).toHaveBeenCalled()
+    expect(canvas.emitAfterChange).toHaveBeenCalled()
+  })
+
+  it('skips nodes that cannot be created and warns for unresolved links', () => {
+    const canvas = createCanvas()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const node = createNode()
+    vi.spyOn(LiteGraph, 'createNode')
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(node)
+    const data = JSON.stringify({
+      nodes: [
+        { type: 'Missing', pos: [0, 0] },
+        { type: 'Present', pos: [10, 10] }
+      ],
+      links: [[0, 0, 1, 0]]
+    })
+
+    deserialiseAndCreate(data, canvas)
+
+    expect(canvas.graph!.add).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith('Warning, nodes missing on pasting')
+    expect(canvas.emitAfterChange).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Canary PR that replays #13362 on top of #13486 to verify CodeRabbit honors the pending test path instructions before #13486 merges.

## Changes

- **What**: Applies the existing #13362 diff as one clean commit on top of `codex/coderabbit-test-quality-path-instructions`.
- **Dependencies**: None.

## Review Focus

- Confirm CodeRabbit uses the #13486 `.coderabbit.yaml` path instructions for changed `**/*.test.ts` and `src/lib/litegraph/**/*.test.ts` files.
- This PR is verification-only and should be closed after CodeRabbit review confirms behavior.

Created by Codex