### PR TITLE
test(website): expect 6 cloud model cards after GPT Image 2 addition

### DIFF
--- a/apps/website/e2e/cloud.spec.ts
+++ b/apps/website/e2e/cloud.spec.ts
@@ -40,7 +40,7 @@ test.describe('Cloud page @smoke', () => {
     }
   })
 
-  test('AIModelsSection heading and 5 model cards are visible', async ({
+  test('AIModelsSection heading and 6 model cards are visible', async ({
     page
   }) => {
     const heading = page.getByRole('heading', { name: /leading AI models/i })
@@ -49,7 +49,7 @@ test.describe('Cloud page @smoke', () => {
     const section = heading.locator('xpath=ancestor::section')
     const grid = section.locator('.grid')
     const modelCards = grid.locator('a[href="https://comfy.org/workflows"]')
-    await expect(modelCards).toHaveCount(5)
+    await expect(modelCards).toHaveCount(6)
   })
 
   test('AIModelsSection CTA links to workflows', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fix the `website-e2e` suite that has been red on `main` since #13431, which added GPT Image 2 as a 6th card to `AIModelsSection` but left the cloud smoke test asserting 5.

## Changes

- **What**: Update `cloud.spec.ts` model-card assertion from `toHaveCount(5)` to `toHaveCount(6)` (and the test name) to match the 6 cards now rendered in the "leading AI models" grid.

## Review Focus

`AIModelsSection.vue` `modelCards` currently has 6 entries (seedance20, nanoBananaPro, grokImagine, qwenImageEdit, wan22TextToVideo, gptImage2); each renders one `a[href=workflows]` inside `.grid`. The section CTA link sits outside `.grid` and is not counted.

Note: this addresses only the deterministic count regression. The `website-e2e` job may still intermittently fail on flaky product-cards visual diffs (~1% pixel jitter) and the two FAQ interaction tests; those need a separate stabilization PR.
