### PR TITLE
[Feature Request]: Automatically change workflow tab layout on mobile screen #2891

### DIFF
--- a/browser_tests/tests/workflowTabsMobile.spec.ts
+++ b/browser_tests/tests/workflowTabsMobile.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+const MIN_TOUCH_WIDTH = 120
+const MIN_TOUCH_HEIGHT = 44
+
+test.describe(
+  'Workflow Tabs on mobile',
+  { tag: ['@mobile', '@workflow'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.Workflow.WorkflowTabsPosition',
+        'Topbar'
+      )
+      await comfyPage.setup()
+    })
+
+    test('@mobile enlarges tab touch targets instead of squishing them', async ({
+      comfyPage
+    }) => {
+      await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
+      await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
+
+      const tabs = comfyPage.page.locator('.workflow-tabs .p-togglebutton')
+      await expect(tabs).not.toHaveCount(0)
+
+      const count = await tabs.count()
+      for (let i = 0; i < count; i++) {
+        const box = await tabs.nth(i).boundingBox()
+        expect(box).not.toBeNull()
+        expect(box!.width).toBeGreaterThanOrEqual(MIN_TOUCH_WIDTH)
+        expect(box!.height).toBeGreaterThanOrEqual(MIN_TOUCH_HEIGHT)
+      }
+    })
+
+    test('@mobile keeps the horizontal strip with overflow scrolling', async ({
+      comfyPage
+    }) => {
+      for (let i = 0; i < 4; i++) {
+        await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
+      }
+
+      const strip = comfyPage.page.getByTestId('topbar-workflow-tabs')
+      await expect(strip).toBeVisible()
+
+      const scrollContent = comfyPage.page.locator('.p-scrollpanel-content')
+      await expect
+        .poll(() =>
+          scrollContent.evaluate((el) => el.scrollWidth > el.clientWidth)
+        )
+        .toBe(true)
+    })
+  }
+)

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -2,7 +2,10 @@
   <div
     ref="containerRef"
     class="workflow-tabs-container flex h-full max-w-full flex-auto flex-row overflow-hidden"
-    :class="{ 'workflow-tabs-container-desktop': isDesktop }"
+    :class="{
+      'workflow-tabs-container-desktop': isDesktop,
+      'workflow-tabs-container-mobile': isMobile
+    }"
   >
     <Button
       v-if="showOverflowArrows"
@@ -106,7 +109,7 @@
 </template>
 
 <script setup lang="ts">
-import { useScroll } from '@vueuse/core'
+import { breakpointsTailwind, useBreakpoints, useScroll } from '@vueuse/core'
 import ScrollPanel from 'primevue/scrollpanel'
 import SelectButton from 'primevue/selectbutton'
 import { computed, nextTick, onUpdated, ref, watch } from 'vue'
@@ -146,6 +149,8 @@ const workflowService = useWorkflowService()
 const commandStore = useCommandStore()
 const { isLoggedIn } = useCurrentUser()
 const { flags } = useFeatureFlags()
+
+const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
 
 const isIntegratedTabBar = computed(
   () => settingStore.get('Comfy.UI.TabBarLayout') !== 'Legacy'
@@ -336,9 +341,21 @@ onUpdated(() => {
   min-width: 90px;
 }
 
+/* Enlarge touch targets on mobile and keep tabs from squishing below a
+   tappable size; overflow is handled by the scroll arrows instead. */
+.workflow-tabs-container-mobile :deep(.p-togglebutton) {
+  flex-shrink: 0;
+  min-width: 120px;
+  min-height: 44px;
+}
+
 .overflow-arrow {
   border-radius: 0;
   padding-inline: calc(var(--spacing) * 2);
+}
+
+.workflow-tabs-container-mobile .overflow-arrow {
+  min-width: 44px;
 }
 
 .overflow-arrow[disabled] {


### PR DESCRIPTION
## Summary

Make the workflow tab strip touch-friendly on mobile viewports instead of letting tabs squish into an unusable state below the `md` breakpoint.

## Changes

- **What**: In `WorkflowTabs.vue`, detect narrow viewports (`useBreakpoints(breakpointsTailwind).smaller('md')`, <768px) and enlarge tab touch targets (min 120×44px) while preventing shrink, so the horizontal strip overflows into the existing scroll-arrow / overflow-menu affordance rather than compressing. Desktop layout is unchanged — all mobile rules are scoped behind a `workflow-tabs-container-mobile` class.

## Review Focus

- Mobile CSS is scoped to the new class only; the original `min-width: 90px` desktop rule is retained unchanged, so desktop rendering should be byte-for-byte identical.
- Overflow handling reuses the existing scroll chevrons + `WorkflowOverflowMenu` (no new overflow UI); they now engage on mobile because tabs no longer shrink below tappable size.
- New `@mobile` e2e test (`browser_tests/tests/workflowTabsMobile.spec.ts`) asserts touch-target dimensions and overflow scrolling; it has not yet been run against a live backend.

Fixes #2891
