### PR TITLE
fix(website): make the announcement banner on-brand and hide it on its own destination

### DIFF
--- a/apps/website/src/config/banner.ts
+++ b/apps/website/src/config/banner.ts
@@ -53,6 +53,8 @@ export const bannerConfig: BannerConfig = {
   link: {
     href: '/mcp',
     titleKey: 'launches.banner.cta',
+    // Minimal yellow text link (animated underline on hover) + arrow — no
+    // bordered pill, so the CTA reads as inline emphasis in the bar.
     buttonVariant: 'underlineLink'
   }
 }

--- a/apps/website/src/config/banner.ts
+++ b/apps/website/src/config/banner.ts
@@ -53,8 +53,6 @@ export const bannerConfig: BannerConfig = {
   link: {
     href: '/mcp',
     titleKey: 'launches.banner.cta',
-    // Minimal yellow text link (animated underline on hover) + arrow — no
-    // bordered pill, so the CTA reads as inline emphasis in the bar.
     buttonVariant: 'underlineLink'
   }
 }

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -11,7 +11,8 @@ import {
   BANNER_DISMISS_ATTR,
   BANNER_STORAGE_KEY,
   createBannerVersion,
-  evaluateBannerVisibility
+  evaluateBannerVisibility,
+  normalizeBannerPath
 } from '../utils/banner'
 import { escapeJsonLd } from '../utils/escapeJsonLd'
 import { fetchGitHubStars, formatStarCount } from '../utils/github'
@@ -44,19 +45,18 @@ const githubStars = rawStars ? formatStarCount(rawStars) : ''
 
 // Announcement banner — build-time visibility gate + content-hash version key.
 const bannerData = getBannerData(bannerConfig, locale)
-const bannerCurrentPath = Astro.url.pathname.replace(/^\/zh-CN/, '') || '/'
-const bannerExcludePaths = bannerConfig.link?.href.startsWith('/')
-  ? [bannerConfig.link.href]
-  : undefined
-const bannerVisible = evaluateBannerVisibility(
-  { ...bannerConfig, excludePaths: bannerExcludePaths },
-  {
+// Don't show the banner on its own CTA destination (e.g. the /mcp page).
+const onBannerDestination =
+  !!bannerConfig.link &&
+  normalizeBannerPath(Astro.url.pathname) ===
+    normalizeBannerPath(bannerConfig.link.href)
+const bannerVisible =
+  !onBannerDestination &&
+  evaluateBannerVisibility(bannerConfig, {
     currentLocale: locale,
     currentSection: 'sitewide',
-    currentPath: bannerCurrentPath,
     now: new Date(),
-  }
-)
+  })
 const bannerVersion = createBannerVersion(bannerData, locale)
 
 const gtmId = 'GTM-NP9JM6K7'

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -44,11 +44,21 @@ const githubStars = rawStars ? formatStarCount(rawStars) : ''
 
 // Announcement banner — build-time visibility gate + content-hash version key.
 const bannerData = getBannerData(bannerConfig, locale)
-const bannerVisible = evaluateBannerVisibility(bannerConfig, {
-  currentLocale: locale,
-  currentSection: 'sitewide',
-  now: new Date(),
-})
+// Path with the locale prefix stripped, so exclusion works on both /mcp and /zh-CN/mcp.
+const bannerCurrentPath = Astro.url.pathname.replace(/^\/zh-CN/, '') || '/'
+// Never show the banner on its own internal CTA destination (e.g. the /mcp page).
+const bannerExcludePaths = bannerConfig.link?.href.startsWith('/')
+  ? [bannerConfig.link.href]
+  : undefined
+const bannerVisible = evaluateBannerVisibility(
+  { ...bannerConfig, excludePaths: bannerExcludePaths },
+  {
+    currentLocale: locale,
+    currentSection: 'sitewide',
+    currentPath: bannerCurrentPath,
+    now: new Date(),
+  }
+)
 const bannerVersion = createBannerVersion(bannerData, locale)
 
 const gtmId = 'GTM-NP9JM6K7'

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -44,9 +44,7 @@ const githubStars = rawStars ? formatStarCount(rawStars) : ''
 
 // Announcement banner — build-time visibility gate + content-hash version key.
 const bannerData = getBannerData(bannerConfig, locale)
-// Path with the locale prefix stripped, so exclusion works on both /mcp and /zh-CN/mcp.
 const bannerCurrentPath = Astro.url.pathname.replace(/^\/zh-CN/, '') || '/'
-// Never show the banner on its own internal CTA destination (e.g. the /mcp page).
 const bannerExcludePaths = bannerConfig.link?.href.startsWith('/')
   ? [bannerConfig.link.href]
   : undefined

--- a/apps/website/src/templates/drops/AnnouncementBanner.vue
+++ b/apps/website/src/templates/drops/AnnouncementBanner.vue
@@ -21,8 +21,7 @@ const {
 
 const { isVisible, close, persistHidden } = useBannerDismissal(version)
 
-// Clicking the CTA is engagement: persist the dismissal so the banner doesn't
-// linger on the destination page or keep nagging on later navigations.
+// Engaging with the CTA dismisses the banner too.
 function onCtaClick(): void {
   close()
   persistHidden()
@@ -37,8 +36,7 @@ function onCtaClick(): void {
           data-slot="announcement-banner"
           class="bg-primary-comfy-ink-light relative flex items-center gap-x-4 px-4 py-2.5 sm:before:flex-1"
         >
-          <!-- Acid-yellow hairline along the bottom edge: the one brand accent
-               that separates this dark bar from the dark navbar below it. -->
+          <!-- Acid-yellow hairline separating the bar from the navbar. -->
           <div
             class="bg-primary-comfy-yellow/40 pointer-events-none absolute inset-x-0 bottom-0 h-px"
             aria-hidden="true"

--- a/apps/website/src/templates/drops/AnnouncementBanner.vue
+++ b/apps/website/src/templates/drops/AnnouncementBanner.vue
@@ -21,7 +21,8 @@ const {
 
 const { isVisible, close, persistHidden } = useBannerDismissal(version)
 
-// Engaging with the CTA dismisses the banner too.
+// Engaging with the CTA dismisses the banner too. (An inline handler here gets
+// reflowed by oxfmt into a multi-line form vue-tsc rejects.)
 function onCtaClick(): void {
   close()
   persistHidden()
@@ -34,14 +35,8 @@ function onCtaClick(): void {
       <div class="min-h-0 overflow-hidden">
         <div
           data-slot="announcement-banner"
-          class="bg-primary-comfy-ink-light relative flex items-center gap-x-4 px-4 py-2.5 sm:before:flex-1"
+          class="bg-primary-comfy-ink-light after:bg-primary-comfy-yellow/40 relative flex items-center gap-x-4 px-4 py-2.5 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px sm:before:flex-1"
         >
-          <!-- Acid-yellow hairline separating the bar from the navbar. -->
-          <div
-            class="bg-primary-comfy-yellow/40 pointer-events-none absolute inset-x-0 bottom-0 h-px"
-            aria-hidden="true"
-          />
-
           <div
             class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5"
           >
@@ -59,7 +54,7 @@ function onCtaClick(): void {
               :href="data.link.href"
               :target="data.link.target"
               :rel="data.link.rel"
-              :variant="data.link.buttonVariant ?? 'default'"
+              :variant="data.link.buttonVariant ?? 'underlineLink'"
               size="sm"
               class="group/cta shrink-0"
               @click="onCtaClick"

--- a/apps/website/src/templates/drops/AnnouncementBanner.vue
+++ b/apps/website/src/templates/drops/AnnouncementBanner.vue
@@ -76,7 +76,6 @@ function onCtaClick(): void {
           <div class="flex flex-1 justify-end">
             <IconButton
               type="button"
-              class="text-primary-warm-white/70 hover:text-primary-warm-white"
               :aria-label="t('nav.close', locale)"
               @click="close"
             >

--- a/apps/website/src/templates/drops/AnnouncementBanner.vue
+++ b/apps/website/src/templates/drops/AnnouncementBanner.vue
@@ -20,6 +20,13 @@ const {
 }>()
 
 const { isVisible, close, persistHidden } = useBannerDismissal(version)
+
+// Clicking the CTA is engagement: persist the dismissal so the banner doesn't
+// linger on the destination page or keep nagging on later navigations.
+function onCtaClick(): void {
+  close()
+  persistHidden()
+}
 </script>
 
 <template>
@@ -28,22 +35,23 @@ const { isVisible, close, persistHidden } = useBannerDismissal(version)
       <div class="min-h-0 overflow-hidden">
         <div
           data-slot="announcement-banner"
-          class="after:bg-transparency-white-t4 relative flex items-center gap-x-6 px-6 py-4 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px sm:px-3.5 sm:before:flex-1"
-          style="
-            background: linear-gradient(
-              90deg,
-              var(--color-primary-comfy-plum) 0%,
-              var(--color-secondary-deep-plum) 53.85%,
-              var(--color-secondary-mauve) 100%
-            );
-          "
+          class="bg-primary-comfy-ink-light relative flex items-center gap-x-4 px-4 py-2.5 sm:before:flex-1"
         >
-          <div class="flex flex-wrap items-center gap-x-8 gap-y-2">
+          <!-- Acid-yellow hairline along the bottom edge: the one brand accent
+               that separates this dark bar from the dark navbar below it. -->
+          <div
+            class="bg-primary-comfy-yellow/40 pointer-events-none absolute inset-x-0 bottom-0 h-px"
+            aria-hidden="true"
+          />
+
+          <div
+            class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5"
+          >
             <p
-              class="text-primary-warm-white ppformula-text-center text-sm md:text-base/6"
+              class="ppformula-text-center text-primary-warm-white text-sm md:text-[15px]/6"
             >
               {{ data.title }}
-              <span v-if="data.description" class="text-primary-warm-white/80">
+              <span v-if="data.description" class="text-primary-warm-white/70">
                 {{ data.description }}
               </span>
             </p>
@@ -53,18 +61,24 @@ const { isVisible, close, persistHidden } = useBannerDismissal(version)
               :href="data.link.href"
               :target="data.link.target"
               :rel="data.link.rel"
-              :variant="data.link.buttonVariant ?? 'underlineLink'"
+              :variant="data.link.buttonVariant ?? 'default'"
               size="sm"
+              class="group/cta shrink-0"
+              @click="onCtaClick"
             >
               {{ data.link.title }}
               <template #append>
-                <ArrowRight class="size-4" />
+                <ArrowRight
+                  class="size-4 transition-transform duration-200 group-hover/cta:translate-x-0.5"
+                />
               </template>
             </Button>
           </div>
+
           <div class="flex flex-1 justify-end">
             <IconButton
               type="button"
+              class="text-primary-warm-white/70 hover:text-primary-warm-white"
               :aria-label="t('nav.close', locale)"
               @click="close"
             >

--- a/apps/website/src/utils/banner.test.ts
+++ b/apps/website/src/utils/banner.test.ts
@@ -12,12 +12,40 @@ const base: EvaluableBanner = {
 const ctx = {
   currentLocale: 'en',
   currentSection: 'sitewide',
+  currentPath: '/',
   now: new Date('2026-07-06T00:00:00Z')
 }
 
 describe('evaluateBannerVisibility', () => {
   it('shows an active, untargeted, sitewide banner', () => {
     expect(evaluateBannerVisibility(base, ctx)).toBe(true)
+  })
+
+  it("hides on an excluded path (the banner's own CTA destination)", () => {
+    expect(
+      evaluateBannerVisibility(
+        { ...base, excludePaths: ['/mcp'] },
+        { ...ctx, currentPath: '/mcp' }
+      )
+    ).toBe(false)
+  })
+
+  it('still shows on other paths when excludePaths is set', () => {
+    expect(
+      evaluateBannerVisibility(
+        { ...base, excludePaths: ['/mcp'] },
+        { ...ctx, currentPath: '/' }
+      )
+    ).toBe(true)
+  })
+
+  it('matches excluded paths regardless of a trailing slash', () => {
+    expect(
+      evaluateBannerVisibility(
+        { ...base, excludePaths: ['/mcp'] },
+        { ...ctx, currentPath: '/mcp/' }
+      )
+    ).toBe(false)
   })
 
   it('hides when inactive', () => {

--- a/apps/website/src/utils/banner.test.ts
+++ b/apps/website/src/utils/banner.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type { EvaluableBanner } from './banner'
 
-import { createBannerVersion, evaluateBannerVisibility } from './banner'
+import {
+  createBannerVersion,
+  evaluateBannerVisibility,
+  normalizeBannerPath
+} from './banner'
 
 const base: EvaluableBanner = {
   isActive: true,
@@ -12,34 +16,12 @@ const base: EvaluableBanner = {
 const ctx = {
   currentLocale: 'en',
   currentSection: 'sitewide',
-  currentPath: '/',
   now: new Date('2026-07-06T00:00:00Z')
 }
 
 describe('evaluateBannerVisibility', () => {
   it('shows an active, untargeted, sitewide banner', () => {
     expect(evaluateBannerVisibility(base, ctx)).toBe(true)
-  })
-
-  it.for([
-    {
-      name: "hides on the banner's own CTA destination",
-      path: '/mcp',
-      visible: false
-    },
-    { name: 'shows on non-excluded paths', path: '/', visible: true },
-    {
-      name: 'matches an excluded path despite a trailing slash',
-      path: '/mcp/',
-      visible: false
-    }
-  ])('excludePaths: $name', ({ path, visible }, { expect }) => {
-    expect(
-      evaluateBannerVisibility(
-        { ...base, excludePaths: ['/mcp'] },
-        { ...ctx, currentPath: path }
-      )
-    ).toBe(visible)
   })
 
   it('hides when inactive', () => {
@@ -95,6 +77,20 @@ describe('evaluateBannerVisibility', () => {
 
   it('hides when targetSections is absent (nothing to match)', () => {
     expect(evaluateBannerVisibility({ isActive: true }, ctx)).toBe(false)
+  })
+})
+
+describe('normalizeBannerPath', () => {
+  it.for([
+    { path: '/mcp', normalized: '/mcp' },
+    { path: '/mcp/', normalized: '/mcp' },
+    { path: '/zh-CN/mcp', normalized: '/mcp' },
+    { path: '/zh-CN/mcp/', normalized: '/mcp' },
+    { path: '/', normalized: '/' },
+    { path: '/zh-CN', normalized: '/' },
+    { path: '/pricing', normalized: '/pricing' }
+  ])('$path normalizes to $normalized', ({ path, normalized }, { expect }) => {
+    expect(normalizeBannerPath(path)).toBe(normalized)
   })
 })
 

--- a/apps/website/src/utils/banner.test.ts
+++ b/apps/website/src/utils/banner.test.ts
@@ -21,31 +21,25 @@ describe('evaluateBannerVisibility', () => {
     expect(evaluateBannerVisibility(base, ctx)).toBe(true)
   })
 
-  it("hides on an excluded path (the banner's own CTA destination)", () => {
+  it.for([
+    {
+      name: "hides on the banner's own CTA destination",
+      path: '/mcp',
+      visible: false
+    },
+    { name: 'shows on non-excluded paths', path: '/', visible: true },
+    {
+      name: 'matches an excluded path despite a trailing slash',
+      path: '/mcp/',
+      visible: false
+    }
+  ])('excludePaths: $name', ({ path, visible }, { expect }) => {
     expect(
       evaluateBannerVisibility(
         { ...base, excludePaths: ['/mcp'] },
-        { ...ctx, currentPath: '/mcp' }
+        { ...ctx, currentPath: path }
       )
-    ).toBe(false)
-  })
-
-  it('still shows on other paths when excludePaths is set', () => {
-    expect(
-      evaluateBannerVisibility(
-        { ...base, excludePaths: ['/mcp'] },
-        { ...ctx, currentPath: '/' }
-      )
-    ).toBe(true)
-  })
-
-  it('matches excluded paths regardless of a trailing slash', () => {
-    expect(
-      evaluateBannerVisibility(
-        { ...base, excludePaths: ['/mcp'] },
-        { ...ctx, currentPath: '/mcp/' }
-      )
-    ).toBe(false)
+    ).toBe(visible)
   })
 
   it('hides when inactive', () => {

--- a/apps/website/src/utils/banner.ts
+++ b/apps/website/src/utils/banner.ts
@@ -10,7 +10,6 @@ export const BANNER_DISMISS_ATTR = 'data-banner-dismissed'
 export interface BannerVisibilityContext {
   currentLocale: string
   currentSection: string
-  /** The current page path (locale prefix stripped), for `excludePaths`. */
   currentPath: string
   now: Date
 }
@@ -21,14 +20,10 @@ export interface EvaluableBanner {
   endsAt?: string
   targetLocales?: readonly string[]
   targetSections?: readonly string[]
-  /**
-   * Paths the banner must NOT render on — typically its own CTA destination, so
-   * a "Go to X" banner doesn't linger on page X. Compared locale-agnostically.
-   */
+  /** Paths the banner must not render on (e.g. its own CTA destination). */
   excludePaths?: readonly string[]
 }
 
-/** Leading slash, no trailing slash, so `/mcp` and `/mcp/` compare equal. */
 function normalizePath(path: string): string {
   const withLead = path.startsWith('/') ? path : `/${path}`
   return withLead.length > 1 ? withLead.replace(/\/+$/, '') : withLead

--- a/apps/website/src/utils/banner.ts
+++ b/apps/website/src/utils/banner.ts
@@ -10,6 +10,8 @@ export const BANNER_DISMISS_ATTR = 'data-banner-dismissed'
 export interface BannerVisibilityContext {
   currentLocale: string
   currentSection: string
+  /** The current page path (locale prefix stripped), for `excludePaths`. */
+  currentPath: string
   now: Date
 }
 
@@ -19,12 +21,24 @@ export interface EvaluableBanner {
   endsAt?: string
   targetLocales?: readonly string[]
   targetSections?: readonly string[]
+  /**
+   * Paths the banner must NOT render on — typically its own CTA destination, so
+   * a "Go to X" banner doesn't linger on page X. Compared locale-agnostically.
+   */
+  excludePaths?: readonly string[]
+}
+
+/** Leading slash, no trailing slash, so `/mcp` and `/mcp/` compare equal. */
+function normalizePath(path: string): string {
+  const withLead = path.startsWith('/') ? path : `/${path}`
+  return withLead.length > 1 ? withLead.replace(/\/+$/, '') : withLead
 }
 
 /**
  * Server/build-time visibility gate. Returns false on the FIRST failing check,
  * in order: active flag → start window → end window → locale targeting →
- * section targeting. An empty/absent `targetLocales` means "all locales".
+ * section targeting → path exclusion. An empty/absent `targetLocales` means
+ * "all locales".
  */
 export function evaluateBannerVisibility(
   banner: EvaluableBanner,
@@ -45,6 +59,14 @@ export function evaluateBannerVisibility(
 
   const targetSections = banner.targetSections ?? []
   if (!targetSections.includes(ctx.currentSection)) return false
+
+  const excludePaths = banner.excludePaths ?? []
+  if (
+    excludePaths.some(
+      (p) => normalizePath(p) === normalizePath(ctx.currentPath)
+    )
+  )
+    return false
 
   return true
 }

--- a/apps/website/src/utils/banner.ts
+++ b/apps/website/src/utils/banner.ts
@@ -10,7 +10,6 @@ export const BANNER_DISMISS_ATTR = 'data-banner-dismissed'
 export interface BannerVisibilityContext {
   currentLocale: string
   currentSection: string
-  currentPath: string
   now: Date
 }
 
@@ -20,20 +19,20 @@ export interface EvaluableBanner {
   endsAt?: string
   targetLocales?: readonly string[]
   targetSections?: readonly string[]
-  /** Paths the banner must not render on (e.g. its own CTA destination). */
-  excludePaths?: readonly string[]
 }
 
-function normalizePath(path: string): string {
-  const withLead = path.startsWith('/') ? path : `/${path}`
-  return withLead.length > 1 ? withLead.replace(/\/+$/, '') : withLead
+/**
+ * Normalize a path for banner-destination comparison: drop the zh-CN locale
+ * prefix and any trailing slash, so /zh-CN/mcp, /mcp and /mcp/ compare equal.
+ */
+export function normalizeBannerPath(path: string): string {
+  return path.replace(/^\/zh-CN/, '').replace(/\/+$/, '') || '/'
 }
 
 /**
  * Server/build-time visibility gate. Returns false on the FIRST failing check,
  * in order: active flag → start window → end window → locale targeting →
- * section targeting → path exclusion. An empty/absent `targetLocales` means
- * "all locales".
+ * section targeting. An empty/absent `targetLocales` means "all locales".
  */
 export function evaluateBannerVisibility(
   banner: EvaluableBanner,
@@ -54,14 +53,6 @@ export function evaluateBannerVisibility(
 
   const targetSections = banner.targetSections ?? []
   if (!targetSections.includes(ctx.currentSection)) return false
-
-  const excludePaths = banner.excludePaths ?? []
-  if (
-    excludePaths.some(
-      (p) => normalizePath(p) === normalizePath(ctx.currentPath)
-    )
-  )
-    return false
 
   return true
 }


### PR DESCRIPTION
## Summary

Re-skins the sitewide announcement banner to the site's dark comfy-ink + acid-yellow brand (it was an off-brand purple gradient) and stops it from rendering on the page its own CTA links to.

## Changes

- **What**:
  - **Look**: the banner is now a dark `comfy-ink-light` bar with a thin acid-yellow hairline separator and a slimmer layout, so it reads as a seamless extension of the dark navbar. Replaces the muddy 3-stop purple gradient (`comfy-plum → deep-plum → mauve`), which had no relationship to the site's dark/yellow chrome. The CTA stays a minimal yellow underline link.
  - **`/mcp` visibility bug**: `evaluateBannerVisibility` now accepts `excludePaths` + `currentPath`, so a "Go to X" banner never renders on page X. `BaseLayout` derives the exclusion from the banner's own internal CTA href and strips the locale prefix, so it covers both `/mcp` and `/zh-CN/mcp`.
  - **Dismissal**: clicking the CTA now persists the dismissal (via the existing content-hash key), so the banner doesn't linger on later navigations after a visitor has engaged.
  - Tests for the new `excludePaths` gate, including a trailing-slash match.

## Review Focus

- `apps/website/src/utils/banner.ts` — the pure visibility gate; `excludePaths` is compared locale-agnostically via `normalizePath` (leading slash, no trailing slash).
- `apps/website/src/layouts/BaseLayout.astro` — how `currentPath` (locale-stripped) and `excludePaths` (derived from `link.href`) are passed in.
- The dismissal-on-CTA-click behavior is intentional (engagement = dismiss). Shout if you'd rather it keep showing on other pages until the X is clicked.

## Screenshots

### Before:
<img width="1800" height="490" alt="image" src="https://github.com/user-attachments/assets/b5f28171-3a29-4aaa-96fb-83fb3b09d0e5" />

### After:
<img width="1800" height="429" alt="image" src="https://github.com/user-attachments/assets/13c58d99-492b-46b0-9351-5b794076c2ea" />
