### PR TITLE
feat: render BYOK provider surface (labels / logos / help) from server data

### DIFF
--- a/public/assets/images/gemini.svg
+++ b/public/assets/images/gemini.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Google Gemini">
+  <path d="M12 1c.6 5.4 4.6 9.4 10 10-5.4.6-9.4 4.6-10 10-.6-5.4-4.6-9.4-10-10 5.4-.6 9.4-4.6 10-10z" fill="#4285F4"/>
+</svg>

--- a/public/assets/images/runway.svg
+++ b/public/assets/images/runway.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Runway">
+  <rect width="24" height="24" rx="5" fill="#6E56CF"/>
+  <path d="M9.5 8.2v7.6l6.3-3.8z" fill="#ffffff"/>
+</svg>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4402,6 +4402,10 @@
     "namePlaceholder": "e.g., My API Key",
     "provider": "Provider",
     "providerHint": "Optional. Selecting a provider enables automatic token usage.",
+    "providerHelp": {
+      "runway": "Enter your Runway API key. You can find it in your Runway account settings under API keys.",
+      "gemini": "Enter your Google Gemini API key. You can generate one in Google AI Studio."
+    },
     "secretValue": "Secret Value",
     "secretValuePlaceholder": "Enter your API key",
     "secretValuePlaceholderEdit": "Enter new value to change",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4401,7 +4401,7 @@
     "name": "Name",
     "namePlaceholder": "e.g., My API Key",
     "provider": "Provider",
-    "providerHint": "Optional. Selecting a provider enables automatic token usage.",
+    "providerHint": "Select a provider to enable automatic token usage.",
     "providerHelp": {
       "runway": "Enter your Runway API key. You can find it in your Runway account settings under API keys.",
       "gemini": "Enter your Google Gemini API key. You can generate one in Google AI Studio."

--- a/src/platform/secrets/components/SecretFormDialog.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.test.ts
@@ -12,6 +12,7 @@ vi.mock('../composables/useSecretForm', () => ({
     loading: false,
     apiError: '',
     providerOptions: [],
+    providerHelp: '',
     handleSubmit: vi.fn()
   })
 }))

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -37,12 +37,23 @@
                   :value="option.value"
                   :disabled="option.disabled"
                 >
-                  {{ option.label }}
+                  <span class="flex items-center gap-2">
+                    <img
+                      v-if="option.logo"
+                      :src="option.logo"
+                      :alt="option.label"
+                      class="size-4"
+                    />
+                    {{ option.label }}
+                  </span>
                 </SelectItem>
               </SelectContent>
             </Select>
             <small v-if="errors.provider" class="text-red-500">
               {{ errors.provider }}
+            </small>
+            <small v-else class="text-muted">
+              {{ providerHelp }}
             </small>
           </div>
 
@@ -134,7 +145,7 @@ import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
 import SelectValue from '@/components/ui/select/SelectValue.vue'
 
 import { useSecretForm } from '../composables/useSecretForm'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 const {
   secret,
@@ -143,7 +154,7 @@ const {
   mode = 'create'
 } = defineProps<{
   secret?: SecretMetadata
-  existingProviders?: SecretProvider[]
+  existingProviders?: string[]
   availableProviders?: string[] | null
   mode?: 'create' | 'edit'
 }>()
@@ -156,8 +167,15 @@ const emit = defineEmits<{
 
 const titleId = useId()
 
-const { form, errors, loading, apiError, providerOptions, handleSubmit } =
-  useSecretForm({
+const {
+  form,
+  errors,
+  loading,
+  apiError,
+  providerOptions,
+  providerHelp,
+  handleSubmit
+} = useSecretForm({
     mode,
     secret: () => secret,
     existingProviders: () => existingProviders,

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -176,11 +176,11 @@ const {
   providerHelp,
   handleSubmit
 } = useSecretForm({
-    mode,
-    secret: () => secret,
-    existingProviders: () => existingProviders,
-    availableProviders: () => availableProviders,
-    visible,
-    onSaved: () => emit('saved')
-  })
+  mode,
+  secret: () => secret,
+  existingProviders: () => existingProviders,
+  availableProviders: () => availableProviders,
+  visible,
+  onSaved: () => emit('saved')
+})
 </script>

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -13,6 +13,7 @@ vi.mock('../composables/useSecretForm', () => ({
     loading: false,
     apiError: '',
     providerOptions: [],
+    providerHelp: '',
     handleSubmit: vi.fn()
   })
 }))

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SecretMetadata, SecretProvider } from '../types'
@@ -226,6 +226,22 @@ describe('useSecretForm', () => {
       expect(providerOptions.value.map((o) => o.value)).toEqual(['civitai'])
     })
 
+    it('dedupes repeated provider ids from the server', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['civitai', 'civitai', 'huggingface'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual([
+        'civitai',
+        'huggingface'
+      ])
+    })
+
     it('renders server-listed BYOK providers with labels and logos', () => {
       const visible = ref(true)
       const { providerOptions } = useSecretForm({
@@ -284,6 +300,43 @@ describe('useSecretForm', () => {
       availableProviders.value = ['huggingface']
 
       expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
+    })
+
+    it('clears a selection the resolved allowlist no longer offers', async () => {
+      const visible = ref(true)
+      const availableProviders = ref<string[] | null>(null)
+      const { form, providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => availableProviders.value,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'civitai'
+      availableProviders.value = ['huggingface']
+      await nextTick()
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
+      expect(form.provider).toBeNull()
+    })
+
+    it('keeps a selection the resolved allowlist still offers', async () => {
+      const visible = ref(true)
+      const availableProviders = ref<string[] | null>(null)
+      const { form } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => availableProviders.value,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'huggingface'
+      availableProviders.value = ['huggingface', 'civitai']
+      await nextTick()
+
+      expect(form.provider).toBe('huggingface')
     })
 
     it('ignores the availableProviders filter in edit mode', () => {

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -226,6 +226,48 @@ describe('useSecretForm', () => {
       expect(providerOptions.value.map((o) => o.value)).toEqual(['civitai'])
     })
 
+    it('renders server-listed BYOK providers with labels and logos', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['runway', 'gemini'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([
+        {
+          value: 'runway',
+          label: 'Runway',
+          logo: '/assets/images/runway.svg',
+          disabled: false
+        },
+        {
+          value: 'gemini',
+          label: 'Google Gemini',
+          logo: '/assets/images/gemini.svg',
+          disabled: false
+        }
+      ])
+    })
+
+    it('omits BYOK providers the server does not list', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['huggingface'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const values = providerOptions.value.map((o) => o.value)
+      expect(values).toEqual(['huggingface'])
+      expect(values).not.toContain('runway')
+      expect(values).not.toContain('gemini')
+    })
+
     it('reacts to availableProviders changing', () => {
       const visible = ref(true)
       const availableProviders = ref<string[] | null>(null)
@@ -280,6 +322,51 @@ describe('useSecretForm', () => {
       expect(
         providerOptions.value.find((o) => o.value === 'huggingface')?.disabled
       ).toBe(false)
+    })
+  })
+
+  describe('providerHelp', () => {
+    it('uses the generic hint when no provider is selected', () => {
+      const visible = ref(true)
+      const { providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      // t() is mocked to echo the key.
+      expect(providerHelp.value).toBe('secrets.providerHint')
+    })
+
+    it('uses provider-specific help when a BYOK provider is selected', () => {
+      const visible = ref(true)
+      const { form, providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['runway', 'gemini'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'runway'
+      expect(providerHelp.value).toBe('secrets.providerHelp.runway')
+
+      form.provider = 'gemini'
+      expect(providerHelp.value).toBe('secrets.providerHelp.gemini')
+    })
+
+    it('falls back to the generic hint for a provider without a help key', () => {
+      const visible = ref(true)
+      const { form, providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'huggingface'
+      expect(providerHelp.value).toBe('secrets.providerHint')
     })
   })
 

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -4,13 +4,19 @@ import { computed, reactive, ref, toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { createSecret, SecretsApiError, updateSecret } from '../api/secretsApi'
-import { SECRET_PROVIDERS } from '../providers'
-import type { SecretErrorCode, SecretMetadata, SecretProvider } from '../types'
+import {
+  DEFAULT_PROVIDER_IDS,
+  getProviderHelpKey,
+  getProviderLabel,
+  getProviderLogo
+} from '../providers'
+import type { SecretErrorCode, SecretMetadata } from '../types'
 
 interface SecretFormState {
   name: string
   secretValue: string
-  provider: SecretProvider | null
+  // Free-form string: the set of selectable providers is server-driven.
+  provider: string | null
 }
 
 interface SecretFormErrors {
@@ -21,14 +27,15 @@ interface SecretFormErrors {
 
 interface ProviderOption {
   label: string
-  value: SecretProvider
+  value: string
+  logo?: string
   disabled: boolean
 }
 
 interface UseSecretFormOptions {
   mode: 'create' | 'edit'
   secret?: MaybeRefOrGetter<SecretMetadata | undefined>
-  existingProviders: MaybeRefOrGetter<SecretProvider[]>
+  existingProviders: MaybeRefOrGetter<string[]>
   availableProviders?: MaybeRefOrGetter<string[] | null>
   visible: { value: boolean }
   onSaved: () => void
@@ -62,18 +69,40 @@ export function useSecretForm(options: UseSecretFormOptions) {
   })
 
   const providerOptions = computed<ProviderOption[]>(() => {
+    // Which provider ids to render:
+    // - edit mode: the field is disabled; show the defaults plus the stored
+    //   provider so the disabled selector can display its label/logo.
+    // - create + list not yet loaded (null): show the defaults as a sensible
+    //   placeholder while the request is in flight.
+    // - create + list loaded: render exactly what the server returned, so
+    //   providers added server-side (e.g. runway/gemini) appear with no FE
+    //   change and providers omitted server-side do not appear.
     const available = toValue(availableProviders)
-    const providers =
-      mode === 'edit' || available === null
-        ? SECRET_PROVIDERS
-        : SECRET_PROVIDERS.filter((p) => available.includes(p.value))
-    return providers.map((p) => ({
-      label: p.label,
-      value: p.value,
-      disabled:
-        mode === 'edit' ? false : toValue(existingProviders).includes(p.value)
+    let ids: string[]
+    if (mode === 'edit') {
+      const stored = toValue(secretRef)?.provider
+      ids =
+        stored && !DEFAULT_PROVIDER_IDS.includes(stored as never)
+          ? [...DEFAULT_PROVIDER_IDS, stored]
+          : [...DEFAULT_PROVIDER_IDS]
+    } else {
+      ids = available === null ? [...DEFAULT_PROVIDER_IDS] : available
+    }
+
+    const existing = toValue(existingProviders)
+    return ids.map((id) => ({
+      value: id,
+      label: getProviderLabel(id),
+      logo: getProviderLogo(id),
+      disabled: mode === 'edit' ? false : existing.includes(id)
     }))
   })
+
+  // Provider-specific help text when the selected provider defines it, else the
+  // generic hint. Sourced from the presentational registry, not the server.
+  const providerHelp = computed(() =>
+    t(getProviderHelpKey(form.provider ?? undefined) ?? 'secrets.providerHint')
+  )
 
   const apiError = computed(() => {
     if (!apiErrorCode.value && !apiErrorMessage.value) return null
@@ -91,10 +120,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     const secret = toValue(secretRef)
     if (mode === 'edit' && secret) {
       form.name = secret.name
-      // Stored provider is a free-form string; in edit mode the field is
-      // disabled and only needs to be non-empty for validation (it is never
-      // re-sent), so narrowing to the form's known-provider type is safe here.
-      form.provider = (secret.provider ?? null) as SecretProvider | null
+      form.provider = secret.provider ?? null
       form.secretValue = ''
     } else {
       form.name = ''
@@ -176,6 +202,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     loading,
     apiError,
     providerOptions,
+    providerHelp,
     handleSubmit
   }
 }

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -1,6 +1,6 @@
 import { whenever } from '@vueuse/core'
 import type { MaybeRefOrGetter } from 'vue'
-import { computed, reactive, ref, toValue } from 'vue'
+import { computed, reactive, ref, toValue, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { createSecret, SecretsApiError, updateSecret } from '../api/secretsApi'
@@ -82,11 +82,12 @@ export function useSecretForm(options: UseSecretFormOptions) {
     if (mode === 'edit') {
       const stored = toValue(secretRef)?.provider
       ids =
-        stored && !DEFAULT_PROVIDER_IDS.includes(stored as never)
+        stored && !DEFAULT_PROVIDER_IDS.some((id) => id === stored)
           ? [...DEFAULT_PROVIDER_IDS, stored]
           : [...DEFAULT_PROVIDER_IDS]
     } else {
-      ids = available === null ? [...DEFAULT_PROVIDER_IDS] : available
+      ids =
+        available === null ? [...DEFAULT_PROVIDER_IDS] : [...new Set(available)]
     }
 
     const existing = toValue(existingProviders)
@@ -96,6 +97,14 @@ export function useSecretForm(options: UseSecretFormOptions) {
       logo: getProviderLogo(id),
       disabled: mode === 'edit' ? false : existing.includes(id)
     }))
+  })
+
+  // Once the server allowlist resolves, drop a selection the resolved list no
+  // longer offers so the user cannot submit an unlisted provider.
+  watch(providerOptions, (options) => {
+    if (form.provider && !options.some((o) => o.value === form.provider)) {
+      form.provider = null
+    }
   })
 
   // Provider-specific help text when the selected provider defines it, else the

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -21,9 +21,7 @@ export function useSecrets() {
   const operatingSecretId = ref<string | null>(null)
 
   const existingProviders = computed<string[]>(() =>
-    secrets.value
-      .map((s) => s.provider)
-      .filter((p): p is string => p !== undefined)
+    secrets.value.map((s) => s.provider).filter((p): p is string => p != null)
   )
 
   async function fetchSecrets() {

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -9,7 +9,7 @@ import {
   listSecrets,
   SecretsApiError
 } from '../api/secretsApi'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 export function useSecrets() {
   const { t } = useI18n()
@@ -20,10 +20,10 @@ export function useSecrets() {
   const availableProviders = ref<string[] | null>(null)
   const operatingSecretId = ref<string | null>(null)
 
-  const existingProviders = computed<SecretProvider[]>(() =>
+  const existingProviders = computed<string[]>(() =>
     secrets.value
       .map((s) => s.provider)
-      .filter((p): p is SecretProvider => p !== undefined)
+      .filter((p): p is string => p !== undefined)
   )
 
   async function fetchSecrets() {

--- a/src/platform/secrets/providers.test.ts
+++ b/src/platform/secrets/providers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PROVIDER_IDS,
+  getProviderHelpKey,
+  getProviderLabel,
+  getProviderLogo
+} from './providers'
+
+describe('secret provider registry', () => {
+  it('maps known providers (including BYOK) to display labels', () => {
+    expect(getProviderLabel('huggingface')).toBe('HuggingFace')
+    expect(getProviderLabel('civitai')).toBe('Civitai')
+    expect(getProviderLabel('runway')).toBe('Runway')
+    expect(getProviderLabel('gemini')).toBe('Google Gemini')
+  })
+
+  it('maps known providers to logos under public/assets/images', () => {
+    expect(getProviderLogo('huggingface')).toBe('/assets/images/hf-logo.svg')
+    expect(getProviderLogo('civitai')).toBe('/assets/images/civitai.svg')
+    expect(getProviderLogo('runway')).toBe('/assets/images/runway.svg')
+    expect(getProviderLogo('gemini')).toBe('/assets/images/gemini.svg')
+  })
+
+  it('exposes per-provider help keys for the BYOK providers', () => {
+    expect(getProviderHelpKey('runway')).toBe('secrets.providerHelp.runway')
+    expect(getProviderHelpKey('gemini')).toBe('secrets.providerHelp.gemini')
+    // Model-download providers reuse the generic hint (no dedicated help key).
+    expect(getProviderHelpKey('huggingface')).toBeUndefined()
+    expect(getProviderHelpKey('civitai')).toBeUndefined()
+  })
+
+  it('falls back to the raw id with no logo/help for unknown providers', () => {
+    // A provider added server-side but absent from the registry still renders.
+    expect(getProviderLabel('brand-new-provider')).toBe('brand-new-provider')
+    expect(getProviderLogo('brand-new-provider')).toBeUndefined()
+    expect(getProviderHelpKey('brand-new-provider')).toBeUndefined()
+  })
+
+  it('returns an empty label and no logo for an undefined provider', () => {
+    expect(getProviderLabel(undefined)).toBe('')
+    expect(getProviderLogo(undefined)).toBeUndefined()
+    expect(getProviderHelpKey(undefined)).toBeUndefined()
+  })
+
+  it('keeps the not-loaded fallback list to the pre-BYOK baseline', () => {
+    // Defaults are a transient placeholder only; the authoritative list is the
+    // server response. They must not silently include BYOK providers.
+    expect([...DEFAULT_PROVIDER_IDS]).toEqual(['huggingface', 'civitai'])
+  })
+})

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -1,30 +1,69 @@
-import type { SecretProvider } from './types'
-
 interface ProviderConfig {
-  value: SecretProvider
+  /** Provider identifier as returned by `GET /secrets/providers`. */
+  value: string
+  /** Human-facing display label. Brand names are intentionally not translated. */
   label: string
+  /** Path to the provider logo under `public/assets/images/`. */
   logo: string
+  /** Optional i18n key for provider-specific help text shown under the picker. */
+  helpKey?: string
 }
 
+/**
+ * Presentational metadata for known providers: how a provider id renders
+ * (label, logo, help text). This table is NOT the source of truth for which
+ * providers a user may configure — that list is server-driven via
+ * `GET /secrets/providers`. Ids the server returns that are absent here fall
+ * back to the raw id with no logo, so adding a provider server-side renders
+ * without an FE change (a dedicated logo/label is an optional enhancement).
+ */
 export const SECRET_PROVIDERS: ProviderConfig[] = [
   {
     value: 'huggingface',
     label: 'HuggingFace',
     logo: '/assets/images/hf-logo.svg'
   },
-  { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' }
-] as const
+  { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' },
+  {
+    value: 'runway',
+    label: 'Runway',
+    logo: '/assets/images/runway.svg',
+    helpKey: 'secrets.providerHelp.runway'
+  },
+  {
+    value: 'gemini',
+    label: 'Google Gemini',
+    logo: '/assets/images/gemini.svg',
+    helpKey: 'secrets.providerHelp.gemini'
+  }
+]
+
+/**
+ * Providers shown as a sensible default before the server list resolves, and to
+ * seed the disabled selector in edit mode. This is NOT the source of truth for
+ * which providers a user may configure — once `GET /secrets/providers` resolves,
+ * its list is rendered verbatim.
+ */
+export const DEFAULT_PROVIDER_IDS = ['huggingface', 'civitai'] as const
+
+function findProvider(provider: string | undefined): ProviderConfig | undefined {
+  if (!provider) return undefined
+  return SECRET_PROVIDERS.find((p) => p.value === provider)
+}
 
 export function getProviderLabel(provider: string | undefined): string {
   if (!provider) return ''
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.label ?? provider
+  return findProvider(provider)?.label ?? provider
 }
 
 export function getProviderLogo(
   provider: string | undefined
 ): string | undefined {
-  if (!provider) return undefined
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.logo
+  return findProvider(provider)?.logo
+}
+
+export function getProviderHelpKey(
+  provider: string | undefined
+): string | undefined {
+  return findProvider(provider)?.helpKey
 }

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -17,7 +17,7 @@ interface ProviderConfig {
  * back to the raw id with no logo, so adding a provider server-side renders
  * without an FE change (a dedicated logo/label is an optional enhancement).
  */
-export const SECRET_PROVIDERS: ProviderConfig[] = [
+const SECRET_PROVIDERS: ProviderConfig[] = [
   {
     value: 'huggingface',
     label: 'HuggingFace',

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -46,7 +46,9 @@ export const SECRET_PROVIDERS: ProviderConfig[] = [
  */
 export const DEFAULT_PROVIDER_IDS = ['huggingface', 'civitai'] as const
 
-function findProvider(provider: string | undefined): ProviderConfig | undefined {
+function findProvider(
+  provider: string | undefined
+): ProviderConfig | undefined {
   if (!provider) return undefined
   return SECRET_PROVIDERS.find((p) => p.value === provider)
 }

--- a/src/platform/secrets/types.ts
+++ b/src/platform/secrets/types.ts
@@ -10,15 +10,18 @@ import type { SecretResponse } from '@comfyorg/ingest-types'
 export type SecretMetadata = SecretResponse
 
 /**
- * Base providers the UI renders with a dedicated label/logo. The full set of
- * configurable providers is data-driven via `GET /secrets/providers`.
+ * Base providers the UI renders with a dedicated first-class label/logo. This
+ * union documents the historically-known providers only — the full set of
+ * configurable providers is data-driven via `GET /secrets/providers`, so the
+ * selected provider is stored/sent as a free-form string.
  */
 export type SecretProvider = 'huggingface' | 'civitai'
 
 export interface SecretCreateRequest {
   name: string
   secret_value: string
-  provider?: SecretProvider
+  /** Provider identifier as returned by `GET /secrets/providers`. */
+  provider?: string
 }
 
 export interface SecretUpdateRequest {


### PR DESCRIPTION
## ELI-5

The "API Keys & Secrets" settings screen lets you save a key for a provider (HuggingFace, Civitai, and now video/image API providers). The list of which providers you can pick is decided by the server. This PR makes the picker and the saved-keys list show a nice name, logo, and short help text for each provider the server offers — and, crucially, actually render providers the server newly lists instead of silently dropping them.

## What

- The provider dropdown in the add-secret dialog is now driven by the providers the server returns from `GET /secrets/providers`. Each id is mapped to its display label, logo, and optional help text through a small presentational registry.
- Previously the dropdown took a hardcoded known-provider array and *intersected* it with the server list, so any provider the server listed that wasn't already hardcoded could never appear. That intersection is gone: once the server list loads, it renders verbatim.
- Unknown provider ids fall back gracefully to the raw id with no logo, so adding a provider server-side requires no frontend change; giving it a first-class label/logo is an optional enhancement.
- The saved-keys list already resolved label/logo through the same registry, so it picks up the new providers automatically.
- Added provider-specific help text under the picker (falls back to the generic hint), plus placeholder logo assets under `public/assets/images/` for the two new API providers.

## Why

Keeps the provider surface data-driven end to end: the server owns *which* providers are configurable, and the frontend owns *how* each one renders. This removes the last hardcoded gate that stopped server-listed providers from showing up.

## Tests

- New `providers.test.ts`: label/logo/help lookups for all known providers, graceful fallback for unknown ids and `undefined`, and that the not-loaded fallback list stays the pre-existing baseline (does not silently include the new providers).
- Extended `useSecretForm.test.ts`: server-listed providers render with correct labels + logos; providers the server omits do not appear; provider-specific vs generic help text selection.
- Full secrets suite green (66 tests). Changed files typecheck clean.

Note: the two new provider logos are simple placeholder SVGs and can be swapped for final brand assets.
