### PR TITLE
Refine onboarding survey layout, interactions, and styling

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -57,8 +57,6 @@ const config: KnipConfig = {
     // Marketing media tooling — adopted by pages in a follow-up PR
     'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',
-    // Agent review check config, not part of the build
-    '.agents/checks/eslint.strict.config.js',
     // Devtools extensions, included dynamically
     'tools/devtools/web/**'
   ],

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3123,7 +3123,7 @@
   "cloudOnboarding": {
     "skipToCloudApp": "Skip to the cloud app",
     "survey": {
-      "title": "Cloud Survey",
+      "title": "Let's get to know you",
       "placeholder": "Survey questions placeholder",
       "intro": "A few quick questions so we can set up ComfyUI for you.",
       "otherPlaceholder": "Tell us more",

--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="dark-theme flex h-152 max-h-[85vh] w-full max-w-md flex-col overflow-y-auto px-4 sm:px-6"
+    class="dark-theme mt-[12vh] flex max-h-[85vh] w-full max-w-md flex-col self-start overflow-y-auto px-4 sm:px-6"
   >
     <h1
       class="-mb-1 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
@@ -9,7 +9,6 @@
     </h1>
     <DynamicSurveyForm
       :key="activeSurvey.version"
-      class="flex-1"
       :survey="activeSurvey"
       :is-submitting="isSubmitting"
       @submit="onSubmitSurvey"

--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -1,7 +1,12 @@
 <template>
   <div
-    class="dark-theme flex max-h-[85vh] w-[360px] max-w-[90vw] flex-col overflow-y-auto"
+    class="dark-theme flex max-h-[85vh] w-full max-w-md flex-col overflow-y-auto px-4 sm:px-6"
   >
+    <h1
+      class="-mb-1 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
+    >
+      {{ $t('cloudOnboarding.survey.title') }}
+    </h1>
     <DynamicSurveyForm
       :key="activeSurvey.version"
       :survey="activeSurvey"

--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="dark-theme flex max-h-[85vh] w-full max-w-md flex-col overflow-y-auto px-4 sm:px-6"
+    class="dark-theme flex h-152 max-h-[85vh] w-full max-w-md flex-col overflow-y-auto px-4 sm:px-6"
   >
     <h1
       class="-mb-1 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
@@ -9,6 +9,7 @@
     </h1>
     <DynamicSurveyForm
       :key="activeSurvey.version"
+      class="flex-1"
       :survey="activeSurvey"
       :is-submitting="isSubmitting"
       @submit="onSubmitSurvey"

--- a/src/platform/cloud/onboarding/components/CloudTemplate.vue
+++ b/src/platform/cloud/onboarding/components/CloudTemplate.vue
@@ -5,7 +5,7 @@
     <div class="relative flex flex-1 flex-col">
       <div class="flex h-16 shrink-0 items-center px-6">
         <i
-          class="icon-[comfy--comfy-logo] h-5 w-22 text-brand-yellow md:h-6 md:w-26"
+          class="icon-[comfy--comfy-logo] aspect-100/23 h-5 w-auto text-brand-yellow md:h-6"
         />
       </div>
       <div class="flex flex-1 items-center justify-center overflow-auto">
@@ -13,15 +13,24 @@
       </div>
       <CloudTemplateFooter />
     </div>
-    <div class="relative hidden flex-1 overflow-hidden py-2 pr-2 lg:block">
+    <div
+      v-if="!hideHero"
+      class="relative hidden flex-1 overflow-hidden py-2 pr-2 lg:block"
+    >
       <CloudHeroCarousel />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
 import CloudHeroCarousel from '@/platform/cloud/onboarding/components/CloudHeroCarousel.vue'
 import CloudTemplateFooter from '@/platform/cloud/onboarding/components/CloudTemplateFooter.vue'
+
+const route = useRoute()
+const hideHero = computed(() => Boolean(route.meta.hideHero))
 </script>
 <style>
 @import '../assets/css/fonts.css';

--- a/src/platform/cloud/onboarding/components/CloudTemplateFooter.vue
+++ b/src/platform/cloud/onboarding/components/CloudTemplateFooter.vue
@@ -5,20 +5,20 @@
     <a
       href="https://www.comfy.org/terms-of-service"
       target="_blank"
-      class="cursor-pointer text-sm text-gray-600 no-underline"
+      class="cursor-pointer text-sm text-primary-comfy-canvas/60 no-underline"
     >
       {{ t('auth.login.termsLink') }}
     </a>
     <a
       href="https://www.comfy.org/privacy-policy"
       target="_blank"
-      class="cursor-pointer text-sm text-gray-600 no-underline"
+      class="cursor-pointer text-sm text-primary-comfy-canvas/60 no-underline"
     >
       {{ t('auth.login.privacyLink') }}
     </a>
     <a
       href="https://support.comfy.org"
-      class="cursor-pointer text-sm text-gray-600 no-underline"
+      class="cursor-pointer text-sm text-primary-comfy-canvas/60 no-underline"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -94,7 +94,7 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         name: 'cloud-survey',
         component: () =>
           import('@/platform/cloud/onboarding/CloudSurveyView.vue'),
-        meta: { requiresAuth: true }
+        meta: { requiresAuth: true, hideHero: true }
       },
       {
         path: 'oauth/consent',
@@ -106,7 +106,7 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         name: 'cloud-user-check',
         component: () =>
           import('@/platform/cloud/onboarding/UserCheckView.vue'),
-        meta: { requiresAuth: true }
+        meta: { requiresAuth: true, hideHero: true }
       },
       {
         path: 'sorry-contact-support',

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyField.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyField.vue
@@ -2,9 +2,9 @@
   <fieldset
     v-if="field.type !== 'text'"
     :aria-invalid="Boolean(errorMessage)"
-    class="flex flex-col gap-4 border-0 p-0"
+    class="m-0 flex flex-col gap-4 border-0 p-0"
   >
-    <legend class="mb-2 block text-lg font-medium text-base-foreground">
+    <legend class="mb-2 block text-lg font-medium text-primary-comfy-canvas">
       {{ resolvedLabel }}
     </legend>
     <ToggleGroup
@@ -22,7 +22,9 @@
       >
         <i
           v-if="option.icon"
-          :class="cn('size-4 shrink-0 text-muted-foreground', option.icon)"
+          :class="
+            cn('size-4 shrink-0 text-primary-comfy-canvas/60', option.icon)
+          "
           aria-hidden="true"
         />
         <span class="flex-1">{{ resolveOptionLabel(option) }}</span>
@@ -44,7 +46,9 @@
       >
         <i
           v-if="option.icon"
-          :class="cn('size-4 shrink-0 text-muted-foreground', option.icon)"
+          :class="
+            cn('size-4 shrink-0 text-primary-comfy-canvas/60', option.icon)
+          "
           aria-hidden="true"
         />
         <span class="flex-1">{{ resolveOptionLabel(option) }}</span>
@@ -54,6 +58,7 @@
     <Input
       v-if="field.allowOther && field.otherFieldId && isOtherSelected"
       :model-value="(otherValue as string) ?? ''"
+      :class="inputClass"
       :placeholder="
         $t(
           `cloudOnboarding.survey.options.${field.id}.otherPlaceholder`,
@@ -67,7 +72,7 @@
   <div v-else class="flex flex-col gap-3">
     <label
       :for="controlId"
-      class="block text-lg font-medium text-base-foreground"
+      class="block text-lg font-medium text-primary-comfy-canvas"
     >
       {{ resolvedLabel }}
     </label>
@@ -76,6 +81,7 @@
       :model-value="(modelValue as string) ?? ''"
       :placeholder="field.placeholder"
       :aria-invalid="Boolean(errorMessage)"
+      :class="inputClass"
       @update:model-value="onTextChange"
     />
     <p v-if="errorMessage" class="text-danger text-xs">{{ errorMessage }}</p>
@@ -116,10 +122,13 @@ const { t, te, locale } = useI18n()
 const controlId = useId()
 
 const optionCardClass =
-  'group h-auto w-full items-center justify-start gap-3 rounded-lg bg-node-component-surface px-4 py-3 text-left text-sm text-base-foreground transition-colors hover:bg-tertiary-background data-[state=on]:bg-muted-background data-[state=on]:ring-1 data-[state=on]:ring-brand-yellow'
+  'group h-auto w-full items-center justify-start gap-3 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 px-4 py-3 text-left text-sm text-primary-comfy-canvas shadow-inset-highlight transition-colors hover:bg-sand-300/20 data-[state=on]:bg-sand-300/15 data-[state=on]:ring-1 data-[state=on]:ring-inset data-[state=on]:ring-brand-yellow'
 
 const checkMarkClass =
   'icon-[lucide--check] size-4 shrink-0 text-brand-yellow opacity-0 group-data-[state=on]:opacity-100'
+
+const inputClass =
+  'border-smoke-800/10 bg-smoke-800/10 text-primary-comfy-canvas placeholder:text-primary-comfy-canvas/50'
 
 const isOtherSelected = computed(() =>
   Array.isArray(modelValue)

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.test.ts
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.test.ts
@@ -9,7 +9,8 @@ import type { OnboardingSurvey } from '@/platform/remoteConfig/types'
 import DynamicSurveyForm from './DynamicSurveyForm.vue'
 import { defaultOnboardingSurvey } from './defaultSurveySchema'
 
-const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 20))
+// Waits past the single-select auto-advance delay (autoAdvanceDelayMs = 150)
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 300))
 
 const renderForm = (survey: OnboardingSurvey) =>
   render(DynamicSurveyForm, {
@@ -91,9 +92,10 @@ describe('DynamicSurveyForm', () => {
 
     expect(screen.getByText('What do you want to make?')).toBeVisible()
     expect(screen.getByText('Images')).toBeInTheDocument()
-    // One card per option, plus the single Next button on the first step.
+    // Required single-select auto-advances on pick, so there is no Next button
+    // on this step — just one card per option.
     expect(screen.getAllByRole('button')).toHaveLength(
-      firstField.options!.length + 1
+      firstField.options!.length
     )
   })
 
@@ -137,6 +139,23 @@ describe('DynamicSurveyForm', () => {
     await user.click(screen.getByRole('button', { name: 'Back' }))
     await flushPromises()
     expect(screen.getByText('What do you want to make?')).toBeVisible()
+  })
+
+  it('offers Next on an already-answered single-select reached via Back', async () => {
+    const user = userEvent.setup()
+    renderForm(twoStepSurvey)
+
+    await clickOption(user, 'Images')
+    await flushPromises()
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    await flushPromises()
+
+    // The step is answered, so Next lets the user move forward again without
+    // re-picking (which would toggle the choice off).
+    const next = screen.getByRole('button', { name: 'Next' })
+    await user.click(next)
+    await flushPromises()
+    expect(screen.getByText('Pick everything that applies')).toBeVisible()
   })
 
   it('reveals a branched follow-up step from the answer and submits it', async () => {

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
@@ -12,43 +12,38 @@
       />
     </div>
 
-    <div
-      class="overflow-hidden transition-[height] duration-300 ease-out"
-      :style="animatedHeightStyle"
-    >
-      <div ref="questionContent" class="relative">
-        <Transition
-          enter-active-class="transition-opacity duration-300 ease-out"
-          enter-from-class="opacity-0"
-          leave-active-class="absolute inset-x-0 top-0 transition-opacity duration-300 ease-out"
-          leave-to-class="opacity-0"
+    <div class="relative flex-1">
+      <Transition
+        enter-active-class="transition-opacity duration-300 ease-out"
+        enter-from-class="opacity-0"
+        leave-active-class="absolute inset-x-0 top-0 transition-opacity duration-300 ease-out"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="currentField"
+          :key="currentField.id"
+          class="flex flex-col gap-4"
         >
-          <div
-            v-if="currentField"
-            :key="currentField.id"
-            class="flex flex-col gap-4"
-          >
-            <DynamicSurveyField
-              :field="currentField"
-              :model-value="values[currentField.id]"
-              :other-value="
-                currentField.otherFieldId
-                  ? (values[currentField.otherFieldId] as string)
-                  : undefined
-              "
-              :error-message="currentError"
-              @update:model-value="
-                (value) => onFieldChange(currentField.id, value)
-              "
-              @update:other-value="
-                (value) =>
-                  currentField.otherFieldId &&
-                  onFieldChange(currentField.otherFieldId, value)
-              "
-            />
-          </div>
-        </Transition>
-      </div>
+          <DynamicSurveyField
+            :field="currentField"
+            :model-value="values[currentField.id]"
+            :other-value="
+              currentField.otherFieldId
+                ? (values[currentField.otherFieldId] as string)
+                : undefined
+            "
+            :error-message="currentError"
+            @update:model-value="
+              (value) => onFieldChange(currentField.id, value)
+            "
+            @update:other-value="
+              (value) =>
+                currentField.otherFieldId &&
+                onFieldChange(currentField.otherFieldId, value)
+            "
+          />
+        </div>
+      </Transition>
     </div>
 
     <div
@@ -95,7 +90,6 @@
 
 <script setup lang="ts">
 import { toTypedSchema } from '@vee-validate/zod'
-import { useElementSize } from '@vueuse/core'
 import { useForm } from 'vee-validate'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -164,12 +158,6 @@ const visible = computed(() =>
 )
 const stepIndex = ref(0)
 const touched = ref(new Set<string>())
-
-const questionContent = ref<HTMLElement | null>(null)
-const { height: contentHeight } = useElementSize(questionContent)
-const animatedHeightStyle = computed(() =>
-  contentHeight.value ? { height: `${contentHeight.value}px` } : {}
-)
 
 const currentField = computed(() => visible.value[stepIndex.value])
 const isFirst = computed(() => stepIndex.value === 0)

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
@@ -12,7 +12,7 @@
       />
     </div>
 
-    <div class="relative flex-1">
+    <div class="relative">
       <Transition
         enter-active-class="transition-opacity duration-300 ease-out"
         enter-from-class="opacity-0"

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
@@ -16,11 +16,12 @@
       class="overflow-hidden transition-[height] duration-300 ease-out"
       :style="animatedHeightStyle"
     >
-      <div ref="questionContent">
+      <div ref="questionContent" class="relative">
         <Transition
-          enter-active-class="transition duration-200 ease-out"
-          enter-from-class="opacity-0 translate-y-1"
-          enter-to-class="opacity-100 translate-y-0"
+          enter-active-class="transition-opacity duration-300 ease-out"
+          enter-from-class="opacity-0"
+          leave-active-class="absolute inset-x-0 top-0 transition-opacity duration-300 ease-out"
+          leave-to-class="opacity-0"
         >
           <div
             v-if="currentField"

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
@@ -1,10 +1,10 @@
 <template>
   <form class="flex w-full flex-col" @submit.prevent="onSubmit">
-    <p v-if="introText" class="mb-4 text-sm text-muted-foreground">
+    <p v-if="introText" class="mb-4 text-sm text-primary-comfy-canvas/70">
       {{ introText }}
     </p>
     <div
-      class="mb-8 h-1.5 w-full overflow-hidden rounded-full bg-secondary-background"
+      class="mb-8 h-1.5 w-full overflow-hidden rounded-full bg-primary-comfy-canvas/10"
     >
       <div
         class="h-full bg-brand-yellow transition-[width] duration-300 ease-out"
@@ -12,65 +12,89 @@
       />
     </div>
 
-    <div v-if="currentField" :key="currentField.id" class="flex flex-col gap-4">
-      <DynamicSurveyField
-        :field="currentField"
-        :model-value="values[currentField.id]"
-        :other-value="
-          currentField.otherFieldId
-            ? (values[currentField.otherFieldId] as string)
-            : undefined
-        "
-        :error-message="currentError"
-        @update:model-value="(value) => onFieldChange(currentField.id, value)"
-        @update:other-value="
-          (value) =>
-            currentField.otherFieldId &&
-            onFieldChange(currentField.otherFieldId, value)
-        "
-      />
+    <div
+      class="overflow-hidden transition-[height] duration-300 ease-out"
+      :style="animatedHeightStyle"
+    >
+      <div ref="questionContent">
+        <Transition
+          enter-active-class="transition duration-200 ease-out"
+          enter-from-class="opacity-0 translate-y-1"
+          enter-to-class="opacity-100 translate-y-0"
+        >
+          <div
+            v-if="currentField"
+            :key="currentField.id"
+            class="flex flex-col gap-4"
+          >
+            <DynamicSurveyField
+              :field="currentField"
+              :model-value="values[currentField.id]"
+              :other-value="
+                currentField.otherFieldId
+                  ? (values[currentField.otherFieldId] as string)
+                  : undefined
+              "
+              :error-message="currentError"
+              @update:model-value="
+                (value) => onFieldChange(currentField.id, value)
+              "
+              @update:other-value="
+                (value) =>
+                  currentField.otherFieldId &&
+                  onFieldChange(currentField.otherFieldId, value)
+              "
+            />
+          </div>
+        </Transition>
+      </div>
     </div>
 
-    <div class="mt-8 flex gap-4">
+    <div
+      v-if="!isFirst || showNext || isLast"
+      class="mt-8 flex items-center justify-between gap-4"
+    >
       <Button
         v-if="!isFirst"
         type="button"
-        variant="secondary"
+        variant="link"
         size="lg"
-        class="flex-1"
+        class="px-0 text-primary-comfy-canvas/70 hover:text-primary-comfy-canvas"
         @click="goPrevious"
       >
         <i class="icon-[lucide--chevron-left] size-4" aria-hidden="true" />
         {{ $t('g.back') }}
       </Button>
-      <span v-else class="flex-1" />
+      <span v-else />
       <Button
-        v-if="!isLast"
+        v-if="showNext"
         type="button"
         size="lg"
         :disabled="!isCurrentValid"
-        class="flex-1 bg-brand-yellow text-primary-comfy-ink hover:bg-brand-yellow/85"
+        class="bg-brand-yellow text-primary-comfy-ink hover:bg-brand-yellow/85 disabled:bg-smoke-800/10 disabled:text-primary-comfy-canvas/40 disabled:opacity-100"
         @click="goNext"
       >
         {{ $t('g.next') }}
         <i class="icon-[lucide--chevron-right] size-4" aria-hidden="true" />
       </Button>
       <Button
-        v-else
+        v-else-if="isLast"
         type="submit"
         size="lg"
         :disabled="!isCurrentValid || isSubmitting"
         :loading="isSubmitting"
-        class="flex-1 bg-brand-yellow text-primary-comfy-ink hover:bg-brand-yellow/85"
+        class="bg-brand-yellow text-primary-comfy-ink hover:bg-brand-yellow/85 disabled:bg-smoke-800/10 disabled:text-primary-comfy-canvas/40 disabled:opacity-100"
       >
         {{ $t('g.submit') }}
       </Button>
+      <span v-else />
     </div>
   </form>
 </template>
 
 <script setup lang="ts">
 import { toTypedSchema } from '@vee-validate/zod'
+import { useElementSize } from '@vueuse/core'
 import { useForm } from 'vee-validate'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -130,6 +154,7 @@ watch(
     resetForm({ values: fresh })
     stepIndex.value = 0
     touched.value = new Set()
+    isAdvancing.value = false
   }
 )
 
@@ -139,17 +164,44 @@ const visible = computed(() =>
 const stepIndex = ref(0)
 const touched = ref(new Set<string>())
 
+const questionContent = ref<HTMLElement | null>(null)
+const { height: contentHeight } = useElementSize(questionContent)
+const animatedHeightStyle = computed(() =>
+  contentHeight.value ? { height: `${contentHeight.value}px` } : {}
+)
+
 const currentField = computed(() => visible.value[stepIndex.value])
 const isFirst = computed(() => stepIndex.value === 0)
 const isLast = computed(() => stepIndex.value === visible.value.length - 1)
 
+const isAdvancing = ref(false)
+
+const showNext = computed(() => {
+  if (isLast.value || isAdvancing.value) return false
+  const field = currentField.value
+  if (!field) return false
+  if (field.type === 'single') {
+    const value = values[field.id]
+    const isEmpty = typeof value !== 'string' || value.length === 0
+    return !(field.required && isEmpty)
+  }
+  return true
+})
+
 const currentError = computed(() => {
   const field = currentField.value
-  if (!field || !touched.value.has(field.id)) return undefined
-  return (
-    errors.value[field.id] ??
-    (field.otherFieldId ? errors.value[field.otherFieldId] : undefined)
-  )
+  if (!field) return undefined
+  if (touched.value.has(field.id) && errors.value[field.id]) {
+    return errors.value[field.id]
+  }
+  if (
+    field.otherFieldId &&
+    touched.value.has(field.otherFieldId) &&
+    errors.value[field.otherFieldId]
+  ) {
+    return errors.value[field.otherFieldId]
+  }
+  return undefined
 })
 
 const totalSteps = computed(() => Math.max(visible.value.length, 1))
@@ -179,6 +231,8 @@ const isCurrentValid = computed(() => {
   return true
 })
 
+const autoAdvanceDelayMs = 150
+
 const isAutoAdvanceValue = (field: OnboardingSurveyField, value: unknown) =>
   field.type === 'single' && typeof value === 'string' && value !== 'other'
 
@@ -196,8 +250,13 @@ const onFieldChange = async (id: string, value: string | string[]) => {
 
   const field = currentField.value
   if (field?.id === id && isAutoAdvanceValue(field, value)) {
+    const fromStep = stepIndex.value
+    isAdvancing.value = true
     await nextTick()
-    goNext()
+    window.setTimeout(() => {
+      if (stepIndex.value === fromStep) goNext()
+      isAdvancing.value = false
+    }, autoAdvanceDelayMs)
   }
 }
 
@@ -210,7 +269,10 @@ const goPrevious = () => {
 
 const onSubmit = async () => {
   const field = currentField.value
-  if (field) markTouched(field.id)
+  if (field) {
+    markTouched(field.id)
+    if (field.otherFieldId) markTouched(field.otherFieldId)
+  }
   const result = await validate()
   if (!result.valid) return
   emit(

--- a/src/platform/cloud/onboarding/survey/defaultSurveySchema.ts
+++ b/src/platform/cloud/onboarding/survey/defaultSurveySchema.ts
@@ -34,7 +34,7 @@ export const defaultOnboardingSurvey: OnboardingSurvey = {
           workflows: 'icon-[lucide--workflow]',
           apps_api: 'icon-[lucide--blocks]',
           exploring: 'icon-[lucide--compass]',
-          other: 'icon-[lucide--sparkles]'
+          other: 'icon-[lucide--pencil]'
         }
       )
     },


### PR DESCRIPTION
## Summary

Refine the redesigned Cloud onboarding survey — layout, interactions, and on-brand styling — on top of `feat/onboarding-survey-redesign`.

## Changes

- **What**:
  - Give the survey its own centered layout by hiding the login hero on the survey and user-check routes, so it reads as a distinct step rather than an extension of login
  - Align option cards, inputs, and buttons with the on-brand onboarding shell tokens instead of the neutral in-product components
  - Single-select auto-advance: hide Next until the step is answered, show it again when revisiting an answered step, and briefly highlight the choice before advancing
  - Add a survey title, animate step height changes (`useElementSize` + CSS transition), and fade between steps
  - Keep the free-text hint in the placeholder and stop the required error from showing before the field is touched
  - Inset the selected-card ring so it isn't clipped, normalize the fieldset width, correct the logo aspect ratio, lighten the footer links, and center the post-submit loading spinner

## Review Focus

- Base is `feat/onboarding-survey-redesign`; this stacks on it. The TEMPORARY preview toggles are untouched.
- The `chore:` commit removes a redundant `.agents/checks/eslint.strict.config.js` entry from `knip.config.ts` that knip 6.15.0 reports as dead and that trips the local pre-push hook — unrelated to the survey but needed to push.

## Screenshots

The survey is behind auth; view it locally at `/cloud/survey` using the branch's preview toggles.
