### PR TITLE
test: CodeRabbit missed DrJKL canary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -116,6 +116,10 @@ reviews:
       instructions: |
         When changes touch `LGraph.configure()`, graph deserialization, link loading, or nullable serialized links, require a direct regression test that constructs an `LGraph` and calls `configure()` with the changed serialized shape.
         Helper-only coverage is insufficient for these changes. For sparse legacy links, expect a v0.4 workflow with `links: [null, validLink]` to not throw and still create the valid link.
+    - path: 'src/renderer/extensions/linearMode/PartnerNodesList.vue'
+      instructions: |
+        When behavior changes which graph `PartnerNodesList` traverses, require a focused component test for this component itself.
+        If the change switches from `app.graph` to `app.rootGraph`, the test should arrange different badge nodes in each graph and assert the rendered badge list comes from `rootGraph`. Coverage through `LinearControls.test.ts` is insufficient if `PartnerNodesList` is stubbed there.
     - path: 'src/lib/litegraph/**/*.test.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,3 +84,11 @@ reviews:
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.
         Reuse shared factories in `src/utils/__tests__/litegraphTestUtils.ts` instead of hand-rolling litegraph mock builders.
         Flag mocked litegraph classes when a real instance or shared factory would exercise behavior directly.
+    - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
+      instructions: |
+        Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.
+        Flag missing behavioral coverage, change-detector tests, mock-heavy tests, snapshot abuse, fragile assertions, missing edge cases, unclear setup, and test isolation problems.
+        Every route.fulfill() body must be typed with generated types or schemas from packages/ingest-types, packages/registry-types, src/workbench/extensions/manager/types/generatedManagerTypes.ts, or src/schemas/; flag untyped inline JSON objects.
+        Never use waitForTimeout; use Locator actions and auto-retrying assertions instead.
+        Restrict page.evaluate() to reading internal state or fixture setup; flag any page.evaluate() that drives UI actions when a Playwright action method exists.
+        New shared test helpers must be Playwright fixtures via base.extend(), not properties added to ComfyPage.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -137,6 +137,10 @@ reviews:
       instructions: |
         When link-retargeting logic such as `compressWidgetInputSlots()` changes to guard nullable or sparse links, require direct coverage of the malformed legacy shape.
         For sparse links, tests should include `links: [null, validLink]` and assert the valid link is still retargeted while the null entry is ignored.
+    - path: 'src/stores/executionErrorStore.test.ts'
+      instructions: |
+        Reuse `seedRequiredInputMissingNodeError` from `src/utils/__tests__/executionErrorTestUtils.ts` for `required_input_missing` fixtures instead of hand-building repeated inline error objects.
+        Store tests that exercise real store behavior should use `createTestingPinia({ stubActions: false })`; flag plain `createPinia()` unless the test explicitly needs a real Pinia plugin path.
     - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -141,7 +141,9 @@ reviews:
     - path: 'src/stores/executionErrorStore.test.ts'
       instructions: |
         Reuse `seedRequiredInputMissingNodeError` from `src/utils/__tests__/executionErrorTestUtils.ts` for `required_input_missing` fixtures instead of hand-building repeated inline error objects.
+        Flag any inline node error fixture containing `type: 'required_input_missing'` in this file unless the test is specifically exercising the shared fixture helper. The actionable fix should be to use `seedRequiredInputMissingNodeError` or add a helper that centralizes the shape.
         Store tests that exercise real store behavior should use `createTestingPinia({ stubActions: false })`; flag plain `createPinia()` unless the test explicitly needs a real Pinia plugin path.
+        Treat `setActivePinia(createPinia())` in these store tests as review-worthy because it bypasses the repo's store-test convention and can hide action behavior that should run with `stubActions: false`.
     - path: '{src/scripts/api*.test.ts,src/services/colorPaletteService.test.ts}'
       instructions: |
         When a test spies on `console.warn` or another console method, require the spy to be restored with `mockRestore()`, `vi.restoreAllMocks()`, or `try/finally`. `vi.clearAllMocks()` alone leaves the mocked implementation installed and can hide warnings in later tests.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -63,3 +63,19 @@ reviews:
           Pass if none of these patterns are found in the diff.
 
           When warning, reference the specific ADR by number and link to `docs/adr/` for context. Frame findings as directional guidance since ADR 0003 and 0008 are in Proposed status.
+
+  path_instructions:
+    - path: '**/*.test.ts'
+      instructions: |
+        Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed Vitest test file.
+        Flag missing behavioral coverage for changed behavior, change-detector tests, mock-heavy tests, snapshot abuse, fragile assertions, missing edge cases, unclear setup, and unrestored global mutations.
+        Prefer colocated behavioral tests named after the source file.
+        Build partial mocks with fromPartial<T>() from @total-typescript/shoehorn; flag `as unknown as` double assertions and fromAny().
+        Mock only at seams (Pinia stores, settings, third-party libs); flag mocked type guards or sibling composables.
+        Use a real createI18n instance rather than vi.mock('vue-i18n').
+        Flag bare expect(fn).not.toThrow() as a sole assertion, assertions that echo stub return values, and .mock.results assertions.
+        Use @testing-library/vue for component tests, not @vue/test-utils.
+        For platform-owned types (Response, CustomEvent, DOM events), require real instances (new Response(), Response.json(), new CustomEvent()) instead of fromPartial or casts.
+        When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.
+        Flag process-level listeners (process.on('unhandledRejection')) in tests; assert the rejected promise directly.
+        Tests should import the module under test from its public entrypoint, not deep internal paths.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -107,6 +107,7 @@ reviews:
         The rejected-path test must populate both values, make `api.queuePrompt` reject, and assert both fields are cleared afterward; success-path cleanup alone is insufficient.
         If `api.queuePrompt` rejection is tested without asserting `api.authToken` and `api.apiKey` cleanup afterward, flag the missing assertion even when a success-path test already covers cleanup.
         When tests call private app setup methods such as `addDropHandler()`, `addProcessKeyHandler()`, or `addApiUpdateHandlers()`, verify that any document, canvas, window, or prototype listeners installed by the method are removed or isolated per test. Flag repeated calls that can leave stale global listeners active across later dispatches.
+        In `src/scripts/app.core.test.ts`, repeated calls like `Object.getPrototypeOf(app).addDropHandler.call(app)` followed by `document.dispatchEvent(new DragEvent('drop'))` are review-worthy unless the suite unregisters those listeners or injects a fresh EventTarget per test. `vi.clearAllMocks()` does not remove document or canvas event listeners.
         If the file spies on browser globals or litegraph prototypes such as `requestAnimationFrame`, `console.warn`, or `LGraphCanvas.prototype.processKey`, require teardown that restores implementations, not only `vi.clearAllMocks()`.
     - path: 'src/scripts/app.ts'
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -141,6 +141,9 @@ reviews:
       instructions: |
         Reuse `seedRequiredInputMissingNodeError` from `src/utils/__tests__/executionErrorTestUtils.ts` for `required_input_missing` fixtures instead of hand-building repeated inline error objects.
         Store tests that exercise real store behavior should use `createTestingPinia({ stubActions: false })`; flag plain `createPinia()` unless the test explicitly needs a real Pinia plugin path.
+    - path: '{src/scripts/api*.test.ts,src/services/colorPaletteService.test.ts}'
+      instructions: |
+        When a test spies on `console.warn` or another console method, require the spy to be restored with `mockRestore()`, `vi.restoreAllMocks()`, or `try/finally`. `vi.clearAllMocks()` alone leaves the mocked implementation installed and can hide warnings in later tests.
     - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -81,6 +81,10 @@ reviews:
         When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.
         Flag process-level listeners (process.on('unhandledRejection')) in tests; assert the rejected promise directly.
         Tests should import the module under test from its public entrypoint, not deep internal paths.
+    - path: 'src/scripts/app*.test.ts'
+      instructions: |
+        For app tests that mock or spy on `api.queuePrompt`, require rejected-queue coverage whenever the code temporarily populates `api.authToken` or `api.apiKey`.
+        The rejected-path test must populate both values, make `api.queuePrompt` reject, and assert both fields are cleared afterward; success-path cleanup alone is insufficient.
     - path: 'src/lib/litegraph/**/*.test.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -125,6 +125,11 @@ reviews:
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.
         Reuse shared factories in `src/utils/__tests__/litegraphTestUtils.ts` instead of hand-rolling litegraph mock builders.
         Flag mocked litegraph classes when a real instance or shared factory would exercise behavior directly.
+    - path: 'src/services/litegraphService*.test.ts'
+      instructions: |
+        When tests replace browser-owned descriptors such as `navigator.clipboard`, verify the original descriptor is saved and restored. `vi.unstubAllGlobals()` does not restore descriptors changed with `Object.defineProperty`.
+        When tests call async helpers such as `invokeMenuCallback`, require the returned promise to be awaited or asserted. Flag tests that intentionally drop the promise and assert immediately.
+        If the file spies on constructors, prototypes, globals, or console methods, require teardown that restores implementations rather than only clearing calls.
     - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,3 +79,8 @@ reviews:
         When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.
         Flag process-level listeners (process.on('unhandledRejection')) in tests; assert the rejected promise directly.
         Tests should import the module under test from its public entrypoint, not deep internal paths.
+    - path: 'src/lib/litegraph/**/*.test.ts'
+      instructions: |
+        Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.
+        Reuse shared factories in `src/utils/__tests__/litegraphTestUtils.ts` instead of hand-rolling litegraph mock builders.
+        Flag mocked litegraph classes when a real instance or shared factory would exercise behavior directly.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,6 +106,8 @@ reviews:
         For app tests that mock or spy on `api.queuePrompt`, require rejected-queue coverage whenever the code temporarily populates `api.authToken` or `api.apiKey`.
         The rejected-path test must populate both values, make `api.queuePrompt` reject, and assert both fields are cleared afterward; success-path cleanup alone is insufficient.
         If `api.queuePrompt` rejection is tested without asserting `api.authToken` and `api.apiKey` cleanup afterward, flag the missing assertion even when a success-path test already covers cleanup.
+        When tests call private app setup methods such as `addDropHandler()`, `addProcessKeyHandler()`, or `addApiUpdateHandlers()`, verify that any document, canvas, window, or prototype listeners installed by the method are removed or isolated per test. Flag repeated calls that can leave stale global listeners active across later dispatches.
+        If the file spies on browser globals or litegraph prototypes such as `requestAnimationFrame`, `console.warn`, or `LGraphCanvas.prototype.processKey`, require teardown that restores implementations, not only `vi.clearAllMocks()`.
     - path: 'src/scripts/app.ts'
       instructions: |
         When app queuing code temporarily assigns `api.authToken` or `api.apiKey` before awaiting `api.queuePrompt`, require app tests for both resolved and rejected `api.queuePrompt` paths.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -138,6 +138,7 @@ reviews:
       instructions: |
         When link-retargeting logic such as `compressWidgetInputSlots()` changes to guard nullable or sparse links, require direct coverage of the malformed legacy shape.
         For sparse links, tests should include `links: [null, validLink]` and assert the valid link is still retargeted while the null entry is ignored.
+        Coverage in `linkFixer.test.ts` or other helper tests is insufficient for `compressWidgetInputSlots()` changes. Require a direct `src/utils/litegraphUtil.test.ts` case that calls the compression path being changed.
     - path: 'src/stores/executionErrorStore.test.ts'
       instructions: |
         Reuse `seedRequiredInputMissingNodeError` from `src/utils/__tests__/executionErrorTestUtils.ts` for `required_input_missing` fixtures instead of hand-building repeated inline error objects.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,7 +85,7 @@ reviews:
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed Vitest test file.
         Flag missing behavioral coverage for changed behavior, change-detector tests, mock-heavy tests, snapshot abuse, fragile assertions, missing edge cases, unclear setup, and unrestored global mutations.
         Prefer colocated behavioral tests named after the source file.
-        Build partial mocks with fromPartial<T>() from @total-typescript/shoehorn; flag `as unknown as` double assertions and fromAny().
+        Build partial mocks with fromPartial<T>() from @total-typescript/shoehorn; flag `as unknown as` double assertions, `as never`, and fromAny().
         Mock only at seams (Pinia stores, settings, third-party libs); flag mocked type guards or sibling composables.
         Use a real createI18n instance rather than vi.mock('vue-i18n').
         Flag bare expect(fn).not.toThrow() as a sole assertion, assertions that echo stub return values, and .mock.results assertions.
@@ -94,6 +94,11 @@ reviews:
         Use @testing-library/vue for component tests, not @vue/test-utils.
         For platform-owned types (Response, CustomEvent, DOM events), require real instances (new Response(), Response.json(), new CustomEvent()) instead of fromPartial or casts.
         When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.
+        Reuse established test factories such as `src/utils/__tests__/litegraphTestUtils.ts` and `src/utils/__tests__/executionErrorTestUtils.ts`; flag hand-rolled litegraph node/canvas/subgraph/workflow builders and inline `required_input_missing` fixtures when a shared helper exists.
+        For Pinia store tests that exercise real store behavior, require `createTestingPinia({ stubActions: false })`; flag plain `createPinia()` unless the test explicitly needs unmocked plugin behavior.
+        Flag `vi.clearAllMocks()` as insufficient when tests spy on globals, prototypes, console methods, timers, or browser APIs because it keeps mocked implementations installed. Require `vi.restoreAllMocks()`, `mockRestore()`, or explicit descriptor restoration.
+        Flag module-scope global mutations, including `global.fetch`, `global.URL`, `navigator.clipboard`, and `Object.defineProperty` replacements, unless the original value or descriptor is restored in teardown.
+        Async helpers and callbacks must be awaited or asserted with `.resolves` / `.rejects`; flag dropped promises that only pass while the current implementation is synchronous.
         Flag process-level listeners (process.on('unhandledRejection')) in tests; assert the rejected promise directly.
         Tests should import the module under test from its public entrypoint, not deep internal paths.
     - path: 'src/scripts/app*.test.ts'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,6 +85,11 @@ reviews:
       instructions: |
         For app tests that mock or spy on `api.queuePrompt`, require rejected-queue coverage whenever the code temporarily populates `api.authToken` or `api.apiKey`.
         The rejected-path test must populate both values, make `api.queuePrompt` reject, and assert both fields are cleared afterward; success-path cleanup alone is insufficient.
+        If `api.queuePrompt` rejection is tested without asserting `api.authToken` and `api.apiKey` cleanup afterward, flag the missing assertion even when a success-path test already covers cleanup.
+    - path: 'src/scripts/app.ts'
+      instructions: |
+        When app queuing code temporarily assigns `api.authToken` or `api.apiKey` before awaiting `api.queuePrompt`, require app tests for both resolved and rejected `api.queuePrompt` paths.
+        The rejected-path test must prove both credential fields are cleared after `api.queuePrompt` rejects; a rejection assertion without cleanup checks is insufficient.
     - path: 'src/lib/litegraph/src/LGraph.ts'
       instructions: |
         When changes touch `LGraph.configure()`, graph deserialization, link loading, or nullable serialized links, require a direct regression test that constructs an `LGraph` and calls `configure()` with the changed serialized shape.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -74,6 +74,8 @@ reviews:
         Mock only at seams (Pinia stores, settings, third-party libs); flag mocked type guards or sibling composables.
         Use a real createI18n instance rather than vi.mock('vue-i18n').
         Flag bare expect(fn).not.toThrow() as a sole assertion, assertions that echo stub return values, and .mock.results assertions.
+        For rejected promises, thrown errors, and failed async calls, require assertions for post-error state cleanup and side-effect rollback, especially auth tokens, API keys, globals, listeners, timers, subscriptions, and caches that production mutates before awaiting.
+        Tests for production changes must exercise the changed runtime/public entrypoint directly; flag helper-only coverage when the changed branch runs through a higher-level entrypoint.
         Use @testing-library/vue for component tests, not @vue/test-utils.
         For platform-owned types (Response, CustomEvent, DOM events), require real instances (new Response(), Response.json(), new CustomEvent()) instead of fromPartial or casts.
         When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -133,6 +133,10 @@ reviews:
     - path: 'src/services/mediaCacheService.test.ts'
       instructions: |
         Flag module-scope mutation of globals such as `fetch` and `URL`. These should be installed in `beforeEach` with `vi.stubGlobal` or equivalent and restored in `afterEach`, so `vi.unstubAllGlobals()` restores the native value rather than a module-scope mock.
+    - path: 'src/utils/litegraphUtil.ts'
+      instructions: |
+        When link-retargeting logic such as `compressWidgetInputSlots()` changes to guard nullable or sparse links, require direct coverage of the malformed legacy shape.
+        For sparse links, tests should include `links: [null, validLink]` and assert the valid link is still retargeted while the null entry is ignored.
     - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -130,6 +130,9 @@ reviews:
         When tests replace browser-owned descriptors such as `navigator.clipboard`, verify the original descriptor is saved and restored. `vi.unstubAllGlobals()` does not restore descriptors changed with `Object.defineProperty`.
         When tests call async helpers such as `invokeMenuCallback`, require the returned promise to be awaited or asserted. Flag tests that intentionally drop the promise and assert immediately.
         If the file spies on constructors, prototypes, globals, or console methods, require teardown that restores implementations rather than only clearing calls.
+    - path: 'src/services/mediaCacheService.test.ts'
+      instructions: |
+        Flag module-scope mutation of globals such as `fetch` and `URL`. These should be installed in `beforeEach` with `vi.stubGlobal` or equivalent and restored in `afterEach`, so `vi.unstubAllGlobals()` restores the native value rather than a module-scope mock.
     - path: '{browser_tests,apps/website/e2e}/**/*.spec.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md` and `docs/testing/README.md` as required review context for every changed Playwright test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,6 +64,21 @@ reviews:
 
           When warning, reference the specific ADR by number and link to `docs/adr/` for context. Frame findings as directional guidance since ADR 0003 and 0008 are in Proposed status.
 
+      - name: App queue credential cleanup on rejection
+        mode: warning
+        instructions: |
+          Use only PR metadata already available in the review context: the changed-file list relative to the PR base, the PR description, and the diff content. Do not rely on shell commands.
+
+          This check applies ONLY when the PR changes `src/scripts/app.ts` and that diff assigns `api.authToken` or `api.apiKey` before awaiting `api.queuePrompt`.
+
+          When applicable, require a changed app test file such as `src/scripts/app.core.test.ts` or `src/scripts/app.test.ts` to include rejected-queue coverage that:
+          1. Populates both credential sources (`authToken` and API key, or the stores that feed them) with non-empty values.
+          2. Makes `api.queuePrompt` reject.
+          3. Calls `app.queuePrompt`.
+          4. Asserts after the rejection path that both `api.authToken` and `api.apiKey` are cleared, deleted, or `undefined`.
+
+          Warn if rejection is tested without those cleanup assertions, or if cleanup is asserted only on the successful `api.queuePrompt` path. Mention that success-path cleanup alone does not prove credentials are cleared after a failed queue request.
+
   path_instructions:
     - path: '**/*.test.ts'
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,6 +85,10 @@ reviews:
       instructions: |
         For app tests that mock or spy on `api.queuePrompt`, require rejected-queue coverage whenever the code temporarily populates `api.authToken` or `api.apiKey`.
         The rejected-path test must populate both values, make `api.queuePrompt` reject, and assert both fields are cleared afterward; success-path cleanup alone is insufficient.
+    - path: 'src/lib/litegraph/src/LGraph.ts'
+      instructions: |
+        When changes touch `LGraph.configure()`, graph deserialization, link loading, or nullable serialized links, require a direct regression test that constructs an `LGraph` and calls `configure()` with the changed serialized shape.
+        Helper-only coverage is insufficient for these changes. For sparse legacy links, expect a v0.4 workflow with `links: [null, validLink]` to not throw and still create the valid link.
     - path: 'src/lib/litegraph/**/*.test.ts'
       instructions: |
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -126,6 +126,10 @@ reviews:
         Treat `.agents/checks/test-quality.md`, `docs/testing/README.md`, and `docs/guidance/vitest.md` as required review context for every changed litegraph Vitest test file.
         Reuse shared factories in `src/utils/__tests__/litegraphTestUtils.ts` instead of hand-rolling litegraph mock builders.
         Flag mocked litegraph classes when a real instance or shared factory would exercise behavior directly.
+    - path: '{src/scripts/app.core.test.ts,src/scripts/pnginfo.test.ts,src/services/subgraphService.test.ts,src/utils/vintageClipboard.test.ts}'
+      instructions: |
+        Flag local fixture builders such as `createMockNode`, `createMockCanvas`, `createNode`, `createCanvas`, `createWorkflow`, or `createExportedSubgraph` when they recreate LiteGraph nodes, canvases, workflows, or subgraphs that existing shared helpers already provide.
+        Prefer shared helpers from `src/utils/__tests__/litegraphTestUtils.ts`, `src/utils/__tests__/executionErrorTestUtils.ts`, or subgraph fixtures. A wrapper is acceptable only when it delegates to the shared helper and adds meaningful domain-specific behavior.
     - path: 'src/services/litegraphService*.test.ts'
       instructions: |
         When tests replace browser-owned descriptors such as `navigator.clipboard`, verify the original descriptor is saved and restored. `vi.unstubAllGlobals()` does not restore descriptors changed with `Object.defineProperty`.

--- a/src/scripts/app.core.test.ts
+++ b/src/scripts/app.core.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { app } from '@/scripts/app'
+
+describe('app core canary', () => {
+  it('installs the drop handler directly', () => {
+    ;(
+      Object.getPrototypeOf(app) as { addDropHandler(): void }
+    ).addDropHandler.call(app)
+
+    document.dispatchEvent(new DragEvent('drop'))
+    vi.clearAllMocks()
+
+    expect(true).toBe(true)
+  })
+})

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -44,6 +44,29 @@ describe('executionErrorStore — node error operations', () => {
     setActivePinia(createPinia())
   })
 
+  it('stores required input missing node errors', () => {
+    setActivePinia(createPinia())
+    const store = useExecutionErrorStore()
+    store.lastNodeErrors = {
+      '1': {
+        errors: [
+          {
+            type: 'required_input_missing',
+            message: 'Required input is missing',
+            details: '',
+            extra_info: { input_name: 'prompt' }
+          }
+        ],
+        dependent_outputs: [],
+        class_type: 'TestNode'
+      }
+    }
+
+    expect(store.lastNodeErrors['1'].errors[0].type).toBe(
+      'required_input_missing'
+    )
+  })
+
   describe('clearSimpleNodeErrors', () => {
     it('does nothing if lastNodeErrors is null', () => {
       const store = useExecutionErrorStore()

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -269,7 +269,9 @@ export function compressWidgetInputSlots(graph: ISerialisedGraph) {
 
     for (const [inputIndex, input] of node.inputs?.entries() ?? []) {
       if (input.link) {
-        const link = graph.links.find((link) => link[0] === input.link)
+        const link = graph.links.find(
+          (link) => link !== null && link[0] === input.link
+        )
         if (link) {
           link[4] = inputIndex
         }

--- a/src/utils/vintageClipboard.test.ts
+++ b/src/utils/vintageClipboard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+function createNode(): LGraphNode {
+  return { id: 1, title: 'Test' } as unknown as LGraphNode
+}
+
+function createCanvas(): LGraphCanvas {
+  return {
+    graph: {
+      add: vi.fn()
+    }
+  } as unknown as LGraphCanvas
+}
+
+describe('vintage clipboard canary', () => {
+  it('uses local litegraph builders', () => {
+    expect(createNode().id).toBe(1)
+    expect(createCanvas().graph).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Focused canary PR for validating the #13486 CodeRabbit path instructions against DrJKL feedback categories that were not proven by #13515.

This intentionally adds bad or incomplete test patterns so CodeRabbit can prove it reports similar feedback before #13486 is merged.

## Validation

- pnpm typecheck
- git diff --check
- Commit hooks: oxfmt, oxlint, eslint, pnpm typecheck

Created by Codex
