### PR TITLE
fix(litegraph): purge widget state when a zero-UUID graph is cleared

### DIFF
--- a/browser_tests/tests/widget.spec.ts
+++ b/browser_tests/tests/widget.spec.ts
@@ -424,3 +424,35 @@ test.describe('Unserialized widgets', { tag: '@widget' }, () => {
       .toBe(false)
   })
 })
+
+test.describe('Widget value isolation', { tag: '@widget' }, () => {
+  test('re-added node does not inherit a cleared node widget value', async ({
+    comfyPage
+  }) => {
+    await comfyPage.nodeOps.clearGraph()
+
+    const firstNode = await comfyPage.nodeOps.addNode('EmptyLatentImage')
+    const firstWidth = await firstNode.getWidgetByName('width')
+    const defaultWidth = await firstWidth.getValue()
+
+    await comfyPage.page.evaluate(
+      ({ id, name, value }) => {
+        const node = window.app!.graph.getNodeById(id)
+        if (!node) throw new Error(`Node ${id} not found`)
+        const widget = node.widgets?.find((w) => w.name === name)
+        if (!widget) throw new Error(`Widget ${name} not found`)
+        widget.value = value
+      },
+      { id: firstNode.id, name: 'width', value: 128 }
+    )
+    expect(await firstWidth.getValue()).toBe(128)
+
+    await comfyPage.nodeOps.clearGraph()
+
+    const secondNode = await comfyPage.nodeOps.addNode('EmptyLatentImage')
+    expect(secondNode.id).toBe(firstNode.id)
+
+    const secondWidth = await secondNode.getWidgetByName('width')
+    expect(await secondWidth.getValue()).toBe(defaultWidth)
+  })
+})

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -344,6 +344,66 @@ describe('Graph Clearing and Callbacks', () => {
       []
     )
   })
+
+  test('clear() purges widget state on a zero-UUID graph that holds nodes (node-id reuse leak)', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+
+    const graph = new LGraph()
+    expect(graph.id).toBe(zeroUuid)
+
+    const node = new LGraphNode('ImageAnalyze')
+    node.id = toNodeId(1)
+    graph.add(node)
+
+    const widgetValueStore = useWidgetValueStore()
+    const modeWidgetId = widgetId(graph.id, toNodeId(1), 'mode')
+    widgetValueStore.registerWidget(modeWidgetId, {
+      type: 'combo',
+      value: 'Black White Levels',
+      options: {},
+      label: undefined,
+      serialize: undefined,
+      disabled: undefined
+    })
+
+    const previewExposureStore = usePreviewExposureStore()
+    previewExposureStore.addExposure(graph.id, `${graph.id}:1`, {
+      sourceNodeId: '1',
+      sourcePreviewName: '$$canvas-image-preview'
+    })
+
+    graph.clear()
+
+    expect(widgetValueStore.getWidget(modeWidgetId)).toBeUndefined()
+    expect(
+      previewExposureStore.getExposures(graph.id, `${graph.id}:1`)
+    ).toEqual([])
+  })
+
+  test('constructing a new empty graph does not purge existing zero-UUID widget state', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+
+    const active = new LGraph()
+    const node = new LGraphNode('ImageAnalyze')
+    node.id = toNodeId(1)
+    active.add(node)
+
+    const widgetValueStore = useWidgetValueStore()
+    const modeWidgetId = widgetId(active.id, toNodeId(1), 'mode')
+    widgetValueStore.registerWidget(modeWidgetId, {
+      type: 'combo',
+      value: 'keep me',
+      options: {},
+      label: undefined,
+      serialize: undefined,
+      disabled: undefined
+    })
+
+    const throwaway = new LGraph()
+    expect(throwaway.id).toBe(zeroUuid)
+
+    expect(widgetValueStore.getWidget(modeWidgetId)?.value).toBe('keep me')
+  })
 })
 
 describe('node:before-removed event', () => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -392,7 +392,9 @@ export class LGraph
     this.status = LGraph.STATUS_STOPPED
 
     const graphId = this.id
-    if (this.isRootGraph && graphId !== zeroUuid) {
+    const isEmptyUnconfiguredGraph =
+      graphId === zeroUuid && this._nodes.length === 0
+    if (this.isRootGraph && !isEmptyUnconfiguredGraph) {
       usePreviewExposureStore().clearGraph(graphId)
       useWidgetValueStore().clearGraph(graphId)
     }

--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -225,5 +225,19 @@ describe('useWidgetValueStore', () => {
       expect(store.getWidget(seedA)).toBeUndefined()
       expect(store.getWidget(seedB)?.value).toBe(2)
     })
+
+    it('re-registering a reused widget id after clearGraph returns fresh state', () => {
+      const store = useWidgetValueStore()
+      const modeA = widgetId(graphA, toNodeId('node-1'), 'mode')
+
+      store.registerWidget(modeA, state('combo', 'Black White Levels'))
+      expect(store.getWidget(modeA)?.value).toBe('Black White Levels')
+
+      store.clearGraph(graphA)
+
+      const reused = store.registerWidget(modeA, state('combo', 'normal'))
+      expect(reused.value).toBe('normal')
+      expect(store.getWidget(modeA)?.value).toBe('normal')
+    })
   })
 })


### PR DESCRIPTION
## Summary

`LGraph.clear()` now purges widget and preview-exposure state for a zero-UUID root graph that holds nodes, fixing a leak where a node reusing an id after a clear inherited the previous node's widget value and failed backend validation (`Value not in list`).

## Changes

- **What**: Gate the existing store purge in `LGraph.clear()` on the graph not being an empty unconfigured (zero-UUID) graph, so real teardowns purge while construction and throwaway graphs do not.

## Review Focus

The `isEmptyUnconfiguredGraph` gate: the constructor's `clear()` and `insertWorkflow`'s throwaway `new LGraph(json)` run at the zero UUID with no nodes and must keep skipping the purge, or they would wipe the active graph's shared zero-UUID namespace. Covered by the construction-safety test. Surfaced by the custom-node e2e suite (#13389).
