### PR TITLE
feat: gate BYOK secret providers behind byok_partner_nodes flag

### DIFF
--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -25,6 +25,7 @@ export enum ServerFeatureFlag {
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
   TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
+  BYOK_PARTNER_NODES = 'byok_partner_nodes',
   NODE_REPLACEMENTS = 'node_replacements',
   NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
   WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
@@ -137,6 +138,13 @@ export function useFeatureFlags() {
       return resolveFlag(
         ServerFeatureFlag.USER_SECRETS_ENABLED,
         remoteConfig.value.user_secrets_enabled,
+        false
+      )
+    },
+    get byokPartnerNodesEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.BYOK_PARTNER_NODES,
+        remoteConfig.value.byok_partner_nodes,
         false
       )
     },

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -107,6 +107,7 @@ export type RemoteConfig = {
   linear_toggle_enabled?: boolean
   team_workspaces_enabled?: boolean
   user_secrets_enabled?: boolean
+  byok_partner_nodes?: boolean
   node_library_essentials_enabled?: boolean
   free_tier_credits?: number
   new_free_tier_subscriptions?: boolean

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -134,7 +134,7 @@ import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
 import SelectValue from '@/components/ui/select/SelectValue.vue'
 
 import { useSecretForm } from '../composables/useSecretForm'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 const {
   secret,
@@ -143,7 +143,7 @@ const {
   mode = 'create'
 } = defineProps<{
   secret?: SecretMetadata
-  existingProviders?: SecretProvider[]
+  existingProviders?: string[]
   availableProviders?: string[] | null
   mode?: 'create' | 'edit'
 }>()

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -226,6 +226,23 @@ describe('useSecretForm', () => {
       expect(providerOptions.value.map((o) => o.value)).toEqual(['civitai'])
     })
 
+    it('surfaces partner providers from the server with friendly labels', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['huggingface', 'gemini', 'runway'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([
+        { label: 'HuggingFace', value: 'huggingface', disabled: false },
+        { label: 'Gemini', value: 'gemini', disabled: false },
+        { label: 'Runway', value: 'runway', disabled: false }
+      ])
+    })
+
     it('reacts to availableProviders changing', () => {
       const visible = ref(true)
       const availableProviders = ref<string[] | null>(null)

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -4,13 +4,13 @@ import { computed, reactive, ref, toValue } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { createSecret, SecretsApiError, updateSecret } from '../api/secretsApi'
-import { SECRET_PROVIDERS } from '../providers'
-import type { SecretErrorCode, SecretMetadata, SecretProvider } from '../types'
+import { getProviderLabel, SECRET_PROVIDERS } from '../providers'
+import type { SecretErrorCode, SecretMetadata } from '../types'
 
 interface SecretFormState {
   name: string
   secretValue: string
-  provider: SecretProvider | null
+  provider: string | null
 }
 
 interface SecretFormErrors {
@@ -21,14 +21,14 @@ interface SecretFormErrors {
 
 interface ProviderOption {
   label: string
-  value: SecretProvider
+  value: string
   disabled: boolean
 }
 
 interface UseSecretFormOptions {
   mode: 'create' | 'edit'
   secret?: MaybeRefOrGetter<SecretMetadata | undefined>
-  existingProviders: MaybeRefOrGetter<SecretProvider[]>
+  existingProviders: MaybeRefOrGetter<string[]>
   availableProviders?: MaybeRefOrGetter<string[] | null>
   visible: { value: boolean }
   onSaved: () => void
@@ -64,14 +64,12 @@ export function useSecretForm(options: UseSecretFormOptions) {
   const providerOptions = computed<ProviderOption[]>(() => {
     const available = toValue(availableProviders)
     const providers =
-      mode === 'edit' || available === null
-        ? SECRET_PROVIDERS
-        : SECRET_PROVIDERS.filter((p) => available.includes(p.value))
-    return providers.map((p) => ({
-      label: p.label,
-      value: p.value,
+      mode === 'edit' || available === null ? SECRET_PROVIDERS : available
+    return providers.map((provider) => ({
+      label: getProviderLabel(provider),
+      value: provider,
       disabled:
-        mode === 'edit' ? false : toValue(existingProviders).includes(p.value)
+        mode === 'edit' ? false : toValue(existingProviders).includes(provider)
     }))
   })
 
@@ -91,10 +89,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     const secret = toValue(secretRef)
     if (mode === 'edit' && secret) {
       form.name = secret.name
-      // Stored provider is a free-form string; in edit mode the field is
-      // disabled and only needs to be non-empty for validation (it is never
-      // re-sent), so narrowing to the form's known-provider type is safe here.
-      form.provider = (secret.provider ?? null) as SecretProvider | null
+      form.provider = secret.provider ?? null
       form.secretValue = ''
     } else {
       form.name = ''

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -4,6 +4,7 @@ import type { SecretMetadata } from '../types'
 import { useSecrets } from './useSecrets'
 
 const mockAdd = vi.fn()
+const { byokFlag } = vi.hoisted(() => ({ byokFlag: { enabled: false } }))
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key })
@@ -11,6 +12,16 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: mockAdd })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get byokPartnerNodesEnabled() {
+        return byokFlag.enabled
+      }
+    }
+  })
 }))
 
 const mockListSecrets = vi.fn()
@@ -49,6 +60,7 @@ function createMockSecret(
 describe('useSecrets', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    byokFlag.enabled = false
   })
 
   describe('fetchSecrets', () => {
@@ -171,6 +183,56 @@ describe('useSecrets', () => {
 
       expect(availableProviders.value).toBeNull()
       expect(mockAdd).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('BYOK partner provider gating', () => {
+    it('hides BYOK providers while keeping base providers when the flag is off', async () => {
+      byokFlag.enabled = false
+      mockListSecretProviders.mockResolvedValue([
+        'huggingface',
+        'civitai',
+        'gemini',
+        'runway'
+      ])
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toEqual(['huggingface', 'civitai'])
+    })
+
+    it('includes BYOK providers returned by the server when the flag is on', async () => {
+      byokFlag.enabled = true
+      mockListSecretProviders.mockResolvedValue([
+        'huggingface',
+        'civitai',
+        'gemini',
+        'runway'
+      ])
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toEqual([
+        'huggingface',
+        'civitai',
+        'gemini',
+        'runway'
+      ])
+    })
+
+    it('does not add BYOK providers the server did not return when the flag is on', async () => {
+      byokFlag.enabled = true
+      mockListSecretProviders.mockResolvedValue(['huggingface', 'civitai'])
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toEqual(['huggingface', 'civitai'])
     })
   })
 

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -11,7 +11,7 @@ import {
   SecretsApiError
 } from '../api/secretsApi'
 import { BYOK_PARTNER_PROVIDERS } from '../providers'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 export function useSecrets() {
   const { t } = useI18n()
@@ -29,10 +29,10 @@ export function useSecrets() {
     return providers.filter((p) => !BYOK_PARTNER_PROVIDERS.has(p))
   })
 
-  const existingProviders = computed<SecretProvider[]>(() =>
+  const existingProviders = computed<string[]>(() =>
     secrets.value
       .map((s) => s.provider)
-      .filter((p): p is SecretProvider => p !== undefined)
+      .filter((p): p is string => p !== undefined)
   )
 
   async function fetchSecrets() {

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import {
@@ -9,16 +10,24 @@ import {
   listSecrets,
   SecretsApiError
 } from '../api/secretsApi'
+import { BYOK_PARTNER_PROVIDERS } from '../providers'
 import type { SecretMetadata, SecretProvider } from '../types'
 
 export function useSecrets() {
   const { t } = useI18n()
   const toastStore = useToastStore()
+  const { flags } = useFeatureFlags()
 
   const loading = ref(false)
   const secrets = ref<SecretMetadata[]>([])
-  const availableProviders = ref<string[] | null>(null)
+  const serverProviders = ref<string[] | null>(null)
   const operatingSecretId = ref<string | null>(null)
+
+  const availableProviders = computed<string[] | null>(() => {
+    const providers = serverProviders.value
+    if (providers === null || flags.byokPartnerNodesEnabled) return providers
+    return providers.filter((p) => !BYOK_PARTNER_PROVIDERS.has(p))
+  })
 
   const existingProviders = computed<SecretProvider[]>(() =>
     secrets.value
@@ -52,7 +61,7 @@ export function useSecrets() {
 
   async function fetchProviders() {
     try {
-      availableProviders.value = await listSecretProviders()
+      serverProviders.value = await listSecretProviders()
     } catch (err) {
       console.error('Unexpected error fetching secret providers:', err)
     }

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -15,6 +15,17 @@ export const SECRET_PROVIDERS: ProviderConfig[] = [
   { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' }
 ] as const
 
+/**
+ * BYOK (bring-your-own-key) partner providers. The server payload does not mark
+ * providers as partner-owned, so this is the known-id allowlist gated behind the
+ * `byokPartnerNodesEnabled` feature flag. Base providers (huggingface, civitai)
+ * are never gated here.
+ */
+export const BYOK_PARTNER_PROVIDERS: ReadonlySet<string> = new Set([
+  'gemini',
+  'runway'
+])
+
 export function getProviderLabel(provider: string | undefined): string {
   if (!provider) return ''
   const config = SECRET_PROVIDERS.find((p) => p.value === provider)

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -1,19 +1,32 @@
 import type { SecretProvider } from './types'
 
 interface ProviderConfig {
-  value: SecretProvider
   label: string
-  logo: string
+  logo?: string
 }
 
-export const SECRET_PROVIDERS: ProviderConfig[] = [
-  {
-    value: 'huggingface',
-    label: 'HuggingFace',
-    logo: '/assets/images/hf-logo.svg'
-  },
-  { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' }
-] as const
+/**
+ * Display metadata (label + optional logo) for known providers, keyed by the
+ * free-form provider id. Providers not listed here fall back to their raw id as
+ * the label and render without a logo.
+ */
+const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
+  huggingface: { label: 'HuggingFace', logo: '/assets/images/hf-logo.svg' },
+  civitai: { label: 'Civitai', logo: '/assets/images/civitai.svg' },
+  gemini: { label: 'Gemini' },
+  runway: { label: 'Runway' }
+}
+
+/**
+ * Base providers shown in the add-secret dropdown before/without a
+ * server-provided list. Partner providers are surfaced only when the server
+ * returns them and the BYOK flag is on (see `BYOK_PARTNER_PROVIDERS`), so they
+ * are intentionally excluded from this fallback set.
+ */
+export const SECRET_PROVIDERS: readonly SecretProvider[] = [
+  'huggingface',
+  'civitai'
+]
 
 /**
  * BYOK (bring-your-own-key) partner providers. The server payload does not mark
@@ -28,14 +41,12 @@ export const BYOK_PARTNER_PROVIDERS: ReadonlySet<string> = new Set([
 
 export function getProviderLabel(provider: string | undefined): string {
   if (!provider) return ''
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.label ?? provider
+  return PROVIDER_CONFIGS[provider]?.label ?? provider
 }
 
 export function getProviderLogo(
   provider: string | undefined
 ): string | undefined {
   if (!provider) return undefined
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.logo
+  return PROVIDER_CONFIGS[provider]?.logo
 }

--- a/src/platform/secrets/types.ts
+++ b/src/platform/secrets/types.ts
@@ -18,7 +18,7 @@ export type SecretProvider = 'huggingface' | 'civitai'
 export interface SecretCreateRequest {
   name: string
   secret_value: string
-  provider?: SecretProvider
+  provider?: string
 }
 
 export interface SecretUpdateRequest {


### PR DESCRIPTION
## ELI-5

The Secrets settings panel lets you add API keys for providers. We're piloting "bring-your-own-key" (BYOK) partner providers (Gemini, Runway) for a specific customer cohort. This adds a per-user server flag so those two providers only appear in the "add secret" dropdown for users the backend has opted in — everyone else keeps seeing just the base providers (HuggingFace, Civitai). The panel itself is unchanged; only the contents of the provider dropdown gain this extra gate.

## Summary

Gate the BYOK partner secret providers (gemini/runway) in the provider dropdown behind a new per-user `byok_partner_nodes` server flag, on top of the existing entitlement + `user_secrets_enabled` gates.

## Changes

- **What**:
  - `useFeatureFlags`: add `ServerFeatureFlag.BYOK_PARTNER_NODES = 'byok_partner_nodes'` and a `byokPartnerNodesEnabled` getter mirroring `userSecretsEnabled` (default `false`); add the matching `byok_partner_nodes?: boolean` field to the `RemoteConfig` type.
  - `secrets/providers.ts`: add `BYOK_PARTNER_PROVIDERS` (`gemini`, `runway`) — the known-id allowlist.
  - `useSecrets`: the server-returned provider list (from `GET /secrets/providers`, PR #13494) is now exposed through a computed `availableProviders` that strips BYOK partner ids when `byokPartnerNodesEnabled` is off. Base providers are never gated. This is the single choke point that already threads to both create/edit dialogs, so no component wiring changes were needed.
- **Breaking**: none. With the flag off (its default until the backend ships the flag), BYOK providers stay hidden regardless of entitlement — safe.

## Review Focus

- **Hardcoded id allowlist, not a server marker.** The `/secrets/providers` payload (`SecretProvider`) exposes only `id` — it does not mark providers as partner-owned — so the gate uses the known-id set `{gemini, runway}` per the ticket's fallback branch. If the backend later adds a partner marker to the payload, this can switch to reading that field.
- **Defense-in-depth, not the only gate.** Entitlement still governs whether the server returns BYOK providers at all; this flag is an additional per-user visibility gate on top (a user must be both entitled AND flagged). The "flag on but server didn't return the provider" case is covered by a test — nothing is fabricated client-side.
- **`null` pass-through preserved.** When the providers list hasn't loaded (`null`, endpoint absent/unreachable), the computed returns `null` unchanged, so `useSecretForm`'s existing fall-back-to-base-providers behavior is untouched.
- **Panel mount unchanged.** The Secrets panel visibility (`useSettingUI.ts`) stays on `userSecretsEnabled` only — this flag is not added there.
- **Edit-mode note (judgment call).** `useSecretForm` intentionally ignores `availableProviders` in edit mode, where the provider `<Select>` is disabled and only reflects the existing secret's provider. Combined with BYOK ids not yet having local label/logo config in `SECRET_PROVIDERS`, there is no path to newly select a gated provider. The create flow (the actionable path) is fully gated; if the provider label/logo follow-up later adds gemini/runway to `SECRET_PROVIDERS`, revisit whether the disabled edit dropdown also needs the gate.

## Test plan

- `useSecrets.test.ts`: flag off → gemini/runway stripped, huggingface/civitai kept; flag on → server-returned BYOK providers included; flag on but server omits them → not added.
- Existing `useSecrets` / `useSecretForm` / `SecretsPanel` suites unchanged and green.
