### PR TITLE
test: pin unknown-provider flow-through in server-driven provider options

### DIFF
--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -268,6 +268,27 @@ describe('useSecretForm', () => {
       ])
     })
 
+    it('passes a server-listed provider absent from the local registry through with its raw id as label and no logo', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['brand-new-provider'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([
+        {
+          value: 'brand-new-provider',
+          label: 'brand-new-provider',
+          logo: undefined,
+          disabled: false
+        }
+      ])
+      expect(providerOptions.value[0]?.logo).toBeUndefined()
+    })
+
     it('omits BYOK providers the server does not list', () => {
       const visible = ref(true)
       const { providerOptions } = useSecretForm({


### PR DESCRIPTION
## ELI-5

The provider picker for BYOK secrets is now driven by the server's `availableProviders` list, not a hardcoded frontend list. The point is that a provider the server offers but the frontend has never heard of should still show up — using its raw id as the label and no logo. This adds the one test that actually pins that behavior, so nobody can later re-add a "only show providers the frontend knows about" filter without a test going red.

## Summary

Regression test for the server-driven provider options introduced in #13509: asserts that an unknown provider id passes through `providerOptions` rather than being filtered against the local presentational registry.

## Changes

- **What**: Adds one `useSecretForm.test.ts` case asserting that a create-mode `availableProviders` list containing an id absent from the local `SECRET_PROVIDERS` registry (`'brand-new-provider'`) yields a single `providerOptions` entry rendered with the raw id as its label and `logo: undefined`.

## Review Focus

The existing suite already covers the registry fallback (`providers.test.ts`) and server-listed *known* ids (`runway`/`gemini`), but every one of those cases uses an id that exists in the local registry — so a future change that re-filtered `availableProviders` against `SECRET_PROVIDERS` could pass all current tests while silently dropping unknown providers. This test closes that gap by using an id that is deliberately absent from the registry, so it fails if pass-through is ever broken. Follow-up to the optional review ask on #13509. Test-only; no production code changes.
