### PR TITLE
fix: identify Customer.io users with email trait so in-app messages deliver

### DIFF
--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -13,6 +13,7 @@ const hoisted = vi.hoisted(() => {
     analytics,
     load: vi.fn(() => analytics),
     inAppPlugin: vi.fn(() => ({ name: 'Customer.io In-App Plugin' })),
+    userEmail: { value: null as string | null },
     onUserResolved: vi.fn((cb: (user: { id: string }) => void) => {
       resolvedCb = cb
     }),
@@ -31,6 +32,7 @@ vi.mock('@customerio/cdp-analytics-browser', () => ({
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({
+    userEmail: hoisted.userEmail,
     onUserResolved: hoisted.onUserResolved,
     onUserLogout: hoisted.onUserLogout
   })
@@ -59,6 +61,7 @@ describe('CustomerIoTelemetryProvider', () => {
     vi.clearAllMocks()
     hoisted.load.mockReturnValue(hoisted.analytics)
     hoisted.analytics.register.mockResolvedValue(undefined)
+    hoisted.userEmail.value = null
     window.__CONFIG__ = {} as typeof window.__CONFIG__
   })
 
@@ -89,13 +92,28 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(hoisted.load).not.toHaveBeenCalled()
   })
 
-  it('identifies the person by uid only on auth resolve', async () => {
+  it('identifies with uid and the email trait on auth resolve', async () => {
+    createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.userEmail.value = 'user@example.com'
+    hoisted.resolveUser('test-uid-7f3a9c')
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c', {
+      email: 'user@example.com'
+    })
+  })
+
+  it('identifies with uid alone when no email is available', async () => {
     createProvider()
     await vi.dynamicImportSettled()
 
     hoisted.resolveUser('test-uid-7f3a9c')
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c')
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+      'test-uid-7f3a9c',
+      undefined
+    )
   })
 
   it('identifies with the configured user_id override without waiting for auth', async () => {

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -63,7 +63,13 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         if (userIdOverride) {
           void analytics.identify(userIdOverride)
         } else {
-          currentUser.onUserResolved((user) => void analytics.identify(user.id))
+          // Journeys profiles minted by server-side event pipelines are keyed
+          // by email with no id; sending the email trait attaches this uid to
+          // them so queued in-app messages (fetched by uid) reach the user.
+          currentUser.onUserResolved((user) => {
+            const email = currentUser.userEmail.value
+            void analytics.identify(user.id, email ? { email } : undefined)
+          })
         }
         currentUser.onUserLogout(() => void analytics.reset())
 


### PR DESCRIPTION
## Problem

Customer.io in-app campaign messages never display on cloud.comfy.org (MAR-469): the free-tier activation nudge campaign shows 1,463 sent / 0 opened since Jul 7.

Root cause is an identifier mismatch, not a missing SDK (the SDK from #12878 is live in prod):

- The web SDK identifies to Customer.io with the Firebase uid only: `analytics.identify(user.id)`.
- The PostHog -> Customer.io destination that triggers the campaign identifies people by email only (`identifiers: { email }`, never an id), so campaign entrants are email-keyed profiles with `id: null`, created at event time.
- Queued in-app messages attach to the email-keyed profile, while the SDK fetches messages for the uid identity. Nothing matches, so messages sit in "sent" until they expire.

## Fix

Send the email trait alongside the uid on identify. Per Customer.io identifier semantics, an identify carrying a new id plus an existing profile's email updates that profile and assigns it the id, so the two identities converge and queued in-app messages become fetchable by the SDK's uid token.

## Verification

- Unit tests: identify includes `{ email }` trait; uid-only fallback when no email is available (e.g. GitHub OAuth with private email). 20 passed.
- `pnpm typecheck`, eslint, oxfmt clean.
- Manual test plan: log into cloud with a test account, confirm the CIO profile carries both `id` and `email` identifiers, fire `billing:free_tier_granted` for it, and confirm the in-app nudge renders and the campaign Opened metric increments.

Needs backport to the current cloud release line (cloud/1.47 label applied).

MAR-469