### PR TITLE
feat: add Share with team toggle to media save nodes

### DIFF
--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -21,6 +21,7 @@ if (!isCloud) {
 import './noteNode'
 import './painter'
 import './previewAny'
+import './publishToWorkspace'
 import './saveText'
 import './rerouteNode'
 import './saveImageExtraOutput'

--- a/src/extensions/core/publishToWorkspace.test.ts
+++ b/src/extensions/core/publishToWorkspace.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    extension: null as { nodeCreated: (node: unknown) => void } | null
+  }
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: (ext: { nodeCreated: (node: unknown) => void }) => {
+      state.extension = ext
+    }
+  })
+}))
+
+// Resolve keys against the real locale file so a missing key fails the test.
+vi.mock('@/i18n', async () => {
+  const messages = (await import('@/locales/en/main.json')).default
+  return {
+    t: (key: string) => {
+      const value = key
+        .split('.')
+        .reduce<unknown>(
+          (node, part) => (node as Record<string, unknown> | undefined)?.[part],
+          messages
+        )
+      if (typeof value !== 'string') {
+        throw new Error(`Missing i18n key: ${key}`)
+      }
+      return value
+    }
+  }
+})
+
+await import('./publishToWorkspace')
+
+interface MockWidget {
+  type: string
+  name: string
+  value: unknown
+  options: Record<string, unknown>
+  label?: string
+  serialize: boolean
+}
+
+function makeNode(comfyClass: string) {
+  const widgets: MockWidget[] = []
+  return {
+    constructor: { comfyClass },
+    widgets,
+    addWidget: vi.fn(
+      (
+        type: string,
+        name: string,
+        value: unknown,
+        _callback: (...args: unknown[]) => unknown,
+        options: Record<string, unknown>
+      ) => {
+        const widget: MockWidget = {
+          type,
+          name,
+          value,
+          options,
+          serialize: true
+        }
+        widgets.push(widget)
+        return widget
+      }
+    )
+  }
+}
+
+function createNode(comfyClass = 'SaveImage') {
+  const node = makeNode(comfyClass)
+  state.extension!.nodeCreated(node)
+  return { node, widget: node.widgets[0] }
+}
+
+describe('Comfy.PublishToWorkspace extension', () => {
+  it('adds an off-by-default toggle to media save nodes', () => {
+    const { widget } = createNode()
+    expect(widget.type).toBe('toggle')
+    expect(widget.name).toBe('publish_to_workspace')
+    expect(widget.value).toBe(false)
+    expect(widget.label).toBe(enMessages.publishToWorkspace.widgetLabel)
+  })
+
+  it('keeps the flag frontend-only (out of workflow JSON and API prompt)', () => {
+    const { widget } = createNode()
+    expect(widget.serialize).toBe(false)
+    expect(widget.options.serialize).toBe(false)
+  })
+
+  it('covers non-image media save nodes', () => {
+    for (const type of ['SaveVideo', 'SaveAudio', 'SaveGLB']) {
+      const { widget } = createNode(type)
+      expect(widget?.name).toBe('publish_to_workspace')
+    }
+  })
+
+  it('does not touch non-save nodes', () => {
+    const node = makeNode('KSampler')
+    state.extension!.nodeCreated(node)
+    expect(node.addWidget).not.toHaveBeenCalled()
+  })
+})

--- a/src/extensions/core/publishToWorkspace.ts
+++ b/src/extensions/core/publishToWorkspace.ts
@@ -1,0 +1,56 @@
+import { t } from '@/i18n'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useExtensionService } from '@/services/extensionService'
+
+/**
+ * Media save nodes that can publish their outputs to a team workspace. This is
+ * the media subset of the core save-node list in
+ * {@link ./saveImageExtraOutput.ts} — model/latent saves are intentionally
+ * excluded.
+ */
+const MEDIA_SAVE_NODES = new Set([
+  'SaveImage',
+  'SaveImageAdvanced',
+  'SaveSVGNode',
+  'SaveVideo',
+  'SaveWEBM',
+  'SaveAnimatedWEBP',
+  'SaveAnimatedPNG',
+  'SaveAudio',
+  'SaveAudioMP3',
+  'SaveAudioOpus',
+  'SaveAudioAdvanced',
+  'SaveGLB'
+])
+
+const WIDGET_NAME = 'publish_to_workspace'
+
+/**
+ * Adds a "Share with team" toggle to media save nodes, off by default.
+ *
+ * VISIBILITY — currently shown to ALL users. This toggle should only be shown to
+ * users who are currently in a cloud team workspace, gated the same way as the
+ * topbar workspace indicator (`showWorkspaceIcon` in CurrentUserButton.vue:
+ * `isCloud && flags.teamWorkspacesEnabled && initState === 'ready' &&
+ * !isInPersonalWorkspace`). That gate is omitted for now only because team
+ * workspaces are impractical to activate in staging — it must be restored before
+ * production so the toggle does not show for everyone.
+ *
+ * REFERENCE BUILD — the toggle is a frontend-only, session-scoped flag: kept out
+ * of the workflow JSON and the API prompt (the backend save node has no such
+ * input). Wiring the actual publish is a follow-up: when a real publish endpoint
+ * exists, read this value on the `executed` event and share the node's outputs
+ * via useAssetVisibilityStore (see feat/media-assets-publish-share).
+ */
+useExtensionService().registerExtension({
+  name: 'Comfy.PublishToWorkspace',
+
+  nodeCreated(node: LGraphNode) {
+    if (!MEDIA_SAVE_NODES.has(node.constructor.comfyClass ?? '')) return
+
+    const widget = node.addWidget('toggle', WIDGET_NAME, false, () => {}, {})
+    widget.label = t('publishToWorkspace.widgetLabel')
+    widget.serialize = false
+    widget.options.serialize = false
+  }
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4380,6 +4380,9 @@
       "failed": "Failed"
     }
   },
+  "publishToWorkspace": {
+    "widgetLabel": "Share with team"
+  },
   "exportToast": {
     "exportingAssets": "Exporting Assets",
     "preparingExport": "Preparing export...",


### PR DESCRIPTION
## Summary

Adds a "Share with team" toggle to media save nodes (Save Image / Video / Audio / GLB / etc.) as the node-side entry point for publishing a node's outputs to a team workspace. Stacked on the publish/share PR.

## Changes

- **What**: A new core extension (`src/extensions/core/publishToWorkspace.ts`) adds an off-by-default `toggle` widget labeled **"Share with team"** to the 12 media save node types (the media subset of the core save-node list; model/latent saves excluded). The widget id stays `publish_to_workspace`; the label comes from the `publishToWorkspace.widgetLabel` i18n key. The flag is frontend-only — kept out of the workflow JSON and the API prompt (`serialize` off on both paths), since the backend save node has no such input.
- **Breaking**: none. No changes to entity callbacks or `node.widgets` semantics for existing nodes.
- **Dependencies**: none new.

## Review Focus

- VISIBILITY — the toggle is currently shown to ALL users. It must only be shown to users currently in a cloud team workspace, gated the same way as the topbar workspace indicator (`showWorkspaceIcon` in `CurrentUserButton.vue`: `isCloud && flags.teamWorkspacesEnabled && initState === 'ready' && !isInPersonalWorkspace`). That gate is deliberately omitted here only because team workspaces are impractical to activate in staging; it must be restored before this ships to production so the toggle does not show for everyone. Documented in the extension header comment.
- REFERENCE BUILD — the toggle only holds state today. Wiring the actual publish (reading the flag on the `executed` event and sharing the node's outputs via `useAssetVisibilityStore`) is a follow-up; there is no backend publish endpoint yet.
- Depends on the publish/share PR (base branch = `feat/media-assets-publish-share`). Merge that first, then this retargets to `main`.
- Stacked PR 3 of 3: #13561 → #13562 → **this**.

<!-- Add the tracking issue if there is one, e.g. Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- the toggle on a Save Image node -->
