### PR TITLE
fix(cloud): keep survey footer visible on small screens

### DIFF
--- a/src/platform/cloud/onboarding/CloudSurveyView.vue
+++ b/src/platform/cloud/onboarding/CloudSurveyView.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="dark-theme flex max-h-[85vh] w-full max-w-md flex-col overflow-y-auto px-4 sm:px-6"
-  >
+  <div class="dark-theme flex max-h-full w-full max-w-md flex-col px-4 sm:px-6">
     <h1
       class="-mb-1 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
     >

--- a/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
+++ b/src/platform/cloud/onboarding/survey/DynamicSurveyForm.vue
@@ -13,7 +13,7 @@
     </div>
 
     <div
-      class="overflow-hidden transition-[height] duration-300 ease-out"
+      class="max-h-[45vh] overflow-y-auto transition-[height] duration-300 ease-out sm:max-h-[55vh]"
       :style="animatedHeightStyle"
     >
       <div ref="questionContent" class="relative">


### PR DESCRIPTION
## Summary

Keep the onboarding survey's Back/Submit footer visible on small screens by scrolling only the question area instead of the whole survey.

## Changes

- **What**: The survey scrolled as a single block , so on short viewports the button row slid under the template footer (Terms/Privacy). Now the outer is bounded to its slot and the question wrapper in `DynamicSurveyForm` scrolls internally with a responsive cap , so option lists scroll while the footer buttons stay pinned. The step height animation is unchanged.

## Screen Recording
https://github.com/user-attachments/assets/6d7f6d50-59b8-4dc0-b20e-8f4ca08167c6

