### PR TITLE
feat: credit auto-reload with a monthly budget

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,9 +55,7 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     // Pending integration in the workspace-settings stacked PRs: consumed by
-    // split/auto-reload + split/allowlist (Switch) and split/member-auditing
-    // + split/allowlist (Pagination); each consumer removes its entry
-    'src/components/ui/switch/Switch.vue',
+    // split/member-auditing + split/allowlist; each consumer removes its entry
     'src/components/ui/pagination/Pagination.vue',
     // Marketing media tooling — adopted by pages in a follow-up PR
     'apps/website/src/components/common/SiteVideo.vue',

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3070,6 +3070,41 @@
         "invoices": "Invoices",
         "overview": "Credits"
       }
+    },
+    "autoReload": {
+      "badge": {
+        "off": "Off",
+        "paused": "Paused"
+      },
+      "dialog": {
+        "allowsReloads": "Allows {count} reload /mo | Allows {count} reloads /mo",
+        "amountLabel": "Add this amount of credits:",
+        "budgetPlaceholderCredits": "Enter an amount of credits",
+        "budgetPlaceholderUsd": "Enter an amount of dollars",
+        "budgetToggleHint": "Limit how much is auto-reloaded per month",
+        "budgetToggleLabel": "Monthly budget",
+        "cancel": "Cancel",
+        "minReload": "Minimum amount is {amount}",
+        "thresholdLabel": "When credits drop below:",
+        "title": "Auto-reload credits",
+        "update": "Update"
+      },
+      "disabled": "Disabled",
+      "edit": "Edit",
+      "empty": {
+        "body": "Keep your workflows running with auto-reloaded credits. Set a monthly budget so charges don't surprise you.",
+        "cta": "Set up auto-reload"
+      },
+      "enabled": "Enabled",
+      "subtitle": "Automatically add credits when your balance runs low, within an optional monthly budget.",
+      "tile": {
+        "label": "Auto-reload",
+        "monthlyBudget": "Monthly budget",
+        "percentSpent": "{percent}% spent",
+        "spentOfBudget": "{spent} of {budget}",
+        "whenBelow": "when credits drop below"
+      },
+      "title": "Credit auto-reload"
     }
   },
   "teamWorkspacesDialog": {

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
@@ -1,0 +1,313 @@
+<template>
+  <div
+    class="flex w-132 max-w-full flex-col rounded-2xl border border-border-default bg-base-background"
+  >
+    <div
+      class="flex h-12 items-center justify-between border-b border-border-default px-4"
+    >
+      <h2 class="m-0 text-sm font-normal text-base-foreground">
+        {{ $t('workspacePanel.autoReload.dialog.title') }}
+      </h2>
+      <button
+        class="cursor-pointer rounded-sm border-none bg-transparent p-0 text-muted-foreground transition-colors hover:text-base-foreground"
+        :aria-label="$t('g.close')"
+        @click="onClose"
+      >
+        <i class="pi pi-times size-4" />
+      </button>
+    </div>
+
+    <div class="flex flex-col gap-4 p-4">
+      <div class="flex flex-col gap-2">
+        <label
+          for="auto-reload-threshold"
+          class="text-sm text-muted-foreground"
+        >
+          {{ $t('workspacePanel.autoReload.dialog.thresholdLabel') }}
+        </label>
+        <div :class="fieldClass">
+          <i class="icon-[lucide--coins] size-4 shrink-0 text-credit" />
+          <input
+            id="auto-reload-threshold"
+            v-model="thresholdModel"
+            inputmode="numeric"
+            class="w-full min-w-0 border-none bg-transparent text-sm text-base-foreground tabular-nums outline-none"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="auto-reload-amount" class="text-sm text-muted-foreground">
+          {{ $t('workspacePanel.autoReload.dialog.amountLabel') }}
+        </label>
+        <div
+          :class="cn(fieldClass, reloadBelowMinimum && 'ring-1 ring-red-500')"
+        >
+          <i
+            v-if="unit === 'credits'"
+            class="icon-[lucide--coins] size-4 shrink-0 text-credit"
+          />
+          <span v-else class="shrink-0 text-sm text-muted-foreground">$</span>
+          <input
+            id="auto-reload-amount"
+            v-model="reloadModel"
+            inputmode="numeric"
+            class="w-full min-w-0 border-none bg-transparent text-sm text-base-foreground tabular-nums outline-none"
+          />
+          <span
+            class="flex shrink-0 items-center gap-1 text-sm text-muted-foreground tabular-nums"
+          >
+            <template v-if="unit === 'credits'"
+              >≈ {{ reloadCostLabel }}</template
+            >
+            <template v-else>
+              ≈
+              <i class="icon-[lucide--coins] size-3.5 text-muted-foreground" />
+              {{ reloadCreditsLabel }}
+            </template>
+          </span>
+        </div>
+        <p v-if="reloadError" class="m-0 text-xs text-red-500">
+          {{ reloadError }}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2 border-t border-border-default p-4">
+      <div class="flex items-center justify-between">
+        <span
+          id="auto-reload-budget-label"
+          class="text-sm font-medium text-base-foreground"
+        >
+          {{ $t('workspacePanel.autoReload.dialog.budgetToggleLabel') }}
+        </span>
+        <span class="flex items-center gap-2 text-sm text-muted-foreground">
+          {{
+            budgetEnabled
+              ? $t('workspacePanel.autoReload.enabled')
+              : $t('workspacePanel.autoReload.disabled')
+          }}
+          <Switch v-model="budgetEnabled" />
+        </span>
+      </div>
+      <p class="m-0 text-sm text-muted-foreground">
+        {{ $t('workspacePanel.autoReload.dialog.budgetToggleHint') }}
+      </p>
+      <div :class="cn(fieldClass, !budgetEnabled && 'opacity-50')">
+        <i
+          v-if="unit === 'credits'"
+          class="icon-[lucide--coins] size-4 shrink-0 text-credit"
+        />
+        <span v-else class="shrink-0 text-sm text-muted-foreground">$</span>
+        <input
+          v-model="budgetModel"
+          :disabled="!budgetEnabled"
+          aria-labelledby="auto-reload-budget-label"
+          inputmode="numeric"
+          :placeholder="budgetPlaceholder"
+          class="w-full min-w-0 border-none bg-transparent text-sm text-base-foreground tabular-nums outline-none disabled:cursor-not-allowed"
+        />
+        <span
+          v-if="budgetEnabled && budgetCents > 0"
+          class="flex shrink-0 items-center gap-1 text-sm text-muted-foreground tabular-nums"
+        >
+          <template v-if="unit === 'credits'">≈ {{ budgetUsdLabel }}</template>
+          <template v-else>
+            ≈
+            <i class="icon-[lucide--coins] size-3.5 text-muted-foreground" />
+            {{ budgetCreditsLabel }}
+          </template>
+        </span>
+      </div>
+      <p
+        v-if="budgetEnabled && budgetCents > 0"
+        class="m-0 text-xs text-muted-foreground"
+      >
+        {{ allowsReloadsLabel }}
+      </p>
+    </div>
+
+    <div
+      class="flex items-center justify-between border-t border-border-default p-4"
+    >
+      <ToggleGroup
+        type="single"
+        :model-value="unit"
+        class="rounded-lg bg-secondary-background p-0.5"
+        @update:model-value="onUnitChange"
+      >
+        <ToggleGroupItem
+          v-for="option in unitOptions"
+          :key="option"
+          :value="option"
+          size="lg"
+        >
+          {{ $t(`workspacePanel.autoReload.dialog.${option}`) }}
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div class="flex items-center gap-4">
+        <Button variant="muted-textonly" @click="onClose">
+          {{ $t('workspacePanel.autoReload.dialog.cancel') }}
+        </Button>
+        <Button
+          variant="secondary"
+          size="lg"
+          :disabled="!canUpdate"
+          @click="onUpdate"
+        >
+          {{ $t('workspacePanel.autoReload.dialog.update') }}
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import {
+  centsToCredits,
+  creditsToCents,
+  creditsToUsd,
+  usdToCents,
+  usdToCredits
+} from '@/base/credits/comfyCredits'
+import Button from '@/components/ui/button/Button.vue'
+import Switch from '@/components/ui/switch/Switch.vue'
+import ToggleGroup from '@/components/ui/toggle-group/ToggleGroup.vue'
+import ToggleGroupItem from '@/components/ui/toggle-group/ToggleGroupItem.vue'
+import { useAutoReload } from '@/platform/workspace/composables/useAutoReload'
+import { useDialogStore } from '@/stores/dialogStore'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { t, n: fmtNumber } = useI18n()
+const dialogStore = useDialogStore()
+const { config, save } = useAutoReload()
+
+type Unit = 'credits' | 'usd'
+const unitOptions: Unit[] = ['credits', 'usd']
+const unit = ref<Unit>('credits')
+
+// reka's single ToggleGroup can emit '' on re-click (deselect); ignore that so a
+// unit always stays selected.
+function onUnitChange(value: unknown) {
+  if (value === 'credits' || value === 'usd') unit.value = value
+}
+
+const thresholdCredits = ref(config.thresholdCredits ?? 1000)
+const reloadCredits = ref(config.reloadCredits ?? 5000)
+const budgetEnabled = ref(config.monthlyBudgetCents != null)
+const budgetCents = ref(config.monthlyBudgetCents ?? 0)
+
+const fieldClass =
+  'flex items-center gap-2 rounded-lg bg-secondary-background px-3 py-2.5'
+
+const fmtInt = (value: number) => fmtNumber(value, { maximumFractionDigits: 0 })
+const fmtUsd = (cents: number) =>
+  fmtNumber(cents / 100, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  })
+const parseNum = (raw: string) => {
+  const parsed = Number(raw.replace(/[^0-9.]/g, ''))
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+// A 0 value renders as an empty field (not "0") so backspacing clears it.
+const thresholdModel = computed({
+  get: () =>
+    thresholdCredits.value === 0 ? '' : fmtInt(thresholdCredits.value),
+  set: (value) => (thresholdCredits.value = Math.round(parseNum(value)))
+})
+
+const reloadModel = computed({
+  get: () => {
+    if (reloadCredits.value === 0) return ''
+    return unit.value === 'credits'
+      ? fmtInt(reloadCredits.value)
+      : fmtInt(creditsToUsd(reloadCredits.value))
+  },
+  set: (value) => {
+    const parsed = parseNum(value)
+    reloadCredits.value =
+      unit.value === 'credits' ? Math.round(parsed) : usdToCredits(parsed)
+  }
+})
+const reloadCostLabel = computed(() =>
+  fmtUsd(creditsToCents(reloadCredits.value))
+)
+const reloadCreditsLabel = computed(() => fmtInt(reloadCredits.value))
+
+const budgetModel = computed({
+  get: () => {
+    if (budgetCents.value === 0) return ''
+    return unit.value === 'credits'
+      ? fmtInt(centsToCredits(budgetCents.value))
+      : fmtInt(Math.round(budgetCents.value / 100))
+  },
+  set: (value) => {
+    const parsed = parseNum(value)
+    budgetCents.value =
+      unit.value === 'credits'
+        ? creditsToCents(Math.round(parsed))
+        : usdToCents(parsed)
+  }
+})
+const budgetUsdLabel = computed(() => fmtUsd(budgetCents.value))
+const budgetCreditsLabel = computed(() =>
+  fmtInt(centsToCredits(budgetCents.value))
+)
+const budgetPlaceholder = computed(() =>
+  unit.value === 'credits'
+    ? t('workspacePanel.autoReload.dialog.budgetPlaceholderCredits')
+    : t('workspacePanel.autoReload.dialog.budgetPlaceholderUsd')
+)
+
+const allowsReloadsLabel = computed(() => {
+  const reloads =
+    reloadCredits.value > 0
+      ? Math.floor(centsToCredits(budgetCents.value) / reloadCredits.value)
+      : 0
+  return t('workspacePanel.autoReload.dialog.allowsReloads', reloads)
+})
+
+// The reload amount must be worth at least $5 (its credit equivalent).
+const MIN_RELOAD_CENTS = 500
+const MIN_RELOAD_CREDITS = usdToCredits(5)
+
+const reloadBelowMinimum = computed(
+  () => reloadCredits.value > 0 && reloadCredits.value < MIN_RELOAD_CREDITS
+)
+const reloadError = computed(() => {
+  if (!reloadBelowMinimum.value) return ''
+  const amount =
+    unit.value === 'credits'
+      ? fmtInt(MIN_RELOAD_CREDITS)
+      : fmtUsd(MIN_RELOAD_CENTS)
+  return t('workspacePanel.autoReload.dialog.minReload', { amount })
+})
+
+const canUpdate = computed(
+  () =>
+    thresholdCredits.value > 0 &&
+    reloadCredits.value >= MIN_RELOAD_CREDITS &&
+    (!budgetEnabled.value || budgetCents.value > 0)
+)
+
+function onClose() {
+  dialogStore.closeDialog({ key: 'auto-reload' })
+}
+
+function onUpdate() {
+  if (!canUpdate.value) return
+  save({
+    thresholdCredits: thresholdCredits.value,
+    reloadCredits: reloadCredits.value,
+    monthlyBudgetCents:
+      budgetEnabled.value && budgetCents.value > 0 ? budgetCents.value : null
+  })
+  onClose()
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
+++ b/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
@@ -1,0 +1,205 @@
+<template>
+  <div
+    :class="
+      cn(
+        'flex flex-col gap-4 rounded-2xl border border-interface-stroke/60 p-6 transition-opacity',
+        // A lapsed plan can't auto-reload, so freeze the whole section: dim it,
+        // block interaction, and force the toggle to read Disabled.
+        frozen && 'pointer-events-none opacity-50'
+      )
+    "
+  >
+    <div
+      class="flex flex-col gap-4 @4xl:flex-row @4xl:items-start @4xl:justify-between"
+    >
+      <div class="flex flex-col gap-1">
+        <span class="text-sm font-medium text-base-foreground">
+          {{ $t('workspacePanel.autoReload.title') }}
+        </span>
+        <span class="max-w-md text-sm text-muted-foreground">
+          {{ $t('workspacePanel.autoReload.subtitle') }}
+        </span>
+      </div>
+      <div v-if="isConfigured" class="flex shrink-0 items-center gap-3">
+        <span class="flex items-center gap-2 text-sm text-muted-foreground">
+          {{ enabledLabel }}
+          <Switch
+            :model-value="displayEnabled"
+            @update:model-value="setEnabled"
+          />
+        </span>
+        <Button variant="secondary" size="lg" @click="openConfig">
+          {{ $t('workspacePanel.autoReload.edit') }}
+        </Button>
+      </div>
+    </div>
+
+    <!-- Empty / not-set-up state — same one-column grid as the configured tile
+         so both sit at the top tiles' width. -->
+    <div v-if="!isConfigured" class="grid grid-cols-1 gap-4 @4xl:grid-cols-2">
+      <div
+        class="flex flex-col gap-3 rounded-xl bg-modal-panel-background px-6 py-5"
+      >
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ $t('workspacePanel.autoReload.empty.body') }}
+        </p>
+        <Button variant="tertiary" size="lg" class="w-full" @click="openConfig">
+          {{ $t('workspacePanel.autoReload.empty.cta') }}
+        </Button>
+      </div>
+    </div>
+
+    <!-- Configured tile — constrained to one column of the same grid the top
+         tiles use, so it matches their width (empty second column left open). -->
+    <div v-else class="grid grid-cols-1 gap-4 @4xl:grid-cols-2">
+      <div
+        :class="
+          cn(
+            'flex flex-col gap-4 rounded-xl bg-modal-panel-background px-6 py-5 transition-opacity',
+            // Skip this dim when frozen — the section root already dims uniformly.
+            !frozen && !isEnabled && 'opacity-50'
+          )
+        "
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-muted-foreground">
+            {{ $t('workspacePanel.autoReload.tile.label') }}
+          </span>
+          <StatusBadge v-if="badge" :label="badge" :severity="badgeSeverity" />
+        </div>
+
+        <p
+          :class="
+            cn(
+              'm-0 flex items-center gap-1.5 text-sm text-muted-foreground',
+              isPaused && 'opacity-50'
+            )
+          "
+        >
+          <i class="icon-[lucide--coins] size-4 text-credit" />
+          <span
+            class="text-2xl leading-none font-semibold text-base-foreground tabular-nums"
+          >
+            {{ reloadCreditsLabel }}
+          </span>
+          {{ $t('workspacePanel.autoReload.tile.whenBelow') }}
+          <span class="font-semibold text-base-foreground tabular-nums">
+            {{ thresholdLabel }}
+          </span>
+        </p>
+
+        <template v-if="hasBudget">
+          <div class="h-px w-full bg-interface-stroke" />
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-muted-foreground">
+                {{ $t('workspacePanel.autoReload.tile.monthlyBudget') }}
+              </span>
+              <span :class="cn('tabular-nums', percentSpentClass)">
+                {{ percentSpentLabel }}
+              </span>
+            </div>
+            <ProgressBar :value="budgetUsedFraction" />
+            <div class="flex justify-end text-sm">
+              <span class="text-muted-foreground tabular-nums">
+                {{ budgetSpentLabel }}
+              </span>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import Button from '@/components/ui/button/Button.vue'
+import Switch from '@/components/ui/switch/Switch.vue'
+import ProgressBar from '@/platform/workspace/components/dialogs/settings/ProgressBar.vue'
+import { useAutoReload } from '@/platform/workspace/composables/useAutoReload'
+import { useDialogService } from '@/services/dialogService'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { frozen = false } = defineProps<{
+  /**
+   * The plan can't spend (lapsed or paused): render the whole section dimmed,
+   * off, and non-interactive.
+   */
+  frozen?: boolean
+}>()
+
+const { t, n: fmtNumber } = useI18n()
+
+const {
+  config,
+  isConfigured,
+  isEnabled,
+  hasBudget,
+  budgetUsedFraction,
+  isPaused,
+  isWarning,
+  setEnabled
+} = useAutoReload()
+
+const displayEnabled = computed(() => !frozen && isEnabled.value)
+
+const { showAutoReloadDialog } = useDialogService()
+
+function openConfig() {
+  void showAutoReloadDialog()
+}
+
+const fmtCredits = (value: number) =>
+  fmtNumber(value, { maximumFractionDigits: 0 })
+const fmtUsd = (cents: number) =>
+  fmtNumber(cents / 100, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  })
+
+const enabledLabel = computed(() =>
+  displayEnabled.value
+    ? t('workspacePanel.autoReload.enabled')
+    : t('workspacePanel.autoReload.disabled')
+)
+
+const badge = computed(() => {
+  if (frozen) return t('workspacePanel.autoReload.badge.off')
+  if (isPaused.value) return t('workspacePanel.autoReload.badge.paused')
+  if (!isEnabled.value) return t('workspacePanel.autoReload.badge.off')
+  return ''
+})
+
+// Paused is an alert state, so give it the high-contrast (inverted) pill; the
+// quieter "off" state keeps the secondary treatment.
+const badgeSeverity = computed(() =>
+  isPaused.value ? 'contrast' : 'secondary'
+)
+
+const reloadCreditsLabel = computed(() => fmtCredits(config.reloadCredits))
+const thresholdLabel = computed(() => fmtCredits(config.thresholdCredits))
+
+const percentSpentLabel = computed(() =>
+  t('workspacePanel.autoReload.tile.percentSpent', {
+    percent: Math.round(budgetUsedFraction.value * 100)
+  })
+)
+const percentSpentClass = computed(() =>
+  isPaused.value
+    ? 'text-danger'
+    : isWarning.value
+      ? 'text-credit'
+      : 'text-muted-foreground'
+)
+const budgetSpentLabel = computed(() =>
+  t('workspacePanel.autoReload.tile.spentOfBudget', {
+    spent: fmtUsd(config.spentThisCycleCents),
+    budget: fmtUsd(config.monthlyBudgetCents ?? 0)
+  })
+)
+</script>

--- a/src/platform/workspace/components/dialogs/settings/ProgressBar.vue
+++ b/src/platform/workspace/components/dialogs/settings/ProgressBar.vue
@@ -1,0 +1,18 @@
+<template>
+  <div
+    class="h-2 w-full overflow-hidden rounded-full bg-secondary-background-hover"
+  >
+    <div
+      class="h-full rounded-full bg-credit transition-[width]"
+      :style="{ width: `${clamped * 100}%` }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const { value } = defineProps<{ value: number }>()
+
+const clamped = computed(() => Math.min(1, Math.max(0, value)))
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceOverviewContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceOverviewContent.vue
@@ -191,6 +191,13 @@
       </div>
     </div>
 
+    <!-- Credit auto-reload; frozen alongside the tile whenever the plan can't
+    spend — lapsed or paused. -->
+    <AutoReloadSection
+      v-if="canManageBilling"
+      :frozen="isInactive || isPaused"
+    />
+
     <!-- mt-auto floats the footer to the panel's bottom edge; pb-6 (matching
     the other tabs) keeps it level with their footers. -->
     <div
@@ -248,6 +255,7 @@ import { useExternalLink } from '@/composables/useExternalLink'
 import { useSettingsNavigation } from '@/platform/settings/composables/useSettingsNavigation'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import CreditsTile from '@/platform/cloud/subscription/components/CreditsTile.vue'
+import AutoReloadSection from '@/platform/workspace/components/dialogs/settings/AutoReloadSection.vue'
 import { buildSupportUrl } from '@/platform/support/config'
 import { useAutoPageSize } from '@/platform/workspace/composables/useAutoPageSize'
 import { requestMembersSort } from '@/platform/workspace/composables/useMembersPanel'

--- a/src/platform/workspace/composables/useAutoReload.ts
+++ b/src/platform/workspace/composables/useAutoReload.ts
@@ -1,0 +1,96 @@
+import { computed, reactive } from 'vue'
+
+import { creditsToCents } from '@/base/credits/comfyCredits'
+
+interface AutoReloadConfig {
+  configured: boolean
+  enabled: boolean
+  thresholdCredits: number
+  reloadCredits: number
+  // null = no monthly budget set
+  monthlyBudgetCents: number | null
+  spentThisCycleCents: number
+}
+
+// TODO(auto-reload endpoint): there is no auto-reload API yet, so the config
+// is client-side state — it starts unconfigured and edits don't persist
+// across reloads.
+const config = reactive<AutoReloadConfig>({
+  configured: false,
+  enabled: false,
+  thresholdCredits: 1000,
+  reloadCredits: 5000,
+  monthlyBudgetCents: null,
+  spentThisCycleCents: 0
+})
+
+export function useAutoReload() {
+  const isConfigured = computed(() => config.configured)
+  const isEnabled = computed(() => config.enabled)
+  const hasBudget = computed(() => config.monthlyBudgetCents != null)
+
+  const reloadCostCents = computed(() => creditsToCents(config.reloadCredits))
+
+  const budgetLeftCents = computed(() =>
+    config.monthlyBudgetCents == null
+      ? 0
+      : Math.max(0, config.monthlyBudgetCents - config.spentThisCycleCents)
+  )
+
+  const budgetUsedFraction = computed(() =>
+    config.monthlyBudgetCents != null && config.monthlyBudgetCents > 0
+      ? Math.min(1, config.spentThisCycleCents / config.monthlyBudgetCents)
+      : 0
+  )
+
+  const reloadsLeft = computed(() =>
+    hasBudget.value
+      ? Math.floor(budgetLeftCents.value / reloadCostCents.value)
+      : null
+  )
+
+  // Budget drained while still enabled → auto-reload can't fire, so it's paused.
+  const isPaused = computed(
+    () => config.enabled && hasBudget.value && budgetLeftCents.value <= 0
+  )
+
+  // One reload (or none) of headroom left before the budget pauses it.
+  const isWarning = computed(
+    () =>
+      config.enabled &&
+      hasBudget.value &&
+      !isPaused.value &&
+      (reloadsLeft.value ?? Infinity) <= 1
+  )
+
+  function setEnabled(value: boolean) {
+    config.enabled = value
+  }
+
+  function save(next: {
+    thresholdCredits: number
+    reloadCredits: number
+    monthlyBudgetCents: number | null
+  }) {
+    config.configured = true
+    config.enabled = true
+    config.thresholdCredits = next.thresholdCredits
+    config.reloadCredits = next.reloadCredits
+    config.monthlyBudgetCents = next.monthlyBudgetCents
+  }
+
+  return {
+    config,
+    isConfigured,
+    isEnabled,
+    hasBudget,
+    reloadCostCents,
+    budgetLeftCents,
+    budgetUsedFraction,
+    reloadsLeft,
+    isPaused,
+    isWarning,
+    setEnabled,
+    save
+  }
+}

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -583,6 +583,18 @@ export const useDialogService = () => {
     })
   }
 
+  async function showAutoReloadDialog() {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/AutoReloadDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'auto-reload',
+      component,
+      dialogComponentProps: {
+        ...workspaceDialogProps
+      }
+    })
+  }
+
   async function showMemberLimitDialog() {
     const { default: component } =
       await import('@/platform/workspace/components/dialogs/RequestMoreDialogContent.vue')
@@ -773,6 +785,7 @@ export const useDialogService = () => {
     showRevokeInviteDialog,
     showInviteMemberDialog,
     showInviteMemberUpsellDialog,
+    showAutoReloadDialog,
     showMemberLimitDialog,
     showWorkflowQueuedDialog,
     showBillingComingSoonDialog,


### PR DESCRIPTION
<!-- branch: split/auto-reload | base: split/plan-credits-tabs -->
<!-- title: feat: credit auto-reload with a monthly budget -->

## What

- **Auto-reload section** on the Credits tab: threshold + reload amount via dialog (minimum-amount guard), optional monthly budget with color-coded progress (muted → amber near cap → red + Paused badge when exhausted), toggle-first enable sentence
- Section **freezes** (dimmed, forced off) whenever the plan can't spend (paused/lapsed); card failures are covered by the shared payment-declined banner

Linear: [DES-378](https://linear.app/comfyorg/issue/DES-378)

## Notes for reviewers

- **No auto-reload endpoint yet**: config is client-side, starts unconfigured, edits don't persist. `useAutoReload` is the wiring seam.

- **Budget reset semantics (settled 2026-07-20)**: the monthly budget window anchors to the subscription date's monthly anniversary on both monthly and yearly plans — the eventual endpoint owns the reset; the client only displays `spent / budget` for the current window.
