### PR TITLE
feat: workspace activity ledger + member auditing

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -54,9 +54,6 @@ const config: KnipConfig = {
     '.github/workflows/ci-oss-assets-validation.yaml',
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
-    // Pending integration in the workspace-settings stacked PRs: consumed by
-    // split/member-auditing + split/allowlist; each consumer removes its entry
-    'src/components/ui/pagination/Pagination.vue',
     // Marketing media tooling — adopted by pages in a follow-up PR
     'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',

--- a/src/components/ui/hover-card/HoverCard.vue
+++ b/src/components/ui/hover-card/HoverCard.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { HoverCardRoot, useForwardPropsEmits } from 'reka-ui'
+import type { HoverCardRootEmits, HoverCardRootProps } from 'reka-ui'
+import { provide, ref } from 'vue'
+
+import { hoverCardOpenKey } from './hoverCardContext'
+
+// eslint-disable-next-line vue/no-unused-properties -- forwarded to Reka via useForwardPropsEmits
+const props = defineProps<HoverCardRootProps>()
+const emits = defineEmits<HoverCardRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+
+const isOpen = ref(false)
+provide(hoverCardOpenKey, isOpen)
+</script>
+
+<template>
+  <HoverCardRoot v-bind="forwarded" v-model:open="isOpen">
+    <slot />
+  </HoverCardRoot>
+</template>

--- a/src/components/ui/hover-card/HoverCardContent.vue
+++ b/src/components/ui/hover-card/HoverCardContent.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ZIndex } from '@primeuix/utils/zindex'
+import { HoverCardContent, HoverCardPortal, useForwardProps } from 'reka-ui'
+import type { HoverCardContentProps } from 'reka-ui'
+import { computed, inject } from 'vue'
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+import { hoverCardOpenKey } from './hoverCardContext'
+
+// Shared base for @primeuix's auto-incrementing 'modal' z-index counter.
+const MODAL_BASE_Z_INDEX = 1700
+
+const {
+  class: className,
+  side = 'bottom',
+  sideOffset = 8,
+  ...rest
+} = defineProps<HoverCardContentProps & { class?: HTMLAttributes['class'] }>()
+
+const forwarded = useForwardProps(computed(() => rest))
+
+// Body-portaled content sits at a static z-1700 unless a dialog that joined
+// @primeuix's 'modal' counter is open above it; then lift past that dialog.
+const open = inject(hoverCardOpenKey, undefined)
+const contentStyle = computed(() => {
+  if (!open?.value) return undefined
+  const topZIndex = ZIndex.getCurrent('modal')
+  return topZIndex >= MODAL_BASE_Z_INDEX ? { zIndex: topZIndex + 1 } : undefined
+})
+</script>
+
+<template>
+  <HoverCardPortal>
+    <HoverCardContent
+      v-bind="forwarded"
+      :side
+      :side-offset
+      :style="contentStyle"
+      :class="
+        cn(
+          'z-1700 rounded-lg border border-border-subtle bg-secondary-background p-2.5 shadow-md outline-none',
+          className
+        )
+      "
+    >
+      <slot />
+    </HoverCardContent>
+  </HoverCardPortal>
+</template>

--- a/src/components/ui/hover-card/HoverCardTrigger.vue
+++ b/src/components/ui/hover-card/HoverCardTrigger.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { HoverCardTrigger } from 'reka-ui'
+import type { HoverCardTriggerProps } from 'reka-ui'
+
+const props = defineProps<HoverCardTriggerProps>()
+</script>
+
+<template>
+  <HoverCardTrigger v-bind="props">
+    <slot />
+  </HoverCardTrigger>
+</template>

--- a/src/components/ui/hover-card/hoverCardContext.ts
+++ b/src/components/ui/hover-card/hoverCardContext.ts
@@ -1,0 +1,7 @@
+import type { InjectionKey, Ref } from 'vue'
+
+// Shares the root open-state with the content so it can lift its z-index above
+// a dialog that joined @primeuix's incrementing 'modal' counter (otherwise the
+// body-portaled content renders behind the settings dialog).
+export const hoverCardOpenKey: InjectionKey<Ref<boolean>> =
+  Symbol('hoverCardOpen')

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3068,7 +3068,8 @@
     "planCredits": {
       "tabs": {
         "invoices": "Invoices",
-        "overview": "Credits"
+        "overview": "Credits",
+        "activity": "Activity"
       }
     },
     "autoReload": {
@@ -3105,6 +3106,24 @@
         "whenBelow": "when credits drop below"
       },
       "title": "Credit auto-reload"
+    },
+    "activity": {
+      "columns": {
+        "creditsUsed": "Credits",
+        "date": "Date",
+        "eventDetails": "Event details",
+        "eventType": "Event type",
+        "user": "User"
+      },
+      "fullActivity": "Full activity",
+      "hoverCard": {
+        "lastActivity": "Last activity",
+        "partnerNodeUsed": "Partner node used",
+        "totalCreditsUsed": "Total credits used"
+      },
+      "perUserHint": "Looking for total usage per user?",
+      "seeMembers": "See Members",
+      "empty": "No activity yet."
     }
   },
   "teamWorkspacesDialog": {

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -3,22 +3,33 @@
     :class="
       cn(
         '@container flex min-h-0 flex-1 flex-col gap-4',
-        // The panel runs flush to the bottom edge (BaseModalLayout 'flush');
-        // Invoices keeps its prior bottom gap, Overview doesn't.
+        // The panel runs flush to the bottom edge (BaseModalLayout 'flush'); the
+        // Activity/Invoices tables keep their prior bottom gap, Overview doesn't.
         activeView !== 'overview' && 'pb-6'
       )
     "
   >
-    <div class="flex w-full items-center gap-2">
-      <Button
-        v-for="tab in tabs"
-        :key="tab.key"
-        :variant="activeView === tab.key ? 'secondary' : 'muted-textonly'"
+    <div
+      class="flex w-full flex-col gap-3 @2xl:flex-row @2xl:items-center @2xl:gap-9"
+    >
+      <div class="flex min-w-0 flex-1 items-center gap-2">
+        <Button
+          v-for="tab in tabs"
+          :key="tab.key"
+          :variant="activeView === tab.key ? 'secondary' : 'muted-textonly'"
+          size="lg"
+          @click="setView(tab.key)"
+        >
+          {{ tab.label }}
+        </Button>
+      </div>
+      <SearchInput
+        v-if="activeView === 'activity'"
+        v-model="searchQuery"
+        :placeholder="$t('g.search')"
         size="lg"
-        @click="setView(tab.key)"
-      >
-        {{ tab.label }}
-      </Button>
+        class="w-full @2xl:w-64"
+      />
     </div>
 
     <BillingStatusBanner>
@@ -35,7 +46,14 @@
       </template>
     </BillingStatusBanner>
 
-    <WorkspaceOverviewContent v-if="activeView === 'overview'" />
+    <WorkspaceOverviewContent
+      v-if="activeView === 'overview'"
+      @navigate="setView"
+    />
+    <WorkspaceActivityContent
+      v-else-if="activeView === 'activity'"
+      :search="searchQuery"
+    />
     <WorkspaceInvoicesContent v-else />
   </div>
 </template>
@@ -44,15 +62,17 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
 import BillingStatusBanner from '@/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue'
+import WorkspaceActivityContent from '@/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue'
 import WorkspaceOverviewContent from '@/platform/workspace/components/dialogs/settings/WorkspaceOverviewContent.vue'
 import WorkspaceInvoicesContent from '@/platform/workspace/components/dialogs/settings/WorkspaceInvoicesContent.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { cn } from '@comfyorg/tailwind-utils'
 
-type View = 'overview' | 'invoices'
+type View = 'overview' | 'activity' | 'invoices'
 
 const { t } = useI18n()
 
@@ -65,7 +85,8 @@ function openInvoiceHistory() {
 
 const tabs = computed(() => {
   const base: { key: View; label: string }[] = [
-    { key: 'overview', label: t('workspacePanel.planCredits.tabs.overview') }
+    { key: 'overview', label: t('workspacePanel.planCredits.tabs.overview') },
+    { key: 'activity', label: t('workspacePanel.planCredits.tabs.activity') }
   ]
   // Invoices are billing details — owners/admins only.
   if (permissions.value.canManageSubscription) {
@@ -77,8 +98,10 @@ const tabs = computed(() => {
   return base
 })
 const activeView = ref<View>('overview')
+const searchQuery = ref('')
 
 function setView(view: View) {
   activeView.value = view
+  searchQuery.value = ''
 }
 </script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue
@@ -1,0 +1,315 @@
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-4">
+    <div
+      ref="tableContainer"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-interface-stroke/60"
+    >
+      <Table class="min-h-0 flex-1 px-4">
+        <TableHeader class="sticky top-0 z-10 bg-base-background">
+          <TableRow
+            class="hover:bg-transparent [&>th]:h-14 [&>th]:border-b [&>th]:border-interface-stroke/60"
+          >
+            <TableHead class="w-40" :aria-sort="ariaSort('date')">
+              <button :class="sortHeaderClass" @click="toggleSort('date')">
+                {{ $t('workspacePanel.activity.columns.date') }}
+                <i :class="sortIcon('date')" />
+              </button>
+            </TableHead>
+            <TableHead class="w-56" :aria-sort="ariaSort('user')">
+              <button :class="sortHeaderClass" @click="toggleSort('user')">
+                {{ $t('workspacePanel.activity.columns.user') }}
+                <i :class="sortIcon('user')" />
+              </button>
+            </TableHead>
+            <TableHead :aria-sort="ariaSort('eventType')">
+              <button :class="sortHeaderClass" @click="toggleSort('eventType')">
+                {{ $t('workspacePanel.activity.columns.eventType') }}
+                <i :class="sortIcon('eventType')" />
+              </button>
+            </TableHead>
+            <TableHead class="w-32" :aria-sort="ariaSort('detail')">
+              <button :class="sortHeaderClass" @click="toggleSort('detail')">
+                {{ $t('workspacePanel.activity.columns.eventDetails') }}
+                <i :class="sortIcon('detail')" />
+              </button>
+            </TableHead>
+            <TableHead class="w-40" :aria-sort="ariaSort('credits')">
+              <button
+                :class="cn(sortHeaderClass, 'ml-auto')"
+                @click="toggleSort('credits')"
+              >
+                <i class="icon-[lucide--coins] size-4" />
+                {{ $t('workspacePanel.activity.columns.creditsUsed') }}
+                <i :class="sortIcon('credits')" />
+              </button>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow
+            v-for="event in pagedItems"
+            :key="event.id"
+            class="hover:bg-transparent [&:last-child>td]:border-b-0 [&>td]:border-b [&>td]:border-interface-stroke/20"
+          >
+            <TableCell class="text-sm text-muted-foreground tabular-nums">
+              {{ formatDate(event.date) }}
+            </TableCell>
+            <TableCell>
+              <HoverCard
+                v-if="event.userName"
+                :open-delay="150"
+                :close-delay="0"
+              >
+                <HoverCardTrigger
+                  as="div"
+                  class="flex w-fit cursor-default items-center gap-3"
+                >
+                  <span
+                    class="flex size-5 shrink-0 items-center justify-center rounded-full"
+                    :style="{ backgroundColor: userBadgeColor(event.userName) }"
+                  >
+                    <span class="text-2xs font-bold text-base-foreground">
+                      {{ event.userName.charAt(0).toUpperCase() }}
+                    </span>
+                  </span>
+                  <span class="truncate text-sm text-base-foreground">
+                    {{ event.userName }}
+                  </span>
+                </HoverCardTrigger>
+                <HoverCardContent class="w-64" align="start">
+                  <div class="flex w-full flex-col gap-2">
+                    <div class="flex h-5 items-center justify-between">
+                      <span class="text-sm text-muted-foreground">
+                        {{
+                          $t(
+                            'workspacePanel.activity.hoverCard.totalCreditsUsed'
+                          )
+                        }}
+                      </span>
+                      <span class="flex items-center gap-1">
+                        <i
+                          class="icon-[lucide--coins] size-4 text-muted-foreground"
+                        />
+                        <span class="text-sm text-base-foreground tabular-nums">
+                          {{
+                            summaryFor(
+                              event.userName
+                            ).totalCredits.toLocaleString()
+                          }}
+                        </span>
+                      </span>
+                    </div>
+                    <div class="flex h-5 items-center justify-between">
+                      <span class="text-sm text-muted-foreground">
+                        {{
+                          $t('workspacePanel.activity.hoverCard.lastActivity')
+                        }}
+                      </span>
+                      <span class="text-sm text-base-foreground">
+                        {{ lastActivityLabel(event.userName) }}
+                      </span>
+                    </div>
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
+              <span v-else class="text-sm text-muted-foreground">—</span>
+            </TableCell>
+            <TableCell class="text-sm text-muted-foreground">
+              <HoverCard
+                v-if="event.partnerNode"
+                :open-delay="150"
+                :close-delay="0"
+              >
+                <HoverCardTrigger as="span" class="cursor-default">
+                  {{ event.eventType }}
+                </HoverCardTrigger>
+                <HoverCardContent class="w-72" align="start">
+                  <div class="flex h-5 items-center justify-between gap-4">
+                    <span
+                      class="text-sm whitespace-nowrap text-muted-foreground"
+                    >
+                      {{
+                        $t('workspacePanel.activity.hoverCard.partnerNodeUsed')
+                      }}
+                    </span>
+                    <span class="truncate text-sm text-base-foreground">
+                      {{ event.partnerNode }}
+                    </span>
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
+              <template v-else>{{ event.eventType }}</template>
+            </TableCell>
+            <TableCell class="text-sm text-muted-foreground tabular-nums">
+              {{ event.detail || '—' }}
+            </TableCell>
+            <TableCell
+              :class="
+                cn(
+                  'text-right text-sm tabular-nums',
+                  event.credited ? 'text-credit' : 'text-muted-foreground'
+                )
+              "
+            >
+              {{ event.credited ? '+' : ''
+              }}{{ event.credits.toLocaleString() }}
+            </TableCell>
+          </TableRow>
+          <TableRow v-if="pagedItems.length === 0" class="hover:bg-transparent">
+            <TableCell
+              :colspan="5"
+              class="py-6 text-center text-sm text-muted-foreground"
+            >
+              {{ $t('workspacePanel.activity.empty') }}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+
+    <div class="flex flex-col gap-3 @2xl:h-8 @2xl:flex-row @2xl:items-center">
+      <div
+        v-if="canViewTeamUsage"
+        class="flex flex-wrap items-center gap-x-6 gap-y-2"
+      >
+        <a
+          :href="fullActivityUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex cursor-pointer items-center gap-1 text-sm text-muted-foreground no-underline transition-colors hover:text-base-foreground"
+        >
+          <i class="icon-[lucide--external-link] size-4" />
+          {{ $t('workspacePanel.activity.fullActivity') }}
+        </a>
+        <div class="flex items-center gap-3">
+          <p class="text-sm text-muted-foreground">
+            {{ $t('workspacePanel.activity.perUserHint') }}
+          </p>
+          <button
+            class="flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 font-[inherit] text-sm text-base-foreground transition-colors hover:text-muted-foreground"
+            @click="goToMembers"
+          >
+            {{ $t('workspacePanel.activity.seeMembers') }}
+            <i class="icon-[lucide--arrow-right] size-4" />
+          </button>
+        </div>
+      </div>
+      <Pagination
+        v-model:page="page"
+        :total="total"
+        :items-per-page="itemsPerPage"
+        class="@2xl:ml-auto"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import HoverCard from '@/components/ui/hover-card/HoverCard.vue'
+import HoverCardContent from '@/components/ui/hover-card/HoverCardContent.vue'
+import HoverCardTrigger from '@/components/ui/hover-card/HoverCardTrigger.vue'
+import Pagination from '@/components/ui/pagination/Pagination.vue'
+import Table from '@/components/ui/table/Table.vue'
+import TableBody from '@/components/ui/table/TableBody.vue'
+import TableCell from '@/components/ui/table/TableCell.vue'
+import TableHead from '@/components/ui/table/TableHead.vue'
+import TableHeader from '@/components/ui/table/TableHeader.vue'
+import TableRow from '@/components/ui/table/TableRow.vue'
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import { useSettingsNavigation } from '@/platform/settings/composables/useSettingsNavigation'
+import { useAutoPageSize } from '@/platform/workspace/composables/useAutoPageSize'
+import { requestMembersSort } from '@/platform/workspace/composables/useMembersPanel'
+import { useWorkspaceActivity } from '@/platform/workspace/composables/useWorkspaceActivity'
+import type { ActivitySortField } from '@/platform/workspace/composables/useWorkspaceActivity'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { userBadgeColor } from '@/platform/workspace/utils/badgeColor'
+import { formatRelativeTime } from '@/platform/workspace/utils/relativeTime'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { search } = defineProps<{ search: string }>()
+
+const { t, d } = useI18n()
+
+const tableContainer = ref<HTMLElement | null>(null)
+const { pageSize } = useAutoPageSize(tableContainer, 1)
+
+// Owners/admins see team-wide activity + the per-user footer; members see only
+// their own usage, scoped to their name.
+const { permissions } = useWorkspaceUI()
+const { userDisplayName, userEmail } = useCurrentUser()
+const canViewTeamUsage = computed(() => permissions.value.canManageSubscription)
+const selfName = computed(() =>
+  canViewTeamUsage.value
+    ? null
+    : userDisplayName.value || userEmail.value || t('g.you')
+)
+
+const fullActivityUrl = `${getComfyPlatformBaseUrl()}/profile/usage`
+
+const { navigateToPanel } = useSettingsNavigation()
+
+function goToMembers() {
+  requestMembersSort('credits')
+  navigateToPanel('workspace-members')
+}
+
+const {
+  page,
+  total,
+  itemsPerPage,
+  pagedItems,
+  sortField,
+  sortDirection,
+  toggleSort,
+  userSummaries
+} = useWorkspaceActivity(() => search, pageSize, selfName)
+
+function summaryFor(userName: string) {
+  return (
+    userSummaries.value.get(userName) ?? {
+      totalCredits: 0,
+      lastActivity: new Date()
+    }
+  )
+}
+
+function lastActivityLabel(userName: string): string {
+  return formatRelativeTime(summaryFor(userName).lastActivity, new Date(), {
+    justNow: t('workspacePanel.members.activity.justNow'),
+    minutesAgo: (n) => t('workspacePanel.members.activity.minutesAgo', { n }),
+    hoursAgo: (n) => t('workspacePanel.members.activity.hoursAgo', { n }),
+    daysAgo: (n) => t('workspacePanel.members.activity.daysAgo', n)
+  })
+}
+
+const sortHeaderClass =
+  'flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-left font-[inherit] text-sm text-muted-foreground'
+
+function sortIcon(field: ActivitySortField) {
+  if (sortField.value !== field) return 'icon-[lucide--chevrons-up-down] size-3'
+  return sortDirection.value === 'asc'
+    ? 'icon-[lucide--chevron-up] size-3'
+    : 'icon-[lucide--chevron-down] size-3'
+}
+
+function ariaSort(
+  field: ActivitySortField
+): 'ascending' | 'descending' | 'none' {
+  if (sortField.value !== field) return 'none'
+  return sortDirection.value === 'asc' ? 'ascending' : 'descending'
+}
+
+function formatDate(date: Date): string {
+  return d(date, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  })
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceOverviewContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceOverviewContent.vue
@@ -265,6 +265,8 @@ import { useWorkspaceOverview } from '@/platform/workspace/composables/useWorksp
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogService } from '@/services/dialogService'
 
+const emit = defineEmits<{ navigate: [view: 'activity'] }>()
+
 const { t } = useI18n()
 
 // Plan lifecycle actions are for the workspace creator (Owner) only; Admins and
@@ -382,12 +384,14 @@ const snapshotEmptyMessage = computed(() => {
     : null
 })
 
-// Both snapshot tabs deep-link to the Members panel (sorted by spend or
-// recency) until the Activity tab exists.
+// Top spenders → the Members panel pre-sorted by credit usage; Recent activity
+// → the Activity tab.
 function handleSeeMore() {
-  requestMembersSort(
-    snapshotView.value === 'recent' ? 'lastActivity' : 'credits'
-  )
+  if (snapshotView.value === 'recent') {
+    emit('navigate', 'activity')
+    return
+  }
+  requestMembersSort('credits')
   navigateToPanel('workspace-members')
 }
 </script>

--- a/src/platform/workspace/composables/useWorkspaceActivity.ts
+++ b/src/platform/workspace/composables/useWorkspaceActivity.ts
@@ -1,0 +1,126 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, ref, toValue, watch } from 'vue'
+
+export interface ActivityEvent {
+  id: string
+  date: Date
+  userName: string
+  eventType: string
+  detail: string
+  credits: number
+  /** The partner node used, for 'Partner node usage' events. */
+  partnerNode?: string
+  /** True for credit inflows (auto-reload, top-up) vs. usage outflows. */
+  credited?: boolean
+}
+
+export interface UserSummary {
+  totalCredits: number
+  lastActivity: Date
+}
+
+// TODO(usage-activity endpoint): there is no per-workspace activity API yet;
+// the ledger renders its empty state until events arrive from the backend.
+const events: ActivityEvent[] = []
+
+export type ActivitySortField =
+  | 'date'
+  | 'user'
+  | 'eventType'
+  | 'detail'
+  | 'credits'
+
+export function useWorkspaceActivity(
+  search: MaybeRefOrGetter<string>,
+  pageSize: MaybeRefOrGetter<number>,
+  selfName: MaybeRefOrGetter<string | null> = null
+) {
+  const page = ref(1)
+  const perPage = computed(() => Math.max(1, toValue(pageSize)))
+  const sortField = ref<ActivitySortField>('date')
+  const sortDirection = ref<'asc' | 'desc'>('desc')
+
+  // Members only see their own usage; credit inflows stay workspace-level.
+  const base = computed<ActivityEvent[]>(() => {
+    const self = toValue(selfName)
+    if (!self) return events
+    return events.filter((event) => event.credited || event.userName === self)
+  })
+
+  const filtered = computed(() => {
+    const q = toValue(search).trim().toLowerCase()
+    if (!q) return base.value
+    return base.value.filter(
+      (event) =>
+        event.userName.toLowerCase().includes(q) ||
+        event.eventType.toLowerCase().includes(q)
+    )
+  })
+
+  const sorted = computed(() => {
+    const dir = sortDirection.value === 'asc' ? 1 : -1
+    return [...filtered.value].sort((a, b) => {
+      if (sortField.value === 'credits') return dir * (a.credits - b.credits)
+      if (sortField.value === 'user')
+        return dir * a.userName.localeCompare(b.userName)
+      if (sortField.value === 'eventType')
+        return dir * a.eventType.localeCompare(b.eventType)
+      if (sortField.value === 'detail')
+        return dir * a.detail.localeCompare(b.detail)
+      return dir * (a.date.getTime() - b.date.getTime())
+    })
+  })
+
+  const total = computed(() => filtered.value.length)
+
+  const pagedItems = computed(() => {
+    const start = (page.value - 1) * perPage.value
+    return sorted.value.slice(start, start + perPage.value)
+  })
+
+  function toggleSort(field: ActivitySortField) {
+    if (sortField.value === field) {
+      sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    } else {
+      sortField.value = field
+      sortDirection.value = 'desc'
+    }
+  }
+
+  watch([total, perPage], ([count]) => {
+    const lastPage = Math.max(1, Math.ceil(count / perPage.value))
+    if (page.value > lastPage) page.value = lastPage
+  })
+
+  // Per-user rollups behind the User hover card: lifetime credits and the most
+  // recent event, aggregated across the whole (unpaged) list.
+  const userSummaries = computed(() => {
+    const map = new Map<string, UserSummary>()
+    for (const event of base.value) {
+      if (event.credited) continue
+      const existing = map.get(event.userName)
+      if (!existing) {
+        map.set(event.userName, {
+          totalCredits: event.credits,
+          lastActivity: event.date
+        })
+      } else {
+        existing.totalCredits += event.credits
+        if (event.date > existing.lastActivity)
+          existing.lastActivity = event.date
+      }
+    }
+    return map
+  })
+
+  return {
+    page,
+    total,
+    itemsPerPage: perPage,
+    pagedItems,
+    sortField,
+    sortDirection,
+    toggleSort,
+    userSummaries
+  }
+}


### PR DESCRIPTION
<!-- branch: split/member-auditing | base: split/auto-reload -->
<!-- title: feat: workspace activity ledger + member auditing -->

## What

- **Activity tab**: sortable, paginated credit ledger (auto page-sized) with per-user hover-card rollups and partner-node detail; members scoped to their own rows
- Credits-tab snapshot "Recent activity" deep-links here; tab-row search scopes the ledger

Linear: [DES-479](https://linear.app/comfyorg/issue/DES-479)

## Notes for reviewers

- **No usage-activity endpoint yet**: the ledger renders its empty state; filter/sort/pagination/rollup machinery is real and ready for data (`useWorkspaceActivity` is the seam).
- The prototype's mock-data test for this composable was dropped with the mock; behavioral tests should come with the real data wiring.
