### PR TITLE
fix: prevent unintended nodes from moving during alt-drag clone

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -108,7 +108,7 @@ export function useNodePointerInteractions(
     }
 
     if (layoutStore.isDraggingVueNodes.value) {
-      handleDrag(event, nodeId)
+      handleDrag(event)
     }
   }
 
@@ -126,8 +126,7 @@ export function useNodePointerInteractions(
 
   function safeDragEnd(event: PointerEvent) {
     try {
-      const nodeId = toValue(nodeIdRef)
-      endDrag(event, nodeId)
+      endDrag(event)
     } catch (error) {
       console.error('Error during endDrag:', error)
     } finally {

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -173,7 +173,7 @@ describe('useNodeDrag', () => {
     const { startDrag, handleDrag } = useNodeDrag()
 
     startDrag(pointerEvent(10, 20), node1)
-    handleDrag(pointerEvent(30, 40), node1)
+    handleDrag(pointerEvent(30, 40))
     testState.requestAnimationFrameCallback?.(0)
 
     expect(testState.mutationFns.batchMoveNodes).toHaveBeenCalledTimes(1)
@@ -194,7 +194,7 @@ describe('useNodeDrag', () => {
     const { startDrag, handleDrag } = useNodeDrag()
 
     startDrag(pointerEvent(5, 10), node1)
-    handleDrag(pointerEvent(25, 30), node1)
+    handleDrag(pointerEvent(25, 30))
     testState.requestAnimationFrameCallback?.(0)
 
     expect(testState.mutationFns.batchMoveNodes).toHaveBeenCalledTimes(1)
@@ -219,8 +219,8 @@ describe('useNodeDrag', () => {
     const { startDrag, handleDrag, endDrag } = useNodeDrag()
 
     startDrag(pointerEvent(5, 10), node1)
-    handleDrag(pointerEvent(25, 30), node1)
-    endDrag({} as PointerEvent, node1)
+    handleDrag(pointerEvent(25, 30))
+    endDrag({} as PointerEvent)
 
     expect(testState.cancelAnimationFrame).toHaveBeenCalledTimes(1)
     expect(testState.cancelAnimationFrame).toHaveBeenCalledWith(1)
@@ -249,7 +249,7 @@ describe('useNodeDrag', () => {
     const { startDrag, handleDrag } = useNodeDrag()
 
     startDrag(pointerEvent(5, 10), node2)
-    handleDrag(pointerEvent(25, 30), node1)
+    handleDrag(pointerEvent(25, 30))
     testState.requestAnimationFrameCallback?.(0)
 
     expect(testState.mutationFns.batchMoveNodes).toHaveBeenCalledTimes(1)
@@ -300,7 +300,7 @@ describe('useNodeDrag auto-pan', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(750, 300), node1)
 
-    drag.handleDrag(pointerEvent(760, 300), node1)
+    drag.handleDrag(pointerEvent(760, 300))
     testState.requestAnimationFrameCallback?.(0)
 
     expect(testState.mutationFns.batchMoveNodes).toHaveBeenLastCalledWith([
@@ -322,7 +322,7 @@ describe('useNodeDrag auto-pan', () => {
     const drag = useNodeDrag()
 
     drag.startDrag(pointerEvent(750, 300), node1)
-    drag.handleDrag(pointerEvent(760, 300), node1)
+    drag.handleDrag(pointerEvent(760, 300))
     testState.mutationFns.batchMoveNodes.mockClear()
 
     testState.mockDs.offset[0] -= 5
@@ -339,7 +339,7 @@ describe('useNodeDrag auto-pan', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), node1)
 
-    drag.handleDrag(pointerEvent(790, 300), node1)
+    drag.handleDrag(pointerEvent(790, 300))
 
     const autoPan = testState.capturedAutoPanInstance.current
     if (!autoPan) throw new Error('Auto-pan controller was not created')
@@ -351,12 +351,12 @@ describe('useNodeDrag auto-pan', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), node1)
 
-    drag.handleDrag(pointerEvent(790, 300), node1)
+    drag.handleDrag(pointerEvent(790, 300))
     const autoPan = testState.capturedAutoPanInstance.current
     if (!autoPan) throw new Error('Auto-pan controller was not created')
 
     testState.requestAnimationFrameCallback?.(0)
-    drag.handleDrag(pointerEvent(795, 305), node1)
+    drag.handleDrag(pointerEvent(795, 305))
 
     expect(testState.capturedAutoPanInstance.current).toBe(autoPan)
     expect(autoPan.start).toHaveBeenCalledTimes(1)
@@ -374,10 +374,10 @@ describe('useNodeDrag auto-pan', () => {
   it('stops auto-pan on endDrag', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), node1)
-    drag.handleDrag(pointerEvent(400, 300), node1)
+    drag.handleDrag(pointerEvent(400, 300))
     expect(testState.capturedAutoPanInstance.current).not.toBeNull()
 
-    drag.endDrag(pointerEvent(400, 300), node1)
+    drag.endDrag(pointerEvent(400, 300))
 
     expect(testState.capturedAutoPanInstance.current!.stop).toHaveBeenCalled()
   })
@@ -385,10 +385,10 @@ describe('useNodeDrag auto-pan', () => {
   it('does not move nodes if onPan fires after endDrag', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), node1)
-    drag.handleDrag(pointerEvent(400, 300), node1)
+    drag.handleDrag(pointerEvent(400, 300))
     const onPan = testState.capturedOnPan.current!
 
-    drag.endDrag(pointerEvent(400, 300), node1)
+    drag.endDrag(pointerEvent(400, 300))
     testState.mutationFns.batchMoveNodes.mockClear()
 
     onPan(5, 0)

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -237,6 +237,26 @@ describe('useNodeDrag', () => {
       }
     ])
   })
+
+  it('moves active node even when drag event targets a different node', () => {
+    const node2 = toNodeId('2')
+    testState.selectedNodeIds.value = new Set([node2])
+    testState.nodeLayouts.set('2', {
+      position: { x: 50, y: 80 },
+      size: { width: 180, height: 110 }
+    })
+
+    const { startDrag, handleDrag } = useNodeDrag()
+
+    startDrag(pointerEvent(5, 10), node2)
+    handleDrag(pointerEvent(25, 30), node1)
+    testState.requestAnimationFrameCallback?.(0)
+
+    expect(testState.mutationFns.batchMoveNodes).toHaveBeenCalledTimes(1)
+    expect(testState.mutationFns.batchMoveNodes).toHaveBeenCalledWith([
+      { nodeId: '2', position: { x: 70, y: 100 } }
+    ])
+  })
 })
 
 describe('useNodeDrag auto-pan', () => {

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -50,9 +50,9 @@ function useNodeDragIndividual() {
   let lastPointerY = 0
 
   function startDrag(event: PointerEvent, nodeId: NodeId) {
-    activeDragNodeId = nodeId
     const layout = toValue(layoutStore.getNodeLayoutRef(nodeId))
     if (!layout) return
+    activeDragNodeId = nodeId
     const position = layout.position ?? { x: 0, y: 0 }
 
     // Track shift key state and sync to canvas for snap preview
@@ -194,9 +194,8 @@ function useNodeDragIndividual() {
     lastCanvasDelta = canvasDelta
   }
 
-  function handleDrag(event: PointerEvent, nodeId: NodeId) {
-    const activeNodeId = activeDragNodeId ?? nodeId
-    if (!dragStartPos || !dragStartMouse) {
+  function handleDrag(event: PointerEvent) {
+    if (!dragStartPos || !dragStartMouse || !activeDragNodeId) {
       return
     }
 
@@ -211,22 +210,23 @@ function useNodeDragIndividual() {
 
     lastPointerX = event.clientX
     lastPointerY = event.clientY
-    startAutoPan(event, activeNodeId)
+    startAutoPan(event, activeDragNodeId)
 
     rafId = requestAnimationFrame(() => {
       rafId = null
-      updateNodePositions(activeNodeId)
+      updateNodePositions(activeDragNodeId!)
     })
   }
 
-  function endDrag(event: PointerEvent, nodeId: NodeId | undefined) {
-    const activeNodeId = activeDragNodeId ?? nodeId
+  function endDrag(event: PointerEvent) {
     // Apply snap to final position if snap was active (matches LiteGraph behavior)
-    if (shouldSnap(event) && activeNodeId) {
+    if (shouldSnap(event) && activeDragNodeId) {
       const boundsUpdates: NodeBoundsUpdate[] = []
 
       // Snap main node
-      const currentLayout = toValue(layoutStore.getNodeLayoutRef(activeNodeId))
+      const currentLayout = toValue(
+        layoutStore.getNodeLayoutRef(activeDragNodeId)
+      )
       if (currentLayout) {
         const currentPos = currentLayout.position
         const snappedPos = applySnapToPosition({ ...currentPos })
@@ -234,7 +234,7 @@ function useNodeDragIndividual() {
         // Only add update if position actually changed
         if (snappedPos.x !== currentPos.x || snappedPos.y !== currentPos.y) {
           boundsUpdates.push({
-            nodeId: activeNodeId,
+            nodeId: activeDragNodeId,
             bounds: {
               x: snappedPos.x,
               y: snappedPos.y,

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -33,6 +33,7 @@ function useNodeDragIndividual() {
   const canvasStore = useCanvasStore()
 
   // Drag state
+  let activeDragNodeId: NodeId | null = null
   let dragStartPos: Point | null = null
   let dragStartMouse: Point | null = null
   let otherSelectedNodesStartPositions: Map<NodeId, Point> | null = null
@@ -49,6 +50,7 @@ function useNodeDragIndividual() {
   let lastPointerY = 0
 
   function startDrag(event: PointerEvent, nodeId: NodeId) {
+    activeDragNodeId = nodeId
     const layout = toValue(layoutStore.getNodeLayoutRef(nodeId))
     if (!layout) return
     const position = layout.position ?? { x: 0, y: 0 }
@@ -193,6 +195,7 @@ function useNodeDragIndividual() {
   }
 
   function handleDrag(event: PointerEvent, nodeId: NodeId) {
+    const activeNodeId = activeDragNodeId ?? nodeId
     if (!dragStartPos || !dragStartMouse) {
       return
     }
@@ -208,21 +211,22 @@ function useNodeDragIndividual() {
 
     lastPointerX = event.clientX
     lastPointerY = event.clientY
-    startAutoPan(event, nodeId)
+    startAutoPan(event, activeNodeId)
 
     rafId = requestAnimationFrame(() => {
       rafId = null
-      updateNodePositions(nodeId)
+      updateNodePositions(activeNodeId)
     })
   }
 
   function endDrag(event: PointerEvent, nodeId: NodeId | undefined) {
+    const activeNodeId = activeDragNodeId ?? nodeId
     // Apply snap to final position if snap was active (matches LiteGraph behavior)
-    if (shouldSnap(event) && nodeId) {
+    if (shouldSnap(event) && activeNodeId) {
       const boundsUpdates: NodeBoundsUpdate[] = []
 
       // Snap main node
-      const currentLayout = toValue(layoutStore.getNodeLayoutRef(nodeId))
+      const currentLayout = toValue(layoutStore.getNodeLayoutRef(activeNodeId))
       if (currentLayout) {
         const currentPos = currentLayout.position
         const snappedPos = applySnapToPosition({ ...currentPos })
@@ -230,7 +234,7 @@ function useNodeDragIndividual() {
         // Only add update if position actually changed
         if (snappedPos.x !== currentPos.x || snappedPos.y !== currentPos.y) {
           boundsUpdates.push({
-            nodeId,
+            nodeId: activeNodeId,
             bounds: {
               x: snappedPos.x,
               y: snappedPos.y,
@@ -282,6 +286,7 @@ function useNodeDragIndividual() {
   }
 
   function resetDragState() {
+    activeDragNodeId = null
     dragStartPos = null
     dragStartMouse = null
     otherSelectedNodesStartPositions = null


### PR DESCRIPTION
## Summary

Prevents unintended nodes from moving during alt-drag cloning. This fixes the following bugs:

1. Cloning and moving a node with alt+drag would end up moving another node instead of the cloned node.
2. Cloned nodes not moving with the cursor.
3. Dragging a cloned node would "magnetize" any nodes around it/come in contact with, causing them to "follow" the cloned node.

## Changes

Sets activeDragNodeId at drag start to ensure all movement updates apply to the correct node, instead of relying on the browser's mouse event target.

## Review Focus

Fixes [FE-1163](https://linear.app/comfyorg/issue/FE-1163/altdrag-duplicate-node-doesnt-stay-attached-to-cursor-nodes-20)
Fixes [FE-1164](https://linear.app/comfyorg/issue/FE-1164/altdrag-sometimes-attaches-an-unrelated-node-to-the-cursor-nodes-20)