### PR TITLE
feat: enforce partner-node governance across the workbench

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -82,7 +82,9 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { app } from '@/scripts/app'
 import { useCommandStore } from '@/stores/commandStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import {
   isInstantMode,
   isInstantRunningMode,
@@ -98,6 +100,10 @@ const { mode: queueMode, batchCount } = storeToRefs(useQueueSettingsStore())
 const nodeDefStore = useNodeDefStore()
 const hasMissingNodes = computed(() =>
   graphHasMissingNodes(app.rootGraph, nodeDefStore.nodeDefsByName)
+)
+const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
+const hasDisabledNodes = computed(
+  () => disabledPartnerNodesStore.offenders.length > 0
 )
 
 const { t } = useI18n()
@@ -190,7 +196,7 @@ const iconClass = computed(() => {
   if (isStopInstantAction.value) {
     return 'icon-[lucide--square]'
   }
-  if (hasMissingNodes.value) {
+  if (hasMissingNodes.value || hasDisabledNodes.value) {
     return 'icon-[lucide--triangle-alert]'
   }
   if (workspaceStore.shiftDown) {
@@ -215,6 +221,9 @@ const queueButtonTooltip = computed(() => {
   if (hasMissingNodes.value) {
     return t('menu.runWorkflowDisabled')
   }
+  if (hasDisabledNodes.value) {
+    return t('menu.runWorkflowDisabledNodes')
+  }
   if (workspaceStore.shiftDown) {
     return t('menu.runWorkflowFront')
   }
@@ -225,6 +234,11 @@ const commandStore = useCommandStore()
 const queuePrompt = async (e: Event) => {
   if (isStopInstantAction.value) {
     queueMode.value = 'instant-idle'
+    return
+  }
+
+  if (hasDisabledNodes.value) {
+    useRightSidePanelStore().openPanel('errors')
     return
   }
 

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -38,6 +38,7 @@ import {
 } from './shared'
 import SubgraphEditor from './subgraph/SubgraphEditor.vue'
 import TabErrors from './errors/TabErrors.vue'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 
 const canvasStore = useCanvasStore()
 const executionErrorStore = useExecutionErrorStore()
@@ -157,14 +158,28 @@ const hasMissingMediaSelected = computed(
     )
 )
 
+const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
+const disabledGraphNodeIds = computed(
+  () => new Set(disabledPartnerNodesStore.offenders.map((o) => o.graphNodeId))
+)
+const hasDisabledNodeSelected = computed(
+  () =>
+    hasSelection.value &&
+    selectedNodes.value.some((node) =>
+      disabledGraphNodeIds.value.has(String(node.id))
+    )
+)
+
 const hasRelevantErrors = computed(() => {
-  if (!hasSelection.value) return hasAnyError.value
+  if (!hasSelection.value)
+    return hasAnyError.value || disabledPartnerNodesStore.offenders.length > 0
   return (
     hasDirectNodeError.value ||
     hasContainerInternalError.value ||
     hasMissingNodeSelected.value ||
     hasMissingModelSelected.value ||
-    hasMissingMediaSelected.value
+    hasMissingMediaSelected.value ||
+    hasDisabledNodeSelected.value
   )
 })
 

--- a/src/components/rightSidePanel/errors/ErrorGroupList.vue
+++ b/src/components/rightSidePanel/errors/ErrorGroupList.vue
@@ -309,6 +309,13 @@
               :highlighted-node-ids="selectionMatchedAssetNodeIds"
               @locate-node="handleLocateAssetNode"
             />
+
+            <!-- Admin-disabled partner nodes -->
+            <DisabledNodesCard
+              v-if="group.type === 'disabled_node'"
+              :offenders="filteredDisabledNodes"
+              @locate-node="handleLocateAssetNode"
+            />
           </ErrorCardSection>
         </TransitionGroup>
       </div>
@@ -336,6 +343,7 @@ import MissingNodeCard from './MissingNodeCard.vue'
 import SwapNodesCard from '@/platform/nodeReplacement/components/SwapNodesCard.vue'
 import MissingModelCard from '@/platform/missingModel/components/MissingModelCard.vue'
 import MissingMediaCard from '@/platform/missingMedia/components/MissingMediaCard.vue'
+import DisabledNodesCard from '@/platform/workspace/components/errors/DisabledNodesCard.vue'
 import { isCloud } from '@/platform/distribution/types'
 import Button from '@/components/ui/button/Button.vue'
 import DotSpinner from '@/components/common/DotSpinner.vue'
@@ -432,6 +440,7 @@ const {
   missingPackGroups,
   missingModelGroups,
   missingMediaGroups,
+  filteredDisabledNodes,
   swapNodeGroups,
   hasSelection,
   selectedNodeCount,

--- a/src/components/rightSidePanel/errors/types.ts
+++ b/src/components/rightSidePanel/errors/types.ts
@@ -45,3 +45,6 @@ export type ErrorGroup =
   | (ErrorGroupBase & {
       type: 'missing_media'
     })
+  | (ErrorGroupBase & {
+      type: 'disabled_node'
+    })

--- a/src/components/rightSidePanel/errors/useErrorGroups.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.ts
@@ -5,6 +5,7 @@ import type { IFuseOptions } from 'fuse.js'
 
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useComfyRegistryStore } from '@/stores/comfyRegistryStore'
@@ -20,7 +21,7 @@ import {
 } from '@/utils/graphTraversalUtil'
 import { resolveNodeDisplayName } from '@/utils/nodeTitleUtil'
 import { isLGraphNode } from '@/utils/litegraphUtil'
-import { st } from '@/i18n'
+import { st, t } from '@/i18n'
 import type { MissingNodeType } from '@/types/comfy'
 import type { ErrorCardData, ErrorGroup, ErrorItem } from './types'
 import { shouldRenderExecutionItemList } from './executionItemList'
@@ -236,6 +237,7 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
   const missingNodesStore = useMissingNodesErrorStore()
   const missingModelStore = useMissingModelStore()
   const missingMediaStore = useMissingMediaStore()
+  const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
   const canvasStore = useCanvasStore()
   const { inferPackFromNodeName } = useComfyRegistryStore()
   const collapseState = reactive<Record<string, boolean>>({})
@@ -647,6 +649,31 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
     return groups.sort((a, b) => a.priority - b.priority)
   }
 
+  const filteredDisabledNodes = computed(() => {
+    const all = disabledPartnerNodesStore.offenders
+    if (!selectedNodeInfo.value.nodeIds) return all
+    return all.filter((offender) => isAssetErrorInSelection(offender.nodeId))
+  })
+
+  function buildDisabledNodeGroups(
+    offenders: typeof disabledPartnerNodesStore.offenders
+  ): ErrorGroup[] {
+    if (!offenders.length) return []
+    return [
+      {
+        type: 'disabled_node' as const,
+        groupKey: 'disabled_node',
+        count: offenders.length,
+        priority: 0,
+        displayTitle: t('rightSidePanel.disabledNodes.title', offenders.length),
+        displayMessage: t(
+          'rightSidePanel.disabledNodes.message',
+          offenders.length
+        )
+      }
+    ]
+  }
+
   const missingModelGroups = computed<MissingModelGroup[]>(() => {
     return groupMissingModelCandidates(
       missingModelStore.missingModelCandidates,
@@ -797,6 +824,7 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
     processExecutionError(groupsMap)
 
     return [
+      ...buildDisabledNodeGroups(disabledPartnerNodesStore.offenders),
       ...buildMissingNodeGroups(),
       ...buildMissingModelGroups(),
       ...buildMissingMediaGroups(),
@@ -819,6 +847,7 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
     processExecutionError(groupsMap, true)
 
     return [
+      ...buildDisabledNodeGroups(filteredDisabledNodes.value),
       ...buildMissingNodeGroups((nodeTypes) =>
         someNodeTypeInSelection(nodeTypes, selectionMatchedAssetNodeIds.value)
       ),
@@ -903,6 +932,7 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
     missingPackGroups,
     missingModelGroups,
     missingMediaGroups,
+    filteredDisabledNodes,
     swapNodeGroups,
     hasSelection,
     selectedNodeCount,

--- a/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
@@ -34,7 +34,9 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: () => ({
-    getInputSpecForWidget: vi.fn()
+    getInputSpecForWidget: vi.fn(),
+    registerNodeDefFilter: vi.fn(),
+    nodeDefsByName: {}
   })
 }))
 

--- a/src/components/searchbox/v2/NodeSearchContent.vue
+++ b/src/components/searchbox/v2/NodeSearchContent.vue
@@ -99,7 +99,11 @@
             data-testid="no-results"
             class="px-4 py-8 text-center text-muted-foreground"
           >
-            {{ $t('g.noResults') }}
+            {{
+              disabledMatchCount > 0
+                ? $t('nodeSearch.disabledByTeamAdmin', disabledMatchCount)
+                : $t('g.noResults')
+            }}
           </div>
         </div>
       </div>
@@ -125,6 +129,8 @@ import { useSearchQueryTracking } from '@/platform/telemetry/searchQuery/useSear
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
+import { NodeSearchService } from '@/services/nodeSearchService'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   BLUEPRINT_CATEGORY,
@@ -158,6 +164,7 @@ const { flags } = useFeatureFlags()
 const nodeDefStore = useNodeDefStore()
 const nodeFrequencyStore = useNodeFrequencyStore()
 const nodeBookmarkStore = useNodeBookmarkStore()
+const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
 
 const nodeAvailability = computed(() => {
   let essential = false
@@ -216,21 +223,28 @@ const rootFilterLabel = computed(() => {
   }
 })
 
+function rootFilterPredicate(
+  root: RootCategoryId
+): (n: ComfyNodeDefImpl) => boolean {
+  const sourceFilter = sourceCategoryFilters[root]
+  if (sourceFilter) return sourceFilter
+  switch (root) {
+    case RootCategory.Favorites:
+      return (n) => nodeBookmarkStore.isBookmarked(n)
+    case RootCategory.Blueprint:
+      return (n) => n.category.startsWith(BLUEPRINT_CATEGORY)
+    case RootCategory.PartnerNodes:
+      return (n) => n.api_node
+    default:
+      return () => true
+  }
+}
+
 const rootFilteredNodeDefs = computed(() => {
   if (!rootFilter.value) return nodeDefStore.visibleNodeDefs
-  const allNodes = nodeDefStore.visibleNodeDefs
-  const sourceFilter = sourceCategoryFilters[rootFilter.value]
-  if (sourceFilter) return allNodes.filter(sourceFilter)
-  switch (rootFilter.value) {
-    case RootCategory.Favorites:
-      return allNodes.filter((n) => nodeBookmarkStore.isBookmarked(n))
-    case RootCategory.Blueprint:
-      return allNodes.filter((n) => n.category.startsWith(BLUEPRINT_CATEGORY))
-    case RootCategory.PartnerNodes:
-      return allNodes.filter((n) => n.api_node)
-    default:
-      return allNodes
-  }
+  return nodeDefStore.visibleNodeDefs.filter(
+    rootFilterPredicate(rootFilter.value)
+  )
 })
 
 function onToggleFilter(
@@ -334,6 +348,35 @@ const displayedResults = computed<ComfyNodeDefImpl[]>(() => {
   const sourceFilter = sourceCategoryFilters[category]
   if (sourceFilter) return source.filter(sourceFilter)
   return getCategoryResults(source, category)
+})
+
+// Same matcher over the hidden (admin-disabled) defs: when results are empty
+// the panel can say WHY — the partition, not a second heuristic, decides.
+const disabledNodeDefs = computed(() =>
+  Object.values(nodeDefStore.nodeDefsByName).filter((d) =>
+    disabledPartnerNodesStore.isNodeDefDisabled(d)
+  )
+)
+const disabledSearchService = computed(
+  () => new NodeSearchService(disabledNodeDefs.value)
+)
+const disabledMatchCount = computed(() => {
+  if (displayedResults.value.length > 0) return 0
+  if (disabledNodeDefs.value.length === 0) return 0
+  const inRoot = rootFilter.value
+    ? disabledNodeDefs.value.filter(rootFilterPredicate(rootFilter.value))
+    : disabledNodeDefs.value
+  if (!searchQuery.value && filters.length === 0) {
+    return rootFilter.value ? inRoot.length : 0
+  }
+  const matched = disabledSearchService.value.searchNode(
+    searchQuery.value,
+    filters,
+    { limit: 64 }
+  )
+  if (!rootFilter.value) return matched.length
+  const inRootNames = new Set(inRoot.map((n) => n.name))
+  return matched.filter((n) => inRootNames.has(n.name)).length
 })
 
 const hoveredNodeDef = computed(

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.vue
@@ -96,9 +96,11 @@
               class="flex min-h-0 flex-1 items-center justify-center px-6 py-8 text-center text-sm text-muted-foreground"
             >
               {{
-                $t('sideToolbar.nodeLibraryTab.noMatchingNodes', {
-                  query: searchQuery
-                })
+                disabledMatchCount > 0
+                  ? $t('nodeSearch.disabledByTeamAdmin', disabledMatchCount)
+                  : $t('sideToolbar.nodeLibraryTab.noMatchingNodes', {
+                      query: searchQuery
+                    })
               }}
             </div>
             <AllNodesPanel
@@ -150,6 +152,8 @@ import {
 } from '@/services/nodeOrganizationService'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { buildNodeDefTree, useNodeDefStore } from '@/stores/nodeDefStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
+import { NodeSearchService } from '@/services/nodeSearchService'
 import type {
   NodeCategoryId,
   NodeSection,
@@ -276,6 +280,24 @@ useSearchQueryTracking('node_sidebar', searchQuery, filteredNodeDefs)
 const hasNoMatches = computed(
   () => searchQuery.value.length > 0 && filteredNodeDefs.value.length === 0
 )
+
+// When nothing matched, check whether the query WOULD have hit an
+// admin-disabled partner node so the empty state can say so.
+const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
+const disabledNodeDefs = computed(() =>
+  Object.values(nodeDefStore.nodeDefsByName).filter((d) =>
+    disabledPartnerNodesStore.isNodeDefDisabled(d)
+  )
+)
+const disabledMatchCount = computed(() => {
+  if (!hasNoMatches.value || disabledNodeDefs.value.length === 0) return 0
+  return new NodeSearchService(disabledNodeDefs.value).searchNode(
+    searchQuery.value,
+    [],
+    { limit: 64 },
+    { matchWildcards: false }
+  ).length
+})
 
 const sections = computed(() => {
   return nodeOrganizationService.organizeNodesTab(activeNodes.value)

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -1,5 +1,26 @@
 <template>
   <Toast />
+  <Toast group="disabled-nodes" position="top-right">
+    <template #message="slotProps">
+      <div class="flex min-w-0 flex-1 flex-col gap-2">
+        <span class="text-sm font-semibold">
+          {{ slotProps.message.summary }}
+        </span>
+        <span class="text-sm text-muted-foreground">
+          {{ slotProps.message.detail }}
+        </span>
+        <div class="flex justify-end">
+          <Button
+            size="sm"
+            variant="secondary"
+            @click="viewDisabledNodeDetails(slotProps.message)"
+          >
+            {{ $t('rightSidePanel.disabledNodes.viewDetails') }}
+          </Button>
+        </div>
+      </div>
+    </template>
+  </Toast>
   <Toast group="billing-operation" position="top-right">
     <template #message="slotProps">
       <div class="flex items-center gap-2">
@@ -15,12 +36,19 @@ import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { nextTick, watch } from 'vue'
 
+import Button from '@/components/ui/button/Button.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 
 const toast = useToast()
 const toastStore = useToastStore()
 const settingStore = useSettingStore()
+
+function viewDisabledNodeDetails(message: object) {
+  useRightSidePanelStore().openPanel('errors')
+  toast.remove(message)
+}
 
 watch(
   () => toastStore.messagesToAdd,

--- a/src/composables/graph/useNodeErrorFlagSync.ts
+++ b/src/composables/graph/useNodeErrorFlagSync.ts
@@ -4,6 +4,7 @@ import { computed, watch } from 'vue'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import type { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { app } from '@/scripts/app'
 import type { NodeError } from '@/schemas/apiSchema'
@@ -34,7 +35,8 @@ function reconcileNodeErrorFlags(
   rootGraph: LGraph,
   nodeErrors: Record<string, NodeError> | null,
   missingModelExecIds: Set<string>,
-  missingMediaExecIds: Set<string> = new Set()
+  missingMediaExecIds: Set<string> = new Set(),
+  disabledNodeExecIds: Set<string> = new Set()
 ): void {
   // Collect nodes and slot info that should be flagged
   // Includes both error-owning nodes and their ancestor containers
@@ -71,6 +73,11 @@ function reconcileNodeErrorFlags(
     if (node) flaggedNodes.add(node)
   }
 
+  for (const execId of disabledNodeExecIds) {
+    const node = getNodeByExecutionId(rootGraph, execId)
+    if (node) flaggedNodes.add(node)
+  }
+
   forEachNode(rootGraph, (node) => {
     setNodeHasErrors(node, flaggedNodes.has(node))
 
@@ -86,7 +93,8 @@ function reconcileNodeErrorFlags(
 export function useNodeErrorFlagSync(
   lastNodeErrors: Ref<Record<string, NodeError> | null>,
   missingModelStore: ReturnType<typeof useMissingModelStore>,
-  missingMediaStore: ReturnType<typeof useMissingMediaStore>
+  missingMediaStore: ReturnType<typeof useMissingMediaStore>,
+  disabledPartnerNodesStore: ReturnType<typeof useDisabledPartnerNodesStore>
 ): () => void {
   const settingStore = useSettingStore()
   const showErrorsTab = computed(() =>
@@ -98,6 +106,7 @@ export function useNodeErrorFlagSync(
       lastNodeErrors,
       () => missingModelStore.missingModelNodeIds,
       () => missingMediaStore.missingMediaNodeIds,
+      () => disabledPartnerNodesStore.disabledAncestorExecutionIds,
       showErrorsTab
     ],
     () => {
@@ -114,6 +123,9 @@ export function useNodeErrorFlagSync(
           : new Set(),
         showErrorsTab.value
           ? missingMediaStore.missingMediaAncestorExecutionIds
+          : new Set(),
+        showErrorsTab.value
+          ? disabledPartnerNodesStore.disabledAncestorExecutionIds
           : new Set()
       )
     },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1091,6 +1091,7 @@
     "runWorkflow": "Run workflow (Shift to queue at front)",
     "runWorkflowFront": "Run workflow (Queue at front)",
     "runWorkflowDisabled": "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow.",
+    "runWorkflowDisabledNodes": "Workflows with disabled nodes cannot be run. Check the Errors tab for details.",
     "run": "Run",
     "stopRunInstant": "Stop Run (Instant)",
     "stopRunInstantTooltip": "Stop running",
@@ -3992,6 +3993,12 @@
     "errorNodesSummary": "{nodes} nodes — {count} error | {nodes} nodes — {count} errors",
     "errorsSummary": "{count} error | {count} errors",
     "resolveBeforeRun": "Resolve before running the workflow",
+    "disabledNodes": {
+      "title": "Disabled node | Disabled nodes",
+      "message": "This node has been disabled by your team admin. Use a different node. | These nodes have been disabled by your team admin. Use different nodes.",
+      "toastDetail": "This node has been disabled by your team admin. | These nodes have been disabled by your team admin.",
+      "viewDetails": "View details"
+    },
     "expand": "Expand",
     "collapse": "Collapse",
     "executionErrorOccurred": "An error occurred during execution. Check the Errors tab for details.",
@@ -4491,7 +4498,11 @@
     "hideDevOnly": "Hide Dev-Only Nodes",
     "hideDevOnlyDescription": "Hides nodes marked as dev-only unless dev mode is enabled",
     "hideSubgraph": "Hide Subgraph Nodes",
-    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search"
+    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search",
+    "hideDisabledPartnerNodes": "Hide admin-disabled partner nodes"
+  },
+  "nodeSearch": {
+    "disabledByTeamAdmin": "This node has been disabled by your team admin. | These nodes have been disabled by your team admin."
   },
   "secrets": {
     "title": "API Keys & Secrets",

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -26,7 +26,8 @@ vi.mock('@/platform/nodeReplacement/cnrIdUtil', () => ({
 }))
 
 vi.mock('@/i18n', () => ({
-  st: vi.fn((_key: string, fallback: string) => fallback)
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key)
 }))
 
 vi.mock('@/platform/distribution/types', () => ({

--- a/src/platform/workspace/components/errors/DisabledNodesCard.vue
+++ b/src/platform/workspace/components/errors/DisabledNodesCard.vue
@@ -1,0 +1,37 @@
+<template>
+  <ul class="m-0 list-none space-y-1 p-0 px-3">
+    <li
+      v-for="offender in offenders"
+      :key="offender.nodeId"
+      class="flex min-w-0 items-center gap-2"
+    >
+      <button
+        type="button"
+        class="focus-visible:ring-ring m-0 inline max-w-full flex-1 cursor-pointer appearance-none truncate rounded-sm border-0 bg-transparent p-0 text-left text-xs/relaxed font-normal text-muted-foreground outline-none hover:text-base-foreground focus:outline-none focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-inset"
+        @click="emit('locateNode', offender.nodeId)"
+      >
+        {{ offender.displayName }}
+      </button>
+      <Button
+        variant="textonly"
+        size="icon-sm"
+        class="size-8 shrink-0 text-muted-foreground hover:text-base-foreground focus-visible:ring-inset"
+        :aria-label="
+          $t('rightSidePanel.locateNodeFor', { item: offender.displayName })
+        "
+        @click.stop="emit('locateNode', offender.nodeId)"
+      >
+        <i class="icon-[lucide--locate] size-4" />
+      </Button>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+import type { DisabledGraphNode } from '@/platform/workspace/stores/disabledPartnerNodesStore'
+
+const { offenders } = defineProps<{ offenders: DisabledGraphNode[] }>()
+
+const emit = defineEmits<{ locateNode: [nodeId: string] }>()
+</script>

--- a/src/platform/workspace/composables/usePartnerNodes.test.ts
+++ b/src/platform/workspace/composables/usePartnerNodes.test.ts
@@ -22,6 +22,13 @@ vi.mock('@/platform/workspace/api/partnerNodesApi', () => ({
   }
 }))
 
+const mockApplyGovernanceChange = vi.fn()
+vi.mock('@/platform/workspace/stores/disabledPartnerNodesStore', () => ({
+  useDisabledPartnerNodesStore: () => ({
+    applyGovernanceChange: mockApplyGovernanceChange
+  })
+}))
+
 function node(overrides: Partial<PartnerNode> = {}): PartnerNode {
   return {
     id: 'pn-1',

--- a/src/platform/workspace/composables/usePartnerNodes.ts
+++ b/src/platform/workspace/composables/usePartnerNodes.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { PartnerNode } from '@/platform/workspace/api/partnerNodesApi'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import { partnerNodesApi } from '@/platform/workspace/api/partnerNodesApi'
 
 export interface PartnerGroup {
@@ -161,6 +162,7 @@ export function usePartnerNodes() {
     applyEnabled([node.id], enabled)
     try {
       await partnerNodesApi.setEnabled(node.id, enabled)
+      void useDisabledPartnerNodesStore().applyGovernanceChange()
     } catch {
       nodes.value = nodes.value.map((n) =>
         n.id === node.id
@@ -188,6 +190,7 @@ export function usePartnerNodes() {
     applyEnabled(ids, enabled)
     try {
       await partnerNodesApi.setEnabledBulk(ids, enabled)
+      void useDisabledPartnerNodesStore().applyGovernanceChange()
       return true
     } catch {
       nodes.value = nodes.value.map((n) =>

--- a/src/platform/workspace/stores/disabledPartnerNodesStore.ts
+++ b/src/platform/workspace/stores/disabledPartnerNodesStore.ts
@@ -1,0 +1,193 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { t } from '@/i18n'
+import { isCloud } from '@/platform/distribution/types'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { app } from '@/scripts/app'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { getAncestorExecutionIds } from '@/types/nodeIdentification'
+import { forEachNode, getExecutionIdByNode } from '@/utils/graphTraversalUtil'
+
+export interface DisabledGraphNode {
+  nodeId: NodeExecutionId
+  graphNodeId: string
+  displayName: string
+}
+
+/**
+ * Enforcement side of partner-node governance: which allowlist-disabled
+ * partner nodes are present in the open workflow. Feeds the Workflow
+ * Overview error panel, canvas error flags, run gating, and the load toast.
+ */
+export const useDisabledPartnerNodesStore = defineStore(
+  'disabledPartnerNodes',
+  () => {
+    const disabledNames = ref<Set<string>>(new Set())
+    const offenders = ref<DisabledGraphNode[]>([])
+
+    function isNodeDefDisabled(
+      def: Pick<ComfyNodeDefImpl, 'name' | 'display_name' | 'api_node'>
+    ): boolean {
+      if (!def.api_node) return false
+      return (
+        disabledNames.value.has(def.display_name) ||
+        disabledNames.value.has(def.name)
+      )
+    }
+
+    // Hides disabled partner nodes from every discovery surface (node search,
+    // node library) — same mechanism as the deprecated/experimental filters.
+    // Canvas instances are untouched; they surface through the error panel.
+    useNodeDefStore().registerNodeDefFilter({
+      id: 'workspace.disabled-partner-nodes',
+      name: t('nodeFilters.hideDisabledPartnerNodes'),
+      predicate: (def) => !isNodeDefDisabled(def)
+    })
+
+    const disabledAncestorExecutionIds = computed<Set<NodeExecutionId>>(() => {
+      const ids = new Set<NodeExecutionId>()
+      for (const offender of offenders.value) {
+        for (const id of getAncestorExecutionIds(offender.nodeId)) {
+          ids.add(id)
+        }
+      }
+      return ids
+    })
+
+    const { flags } = useFeatureFlags()
+
+    async function fetchDisabledNames(): Promise<void> {
+      // Governance exists only for team workspaces; the guard also keeps unit
+      // tests and personal accounts from ever touching the network.
+      if (!isCloud || !flags.teamWorkspacesEnabled) return
+      try {
+        // Dynamic import keeps the auth/axios subtree out of the app's
+        // startup module graph; governance is a post-load concern.
+        const { partnerNodesApi } =
+          await import('@/platform/workspace/api/partnerNodesApi')
+        const { partner_nodes } = await partnerNodesApi.list()
+        disabledNames.value = new Set(
+          partner_nodes.filter((n) => !n.enabled).map((n) => n.name)
+        )
+      } catch {
+        // Governance unavailable (no team workspace / endpoint missing):
+        // enforce nothing rather than fail the workflow load.
+        disabledNames.value = new Set()
+      }
+    }
+
+    // The legacy right-click Add Node menu and litegraph palette read
+    // skip_list off the registered types (the dev-only filter's mechanism);
+    // api_node types are disjoint from dev_only so the two writers never clash.
+    function syncLitegraphSkipList(): void {
+      const nodeDefStore = useNodeDefStore()
+      for (const def of Object.values(nodeDefStore.nodeDefsByName)) {
+        if (!def.api_node) continue
+        const nodeType = LiteGraph.registered_node_types[def.name]
+        if (!nodeType) continue
+        nodeType.skip_list = isNodeDefDisabled(def)
+      }
+    }
+
+    let hookedGraph: LGraph | null = null
+    let rescanTimer: ReturnType<typeof setTimeout> | null = null
+
+    function scheduleRescan(): void {
+      if (rescanTimer) clearTimeout(rescanTimer)
+      rescanTimer = setTimeout(() => {
+        rescanTimer = null
+        scan()
+      }, 250)
+    }
+
+    // Placing or deleting nodes must re-derive offenders; the load-time scan
+    // alone misses an already-disabled node added mid-session.
+    function ensureGraphHooks(): void {
+      const graph = app.rootGraph
+      if (!graph || hookedGraph === graph) return
+      hookedGraph = graph
+      const prevAdded = graph.onNodeAdded
+      graph.onNodeAdded = function (node) {
+        prevAdded?.call(this, node)
+        scheduleRescan()
+      }
+      const prevRemoved = graph.onNodeRemoved
+      graph.onNodeRemoved = function (node) {
+        prevRemoved?.call(this, node)
+        scheduleRescan()
+      }
+    }
+
+    function scan(): void {
+      syncLitegraphSkipList()
+      if (!app.isGraphReady || disabledNames.value.size === 0) {
+        offenders.value = []
+        return
+      }
+      const nodeDefStore = useNodeDefStore()
+      const found: DisabledGraphNode[] = []
+      forEachNode(app.rootGraph, (node) => {
+        if (!node.type) return
+        const def = nodeDefStore.nodeDefsByName[node.type]
+        if (!def?.api_node) return
+        const disabled =
+          disabledNames.value.has(def.display_name) ||
+          disabledNames.value.has(def.name)
+        if (!disabled) return
+        const execId = getExecutionIdByNode(app.rootGraph, node)
+        if (!execId) return
+        found.push({
+          nodeId: execId,
+          graphNodeId: String(node.id),
+          displayName: def.display_name || def.name
+        })
+      })
+      offenders.value = found.sort((a, b) =>
+        a.displayName.localeCompare(b.displayName)
+      )
+    }
+
+    /** Workflow-load entry point: refresh governance, scan, announce. */
+    async function surfaceDisabledNodes(
+      options: { silent?: boolean } = {}
+    ): Promise<void> {
+      await fetchDisabledNames()
+      ensureGraphHooks()
+      scan()
+      if (options.silent || offenders.value.length === 0) return
+      useToastStore().add({
+        severity: 'error',
+        group: 'disabled-nodes',
+        summary: t(
+          'rightSidePanel.disabledNodes.title',
+          offenders.value.length
+        ),
+        detail: t(
+          'rightSidePanel.disabledNodes.toastDetail',
+          offenders.value.length
+        ),
+        life: 10000
+      })
+    }
+
+    /** Settings-panel toggles call this so an open workflow updates live. */
+    async function applyGovernanceChange(): Promise<void> {
+      await fetchDisabledNames()
+      scan()
+    }
+
+    return {
+      offenders,
+      disabledAncestorExecutionIds,
+      isNodeDefDisabled,
+      surfaceDisabledNodes,
+      applyGovernanceChange
+    }
+  }
+)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -106,6 +106,7 @@ import {
 import type { MissingModelPipelineResult } from '@/platform/missingModel/missingModelPipeline'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import {
   scanAllMediaCandidates,
@@ -1510,6 +1511,10 @@ export class ComfyApp {
 
         await this.runMissingMediaPipeline(silentAssetErrors)
       }
+
+      void useDisabledPartnerNodesStore().surfaceDisabledNodes({
+        silent: silentAssetErrors
+      })
 
       if (!deferWarnings) {
         useWorkflowService().showPendingWarnings(undefined, {

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -7,7 +7,8 @@ import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 // Mock dependencies
 vi.mock('@/i18n', () => ({
-  st: vi.fn((_key: string, fallback: string) => fallback)
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key)
 }))
 
 vi.mock('@/platform/distribution/types', () => ({

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -5,6 +5,7 @@ import { useNodeErrorFlagSync } from '@/composables/graph/useNodeErrorFlagSync'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
+import { useDisabledPartnerNodesStore } from '@/platform/workspace/stores/disabledPartnerNodesStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -34,6 +35,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   const workflowStore = useWorkflowStore()
   const canvasStore = useCanvasStore()
   const missingModelStore = useMissingModelStore()
+  const disabledPartnerNodesStore = useDisabledPartnerNodesStore()
   const missingNodesStore = useMissingNodesErrorStore()
   const missingMediaStore = useMissingMediaStore()
 
@@ -361,7 +363,12 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     return errorAncestorExecutionIds.value.has(execId)
   }
 
-  useNodeErrorFlagSync(lastNodeErrors, missingModelStore, missingMediaStore)
+  useNodeErrorFlagSync(
+    lastNodeErrors,
+    missingModelStore,
+    missingMediaStore,
+    disabledPartnerNodesStore
+  )
 
   return {
     // Raw state

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -29,7 +29,8 @@ vi.mock('@/utils/graphTraversalUtil', async () => {
 })
 
 vi.mock('@/i18n', () => ({
-  st: vi.fn((_key: string, fallback: string) => fallback)
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key)
 }))
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))


### PR DESCRIPTION
<!-- branch: split/node-enforcement | base: split/allowlist -->
<!-- title: feat: enforce partner-node governance across the workbench -->

## What

Admin-disabled partner nodes (from the Allowlist, #13594) now enforce everywhere users meet nodes:

- **Discovery**: a `workspace.disabled-partner-nodes` `NodeDefFilter` (the deprecated/experimental seam) hides disabled nodes from node search, the category sidebar, and the node library. When a query — or the Partner filter — *would have matched* only disabled nodes, the empty state explains: "This node has been disabled by your team admin." (same matcher over the hidden defs, partitioned — no second heuristic). The legacy right-click menu hides them via `skip_list` sync on registered types.
- **Canvas**: offenders surface as a "Disabled node(s)" group in Workflow Overview › Errors with jump-to-node rows, flag the node error highlight, gate the Run button (opens the Errors tab instead of queueing), and announce once per workflow load via a toast with a View details action. Offenders re-derive live on node add/remove and on Allowlist toggles.

Linear: [DES-484](https://linear.app/comfyorg/issue/DES-484). Figma: [error states](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4528-27754), [search hiding](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4489-24844).

## Notes for reviewers

- `disabledPartnerNodesStore` owns governance state: fetches the partner-nodes list (lazy-imported; guarded on cloud + team-workspaces flag), scans the graph matching `api_node` defs by display name, exposes the def predicate. Enforcement activates once the backend serves the endpoint — until then the store enforces nothing.
- Templates deliberately get no distinction (design decision, may revisit). A node absent from the governance list is fail-open — the BE contract for auto-appending new catalog nodes is an open question on DES-484.
- Toast rule: once per workflow load; settings toggles update everything live but don't re-toast.
