### PR TITLE
fix(i18n): preserve raw messages on compile errors

### DIFF
--- a/src/i18n.safeTranslation.test.ts
+++ b/src/i18n.safeTranslation.test.ts
@@ -68,7 +68,9 @@ describe('stRaw', () => {
       }
     })
 
-    expect(stRaw('safeTranslationTest.rawSyntax', 'Fallback value')).toBe(message)
+    expect(stRaw('safeTranslationTest.rawSyntax', 'Fallback value')).toBe(
+      message
+    )
   })
 
   it('returns the fallback when the key is not found', () => {

--- a/src/i18n.safeTranslation.test.ts
+++ b/src/i18n.safeTranslation.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { i18n, st } from './i18n'
+import { i18n, st, stRaw } from './i18n'
 
 describe('st', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
+  })
+
+  it('returns the fallback when the key is not found', () => {
+    expect(st('safeTranslationTest.missing', 'Fallback value')).toBe(
+      'Fallback value'
+    )
   })
 
   it('uses compiled translations for valid locale messages', () => {
@@ -31,6 +37,43 @@ describe('st', () => {
 
     expect(st('safeTranslationTest.invalidLinkedFormat', 'Fallback value')).toBe(
       message
+    )
+  })
+})
+
+describe('stRaw', () => {
+  beforeEach(() => {
+    i18n.global.locale.value = 'en'
+  })
+
+  it('returns raw locale messages for valid keys', () => {
+    i18n.global.mergeLocaleMessage('en', {
+      safeTranslationTest: {
+        rawValue: 'Raw value'
+      }
+    })
+
+    expect(stRaw('safeTranslationTest.rawValue', 'Fallback value')).toBe(
+      'Raw value'
+    )
+  })
+
+  it('returns raw messages containing vue-i18n syntax', () => {
+    const message =
+      'Provided by @acme/model with JSON such as {"mode":"fast"}'
+
+    i18n.global.mergeLocaleMessage('en', {
+      safeTranslationTest: {
+        rawSyntax: message
+      }
+    })
+
+    expect(stRaw('safeTranslationTest.rawSyntax', 'Fallback value')).toBe(message)
+  })
+
+  it('returns the fallback when the key is not found', () => {
+    expect(stRaw('safeTranslationTest.rawMissing', 'Fallback value')).toBe(
+      'Fallback value'
     )
   })
 })

--- a/src/i18n.safeTranslation.test.ts
+++ b/src/i18n.safeTranslation.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { i18n, st } from './i18n'
+
+describe('st', () => {
+  beforeEach(() => {
+    i18n.global.locale.value = 'en'
+  })
+
+  it('uses compiled translations for valid locale messages', () => {
+    i18n.global.mergeLocaleMessage('en', {
+      safeTranslationTest: {
+        valid: 'Translated value'
+      }
+    })
+
+    expect(st('safeTranslationTest.valid', 'Fallback value')).toBe(
+      'Translated value'
+    )
+  })
+
+  it('returns raw locale messages when vue-i18n compilation fails', () => {
+    const message =
+      'Provided by @acme/model with JSON such as {"mode":"fast"}'
+
+    i18n.global.mergeLocaleMessage('en', {
+      safeTranslationTest: {
+        invalidLinkedFormat: message
+      }
+    })
+
+    expect(st('safeTranslationTest.invalidLinkedFormat', 'Fallback value')).toBe(
+      message
+    )
+  })
+})

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -159,15 +159,28 @@ export const te: (typeof i18n.global)['te'] = i18n.global.te
 export const d: (typeof i18n.global)['d'] = i18n.global.d
 const tm = i18n.global.tm
 
+function rawTranslationOrFallback(key: string, fallbackMessage: string) {
+  const message = tm(key)
+  return typeof message === 'string' ? message : fallbackMessage
+}
+
 /**
  * Safe translation function that returns the fallback message if the key is not found.
+ * Invalid message syntax falls back to the raw locale message instead of crashing.
  *
  * @param key - The key to translate.
  * @param fallbackMessage - The fallback message to use if the key is not found.
  */
 export function st(key: string, fallbackMessage: string) {
-  // The normal defaultMsg overload fails in some cases for custom nodes
-  return te(key) ? t(key) : fallbackMessage
+  if (!te(key)) return fallbackMessage
+
+  try {
+    // The normal defaultMsg overload fails in some cases for custom nodes
+    return t(key)
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error
+    return rawTranslationOrFallback(key, fallbackMessage)
+  }
 }
 
 /**
@@ -180,6 +193,5 @@ export function st(key: string, fallbackMessage: string) {
 export function stRaw(key: string, fallbackMessage: string) {
   if (!te(key)) return fallbackMessage
 
-  const message = tm(key)
-  return typeof message === 'string' ? message : fallbackMessage
+  return rawTranslationOrFallback(key, fallbackMessage)
 }


### PR DESCRIPTION
## Summary

Prevent Vue-i18n message compiler errors from aborting frontend initialization when an existing locale message contains raw metadata such as `@` references or JSON-like braces.

## Changes

- Keep the normal `t()` path for valid translated messages.
- Catch only `SyntaxError` compilation failures and return the existing raw `tm()` message instead.
- Reuse the raw-message fallback in `stRaw()`.
- Add focused regression coverage for valid translations, missing keys, invalid linked-message syntax, and `stRaw()` behavior.

## Root cause

`st()` currently calls `t()` whenever a translation key exists. Node-definition strings can contain characters that Vue-i18n interprets as linked-message or interpolation syntax. A compile error then escapes from `translateNodeDef()`, stops frontend bootstrap, and leaves only the empty canvas/grid visible.

This retains normal translation compilation and interpolation behavior for valid messages while preventing malformed metadata strings from crashing the entire application.

Fixes #13545
Fixes #13575

## Validation

- Manually reproduced the empty-canvas failure with `SyntaxError: Invalid linked format` on the current custom frontend.
- Confirmed that returning the raw locale message allows frontend initialization to complete.
- Added focused Vitest coverage in `src/i18n.safeTranslation.test.ts` for:
  - missing `st()` keys
  - valid compiled translations
  - compile-error recovery
  - valid and syntax-bearing `stRaw()` messages
  - missing `stRaw()` keys
- Repository CI is pending maintainer approval for workflows from the fork.

## E2E coverage rationale

No browser test is added because the regression is caused by a synchronous, deterministic failure inside the shared i18n helper. The focused unit test exercises the exact Vue-i18n compiler failure and fallback contract without requiring a backend/custom-node fixture. The end-to-end symptom was also reproduced manually against the built frontend.

## Related

- #12469 introduced the existing `stRaw()`/`tm()` path for node tooltip metadata.
- #4100 previously addressed the same Vue-i18n parsing class for extension setting tooltips.