### PR TITLE
FE-1257 feat: create Load3DAdvanced node when dropping mesh files onto canvas

### DIFF
--- a/src/extensions/core/load3d/constants.ts
+++ b/src/extensions/core/load3d/constants.ts
@@ -3,12 +3,16 @@
  * This file can be imported without pulling in the entire THREE.js bundle
  */
 
-export const SUPPORTED_EXTENSIONS = new Set([
+export const SUPPORTED_MESH_EXTENSIONS = new Set([
   '.gltf',
   '.glb',
   '.obj',
   '.fbx',
-  '.stl',
+  '.stl'
+])
+
+export const SUPPORTED_EXTENSIONS = new Set([
+  ...SUPPORTED_MESH_EXTENSIONS,
   '.spz',
   '.splat',
   '.ply',

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -19,6 +19,7 @@ import {
   pasteVideoNode,
   pasteVideoNodes
 } from '@/composables/usePaste'
+import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { api } from '@/scripts/api'
@@ -102,6 +103,12 @@ vi.mock('@/composables/usePaste', () => ({
 
 vi.mock('@/scripts/metadata/parser', () => ({
   getWorkflowDataFromFile: vi.fn()
+}))
+
+vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
+  default: {
+    uploadFile: vi.fn()
+  }
 }))
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
@@ -589,6 +596,60 @@ describe('ComfyApp', () => {
         expect.any(DataTransferItemList),
         mockNode
       )
+    })
+
+    it('should handle mesh model files by uploading and creating Load3DAdvanced node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue(undefined)
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue('3d/model.glb')
+
+      const modelWidget = {
+        name: 'model_file',
+        value: 'existing.glb',
+        options: { values: ['existing.glb'] }
+      }
+      const mockNode = createMockNode({
+        type: 'Load3DAdvanced',
+        widgets: [modelWidget]
+      })
+      vi.mocked(createNode).mockResolvedValue(mockNode)
+
+      const meshFile = createTestFile('model.glb', '')
+
+      await app.handleFile(meshFile)
+
+      expect(Load3dUtils.uploadFile).toHaveBeenCalledWith(meshFile, '3d')
+      expect(createNode).toHaveBeenCalledWith(mockCanvas, 'Load3DAdvanced')
+      expect(modelWidget.value).toBe('3d/model.glb')
+      expect(modelWidget.options.values).toContain('3d/model.glb')
+    })
+
+    it('should load embedded workflow from mesh files instead of creating Load3DAdvanced node', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        workflow: createWorkflowGraphData()
+      })
+      const loadGraphData = vi
+        .spyOn(app, 'loadGraphData')
+        .mockResolvedValue(undefined)
+
+      const meshFile = createTestFile('model.glb', 'model/gltf-binary')
+
+      await app.handleFile(meshFile)
+
+      expect(loadGraphData).toHaveBeenCalled()
+      expect(Load3dUtils.uploadFile).not.toHaveBeenCalled()
+      expect(createNode).not.toHaveBeenCalled()
+    })
+
+    it('should not create Load3DAdvanced node when mesh upload fails', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue(undefined)
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue(undefined)
+
+      const meshFile = createTestFile('model.obj', '')
+
+      await app.handleFile(meshFile)
+
+      expect(Load3dUtils.uploadFile).toHaveBeenCalledWith(meshFile, '3d')
+      expect(createNode).not.toHaveBeenCalled()
     })
 
     it('should handle image files with non-workflow metadata by creating LoadImage node', async () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -652,6 +652,70 @@ describe('ComfyApp', () => {
       expect(createNode).not.toHaveBeenCalled()
     })
 
+    it('should report each created Load3DAdvanced node via onNodeCreated', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue(undefined)
+      vi.mocked(Load3dUtils.uploadFile)
+        .mockResolvedValueOnce('3d/a.glb')
+        .mockResolvedValueOnce('3d/b.glb')
+
+      const modelWidgetA = { name: 'model_file', value: '', options: {} }
+      const modelWidgetB = { name: 'model_file', value: '', options: {} }
+      const nodeA = createMockNode({
+        id: 1,
+        type: 'Load3DAdvanced',
+        widgets: [modelWidgetA]
+      })
+      const nodeB = createMockNode({
+        id: 2,
+        type: 'Load3DAdvanced',
+        widgets: [modelWidgetB]
+      })
+      vi.mocked(createNode)
+        .mockResolvedValueOnce(nodeA)
+        .mockResolvedValueOnce(nodeB)
+
+      const onNodeCreated = vi.fn()
+      await app.handleFile(createTestFile('a.glb', ''), 'file_drop', {
+        onNodeCreated
+      })
+      await app.handleFile(createTestFile('b.glb', ''), 'file_drop', {
+        onNodeCreated
+      })
+
+      expect(onNodeCreated).toHaveBeenNthCalledWith(1, nodeA)
+      expect(onNodeCreated).toHaveBeenNthCalledWith(2, nodeB)
+    })
+
+    it('should not report a node via onNodeCreated when mesh upload fails', async () => {
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue(undefined)
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue(undefined)
+
+      const onNodeCreated = vi.fn()
+      await app.handleFile(createTestFile('a.glb', ''), 'file_drop', {
+        onNodeCreated
+      })
+
+      expect(onNodeCreated).not.toHaveBeenCalled()
+    })
+
+    it('positionNodes spreads stacked nodes so multi-mesh drops do not overlap', () => {
+      const nodes = [
+        createMockNode({
+          id: 1,
+          pos: [100, 200],
+          getBounding: vi.fn(() => new Float64Array([100, 200, 200, 100]))
+        }),
+        createMockNode({ id: 2, pos: [100, 200] }),
+        createMockNode({ id: 3, pos: [100, 200] })
+      ]
+
+      app.positionNodes(nodes)
+
+      expect(nodes[0].pos).toEqual([100, 200])
+      expect(nodes[1].pos).toEqual([100, 400])
+      expect(nodes[2].pos).toEqual([100, 575])
+    })
+
     it('should handle image files with non-workflow metadata by creating LoadImage node', async () => {
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
         Software: 'gnome-screenshot'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -666,6 +666,12 @@ export class ComfyApp {
             imageFiles.length + audioFiles.length + videoFiles.length
           const hasMultipleMedia = totalMedia > 1
 
+          const createdNodes: LGraphNode[] = []
+          const handleFileOptions = {
+            deferWarnings: true,
+            onNodeCreated: (node: LGraphNode) => createdNodes.push(node)
+          }
+
           if (hasMultipleMedia) {
             if (imageFiles.length > 0) {
               await this.handleFileList(imageFiles)
@@ -677,17 +683,15 @@ export class ComfyApp {
               await this.handleVideoFileList(videoFiles)
             }
             for (const file of files.filter((f) => !isMediaFile(f))) {
-              await this.handleFile(file, 'file_drop', {
-                deferWarnings: true
-              })
+              await this.handleFile(file, 'file_drop', handleFileOptions)
             }
           } else {
             for (const file of files) {
-              await this.handleFile(file, 'file_drop', {
-                deferWarnings: true
-              })
+              await this.handleFile(file, 'file_drop', handleFileOptions)
             }
           }
+
+          this.positionNodes(createdNodes)
         } finally {
           workspace.spinner = false
         }
@@ -1851,7 +1855,10 @@ export class ComfyApp {
   async handleFile(
     file: File,
     openSource?: WorkflowOpenSource,
-    options?: { deferWarnings?: boolean }
+    options?: {
+      deferWarnings?: boolean
+      onNodeCreated?: (node: LGraphNode) => void
+    }
   ) {
     const fileName = file.name.replace(/\.\w+$/, '') // Strip file extension
     const workflowData = await getWorkflowDataFromFile(file)
@@ -1873,11 +1880,13 @@ export class ComfyApp {
         transfer.items.add(file)
         const node = await createNode(this.canvas, nodeType)
         await pasteFn(this.canvas, transfer.items, node)
+        if (node) options?.onNodeCreated?.(node)
         return
       }
 
       if (isMeshModelFile(file)) {
-        await this.handleMeshFile(file)
+        const node = await this.handleMeshFile(file)
+        if (node) options?.onNodeCreated?.(node)
         return
       }
 
@@ -1963,13 +1972,15 @@ export class ComfyApp {
    * Uploads a mesh model file and creates a Load3DAdvanced node displaying it
    * @param {File} file
    */
-  private async handleMeshFile(file: File) {
+  private async handleMeshFile(file: File): Promise<LGraphNode | null> {
     const uploadedPath = await Load3dUtils.uploadFile(file, '3d')
-    if (!uploadedPath) return
+    if (!uploadedPath) return null
 
     const node = await createNode(this.canvas, 'Load3DAdvanced')
-    const modelWidget = node?.widgets?.find((w) => w.name === 'model_file')
-    if (!modelWidget) return
+    if (!node) return null
+
+    const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
+    if (!modelWidget) return node
 
     const values = (modelWidget.options as { values?: string[] } | undefined)
       ?.values
@@ -1977,6 +1988,7 @@ export class ComfyApp {
       values.push(uploadedPath)
     }
     modelWidget.value = uploadedPath
+    return node
   }
 
   /**

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -155,6 +155,8 @@ import {
   isMediaFile
 } from '@/utils/eventUtils'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
+import { SUPPORTED_MESH_EXTENSIONS } from '@/extensions/core/load3d/constants'
+import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import {
   pasteAudioNode,
   pasteAudioNodes,
@@ -165,6 +167,11 @@ import {
 } from '@/composables/usePaste'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
+
+function isMeshModelFile(file: File): boolean {
+  const name = file.name.toLowerCase()
+  return SUPPORTED_MESH_EXTENSIONS.has(name.slice(name.lastIndexOf('.')))
+}
 
 export function sanitizeNodeName(string: string) {
   let entityMap = {
@@ -1869,6 +1876,11 @@ export class ComfyApp {
         return
       }
 
+      if (isMeshModelFile(file)) {
+        await this.handleMeshFile(file)
+        return
+      }
+
       this.showErrorOnFileLoad(file)
       return
     }
@@ -1945,6 +1957,26 @@ export class ComfyApp {
     }
 
     this.showErrorOnFileLoad(file)
+  }
+
+  /**
+   * Uploads a mesh model file and creates a Load3DAdvanced node displaying it
+   * @param {File} file
+   */
+  private async handleMeshFile(file: File) {
+    const uploadedPath = await Load3dUtils.uploadFile(file, '3d')
+    if (!uploadedPath) return
+
+    const node = await createNode(this.canvas, 'Load3DAdvanced')
+    const modelWidget = node?.widgets?.find((w) => w.name === 'model_file')
+    if (!modelWidget) return
+
+    const values = (modelWidget.options as { values?: string[] } | undefined)
+      ?.values
+    if (values && !values.includes(uploadedPath)) {
+      values.push(uploadedPath)
+    }
+    modelWidget.value = uploadedPath
   }
 
   /**


### PR DESCRIPTION
## Summary
Dragging an image file from the OS onto the canvas already creates a LoadImage node; this change extends the same behavior to 3D mesh files (.glb, .gltf, .obj, .fbx, .stl).
- When a dropped mesh file has no embedded workflow, it is uploaded to the 3d input subfolder and a Load3DAdvanced node is created at the cursor with its model_file widget set, so the viewer loads the model automatically.
- Files with embedded workflow metadata (e.g. .glb saved by SaveGLB) still load the workflow as before.
- Splat / point cloud formats are intentionally out of scope for now.

## Screenshots
https://github.com/user-attachments/assets/ba68c8aa-ae91-4ed9-b4f9-6eea7d1a70c5

