### PR TITLE
fix: preserve saved widget value on remote combo first load

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -211,6 +211,76 @@ describe('useRemoteWidget', () => {
     })
   })
 
+  describe('preserving a pre-existing widget value on first load', () => {
+    it('keeps a value restored from a saved workflow if still present in the resolved options', async () => {
+      const widget = createMockWidget({ value: 'saved_model.safetensors' })
+      const options = createMockOptions()
+      options.widget = widget
+      mockAxiosResponse([
+        'a.safetensors',
+        'saved_model.safetensors',
+        'b.safetensors'
+      ])
+
+      const hook = useRemoteWidget(options)
+      await new Promise<void>((resolve) => hook.getValue(() => resolve()))
+
+      expect(widget.value).toBe('saved_model.safetensors')
+    })
+
+    it('falls back to the first option when the saved value no longer exists', async () => {
+      const widget = createMockWidget({ value: 'deleted_model.safetensors' })
+      const options = createMockOptions()
+      options.widget = widget
+      mockAxiosResponse(['a.safetensors', 'b.safetensors'])
+
+      const hook = useRemoteWidget(options)
+      await new Promise<void>((resolve) => hook.getValue(() => resolve()))
+
+      expect(widget.value).toBe('a.safetensors')
+    })
+
+    it('uses the first option for a brand new widget still on the loading placeholder', async () => {
+      const widget = createMockWidget({ value: DEFAULT_VALUE })
+      const options = createMockOptions()
+      options.widget = widget
+      mockAxiosResponse(['a.safetensors', 'b.safetensors'])
+
+      const hook = useRemoteWidget(options)
+      await new Promise<void>((resolve) => hook.getValue(() => resolve()))
+
+      expect(widget.value).toBe('a.safetensors')
+    })
+
+    it('falls back to the default value when a saved value exists but the resolved options array is empty', async () => {
+      const widget = createMockWidget({ value: 'saved_model.safetensors' })
+      const options = createMockOptions()
+      options.widget = widget
+      mockAxiosResponse([])
+
+      const hook = useRemoteWidget(options)
+      await new Promise<void>((resolve) => hook.getValue(() => resolve()))
+
+      expect(widget.value).toBe(DEFAULT_VALUE)
+    })
+
+    it('does not touch widget.value when the fetch fails before any options resolve', async () => {
+      const widget = createMockWidget({ value: 'saved_model.safetensors' })
+      const options = createMockOptions()
+      options.widget = widget
+      mockAxiosError('Network error')
+
+      const hook = useRemoteWidget(options)
+      await new Promise<void>((resolve) => hook.getValue(() => resolve()))
+
+      // onFirstLoad only fires once options have actually resolved
+      // (isInitialized checks a successful fetch's timestamp), so a widget
+      // value restored from a saved workflow must survive a failed fetch
+      // rather than being reset before any valid options exist.
+      expect(widget.value).toBe('saved_model.safetensors')
+    })
+  })
+
   describe('refresh behavior', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
@@ -132,9 +132,21 @@ export function useRemoteWidget<
 
   const onFirstLoad = (data: T | T[]) => {
     isLoaded = true
-    const nextValue =
-      Array.isArray(data) && data.length > 0 ? data[0] : undefined
-    widget.value = nextValue ?? (Array.isArray(data) ? defaultValue : data)
+
+    if (Array.isArray(data) && data.length > 0) {
+      // The widget may already hold a value assigned during workflow
+      // deserialization (node.configure), which runs synchronously and
+      // therefore completes before this async remote fetch resolves. If
+      // that value is still a valid choice in the freshly resolved
+      // options, preserve it instead of clobbering it with data[0] -
+      // otherwise saved selections (e.g. unet_name/clip_name/vae_name on
+      // registry Components) get silently reset on every workflow load.
+      const currentValue = widget.value as T
+      widget.value = data.includes(currentValue) ? currentValue : data[0]
+    } else {
+      widget.value = Array.isArray(data) ? defaultValue : data
+    }
+
     widget.callback?.(widget.value)
     node.graph?.setDirtyCanvas(true)
   }


### PR DESCRIPTION
onFirstLoad in useRemoteWidget unconditionally overwrote widget.value with data[0] the first time a remote combo's options resolved. Since node.configure() runs synchronously during workflow deserialization (before the async remote fetch resolves), this silently clobbered values restored from a saved workflow - most visibly on registry Component/Subgraph widgets like unet_name/clip_name/vae_name.

Now the pre-existing value is preserved if it's still a valid option in the resolved list, and only falls back to data[0] if it isn't.

## Summary

Fixes saved values on remote combo widgets (e.g. `unet_name`/`clip_name`/`vae_name` on registry Component/Subgraph nodes) being silently reset to the first alphabetical option every time a workflow is loaded.

## Changes

- **What**: `onFirstLoad()` in `useRemoteWidget.ts` unconditionally overwrote `widget.value` with `data[0]` the first time a remote combo's options array resolved from the backend. Because `node.configure()` runs synchronously during workflow deserialization — before this async fetch resolves — it was clobbering values already restored from the saved workflow. The fix checks whether the widget's current value is still present in the newly resolved options and preserves it if so, only falling back to `data[0]` when it isn't (e.g. a brand new node, or a saved value pointing at a file that no longer exists).
- **Breaking**: none

## Review Focus

`data.includes(currentValue)` uses reference equality, which is correct for the string filenames these combos carry in practice, but wouldn't dedupe an object-typed value. Flagging in case `T` is ever extended to objects here.

Test coverage in `useRemoteWidget.test.ts` includes: saved value preserved when still valid, fallback to `data[0]` when the saved value no longer exists, brand-new widget defaulting to `data[0]`, an empty resolved-options array falling back to the default value, and a failed fetch leaving an existing widget value untouched (since `onFirstLoad` never fires until options actually resolve successfully).

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->
