### PR TITLE
fix: preserve PrimitiveNode widgets_values through clone-serialize

### DIFF
--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,8 +1,19 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 
-import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+vi.mock('@/scripts/app', () => ({
+  app: {
+    registerExtension: vi.fn(),
+    configuringGraph: false
+  }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: { shouldUseAssetBrowser: () => false }
+}))
+
+import { PrimitiveNode } from './widgetInputs'
 
 describe('PrimitiveNode serialize override', () => {
   beforeEach(() => {
@@ -10,40 +21,21 @@ describe('PrimitiveNode serialize override', () => {
   })
 
   it('preserves widgets_values through clone-serialize when node has no widgets', () => {
-    const node = new LGraphNode('test')
-    node.serialize_widgets = true
+    const node = new PrimitiveNode('test')
     node.widgets_values = [42, 'fixed', '']
 
-    const base = node.serialize()
-    expect(base.widgets_values).toBeUndefined()
+    const serialized = node.serialize()
 
-    node.serialize = function () {
-      const o = LGraphNode.prototype.serialize.call(this)
-      if (!o.widgets_values && this.widgets_values) {
-        o.widgets_values = this.widgets_values
-      }
-      return o
-    }
-
-    const patched = node.serialize()
-    expect(patched.widgets_values).toEqual([42, 'fixed', ''])
+    expect(serialized.widgets_values).toEqual([42, 'fixed', ''])
   })
 
-  it('does not override widgets_values when base serialize produces them', () => {
-    const node = new LGraphNode('test')
-    node.serialize_widgets = true
+  it('uses base serialize when node has widgets', () => {
+    const node = new PrimitiveNode('test')
     node.widgets_values = [99, 'decrement']
     node.addWidget('number', 'value', 42, () => {})
 
-    node.serialize = function () {
-      const o = LGraphNode.prototype.serialize.call(this)
-      if (!o.widgets_values && this.widgets_values) {
-        o.widgets_values = this.widgets_values
-      }
-      return o
-    }
-
     const serialized = node.serialize()
+
     expect(serialized.widgets_values).toBeDefined()
     expect(serialized.widgets_values?.[0]).toBe(42)
   })

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+describe('PrimitiveNode serialize override', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('preserves widgets_values through clone-serialize when node has no widgets', () => {
+    const node = new LGraphNode('test')
+    node.serialize_widgets = true
+    node.widgets_values = [42, 'fixed', '']
+
+    const base = node.serialize()
+    expect(base.widgets_values).toBeUndefined()
+
+    node.serialize = function () {
+      const o = LGraphNode.prototype.serialize.call(this)
+      if (!o.widgets_values && this.widgets_values) {
+        o.widgets_values = this.widgets_values
+      }
+      return o
+    }
+
+    const patched = node.serialize()
+    expect(patched.widgets_values).toEqual([42, 'fixed', ''])
+  })
+
+  it('does not override widgets_values when base serialize produces them', () => {
+    const node = new LGraphNode('test')
+    node.serialize_widgets = true
+    node.widgets_values = [99, 'decrement']
+    node.addWidget('number', 'value', 42, () => {})
+
+    node.serialize = function () {
+      const o = LGraphNode.prototype.serialize.call(this)
+      if (!o.widgets_values && this.widgets_values) {
+        o.widgets_values = this.widgets_values
+      }
+      return o
+    }
+
+    const serialized = node.serialize()
+    expect(serialized.widgets_values).toBeDefined()
+    expect(serialized.widgets_values?.[0]).toBe(42)
+  })
+})

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -3,6 +3,7 @@ import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   INodeInputSlot,
   INodeOutputSlot,
+  ISerialisedNode,
   ISlotType,
   LLink
 } from '@/lib/litegraph/src/litegraph'
@@ -68,6 +69,14 @@ export class PrimitiveNode extends LGraphNode {
         widget.callback?.(widget.value)
       }
     }
+  }
+
+  override serialize(): ISerialisedNode {
+    const o = super.serialize()
+    if (!o.widgets_values && this.widgets_values) {
+      o.widgets_values = this.widgets_values
+    }
+    return o
   }
 
   override onAfterGraphConfigured() {


### PR DESCRIPTION
Fixes #1757

PrimitiveNode creates widgets dynamically on connection. When copied via `clone()`, the fresh node has no `this.widgets`, so `LGraphNode.serialize()` skips the `widgets_values` block entirely (line 983). This causes secondary widget values like `control_after_generate` to be lost on paste.

Override `serialize()` on PrimitiveNode to fall back to `this.widgets_values` (set during `configure()`) when the base implementation omits it.

Follows ADR-0006 Option A.

### Compatibility

This override is purely additive: it only populates `widgets_values` when the base `serialize()` omits it (i.e., when `this.widgets` is empty on a cloned PrimitiveNode). Nodes that already have widgets serialize normally via the base path. No existing serialization contracts are changed — downstream custom nodes that extend or interact with PrimitiveNode will see the same `widgets_values` shape they always expected, just no longer silently dropped during copy-paste.