### PR TITLE
[backport cloud/1.45] BYOK secrets chain: server-driven providers (#13494, #13509, #13546, #13510)

### DIFF
--- a/packages/ingest-types/src/index.ts
+++ b/packages/ingest-types/src/index.ts
@@ -731,6 +731,8 @@ export type {
   RevokeWorkspaceInviteResponse,
   RevokeWorkspaceInviteResponses,
   SecretListResponse,
+  SecretProvider,
+  SecretProvidersResponse,
   SecretResponse,
   SetReviewStatusData,
   SetReviewStatusError,

--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -9349,3 +9349,25 @@ export type GetLegacyViewMetadataErrors = {
    */
   404: unknown
 }
+
+// --- Backport-only addition (cloud/1.45) ---
+// SecretProvidersResponse/SecretProvider exist on main via #12777 (full ingest
+// types refresh, not backported). Grafted here so the #13494 BYOK backport
+// compiles; the next full types regen on this branch will supersede this block.
+
+/**
+ * The providers available to the authenticated user in the current workspace.
+ */
+export type SecretProvidersResponse = {
+  data: Array<SecretProvider>
+}
+
+/**
+ * A provider the user may configure a secret for. The shape is deliberately minimal (identifier only) and reserved for future per-provider fields such as sub-keys.
+ */
+export type SecretProvider = {
+  /**
+   * Provider identifier (e.g., huggingface, civitai, runway, gemini)
+   */
+  id: string
+}

--- a/public/assets/images/gemini.svg
+++ b/public/assets/images/gemini.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Google Gemini">
+  <path d="M12 1c.6 5.4 4.6 9.4 10 10-5.4.6-9.4 4.6-10 10-.6-5.4-4.6-9.4-10-10 5.4-.6 9.4-4.6 10-10z" fill="#4285F4"/>
+</svg>

--- a/public/assets/images/runway.svg
+++ b/public/assets/images/runway.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Runway">
+  <rect width="24" height="24" rx="5" fill="#6E56CF"/>
+  <path d="M9.5 8.2v7.6l6.3-3.8z" fill="#ffffff"/>
+</svg>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4259,7 +4259,11 @@
     "name": "Name",
     "namePlaceholder": "e.g., My API Key",
     "provider": "Provider",
-    "providerHint": "Optional. Selecting a provider enables automatic token usage.",
+    "providerHint": "Select a provider to enable automatic token usage.",
+    "providerHelp": {
+      "runway": "Enter your Runway API key. You can find it in your Runway account settings under API keys.",
+      "gemini": "Enter your Google Gemini API key. You can generate one in Google AI Studio."
+    },
     "secretValue": "Secret Value",
     "secretValuePlaceholder": "Enter your API key",
     "secretValuePlaceholderEdit": "Enter new value to change",

--- a/src/platform/secrets/api/secretsApi.test.ts
+++ b/src/platform/secrets/api/secretsApi.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { listSecretProviders } from './secretsApi'
+
+const mockFetchApi = vi.fn()
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: (...args: unknown[]) => mockFetchApi(...args)
+  }
+}))
+
+function jsonResponse(body: unknown, init: Partial<Response> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    ...init
+  } as Response
+}
+
+describe('listSecretProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('requests the providers endpoint and maps ids', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({ data: [{ id: 'huggingface' }, { id: 'civitai' }] })
+    )
+
+    const providers = await listSecretProviders()
+
+    expect(mockFetchApi).toHaveBeenCalledWith('/secrets/providers')
+    expect(providers).toEqual(['huggingface', 'civitai'])
+  })
+
+  it('returns an empty list when data is missing', async () => {
+    mockFetchApi.mockResolvedValue(jsonResponse({}))
+
+    const providers = await listSecretProviders()
+
+    expect(providers).toEqual([])
+  })
+
+  it('throws SecretsApiError on a failed response', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse(
+        { message: 'unavailable' },
+        { ok: false, status: 503, statusText: 'Service Unavailable' }
+      )
+    )
+
+    await expect(listSecretProviders()).rejects.toMatchObject({
+      name: 'SecretsApiError',
+      status: 503,
+      message: 'unavailable'
+    })
+  })
+})

--- a/src/platform/secrets/api/secretsApi.ts
+++ b/src/platform/secrets/api/secretsApi.ts
@@ -1,3 +1,8 @@
+import type {
+  SecretListResponse,
+  SecretProvidersResponse
+} from '@comfyorg/ingest-types'
+
 import { api } from '@/scripts/api'
 
 import type {
@@ -7,10 +12,6 @@ import type {
   SecretUpdateRequest
 } from '../types'
 import { SECRET_ERROR_CODES } from '../types'
-
-interface ListSecretsResponse {
-  data: SecretMetadata[]
-}
 
 interface ErrorResponse {
   message?: string
@@ -52,8 +53,14 @@ async function handleResponse<T>(response: Response): Promise<T> {
 
 export async function listSecrets(): Promise<SecretMetadata[]> {
   const response = await api.fetchApi('/secrets')
-  const data = await handleResponse<ListSecretsResponse>(response)
+  const data = await handleResponse<SecretListResponse>(response)
   return data.data
+}
+
+export async function listSecretProviders(): Promise<string[]> {
+  const response = await api.fetchApi('/secrets/providers')
+  const data = await handleResponse<SecretProvidersResponse>(response)
+  return (data.data ?? []).map((provider) => provider.id)
 }
 
 export async function createSecret(

--- a/src/platform/secrets/components/SecretFormDialog.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.test.ts
@@ -12,6 +12,7 @@ vi.mock('../composables/useSecretForm', () => ({
     loading: false,
     apiError: '',
     providerOptions: [],
+    providerHelp: '',
     handleSubmit: vi.fn()
   })
 }))

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -41,7 +41,7 @@
                     <img
                       v-if="option.logo"
                       :src="option.logo"
-                      :alt="option.label"
+                      alt=""
                       class="size-4"
                     />
                     {{ option.label }}

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -37,12 +37,23 @@
                   :value="option.value"
                   :disabled="option.disabled"
                 >
-                  {{ option.label }}
+                  <span class="flex items-center gap-2">
+                    <img
+                      v-if="option.logo"
+                      :src="option.logo"
+                      :alt="option.label"
+                      class="size-4"
+                    />
+                    {{ option.label }}
+                  </span>
                 </SelectItem>
               </SelectContent>
             </Select>
             <small v-if="errors.provider" class="text-red-500">
               {{ errors.provider }}
+            </small>
+            <small v-else class="text-muted">
+              {{ providerHelp }}
             </small>
           </div>
 
@@ -134,7 +145,7 @@ import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
 import SelectValue from '@/components/ui/select/SelectValue.vue'
 
 import { useSecretForm } from '../composables/useSecretForm'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 const {
   secret,
@@ -143,7 +154,7 @@ const {
   mode = 'create'
 } = defineProps<{
   secret?: SecretMetadata
-  existingProviders?: SecretProvider[]
+  existingProviders?: string[]
   availableProviders?: string[] | null
   mode?: 'create' | 'edit'
 }>()
@@ -156,13 +167,20 @@ const emit = defineEmits<{
 
 const titleId = useId()
 
-const { form, errors, loading, apiError, providerOptions, handleSubmit } =
-  useSecretForm({
-    mode,
-    secret: () => secret,
-    existingProviders: () => existingProviders,
-    availableProviders: () => availableProviders,
-    visible,
-    onSaved: () => emit('saved')
-  })
+const {
+  form,
+  errors,
+  loading,
+  apiError,
+  providerOptions,
+  providerHelp,
+  handleSubmit
+} = useSecretForm({
+  mode,
+  secret: () => secret,
+  existingProviders: () => existingProviders,
+  availableProviders: () => availableProviders,
+  visible,
+  onSaved: () => emit('saved')
+})
 </script>

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -139,10 +139,12 @@ import type { SecretMetadata, SecretProvider } from '../types'
 const {
   secret,
   existingProviders = [],
+  availableProviders = null,
   mode = 'create'
 } = defineProps<{
   secret?: SecretMetadata
   existingProviders?: SecretProvider[]
+  availableProviders?: string[] | null
   mode?: 'create' | 'edit'
 }>()
 
@@ -159,6 +161,7 @@ const { form, errors, loading, apiError, providerOptions, handleSubmit } =
     mode,
     secret: () => secret,
     existingProviders: () => existingProviders,
+    availableProviders: () => availableProviders,
     visible,
     onSaved: () => emit('saved')
   })

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -13,6 +13,7 @@ vi.mock('../composables/useSecretForm', () => ({
     loading: false,
     apiError: '',
     providerOptions: [],
+    providerHelp: '',
     handleSubmit: vi.fn()
   })
 }))

--- a/src/platform/secrets/components/SecretsPanel.vue
+++ b/src/platform/secrets/components/SecretsPanel.vue
@@ -48,6 +48,7 @@
         v-model:visible="createDialogVisible"
         mode="create"
         :existing-providers="existingProviders"
+        :available-providers="availableProviders"
         @saved="fetchSecrets"
       />
 
@@ -56,6 +57,7 @@
         mode="edit"
         :secret="selectedSecret"
         :existing-providers="existingProviders"
+        :available-providers="availableProviders"
         @saved="fetchSecrets"
       />
 
@@ -86,9 +88,11 @@ const confirm = useConfirm()
 const {
   loading,
   secrets,
+  availableProviders,
   operatingSecretId,
   existingProviders,
   fetchSecrets,
+  fetchProviders,
   deleteSecret
 } = useSecrets()
 
@@ -116,4 +120,5 @@ function confirmDelete(secret: SecretMetadata) {
 }
 
 fetchSecrets()
+fetchProviders()
 </script>

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -184,6 +184,83 @@ describe('useSecretForm', () => {
       expect(civitai?.disabled).toBe(false)
     })
 
+    it('falls back to all base providers when availableProviders is not loaded', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => null,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual([
+        'huggingface',
+        'civitai'
+      ])
+    })
+
+    it('shows no options when the server returns an empty allowlist', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([])
+    })
+
+    it('restricts options to the providers returned by the server', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['civitai'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual(['civitai'])
+    })
+
+    it('reacts to availableProviders changing', () => {
+      const visible = ref(true)
+      const availableProviders = ref<string[] | null>(null)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => availableProviders.value,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toHaveLength(2)
+
+      availableProviders.value = ['huggingface']
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
+    })
+
+    it('ignores the availableProviders filter in edit mode', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'edit',
+        secret: () => createMockSecret({ provider: 'huggingface' }),
+        existingProviders: () => [],
+        availableProviders: () => ['civitai'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual([
+        'huggingface',
+        'civitai'
+      ])
+    })
+
     it('updates disabled state when existingProviders changes', () => {
       const visible = ref(true)
       const existingProviders = ref<SecretProvider[]>(['huggingface'])

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -268,6 +268,27 @@ describe('useSecretForm', () => {
       ])
     })
 
+    it('passes a server-listed provider absent from the local registry through with its raw id as label and no logo', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['brand-new-provider'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([
+        {
+          value: 'brand-new-provider',
+          label: 'brand-new-provider',
+          logo: undefined,
+          disabled: false
+        }
+      ])
+      expect(providerOptions.value[0]?.logo).toBeUndefined()
+    })
+
     it('omits BYOK providers the server does not list', () => {
       const visible = ref(true)
       const { providerOptions } = useSecretForm({

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SecretMetadata, SecretProvider } from '../types'
@@ -226,6 +226,64 @@ describe('useSecretForm', () => {
       expect(providerOptions.value.map((o) => o.value)).toEqual(['civitai'])
     })
 
+    it('dedupes repeated provider ids from the server', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['civitai', 'civitai', 'huggingface'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual([
+        'civitai',
+        'huggingface'
+      ])
+    })
+
+    it('renders server-listed BYOK providers with labels and logos', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['runway', 'gemini'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(providerOptions.value).toEqual([
+        {
+          value: 'runway',
+          label: 'Runway',
+          logo: '/assets/images/runway.svg',
+          disabled: false
+        },
+        {
+          value: 'gemini',
+          label: 'Google Gemini',
+          logo: '/assets/images/gemini.svg',
+          disabled: false
+        }
+      ])
+    })
+
+    it('omits BYOK providers the server does not list', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['huggingface'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const values = providerOptions.value.map((o) => o.value)
+      expect(values).toEqual(['huggingface'])
+      expect(values).not.toContain('runway')
+      expect(values).not.toContain('gemini')
+    })
+
     it('reacts to availableProviders changing', () => {
       const visible = ref(true)
       const availableProviders = ref<string[] | null>(null)
@@ -242,6 +300,43 @@ describe('useSecretForm', () => {
       availableProviders.value = ['huggingface']
 
       expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
+    })
+
+    it('clears a selection the resolved allowlist no longer offers', async () => {
+      const visible = ref(true)
+      const availableProviders = ref<string[] | null>(null)
+      const { form, providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => availableProviders.value,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'civitai'
+      availableProviders.value = ['huggingface']
+      await nextTick()
+
+      expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
+      expect(form.provider).toBeNull()
+    })
+
+    it('keeps a selection the resolved allowlist still offers', async () => {
+      const visible = ref(true)
+      const availableProviders = ref<string[] | null>(null)
+      const { form } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => availableProviders.value,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'huggingface'
+      availableProviders.value = ['huggingface', 'civitai']
+      await nextTick()
+
+      expect(form.provider).toBe('huggingface')
     })
 
     it('ignores the availableProviders filter in edit mode', () => {
@@ -280,6 +375,51 @@ describe('useSecretForm', () => {
       expect(
         providerOptions.value.find((o) => o.value === 'huggingface')?.disabled
       ).toBe(false)
+    })
+  })
+
+  describe('providerHelp', () => {
+    it('uses the generic hint when no provider is selected', () => {
+      const visible = ref(true)
+      const { providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      // t() is mocked to echo the key.
+      expect(providerHelp.value).toBe('secrets.providerHint')
+    })
+
+    it('uses provider-specific help when a BYOK provider is selected', () => {
+      const visible = ref(true)
+      const { form, providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => ['runway', 'gemini'],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'runway'
+      expect(providerHelp.value).toBe('secrets.providerHelp.runway')
+
+      form.provider = 'gemini'
+      expect(providerHelp.value).toBe('secrets.providerHelp.gemini')
+    })
+
+    it('falls back to the generic hint for a provider without a help key', () => {
+      const visible = ref(true)
+      const { form, providerHelp } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'huggingface'
+      expect(providerHelp.value).toBe('secrets.providerHint')
     })
   })
 

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -1,16 +1,22 @@
 import { whenever } from '@vueuse/core'
 import type { MaybeRefOrGetter } from 'vue'
-import { computed, reactive, ref, toValue } from 'vue'
+import { computed, reactive, ref, toValue, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { createSecret, SecretsApiError, updateSecret } from '../api/secretsApi'
-import { SECRET_PROVIDERS } from '../providers'
-import type { SecretErrorCode, SecretMetadata, SecretProvider } from '../types'
+import {
+  DEFAULT_PROVIDER_IDS,
+  getProviderHelpKey,
+  getProviderLabel,
+  getProviderLogo
+} from '../providers'
+import type { SecretErrorCode, SecretMetadata } from '../types'
 
 interface SecretFormState {
   name: string
   secretValue: string
-  provider: SecretProvider | null
+  // Free-form string: the set of selectable providers is server-driven.
+  provider: string | null
 }
 
 interface SecretFormErrors {
@@ -21,14 +27,15 @@ interface SecretFormErrors {
 
 interface ProviderOption {
   label: string
-  value: SecretProvider
+  value: string
+  logo?: string
   disabled: boolean
 }
 
 interface UseSecretFormOptions {
   mode: 'create' | 'edit'
   secret?: MaybeRefOrGetter<SecretMetadata | undefined>
-  existingProviders: MaybeRefOrGetter<SecretProvider[]>
+  existingProviders: MaybeRefOrGetter<string[]>
   availableProviders?: MaybeRefOrGetter<string[] | null>
   visible: { value: boolean }
   onSaved: () => void
@@ -62,18 +69,49 @@ export function useSecretForm(options: UseSecretFormOptions) {
   })
 
   const providerOptions = computed<ProviderOption[]>(() => {
+    // Which provider ids to render:
+    // - edit mode: the field is disabled; show the defaults plus the stored
+    //   provider so the disabled selector can display its label/logo.
+    // - create + list not yet loaded (null): show the defaults as a sensible
+    //   placeholder while the request is in flight.
+    // - create + list loaded: render exactly what the server returned, so
+    //   providers added server-side (e.g. runway/gemini) appear with no FE
+    //   change and providers omitted server-side do not appear.
     const available = toValue(availableProviders)
-    const providers =
-      mode === 'edit' || available === null
-        ? SECRET_PROVIDERS
-        : SECRET_PROVIDERS.filter((p) => available.includes(p.value))
-    return providers.map((p) => ({
-      label: p.label,
-      value: p.value,
-      disabled:
-        mode === 'edit' ? false : toValue(existingProviders).includes(p.value)
+    let ids: string[]
+    if (mode === 'edit') {
+      const stored = toValue(secretRef)?.provider
+      ids =
+        stored && !DEFAULT_PROVIDER_IDS.some((id) => id === stored)
+          ? [...DEFAULT_PROVIDER_IDS, stored]
+          : [...DEFAULT_PROVIDER_IDS]
+    } else {
+      ids =
+        available === null ? [...DEFAULT_PROVIDER_IDS] : [...new Set(available)]
+    }
+
+    const existing = toValue(existingProviders)
+    return ids.map((id) => ({
+      value: id,
+      label: getProviderLabel(id),
+      logo: getProviderLogo(id),
+      disabled: mode === 'edit' ? false : existing.includes(id)
     }))
   })
+
+  // Once the server allowlist resolves, drop a selection the resolved list no
+  // longer offers so the user cannot submit an unlisted provider.
+  watch(providerOptions, (options) => {
+    if (form.provider && !options.some((o) => o.value === form.provider)) {
+      form.provider = null
+    }
+  })
+
+  // Provider-specific help text when the selected provider defines it, else the
+  // generic hint. Sourced from the presentational registry, not the server.
+  const providerHelp = computed(() =>
+    t(getProviderHelpKey(form.provider ?? undefined) ?? 'secrets.providerHint')
+  )
 
   const apiError = computed(() => {
     if (!apiErrorCode.value && !apiErrorMessage.value) return null
@@ -91,10 +129,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     const secret = toValue(secretRef)
     if (mode === 'edit' && secret) {
       form.name = secret.name
-      // Stored provider is a free-form string; in edit mode the field is
-      // disabled and only needs to be non-empty for validation (it is never
-      // re-sent), so narrowing to the form's known-provider type is safe here.
-      form.provider = (secret.provider ?? null) as SecretProvider | null
+      form.provider = secret.provider ?? null
       form.secretValue = ''
     } else {
       form.name = ''
@@ -176,6 +211,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     loading,
     apiError,
     providerOptions,
+    providerHelp,
     handleSubmit
   }
 }

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -29,6 +29,7 @@ interface UseSecretFormOptions {
   mode: 'create' | 'edit'
   secret?: MaybeRefOrGetter<SecretMetadata | undefined>
   existingProviders: MaybeRefOrGetter<SecretProvider[]>
+  availableProviders?: MaybeRefOrGetter<string[] | null>
   visible: { value: boolean }
   onSaved: () => void
 }
@@ -39,6 +40,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
     mode,
     secret: secretRef,
     existingProviders,
+    availableProviders = null,
     visible,
     onSaved
   } = options
@@ -59,14 +61,19 @@ export function useSecretForm(options: UseSecretFormOptions) {
     provider: ''
   })
 
-  const providerOptions = computed<ProviderOption[]>(() =>
-    SECRET_PROVIDERS.map((p) => ({
+  const providerOptions = computed<ProviderOption[]>(() => {
+    const available = toValue(availableProviders)
+    const providers =
+      mode === 'edit' || available === null
+        ? SECRET_PROVIDERS
+        : SECRET_PROVIDERS.filter((p) => available.includes(p.value))
+    return providers.map((p) => ({
       label: p.label,
       value: p.value,
       disabled:
         mode === 'edit' ? false : toValue(existingProviders).includes(p.value)
     }))
-  )
+  })
 
   const apiError = computed(() => {
     if (!apiErrorCode.value && !apiErrorMessage.value) return null
@@ -84,7 +91,10 @@ export function useSecretForm(options: UseSecretFormOptions) {
     const secret = toValue(secretRef)
     if (mode === 'edit' && secret) {
       form.name = secret.name
-      form.provider = secret.provider ?? null
+      // Stored provider is a free-form string; in edit mode the field is
+      // disabled and only needs to be non-empty for validation (it is never
+      // re-sent), so narrowing to the form's known-provider type is safe here.
+      form.provider = (secret.provider ?? null) as SecretProvider | null
       form.secretValue = ''
     } else {
       form.name = ''

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -101,8 +101,11 @@ export function useSecretForm(options: UseSecretFormOptions) {
 
   // Once the server allowlist resolves, drop a selection the resolved list no
   // longer offers so the user cannot submit an unlisted provider.
-  watch(providerOptions, (options) => {
-    if (form.provider && !options.some((o) => o.value === form.provider)) {
+  watch(providerOptions, (resolvedOptions) => {
+    if (
+      form.provider &&
+      !resolvedOptions.some((o) => o.value === form.provider)
+    ) {
       form.provider = null
     }
   })

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -14,10 +14,12 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
 }))
 
 const mockListSecrets = vi.fn()
+const mockListSecretProviders = vi.fn()
 const mockDeleteSecret = vi.fn()
 
 vi.mock('../api/secretsApi', () => ({
   listSecrets: () => mockListSecrets(),
+  listSecretProviders: () => mockListSecretProviders(),
   deleteSecret: (id: string) => mockDeleteSecret(id),
   SecretsApiError: class SecretsApiError extends Error {
     constructor(
@@ -131,6 +133,44 @@ describe('useSecrets', () => {
         summary: 'g.error',
         detail: 'Delete failed'
       })
+    })
+  })
+
+  describe('fetchProviders', () => {
+    it('populates availableProviders from the API', async () => {
+      mockListSecretProviders.mockResolvedValue(['huggingface', 'civitai'])
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      expect(availableProviders.value).toBeNull()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toEqual(['huggingface', 'civitai'])
+    })
+
+    it('distinguishes a server-returned empty allowlist from not-loaded', async () => {
+      mockListSecretProviders.mockResolvedValue([])
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toEqual([])
+    })
+
+    it('leaves availableProviders null on API failure', async () => {
+      const { SecretsApiError } = await import('../api/secretsApi')
+      mockListSecretProviders.mockRejectedValue(
+        new SecretsApiError('unavailable', 503)
+      )
+
+      const { availableProviders, fetchProviders } = useSecrets()
+
+      await fetchProviders()
+
+      expect(availableProviders.value).toBeNull()
+      expect(mockAdd).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -9,7 +9,7 @@ import {
   listSecrets,
   SecretsApiError
 } from '../api/secretsApi'
-import type { SecretMetadata, SecretProvider } from '../types'
+import type { SecretMetadata } from '../types'
 
 export function useSecrets() {
   const { t } = useI18n()
@@ -20,10 +20,8 @@ export function useSecrets() {
   const availableProviders = ref<string[] | null>(null)
   const operatingSecretId = ref<string | null>(null)
 
-  const existingProviders = computed<SecretProvider[]>(() =>
-    secrets.value
-      .map((s) => s.provider)
-      .filter((p): p is SecretProvider => p !== undefined)
+  const existingProviders = computed<string[]>(() =>
+    secrets.value.map((s) => s.provider).filter((p): p is string => p != null)
   )
 
   async function fetchSecrets() {

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -5,6 +5,7 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import {
   deleteSecret as deleteSecretApi,
+  listSecretProviders,
   listSecrets,
   SecretsApiError
 } from '../api/secretsApi'
@@ -16,6 +17,7 @@ export function useSecrets() {
 
   const loading = ref(false)
   const secrets = ref<SecretMetadata[]>([])
+  const availableProviders = ref<string[] | null>(null)
   const operatingSecretId = ref<string | null>(null)
 
   const existingProviders = computed<SecretProvider[]>(() =>
@@ -48,6 +50,14 @@ export function useSecrets() {
     }
   }
 
+  async function fetchProviders() {
+    try {
+      availableProviders.value = await listSecretProviders()
+    } catch (err) {
+      console.error('Unexpected error fetching secret providers:', err)
+    }
+  }
+
   async function deleteSecret(secret: SecretMetadata) {
     operatingSecretId.value = secret.id
     try {
@@ -76,9 +86,11 @@ export function useSecrets() {
   return {
     loading,
     secrets,
+    availableProviders,
     operatingSecretId,
     existingProviders,
     fetchSecrets,
+    fetchProviders,
     deleteSecret
   }
 }

--- a/src/platform/secrets/providers.test.ts
+++ b/src/platform/secrets/providers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PROVIDER_IDS,
+  getProviderHelpKey,
+  getProviderLabel,
+  getProviderLogo
+} from './providers'
+
+describe('secret provider registry', () => {
+  it('maps known providers (including BYOK) to display labels', () => {
+    expect(getProviderLabel('huggingface')).toBe('HuggingFace')
+    expect(getProviderLabel('civitai')).toBe('Civitai')
+    expect(getProviderLabel('runway')).toBe('Runway')
+    expect(getProviderLabel('gemini')).toBe('Google Gemini')
+  })
+
+  it('maps known providers to logos under public/assets/images', () => {
+    expect(getProviderLogo('huggingface')).toBe('/assets/images/hf-logo.svg')
+    expect(getProviderLogo('civitai')).toBe('/assets/images/civitai.svg')
+    expect(getProviderLogo('runway')).toBe('/assets/images/runway.svg')
+    expect(getProviderLogo('gemini')).toBe('/assets/images/gemini.svg')
+  })
+
+  it('exposes per-provider help keys for the BYOK providers', () => {
+    expect(getProviderHelpKey('runway')).toBe('secrets.providerHelp.runway')
+    expect(getProviderHelpKey('gemini')).toBe('secrets.providerHelp.gemini')
+    // Model-download providers reuse the generic hint (no dedicated help key).
+    expect(getProviderHelpKey('huggingface')).toBeUndefined()
+    expect(getProviderHelpKey('civitai')).toBeUndefined()
+  })
+
+  it('falls back to the raw id with no logo/help for unknown providers', () => {
+    // A provider added server-side but absent from the registry still renders.
+    expect(getProviderLabel('brand-new-provider')).toBe('brand-new-provider')
+    expect(getProviderLogo('brand-new-provider')).toBeUndefined()
+    expect(getProviderHelpKey('brand-new-provider')).toBeUndefined()
+  })
+
+  it('returns an empty label and no logo for an undefined provider', () => {
+    expect(getProviderLabel(undefined)).toBe('')
+    expect(getProviderLogo(undefined)).toBeUndefined()
+    expect(getProviderHelpKey(undefined)).toBeUndefined()
+  })
+
+  it('keeps the not-loaded fallback list to the pre-BYOK baseline', () => {
+    // Defaults are a transient placeholder only; the authoritative list is the
+    // server response. They must not silently include BYOK providers.
+    expect([...DEFAULT_PROVIDER_IDS]).toEqual(['huggingface', 'civitai'])
+  })
+})

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -1,30 +1,71 @@
-import type { SecretProvider } from './types'
-
 interface ProviderConfig {
-  value: SecretProvider
+  /** Provider identifier as returned by `GET /secrets/providers`. */
+  value: string
+  /** Human-facing display label. Brand names are intentionally not translated. */
   label: string
+  /** Path to the provider logo under `public/assets/images/`. */
   logo: string
+  /** Optional i18n key for provider-specific help text shown under the picker. */
+  helpKey?: string
 }
 
-export const SECRET_PROVIDERS: ProviderConfig[] = [
+/**
+ * Presentational metadata for known providers: how a provider id renders
+ * (label, logo, help text). This table is NOT the source of truth for which
+ * providers a user may configure — that list is server-driven via
+ * `GET /secrets/providers`. Ids the server returns that are absent here fall
+ * back to the raw id with no logo, so adding a provider server-side renders
+ * without an FE change (a dedicated logo/label is an optional enhancement).
+ */
+const SECRET_PROVIDERS: ProviderConfig[] = [
   {
     value: 'huggingface',
     label: 'HuggingFace',
     logo: '/assets/images/hf-logo.svg'
   },
-  { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' }
-] as const
+  { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' },
+  {
+    value: 'runway',
+    label: 'Runway',
+    logo: '/assets/images/runway.svg',
+    helpKey: 'secrets.providerHelp.runway'
+  },
+  {
+    value: 'gemini',
+    label: 'Google Gemini',
+    logo: '/assets/images/gemini.svg',
+    helpKey: 'secrets.providerHelp.gemini'
+  }
+]
+
+/**
+ * Providers shown as a sensible default before the server list resolves, and to
+ * seed the disabled selector in edit mode. This is NOT the source of truth for
+ * which providers a user may configure — once `GET /secrets/providers` resolves,
+ * its list is rendered verbatim.
+ */
+export const DEFAULT_PROVIDER_IDS = ['huggingface', 'civitai'] as const
+
+function findProvider(
+  provider: string | undefined
+): ProviderConfig | undefined {
+  if (!provider) return undefined
+  return SECRET_PROVIDERS.find((p) => p.value === provider)
+}
 
 export function getProviderLabel(provider: string | undefined): string {
   if (!provider) return ''
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.label ?? provider
+  return findProvider(provider)?.label ?? provider
 }
 
 export function getProviderLogo(
   provider: string | undefined
 ): string | undefined {
-  if (!provider) return undefined
-  const config = SECRET_PROVIDERS.find((p) => p.value === provider)
-  return config?.logo
+  return findProvider(provider)?.logo
+}
+
+export function getProviderHelpKey(
+  provider: string | undefined
+): string | undefined {
+  return findProvider(provider)?.helpKey
 }

--- a/src/platform/secrets/providers.ts
+++ b/src/platform/secrets/providers.ts
@@ -15,14 +15,14 @@ export const SECRET_PROVIDERS: ProviderConfig[] = [
   { value: 'civitai', label: 'Civitai', logo: '/assets/images/civitai.svg' }
 ] as const
 
-export function getProviderLabel(provider: SecretProvider | undefined): string {
+export function getProviderLabel(provider: string | undefined): string {
   if (!provider) return ''
   const config = SECRET_PROVIDERS.find((p) => p.value === provider)
   return config?.label ?? provider
 }
 
 export function getProviderLogo(
-  provider: SecretProvider | undefined
+  provider: string | undefined
 ): string | undefined {
   if (!provider) return undefined
   const config = SECRET_PROVIDERS.find((p) => p.value === provider)

--- a/src/platform/secrets/types.ts
+++ b/src/platform/secrets/types.ts
@@ -1,13 +1,19 @@
-export type SecretProvider = 'huggingface' | 'civitai'
+import type { SecretResponse } from '@comfyorg/ingest-types'
 
-export interface SecretMetadata {
-  id: string
-  name: string
-  provider?: SecretProvider
-  last_used_at?: string
-  created_at: string
-  updated_at: string
-}
+/**
+ * Secret metadata as returned by the ingest API, sourced from the generated
+ * OpenAPI types (`SecretResponse`). The secret value itself is never returned
+ * after creation. `provider` is a free-form identifier (huggingface, civitai,
+ * and BYOK providers); the `SecretProvider` union below is only the subset the
+ * UI renders first-class.
+ */
+export type SecretMetadata = SecretResponse
+
+/**
+ * Base providers the UI renders with a dedicated label/logo. The full set of
+ * configurable providers is data-driven via `GET /secrets/providers`.
+ */
+export type SecretProvider = 'huggingface' | 'civitai'
 
 export interface SecretCreateRequest {
   name: string

--- a/src/platform/secrets/types.ts
+++ b/src/platform/secrets/types.ts
@@ -10,15 +10,18 @@ import type { SecretResponse } from '@comfyorg/ingest-types'
 export type SecretMetadata = SecretResponse
 
 /**
- * Base providers the UI renders with a dedicated label/logo. The full set of
- * configurable providers is data-driven via `GET /secrets/providers`.
+ * Base providers the UI renders with a dedicated first-class label/logo. This
+ * union documents the historically-known providers only — the full set of
+ * configurable providers is data-driven via `GET /secrets/providers`, so the
+ * selected provider is stored/sent as a free-form string.
  */
 export type SecretProvider = 'huggingface' | 'civitai'
 
 export interface SecretCreateRequest {
   name: string
   secret_value: string
-  provider?: SecretProvider
+  /** Provider identifier as returned by `GET /secrets/providers`. */
+  provider?: string
 }
 
 export interface SecretUpdateRequest {

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -39,6 +39,14 @@ interface CustomDialogComponentProps {
   pt?: DialogPassThroughOptions
   closeOnEscape?: boolean
   dismissableMask?: boolean
+  /**
+   * When `false`, the Reka dialog does not dismiss when focus leaves its
+   * content. Set on container dialogs (e.g. Settings) that host nested dialogs,
+   * where a nested dialog closing can move focus onto an ordinary app element
+   * — a programmatic shift that must not be read as a dismiss. Escape and
+   * outside-pointer dismissal are unaffected. Defaults to `true`.
+   */
+  dismissOnFocusOutside?: boolean
   unstyled?: boolean
   headless?: boolean
   renderer?: DialogRenderer


### PR DESCRIPTION
Backport of the BYOK secrets chain to cloud/1.45, cherry-picked in merge order:

- #13494 feat: render secrets provider dropdown from server data
- #13509 feat: render BYOK provider surface (labels / logos / help) from server data
- #13546 test: pin unknown-provider flow-through in server-driven provider options
- #13510 fix(dialog) — partial: kept the SecretFormDialog/useSecretForm changes and the dialogStore interface prop

Adjustments for this branch (details in each commit body):
- Dropped SecretsPanel.test.ts from #13494 — introduced on main by #12502 (Reka ConfirmDialog migration), not on this branch.
- Dropped #13510's rekaPrimeVueBridge/GlobalDialog/useSettingsDialog changes and cloudSecrets.spec.ts E2E — Settings on cloud/1.45 is a layout dialog and rekaPrimeVueBridge.ts does not exist here, so the focus-outside dismissal bug cannot occur. Coverage exists on the 1.47 line.
- Grafted SecretProvidersResponse/SecretProvider into packages/ingest-types (type-only) — added on main by #12777, a full generated-types refresh that conflicts wholesale with this branch.

Verified in worktree: typecheck passes, secrets unit tests 67/67 pass, oxlint 0 errors, format clean.

Follow-up: #13571 (JSON file upload input types) backports here manually after it merges to main.