### PR TITLE
feat: extend charcoal scale with 900 and 950 steps

### DIFF
--- a/packages/design-system/src/css/_palette.css
+++ b/packages/design-system/src/css/_palette.css
@@ -11,6 +11,8 @@
   --color-charcoal-600: #262729;
   --color-charcoal-700: #202121;
   --color-charcoal-800: #171718;
+  --color-charcoal-900: #111111;
+  --color-charcoal-950: #09090a;
 
   --color-neutral-550: #636363;
 


### PR DESCRIPTION
> [!NOTE]
> **#13842 builds on this.** It applies these two steps across the editor chrome (topbar, tabs, sidebar, canvas backdrop), so the tokens actually get consumers — Tailwind v4 tree-shakes `@theme` colours nothing references. Reviewing them together gives the full picture; merging this one first reduces #13842 to just the application.

Adds two darker steps to the charcoal palette in
packages/design-system/src/css/_palette.css:

- --color-charcoal-900: #111111
- --color-charcoal-950: #09090a

The scale previously stopped at 800 (#171718), so canvas surfaces relied
on strokes to differentiate at the dark end. These steps extend the range
for deeper canvas depth (Proposal A — Conservative, from design).

Steps 100–800 are unchanged. Tailwind v4 auto-generates the
bg-/text-/border-charcoal-900/950 utilities from the @theme block; no
config change needed. Nothing consumes these tokens yet — a follow-up can
wire semantic tokens if design wants.

