### PR TITLE
fix(dialog): treat aria-haspopup triggers as inside non-modal dialogs

### DIFF
--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -486,4 +486,19 @@ describe('shouldPreventRekaDismiss', () => {
     expect(event.defaultPrevented).toBe(true)
     portal.remove()
   })
+
+  it('focus-outside on an aria-haspopup trigger still dismisses (triggers are pointer-only)', () => {
+    // Tab focus is not blocked by the non-modal scrim, so keyboard focus
+    // landing on an app-chrome popup trigger must dismiss like any other
+    // outside element.
+    const trigger = document.createElement('button')
+    trigger.setAttribute('aria-haspopup', 'menu')
+    document.body.appendChild(trigger)
+
+    const event = makeEvent(trigger)
+    onRekaFocusOutside(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    trigger.remove()
+  })
 })

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -418,6 +418,23 @@ describe('shouldPreventRekaDismiss', () => {
     }
   )
 
+  it.for(['true', 'grid', 'tree'])(
+    'allows dismiss for unsupported aria-haspopup="%s" values',
+    (popupType) => {
+      // Only the values Reka trigger primitives emit are allowlisted; other
+      // ARIA values stay ordinary outside elements.
+      const trigger = document.createElement('button')
+      trigger.setAttribute('aria-haspopup', popupType)
+      document.body.appendChild(trigger)
+
+      const event = makeEvent(trigger)
+      onRekaPointerDownOutside({ dismissableMask: undefined }, event)
+
+      expect(event.defaultPrevented).toBe(false)
+      trigger.remove()
+    }
+  )
+
   it('allows dismiss when target is outside any PrimeVue overlay', () => {
     const event = makeEvent(document.body)
     onRekaPointerDownOutside({ dismissableMask: undefined }, event)

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -398,6 +398,26 @@ describe('shouldPreventRekaDismiss', () => {
     overlay.remove()
   })
 
+  it.for(['menu', 'dialog', 'listbox'])(
+    'prevents dismiss when clicking an aria-haspopup="%s" trigger',
+    (popupType) => {
+      // Clicking an open popup's trigger to close it must not tear down the
+      // surrounding dialog: while the popup layer is open, the parent
+      // DismissableLayer classifies the trigger click as outside.
+      const trigger = document.createElement('button')
+      trigger.setAttribute('aria-haspopup', popupType)
+      const icon = document.createElement('i')
+      trigger.appendChild(icon)
+      document.body.appendChild(trigger)
+
+      const event = makeEvent(icon)
+      onRekaPointerDownOutside({ dismissableMask: undefined }, event)
+
+      expect(event.defaultPrevented).toBe(true)
+      trigger.remove()
+    }
+  )
+
   it('allows dismiss when target is outside any PrimeVue overlay', () => {
     const event = makeEvent(document.body)
     onRekaPointerDownOutside({ dismissableMask: undefined }, event)

--- a/src/components/dialog/rekaPrimeVueBridge.ts
+++ b/src/components/dialog/rekaPrimeVueBridge.ts
@@ -9,10 +9,12 @@ const PRIMEVUE_OVERLAY_SELECTORS =
 // Reka portals its own dialogs / popovers / menus into the body too. When a
 // nested Reka layer opens on top of a non-modal parent, the parent's
 // DismissableLayer sees the focus shift / pointer-down as "outside" and would
-// dismiss itself. These selectors cover the portaled roots so we can treat
-// interactions on them as inside.
+// dismiss itself. These selectors cover the portaled roots — and the
+// `aria-haspopup` triggers that toggle them, because while a popup is open the
+// parent layer classifies a click on the trigger (closing the popup) as
+// outside too — so we can treat interactions on them as inside.
 const REKA_PORTAL_SELECTORS =
-  '[data-reka-popper-content-wrapper], [data-reka-dialog-content], [data-reka-menu-content], [data-reka-context-menu-content], [role="dialog"], [role="menu"], [role="listbox"], [role="tooltip"]'
+  '[data-reka-popper-content-wrapper], [data-reka-dialog-content], [data-reka-menu-content], [data-reka-context-menu-content], [role="dialog"], [role="menu"], [role="listbox"], [role="tooltip"], [aria-haspopup="menu"], [aria-haspopup="dialog"], [aria-haspopup="listbox"]'
 
 const OUTSIDE_LAYER_SELECTORS = `${PRIMEVUE_OVERLAY_SELECTORS}, ${REKA_PORTAL_SELECTORS}`
 

--- a/src/components/dialog/rekaPrimeVueBridge.ts
+++ b/src/components/dialog/rekaPrimeVueBridge.ts
@@ -9,14 +9,21 @@ const PRIMEVUE_OVERLAY_SELECTORS =
 // Reka portals its own dialogs / popovers / menus into the body too. When a
 // nested Reka layer opens on top of a non-modal parent, the parent's
 // DismissableLayer sees the focus shift / pointer-down as "outside" and would
-// dismiss itself. These selectors cover the portaled roots — and the
-// `aria-haspopup` triggers that toggle them, because while a popup is open the
-// parent layer classifies a click on the trigger (closing the popup) as
-// outside too — so we can treat interactions on them as inside.
+// dismiss itself. These selectors cover the portaled roots so we can treat
+// interactions on them as inside.
 const REKA_PORTAL_SELECTORS =
-  '[data-reka-popper-content-wrapper], [data-reka-dialog-content], [data-reka-menu-content], [data-reka-context-menu-content], [role="dialog"], [role="menu"], [role="listbox"], [role="tooltip"], [aria-haspopup="menu"], [aria-haspopup="dialog"], [aria-haspopup="listbox"]'
+  '[data-reka-popper-content-wrapper], [data-reka-dialog-content], [data-reka-menu-content], [data-reka-context-menu-content], [role="dialog"], [role="menu"], [role="listbox"], [role="tooltip"]'
 
 const OUTSIDE_LAYER_SELECTORS = `${PRIMEVUE_OVERLAY_SELECTORS}, ${REKA_PORTAL_SELECTORS}`
+
+// While a popup is open, the parent layer also classifies a pointer-down on
+// the popup's own trigger (closing it) as outside, so triggers are allowlisted
+// for the pointer path only. The focus path must not match them: the non-modal
+// scrim intercepts background clicks but not Tab focus, so a focus-outside
+// match would keep the dialog open whenever keyboard focus merely lands on an
+// app-chrome popup trigger.
+const POPUP_TRIGGER_SELECTORS =
+  '[aria-haspopup="menu"], [aria-haspopup="dialog"], [aria-haspopup="listbox"]'
 
 type OutsideEvent = CustomEvent<{ originalEvent: Event }>
 
@@ -24,6 +31,13 @@ function isInsideOverlay(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
     target.closest(OUTSIDE_LAYER_SELECTORS) !== null
+  )
+}
+
+function isPopupTrigger(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(POPUP_TRIGGER_SELECTORS) !== null
   )
 }
 
@@ -42,7 +56,8 @@ export function onRekaPointerDownOutside(
     event.preventDefault()
     return
   }
-  if (isInsideOverlay(event.detail.originalEvent.target)) {
+  const target = event.detail.originalEvent.target
+  if (isInsideOverlay(target) || isPopupTrigger(target)) {
     event.preventDefault()
     return
   }


### PR DESCRIPTION
## Summary

Clicking an open popup's trigger (menu / dialog / listbox) inside a non-modal Reka dialog dismissed the surrounding dialog; the trigger is now allowlisted as "inside" — on the pointer path only.

## Changes

- **What**: new `POPUP_TRIGGER_SELECTORS` (`[aria-haspopup="menu"|"dialog"|"listbox"]`) in `rekaPrimeVueBridge.ts`, consulted by `onRekaPointerDownOutside` but **not** `onRekaFocusOutside`. The non-modal scrim intercepts background clicks but not Tab focus, so a pointer-path match can only ever be an in-dialog trigger, while a focus-path match would wrongly keep the dialog open when keyboard focus lands on an app-chrome trigger (Manager/Subscription-legacy don't opt out of focus-outside dismissal).
- Unit coverage: the three allowlisted values on the pointer path, unsupported values (`true`/`grid`/`tree`) staying dismissable, and a focus-path case asserting triggers still dismiss there.

## Review Focus

- Failure mode: while a popup layer is open, the parent non-modal dialog's `DismissableLayer` classifies a click on the popup's own trigger (to close it) as outside — the same non-modal container class tracked in #13558.
- Pointer-only scoping was chosen over `[aria-expanded="true"]` scoping: on touch, Reka defers the outside dispatch to `click`, by which time the render flush may have already set `aria-expanded="false"` on the closing trigger.
- Standalone reimplementation of the bridge portion of #13487 (design-preview PR, not landing). Per the land order in https://github.com/Comfy-Org/ComfyUI_frontend/issues/13558#issuecomment-4957678522, this should land before #12611 (Phase 6b) rebases the bridge.
