### PR TITLE
fix(website): replace em dash meta title separators with hyphens

### DIFF
--- a/apps/website/e2e/careers.spec.ts
+++ b/apps/website/e2e/careers.spec.ts
@@ -8,7 +8,7 @@ test.describe('Careers page @smoke', () => {
   })
 
   test('has correct title', async ({ page }) => {
-    await expect(page).toHaveTitle('Careers — Comfy')
+    await expect(page).toHaveTitle('Careers - Comfy')
   })
 
   test('Roles section heading is visible', async ({ page }) => {
@@ -72,7 +72,7 @@ test.describe('Careers page role links', () => {
 test.describe('Careers page (zh-CN) @smoke', () => {
   test('renders localized heading and roles', async ({ page }) => {
     await page.goto('/zh-CN/careers')
-    await expect(page).toHaveTitle('招聘 — Comfy')
+    await expect(page).toHaveTitle('招聘 - Comfy')
     await expect(
       page.getByRole('heading', { name: '职位', level: 2 })
     ).toBeVisible()

--- a/apps/website/e2e/cloud-nodes.spec.ts
+++ b/apps/website/e2e/cloud-nodes.spec.ts
@@ -9,7 +9,7 @@ test.describe('Cloud nodes page @smoke', () => {
 
   test('has correct title', async ({ page }) => {
     await expect(page).toHaveTitle(
-      'Custom-node packs on Comfy Cloud — supported by default'
+      'Custom-node packs on Comfy Cloud - supported by default'
     )
   })
 

--- a/apps/website/e2e/cloud.spec.ts
+++ b/apps/website/e2e/cloud.spec.ts
@@ -8,7 +8,7 @@ test.describe('Cloud page @smoke', () => {
   })
 
   test('has correct title', async ({ page }) => {
-    await expect(page).toHaveTitle('Comfy Cloud — AI in the Cloud')
+    await expect(page).toHaveTitle('Comfy Cloud - AI in the Cloud')
   })
 
   test('HeroSection heading and subtitle are visible', async ({ page }) => {

--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -16,7 +16,7 @@ test.describe('Download page @smoke', () => {
 
   test('has correct title', async ({ page }) => {
     await expect(page).toHaveTitle(
-      'Download Comfy Desktop — Run AI on Your Hardware'
+      'Download Comfy Desktop - Run AI on Your Hardware'
     )
   })
 

--- a/apps/website/e2e/homepage.spec.ts
+++ b/apps/website/e2e/homepage.spec.ts
@@ -17,7 +17,7 @@ test.describe('Homepage @smoke', () => {
   })
 
   test('has correct title', async ({ page }) => {
-    await expect(page).toHaveTitle('Comfy — Professional Control of Visual AI')
+    await expect(page).toHaveTitle('Comfy - Professional Control of Visual AI')
   })
 
   test('HeroSection heading is visible', async ({ page }) => {

--- a/apps/website/e2e/learning.spec.ts
+++ b/apps/website/e2e/learning.spec.ts
@@ -13,7 +13,7 @@ test.describe('Learning page @smoke', () => {
   })
 
   test('has correct title', async ({ page }) => {
-    await expect(page).toHaveTitle('Learning — Comfy')
+    await expect(page).toHaveTitle('Learning - Comfy')
   })
 
   test('hero headline references ComfyUI', async ({ page }) => {
@@ -137,7 +137,7 @@ test.describe('Learning page (zh-CN) @smoke', () => {
   test('renders localized title, headings, and tutorials', async ({ page }) => {
     await page.goto('/zh-CN/learning')
 
-    await expect(page).toHaveTitle('学习 — Comfy')
+    await expect(page).toHaveTitle('学习 - Comfy')
     await expect(page.getByRole('heading', { level: 1 })).toContainText(
       /[一-鿿]/
     )

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -22,7 +22,7 @@ test.describe('Payment success page @smoke', () => {
   })
 
   test('has correct title and is noindex', async ({ page }) => {
-    await expect(page).toHaveTitle('Payment Successful — Comfy')
+    await expect(page).toHaveTitle('Payment Successful - Comfy')
     await expectNoIndex(page)
   })
 
@@ -54,7 +54,7 @@ test.describe('Payment failed page @smoke', () => {
   })
 
   test('has correct title and is noindex', async ({ page }) => {
-    await expect(page).toHaveTitle('Payment Failed — Comfy')
+    await expect(page).toHaveTitle('Payment Failed - Comfy')
     await expectNoIndex(page)
   })
 
@@ -84,7 +84,7 @@ test.describe('Payment failed page @smoke', () => {
 test.describe('Payment pages zh-CN @smoke', () => {
   test('zh-CN success page renders and links correctly', async ({ page }) => {
     await page.goto('/zh-CN/payment/success')
-    await expect(page).toHaveTitle('支付成功 — Comfy')
+    await expect(page).toHaveTitle('支付成功 - Comfy')
     await expectNoIndex(page)
     await expect(
       page.getByRole('heading', { name: '支付成功', level: 1 })
@@ -99,7 +99,7 @@ test.describe('Payment pages zh-CN @smoke', () => {
 
   test('zh-CN failed page renders and links correctly', async ({ page }) => {
     await page.goto('/zh-CN/payment/failed')
-    await expect(page).toHaveTitle('支付失败 — Comfy')
+    await expect(page).toHaveTitle('支付失败 - Comfy')
     await expectNoIndex(page)
     await expect(
       page.getByRole('heading', { name: '无法完成支付', level: 1 })

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -823,7 +823,7 @@ const translations = {
     'zh-CN': 'Comfy Cloud 支持的自定义节点包'
   },
   'cloudNodes.meta.title': {
-    en: 'Custom-node packs on Comfy Cloud — supported by default',
+    en: 'Custom-node packs on Comfy Cloud - supported by default',
     'zh-CN': 'Comfy Cloud 自定义节点包合集——开箱即用'
   },
   'cloudNodes.meta.description': {
@@ -1845,8 +1845,8 @@ const translations = {
 
   // MCP – Meta
   'mcp.meta.title': {
-    en: 'Comfy MCP — Drive ComfyUI from any AI agent',
-    'zh-CN': 'Comfy MCP — 让任何 AI 智能体驱动 ComfyUI'
+    en: 'Comfy MCP - Drive ComfyUI from any AI agent',
+    'zh-CN': 'Comfy MCP - 让任何 AI 智能体驱动 ComfyUI'
   },
   'mcp.meta.description': {
     en: 'Comfy MCP exposes the full ComfyUI engine over the Model Context Protocol. Generate images, video, audio, and 3D from Claude Code, Claude Desktop, and any MCP-compatible client.',
@@ -3483,8 +3483,8 @@ const translations = {
   },
 
   'affiliate-terms.page.title': {
-    en: 'Affiliate Terms — Comfy',
-    'zh-CN': 'Affiliate Terms — Comfy'
+    en: 'Affiliate Terms - Comfy',
+    'zh-CN': 'Affiliate Terms - Comfy'
   },
   'affiliate-terms.page.description': {
     en: 'Comfy.org Affiliate Program Terms and Conditions.',
@@ -3896,8 +3896,8 @@ const translations = {
       'This document reproduces the current template of the Enterprise Customer Agreement for reference only. The executed Agreement between Comfy and Customer, together with any signed Order Forms, governs the relationship between the parties. To request an executable copy, please contact <a href="mailto:sales@comfy.org" class="text-white underline">sales@comfy.org</a>.'
   },
   'enterprise-msa.page.title': {
-    en: 'Enterprise MSA — Comfy',
-    'zh-CN': 'Enterprise MSA — Comfy'
+    en: 'Enterprise MSA - Comfy',
+    'zh-CN': 'Enterprise MSA - Comfy'
   },
   'enterprise-msa.page.description': {
     en: 'Comfy Enterprise Customer Agreement — the master services agreement that governs Comfy Enterprise deployments of Comfy Cloud, Comfy API, and related products.',
@@ -4361,8 +4361,8 @@ const translations = {
 
   // Affiliate page (/affiliates) — head metadata
   'affiliate.page.title': {
-    en: 'Comfy.org Affiliate Program — Become a Partner',
-    'zh-CN': 'Comfy.org 联盟计划 — 成为合作伙伴'
+    en: 'Comfy.org Affiliate Program - Become a Partner',
+    'zh-CN': 'Comfy.org 联盟计划 - 成为合作伙伴'
   },
   'affiliate.page.description': {
     en: 'Earn 30% recurring commission for 3 months on every Comfy Cloud subscription you refer. Apply to become a Comfy Partner.',
@@ -4387,8 +4387,8 @@ const translations = {
   // Launches page (/launches) — head metadata
   // zh-CN strings pending native review (see apps/website/.scratch/drops-page/PRD.md)
   'launches.page.title': {
-    en: 'ComfyUI Live Demo & Q&A — June 29 Launch Livestream',
-    'zh-CN': 'ComfyUI 直播演示与问答 — 6 月 29 日发布直播'
+    en: 'ComfyUI Live Demo & Q&A - June 29 Launch Livestream',
+    'zh-CN': 'ComfyUI 直播演示与问答 - 6 月 29 日发布直播'
   },
   'launches.page.description': {
     en: 'Join the ComfyUI livestream on June 29 for a hands-on product demo and live Q&A. See what’s new across desktop, cloud, and community, and get your questions answered.',

--- a/apps/website/src/pages/404.astro
+++ b/apps/website/src/pages/404.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 ---
 
 <BaseLayout
-  title="404 — Page Not Found — Comfy"
+  title="404 - Page Not Found - Comfy"
   noindex>
   <div
     class="flex w-full flex-col items-center p-4 h-[calc(100dvh-12rem)]">

--- a/apps/website/src/pages/about.astro
+++ b/apps/website/src/pages/about.astro
@@ -16,7 +16,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="About Us — Comfy"
+  title="About Us - Comfy"
   pageType="AboutPage"
   mainEntityId={organizationId(siteUrl)}
   breadcrumbs={[

--- a/apps/website/src/pages/careers.astro
+++ b/apps/website/src/pages/careers.astro
@@ -42,7 +42,7 @@ const roles = itemListNode(
 ---
 
 <BaseLayout
-  title="Careers — Comfy"
+  title="Careers - Comfy"
   description="Join the team building the operating system for generative AI. Open roles in engineering, design, marketing, and more."
   pageType="CollectionPage"
   mainEntityId={jsonLdId(url, 'itemlist')}

--- a/apps/website/src/pages/case-studies.astro
+++ b/apps/website/src/pages/case-studies.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 import ComingSoon from '../components/common/ComingSoon.astro'
 ---
 
-<BaseLayout title="Case Studies — Comfy">
+<BaseLayout title="Case Studies - Comfy">
   <ComingSoon />
 </BaseLayout>

--- a/apps/website/src/pages/cloud/index.astro
+++ b/apps/website/src/pages/cloud/index.astro
@@ -11,7 +11,7 @@ import { t } from '../../i18n/translations'
 ---
 
 <BaseLayout
-  title="Comfy Cloud — AI in the Cloud"
+  title="Comfy Cloud - AI in the Cloud"
   description={t('cloud.hero.subtitle', 'en')}
   keywords={['comfyui web app', 'comfyui app', 'comfyui online', 'comfyui cloud', 'comfy cloud', 'comfy ui application', 'comfyui browser', 'cloud comfyui', 'managed comfyui']}
 >

--- a/apps/website/src/pages/cloud/pricing.astro
+++ b/apps/website/src/pages/cloud/pricing.astro
@@ -20,7 +20,7 @@ const productId = jsonLdId(url, 'product')
 ---
 
 <BaseLayout
-  title="Pricing — Comfy Cloud"
+  title="Pricing - Comfy Cloud"
   mainEntityId={productId}
   breadcrumbs={[
     { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },

--- a/apps/website/src/pages/contact.astro
+++ b/apps/website/src/pages/contact.astro
@@ -13,7 +13,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="Contact — Comfy"
+  title="Contact - Comfy"
   pageType="ContactPage"
   mainEntityId={organizationId(siteUrl)}
   breadcrumbs={[

--- a/apps/website/src/pages/customers.astro
+++ b/apps/website/src/pages/customers.astro
@@ -11,7 +11,7 @@ import { loadStories } from '../utils/loadStories'
 const stories = (await loadStories('en')).map(toCardProps)
 ---
 
-<BaseLayout title="Customer Stories — Comfy">
+<BaseLayout title="Customer Stories - Comfy">
   <HeroSection client:load />
   <StorySection stories={stories} />
   <FeedbackSection client:load />

--- a/apps/website/src/pages/customers/[slug].astro
+++ b/apps/website/src/pages/customers/[slug].astro
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 const { entry, next } = Astro.props
 ---
 
-<BaseLayout title={`${entry.data.title} — Comfy`}>
+<BaseLayout title={`${entry.data.title} - Comfy`}>
   <DetailHeroSection
     label={entry.data.category}
     title={entry.data.title}

--- a/apps/website/src/pages/demos/[slug].astro
+++ b/apps/website/src/pages/demos/[slug].astro
@@ -58,7 +58,7 @@ const learningResource: JsonLdNode = {
 ---
 
 <BaseLayout
-  title={`${title} — Comfy`}
+  title={`${title} - Comfy`}
   description={description}
   ogImage={demo.ogImage}
   mainEntityId={learningId}

--- a/apps/website/src/pages/demos/index.astro
+++ b/apps/website/src/pages/demos/index.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 import ComingSoon from '../../components/common/ComingSoon.astro'
 ---
 
-<BaseLayout title="Demos — Comfy" description="Interactive demos and tutorials for ComfyUI.">
+<BaseLayout title="Demos - Comfy" description="Interactive demos and tutorials for ComfyUI.">
   <ComingSoon />
 </BaseLayout>

--- a/apps/website/src/pages/download.astro
+++ b/apps/website/src/pages/download.astro
@@ -23,7 +23,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="Download Comfy Desktop — Run AI on Your Hardware"
+  title="Download Comfy Desktop - Run AI on Your Hardware"
   description={t('download.hero.subtitle', 'en')}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   breadcrumbs={[

--- a/apps/website/src/pages/gallery.astro
+++ b/apps/website/src/pages/gallery.astro
@@ -5,7 +5,7 @@ import GallerySection from '../components/gallery/GallerySection.vue'
 import ContactSection from '../components/gallery/ContactSection.vue'
 ---
 
-<BaseLayout title="Gallery — Comfy">
+<BaseLayout title="Gallery - Comfy">
   <HeroSection />
   <GallerySection client:load />
   <ContactSection />

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -24,7 +24,7 @@ const { siteUrl } = pageContext(
 ---
 
 <BaseLayout
-  title="Comfy — Professional Control of Visual AI"
+  title="Comfy - Professional Control of Visual AI"
   description={t("hero.subtitle", "en")}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   extraJsonLd={[

--- a/apps/website/src/pages/learning.astro
+++ b/apps/website/src/pages/learning.astro
@@ -12,7 +12,7 @@ import { externalLinks } from '../config/routes'
 const routes = getRoutes('en')
 ---
 
-<BaseLayout title="Learning — Comfy">
+<BaseLayout title="Learning - Comfy">
   <HeroSection client:load />
   <FeaturedWorkflowSection client:visible />
   <TutorialsSection client:visible />

--- a/apps/website/src/pages/models.astro
+++ b/apps/website/src/pages/models.astro
@@ -7,7 +7,7 @@ import ProductShowcaseSection from '../components/home/ProductShowcaseSection.vu
 ---
 
 <BaseLayout
-  title="Models — Comfy"
+  title="Models - Comfy"
   description="Run the world's leading AI models in ComfyUI. Browse every supported model with community workflow templates ready to run."
 >
   <ModelsHeroSection

--- a/apps/website/src/pages/p/supported-models/[slug].astro
+++ b/apps/website/src/pages/p/supported-models/[slug].astro
@@ -103,7 +103,7 @@ const faqPage: JsonLdNode = {
 ---
 
 <BaseLayout
-  title={`${pageTitle} — Comfy`}
+  title={`${pageTitle} - Comfy`}
   description={pageDescription}
   ogImage={model.thumbnailUrl}
   mainEntityId={softwareId}

--- a/apps/website/src/pages/p/supported-models/index.astro
+++ b/apps/website/src/pages/p/supported-models/index.astro
@@ -43,7 +43,7 @@ const dirLabel: Record<string, string> = {
 ---
 
 <BaseLayout
-  title={`${title} — Comfy`}
+  title={`${title} - Comfy`}
   description={subtitle}
   pageType="CollectionPage"
   mainEntityId={jsonLdId(url, 'itemlist')}

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -4,7 +4,7 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
 ---
 
 <BaseLayout
-  title="Payment Failed — Comfy"
+  title="Payment Failed - Comfy"
   description="Your payment was not completed."
   noindex
 >

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -4,7 +4,7 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
 ---
 
 <BaseLayout
-  title="Payment Successful — Comfy"
+  title="Payment Successful - Comfy"
   description="Your payment was processed successfully."
   noindex
 >

--- a/apps/website/src/pages/privacy-policy.astro
+++ b/apps/website/src/pages/privacy-policy.astro
@@ -5,7 +5,7 @@ import HeroSection from '../components/legal/HeroSection.vue'
 ---
 
 <BaseLayout
-  title="Privacy Policy — Comfy"
+  title="Privacy Policy - Comfy"
   description="Comfy privacy policy. Learn how we collect, use, and protect your personal information."
   noindex
 >

--- a/apps/website/src/pages/privacy/desktop.astro
+++ b/apps/website/src/pages/privacy/desktop.astro
@@ -5,7 +5,7 @@ import HeroSection from '../../components/legal/HeroSection.vue'
 ---
 
 <BaseLayout
-  title="Desktop Privacy Policy — Comfy"
+  title="Desktop Privacy Policy - Comfy"
   description="Privacy policy for Comfy Desktop. Named processors, lawful basis under GDPR/UK GDPR, retention periods, and your rights."
 >
   <HeroSection title="Desktop Privacy Policy" />

--- a/apps/website/src/pages/terms-of-service.astro
+++ b/apps/website/src/pages/terms-of-service.astro
@@ -6,7 +6,7 @@ import { t } from '../i18n/translations'
 ---
 
 <BaseLayout
-  title="Terms of Service — Comfy"
+  title="Terms of Service - Comfy"
   description="Terms of Service governing use of the Comfy Products, including Comfy Cloud, Comfy API, and Comfy Enterprise."
   noindex
 >

--- a/apps/website/src/pages/videos.astro
+++ b/apps/website/src/pages/videos.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 import ComingSoon from '../components/common/ComingSoon.astro'
 ---
 
-<BaseLayout title="Videos — Comfy">
+<BaseLayout title="Videos - Comfy">
   <ComingSoon />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/about.astro
+++ b/apps/website/src/pages/zh-CN/about.astro
@@ -16,7 +16,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="关于我们 — Comfy"
+  title="关于我们 - Comfy"
   description="了解 ComfyUI 背后的团队和使命——开源的生成式 AI 平台。"
   pageType="AboutPage"
   mainEntityId={organizationId(siteUrl)}

--- a/apps/website/src/pages/zh-CN/careers.astro
+++ b/apps/website/src/pages/zh-CN/careers.astro
@@ -42,7 +42,7 @@ const roles = itemListNode(
 ---
 
 <BaseLayout
-  title="招聘 — Comfy"
+  title="招聘 - Comfy"
   description="加入构建生成式 AI 操作系统的团队。工程、设计、市场营销等岗位开放招聘中。"
   pageType="CollectionPage"
   mainEntityId={jsonLdId(url, 'itemlist')}

--- a/apps/website/src/pages/zh-CN/case-studies.astro
+++ b/apps/website/src/pages/zh-CN/case-studies.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 import ComingSoon from '../../components/common/ComingSoon.astro'
 ---
 
-<BaseLayout title="案例研究 — Comfy">
+<BaseLayout title="案例研究 - Comfy">
   <ComingSoon />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/cloud/index.astro
+++ b/apps/website/src/pages/zh-CN/cloud/index.astro
@@ -11,7 +11,7 @@ import { t } from '../../../i18n/translations'
 ---
 
 <BaseLayout
-  title="Comfy Cloud — 云端 AI"
+  title="Comfy Cloud - 云端 AI"
   description={t('cloud.hero.subtitle', 'zh-CN')}
   keywords={['comfyui web app', 'comfyui app', 'comfyui online', 'comfyui cloud', 'ComfyUI 网页版', 'ComfyUI 云端', 'ComfyUI 应用', 'Comfy Cloud', '云端 ComfyUI']}
 >

--- a/apps/website/src/pages/zh-CN/cloud/pricing.astro
+++ b/apps/website/src/pages/zh-CN/cloud/pricing.astro
@@ -20,7 +20,7 @@ const productId = jsonLdId(url, 'product')
 ---
 
 <BaseLayout
-  title="定价 — Comfy Cloud"
+  title="定价 - Comfy Cloud"
   mainEntityId={productId}
   breadcrumbs={[
     {

--- a/apps/website/src/pages/zh-CN/contact.astro
+++ b/apps/website/src/pages/zh-CN/contact.astro
@@ -13,7 +13,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="联系我们 — Comfy"
+  title="联系我们 - Comfy"
   pageType="ContactPage"
   mainEntityId={organizationId(siteUrl)}
   breadcrumbs={[

--- a/apps/website/src/pages/zh-CN/customers.astro
+++ b/apps/website/src/pages/zh-CN/customers.astro
@@ -11,7 +11,7 @@ import { loadStories } from '../../utils/loadStories'
 const stories = (await loadStories('zh-CN')).map(toCardProps)
 ---
 
-<BaseLayout title="客户故事 — Comfy">
+<BaseLayout title="客户故事 - Comfy">
   <HeroSection locale="zh-CN" client:load />
   <StorySection stories={stories} locale="zh-CN" />
   <FeedbackSection locale="zh-CN" client:load />

--- a/apps/website/src/pages/zh-CN/customers/[slug].astro
+++ b/apps/website/src/pages/zh-CN/customers/[slug].astro
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 const { entry, next } = Astro.props
 ---
 
-<BaseLayout title={`${entry.data.title} — Comfy`}>
+<BaseLayout title={`${entry.data.title} - Comfy`}>
   <DetailHeroSection
     label={entry.data.category}
     title={entry.data.title}

--- a/apps/website/src/pages/zh-CN/demos/[slug].astro
+++ b/apps/website/src/pages/zh-CN/demos/[slug].astro
@@ -58,7 +58,7 @@ const learningResource: JsonLdNode = {
 ---
 
 <BaseLayout
-  title={`${title} — Comfy`}
+  title={`${title} - Comfy`}
   description={description}
   ogImage={demo.ogImage}
   mainEntityId={learningId}

--- a/apps/website/src/pages/zh-CN/demos/index.astro
+++ b/apps/website/src/pages/zh-CN/demos/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro'
 import { t } from '../../../i18n/translations'
 ---
 
-<BaseLayout title="演示 — Comfy" description="ComfyUI 的互动演示和教程。">
+<BaseLayout title="演示 - Comfy" description="ComfyUI 的互动演示和教程。">
   <section class="flex min-h-[60vh] items-center justify-center px-6">
     <div class="text-center">
       <h1 class="text-primary-comfy-canvas text-4xl font-light">

--- a/apps/website/src/pages/zh-CN/download.astro
+++ b/apps/website/src/pages/zh-CN/download.astro
@@ -23,7 +23,7 @@ const { siteUrl, locale } = pageContext(
 ---
 
 <BaseLayout
-  title="下载 Comfy 桌面版 — 在您的硬件上运行 AI"
+  title="下载 Comfy 桌面版 - 在您的硬件上运行 AI"
   description={t('download.hero.subtitle', 'zh-CN')}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   breadcrumbs={[

--- a/apps/website/src/pages/zh-CN/gallery.astro
+++ b/apps/website/src/pages/zh-CN/gallery.astro
@@ -5,7 +5,7 @@ import GallerySection from '../../components/gallery/GallerySection.vue'
 import ContactSection from '../../components/gallery/ContactSection.vue'
 ---
 
-<BaseLayout title="作品集 — Comfy">
+<BaseLayout title="作品集 - Comfy">
   <HeroSection locale="zh-CN" />
   <GallerySection locale="zh-CN" client:load />
   <ContactSection locale="zh-CN" />

--- a/apps/website/src/pages/zh-CN/index.astro
+++ b/apps/website/src/pages/zh-CN/index.astro
@@ -24,7 +24,7 @@ const { siteUrl } = pageContext(
 ---
 
 <BaseLayout
-  title="Comfy — 视觉 AI 的最强可控性"
+  title="Comfy - 视觉 AI 的最强可控性"
   description={t('hero.subtitle', 'zh-CN')}
   mainEntityId={comfyUiSoftwareId(siteUrl)}
   extraJsonLd={[comfyUiApplicationNode(siteUrl), comfyUiSourceCodeNode(siteUrl)]}

--- a/apps/website/src/pages/zh-CN/learning.astro
+++ b/apps/website/src/pages/zh-CN/learning.astro
@@ -11,7 +11,7 @@ import { learningEvents } from '../../data/events'
 const routes = getRoutes('zh-CN')
 ---
 
-<BaseLayout title="学习 — Comfy">
+<BaseLayout title="学习 - Comfy">
   <HeroSection locale="zh-CN" client:load />
   <FeaturedWorkflowSection locale="zh-CN" client:visible />
   <TutorialsSection locale="zh-CN" client:visible />

--- a/apps/website/src/pages/zh-CN/models.astro
+++ b/apps/website/src/pages/zh-CN/models.astro
@@ -7,7 +7,7 @@ import ProductShowcaseSection from '../../components/home/ProductShowcaseSection
 ---
 
 <BaseLayout
-  title="模型 — Comfy"
+  title="模型 - Comfy"
   description="在 ComfyUI 中运行世界领先的 AI 模型。浏览所有支持的模型及社区工作流模板。"
 >
   <ModelsHeroSection

--- a/apps/website/src/pages/zh-CN/payment/failed.astro
+++ b/apps/website/src/pages/zh-CN/payment/failed.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../../../layouts/BaseLayout.astro'
 import PaymentStatusSection from '../../../components/payment/PaymentStatusSection.vue'
 ---
 
-<BaseLayout title="支付失败 — Comfy" description="您的支付未能完成。" noindex>
+<BaseLayout title="支付失败 - Comfy" description="您的支付未能完成。" noindex>
   <PaymentStatusSection status="failed" locale="zh-CN" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/success.astro
+++ b/apps/website/src/pages/zh-CN/payment/success.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../../../layouts/BaseLayout.astro'
 import PaymentStatusSection from '../../../components/payment/PaymentStatusSection.vue'
 ---
 
-<BaseLayout title="支付成功 — Comfy" description="您的支付已成功完成。" noindex>
+<BaseLayout title="支付成功 - Comfy" description="您的支付已成功完成。" noindex>
   <PaymentStatusSection status="success" locale="zh-CN" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/privacy-policy.astro
+++ b/apps/website/src/pages/zh-CN/privacy-policy.astro
@@ -5,7 +5,7 @@ import HeroSection from '../../components/legal/HeroSection.vue'
 ---
 
 <BaseLayout
-  title="隐私政策 — Comfy"
+  title="隐私政策 - Comfy"
   description="Comfy 隐私政策。了解我们如何收集、使用和保护您的个人信息。"
   noindex
 >

--- a/apps/website/src/pages/zh-CN/privacy/desktop.astro
+++ b/apps/website/src/pages/zh-CN/privacy/desktop.astro
@@ -5,7 +5,7 @@ import HeroSection from '../../../components/legal/HeroSection.vue'
 ---
 
 <BaseLayout
-  title="Desktop 隐私政策 — Comfy"
+  title="Desktop 隐私政策 - Comfy"
   description="Comfy Desktop 隐私政策。命名的数据处理方、GDPR/UK GDPR 下的合法依据、保留期限和您的权利。"
 >
   <HeroSection title="Desktop 隐私政策" />

--- a/apps/website/src/pages/zh-CN/videos.astro
+++ b/apps/website/src/pages/zh-CN/videos.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 import ComingSoon from '../../components/common/ComingSoon.astro'
 ---
 
-<BaseLayout title="视频 — Comfy">
+<BaseLayout title="视频 - Comfy">
   <ComingSoon />
 </BaseLayout>


### PR DESCRIPTION
## Summary

Switch the meta title separator sitewide from an em dash (—) to a spaced hyphen ( - ), the follow-up to #13480 tracked as FE-1233, based on the Screaming Frog crawl that flagged the em dash titles.

## Changes

- **What**: Replaced the em dash separator with a hyphen in every page meta title, in both `en` and `zh-CN`. Covers ~44 inline page titles, the shared title keys in `i18n/translations.ts` (`cloudNodes.meta.title`, `mcp.meta.title`, `affiliate-terms.page.title`, `enterprise-msa.page.title`, `affiliate.page.title`, `launches.page.title`), and the dynamic `customers`, `demos`, and `supported-models` `... - Comfy` suffixes. `BaseLayout` reuses each page title for `og:title`, `twitter:title`, and the JSON-LD `name`, so those inherit the change from a single source per page.
- Updated the e2e title assertions to match. `launches` asserts via `t()` so it follows the translation change automatically.

## Review Focus

- **Scope is titles only.** The crawl and this ticket are about meta titles. Description / body copy em dashes are left untouched, they are marketing copy, which we keep em-dashed per the comms-only styling decision. A full JSON-LD audit across all 57 routes confirms every `name`/title field is now em-dash-free.
- **zh-CN cloud-nodes title keeps its Chinese double dash `——`** (`自定义节点包合集——开箱即用`). That is correct CJK punctuation, a dash break, not a brand/Latin separator, so the Latin-script separator concern does not apply. Its e2e assertion is left as `——` to match.
- No visual change: titles are `<head>` metadata, not rendered UI, so there is nothing to screenshot on the page. Rendered `<title>` output was verified on the dev server across inline, `t()`-based, zh-CN, dynamic, and 404 routes, and `og:`/`twitter:` inheritance was confirmed.

Ref: FE-1233
