### PR TITLE
fix: use ComfyUI version for Cloud release notes

### DIFF
--- a/docs/adr/0012-cloud-release-notes-use-comfyui-version.md
+++ b/docs/adr/0012-cloud-release-notes-use-comfyui-version.md
@@ -1,0 +1,74 @@
+# 12. Cloud Release Notes Use the ComfyUI Version
+
+Date: 2026-07-13
+
+## Status
+
+Accepted
+
+<!-- [Proposed | Accepted | Rejected | Deprecated | Superseded by [ADR-NNNN](NNNN-title.md)] -->
+
+## Context
+
+The release-note system (`releaseStore`) decides whether to surface new-release
+UI — the desktop toast/red-dot and the "what's new" popup — by comparing the
+version of the most recent entry in the `/releases` feed against the version the
+user is currently running.
+
+`currentVersion` sourced that "current version" differently per platform:
+
+- on Cloud, from `system_stats.system.cloud_version`,
+- everywhere else, from `system_stats.system.comfyui_version`.
+
+The `/releases` feed, however, is authored in the docs repo and its entries are
+keyed by **ComfyUI** version for every project, including `project: 'cloud'`.
+There is no separate cloud-versioned feed, and the "learn more" link on every
+release note points at <https://docs.comfy.org/changelog>, which only lists
+ComfyUI versions.
+
+This mismatch broke the feature on Cloud (tracked as **FE-1237**):
+
+- Cloud runs a much higher `cloud_version` (e.g. `0.160.1`) than the ComfyUI
+  version the feed entries carry (e.g. `0.27.1`).
+- The comparison therefore resolved as `0.27.1 < 0.160.1` → "already ahead of
+  the latest release" → the popup's `isLatestVersion` gate never passed and the
+  popup never showed.
+- Analytics confirmed the regression: `release_note` clicks fell from 13.4% of
+  clicks over 90 days to 0% over 30 days, and `cloud_release_note` was
+  effectively never clicked.
+
+Two directions could fix the mismatch:
+
+1. Give Cloud its own cloud-versioned release feed and a cloud changelog page.
+2. Compare against the ComfyUI version on Cloud too, so the running version and
+   the feed entries share the same version namespace.
+
+Option 1 requires infrastructure that does not exist: no cloud changelog page,
+and in current practice a single person maintains the changelog in the docs
+repo using ComfyUI versions, updated after each Cloud deploy completes. A
+cloud-versioned popup would deep-link users to a changelog page that has no
+matching entry, which is more confusing than the version label itself.
+
+## Decision
+
+`currentVersion` always uses `comfyui_version`, on Cloud as well as everywhere
+else. `cloud_version` is no longer consulted for release-note version
+comparisons.
+
+The `/releases` request still sends `project: 'cloud'` on Cloud, so Cloud can
+receive a curated subset of release notes; only the version used for comparison
+changes.
+
+## Consequences
+
+- Cloud shows a release note once the running ComfyUI version matches the latest
+  published feed entry — consistent with the practice of updating the changelog
+  after a Cloud deploy lands. Publishing a note for a version Cloud has not yet
+  deployed correctly withholds the popup until the deploy catches up.
+- The popup and its "learn more" link now reference a ComfyUI version that
+  actually exists on the changelog page.
+- `cloud_version` remains available in `system_stats` for other consumers; this
+  decision scopes only to release-note version comparison.
+- If Cloud later wants release notes tied to its own versioning, it would need a
+  cloud-versioned feed **and** a cloud changelog page, at which point this ADR
+  should be revisited.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [0009](0009-subgraph-promoted-widgets-use-linked-inputs.md) | Subgraph Promoted Widgets Use Linked Inputs | Proposed | 2026-05-05 |
 | [0010](0010-remove-nx-orchestration.md)                     | Remove Nx Orchestration                     | Accepted | 2026-05-19 |
 | [0011](0011-derived-credential-lifecycle.md)                | Derived Credential Lifecycle for Cloud Auth | Proposed | 2026-07-09 |
+| [0012](0012-cloud-release-notes-use-comfyui-version.md)     | Cloud Release Notes Use the ComfyUI Version | Accepted | 2026-07-13 |
 
 ## Creating a New ADR
 

--- a/src/platform/updates/common/releaseStore.test.ts
+++ b/src/platform/updates/common/releaseStore.test.ts
@@ -18,13 +18,15 @@ vi.mock('semver', () => ({
   valid: vi.fn(() => '1.0.0')
 }))
 
-const mockData = vi.hoisted(() => ({ isDesktop: true }))
+const mockData = vi.hoisted(() => ({ isDesktop: true, isCloud: false }))
 
 vi.mock('@/platform/distribution/types', () => ({
   get isDesktop() {
     return mockData.isDesktop
   },
-  isCloud: false
+  get isCloud() {
+    return mockData.isCloud
+  }
 }))
 
 vi.mock('@/platform/updates/common/releaseService', () => {
@@ -115,6 +117,7 @@ describe('useReleaseStore', () => {
 
     vi.resetAllMocks()
     mockSystemStatsState.reset()
+    mockData.isCloud = false
   })
 
   describe('initial state', () => {
@@ -678,6 +681,33 @@ describe('useReleaseStore', () => {
 
       // Should only call API once due to loading check
       expect(releaseService.getReleases).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('isCloud environment (FE-1237)', () => {
+    beforeEach(() => {
+      mockData.isCloud = true
+    })
+
+    it('should use comfyui_version, not cloud_version, as the current version', async () => {
+      const store = useReleaseStore()
+      const releaseService = useReleaseService()
+      const systemStatsStore = useSystemStatsStore()
+      systemStatsStore.systemStats!.system.comfyui_version = '0.27.1'
+      systemStatsStore.systemStats!.system.cloud_version = '0.160.1'
+      vi.mocked(releaseService.getReleases).mockResolvedValue([mockRelease])
+
+      await store.initialize()
+
+      expect(releaseService.getReleases).toHaveBeenCalledWith(
+        {
+          project: 'cloud',
+          current_version: '0.27.1',
+          form_factor: 'git-windows',
+          locale: 'en'
+        },
+        { deployEnvironment: undefined }
+      )
     })
   })
 

--- a/src/platform/updates/common/releaseStore.ts
+++ b/src/platform/updates/common/releaseStore.ts
@@ -23,12 +23,9 @@ export const useReleaseStore = defineStore('release', () => {
   const systemStatsStore = useSystemStatsStore()
   const settingStore = useSettingStore()
 
-  const currentVersion = computed(() => {
-    if (isCloud) {
-      return systemStatsStore?.systemStats?.system?.cloud_version ?? ''
-    }
-    return systemStatsStore?.systemStats?.system?.comfyui_version ?? ''
-  })
+  const currentVersion = computed(
+    () => systemStatsStore?.systemStats?.system?.comfyui_version ?? ''
+  )
 
   // Release data from settings
   const locale = computed(() => settingStore.get('Comfy.Locale'))


### PR DESCRIPTION
## Summary

On Cloud, `releaseStore.currentVersion` sourced `cloud_version` (e.g. `0.160.1`) while the `/releases` feed keys its entries by **ComfyUI** version (e.g. `0.27.1`). The what's-new popup compares the latest feed entry against the running version, so `0.27.1 < 0.160.1` read as "already ahead of the latest release" and the popup never showed.

- Analytics confirmed the regression: `release_note` clicks fell from **13.4% (90d) → 0% (30d)**; `cloud_release_note` was effectively never clicked.

## Change

- `currentVersion` always uses `comfyui_version` (drops the `isCloud → cloud_version` branch). The feed request keeps `project: 'cloud'`.
- Rationale: the changelog page and each note's "learn more" link are ComfyUI-versioned, and Cloud has no separate versioned feed or changelog page. The changelog is maintained with ComfyUI versions, updated after each Cloud deploy lands.

## Tests

- Adds a regression test (`isCloud environment (FE-1237)`) pinning that Cloud uses `comfyui_version`, not `cloud_version`. Verified via negative control: reverting the fix fails it with `0.160.1` vs expected `0.27.1`.
- `test:unit` (releaseStore): 49 passed · `typecheck`, `lint`, `format:check`, `knip`: clean.

## ADR

Adds `docs/adr/0012-cloud-release-notes-use-comfyui-version.md` (Accepted) recording the rationale and history, and updates the ADR index.

Fixes FE-1237

🤖 Generated with [Claude Code](https://claude.com/claude-code)