### PR TITLE
test: run Chromium E2E with four workers

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -93,7 +93,7 @@ jobs:
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright
-        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
+        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=4 --reporter=blob
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
           COLLECT_COVERAGE: 'true'


### PR DESCRIPTION
## Summary

Run each Chromium E2E shard with four Playwright workers to reduce PR validation time without increasing GitHub runner-job count.

## Changes

- **What**: Add `--workers=4` to the sharded Chromium Playwright command.

## Review Focus

- Watch the first CI runs for duration, CPU contention, and flakiness.

## Validation

- CodeRabbit pre-commit review: no findings
- YAML parse
- `pnpm typecheck` (Node 25)

Created by Codex