### PR TITLE
fix(website): remove opacity-80 washing out footer logo colors

### DIFF
--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -175,10 +175,7 @@ const contactColumn: { title: string; links: FooterLink[] } = {
       </div>
 
       <!-- Logo -->
-      <canvas
-        ref="canvasRef"
-        class="pointer-events-none size-52 opacity-80 lg:mt-28"
-      />
+      <canvas ref="canvasRef" class="pointer-events-none size-52 lg:mt-28" />
     </div>
   </footer>
 </template>


### PR DESCRIPTION
## Problem
The animated logo in the site footer (a webp frame sequence drawn to a `<canvas>`) renders with dull, darkened colors. The brand neon yellow `rgb(242, 255, 90)` shows up as a muddy olive `≈ rgb(198, 209, 80)`, and the gray/pastel faces are darkened and purple-tinted.

## Cause
The footer `<canvas>` carried an `opacity-80` Tailwind class. At 80% opacity the browser composites the animation 20% over the dark purple footer background (`rgb(33, 25, 39)`), shifting every color. The source webp frames themselves are correct — the shift only happens at display time.

## Fix
Remove `opacity-80` from the canvas in `SiteFooter.vue` so it renders the authored frame colors at full opacity.

## Verify
- Pre-check (no deploy): in DevTools, select the footer `<canvas>` and untick `opacity: 0.8` — colors pop back immediately.
- After change: sample a yellow cube face in the footer animation with a color picker — it should read `#F2FF5A` / `rgb(242, 255, 90)`, not `rgb(198, 209, 80)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)