### PR TITLE
perf: shard Chromium E2E across 16 jobs

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -93,7 +93,7 @@ jobs:
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright
-        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
+        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
           COLLECT_COVERAGE: 'true'
@@ -150,7 +150,7 @@ jobs:
       # Run tests (browsers pre-installed in container)
       - name: Run Playwright tests (${{ matrix.browser }})
         id: playwright
-        run: pnpm exec playwright test --project=${{ matrix.browser }} --reporter=blob
+        run: pnpm exec playwright test --project=${{ matrix.browser }}
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
 

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -93,7 +93,7 @@ jobs:
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright
-        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=2 --reporter=blob
+        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
           COLLECT_COVERAGE: 'true'

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -73,8 +73,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shardTotal: [16]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -93,7 +93,7 @@ jobs:
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright
-        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
+        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=2 --reporter=blob
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
           COLLECT_COVERAGE: 'true'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ const maybeLocalOptions: PlaywrightTestConfig = process.env.PLAYWRIGHT_LOCAL
     }
   : {
       retries: process.env.CI ? 3 : 0,
+      workers: process.env.CI ? 2 : undefined,
       use: {
         trace: 'on-first-retry'
       }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   testDir: './browser_tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  reporter: 'html',
+  reporter: process.env.PLAYWRIGHT_BLOB_OUTPUT_DIR ? 'blob' : 'html',
   ...maybeLocalOptions,
 
   globalSetup: './browser_tests/globalSetup.ts',


### PR DESCRIPTION
## Summary

> [!NOTE]
> Bumping to [24 shards](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13664) reduces time from 11m14s to 9m31s, but costs 15% more in GitHub Action runner time. Keep it 16 for now to be conservative and bump to 24 if it works well for a week

Split Chromium E2E into 16 shards with two Playwright workers each, preserving the current per-runner worker density while doubling effective concurrency.

### 16 shards
| Run | E2E time | Shards |
|---|---:|---:|
| [1](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29370163062) | 11m38s | 16/16 pass |
| [2](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29371313957) | 11m32s | 16/16 pass |
| [3](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29372283949) | 10m50s | 16/16 pass |
| [4](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29373163198) | 11m00s | 16/16 pass |
| [5](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29374055787) | 11m12s | 16/16 pass |

### 24 shards
| Run | E2E time | Shards |
|---|---:|---:|
| [1](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29379798083) | 9m13s | 24/24 pass |
| [2](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29380286857) | 9m33s | 24/24 pass |
| [3](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29380761689) | 9m38s | 24/24 pass |
| [4](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29381219308) | 10m02s | 24/24 pass |
| [5](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29381669526) | 9m07s | 24/24 pass |

## Changes

- **What**: Run Chromium as 16 shards with explicit `--workers=2`.

## Review Focus

- Compare full E2E time, shard skew, runner queue time, and flakiness with the 8×2 baseline.

## Validation

- YAML parse and oxfmt check
- Pre-commit formatting, linting, and root typecheck
- Pre-push Knip
- Local CodeRabbit review is rate-limited for 24 minutes; server-side CodeRabbit remains pending.

Created by Codex


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and Playwright config; no application runtime, auth, or data paths are touched.
> 
> **Overview**
> **Chromium E2E CI** now runs as **16 parallel shards** (up from 8), with **`workers: 2` on CI** in `playwright.config.ts` so each runner keeps two Playwright workers while overall concurrency doubles.
> 
> Reporter wiring shifts so **blob output is chosen in config** when `PLAYWRIGHT_BLOB_OUTPUT_DIR` is set (default reporter is `html` otherwise); workflow steps drop inline `--reporter=blob` from the Playwright CLI for both sharded Chromium and the other browser matrix jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3707e70611fd5ce07e1204a37e08799e9a45b8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->