### PR TITLE
feat(workspace): add per-member credit limits

### DIFF
--- a/src/components/common/DropdownItem.vue
+++ b/src/components/common/DropdownItem.vue
@@ -10,6 +10,7 @@ import {
 } from 'reka-ui'
 import { useI18n } from 'vue-i18n'
 import { toValue } from 'vue'
+import type { StyleValue } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -19,7 +20,12 @@ defineOptions({
   inheritAttrs: false
 })
 
-defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
+defineProps<{
+  itemClass: string
+  contentClass: string
+  contentStyle?: StyleValue
+  item: MenuItem
+}>()
 </script>
 <template>
   <DropdownMenuSeparator
@@ -37,7 +43,9 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
     <DropdownMenuPortal>
       <DropdownMenuSubContent
         :class="contentClass"
-        :side-offset="2"
+        :style="contentStyle"
+        :aria-label="toValue(item.label)"
+        :side-offset="12"
         :align-offset="-5"
       >
         <DropdownItem
@@ -46,6 +54,7 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
           :item="subitem"
           :item-class
           :content-class
+          :content-style
         />
       </DropdownMenuSubContent>
     </DropdownMenuPortal>

--- a/src/components/common/DropdownMenu.vue
+++ b/src/components/common/DropdownMenu.vue
@@ -87,6 +87,7 @@ const contentStyle = computed(() => {
             :key="toValue(item.label) ?? index"
             :item-class
             :content-class
+            :content-style
             :item
           />
         </slot>

--- a/src/components/common/DropdownMenu.zindex.test.ts
+++ b/src/components/common/DropdownMenu.zindex.test.ts
@@ -1,7 +1,8 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import type { MenuItem } from 'primevue/menuitem'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
@@ -14,9 +15,9 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function renderMenu() {
+function renderMenu(entries: MenuItem[] = [{ label: 'Item A' }], modal = true) {
   return render(DropdownMenu, {
-    props: { entries: [{ label: 'Item A' }] },
+    props: { entries, modal },
     global: { plugins: [i18n], directives: { tooltip: {} } }
   })
 }
@@ -52,5 +53,34 @@ describe('DropdownMenu z-index', () => {
     const menu = await screen.findByRole('menu')
     expect(menu.style.zIndex).toBe('')
     expect(menu.className).toContain('z-1700')
+  })
+
+  it('shows submenu items above an open dialog when clicked', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    const dialogZ = Number(openModal.style.zIndex)
+    const command = vi.fn()
+    const user = userEvent.setup()
+    renderMenu(
+      [
+        {
+          label: 'Change role',
+          items: [
+            { label: 'Admin', command },
+            { label: 'Member', command }
+          ]
+        }
+      ],
+      false
+    )
+
+    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByText('Change role'))
+
+    expect(screen.getByText('Admin')).toBeVisible()
+    expect(screen.getByText('Member')).toBeVisible()
+    expect(
+      Number(screen.getByRole('menu', { name: 'Change role' }).style.zIndex)
+    ).toBeGreaterThan(dialogZ)
   })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2925,7 +2925,17 @@
         "resendInvite": "Resend invite",
         "cancelInvite": "Cancel invite",
         "changeRole": "Change role",
+        "setCreditLimit": "Set credit limit",
         "removeMember": "Remove member"
+      },
+      "creditLimitDialog": {
+        "title": "Set a monthly credit limit for {name}",
+        "description": "Once they reach this limit, they’ll be unable to run workflows.",
+        "limitOption": "Limit monthly credit usage to:",
+        "noLimit": "No limit",
+        "warning": "This user has already spent {credits} credits. Setting this cap will prevent further runs until next month.",
+        "invalidLimit": "Enter a credit limit greater than zero.",
+        "update": "Update limit"
       },
       "upsellBanner": "To add teammates, upgrade your plan.",
       "upsellBannerReactivate": "To add more teammates, reactivate your plan.",

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -42,6 +42,7 @@ export interface Member {
   // does not carry these fields yet.
   last_active_at?: string | null
   credits_used_this_month?: number
+  monthly_credit_limit?: number | null
 }
 
 interface PaginationInfo {

--- a/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.test.ts
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SetMemberCreditLimitDialogContent from './SetMemberCreditLimitDialogContent.vue'
+
+const { mockSetMemberCreditLimit, mockCloseDialog } = vi.hoisted(() => ({
+  mockSetMemberCreditLimit: vi.fn(),
+  mockCloseDialog: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    setMemberCreditLimit: mockSetMemberCreditLimit
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ closeDialog: mockCloseDialog })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { close: 'Close', cancel: 'Cancel' },
+      workspacePanel: {
+        members: {
+          creditLimitDialog: {
+            title: 'Set a monthly credit limit for {name}',
+            description: 'Description',
+            limitOption: 'Limit monthly credit usage to:',
+            noLimit: 'No limit',
+            warning: 'Already spent {credits}',
+            invalidLimit: 'Invalid limit',
+            update: 'Update limit'
+          }
+        }
+      }
+    }
+  }
+})
+
+function renderDialog(currentLimit: number | null = 3000) {
+  const user = userEvent.setup()
+  const result = render(SetMemberCreditLimitDialogContent, {
+    props: {
+      memberId: 'mem-1',
+      memberName: 'Jane',
+      creditsUsed: 645,
+      currentLimit
+    },
+    global: { plugins: [i18n] }
+  })
+  return { ...result, user }
+}
+
+describe('SetMemberCreditLimitDialogContent', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('updates an existing limit', async () => {
+    const { user } = renderDialog()
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAccessibleName('Limit monthly credit usage to:')
+    await user.clear(input)
+    await user.type(input, '2500')
+    await user.click(screen.getByRole('button', { name: 'Update limit' }))
+
+    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', 2500)
+    expect(mockCloseDialog).toHaveBeenCalledWith({
+      key: 'set-member-credit-limit'
+    })
+  })
+
+  it('removes a limit', async () => {
+    const { user } = renderDialog()
+    await user.click(screen.getByRole('radio', { name: 'No limit' }))
+    await user.click(screen.getByRole('button', { name: 'Update limit' }))
+    expect(mockSetMemberCreditLimit).toHaveBeenCalledWith('mem-1', null)
+  })
+
+  it('supports keyboard navigation between limit modes', async () => {
+    const { user } = renderDialog()
+    const limitedRadio = screen.getByRole('radio', {
+      name: 'Limit monthly credit usage to:'
+    })
+    await user.click(limitedRadio)
+    await user.keyboard('{ArrowDown}')
+
+    expect(screen.getByRole('radio', { name: 'No limit' })).toBeChecked()
+  })
+
+  it('warns when the new limit equals current usage', async () => {
+    const { user } = renderDialog()
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, '645')
+    expect(screen.getByText('Already spent 645')).toBeInTheDocument()
+  })
+
+  it('rejects limits beyond the safe whole-number range', async () => {
+    const { user } = renderDialog(null)
+    const input = screen.getByRole('textbox')
+    await user.type(input, '9007199254740992')
+
+    expect(input).toHaveValue('9007199254740992')
+    expect(screen.getByRole('button', { name: 'Update limit' })).toBeDisabled()
+    expect(screen.getByText('Invalid limit')).toBeInTheDocument()
+  })
+})

--- a/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.vue
@@ -1,0 +1,172 @@
+<template>
+  <div
+    class="flex w-lg max-w-full flex-col rounded-2xl border border-border-default bg-base-background"
+  >
+    <div
+      class="flex h-12 items-center justify-between border-b border-border-default px-4"
+    >
+      <h2 class="m-0 text-sm font-normal text-base-foreground">
+        {{
+          $t('workspacePanel.members.creditLimitDialog.title', {
+            name: memberName
+          })
+        }}
+      </h2>
+      <button
+        class="cursor-pointer rounded-sm border-none bg-transparent p-1 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:ring-border-default focus-visible:outline-none"
+        :aria-label="$t('g.close')"
+        @click="onClose"
+      >
+        <i class="pi pi-times size-4" />
+      </button>
+    </div>
+
+    <div class="flex flex-col gap-6 p-4">
+      <p class="m-0 text-sm text-muted-foreground">
+        {{ $t('workspacePanel.members.creditLimitDialog.description') }}
+      </p>
+      <div class="flex flex-col gap-2">
+        <div
+          class="flex cursor-pointer items-start gap-2 rounded-lg p-2 text-sm text-muted-foreground transition-colors hover:bg-secondary-background-hover/30"
+          @click="mode = 'limited'"
+        >
+          <input
+            :id="`${modeGroupName}-limited`"
+            v-model="mode"
+            type="radio"
+            :name="modeGroupName"
+            value="limited"
+            class="mt-0.5 size-4 appearance-none rounded-full border border-muted-background checked:border-3 checked:bg-white focus-visible:ring-2 focus-visible:ring-border-default focus-visible:outline-none"
+          />
+          <span class="flex flex-1 flex-col gap-2">
+            <label :for="`${modeGroupName}-limited`" class="cursor-pointer">
+              {{ $t('workspacePanel.members.creditLimitDialog.limitOption') }}
+            </label>
+            <span
+              class="flex h-10 items-center gap-2 rounded-lg bg-secondary-background px-4"
+            >
+              <i class="icon-[lucide--coins] size-4 shrink-0 text-credit" />
+              <input
+                v-model="limitModel"
+                inputmode="numeric"
+                :aria-label="
+                  $t('workspacePanel.members.creditLimitDialog.limitOption')
+                "
+                class="w-full border-none bg-transparent text-sm text-base-foreground tabular-nums outline-none"
+                @focus="mode = 'limited'"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          class="flex cursor-pointer items-center gap-2 rounded-lg p-2 text-sm text-muted-foreground transition-colors hover:bg-secondary-background-hover/30"
+          @click="mode = 'unlimited'"
+        >
+          <input
+            :id="`${modeGroupName}-unlimited`"
+            v-model="mode"
+            type="radio"
+            :name="modeGroupName"
+            value="unlimited"
+            class="size-4 appearance-none rounded-full border border-muted-background checked:border-3 checked:bg-white focus-visible:ring-2 focus-visible:ring-border-default focus-visible:outline-none"
+          />
+          <label :for="`${modeGroupName}-unlimited`" class="cursor-pointer">
+            {{ $t('workspacePanel.members.creditLimitDialog.noLimit') }}
+          </label>
+        </div>
+      </div>
+      <p v-if="showWarning" class="m-0 flex gap-1 text-sm text-credit">
+        <i class="mt-0.5 icon-[lucide--triangle-alert] size-4 shrink-0" />
+        {{
+          $t('workspacePanel.members.creditLimitDialog.warning', {
+            credits: creditsUsed.toLocaleString()
+          })
+        }}
+      </p>
+      <p v-if="showError" class="m-0 text-sm text-destructive-background">
+        {{ $t('workspacePanel.members.creditLimitDialog.invalidLimit') }}
+      </p>
+    </div>
+
+    <div class="flex items-center justify-end gap-4 p-4">
+      <Button variant="muted-textonly" @click="onClose">{{
+        $t('g.cancel')
+      }}</Button>
+      <Button
+        variant="secondary"
+        size="lg"
+        :disabled="!canUpdate"
+        @click="onUpdate"
+      >
+        {{ $t('workspacePanel.members.creditLimitDialog.update') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue'
+
+import Button from '@/components/ui/button/Button.vue'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const { memberId, currentLimit, creditsUsed } = defineProps<{
+  memberId: string
+  memberName: string
+  creditsUsed: number
+  currentLimit: number | null
+}>()
+
+const dialogStore = useDialogStore()
+const workspaceStore = useTeamWorkspaceStore()
+const modeGroupName = useId()
+const mode = ref<'limited' | 'unlimited'>(
+  currentLimit ? 'limited' : 'unlimited'
+)
+const limitInput = ref(currentLimit?.toString() ?? '')
+const limitModel = computed({
+  get: () => {
+    if (!limitInput.value) return ''
+    const value = Number(limitInput.value)
+    return Number.isSafeInteger(value)
+      ? value.toLocaleString()
+      : limitInput.value
+  },
+  set: (value: string) => {
+    limitInput.value = value.replace(/[^0-9]/g, '')
+  }
+})
+const parsedLimit = computed(() => Number(limitInput.value))
+const hasValidLimit = computed(
+  () => Number.isSafeInteger(parsedLimit.value) && parsedLimit.value > 0
+)
+const canUpdate = computed(
+  () => mode.value === 'unlimited' || hasValidLimit.value
+)
+const showError = computed(
+  () =>
+    mode.value === 'limited' &&
+    limitInput.value.length > 0 &&
+    !hasValidLimit.value
+)
+const showWarning = computed(
+  () =>
+    mode.value === 'limited' &&
+    hasValidLimit.value &&
+    parsedLimit.value <= creditsUsed
+)
+
+function onClose() {
+  dialogStore.closeDialog({ key: 'set-member-credit-limit' })
+}
+
+function onUpdate() {
+  if (!canUpdate.value) return
+  workspaceStore.setMemberCreditLimit(
+    memberId,
+    mode.value === 'limited' ? parsedLimit.value : null
+  )
+  onClose()
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/MemberTableRow.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberTableRow.vue
@@ -34,18 +34,27 @@
     <TableCell v-if="canManageMembers" class="text-sm text-muted-foreground">
       {{ lastActivityLabel }}
     </TableCell>
-    <TableCell
-      v-if="canManageMembers"
-      class="text-right text-sm text-muted-foreground tabular-nums"
-    >
-      {{ creditsLabel }}
+    <TableCell v-if="canManageMembers" class="text-sm tabular-nums">
+      <div v-if="member.monthlyCreditLimit" class="flex flex-col gap-1">
+        <span class="text-base-foreground">{{ creditsLabel }}</span>
+        <div
+          class="h-1 overflow-hidden rounded-full bg-secondary-background-hover"
+        >
+          <div
+            class="h-full rounded-full bg-credit"
+            :style="{ width: `${creditUsagePercent}%` }"
+          />
+        </div>
+      </div>
+      <span v-else class="text-muted-foreground">{{ creditsLabel }}</span>
     </TableCell>
     <TableCell v-if="canManageMembers" class="text-right" @click.stop>
       <DropdownMenu
         v-if="showMenu"
         :entries="menuItems"
         :modal="false"
-        content-class="min-w-44"
+        content-class="w-56 min-w-0 px-2 py-3 shadow-sm"
+        item-class="m-0 h-8 rounded-sm p-2 text-sm leading-none"
       >
         <template #button>
           <Button
@@ -96,10 +105,7 @@ const initial = computed(() =>
   (member.name || member.email).charAt(0).toUpperCase()
 )
 
-// The creator and the current user can't be managed from their own row.
-const showMenu = computed(
-  () => canManageMembers && !isCurrentUser && !isOriginalOwner
-)
+const showMenu = computed(() => canManageMembers && menuItems.length > 0)
 
 const lastActivityLabel = computed(() => {
   if (!member.lastActivity) return '—'
@@ -111,7 +117,18 @@ const lastActivityLabel = computed(() => {
   })
 })
 
-const creditsLabel = computed(() =>
-  (member.creditsUsedThisMonth ?? 0).toLocaleString()
-)
+const creditsLabel = computed(() => {
+  const used = (member.creditsUsedThisMonth ?? 0).toLocaleString()
+  return member.monthlyCreditLimit
+    ? `${used} / ${member.monthlyCreditLimit.toLocaleString()}`
+    : used
+})
+
+const creditUsagePercent = computed(() => {
+  if (!member.monthlyCreditLimit) return 0
+  return Math.min(
+    100,
+    ((member.creditsUsedThisMonth ?? 0) / member.monthlyCreditLimit) * 100
+  )
+})
 </script>

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -105,10 +105,7 @@
               class="w-64"
               :aria-sort="ariaSort('credits')"
             >
-              <button
-                :class="cn(sortHeaderClass, 'ml-auto')"
-                @click="toggleSort('credits')"
-              >
+              <button :class="sortHeaderClass" @click="toggleSort('credits')">
                 <i class="icon-[lucide--coins] size-4" />
                 {{ $t('workspacePanel.members.columns.creditsUsed') }}
                 <i :class="sortIcon('credits')" />
@@ -235,7 +232,6 @@ import MemberTableRow from '@/platform/workspace/components/dialogs/settings/Mem
 import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue'
 import PendingInviteRow from '@/platform/workspace/components/dialogs/settings/PendingInviteRow.vue'
 import { useMembersPanel } from '@/platform/workspace/composables/useMembersPanel'
-import { cn } from '@comfyorg/tailwind-utils'
 import { computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -251,6 +251,7 @@ const mockResendInvite = vi.fn()
 const mockShowRemoveMemberDialog = vi.fn()
 const mockShowRevokeInviteDialog = vi.fn()
 const mockShowChangeMemberRoleDialog = vi.fn()
+const mockShowSetMemberCreditLimitDialog = vi.fn()
 const mockShowSubscriptionDialog = vi.fn()
 const mockShowInviteMemberDialog = vi.fn()
 const mockShowInviteMemberUpsellDialog = vi.fn()
@@ -394,6 +395,7 @@ vi.mock('@/services/dialogService', () => ({
     showRemoveMemberDialog: mockShowRemoveMemberDialog,
     showRevokeInviteDialog: mockShowRevokeInviteDialog,
     showChangeMemberRoleDialog: mockShowChangeMemberRoleDialog,
+    showSetMemberCreditLimitDialog: mockShowSetMemberCreditLimitDialog,
     showInviteMemberDialog: mockShowInviteMemberDialog,
     showInviteMemberUpsellDialog: mockShowInviteMemberUpsellDialog,
     showMemberLimitDialog: mockShowMemberLimitDialog
@@ -593,6 +595,8 @@ describe('useMembersPanel', () => {
 
       expect(items.map((i) => i.label)).toEqual([
         'workspacePanel.members.actions.changeRole',
+        'workspacePanel.members.actions.setCreditLimit',
+        undefined,
         'workspacePanel.members.actions.removeMember'
       ])
 
@@ -629,7 +633,7 @@ describe('useMembersPanel', () => {
     it('routes Remove member to the remove dialog', async () => {
       const panel = await setup()
       const member = createMember({ id: 'mem-9' })
-      const removeItem = panel.memberMenuItems(member)[1]
+      const removeItem = panel.memberMenuItems(member)[3]
 
       removeItem.command?.({
         originalEvent: new Event('click'),
@@ -637,6 +641,45 @@ describe('useMembersPanel', () => {
       })
 
       expect(mockShowRemoveMemberDialog).toHaveBeenCalledWith('mem-9')
+    })
+
+    it('opens the credit-limit dialog with the member usage', async () => {
+      const panel = await setup()
+      const member = createMember({
+        id: 'mem-9',
+        name: 'Jane',
+        creditsUsedThisMonth: 645,
+        monthlyCreditLimit: 3000
+      })
+      const limitItem = panel.memberMenuItems(member)[1]
+
+      limitItem.command?.({
+        originalEvent: new Event('click'),
+        item: limitItem
+      })
+
+      expect(mockShowSetMemberCreditLimitDialog).toHaveBeenCalledWith({
+        memberId: 'mem-9',
+        memberName: 'Jane',
+        creditsUsed: 645,
+        currentLimit: 3000
+      })
+    })
+
+    it('lets the original owner manage their own credit limit only', async () => {
+      mockOriginalOwnerId.value = 'creator-1'
+      const panel = await setup()
+      const items = panel.memberMenuItems(
+        createMember({
+          id: 'creator-1',
+          email: 'owner@example.com',
+          role: 'owner'
+        })
+      )
+
+      expect(items.map((item) => item.label)).toEqual([
+        'workspacePanel.members.actions.setCreditLimit'
+      ])
     })
   })
 

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -126,6 +126,7 @@ export function useMembersPanel() {
     showRemoveMemberDialog,
     showRevokeInviteDialog,
     showChangeMemberRoleDialog,
+    showSetMemberCreditLimitDialog,
     showInviteMemberDialog,
     showInviteMemberUpsellDialog,
     showMemberLimitDialog
@@ -225,6 +226,21 @@ export function useMembersPanel() {
   }
 
   function memberMenuItems(member: WorkspaceMember): MenuItem[] {
+    const creditLimitItem: MenuItem = {
+      label: t('workspacePanel.members.actions.setCreditLimit'),
+      command: () =>
+        void showSetMemberCreditLimitDialog({
+          memberId: member.id,
+          memberName: member.name,
+          creditsUsed: member.creditsUsedThisMonth ?? 0,
+          currentLimit: member.monthlyCreditLimit ?? null
+        })
+    }
+
+    if (isCurrentUser(member) || isOriginalOwner(member)) {
+      return [creditLimitItem]
+    }
+
     return [
       {
         label: t('workspacePanel.members.actions.changeRole'),
@@ -233,6 +249,8 @@ export function useMembersPanel() {
           roleMenuItem(member, 'member', t('workspaceSwitcher.roleMember'))
         ]
       },
+      creditLimitItem,
+      { separator: true },
       {
         label: t('workspacePanel.members.actions.removeMember'),
         command: () => handleRemoveMember(member)

--- a/src/platform/workspace/dev/billingMockHarness.ts
+++ b/src/platform/workspace/dev/billingMockHarness.ts
@@ -367,7 +367,8 @@ function members(): unknown {
     role: 'owner',
     is_original_owner: true,
     last_active_at: hoursAgo(2),
-    credits_used_this_month: usage(6532)
+    credits_used_this_month: usage(546),
+    monthly_credit_limit: 3000
   }
   const selfRow =
     cfg.role === 'owner'
@@ -424,8 +425,9 @@ function members(): unknown {
     is_original_owner: false,
     last_active_at: hoursAgo([0.1, 2, 7, 23, 24, 72, 120][i % 7]),
     credits_used_this_month: usage(
-      [15, 140, 320, 1025, 2586, 88, 1740, 6][i % 7] * (i + 1)
-    )
+      i === 2 ? 5400 : [15, 140, 320, 1025, 2586, 88, 1740, 6][i % 7] * (i + 1)
+    ),
+    monthly_credit_limit: i < 3 ? [3000, 2500, 5000][i] : null
   }))
   const list = cfg.ws === 'team' ? [creator, ...selfRow, ...team] : [creator]
   return {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -25,6 +25,7 @@ export interface WorkspaceMember {
   isOriginalOwner: boolean
   lastActivity?: Date | null
   creditsUsedThisMonth?: number
+  monthlyCreditLimit?: number | null
 }
 
 export interface PendingInvite {
@@ -57,7 +58,8 @@ function mapApiMemberToWorkspaceMember(member: Member): WorkspaceMember {
     lastActivity: member.last_active_at
       ? new Date(member.last_active_at)
       : null,
-    creditsUsedThisMonth: member.credits_used_this_month ?? 0
+    creditsUsedThisMonth: member.credits_used_this_month ?? 0,
+    monthlyCreditLimit: member.monthly_credit_limit ?? null
   }
 }
 
@@ -605,6 +607,16 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     }
   }
 
+  function setMemberCreditLimit(userId: string, limit: number | null): void {
+    const current = activeWorkspace.value
+    if (!current) return
+    updateActiveWorkspace({
+      members: current.members.map((member) =>
+        member.id === userId ? { ...member, monthlyCreditLimit: limit } : member
+      )
+    })
+  }
+
   /**
    * Fetch pending invites for the current workspace.
    */
@@ -761,6 +773,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     ensureMembersLoaded,
     removeMember,
     changeMemberRole,
+    setMemberCreditLimit,
 
     // Invite Actions
     fetchPendingInvites,

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -559,6 +559,22 @@ export const useDialogService = () => {
     })
   }
 
+  async function showSetMemberCreditLimitDialog(props: {
+    memberId: string
+    memberName: string
+    creditsUsed: number
+    currentLimit: number | null
+  }) {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'set-member-credit-limit',
+      component,
+      props,
+      dialogComponentProps: workspaceDialogProps
+    })
+  }
+
   async function showInviteMemberDialog() {
     const { default: component } =
       await import('@/platform/workspace/components/dialogs/InviteMemberDialogContent.vue')
@@ -782,6 +798,7 @@ export const useDialogService = () => {
     showEditWorkspaceDialog,
     showRemoveMemberDialog,
     showChangeMemberRoleDialog,
+    showSetMemberCreditLimitDialog,
     showRevokeInviteDialog,
     showInviteMemberDialog,
     showAutoReloadDialog,


### PR DESCRIPTION
## Summary

Adds the Team Workspaces prototype for configuring a monthly credit limit per member, matching the linked Figma designs.

## Changes

- **What**: Shows member credit usage against an optional limit, adds owner/admin controls to set or remove limits, and implements role selection through the member action submenu.
- **Dependencies**: Stacked on #13487 (`comfydesigner/team-workspaces-v1`); no new package dependencies.

## Review Focus

- Prototype state is local to the existing billing mock harness because no member-limit API contract is available yet.
- Owners can configure their own limit, while role and member actions retain the existing permission rules.
- Dialog validation rejects non-positive and unsafe integer values and warns when usage has already reached the chosen limit.

## Screenshots (if applicable)

[Figma: Team Plan Workspaces](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4639-20147)
