### PR TITLE
fix(release): support manual target-branch override + major versions in resolve-comfyui-release

### DIFF
--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -23,6 +23,10 @@ on:
         required: false
         default: 'Comfy-Org/ComfyUI'
         type: string
+      target_branch:
+        description: 'Optional: force a specific release branch, e.g. core/1.47 or core/2.0. Overrides the pin-derived target — use to skip a dead minor or do an out-of-cadence / major release.'
+        required: false
+        type: string
 
 jobs:
   check-release-week:
@@ -55,6 +59,7 @@ jobs:
           echo "- Is release week: ${{ steps.check.outputs.is_release_week }}" >> $GITHUB_STEP_SUMMARY
           echo "- Manual trigger: ${{ github.event_name == 'workflow_dispatch' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Release type: ${{ inputs.release_type || 'minor (scheduled)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Target branch override: ${{ inputs.target_branch || '(none — pin-derived)' }}" >> $GITHUB_STEP_SUMMARY
 
   resolve-version:
     needs: check-release-week
@@ -103,6 +108,7 @@ jobs:
         working-directory: frontend
         env:
           RELEASE_TYPE: ${{ inputs.release_type || 'minor' }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -53,13 +53,15 @@ jobs:
           fi
 
       - name: Summary
+        env:
+          TARGET_BRANCH_OVERRIDE: ${{ inputs.target_branch }}
         run: |
           echo "## Release Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Is release week: ${{ steps.check.outputs.is_release_week }}" >> $GITHUB_STEP_SUMMARY
           echo "- Manual trigger: ${{ github.event_name == 'workflow_dispatch' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Release type: ${{ inputs.release_type || 'minor (scheduled)' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Target branch override: ${{ inputs.target_branch || '(none — pin-derived)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Target branch override: ${TARGET_BRANCH_OVERRIDE:-(none — pin-derived)}" >> $GITHUB_STEP_SUMMARY
 
   resolve-version:
     needs: check-release-week

--- a/scripts/cicd/resolve-comfyui-release.test.ts
+++ b/scripts/cicd/resolve-comfyui-release.test.ts
@@ -1,0 +1,120 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  computeTargetVersion,
+  isValidSemver,
+  parseRequirementsVersion,
+  parseTargetBranchOverride
+} from './resolve-comfyui-release'
+
+describe('parseRequirementsVersion', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-release-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  function writeRequirements(content: string): string {
+    const filePath = path.join(dir, 'requirements.txt')
+    fs.writeFileSync(filePath, content)
+    return filePath
+  }
+
+  it('parses a pinned == version', () => {
+    const file = writeRequirements(
+      'torch\ncomfyui-frontend-package==1.45.20\nnumpy'
+    )
+    expect(parseRequirementsVersion(file)).toBe('1.45.20')
+  })
+
+  it('parses a >= constraint', () => {
+    const file = writeRequirements('comfyui-frontend-package>=2.0.3')
+    expect(parseRequirementsVersion(file)).toBe('2.0.3')
+  })
+
+  it('returns null when the package is absent', () => {
+    const file = writeRequirements('torch\nnumpy')
+    expect(parseRequirementsVersion(file)).toBeNull()
+  })
+
+  it('returns null when the file is missing', () => {
+    expect(parseRequirementsVersion(path.join(dir, 'nope.txt'))).toBeNull()
+  })
+})
+
+describe('isValidSemver', () => {
+  it('accepts a valid X.Y.Z', () => {
+    expect(isValidSemver('1.45.20')).toBe(true)
+    expect(isValidSemver('2.0.0')).toBe(true)
+  })
+
+  it('rejects non-three-part versions', () => {
+    expect(isValidSemver('1.45')).toBe(false)
+    expect(isValidSemver('1.45.20.1')).toBe(false)
+  })
+
+  it('rejects non-numeric or leading-zero-padded parts', () => {
+    expect(isValidSemver('1.x.0')).toBe(false)
+    expect(isValidSemver('v1.45.20')).toBe(false)
+    expect(isValidSemver('1.045.20')).toBe(false)
+  })
+
+  it('rejects empty / non-string input', () => {
+    expect(isValidSemver('')).toBe(false)
+    // @ts-expect-error exercising runtime guard
+    expect(isValidSemver(undefined)).toBe(false)
+  })
+})
+
+describe('parseTargetBranchOverride', () => {
+  it('parses core/1.47', () => {
+    expect(parseTargetBranchOverride('core/1.47')).toEqual({
+      major: 1,
+      minor: 47,
+      branch: 'core/1.47'
+    })
+  })
+
+  it('parses a major bump core/2.0', () => {
+    expect(parseTargetBranchOverride('core/2.0')).toEqual({
+      major: 2,
+      minor: 0,
+      branch: 'core/2.0'
+    })
+  })
+
+  it('rejects malformed overrides', () => {
+    expect(parseTargetBranchOverride('core/1')).toBeNull()
+    expect(parseTargetBranchOverride('1.47')).toBeNull()
+    expect(parseTargetBranchOverride('core/1.47.0')).toBeNull()
+    expect(parseTargetBranchOverride('release/1.47')).toBeNull()
+    expect(parseTargetBranchOverride('core/v1.47')).toBeNull()
+    expect(parseTargetBranchOverride('')).toBeNull()
+  })
+})
+
+describe('computeTargetVersion', () => {
+  it('bumps patch on a 2.x line when commits exist', () => {
+    expect(computeTargetVersion(2, 0, 'v2.0.3', true)).toBe('2.0.4')
+  })
+
+  it('keeps the tag version when no new commits exist', () => {
+    expect(computeTargetVersion(2, 0, 'v2.0.3', false)).toBe('2.0.3')
+  })
+
+  it('starts a fresh major.minor line at .0 when no tag exists', () => {
+    expect(computeTargetVersion(2, 0, null, true)).toBe('2.0.0')
+    expect(computeTargetVersion(1, 47, null, true)).toBe('1.47.0')
+  })
+
+  it('returns null for a malformed tag', () => {
+    expect(computeTargetVersion(1, 47, 'v1.47', true)).toBeNull()
+  })
+})

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -81,15 +81,65 @@ function isValidSemver(version: string): boolean {
 }
 
 /**
- * Get the latest patch tag for a given minor version
+ * Parse a target branch override of the form `core/<major>.<minor>`.
+ * Returns the parsed major/minor and normalized branch, or null if malformed.
  */
-function getLatestPatchTag(repoPath: string, minor: number): string | null {
+function parseTargetBranchOverride(
+  branch: string
+): { major: number; minor: number; branch: string } | null {
+  const match = branch.match(/^core\/(\d+)\.(\d+)$/)
+  if (!match) {
+    return null
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    branch
+  }
+}
+
+/**
+ * Compute the next release version for a target major.minor line.
+ *
+ * With no prior tag, the line starts at `.0`. With a prior tag, the patch is
+ * bumped when there are pending commits, otherwise the tagged version stands.
+ * Returns null if the tag is not valid semver.
+ */
+function computeTargetVersion(
+  targetMajor: number,
+  targetMinor: number,
+  latestPatchTag: string | null,
+  hasPendingCommits: boolean
+): string | null {
+  if (!latestPatchTag) {
+    return `${targetMajor}.${targetMinor}.0`
+  }
+
+  const tagVersion = latestPatchTag.replace('v', '')
+  if (!isValidSemver(tagVersion)) {
+    return null
+  }
+
+  const existingPatch = Number(tagVersion.split('.')[2])
+  return hasPendingCommits
+    ? `${targetMajor}.${targetMinor}.${existingPatch + 1}`
+    : tagVersion
+}
+
+/**
+ * Get the latest patch tag for a given major.minor version
+ */
+function getLatestPatchTag(
+  repoPath: string,
+  major: number,
+  minor: number
+): string | null {
   // Fetch all tags
   exec('git fetch --tags', repoPath)
 
   // Use git's native version sorting to get the latest tag
   const latestTag = exec(
-    `git tag -l 'v1.${minor}.*' --sort=-version:refname | head -n 1`,
+    `git tag -l 'v${major}.${minor}.*' --sort=-version:refname | head -n 1`,
     repoPath
   )
 
@@ -101,7 +151,7 @@ function getLatestPatchTag(repoPath: string, minor: number): string | null {
   const validTagRegex = /^v\d+\.\d+\.\d+$/
   if (!validTagRegex.test(latestTag)) {
     console.error(
-      `Latest tag for minor version ${minor} is not valid semver: ${latestTag}`
+      `Latest tag for version ${major}.${minor} is not valid semver: ${latestTag}`
     )
     return null
   }
@@ -132,29 +182,32 @@ function resolveRelease(
     return null
   }
 
-  const [major, currentMinor, patch] = currentVersion.split('.').map(Number)
+  const [currentMajor, currentMinor] = currentVersion.split('.').map(Number)
 
   // Fetch all branches
   exec('git fetch origin', frontendRepoPath)
 
-  // Determine target branch based on release type:
-  //   'patch' → target current minor (hotfix for production version)
-  //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
-  const releaseTypeInput =
-    process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
-  if (releaseTypeInput !== 'minor' && releaseTypeInput !== 'patch') {
-    console.error(
-      `Invalid RELEASE_TYPE: "${releaseTypeInput}". Expected "minor" or "patch"`
-    )
-    return null
-  }
-  const releaseType: 'minor' | 'patch' = releaseTypeInput
+  // Target major defaults to the current pin's major, but a TARGET_BRANCH
+  // override (below) can retarget both major and minor.
+  let targetMajor = currentMajor
   let targetMinor: number
   let targetBranch: string
 
-  if (releaseType === 'patch') {
-    targetMinor = currentMinor
-    targetBranch = `core/1.${targetMinor}`
+  const targetBranchOverride = process.env.TARGET_BRANCH?.trim()
+
+  if (targetBranchOverride) {
+    // Manual override takes precedence over RELEASE_TYPE / pin-derived selection.
+    const parsed = parseTargetBranchOverride(targetBranchOverride)
+    if (!parsed) {
+      console.error(
+        `Invalid TARGET_BRANCH: "${targetBranchOverride}". Expected format: core/<major>.<minor> (e.g. core/1.47 or core/2.0)`
+      )
+      return null
+    }
+
+    targetMajor = parsed.major
+    targetMinor = parsed.minor
+    targetBranch = parsed.branch
 
     const branchExists = exec(
       `git rev-parse --verify origin/${targetBranch}`,
@@ -163,54 +216,92 @@ function resolveRelease(
 
     if (!branchExists) {
       console.error(
-        `Patch release requested but branch ${targetBranch} does not exist`
+        `Manual override branch ${targetBranch} does not exist in frontend repo`
       )
       return null
     }
 
     console.error(
-      `Patch release: targeting current production branch ${targetBranch}`
+      `Manual override: targeting ${targetBranch} (ignoring release_type)`
     )
   } else {
-    // Try next minor first, fall back to current minor if not available
-    targetMinor = currentMinor + 1
-    targetBranch = `core/1.${targetMinor}`
+    // Determine target branch based on release type:
+    //   'patch' → target current minor (hotfix for production version)
+    //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
+    const releaseTypeInput =
+      process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
+    if (releaseTypeInput !== 'minor' && releaseTypeInput !== 'patch') {
+      console.error(
+        `Invalid RELEASE_TYPE: "${releaseTypeInput}". Expected "minor" or "patch"`
+      )
+      return null
+    }
+    const releaseType: 'minor' | 'patch' = releaseTypeInput
 
-    const nextMinorExists = exec(
-      `git rev-parse --verify origin/${targetBranch}`,
-      frontendRepoPath
-    )
-
-    if (!nextMinorExists) {
-      // Fall back to current minor for minor release
+    if (releaseType === 'patch') {
       targetMinor = currentMinor
-      targetBranch = `core/1.${targetMinor}`
+      targetBranch = `core/${targetMajor}.${targetMinor}`
 
-      const currentMinorExists = exec(
+      const branchExists = exec(
         `git rev-parse --verify origin/${targetBranch}`,
         frontendRepoPath
       )
 
-      if (!currentMinorExists) {
+      if (!branchExists) {
         console.error(
-          `Neither core/1.${currentMinor + 1} nor core/1.${currentMinor} branches exist in frontend repo`
+          `Patch release requested but branch ${targetBranch} does not exist`
         )
         return null
       }
 
       console.error(
-        `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for minor release`
+        `Patch release: targeting current production branch ${targetBranch}`
       )
+    } else {
+      // Try next minor first, fall back to current minor if not available
+      targetMinor = currentMinor + 1
+      targetBranch = `core/${targetMajor}.${targetMinor}`
+
+      const nextMinorExists = exec(
+        `git rev-parse --verify origin/${targetBranch}`,
+        frontendRepoPath
+      )
+
+      if (!nextMinorExists) {
+        // Fall back to current minor for minor release
+        targetMinor = currentMinor
+        targetBranch = `core/${targetMajor}.${targetMinor}`
+
+        const currentMinorExists = exec(
+          `git rev-parse --verify origin/${targetBranch}`,
+          frontendRepoPath
+        )
+
+        if (!currentMinorExists) {
+          console.error(
+            `Neither core/${targetMajor}.${currentMinor + 1} nor core/${targetMajor}.${currentMinor} branches exist in frontend repo`
+          )
+          return null
+        }
+
+        console.error(
+          `Next minor branch core/${targetMajor}.${currentMinor + 1} not found, falling back to core/${targetMajor}.${currentMinor} for minor release`
+        )
+      }
     }
   }
 
-  // Get latest patch tag for target minor
-  const latestPatchTag = getLatestPatchTag(frontendRepoPath, targetMinor)
+  // Get latest patch tag for target major.minor
+  const latestPatchTag = getLatestPatchTag(
+    frontendRepoPath,
+    targetMajor,
+    targetMinor
+  )
 
-  let needsRelease = false
-  let branchHeadSha: string | null = null
+  let needsRelease: boolean
+  let branchHeadSha: string | null
   let tagCommitSha: string | null = null
-  let targetVersion = currentVersion
+  let targetVersion: string
 
   if (latestPatchTag) {
     // Get commit SHA for the tag
@@ -231,34 +322,23 @@ function resolveRelease(
     const commitCount = parseInt(commitsBetween, 10)
     needsRelease = !isNaN(commitCount) && commitCount > 0
 
-    // Parse existing patch number and increment if needed
-    const tagVersion = latestPatchTag.replace('v', '')
-
-    // Validate tag version format
-    if (!isValidSemver(tagVersion)) {
+    const nextVersion = computeTargetVersion(
+      targetMajor,
+      targetMinor,
+      latestPatchTag,
+      needsRelease
+    )
+    if (!nextVersion) {
       console.error(
-        `Invalid tag version format: ${tagVersion}. Expected format: X.Y.Z`
+        `Invalid tag version format: ${latestPatchTag}. Expected format: vX.Y.Z`
       )
       return null
     }
-
-    const [, , existingPatch] = tagVersion.split('.').map(Number)
-
-    // Validate existingPatch is a valid number
-    if (!Number.isFinite(existingPatch) || existingPatch < 0) {
-      console.error(`Invalid patch number in tag: ${existingPatch}`)
-      return null
-    }
-
-    if (needsRelease) {
-      targetVersion = `1.${targetMinor}.${existingPatch + 1}`
-    } else {
-      targetVersion = tagVersion
-    }
+    targetVersion = nextVersion
   } else {
-    // No tags exist for this minor version, need to create v1.{targetMinor}.0
+    // No tags exist for this major.minor version, need to create the .0 patch
     needsRelease = true
-    targetVersion = `1.${targetMinor}.0`
+    targetVersion = `${targetMajor}.${targetMinor}.0`
     branchHeadSha = exec(
       `git rev-parse origin/${targetBranch}`,
       frontendRepoPath
@@ -281,26 +361,41 @@ function resolveRelease(
   }
 }
 
-// Main execution
-const comfyuiRepoPath = process.argv[2]
-const frontendRepoPath = process.argv[3] || process.cwd()
+/**
+ * Main execution: parse args, resolve, and print the JSON result.
+ */
+function main(): void {
+  const comfyuiRepoPath = process.argv[2]
+  const frontendRepoPath = process.argv[3] || process.cwd()
 
-if (!comfyuiRepoPath) {
-  console.error(
-    'Usage: resolve-comfyui-release.ts <comfyui-repo-path> [frontend-repo-path]'
-  )
-  process.exit(1)
+  if (!comfyuiRepoPath) {
+    console.error(
+      'Usage: resolve-comfyui-release.ts <comfyui-repo-path> [frontend-repo-path]'
+    )
+    process.exit(1)
+  }
+
+  const releaseInfo = resolveRelease(comfyuiRepoPath, frontendRepoPath)
+
+  if (!releaseInfo) {
+    console.error('Failed to resolve release information')
+    process.exit(1)
+  }
+
+  // Output as JSON for GitHub Actions
+  // oxlint-disable-next-line no-console -- stdout is captured by the workflow
+  console.log(JSON.stringify(releaseInfo, null, 2))
 }
 
-const releaseInfo = resolveRelease(comfyuiRepoPath, frontendRepoPath)
-
-if (!releaseInfo) {
-  console.error('Failed to resolve release information')
-  process.exit(1)
+// Only run when invoked directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
 }
 
-// Output as JSON for GitHub Actions
-// oxlint-disable-next-line no-console -- stdout is captured by the workflow
-console.log(JSON.stringify(releaseInfo, null, 2))
-
-export { resolveRelease }
+export {
+  computeTargetVersion,
+  isValidSemver,
+  parseRequirementsVersion,
+  parseTargetBranchOverride,
+  resolveRelease
+}

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -127,6 +127,13 @@ function computeTargetVersion(
 }
 
 /**
+ * Check whether a branch exists on origin in the given repo.
+ */
+function branchExists(branch: string, repoPath: string): boolean {
+  return Boolean(exec(`git rev-parse --verify origin/${branch}`, repoPath))
+}
+
+/**
  * Get the latest patch tag for a given major.minor version
  */
 function getLatestPatchTag(
@@ -209,12 +216,7 @@ function resolveRelease(
     targetMinor = parsed.minor
     targetBranch = parsed.branch
 
-    const branchExists = exec(
-      `git rev-parse --verify origin/${targetBranch}`,
-      frontendRepoPath
-    )
-
-    if (!branchExists) {
+    if (!branchExists(targetBranch, frontendRepoPath)) {
       console.error(
         `Manual override branch ${targetBranch} does not exist in frontend repo`
       )
@@ -242,12 +244,7 @@ function resolveRelease(
       targetMinor = currentMinor
       targetBranch = `core/${targetMajor}.${targetMinor}`
 
-      const branchExists = exec(
-        `git rev-parse --verify origin/${targetBranch}`,
-        frontendRepoPath
-      )
-
-      if (!branchExists) {
+      if (!branchExists(targetBranch, frontendRepoPath)) {
         console.error(
           `Patch release requested but branch ${targetBranch} does not exist`
         )
@@ -262,22 +259,12 @@ function resolveRelease(
       targetMinor = currentMinor + 1
       targetBranch = `core/${targetMajor}.${targetMinor}`
 
-      const nextMinorExists = exec(
-        `git rev-parse --verify origin/${targetBranch}`,
-        frontendRepoPath
-      )
-
-      if (!nextMinorExists) {
+      if (!branchExists(targetBranch, frontendRepoPath)) {
         // Fall back to current minor for minor release
         targetMinor = currentMinor
         targetBranch = `core/${targetMajor}.${targetMinor}`
 
-        const currentMinorExists = exec(
-          `git rev-parse --verify origin/${targetBranch}`,
-          frontendRepoPath
-        )
-
-        if (!currentMinorExists) {
+        if (!branchExists(targetBranch, frontendRepoPath)) {
           console.error(
             `Neither core/${targetMajor}.${currentMinor + 1} nor core/${targetMajor}.${currentMinor} branches exist in frontend repo`
           )


### PR DESCRIPTION
## Problem

`scripts/cicd/resolve-comfyui-release.ts` derived the release target purely from ComfyUI's `requirements.txt` pin and **hardcoded major version `1`** (`core/1.${minor}`, `v1.${minor}.*`, `1.${minor}.${patch}`) even though it parsed `major` and never used it. Consequences:

- Could not release an out-of-cadence branch (e.g. skip a dead 1.46 to ship 1.47 directly).
- Could not do a major bump (2.x).

## Changes

1. **Resolver (`resolve-comfyui-release.ts`)** — uses the parsed `targetMajor` (defaults to the current pin's major) for every branch/tag/version string instead of literal `1`. `getLatestPatchTag` now takes a `major` param and globs `v${major}.${minor}.*`.

2. **`TARGET_BRANCH` env override (highest precedence)** — when set, validates `^core/(\d+)\.(\d+)$`, verifies `origin/<branch>` exists, and skips the `RELEASE_TYPE`/pin-derived selection entirely. If both `TARGET_BRANCH` and `RELEASE_TYPE` are set, the override wins. `current_version` still comes from the pin (for `diff_url` and the ComfyUI PR "from" version), so the requirements bump jumps straight from the pin to `target_version` (e.g. 1.45.20 → 1.47.8, skipping 1.46).

3. **Workflow (`release-biweekly-comfyui.yaml`)** — new optional `target_branch` `workflow_dispatch` input, wired into the resolve step's `env` as `TARGET_BRANCH`, and surfaced in the run summary. Downstream jobs consume `target_branch`/`target_version` outputs unchanged.

The output JSON shape is identical. Extracted pure helpers (`parseTargetBranchOverride`, `computeTargetVersion`) and guarded the main block so the module is importable by tests.

`release-version-bump.yaml` and `release-branch-create.yaml` were **already** major-aware and are left untouched.

## Tests

New `scripts/cicd/resolve-comfyui-release.test.ts` (15 cases) covering `parseRequirementsVersion` (==, >=, missing/absent), `isValidSemver`, `parseTargetBranchOverride` (valid `core/1.47` and `core/2.0`, malformed rejected), and `computeTargetVersion` including a non-1 major (`v2.0.3` + commits → `2.0.4`).

## Usage

```
gh workflow run release-biweekly-comfyui.yaml --field target_branch=core/1.47
```

releases 1.47.8 directly (skipping a dead 1.46), or `--field target_branch=core/2.0` for a major bump.
