### PR TITLE
perf: shard Chromium E2E across 24 jobs

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -73,8 +73,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24
+          ]
+        shardTotal: [24]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -93,7 +119,7 @@ jobs:
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         id: playwright
-        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
+        run: pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers=2 --reporter=blob
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
           COLLECT_COVERAGE: 'true'


### PR DESCRIPTION
Tests the next E2E parallelism step from the 16x2 baseline in https://github.com/Comfy-Org/ComfyUI_frontend/pull/13650.

- Increase Chromium sharding from 8 to 24 jobs.
- Keep Playwright at 2 workers per shard.
- Acceptance: five sequential exact-SHA runs, E2E P95 under 10 minutes, all shard jobs pass, and no job-level flakes.

Validation: YAML parse, `pnpm exec oxfmt --check .github/workflows/ci-tests-e2e.yaml`, `pnpm typecheck`, and pre-push Knip.

Created by Codex