### PR TITLE
[backport cloud/1.45] fix: resolve cloud output video missing-media false positives (#13507)

### DIFF
--- a/browser_tests/assets/missing/missing_media_cloud_output_video_subfolder.json
+++ b/browser_tests/assets/missing/missing_media_cloud_output_video_subfolder.json
@@ -1,0 +1,37 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadVideo",
+      "pos": [50, 120],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["video/cloud-video-hash.mp4 [output]", "image"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -1,6 +1,11 @@
 import { expect, mergeTests } from '@playwright/test'
 import type { Page, Route } from '@playwright/test'
-import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
+import type {
+  Asset,
+  GetAllSettingsResponse,
+  GetSettingByKeyResponse,
+  ListAssetsResponse
+} from '@comfyorg/ingest-types'
 
 import {
   assetRequestIncludesTag,
@@ -8,6 +13,7 @@ import {
 } from '@e2e/fixtures/assetApiFixture'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import type { WorkspaceStore } from '@e2e/types/globals'
 import {
   createRouteMockJob,
   jobsRouteFixture
@@ -19,10 +25,11 @@ import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 const ossTest = mergeTests(comfyPageFixture, jobsRouteFixture)
 const outputHash =
   '147257c95a3e957e0deee73a077cfec89da2d906dd086ca70a2b0c897a9591d6e.png'
+const outputVideoHash = 'cloud-video-hash.mp4'
 const plainVideoFileName = 'plain_video.mp4'
 const graphDropPosition = { x: 500, y: 300 }
-const missingMediaUploadObservationMs = 1_000
-const missingMediaUploadPollMs = 100
+const missingMediaObservationMs = 1_000
+const missingMediaPollMs = 100
 const emptyMediaLoaderNodes = [
   {
     nodeType: 'LoadImage',
@@ -50,6 +57,18 @@ const cloudOutputAsset: Asset & { hash?: string } = {
   hash: outputHash,
   size: 4_194_304,
   mime_type: 'image/png',
+  tags: ['output'],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  last_access_time: '2026-05-01T00:00:00Z'
+}
+
+const cloudOutputVideoAsset: Asset & { hash?: string } = {
+  id: 'test-output-video-hash-001',
+  name: 'ComfyUI_00001_.mp4',
+  hash: outputVideoHash,
+  size: 4_194_304,
+  mime_type: 'video/mp4',
   tags: ['output'],
   created_at: '2026-05-01T00:00:00Z',
   updated_at: '2026-05-01T00:00:00Z',
@@ -132,10 +151,21 @@ function setComboInputOptions(
 
 async function routeCloudBootstrapApis(page: Page) {
   await page.route('**/api/settings**', async (route) => {
+    const completedSurveySetting: GetSettingByKeyResponse = {
+      value: { usage: 'personal' }
+    }
+    const allSettings: GetAllSettingsResponse = {}
+    const body = route
+      .request()
+      .url()
+      .includes('/api/settings/onboarding_survey')
+      ? completedSurveySetting
+      : allSettings
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({})
+      body: JSON.stringify(body)
     })
   })
   await page.route('**/api/userdata**', async (route) => {
@@ -208,7 +238,10 @@ async function routeSetupObjectInfo(
     await page.unroute('**/object_info', objectInfoRouteHandler)
 }
 
-const cloudOutputTest = createCloudAssetsFixture([cloudOutputAsset]).extend({
+const cloudOutputTest = createCloudAssetsFixture([
+  cloudOutputAsset,
+  cloudOutputVideoAsset
+]).extend({
   page: async ({ page }, use) => {
     await routeCloudBootstrapApis(page)
     const unrouteObjectInfo = await routeSetupObjectInfo(page)
@@ -307,6 +340,33 @@ async function enableErrorsTab(comfyPage: ComfyPage) {
 
 function getErrorOverlay(comfyPage: ComfyPage) {
   return comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+}
+
+function isOutputAssetsRequest(url: string) {
+  return url.includes('/api/assets') && assetRequestIncludesTag(url, 'output')
+}
+
+async function waitForOutputAssetsResponse(comfyPage: ComfyPage) {
+  await comfyPage.page.waitForResponse(
+    (response) =>
+      response.status() === 200 && isOutputAssetsRequest(response.url())
+  )
+}
+
+async function getCachedMissingMediaWarningNames(
+  comfyPage: ComfyPage
+): Promise<string[] | null> {
+  return await comfyPage.page.evaluate(() => {
+    const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
+      .activeWorkflow
+    if (!workflow) return null
+
+    return (
+      workflow.pendingWarnings?.missingMediaCandidates?.map(
+        (candidate) => candidate.name
+      ) ?? []
+    )
+  })
 }
 
 async function expectNoErrorsTab(comfyPage: ComfyPage) {
@@ -411,25 +471,31 @@ async function expectLoadVideoUploading(comfyPage: ComfyPage) {
     .toBe(true)
 }
 
-async function expectNoMissingMediaDuringUpload(comfyPage: ComfyPage) {
+async function expectNoMissingMediaForObservationWindow(comfyPage: ComfyPage) {
   await comfyPage.nextFrame()
   await comfyPage.nextFrame()
 
   let sawErrorOverlay = false
+  let sawCachedMissingMedia = false
   const startedAt = Date.now()
   await expect
     .poll(
       async () => {
+        const cachedMissingMedia =
+          await getCachedMissingMediaWarningNames(comfyPage)
+        sawCachedMissingMedia =
+          sawCachedMissingMedia || !!cachedMissingMedia?.length
         sawErrorOverlay =
           sawErrorOverlay || (await getErrorOverlay(comfyPage).isVisible())
         return (
           !sawErrorOverlay &&
-          Date.now() - startedAt >= missingMediaUploadObservationMs
+          !sawCachedMissingMedia &&
+          Date.now() - startedAt >= missingMediaObservationMs
         )
       },
       {
-        timeout: missingMediaUploadObservationMs + missingMediaUploadPollMs * 5,
-        intervals: [missingMediaUploadPollMs]
+        timeout: missingMediaObservationMs + missingMediaPollMs * 5,
+        intervals: [missingMediaPollMs]
       }
     )
     .toBe(true)
@@ -508,7 +574,7 @@ ossTest.describe(
         })
 
         await expectLoadVideoUploading(comfyPage)
-        await expectNoMissingMediaDuringUpload(comfyPage)
+        await expectNoMissingMediaForObservationWindow(comfyPage)
 
         await delayedUpload.finishUpload()
         await expect(getErrorOverlay(comfyPage)).toBeHidden()
@@ -566,18 +632,30 @@ cloudOutputTest.describe(
 
     cloudOutputTest(
       'resolves compact annotated output media from output assets',
-      async ({ cloudAssetRequests, comfyPage }) => {
+      async ({ comfyPage }) => {
+        const outputAssetsResponse = waitForOutputAssetsResponse(comfyPage)
+
         await comfyPage.workflow.loadWorkflow(
           'missing/missing_media_cloud_output_annotation'
         )
 
-        await expect
-          .poll(() =>
-            cloudAssetRequests.some((url) =>
-              assetRequestIncludesTag(url, 'output')
-            )
-          )
-          .toBe(true)
+        await outputAssetsResponse
+        await expectNoMissingMediaForObservationWindow(comfyPage)
+        await expectNoErrorsTab(comfyPage)
+      }
+    )
+
+    cloudOutputTest(
+      'resolves subfoldered output video media from flat output asset hashes',
+      async ({ comfyPage }) => {
+        const outputAssetsResponse = waitForOutputAssetsResponse(comfyPage)
+
+        await comfyPage.workflow.loadWorkflow(
+          'missing/missing_media_cloud_output_video_subfolder'
+        )
+
+        await outputAssetsResponse
+        await expectNoMissingMediaForObservationWindow(comfyPage)
         await expectNoErrorsTab(comfyPage)
       }
     )
@@ -613,7 +691,7 @@ cloudUploadRaceTest.describe(
         })
 
         await expectLoadVideoUploading(comfyPage)
-        await expectNoMissingMediaDuringUpload(comfyPage)
+        await expectNoMissingMediaForObservationWindow(comfyPage)
 
         markUploadedCloudAssetAvailable()
         await delayedUpload.finishUpload()

--- a/src/platform/missingMedia/missingMediaAssetResolver.test.ts
+++ b/src/platform/missingMedia/missingMediaAssetResolver.test.ts
@@ -152,8 +152,12 @@ describe('resolveMissingMediaAssetSources', () => {
 
   it('stops reading cloud output asset pages once all requested names are found', async () => {
     const target = 'target-output.png'
+    const outputAsset = makeAsset('ComfyUI_00001_.png', target)
     mockGetAssetsPageByTag.mockResolvedValueOnce(
-      makeAssetPage([makeAsset(target)], { hasMore: true, total: 501 })
+      makeAssetPage([outputAsset], {
+        hasMore: true,
+        total: 501
+      })
     )
 
     const result = await resolveMissingMediaAssetSources({
@@ -163,8 +167,54 @@ describe('resolveMissingMediaAssetSources', () => {
       allowCompactSuffix: true
     })
 
-    expect(result.generatedAssets).toEqual([makeAsset(target)])
+    expect(result.generatedAssets).toEqual([outputAsset])
     expect(mockGetAssetsPageByTag).toHaveBeenCalledOnce()
+  })
+
+  it('stops reading cloud output asset pages when a flat target matches by name', async () => {
+    const target = 'ComfyUI_00001_.mp4'
+    const outputAsset = makeAsset(target, 'different-output-hash.mp4')
+    mockGetAssetsPageByTag.mockResolvedValueOnce(
+      makeAssetPage([outputAsset], {
+        hasMore: true,
+        total: 501
+      })
+    )
+
+    const result = await resolveMissingMediaAssetSources({
+      isCloud: true,
+      includeGeneratedAssets: true,
+      generatedMatchNames: new Set([target]),
+      allowCompactSuffix: true
+    })
+
+    expect(result.generatedAssets).toEqual([outputAsset])
+    expect(mockGetAssetsPageByTag).toHaveBeenCalledOnce()
+  })
+
+  it('does not stop cloud output asset paging on a flat asset name collision', async () => {
+    const target = 'target-output.mp4'
+    const collidingNameAsset = makeAsset(target)
+    const matchingHashAsset = makeAsset('ComfyUI_00001_.mp4', target)
+    mockGetAssetsPageByTag
+      .mockResolvedValueOnce(
+        makeAssetPage([collidingNameAsset], { hasMore: true, total: 501 })
+      )
+      .mockResolvedValueOnce(makeAssetPage([matchingHashAsset]))
+
+    const result = await resolveMissingMediaAssetSources({
+      isCloud: true,
+      includeGeneratedAssets: true,
+      generatedMatchNames: new Set([target]),
+      generatedHashRequiredNames: new Set([target]),
+      allowCompactSuffix: true
+    })
+
+    expect(result.generatedAssets).toEqual([
+      collidingNameAsset,
+      matchingHashAsset
+    ])
+    expect(mockGetAssetsPageByTag).toHaveBeenCalledTimes(2)
   })
 
   it('aborts cloud output asset loading when input asset loading fails', async () => {

--- a/src/platform/missingMedia/missingMediaAssetResolver.ts
+++ b/src/platform/missingMedia/missingMediaAssetResolver.ts
@@ -23,6 +23,7 @@ export interface ResolveMissingMediaAssetSourcesOptions {
   isCloud: boolean
   includeGeneratedAssets: boolean
   generatedMatchNames: ReadonlySet<string>
+  generatedHashRequiredNames?: ReadonlySet<string>
   allowCompactSuffix: boolean
 }
 
@@ -35,6 +36,7 @@ export async function resolveMissingMediaAssetSources({
   isCloud,
   includeGeneratedAssets,
   generatedMatchNames,
+  generatedHashRequiredNames = new Set<string>(),
   allowCompactSuffix
 }: ResolveMissingMediaAssetSourcesOptions): Promise<MissingMediaAssetSources> {
   const pathOptions = { allowCompactSuffix }
@@ -60,6 +62,7 @@ export async function resolveMissingMediaAssetSources({
           ? fetchGeneratedAssets(controller.signal, {
               isCloud,
               generatedMatchNames,
+              generatedHashRequiredNames,
               pathOptions
             })
           : Promise.resolve<AssetItem[]>([]),
@@ -76,6 +79,7 @@ export async function resolveMissingMediaAssetSources({
 interface FetchGeneratedAssetsOptions {
   isCloud: boolean
   generatedMatchNames: ReadonlySet<string>
+  generatedHashRequiredNames: ReadonlySet<string>
   pathOptions: MediaPathDetectionOptions
 }
 
@@ -98,12 +102,18 @@ export function getAssetDetectionNames(
 
 async function fetchGeneratedAssets(
   signal: AbortSignal | undefined,
-  { isCloud, generatedMatchNames, pathOptions }: FetchGeneratedAssetsOptions
+  {
+    isCloud,
+    generatedMatchNames,
+    generatedHashRequiredNames,
+    pathOptions
+  }: FetchGeneratedAssetsOptions
 ): Promise<AssetItem[]> {
   if (isCloud) {
     return await fetchCloudGeneratedAssets(
       signal,
       generatedMatchNames,
+      generatedHashRequiredNames,
       pathOptions
     )
   }
@@ -118,6 +128,7 @@ async function fetchGeneratedAssets(
 async function fetchCloudGeneratedAssets(
   signal: AbortSignal | undefined,
   targetNames: ReadonlySet<string>,
+  hashRequiredNames: ReadonlySet<string>,
   pathOptions: MediaPathDetectionOptions
 ): Promise<AssetItem[]> {
   const assets: AssetItem[] = []
@@ -140,9 +151,10 @@ async function fetchCloudGeneratedAssets(
 
     for (const asset of batch) {
       assets.push(asset)
-      rememberResolvedTargetNames(
+      rememberResolvedCloudTargetNames(
         asset,
         targetNames,
+        hashRequiredNames,
         foundTargetNames,
         pathOptions
       )
@@ -259,6 +271,28 @@ function rememberResolvedTargetNames(
 
   for (const name of getAssetDetectionNames(asset, options)) {
     if (targetNames.has(name)) foundTargetNames.add(name)
+  }
+}
+
+function rememberResolvedCloudTargetNames(
+  asset: AssetItem,
+  targetNames: ReadonlySet<string>,
+  hashRequiredNames: ReadonlySet<string>,
+  foundTargetNames: Set<string>,
+  options: MediaPathDetectionOptions
+) {
+  if (targetNames.size === 0) return
+
+  if (asset.hash) {
+    for (const name of getMediaPathDetectionNames(asset.hash, options)) {
+      if (targetNames.has(name)) foundTargetNames.add(name)
+    }
+  }
+
+  for (const name of getAssetDetectionNames(asset, options)) {
+    if (!hashRequiredNames.has(name) && targetNames.has(name)) {
+      foundTargetNames.add(name)
+    }
   }
 }
 

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -528,6 +528,7 @@ describe('verifyMediaCandidates', () => {
       isCloud: true,
       includeGeneratedAssets: false,
       generatedMatchNames: new Set(),
+      generatedHashRequiredNames: new Set(),
       allowCompactSuffix: true
     })
   })
@@ -621,10 +622,93 @@ describe('verifyMediaCandidates', () => {
       generatedMatchNames: new Set([
         '147257c95a3e957e0deee73a077cfec89da2d906dd086ca70a2b0c897a9591d6e.png'
       ]),
+      generatedHashRequiredNames: new Set(),
       allowCompactSuffix: true
     })
     expect(candidates[0]).toMatchObject({
       name: '147257c95a3e957e0deee73a077cfec89da2d906dd086ca70a2b0c897a9591d6e.png [output]',
+      isMissing: false
+    })
+  })
+
+  it('matches cloud output videos with history subfolders against flat asset hashes', async () => {
+    const outputHash = 'cloud-video-hash.mp4'
+    const candidates = [
+      makeCandidate('1', `video/${outputHash} [output]`, {
+        nodeType: 'LoadVideo',
+        widgetName: 'file',
+        mediaType: 'video',
+        isMissing: undefined
+      })
+    ]
+    const resolveAssetSources = makeAssetResolver(
+      [],
+      [makeAsset('ComfyUI_00001_.mp4', outputHash)]
+    )
+
+    await verifyMediaCandidates(candidates, {
+      isCloud: true,
+      resolveAssetSources
+    })
+
+    expect(resolveAssetSources).toHaveBeenCalledWith({
+      signal: undefined,
+      isCloud: true,
+      includeGeneratedAssets: true,
+      generatedMatchNames: new Set([outputHash]),
+      generatedHashRequiredNames: new Set([outputHash]),
+      allowCompactSuffix: true
+    })
+    expect(candidates[0]).toMatchObject({
+      name: `video/${outputHash} [output]`,
+      isMissing: false
+    })
+  })
+
+  it('does not match subfoldered cloud output media against unrelated flat asset names', async () => {
+    const outputHash = 'cloud-video-hash.mp4'
+    const candidates = [
+      makeCandidate('1', `video/${outputHash} [output]`, {
+        nodeType: 'LoadVideo',
+        widgetName: 'file',
+        mediaType: 'video',
+        isMissing: undefined
+      })
+    ]
+    const resolveAssetSources = makeAssetResolver([], [makeAsset(outputHash)])
+
+    await verifyMediaCandidates(candidates, {
+      isCloud: true,
+      resolveAssetSources
+    })
+
+    expect(candidates[0]).toMatchObject({
+      name: `video/${outputHash} [output]`,
+      isMissing: true
+    })
+  })
+
+  it('stops cloud output paging after a subfoldered candidate matches a flat asset hash', async () => {
+    const outputHash = 'cloud-video-hash.mp4'
+    const candidates = [
+      makeCandidate('1', `video/${outputHash} [output]`, {
+        nodeType: 'LoadVideo',
+        widgetName: 'file',
+        mediaType: 'video',
+        isMissing: undefined
+      })
+    ]
+    mockGetAssetsPageByTag.mockResolvedValueOnce(
+      makeAssetPage([makeAsset('ComfyUI_00001_.mp4', outputHash)], {
+        hasMore: true
+      })
+    )
+
+    await verifyMediaCandidates(candidates, { isCloud: true })
+
+    expect(mockGetAssetsPageByTag).toHaveBeenCalledOnce()
+    expect(candidates[0]).toMatchObject({
+      name: `video/${outputHash} [output]`,
       isMissing: false
     })
   })
@@ -702,6 +786,7 @@ describe('verifyMediaCandidates', () => {
       isCloud: false,
       includeGeneratedAssets: false,
       generatedMatchNames: new Set(),
+      generatedHashRequiredNames: new Set(),
       allowCompactSuffix: false
     })
     expect(candidates[0].isMissing).toBe(true)

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -136,6 +136,11 @@ interface MediaVerificationOptions {
   resolveAssetSources?: MissingMediaAssetResolver
 }
 
+interface GeneratedCandidateMatchNames {
+  names: Set<string>
+  hashRequiredNames: Set<string>
+}
+
 /**
  * Verify media candidates against assets available to the current runtime.
  *
@@ -166,6 +171,7 @@ export async function verifyMediaCandidates(
   const pathOptions = { allowCompactSuffix: isCloud }
   const generatedMatchNames = getGeneratedCandidateMatchNames(
     pending,
+    isCloud,
     pathOptions
   )
 
@@ -175,8 +181,9 @@ export async function verifyMediaCandidates(
     const assetSources = await resolveAssetSources({
       signal,
       isCloud,
-      includeGeneratedAssets: generatedMatchNames.size > 0,
-      generatedMatchNames,
+      includeGeneratedAssets: generatedMatchNames.names.size > 0,
+      generatedMatchNames: generatedMatchNames.names,
+      generatedHashRequiredNames: generatedMatchNames.hashRequiredNames,
       allowCompactSuffix: isCloud
     })
     inputAssets = assetSources.inputAssets
@@ -190,37 +197,58 @@ export async function verifyMediaCandidates(
 
   const inputAssetIdentifiers = new Set<string>()
   const outputAssetIdentifiers = new Set<string>()
+  const outputAssetHashIdentifiers = new Set<string>()
   addAssetIdentifiers(inputAssetIdentifiers, inputAssets, pathOptions)
   addAssetIdentifiers(outputAssetIdentifiers, generatedAssets, pathOptions)
+  addAssetHashIdentifiers(
+    outputAssetHashIdentifiers,
+    generatedAssets,
+    pathOptions
+  )
 
   for (const candidate of pending) {
-    const detectionNames = getMediaPathDetectionNames(
-      candidate.name,
-      pathOptions
-    )
     const type = getAnnotatedMediaPathTypeForDetection(
       candidate.name,
       pathOptions
     )
-    const identifiers =
-      type === 'output' ? outputAssetIdentifiers : inputAssetIdentifiers
-    candidate.isMissing = !detectionNames.some((name) => identifiers.has(name))
+    const isOutputCandidate = type === 'output'
+    const identifiers = isOutputCandidate
+      ? outputAssetIdentifiers
+      : inputAssetIdentifiers
+    candidate.isMissing = !isCandidateResolved(
+      candidate,
+      identifiers,
+      isOutputCandidate,
+      isCloud,
+      outputAssetHashIdentifiers,
+      pathOptions
+    )
   }
 }
 
 function getGeneratedCandidateMatchNames(
   candidates: MissingMediaCandidate[],
+  isCloud: boolean,
   pathOptions: { allowCompactSuffix: boolean }
-): Set<string> {
+): GeneratedCandidateMatchNames {
   const names = new Set<string>()
+  const hashRequiredNames = new Set<string>()
+
   for (const candidate of candidates) {
     if (!isGeneratedCandidate(candidate, pathOptions)) continue
 
-    names.add(
-      normalizeAnnotatedMediaPathForDetection(candidate.name, pathOptions)
+    const normalized = normalizeAnnotatedMediaPathForDetection(
+      candidate.name,
+      pathOptions
     )
+    const lookupName = isCloud ? getMediaPathBasename(normalized) : normalized
+    names.add(lookupName)
+    if (isCloud && lookupName !== normalized) {
+      hashRequiredNames.add(lookupName)
+    }
   }
-  return names
+
+  return { names, hashRequiredNames }
 }
 
 function isGeneratedCandidate(
@@ -234,6 +262,34 @@ function isGeneratedCandidate(
   return type === 'output'
 }
 
+function isCandidateResolved(
+  candidate: MissingMediaCandidate,
+  identifiers: ReadonlySet<string>,
+  isOutputCandidate: boolean,
+  isCloud: boolean,
+  outputAssetHashIdentifiers: ReadonlySet<string>,
+  pathOptions: { allowCompactSuffix: boolean }
+): boolean {
+  const detectionNames = getMediaPathDetectionNames(candidate.name, pathOptions)
+  if (detectionNames.some((name) => identifiers.has(name))) return true
+  if (!isOutputCandidate || !isCloud) return false
+
+  const normalized = normalizeAnnotatedMediaPathForDetection(
+    candidate.name,
+    pathOptions
+  )
+  const basename = getMediaPathBasename(normalized)
+  return basename !== normalized && outputAssetHashIdentifiers.has(basename)
+}
+
+function getMediaPathBasename(value: string): string {
+  const separatorIndex = Math.max(
+    value.lastIndexOf('/'),
+    value.lastIndexOf('\\')
+  )
+  return separatorIndex === -1 ? value : value.slice(separatorIndex + 1)
+}
+
 function addAssetIdentifiers(
   identifiers: Set<string>,
   assets: AssetItem[],
@@ -241,6 +297,19 @@ function addAssetIdentifiers(
 ) {
   for (const asset of assets) {
     for (const name of getAssetDetectionNames(asset, pathOptions)) {
+      identifiers.add(name)
+    }
+  }
+}
+
+function addAssetHashIdentifiers(
+  identifiers: Set<string>,
+  assets: AssetItem[],
+  pathOptions: { allowCompactSuffix: boolean }
+) {
+  for (const asset of assets) {
+    if (!asset.hash) continue
+    for (const name of getMediaPathDetectionNames(asset.hash, pathOptions)) {
       identifiers.add(name)
     }
   }


### PR DESCRIPTION
## Summary

Backports #13507 to `cloud/1.45` so valid subfoldered Cloud output videos are not reported as missing media.

## Changes

- **What**: Match subfoldered Cloud output candidates against output asset hashes and make pagination completion hash-aware.
- **What**: Backport the unit and Cloud E2E regressions from #13507.

## Review Focus

The manual conflict resolution was limited to `errorsTabMissingMediaRuntime.spec.ts`: it preserves the branch's local `object_info` route helper and uses the equivalent `GetSettingByKeyResponse` type available on `cloud/1.45`. Runtime files applied without conflicts.

Validated with 59 targeted unit tests, two targeted Cloud E2E tests, TypeScript and browser typechecks, lint, format check, and knip.

Backport of #13507.

## Screenshots (if applicable)

See the before/after recordings in #13507.
