### PR TITLE
fix: sequence Customer.io identification before auth events

### DIFF
--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hoisted = vi.hoisted(() => {
   const analytics = {
-    identify: vi.fn(),
-    track: vi.fn(),
+    identify: vi.fn().mockResolvedValue(undefined),
+    track: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn(),
     register: vi.fn().mockResolvedValue(undefined)
   }
@@ -13,6 +13,7 @@ const hoisted = vi.hoisted(() => {
     analytics,
     load: vi.fn(() => analytics),
     inAppPlugin: vi.fn(() => ({ name: 'Customer.io In-App Plugin' })),
+    userEmail: { value: null as string | null },
     onUserResolved: vi.fn((cb: (user: { id: string }) => void) => {
       resolvedCb = cb
     }),
@@ -20,7 +21,11 @@ const hoisted = vi.hoisted(() => {
       logoutCb = cb
     }),
     resolveUser: (id: string) => resolvedCb?.({ id }),
-    logoutUser: () => logoutCb?.()
+    logoutUser: () => logoutCb?.(),
+    resetCallbacks: () => {
+      resolvedCb = undefined
+      logoutCb = undefined
+    }
   }
 })
 
@@ -31,6 +36,7 @@ vi.mock('@customerio/cdp-analytics-browser', () => ({
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({
+    userEmail: hoisted.userEmail,
     onUserResolved: hoisted.onUserResolved,
     onUserLogout: hoisted.onUserLogout
   })
@@ -54,11 +60,23 @@ function createProvider(
   return new CustomerIoTelemetryProvider()
 }
 
+function createDeferred() {
+  let resolve = () => {}
+  const promise = new Promise<void>((complete) => {
+    resolve = complete
+  })
+  return { promise, resolve }
+}
+
 describe('CustomerIoTelemetryProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hoisted.resetCallbacks()
     hoisted.load.mockReturnValue(hoisted.analytics)
+    hoisted.analytics.identify.mockResolvedValue(undefined)
+    hoisted.analytics.track.mockResolvedValue(undefined)
     hoisted.analytics.register.mockResolvedValue(undefined)
+    hoisted.userEmail.value = null
     window.__CONFIG__ = {} as typeof window.__CONFIG__
   })
 
@@ -89,13 +107,16 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(hoisted.load).not.toHaveBeenCalled()
   })
 
-  it('identifies the person by uid only on auth resolve', async () => {
+  it('identifies the resolved user with uid and email traits', async () => {
     createProvider()
     await vi.dynamicImportSettled()
 
+    hoisted.userEmail.value = 'user@example.com'
     hoisted.resolveUser('test-uid-7f3a9c')
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c')
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c', {
+      email: 'user@example.com'
+    })
   })
 
   it('identifies with the configured user_id override without waiting for auth', async () => {
@@ -108,8 +129,33 @@ describe('CustomerIoTelemetryProvider', () => {
     })
     await vi.dynamicImportSettled()
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid')
-    expect(hoisted.onUserResolved).not.toHaveBeenCalled()
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+      'forced-uid',
+      undefined
+    )
+    expect(hoisted.onUserResolved).toHaveBeenCalledOnce()
+  })
+
+  it('re-identifies with the configured user id after logout and re-login', async () => {
+    createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    await vi.dynamicImportSettled()
+
+    hoisted.logoutUser()
+    hoisted.userEmail.value = 'returning@example.com'
+    hoisted.resolveUser('resolved-uid')
+
+    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+    expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
+      2,
+      'forced-uid',
+      { email: 'returning@example.com' }
+    )
   })
 
   it('identifies before flushing events buffered before the SDK loads', async () => {
@@ -189,6 +235,7 @@ describe('CustomerIoTelemetryProvider', () => {
       invoke: (p) =>
         p.trackShareFlow({
           step: 'dialog_opened',
+          share_id: 'share-1',
           view_mode: 'graph',
           is_app_mode: false
         }),
@@ -212,6 +259,86 @@ describe('CustomerIoTelemetryProvider', () => {
       expect(hoisted.analytics.track).toHaveBeenCalledWith(event, expected)
     }
   )
+
+  it('awaits auth identification before tracking without raw identifiers', async () => {
+    const identifyResult = createDeferred()
+    hoisted.analytics.identify.mockReturnValueOnce(identifyResult.promise)
+    const provider = createProvider()
+
+    provider.trackAuth({
+      method: 'google',
+      is_new_user: true,
+      user_id: 'uid-1',
+      email: 'person@example.com',
+      share_id: 'share-1'
+    })
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('uid-1', {
+      email: 'person@example.com'
+    })
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+
+    identifyResult.resolve()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        {
+          ...SOURCE,
+          method: 'google',
+          is_new_user: true,
+          user_id: 'uid-1'
+        }
+      )
+    )
+    expect(hoisted.analytics.identify.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.analytics.track.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('tracks auth after identifying a user without an email', async () => {
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({ user_id: 'uid-without-email' })
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+      'uid-without-email',
+      undefined
+    )
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        { ...SOURCE, user_id: 'uid-without-email' }
+      )
+    )
+  })
+
+  it('tracks auth after identification fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    hoisted.analytics.identify.mockRejectedValueOnce(
+      new Error('identify failed')
+    )
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({
+      user_id: 'uid-1',
+      email: 'person@example.com'
+    })
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        { ...SOURCE, user_id: 'uid-1' }
+      )
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to identify Customer.io user:',
+      expect.any(Error)
+    )
+  })
 
   it('flushes events buffered before load once, in order', async () => {
     const provider = createProvider()

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -86,6 +86,7 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.load.mockReturnValue(hoisted.analytics)
     hoisted.analytics.identify.mockResolvedValue(undefined)
     hoisted.analytics.track.mockResolvedValue(undefined)
+    hoisted.analytics.reset.mockReset().mockResolvedValue(undefined)
     hoisted.analytics.register.mockResolvedValue(undefined)
     hoisted.userEmail.value = null
     window.__CONFIG__ = {} as typeof window.__CONFIG__
@@ -152,6 +153,25 @@ describe('CustomerIoTelemetryProvider', () => {
       undefined
     )
     expect(hoisted.onUserResolved).toHaveBeenCalledOnce()
+  })
+
+  it('identifies a restored session with the configured user id once', async () => {
+    hoisted.userEmail.value = 'restored@example.com'
+    hoisted.resolvedUserInfo.value = { id: 'resolved-uid' }
+
+    createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledOnce()
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid', {
+      email: 'restored@example.com'
+    })
   })
 
   it('re-identifies with the configured user id after logout and re-login', async () => {
@@ -391,6 +411,7 @@ describe('CustomerIoTelemetryProvider', () => {
 
   it('tracks auth before resetting identity on logout', async () => {
     const identifyResult = createDeferred()
+    const trackResult = createDeferred()
     let activeUser: string | null = null
     let trackedUser: string | null = null
     hoisted.analytics.identify.mockImplementationOnce((userId: string) => {
@@ -399,7 +420,7 @@ describe('CustomerIoTelemetryProvider', () => {
     })
     hoisted.analytics.track.mockImplementationOnce(() => {
       trackedUser = activeUser
-      return Promise.resolve()
+      return trackResult.promise
     })
     hoisted.analytics.reset.mockImplementationOnce(() => {
       activeUser = null
@@ -418,6 +439,34 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(trackedUser).toBe('uid-1')
     expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.analytics.reset.mock.invocationCallOrder[0]
+    )
+    trackResult.resolve()
+  })
+
+  it('restores a configured identity after tracking auth with the Firebase uid', async () => {
+    const provider = createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    await vi.dynamicImportSettled()
+    hoisted.analytics.identify.mockClear()
+
+    provider.trackAuth({
+      user_id: 'firebase-uid',
+      email: 'person@example.com'
+    })
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify.mock.calls).toEqual([
+        ['firebase-uid', { email: 'person@example.com' }],
+        ['forced-uid', undefined]
+      ])
+    )
+    expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.analytics.identify.mock.invocationCallOrder[1]
     )
   })
 
@@ -439,6 +488,21 @@ describe('CustomerIoTelemetryProvider', () => {
         { ...SOURCE, user_id: 'uid-without-email' }
       )
     )
+  })
+
+  it('tracks auth without identifying when user_id is absent', async () => {
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({ method: 'google', email: 'person@example.com' })
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        { ...SOURCE, method: 'google' }
+      )
+    )
+    expect(hoisted.analytics.identify).not.toHaveBeenCalled()
   })
 
   it('tracks auth after identification fails', async () => {
@@ -499,6 +563,45 @@ describe('CustomerIoTelemetryProvider', () => {
         ['app:user_auth_completed', { ...SOURCE, user_id: 'uid-1' }],
         ['execution_start', SOURCE]
       ])
+    )
+  })
+
+  it('does not wait for event delivery before handing off later events', async () => {
+    const trackResult = createDeferred()
+    hoisted.analytics.track.mockReturnValueOnce(trackResult.promise)
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackWorkflowExecution()
+    provider.trackAddApiCreditButtonClicked()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track.mock.calls).toEqual([
+        ['execution_start', SOURCE],
+        ['app:add_api_credit_button_clicked', SOURCE]
+      ])
+    )
+    trackResult.resolve()
+  })
+
+  it('snapshots resolved user email before queued identification', async () => {
+    const identifyResult = createDeferred()
+    hoisted.analytics.identify.mockReturnValueOnce(identifyResult.promise)
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({ user_id: 'blocking-uid' })
+    hoisted.userEmail.value = 'first@example.com'
+    hoisted.resolveUser('resolved-uid')
+    hoisted.userEmail.value = 'second@example.com'
+    identifyResult.resolve()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
+        2,
+        'resolved-uid',
+        { email: 'first@example.com' }
+      )
     )
   })
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hoisted = vi.hoisted(() => {
   const analytics = {
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => {
   }
   let resolvedCb: ((user: { id: string }) => void) | undefined
   let logoutCb: (() => void) | undefined
+  const resolvedUserInfo = { value: null as { id: string } | null }
   return {
     analytics,
     load: vi.fn(() => analytics),
@@ -16,15 +17,24 @@ const hoisted = vi.hoisted(() => {
     userEmail: { value: null as string | null },
     onUserResolved: vi.fn((cb: (user: { id: string }) => void) => {
       resolvedCb = cb
+      if (resolvedUserInfo.value) cb(resolvedUserInfo.value)
     }),
     onUserLogout: vi.fn((cb: () => void) => {
       logoutCb = cb
     }),
-    resolveUser: (id: string) => resolvedCb?.({ id }),
-    logoutUser: () => logoutCb?.(),
+    resolvedUserInfo,
+    resolveUser: (id: string) => {
+      resolvedUserInfo.value = { id }
+      resolvedCb?.({ id })
+    },
+    logoutUser: () => {
+      resolvedUserInfo.value = null
+      logoutCb?.()
+    },
     resetCallbacks: () => {
       resolvedCb = undefined
       logoutCb = undefined
+      resolvedUserInfo.value = null
     }
   }
 })
@@ -37,6 +47,7 @@ vi.mock('@customerio/cdp-analytics-browser', () => ({
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({
     userEmail: hoisted.userEmail,
+    resolvedUserInfo: hoisted.resolvedUserInfo,
     onUserResolved: hoisted.onUserResolved,
     onUserLogout: hoisted.onUserLogout
   })
@@ -80,6 +91,10 @@ describe('CustomerIoTelemetryProvider', () => {
     window.__CONFIG__ = {} as typeof window.__CONFIG__
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('loads the client and registers the in-app plugin with the site id', async () => {
     createProvider()
     await vi.dynamicImportSettled()
@@ -114,9 +129,12 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.userEmail.value = 'user@example.com'
     hoisted.resolveUser('test-uid-7f3a9c')
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c', {
-      email: 'user@example.com'
-    })
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+        'test-uid-7f3a9c',
+        { email: 'user@example.com' }
+      )
+    )
   })
 
   it('identifies with the configured user_id override without waiting for auth', async () => {
@@ -150,12 +168,14 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.userEmail.value = 'returning@example.com'
     hoisted.resolveUser('resolved-uid')
 
-    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
-    expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
-      2,
-      'forced-uid',
-      { email: 'returning@example.com' }
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
+        2,
+        'forced-uid',
+        { email: 'returning@example.com' }
+      )
     )
+    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
   })
 
   it('identifies before flushing events buffered before the SDK loads', async () => {
@@ -175,13 +195,83 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(identifyOrder).toBeLessThan(trackOrder)
   })
 
+  it('restores the resolved user after flushing an older auth event', async () => {
+    let activeUser: string | null = null
+    hoisted.analytics.identify.mockImplementation((userId: string) => {
+      activeUser = userId
+      return Promise.resolve()
+    })
+    hoisted.userEmail.value = 'current@example.com'
+    hoisted.resolvedUserInfo.value = { id: 'current-uid' }
+    const provider = createProvider()
+
+    provider.trackAuth({
+      user_id: 'queued-uid',
+      email: 'queued@example.com'
+    })
+    await vi.dynamicImportSettled()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify.mock.calls).toEqual([
+        ['current-uid', { email: 'current@example.com' }],
+        ['queued-uid', { email: 'queued@example.com' }],
+        ['current-uid', { email: 'current@example.com' }]
+      ])
+    )
+    expect(activeUser).toBe('current-uid')
+  })
+
+  it('resets identity after flushing auth for a signed-out user', async () => {
+    let activeUser: string | null = null
+    hoisted.analytics.identify.mockImplementation((userId: string) => {
+      activeUser = userId
+      return Promise.resolve()
+    })
+    hoisted.analytics.reset.mockImplementation(() => {
+      activeUser = null
+    })
+    const provider = createProvider()
+
+    provider.trackAuth({
+      user_id: 'queued-uid',
+      email: 'queued@example.com'
+    })
+    await vi.dynamicImportSettled()
+
+    await vi.waitFor(() => expect(hoisted.analytics.reset).toHaveBeenCalled())
+    expect(activeUser).toBeNull()
+  })
+
   it('resets on logout', async () => {
     createProvider()
     await vi.dynamicImportSettled()
 
     hoisted.logoutUser()
 
-    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+    )
+  })
+
+  it('continues tracking after reset fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    hoisted.analytics.reset.mockRejectedValueOnce(new Error('reset failed'))
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.logoutUser()
+    provider.trackWorkflowExecution()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'execution_start',
+        SOURCE
+      )
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to process Customer.io operation:',
+      expect.any(Error)
+    )
   })
 
   const DIRECT_EVENTS: Array<{
@@ -256,7 +346,9 @@ describe('CustomerIoTelemetryProvider', () => {
 
       invoke(provider)
 
-      expect(hoisted.analytics.track).toHaveBeenCalledWith(event, expected)
+      await vi.waitFor(() =>
+        expect(hoisted.analytics.track).toHaveBeenCalledWith(event, expected)
+      )
     }
   )
 
@@ -297,15 +389,49 @@ describe('CustomerIoTelemetryProvider', () => {
     )
   })
 
+  it('tracks auth before resetting identity on logout', async () => {
+    const identifyResult = createDeferred()
+    let activeUser: string | null = null
+    let trackedUser: string | null = null
+    hoisted.analytics.identify.mockImplementationOnce((userId: string) => {
+      activeUser = userId
+      return identifyResult.promise
+    })
+    hoisted.analytics.track.mockImplementationOnce(() => {
+      trackedUser = activeUser
+      return Promise.resolve()
+    })
+    hoisted.analytics.reset.mockImplementationOnce(() => {
+      activeUser = null
+    })
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({
+      user_id: 'uid-1',
+      email: 'person@example.com'
+    })
+    hoisted.logoutUser()
+    identifyResult.resolve()
+
+    await vi.waitFor(() => expect(hoisted.analytics.reset).toHaveBeenCalled())
+    expect(trackedUser).toBe('uid-1')
+    expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.analytics.reset.mock.invocationCallOrder[0]
+    )
+  })
+
   it('tracks auth after identifying a user without an email', async () => {
     const provider = createProvider()
     await vi.dynamicImportSettled()
 
     provider.trackAuth({ user_id: 'uid-without-email' })
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith(
-      'uid-without-email',
-      undefined
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+        'uid-without-email',
+        undefined
+      )
     )
     await vi.waitFor(() =>
       expect(hoisted.analytics.track).toHaveBeenCalledWith(
@@ -354,6 +480,28 @@ describe('CustomerIoTelemetryProvider', () => {
     ])
   })
 
+  it('waits for queued auth identification before later events', async () => {
+    const identifyResult = createDeferred()
+    hoisted.analytics.identify.mockReturnValueOnce(identifyResult.promise)
+    const provider = createProvider()
+    provider.trackAuth({
+      user_id: 'uid-1',
+      email: 'person@example.com'
+    })
+    provider.trackWorkflowExecution()
+
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+    identifyResult.resolve()
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track.mock.calls).toEqual([
+        ['app:user_auth_completed', { ...SOURCE, user_id: 'uid-1' }],
+        ['execution_start', SOURCE]
+      ])
+    )
+  })
+
   it('disables tracking when the SDK fails to load', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     hoisted.load.mockImplementation(() => {
@@ -380,12 +528,12 @@ describe('CustomerIoTelemetryProvider', () => {
     provider.trackWorkflowExecution()
     provider.trackAddApiCreditButtonClicked()
 
-    expect(hoisted.analytics.track).toHaveBeenCalledTimes(2)
     await vi.waitFor(() =>
-      expect(console.error).toHaveBeenCalledWith(
-        'Failed to track Customer.io event:',
-        expect.any(Error)
-      )
+      expect(hoisted.analytics.track).toHaveBeenCalledTimes(2)
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to track Customer.io event:',
+      expect.any(Error)
     )
   })
 })

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -217,8 +217,13 @@ describe('CustomerIoTelemetryProvider', () => {
 
   it('restores the resolved user after flushing an older auth event', async () => {
     let activeUser: string | null = null
+    const trackedUsers: Array<[string, string | null]> = []
     hoisted.analytics.identify.mockImplementation((userId: string) => {
       activeUser = userId
+      return Promise.resolve()
+    })
+    hoisted.analytics.track.mockImplementation((event: string) => {
+      trackedUsers.push([event, activeUser])
       return Promise.resolve()
     })
     hoisted.userEmail.value = 'current@example.com'
@@ -229,6 +234,7 @@ describe('CustomerIoTelemetryProvider', () => {
       user_id: 'queued-uid',
       email: 'queued@example.com'
     })
+    provider.trackWorkflowExecution()
     await vi.dynamicImportSettled()
 
     await vi.waitFor(() =>
@@ -239,12 +245,21 @@ describe('CustomerIoTelemetryProvider', () => {
       ])
     )
     expect(activeUser).toBe('current-uid')
+    expect(trackedUsers).toEqual([
+      ['app:user_auth_completed', 'queued-uid'],
+      ['execution_start', 'current-uid']
+    ])
   })
 
   it('resets identity after flushing auth for a signed-out user', async () => {
     let activeUser: string | null = null
+    let trackedUser: string | null = null
     hoisted.analytics.identify.mockImplementation((userId: string) => {
       activeUser = userId
+      return Promise.resolve()
+    })
+    hoisted.analytics.track.mockImplementation(() => {
+      trackedUser = activeUser
       return Promise.resolve()
     })
     hoisted.analytics.reset.mockImplementation(() => {
@@ -259,6 +274,7 @@ describe('CustomerIoTelemetryProvider', () => {
     await vi.dynamicImportSettled()
 
     await vi.waitFor(() => expect(hoisted.analytics.reset).toHaveBeenCalled())
+    expect(trackedUser).toBe('queued-uid')
     expect(activeUser).toBeNull()
   })
 
@@ -407,6 +423,34 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(hoisted.analytics.identify.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.analytics.track.mock.invocationCallOrder[0]
     )
+  })
+
+  it('reuses matching resolved-user identification for auth delivery', async () => {
+    const identifyResult = createDeferred()
+    hoisted.analytics.identify.mockReturnValueOnce(identifyResult.promise)
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.userEmail.value = 'person@example.com'
+    hoisted.resolveUser('uid-1')
+    provider.trackAuth({
+      user_id: 'uid-1',
+      email: 'person@example.com'
+    })
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenCalledOnce()
+    )
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+    identifyResult.resolve()
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        { ...SOURCE, user_id: 'uid-1' }
+      )
+    )
+    expect(hoisted.analytics.identify).toHaveBeenCalledOnce()
   })
 
   it('tracks auth before resetting identity on logout', async () => {

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -94,6 +94,7 @@ describe('CustomerIoTelemetryProvider', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('loads the client and registers the in-app plugin with the site id', async () => {
@@ -550,6 +551,49 @@ describe('CustomerIoTelemetryProvider', () => {
     )
     expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.analytics.identify.mock.invocationCallOrder[1]
+    )
+  })
+
+  it('does not reset identity when login resolution follows auth tracking', async () => {
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({ user_id: 'uid-1', email: 'person@example.com' })
+    hoisted.userEmail.value = 'person@example.com'
+    hoisted.resolveUser('uid-1')
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(
+        'app:user_auth_completed',
+        { ...SOURCE, user_id: 'uid-1' }
+      )
+    )
+    expect(hoisted.analytics.identify).toHaveBeenCalledOnce()
+    expect(hoisted.analytics.reset).not.toHaveBeenCalled()
+  })
+
+  it('does not stall later events when identification never settles', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    hoisted.analytics.identify.mockReturnValueOnce(new Promise(() => {}))
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({ user_id: 'uid-1', email: 'person@example.com' })
+    provider.trackWorkflowExecution()
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.track.mock.calls).toEqual([
+        ['app:user_auth_completed', { ...SOURCE, user_id: 'uid-1' }],
+        ['execution_start', SOURCE]
+      ])
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to identify Customer.io user:',
+      expect.any(Error)
     )
   })
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -487,6 +487,45 @@ describe('CustomerIoTelemetryProvider', () => {
     trackResult.resolve()
   })
 
+  it('restores signed-out identity when auth delivery follows logout', async () => {
+    let activeUser: string | null = null
+    let trackedUser: string | null = null
+    hoisted.analytics.identify.mockImplementation((userId: string) => {
+      activeUser = userId
+      return Promise.resolve()
+    })
+    hoisted.analytics.track.mockImplementation(() => {
+      trackedUser = activeUser
+      return Promise.resolve()
+    })
+    hoisted.analytics.reset.mockImplementation(() => {
+      activeUser = null
+    })
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.userEmail.value = 'person@example.com'
+    hoisted.resolveUser('uid-1')
+    hoisted.logoutUser()
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+    )
+
+    provider.trackAuth({
+      user_id: 'uid-1',
+      email: 'person@example.com'
+    })
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.reset).toHaveBeenCalledTimes(2)
+    )
+    expect(trackedUser).toBe('uid-1')
+    expect(activeUser).toBeNull()
+    expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.analytics.reset.mock.invocationCallOrder[1]
+    )
+  })
+
   it('restores a configured identity after tracking auth with the Firebase uid', async () => {
     const provider = createProvider({
       customer_io: {

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -22,6 +22,7 @@ interface QueuedEvent {
   event: string
   properties: Record<string, unknown>
   identity?: CustomerIoIdentity
+  restoreIdentity?: CustomerIoIdentity
 }
 
 interface CustomerIoIdentity {
@@ -41,6 +42,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private isEnabled = true
   private eventQueue: QueuedEvent[] = []
   private identifiedUser: CustomerIoIdentity | null = null
+  private sessionIdentity: CustomerIoIdentity | null = null
   private operationQueue: Promise<void> = Promise.resolve()
 
   constructor() {
@@ -49,6 +51,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       site_id: siteId,
       user_id: userIdOverride
     } = window.__CONFIG__?.customer_io ?? {}
+    this.sessionIdentity = userIdOverride ? { userId: userIdOverride } : null
     if (!writeKey || !siteId) {
       this.isEnabled = false
       return
@@ -73,15 +76,16 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         const hasQueuedIdentity = this.eventQueue.some(({ identity }) =>
           Boolean(identity)
         )
-        const identifyResolvedUser = (user: AuthUserInfo) =>
-          this.enqueueOperation(() =>
-            this.identify({
-              userId: userIdOverride || user.id,
-              email: currentUser.userEmail.value || undefined
-            })
-          )
+        const identifyResolvedUser = (user: AuthUserInfo) => {
+          const identity = {
+            userId: userIdOverride || user.id,
+            email: currentUser.userEmail.value || undefined
+          }
+          this.sessionIdentity = identity
+          return this.enqueueOperation(() => this.identify(identity))
+        }
 
-        if (userIdOverride) {
+        if (userIdOverride && !currentUser.resolvedUserInfo.value) {
           void this.enqueueOperation(() =>
             this.identify({ userId: userIdOverride })
           )
@@ -90,6 +94,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
           void identifyResolvedUser(user)
         })
         currentUser.onUserLogout(() => {
+          this.sessionIdentity = null
           void this.enqueueOperation(() => this.resetIdentity())
         })
 
@@ -155,31 +160,35 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private async send(
     event: string,
     properties: Record<string, unknown>,
-    identity?: CustomerIoIdentity
+    identity?: CustomerIoIdentity,
+    restoreIdentity?: CustomerIoIdentity
   ): Promise<void> {
     const analytics = this.analytics
     if (!analytics) return
 
     if (identity) await this.identify(identity)
 
-    try {
-      await analytics.track(event, properties)
-    } catch (error) {
+    void analytics.track(event, properties).catch((error) => {
       console.error('Failed to track Customer.io event:', error)
-    }
+    })
+
+    if (restoreIdentity) await this.identify(restoreIdentity)
   }
 
   private track(
     event: string,
     metadata?: TelemetryEventProperties,
-    identity?: CustomerIoIdentity
+    identity?: CustomerIoIdentity,
+    restoreIdentity?: CustomerIoIdentity
   ): void {
     if (!this.isEnabled) return
     const properties = { ...metadata, event_source: EVENT_SOURCE }
     if (this.analytics) {
-      void this.enqueueOperation(() => this.send(event, properties, identity))
+      void this.enqueueOperation(() =>
+        this.send(event, properties, identity, restoreIdentity)
+      )
     } else {
-      this.eventQueue.push({ event, properties, identity })
+      this.eventQueue.push({ event, properties, identity, restoreIdentity })
     }
   }
 
@@ -188,22 +197,24 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     const queue = this.eventQueue
     this.eventQueue = []
     await this.enqueueOperation(async () => {
-      for (const { event, properties, identity } of queue) {
-        await this.send(event, properties, identity)
+      for (const { event, properties, identity, restoreIdentity } of queue) {
+        await this.send(event, properties, identity, restoreIdentity)
       }
     })
   }
 
   trackAuth(metadata: AuthMetadata): void {
+    const identity = metadata.user_id
+      ? {
+          userId: metadata.user_id,
+          email: metadata.email || undefined
+        }
+      : undefined
     this.track(
       TelemetryEvents.USER_AUTH_COMPLETED,
       omit(metadata, ['email', 'share_id']),
-      metadata.user_id
-        ? {
-            userId: metadata.user_id,
-            email: metadata.email || undefined
-          }
-        : undefined
+      identity,
+      identity ? this.sessionIdentity || undefined : undefined
     )
   }
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -152,7 +152,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     event: string,
     properties: Record<string, unknown>,
     identity?: CustomerIoIdentity,
-    restoreIdentity?: CustomerIoIdentity
+    restoreIdentity?: CustomerIoIdentity | null
   ): Promise<void> {
     const analytics = this.analytics
     if (!analytics) return
@@ -163,14 +163,18 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       console.error('Failed to track Customer.io event:', error)
     })
 
-    if (restoreIdentity) await this.identify(restoreIdentity)
+    if (restoreIdentity) {
+      await this.identify(restoreIdentity)
+    } else if (restoreIdentity === null) {
+      await this.resetIdentity()
+    }
   }
 
   private track(
     event: string,
     metadata?: TelemetryEventProperties,
     identity?: CustomerIoIdentity,
-    restoreIdentity?: CustomerIoIdentity
+    restoreIdentity?: CustomerIoIdentity | null
   ): void {
     if (!this.isEnabled) return
     const properties = { ...metadata, event_source: EVENT_SOURCE }
@@ -206,7 +210,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       TelemetryEvents.USER_AUTH_COMPLETED,
       omit(metadata, ['email', 'share_id']),
       identity,
-      identity ? this.sessionIdentity || undefined : undefined
+      identity ? this.sessionIdentity : undefined
     )
   }
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -22,7 +22,6 @@ interface QueuedEvent {
   event: string
   properties: Record<string, unknown>
   identity?: CustomerIoIdentity
-  restoreIdentity?: CustomerIoIdentity
 }
 
 interface CustomerIoIdentity {
@@ -73,9 +72,6 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         this.analytics = analytics
 
         const currentUser = useCurrentUser()
-        const hasQueuedIdentity = this.eventQueue.some(({ identity }) =>
-          Boolean(identity)
-        )
         const identifyResolvedUser = (user: AuthUserInfo) => {
           const identity = {
             userId: userIdOverride || user.id,
@@ -99,19 +95,6 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         })
 
         void this.flushQueue()
-
-        if (hasQueuedIdentity) {
-          const resolvedUser = currentUser.resolvedUserInfo.value
-          if (resolvedUser) {
-            void identifyResolvedUser(resolvedUser)
-          } else if (userIdOverride) {
-            void this.enqueueOperation(() =>
-              this.identify({ userId: userIdOverride })
-            )
-          } else {
-            void this.enqueueOperation(() => this.resetIdentity())
-          }
-        }
       })
       .catch((error) => {
         console.error('Failed to load Customer.io:', error)
@@ -132,6 +115,14 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private async resetIdentity(): Promise<void> {
     this.identifiedUser = null
     await this.analytics?.reset()
+  }
+
+  private async restoreSessionIdentity(): Promise<void> {
+    if (this.sessionIdentity) {
+      await this.identify(this.sessionIdentity)
+    } else {
+      await this.resetIdentity()
+    }
   }
 
   private async identify(identity: CustomerIoIdentity): Promise<void> {
@@ -188,7 +179,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         this.send(event, properties, identity, restoreIdentity)
       )
     } else {
-      this.eventQueue.push({ event, properties, identity, restoreIdentity })
+      this.eventQueue.push({ event, properties, identity })
     }
   }
 
@@ -197,8 +188,9 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     const queue = this.eventQueue
     this.eventQueue = []
     await this.enqueueOperation(async () => {
-      for (const { event, properties, identity, restoreIdentity } of queue) {
-        await this.send(event, properties, identity, restoreIdentity)
+      for (const { event, properties, identity } of queue) {
+        await this.send(event, properties, identity)
+        if (identity) await this.restoreSessionIdentity()
       }
     })
   }

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -1,5 +1,5 @@
 import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
-import { omit } from 'es-toolkit'
+import { omit, withTimeout } from 'es-toolkit'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import type { AuthUserInfo } from '@/types/authTypes'
@@ -17,6 +17,8 @@ import type {
 } from '../../types'
 
 export const EVENT_SOURCE = 'web-sdk'
+
+const SDK_OPERATION_TIMEOUT_MS = 10_000
 
 interface QueuedEvent {
   event: string
@@ -114,7 +116,11 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
 
   private async resetIdentity(): Promise<void> {
     this.identifiedUser = null
-    await this.analytics?.reset()
+    const analytics = this.analytics
+    if (!analytics) return
+    await withTimeout(async () => {
+      await analytics.reset()
+    }, SDK_OPERATION_TIMEOUT_MS)
   }
 
   private async restoreSessionIdentity(): Promise<void> {
@@ -138,10 +144,12 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
 
     this.identifiedUser = identity
     try {
-      await analytics.identify(
-        identity.userId,
-        identity.email ? { email: identity.email } : undefined
-      )
+      await withTimeout(async () => {
+        await analytics.identify(
+          identity.userId,
+          identity.email ? { email: identity.email } : undefined
+        )
+      }, SDK_OPERATION_TIMEOUT_MS)
     } catch (error) {
       this.identifiedUser = null
       console.error('Failed to identify Customer.io user:', error)
@@ -151,8 +159,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private async send(
     event: string,
     properties: Record<string, unknown>,
-    identity?: CustomerIoIdentity,
-    restoreIdentity?: CustomerIoIdentity | null
+    identity?: CustomerIoIdentity
   ): Promise<void> {
     const analytics = this.analytics
     if (!analytics) return
@@ -163,25 +170,18 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       console.error('Failed to track Customer.io event:', error)
     })
 
-    if (restoreIdentity) {
-      await this.identify(restoreIdentity)
-    } else if (restoreIdentity === null) {
-      await this.resetIdentity()
-    }
+    if (identity) await this.restoreSessionIdentity()
   }
 
   private track(
     event: string,
     metadata?: TelemetryEventProperties,
-    identity?: CustomerIoIdentity,
-    restoreIdentity?: CustomerIoIdentity | null
+    identity?: CustomerIoIdentity
   ): void {
     if (!this.isEnabled) return
     const properties = { ...metadata, event_source: EVENT_SOURCE }
     if (this.analytics) {
-      void this.enqueueOperation(() =>
-        this.send(event, properties, identity, restoreIdentity)
-      )
+      void this.enqueueOperation(() => this.send(event, properties, identity))
     } else {
       this.eventQueue.push({ event, properties, identity })
     }
@@ -194,7 +194,6 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     await this.enqueueOperation(async () => {
       for (const { event, properties, identity } of queue) {
         await this.send(event, properties, identity)
-        if (identity) await this.restoreSessionIdentity()
       }
     })
   }
@@ -209,8 +208,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     this.track(
       TelemetryEvents.USER_AUTH_COMPLETED,
       omit(metadata, ['email', 'share_id']),
-      identity,
-      identity ? this.sessionIdentity : undefined
+      identity
     )
   }
 

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
+import { omit } from 'es-toolkit'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 
@@ -19,6 +20,12 @@ export const EVENT_SOURCE = 'web-sdk'
 interface QueuedEvent {
   event: string
   properties: Record<string, unknown>
+  identity?: CustomerIoIdentity
+}
+
+interface CustomerIoIdentity {
+  userId: string
+  email?: string
 }
 
 /**
@@ -32,6 +39,8 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private analytics: AnalyticsBrowser | null = null
   private isEnabled = true
   private eventQueue: QueuedEvent[] = []
+  private identifiedUser: CustomerIoIdentity | null = null
+  private identifyPromise: Promise<void> = Promise.resolve()
 
   constructor() {
     const {
@@ -61,11 +70,19 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
 
         const currentUser = useCurrentUser()
         if (userIdOverride) {
-          void analytics.identify(userIdOverride)
-        } else {
-          currentUser.onUserResolved((user) => void analytics.identify(user.id))
+          void this.identify({ userId: userIdOverride })
         }
-        currentUser.onUserLogout(() => void analytics.reset())
+        currentUser.onUserResolved((user) => {
+          void this.identify({
+            userId: userIdOverride || user.id,
+            email: currentUser.userEmail.value || undefined
+          })
+        })
+        currentUser.onUserLogout(() => {
+          this.identifiedUser = null
+          this.identifyPromise = Promise.resolve()
+          void analytics.reset()
+        })
 
         this.flushQueue()
       })
@@ -76,32 +93,79 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       })
   }
 
-  private send(event: string, properties: Record<string, unknown>): void {
-    void this.analytics?.track(event, properties)?.catch((error) => {
+  private identify(identity: CustomerIoIdentity): Promise<void> {
+    const analytics = this.analytics
+    if (!analytics) return Promise.resolve()
+
+    if (
+      this.identifiedUser?.userId === identity.userId &&
+      this.identifiedUser.email === identity.email
+    ) {
+      return this.identifyPromise
+    }
+
+    this.identifiedUser = identity
+    this.identifyPromise = analytics
+      .identify(
+        identity.userId,
+        identity.email ? { email: identity.email } : undefined
+      )
+      .then(() => undefined)
+      .catch((error) => {
+        if (this.identifiedUser === identity) this.identifiedUser = null
+        console.error('Failed to identify Customer.io user:', error)
+      })
+    return this.identifyPromise
+  }
+
+  private async send(
+    event: string,
+    properties: Record<string, unknown>,
+    identity?: CustomerIoIdentity
+  ): Promise<void> {
+    const analytics = this.analytics
+    if (!analytics) return
+
+    if (identity) await this.identify(identity)
+
+    await analytics.track(event, properties).catch((error) => {
       console.error('Failed to track Customer.io event:', error)
     })
   }
 
-  private track(event: string, metadata?: TelemetryEventProperties): void {
+  private track(
+    event: string,
+    metadata?: TelemetryEventProperties,
+    identity?: CustomerIoIdentity
+  ): void {
     if (!this.isEnabled) return
     const properties = { ...metadata, event_source: EVENT_SOURCE }
     if (this.analytics) {
-      this.send(event, properties)
+      void this.send(event, properties, identity)
     } else {
-      this.eventQueue.push({ event, properties })
+      this.eventQueue.push({ event, properties, identity })
     }
   }
 
   private flushQueue(): void {
     if (!this.analytics) return
-    for (const { event, properties } of this.eventQueue) {
-      this.send(event, properties)
+    for (const { event, properties, identity } of this.eventQueue) {
+      void this.send(event, properties, identity)
     }
     this.eventQueue = []
   }
 
   trackAuth(metadata: AuthMetadata): void {
-    this.track(TelemetryEvents.USER_AUTH_COMPLETED, metadata)
+    this.track(
+      TelemetryEvents.USER_AUTH_COMPLETED,
+      omit(metadata, ['email', 'share_id']),
+      metadata.user_id
+        ? {
+            userId: metadata.user_id,
+            email: metadata.email || undefined
+          }
+        : undefined
+    )
   }
 
   trackSubscription(
@@ -137,6 +201,6 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {
-    this.track(TelemetryEvents.SHARE_FLOW, metadata)
+    this.track(TelemetryEvents.SHARE_FLOW, omit(metadata, ['share_id']))
   }
 }

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -2,6 +2,7 @@ import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
 import { omit } from 'es-toolkit'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import type { AuthUserInfo } from '@/types/authTypes'
 
 import { TelemetryEvents } from '../../types'
 import type {
@@ -40,7 +41,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   private isEnabled = true
   private eventQueue: QueuedEvent[] = []
   private identifiedUser: CustomerIoIdentity | null = null
-  private identifyPromise: Promise<void> = Promise.resolve()
+  private operationQueue: Promise<void> = Promise.resolve()
 
   constructor() {
     const {
@@ -69,22 +70,43 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         this.analytics = analytics
 
         const currentUser = useCurrentUser()
+        const hasQueuedIdentity = this.eventQueue.some(({ identity }) =>
+          Boolean(identity)
+        )
+        const identifyResolvedUser = (user: AuthUserInfo) =>
+          this.enqueueOperation(() =>
+            this.identify({
+              userId: userIdOverride || user.id,
+              email: currentUser.userEmail.value || undefined
+            })
+          )
+
         if (userIdOverride) {
-          void this.identify({ userId: userIdOverride })
+          void this.enqueueOperation(() =>
+            this.identify({ userId: userIdOverride })
+          )
         }
         currentUser.onUserResolved((user) => {
-          void this.identify({
-            userId: userIdOverride || user.id,
-            email: currentUser.userEmail.value || undefined
-          })
+          void identifyResolvedUser(user)
         })
         currentUser.onUserLogout(() => {
-          this.identifiedUser = null
-          this.identifyPromise = Promise.resolve()
-          void analytics.reset()
+          void this.enqueueOperation(() => this.resetIdentity())
         })
 
-        this.flushQueue()
+        void this.flushQueue()
+
+        if (hasQueuedIdentity) {
+          const resolvedUser = currentUser.resolvedUserInfo.value
+          if (resolvedUser) {
+            void identifyResolvedUser(resolvedUser)
+          } else if (userIdOverride) {
+            void this.enqueueOperation(() =>
+              this.identify({ userId: userIdOverride })
+            )
+          } else {
+            void this.enqueueOperation(() => this.resetIdentity())
+          }
+        }
       })
       .catch((error) => {
         console.error('Failed to load Customer.io:', error)
@@ -93,29 +115,41 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       })
   }
 
-  private identify(identity: CustomerIoIdentity): Promise<void> {
+  private enqueueOperation(
+    operation: () => Promise<void> | void
+  ): Promise<void> {
+    this.operationQueue = this.operationQueue.then(operation).catch((error) => {
+      console.error('Failed to process Customer.io operation:', error)
+    })
+    return this.operationQueue
+  }
+
+  private async resetIdentity(): Promise<void> {
+    this.identifiedUser = null
+    await this.analytics?.reset()
+  }
+
+  private async identify(identity: CustomerIoIdentity): Promise<void> {
     const analytics = this.analytics
-    if (!analytics) return Promise.resolve()
+    if (!analytics) return
 
     if (
       this.identifiedUser?.userId === identity.userId &&
       this.identifiedUser.email === identity.email
     ) {
-      return this.identifyPromise
+      return
     }
 
     this.identifiedUser = identity
-    this.identifyPromise = analytics
-      .identify(
+    try {
+      await analytics.identify(
         identity.userId,
         identity.email ? { email: identity.email } : undefined
       )
-      .then(() => undefined)
-      .catch((error) => {
-        if (this.identifiedUser === identity) this.identifiedUser = null
-        console.error('Failed to identify Customer.io user:', error)
-      })
-    return this.identifyPromise
+    } catch (error) {
+      this.identifiedUser = null
+      console.error('Failed to identify Customer.io user:', error)
+    }
   }
 
   private async send(
@@ -128,9 +162,11 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
 
     if (identity) await this.identify(identity)
 
-    await analytics.track(event, properties).catch((error) => {
+    try {
+      await analytics.track(event, properties)
+    } catch (error) {
       console.error('Failed to track Customer.io event:', error)
-    })
+    }
   }
 
   private track(
@@ -141,18 +177,21 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     if (!this.isEnabled) return
     const properties = { ...metadata, event_source: EVENT_SOURCE }
     if (this.analytics) {
-      void this.send(event, properties, identity)
+      void this.enqueueOperation(() => this.send(event, properties, identity))
     } else {
       this.eventQueue.push({ event, properties, identity })
     }
   }
 
-  private flushQueue(): void {
+  private async flushQueue(): Promise<void> {
     if (!this.analytics) return
-    for (const { event, properties, identity } of this.eventQueue) {
-      void this.send(event, properties, identity)
-    }
+    const queue = this.eventQueue
     this.eventQueue = []
+    await this.enqueueOperation(async () => {
+      for (const { event, properties, identity } of queue) {
+        await this.send(event, properties, identity)
+      }
+    })
   }
 
   trackAuth(metadata: AuthMetadata): void {


### PR DESCRIPTION
We need this fix urgently, blocking all welcome emails and fixing several vectors.

## Summary

Identify Customer.io users with Firebase UID and email traits, then wait for that profile update before sending `app:user_auth_completed` so Welcome Onboarding entrants satisfy the Valid Email Address segment. Preserve the correct session or anonymous identity after the auth event is handed to the SDK.

## Changes

- **Auth delivery ordering**: Queue auth events with their Firebase identity and send the event only after Customer.io `identify(uid, { email })` settles. Missing-email identities fall back to UID-only identification, and rejected identifies are logged without suppressing auth telemetry.
- **Identity lifecycle**: Serialize identity transitions and event handoff, deduplicate matching `identify()` operations, and snapshot resolved UID/email together. After auth delivery, restore the configured or resolved session identity—or reset to anonymous—including for SDK-late buffered events and auth callbacks that arrive after logout. Ordinary event delivery does not hold the identity queue open while its network request completes.
- **Payload privacy**: Use email as a Customer.io person trait while excluding raw `email` and `share_id` from Customer.io event properties.
- **Dependencies**: None.

## Incident evidence

- Campaign 1 triggers on `app:user_auth_completed` with `is_new_user=true` and requires the Valid Email Address segment.
- In a recent 15-minute sample, all 30 new-user events had an email property, while all 30 corresponding Customer.io person profiles had `identifiers.email=null`.
- Starts fell from 556/day through June 30 to 23.5/day after July 1, excluding a one-day spike.
- Event properties do not update Customer.io person identifiers, and the previous fire-and-forget identify allowed the auth event to race the profile update.

## Review Focus

The auth result's `user_id` is the authoritative Firebase UID for the identify that gates `app:user_auth_completed`. Once the SDK snapshots that event, the provider restores the current configured/resolved identity or the signed-out anonymous state before handing off later events. Matching identity operations are deduplicated; repeated auth completions remain distinct telemetry events. A rejected identify must not suppress auth telemetry.

This supersedes the partial fixes in #13556 (email trait without ordering) and #12888 (reset/re-login and redaction without the email-profile race fix).

## Validation

- `pnpm test:unit src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts` — 35 passed
- `pnpm typecheck`
- File-scoped type-aware Oxlint
- File-scoped ESLint
- File-scoped oxfmt check
- `pnpm knip` via the pre-push hook

A browser E2E test is not practical for this SDK delivery-ordering fix: the regressions require controlling unresolved Customer.io `identify`/`track` promises and observing the active identity when each event is handed to the SDK. The focused unit suite controls those boundaries directly and covers SDK-late queueing, configured overrides, identity restoration, logout races, missing email, rejection fallback, payload redaction, and non-blocking event delivery.

## Rollout / backfill

- Deploy or backport this change to the active cloud release line.
- Verify new-user Customer.io profiles receive a non-null email identifier before the auth event is processed, then monitor Campaign 1 starts against the pre-July baseline.
- Backfill or re-trigger already affected new users separately; this frontend change repairs future auth deliveries and does not replay historical events.
- No live Customer.io campaign changes are included.
