### PR TITLE
[GTM-278] Report Firebase auth state to Desktop telemetry

### DIFF
--- a/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
+++ b/packages/comfyui-desktop-bridge-types/comfyDesktopBridge.d.ts
@@ -40,6 +40,11 @@ export type ComfyDesktop2TelemetryProperties = Record<
   ComfyDesktop2TelemetryValue | ComfyDesktop2TelemetryValue[]
 >
 
+export type ComfyDesktop2FirebaseAuthState =
+  | { status: 'pending' }
+  | { status: 'signed_out' }
+  | { status: 'signed_in'; userId: string }
+
 export interface ComfyDesktop2TerminalBridge {
   subscribe(installationId?: string): Promise<TerminalRestore>
   unsubscribe(installationId?: string): Promise<void>
@@ -60,6 +65,7 @@ export interface ComfyDesktop2LogsBridge {
 
 export interface ComfyDesktop2TelemetryBridge {
   capture(event: string, properties?: ComfyDesktop2TelemetryProperties): void
+  reportFirebaseAuthState?(state: ComfyDesktop2FirebaseAuthState): void
 }
 
 export interface ComfyDesktop2Bridge {

--- a/packages/comfyui-desktop-bridge-types/package.json
+++ b/packages/comfyui-desktop-bridge-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/comfyui-desktop-bridge-types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript definitions for the Comfy Desktop hosted frontend bridge",
   "homepage": "https://comfy.org",
   "license": "MIT",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
   configValueOrDefault,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
+import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
 import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
 import { isDesktop, isNightly } from '@/platform/distribution/types'
@@ -140,6 +141,10 @@ app
     firebaseApp,
     modules: [VueFireAuth()]
   })
+
+if (isCloud && hasHostTelemetryBridge) {
+  syncHostUserIdWithFirebaseAuth()
+}
 
 LGraph.proxyWidgetMigrationFlush = (hostNode, nodeData) =>
   flushProxyWidgetMigration({

--- a/src/platform/telemetry/hostUserIdSync.test.ts
+++ b/src/platform/telemetry/hostUserIdSync.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as VueModule from 'vue'
+import { nextTick } from 'vue'
+
+type MockAuthStore = {
+  isInitialized: boolean
+  currentUser: { uid: string } | null
+}
+
+const hoisted = vi.hoisted(() => ({
+  authStore: null as unknown as MockAuthStore
+}))
+
+vi.mock('@/stores/authStore', async () => {
+  const { reactive } = await vi.importActual<typeof VueModule>('vue')
+  hoisted.authStore = reactive<MockAuthStore>({
+    isInitialized: false,
+    currentUser: null
+  })
+  return { useAuthStore: () => hoisted.authStore }
+})
+
+import { syncHostUserIdWithFirebaseAuth } from './hostUserIdSync'
+
+const stopHandles: Array<() => void> = []
+
+function installTelemetryBridge() {
+  const reportFirebaseAuthState = vi.fn()
+  window.__comfyDesktop2 = {
+    isRemote: () => false,
+    Telemetry: {
+      capture: vi.fn(),
+      reportFirebaseAuthState
+    }
+  }
+  return { reportFirebaseAuthState }
+}
+
+function startSync(): void {
+  const stop = syncHostUserIdWithFirebaseAuth()
+  if (stop) stopHandles.push(stop)
+}
+
+describe('host user ID sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.authStore.isInitialized = false
+    hoisted.authStore.currentUser = null
+  })
+
+  afterEach(() => {
+    while (stopHandles.length) stopHandles.pop()?.()
+    delete window.__comfyDesktop2
+  })
+
+  it('waits for Firebase auth initialization before reporting a user', async () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    startSync()
+
+    expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'pending'
+    })
+
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
+
+    hoisted.authStore.isInitialized = true
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'signed_in',
+      userId: 'firebase-user-a'
+    })
+  })
+
+  it('reports a restored Firebase session immediately', () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    hoisted.authStore.isInitialized = true
+
+    startSync()
+
+    expect(reportFirebaseAuthState.mock.calls).toEqual([
+      [{ status: 'pending' }],
+      [{ status: 'signed_in', userId: 'firebase-user-a' }]
+    ])
+  })
+
+  it('reports an initially signed-out Firebase session', () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    hoisted.authStore.isInitialized = true
+
+    startSync()
+
+    expect(reportFirebaseAuthState.mock.calls).toEqual([
+      [{ status: 'pending' }],
+      [{ status: 'signed_out' }]
+    ])
+  })
+
+  it('reports signed out when Firebase finishes initialization', async () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    startSync()
+
+    expect(reportFirebaseAuthState).toHaveBeenCalledOnce()
+
+    hoisted.authStore.isInitialized = true
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'signed_out'
+    })
+  })
+
+  it('reports account switches, logout, and subsequent login', async () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    hoisted.authStore.isInitialized = true
+    startSync()
+
+    hoisted.authStore.currentUser = { uid: 'firebase-user-b' }
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'signed_in',
+      userId: 'firebase-user-b'
+    })
+
+    hoisted.authStore.currentUser = null
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'signed_out'
+    })
+
+    hoisted.authStore.currentUser = { uid: 'firebase-user-c' }
+    await nextTick()
+
+    expect(reportFirebaseAuthState.mock.calls).toEqual([
+      [{ status: 'pending' }],
+      [{ status: 'signed_in', userId: 'firebase-user-a' }],
+      [{ status: 'signed_in', userId: 'firebase-user-b' }],
+      [{ status: 'signed_out' }],
+      [{ status: 'signed_in', userId: 'firebase-user-c' }]
+    ])
+  })
+
+  it('does not report again when Firebase replaces the user object with the same UID', async () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    hoisted.authStore.isInitialized = true
+    startSync()
+
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    await nextTick()
+
+    expect(reportFirebaseAuthState.mock.calls).toEqual([
+      [{ status: 'pending' }],
+      [{ status: 'signed_in', userId: 'firebase-user-a' }]
+    ])
+  })
+
+  it('does not let a host reporting failure interrupt Firebase state sync', async () => {
+    const { reportFirebaseAuthState } = installTelemetryBridge()
+    reportFirebaseAuthState.mockImplementationOnce(() => {
+      throw new Error('host unavailable')
+    })
+
+    expect(() => startSync()).not.toThrow()
+
+    hoisted.authStore.currentUser = { uid: 'firebase-user-a' }
+    hoisted.authStore.isInitialized = true
+    await nextTick()
+
+    expect(reportFirebaseAuthState).toHaveBeenLastCalledWith({
+      status: 'signed_in',
+      userId: 'firebase-user-a'
+    })
+  })
+})

--- a/src/platform/telemetry/hostUserIdSync.ts
+++ b/src/platform/telemetry/hostUserIdSync.ts
@@ -1,0 +1,49 @@
+import { watch } from 'vue'
+import type { WatchStopHandle } from 'vue'
+
+import { useAuthStore } from '@/stores/authStore'
+
+function safelyReportFirebaseAuthState(report: () => void): void {
+  try {
+    report()
+  } catch {
+    // A host bridge failure must not block renderer startup or Firebase auth.
+  }
+}
+
+/**
+ * Keep the Desktop main-process telemetry identity aligned with Firebase auth.
+ * Must run after Pinia and VueFire are installed.
+ */
+export function syncHostUserIdWithFirebaseAuth(): WatchStopHandle | undefined {
+  const telemetry = window.__comfyDesktop2?.Telemetry
+  if (!telemetry) return
+
+  // Register this Cloud renderer before Firebase resolves. Desktop may host
+  // multiple Cloud main frames whose isolated browser partitions have
+  // different auth states, so main owns all cross-WebContents arbitration.
+  safelyReportFirebaseAuthState(() =>
+    telemetry.reportFirebaseAuthState?.({ status: 'pending' })
+  )
+
+  const authStore = useAuthStore()
+
+  return watch(
+    () =>
+      authStore.isInitialized
+        ? (authStore.currentUser?.uid ?? null)
+        : undefined,
+    (userId) => {
+      if (userId === undefined) return
+
+      safelyReportFirebaseAuthState(() =>
+        telemetry.reportFirebaseAuthState?.(
+          userId === null
+            ? { status: 'signed_out' }
+            : { status: 'signed_in', userId }
+        )
+      )
+    },
+    { immediate: true }
+  )
+}


### PR DESCRIPTION
## Summary

Reports each hosted Cloud renderer's declarative Firebase auth state to Desktop. Desktop remains the sole owner of PostHog identity and arbitrates all live `WebContents` before changing the process-global person.

Linear: [GTM-278](https://linear.app/comfyorg/issue/GTM-278) · Parent: [GTM-93](https://linear.app/comfyorg/issue/GTM-93)

## Changes

- reports `pending` as soon as host auth synchronization starts
- waits for Firebase initialization, then reports `signed_out` or `signed_in` with the Firebase UID
- reports restored sessions, logout, and direct account switches through the same declarative state contract
- makes repeated same-UID Firebase updates a no-op
- adds the optional `reportFirebaseAuthState` contract to the Desktop bridge types
- keeps host bridge failures from interrupting renderer startup or Firebase auth

## Ownership and privacy

- the frontend never calls PostHog `identify`, `alias`, bind, or unbind APIs
- browser PostHog provider behavior is unchanged
- the auth-state message is local to Desktop; Desktop #1272 applies its own telemetry-consent gate before any PostHog identify or emission
- `enable_telemetry` controls only the frontend `HostTelemetrySink` (renderer event forwarding), so this observer deliberately does not share that rollout flag
- no canonical `comfy_user_id`, `/api/user` lookup, Cloud API dependency, Redis state, token redemption, or website transport change is added

## Review and rollout order

Review [Comfy-Desktop #1272](https://github.com/Comfy-Org/Comfy-Desktop/pull/1272) first because it defines the trusted state-reporting API and consensus policy. Deploy this frontend first: the method is optional and therefore a no-op on older Desktop builds. Then release Desktop #1272, and only afterward deploy [comfy-router #34](https://github.com/Comfy-Org/comfy-router/pull/34).

Auth [Comfy-Desktop #1222](https://github.com/Comfy-Org/Comfy-Desktop/pull/1222) must not become an identity authority; with Desktop #1272 its legacy imperative bind is inert and the post-reload Firebase report is the source of truth.

## Testing

- `pnpm test:unit src/platform/telemetry/hostUserIdSync.test.ts src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts` — 53 tests passed
- `pnpm typecheck`
- targeted Oxlint and ESLint
- targeted `oxfmt --check`
- `pnpm knip`
- pre-commit typecheck/lint/format hooks
- pre-push `knip`
- `git diff --check`

No user-facing UI changes.
