### PR TITLE
feat(onboarding-tour): smoother tour transitions, framing, and copy

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2334,8 +2334,8 @@
         "body": "This prompt reshapes the image: same style, new subject. This line is yours to change."
       },
       "run": {
-        "title": "Now run it and watch it come to life",
-        "body": "Press Run and your result starts generating."
+        "title": "Run your workflow",
+        "body": "Press Run to start generating your result"
       },
       "result": {
         "image": {
@@ -2350,9 +2350,9 @@
     },
     "generating": "Generating…",
     "gettingStarted": {
-      "title": "Get started with Graph",
+      "title": "Get started with graph",
       "subtitle": "Start a workflow from scratch or load one that's ready to go.",
-      "screenLabel": "Get started with Graph",
+      "screenLabel": "Get started with graph",
       "tabsLabel": "Getting started options",
       "tabs": {
         "templates": "Templates",

--- a/src/renderer/extensions/onboardingTour/OnboardingTourNudge.test.ts
+++ b/src/renderer/extensions/onboardingTour/OnboardingTourNudge.test.ts
@@ -46,7 +46,10 @@ const i18n = createI18n({
 })
 
 function renderNudge() {
-  return render(OnboardingTourNudge, { global: { plugins: [i18n] } })
+  return render(OnboardingTourNudge, {
+    props: { appearDelayMs: 0 },
+    global: { plugins: [i18n] }
+  })
 }
 
 const nudgeTitle = enMessages.onboardingTour.nudge.title

--- a/src/renderer/extensions/onboardingTour/OnboardingTourNudge.vue
+++ b/src/renderer/extensions/onboardingTour/OnboardingTourNudge.vue
@@ -1,73 +1,79 @@
 <!-- Bottom-right "explore templates" nudge shown once the tour ends. -->
 <template>
-  <div
-    v-if="shouldShow"
-    role="status"
-    class="pointer-events-auto fixed right-4 bottom-4 z-1000 flex w-80 flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-interface"
+  <Transition
+    enter-active-class="transition-opacity duration-500 ease-out"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
   >
-    <div class="relative h-50 w-full bg-secondary-background">
-      <video
-        v-if="media?.kind === 'video'"
-        :src="media.url"
-        data-testid="onboarding-nudge-video"
-        class="size-full object-cover"
-        autoplay
-        muted
-        loop
-        playsinline
-      />
-      <img
-        v-else
-        :src="media?.url ?? FALLBACK_MEDIA"
-        :alt="t('onboardingTour.nudge.title')"
-        class="size-full object-cover"
-      />
-      <Button
-        class="absolute top-2 right-2 size-8 opacity-50 hover:opacity-100"
-        variant="secondary"
-        size="icon"
-        :aria-label="t('g.close')"
-        @click="store.dismissNudge()"
-      >
-        <i class="icon-[lucide--x] size-4" aria-hidden="true" />
-      </Button>
-    </div>
-
     <div
-      class="flex flex-col gap-2 border-t border-border-default px-4 pt-6 pb-4"
+      v-if="shown"
+      role="status"
+      class="pointer-events-auto fixed right-4 bottom-4 z-1000 flex w-80 flex-col overflow-hidden rounded-lg border border-border-default bg-base-background shadow-interface"
     >
-      <p class="m-0 text-sm/5 font-bold text-base-foreground">
-        {{ t('onboardingTour.nudge.title') }}
-      </p>
-      <p class="m-0 text-sm text-muted-foreground">
-        {{ t('onboardingTour.nudge.body') }}
-      </p>
-    </div>
+      <div class="relative h-50 w-full bg-secondary-background">
+        <video
+          v-if="media?.kind === 'video'"
+          :src="media.url"
+          data-testid="onboarding-nudge-video"
+          class="size-full object-cover"
+          autoplay
+          muted
+          loop
+          playsinline
+        />
+        <img
+          v-else
+          :src="media?.url ?? FALLBACK_MEDIA"
+          :alt="t('onboardingTour.nudge.title')"
+          class="size-full object-cover"
+        />
+        <Button
+          class="absolute top-2 right-2 size-8 opacity-50 hover:opacity-100"
+          variant="secondary"
+          size="icon"
+          :aria-label="t('g.close')"
+          @click="store.dismissNudge()"
+        >
+          <i class="icon-[lucide--x] size-4" aria-hidden="true" />
+        </Button>
+      </div>
 
-    <div class="flex items-center justify-end gap-4 px-4 pb-4">
-      <Button
-        variant="link"
-        size="unset"
-        class="h-6 text-sm font-normal"
-        @click="store.dismissNudge()"
+      <div
+        class="flex flex-col gap-2 border-t border-border-default px-4 pt-6 pb-4"
       >
-        {{ t('onboardingTour.nudge.dismiss') }}
-      </Button>
-      <Button
-        variant="inverted"
-        size="lg"
-        class="font-normal"
-        @click="onExplore"
-      >
-        {{ t('onboardingTour.nudge.explore') }}
-      </Button>
+        <p class="m-0 text-sm/5 font-bold text-base-foreground">
+          {{ t('onboardingTour.nudge.title') }}
+        </p>
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ t('onboardingTour.nudge.body') }}
+        </p>
+      </div>
+
+      <div class="flex items-center justify-end gap-4 px-4 pb-4">
+        <Button
+          variant="link"
+          size="unset"
+          class="h-6 text-sm font-normal"
+          @click="store.dismissNudge()"
+        >
+          {{ t('onboardingTour.nudge.dismiss') }}
+        </Button>
+        <Button
+          variant="inverted"
+          size="lg"
+          class="font-normal"
+          @click="onExplore"
+        >
+          {{ t('onboardingTour.nudge.explore') }}
+        </Button>
+      </div>
     </div>
-  </div>
+  </Transition>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
@@ -81,6 +87,8 @@ import {
 
 const FALLBACK_MEDIA = '/assets/images/og-image.png'
 
+const { appearDelayMs = 2000 } = defineProps<{ appearDelayMs?: number }>()
+
 const { t } = useI18n()
 const store = useOnboardingTourStore()
 
@@ -88,16 +96,35 @@ const { resultMedia: media } = storeToRefs(store)
 
 const shouldShow = computed(() => store.shouldShowNudge)
 
+// Give the fresh result a beat to land, then fade the nudge in over it.
+const shown = ref(false)
+let appearTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(shouldShow, (visible) => {
+  if (appearTimer !== null) {
+    clearTimeout(appearTimer)
+    appearTimer = null
+  }
+  if (!visible) {
+    shown.value = false
+    return
+  }
+  appearTimer = setTimeout(() => {
+    shown.value = true
+    useTelemetry()?.trackOnboardingTourNudgeShown?.()
+  }, appearDelayMs)
+})
+
+onUnmounted(() => {
+  if (appearTimer !== null) clearTimeout(appearTimer)
+})
+
 // No-funds fallback: the run-step gate opens the upgrade modal and arms the
 // nudge; surface it only once that modal has closed so the two never overlap.
 const upgradeModalOpen = computed(() => isUpgradeModalOpen())
 
 watch(upgradeModalOpen, (open, wasOpen) => {
   if (wasOpen && !open && store.nudgeArmed) store.showNudge()
-})
-
-watch(shouldShow, (visible) => {
-  if (visible) useTelemetry()?.trackOnboardingTourNudgeShown?.()
 })
 
 function onExplore() {

--- a/src/renderer/extensions/onboardingTour/OnboardingTourOverlay.test.ts
+++ b/src/renderer/extensions/onboardingTour/OnboardingTourOverlay.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./canvasSpotlightAdapter', () => ({
   RUN_BUTTON_SELECTOR:
     '[data-testid="queue-button"], [data-testid="subscribe-to-run-button"]',
+  TOUR_FOCUS_DURATION_MS: 0,
   // Return a fresh array (like prod) so a caller pushing to it can't grow the mock.
   maskRectsFor: (ids: unknown[]) =>
     mocks.rectsById === null
@@ -283,7 +284,7 @@ describe('OnboardingTourOverlay', () => {
 
     renderOverlay()
 
-    await screen.findByText('Press Run and your result starts generating.')
+    await screen.findByText('Press Run to start generating your result')
     expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Done' })).toBeNull()
     // Skip and Back remain so the user is never trapped.

--- a/src/renderer/extensions/onboardingTour/OnboardingTourOverlay.vue
+++ b/src/renderer/extensions/onboardingTour/OnboardingTourOverlay.vue
@@ -17,7 +17,7 @@
           <mask id="onboarding-tour-spotlight">
             <rect width="100%" height="100%" fill="white" />
             <rect
-              v-for="(hole, i) in holeRects"
+              v-for="(hole, i) in visibleHoleRects"
               :key="i"
               :x="hole.left"
               :y="hole.top"
@@ -31,7 +31,12 @@
         <rect
           width="100%"
           height="100%"
-          class="fill-base-background/95"
+          :class="
+            cn(
+              'fill-base-background/95 transition-opacity duration-500 ease-out',
+              revealed ? 'opacity-100' : 'opacity-0'
+            )
+          "
           mask="url(#onboarding-tour-spotlight)"
         />
       </svg>
@@ -42,10 +47,9 @@
         data-testid="onboarding-spotlight"
         :class="
           cn(
-            'absolute transition-all duration-500 ease-out',
-            isRunStep
-              ? 'rounded-lg border border-node-component-outline'
-              : 'rounded-xl border-3 border-node-component-outline'
+            'absolute border border-node-component-outline/30 transition-opacity duration-300 ease-out',
+            revealed ? 'opacity-100' : 'opacity-0',
+            isRunStep ? 'rounded-lg' : 'rounded-xl'
           )
         "
         :style="ringStyle(hole)"
@@ -53,7 +57,14 @@
 
       <div
         ref="bubbleRef"
-        class="pointer-events-auto absolute flex h-fit w-full max-w-xs flex-col gap-6 rounded-2xl bg-secondary-background p-5 shadow-interface transition-[top,left] duration-500 ease-out"
+        :class="
+          cn(
+            'absolute flex h-fit w-full max-w-xs flex-col gap-6 rounded-2xl bg-secondary-background p-5 shadow-interface',
+            bubbleVisible
+              ? 'pointer-events-auto opacity-100 transition-[top,left,opacity] duration-500 ease-out'
+              : 'pointer-events-none opacity-0 transition-opacity duration-200 ease-out'
+          )
+        "
         :style="bubbleStyle"
         tabindex="-1"
         aria-live="polite"
@@ -149,6 +160,8 @@ import DotSpinner from '@/components/common/DotSpinner.vue'
 
 import {
   RUN_BUTTON_SELECTOR,
+  TOUR_FOCUS_DURATION_MS,
+  TOUR_ZOOM_FILL,
   coachMarkPosition,
   focusNodes,
   maskRectsFor
@@ -205,6 +218,80 @@ const copy = computed(() =>
   currentStep.value ? stepCopyKey(currentStep.value) : { title: '', body: '' }
 )
 
+// When the tour opens, hold on the whole workflow undimmed for a beat so the
+// user gets the lay of the land, THEN start the guided steps. Per step, let the
+// camera finish framing the target before the highlight lights up (so it lands
+// on an element already in position, not mid-zoom), then a beat later show the
+// coach-mark copy. The Run step has no camera move, so its highlight is instant.
+const INTRO_PREVIEW_MS = 1000
+const CAMERA_SETTLE_MS = TOUR_FOCUS_DURATION_MS + 60
+const MESSAGE_AFTER_SETTLE_MS = 140
+const revealed = ref(false)
+const bubbleVisible = ref(false)
+// True once the tour has zoomed in on its first target; later steps only pan.
+let framedOnce = false
+let introTimer: ReturnType<typeof setTimeout> | null = null
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
+let messageTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearStepTimers() {
+  for (const timer of [introTimer, highlightTimer, messageTimer]) {
+    if (timer !== null) clearTimeout(timer)
+  }
+  introTimer = highlightTimer = messageTimer = null
+}
+
+// Reveal the spotlight and frame the target. The highlight stays lit through the
+// whole tour and simply glides to each new target as the camera moves (rects
+// track the node every frame, in sync with the eased camera), so the scrim never
+// blacks out or pulses between steps. The copy is held back until the camera
+// settles so the text doesn't slide across the screen mid-move.
+function beginStepReveal() {
+  // The first step stays at the workflow's default framing — no camera move, no
+  // zoom; the highlight just lands where the first target already sits. A later
+  // step that hasn't zoomed yet zooms in (its highlight appears only once the
+  // camera settles, at final size); pan steps keep the highlight lit and glide
+  // it over.
+  const isFirstStep = stepIndex.value === 0
+  const zoomsIn = !isFirstStep && !framedOnce && !isRunStep.value
+  if (!isFirstStep) focusCurrentStep()
+  const settle = isFirstStep || isRunStep.value ? 0 : CAMERA_SETTLE_MS
+  if (zoomsIn) {
+    highlightTimer = setTimeout(() => {
+      revealed.value = true
+    }, settle)
+  } else {
+    revealed.value = true
+  }
+  messageTimer = setTimeout(() => {
+    bubbleVisible.value = true
+  }, settle + MESSAGE_AFTER_SETTLE_MS)
+}
+
+watch(
+  [isActive, stepIndex],
+  ([active], oldValues) => {
+    clearStepTimers()
+    bubbleVisible.value = false
+    if (!active) {
+      revealed.value = false
+      framedOnce = false
+      return
+    }
+    // Fresh open (idle→active): hold on the undimmed full-flow preview, then
+    // reveal and begin the guided steps. Between steps the spotlight stays lit
+    // and glides to the next target.
+    if (oldValues?.[0] !== true) {
+      revealed.value = false
+      framedOnce = false
+      introTimer = setTimeout(beginStepReveal, INTRO_PREVIEW_MS)
+      return
+    }
+    beginStepReveal()
+  },
+  { immediate: true }
+)
+
 function onNext() {
   if (isLastStep.value) {
     controller.end('done')
@@ -220,7 +307,22 @@ const RUN_PROGRESS_SELECTOR =
 const holeRects = ref<ScreenRect[]>([])
 const spotRects = ref<ScreenRect[]>([])
 
-const focusRect = computed(() => spotRects.value[0] ?? null)
+// The hole is cut only while the guided steps are showing (not during the
+// intro preview); it tracks the target node every frame as the camera moves.
+const visibleHoleRects = computed(() => (revealed.value ? holeRects.value : []))
+
+// Keep the last valid focus rect: during a transition the RAF can momentarily
+// resolve no rects (the new target isn't ready for a frame), and letting this
+// fall to null would snap the coach-mark to screen center and back — the flicker
+// where the tooltip appears, vanishes, then reappears. Retaining the last rect
+// holds it in place until the new target resolves.
+const focusRect = ref<ScreenRect | null>(null)
+watch(
+  () => spotRects.value[0] ?? null,
+  (rect) => {
+    if (rect) focusRect.value = rect
+  }
+)
 
 const bubbleRef = useTemplateRef<HTMLElement>('bubbleRef')
 
@@ -259,8 +361,12 @@ function recompute() {
 // RAF keeps the rects aligned while the user pans/zooms the canvas.
 const { pause, resume } = useRafFn(recompute, { immediate: false })
 
+// Zoom in only on the first framed step; every later step pans at that same
+// scale (zoom 0), so the view never zooms back out and in again between steps.
 function focusCurrentStep() {
-  if (!isRunStep.value) focusNodes([...spotlitNodeIds.value])
+  if (isRunStep.value) return
+  focusNodes([...spotlitNodeIds.value], framedOnce ? 0 : TOUR_ZOOM_FILL)
+  framedOnce = true
 }
 
 watch(
@@ -268,7 +374,6 @@ watch(
   ([active]) => {
     if (active) {
       recompute()
-      focusCurrentStep()
       resume()
     } else {
       pause()
@@ -288,6 +393,7 @@ watch(isActive, (active) => {
 // Tearing down the overlay (e.g. route away mid-tour) must end the tour so the
 // controller's grace timer can't outlive the UI it drives.
 onUnmounted(() => {
+  clearStepTimers()
   if (isActive.value) controller.end('skip')
 })
 

--- a/src/renderer/extensions/onboardingTour/canvasSpotlightAdapter.test.ts
+++ b/src/renderer/extensions/onboardingTour/canvasSpotlightAdapter.test.ts
@@ -28,6 +28,8 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 }))
 
 import {
+  TOUR_FOCUS_DURATION_MS,
+  TOUR_ZOOM_FILL,
   canvasTransformValid,
   coachMarkPosition,
   focusNodes,
@@ -154,7 +156,26 @@ describe('canvasSpotlightAdapter', () => {
       focusNodes([toNodeId(3)])
 
       // createBounds pads the [0,0,100,100] node by 10 on every side.
-      expect(animate).toHaveBeenCalledWith([-10, -10, 120, 120], { zoom: 0.4 })
+      expect(animate).toHaveBeenCalledWith([-10, -10, 120, 120], {
+        zoom: TOUR_ZOOM_FILL,
+        duration: TOUR_FOCUS_DURATION_MS
+      })
+    })
+
+    it('pans without re-zooming when zoom is 0', () => {
+      const animate = vi.fn()
+      const node = fakeNode(3, [0, 0, 100, 100])
+      mocks.canvas = { ...fakeCanvas({}), animateToBounds: animate }
+      mocks.currentGraph = fromPartial<LGraph>({
+        getNodeById: (id: NodeId) => (id === toNodeId(3) ? node : null)
+      })
+
+      focusNodes([toNodeId(3)], 0)
+
+      expect(animate).toHaveBeenCalledWith([-10, -10, 120, 120], {
+        zoom: 0,
+        duration: TOUR_FOCUS_DURATION_MS
+      })
     })
 
     it('does nothing when no nodes resolve', () => {

--- a/src/renderer/extensions/onboardingTour/canvasSpotlightAdapter.ts
+++ b/src/renderer/extensions/onboardingTour/canvasSpotlightAdapter.ts
@@ -189,14 +189,31 @@ export function maskRectsFor(nodeIds: NodeId[]): ScreenRect[] {
 }
 
 /**
- * Smoothly frame the view around the given nodes. `zoom` is the fill fraction of
- * the viewport (not a scale). Uses the animated focus path (marks the canvas
- * dirty for us); no-op when none resolve.
+ * Duration of the tour's framing animation. The overlay waits this out before
+ * revealing the highlight, so it lands on an element already in position rather
+ * than tracking it mid-zoom.
  */
-export function focusNodes(nodeIds: NodeId[], zoom = 0.4): void {
+export const TOUR_FOCUS_DURATION_MS = 450
+
+/** Viewport fill fraction for the framing zoom — higher makes the node larger. */
+export const TOUR_ZOOM_FILL = 0.3
+
+/**
+ * Frame the view around the given nodes. `zoom` is the viewport fill fraction
+ * (higher = node appears larger); pass 0 to pan to the nodes at the current
+ * scale without re-zooming, so the view zooms in once and then only pans. Uses
+ * the animated focus path (marks the canvas dirty for us); no-op when none resolve.
+ */
+export function focusNodes(
+  nodeIds: NodeId[],
+  zoom: number = TOUR_ZOOM_FILL
+): void {
   const nodes = resolveNodes(nodeIds)
   if (nodes.length === 0) return
   const bounds = createBounds(nodes)
   if (!bounds) return
-  app.canvas?.animateToBounds(bounds, { zoom })
+  app.canvas?.animateToBounds(bounds, {
+    zoom,
+    duration: TOUR_FOCUS_DURATION_MS
+  })
 }


### PR DESCRIPTION
Polishes the guided onboarding tour's transitions and framing. Stacked on top of the tour PR (base branch `feat/onboarding-tour-pr7`).

## Behavior
- First step stays at the workflow's default framing (no zoom). A later step zooms in once; the rest only pan.
- The spotlight glides to each target as the camera moves, and the scrim stays dimmed throughout, so steps never black out or pulse between transitions.
- The highlight lands at its final size once the camera settles; the coach-mark copy follows a beat later so text never slides mid-move.
- 1s undimmed full-flow preview when the tour opens.
- Thinner, softer highlight stroke (3px -> 1px at 30% opacity).
- Retain the last focus rect during transitions so the coach-mark can't flicker to screen center and back.
- Explore-templates nudge fades in 2s after the tour ends.

## Copy
- Run step: "Run your workflow" / "Press Run to start generating your result".
- Getting Started title lowercases "graph".

## Testing
- `pnpm typecheck`, `pnpm lint`, onboarding unit tests (175) pass.