### PR TITLE
feat(website): strengthen the ComfyUI entity links in JSON-LD

### DIFF
--- a/apps/website/src/pages/download.astro
+++ b/apps/website/src/pages/download.astro
@@ -12,6 +12,7 @@ import {
   absoluteUrl,
   comfyUiApplicationNode,
   comfyUiSoftwareId,
+  comfyUiSourceCodeNode,
   pageContext,
 } from '../utils/jsonLd'
 
@@ -30,7 +31,7 @@ const { siteUrl, locale } = pageContext(
     { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },
     { name: t('breadcrumb.download', locale) },
   ]}
-  extraJsonLd={[comfyUiApplicationNode(siteUrl)]}
+  extraJsonLd={[comfyUiApplicationNode(siteUrl), comfyUiSourceCodeNode(siteUrl)]}
   keywords={['comfyui app', 'comfyui desktop app', 'comfyui desktop', 'comfy ui application', 'comfyui download', 'download comfyui', 'comfyui windows', 'comfyui mac', 'comfyui linux']}
 >
   <CloudBannerSection />

--- a/apps/website/src/pages/zh-CN/download.astro
+++ b/apps/website/src/pages/zh-CN/download.astro
@@ -12,6 +12,7 @@ import {
   absoluteUrl,
   comfyUiApplicationNode,
   comfyUiSoftwareId,
+  comfyUiSourceCodeNode,
   pageContext,
 } from '../../utils/jsonLd'
 
@@ -33,7 +34,7 @@ const { siteUrl, locale } = pageContext(
     },
     { name: t('breadcrumb.download', locale) },
   ]}
-  extraJsonLd={[comfyUiApplicationNode(siteUrl)]}
+  extraJsonLd={[comfyUiApplicationNode(siteUrl), comfyUiSourceCodeNode(siteUrl)]}
   keywords={['comfyui app', 'comfyui desktop app', 'comfyui download', 'ComfyUI 下载', 'ComfyUI 桌面应用', 'ComfyUI 应用', 'ComfyUI Windows', 'ComfyUI macOS', 'ComfyUI Linux']}
 >
   <CloudBannerSection locale="zh-CN" />

--- a/apps/website/src/utils/jsonLd.test.ts
+++ b/apps/website/src/utils/jsonLd.test.ts
@@ -171,6 +171,31 @@ describe('comfyUiSourceCodeNode', () => {
   })
 })
 
+describe('ComfyUI entity links', () => {
+  it('names the home page as the canonical page for the application', () => {
+    const node = comfyUiApplicationNode(siteUrl)
+    expect(node.mainEntityOfPage).toBe(`${siteUrl}/`)
+  })
+
+  it('links the application back to the source code emitted alongside it', () => {
+    const app = comfyUiApplicationNode(siteUrl)
+    const source = comfyUiSourceCodeNode(siteUrl)
+    expect(app.isBasedOn).toEqual({ '@id': source['@id'] })
+  })
+
+  it('claims no canonical page or source code for third-party software', () => {
+    const node = softwareApplicationNode({
+      siteUrl,
+      id: 'https://comfy.org/p/supported-models/foo/#software',
+      name: 'Foo Model',
+      url: 'https://comfy.org/p/supported-models/foo/',
+      applicationCategory: 'MultimediaApplication'
+    })
+    expect(node.mainEntityOfPage).toBeUndefined()
+    expect(node.isBasedOn).toBeUndefined()
+  })
+})
+
 describe('buildPageGraph', () => {
   const url = 'https://comfy.org/cloud/pricing/'
   const graph = buildPageGraph(

--- a/apps/website/src/utils/jsonLd.ts
+++ b/apps/website/src/utils/jsonLd.ts
@@ -194,6 +194,8 @@ export interface SoftwareAppInput {
   authorName?: string
   isFree?: boolean
   sameAs?: string[]
+  mainEntityOfPage?: string
+  isBasedOnId?: string
 }
 
 export function softwareApplicationNode(input: SoftwareAppInput): JsonLdNode {
@@ -219,6 +221,8 @@ export function softwareApplicationNode(input: SoftwareAppInput): JsonLdNode {
     author,
     publisher: input.firstParty ? orgRef : undefined,
     sameAs: input.sameAs,
+    mainEntityOfPage: input.mainEntityOfPage,
+    isBasedOn: input.isBasedOnId ? { '@id': input.isBasedOnId } : undefined,
     offers: input.isFree
       ? {
           '@type': 'Offer',
@@ -257,6 +261,10 @@ export function comfyUiSoftwareId(siteUrl: string): string {
   return `${siteUrl}/#software`
 }
 
+function comfyUiSourceCodeId(siteUrl: string): string {
+  return `${siteUrl}/#sourcecode`
+}
+
 export function comfyUiApplicationNode(siteUrl: string): JsonLdNode {
   return softwareApplicationNode({
     siteUrl,
@@ -267,14 +275,16 @@ export function comfyUiApplicationNode(siteUrl: string): JsonLdNode {
     applicationCategory: 'MultimediaApplication',
     operatingSystem: 'Windows, macOS, Linux',
     isFree: true,
-    sameAs: comfyUiSameAs
+    sameAs: comfyUiSameAs,
+    mainEntityOfPage: `${siteUrl}/`,
+    isBasedOnId: comfyUiSourceCodeId(siteUrl)
   })
 }
 
 export function comfyUiSourceCodeNode(siteUrl: string): JsonLdNode {
   return softwareSourceCodeNode({
     siteUrl,
-    id: `${siteUrl}/#sourcecode`,
+    id: comfyUiSourceCodeId(siteUrl),
     name: 'ComfyUI',
     codeRepository: externalLinks.github,
     programmingLanguage: 'Python',


### PR DESCRIPTION
## Summary

Implements the genuine parts of the schema enrichment follow-up to #13480 (FE-1232): the ComfyUI `SoftwareApplication` now names its canonical page and links back to its `SoftwareSourceCode`. Several other items from the recommendations doc are deliberately **not** implemented, with reasoning below.

## Changes

- **`mainEntityOfPage` on the ComfyUI application.** The WebPage already pointed at the app via `mainEntity`; the app now points back at the home page, completing the relationship.
- **`isBasedOn` linking the app to its source code.** `SoftwareSourceCode` already declared `targetProduct` -> the app, but only on the home page, and the app had no reverse link. The app now references the source node, so the application and its GitHub repository resolve as one connected entity.
- **Download pages now emit the source code node** (en + zh-CN). They render the application node, so without this the new `isBasedOn` reference would not resolve inside their graph. `/download` previously described the app with no link to the repo at all.
- Extracted a shared `comfyUiSourceCodeId()` so the `#sourcecode` anchor has one definition, matching the `comfyUiSoftwareId()` pattern from #13480 review.
- 3 unit tests: canonical page is set, `isBasedOn` round-trips to the source node's real `@id`, and third-party software gets neither.

## Review Focus

**Why `mainEntityOfPage` is a plain URL, not an `@id` reference.** The app node is shared by `/` and `/download` under one site-wide `@id` (`/#software`). A per-page reference would make the same entity claim two different canonical pages, and pointing at the home page's `#webpage` id would leave an unresolved reference on `/download`, which `validate:jsonld` fails the build on. A plain URL keeps the node byte-identical everywhere it is emitted.

**Coupling worth knowing about:** any page emitting `comfyUiApplicationNode` must also emit `comfyUiSourceCodeNode`, or the `isBasedOn` reference dangles. This is enforced at build time by `validate:jsonld`, so it fails loudly rather than shipping a broken graph.

**Third-party software is untouched.** Packs and models get neither property, the same isolation already applied to `author`, `publisher`, `seller` and `sameAs`. They are not our application and do not share our repository.

## Not implemented, and why

The recommendations doc proposed six schema changes. Four are not actionable:

1. **`Review` + `AggregateRating` (4.8 / 126, "Verified User")** - invented numbers with no real review system behind them. Google disallows self-serving ratings that are not backed by genuine on-page reviews, and this repo's own build validator fails on fabricated ratings.
2. **`brand` on the `SoftwareApplication`** - not valid. Per schema.org, `brand` applies to Organization, Person, Product and Service. `SoftwareApplication` is a `CreativeWork`, not a `Product`, so `brand` is outside its domain. The doc's own proposed code puts `brand` on a `Product` node, not on a `SoftwareApplication`, so the recommendation does not match the example it ships with. The relationship it is reaching for already exists here: the app declares `author` and `publisher` -> Comfy Org, the free Offer declares `seller` -> Comfy Org, and our actual `Product` (Comfy Cloud, on `/cloud/pricing`) already carries `brand` -> Comfy Org.
3. **`seller` on the Offer** - already shipped in #13480. Live on the free Offer and on all three pricing tiers.
4. **Strengthening the Organization (logo, `sameAs`)** - already shipped, and the proposed version is a downgrade: it uses `favicon.ico` in place of our 512x512 PNG, and its `sameAs` points at the Wikipedia article for "Comfort" (the feeling). The accompanying `about`/`mentions` entities map our title words to unrelated pages (Canvas -> Canvas Networks, Scratch -> Abrasion). We already link the correct Wikidata entities, the ComfyUI Wikipedia article and G2.

The document's larger "Watch Page" checklist targets a video watch/listing page that does not exist on this site, and is mostly content work rather than schema.

## Scope note

This is entity-graph hygiene, not a ranking change. `mainEntityOfPage` and `SoftwareSourceCode` do not produce rich results. The value is that machines can resolve that Comfy Org publishes ComfyUI, an open-source application whose code lives on GitHub.

## Verification

`test:unit` 199 passed, `astro check` 0 errors, `knip` clean, `build` 498 pages, **`validate:jsonld` passed across 501 pages** (confirms no unresolved `@id` on any page), and e2e for the download, cloud-nodes and affiliates specs (the JSON-LD asserting ones) 38 passed.

No visual change: this is `<head>` structured data only, so there is nothing to screenshot.

Ref: FE-1232
