### PR TITLE
feat(website): promote In-App Agent on /mcp FAQ and /launches

### DIFF
--- a/apps/website/src/components/blocks/FAQSplit01.vue
+++ b/apps/website/src/components/blocks/FAQSplit01.vue
@@ -2,7 +2,10 @@
 import { cn } from '@comfyorg/tailwind-utils'
 import { reactive, watch } from 'vue'
 
-type Faq = { id: string; question: string; answer: string }
+import { resolveRel } from '../../utils/cta'
+
+type FaqLink = { href: string; label: string; target?: '_blank' }
+type Faq = { id: string; question: string; answer: string; link?: FaqLink }
 
 const { faqs } = defineProps<{
   heading: string
@@ -86,6 +89,15 @@ function toggle(index: number) {
             <p class="text-sm whitespace-pre-line text-primary-comfy-canvas/70">
               {{ faq.answer }}
             </p>
+            <a
+              v-if="faq.link"
+              :href="faq.link.href"
+              :target="faq.link.target"
+              :rel="resolveRel(faq.link)"
+              class="text-primary-comfy-yellow mt-4 inline-block text-sm hover:underline"
+            >
+              {{ faq.link.label }}
+            </a>
           </section>
         </div>
       </div>

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -80,6 +80,7 @@ export const externalLinks = {
   discord: 'https://discord.com/invite/comfyorg',
   docs: 'https://docs.comfy.org/',
   docsApi: 'https://docs.comfy.org/development/cloud/overview#quick-start',
+  docsInAppAgent: 'https://docs.comfy.org/agent-tools/in-app-agent',
   docsMcp: 'https://docs.comfy.org/agent-tools/cloud',
   docsSubscription: 'https://docs.comfy.org/support/subscription/subscribing',
   g2ComfyUi: 'https://www.g2.com/products/comfyui',

--- a/apps/website/src/data/drops.ts
+++ b/apps/website/src/data/drops.ts
@@ -169,23 +169,24 @@ export const drops: readonly Drop[] = [
     }
   },
   {
-    id: 'supported-nodes',
-    category: MODELS_AND_NODES,
-    media: videoFor('Drops_3x3card_supported nodes.mp4', {
-      en: 'Supported Nodes',
-      'zh-CN': '支持的节点'
+    id: 'in-app-agent',
+    badge: { en: 'PRIVATE ALPHA', 'zh-CN': '私测' },
+    category: CLOUD,
+    media: imageFor('Drops_3x3card_InAppAgent.jpg', {
+      en: 'Comfy In-App Agent',
+      'zh-CN': 'Comfy 应用内智能体'
     }),
-    title: { en: 'Supported Nodes', 'zh-CN': '支持的节点' },
+    title: { en: 'Comfy In-App Agent', 'zh-CN': 'Comfy 应用内智能体' },
     description: {
-      en: 'Thousands of community and partner nodes, curated and verified to run on Comfy Cloud.',
+      en: 'Describe the workflow; the agent builds it on your canvas in Comfy Cloud — every change confirmed by you.',
       'zh-CN':
-        '数千个社区与合作伙伴节点，经过精选与验证，可在 Comfy Cloud 上运行。'
+        '描述您要的工作流，智能体直接在 Comfy Cloud 画布上构建，任何更改都需经您确认。'
     },
     cta: {
-      label: EXPLORE,
+      label: { en: 'LEARN MORE', 'zh-CN': '了解更多' },
       href: {
-        en: '/cloud/supported-nodes',
-        'zh-CN': '/zh-CN/cloud/supported-nodes'
+        en: externalLinks.docsInAppAgent,
+        'zh-CN': 'https://docs.comfy.org/zh/agent-tools/in-app-agent'
       }
     }
   },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2157,6 +2157,19 @@ const translations = {
     en: 'Comfy Cloud MCP is in open beta and available to everyone.',
     'zh-CN': 'Comfy Cloud MCP 目前处于公开测试阶段，所有人均可使用。'
   },
+  'mcp.faq.9.q': {
+    en: 'Is there an agent inside ComfyUI itself?',
+    'zh-CN': 'ComfyUI 里有内置智能体吗？'
+  },
+  'mcp.faq.9.a': {
+    en: 'Yes. Comfy In-App Agent runs in Comfy Cloud and builds or edits workflows directly on your canvas, with your confirmation before anything changes. It is in private alpha — join the waitlist from the docs.',
+    'zh-CN':
+      '有。Comfy In-App Agent 在 Comfy Cloud 中运行，直接在您的画布上构建或编辑工作流，任何更改都需经您确认。目前处于私测阶段，可通过文档页面加入候补名单。'
+  },
+  'mcp.faq.9.link': {
+    en: 'VIEW DOCS',
+    'zh-CN': '查看文档'
+  },
 
   // SiteNav
   'nav.products': { en: 'Products', 'zh-CN': '产品' },

--- a/apps/website/src/templates/mcp/FAQSection.vue
+++ b/apps/website/src/templates/mcp/FAQSection.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
 import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
+import { externalLinks } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
-const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8] as const
+const faqNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 
 const faqs = faqNumbers.map((n) => ({
   id: String(n),
   question: t(`mcp.faq.${n}.q`, locale),
-  answer: t(`mcp.faq.${n}.a`, locale)
+  answer: t(`mcp.faq.${n}.a`, locale),
+  ...(n === 9 && {
+    link: {
+      href: externalLinks.docsInAppAgent,
+      label: t('mcp.faq.9.link', locale),
+      target: '_blank' as const
+    }
+  })
 }))
 </script>
 


### PR DESCRIPTION
## Summary

Give the Comfy In-App Agent (private alpha) its first presence on comfy.org: a new /mcp FAQ entry and a /launches card, both linking to https://docs.comfy.org/agent-tools/in-app-agent.

## Changes

- **What**:
  - /mcp FAQ: adds item 9 ("Is there an agent inside ComfyUI itself?") with a VIEW DOCS link. `FAQSplit01` gains an optional per-item `link` (href/label/target, rel via existing `resolveRel`); the other consumer (affiliate FAQ) is unaffected.
  - /launches: replaces the `supported-nodes` card with an `in-app-agent` card (PRIVATE ALPHA badge, Cloud category, LEARN MORE → docs). Supported Nodes stays reachable at /cloud/supported-nodes via the footer.
  - Adds `externalLinks.docsInAppAgent` to the routes config.

## Review Focus

- Copy deliberately frames the feature as private alpha + waitlist (rollout is gated per the docs page).
- Card artwork `Drops_3x3card_InAppAgent.jpg` is not yet uploaded to media.comfy.org/website/drops/ — the media area renders empty until then (same pending-uploads situation noted at the top of drops.ts).
- zh-CN strings pending native review, matching the existing note for the launches page.