### PR TITLE
feat(website): show copyable MCP endpoint URL in setup step 2

### DIFF
--- a/apps/website/src/components/blocks/FeatureGrid01.vue
+++ b/apps/website/src/components/blocks/FeatureGrid01.vue
@@ -24,7 +24,7 @@ export interface FeatureCard {
   label?: string
   title: string
   description: string
-  action?: CardAction
+  actions?: CardAction[]
 }
 
 type ColumnCount = 2 | 3 | 4
@@ -91,28 +91,29 @@ const columnClass: Record<ColumnCount, string> = {
           {{ card.description }}
         </p>
 
-        <div v-if="card.action" class="mt-6">
-          <Button
-            v-if="card.action.type === 'link'"
-            as="a"
-            :href="card.action.href"
-            :target="card.action.target"
-            :rel="
-              card.action.target === '_blank'
-                ? 'noopener noreferrer'
-                : undefined
-            "
-            :variant="card.action.variant ?? 'outline'"
-            :append-icon="card.action.icon"
-          >
-            {{ card.action.label }}
-          </Button>
-          <CopyableField
-            v-else
-            :value="card.action.value"
-            :copy-label="copyLabel"
-            :copied-label="copiedLabel"
-          />
+        <div v-if="card.actions?.length" class="mt-6 flex flex-col gap-3">
+          <template v-for="(action, index) in card.actions" :key="index">
+            <Button
+              v-if="action.type === 'link'"
+              as="a"
+              class="self-start"
+              :href="action.href"
+              :target="action.target"
+              :rel="
+                action.target === '_blank' ? 'noopener noreferrer' : undefined
+              "
+              :variant="action.variant ?? 'outline'"
+              :append-icon="action.icon"
+            >
+              {{ action.label }}
+            </Button>
+            <CopyableField
+              v-else
+              :value="action.value"
+              :copy-label="copyLabel"
+              :copied-label="copiedLabel"
+            />
+          </template>
         </div>
       </div>
     </div>

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -87,6 +87,7 @@ export const externalLinks = {
   githubInstall: 'https://github.com/Comfy-Org/ComfyUI#installing',
   instagram: 'https://www.instagram.com/comfyui/',
   linkedin: 'https://www.linkedin.com/company/comfyui',
+  mcpEndpoint: 'https://cloud.comfy.org/mcp',
   mcpSkills: 'https://github.com/Comfy-Org/comfy-skills',
   platform: 'https://platform.comfy.org',
   platformUsage: 'https://platform.comfy.org/profile/usage',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1931,9 +1931,9 @@ const translations = {
     'zh-CN': '或手动添加'
   },
   'mcp.setup.step2.description': {
-    en: 'Prefer manual setup? Add Comfy Cloud as a custom connector with the MCP URL. The docs cover every client.',
+    en: 'Prefer manual setup? Add this URL as a custom connector or remote MCP server in any client, then sign in when prompted. The docs cover every client.',
     'zh-CN':
-      '想手动配置？用 MCP URL 将 Comfy Cloud 添加为自定义连接器。文档涵盖各类客户端。'
+      '想手动配置？将此 URL 添加为任意客户端的自定义连接器或远程 MCP 服务器，然后按提示登录。文档涵盖各类客户端。'
   },
   'mcp.setup.step2.cta': {
     en: 'COMFY CLOUD MCP DOCS',

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -15,41 +15,48 @@ const cards: FeatureCard[] = [
     label: t('mcp.setup.step1.label', locale),
     title: t('mcp.setup.step1.title', locale),
     description: t('mcp.setup.step1.description', locale),
-    action: {
-      type: 'code',
-      value: t('mcp.setup.step1.command', locale).replace(
-        '{url}',
-        externalLinks.docsMcp
-      )
-    }
+    actions: [
+      {
+        type: 'code',
+        value: t('mcp.setup.step1.command', locale).replace(
+          '{url}',
+          externalLinks.docsMcp
+        )
+      }
+    ]
   },
   {
     id: 'step2',
     label: t('mcp.setup.step2.label', locale),
     title: t('mcp.setup.step2.title', locale),
     description: t('mcp.setup.step2.description', locale),
-    action: {
-      type: 'link',
-      label: t('mcp.setup.step2.cta', locale),
-      href: externalLinks.docsMcp,
-      target: '_blank',
-      icon: ArrowUpRight,
-      variant: 'default'
-    }
+    actions: [
+      { type: 'code', value: externalLinks.mcpEndpoint },
+      {
+        type: 'link',
+        label: t('mcp.setup.step2.cta', locale),
+        href: externalLinks.docsMcp,
+        target: '_blank',
+        icon: ArrowUpRight,
+        variant: 'default'
+      }
+    ]
   },
   {
     id: 'step3',
     label: t('mcp.setup.step3.label', locale),
     title: t('mcp.setup.step3.title', locale),
     description: t('mcp.setup.step3.description', locale),
-    action: {
-      type: 'link',
-      label: t('mcp.setup.step3.cta', locale),
-      href: externalLinks.mcpSkills,
-      target: '_blank',
-      icon: ArrowUpRight,
-      variant: 'default'
-    }
+    actions: [
+      {
+        type: 'link',
+        label: t('mcp.setup.step3.cta', locale),
+        href: externalLinks.mcpSkills,
+        target: '_blank',
+        icon: ArrowUpRight,
+        variant: 'default'
+      }
+    ]
   }
 ]
 </script>


### PR DESCRIPTION
## Summary

Step 2 of the /mcp setup module ("Or add it by hand") never showed the URL you actually need for manual setup; this adds `https://cloud.comfy.org/mcp` as a copy-to-clipboard field while keeping the agent-install path in Step 1 untouched.

## Changes

- **What**:
  - `FeatureGrid01` cards now take an `actions` array instead of a single `action`, so a card can stack a copyable field and a link button (SetupSection is the only consumer).
  - Step 2 renders the MCP endpoint as a `CopyableField` above the existing docs button; Step 1 (agent install) and Step 3 are unchanged.
  - New `externalLinks.mcpEndpoint` entry; Step 2 description updated in en and zh-CN.

## Review Focus

- The endpoint string `https://cloud.comfy.org/mcp` is the prod server verified in the PM-132 audit (v0.30.1, OAuth confirmed) — this is the canonical copyable primitive.
- Verified locally on `/mcp` and `/zh-CN/mcp`: Step 2 shows the copyable URL plus the docs button, Step 1 keeps the agent command.

Linear: [PM-132](https://linear.app/comfyorg/issue/PM-132/comfyorgmcp-faq-is-stale-and-contradicts-the-page-rewrite-faq-fix)

## Screenshots (if applicable)