### PR TITLE
[backport cloud/1.47] feat: data-driven provider input types with JSON file upload for BYOK secrets (#13571)

### DIFF
--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -1320,13 +1320,21 @@ export type SecretProvidersResponse = {
 }
 
 /**
- * A provider the user may configure a secret for. The shape is deliberately minimal (identifier only) and reserved for future per-provider fields such as sub-keys.
+ * A provider the user may configure a secret for.
  */
 export type SecretProvider = {
   /**
    * Provider identifier (e.g., huggingface, civitai, runway, gemini)
    */
   id: string
+  /**
+   * How the credential is entered. `text` is a single-line secret (an API key); `json_file` is an uploaded/pasted JSON document (e.g. a Vertex service-account key). Defaults to `text` when omitted.
+   */
+  input_type?: 'text' | 'json_file'
+  /**
+   * Human-facing display label for the provider. Falls back to the frontend registry label, then the raw id, when omitted.
+   */
+  label?: string
 }
 
 /**

--- a/packages/ingest-types/src/zod.gen.ts
+++ b/packages/ingest-types/src/zod.gen.ts
@@ -874,10 +874,12 @@ export const zTeamCreditStopSummary = z.object({
 })
 
 /**
- * A provider the user may configure a secret for. The shape is deliberately minimal (identifier only) and reserved for future per-provider fields such as sub-keys.
+ * A provider the user may configure a secret for.
  */
 export const zSecretProvider = z.object({
-  id: z.string()
+  id: z.string(),
+  input_type: z.enum(['text', 'json_file']).optional(),
+  label: z.string().optional()
 })
 
 /**

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4417,6 +4417,10 @@
     "secretValuePlaceholderEdit": "Enter new value to change",
     "secretValueHint": "This value will be encrypted and cannot be viewed again.",
     "secretValueHintEdit": "Leave blank to keep the current value.",
+    "uploadJsonFile": "Upload JSON file",
+    "jsonFilePlaceholder": "Upload or paste the provider JSON credential",
+    "jsonFileHint": "Paste the JSON or upload a file. It will be encrypted and cannot be viewed again.",
+    "jsonFileHintEdit": "Leave blank to keep the current value, or upload a new JSON file to replace it.",
     "createdAt": "Created {date}",
     "lastUsed": "Last used {date}",
     "deleteConfirmTitle": "Delete Secret",
@@ -4426,6 +4430,9 @@
       "nameTooLong": "Name must be 255 characters or less",
       "providerRequired": "Provider is required",
       "secretValueRequired": "Secret value is required",
+      "invalidJson": "File must contain a valid JSON object",
+      "fileTooLarge": "File is too large. Upload a JSON credential under 1 MB",
+      "fileReadFailed": "Could not read the selected file. Please try again",
       "duplicateName": "A secret with this name already exists",
       "duplicateProvider": "A secret for this provider already exists"
     }

--- a/src/platform/secrets/api/secretsApi.test.ts
+++ b/src/platform/secrets/api/secretsApi.test.ts
@@ -25,7 +25,7 @@ describe('listSecretProviders', () => {
     vi.clearAllMocks()
   })
 
-  it('requests the providers endpoint and maps ids', async () => {
+  it('requests the providers endpoint and returns the provider list', async () => {
     mockFetchApi.mockResolvedValue(
       jsonResponse({ data: [{ id: 'huggingface' }, { id: 'civitai' }] })
     )
@@ -33,7 +33,23 @@ describe('listSecretProviders', () => {
     const providers = await listSecretProviders()
 
     expect(mockFetchApi).toHaveBeenCalledWith('/secrets/providers')
-    expect(providers).toEqual(['huggingface', 'civitai'])
+    expect(providers).toEqual([{ id: 'huggingface' }, { id: 'civitai' }])
+  })
+
+  it('passes through per-provider input_type and label metadata', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        data: [
+          { id: 'gemini', input_type: 'json_file', label: 'Gemini (Vertex)' }
+        ]
+      })
+    )
+
+    const providers = await listSecretProviders()
+
+    expect(providers).toEqual([
+      { id: 'gemini', input_type: 'json_file', label: 'Gemini (Vertex)' }
+    ])
   })
 
   it('returns an empty list when data is missing', async () => {

--- a/src/platform/secrets/api/secretsApi.ts
+++ b/src/platform/secrets/api/secretsApi.ts
@@ -9,6 +9,7 @@ import type {
   SecretCreateRequest,
   SecretErrorCode,
   SecretMetadata,
+  SecretProviderInfo,
   SecretUpdateRequest
 } from '../types'
 import { SECRET_ERROR_CODES } from '../types'
@@ -57,10 +58,10 @@ export async function listSecrets(): Promise<SecretMetadata[]> {
   return data.data
 }
 
-export async function listSecretProviders(): Promise<string[]> {
+export async function listSecretProviders(): Promise<SecretProviderInfo[]> {
   const response = await api.fetchApi('/secrets/providers')
   const data = await handleResponse<SecretProvidersResponse>(response)
-  return (data.data ?? []).map((provider) => provider.id)
+  return data.data ?? []
 }
 
 export async function createSecret(

--- a/src/platform/secrets/components/SecretFormDialog.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.test.ts
@@ -1,9 +1,12 @@
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import SecretFormDialog from './SecretFormDialog.vue'
+
+const mockState = vi.hoisted(() => ({ inputType: 'text' as string }))
 
 vi.mock('../composables/useSecretForm', () => ({
   useSecretForm: () => ({
@@ -13,6 +16,9 @@ vi.mock('../composables/useSecretForm', () => ({
     apiError: '',
     providerOptions: [],
     providerHelp: '',
+    selectedInputType: computed(() => mockState.inputType),
+    fileName: ref(''),
+    loadSecretFromFile: vi.fn(),
     handleSubmit: vi.fn()
   })
 }))
@@ -83,6 +89,7 @@ const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
 describe('SecretFormDialog', () => {
   beforeEach(() => {
     capturedPointerDownOutside = null
+    mockState.inputType = 'text'
   })
 
   it('prevents backdrop pointer-down-outside from closing the dialog', () => {
@@ -95,5 +102,54 @@ describe('SecretFormDialog', () => {
     const event = new CustomEvent('pointerDownOutside', { cancelable: true })
     capturedPointerDownOutside!(event)
     expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('does not render the JSON upload control for a text provider', () => {
+    render(SecretFormDialog, {
+      global: { plugins: [i18n] },
+      props: { visible: true }
+    })
+
+    expect(screen.queryByText('secrets.uploadJsonFile')).toBeNull()
+    expect(
+      screen.queryByPlaceholderText('secrets.jsonFilePlaceholder')
+    ).toBeNull()
+  })
+
+  it('renders a file upload and textarea for a json_file provider', () => {
+    mockState.inputType = 'json_file'
+
+    render(SecretFormDialog, {
+      global: { plugins: [i18n] },
+      props: { visible: true }
+    })
+
+    expect(screen.getByText('secrets.uploadJsonFile')).toBeTruthy()
+    expect(
+      screen.getByPlaceholderText('secrets.jsonFilePlaceholder')
+    ).toBeTruthy()
+  })
+
+  it('opens the file dialog when the JSON upload button is activated by keyboard', async () => {
+    mockState.inputType = 'json_file'
+
+    const fileClickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(() => {})
+
+    render(SecretFormDialog, {
+      global: { plugins: [i18n] },
+      props: { visible: true }
+    })
+
+    const uploadButton = screen.getByRole('button', {
+      name: 'secrets.uploadJsonFile'
+    })
+    expect(uploadButton.tabIndex).not.toBe(-1)
+
+    uploadButton.focus()
+    await userEvent.keyboard('{Enter}')
+
+    expect(fileClickSpy).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -76,7 +76,37 @@
             <label for="secret-value" class="text-sm font-medium">
               {{ $t('secrets.secretValue') }}
             </label>
+            <template v-if="selectedInputType === 'json_file'">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                class="w-fit"
+                @click="fileInput?.click()"
+              >
+                <i class="pi pi-upload" />
+                {{ $t('secrets.uploadJsonFile') }}
+              </Button>
+              <input
+                ref="fileInput"
+                type="file"
+                accept="application/json,.json"
+                class="hidden"
+                @change="onFileChange"
+              />
+              <span v-if="fileName" class="text-sm text-muted">
+                {{ fileName }}
+              </span>
+              <Textarea
+                id="secret-value"
+                v-model="form.secretValue"
+                :placeholder="$t('secrets.jsonFilePlaceholder')"
+                class="min-h-32 font-mono"
+                :class="{ 'p-invalid': errors.secretValue }"
+              />
+            </template>
             <Password
+              v-else
               id="secret-value"
               v-model="form.secretValue"
               :placeholder="
@@ -93,11 +123,7 @@
               {{ errors.secretValue }}
             </small>
             <small v-else class="text-muted">
-              {{
-                mode === 'edit'
-                  ? $t('secrets.secretValueHintEdit')
-                  : $t('secrets.secretValueHint')
-              }}
+              {{ secretValueHint }}
             </small>
           </div>
 
@@ -127,7 +153,8 @@
 <script setup lang="ts">
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
-import { useId } from 'vue'
+import { computed, useId, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import Dialog from '@/components/ui/dialog/Dialog.vue'
@@ -143,9 +170,10 @@ import SelectContent from '@/components/ui/select/SelectContent.vue'
 import SelectItem from '@/components/ui/select/SelectItem.vue'
 import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
 import SelectValue from '@/components/ui/select/SelectValue.vue'
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 
 import { useSecretForm } from '../composables/useSecretForm'
-import type { SecretMetadata } from '../types'
+import type { SecretMetadata, SecretProviderInfo } from '../types'
 
 const {
   secret,
@@ -155,7 +183,7 @@ const {
 } = defineProps<{
   secret?: SecretMetadata
   existingProviders?: string[]
-  availableProviders?: string[] | null
+  availableProviders?: SecretProviderInfo[] | null
   mode?: 'create' | 'edit'
 }>()
 
@@ -165,7 +193,9 @@ const emit = defineEmits<{
   saved: []
 }>()
 
+const { t } = useI18n()
 const titleId = useId()
+const fileInput = useTemplateRef<HTMLInputElement>('fileInput')
 
 const {
   form,
@@ -174,6 +204,9 @@ const {
   apiError,
   providerOptions,
   providerHelp,
+  selectedInputType,
+  fileName,
+  loadSecretFromFile,
   handleSubmit
 } = useSecretForm({
   mode,
@@ -183,4 +216,21 @@ const {
   visible,
   onSaved: () => emit('saved')
 })
+
+const secretValueHint = computed(() => {
+  if (selectedInputType.value === 'json_file') {
+    return mode === 'edit'
+      ? t('secrets.jsonFileHintEdit')
+      : t('secrets.jsonFileHint')
+  }
+  return mode === 'edit'
+    ? t('secrets.secretValueHintEdit')
+    : t('secrets.secretValueHint')
+})
+
+async function onFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  await loadSecretFromFile(input.files?.[0] ?? null)
+  input.value = ''
+}
 </script>

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -2,6 +2,7 @@ import { ZIndex } from '@primeuix/utils/zindex'
 import { cleanup, render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import SecretFormDialog from './SecretFormDialog.vue'
@@ -14,6 +15,9 @@ vi.mock('../composables/useSecretForm', () => ({
     apiError: '',
     providerOptions: [],
     providerHelp: '',
+    selectedInputType: ref('text'),
+    fileName: ref(''),
+    loadSecretFromFile: vi.fn(),
     handleSubmit: vi.fn()
   })
 }))

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -1,7 +1,11 @@
 import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SecretMetadata, SecretProvider } from '../types'
+import type {
+  SecretMetadata,
+  SecretProvider,
+  SecretProviderInfo
+} from '../types'
 import { useSecretForm } from './useSecretForm'
 
 vi.mock('vue-i18n', () => ({
@@ -218,7 +222,7 @@ describe('useSecretForm', () => {
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['civitai'],
+        availableProviders: () => [{ id: 'civitai' }],
         visible,
         onSaved: vi.fn()
       })
@@ -231,7 +235,11 @@ describe('useSecretForm', () => {
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['civitai', 'civitai', 'huggingface'],
+        availableProviders: () => [
+          { id: 'civitai' },
+          { id: 'civitai' },
+          { id: 'huggingface' }
+        ],
         visible,
         onSaved: vi.fn()
       })
@@ -247,7 +255,7 @@ describe('useSecretForm', () => {
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['runway', 'gemini'],
+        availableProviders: () => [{ id: 'runway' }, { id: 'gemini' }],
         visible,
         onSaved: vi.fn()
       })
@@ -273,7 +281,7 @@ describe('useSecretForm', () => {
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['brand-new-provider'],
+        availableProviders: () => [{ id: 'brand-new-provider' }],
         visible,
         onSaved: vi.fn()
       })
@@ -294,7 +302,7 @@ describe('useSecretForm', () => {
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['huggingface'],
+        availableProviders: () => [{ id: 'huggingface' }],
         visible,
         onSaved: vi.fn()
       })
@@ -307,7 +315,7 @@ describe('useSecretForm', () => {
 
     it('reacts to availableProviders changing', () => {
       const visible = ref(true)
-      const availableProviders = ref<string[] | null>(null)
+      const availableProviders = ref<SecretProviderInfo[] | null>(null)
       const { providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
@@ -318,14 +326,14 @@ describe('useSecretForm', () => {
 
       expect(providerOptions.value).toHaveLength(2)
 
-      availableProviders.value = ['huggingface']
+      availableProviders.value = [{ id: 'huggingface' }]
 
       expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
     })
 
     it('clears a selection the resolved allowlist no longer offers', async () => {
       const visible = ref(true)
-      const availableProviders = ref<string[] | null>(null)
+      const availableProviders = ref<SecretProviderInfo[] | null>(null)
       const { form, providerOptions } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
@@ -335,7 +343,7 @@ describe('useSecretForm', () => {
       })
 
       form.provider = 'civitai'
-      availableProviders.value = ['huggingface']
+      availableProviders.value = [{ id: 'huggingface' }]
       await nextTick()
 
       expect(providerOptions.value.map((o) => o.value)).toEqual(['huggingface'])
@@ -344,7 +352,7 @@ describe('useSecretForm', () => {
 
     it('keeps a selection the resolved allowlist still offers', async () => {
       const visible = ref(true)
-      const availableProviders = ref<string[] | null>(null)
+      const availableProviders = ref<SecretProviderInfo[] | null>(null)
       const { form } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
@@ -354,7 +362,7 @@ describe('useSecretForm', () => {
       })
 
       form.provider = 'huggingface'
-      availableProviders.value = ['huggingface', 'civitai']
+      availableProviders.value = [{ id: 'huggingface' }, { id: 'civitai' }]
       await nextTick()
 
       expect(form.provider).toBe('huggingface')
@@ -366,7 +374,7 @@ describe('useSecretForm', () => {
         mode: 'edit',
         secret: () => createMockSecret({ provider: 'huggingface' }),
         existingProviders: () => [],
-        availableProviders: () => ['civitai'],
+        availableProviders: () => [{ id: 'civitai' }],
         visible,
         onSaved: vi.fn()
       })
@@ -418,7 +426,7 @@ describe('useSecretForm', () => {
       const { form, providerHelp } = useSecretForm({
         mode: 'create',
         existingProviders: () => [],
-        availableProviders: () => ['runway', 'gemini'],
+        availableProviders: () => [{ id: 'runway' }, { id: 'gemini' }],
         visible,
         onSaved: vi.fn()
       })
@@ -441,6 +449,236 @@ describe('useSecretForm', () => {
 
       form.provider = 'huggingface'
       expect(providerHelp.value).toBe('secrets.providerHint')
+    })
+  })
+
+  describe('server-driven provider metadata', () => {
+    it('prefers the server-provided label over the registry label', () => {
+      const visible = ref(true)
+      const { providerOptions } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => [{ id: 'gemini', label: 'Gemini (Vertex)' }],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(
+        providerOptions.value.find((o) => o.value === 'gemini')?.label
+      ).toBe('Gemini (Vertex)')
+    })
+
+    it('defaults selectedInputType to text', () => {
+      const visible = ref(true)
+      const { form, selectedInputType } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => [{ id: 'gemini' }],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      expect(selectedInputType.value).toBe('text')
+      form.provider = 'gemini'
+      expect(selectedInputType.value).toBe('text')
+    })
+
+    it('reports json_file input type for a json_file provider', () => {
+      const visible = ref(true)
+      const { form, selectedInputType } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => [{ id: 'gemini', input_type: 'json_file' }],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'gemini'
+      expect(selectedInputType.value).toBe('json_file')
+    })
+  })
+
+  describe('json_file credential input', () => {
+    const vertexProviders: SecretProviderInfo[] = [
+      { id: 'gemini', input_type: 'json_file' }
+    ]
+
+    it('loads file contents into the secret value', async () => {
+      const visible = ref(true)
+      const { form, fileName, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const file = new File(['{"type":"service_account"}'], 'sa.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(file)
+
+      expect(form.secretValue).toBe('{"type":"service_account"}')
+      expect(fileName.value).toBe('sa.json')
+    })
+
+    it('rejects invalid JSON for a json_file provider', async () => {
+      const visible = ref(true)
+      const { form, errors, handleSubmit } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.name = 'Vertex SA'
+      form.provider = 'gemini'
+      form.secretValue = 'not json'
+
+      await handleSubmit()
+
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(errors.secretValue).toBe('secrets.errors.invalidJson')
+    })
+
+    it('rejects JSON that is not an object for a json_file provider', async () => {
+      const visible = ref(true)
+      const { form, errors, handleSubmit } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.name = 'Vertex SA'
+      form.provider = 'gemini'
+      form.secretValue = '["not", "an", "object"]'
+
+      await handleSubmit()
+
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(errors.secretValue).toBe('secrets.errors.invalidJson')
+    })
+
+    it('rejects a file larger than the size cap', async () => {
+      const visible = ref(true)
+      const { form, fileName, errors, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const oversized = new File(['x'.repeat(1024 * 1024 + 1)], 'big.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(oversized)
+
+      expect(form.secretValue).toBe('')
+      expect(fileName.value).toBe('')
+      expect(errors.secretValue).toBe('secrets.errors.fileTooLarge')
+    })
+
+    it('reports an error when the file read fails', async () => {
+      const visible = ref(true)
+      const { errors, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const unreadable = {
+        name: 'sa.json',
+        size: 20,
+        text: () => Promise.reject(new Error('read failed'))
+      } as unknown as File
+      await loadSecretFromFile(unreadable)
+
+      expect(errors.secretValue).toBe('secrets.errors.fileReadFailed')
+    })
+
+    it('clears an uploaded credential when the provider changes', async () => {
+      const visible = ref(true)
+      const { form, fileName, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'gemini'
+      await nextTick()
+      const file = new File(['{"type":"service_account"}'], 'sa.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(file)
+      expect(form.secretValue).toBe('{"type":"service_account"}')
+
+      form.provider = 'huggingface'
+      await nextTick()
+
+      expect(form.secretValue).toBe('')
+      expect(fileName.value).toBe('')
+    })
+
+    it('discards a file read superseded by a provider change', async () => {
+      const visible = ref(true)
+      const { form, fileName, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'gemini'
+      await nextTick()
+
+      let resolveRead: (value: string) => void = () => {}
+      const slowFile = {
+        name: 'sa.json',
+        size: 26,
+        text: () =>
+          new Promise<string>((resolve) => {
+            resolveRead = resolve
+          })
+      } as unknown as File
+
+      const pending = loadSecretFromFile(slowFile)
+      form.provider = 'huggingface'
+      await nextTick()
+      resolveRead('{"type":"service_account"}')
+      await pending
+
+      expect(form.secretValue).toBe('')
+      expect(fileName.value).toBe('')
+    })
+
+    it('submits valid JSON for a json_file provider', async () => {
+      const visible = ref(true)
+      mockCreate.mockResolvedValue({})
+      const { form, handleSubmit } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.name = 'Vertex SA'
+      form.provider = 'gemini'
+      form.secretValue = '{"type":"service_account"}'
+
+      await handleSubmit()
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: 'Vertex SA',
+        secret_value: '{"type":"service_account"}',
+        provider: 'gemini'
+      })
     })
   })
 

--- a/src/platform/secrets/composables/useSecretForm.test.ts
+++ b/src/platform/secrets/composables/useSecretForm.test.ts
@@ -117,6 +117,7 @@ describe('useSecretForm', () => {
 
       form.name = 'My Secret'
       form.provider = 'huggingface'
+      await nextTick()
       form.secretValue = ''
 
       await handleSubmit()
@@ -533,6 +534,7 @@ describe('useSecretForm', () => {
 
       form.name = 'Vertex SA'
       form.provider = 'gemini'
+      await nextTick()
       form.secretValue = 'not json'
 
       await handleSubmit()
@@ -553,6 +555,7 @@ describe('useSecretForm', () => {
 
       form.name = 'Vertex SA'
       form.provider = 'gemini'
+      await nextTick()
       form.secretValue = '["not", "an", "object"]'
 
       await handleSubmit()
@@ -655,6 +658,152 @@ describe('useSecretForm', () => {
 
       expect(form.secretValue).toBe('')
       expect(fileName.value).toBe('')
+    })
+
+    it('clears a previously loaded credential when a replacement is oversized', async () => {
+      const visible = ref(true)
+      const { form, fileName, errors, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const good = new File(['{"type":"service_account"}'], 'sa.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(good)
+      expect(form.secretValue).toBe('{"type":"service_account"}')
+
+      const oversized = new File(['x'.repeat(1024 * 1024)], 'big.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(oversized)
+
+      expect(form.secretValue).toBe('')
+      expect(fileName.value).toBe('')
+      expect(errors.secretValue).toBe('secrets.errors.fileTooLarge')
+    })
+
+    it('clears a previously loaded credential when a replacement read fails', async () => {
+      const visible = ref(true)
+      const { form, fileName, errors, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        visible,
+        onSaved: vi.fn()
+      })
+
+      const good = new File(['{"type":"service_account"}'], 'sa.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(good)
+      expect(form.secretValue).toBe('{"type":"service_account"}')
+
+      const unreadable = {
+        name: 'replacement.json',
+        size: 20,
+        text: () => Promise.reject(new Error('read failed'))
+      } as unknown as File
+      await loadSecretFromFile(unreadable)
+
+      expect(form.secretValue).toBe('')
+      expect(fileName.value).toBe('')
+      expect(errors.secretValue).toBe('secrets.errors.fileReadFailed')
+    })
+
+    it('discards an in-flight read invalidated by a later oversized selection', async () => {
+      const visible = ref(true)
+      const { form, errors, loadSecretFromFile } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.provider = 'gemini'
+      await nextTick()
+
+      let resolveRead: (value: string) => void = () => {}
+      const slowFile = {
+        name: 'sa.json',
+        size: 26,
+        text: () =>
+          new Promise<string>((resolve) => {
+            resolveRead = resolve
+          })
+      } as unknown as File
+
+      const pending = loadSecretFromFile(slowFile)
+      const oversized = new File(['x'.repeat(1024 * 1024)], 'big.json', {
+        type: 'application/json'
+      })
+      await loadSecretFromFile(oversized)
+      resolveRead('{"type":"service_account"}')
+      await pending
+
+      expect(form.secretValue).toBe('')
+      expect(errors.secretValue).toBe('secrets.errors.fileTooLarge')
+    })
+
+    it('discards a file read superseded by a form reset', async () => {
+      const visible = ref(false)
+      const secret = createMockSecret({ provider: 'gemini' })
+      const { form, loadSecretFromFile } = useSecretForm({
+        mode: 'edit',
+        secret: () => secret,
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      visible.value = true
+      await nextTick()
+
+      let resolveRead: (value: string) => void = () => {}
+      const slowFile = {
+        name: 'sa.json',
+        size: 26,
+        text: () =>
+          new Promise<string>((resolve) => {
+            resolveRead = resolve
+          })
+      } as unknown as File
+
+      const pending = loadSecretFromFile(slowFile)
+
+      visible.value = false
+      await nextTick()
+      visible.value = true
+      await nextTick()
+
+      resolveRead('{"type":"service_account"}')
+      await pending
+
+      expect(form.secretValue).toBe('')
+    })
+
+    it('rejects pasted JSON that exceeds the size cap', async () => {
+      const visible = ref(true)
+      const { form, errors, handleSubmit } = useSecretForm({
+        mode: 'create',
+        existingProviders: () => [],
+        availableProviders: () => vertexProviders,
+        visible,
+        onSaved: vi.fn()
+      })
+
+      form.name = 'Vertex SA'
+      form.provider = 'gemini'
+      await nextTick()
+      form.secretValue = `{"key":"${'a'.repeat(1024 * 1024)}"}`
+
+      await handleSubmit()
+
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(errors.secretValue).toBe('secrets.errors.fileTooLarge')
     })
 
     it('submits valid JSON for a json_file provider', async () => {

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -169,6 +169,16 @@ export function useSecretForm(options: UseSecretFormOptions) {
     }
   })
 
+  // Bumped whenever a read is started or invalidated (by a provider change or a
+  // form reset), so a slow read that resolves after the user has moved on is
+  // discarded instead of overwriting the current field.
+  let latestFileReadId = 0
+
+  function clearSecretValue() {
+    form.secretValue = ''
+    fileName.value = ''
+  }
+
   function resetForm() {
     const secret = toValue(secretRef)
     if (mode === 'edit' && secret) {
@@ -186,21 +196,20 @@ export function useSecretForm(options: UseSecretFormOptions) {
     errors.provider = ''
     apiErrorCode.value = null
     apiErrorMessage.value = null
+    latestFileReadId++
   }
-
-  // Bumped whenever a read is started or invalidated (by a provider change), so
-  // a slow read that resolves after the user has moved on is discarded instead
-  // of overwriting the current field.
-  let latestFileReadId = 0
 
   async function loadSecretFromFile(file: File | null) {
     if (!file) return
+    // Invalidate any in-flight read up front so a slower earlier read can't
+    // resolve later and overwrite the outcome of this selection.
+    const readId = ++latestFileReadId
     errors.secretValue = ''
-    if (file.size > MAX_JSON_FILE_BYTES) {
+    if (file.size >= MAX_JSON_FILE_BYTES) {
+      clearSecretValue()
       errors.secretValue = t('secrets.errors.fileTooLarge')
       return
     }
-    const readId = ++latestFileReadId
     try {
       const text = await file.text()
       if (readId !== latestFileReadId) return
@@ -208,6 +217,7 @@ export function useSecretForm(options: UseSecretFormOptions) {
       fileName.value = file.name
     } catch {
       if (readId !== latestFileReadId) return
+      clearSecretValue()
       errors.secretValue = t('secrets.errors.fileReadFailed')
     }
   }
@@ -219,8 +229,8 @@ export function useSecretForm(options: UseSecretFormOptions) {
     () => form.provider,
     () => {
       latestFileReadId++
-      form.secretValue = ''
-      fileName.value = ''
+      clearSecretValue()
+      errors.secretValue = ''
     }
   )
 
@@ -247,13 +257,17 @@ export function useSecretForm(options: UseSecretFormOptions) {
       errors.secretValue = t('secrets.errors.secretValueRequired')
       return false
     }
-    if (
-      selectedInputType.value === 'json_file' &&
-      form.secretValue &&
-      !isJsonObject(form.secretValue)
-    ) {
-      errors.secretValue = t('secrets.errors.invalidJson')
-      return false
+    if (selectedInputType.value === 'json_file' && form.secretValue) {
+      // Guard the size cap for pasted content too, so an arbitrarily large
+      // string can't block the main thread on JSON.parse below.
+      if (form.secretValue.length >= MAX_JSON_FILE_BYTES) {
+        errors.secretValue = t('secrets.errors.fileTooLarge')
+        return false
+      }
+      if (!isJsonObject(form.secretValue)) {
+        errors.secretValue = t('secrets.errors.invalidJson')
+        return false
+      }
     }
     return true
   }

--- a/src/platform/secrets/composables/useSecretForm.ts
+++ b/src/platform/secrets/composables/useSecretForm.ts
@@ -10,7 +10,12 @@ import {
   getProviderLabel,
   getProviderLogo
 } from '../providers'
-import type { SecretErrorCode, SecretMetadata } from '../types'
+import type {
+  SecretErrorCode,
+  SecretInputType,
+  SecretMetadata,
+  SecretProviderInfo
+} from '../types'
 
 interface SecretFormState {
   name: string
@@ -32,11 +37,28 @@ interface ProviderOption {
   disabled: boolean
 }
 
+// A json_file credential (e.g. a Vertex service-account key) must be a JSON
+// object, so scalars and arrays are rejected even though they parse.
+function isJsonObject(value: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return (
+      typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    )
+  } catch {
+    return false
+  }
+}
+
+// Service-account keys are only a few KB; cap uploads well above that so a huge
+// file can't be read into memory or block the main thread on JSON.parse.
+const MAX_JSON_FILE_BYTES = 1024 * 1024
+
 interface UseSecretFormOptions {
   mode: 'create' | 'edit'
   secret?: MaybeRefOrGetter<SecretMetadata | undefined>
   existingProviders: MaybeRefOrGetter<string[]>
-  availableProviders?: MaybeRefOrGetter<string[] | null>
+  availableProviders?: MaybeRefOrGetter<SecretProviderInfo[] | null>
   visible: { value: boolean }
   onSaved: () => void
 }
@@ -55,6 +77,8 @@ export function useSecretForm(options: UseSecretFormOptions) {
   const loading = ref(false)
   const apiErrorCode = ref<SecretErrorCode | null>(null)
   const apiErrorMessage = ref<string | null>(null)
+  // Name of the uploaded credential file (json_file providers), for display.
+  const fileName = ref('')
 
   const form = reactive<SecretFormState>({
     name: '',
@@ -66,6 +90,14 @@ export function useSecretForm(options: UseSecretFormOptions) {
     name: '',
     secretValue: '',
     provider: ''
+  })
+
+  // The server-returned provider metadata keyed by id, so option rendering and
+  // the selected provider's input type can look up their `label`/`input_type`.
+  const providerInfoById = computed(() => {
+    const map = new Map<string, SecretProviderInfo>()
+    for (const info of toValue(availableProviders) ?? []) map.set(info.id, info)
+    return map
   })
 
   const providerOptions = computed<ProviderOption[]>(() => {
@@ -87,16 +119,25 @@ export function useSecretForm(options: UseSecretFormOptions) {
           : [...DEFAULT_PROVIDER_IDS]
     } else {
       ids =
-        available === null ? [...DEFAULT_PROVIDER_IDS] : [...new Set(available)]
+        available === null
+          ? [...DEFAULT_PROVIDER_IDS]
+          : [...new Set(available.map((p) => p.id))]
     }
 
     const existing = toValue(existingProviders)
     return ids.map((id) => ({
       value: id,
-      label: getProviderLabel(id),
+      label: providerInfoById.value.get(id)?.label ?? getProviderLabel(id),
       logo: getProviderLogo(id),
       disabled: mode === 'edit' ? false : existing.includes(id)
     }))
+  })
+
+  // How the selected provider's credential is entered. Providers omitting
+  // `input_type` (and any unlisted selection) default to a single-line secret.
+  const selectedInputType = computed<SecretInputType>(() => {
+    if (!form.provider) return 'text'
+    return providerInfoById.value.get(form.provider)?.input_type ?? 'text'
   })
 
   // Once the server allowlist resolves, drop a selection the resolved list no
@@ -139,12 +180,49 @@ export function useSecretForm(options: UseSecretFormOptions) {
       form.secretValue = ''
       form.provider = null
     }
+    fileName.value = ''
     errors.name = ''
     errors.secretValue = ''
     errors.provider = ''
     apiErrorCode.value = null
     apiErrorMessage.value = null
   }
+
+  // Bumped whenever a read is started or invalidated (by a provider change), so
+  // a slow read that resolves after the user has moved on is discarded instead
+  // of overwriting the current field.
+  let latestFileReadId = 0
+
+  async function loadSecretFromFile(file: File | null) {
+    if (!file) return
+    errors.secretValue = ''
+    if (file.size > MAX_JSON_FILE_BYTES) {
+      errors.secretValue = t('secrets.errors.fileTooLarge')
+      return
+    }
+    const readId = ++latestFileReadId
+    try {
+      const text = await file.text()
+      if (readId !== latestFileReadId) return
+      form.secretValue = text
+      fileName.value = file.name
+    } catch {
+      if (readId !== latestFileReadId) return
+      errors.secretValue = t('secrets.errors.fileReadFailed')
+    }
+  }
+
+  // Switching providers discards any entered or uploaded credential so a value
+  // captured for one provider (e.g. an uploaded JSON key) can't be submitted
+  // under another, and invalidates any in-flight file read.
+  watch(
+    () => form.provider,
+    () => {
+      latestFileReadId++
+      form.secretValue = ''
+      fileName.value = ''
+    }
+  )
 
   whenever(() => visible.value, resetForm)
 
@@ -167,6 +245,14 @@ export function useSecretForm(options: UseSecretFormOptions) {
     }
     if (mode === 'create' && !form.secretValue) {
       errors.secretValue = t('secrets.errors.secretValueRequired')
+      return false
+    }
+    if (
+      selectedInputType.value === 'json_file' &&
+      form.secretValue &&
+      !isJsonObject(form.secretValue)
+    ) {
+      errors.secretValue = t('secrets.errors.invalidJson')
       return false
     }
     return true
@@ -215,6 +301,9 @@ export function useSecretForm(options: UseSecretFormOptions) {
     apiError,
     providerOptions,
     providerHelp,
+    selectedInputType,
+    fileName,
+    loadSecretFromFile,
     handleSubmit
   }
 }

--- a/src/platform/secrets/composables/useSecrets.test.ts
+++ b/src/platform/secrets/composables/useSecrets.test.ts
@@ -138,7 +138,10 @@ describe('useSecrets', () => {
 
   describe('fetchProviders', () => {
     it('populates availableProviders from the API', async () => {
-      mockListSecretProviders.mockResolvedValue(['huggingface', 'civitai'])
+      mockListSecretProviders.mockResolvedValue([
+        { id: 'huggingface' },
+        { id: 'civitai' }
+      ])
 
       const { availableProviders, fetchProviders } = useSecrets()
 
@@ -146,7 +149,10 @@ describe('useSecrets', () => {
 
       await fetchProviders()
 
-      expect(availableProviders.value).toEqual(['huggingface', 'civitai'])
+      expect(availableProviders.value).toEqual([
+        { id: 'huggingface' },
+        { id: 'civitai' }
+      ])
     })
 
     it('distinguishes a server-returned empty allowlist from not-loaded', async () => {

--- a/src/platform/secrets/composables/useSecrets.ts
+++ b/src/platform/secrets/composables/useSecrets.ts
@@ -9,7 +9,7 @@ import {
   listSecrets,
   SecretsApiError
 } from '../api/secretsApi'
-import type { SecretMetadata } from '../types'
+import type { SecretMetadata, SecretProviderInfo } from '../types'
 
 export function useSecrets() {
   const { t } = useI18n()
@@ -17,7 +17,7 @@ export function useSecrets() {
 
   const loading = ref(false)
   const secrets = ref<SecretMetadata[]>([])
-  const availableProviders = ref<string[] | null>(null)
+  const availableProviders = ref<SecretProviderInfo[] | null>(null)
   const operatingSecretId = ref<string | null>(null)
 
   const existingProviders = computed<string[]>(() =>

--- a/src/platform/secrets/types.ts
+++ b/src/platform/secrets/types.ts
@@ -1,4 +1,7 @@
-import type { SecretResponse } from '@comfyorg/ingest-types'
+import type {
+  SecretProvider as SecretProviderSchema,
+  SecretResponse
+} from '@comfyorg/ingest-types'
 
 /**
  * Secret metadata as returned by the ingest API, sourced from the generated
@@ -16,6 +19,19 @@ export type SecretMetadata = SecretResponse
  * selected provider is stored/sent as a free-form string.
  */
 export type SecretProvider = 'huggingface' | 'civitai'
+
+/**
+ * A configurable provider as returned by `GET /secrets/providers`: its id plus
+ * optional presentation (`label`) and credential-entry (`input_type`) metadata.
+ */
+export type SecretProviderInfo = SecretProviderSchema
+
+/**
+ * How a provider's credential is entered. `text` is a single-line secret (an API
+ * key); `json_file` is an uploaded/pasted JSON document (e.g. a Vertex
+ * service-account key). Providers omitting `input_type` are treated as `text`.
+ */
+export type SecretInputType = NonNullable<SecretProviderInfo['input_type']>
 
 export interface SecretCreateRequest {
   name: string


### PR DESCRIPTION
## ELI-5

The BYOK secrets form can render a different input per provider — a normal text box for API keys, or a JSON file upload for providers whose credential is a JSON document (e.g. a Vertex service-account key). Which providers get which input is decided by the server, not the frontend. This backports that capability to the cloud/1.47 release line.

## What

Cherry-pick of #13571 (merged to main, shipped in v1.48.3) onto `cloud/1.47`. Clean pick — only a locale auto-merge, no conflicts.

## Why this is a manual PR (not the backport bot)

The auto-backport on #13571's merge (2026-07-13) failed on a cherry-pick conflict in `useSecretForm.test.ts`, because the #13546/#13510 backports that rewrite that same test had not yet landed on the release branches. They have since landed (#13623/#13624), so the pick is now clean — but the bot's `workflow_dispatch` re-run path is separately broken (its validate-inputs step calls `gh pr view` before checkout with no repo context → "PR not found"), so this PR was raised by hand from the same clean cherry-pick.

## Risk

Dormant by design: the JSON upload only renders for providers the server tags with `input_type: json_file`. Today's `GET /secrets/providers` returns ids only, so nothing is user-visible until the server-side metadata ships — every provider keeps the current single-line secret field.

## Testing

- `vitest src/platform/secrets` on this branch: 8 files, 85/85 passing.