### PR TITLE
fix: give pr-backport manual dispatch gh calls repo context

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -62,6 +62,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -80,6 +81,9 @@ jobs:
 
       - name: Collect backport targets
         id: targets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TARGETS=()
           declare -A SEEN=()
@@ -230,6 +234,8 @@ jobs:
         id: backport
         env:
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           FAILED=""
           SUCCESS=""


### PR DESCRIPTION
## ELI-5

The auto-backport bot can be kicked off by hand (Actions → PR Backport → Run workflow) to retry a backport. That manual path was broken: the very first step asked `gh` "is this PR merged?" before the repo was ever checked out and without telling `gh` which repo to look in, so `gh` couldn't resolve a repository and the run aborted with `PR #<n> not found or inaccessible`. This gives the manual-trigger `gh` calls the repo (and token) context they need so a hand-triggered backport actually runs.

## Summary

Fix the `workflow_dispatch` (manual) path of `pr-backport.yaml`, which failed immediately because `gh` had no repository context.

## Changes

- **What**:
  - Add `GH_REPO: ${{ github.repository }}` to the `workflow_dispatch`-only **Validate inputs for manual triggers** step. This step runs before `actions/checkout`, so `gh` has no git remote to infer the repo from; without `GH_REPO`/`--repo` it errors and reports `PR #<n> not found or inaccessible`, aborting the run. (This is the ticket's core one-line fix.)
  - Also give the other two `workflow_dispatch`-only `gh` call sites the same context — **Collect backport targets** (no `env` block at all) and **Backport commits** (`env` had only `PR_NUMBER`) each call `gh pr view` in the manual branch but carried no `GH_TOKEN`. In GitHub Actions `gh` requires an explicit token, so without this the manual path would only get past step 1 and then fail again at these steps. Every other `gh` step in this workflow (and `backport-auto-merge.yaml`, `pr-update-playwright-expectations.yaml`) already sets `GH_TOKEN` explicitly — these two were the outliers, only exposed now that the manual path can proceed.
- **Breaking**: None.

## Review Focus

- The automatic path (`pull_request_target`) is unaffected: those branches read PR data from `GITHUB_EVENT_PATH` via `jq` and never invoke `gh`, so the added env vars are simply unused there. The `gh` calls that gained context all sit inside `if [ "$github.event_name" = "workflow_dispatch" ]` guards.
- The load-bearing add on the two downstream steps is `GH_TOKEN` (they run post-checkout, so repo resolves from the remote); `GH_REPO` is added for explicit consistency with the validate step and this repo's `--repo`-everywhere convention.
- Verification: `yamllint` (the repo's `CI: YAML Validation` gate) passes on the changed file; there is no product-code surface, so no unit/typecheck coverage applies to a CI-workflow-only change. The manual dispatch itself can only be exercised end-to-end once merged (running the workflow requires it to live on the default branch).
