### PR TITLE
feat: tag Cloud RUM with navigation type

### DIFF
--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -3,22 +3,50 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
 const addAction = vi.fn()
+const setViewContextProperty = vi.fn()
 
 function installDatadogRum(): void {
   Object.defineProperty(window, 'DD_RUM', {
     configurable: true,
-    value: { addAction }
+    value: { addAction, setViewContextProperty }
   })
+}
+
+function setNavigationType(type?: NavigationTimingType): void {
+  vi.spyOn(performance, 'getEntriesByType').mockReturnValue(
+    type ? ([{ type }] as PerformanceNavigationTiming[]) : []
+  )
 }
 
 afterEach(() => {
   addAction.mockReset()
+  setViewContextProperty.mockReset()
+  vi.restoreAllMocks()
   Reflect.deleteProperty(window, 'DD_RUM')
 })
 
 describe('DatadogRumTelemetryProvider', () => {
+  it.for([
+    { expected: 'navigate', type: 'navigate' },
+    { expected: 'reload', type: 'reload' },
+    { expected: 'back_forward', type: 'back_forward' },
+    { expected: 'prerender', type: 'prerender' },
+    { expected: 'unknown', type: undefined }
+  ] as const)('sets $expected navigation context', ({ expected, type }) => {
+    installDatadogRum()
+    setNavigationType(type)
+
+    new DatadogRumTelemetryProvider()
+
+    expect(setViewContextProperty).toHaveBeenCalledWith(
+      'navigation_type',
+      expected
+    )
+  })
+
   it('tracks workflow execution starts', () => {
     installDatadogRum()
+    setNavigationType('navigate')
 
     new DatadogRumTelemetryProvider().trackWorkflowExecution()
 
@@ -43,6 +71,7 @@ describe('DatadogRumTelemetryProvider', () => {
     'tracks workflow $outcome outcomes',
     ({ outcome, trackOutcome }) => {
       installDatadogRum()
+      setNavigationType('navigate')
       const provider = new DatadogRumTelemetryProvider()
 
       trackOutcome(provider)

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -2,6 +2,7 @@ import type { TelemetryProvider } from '../../types'
 
 interface DatadogRumClient {
   addAction(name: string, context?: Record<string, unknown>): void
+  setViewContextProperty(name: string, value: unknown): void
 }
 
 interface WindowWithDatadogRum extends Window {
@@ -17,7 +18,21 @@ function getDatadogRum(): DatadogRumClient | undefined {
   return (window as WindowWithDatadogRum).DD_RUM
 }
 
+function getNavigationType(): NavigationTimingType | 'unknown' {
+  const [navigation] = performance.getEntriesByType(
+    'navigation'
+  ) as PerformanceNavigationTiming[]
+  return navigation?.type ?? 'unknown'
+}
+
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  constructor() {
+    getDatadogRum()?.setViewContextProperty(
+      'navigation_type',
+      getNavigationType()
+    )
+  }
+
   trackWorkflowExecution(): void {
     getDatadogRum()?.addAction('workflow_execution_started', WORKFLOW_CONTEXT)
   }


### PR DESCRIPTION
## Summary

Add the browser navigation type to the active Datadog RUM view so reload behavior can be measured separately from native click-frustration signals.

Stacked on https://github.com/Comfy-Org/ComfyUI_frontend/pull/13708.

## Changes

- Read `PerformanceNavigationTiming.type` when the Cloud RUM provider initializes.
- Set `navigation_type` to `navigate`, `reload`, `back_forward`, `prerender`, or `unknown`.
- Keep the context bounded and omit request/session identifiers.

## Validation

- `pnpm exec vitest run src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts` (9 tests)
- `pnpm typecheck`
- Targeted Oxfmt, Oxlint, and ESLint
- Pre-commit hooks
- Pre-push `pnpm knip --cache`
- CodeRabbit CLI review: 0 findings

Created by Codex