### PR TITLE
feat: 2/x apply stable names to automatic Cloud RUM views

### DIFF
--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -28,7 +28,8 @@ export async function initTelemetry(): Promise<void> {
       { PostHogTelemetryProvider },
       { ClickHouseTelemetryProvider },
       { SyftTelemetryProvider },
-      { CustomerIoTelemetryProvider }
+      { CustomerIoTelemetryProvider },
+      { DatadogRumTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
       import('./providers/cloud/MixpanelTelemetryProvider'),
@@ -37,7 +38,8 @@ export async function initTelemetry(): Promise<void> {
       import('./providers/cloud/PostHogTelemetryProvider'),
       import('./providers/cloud/ClickHouseTelemetryProvider'),
       import('./providers/cloud/SyftTelemetryProvider'),
-      import('./providers/cloud/CustomerIoTelemetryProvider')
+      import('./providers/cloud/CustomerIoTelemetryProvider'),
+      import('./providers/cloud/DatadogRumTelemetryProvider')
     ])
 
     const registry = new TelemetryRegistry()
@@ -48,6 +50,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new ClickHouseTelemetryProvider())
     registry.registerProvider(new SyftTelemetryProvider())
     registry.registerProvider(new CustomerIoTelemetryProvider())
+    registry.registerProvider(new DatadogRumTelemetryProvider())
 
     setTelemetryRegistry(registry)
   })()

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
+
+const setViewName = vi.fn()
+
+function installDatadogRum(): void {
+  Object.defineProperty(window, 'DD_RUM', {
+    configurable: true,
+    value: { setViewName }
+  })
+}
+
+afterEach(() => {
+  setViewName.mockReset()
+  Reflect.deleteProperty(window, 'DD_RUM')
+})
+
+describe('DatadogRumTelemetryProvider', () => {
+  it.for([
+    { expected: 'workspace', path: 'https://cloud.comfy.org/' },
+    { expected: 'account_access', path: 'https://cloud.comfy.org/cloud/' },
+    { expected: 'account_access', path: 'https://cloud.comfy.org/cloud/login' },
+    {
+      expected: 'account_access',
+      path: 'https://cloud.comfy.org/cloud/subscribe?plan=creator'
+    },
+    {
+      expected: 'oauth_consent',
+      path: 'https://cloud.comfy.org/cloud/oauth/consent?oauth_request_id=redacted'
+    },
+    {
+      expected: 'support_recovery',
+      path: 'https://cloud.comfy.org/cloud/forgot-password'
+    },
+    {
+      expected: 'support_recovery',
+      path: 'https://cloud.comfy.org/cloud/sorry-contact-support'
+    },
+    {
+      expected: 'support_recovery',
+      path: 'https://cloud.comfy.org/cloud/auth-timeout'
+    }
+  ] as const)('names the current view $expected', ({ expected, path }) => {
+    installDatadogRum()
+
+    new DatadogRumTelemetryProvider().trackPageView('ignored', { path })
+
+    expect(setViewName).toHaveBeenCalledWith(expected)
+  })
+
+  it('does nothing when Datadog RUM is unavailable', () => {
+    expect(() =>
+      new DatadogRumTelemetryProvider().trackPageView('ignored')
+    ).not.toThrow()
+  })
+})

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,0 +1,40 @@
+import type { PageViewMetadata, TelemetryProvider } from '../../types'
+
+interface DatadogRumClient {
+  setViewName(name: string): void
+}
+
+interface WindowWithDatadogRum extends Window {
+  DD_RUM?: DatadogRumClient
+}
+
+type ViewName =
+  | 'account_access'
+  | 'oauth_consent'
+  | 'support_recovery'
+  | 'workspace'
+
+const SUPPORT_RECOVERY_PATHS = new Set([
+  '/cloud/auth-timeout',
+  '/cloud/forgot-password',
+  '/cloud/sorry-contact-support'
+])
+
+function getViewName(path = window.location.href): ViewName {
+  const pathname = new URL(path, window.location.origin).pathname.replace(
+    /\/$/,
+    ''
+  )
+  if (pathname === '/cloud/oauth/consent') return 'oauth_consent'
+  if (SUPPORT_RECOVERY_PATHS.has(pathname)) return 'support_recovery'
+  if (pathname === '/cloud' || pathname.startsWith('/cloud/'))
+    return 'account_access'
+  return 'workspace'
+}
+
+export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackPageView(_pageName: string, properties?: PageViewMetadata): void {
+    const rum = (window as WindowWithDatadogRum).DD_RUM
+    rum?.setViewName(getViewName(properties?.path))
+  }
+}


### PR DESCRIPTION
## Summary

Keep Datadog's automatic RUM Views and replace route-derived names with a bounded taxonomy via `setViewName()`.

Based on `main`.

## View names

- `workspace`
- `account_access`
- `oauth_consent`
- `support_recovery`

The SDK continues creating Views automatically. This PR only renames the current View, so native Datadog view IDs and timing remain intact.

## Validation

- provider test (9)
- typecheck
- targeted style
- hooks/knip

Created by Codex