### PR TITLE
feat(subscription): recolor credit token and use it for subscribe buttons

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -49,7 +49,7 @@
   --color-gold-500: #fdab34;
   --color-gold-600: #fd9903;
 
-  --color-credit: #fabc25;
+  --color-credit: #ddbd31;
 
   --color-coral-500: #f75951;
   --color-coral-600: #e04e48;
@@ -140,25 +140,10 @@
   --button-surface: var(--color-white);
   --button-surface-contrast: var(--color-black);
 
-  --subscription-button-gradient:
-    linear-gradient(
-      315deg,
-      rgb(105 230 255 / 0.15) 0%,
-      rgb(99 73 233 / 0.5) 100%
-    ),
-    radial-gradient(
-      70.71% 70.71% at 50% 50%,
-      rgb(62 99 222 / 0.15) 0.01%,
-      rgb(66 0 123 / 0.5) 100%
-    ),
-    linear-gradient(
-      92deg,
-      #d000ff 0.38%,
-      #b009fe 37.07%,
-      #3e1ffc 65.17%,
-      #009dff 103.86%
-    ),
-    linear-gradient(var(--color-button-surface, #2d2e32));
+  --subscription-button-gradient: linear-gradient(
+    var(--color-credit),
+    var(--color-credit)
+  );
 
   /* Code styling colors for help menu*/
   --code-text-color: rgb(0 122 255 / 1);

--- a/src/components/ui/button/button.variants.ts
+++ b/src/components/ui/button/button.variants.ts
@@ -25,7 +25,7 @@ export const buttonVariants = cva({
       tertiary:
         'bg-tertiary-background text-base-foreground hover:bg-tertiary-background-hover',
       gradient:
-        'border-transparent bg-(image:--subscription-button-gradient) text-white hover:opacity-90'
+        'border-transparent bg-(image:--subscription-button-gradient) text-charcoal-800 hover:opacity-90'
     },
     size: {
       sm: 'h-6 rounded-sm px-2 py-1 text-xs',


### PR DESCRIPTION
## Summary

Update the credit accent color and make subscription buttons share it, so credit indicators and subscribe CTAs read as one gold system.

## Changes

- **What**: Change `--color-credit` from `#fabc25` to `#ddbd31`, and repoint `--subscription-button-gradient` from the purple gradient to a solid credit fill. The `gradient` button variant now uses dark text (`text-charcoal-800`) for contrast on the gold.

## Review Focus

- The `gradient` button variant is shared by all subscription CTAs (`SubscribeToRun`, `SubscribeButton`, `CreditsTile` free-tier upgrade, user popover), so they all become solid gold together. The credit token also drives the `CreditsTile` indicators (`text-credit`) and the Monthly progress bar (`bg-credit`).

## Screenshots (if applicable)

Verified in Storybook (`Components/Button/Button -> AllVariants`, `gradient` variant) and the running cloud app: `--color-credit` resolves to `#ddbd31`, the subscribe button renders `rgb(221,189,49)` with `#171718` text.