### PR TITLE
feat(website): move Comfy MCP from Features to Products in main nav

### DIFF
--- a/apps/website/src/data/mainNavigation.ts
+++ b/apps/website/src/data/mainNavigation.ts
@@ -69,6 +69,11 @@ export function getMainNavigation(locale: Locale): NavItem[] {
               badge: 'new'
             },
             {
+              label: t('nav.mcpServer', locale),
+              href: routes.mcp,
+              badge: 'new'
+            },
+            {
               label: t('nav.comfyEnterprise', locale),
               href: routes.cloudEnterprise
             }
@@ -77,11 +82,6 @@ export function getMainNavigation(locale: Locale): NavItem[] {
         {
           header: t('nav.colFeatures', locale),
           items: [
-            {
-              label: t('nav.mcpServer', locale),
-              href: routes.mcp,
-              badge: 'new'
-            },
             // TODO: no page yet — re-enable when landing pages ship
             // { label: t('nav.appMode', locale), href: '#' },
             // { label: t('nav.agentSkills', locale), href: '#' },


### PR DESCRIPTION
## Summary

Comfy MCP was listed under the Features column of the Products dropdown; it now sits in the Products column (after Comfy API, before Comfy Enterprise), matching how the footer already categorizes it.

## Changes

- **What**: Moved the `nav.mcpServer` entry in `src/data/mainNavigation.ts` from the Features column to the Products column, keeping its `new` badge. Features column now holds Launches, Supported Models, and Docs. Desktop and mobile navs share this data source, so both are covered.

## Review Focus

- Placement order within Products (Desktop, Cloud, API, MCP, Enterprise) — Enterprise stays last.
- Verified in-browser: dropdown renders the new grouping, MCP featured card unchanged, no test asserts the old placement.

## Screenshots (if applicable)