### PR TITLE
feat(website): rename Comfy Hub to Comfy Workflows in user-facing copy

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -83,8 +83,8 @@ const translations = {
       '如果您是 ComfyUI 新手，可以从 App 模式开始——这是工作流的简化视图。您随时可以切换回节点图视图以深入了解。'
   },
   'showcase.feature3.title': {
-    en: 'Community Workflows on Comfy Hub',
-    'zh-CN': 'Comfy Hub 上的社区工作流'
+    en: 'Community Workflows on Comfy Workflows',
+    'zh-CN': 'Comfy Workflows 上的社区工作流'
   },
   'showcase.feature3.description': {
     en: 'Browse and remix thousands of community-shared workflows. Start from a proven template and customize it to your needs.',
@@ -2262,7 +2262,7 @@ const translations = {
     en: 'Comfy Enterprise',
     'zh-CN': 'Comfy 企业版'
   },
-  'nav.comfyHub': { en: 'Comfy Hub', 'zh-CN': 'Comfy Hub' },
+  'nav.comfyHub': { en: 'Comfy Workflows', 'zh-CN': 'Comfy Workflows' },
   'nav.gallery': { en: 'Gallery', 'zh-CN': '画廊' },
   'nav.learning': { en: 'Learning', 'zh-CN': '学习' },
   'nav.blogs': { en: 'Blog', 'zh-CN': '博客' },
@@ -4292,8 +4292,8 @@ const translations = {
     'zh-CN': '{count} 个工作流'
   },
   'models.list.contact.label': {
-    en: 'COMFY HUB',
-    'zh-CN': 'COMFY HUB'
+    en: 'COMFY WORKFLOWS',
+    'zh-CN': 'COMFY WORKFLOWS'
   },
   'models.showcase.label': { en: 'AI MODELS', 'zh-CN': 'AI 模型' },
   'models.showcase.heading': {
@@ -4329,9 +4329,9 @@ const translations = {
     'zh-CN': 'Wan 2.2\n文字转视频'
   },
   'models.list.contact.heading': {
-    en: 'Pick a model and explore what the community has built. <a href="https://comfy.org/workflows" target="_blank" rel="noopener noreferrer" class="text-primary-comfy-yellow underline">Browse Comfy Hub</a> for the newest workflows.',
+    en: 'Pick a model and explore what the community has built. <a href="https://comfy.org/workflows" target="_blank" rel="noopener noreferrer" class="text-primary-comfy-yellow underline">Browse Comfy Workflows</a> for the newest workflows.',
     'zh-CN':
-      '选择一个模型，浏览社区的创作成果。<a href="https://comfy.org/workflows" target="_blank" rel="noopener noreferrer" class="text-primary-comfy-yellow underline">访问 Comfy Hub</a> 查看最新工作流。'
+      '选择一个模型，浏览社区的创作成果。<a href="https://comfy.org/workflows" target="_blank" rel="noopener noreferrer" class="text-primary-comfy-yellow underline">访问 Comfy Workflows</a> 查看最新工作流。'
   },
 
   // Payment status pages

--- a/apps/website/src/pages/p/supported-models/[slug].astro
+++ b/apps/website/src/pages/p/supported-models/[slug].astro
@@ -44,7 +44,7 @@ const dirDescriptions: Record<string, string> = {
 }
 
 const dirDesc = dirDescriptions[model.directory] ?? 'an AI model'
-const whatIsDescription = `${displayName} is ${dirDesc}. You can run it locally in ComfyUI with full control over every parameter, or access it through Comfy Cloud. ComfyUI's node-based workflow editor lets you connect ${displayName} with ControlNets, LoRAs, upscalers, and custom nodes to build any pipeline you need. There are ${model.workflowCount} community workflow templates using ${displayName} on Comfy Hub, ready to load and customize.`
+const whatIsDescription = `${displayName} is ${dirDesc}. You can run it locally in ComfyUI with full control over every parameter, or access it through Comfy Cloud. ComfyUI's node-based workflow editor lets you connect ${displayName} with ControlNets, LoRAs, upscalers, and custom nodes to build any pipeline you need. There are ${model.workflowCount} community workflow templates using ${displayName} on Comfy Workflows, ready to load and customize.`
 
 const pageTitle = `${displayName} in ComfyUI`
 const pageDescription = `Run ${displayName} in ComfyUI with full parameter control. ${model.workflowCount} community workflow templates, step-by-step tutorials, and free local inference.`
@@ -87,7 +87,7 @@ const faqPage: JsonLdNode = {
       name: `How many ComfyUI workflows use ${displayName}?`,
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `There are ${model.workflowCount} community workflow templates that use ${displayName} on Comfy Hub. Each template is ready to run in ComfyUI and can be customized to suit your project.`,
+        text: `There are ${model.workflowCount} community workflow templates that use ${displayName} on Comfy Workflows. Each template is ready to run in ComfyUI and can be customized to suit your project.`,
       },
     },
     {


### PR DESCRIPTION
## Summary

Marketing-site half of the **Comfy Hub → Comfy Workflows** rename ([GTM-271](https://linear.app/comfyorg/issue/GTM-271/comfy-workflows-rename-site-docs-copylogo-sweep)); the hub-side sweep is Comfy-Org/workflow_templates#1015. Silent copy change, links keep pointing at comfy.org/workflows.

## Changes

- **What**: renames the six user-facing "Comfy Hub" mentions to "Comfy Workflows": the Community nav item, the homepage/models showcase card title, the models-page "COMFY HUB" eyebrow, the "Browse Comfy Hub" link (en + zh-CN), and the two supported-models sentences (body copy + FAQ JSON-LD text).
- Internal identifiers unchanged per the rename PRD non-goals (the `nav.comfyHub` i18n key stays).

## Review Focus

- The supported-models copy also feeds the FAQPage JSON-LD; `validate:jsonld` passes on all 503 pages.
- zh-CN strings keep the brand in Latin script ("Comfy Workflows"), matching how "Comfy Hub" was handled.

## Verification

- typecheck 0 errors · unit 199/199 · oxfmt clean · build 500 pages · validate:jsonld 503 pages · built HTML contains zero remaining "Comfy Hub".

## Screenshots (if applicable)

Attached below (Community nav dropdown, models-page showcase section).
