### PR TITLE
feat(onboarding): generalize the coachmark engine for a second consumer

### DIFF
--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -8,13 +8,14 @@ import { createI18n } from 'vue-i18n'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import TourOverlay from './TourOverlay.vue'
-import type { CoachStep } from './onboardingTours'
+import type { CoachStep, EntryPath } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
 vi.mock('./onboardingTourStore', () => ({ useOnboardingTourStore: vi.fn() }))
 
 function makeTourState() {
   return {
+    activeTour: ref<EntryPath>('appMode'),
     step: ref<CoachStep | null>(null),
     title: ref('Canvas title'),
     body: ref('Canvas body'),

--- a/src/platform/onboarding/TourOverlay.vue
+++ b/src/platform/onboarding/TourOverlay.vue
@@ -1,6 +1,6 @@
 <template>
   <CoachmarkLanding
-    v-if="tour.step?.landing"
+    v-if="isRegistryTour && tour.step?.landing"
     :title="tour.title"
     :message="tour.body"
     :image="tour.step.image"
@@ -11,7 +11,7 @@
     @skip="tour.skip"
   />
   <TourSpotlight
-    v-else-if="tour.step"
+    v-else-if="isRegistryTour && tour.step"
     :step="tour.step"
     :title="tour.title"
     :body="tour.body"
@@ -30,9 +30,17 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import CoachmarkLanding from './CoachmarkLanding.vue'
 import TourSpotlight from './TourSpotlight.vue'
+import { TOURS } from './onboardingTours'
 import { useOnboardingTourStore } from './onboardingTourStore'
 
 const tour = useOnboardingTourStore()
+
+// firstRun renders its own overlay; here, render only registry-backed tours.
+const isRegistryTour = computed(
+  () => tour.activeTour != null && tour.activeTour in TOURS
+)
 </script>

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, readonly, ref, shallowRef, watch } from 'vue'
 
 import { t, te } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -51,7 +51,8 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     skipReason?: OnboardingTourSkipReason
   ) {
     const tour = activeTour.value
-    if (!tour) return
+    // Definition-driven tours (firstRun) aren't in TOURS and report their own telemetry.
+    if (!tour || !TOURS[tour]) return
     telemetry?.trackOnboardingTour(stage, {
       tour,
       step_count: countedSteps.value.length,
@@ -192,10 +193,18 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     void settingStore.set(TOUR_SEEN_SETTING, [...seen, entryPath])
   }
 
-  function startTour(entryPath: EntryPath, force = false) {
+  function startTour(
+    entryPath: EntryPath,
+    {
+      force = false,
+      definition
+    }: { force?: boolean; definition?: CoachStep[] } = {}
+  ) {
     if (steps.value.length) return
     if (!force && hasSeenTour(entryPath)) return
-    const resolved = resolveSteps(TOURS[entryPath], targetMounted)
+    const def = definition ?? TOURS[entryPath]
+    if (!def) return
+    const resolved = resolveSteps(def, targetMounted)
     if (!resolved.length) return
     steps.value = resolved
     activeTour.value = entryPath
@@ -204,7 +213,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
   }
 
   function replayTour(entryPath: EntryPath) {
-    startTour(entryPath, true)
+    startTour(entryPath, { force: true })
   }
 
   return {
@@ -219,6 +228,8 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     countedStepIdx,
     countedStepsTotal,
     waitingForTarget,
+    activeTour: readonly(activeTour),
+    startTour,
     replayTour,
     next,
     back,

--- a/src/platform/onboarding/onboardingTours.ts
+++ b/src/platform/onboarding/onboardingTours.ts
@@ -1,4 +1,4 @@
-export type EntryPath = 'appMode'
+export type EntryPath = 'appMode' | 'firstRun'
 
 /** Setting holding the tours the user has completed or dismissed. */
 export const TOUR_SEEN_SETTING = 'Comfy.OnboardingCoachmarks.Seen'
@@ -55,7 +55,7 @@ export function resolveSteps(
   )
 }
 
-export const TOURS: Record<EntryPath, CoachStep[]> = {
+export const TOURS: Partial<Record<EntryPath, CoachStep[]>> = {
   appMode: [
     {
       name: 'landing',


### PR DESCRIPTION
- EntryPath adds 'firstRun'; TOURS is Partial so an injected tour needs no static entry
- startTour accepts a precomputed step definition; activeTour is exposed read-only
- engine telemetry and TourOverlay cover only registry (TOURS) tours; injected tours self-render and self-report
- TourOverlay.test mock provides activeTour for the new gate (assertions unchanged)

## Summary

<!-- One sentence describing what changed and why. -->

## Changes

- **What**: <!-- Core functionality added/modified -->
- **Breaking**: <!-- Any breaking changes (if none, remove this line) -->
- **Dependencies**: <!-- New dependencies (if none, remove this line) -->

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->
