### PR TITLE
fix(auth): use Turnstile test sitekey in local dev cloud builds

### DIFF
--- a/src/config/turnstile.test.ts
+++ b/src/config/turnstile.test.ts
@@ -59,14 +59,36 @@ describe('getTurnstileSiteKey', () => {
       vi.stubGlobal('__DISTRIBUTION__', 'cloud')
     })
 
-    it('returns the sitekey delivered via remote config', () => {
-      mockRemoteConfig.value = { turnstile_sitekey: '0x4AAAAAreal' }
+    describe('production / preview (not a dev server)', () => {
+      beforeEach(() => {
+        vi.stubEnv('DEV', false)
+      })
 
-      expect(getTurnstileSiteKey()).toBe('0x4AAAAAreal')
+      it('returns the sitekey delivered via remote config', () => {
+        mockRemoteConfig.value = { turnstile_sitekey: '0x4AAAAAreal' }
+
+        expect(getTurnstileSiteKey()).toBe('0x4AAAAAreal')
+      })
+
+      it('falls back to the build-time per-env sitekey during a remote-config gap', () => {
+        expect(getTurnstileSiteKey()).toBe(STAGING_TURNSTILE_SITE_KEY)
+      })
     })
 
-    it('falls back to the build-time per-env sitekey during a remote-config gap', () => {
-      expect(getTurnstileSiteKey()).toBe(STAGING_TURNSTILE_SITE_KEY)
+    describe('local dev server', () => {
+      beforeEach(() => {
+        vi.stubEnv('DEV', true)
+      })
+
+      it('uses the always-pass test key instead of the real sitekey, since a dev-server hostname is never in the real widget allowlist', () => {
+        expect(getTurnstileSiteKey()).toBe(TURNSTILE_TEST_SITE_KEY)
+      })
+
+      it('ignores a remote-config sitekey too, so it never overrides the test key locally', () => {
+        mockRemoteConfig.value = { turnstile_sitekey: '0x4AAAAAreal' }
+
+        expect(getTurnstileSiteKey()).toBe(TURNSTILE_TEST_SITE_KEY)
+      })
     })
   })
 })

--- a/src/config/turnstile.ts
+++ b/src/config/turnstile.ts
@@ -24,6 +24,14 @@ const STAGING_TURNSTILE_SITE_KEY = '0x4AAAAAADnYY4_Q0qxHZ5a7'
  * - Cloud builds prefer the per-env sitekey delivered via remote config
  *   (`turnstile_sitekey`) and fall back to the build-time constant, so the widget
  *   still renders during a remote-config gap rather than silently disappearing.
+ * - Cloud dev-server builds (e.g. running locally against the staging API) are
+ *   the one exception: a dev-server hostname is never in a real widget's
+ *   domain allowlist, so the real sitekey is guaranteed to fail there ("Verifying…"
+ *   loops into "Verification failed"). We use the always-pass test key instead —
+ *   it's cryptographically isolated from the real widgets' secrets, so it can't
+ *   mint a token those widgets (or their siteverify checks) would trust.
+ *   Production/preview cloud builds are unaffected and keep the remote-config
+ *   → build-time-constant resolution above.
  */
 export function getTurnstileSiteKey(): string {
   // Gate on the __DISTRIBUTION__ build define rather than the cross-module
@@ -33,6 +41,10 @@ export function getTurnstileSiteKey(): string {
   const isCloudBuild = __DISTRIBUTION__ === 'cloud'
   if (!isCloudBuild) {
     return import.meta.env.DEV ? TURNSTILE_TEST_SITE_KEY : ''
+  }
+
+  if (import.meta.env.DEV) {
+    return TURNSTILE_TEST_SITE_KEY
   }
 
   return configValueOrDefault(


### PR DESCRIPTION
## Problem

In a cloud build served from a dev server (`import.meta.env.DEV`, e.g. `localhost:5173`), `getTurnstileSiteKey()` resolves the real per-environment Turnstile sitekey (remote config → baked constant). Real Turnstile widgets are domain-locked and do not allowlist dev-server hostnames, so the signup challenge can never pass there: the widget loops "Verifying…" → "Verification failed. Please try again.", which reads as a hard signup block to anyone testing locally.

## Fix

Inside the existing cloud-build branch of `getTurnstileSiteKey()`, short-circuit to Cloudflare's documented always-pass **test** sitekey (`1x00000000000000000000AA`) when `import.meta.env.DEV` is true. Production and preview cloud builds are unchanged — they keep the remote-config-then-baked-constant resolution.

Security notes:
- The test sitekey is cryptographically isolated from the real widgets' secrets — tokens it mints are rejected by a real secret's siteverify, so this cannot be used to forge trusted tokens.
- The `__DISTRIBUTION__` gating structure is untouched, so dead-code elimination still strips the real per-env sitekeys from OSS/desktop bundles (verified by the dist telemetry scan job's assumptions).

## Tests

- Split the `cloud build` cases in `src/config/turnstile.test.ts` into `production / preview` (explicit `DEV=false`) and a new `local dev server` block (`DEV=true`): returns the test key, and ignores a remote-config sitekey even when present.
- `vitest run --coverage` on the touched turnstile test files (matches CI's coverage mode): 34/34 passing. Full `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitation

A dev server pointed at the **production** backend (`pnpm dev:cloud:prod`) also gets the test sitekey. The widget now passes client-side there, but the token it produces will not validate against the production widget's secret in server-side siteverify — same server-side outcome as any missing/invalid token. Previously that combination failed visibly at the widget; now it fails only at server-side verification. Harmless while verification runs in shadow mode; if enforcement is enabled, local-dev signups against production would be rejected at submit. Accepting a test token server-side is intentionally out of scope here.
