### PR TITLE
feat(website): lead /mcp setup with manual install as option 1

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1919,37 +1919,37 @@ const translations = {
     'zh-CN': '配置 Comfy MCP'
   },
   'mcp.setup.subtitle': {
-    en: 'Two ways to connect: ask your agent to install it, or add the server yourself. Sign in once, and the full ComfyUI toolset is available right in your chat.',
+    en: 'Two ways to connect: add the server yourself, or ask your agent to install it. Sign in once, and the full ComfyUI toolset is available right in your chat.',
     'zh-CN':
-      '两种接入方式：让你的智能体自动安装，或自行添加服务器。登录一次，ComfyUI 全套工具即可直接在对话中使用。'
+      '两种接入方式：自行添加服务器，或让你的智能体自动安装。登录一次，ComfyUI 全套工具即可直接在对话中使用。'
   },
-  'mcp.setup.option1.label': { en: 'OPTION 1', 'zh-CN': '方式一' },
-  'mcp.setup.option1.title': {
-    en: 'Ask your agent to install Comfy MCP',
-    'zh-CN': '让你的智能体安装 Comfy MCP'
-  },
-  'mcp.setup.option1.command': {
-    en: 'Help me install Comfy MCP.\nFollow the setup guide at {url}',
-    'zh-CN': '帮我安装 Comfy MCP。\n请按照 {url} 上的设置指南操作。'
-  },
-  'mcp.setup.option1.description': {
-    en: 'Paste this into Claude, Cursor, Codex, or any MCP-compatible agent. It reads the docs and adds the connector for you.',
-    'zh-CN':
-      '将它粘贴到 Claude、Cursor、Codex 或任意兼容 MCP 的智能体中。它会读取文档并为你添加连接器。'
-  },
-  'mcp.setup.option2.label': { en: 'OPTION 2', 'zh-CN': '方式二' },
-  'mcp.setup.option2.title': {
+  'mcp.setup.manual.label': { en: 'OPTION 1', 'zh-CN': '方式一' },
+  'mcp.setup.manual.title': {
     en: 'Install manually',
     'zh-CN': '手动安装'
   },
-  'mcp.setup.option2.description': {
-    en: 'Prefer manual setup? Add this URL as a custom connector or remote MCP server in your client, then sign in when prompted.',
+  'mcp.setup.manual.description': {
+    en: 'Add this URL as a custom connector or remote MCP server in your client, then sign in when prompted.',
     'zh-CN':
-      '想手动配置？将此 URL 添加为客户端的自定义连接器或远程 MCP 服务器，然后按提示登录。'
+      '将此 URL 添加为客户端的自定义连接器或远程 MCP 服务器，然后按提示登录。'
   },
-  'mcp.setup.option2.tabsLabel': {
+  'mcp.setup.manual.tabsLabel': {
     en: 'Pick your client',
     'zh-CN': '选择你的客户端'
+  },
+  'mcp.setup.agent.label': { en: 'OPTION 2', 'zh-CN': '方式二' },
+  'mcp.setup.agent.title': {
+    en: 'Ask your agent to install Comfy MCP',
+    'zh-CN': '让你的智能体安装 Comfy MCP'
+  },
+  'mcp.setup.agent.command': {
+    en: 'Help me install Comfy MCP.\nFollow the setup guide at {url}',
+    'zh-CN': '帮我安装 Comfy MCP。\n请按照 {url} 上的设置指南操作。'
+  },
+  'mcp.setup.agent.description': {
+    en: 'Prefer to let your agent do it? Paste this into Claude, Cursor, Codex, or any MCP-compatible agent. It reads the docs and adds the connector for you.',
+    'zh-CN':
+      '想让智能体代劳？将它粘贴到 Claude、Cursor、Codex 或任意兼容 MCP 的智能体中。它会读取文档并为你添加连接器。'
   },
   'mcp.setup.clients.claudeCode.step': {
     en: 'Run this in your terminal, then use /mcp to pick comfy-cloud and authenticate.',

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -10,7 +10,7 @@ import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
-const agentCommand = t('mcp.setup.option1.command', locale).replace(
+const agentCommand = t('mcp.setup.agent.command', locale).replace(
   '{url}',
   externalLinks.docsMcp
 )
@@ -87,45 +87,14 @@ const copiedLabel = t('ui.copied', locale)
       <div
         class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
       >
-        <SectionLabel>{{ t('mcp.setup.option1.label', locale) }}</SectionLabel>
+        <SectionLabel>{{ t('mcp.setup.manual.label', locale) }}</SectionLabel>
         <h3
           class="mt-3 text-xl font-light text-primary-comfy-canvas lg:text-2xl"
         >
-          {{ t('mcp.setup.option1.title', locale) }}
+          {{ t('mcp.setup.manual.title', locale) }}
         </h3>
         <p class="mt-3 text-sm text-smoke-700">
-          {{ t('mcp.setup.option1.description', locale) }}
-        </p>
-        <div class="mt-6">
-          <CopyableField
-            :value="agentCommand"
-            :copy-label="copyLabel"
-            :copied-label="copiedLabel"
-          />
-        </div>
-        <p class="mt-auto pt-6 text-sm text-smoke-700">
-          {{ t('mcp.setup.skillsNote', locale)
-          }}<a
-            :href="externalLinks.mcpSkills"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
-            >{{ t('mcp.setup.skillsLink', locale) }}</a
-          >
-        </p>
-      </div>
-
-      <div
-        class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
-      >
-        <SectionLabel>{{ t('mcp.setup.option2.label', locale) }}</SectionLabel>
-        <h3
-          class="mt-3 text-xl font-light text-primary-comfy-canvas lg:text-2xl"
-        >
-          {{ t('mcp.setup.option2.title', locale) }}
-        </h3>
-        <p class="mt-3 text-sm text-smoke-700">
-          {{ t('mcp.setup.option2.description', locale) }}
+          {{ t('mcp.setup.manual.description', locale) }}
         </p>
         <div class="mt-6">
           <CopyableField
@@ -137,7 +106,7 @@ const copiedLabel = t('ui.copied', locale)
 
         <TabsRoot default-value="claude-code" class="mt-6">
           <TabsList
-            :aria-label="t('mcp.setup.option2.tabsLabel', locale)"
+            :aria-label="t('mcp.setup.manual.tabsLabel', locale)"
             class="flex flex-wrap gap-2"
           >
             <TabsTrigger
@@ -174,6 +143,37 @@ const copiedLabel = t('ui.copied', locale)
             />
           </TabsContent>
         </TabsRoot>
+      </div>
+
+      <div
+        class="bg-transparency-white-t4 flex flex-col rounded-3xl p-6 lg:p-8"
+      >
+        <SectionLabel>{{ t('mcp.setup.agent.label', locale) }}</SectionLabel>
+        <h3
+          class="mt-3 text-xl font-light text-primary-comfy-canvas lg:text-2xl"
+        >
+          {{ t('mcp.setup.agent.title', locale) }}
+        </h3>
+        <p class="mt-3 text-sm text-smoke-700">
+          {{ t('mcp.setup.agent.description', locale) }}
+        </p>
+        <div class="mt-6">
+          <CopyableField
+            :value="agentCommand"
+            :copy-label="copyLabel"
+            :copied-label="copiedLabel"
+          />
+        </div>
+        <p class="mt-auto pt-6 text-sm text-smoke-700">
+          {{ t('mcp.setup.skillsNote', locale)
+          }}<a
+            :href="externalLinks.mcpSkills"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="focus-visible:ring-primary-comfy-yellow/50 rounded-sm text-primary-comfy-canvas underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+            >{{ t('mcp.setup.skillsLink', locale) }}</a
+          >
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Swaps the two setup options on /mcp: manual install (copyable URL + client tabs) is now Option 1 and leads the grid; the agent-install command is Option 2.

## Changes

- **What**: Reordered the cards in `SetupSection.vue` and renamed the translation keys semantically (`option1.*` → `agent.*`, `option2.*` → `manual.*`) so key names describe the content, not the position. Copy adjusted to fit the new order: the subtitle lists manual first, the manual card drops its "Prefer manual setup?" lead-in (it's the default now), and the agent card gains "Prefer to let your agent do it?". en + zh-CN.

## Review Focus

- Verified rendering: cards read OPTION 1 / Install manually, OPTION 2 / Ask your agent; all 7 mcp e2e tests pass unchanged (heading-based selectors).

## Screenshots (if applicable)