### PR TITLE
feat(website): add page-specific JSON-LD to the education page

### DIFF
--- a/apps/website/e2e/education.spec.ts
+++ b/apps/website/e2e/education.spec.ts
@@ -105,21 +105,32 @@ test.describe('Education landing — desktop @smoke', () => {
 type JsonLdNode = Record<string, unknown>
 
 // The page emits one connected @graph, so every node (FAQPage, Product,
-// breadcrumbs) is read from that single ld+json block.
+// breadcrumbs) is read from that single ld+json block. Blocks are selected by
+// parsed structure, not text matching, and the "exactly one" assumption is
+// asserted rather than assumed.
 const readJsonLdGraph = async (page: Page): Promise<JsonLdNode[]> => {
-  const raw = await page.evaluate(() => {
+  const graphs = await page.evaluate(() => {
     const scripts = Array.from(
       document.querySelectorAll<HTMLScriptElement>(
         'script[type="application/ld+json"]'
       )
     )
-    const graph = scripts.find((s) =>
-      (s.textContent ?? '').includes('"@graph"')
-    )
-    return graph?.textContent ?? null
+    return scripts
+      .map((script) => {
+        try {
+          return JSON.parse(script.textContent ?? '') as unknown
+        } catch {
+          return null
+        }
+      })
+      .filter(
+        (parsed): parsed is { '@graph': unknown[] } =>
+          parsed !== null &&
+          Array.isArray((parsed as Record<string, unknown>)['@graph'])
+      )
   })
-  expect(raw, 'JSON-LD @graph script').not.toBeNull()
-  return (JSON.parse(raw!) as { '@graph': JsonLdNode[] })['@graph']
+  expect(graphs, 'exactly one JSON-LD @graph block').toHaveLength(1)
+  return graphs[0]['@graph'] as JsonLdNode[]
 }
 
 test.describe('Education landing — desktop interactions', () => {
@@ -146,14 +157,16 @@ test.describe('Education landing — desktop interactions', () => {
     expect(product, 'Product node').toBeTruthy()
     expect(webPage?.mainEntity).toEqual({ '@id': product!['@id'] })
 
+    // The discounted education prices, not the list prices — a regression to
+    // pricingOffers would still pass a positive-USD check.
     const offers = product!.offers as JsonLdNode[]
-    expect(offers.length).toBeGreaterThan(0)
+    expect(offers.map((offer) => offer.price)).toEqual(['18', '31.50', '90'])
     for (const offer of offers) {
       expect(offer.priceCurrency).toBe('USD')
-      expect(Number(offer.price)).toBeGreaterThan(0)
     }
 
     const breadcrumb = graph.find((node) => node['@type'] === 'BreadcrumbList')
+    expect(breadcrumb, 'BreadcrumbList node').toBeTruthy()
     const names = (breadcrumb!.itemListElement as JsonLdNode[]).map(
       (item) => item.name
     )

--- a/apps/website/e2e/education.spec.ts
+++ b/apps/website/e2e/education.spec.ts
@@ -102,6 +102,26 @@ test.describe('Education landing — desktop @smoke', () => {
   })
 })
 
+type JsonLdNode = Record<string, unknown>
+
+// The page emits one connected @graph, so every node (FAQPage, Product,
+// breadcrumbs) is read from that single ld+json block.
+const readJsonLdGraph = async (page: Page): Promise<JsonLdNode[]> => {
+  const raw = await page.evaluate(() => {
+    const scripts = Array.from(
+      document.querySelectorAll<HTMLScriptElement>(
+        'script[type="application/ld+json"]'
+      )
+    )
+    const graph = scripts.find((s) =>
+      (s.textContent ?? '').includes('"@graph"')
+    )
+    return graph?.textContent ?? null
+  })
+  expect(raw, 'JSON-LD @graph script').not.toBeNull()
+  return (JSON.parse(raw!) as { '@graph': JsonLdNode[] })['@graph']
+}
+
 test.describe('Education landing — desktop interactions', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PATH)
@@ -110,22 +130,37 @@ test.describe('Education landing — desktop interactions', () => {
   test('emits FAQPage structured data with one entry per FAQ', async ({
     page
   }) => {
-    const faqJsonLd = await page.evaluate(() => {
-      const scripts = Array.from(
-        document.querySelectorAll<HTMLScriptElement>(
-          'script[type="application/ld+json"]'
-        )
-      )
-      const match = scripts.find((s) =>
-        (s.textContent ?? '').includes('FAQPage')
-      )
-      return match?.textContent ?? null
-    })
-    expect(faqJsonLd, 'FAQ JSON-LD script').not.toBeNull()
-    const parsed = JSON.parse(faqJsonLd!)
-    expect(parsed['@type']).toBe('FAQPage')
-    expect(Array.isArray(parsed.mainEntity)).toBe(true)
-    expect(parsed.mainEntity.length).toBe(FAQ_COUNT)
+    const graph = await readJsonLdGraph(page)
+    const faqPage = graph.find((node) => node['@type'] === 'FAQPage')
+    expect(faqPage, 'FAQPage node').toBeTruthy()
+    expect(Array.isArray(faqPage!.mainEntity)).toBe(true)
+    expect((faqPage!.mainEntity as unknown[]).length).toBe(FAQ_COUNT)
+  })
+
+  test('describes the discounted plans as a priced Product', async ({
+    page
+  }) => {
+    const graph = await readJsonLdGraph(page)
+    const product = graph.find((node) => node['@type'] === 'Product')
+    const webPage = graph.find((node) => node['@type'] === 'WebPage')
+    expect(product, 'Product node').toBeTruthy()
+    expect(webPage?.mainEntity).toEqual({ '@id': product!['@id'] })
+
+    const offers = product!.offers as JsonLdNode[]
+    expect(offers.length).toBeGreaterThan(0)
+    for (const offer of offers) {
+      expect(offer.priceCurrency).toBe('USD')
+      expect(Number(offer.price)).toBeGreaterThan(0)
+    }
+
+    const breadcrumb = graph.find((node) => node['@type'] === 'BreadcrumbList')
+    const names = (breadcrumb!.itemListElement as JsonLdNode[]).map(
+      (item) => item.name
+    )
+    expect(names).toEqual([
+      t('breadcrumb.home', 'en'),
+      t('nav.education', 'en')
+    ])
   })
 
   test('FAQ items toggle open and closed on click', async ({ page }) => {

--- a/apps/website/src/config/pricing.test.ts
+++ b/apps/website/src/config/pricing.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { educationOffers, pricingOffers } from './pricing'
+
+describe('educationOffers', () => {
+  it('marks up the discounted education prices, not the list prices', () => {
+    const edu = educationOffers('en')
+    const list = pricingOffers('en')
+
+    // Same plans in the same order, so a per-tier comparison is meaningful.
+    expect(edu.map((offer) => offer.name)).toEqual(
+      list.map((offer) => offer.name)
+    )
+    expect(edu.length).toBeGreaterThan(0)
+
+    edu.forEach((offer, index) => {
+      expect(offer.price).toMatch(/^\d+(\.\d+)?$/)
+      expect(Number(offer.price)).toBeLessThan(Number(list[index].price))
+    })
+  })
+})

--- a/apps/website/src/config/pricing.ts
+++ b/apps/website/src/config/pricing.ts
@@ -6,23 +6,27 @@ interface PricingTier {
   slug: string
   labelKey: TranslationKey
   priceKey: TranslationKey
+  eduPriceKey: TranslationKey
 }
 
 const tiers: PricingTier[] = [
   {
     slug: 'standard',
     labelKey: 'pricing.plan.standard.label',
-    priceKey: 'pricing.plan.standard.price'
+    priceKey: 'pricing.plan.standard.price',
+    eduPriceKey: 'pricing.plan.standard.eduPrice'
   },
   {
     slug: 'creator',
     labelKey: 'pricing.plan.creator.label',
-    priceKey: 'pricing.plan.creator.price'
+    priceKey: 'pricing.plan.creator.price',
+    eduPriceKey: 'pricing.plan.creator.eduPrice'
   },
   {
     slug: 'pro',
     labelKey: 'pricing.plan.pro.label',
-    priceKey: 'pricing.plan.pro.price'
+    priceKey: 'pricing.plan.pro.price',
+    eduPriceKey: 'pricing.plan.pro.eduPrice'
   }
 ]
 
@@ -32,9 +36,13 @@ export interface PricingOffer {
   url: string
 }
 
-export function pricingOffers(locale: Locale): PricingOffer[] {
+// Shared offer builder: the pricing page marks up list prices, the education
+// page marks up the discounted student/educator prices. Only plain USD amounts
+// become offers so the JSON-LD Offer always carries a concrete numeric price.
+function offersFrom(locale: Locale, education: boolean): PricingOffer[] {
   return tiers.flatMap((tier) => {
-    const display = t(tier.priceKey, locale).trim()
+    const priceKey = education ? tier.eduPriceKey : tier.priceKey
+    const display = t(priceKey, locale).trim()
     const match = /^\$(\d+(?:\.\d+)?)$/.exec(display)
     if (!match) {
       console.warn(
@@ -50,4 +58,12 @@ export function pricingOffers(locale: Locale): PricingOffer[] {
       }
     ]
   })
+}
+
+export function pricingOffers(locale: Locale): PricingOffer[] {
+  return offersFrom(locale, false)
+}
+
+export function educationOffers(locale: Locale): PricingOffer[] {
+  return offersFrom(locale, true)
 }

--- a/apps/website/src/config/pricing.ts
+++ b/apps/website/src/config/pricing.ts
@@ -46,7 +46,7 @@ function offersFrom(locale: Locale, education: boolean): PricingOffer[] {
     const match = /^\$(\d+(?:\.\d+)?)$/.exec(display)
     if (!match) {
       console.warn(
-        `pricingOffers: skipping tier "${tier.slug}" (${locale}) — price "${display}" is not a plain USD amount`
+        `${education ? 'educationOffers' : 'pricingOffers'}: skipping tier "${tier.slug}" (${locale}) — price "${display}" is not a plain USD amount`
       )
       return []
     }

--- a/apps/website/src/pages/education.astro
+++ b/apps/website/src/pages/education.astro
@@ -6,45 +6,58 @@ import CustomerStoriesSection from '../templates/education/CustomerStoriesSectio
 import FAQSection from '../templates/education/FAQSection.vue'
 import HeroSection from '../templates/education/HeroSection.vue'
 import HowItWorksSection from '../templates/education/HowItWorksSection.vue'
+import { educationOffers } from '../config/pricing'
 import { educationFaqs } from '../data/educationFaq'
 import { t } from '../i18n/translations'
 import { isEducationStory, toCardProps } from '../utils/customers'
-import { escapeJsonLd } from '../utils/escapeJsonLd'
+import {
+  absoluteUrl,
+  faqPageNode,
+  jsonLdId,
+  pageContext,
+  productNode
+} from '../utils/jsonLd'
 import { loadStories } from '../utils/loadStories'
 
-const locale = 'en' as const
+const { siteUrl, locale, url } = pageContext(
+  Astro.site,
+  Astro.url.pathname,
+  Astro.currentLocale
+)
 
 // Creative Campus stories power the education carousel.
 const stories = (await loadStories(locale))
   .map(toCardProps)
   .filter((story) => isEducationStory(story.slug))
 
-const faqJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: educationFaqs.map((faq) => ({
-    '@type': 'Question',
-    name: faq.question[locale],
-    acceptedAnswer: {
-      '@type': 'Answer',
-      text: faq.answer[locale]
-    }
-  }))
-}
+// The discounted plans and the FAQ are the page's markup-worthy content, both
+// linked into the single site-wide graph via BaseLayout's extraJsonLd.
+const productId = jsonLdId(url, 'product')
+const faqs = educationFaqs.map((faq) => ({
+  question: faq.question[locale],
+  answer: faq.answer[locale]
+}))
 ---
 
 <BaseLayout
   title={t('education.page.title', locale)}
   description={t('education.page.description', locale)}
+  mainEntityId={productId}
+  breadcrumbs={[
+    { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },
+    { name: t('nav.education', locale) }
+  ]}
+  extraJsonLd={[
+    productNode({
+      siteUrl,
+      id: productId,
+      name: 'Comfy for Education',
+      url,
+      offers: educationOffers(locale)
+    }),
+    faqPageNode(url, faqs)
+  ]}
 >
-  <Fragment slot="head">
-    <script
-      is:inline
-      type="application/ld+json"
-      set:html={escapeJsonLd(faqJsonLd)}
-    />
-  </Fragment>
-
   <HeroSection client:load />
   <PricingSection
     client:visible

--- a/apps/website/src/pages/zh-CN/education.astro
+++ b/apps/website/src/pages/zh-CN/education.astro
@@ -44,7 +44,7 @@ const faqs = educationFaqs.map((faq) => ({
   description={t('education.page.description', locale)}
   mainEntityId={productId}
   breadcrumbs={[
-    { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },
+    { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/zh-CN') },
     { name: t('nav.education', locale) }
   ]}
   extraJsonLd={[

--- a/apps/website/src/pages/zh-CN/education.astro
+++ b/apps/website/src/pages/zh-CN/education.astro
@@ -6,45 +6,58 @@ import CustomerStoriesSection from '../../templates/education/CustomerStoriesSec
 import FAQSection from '../../templates/education/FAQSection.vue'
 import HeroSection from '../../templates/education/HeroSection.vue'
 import HowItWorksSection from '../../templates/education/HowItWorksSection.vue'
+import { educationOffers } from '../../config/pricing'
 import { educationFaqs } from '../../data/educationFaq'
 import { t } from '../../i18n/translations'
 import { isEducationStory, toCardProps } from '../../utils/customers'
-import { escapeJsonLd } from '../../utils/escapeJsonLd'
+import {
+  absoluteUrl,
+  faqPageNode,
+  jsonLdId,
+  pageContext,
+  productNode
+} from '../../utils/jsonLd'
 import { loadStories } from '../../utils/loadStories'
 
-const locale = 'zh-CN' as const
+const { siteUrl, locale, url } = pageContext(
+  Astro.site,
+  Astro.url.pathname,
+  Astro.currentLocale
+)
 
 // Creative Campus stories power the education carousel.
 const stories = (await loadStories(locale))
   .map(toCardProps)
   .filter((story) => isEducationStory(story.slug))
 
-const faqJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: educationFaqs.map((faq) => ({
-    '@type': 'Question',
-    name: faq.question[locale],
-    acceptedAnswer: {
-      '@type': 'Answer',
-      text: faq.answer[locale]
-    }
-  }))
-}
+// The discounted plans and the FAQ are the page's markup-worthy content, both
+// linked into the single site-wide graph via BaseLayout's extraJsonLd.
+const productId = jsonLdId(url, 'product')
+const faqs = educationFaqs.map((faq) => ({
+  question: faq.question[locale],
+  answer: faq.answer[locale]
+}))
 ---
 
 <BaseLayout
   title={t('education.page.title', locale)}
   description={t('education.page.description', locale)}
+  mainEntityId={productId}
+  breadcrumbs={[
+    { name: t('breadcrumb.home', locale), url: absoluteUrl(Astro.site, '/') },
+    { name: t('nav.education', locale) }
+  ]}
+  extraJsonLd={[
+    productNode({
+      siteUrl,
+      id: productId,
+      name: 'Comfy for Education',
+      url,
+      offers: educationOffers(locale)
+    }),
+    faqPageNode(url, faqs)
+  ]}
 >
-  <Fragment slot="head">
-    <script
-      is:inline
-      type="application/ld+json"
-      set:html={escapeJsonLd(faqJsonLd)}
-    />
-  </Fragment>
-
   <HeroSection client:load locale="zh-CN" />
   <PricingSection
     client:visible

--- a/apps/website/src/utils/jsonLd.test.ts
+++ b/apps/website/src/utils/jsonLd.test.ts
@@ -11,6 +11,7 @@ import {
   comfyUiApplicationNode,
   comfyUiSoftwareId,
   comfyUiSourceCodeNode,
+  faqPageNode,
   itemListNode,
   jsonLdId,
   organizationId,
@@ -198,6 +199,25 @@ describe('productNode', () => {
     expect(offers[0].price).toBe('20')
     expect(offers[0].priceCurrency).toBe('USD')
     expect(offers[0].seller).toEqual({ '@id': organizationId(siteUrl) })
+  })
+})
+
+describe('faqPageNode', () => {
+  const pageUrl = 'https://comfy.org/education/'
+
+  it('maps each FAQ to a Question with an accepted answer', () => {
+    const node = faqPageNode(pageUrl, [
+      { question: 'What discount do I get?', answer: 'Up to 25% off.' }
+    ])
+    expect(node['@type']).toBe('FAQPage')
+    expect(node['@id']).toBe(jsonLdId(pageUrl, 'faq'))
+    const questions = node.mainEntity as Record<string, unknown>[]
+    expect(questions).toHaveLength(1)
+    expect(questions[0]).toMatchObject({
+      '@type': 'Question',
+      name: 'What discount do I get?',
+      acceptedAnswer: { '@type': 'Answer', text: 'Up to 25% off.' }
+    })
   })
 })
 

--- a/apps/website/src/utils/jsonLd.ts
+++ b/apps/website/src/utils/jsonLd.ts
@@ -347,6 +347,26 @@ export function productNode(input: ProductInput): JsonLdNode {
   }
 }
 
+export interface FaqEntry {
+  question: string
+  answer: string
+}
+
+export function faqPageNode(pageUrl: string, faqs: FaqEntry[]): JsonLdNode {
+  return {
+    '@type': 'FAQPage',
+    '@id': jsonLdId(pageUrl, 'faq'),
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer
+      }
+    }))
+  }
+}
+
 export interface PageGraphInput {
   url: string
   name: string


### PR DESCRIPTION
## Summary

Brings the `/education` page up to the site-wide JSON-LD standard. It was still being built when the site-wide rollout (#13480) landed, so it only had a hand-rolled FAQPage in the head slot, no breadcrumbs, and no markup for the education offer.

## Changes

- **What**: `/education` (en + zh-CN) now emits one connected `@graph` via `BaseLayout`: a `Product` ("Comfy for Education") whose `offers` are the visible discounted student/educator plans, plus `Home > Education` breadcrumbs, with the FAQ moved from a separate head-slot script into the same graph as a `FAQPage` node. `WebPage.mainEntity` points at the Product.
- New builders: `faqPageNode` in `utils/jsonLd.ts`, `educationOffers(locale)` in `config/pricing.ts` (shares the list-price helper; the pricing page is unchanged).
- **Breaking**: none.

## Review Focus

- **Honesty**: the offers use the visible discounted monthly education prices ($18 / $31.50 / $90 USD), matching how `/cloud/pricing` marks up its monthly Product. No `Course` node — the page is a program/pricing landing page, not a curriculum, so a Course would overreach.
- The FAQPage now rides in the single graph instead of a standalone script. The markup stays valid; note Google restricted FAQ rich results to gov/health sites in 2023, so this is valid structured data rather than a rich-result play (unchanged by this PR, the FAQ markup was already there).
- `/cloud/pricing` is intentionally untouched: it already carries its `productNode` from #13480.

## Verification

- typecheck (astro check): 0 errors
- test:unit: 224/224 (+2: `faqPageNode`, `educationOffers`)
- build: 505 pages; validate:jsonld: passed across 508 pages
- e2e `education.spec.ts` (desktop): 16/16, incl. the updated FAQPage test and a new priced-Product/breadcrumb test
- Built HTML (en + zh-CN): one graph `Organization -> WebSite -> WebPage -> BreadcrumbList -> Product -> FAQPage`, one Organization, `WebPage.mainEntity` -> Product, offers priced in USD, 14 FAQ questions, localized breadcrumbs (Home/Education, 首页/教育), all `@id`s resolve.

No visual change (JSON-LD is not rendered).
