### PR TITLE
fix: honor implied legacy Manager enablement

### DIFF
--- a/src/workbench/extensions/manager/composables/useManagerState.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.test.ts
@@ -126,7 +126,7 @@ describe('useManagerState', () => {
   })
 
   describe('managerUIState property', () => {
-    it('should return DISABLED state when --enable-manager is NOT present', () => {
+    it('should return DISABLED state when no manager flags are present', () => {
       systemStatsStore.$patch({
         systemStats: systemStatsFixture(['python', 'main.py']),
         isInitialized: true
@@ -141,7 +141,6 @@ describe('useManagerState', () => {
         systemStats: systemStatsFixture([
           'python',
           'main.py',
-          '--enable-manager',
           '--enable-manager-legacy-ui'
         ]),
         isInitialized: true

--- a/src/workbench/extensions/manager/composables/useManagerState.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.ts
@@ -67,20 +67,12 @@ export function useManagerState() {
         'extension.manager.supports_csrf_post'
       )
 
-      // Check command line args first (highest priority)
-      // --enable-manager flag enables the manager (opposite of old --disable-manager)
-      const hasEnableManager =
-        systemStats.value?.system?.argv?.includes('--enable-manager')
-
-      // If --enable-manager is NOT present, manager is disabled
-      if (!hasEnableManager) {
-        return ManagerUIState.DISABLED
-      }
-
-      if (
-        systemStats.value?.system?.argv?.includes('--enable-manager-legacy-ui')
-      ) {
+      const argv = systemStats.value?.system?.argv
+      if (argv?.includes('--enable-manager-legacy-ui')) {
         return ManagerUIState.LEGACY_UI
+      }
+      if (!argv?.includes('--enable-manager')) {
+        return ManagerUIState.DISABLED
       }
 
       // Server exposes v4 but is missing the CSRF-hardened POST endpoints


### PR DESCRIPTION
## Summary

Treat `--enable-manager-legacy-ui` as implied Manager enablement so the frontend matches ComfyUI's normalized CLI behavior.

## Changes

- **What**: Resolve legacy Manager UI before requiring a literal `--enable-manager` argument, while preserving support for both flags together.

## Review Focus

Confirm legacy-only and explicit dual-flag launches both select the legacy UI, while launches with neither Manager flag remain disabled.

Fixes Comfy-Org/Comfy-Desktop#1274

## Testing

- `pnpm test:unit src/workbench/extensions/manager/composables/useManagerState.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format:check`