### PR TITLE
feat(camera-info): 3D viewport widget for CreateCameraInfo node

### DIFF
--- a/src/components/cameraInfo/CameraInfo.test.ts
+++ b/src/components/cameraInfo/CameraInfo.test.ts
@@ -1,0 +1,160 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      load3d: {
+        showGizmos: 'Show gizmos',
+        hideGizmos: 'Hide gizmos',
+        lookThrough: 'Camera view',
+        exitLookThrough: 'Exit camera view',
+        transformGizmo: {
+          none: 'None',
+          target: 'Target',
+          cameraTranslate: 'Cam pos',
+          cameraRotate: 'Cam rot'
+        }
+      }
+    }
+  }
+})
+
+type ApiMocks = Record<string, ReturnType<typeof vi.fn>>
+
+const holder = vi.hoisted(() => ({
+  modeRef: null as { value: string } | null,
+  api: null as ApiMocks | null
+}))
+
+vi.mock('@/composables/useCameraInfo', async () => {
+  const { ref } = await import('vue')
+  const modeRef = ref('orbit')
+  const api = {
+    initialize: vi.fn(),
+    cleanup: vi.fn(),
+    handleMouseEnter: vi.fn(),
+    handleMouseLeave: vi.fn(),
+    setGizmosVisible: vi.fn(),
+    setTransformGizmoMode: vi.fn(),
+    setLookThrough: vi.fn()
+  }
+  holder.modeRef = modeRef
+  holder.api = api
+  return { useCameraInfo: () => ({ ...api, mode: modeRef }) }
+})
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const { ref } = await import('vue')
+  return {
+    ...actual,
+    useElementSize: () => ({ width: ref(600), height: ref(400) })
+  }
+})
+
+import CameraInfo from './CameraInfo.vue'
+
+function makeWidget(): SimplifiedWidget {
+  return {
+    name: 'camera_info_state',
+    type: 'cameraInfo',
+    value: [],
+    options: {}
+  } as unknown as SimplifiedWidget
+}
+
+function renderComponent() {
+  return render(CameraInfo, {
+    props: { widget: makeWidget() },
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: {} }
+    }
+  })
+}
+
+function setMode(value: string) {
+  holder.modeRef!.value = value
+}
+
+function api(): ApiMocks {
+  return holder.api!
+}
+
+describe('CameraInfo toolbar', () => {
+  beforeEach(() => {
+    setMode('orbit')
+    Object.values(api()).forEach((fn) => fn.mockClear())
+  })
+
+  it('initializes the viewport on mount and cleans up on unmount', () => {
+    const { unmount } = renderComponent()
+    expect(api().initialize).toHaveBeenCalledOnce()
+
+    unmount()
+    expect(api().cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('toggles gizmo visibility when the gizmos button is clicked', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Hide gizmos' }))
+
+    expect(api().setGizmosVisible).toHaveBeenCalledWith(false)
+  })
+
+  it('enters camera view when the camera-view button is clicked', async () => {
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Camera view' }))
+
+    expect(api().setLookThrough).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('CameraInfo transform gizmo reconciliation', () => {
+  beforeEach(() => {
+    setMode('orbit')
+    Object.values(api()).forEach((fn) => fn.mockClear())
+  })
+
+  it('resets the selected gizmo to none when the new mode disables it', async () => {
+    setMode('quaternion')
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Cam rot' }))
+    expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith(
+      'camera-rotate'
+    )
+
+    setMode('orbit')
+    await nextTick()
+
+    expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith('none')
+  })
+
+  it('keeps the selected gizmo when the new mode still supports it', async () => {
+    setMode('orbit')
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Target' }))
+    expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith('target')
+
+    setMode('look_at')
+    await nextTick()
+
+    expect(api().setTransformGizmoMode).not.toHaveBeenCalledWith('none')
+  })
+})

--- a/src/components/cameraInfo/CameraInfo.test.ts
+++ b/src/components/cameraInfo/CameraInfo.test.ts
@@ -144,6 +144,24 @@ describe('CameraInfo transform gizmo reconciliation', () => {
     expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith('none')
   })
 
+  it('restores the previous selection when the mode re-enables it', async () => {
+    setMode('quaternion')
+    renderComponent()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Cam rot' }))
+    setMode('orbit')
+    await nextTick()
+    expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith('none')
+
+    setMode('quaternion')
+    await nextTick()
+
+    expect(api().setTransformGizmoMode).toHaveBeenLastCalledWith(
+      'camera-rotate'
+    )
+  })
+
   it('keeps the selected gizmo when the new mode still supports it', async () => {
     setMode('orbit')
     renderComponent()

--- a/src/components/cameraInfo/CameraInfo.vue
+++ b/src/components/cameraInfo/CameraInfo.vue
@@ -1,0 +1,225 @@
+<template>
+  <div
+    class="relative size-full min-h-[300px]"
+    @pointerdown.stop
+    @mousedown.stop
+  >
+    <div
+      ref="container"
+      class="relative size-full"
+      data-capture-wheel="true"
+      tabindex="-1"
+      @pointerdown.stop="focusContainer"
+      @contextmenu.stop.prevent
+      @mouseenter="handleMouseEnter"
+      @mouseleave="handleMouseLeave"
+    />
+    <div class="pointer-events-none absolute inset-x-0 top-0">
+      <div
+        ref="toolbar"
+        class="pointer-events-auto flex h-10 items-center gap-1 bg-interface-menu-surface px-2"
+        @wheel.stop
+      >
+        <button
+          v-tooltip.bottom="tip(gizmosLabel)"
+          type="button"
+          :disabled="lookingThrough"
+          :class="
+            cn(
+              actionClass(!lookingThrough && gizmosOn),
+              lookingThrough && 'cursor-not-allowed opacity-40'
+            )
+          "
+          :aria-pressed="!lookingThrough && gizmosOn"
+          :aria-label="compact ? gizmosLabel : undefined"
+          @click="toggleGizmos"
+        >
+          <i
+            :class="
+              cn(
+                'size-4',
+                gizmosOn ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off]'
+              )
+            "
+          />
+          <span v-if="!compact">{{ gizmosLabel }}</span>
+        </button>
+        <div class="mx-1 h-5 w-px shrink-0 bg-interface-menu-stroke" />
+        <button
+          v-for="option in transformGizmoOptions"
+          :key="option.value"
+          v-tooltip.bottom="tip($t(option.labelKey))"
+          type="button"
+          :disabled="lookingThrough || !option.enabled"
+          :aria-pressed="!lookingThrough && transformGizmoMode === option.value"
+          :aria-label="compact ? $t(option.labelKey) : undefined"
+          :class="
+            cn(
+              actionClass(
+                !lookingThrough && transformGizmoMode === option.value
+              ),
+              (lookingThrough || !option.enabled) &&
+                'cursor-not-allowed opacity-40'
+            )
+          "
+          @click="selectTransformGizmo(option.value)"
+        >
+          <i :class="cn('size-4', option.icon)" />
+          <span v-if="!compact">{{ $t(option.labelKey) }}</span>
+        </button>
+      </div>
+    </div>
+    <div class="pointer-events-none absolute inset-x-0 bottom-0">
+      <div
+        class="pointer-events-auto flex h-10 items-center justify-end gap-1 bg-interface-menu-surface px-2"
+        @wheel.stop
+      >
+        <button
+          v-tooltip.top="tip(lookThroughLabel)"
+          type="button"
+          :class="
+            cn(iconBtnClass, lookingThrough && 'bg-button-active-surface')
+          "
+          :aria-pressed="lookingThrough"
+          :aria-label="lookThroughLabel"
+          @click="toggleLookThrough"
+        >
+          <i class="icon-[lucide--video] size-4" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useElementSize } from '@vueuse/core'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import {
+  actionClass,
+  iconBtnClass,
+  tip
+} from '@/components/load3d/menubar/menuBarStyles'
+import { useCameraInfo } from '@/composables/useCameraInfo'
+import type { TransformGizmoMode } from '@/extensions/core/cameraInfo/CameraInfoViewport'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ComponentWidget } from '@/scripts/domWidget'
+import type { NodeId } from '@/types/nodeId'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { resolveNode } from '@/utils/litegraphUtil'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { widget, nodeId } = defineProps<{
+  widget: ComponentWidget<string[]> | SimplifiedWidget
+  nodeId?: NodeId
+}>()
+
+function isComponentWidget(
+  w: ComponentWidget<string[]> | SimplifiedWidget
+): w is ComponentWidget<string[]> {
+  return 'node' in w && w.node !== undefined
+}
+
+const node = ref<LGraphNode | null>(null)
+if (isComponentWidget(widget)) {
+  node.value = widget.node
+} else if (nodeId) {
+  onMounted(() => {
+    node.value = resolveNode(nodeId) ?? null
+  })
+}
+
+const { t } = useI18n()
+
+const container = ref<HTMLElement | null>(null)
+const toolbar = ref<HTMLElement | null>(null)
+const { width: toolbarWidth } = useElementSize(toolbar)
+const compactWidthThreshold = 480
+const compact = computed(
+  () => toolbarWidth.value > 0 && toolbarWidth.value < compactWidthThreshold
+)
+const gizmosOn = ref(true)
+const lookingThrough = ref(false)
+const transformGizmoMode = ref<TransformGizmoMode>('none')
+const {
+  initialize,
+  cleanup,
+  handleMouseEnter,
+  handleMouseLeave,
+  setGizmosVisible,
+  setTransformGizmoMode,
+  setLookThrough,
+  mode
+} = useCameraInfo(node as Ref<LGraphNode | null>)
+
+const gizmosLabel = computed(() =>
+  gizmosOn.value ? t('load3d.hideGizmos') : t('load3d.showGizmos')
+)
+
+const lookThroughLabel = computed(() =>
+  lookingThrough.value ? t('load3d.exitLookThrough') : t('load3d.lookThrough')
+)
+
+const transformGizmoOptions = computed(() => [
+  {
+    value: 'none' as const,
+    labelKey: 'load3d.transformGizmo.none',
+    icon: 'icon-[lucide--ban]',
+    enabled: true
+  },
+  {
+    value: 'target' as const,
+    labelKey: 'load3d.transformGizmo.target',
+    icon: 'icon-[lucide--target]',
+    enabled: mode.value === 'orbit' || mode.value === 'look_at'
+  },
+  {
+    value: 'camera-translate' as const,
+    labelKey: 'load3d.transformGizmo.cameraTranslate',
+    icon: 'icon-[lucide--move-3d]',
+    enabled: mode.value === 'look_at' || mode.value === 'quaternion'
+  },
+  {
+    value: 'camera-rotate' as const,
+    labelKey: 'load3d.transformGizmo.cameraRotate',
+    icon: 'icon-[lucide--rotate-3d]',
+    enabled: mode.value === 'quaternion'
+  }
+])
+
+function focusContainer() {
+  container.value?.focus()
+}
+
+function toggleGizmos() {
+  gizmosOn.value = !gizmosOn.value
+}
+
+function toggleLookThrough() {
+  lookingThrough.value = !lookingThrough.value
+}
+
+function selectTransformGizmo(value: TransformGizmoMode) {
+  transformGizmoMode.value = value
+}
+
+watch(gizmosOn, (on) => setGizmosVisible(on))
+watch(transformGizmoMode, (m) => setTransformGizmoMode(m))
+watch(lookingThrough, (on) => setLookThrough(on))
+watch(mode, () => {
+  const selected = transformGizmoOptions.value.find(
+    ({ value }) => value === transformGizmoMode.value
+  )
+  if (!selected?.enabled) transformGizmoMode.value = 'none'
+})
+
+onMounted(() => {
+  if (container.value) initialize(container.value)
+})
+
+onUnmounted(() => {
+  cleanup()
+})
+</script>

--- a/src/components/cameraInfo/CameraInfo.vue
+++ b/src/components/cameraInfo/CameraInfo.vue
@@ -51,12 +51,14 @@
           v-tooltip.bottom="tip($t(option.labelKey))"
           type="button"
           :disabled="lookingThrough || !option.enabled"
-          :aria-pressed="!lookingThrough && transformGizmoMode === option.value"
+          :aria-pressed="
+            !lookingThrough && effectiveTransformGizmoMode === option.value
+          "
           :aria-label="compact ? $t(option.labelKey) : undefined"
           :class="
             cn(
               actionClass(
-                !lookingThrough && transformGizmoMode === option.value
+                !lookingThrough && effectiveTransformGizmoMode === option.value
               ),
               (lookingThrough || !option.enabled) &&
                 'cursor-not-allowed opacity-40'
@@ -189,6 +191,14 @@ const transformGizmoOptions = computed(() => [
   }
 ])
 
+const effectiveTransformGizmoMode = computed<TransformGizmoMode>(() =>
+  transformGizmoOptions.value.some(
+    ({ value, enabled }) => value === transformGizmoMode.value && enabled
+  )
+    ? transformGizmoMode.value
+    : 'none'
+)
+
 function focusContainer() {
   container.value?.focus()
 }
@@ -206,14 +216,8 @@ function selectTransformGizmo(value: TransformGizmoMode) {
 }
 
 watch(gizmosOn, (on) => setGizmosVisible(on))
-watch(transformGizmoMode, (m) => setTransformGizmoMode(m))
+watch(effectiveTransformGizmoMode, (m) => setTransformGizmoMode(m))
 watch(lookingThrough, (on) => setLookThrough(on))
-watch(mode, () => {
-  const selected = transformGizmoOptions.value.find(
-    ({ value }) => value === transformGizmoMode.value
-  )
-  if (!selected?.enabled) transformGizmoMode.value = 'none'
-})
 
 onMounted(() => {
   if (container.value) initialize(container.value)

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -72,6 +72,8 @@
         v-if="showCameraControls"
         v-model:camera-type="cameraConfig!.cameraType"
         v-model:fov="cameraConfig!.fov"
+        v-model:use-custom-up="cameraConfig!.useCustomUp"
+        :has-custom-up="cameraConfig!.hasCustomUp ?? false"
       />
 
       <div v-if="showLightControls" class="flex flex-col">

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -72,8 +72,8 @@
         v-if="showCameraControls"
         v-model:camera-type="cameraConfig!.cameraType"
         v-model:fov="cameraConfig!.fov"
-        v-model:use-custom-up="cameraConfig!.useCustomUp"
-        :has-custom-up="cameraConfig!.hasCustomUp ?? false"
+        v-model:use-custom-up="useCustomUp"
+        :has-custom-up="cameraConfig!.hasCustomUp"
       />
 
       <div v-if="showLightControls" class="flex flex-col">
@@ -154,6 +154,17 @@ const sceneConfig = defineModel<SceneConfig>('sceneConfig')
 const modelConfig = defineModel<ModelConfig>('modelConfig')
 const cameraConfig = defineModel<CameraConfig>('cameraConfig')
 const lightConfig = defineModel<LightConfig>('lightConfig')
+
+const useCustomUp = computed({
+  get: () =>
+    cameraConfig.value?.hasCustomUp === true && cameraConfig.value.useCustomUp,
+  set: (value: boolean) => {
+    const config = cameraConfig.value
+    if (config?.hasCustomUp) {
+      cameraConfig.value = { ...config, useCustomUp: value }
+    }
+  }
+})
 
 const isMenuOpen = ref(false)
 const menuPanelRef = ref<HTMLElement | null>(null)

--- a/src/components/load3d/controls/CameraControls.vue
+++ b/src/components/load3d/controls/CameraControls.vue
@@ -13,6 +13,33 @@
     >
       <i class="pi pi-camera text-lg text-base-foreground" />
     </Button>
+    <Button
+      v-if="hasCustomUp"
+      v-tooltip.right="{
+        value: useCustomUp
+          ? $t('load3d.useNaturalUp')
+          : $t('load3d.useCustomUp'),
+        showDelay: 300
+      }"
+      size="icon"
+      variant="textonly"
+      class="rounded-full"
+      :aria-label="
+        useCustomUp ? $t('load3d.useNaturalUp') : $t('load3d.useCustomUp')
+      "
+      @click="toggleUp"
+    >
+      <i
+        :class="
+          cn(
+            useCustomUp
+              ? 'icon-[lucide--compass]'
+              : 'icon-[lucide--rotate-ccw]',
+            'size-5 text-base-foreground'
+          )
+        "
+      />
+    </Button>
     <PopupSlider
       v-if="showFOVButton"
       v-model="fov"
@@ -27,13 +54,24 @@ import { computed } from 'vue'
 import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { CameraType } from '@/extensions/core/load3d/interfaces'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const { hasCustomUp = false } = defineProps<{
+  hasCustomUp?: boolean
+}>()
 
 const cameraType = defineModel<CameraType>('cameraType')
 const fov = defineModel<number>('fov')
+const useCustomUp = defineModel<boolean>('useCustomUp', { default: false })
+
 const showFOVButton = computed(() => cameraType.value === 'perspective')
 
 const switchCamera = () => {
   cameraType.value =
     cameraType.value === 'perspective' ? 'orthographic' : 'perspective'
+}
+
+const toggleUp = () => {
+  useCustomUp.value = !useCustomUp.value
 }
 </script>

--- a/src/components/load3d/menubar/CameraMenuGroup.test.ts
+++ b/src/components/load3d/menubar/CameraMenuGroup.test.ts
@@ -13,7 +13,9 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function makeConfig(overrides: Partial<CameraConfig> = {}): CameraConfig {
+function makeConfig(
+  overrides: Partial<Pick<CameraConfig, 'cameraType' | 'fov'>> = {}
+): CameraConfig {
   return { cameraType: 'perspective', fov: 75, ...overrides }
 }
 

--- a/src/composables/useCameraInfo.test.ts
+++ b/src/composables/useCameraInfo.test.ts
@@ -1,0 +1,234 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+interface ViewportInstance {
+  ctorArgs: unknown[]
+  applyState: ReturnType<typeof vi.fn>
+  setGizmosVisible: ReturnType<typeof vi.fn>
+  setTransformGizmoMode: ReturnType<typeof vi.fn>
+  setLookThrough: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+  viewport: {
+    updateStatusMouseOnScene: ReturnType<typeof vi.fn>
+    updateStatusMouseOnNode: ReturnType<typeof vi.fn>
+    refreshViewport: ReturnType<typeof vi.fn>
+  }
+}
+
+const { ViewportMock, instances, addAlert } = vi.hoisted(() => {
+  const instances: ViewportInstance[] = []
+  const ViewportMock = vi.fn(function (...ctorArgs: unknown[]) {
+    const instance: ViewportInstance = {
+      ctorArgs,
+      applyState: vi.fn(),
+      setGizmosVisible: vi.fn(),
+      setTransformGizmoMode: vi.fn(),
+      setLookThrough: vi.fn(),
+      remove: vi.fn(),
+      viewport: {
+        updateStatusMouseOnScene: vi.fn(),
+        updateStatusMouseOnNode: vi.fn(),
+        refreshViewport: vi.fn()
+      }
+    }
+    instances.push(instance)
+    return instance
+  })
+  return { ViewportMock, instances, addAlert: vi.fn() }
+})
+
+vi.mock('@/extensions/core/cameraInfo/CameraInfoViewport', () => ({
+  CameraInfoViewport: ViewportMock
+}))
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert })
+}))
+
+import { useCameraInfo } from './useCameraInfo'
+
+interface FakeWidget {
+  name: string
+  value: unknown
+  callback?: (value: unknown, ...rest: unknown[]) => void
+}
+
+interface FakeNode {
+  widgets: FakeWidget[]
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+}
+
+function makeNode(values: Record<string, unknown>): FakeNode {
+  return {
+    widgets: Object.entries(values).map(([name, value]) => ({ name, value }))
+  }
+}
+
+function widget(node: FakeNode, name: string): FakeWidget {
+  const found = node.widgets.find((w) => w.name === name)
+  if (!found) throw new Error(`missing widget ${name}`)
+  return found
+}
+
+function nodeRef(node: FakeNode) {
+  return ref(node) as unknown as Ref<LGraphNode | null>
+}
+
+beforeEach(() => {
+  instances.length = 0
+  ViewportMock.mockClear()
+  addAlert.mockClear()
+})
+
+describe('useCameraInfo', () => {
+  it('constructs the viewport from widget state and exposes the mode', () => {
+    const node = makeNode({ mode: 'look_at', 'mode.distance': 7 })
+    const container = document.createElement('div')
+    const camera = useCameraInfo(nodeRef(node))
+
+    camera.initialize(container)
+
+    expect(ViewportMock).toHaveBeenCalledOnce()
+    const [ctorContainer, initialState] = instances[0].ctorArgs as [
+      HTMLElement,
+      { mode: string; orbit: { distance: number } }
+    ]
+    expect(ctorContainer).toBe(container)
+    expect(initialState.mode).toBe('look_at')
+    expect(initialState.orbit.distance).toBe(7)
+    expect(camera.mode.value).toBe('look_at')
+  })
+
+  it('does nothing when the node is null', () => {
+    const camera = useCameraInfo(ref(null))
+    camera.initialize(document.createElement('div'))
+
+    expect(ViewportMock).not.toHaveBeenCalled()
+  })
+
+  it('alerts and does not throw when the viewport fails to construct', () => {
+    ViewportMock.mockImplementationOnce(() => {
+      throw new Error('webgl unavailable')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
+
+    expect(() => camera.initialize(document.createElement('div'))).not.toThrow()
+    expect(addAlert).toHaveBeenCalledOnce()
+
+    consoleError.mockRestore()
+  })
+
+  it('forwards toolbar actions to the viewport', () => {
+    const camera = useCameraInfo(nodeRef(makeNode({ mode: 'orbit' })))
+    camera.initialize(document.createElement('div'))
+
+    camera.setGizmosVisible(false)
+    camera.setTransformGizmoMode('camera-rotate')
+    camera.setLookThrough(true)
+
+    expect(instances[0].setGizmosVisible).toHaveBeenCalledWith(false)
+    expect(instances[0].setTransformGizmoMode).toHaveBeenCalledWith(
+      'camera-rotate'
+    )
+    expect(instances[0].setLookThrough).toHaveBeenCalledWith(true)
+  })
+
+  it('re-applies state to the viewport when a widget changes, keeping the original callback', () => {
+    const node = makeNode({ mode: 'orbit', target_x: 0 })
+    const original = vi.fn()
+    widget(node, 'target_x').callback = original
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    const targetX = widget(node, 'target_x')
+    targetX.value = 3
+    targetX.callback!(3)
+
+    expect(original).toHaveBeenCalledWith(3)
+    const applied = instances[0].applyState.mock.lastCall?.[0] as {
+      target: { x: number }
+    }
+    expect(applied.target.x).toBe(3)
+  })
+
+  it('updates the mode ref when the mode widget changes', () => {
+    const node = makeNode({ mode: 'orbit' })
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    const modeWidget = widget(node, 'mode')
+    modeWidget.value = 'quaternion'
+    modeWidget.callback!('quaternion')
+
+    expect(camera.mode.value).toBe('quaternion')
+  })
+
+  it('routes node hover into the viewport status flags', () => {
+    const node = makeNode({ mode: 'orbit' })
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    camera.handleMouseEnter()
+    camera.handleMouseLeave()
+    node.onMouseEnter?.()
+
+    expect(instances[0].viewport.updateStatusMouseOnScene).toHaveBeenCalledWith(
+      true
+    )
+    expect(instances[0].viewport.updateStatusMouseOnScene).toHaveBeenCalledWith(
+      false
+    )
+    expect(instances[0].viewport.updateStatusMouseOnNode).toHaveBeenCalledWith(
+      true
+    )
+  })
+
+  it('removes the viewport and restores widget callbacks on cleanup', () => {
+    const node = makeNode({ mode: 'orbit', target_x: 0 })
+    const original = vi.fn()
+    widget(node, 'target_x').callback = original
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    camera.cleanup()
+
+    expect(instances[0].remove).toHaveBeenCalledOnce()
+    expect(widget(node, 'target_x').callback).toBe(original)
+  })
+
+  it('restores the node mouse handlers on cleanup', () => {
+    const node = makeNode({ mode: 'orbit' })
+    const originalEnter = vi.fn()
+    const originalLeave = vi.fn()
+    node.onMouseEnter = originalEnter
+    node.onMouseLeave = originalLeave
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+
+    expect(node.onMouseEnter).not.toBe(originalEnter)
+
+    camera.cleanup()
+
+    expect(node.onMouseEnter).toBe(originalEnter)
+    expect(node.onMouseLeave).toBe(originalLeave)
+  })
+
+  it('re-wires widgets on a second initialize after cleanup', () => {
+    const node = makeNode({ mode: 'orbit', target_x: 0 })
+    const camera = useCameraInfo(nodeRef(node))
+    camera.initialize(document.createElement('div'))
+    camera.cleanup()
+    camera.initialize(document.createElement('div'))
+
+    const targetX = widget(node, 'target_x')
+    targetX.value = 5
+    targetX.callback!(5)
+
+    expect(instances).toHaveLength(2)
+    expect(instances[1].applyState).toHaveBeenCalled()
+  })
+})

--- a/src/composables/useCameraInfo.ts
+++ b/src/composables/useCameraInfo.ts
@@ -1,0 +1,171 @@
+import { ref, toRaw, toRef } from 'vue'
+import type { MaybeRef } from 'vue'
+
+import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { CameraInfoViewport } from '@/extensions/core/cameraInfo/CameraInfoViewport'
+import type { TransformGizmoMode } from '@/extensions/core/cameraInfo/CameraInfoViewport'
+import { DEFAULT_CAMERA_INFO_STATE } from '@/extensions/core/cameraInfo/types'
+import type { CameraInfoMode } from '@/extensions/core/cameraInfo/types'
+import {
+  readStateFromWidgets,
+  writeWidgetValue
+} from '@/extensions/core/cameraInfo/widgetBridge'
+import type { NodeWithWidgets } from '@/extensions/core/cameraInfo/widgetBridge'
+import { t } from '@/i18n'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+
+type WidgetCallback = (value: unknown, ...rest: unknown[]) => void
+interface MutableWidget {
+  name: string
+  value: unknown
+  callback?: WidgetCallback
+}
+
+const WIDGET_NAMES = [
+  'mode',
+  'camera_type',
+  'target_x',
+  'target_y',
+  'target_z',
+  'roll',
+  'fov',
+  'zoom',
+  'mode.yaw',
+  'mode.pitch',
+  'mode.distance',
+  'mode.position_x',
+  'mode.position_y',
+  'mode.position_z',
+  'mode.quat_x',
+  'mode.quat_y',
+  'mode.quat_z',
+  'mode.quat_w'
+] as const
+
+export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
+  const node = toRef(nodeRef)
+  let viewport: CameraInfoViewport | null = null
+  let wiredNode: LGraphNode | null = null
+  let originalOnMouseEnter: LGraphNode['onMouseEnter']
+  let originalOnMouseLeave: LGraphNode['onMouseLeave']
+
+  const mode = ref<CameraInfoMode>(DEFAULT_CAMERA_INFO_STATE.mode)
+
+  const wrappedWidgets: { widget: MutableWidget; original?: WidgetCallback }[] =
+    []
+  const wrappedSet = new WeakSet<MutableWidget>()
+
+  const initialize = (container: HTMLElement): void => {
+    const raw = toRaw(node.value)
+    if (!raw || !container) return
+    if (viewport) cleanup()
+
+    try {
+      const initialState = readStateFromWidgets(raw as NodeWithWidgets)
+      mode.value = initialState.mode
+      viewport = new CameraInfoViewport(container, initialState, {
+        onHandleDrag: (fieldName, value) => {
+          writeWidgetValue(raw as NodeWithWidgets, fieldName, value)
+        }
+      })
+      wireWidgetsToOverlay(raw as NodeWithWidgets)
+      wireNodeMouseStatus(raw as LGraphNode)
+    } catch (error) {
+      console.error('Failed to initialize CameraInfoViewport:', error)
+      cleanup()
+      useToastStore().addAlert(
+        t('toastMessages.failedToInitializeCameraInfoViewer')
+      )
+    }
+  }
+
+  const cleanup = (): void => {
+    unwireWidgets()
+    unwireNodeMouseStatus()
+    viewport?.remove()
+    viewport = null
+  }
+
+  const handleMouseEnter = (): void => {
+    viewport?.viewport.updateStatusMouseOnScene(true)
+    viewport?.viewport.refreshViewport()
+  }
+
+  const handleMouseLeave = (): void => {
+    viewport?.viewport.updateStatusMouseOnScene(false)
+  }
+
+  const setGizmosVisible = (on: boolean): void => {
+    viewport?.setGizmosVisible(on)
+  }
+
+  const setTransformGizmoMode = (gizmoMode: TransformGizmoMode): void => {
+    viewport?.setTransformGizmoMode(gizmoMode)
+  }
+
+  const setLookThrough = (on: boolean): void => {
+    viewport?.setLookThrough(on)
+  }
+
+  function wireNodeMouseStatus(target: LGraphNode): void {
+    wiredNode = target
+    originalOnMouseEnter = target.onMouseEnter
+    originalOnMouseLeave = target.onMouseLeave
+    target.onMouseEnter = useChainCallback(target.onMouseEnter, () => {
+      viewport?.viewport.updateStatusMouseOnNode(true)
+      viewport?.viewport.refreshViewport()
+    })
+    target.onMouseLeave = useChainCallback(target.onMouseLeave, () => {
+      viewport?.viewport.updateStatusMouseOnNode(false)
+    })
+  }
+
+  function unwireNodeMouseStatus(): void {
+    if (!wiredNode) return
+    wiredNode.onMouseEnter = originalOnMouseEnter
+    wiredNode.onMouseLeave = originalOnMouseLeave
+    wiredNode = null
+  }
+
+  function wireWidgetsToOverlay(target: NodeWithWidgets): void {
+    if (!target.widgets) return
+    for (const name of WIDGET_NAMES) {
+      const widget = target.widgets.find(
+        (w): w is MutableWidget => w.name === name
+      )
+      if (!widget || wrappedSet.has(widget)) continue
+      wrappedSet.add(widget)
+      const original = widget.callback
+      const isModeWidget = widget.name === 'mode'
+      wrappedWidgets.push({ widget, original })
+      widget.callback = (value, ...rest) => {
+        original?.call(widget, value, ...rest)
+        if (isModeWidget) wireWidgetsToOverlay(target)
+        if (!viewport) return
+        const state = readStateFromWidgets(target)
+        mode.value = state.mode
+        viewport.applyState(state)
+      }
+    }
+  }
+
+  function unwireWidgets(): void {
+    for (const { widget, original } of wrappedWidgets) {
+      widget.callback = original
+      wrappedSet.delete(widget)
+    }
+    wrappedWidgets.length = 0
+  }
+
+  return {
+    initialize,
+    cleanup,
+    handleMouseEnter,
+    handleMouseLeave,
+    setGizmosVisible,
+    setTransformGizmoMode,
+    setLookThrough,
+    mode
+  }
+}

--- a/src/composables/useCameraInfo.ts
+++ b/src/composables/useCameraInfo.ts
@@ -1,11 +1,11 @@
-import { ref, toRaw, toRef } from 'vue'
+import { computed, ref, toRaw, toRef } from 'vue'
 import type { MaybeRef } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { CameraInfoViewport } from '@/extensions/core/cameraInfo/CameraInfoViewport'
 import type { TransformGizmoMode } from '@/extensions/core/cameraInfo/CameraInfoViewport'
 import { DEFAULT_CAMERA_INFO_STATE } from '@/extensions/core/cameraInfo/types'
-import type { CameraInfoMode } from '@/extensions/core/cameraInfo/types'
+import type { CameraInfoState } from '@/extensions/core/cameraInfo/types'
 import {
   readStateFromWidgets,
   writeWidgetValue
@@ -50,7 +50,8 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
   let originalOnMouseEnter: LGraphNode['onMouseEnter']
   let originalOnMouseLeave: LGraphNode['onMouseLeave']
 
-  const mode = ref<CameraInfoMode>(DEFAULT_CAMERA_INFO_STATE.mode)
+  const cameraState = ref<CameraInfoState>(DEFAULT_CAMERA_INFO_STATE)
+  const mode = computed(() => cameraState.value.mode)
 
   const wrappedWidgets: { widget: MutableWidget; original?: WidgetCallback }[] =
     []
@@ -63,7 +64,7 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
 
     try {
       const initialState = readStateFromWidgets(raw as NodeWithWidgets)
-      mode.value = initialState.mode
+      cameraState.value = initialState
       viewport = new CameraInfoViewport(container, initialState, {
         onHandleDrag: (fieldName, value) => {
           writeWidgetValue(raw as NodeWithWidgets, fieldName, value)
@@ -144,7 +145,7 @@ export function useCameraInfo(nodeRef: MaybeRef<LGraphNode | null>) {
         if (isModeWidget) wireWidgetsToOverlay(target)
         if (!viewport) return
         const state = readStateFromWidgets(target)
-        mode.value = state.mode
+        cameraState.value = state
         viewport.applyState(state)
       }
     }

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -143,7 +143,9 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
   const cameraConfig = ref<CameraConfig>({
     cameraType: 'perspective',
-    fov: 75
+    fov: 75,
+    hasCustomUp: false,
+    useCustomUp: false
   })
 
   const lightConfig = ref<LightConfig>({
@@ -534,6 +536,9 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         nodeRef.value.properties['Camera Config'] = newValue
         load3d.toggleCamera(newValue.cameraType)
         load3d.setFOV(newValue.fov)
+        if (newValue.hasCustomUp) {
+          load3d.setUseCustomUp(newValue.useCustomUp ?? false)
+        }
       }
       markDirty()
     },
@@ -873,6 +878,13 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     },
     cameraTypeChange: (value: string) => {
       cameraConfig.value.cameraType = value as CameraType
+    },
+    cameraUpStateChange: (value: {
+      hasCustomUp: boolean
+      usingCustomUp: boolean
+    }) => {
+      cameraConfig.value.hasCustomUp = value.hasCustomUp
+      cameraConfig.value.useCustomUp = value.usingCustomUp
     },
     showGridChange: (value: boolean) => {
       sceneConfig.value.showGrid = value

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -144,8 +144,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   const cameraConfig = ref<CameraConfig>({
     cameraType: 'perspective',
     fov: 75,
-    hasCustomUp: false,
-    useCustomUp: false
+    hasCustomUp: false
   })
 
   const lightConfig = ref<LightConfig>({
@@ -537,7 +536,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         load3d.toggleCamera(newValue.cameraType)
         load3d.setFOV(newValue.fov)
         if (newValue.hasCustomUp) {
-          load3d.setUseCustomUp(newValue.useCustomUp ?? false)
+          load3d.setUseCustomUp(newValue.useCustomUp)
         }
       }
       markDirty()
@@ -883,8 +882,16 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       hasCustomUp: boolean
       usingCustomUp: boolean
     }) => {
-      cameraConfig.value.hasCustomUp = value.hasCustomUp
-      cameraConfig.value.useCustomUp = value.usingCustomUp
+      const { cameraType, fov, state } = cameraConfig.value
+      cameraConfig.value = value.hasCustomUp
+        ? {
+            cameraType,
+            fov,
+            state,
+            hasCustomUp: true,
+            useCustomUp: value.usingCustomUp
+          }
+        : { cameraType, fov, state, hasCustomUp: false }
     },
     showGridChange: (value: boolean) => {
       sceneConfig.value.showGrid = value

--- a/src/extensions/core/cameraInfo.ts
+++ b/src/extensions/core/cameraInfo.ts
@@ -1,0 +1,40 @@
+import { nextTick } from 'vue'
+
+import CameraInfo from '@/components/cameraInfo/CameraInfo.vue'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
+import { useExtensionService } from '@/services/extensionService'
+
+useExtensionService().registerExtension({
+  name: 'Comfy.CreateCameraInfo',
+
+  getCustomWidgets() {
+    return {
+      CAMERA_INFO_STATE(node) {
+        const widget = new ComponentWidgetImpl({
+          node,
+          name: 'camera_info_state',
+          component: CameraInfo,
+          inputSpec: {
+            name: 'camera_info_state',
+            type: 'CAMERA_INFO_STATE',
+            isPreview: false
+          },
+          options: {}
+        })
+        widget.type = 'cameraInfo'
+        addWidget(node, widget)
+        return { widget }
+      }
+    }
+  },
+
+  async nodeCreated(node: LGraphNode) {
+    if (node.constructor.comfyClass !== 'CreateCameraInfo') return
+
+    const [oldWidth, oldHeight] = node.size
+    node.setSize([Math.max(oldWidth, 360), Math.max(oldHeight, 480)])
+
+    await nextTick()
+  }
+})

--- a/src/extensions/core/cameraInfo.ts
+++ b/src/extensions/core/cameraInfo.ts
@@ -20,9 +20,10 @@ useExtensionService().registerExtension({
             type: 'CAMERA_INFO_STATE',
             isPreview: false
           },
-          options: {}
+          options: { serialize: false }
         })
         widget.type = 'cameraInfo'
+        widget.serialize = false
         addWidget(node, widget)
         return { widget }
       }

--- a/src/extensions/core/cameraInfo/CameraInfoOverlay.test.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoOverlay.test.ts
@@ -1,0 +1,162 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { CameraInfoOverlay } from './CameraInfoOverlay'
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type { CameraInfoState } from './types'
+
+function setupOverlay(initial?: Partial<CameraInfoState>) {
+  const overlay = new CameraInfoOverlay({
+    ...DEFAULT_CAMERA_INFO_STATE,
+    ...initial
+  })
+  const scene = new THREE.Scene()
+  overlay.attach(scene)
+  return { overlay, scene }
+}
+
+function findByName(scene: THREE.Scene, name: string): THREE.Object3D | null {
+  for (const child of scene.children) {
+    if (child.name === name) return child
+  }
+  return null
+}
+
+describe('CameraInfoOverlay', () => {
+  let ctx: ReturnType<typeof setupOverlay>
+
+  beforeEach(() => {
+    ctx = setupOverlay()
+  })
+
+  afterEach(() => {
+    ctx.overlay.dispose()
+  })
+
+  describe('attach / detach', () => {
+    it('adds reference + subject cameras + camera helper to the scene', () => {
+      expect(findByName(ctx.scene, 'CameraInfoReference')).not.toBeNull()
+      const subjectCameras = ctx.scene.children.filter(
+        (c) =>
+          c instanceof THREE.PerspectiveCamera ||
+          c instanceof THREE.OrthographicCamera
+      )
+      expect(subjectCameras).toHaveLength(2)
+      expect(
+        ctx.scene.children.some((c) => c instanceof THREE.CameraHelper)
+      ).toBe(true)
+    })
+
+    it('detach removes everything the overlay added', () => {
+      ctx.overlay.detach()
+
+      expect(findByName(ctx.scene, 'CameraInfoReference')).toBeNull()
+      expect(
+        ctx.scene.children.some(
+          (c) =>
+            c instanceof THREE.PerspectiveCamera ||
+            c instanceof THREE.OrthographicCamera ||
+            c instanceof THREE.CameraHelper
+        )
+      ).toBe(false)
+    })
+
+    it('dispose also detaches its scene objects', () => {
+      ctx.overlay.dispose()
+
+      expect(findByName(ctx.scene, 'CameraInfoReference')).toBeNull()
+      expect(
+        ctx.scene.children.some(
+          (c) =>
+            c instanceof THREE.PerspectiveCamera ||
+            c instanceof THREE.OrthographicCamera ||
+            c instanceof THREE.CameraHelper
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('applyState — orbit mode', () => {
+    it('positions the active subject camera per yaw / pitch / distance', () => {
+      ctx.overlay.applyState({
+        ...DEFAULT_CAMERA_INFO_STATE,
+        mode: 'orbit',
+        target: { x: 0, y: 0, z: 0 },
+        orbit: { yaw: 0, pitch: 0, distance: 5 }
+      })
+
+      const cam = ctx.overlay.getSubjectCamera()
+      expect(cam.position.x).toBeCloseTo(0)
+      expect(cam.position.y).toBeCloseTo(0)
+      expect(cam.position.z).toBeCloseTo(5)
+    })
+
+    it('updates fov on the perspective subject camera', () => {
+      ctx.overlay.applyState({
+        ...DEFAULT_CAMERA_INFO_STATE,
+        fov: 70
+      })
+
+      const cam = ctx.overlay.getSubjectCamera() as THREE.PerspectiveCamera
+      expect(cam.fov).toBe(70)
+    })
+  })
+
+  describe('camera type swap', () => {
+    it('toggling to orthographic swaps the active subject camera and points the helper at it', () => {
+      ctx.overlay.applyState({
+        ...DEFAULT_CAMERA_INFO_STATE,
+        cameraType: 'orthographic'
+      })
+
+      expect(ctx.overlay.getSubjectCamera()).toBeInstanceOf(
+        THREE.OrthographicCamera
+      )
+      const newHelper = ctx.scene.children.find(
+        (c): c is THREE.CameraHelper => c instanceof THREE.CameraHelper
+      )
+      expect(newHelper).toBeDefined()
+      expect(newHelper?.camera).toBe(ctx.overlay.getSubjectCamera())
+      expect(
+        ctx.scene.children.filter((c) => c instanceof THREE.CameraHelper)
+      ).toHaveLength(1)
+    })
+  })
+
+  describe('POV (onActiveCameraChange)', () => {
+    it('hides the camera helper when the render camera IS the subject camera', () => {
+      const subjectCam = ctx.overlay.getSubjectCamera()
+
+      ctx.overlay.onActiveCameraChange(subjectCam)
+
+      const helper = ctx.scene.children.find(
+        (c): c is THREE.CameraHelper => c instanceof THREE.CameraHelper
+      )!
+      expect(helper.visible).toBe(false)
+    })
+
+    it('shows the camera helper when render camera is some other camera', () => {
+      const subjectCam = ctx.overlay.getSubjectCamera()
+      ctx.overlay.onActiveCameraChange(subjectCam)
+      const otherCam = new THREE.PerspectiveCamera()
+
+      ctx.overlay.onActiveCameraChange(otherCam)
+
+      const helper = ctx.scene.children.find(
+        (c): c is THREE.CameraHelper => c instanceof THREE.CameraHelper
+      )!
+      expect(helper.visible).toBe(true)
+    })
+  })
+
+  describe('getState immutability', () => {
+    it('returns a deep clone the caller cannot mutate to affect overlay', () => {
+      const snapshot = ctx.overlay.getState()
+      snapshot.orbit.yaw = 999
+
+      const next = ctx.overlay.getState()
+      expect(next.orbit.yaw).not.toBe(999)
+      expect(next.target).not.toBe(snapshot.target)
+    })
+  })
+})

--- a/src/extensions/core/cameraInfo/CameraInfoOverlay.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoOverlay.ts
@@ -1,0 +1,211 @@
+import * as THREE from 'three'
+
+import type { SceneOverlay } from '@/extensions/core/load3d/interfaces'
+
+import { computeSubjectTransform } from './cameraTransform'
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type { CameraInfoCameraType, CameraInfoState } from './types'
+
+const REFERENCE_CUBE_SIZE = 1
+const SUBJECT_CAMERA_NEAR = 0.1
+const SUBJECT_CAMERA_FAR = 1000
+const ORTHO_FRUSTUM_HALF = 1
+
+export class CameraInfoOverlay implements SceneOverlay {
+  private scene: THREE.Scene | null = null
+  private state: CameraInfoState
+
+  private readonly subjectPerspective: THREE.PerspectiveCamera
+  private readonly subjectOrthographic: THREE.OrthographicCamera
+  private subjectCamera: THREE.Camera
+  private cameraHelper: THREE.CameraHelper | null = null
+
+  private readonly referenceGroup: THREE.Group
+  private readonly referenceCube: THREE.Mesh
+  private readonly referenceCubeEdges: THREE.LineSegments
+  private readonly axesHelper: THREE.AxesHelper
+
+  private renderCamera: THREE.Camera | null = null
+  private disposed = false
+
+  constructor(initialState: CameraInfoState = DEFAULT_CAMERA_INFO_STATE) {
+    this.state = cloneState(initialState)
+
+    this.subjectPerspective = new THREE.PerspectiveCamera(
+      this.state.fov,
+      1,
+      SUBJECT_CAMERA_NEAR,
+      SUBJECT_CAMERA_FAR
+    )
+    this.subjectOrthographic = new THREE.OrthographicCamera(
+      -ORTHO_FRUSTUM_HALF,
+      ORTHO_FRUSTUM_HALF,
+      ORTHO_FRUSTUM_HALF,
+      -ORTHO_FRUSTUM_HALF,
+      SUBJECT_CAMERA_NEAR,
+      SUBJECT_CAMERA_FAR
+    )
+    this.subjectCamera = this.subjectCameraFor(this.state.cameraType)
+
+    const cubeGeometry = new THREE.BoxGeometry(
+      REFERENCE_CUBE_SIZE,
+      REFERENCE_CUBE_SIZE,
+      REFERENCE_CUBE_SIZE
+    )
+    this.referenceCube = new THREE.Mesh(
+      cubeGeometry,
+      new THREE.MeshStandardMaterial({
+        color: 0xb8bcc4,
+        roughness: 0.55,
+        metalness: 0.15
+      })
+    )
+    this.referenceCube.position.set(0, REFERENCE_CUBE_SIZE / 2, 0)
+
+    this.referenceCubeEdges = new THREE.LineSegments(
+      new THREE.EdgesGeometry(cubeGeometry),
+      new THREE.LineBasicMaterial({
+        color: 0x1a1a1a,
+        transparent: true,
+        opacity: 0.4
+      })
+    )
+    this.referenceCube.add(this.referenceCubeEdges)
+
+    this.axesHelper = new THREE.AxesHelper(REFERENCE_CUBE_SIZE * 1.25)
+
+    this.referenceGroup = new THREE.Group()
+    this.referenceGroup.name = 'CameraInfoReference'
+    this.referenceGroup.add(this.referenceCube)
+    this.referenceGroup.add(this.axesHelper)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.referenceGroup)
+    scene.add(this.subjectPerspective)
+    scene.add(this.subjectOrthographic)
+    this.rebuildCameraHelper()
+    this.applyStateToScene()
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.referenceGroup)
+    this.scene.remove(this.subjectPerspective)
+    this.scene.remove(this.subjectOrthographic)
+    if (this.cameraHelper) this.scene.remove(this.cameraHelper)
+    this.scene = null
+  }
+
+  update(_delta: number): void {
+    this.cameraHelper?.update()
+  }
+
+  onActiveCameraChange(camera: THREE.Camera): void {
+    this.renderCamera = camera
+    this.refreshHelperVisibility()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.disposeCameraHelper()
+    this.detach()
+    this.referenceCube.geometry.dispose()
+    ;(this.referenceCube.material as THREE.Material).dispose()
+    this.referenceCubeEdges.geometry.dispose()
+    ;(this.referenceCubeEdges.material as THREE.Material).dispose()
+    this.axesHelper.dispose()
+  }
+
+  getSubjectCamera(): THREE.Camera {
+    return this.subjectCamera
+  }
+
+  setHelperVisible(visible: boolean): void {
+    if (this.cameraHelper) this.cameraHelper.visible = visible
+  }
+
+  getState(): CameraInfoState {
+    return cloneState(this.state)
+  }
+
+  applyState(next: CameraInfoState): void {
+    const cameraTypeChanged = next.cameraType !== this.state.cameraType
+    const modeChanged = next.mode !== this.state.mode
+    this.state = cloneState(next)
+    if (cameraTypeChanged) {
+      this.subjectCamera = this.subjectCameraFor(this.state.cameraType)
+      this.rebuildCameraHelper()
+    }
+    this.applyStateToScene()
+    if (modeChanged || cameraTypeChanged) this.refreshHelperVisibility()
+  }
+
+  private applyStateToScene(): void {
+    const { position, quaternion } = computeSubjectTransform(this.state)
+    this.subjectCamera.position.copy(position)
+    this.subjectCamera.quaternion.copy(quaternion)
+    this.subjectCamera.updateMatrixWorld(true)
+
+    if (this.subjectCamera instanceof THREE.PerspectiveCamera) {
+      this.subjectCamera.fov = this.state.fov
+      this.subjectCamera.zoom = this.state.zoom
+      this.subjectCamera.updateProjectionMatrix()
+    } else if (this.subjectCamera instanceof THREE.OrthographicCamera) {
+      this.subjectCamera.zoom = this.state.zoom
+      this.subjectCamera.updateProjectionMatrix()
+    }
+
+    this.cameraHelper?.update()
+  }
+
+  private subjectCameraFor(type: CameraInfoCameraType): THREE.Camera {
+    return type === 'perspective'
+      ? this.subjectPerspective
+      : this.subjectOrthographic
+  }
+
+  private rebuildCameraHelper(): void {
+    this.disposeCameraHelper()
+    if (!this.scene) return
+    this.cameraHelper = new THREE.CameraHelper(this.subjectCamera)
+    this.scene.add(this.cameraHelper)
+    this.refreshHelperVisibility()
+  }
+
+  private disposeCameraHelper(): void {
+    if (!this.cameraHelper) return
+    if (this.scene) this.scene.remove(this.cameraHelper)
+    this.cameraHelper.geometry.dispose()
+    const material = this.cameraHelper.material as
+      | THREE.Material
+      | THREE.Material[]
+    if (Array.isArray(material)) material.forEach((m) => m.dispose())
+    else material.dispose()
+    this.cameraHelper = null
+  }
+
+  private refreshHelperVisibility(): void {
+    if (!this.cameraHelper) return
+    this.cameraHelper.visible = this.renderCamera !== this.subjectCamera
+  }
+}
+
+function cloneState(state: CameraInfoState): CameraInfoState {
+  return {
+    mode: state.mode,
+    target: { ...state.target },
+    roll: state.roll,
+    fov: state.fov,
+    zoom: state.zoom,
+    cameraType: state.cameraType,
+    orbit: { ...state.orbit },
+    lookAt: { position: { ...state.lookAt.position } },
+    quaternion: {
+      position: { ...state.quaternion.position },
+      quat: { ...state.quaternion.quat }
+    }
+  }
+}

--- a/src/extensions/core/cameraInfo/CameraInfoViewport.test.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoViewport.test.ts
@@ -1,0 +1,434 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createViewport3dMock } = vi.hoisted(() => ({
+  createViewport3dMock: vi.fn()
+}))
+
+vi.mock('@/extensions/core/load3d/createViewport3d', () => ({
+  createViewport3d: createViewport3dMock
+}))
+
+import { CameraInfoViewport } from './CameraInfoViewport'
+
+function makeViewportStub() {
+  const canvas = document.createElement('canvas')
+  canvas.width = 800
+  canvas.height = 600
+  Object.defineProperty(canvas, 'clientWidth', {
+    value: 800,
+    configurable: true
+  })
+  Object.defineProperty(canvas, 'clientHeight', {
+    value: 600,
+    configurable: true
+  })
+  canvas.setPointerCapture = vi.fn()
+  canvas.releasePointerCapture = vi.fn()
+  canvas.hasPointerCapture = vi.fn(() => false)
+  let preRender: (() => void) | null = null
+  let postRender: (() => void) | null = null
+  return {
+    sceneManager: { scene: new THREE.Scene() },
+    cameraManager: { activeCamera: new THREE.PerspectiveCamera() },
+    controlsManager: { controls: { enabled: true } },
+    viewHelperManager: { visibleViewHelper: vi.fn() },
+    renderer: {
+      setViewport: vi.fn(),
+      setScissor: vi.fn(),
+      setScissorTest: vi.fn(),
+      setClearColor: vi.fn(),
+      clear: vi.fn(),
+      render: vi.fn()
+    },
+    domElement: canvas,
+    setOverlay: vi.fn(),
+    addPreRenderCallback: vi.fn((cb: () => void) => {
+      preRender = cb
+      return vi.fn()
+    }),
+    addPostRenderCallback: vi.fn((cb: () => void) => {
+      postRender = cb
+      return vi.fn()
+    }),
+    setExternalActiveCamera: vi.fn(),
+    forceRender: vi.fn(),
+    remove: vi.fn(),
+    runPreRender: () => preRender?.(),
+    runPostRender: () => postRender?.()
+  }
+}
+
+describe('CameraInfoViewport look-through', () => {
+  let stub: ReturnType<typeof makeViewportStub>
+  let viewport: CameraInfoViewport
+
+  beforeEach(() => {
+    stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    viewport = new CameraInfoViewport(document.createElement('div'))
+  })
+
+  afterEach(() => {
+    viewport.remove()
+  })
+
+  it('renders the main viewport through the subject camera', () => {
+    viewport.setLookThrough(true)
+
+    expect(stub.setExternalActiveCamera).toHaveBeenCalledWith(
+      viewport.overlay.getSubjectCamera()
+    )
+    expect(viewport.orbitHandles.isVisible()).toBe(false)
+  })
+
+  it('restores the orbit view and keeps the gnomon hidden on exit', () => {
+    viewport.setLookThrough(true)
+    stub.viewHelperManager.visibleViewHelper.mockClear()
+
+    viewport.setLookThrough(false)
+
+    expect(stub.setExternalActiveCamera).toHaveBeenLastCalledWith(null)
+    expect(viewport.orbitHandles.isVisible()).toBe(true)
+    expect(stub.viewHelperManager.visibleViewHelper).toHaveBeenLastCalledWith(
+      false
+    )
+  })
+
+  it('is idempotent for repeated toggles', () => {
+    viewport.setLookThrough(true)
+    viewport.setLookThrough(true)
+
+    expect(stub.setExternalActiveCamera).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-syncs the external camera when the camera type changes while looking through', () => {
+    viewport.setLookThrough(true)
+    stub.setExternalActiveCamera.mockClear()
+
+    const state = viewport.overlay.getState()
+    viewport.applyState({ ...state, cameraType: 'orthographic' })
+
+    expect(stub.setExternalActiveCamera).toHaveBeenCalledWith(
+      viewport.overlay.getSubjectCamera()
+    )
+  })
+
+  it('leaves the external camera untouched on state changes outside look-through', () => {
+    viewport.applyState(viewport.overlay.getState())
+
+    expect(stub.setExternalActiveCamera).not.toHaveBeenCalled()
+  })
+
+  it('keeps handles hidden while looking through even when gizmos are toggled', () => {
+    viewport.setLookThrough(true)
+    viewport.setGizmosVisible(false)
+
+    expect(viewport.orbitHandles.isVisible()).toBe(false)
+  })
+
+  it('fits the subject camera aspect in the pre-render pass while looking through', () => {
+    viewport.setLookThrough(true)
+    const cam = viewport.overlay.getSubjectCamera() as THREE.PerspectiveCamera
+    cam.aspect = 1
+    cam.updateProjectionMatrix()
+
+    stub.runPreRender()
+
+    expect(cam.aspect).toBeCloseTo(800 / 600)
+  })
+
+  it('leaves the subject camera aspect untouched outside look-through', () => {
+    const cam = viewport.overlay.getSubjectCamera() as THREE.PerspectiveCamera
+    cam.aspect = 1
+    cam.updateProjectionMatrix()
+
+    stub.runPreRender()
+
+    expect(cam.aspect).toBe(1)
+  })
+})
+
+describe('CameraInfoViewport gizmo visibility', () => {
+  let stub: ReturnType<typeof makeViewportStub>
+  let viewport: CameraInfoViewport
+
+  beforeEach(() => {
+    stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    viewport = new CameraInfoViewport(document.createElement('div'))
+  })
+
+  afterEach(() => {
+    viewport.remove()
+  })
+
+  it('hides orbit handles when gizmos are turned off', () => {
+    expect(viewport.orbitHandles.isVisible()).toBe(true)
+
+    viewport.setGizmosVisible(false)
+    expect(viewport.orbitHandles.isVisible()).toBe(false)
+
+    viewport.setGizmosVisible(true)
+    expect(viewport.orbitHandles.isVisible()).toBe(true)
+  })
+
+  it('reveals the target handle in target transform mode', () => {
+    viewport.setTransformGizmoMode('target')
+
+    expect(viewport.targetHandle.isVisible()).toBe(true)
+  })
+
+  it('enables the camera handle for camera-rotate in quaternion mode', () => {
+    viewport.applyState({ ...viewport.overlay.getState(), mode: 'quaternion' })
+    viewport.setTransformGizmoMode('camera-rotate')
+
+    expect(viewport.cameraHandle.isVisible()).toBe(true)
+  })
+
+  it('hides the transform handles when gizmos are turned off', () => {
+    viewport.setTransformGizmoMode('target')
+    expect(viewport.targetHandle.isVisible()).toBe(true)
+
+    viewport.setGizmosVisible(false)
+    expect(viewport.targetHandle.isVisible()).toBe(false)
+  })
+})
+
+describe('CameraInfoViewport subject preview', () => {
+  let stub: ReturnType<typeof makeViewportStub>
+  let viewport: CameraInfoViewport
+
+  beforeEach(() => {
+    stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    viewport = new CameraInfoViewport(document.createElement('div'))
+  })
+
+  afterEach(() => {
+    viewport.remove()
+  })
+
+  it('renders the corner preview after each frame in the editing view', () => {
+    stub.runPostRender()
+
+    expect(stub.renderer.render).toHaveBeenCalledOnce()
+  })
+
+  it('renders the preview for an orthographic subject camera too', () => {
+    viewport.applyState({
+      ...viewport.overlay.getState(),
+      cameraType: 'orthographic'
+    })
+    stub.renderer.render.mockClear()
+
+    stub.runPostRender()
+
+    expect(stub.renderer.render).toHaveBeenCalledOnce()
+  })
+
+  it('skips the corner preview while looking through', () => {
+    viewport.setLookThrough(true)
+    stub.renderer.render.mockClear()
+
+    stub.runPostRender()
+
+    expect(stub.renderer.render).not.toHaveBeenCalled()
+  })
+})
+
+function dispatchPointer(
+  target: HTMLElement,
+  type: string,
+  clientX: number,
+  clientY: number
+): void {
+  const event = new MouseEvent(type, { clientX, clientY, button: 0 })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+  target.dispatchEvent(event)
+}
+
+describe('CameraInfoViewport look-through drag', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('rotates the subject on left-drag while looking through', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+
+    viewport.setLookThrough(true)
+    dispatchPointer(stub.domElement, 'pointerdown', 100, 100)
+    dispatchPointer(stub.domElement, 'pointermove', 140, 100)
+
+    expect(onHandleDrag).toHaveBeenCalledWith('mode.yaw', expect.any(Number))
+
+    viewport.remove()
+  })
+
+  it('dollies the subject on wheel while looking through', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+
+    viewport.setLookThrough(true)
+    stub.domElement.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }))
+
+    expect(onHandleDrag).toHaveBeenCalledWith(
+      'mode.distance',
+      expect.any(Number)
+    )
+
+    viewport.remove()
+  })
+
+  it('ignores the wheel when not looking through', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+
+    stub.domElement.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }))
+
+    expect(onHandleDrag).not.toHaveBeenCalled()
+
+    viewport.remove()
+  })
+
+  it('does not rotate on drag once look-through is exited', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+
+    viewport.setLookThrough(true)
+    viewport.setLookThrough(false)
+    dispatchPointer(stub.domElement, 'pointerdown', 100, 100)
+    dispatchPointer(stub.domElement, 'pointermove', 140, 100)
+
+    expect(onHandleDrag).not.toHaveBeenCalled()
+
+    viewport.remove()
+  })
+})
+
+describe('CameraInfoViewport gizmo drag callbacks', () => {
+  function controlsOf(handle: unknown): {
+    dispatchEvent(e: { type: string }): void
+  } {
+    return (
+      handle as { controls: { dispatchEvent(e: { type: string }): void } }
+    ).controls
+  }
+
+  it('writes camera position fields when the camera handle changes', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+    viewport.applyState({ ...viewport.overlay.getState(), mode: 'quaternion' })
+
+    controlsOf(viewport.cameraHandle).dispatchEvent({ type: 'objectChange' })
+
+    for (const axis of ['x', 'y', 'z']) {
+      expect(onHandleDrag).toHaveBeenCalledWith(
+        `mode.position_${axis}`,
+        expect.any(Number)
+      )
+    }
+
+    viewport.remove()
+  })
+
+  it('writes quaternion fields when the camera handle rotates', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+    viewport.applyState({ ...viewport.overlay.getState(), mode: 'quaternion' })
+    viewport.setTransformGizmoMode('camera-rotate')
+
+    controlsOf(viewport.cameraHandle).dispatchEvent({ type: 'objectChange' })
+
+    expect(onHandleDrag).toHaveBeenCalledWith('mode.quat_w', expect.any(Number))
+
+    viewport.remove()
+  })
+
+  it('writes target fields when the target handle changes', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const onHandleDrag = vi.fn()
+    const viewport = new CameraInfoViewport(
+      document.createElement('div'),
+      undefined,
+      { onHandleDrag }
+    )
+
+    controlsOf(viewport.targetHandle).dispatchEvent({ type: 'objectChange' })
+
+    for (const axis of ['x', 'y', 'z']) {
+      expect(onHandleDrag).toHaveBeenCalledWith(
+        `target_${axis}`,
+        expect.any(Number)
+      )
+    }
+
+    viewport.remove()
+  })
+
+  it('toggles orbit controls while a handle drag is active', () => {
+    const stub = makeViewportStub()
+    createViewport3dMock.mockReturnValue(stub)
+    const viewport = new CameraInfoViewport(document.createElement('div'))
+
+    controlsOf(viewport.targetHandle).dispatchEvent({
+      type: 'dragging-changed',
+      value: true
+    } as { type: string })
+    expect(stub.controlsManager.controls.enabled).toBe(false)
+
+    controlsOf(viewport.targetHandle).dispatchEvent({
+      type: 'dragging-changed',
+      value: false
+    } as { type: string })
+    expect(stub.controlsManager.controls.enabled).toBe(true)
+
+    viewport.remove()
+  })
+})

--- a/src/extensions/core/cameraInfo/CameraInfoViewport.test.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoViewport.test.ts
@@ -257,10 +257,6 @@ describe('CameraInfoViewport look-through drag', () => {
     vi.stubGlobal('cancelAnimationFrame', () => {})
   })
 
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
   it('rotates the subject on left-drag while looking through', () => {
     const stub = makeViewportStub()
     createViewport3dMock.mockReturnValue(stub)

--- a/src/extensions/core/cameraInfo/CameraInfoViewport.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoViewport.ts
@@ -1,0 +1,700 @@
+import * as THREE from 'three'
+
+import type { Viewport3d } from '@/extensions/core/load3d/Viewport3d'
+import { createViewport3d } from '@/extensions/core/load3d/createViewport3d'
+import type { Load3DOptions } from '@/extensions/core/load3d/interfaces'
+
+import { CameraInfoOverlay } from './CameraInfoOverlay'
+import { computeSubjectTransform } from './cameraTransform'
+import { CameraHandle } from './handles/CameraHandle'
+import type {
+  CameraHandleMode,
+  CameraHandleTransform
+} from './handles/CameraHandle'
+import { OrbitHandles } from './handles/OrbitHandles'
+import type { OrbitHandleType } from './handles/OrbitHandles'
+import { RollHandle } from './handles/RollHandle'
+import { TargetHandle } from './handles/TargetHandle'
+import { pickHandleAtPointer } from './handles/handlePicking'
+import {
+  pointToDistance,
+  pointToPitchAngle,
+  pointToYawAngle
+} from './handles/orbitDragMath'
+import { pointToRollAngle } from './handles/rollDragMath'
+import { dollySubjectByWheel, rotateSubjectByDrag } from './lookThroughDragMath'
+import type { LookThroughResult } from './lookThroughDragMath'
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type {
+  CameraInfoFieldName,
+  CameraInfoMode,
+  CameraInfoState
+} from './types'
+
+const PREVIEW_WIDTH = 200
+const PREVIEW_HEIGHT = 150
+const PREVIEW_PADDING = 8
+const PREVIEW_BORDER_COLOR = 0x2a2a2a
+const LOOK_THROUGH_SENSITIVITY = 0.005
+
+type DragHandleType = OrbitHandleType | 'roll'
+
+export type TransformGizmoMode =
+  | 'none'
+  | 'target'
+  | 'camera-translate'
+  | 'camera-rotate'
+
+const FIELD_NAME_FOR: Record<OrbitHandleType, CameraInfoFieldName> = {
+  yaw: 'mode.yaw',
+  pitch: 'mode.pitch',
+  distance: 'mode.distance'
+}
+
+export interface CameraInfoViewportOptions extends Load3DOptions {
+  onHandleDrag?: (fieldName: CameraInfoFieldName, value: number) => void
+}
+
+interface DragState {
+  type: DragHandleType
+  pointerId: number
+}
+
+export class CameraInfoViewport {
+  readonly viewport: Viewport3d
+  readonly overlay: CameraInfoOverlay
+  readonly orbitHandles: OrbitHandles
+  readonly rollHandle: RollHandle
+  readonly targetHandle: TargetHandle
+  readonly cameraHandle: CameraHandle
+
+  private readonly disposePreRender: () => void
+  private readonly disposePostRender: () => void
+  private readonly onHandleDrag?: CameraInfoViewportOptions['onHandleDrag']
+  private readonly raycaster = new THREE.Raycaster()
+  private readonly pointer = new THREE.Vector2()
+
+  private dragState: DragState | null = null
+  private lookThroughDrag: {
+    pointerId: number
+    lastX: number
+    lastY: number
+  } | null = null
+  private pendingRotation: { dx: number; dy: number } | null = null
+  private pendingDolly: number | null = null
+  private inputFrame: number | null = null
+  private hoveredHandle: DragHandleType | null = null
+  private gizmosOn = true
+  private lookingThrough = false
+  private transformGizmoMode: TransformGizmoMode = 'none'
+
+  constructor(
+    container: HTMLElement,
+    initialState: CameraInfoState = DEFAULT_CAMERA_INFO_STATE,
+    options?: CameraInfoViewportOptions
+  ) {
+    this.onHandleDrag = options?.onHandleDrag
+    this.viewport = createViewport3d(container, options)
+    this.viewport.viewHelperManager.visibleViewHelper(false)
+    this.overlay = new CameraInfoOverlay(initialState)
+    this.viewport.setOverlay(this.overlay)
+
+    this.orbitHandles = new OrbitHandles()
+    this.orbitHandles.attach(this.viewport.sceneManager.scene)
+    this.orbitHandles.update(initialState)
+
+    this.rollHandle = new RollHandle()
+    this.rollHandle.attach(this.viewport.sceneManager.scene)
+    this.rollHandle.update(initialState)
+
+    this.targetHandle = new TargetHandle(
+      this.viewport.cameraManager.activeCamera,
+      this.viewport.domElement,
+      (dragging) => {
+        this.viewport.controlsManager.controls.enabled = !dragging
+      },
+      (target) => {
+        const next: CameraInfoState = { ...this.overlay.getState(), target }
+        this.applyDerivedState(next)
+        this.onHandleDrag?.('target_x', target.x)
+        this.onHandleDrag?.('target_y', target.y)
+        this.onHandleDrag?.('target_z', target.z)
+      }
+    )
+    this.targetHandle.attach(this.viewport.sceneManager.scene)
+    this.targetHandle.setTarget(initialState.target)
+
+    this.cameraHandle = new CameraHandle(
+      this.viewport.cameraManager.activeCamera,
+      this.viewport.domElement,
+      (dragging) => {
+        this.viewport.controlsManager.controls.enabled = !dragging
+      },
+      (transform, mode) => this.handleCameraDrag(transform, mode)
+    )
+    this.cameraHandle.attach(this.viewport.sceneManager.scene)
+    this.syncCameraHandleSubject(initialState)
+
+    this.attachPointerHandlers()
+
+    this.disposePreRender = this.viewport.addPreRenderCallback(() => {
+      if (this.lookingThrough) this.fitSubjectAspect()
+    })
+    this.disposePostRender = this.viewport.addPostRenderCallback(() => {
+      if (!this.lookingThrough) this.renderSubjectCameraPreview()
+    })
+  }
+
+  applyState(state: CameraInfoState): void {
+    this.overlay.applyState(state)
+    this.orbitHandles.update(state)
+    this.rollHandle.update(state)
+    this.targetHandle.setTarget(state.target)
+    this.syncCameraHandleSubject(state)
+    this.refreshGizmoVisibility()
+    if (this.lookingThrough) {
+      this.viewport.setExternalActiveCamera(this.overlay.getSubjectCamera())
+    }
+    this.viewport.forceRender()
+  }
+
+  setGizmosVisible(on: boolean): void {
+    if (this.gizmosOn === on) return
+    this.gizmosOn = on
+    this.refreshGizmoVisibility()
+    this.viewport.forceRender()
+  }
+
+  setTransformGizmoMode(mode: TransformGizmoMode): void {
+    if (this.transformGizmoMode === mode) return
+    this.transformGizmoMode = mode
+    this.refreshGizmoVisibility()
+    this.viewport.forceRender()
+  }
+
+  setLookThrough(on: boolean): void {
+    if (this.lookingThrough === on) return
+    this.lookingThrough = on
+    this.lookThroughDrag = null
+    this.cancelInputFrame()
+    this.canvas.style.cursor = ''
+    this.refreshGizmoVisibility()
+    if (on) this.fitSubjectAspect()
+    this.viewport.setExternalActiveCamera(
+      on ? this.overlay.getSubjectCamera() : null
+    )
+    if (!on) this.viewport.viewHelperManager.visibleViewHelper(false)
+  }
+
+  remove(): void {
+    this.detachPointerHandlers()
+    this.cancelInputFrame()
+    this.canvas.style.cursor = ''
+    this.disposePreRender()
+    this.disposePostRender()
+    this.orbitHandles.dispose()
+    this.rollHandle.dispose()
+    this.targetHandle.dispose()
+    this.cameraHandle.dispose()
+    this.viewport.remove()
+  }
+
+  private refreshGizmoVisibility(): void {
+    if (this.lookingThrough) {
+      this.orbitHandles.setVisible(false)
+      this.rollHandle.setVisible(false)
+      this.targetHandle.setVisible(false)
+      this.cameraHandle.setVisible(false)
+      return
+    }
+    const mode = this.overlay.getState().mode
+    this.orbitHandles.setVisible(this.gizmosOn && mode === 'orbit')
+    this.rollHandle.setVisible(this.gizmosOn && rollApplies(mode))
+
+    const wantTarget =
+      this.gizmosOn &&
+      this.transformGizmoMode === 'target' &&
+      targetApplies(mode)
+    this.targetHandle.setVisible(wantTarget)
+
+    const wantTranslate =
+      this.gizmosOn &&
+      this.transformGizmoMode === 'camera-translate' &&
+      cameraTranslateApplies(mode)
+    const wantRotate =
+      this.gizmosOn &&
+      this.transformGizmoMode === 'camera-rotate' &&
+      cameraRotateApplies(mode)
+    const wantCamera = wantTranslate || wantRotate
+    if (wantCamera)
+      this.cameraHandle.setMode(wantRotate ? 'rotate' : 'translate')
+    this.cameraHandle.setVisible(wantCamera)
+  }
+
+  private syncCameraHandleSubject(state: CameraInfoState): void {
+    const { position, quaternion } = computeSubjectTransform(state)
+    this.cameraHandle.setSubject(
+      { x: position.x, y: position.y, z: position.z },
+      { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w }
+    )
+  }
+
+  private applyDerivedState(next: CameraInfoState): void {
+    this.overlay.applyState(next)
+    this.orbitHandles.update(next)
+    this.rollHandle.update(next)
+    this.targetHandle.setTarget(next.target)
+    this.syncCameraHandleSubject(next)
+    this.refreshGizmoVisibility()
+    this.viewport.forceRender()
+  }
+
+  private handleCameraDrag(
+    transform: CameraHandleTransform,
+    mode: CameraHandleMode
+  ): void {
+    const state = this.overlay.getState()
+    const next = nextStateForCameraDrag(state, transform, mode)
+    this.applyDerivedState(next)
+    if (mode === 'translate') {
+      this.onHandleDrag?.('mode.position_x', transform.position.x)
+      this.onHandleDrag?.('mode.position_y', transform.position.y)
+      this.onHandleDrag?.('mode.position_z', transform.position.z)
+    } else {
+      this.onHandleDrag?.('mode.quat_x', transform.quaternion.x)
+      this.onHandleDrag?.('mode.quat_y', transform.quaternion.y)
+      this.onHandleDrag?.('mode.quat_z', transform.quaternion.z)
+      this.onHandleDrag?.('mode.quat_w', transform.quaternion.w)
+    }
+  }
+
+  private get canvas(): HTMLCanvasElement {
+    return this.viewport.domElement
+  }
+
+  private attachPointerHandlers(): void {
+    const canvas = this.canvas
+    canvas.addEventListener('pointerdown', this.onPointerDown)
+    canvas.addEventListener('pointermove', this.onPointerMove)
+    canvas.addEventListener('pointerup', this.onPointerUp)
+    canvas.addEventListener('pointercancel', this.onPointerUp)
+    canvas.addEventListener('pointerleave', this.onPointerLeave)
+    canvas.addEventListener('wheel', this.onWheel, { passive: false })
+  }
+
+  private detachPointerHandlers(): void {
+    const canvas = this.canvas
+    canvas.removeEventListener('pointerdown', this.onPointerDown)
+    canvas.removeEventListener('pointermove', this.onPointerMove)
+    canvas.removeEventListener('pointerup', this.onPointerUp)
+    canvas.removeEventListener('pointercancel', this.onPointerUp)
+    canvas.removeEventListener('pointerleave', this.onPointerLeave)
+    canvas.removeEventListener('wheel', this.onWheel)
+  }
+
+  private readonly onPointerLeave = (): void => {
+    if (this.dragState || this.lookThroughDrag) return
+    this.setHoveredHandle(null)
+  }
+
+  private readonly onWheel = (event: WheelEvent): void => {
+    if (!this.lookingThrough) return
+    event.preventDefault()
+    event.stopPropagation()
+    this.queueDolly(event.deltaY)
+  }
+
+  private updatePointer(event: PointerEvent): void {
+    const rect = this.canvas.getBoundingClientRect()
+    this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+    this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+  }
+
+  private pickableTargetsFor(mode: CameraInfoMode): THREE.Object3D[] {
+    const targets: THREE.Object3D[] = []
+    if (mode === 'orbit') {
+      targets.push(...this.orbitHandles.pickableMeshes())
+    }
+    if (rollApplies(mode)) {
+      targets.push(...this.rollHandle.pickableMeshes())
+    }
+    return targets
+  }
+
+  private pickHandle(event: PointerEvent): DragHandleType | null {
+    if (!this.gizmosOn || this.lookingThrough) return null
+    const targets = this.pickableTargetsFor(this.overlay.getState().mode)
+    if (targets.length === 0) return null
+    this.updatePointer(event)
+    return pickHandleAtPointer<DragHandleType>(
+      this.raycaster,
+      this.pointer,
+      this.viewport.cameraManager.activeCamera,
+      targets,
+      this.canvas
+    )
+  }
+
+  private setHoveredHandle(type: DragHandleType | null): void {
+    if (this.hoveredHandle === type) return
+    this.hoveredHandle = type
+    this.orbitHandles.setHovered(type === 'roll' ? null : type)
+    this.rollHandle.setHovered(type === 'roll')
+    this.canvas.style.cursor = type ? 'grab' : ''
+    this.viewport.forceRender()
+  }
+
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    if (event.button !== 0) return
+
+    if (this.lookingThrough) {
+      this.lookThroughDrag = {
+        pointerId: event.pointerId,
+        lastX: event.clientX,
+        lastY: event.clientY
+      }
+      this.canvas.setPointerCapture(event.pointerId)
+      this.canvas.style.cursor = 'grabbing'
+      event.stopPropagation()
+      return
+    }
+
+    const type = this.pickHandle(event)
+    if (!type) return
+
+    this.setHoveredHandle(type)
+    this.dragState = { type, pointerId: event.pointerId }
+    this.canvas.setPointerCapture(event.pointerId)
+    this.canvas.style.cursor = 'grabbing'
+    this.viewport.controlsManager.controls.enabled = false
+    event.stopPropagation()
+  }
+
+  private readonly onPointerMove = (event: PointerEvent): void => {
+    if (this.lookThroughDrag) {
+      if (event.pointerId !== this.lookThroughDrag.pointerId) return
+      const dx = event.clientX - this.lookThroughDrag.lastX
+      const dy = event.clientY - this.lookThroughDrag.lastY
+      this.lookThroughDrag.lastX = event.clientX
+      this.lookThroughDrag.lastY = event.clientY
+      this.queueRotation(dx, dy)
+      return
+    }
+
+    if (!this.dragState) {
+      this.setHoveredHandle(this.pickHandle(event))
+      return
+    }
+    if (event.pointerId !== this.dragState.pointerId) return
+
+    this.updatePointer(event)
+    this.raycaster.setFromCamera(
+      this.pointer,
+      this.viewport.cameraManager.activeCamera
+    )
+
+    const state = this.overlay.getState()
+    const plane =
+      this.dragState.type === 'roll'
+        ? this.rollHandle.dragPlane(state)
+        : this.orbitHandles.dragPlaneFor(this.dragState.type, state)
+    const point = new THREE.Vector3()
+    if (!this.raycaster.ray.intersectPlane(plane, point)) return
+
+    const { fieldName, value, nextState } = computeNextState(
+      this.dragState.type,
+      state,
+      point
+    )
+    this.applyState(nextState)
+    this.onHandleDrag?.(fieldName, value)
+  }
+
+  private readonly onPointerUp = (event: PointerEvent): void => {
+    if (this.lookThroughDrag) {
+      if (event.pointerId !== this.lookThroughDrag.pointerId) return
+      if (this.canvas.hasPointerCapture(event.pointerId)) {
+        this.canvas.releasePointerCapture(event.pointerId)
+      }
+      this.lookThroughDrag = null
+      this.flushInput()
+      this.cancelInputFrame()
+      this.canvas.style.cursor = ''
+      return
+    }
+
+    if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
+    if (this.canvas.hasPointerCapture(event.pointerId)) {
+      this.canvas.releasePointerCapture(event.pointerId)
+    }
+    this.dragState = null
+    this.viewport.controlsManager.controls.enabled = true
+    this.canvas.style.cursor = this.hoveredHandle ? 'grab' : ''
+  }
+
+  private queueRotation(dx: number, dy: number): void {
+    this.pendingRotation = {
+      dx: (this.pendingRotation?.dx ?? 0) + dx,
+      dy: (this.pendingRotation?.dy ?? 0) + dy
+    }
+    this.scheduleInputFrame()
+  }
+
+  private queueDolly(deltaY: number): void {
+    this.pendingDolly = (this.pendingDolly ?? 0) + deltaY
+    this.scheduleInputFrame()
+  }
+
+  private scheduleInputFrame(): void {
+    if (this.inputFrame !== null) return
+    this.inputFrame = requestAnimationFrame(() => {
+      this.inputFrame = null
+      this.flushInput()
+    })
+  }
+
+  private flushInput(): void {
+    const rotation = this.pendingRotation
+    const dolly = this.pendingDolly
+    this.pendingRotation = null
+    this.pendingDolly = null
+    if (rotation) {
+      this.applyResult(
+        rotateSubjectByDrag(
+          this.overlay.getState(),
+          -rotation.dx * LOOK_THROUGH_SENSITIVITY,
+          -rotation.dy * LOOK_THROUGH_SENSITIVITY
+        )
+      )
+    }
+    if (dolly !== null) {
+      this.applyResult(dollySubjectByWheel(this.overlay.getState(), dolly))
+    }
+  }
+
+  private applyResult(result: LookThroughResult | null): void {
+    if (!result) return
+    this.applyState(result.nextState)
+    for (const update of result.updates) {
+      this.onHandleDrag?.(update.fieldName, update.value)
+    }
+  }
+
+  private cancelInputFrame(): void {
+    if (this.inputFrame !== null) {
+      cancelAnimationFrame(this.inputFrame)
+      this.inputFrame = null
+    }
+    this.pendingRotation = null
+    this.pendingDolly = null
+  }
+
+  private fitSubjectAspect(): void {
+    const canvas = this.viewport.domElement
+    const aspect = canvas.width / canvas.height
+    if (!Number.isFinite(aspect) || aspect <= 0) return
+    const cam = this.overlay.getSubjectCamera()
+    if (cam instanceof THREE.PerspectiveCamera) {
+      if (Math.abs(cam.aspect - aspect) < 1e-4) return
+      cam.aspect = aspect
+      cam.updateProjectionMatrix()
+      return
+    }
+    if (cam instanceof THREE.OrthographicCamera) {
+      const half = (cam.top - cam.bottom) / 2 || 1
+      const left = -half * aspect
+      const right = half * aspect
+      if (
+        Math.abs(cam.left - left) < 1e-4 &&
+        Math.abs(cam.right - right) < 1e-4
+      )
+        return
+      cam.left = left
+      cam.right = right
+      cam.updateProjectionMatrix()
+    }
+  }
+
+  private renderSubjectCameraPreview(): void {
+    const renderer = this.viewport.renderer
+    const canvas = this.viewport.domElement
+    const canvasWidth = canvas.width
+    const canvasHeight = canvas.height
+    if (
+      canvasWidth < PREVIEW_WIDTH + PREVIEW_PADDING * 2 ||
+      canvasHeight < PREVIEW_HEIGHT + PREVIEW_PADDING * 2
+    ) {
+      return
+    }
+
+    const cam = this.overlay.getSubjectCamera()
+    const aspect = PREVIEW_WIDTH / PREVIEW_HEIGHT
+    let savedAspect: number | undefined
+    let savedOrtho:
+      | {
+          left: number
+          right: number
+          top: number
+          bottom: number
+        }
+      | undefined
+
+    if (cam instanceof THREE.PerspectiveCamera) {
+      savedAspect = cam.aspect
+      cam.aspect = aspect
+      cam.updateProjectionMatrix()
+    } else if (cam instanceof THREE.OrthographicCamera) {
+      savedOrtho = {
+        left: cam.left,
+        right: cam.right,
+        top: cam.top,
+        bottom: cam.bottom
+      }
+      const half = (cam.top - cam.bottom) / 2 || 1
+      cam.left = -half * aspect
+      cam.right = half * aspect
+      cam.top = half
+      cam.bottom = -half
+      cam.updateProjectionMatrix()
+    }
+
+    this.overlay.setHelperVisible(false)
+    const handlesWereVisible = this.orbitHandles.isVisible()
+    const rollWasVisible = this.rollHandle.isVisible()
+    const targetWasVisible = this.targetHandle.isVisible()
+    const cameraWasVisible = this.cameraHandle.isVisible()
+    this.orbitHandles.setVisible(false)
+    this.rollHandle.setVisible(false)
+    this.targetHandle.setVisible(false)
+    this.cameraHandle.setVisible(false)
+
+    const x = canvasWidth - PREVIEW_WIDTH - PREVIEW_PADDING
+    const y = PREVIEW_PADDING
+
+    renderer.setViewport(x - 1, y - 1, PREVIEW_WIDTH + 2, PREVIEW_HEIGHT + 2)
+    renderer.setScissor(x - 1, y - 1, PREVIEW_WIDTH + 2, PREVIEW_HEIGHT + 2)
+    renderer.setScissorTest(true)
+    renderer.setClearColor(PREVIEW_BORDER_COLOR)
+    renderer.clear()
+
+    renderer.setViewport(x, y, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+    renderer.setScissor(x, y, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+    renderer.setClearColor(0x0a0a0a)
+    renderer.clear()
+    renderer.render(this.viewport.sceneManager.scene, cam)
+
+    this.overlay.setHelperVisible(true)
+    if (handlesWereVisible) this.orbitHandles.setVisible(true)
+    if (rollWasVisible) this.rollHandle.setVisible(true)
+    if (targetWasVisible) this.targetHandle.setVisible(true)
+    if (cameraWasVisible) this.cameraHandle.setVisible(true)
+
+    if (savedAspect !== undefined && cam instanceof THREE.PerspectiveCamera) {
+      cam.aspect = savedAspect
+      cam.updateProjectionMatrix()
+    } else if (savedOrtho && cam instanceof THREE.OrthographicCamera) {
+      cam.left = savedOrtho.left
+      cam.right = savedOrtho.right
+      cam.top = savedOrtho.top
+      cam.bottom = savedOrtho.bottom
+      cam.updateProjectionMatrix()
+    }
+  }
+}
+
+interface OrbitDragResult {
+  fieldName: CameraInfoFieldName
+  value: number
+  nextState: CameraInfoState
+}
+
+function computeNextState(
+  type: DragHandleType,
+  state: CameraInfoState,
+  point: THREE.Vector3
+): OrbitDragResult {
+  if (type === 'roll') {
+    const cameraPos = computeSubjectTransform(state).position
+    const value = pointToRollAngle(
+      { x: point.x, y: point.y, z: point.z },
+      state.target,
+      { x: cameraPos.x, y: cameraPos.y, z: cameraPos.z }
+    )
+    return {
+      fieldName: 'roll',
+      value,
+      nextState: { ...state, roll: value }
+    }
+  }
+  const fieldName = FIELD_NAME_FOR[type]
+  if (type === 'yaw') {
+    const value = pointToYawAngle(point, state.target)
+    return {
+      fieldName,
+      value,
+      nextState: { ...state, orbit: { ...state.orbit, yaw: value } }
+    }
+  }
+  if (type === 'pitch') {
+    const value = pointToPitchAngle(point, state.target, state.orbit.yaw)
+    return {
+      fieldName,
+      value,
+      nextState: { ...state, orbit: { ...state.orbit, pitch: value } }
+    }
+  }
+  const value = pointToDistance(
+    point,
+    state.target,
+    state.orbit.yaw,
+    state.orbit.pitch
+  )
+  return {
+    fieldName,
+    value,
+    nextState: { ...state, orbit: { ...state.orbit, distance: value } }
+  }
+}
+
+function targetApplies(mode: CameraInfoMode): boolean {
+  return mode === 'orbit' || mode === 'look_at'
+}
+
+function cameraTranslateApplies(mode: CameraInfoMode): boolean {
+  return mode === 'look_at' || mode === 'quaternion'
+}
+
+function cameraRotateApplies(mode: CameraInfoMode): boolean {
+  return mode === 'quaternion'
+}
+
+function rollApplies(mode: CameraInfoMode): boolean {
+  return mode === 'orbit' || mode === 'look_at'
+}
+
+function nextStateForCameraDrag(
+  state: CameraInfoState,
+  transform: CameraHandleTransform,
+  mode: CameraHandleMode
+): CameraInfoState {
+  const { position, quaternion } = transform
+  if (mode === 'translate') {
+    if (state.mode === 'look_at') {
+      return { ...state, lookAt: { position: { ...position } } }
+    }
+    if (state.mode === 'quaternion') {
+      return {
+        ...state,
+        quaternion: { ...state.quaternion, position: { ...position } }
+      }
+    }
+    return state
+  }
+  if (state.mode === 'quaternion') {
+    return {
+      ...state,
+      quaternion: { ...state.quaternion, quat: { ...quaternion } }
+    }
+  }
+  return state
+}

--- a/src/extensions/core/cameraInfo/CameraInfoViewport.ts
+++ b/src/extensions/core/cameraInfo/CameraInfoViewport.ts
@@ -60,6 +60,8 @@ interface DragState {
   pointerId: number
 }
 
+type PointerPosition = Pick<PointerEvent, 'clientX' | 'clientY'>
+
 export class CameraInfoViewport {
   readonly viewport: Viewport3d
   readonly overlay: CameraInfoOverlay
@@ -82,7 +84,10 @@ export class CameraInfoViewport {
   } | null = null
   private pendingRotation: { dx: number; dy: number } | null = null
   private pendingDolly: number | null = null
+  private pendingDragPointer: PointerPosition | null = null
+  private pendingHoverPointer: PointerPosition | null = null
   private inputFrame: number | null = null
+  private readonly dragPoint = new THREE.Vector3()
   private hoveredHandle: DragHandleType | null = null
   private gizmosOn = true
   private lookingThrough = false
@@ -294,6 +299,7 @@ export class CameraInfoViewport {
 
   private readonly onPointerLeave = (): void => {
     if (this.dragState || this.lookThroughDrag) return
+    this.pendingHoverPointer = null
     this.setHoveredHandle(null)
   }
 
@@ -304,10 +310,10 @@ export class CameraInfoViewport {
     this.queueDolly(event.deltaY)
   }
 
-  private updatePointer(event: PointerEvent): void {
+  private updatePointer({ clientX, clientY }: PointerPosition): void {
     const rect = this.canvas.getBoundingClientRect()
-    this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
-    this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+    this.pointer.x = ((clientX - rect.left) / rect.width) * 2 - 1
+    this.pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1
   }
 
   private pickableTargetsFor(mode: CameraInfoMode): THREE.Object3D[] {
@@ -321,11 +327,11 @@ export class CameraInfoViewport {
     return targets
   }
 
-  private pickHandle(event: PointerEvent): DragHandleType | null {
+  private pickHandle(position: PointerPosition): DragHandleType | null {
     if (!this.gizmosOn || this.lookingThrough) return null
     const targets = this.pickableTargetsFor(this.overlay.getState().mode)
     if (targets.length === 0) return null
-    this.updatePointer(event)
+    this.updatePointer(position)
     return pickHandleAtPointer<DragHandleType>(
       this.raycaster,
       this.pointer,
@@ -361,6 +367,7 @@ export class CameraInfoViewport {
 
     const type = this.pickHandle(event)
     if (!type) return
+    this.pendingHoverPointer = null
 
     this.setHoveredHandle(type)
     this.dragState = { type, pointerId: event.pointerId }
@@ -382,12 +389,22 @@ export class CameraInfoViewport {
     }
 
     if (!this.dragState) {
-      this.setHoveredHandle(this.pickHandle(event))
+      this.pendingHoverPointer = {
+        clientX: event.clientX,
+        clientY: event.clientY
+      }
+      this.scheduleInputFrame()
       return
     }
     if (event.pointerId !== this.dragState.pointerId) return
 
-    this.updatePointer(event)
+    this.pendingDragPointer = { clientX: event.clientX, clientY: event.clientY }
+    this.scheduleInputFrame()
+  }
+
+  private processDragMove(position: PointerPosition): void {
+    if (!this.dragState) return
+    this.updatePointer(position)
     this.raycaster.setFromCamera(
       this.pointer,
       this.viewport.cameraManager.activeCamera
@@ -398,13 +415,12 @@ export class CameraInfoViewport {
       this.dragState.type === 'roll'
         ? this.rollHandle.dragPlane(state)
         : this.orbitHandles.dragPlaneFor(this.dragState.type, state)
-    const point = new THREE.Vector3()
-    if (!this.raycaster.ray.intersectPlane(plane, point)) return
+    if (!this.raycaster.ray.intersectPlane(plane, this.dragPoint)) return
 
     const { fieldName, value, nextState } = computeNextState(
       this.dragState.type,
       state,
-      point
+      this.dragPoint
     )
     this.applyState(nextState)
     this.onHandleDrag?.(fieldName, value)
@@ -424,6 +440,8 @@ export class CameraInfoViewport {
     }
 
     if (!this.dragState || event.pointerId !== this.dragState.pointerId) return
+    this.flushInput()
+    this.cancelInputFrame()
     if (this.canvas.hasPointerCapture(event.pointerId)) {
       this.canvas.releasePointerCapture(event.pointerId)
     }
@@ -456,8 +474,17 @@ export class CameraInfoViewport {
   private flushInput(): void {
     const rotation = this.pendingRotation
     const dolly = this.pendingDolly
+    const dragPointer = this.pendingDragPointer
+    const hoverPointer = this.pendingHoverPointer
     this.pendingRotation = null
     this.pendingDolly = null
+    this.pendingDragPointer = null
+    this.pendingHoverPointer = null
+    if (dragPointer) {
+      this.processDragMove(dragPointer)
+    } else if (hoverPointer && !this.dragState) {
+      this.setHoveredHandle(this.pickHandle(hoverPointer))
+    }
     if (rotation) {
       this.applyResult(
         rotateSubjectByDrag(
@@ -487,6 +514,8 @@ export class CameraInfoViewport {
     }
     this.pendingRotation = null
     this.pendingDolly = null
+    this.pendingDragPointer = null
+    this.pendingHoverPointer = null
   }
 
   private fitSubjectAspect(): void {

--- a/src/extensions/core/cameraInfo/cameraTransform.test.ts
+++ b/src/extensions/core/cameraInfo/cameraTransform.test.ts
@@ -1,0 +1,175 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { computeSubjectTransform } from './cameraTransform'
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type { CameraInfoState } from './types'
+
+function withMode(
+  mode: CameraInfoState['mode'],
+  overrides: Partial<CameraInfoState> = {}
+): CameraInfoState {
+  return { ...DEFAULT_CAMERA_INFO_STATE, mode, ...overrides }
+}
+
+describe('computeSubjectTransform', () => {
+  describe('orbit mode', () => {
+    it('positions the camera at target + distance along yaw/pitch', () => {
+      const state = withMode('orbit', {
+        target: { x: 0, y: 0, z: 0 },
+        orbit: { yaw: 0, pitch: 0, distance: 5 }
+      })
+
+      const { position } = computeSubjectTransform(state)
+
+      expect(position.x).toBeCloseTo(0)
+      expect(position.y).toBeCloseTo(0)
+      expect(position.z).toBeCloseTo(5)
+    })
+
+    it('honors yaw=90deg (camera goes to +X)', () => {
+      const state = withMode('orbit', {
+        target: { x: 0, y: 0, z: 0 },
+        orbit: { yaw: 90, pitch: 0, distance: 5 }
+      })
+
+      const { position } = computeSubjectTransform(state)
+
+      expect(position.x).toBeCloseTo(5)
+      expect(position.y).toBeCloseTo(0)
+      expect(position.z).toBeCloseTo(0)
+    })
+
+    it('honors pitch=90deg (camera goes straight up)', () => {
+      const state = withMode('orbit', {
+        target: { x: 0, y: 0, z: 0 },
+        orbit: { yaw: 0, pitch: 90, distance: 5 }
+      })
+
+      const { position } = computeSubjectTransform(state)
+
+      expect(position.x).toBeCloseTo(0)
+      expect(position.y).toBeCloseTo(5)
+      expect(position.z).toBeCloseTo(0, 5)
+    })
+
+    it('offsets the orbit by target', () => {
+      const state = withMode('orbit', {
+        target: { x: 10, y: 20, z: 30 },
+        orbit: { yaw: 0, pitch: 0, distance: 5 }
+      })
+
+      const { position } = computeSubjectTransform(state)
+
+      expect(position.x).toBeCloseTo(10)
+      expect(position.y).toBeCloseTo(20)
+      expect(position.z).toBeCloseTo(35)
+    })
+  })
+
+  describe('look_at mode', () => {
+    it('uses explicit position', () => {
+      const state = withMode('look_at', {
+        lookAt: { position: { x: 1, y: 2, z: 3 } }
+      })
+
+      const { position } = computeSubjectTransform(state)
+
+      expect(position.toArray()).toEqual([1, 2, 3])
+    })
+
+    it('orients the camera so its forward axis points at the target', () => {
+      const state = withMode('look_at', {
+        lookAt: { position: { x: 4, y: 3, z: 5 } },
+        target: { x: -1, y: 0, z: 2 }
+      })
+
+      const { position, quaternion } = computeSubjectTransform(state)
+      const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(quaternion)
+      const toTarget = new THREE.Vector3(-1, 0, 2).sub(position).normalize()
+
+      expect(forward.angleTo(toTarget)).toBeCloseTo(0)
+    })
+  })
+
+  describe('quaternion mode', () => {
+    it('uses explicit position and quaternion (target ignored)', () => {
+      const state = withMode('quaternion', {
+        target: { x: 999, y: 999, z: 999 },
+        quaternion: {
+          position: { x: 7, y: 8, z: 9 },
+          quat: { x: 0, y: 0, z: 0, w: 1 }
+        }
+      })
+
+      const { position, quaternion } = computeSubjectTransform(state)
+
+      expect(position.toArray()).toEqual([7, 8, 9])
+      expect(quaternion.x).toBeCloseTo(0)
+      expect(quaternion.y).toBeCloseTo(0)
+      expect(quaternion.z).toBeCloseTo(0)
+      expect(quaternion.w).toBeCloseTo(1)
+    })
+
+    it('normalizes a non-unit quaternion', () => {
+      const state = withMode('quaternion', {
+        quaternion: {
+          position: { x: 0, y: 0, z: 0 },
+          quat: { x: 2, y: 0, z: 0, w: 0 }
+        }
+      })
+
+      const { quaternion } = computeSubjectTransform(state)
+
+      expect(quaternion.length()).toBeCloseTo(1)
+    })
+
+    it('falls back to identity when given a zero quaternion', () => {
+      const state = withMode('quaternion', {
+        quaternion: {
+          position: { x: 0, y: 0, z: 0 },
+          quat: { x: 0, y: 0, z: 0, w: 0 }
+        }
+      })
+
+      const { quaternion } = computeSubjectTransform(state)
+
+      expect(quaternion.x).toBe(0)
+      expect(quaternion.y).toBe(0)
+      expect(quaternion.z).toBe(0)
+      expect(quaternion.w).toBe(1)
+    })
+  })
+
+  describe('roll', () => {
+    it('rotates around the view axis without moving the camera position', () => {
+      const base = withMode('look_at', {
+        target: { x: 0, y: 0, z: 0 },
+        lookAt: { position: { x: 0, y: 0, z: 5 } },
+        roll: 0
+      })
+      const rolled = { ...base, roll: 45 }
+
+      const a = computeSubjectTransform(base)
+      const b = computeSubjectTransform(rolled)
+
+      expect(a.position.toArray()).toEqual(b.position.toArray())
+
+      const forward = new THREE.Vector3(0, 0, -1)
+      expect(
+        forward
+          .clone()
+          .applyQuaternion(a.quaternion)
+          .angleTo(forward.clone().applyQuaternion(b.quaternion))
+      ).toBeCloseTo(0)
+
+      const up = new THREE.Vector3(0, 1, 0)
+      expect(
+        up
+          .clone()
+          .applyQuaternion(a.quaternion)
+          .angleTo(up.clone().applyQuaternion(b.quaternion))
+      ).toBeCloseTo(Math.PI / 4)
+    })
+  })
+})

--- a/src/extensions/core/cameraInfo/cameraTransform.ts
+++ b/src/extensions/core/cameraInfo/cameraTransform.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three'
+
+import type { CameraInfoState } from './types'
+
+const DEG2RAD = Math.PI / 180
+
+export interface SubjectCameraTransform {
+  position: THREE.Vector3
+  quaternion: THREE.Quaternion
+}
+
+function orbitPosition(
+  target: THREE.Vector3Like,
+  yawDeg: number,
+  pitchDeg: number,
+  distance: number
+): THREE.Vector3 {
+  const y = yawDeg * DEG2RAD
+  const p = pitchDeg * DEG2RAD
+  const cp = Math.cos(p)
+  return new THREE.Vector3(
+    target.x + distance * cp * Math.sin(y),
+    target.y + distance * Math.sin(p),
+    target.z + distance * cp * Math.cos(y)
+  )
+}
+
+function lookAtQuaternion(
+  position: THREE.Vector3,
+  target: THREE.Vector3Like,
+  rollDeg: number
+): THREE.Quaternion {
+  const targetVec = new THREE.Vector3(target.x, target.y, target.z)
+  const m = new THREE.Matrix4().lookAt(
+    position,
+    targetVec,
+    new THREE.Vector3(0, 1, 0)
+  )
+  const q = new THREE.Quaternion().setFromRotationMatrix(m)
+  if (rollDeg !== 0) {
+    const rollQ = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 0, 1),
+      rollDeg * DEG2RAD
+    )
+    q.multiply(rollQ)
+  }
+  return q
+}
+
+export function normalizeQuaternion(q: THREE.Quaternion): THREE.Quaternion {
+  if (q.lengthSq() === 0) q.set(0, 0, 0, 1)
+  else q.normalize()
+  return q
+}
+
+export function computeSubjectTransform(
+  state: CameraInfoState
+): SubjectCameraTransform {
+  if (state.mode === 'quaternion') {
+    const p = state.quaternion.position
+    const q = state.quaternion.quat
+    const quaternion = normalizeQuaternion(
+      new THREE.Quaternion(q.x, q.y, q.z, q.w)
+    )
+    return {
+      position: new THREE.Vector3(p.x, p.y, p.z),
+      quaternion
+    }
+  }
+
+  const position =
+    state.mode === 'orbit'
+      ? orbitPosition(
+          state.target,
+          state.orbit.yaw,
+          state.orbit.pitch,
+          state.orbit.distance
+        )
+      : new THREE.Vector3(
+          state.lookAt.position.x,
+          state.lookAt.position.y,
+          state.lookAt.position.z
+        )
+
+  return {
+    position,
+    quaternion: lookAtQuaternion(position, state.target, state.roll)
+  }
+}

--- a/src/extensions/core/cameraInfo/handles/CameraHandle.test.ts
+++ b/src/extensions/core/cameraInfo/handles/CameraHandle.test.ts
@@ -1,0 +1,130 @@
+import * as THREE from 'three'
+import type { TransformControls } from 'three/examples/jsm/controls/TransformControls'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CameraHandle } from './CameraHandle'
+import type { CameraHandleMode, CameraHandleTransform } from './CameraHandle'
+
+describe('CameraHandle', () => {
+  let scene: THREE.Scene
+  let camera: THREE.PerspectiveCamera
+  let dom: HTMLElement
+  let onDragging: (dragging: boolean) => void
+  let onDraggingMock: ReturnType<typeof vi.fn>
+  let onChange: (
+    transform: CameraHandleTransform,
+    mode: CameraHandleMode
+  ) => void
+  let onChangeMock: ReturnType<typeof vi.fn>
+  let handle: CameraHandle
+
+  beforeEach(() => {
+    scene = new THREE.Scene()
+    camera = new THREE.PerspectiveCamera()
+    dom = document.createElement('div')
+    onDraggingMock = vi.fn()
+    onDragging = onDraggingMock as unknown as (dragging: boolean) => void
+    onChangeMock = vi.fn()
+    onChange = onChangeMock as unknown as (
+      transform: CameraHandleTransform,
+      mode: CameraHandleMode
+    ) => void
+    handle = new CameraHandle(camera, dom, onDragging, onChange)
+    handle.attach(scene)
+  })
+
+  function controls(): TransformControls {
+    return (handle as unknown as { controls: TransformControls }).controls
+  }
+
+  afterEach(() => {
+    handle.dispose()
+  })
+
+  it('adds a proxy + a helper to the scene on attach', () => {
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoCameraProxy')
+    ).toBeDefined()
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoCameraHandle')
+    ).toBeDefined()
+  })
+
+  it('starts hidden with controls disabled', () => {
+    expect(handle.isVisible()).toBe(false)
+    expect(controls().enabled).toBe(false)
+  })
+
+  it('defaults to translate mode', () => {
+    expect(handle.getMode()).toBe('translate')
+  })
+
+  it('setMode switches translate <-> rotate', () => {
+    handle.setMode('rotate')
+    expect(handle.getMode()).toBe('rotate')
+
+    handle.setMode('translate')
+    expect(handle.getMode()).toBe('translate')
+  })
+
+  it('setSubject moves the proxy to the given pose without firing onChange', () => {
+    handle.setSubject({ x: 1, y: 2, z: 3 }, { x: 0, y: 0, z: 0, w: 1 })
+
+    const proxy = scene.children.find(
+      (c) => c.name === 'CameraInfoCameraProxy'
+    )!
+    expect(proxy.position.x).toBe(1)
+    expect(proxy.position.y).toBe(2)
+    expect(proxy.position.z).toBe(3)
+    expect(onChangeMock).not.toHaveBeenCalled()
+  })
+
+  it('setSubject is a no-op when the pose already matches', () => {
+    handle.setSubject({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 1 })
+    onChangeMock.mockClear()
+
+    handle.setSubject({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 1 })
+
+    expect(onChangeMock).not.toHaveBeenCalled()
+  })
+
+  it('setVisible toggles helper.visible and controls.enabled together', () => {
+    handle.setVisible(true)
+    expect(handle.isVisible()).toBe(true)
+    expect(controls().enabled).toBe(true)
+
+    handle.setVisible(false)
+    expect(handle.isVisible()).toBe(false)
+    expect(controls().enabled).toBe(false)
+  })
+
+  it('emits the proxy transform and active mode on gizmo objectChange', () => {
+    const proxy = scene.children.find(
+      (c) => c.name === 'CameraInfoCameraProxy'
+    )!
+    proxy.position.set(1, 2, 3)
+
+    controls().dispatchEvent({ type: 'objectChange' })
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ position: { x: 1, y: 2, z: 3 } }),
+      'translate'
+    )
+  })
+
+  it('forwards dragging-changed to the dragging listener', () => {
+    controls().dispatchEvent({ type: 'dragging-changed', value: true })
+
+    expect(onDraggingMock).toHaveBeenCalledWith(true)
+  })
+
+  it('dispose removes proxy and helper from the scene', () => {
+    handle.dispose()
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoCameraProxy')
+    ).toBeUndefined()
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoCameraHandle')
+    ).toBeUndefined()
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/CameraHandle.test.ts
+++ b/src/extensions/core/cameraInfo/handles/CameraHandle.test.ts
@@ -1,40 +1,38 @@
-import * as THREE from 'three'
+﻿import * as THREE from 'three'
 import type { TransformControls } from 'three/examples/jsm/controls/TransformControls'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CameraHandle } from './CameraHandle'
 import type { CameraHandleMode, CameraHandleTransform } from './CameraHandle'
 
+function gizmoControls(handle: unknown): TransformControls {
+  return (handle as { controls: TransformControls }).controls
+}
+
 describe('CameraHandle', () => {
   let scene: THREE.Scene
   let camera: THREE.PerspectiveCamera
   let dom: HTMLElement
-  let onDragging: (dragging: boolean) => void
-  let onDraggingMock: ReturnType<typeof vi.fn>
-  let onChange: (
-    transform: CameraHandleTransform,
-    mode: CameraHandleMode
-  ) => void
-  let onChangeMock: ReturnType<typeof vi.fn>
+  let onDragging: ReturnType<typeof vi.fn<(dragging: boolean) => void>>
+  let onChange: ReturnType<
+    typeof vi.fn<
+      (transform: CameraHandleTransform, mode: CameraHandleMode) => void
+    >
+  >
   let handle: CameraHandle
 
   beforeEach(() => {
     scene = new THREE.Scene()
     camera = new THREE.PerspectiveCamera()
     dom = document.createElement('div')
-    onDraggingMock = vi.fn()
-    onDragging = onDraggingMock as unknown as (dragging: boolean) => void
-    onChangeMock = vi.fn()
-    onChange = onChangeMock as unknown as (
-      transform: CameraHandleTransform,
-      mode: CameraHandleMode
-    ) => void
+    onDragging = vi.fn()
+    onChange = vi.fn()
     handle = new CameraHandle(camera, dom, onDragging, onChange)
     handle.attach(scene)
   })
 
   function controls(): TransformControls {
-    return (handle as unknown as { controls: TransformControls }).controls
+    return gizmoControls(handle)
   }
 
   afterEach(() => {
@@ -76,16 +74,16 @@ describe('CameraHandle', () => {
     expect(proxy.position.x).toBe(1)
     expect(proxy.position.y).toBe(2)
     expect(proxy.position.z).toBe(3)
-    expect(onChangeMock).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('setSubject is a no-op when the pose already matches', () => {
     handle.setSubject({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 1 })
-    onChangeMock.mockClear()
+    onChange.mockClear()
 
     handle.setSubject({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 1 })
 
-    expect(onChangeMock).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('setVisible toggles helper.visible and controls.enabled together', () => {
@@ -106,7 +104,7 @@ describe('CameraHandle', () => {
 
     controls().dispatchEvent({ type: 'objectChange' })
 
-    expect(onChangeMock).toHaveBeenCalledWith(
+    expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ position: { x: 1, y: 2, z: 3 } }),
       'translate'
     )
@@ -115,7 +113,7 @@ describe('CameraHandle', () => {
   it('forwards dragging-changed to the dragging listener', () => {
     controls().dispatchEvent({ type: 'dragging-changed', value: true })
 
-    expect(onDraggingMock).toHaveBeenCalledWith(true)
+    expect(onDragging).toHaveBeenCalledWith(true)
   })
 
   it('dispose removes proxy and helper from the scene', () => {

--- a/src/extensions/core/cameraInfo/handles/CameraHandle.ts
+++ b/src/extensions/core/cameraInfo/handles/CameraHandle.ts
@@ -1,0 +1,149 @@
+import * as THREE from 'three'
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
+
+import type { DraggingChangeListener } from './types'
+
+export type CameraHandleMode = 'translate' | 'rotate'
+
+export interface CameraHandleTransform {
+  position: THREE.Vector3Like
+  quaternion: { x: number; y: number; z: number; w: number }
+}
+
+type ChangeListener = (
+  transform: CameraHandleTransform,
+  mode: CameraHandleMode
+) => void
+
+export class CameraHandle {
+  private readonly proxy: THREE.Object3D
+  private readonly controls: TransformControls
+  private readonly helper: THREE.Object3D
+  private mode: CameraHandleMode = 'translate'
+  private suppressEcho = false
+  private scene: THREE.Scene | null = null
+  private disposed = false
+
+  constructor(
+    camera: THREE.Camera,
+    domElement: HTMLElement,
+    private readonly onDraggingChange: DraggingChangeListener,
+    private readonly onChange: ChangeListener
+  ) {
+    this.proxy = new THREE.Object3D()
+    this.proxy.name = 'CameraInfoCameraProxy'
+
+    this.controls = new TransformControls(camera, domElement)
+    this.controls.setMode(this.mode)
+    this.controls.setSize(0.8)
+    this.controls.setSpace(spaceFor(this.mode))
+    this.controls.attach(this.proxy)
+    this.helper = this.controls.getHelper()
+    this.helper.name = 'CameraInfoCameraHandle'
+    this.helper.visible = false
+    this.controls.enabled = false
+
+    this.controls.addEventListener('dragging-changed', this.onDragging)
+    this.controls.addEventListener('objectChange', this.onObjectChange)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.proxy)
+    scene.add(this.helper)
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.proxy)
+    this.scene.remove(this.helper)
+    this.scene = null
+  }
+
+  setVisible(visible: boolean): void {
+    this.helper.visible = visible
+    this.controls.enabled = visible
+  }
+
+  isVisible(): boolean {
+    return this.helper.visible
+  }
+
+  setMode(mode: CameraHandleMode): void {
+    if (this.mode === mode) return
+    this.mode = mode
+    this.controls.setMode(mode)
+    this.controls.setSpace(spaceFor(mode))
+  }
+
+  getMode(): CameraHandleMode {
+    return this.mode
+  }
+
+  setSubject(
+    position: THREE.Vector3Like,
+    quaternion: { x: number; y: number; z: number; w: number }
+  ): void {
+    const samePosition =
+      this.proxy.position.x === position.x &&
+      this.proxy.position.y === position.y &&
+      this.proxy.position.z === position.z
+    const sameQuaternion =
+      this.proxy.quaternion.x === quaternion.x &&
+      this.proxy.quaternion.y === quaternion.y &&
+      this.proxy.quaternion.z === quaternion.z &&
+      this.proxy.quaternion.w === quaternion.w
+    if (samePosition && sameQuaternion) return
+    this.suppressEcho = true
+    try {
+      this.proxy.position.set(position.x, position.y, position.z)
+      this.proxy.quaternion.set(
+        quaternion.x,
+        quaternion.y,
+        quaternion.z,
+        quaternion.w
+      )
+      this.proxy.updateMatrixWorld(true)
+    } finally {
+      this.suppressEcho = false
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.controls.removeEventListener('dragging-changed', this.onDragging)
+    this.controls.removeEventListener('objectChange', this.onObjectChange)
+    this.controls.detach()
+    this.detach()
+    this.controls.dispose()
+  }
+
+  private readonly onDragging = (event: { value: unknown }): void => {
+    this.onDraggingChange(event.value === true)
+  }
+
+  private readonly onObjectChange = (): void => {
+    if (this.suppressEcho) return
+    this.onChange(
+      {
+        position: {
+          x: this.proxy.position.x,
+          y: this.proxy.position.y,
+          z: this.proxy.position.z
+        },
+        quaternion: {
+          x: this.proxy.quaternion.x,
+          y: this.proxy.quaternion.y,
+          z: this.proxy.quaternion.z,
+          w: this.proxy.quaternion.w
+        }
+      },
+      this.mode
+    )
+  }
+}
+
+function spaceFor(mode: CameraHandleMode): 'world' | 'local' {
+  return mode === 'translate' ? 'world' : 'local'
+}

--- a/src/extensions/core/cameraInfo/handles/OrbitHandles.test.ts
+++ b/src/extensions/core/cameraInfo/handles/OrbitHandles.test.ts
@@ -1,0 +1,125 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DEFAULT_CAMERA_INFO_STATE } from '../types'
+import { OrbitHandles } from './OrbitHandles'
+
+describe('OrbitHandles', () => {
+  let scene: THREE.Scene
+  let handles: OrbitHandles
+
+  beforeEach(() => {
+    scene = new THREE.Scene()
+    handles = new OrbitHandles()
+    handles.attach(scene)
+  })
+
+  afterEach(() => {
+    handles.dispose()
+  })
+
+  it('adds a single root group to the scene on attach', () => {
+    const root = scene.children.find((c) => c.name === 'CameraInfoOrbitHandles')
+    expect(root).toBeDefined()
+  })
+
+  it('exposes three pickable handle meshes tagged with handleType', () => {
+    const meshes = handles.pickableMeshes()
+    expect(meshes).toHaveLength(3)
+    const types = meshes.map((m) => m.userData.handleType).sort()
+    expect(types).toEqual(['distance', 'pitch', 'yaw'])
+  })
+
+  it('positions the yaw handle on the +Z side of the ring at yaw=0', () => {
+    handles.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'orbit',
+      orbit: { yaw: 0, pitch: 0, distance: 5 }
+    })
+
+    const yawHandle = handles
+      .pickableMeshes()
+      .find((m) => m.userData.handleType === 'yaw')!
+    expect(yawHandle.position.x).toBeCloseTo(0)
+    expect(yawHandle.position.z).toBeCloseTo(1.5)
+  })
+
+  it('places the distance handle at the camera (distance along yaw direction)', () => {
+    handles.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'orbit',
+      target: { x: 0, y: 0, z: 0 },
+      orbit: { yaw: 90, pitch: 0, distance: 7 }
+    })
+
+    const distanceHandle = handles
+      .pickableMeshes()
+      .find((m) => m.userData.handleType === 'distance')!
+    const world = new THREE.Vector3()
+    distanceHandle.getWorldPosition(world)
+    expect(world.x).toBeCloseTo(7)
+    expect(world.y).toBeCloseTo(0)
+    expect(world.z).toBeCloseTo(0)
+  })
+
+  it('places the distance handle along a nonzero-pitch camera direction', () => {
+    handles.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'orbit',
+      target: { x: 0, y: 0, z: 0 },
+      orbit: { yaw: 0, pitch: 45, distance: 10 }
+    })
+
+    const distanceHandle = handles
+      .pickableMeshes()
+      .find((m) => m.userData.handleType === 'distance')!
+    const world = new THREE.Vector3()
+    distanceHandle.getWorldPosition(world)
+    expect(world.x).toBeCloseTo(0)
+    expect(world.y).toBeCloseTo(10 * Math.SQRT1_2)
+    expect(world.z).toBeCloseTo(10 * Math.SQRT1_2)
+  })
+
+  it('hides itself in non-orbit modes', () => {
+    handles.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'look_at' })
+
+    const root = scene.children.find(
+      (c) => c.name === 'CameraInfoOrbitHandles'
+    )!
+    expect(root.visible).toBe(false)
+  })
+
+  it('setVisible forces visibility independent of mode', () => {
+    handles.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'orbit' })
+    handles.setVisible(false)
+
+    const root = scene.children.find(
+      (c) => c.name === 'CameraInfoOrbitHandles'
+    )!
+    expect(root.visible).toBe(false)
+  })
+
+  it('reports not visible in quaternion mode', () => {
+    handles.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'quaternion' })
+
+    expect(handles.isVisible()).toBe(false)
+  })
+
+  it('yaw drag plane is horizontal through target', () => {
+    const plane = handles.dragPlaneFor('yaw', {
+      ...DEFAULT_CAMERA_INFO_STATE,
+      target: { x: 0, y: 3, z: 0 }
+    })
+    expect(plane.normal.y).toBeCloseTo(1)
+    expect(plane.constant).toBeCloseTo(-3)
+  })
+
+  it('pitch drag plane is vertical and orthogonal to yaw direction', () => {
+    const plane = handles.dragPlaneFor('pitch', {
+      ...DEFAULT_CAMERA_INFO_STATE,
+      orbit: { yaw: 0, pitch: 0, distance: 5 }
+    })
+    expect(Math.abs(plane.normal.x)).toBeCloseTo(1)
+    expect(plane.normal.y).toBeCloseTo(0)
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/OrbitHandles.ts
+++ b/src/extensions/core/cameraInfo/handles/OrbitHandles.ts
@@ -1,0 +1,258 @@
+import * as THREE from 'three'
+
+import type { CameraInfoState } from '../types'
+
+const RING_RADIUS = 1.5
+const HANDLE_RADIUS = 0.08
+const GLOW_RADIUS = 0.12
+const TUBE_RADIUS = 0.025
+const ARC_PITCH_LIMIT = 85
+const ARC_SEGMENTS = 32
+
+const YAW_COLOR = 0x00d4ff
+const PITCH_COLOR = 0xff66ff
+const DISTANCE_COLOR = 0xffcc00
+
+const BASE_GLOW_OPACITY = 0.25
+const HOVER_GLOW_OPACITY = 0.6
+const HOVER_SCALE = 1.35
+
+export type OrbitHandleType = 'yaw' | 'pitch' | 'distance'
+
+const DEG2RAD = Math.PI / 180
+
+function buildArcCurve(): THREE.CatmullRomCurve3 {
+  const points: THREE.Vector3[] = []
+  for (let deg = -ARC_PITCH_LIMIT; deg <= ARC_PITCH_LIMIT; deg += 5) {
+    const r = deg * DEG2RAD
+    points.push(
+      new THREE.Vector3(0, RING_RADIUS * Math.sin(r), RING_RADIUS * Math.cos(r))
+    )
+  }
+  return new THREE.CatmullRomCurve3(points)
+}
+
+function makeHandle(color: number, type: OrbitHandleType): THREE.Mesh {
+  const mesh = new THREE.Mesh(
+    new THREE.SphereGeometry(HANDLE_RADIUS, 32, 32),
+    new THREE.MeshStandardMaterial({
+      color,
+      emissive: color,
+      emissiveIntensity: 0.7,
+      roughness: 0.3,
+      metalness: 0.2
+    })
+  )
+  mesh.userData.handleType = type
+  return mesh
+}
+
+function makeGlow(color: number): THREE.Mesh {
+  return new THREE.Mesh(
+    new THREE.SphereGeometry(GLOW_RADIUS, 16, 16),
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity: BASE_GLOW_OPACITY,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending
+    })
+  )
+}
+
+export class OrbitHandles {
+  private readonly root = new THREE.Group()
+  private readonly yawGroup = new THREE.Group()
+
+  private readonly yawRing: THREE.Mesh
+  private readonly pitchArc: THREE.Mesh
+  private readonly distanceLine: THREE.Line
+  private readonly distanceLineGeometry: THREE.BufferGeometry
+
+  private readonly yawHandle: THREE.Mesh
+  private readonly pitchHandle: THREE.Mesh
+  private readonly distanceHandle: THREE.Mesh
+
+  private readonly yawHandleGlow: THREE.Mesh
+  private readonly pitchHandleGlow: THREE.Mesh
+  private readonly distanceHandleGlow: THREE.Mesh
+
+  private scene: THREE.Scene | null = null
+  private disposed = false
+
+  constructor() {
+    this.root.name = 'CameraInfoOrbitHandles'
+    this.root.add(this.yawGroup)
+
+    this.yawRing = new THREE.Mesh(
+      new THREE.TorusGeometry(RING_RADIUS, TUBE_RADIUS, 16, 96),
+      new THREE.MeshBasicMaterial({
+        color: YAW_COLOR,
+        transparent: true,
+        opacity: 0.55
+      })
+    )
+    this.yawRing.rotation.x = Math.PI / 2
+    this.root.add(this.yawRing)
+
+    this.pitchArc = new THREE.Mesh(
+      new THREE.TubeGeometry(
+        buildArcCurve(),
+        ARC_SEGMENTS,
+        TUBE_RADIUS,
+        8,
+        false
+      ),
+      new THREE.MeshBasicMaterial({
+        color: PITCH_COLOR,
+        transparent: true,
+        opacity: 0.55
+      })
+    )
+    this.yawGroup.add(this.pitchArc)
+
+    this.distanceLineGeometry = new THREE.BufferGeometry()
+    this.distanceLineGeometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute([0, 0, 0, 0, 0, 1], 3)
+    )
+    this.distanceLine = new THREE.Line(
+      this.distanceLineGeometry,
+      new THREE.LineBasicMaterial({
+        color: DISTANCE_COLOR,
+        transparent: true,
+        opacity: 0.55
+      })
+    )
+    this.yawGroup.add(this.distanceLine)
+
+    this.yawHandle = makeHandle(YAW_COLOR, 'yaw')
+    this.yawHandleGlow = makeGlow(YAW_COLOR)
+    this.yawHandle.add(this.yawHandleGlow)
+    this.root.add(this.yawHandle)
+
+    this.pitchHandle = makeHandle(PITCH_COLOR, 'pitch')
+    this.pitchHandleGlow = makeGlow(PITCH_COLOR)
+    this.pitchHandle.add(this.pitchHandleGlow)
+    this.yawGroup.add(this.pitchHandle)
+
+    this.distanceHandle = makeHandle(DISTANCE_COLOR, 'distance')
+    this.distanceHandleGlow = makeGlow(DISTANCE_COLOR)
+    this.distanceHandle.add(this.distanceHandleGlow)
+    this.yawGroup.add(this.distanceHandle)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.root)
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.root)
+    this.scene = null
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.detach()
+    const disposables: { dispose: () => void }[] = [
+      this.yawRing.geometry,
+      this.yawRing.material as THREE.Material,
+      this.pitchArc.geometry,
+      this.pitchArc.material as THREE.Material,
+      this.distanceLineGeometry,
+      this.distanceLine.material as THREE.Material,
+      this.yawHandle.geometry,
+      this.yawHandle.material as THREE.Material,
+      this.pitchHandle.geometry,
+      this.pitchHandle.material as THREE.Material,
+      this.distanceHandle.geometry,
+      this.distanceHandle.material as THREE.Material,
+      this.yawHandleGlow.geometry,
+      this.yawHandleGlow.material as THREE.Material,
+      this.pitchHandleGlow.geometry,
+      this.pitchHandleGlow.material as THREE.Material,
+      this.distanceHandleGlow.geometry,
+      this.distanceHandleGlow.material as THREE.Material
+    ]
+    for (const d of disposables) d.dispose()
+  }
+
+  setVisible(visible: boolean): void {
+    this.root.visible = visible
+  }
+
+  isVisible(): boolean {
+    return this.root.visible
+  }
+
+  update(state: CameraInfoState): void {
+    const visible = state.mode === 'orbit'
+    this.root.visible = visible
+    if (!visible) return
+
+    this.root.position.set(state.target.x, state.target.y, state.target.z)
+
+    const yawRad = state.orbit.yaw * DEG2RAD
+    const pitchRad = state.orbit.pitch * DEG2RAD
+    const cosP = Math.cos(pitchRad)
+    const sinP = Math.sin(pitchRad)
+
+    this.yawGroup.rotation.y = yawRad
+
+    this.yawHandle.position.set(
+      RING_RADIUS * Math.sin(yawRad),
+      0,
+      RING_RADIUS * Math.cos(yawRad)
+    )
+
+    this.pitchHandle.position.set(0, RING_RADIUS * sinP, RING_RADIUS * cosP)
+
+    const endY = state.orbit.distance * sinP
+    const endZ = state.orbit.distance * cosP
+    this.distanceHandle.position.set(0, endY, endZ)
+
+    const positions = this.distanceLineGeometry.attributes
+      .position as THREE.BufferAttribute
+    positions.setXYZ(1, 0, endY, endZ)
+    positions.needsUpdate = true
+  }
+
+  pickableMeshes(): THREE.Object3D[] {
+    return [this.yawHandle, this.pitchHandle, this.distanceHandle]
+  }
+
+  setHovered(type: OrbitHandleType | null): void {
+    const entries: [THREE.Mesh, THREE.Mesh, OrbitHandleType][] = [
+      [this.yawHandle, this.yawHandleGlow, 'yaw'],
+      [this.pitchHandle, this.pitchHandleGlow, 'pitch'],
+      [this.distanceHandle, this.distanceHandleGlow, 'distance']
+    ]
+    for (const [handle, glow, handleType] of entries) {
+      const active = handleType === type
+      handle.scale.setScalar(active ? HOVER_SCALE : 1)
+      ;(glow.material as THREE.MeshBasicMaterial).opacity = active
+        ? HOVER_GLOW_OPACITY
+        : BASE_GLOW_OPACITY
+    }
+  }
+
+  dragPlaneFor(type: OrbitHandleType, state: CameraInfoState): THREE.Plane {
+    if (type === 'yaw') {
+      return new THREE.Plane(new THREE.Vector3(0, 1, 0), -state.target.y)
+    }
+    const yawRad = state.orbit.yaw * DEG2RAD
+    const normal = new THREE.Vector3(
+      -Math.cos(yawRad),
+      0,
+      Math.sin(yawRad)
+    ).normalize()
+    const targetVec = vec(state.target)
+    return new THREE.Plane().setFromNormalAndCoplanarPoint(normal, targetVec)
+  }
+}
+
+const vec = (v: THREE.Vector3Like): THREE.Vector3 =>
+  new THREE.Vector3(v.x, v.y, v.z)

--- a/src/extensions/core/cameraInfo/handles/RollHandle.test.ts
+++ b/src/extensions/core/cameraInfo/handles/RollHandle.test.ts
@@ -1,0 +1,110 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DEFAULT_CAMERA_INFO_STATE } from '../types'
+import { RollHandle } from './RollHandle'
+
+describe('RollHandle', () => {
+  let scene: THREE.Scene
+  let handle: RollHandle
+
+  beforeEach(() => {
+    scene = new THREE.Scene()
+    handle = new RollHandle()
+    handle.attach(scene)
+  })
+
+  afterEach(() => {
+    handle.dispose()
+  })
+
+  it('attaches a single root group to the scene', () => {
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoRollHandle')
+    ).toBeDefined()
+  })
+
+  it('exposes one pickable mesh tagged handleType="roll"', () => {
+    const meshes = handle.pickableMeshes()
+    expect(meshes).toHaveLength(1)
+    expect(meshes[0].userData.handleType).toBe('roll')
+  })
+
+  it('hides itself in quaternion mode (rotate gizmo owns roll there)', () => {
+    handle.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'quaternion' })
+
+    expect(handle.isVisible()).toBe(false)
+  })
+
+  it('is visible in orbit and look_at modes', () => {
+    handle.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'orbit' })
+    expect(handle.isVisible()).toBe(true)
+
+    handle.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'look_at' })
+    expect(handle.isVisible()).toBe(true)
+  })
+
+  it('setVisible forces visibility', () => {
+    handle.update({ ...DEFAULT_CAMERA_INFO_STATE, mode: 'orbit' })
+    handle.setVisible(false)
+
+    expect(handle.isVisible()).toBe(false)
+  })
+
+  it('positions itself at the target', () => {
+    handle.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'orbit',
+      target: { x: 1, y: 2, z: 3 }
+    })
+
+    const root = scene.children.find((c) => c.name === 'CameraInfoRollHandle')!
+    expect(root.position.x).toBeCloseTo(1)
+    expect(root.position.y).toBeCloseTo(2)
+    expect(root.position.z).toBeCloseTo(3)
+  })
+
+  it('places the pickable handle on the +right axis at roll=90', () => {
+    handle.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'look_at',
+      target: { x: 0, y: 0, z: 0 },
+      lookAt: { position: { x: 0, y: 0, z: 5 } },
+      roll: 90
+    })
+
+    const world = new THREE.Vector3()
+    handle.pickableMeshes()[0].getWorldPosition(world)
+    expect(world.x).toBeCloseTo(0.9)
+    expect(world.y).toBeCloseTo(0)
+    expect(world.z).toBeCloseTo(0)
+  })
+
+  it('places the pickable handle on the +up axis at roll=0', () => {
+    handle.update({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'look_at',
+      target: { x: 0, y: 0, z: 0 },
+      lookAt: { position: { x: 0, y: 0, z: 5 } },
+      roll: 0
+    })
+
+    const world = new THREE.Vector3()
+    handle.pickableMeshes()[0].getWorldPosition(world)
+    expect(world.x).toBeCloseTo(0)
+    expect(world.y).toBeCloseTo(0.9)
+    expect(world.z).toBeCloseTo(0)
+  })
+
+  it('drag plane normal points along the camera→target backward direction', () => {
+    const plane = handle.dragPlane({
+      ...DEFAULT_CAMERA_INFO_STATE,
+      mode: 'look_at',
+      target: { x: 0, y: 0, z: 0 },
+      lookAt: { position: { x: 0, y: 0, z: 5 } }
+    })
+    expect(plane.normal.x).toBeCloseTo(0)
+    expect(plane.normal.y).toBeCloseTo(0)
+    expect(Math.abs(plane.normal.z)).toBeCloseTo(1)
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/RollHandle.ts
+++ b/src/extensions/core/cameraInfo/handles/RollHandle.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three'
+
+import { computeSubjectTransform } from '../cameraTransform'
+import type { CameraInfoState } from '../types'
+import { rollBasis } from './rollDragMath'
+
+const RING_RADIUS = 0.9
+const HANDLE_RADIUS = 0.08
+const GLOW_RADIUS = 0.12
+const TUBE_RADIUS = 0.025
+
+const ROLL_COLOR = 0xff8800
+const BASE_GLOW_OPACITY = 0.25
+const HOVER_GLOW_OPACITY = 0.6
+const HOVER_SCALE = 1.35
+
+const DEG2RAD = Math.PI / 180
+
+function makeHandle(): THREE.Mesh {
+  const mesh = new THREE.Mesh(
+    new THREE.SphereGeometry(HANDLE_RADIUS, 32, 32),
+    new THREE.MeshStandardMaterial({
+      color: ROLL_COLOR,
+      emissive: ROLL_COLOR,
+      emissiveIntensity: 0.7,
+      roughness: 0.3,
+      metalness: 0.2
+    })
+  )
+  mesh.userData.handleType = 'roll'
+  return mesh
+}
+
+export class RollHandle {
+  private readonly root = new THREE.Group()
+  private readonly ring: THREE.Mesh
+  private readonly handle: THREE.Mesh
+  private readonly handleGlow: THREE.Mesh
+
+  private scene: THREE.Scene | null = null
+  private disposed = false
+
+  constructor() {
+    this.root.name = 'CameraInfoRollHandle'
+
+    this.ring = new THREE.Mesh(
+      new THREE.TorusGeometry(RING_RADIUS, TUBE_RADIUS, 16, 80),
+      new THREE.MeshBasicMaterial({
+        color: ROLL_COLOR,
+        transparent: true,
+        opacity: 0.55
+      })
+    )
+    this.root.add(this.ring)
+
+    this.handle = makeHandle()
+    this.handleGlow = new THREE.Mesh(
+      new THREE.SphereGeometry(GLOW_RADIUS, 16, 16),
+      new THREE.MeshBasicMaterial({
+        color: ROLL_COLOR,
+        transparent: true,
+        opacity: BASE_GLOW_OPACITY,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending
+      })
+    )
+    this.handle.add(this.handleGlow)
+    this.root.add(this.handle)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.root)
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.root)
+    this.scene = null
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.detach()
+    const disposables: { dispose: () => void }[] = [
+      this.ring.geometry,
+      this.ring.material as THREE.Material,
+      this.handle.geometry,
+      this.handle.material as THREE.Material,
+      this.handleGlow.geometry,
+      this.handleGlow.material as THREE.Material
+    ]
+    for (const d of disposables) d.dispose()
+  }
+
+  setVisible(visible: boolean): void {
+    this.root.visible = visible
+  }
+
+  isVisible(): boolean {
+    return this.root.visible
+  }
+
+  update(state: CameraInfoState): void {
+    if (state.mode === 'quaternion') {
+      this.root.visible = false
+      return
+    }
+    this.root.visible = true
+
+    const { position: cameraPos } = computeSubjectTransform(state)
+    const { up, right, backward } = rollBasis(state.target, cameraPos)
+
+    this.root.position.set(state.target.x, state.target.y, state.target.z)
+    const orient = new THREE.Quaternion().setFromRotationMatrix(
+      new THREE.Matrix4().makeBasis(right, up, backward)
+    )
+    this.root.quaternion.copy(orient)
+
+    const theta = state.roll * DEG2RAD
+    this.handle.position.set(
+      RING_RADIUS * Math.sin(theta),
+      RING_RADIUS * Math.cos(theta),
+      0
+    )
+  }
+
+  pickableMeshes(): THREE.Object3D[] {
+    return [this.handle]
+  }
+
+  setHovered(hovered: boolean): void {
+    this.handle.scale.setScalar(hovered ? HOVER_SCALE : 1)
+    ;(this.handleGlow.material as THREE.MeshBasicMaterial).opacity = hovered
+      ? HOVER_GLOW_OPACITY
+      : BASE_GLOW_OPACITY
+  }
+
+  dragPlane(state: CameraInfoState): THREE.Plane {
+    const { position: cameraPos } = computeSubjectTransform(state)
+    const { backward } = rollBasis(state.target, cameraPos)
+    const tgt = new THREE.Vector3(
+      state.target.x,
+      state.target.y,
+      state.target.z
+    )
+    return new THREE.Plane().setFromNormalAndCoplanarPoint(backward, tgt)
+  }
+}

--- a/src/extensions/core/cameraInfo/handles/TargetHandle.test.ts
+++ b/src/extensions/core/cameraInfo/handles/TargetHandle.test.ts
@@ -1,0 +1,84 @@
+import * as THREE from 'three'
+import type { TransformControls } from 'three/examples/jsm/controls/TransformControls'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TargetHandle } from './TargetHandle'
+
+describe('TargetHandle', () => {
+  let scene: THREE.Scene
+  let onDragging: ReturnType<typeof vi.fn>
+  let onChange: ReturnType<typeof vi.fn>
+  let handle: TargetHandle
+
+  beforeEach(() => {
+    scene = new THREE.Scene()
+    onDragging = vi.fn()
+    onChange = vi.fn()
+    handle = new TargetHandle(
+      new THREE.PerspectiveCamera(),
+      document.createElement('div'),
+      onDragging as unknown as (dragging: boolean) => void,
+      onChange as unknown as (target: THREE.Vector3Like) => void
+    )
+    handle.attach(scene)
+  })
+
+  afterEach(() => {
+    handle.dispose()
+  })
+
+  function proxy(): THREE.Object3D {
+    return scene.children.find((c) => c.name === 'CameraInfoTargetProxy')!
+  }
+
+  function controls(): TransformControls {
+    return (handle as unknown as { controls: TransformControls }).controls
+  }
+
+  it('adds proxy + helper to the scene on attach', () => {
+    expect(proxy()).toBeDefined()
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoTargetHandle')
+    ).toBeDefined()
+  })
+
+  it('starts hidden and toggles visibility', () => {
+    expect(handle.isVisible()).toBe(false)
+    handle.setVisible(true)
+    expect(handle.isVisible()).toBe(true)
+  })
+
+  it('setTarget moves the proxy without echoing onChange', () => {
+    handle.setTarget({ x: 1, y: 2, z: 3 })
+
+    expect(proxy().position.toArray()).toEqual([1, 2, 3])
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('setTarget is a no-op when the position already matches', () => {
+    handle.setTarget({ x: 0, y: 0, z: 0 })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('emits onChange with the proxy position on gizmo objectChange', () => {
+    proxy().position.set(4, 5, 6)
+    controls().dispatchEvent({ type: 'objectChange' })
+
+    expect(onChange).toHaveBeenCalledWith({ x: 4, y: 5, z: 6 })
+  })
+
+  it('forwards dragging-changed to onDraggingChange', () => {
+    controls().dispatchEvent({ type: 'dragging-changed', value: true })
+
+    expect(onDragging).toHaveBeenCalledWith(true)
+  })
+
+  it('dispose removes proxy and helper', () => {
+    handle.dispose()
+
+    expect(proxy()).toBeUndefined()
+    expect(
+      scene.children.find((c) => c.name === 'CameraInfoTargetHandle')
+    ).toBeUndefined()
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/TargetHandle.test.ts
+++ b/src/extensions/core/cameraInfo/handles/TargetHandle.test.ts
@@ -4,10 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TargetHandle } from './TargetHandle'
 
+function gizmoControls(handle: unknown): TransformControls {
+  return (handle as { controls: TransformControls }).controls
+}
+
 describe('TargetHandle', () => {
   let scene: THREE.Scene
-  let onDragging: ReturnType<typeof vi.fn>
-  let onChange: ReturnType<typeof vi.fn>
+  let onDragging: ReturnType<typeof vi.fn<(dragging: boolean) => void>>
+  let onChange: ReturnType<typeof vi.fn<(target: THREE.Vector3Like) => void>>
   let handle: TargetHandle
 
   beforeEach(() => {
@@ -17,8 +21,8 @@ describe('TargetHandle', () => {
     handle = new TargetHandle(
       new THREE.PerspectiveCamera(),
       document.createElement('div'),
-      onDragging as unknown as (dragging: boolean) => void,
-      onChange as unknown as (target: THREE.Vector3Like) => void
+      onDragging,
+      onChange
     )
     handle.attach(scene)
   })
@@ -32,7 +36,7 @@ describe('TargetHandle', () => {
   }
 
   function controls(): TransformControls {
-    return (handle as unknown as { controls: TransformControls }).controls
+    return gizmoControls(handle)
   }
 
   it('adds proxy + helper to the scene on attach', () => {
@@ -56,7 +60,10 @@ describe('TargetHandle', () => {
   })
 
   it('setTarget is a no-op when the position already matches', () => {
-    handle.setTarget({ x: 0, y: 0, z: 0 })
+    handle.setTarget({ x: 1, y: 2, z: 3 })
+    handle.setTarget({ x: 1, y: 2, z: 3 })
+
+    expect(proxy().position.toArray()).toEqual([1, 2, 3])
     expect(onChange).not.toHaveBeenCalled()
   })
 

--- a/src/extensions/core/cameraInfo/handles/TargetHandle.ts
+++ b/src/extensions/core/cameraInfo/handles/TargetHandle.ts
@@ -1,0 +1,99 @@
+import * as THREE from 'three'
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
+
+import type { DraggingChangeListener } from './types'
+
+type ChangeListener = (target: THREE.Vector3Like) => void
+
+export class TargetHandle {
+  private readonly proxy: THREE.Object3D
+  private readonly controls: TransformControls
+  private readonly helper: THREE.Object3D
+  private suppressEcho = false
+  private scene: THREE.Scene | null = null
+  private disposed = false
+
+  constructor(
+    camera: THREE.Camera,
+    domElement: HTMLElement,
+    private readonly onDraggingChange: DraggingChangeListener,
+    private readonly onChange: ChangeListener
+  ) {
+    this.proxy = new THREE.Object3D()
+    this.proxy.name = 'CameraInfoTargetProxy'
+
+    this.controls = new TransformControls(camera, domElement)
+    this.controls.setMode('translate')
+    this.controls.setSize(0.8)
+    this.controls.attach(this.proxy)
+    this.helper = this.controls.getHelper()
+    this.helper.name = 'CameraInfoTargetHandle'
+    this.helper.visible = false
+    this.controls.enabled = false
+
+    this.controls.addEventListener('dragging-changed', this.onDragging)
+    this.controls.addEventListener('objectChange', this.onObjectChange)
+  }
+
+  attach(scene: THREE.Scene): void {
+    this.scene = scene
+    scene.add(this.proxy)
+    scene.add(this.helper)
+  }
+
+  detach(): void {
+    if (!this.scene) return
+    this.scene.remove(this.proxy)
+    this.scene.remove(this.helper)
+    this.scene = null
+  }
+
+  setVisible(visible: boolean): void {
+    this.helper.visible = visible
+    this.controls.enabled = visible
+  }
+
+  isVisible(): boolean {
+    return this.helper.visible
+  }
+
+  setTarget(target: THREE.Vector3Like): void {
+    if (
+      this.proxy.position.x === target.x &&
+      this.proxy.position.y === target.y &&
+      this.proxy.position.z === target.z
+    ) {
+      return
+    }
+    this.suppressEcho = true
+    try {
+      this.proxy.position.set(target.x, target.y, target.z)
+      this.proxy.updateMatrixWorld(true)
+    } finally {
+      this.suppressEcho = false
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.controls.removeEventListener('dragging-changed', this.onDragging)
+    this.controls.removeEventListener('objectChange', this.onObjectChange)
+    this.controls.detach()
+    this.detach()
+    this.controls.dispose()
+  }
+
+  private readonly onDragging = (event: { value: unknown }): void => {
+    this.onDraggingChange(event.value === true)
+  }
+
+  private readonly onObjectChange = (): void => {
+    if (this.suppressEcho) return
+    this.onChange({
+      x: this.proxy.position.x,
+      y: this.proxy.position.y,
+      z: this.proxy.position.z
+    })
+  }
+}

--- a/src/extensions/core/cameraInfo/handles/handlePicking.test.ts
+++ b/src/extensions/core/cameraInfo/handles/handlePicking.test.ts
@@ -1,0 +1,104 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { pickHandleAtPointer } from './handlePicking'
+
+const CANVAS = { clientWidth: 400, clientHeight: 400 }
+
+function makeHandle(handleType: string, position: THREE.Vector3): THREE.Mesh {
+  const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.08, 8, 8))
+  mesh.userData.handleType = handleType
+  mesh.position.copy(position)
+  mesh.updateMatrixWorld(true)
+  return mesh
+}
+
+describe('pickHandleAtPointer', () => {
+  let camera: THREE.PerspectiveCamera
+  let raycaster: THREE.Raycaster
+
+  beforeEach(() => {
+    camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100)
+    camera.position.set(0, 0, 10)
+    camera.lookAt(0, 0, 0)
+    camera.updateMatrixWorld(true)
+    camera.updateProjectionMatrix()
+    raycaster = new THREE.Raycaster()
+  })
+
+  it('returns the handle type on a direct raycast hit', () => {
+    const handle = makeHandle('yaw', new THREE.Vector3(0, 0, 0))
+    const picked = pickHandleAtPointer(
+      raycaster,
+      new THREE.Vector2(0, 0),
+      camera,
+      [handle],
+      CANVAS
+    )
+    expect(picked).toBe('yaw')
+  })
+
+  it('picks a handle within the screen-space tolerance on a near miss', () => {
+    const handle = makeHandle('pitch', new THREE.Vector3(0, 0, 0))
+    // ~10px off centre: outside the 0.08-radius sphere but inside tolerance.
+    const nearMissNdc = new THREE.Vector2(10 / (CANVAS.clientWidth / 2), 0)
+    const picked = pickHandleAtPointer(
+      raycaster,
+      nearMissNdc,
+      camera,
+      [handle],
+      CANVAS
+    )
+    expect(picked).toBe('pitch')
+  })
+
+  it('returns null when the pointer is far from every handle', () => {
+    const handle = makeHandle('distance', new THREE.Vector3(0, 0, 0))
+    const picked = pickHandleAtPointer(
+      raycaster,
+      new THREE.Vector2(0.5, 0.5),
+      camera,
+      [handle],
+      CANVAS
+    )
+    expect(picked).toBeNull()
+  })
+
+  it('prefers the nearest handle when several are within tolerance', () => {
+    // The pointer misses both spheres (no direct raycast hit) but sits inside
+    // the screen-space tolerance of each centre; the nearer centre wins.
+    const near = makeHandle('yaw', new THREE.Vector3(0.05, 0, 5))
+    const far = makeHandle('pitch', new THREE.Vector3(-0.05, 0, 5))
+    const picked = pickHandleAtPointer(
+      raycaster,
+      new THREE.Vector2(0.01, -0.04),
+      camera,
+      [far, near],
+      CANVAS
+    )
+    expect(picked).toBe('yaw')
+  })
+
+  it('ignores handles behind the camera', () => {
+    const behind = makeHandle('yaw', new THREE.Vector3(0, 0, 20))
+    const picked = pickHandleAtPointer(
+      raycaster,
+      new THREE.Vector2(0, 0),
+      camera,
+      [behind],
+      CANVAS
+    )
+    expect(picked).toBeNull()
+  })
+
+  it('returns null with no targets', () => {
+    const picked = pickHandleAtPointer(
+      raycaster,
+      new THREE.Vector2(0, 0),
+      camera,
+      [],
+      CANVAS
+    )
+    expect(picked).toBeNull()
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/handlePicking.ts
+++ b/src/extensions/core/cameraInfo/handles/handlePicking.ts
@@ -1,0 +1,51 @@
+import * as THREE from 'three'
+
+const PICK_PIXEL_RADIUS = 14
+
+interface CanvasSize {
+  clientWidth: number
+  clientHeight: number
+}
+
+function toScreenPx(
+  ndcX: number,
+  ndcY: number,
+  canvas: CanvasSize
+): THREE.Vector2 {
+  return new THREE.Vector2(
+    (ndcX + 1) * 0.5 * canvas.clientWidth,
+    (1 - (ndcY + 1) * 0.5) * canvas.clientHeight
+  )
+}
+
+export function pickHandleAtPointer<T extends string>(
+  raycaster: THREE.Raycaster,
+  pointerNdc: THREE.Vector2,
+  camera: THREE.Camera,
+  targets: THREE.Object3D[],
+  canvas: CanvasSize
+): T | null {
+  if (targets.length === 0) return null
+
+  raycaster.setFromCamera(pointerNdc, camera)
+  const hits = raycaster.intersectObjects(targets, false)
+  if (hits.length > 0) return hits[0].object.userData.handleType as T
+
+  const pointerPx = toScreenPx(pointerNdc.x, pointerNdc.y, canvas)
+  const world = new THREE.Vector3()
+  let best: T | null = null
+  let bestDistance = PICK_PIXEL_RADIUS
+  for (const target of targets) {
+    target.getWorldPosition(world)
+    const view = world.clone().applyMatrix4(camera.matrixWorldInverse)
+    if (view.z >= 0) continue // behind the camera
+    const ndc = world.project(camera)
+    const px = toScreenPx(ndc.x, ndc.y, canvas)
+    const distance = px.distanceTo(pointerPx)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = target.userData.handleType as T
+    }
+  }
+  return best
+}

--- a/src/extensions/core/cameraInfo/handles/orbitDragMath.test.ts
+++ b/src/extensions/core/cameraInfo/handles/orbitDragMath.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_DISTANCE,
+  MAX_PITCH,
+  MIN_DISTANCE,
+  MIN_PITCH,
+  pointToDistance,
+  pointToPitchAngle,
+  pointToYawAngle
+} from './orbitDragMath'
+
+const TARGET = { x: 0, y: 0, z: 0 }
+const SHIFTED_TARGET = { x: 2, y: 1, z: -3 }
+
+describe('pointToYawAngle', () => {
+  it('returns 0 when the point sits on +Z relative to the target', () => {
+    expect(pointToYawAngle({ x: 0, y: 0, z: 5 }, TARGET)).toBeCloseTo(0)
+  })
+
+  it('returns 90 when the point sits on +X (rotation around Y)', () => {
+    expect(pointToYawAngle({ x: 5, y: 0, z: 0 }, TARGET)).toBeCloseTo(90)
+  })
+
+  it('returns -90 when the point sits on -X', () => {
+    expect(pointToYawAngle({ x: -5, y: 0, z: 0 }, TARGET)).toBeCloseTo(-90)
+  })
+
+  it('returns 180 (or -180) when the point sits on -Z', () => {
+    expect(
+      Math.abs(pointToYawAngle({ x: 0, y: 0, z: -5 }, TARGET))
+    ).toBeCloseTo(180)
+  })
+
+  it('is invariant to the y component of the point and target', () => {
+    expect(
+      pointToYawAngle({ x: 3, y: 99, z: 4 }, { x: 0, y: -7, z: 0 })
+    ).toBeCloseTo(pointToYawAngle({ x: 3, y: 0, z: 4 }, TARGET))
+  })
+
+  it('works against a non-origin target', () => {
+    expect(
+      pointToYawAngle(
+        { x: SHIFTED_TARGET.x, y: 0, z: SHIFTED_TARGET.z + 5 },
+        SHIFTED_TARGET
+      )
+    ).toBeCloseTo(0)
+  })
+})
+
+describe('pointToPitchAngle', () => {
+  it('returns 0 when the point lies in the horizontal plane', () => {
+    expect(pointToPitchAngle({ x: 0, y: 0, z: 5 }, TARGET, 0)).toBeCloseTo(0)
+  })
+
+  it('returns +45 for a point lifted to (0, h, h) at yaw=0', () => {
+    expect(pointToPitchAngle({ x: 0, y: 5, z: 5 }, TARGET, 0)).toBeCloseTo(45)
+  })
+
+  it('returns -30 for a downward-pointing intersection at yaw=0', () => {
+    const h = 5
+    const v = h * Math.tan((30 * Math.PI) / 180)
+    expect(pointToPitchAngle({ x: 0, y: -v, z: h }, TARGET, 0)).toBeCloseTo(-30)
+  })
+
+  it('respects the current yaw direction when projecting horizontally', () => {
+    expect(pointToPitchAngle({ x: 5, y: 5, z: 0 }, TARGET, 90)).toBeCloseTo(45)
+  })
+
+  it('clamps to MAX_PITCH past the upper pole', () => {
+    expect(pointToPitchAngle({ x: 0, y: 100, z: 0.001 }, TARGET, 0)).toBe(
+      MAX_PITCH
+    )
+  })
+
+  it('clamps to MIN_PITCH past the lower pole', () => {
+    expect(pointToPitchAngle({ x: 0, y: -100, z: 0.001 }, TARGET, 0)).toBe(
+      MIN_PITCH
+    )
+  })
+})
+
+describe('pointToDistance', () => {
+  it('returns the radial projection at yaw=0, pitch=0', () => {
+    expect(pointToDistance({ x: 0, y: 0, z: 7 }, TARGET, 0, 0)).toBeCloseTo(7)
+  })
+
+  it('returns the radial projection along the current yaw direction', () => {
+    expect(pointToDistance({ x: 4, y: 0, z: 0 }, TARGET, 90, 0)).toBeCloseTo(4)
+  })
+
+  it('ignores off-axis components of the point', () => {
+    expect(pointToDistance({ x: 99, y: 0, z: 5 }, TARGET, 0, 0)).toBeCloseTo(5)
+  })
+
+  it('clamps to MIN_DISTANCE when the projection goes behind the target', () => {
+    expect(pointToDistance({ x: 0, y: 0, z: -10 }, TARGET, 0, 0)).toBe(
+      MIN_DISTANCE
+    )
+  })
+
+  it('clamps to MAX_DISTANCE when the projection overshoots', () => {
+    expect(pointToDistance({ x: 0, y: 0, z: 99999 }, TARGET, 0, 0)).toBe(
+      MAX_DISTANCE
+    )
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/orbitDragMath.test.ts
+++ b/src/extensions/core/cameraInfo/handles/orbitDragMath.test.ts
@@ -105,3 +105,20 @@ describe('pointToDistance', () => {
     )
   })
 })
+
+describe('point coinciding with the target', () => {
+  it('yields a finite yaw of 0', () => {
+    expect(pointToYawAngle(SHIFTED_TARGET, SHIFTED_TARGET)).toBe(0)
+  })
+
+  it('yields a finite pitch of 0 at any yaw', () => {
+    expect(pointToPitchAngle(SHIFTED_TARGET, SHIFTED_TARGET, 0)).toBe(0)
+    expect(pointToPitchAngle(SHIFTED_TARGET, SHIFTED_TARGET, 137)).toBe(0)
+  })
+
+  it('yields MIN_DISTANCE instead of collapsing to 0', () => {
+    expect(pointToDistance(SHIFTED_TARGET, SHIFTED_TARGET, 0, 0)).toBe(
+      MIN_DISTANCE
+    )
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/orbitDragMath.ts
+++ b/src/extensions/core/cameraInfo/handles/orbitDragMath.ts
@@ -1,0 +1,50 @@
+import { clamp } from 'es-toolkit'
+
+import type { Vector3Like } from 'three'
+
+const RAD2DEG = 180 / Math.PI
+const DEG2RAD = Math.PI / 180
+
+export const MIN_DISTANCE = 0.5
+export const MAX_DISTANCE = 100
+export const MIN_PITCH = -89
+export const MAX_PITCH = 89
+
+export function pointToYawAngle(
+  point: Vector3Like,
+  target: Vector3Like
+): number {
+  return Math.atan2(point.x - target.x, point.z - target.z) * RAD2DEG
+}
+
+export function pointToPitchAngle(
+  point: Vector3Like,
+  target: Vector3Like,
+  yawDeg: number
+): number {
+  const y = yawDeg * DEG2RAD
+  const dx = point.x - target.x
+  const dy = point.y - target.y
+  const dz = point.z - target.z
+  const horizontal = dx * Math.sin(y) + dz * Math.cos(y)
+  const raw = Math.atan2(dy, horizontal) * RAD2DEG
+  return clamp(raw, MIN_PITCH, MAX_PITCH)
+}
+
+export function pointToDistance(
+  point: Vector3Like,
+  target: Vector3Like,
+  yawDeg: number,
+  pitchDeg: number
+): number {
+  const y = yawDeg * DEG2RAD
+  const p = pitchDeg * DEG2RAD
+  const dirX = Math.cos(p) * Math.sin(y)
+  const dirY = Math.sin(p)
+  const dirZ = Math.cos(p) * Math.cos(y)
+  const dx = point.x - target.x
+  const dy = point.y - target.y
+  const dz = point.z - target.z
+  const projection = dx * dirX + dy * dirY + dz * dirZ
+  return clamp(projection, MIN_DISTANCE, MAX_DISTANCE)
+}

--- a/src/extensions/core/cameraInfo/handles/rollDragMath.test.ts
+++ b/src/extensions/core/cameraInfo/handles/rollDragMath.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { pointToRollAngle, rollBasis } from './rollDragMath'
+
+const TARGET = { x: 0, y: 0, z: 0 }
+
+describe('rollBasis', () => {
+  it('returns world (+X right, +Y up) when the camera looks along -Z', () => {
+    const basis = rollBasis(TARGET, { x: 0, y: 0, z: 5 })
+    expect(basis.up.x).toBeCloseTo(0)
+    expect(basis.up.y).toBeCloseTo(1)
+    expect(basis.up.z).toBeCloseTo(0)
+    expect(basis.right.x).toBeCloseTo(1)
+    expect(basis.right.y).toBeCloseTo(0)
+    expect(basis.right.z).toBeCloseTo(0)
+  })
+
+  it('falls back to an orthonormal basis when the camera looks straight down', () => {
+    const basis = rollBasis(TARGET, { x: 0, y: 5, z: 0 })
+
+    expect(basis.right.x).toBeCloseTo(1)
+    expect(basis.right.length()).toBeCloseTo(1)
+    expect(basis.up.length()).toBeCloseTo(1)
+    expect(basis.up.dot(basis.right)).toBeCloseTo(0)
+    expect(basis.up.dot(basis.backward)).toBeCloseTo(0)
+    expect(basis.up.z).toBeCloseTo(-1)
+  })
+
+  it('falls back to an orthonormal basis when the camera looks straight up', () => {
+    const basis = rollBasis(TARGET, { x: 0, y: -5, z: 0 })
+
+    expect(basis.right.x).toBeCloseTo(1)
+    expect(basis.right.length()).toBeCloseTo(1)
+    expect(basis.up.length()).toBeCloseTo(1)
+    expect(basis.up.dot(basis.right)).toBeCloseTo(0)
+    expect(basis.up.dot(basis.backward)).toBeCloseTo(0)
+    expect(basis.up.z).toBeCloseTo(1)
+  })
+
+  it('orients (up, right) tangent to the camera ray for an oblique view', () => {
+    const basis = rollBasis(TARGET, { x: 3, y: 4, z: 0 })
+
+    expect(basis.right.z).toBeCloseTo(-1)
+    expect(basis.up.dot(basis.right)).toBeCloseTo(0)
+    expect(basis.up.dot(basis.backward)).toBeCloseTo(0)
+  })
+
+  it('returns a valid orthonormal basis when the camera sits on the target', () => {
+    const basis = rollBasis(TARGET, { x: 0, y: 0, z: 0 })
+
+    expect(basis.backward.length()).toBeCloseTo(1)
+    expect(basis.right.length()).toBeCloseTo(1)
+    expect(basis.up.length()).toBeCloseTo(1)
+    expect(basis.up.dot(basis.right)).toBeCloseTo(0)
+    expect(basis.up.dot(basis.backward)).toBeCloseTo(0)
+    expect(basis.right.dot(basis.backward)).toBeCloseTo(0)
+  })
+})
+
+describe('pointToRollAngle', () => {
+  const CAMERA = { x: 0, y: 0, z: 5 }
+
+  it('returns 0 when the point sits in the +up direction', () => {
+    expect(pointToRollAngle({ x: 0, y: 1, z: 0 }, TARGET, CAMERA)).toBeCloseTo(
+      0
+    )
+  })
+
+  it('returns +90 when the point sits in the +right direction', () => {
+    expect(pointToRollAngle({ x: 1, y: 0, z: 0 }, TARGET, CAMERA)).toBeCloseTo(
+      90
+    )
+  })
+
+  it('returns -90 when the point sits in the -right direction', () => {
+    expect(pointToRollAngle({ x: -1, y: 0, z: 0 }, TARGET, CAMERA)).toBeCloseTo(
+      -90
+    )
+  })
+
+  it('returns 180 (or -180) when the point sits in the -up direction', () => {
+    expect(
+      Math.abs(pointToRollAngle({ x: 0, y: -1, z: 0 }, TARGET, CAMERA))
+    ).toBeCloseTo(180)
+  })
+
+  it('is invariant to the off-plane component of the point', () => {
+    const base = pointToRollAngle({ x: 1, y: 1, z: 0 }, TARGET, CAMERA)
+    const offPlane = pointToRollAngle({ x: 1, y: 1, z: 7 }, TARGET, CAMERA)
+    expect(offPlane).toBeCloseTo(base)
+  })
+})

--- a/src/extensions/core/cameraInfo/handles/rollDragMath.ts
+++ b/src/extensions/core/cameraInfo/handles/rollDragMath.ts
@@ -1,0 +1,42 @@
+import * as THREE from 'three'
+
+const RAD2DEG = 180 / Math.PI
+
+export interface RollBasis {
+  up: THREE.Vector3
+  right: THREE.Vector3
+  backward: THREE.Vector3
+}
+
+export function rollBasis(
+  target: THREE.Vector3Like,
+  cameraPos: THREE.Vector3Like
+): RollBasis {
+  const backward = new THREE.Vector3(
+    cameraPos.x - target.x,
+    cameraPos.y - target.y,
+    cameraPos.z - target.z
+  )
+  if (backward.lengthSq() < 1e-8) backward.set(0, 0, 1)
+  else backward.normalize()
+  const worldUp = new THREE.Vector3(0, 1, 0)
+  const right = new THREE.Vector3().crossVectors(worldUp, backward)
+  if (right.lengthSq() < 1e-8) right.set(1, 0, 0)
+  else right.normalize()
+  const up = new THREE.Vector3().crossVectors(backward, right).normalize()
+  return { up, right, backward }
+}
+
+export function pointToRollAngle(
+  point: THREE.Vector3Like,
+  target: THREE.Vector3Like,
+  cameraPos: THREE.Vector3Like
+): number {
+  const { up, right } = rollBasis(target, cameraPos)
+  const rel = new THREE.Vector3(
+    point.x - target.x,
+    point.y - target.y,
+    point.z - target.z
+  )
+  return Math.atan2(rel.dot(right), rel.dot(up)) * RAD2DEG
+}

--- a/src/extensions/core/cameraInfo/handles/types.ts
+++ b/src/extensions/core/cameraInfo/handles/types.ts
@@ -1,0 +1,1 @@
+export type DraggingChangeListener = (dragging: boolean) => void

--- a/src/extensions/core/cameraInfo/lookThroughDragMath.test.ts
+++ b/src/extensions/core/cameraInfo/lookThroughDragMath.test.ts
@@ -1,0 +1,252 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { dollySubjectByWheel, rotateSubjectByDrag } from './lookThroughDragMath'
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type { CameraInfoState } from './types'
+
+const RAD2DEG = 180 / Math.PI
+
+function stateWith(overrides: Partial<CameraInfoState>): CameraInfoState {
+  return { ...structuredClone(DEFAULT_CAMERA_INFO_STATE), ...overrides }
+}
+
+describe('rotateSubjectByDrag - orbit', () => {
+  it('adds the drag deltas to yaw and pitch in degrees', () => {
+    const state = stateWith({ mode: 'orbit' })
+    const result = rotateSubjectByDrag(state, 0.1, 0.05)
+
+    expect(result).not.toBeNull()
+    expect(result!.nextState.orbit.yaw).toBeCloseTo(
+      state.orbit.yaw + 0.1 * RAD2DEG
+    )
+    expect(result!.nextState.orbit.pitch).toBeCloseTo(
+      state.orbit.pitch + 0.05 * RAD2DEG
+    )
+    expect(result!.updates.map((u) => u.fieldName)).toEqual([
+      'mode.yaw',
+      'mode.pitch'
+    ])
+  })
+
+  it('clamps pitch to the pole limit', () => {
+    const state = stateWith({
+      mode: 'orbit',
+      orbit: { yaw: 0, pitch: 80, distance: 4 }
+    })
+    const result = rotateSubjectByDrag(state, 0, 1)
+
+    expect(result!.nextState.orbit.pitch).toBe(89)
+  })
+})
+
+describe('rotateSubjectByDrag - look_at', () => {
+  it('rotates the target around a fixed camera position, preserving distance', () => {
+    const state = stateWith({
+      mode: 'look_at',
+      lookAt: { position: { x: 0, y: 0, z: 5 } },
+      target: { x: 0, y: 0, z: 0 }
+    })
+    const result = rotateSubjectByDrag(state, 0.2, 0)
+
+    expect(result).not.toBeNull()
+    const pos = new THREE.Vector3(0, 0, 5)
+    const before = new THREE.Vector3(0, 0, 0).distanceTo(pos)
+    const nextTarget = result!.nextState.target
+    const after = new THREE.Vector3(
+      nextTarget.x,
+      nextTarget.y,
+      nextTarget.z
+    ).distanceTo(pos)
+
+    expect(after).toBeCloseTo(before)
+    expect(nextTarget.x).not.toBeCloseTo(0)
+    expect(result!.updates.map((u) => u.fieldName)).toEqual([
+      'target_x',
+      'target_y',
+      'target_z'
+    ])
+  })
+
+  it('returns null when the camera sits on the target', () => {
+    const state = stateWith({
+      mode: 'look_at',
+      lookAt: { position: { x: 1, y: 1, z: 1 } },
+      target: { x: 1, y: 1, z: 1 }
+    })
+
+    expect(rotateSubjectByDrag(state, 0.1, 0.1)).toBeNull()
+  })
+})
+
+describe('rotateSubjectByDrag - quaternion', () => {
+  it('rotates the orientation and keeps a unit quaternion', () => {
+    const state = stateWith({
+      mode: 'quaternion',
+      quaternion: {
+        position: { x: 0, y: 0, z: 5 },
+        quat: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    })
+    const result = rotateSubjectByDrag(state, 0.2, 0.1)
+
+    expect(result).not.toBeNull()
+    const q = result!.nextState.quaternion.quat
+    const length = Math.hypot(q.x, q.y, q.z, q.w)
+    expect(length).toBeCloseTo(1)
+    expect(q).not.toEqual({ x: 0, y: 0, z: 0, w: 1 })
+    expect(result!.nextState.quaternion.position).toEqual({ x: 0, y: 0, z: 5 })
+    expect(result!.updates.map((u) => u.fieldName)).toEqual([
+      'mode.quat_x',
+      'mode.quat_y',
+      'mode.quat_z',
+      'mode.quat_w'
+    ])
+  })
+
+  it('treats a zero-length quaternion as identity', () => {
+    const state = stateWith({
+      mode: 'quaternion',
+      quaternion: {
+        position: { x: 0, y: 0, z: 0 },
+        quat: { x: 0, y: 0, z: 0, w: 0 }
+      }
+    })
+    const result = rotateSubjectByDrag(state, 0.1, 0)
+    const q = result!.nextState.quaternion.quat
+
+    expect(Math.hypot(q.x, q.y, q.z, q.w)).toBeCloseTo(1)
+  })
+
+  it('yaw-only rotates forward around world Y, keeping the horizon level', () => {
+    const state = stateWith({
+      mode: 'quaternion',
+      quaternion: {
+        position: { x: 0, y: 0, z: 0 },
+        quat: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    })
+    const q = quatFrom(rotateSubjectByDrag(state, 0.3, 0))
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(q)
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(q)
+
+    expect(forward.y).toBeCloseTo(0)
+    expect(up.y).toBeCloseTo(1)
+    expect(forward.x).toBeLessThan(0)
+  })
+
+  it('pitch-only tilts forward up', () => {
+    const state = stateWith({
+      mode: 'quaternion',
+      quaternion: {
+        position: { x: 0, y: 0, z: 0 },
+        quat: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    })
+    const q = quatFrom(rotateSubjectByDrag(state, 0, 0.3))
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(q)
+
+    expect(forward.y).toBeGreaterThan(0)
+  })
+})
+
+function quatFrom(
+  result: ReturnType<typeof rotateSubjectByDrag>
+): THREE.Quaternion {
+  const { x, y, z, w } = result!.nextState.quaternion.quat
+  return new THREE.Quaternion(x, y, z, w)
+}
+
+describe('dollySubjectByWheel - perspective', () => {
+  it('orbit: scrolling up shortens distance, scrolling down lengthens it', () => {
+    const state = stateWith({ mode: 'orbit', cameraType: 'perspective' })
+
+    const closer = rotateResultDistance(dollySubjectByWheel(state, -100))
+    const farther = rotateResultDistance(dollySubjectByWheel(state, 100))
+
+    expect(closer).toBeLessThan(state.orbit.distance)
+    expect(farther).toBeGreaterThan(state.orbit.distance)
+  })
+
+  it('orbit: clamps distance to the same bounds as the handle drag', () => {
+    const state = stateWith({
+      mode: 'orbit',
+      orbit: { yaw: 0, pitch: 0, distance: 4 }
+    })
+
+    expect(dollySubjectByWheel(state, -100000)!.nextState.orbit.distance).toBe(
+      0.5
+    )
+    expect(dollySubjectByWheel(state, 100000)!.nextState.orbit.distance).toBe(
+      100
+    )
+  })
+
+  it('look_at: moves the position toward the target, preserving direction', () => {
+    const state = stateWith({
+      mode: 'look_at',
+      lookAt: { position: { x: 0, y: 0, z: 5 } },
+      target: { x: 0, y: 0, z: 0 }
+    })
+    const result = dollySubjectByWheel(state, -100)
+    const pos = result!.nextState.lookAt.position
+
+    expect(pos.z).toBeGreaterThan(0)
+    expect(pos.z).toBeLessThan(5)
+    expect(pos.x).toBeCloseTo(0)
+    expect(pos.y).toBeCloseTo(0)
+  })
+
+  it('look_at: clamps distance to the shared maximum on scroll-out', () => {
+    const state = stateWith({
+      mode: 'look_at',
+      lookAt: { position: { x: 0, y: 0, z: 5 } },
+      target: { x: 0, y: 0, z: 0 }
+    })
+    const pos = dollySubjectByWheel(state, 100000)!.nextState.lookAt.position
+
+    expect(Math.hypot(pos.x, pos.y, pos.z)).toBeCloseTo(100)
+  })
+
+  it('quaternion: moves the position along the camera forward axis', () => {
+    const state = stateWith({
+      mode: 'quaternion',
+      quaternion: {
+        position: { x: 0, y: 0, z: 5 },
+        quat: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    })
+    const result = dollySubjectByWheel(state, -100)
+    const pos = result!.nextState.quaternion.position
+
+    expect(pos.z).toBeCloseTo(4)
+    expect(pos.x).toBeCloseTo(0)
+    expect(pos.y).toBeCloseTo(0)
+  })
+})
+
+describe('dollySubjectByWheel - orthographic', () => {
+  it('changes zoom rather than position, regardless of mode', () => {
+    const state = stateWith({ mode: 'orbit', cameraType: 'orthographic' })
+    const zoomedIn = dollySubjectByWheel(state, -100)
+    const zoomedOut = dollySubjectByWheel(state, 100)
+
+    expect(zoomedIn!.updates[0].fieldName).toBe('zoom')
+    expect(zoomedIn!.nextState.zoom).toBeGreaterThan(state.zoom)
+    expect(zoomedOut!.nextState.zoom).toBeLessThan(state.zoom)
+    expect(zoomedIn!.nextState.orbit.distance).toBe(state.orbit.distance)
+  })
+
+  it('clamps zoom within bounds', () => {
+    const state = stateWith({ cameraType: 'orthographic', zoom: 1 })
+
+    expect(dollySubjectByWheel(state, -100000)!.nextState.zoom).toBe(100)
+    expect(dollySubjectByWheel(state, 100000)!.nextState.zoom).toBe(0.05)
+  })
+})
+
+function rotateResultDistance(
+  result: ReturnType<typeof dollySubjectByWheel>
+): number {
+  return result!.nextState.orbit.distance
+}

--- a/src/extensions/core/cameraInfo/lookThroughDragMath.test.ts
+++ b/src/extensions/core/cameraInfo/lookThroughDragMath.test.ts
@@ -23,10 +23,9 @@ describe('rotateSubjectByDrag - orbit', () => {
     expect(result!.nextState.orbit.pitch).toBeCloseTo(
       state.orbit.pitch + 0.05 * RAD2DEG
     )
-    expect(result!.updates.map((u) => u.fieldName)).toEqual([
-      'mode.yaw',
-      'mode.pitch'
-    ])
+    expect(new Set(result!.updates.map((u) => u.fieldName))).toEqual(
+      new Set(['mode.yaw', 'mode.pitch'])
+    )
   })
 
   it('clamps pitch to the pole limit', () => {
@@ -61,11 +60,9 @@ describe('rotateSubjectByDrag - look_at', () => {
 
     expect(after).toBeCloseTo(before)
     expect(nextTarget.x).not.toBeCloseTo(0)
-    expect(result!.updates.map((u) => u.fieldName)).toEqual([
-      'target_x',
-      'target_y',
-      'target_z'
-    ])
+    expect(new Set(result!.updates.map((u) => u.fieldName))).toEqual(
+      new Set(['target_x', 'target_y', 'target_z'])
+    )
   })
 
   it('returns null when the camera sits on the target', () => {
@@ -96,12 +93,9 @@ describe('rotateSubjectByDrag - quaternion', () => {
     expect(length).toBeCloseTo(1)
     expect(q).not.toEqual({ x: 0, y: 0, z: 0, w: 1 })
     expect(result!.nextState.quaternion.position).toEqual({ x: 0, y: 0, z: 5 })
-    expect(result!.updates.map((u) => u.fieldName)).toEqual([
-      'mode.quat_x',
-      'mode.quat_y',
-      'mode.quat_z',
-      'mode.quat_w'
-    ])
+    expect(new Set(result!.updates.map((u) => u.fieldName))).toEqual(
+      new Set(['mode.quat_x', 'mode.quat_y', 'mode.quat_z', 'mode.quat_w'])
+    )
   })
 
   it('treats a zero-length quaternion as identity', () => {

--- a/src/extensions/core/cameraInfo/lookThroughDragMath.ts
+++ b/src/extensions/core/cameraInfo/lookThroughDragMath.ts
@@ -1,0 +1,271 @@
+import { clamp } from 'es-toolkit'
+import * as THREE from 'three'
+
+import { normalizeQuaternion } from './cameraTransform'
+import {
+  MAX_DISTANCE,
+  MAX_PITCH,
+  MIN_DISTANCE,
+  MIN_PITCH
+} from './handles/orbitDragMath'
+import type { CameraInfoFieldName, CameraInfoState } from './types'
+
+const DEG2RAD = Math.PI / 180
+const RAD2DEG = 180 / Math.PI
+const ELEVATION_LIMIT = MAX_PITCH * DEG2RAD
+const DOLLY_EXP_SENSITIVITY = 0.0015
+const FREE_DOLLY_UNIT = 0.01
+const MIN_ZOOM = 0.05
+const MAX_ZOOM = 100
+
+interface FieldUpdate {
+  fieldName: CameraInfoFieldName
+  value: number
+}
+
+export interface LookThroughResult {
+  nextState: CameraInfoState
+  updates: FieldUpdate[]
+}
+
+function directionToSpherical(dir: THREE.Vector3): {
+  azimuth: number
+  elevation: number
+} {
+  return {
+    azimuth: Math.atan2(dir.x, dir.z),
+    elevation: Math.asin(clamp(dir.y, -1, 1))
+  }
+}
+
+function sphericalToDirection(
+  azimuth: number,
+  elevation: number
+): THREE.Vector3 {
+  const ce = Math.cos(elevation)
+  return new THREE.Vector3(
+    ce * Math.sin(azimuth),
+    Math.sin(elevation),
+    ce * Math.cos(azimuth)
+  )
+}
+
+function rotateOrbit(
+  state: CameraInfoState,
+  yawDelta: number,
+  pitchDelta: number
+): LookThroughResult {
+  const yaw = state.orbit.yaw + yawDelta * RAD2DEG
+  const pitch = clamp(
+    state.orbit.pitch + pitchDelta * RAD2DEG,
+    MIN_PITCH,
+    MAX_PITCH
+  )
+  return {
+    nextState: { ...state, orbit: { ...state.orbit, yaw, pitch } },
+    updates: [
+      { fieldName: 'mode.yaw', value: yaw },
+      { fieldName: 'mode.pitch', value: pitch }
+    ]
+  }
+}
+
+function rotateLookAt(
+  state: CameraInfoState,
+  yawDelta: number,
+  pitchDelta: number
+): LookThroughResult | null {
+  const position = new THREE.Vector3(
+    state.lookAt.position.x,
+    state.lookAt.position.y,
+    state.lookAt.position.z
+  )
+  const target = new THREE.Vector3(
+    state.target.x,
+    state.target.y,
+    state.target.z
+  )
+  const offset = target.clone().sub(position)
+  const distance = offset.length()
+  if (distance < 1e-6) return null
+
+  const { azimuth, elevation } = directionToSpherical(
+    offset.clone().normalize()
+  )
+  const nextAzimuth = azimuth + yawDelta
+  const nextElevation = clamp(
+    elevation + pitchDelta,
+    -ELEVATION_LIMIT,
+    ELEVATION_LIMIT
+  )
+  const dir = sphericalToDirection(nextAzimuth, nextElevation)
+  const nextTarget: THREE.Vector3Like = {
+    x: position.x + dir.x * distance,
+    y: position.y + dir.y * distance,
+    z: position.z + dir.z * distance
+  }
+  return {
+    nextState: { ...state, target: nextTarget },
+    updates: [
+      { fieldName: 'target_x', value: nextTarget.x },
+      { fieldName: 'target_y', value: nextTarget.y },
+      { fieldName: 'target_z', value: nextTarget.z }
+    ]
+  }
+}
+
+function rotateQuaternion(
+  state: CameraInfoState,
+  yawDelta: number,
+  pitchDelta: number
+): LookThroughResult {
+  const q = normalizeQuaternion(
+    new THREE.Quaternion(
+      state.quaternion.quat.x,
+      state.quaternion.quat.y,
+      state.quaternion.quat.z,
+      state.quaternion.quat.w
+    )
+  )
+
+  const yawQ = new THREE.Quaternion().setFromAxisAngle(
+    new THREE.Vector3(0, 1, 0),
+    yawDelta
+  )
+  const pitchQ = new THREE.Quaternion().setFromAxisAngle(
+    new THREE.Vector3(1, 0, 0),
+    pitchDelta
+  )
+  q.premultiply(yawQ).multiply(pitchQ).normalize()
+
+  const quat = { x: q.x, y: q.y, z: q.z, w: q.w }
+  return {
+    nextState: { ...state, quaternion: { ...state.quaternion, quat } },
+    updates: [
+      { fieldName: 'mode.quat_x', value: quat.x },
+      { fieldName: 'mode.quat_y', value: quat.y },
+      { fieldName: 'mode.quat_z', value: quat.z },
+      { fieldName: 'mode.quat_w', value: quat.w }
+    ]
+  }
+}
+
+export function rotateSubjectByDrag(
+  state: CameraInfoState,
+  yawDelta: number,
+  pitchDelta: number
+): LookThroughResult | null {
+  switch (state.mode) {
+    case 'orbit':
+      return rotateOrbit(state, yawDelta, pitchDelta)
+    case 'look_at':
+      return rotateLookAt(state, yawDelta, pitchDelta)
+    case 'quaternion':
+      return rotateQuaternion(state, yawDelta, pitchDelta)
+  }
+}
+
+function dollyOrbit(state: CameraInfoState, deltaY: number): LookThroughResult {
+  const factor = Math.exp(deltaY * DOLLY_EXP_SENSITIVITY)
+  const distance = clamp(
+    state.orbit.distance * factor,
+    MIN_DISTANCE,
+    MAX_DISTANCE
+  )
+  return {
+    nextState: { ...state, orbit: { ...state.orbit, distance } },
+    updates: [{ fieldName: 'mode.distance', value: distance }]
+  }
+}
+
+function dollyLookAt(
+  state: CameraInfoState,
+  deltaY: number
+): LookThroughResult | null {
+  const position = new THREE.Vector3(
+    state.lookAt.position.x,
+    state.lookAt.position.y,
+    state.lookAt.position.z
+  )
+  const target = new THREE.Vector3(
+    state.target.x,
+    state.target.y,
+    state.target.z
+  )
+  const offset = position.clone().sub(target)
+  const distance = offset.length()
+  if (distance < 1e-6) return null
+
+  const factor = Math.exp(deltaY * DOLLY_EXP_SENSITIVITY)
+  const nextDistance = clamp(distance * factor, MIN_DISTANCE, MAX_DISTANCE)
+  const next = target
+    .clone()
+    .add(offset.multiplyScalar(nextDistance / distance))
+  const nextPosition: THREE.Vector3Like = { x: next.x, y: next.y, z: next.z }
+  return {
+    nextState: { ...state, lookAt: { position: nextPosition } },
+    updates: [
+      { fieldName: 'mode.position_x', value: nextPosition.x },
+      { fieldName: 'mode.position_y', value: nextPosition.y },
+      { fieldName: 'mode.position_z', value: nextPosition.z }
+    ]
+  }
+}
+
+function dollyQuaternion(
+  state: CameraInfoState,
+  deltaY: number
+): LookThroughResult {
+  const q = normalizeQuaternion(
+    new THREE.Quaternion(
+      state.quaternion.quat.x,
+      state.quaternion.quat.y,
+      state.quaternion.quat.z,
+      state.quaternion.quat.w
+    )
+  )
+
+  const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(q)
+  const step = -deltaY * FREE_DOLLY_UNIT
+  const p = state.quaternion.position
+  const nextPosition: THREE.Vector3Like = {
+    x: p.x + forward.x * step,
+    y: p.y + forward.y * step,
+    z: p.z + forward.z * step
+  }
+  return {
+    nextState: {
+      ...state,
+      quaternion: { ...state.quaternion, position: nextPosition }
+    },
+    updates: [
+      { fieldName: 'mode.position_x', value: nextPosition.x },
+      { fieldName: 'mode.position_y', value: nextPosition.y },
+      { fieldName: 'mode.position_z', value: nextPosition.z }
+    ]
+  }
+}
+
+function dollyZoom(state: CameraInfoState, deltaY: number): LookThroughResult {
+  const factor = Math.exp(deltaY * DOLLY_EXP_SENSITIVITY)
+  const zoom = clamp(state.zoom / factor, MIN_ZOOM, MAX_ZOOM)
+  return {
+    nextState: { ...state, zoom },
+    updates: [{ fieldName: 'zoom', value: zoom }]
+  }
+}
+
+export function dollySubjectByWheel(
+  state: CameraInfoState,
+  deltaY: number
+): LookThroughResult | null {
+  if (state.cameraType === 'orthographic') return dollyZoom(state, deltaY)
+  switch (state.mode) {
+    case 'orbit':
+      return dollyOrbit(state, deltaY)
+    case 'look_at':
+      return dollyLookAt(state, deltaY)
+    case 'quaternion':
+      return dollyQuaternion(state, deltaY)
+  }
+}

--- a/src/extensions/core/cameraInfo/types.ts
+++ b/src/extensions/core/cameraInfo/types.ts
@@ -1,0 +1,65 @@
+import type { QuaternionLike, Vector3Like } from 'three'
+
+export type CameraInfoMode = 'orbit' | 'look_at' | 'quaternion'
+
+export type CameraInfoCameraType = 'perspective' | 'orthographic'
+
+export type CameraInfoFieldName =
+  | 'mode.yaw'
+  | 'mode.pitch'
+  | 'mode.distance'
+  | 'target_x'
+  | 'target_y'
+  | 'target_z'
+  | 'mode.position_x'
+  | 'mode.position_y'
+  | 'mode.position_z'
+  | 'mode.quat_x'
+  | 'mode.quat_y'
+  | 'mode.quat_z'
+  | 'mode.quat_w'
+  | 'roll'
+  | 'fov'
+  | 'zoom'
+
+interface OrbitInputs {
+  yaw: number
+  pitch: number
+  distance: number
+}
+
+interface LookAtInputs {
+  position: Vector3Like
+}
+
+interface QuaternionInputs {
+  position: Vector3Like
+  quat: QuaternionLike
+}
+
+export interface CameraInfoState {
+  mode: CameraInfoMode
+  target: Vector3Like
+  roll: number
+  fov: number
+  zoom: number
+  cameraType: CameraInfoCameraType
+  orbit: OrbitInputs
+  lookAt: LookAtInputs
+  quaternion: QuaternionInputs
+}
+
+export const DEFAULT_CAMERA_INFO_STATE: CameraInfoState = {
+  mode: 'orbit',
+  target: { x: 0, y: 0, z: 0 },
+  roll: 0,
+  fov: 35,
+  zoom: 1,
+  cameraType: 'perspective',
+  orbit: { yaw: 35, pitch: 30, distance: 4 },
+  lookAt: { position: { x: 4, y: 4, z: 4 } },
+  quaternion: {
+    position: { x: 4, y: 4, z: 4 },
+    quat: { x: 0, y: 0, z: 0, w: 1 }
+  }
+}

--- a/src/extensions/core/cameraInfo/widgetBridge.test.ts
+++ b/src/extensions/core/cameraInfo/widgetBridge.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import { readStateFromWidgets, writeWidgetValue } from './widgetBridge'
+import type { NodeWithWidgets } from './widgetBridge'
+
+function nodeWithWidgets(
+  values: Record<string, unknown>
+): NodeWithWidgets & { widgets: { name: string; value: unknown }[] } {
+  return {
+    widgets: Object.entries(values).map(([name, value]) => ({ name, value }))
+  }
+}
+
+describe('readStateFromWidgets', () => {
+  it('returns defaults when the node has no widgets at all', () => {
+    expect(readStateFromWidgets({})).toEqual(DEFAULT_CAMERA_INFO_STATE)
+  })
+
+  it('reads each widget by name (orbit-mode example)', () => {
+    const node = nodeWithWidgets({
+      mode: 'orbit',
+      target_x: 1,
+      target_y: 2,
+      target_z: 3,
+      roll: 10,
+      fov: 50,
+      zoom: 0.8,
+      camera_type: 'perspective',
+      'mode.yaw': 25,
+      'mode.pitch': 40,
+      'mode.distance': 7
+    })
+
+    const state = readStateFromWidgets(node)
+
+    expect(state.mode).toBe('orbit')
+    expect(state.target).toEqual({ x: 1, y: 2, z: 3 })
+    expect(state.roll).toBe(10)
+    expect(state.fov).toBe(50)
+    expect(state.zoom).toBe(0.8)
+    expect(state.orbit).toEqual({ yaw: 25, pitch: 40, distance: 7 })
+  })
+
+  it('reads the orthographic camera type and quaternion-mode fields', () => {
+    const node = nodeWithWidgets({
+      mode: 'quaternion',
+      camera_type: 'orthographic',
+      'mode.position_x': 1,
+      'mode.position_y': 2,
+      'mode.position_z': 3,
+      'mode.quat_x': 0,
+      'mode.quat_y': 0,
+      'mode.quat_z': 0,
+      'mode.quat_w': 1
+    })
+
+    const state = readStateFromWidgets(node)
+
+    expect(state.cameraType).toBe('orthographic')
+    expect(state.mode).toBe('quaternion')
+    expect(state.quaternion.position).toEqual({ x: 1, y: 2, z: 3 })
+    expect(state.quaternion.quat).toEqual({ x: 0, y: 0, z: 0, w: 1 })
+  })
+
+  it('falls back when a widget value has the wrong type', () => {
+    const node = nodeWithWidgets({
+      fov: 'not-a-number',
+      mode: 'invalid-mode',
+      camera_type: 42
+    })
+
+    const state = readStateFromWidgets(node)
+
+    expect(state.fov).toBe(DEFAULT_CAMERA_INFO_STATE.fov)
+    expect(state.mode).toBe(DEFAULT_CAMERA_INFO_STATE.mode)
+    expect(state.cameraType).toBe(DEFAULT_CAMERA_INFO_STATE.cameraType)
+  })
+
+  it('rejects non-finite numbers (NaN / Infinity)', () => {
+    const node = nodeWithWidgets({
+      'mode.yaw': Number.NaN,
+      'mode.distance': Number.POSITIVE_INFINITY
+    })
+
+    const state = readStateFromWidgets(node)
+
+    expect(state.orbit.yaw).toBe(DEFAULT_CAMERA_INFO_STATE.orbit.yaw)
+    expect(state.orbit.distance).toBe(DEFAULT_CAMERA_INFO_STATE.orbit.distance)
+  })
+
+  it('reads quaternion mode widgets', () => {
+    const node = nodeWithWidgets({
+      mode: 'quaternion',
+      'mode.position_x': 1,
+      'mode.position_y': 2,
+      'mode.position_z': 3,
+      'mode.quat_x': 0,
+      'mode.quat_y': 0,
+      'mode.quat_z': 0,
+      'mode.quat_w': 1
+    })
+
+    const state = readStateFromWidgets(node)
+
+    expect(state.mode).toBe('quaternion')
+    expect(state.quaternion.position).toEqual({ x: 1, y: 2, z: 3 })
+    expect(state.quaternion.quat).toEqual({ x: 0, y: 0, z: 0, w: 1 })
+  })
+})
+
+describe('writeWidgetValue', () => {
+  it('updates the named widget when the value differs', () => {
+    const node = nodeWithWidgets({ 'mode.yaw': 0 })
+    writeWidgetValue(node, 'mode.yaw', 45)
+    expect(node.widgets.find((w) => w.name === 'mode.yaw')!.value).toBe(45)
+  })
+
+  it('is a no-op when the value already matches', () => {
+    const node = nodeWithWidgets({ fov: 35 })
+    const before = node.widgets[0].value
+    writeWidgetValue(node, 'fov', 35)
+    expect(node.widgets[0].value).toBe(before)
+  })
+
+  it('is a no-op when the widget does not exist', () => {
+    const node = nodeWithWidgets({ fov: 35 })
+    expect(() => writeWidgetValue(node, 'does_not_exist', 1)).not.toThrow()
+    expect(node.widgets).toHaveLength(1)
+  })
+})

--- a/src/extensions/core/cameraInfo/widgetBridge.ts
+++ b/src/extensions/core/cameraInfo/widgetBridge.ts
@@ -1,0 +1,103 @@
+import { DEFAULT_CAMERA_INFO_STATE } from './types'
+import type {
+  CameraInfoCameraType,
+  CameraInfoMode,
+  CameraInfoState
+} from './types'
+
+interface WidgetLike {
+  name: string
+  value: unknown
+}
+
+export interface NodeWithWidgets {
+  widgets?: WidgetLike[]
+}
+
+const VALID_MODES: readonly CameraInfoMode[] = [
+  'orbit',
+  'look_at',
+  'quaternion'
+]
+const VALID_CAMERA_TYPES: readonly CameraInfoCameraType[] = [
+  'perspective',
+  'orthographic'
+]
+
+function widgetByName(
+  node: NodeWithWidgets,
+  name: string
+): WidgetLike | undefined {
+  return node.widgets?.find((w) => w.name === name)
+}
+
+function num(node: NodeWithWidgets, name: string, fallback: number): number {
+  const v = widgetByName(node, name)?.value
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback
+}
+
+function pickMode(node: NodeWithWidgets): CameraInfoMode {
+  const v = widgetByName(node, 'mode')?.value
+  return typeof v === 'string' && (VALID_MODES as readonly string[]).includes(v)
+    ? (v as CameraInfoMode)
+    : DEFAULT_CAMERA_INFO_STATE.mode
+}
+
+function pickCameraType(node: NodeWithWidgets): CameraInfoCameraType {
+  const v = widgetByName(node, 'camera_type')?.value
+  return typeof v === 'string' &&
+    (VALID_CAMERA_TYPES as readonly string[]).includes(v)
+    ? (v as CameraInfoCameraType)
+    : DEFAULT_CAMERA_INFO_STATE.cameraType
+}
+
+export function readStateFromWidgets(node: NodeWithWidgets): CameraInfoState {
+  const d = DEFAULT_CAMERA_INFO_STATE
+  return {
+    mode: pickMode(node),
+    target: {
+      x: num(node, 'target_x', d.target.x),
+      y: num(node, 'target_y', d.target.y),
+      z: num(node, 'target_z', d.target.z)
+    },
+    roll: num(node, 'roll', d.roll),
+    fov: num(node, 'fov', d.fov),
+    zoom: num(node, 'zoom', d.zoom),
+    cameraType: pickCameraType(node),
+    orbit: {
+      yaw: num(node, 'mode.yaw', d.orbit.yaw),
+      pitch: num(node, 'mode.pitch', d.orbit.pitch),
+      distance: num(node, 'mode.distance', d.orbit.distance)
+    },
+    lookAt: {
+      position: {
+        x: num(node, 'mode.position_x', d.lookAt.position.x),
+        y: num(node, 'mode.position_y', d.lookAt.position.y),
+        z: num(node, 'mode.position_z', d.lookAt.position.z)
+      }
+    },
+    quaternion: {
+      position: {
+        x: num(node, 'mode.position_x', d.quaternion.position.x),
+        y: num(node, 'mode.position_y', d.quaternion.position.y),
+        z: num(node, 'mode.position_z', d.quaternion.position.z)
+      },
+      quat: {
+        x: num(node, 'mode.quat_x', d.quaternion.quat.x),
+        y: num(node, 'mode.quat_y', d.quaternion.quat.y),
+        z: num(node, 'mode.quat_z', d.quaternion.quat.z),
+        w: num(node, 'mode.quat_w', d.quaternion.quat.w)
+      }
+    }
+  }
+}
+
+export function writeWidgetValue(
+  node: NodeWithWidgets,
+  name: string,
+  value: number | string
+): void {
+  const widget = widgetByName(node, name)
+  if (!widget || widget.value === value) return
+  widget.value = value
+}

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -266,4 +266,75 @@ describe('CameraManager', () => {
       ])
     })
   })
+
+  describe('custom up', () => {
+    function rolledState(): CameraState {
+      const q = new THREE.Quaternion().setFromAxisAngle(
+        new THREE.Vector3(0, 0, 1),
+        Math.PI / 2
+      )
+      return {
+        position: new THREE.Vector3(0, 0, 5),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1,
+        cameraType: 'perspective',
+        quaternion: { x: q.x, y: q.y, z: q.z, w: q.w }
+      }
+    }
+
+    it('derives the camera up from an incoming quaternion and flags custom up', () => {
+      manager.setCameraState(rolledState())
+
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+      expect(manager.activeCamera.up.y).toBeCloseTo(0)
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: true
+      })
+    })
+
+    it('toggles between the derived up and world Y', () => {
+      manager.setCameraState(rolledState())
+
+      manager.setUseCustomUp(false)
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+
+      manager.setUseCustomUp(true)
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+    })
+
+    it('setUseCustomUp(true) is a no-op when no custom up was captured', () => {
+      manager.setUseCustomUp(true)
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'cameraUpStateChange',
+        expect.anything()
+      )
+    })
+
+    it('preserves the up vector when the camera type is toggled', () => {
+      manager.setCameraState(rolledState())
+      const up = manager.activeCamera.up.clone()
+
+      manager.toggleCamera('orthographic')
+
+      expect(manager.activeCamera.up.toArray()).toEqual(up.toArray())
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+    })
+
+    it('does not re-enable custom up on a later state restore after toggling it off', () => {
+      manager.setCameraState(rolledState())
+      manager.setUseCustomUp(false)
+      events.emitEvent.mockClear()
+
+      manager.setCameraState(rolledState())
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: false
+      })
+    })
+  })
 })

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -265,4 +265,75 @@ describe('CameraManager', () => {
       ])
     })
   })
+
+  describe('custom up', () => {
+    function rolledState(): CameraState {
+      const q = new THREE.Quaternion().setFromAxisAngle(
+        new THREE.Vector3(0, 0, 1),
+        Math.PI / 2
+      )
+      return {
+        position: new THREE.Vector3(0, 0, 5),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1,
+        cameraType: 'perspective',
+        quaternion: { x: q.x, y: q.y, z: q.z, w: q.w }
+      }
+    }
+
+    it('derives the camera up from an incoming quaternion and flags custom up', () => {
+      manager.setCameraState(rolledState())
+
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+      expect(manager.activeCamera.up.y).toBeCloseTo(0)
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: true
+      })
+    })
+
+    it('toggles between the derived up and world Y', () => {
+      manager.setCameraState(rolledState())
+
+      manager.setUseCustomUp(false)
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+
+      manager.setUseCustomUp(true)
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+    })
+
+    it('setUseCustomUp(true) is a no-op when no custom up was captured', () => {
+      manager.setUseCustomUp(true)
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'cameraUpStateChange',
+        expect.anything()
+      )
+    })
+
+    it('preserves the up vector when the camera type is toggled', () => {
+      manager.setCameraState(rolledState())
+      const up = manager.activeCamera.up.clone()
+
+      manager.toggleCamera('orthographic')
+
+      expect(manager.activeCamera.up.toArray()).toEqual(up.toArray())
+      expect(manager.activeCamera.up.x).toBeCloseTo(-1)
+    })
+
+    it('does not re-enable custom up on a later state restore after toggling it off', () => {
+      manager.setCameraState(rolledState())
+      manager.setUseCustomUp(false)
+      events.emitEvent.mockClear()
+
+      manager.setCameraState(rolledState())
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: false
+      })
+    })
+  })
 })

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -322,6 +322,32 @@ describe('CameraManager', () => {
       expect(manager.activeCamera.up.x).toBeCloseTo(-1)
     })
 
+    it('treats an all-zero quaternion as identity instead of zeroing the up vector', () => {
+      manager.setCameraState({
+        ...rolledState(),
+        quaternion: { x: 0, y: 0, z: 0, w: 0 }
+      })
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+    })
+
+    it('clears custom up when restoring a state without a quaternion', () => {
+      manager.setCameraState(rolledState())
+      events.emitEvent.mockClear()
+
+      const { quaternion: _quaternion, ...noQuaternion } = rolledState()
+      manager.setCameraState(noQuaternion)
+
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraUpStateChange', {
+        hasCustomUp: false,
+        usingCustomUp: false
+      })
+
+      manager.setUseCustomUp(true)
+      expect(manager.activeCamera.up.toArray()).toEqual([0, 1, 0])
+    })
+
     it('does not re-enable custom up on a later state restore after toggling it off', () => {
       manager.setCameraState(rolledState())
       manager.setUseCustomUp(false)

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -17,6 +17,9 @@ export class CameraManager implements CameraManagerInterface {
 
   private controls: OrbitControls | null = null
 
+  private customUp: THREE.Vector3 | null = null
+  private usingCustomUp = false
+
   DEFAULT_DISTANCE = 10
   DEFAULT_LOOK_AT = 0
 
@@ -91,6 +94,7 @@ export class CameraManager implements CameraManagerInterface {
 
     const position = oldCamera.position.clone()
     const rotation = oldCamera.rotation.clone()
+    const up = oldCamera.up.clone()
     const target = this.controls?.target.clone() || new THREE.Vector3()
 
     const oldZoom =
@@ -116,6 +120,7 @@ export class CameraManager implements CameraManagerInterface {
 
     this.activeCamera.position.copy(position)
     this.activeCamera.rotation.copy(rotation)
+    this.activeCamera.up.copy(up)
 
     if (this.activeCamera instanceof THREE.OrthographicCamera) {
       this.activeCamera.zoom = oldZoom
@@ -171,9 +176,20 @@ export class CameraManager implements CameraManagerInterface {
   }
 
   setCameraState(state: CameraState): void {
+    if (state.cameraType && state.cameraType !== this.getCurrentCameraType()) {
+      this.toggleCamera(state.cameraType)
+    }
+
     this.activeCamera.position.copy(state.position)
 
     this.controls?.target.copy(state.target)
+
+    if (
+      state.fov !== undefined &&
+      this.activeCamera instanceof THREE.PerspectiveCamera
+    ) {
+      this.activeCamera.fov = state.fov
+    }
 
     if (this.activeCamera instanceof THREE.OrthographicCamera) {
       this.activeCamera.zoom = state.zoom
@@ -183,7 +199,39 @@ export class CameraManager implements CameraManagerInterface {
       this.activeCamera.updateProjectionMatrix()
     }
 
+    if (state.quaternion) {
+      const q = new THREE.Quaternion(
+        state.quaternion.x,
+        state.quaternion.y,
+        state.quaternion.z,
+        state.quaternion.w
+      )
+      const appliedUp = new THREE.Vector3(0, 1, 0).applyQuaternion(q)
+      const isFirstDerivation = this.customUp === null
+      this.customUp = appliedUp.clone()
+      if (isFirstDerivation) this.usingCustomUp = true
+      if (this.usingCustomUp) this.activeCamera.up.copy(appliedUp)
+      this.eventManager.emitEvent('cameraUpStateChange', {
+        hasCustomUp: true,
+        usingCustomUp: this.usingCustomUp
+      })
+    }
+
     this.controls?.update()
+  }
+
+  setUseCustomUp(use: boolean): void {
+    if (use && !this.customUp) return
+    if (use === this.usingCustomUp) return
+    const target =
+      use && this.customUp ? this.customUp : new THREE.Vector3(0, 1, 0)
+    this.activeCamera.up.copy(target)
+    this.usingCustomUp = use
+    this.controls?.update()
+    this.eventManager.emitEvent('cameraUpStateChange', {
+      hasCustomUp: this.customUp !== null,
+      usingCustomUp: this.usingCustomUp
+    })
   }
 
   handleResize(width: number, height: number): void {

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -206,6 +206,7 @@ export class CameraManager implements CameraManagerInterface {
         state.quaternion.z,
         state.quaternion.w
       )
+      if (q.lengthSq() === 0) q.identity()
       const appliedUp = new THREE.Vector3(0, 1, 0).applyQuaternion(q)
       const isFirstDerivation = this.customUp === null
       this.customUp = appliedUp.clone()
@@ -214,6 +215,14 @@ export class CameraManager implements CameraManagerInterface {
       this.eventManager.emitEvent('cameraUpStateChange', {
         hasCustomUp: true,
         usingCustomUp: this.usingCustomUp
+      })
+    } else if (this.customUp !== null) {
+      this.customUp = null
+      this.usingCustomUp = false
+      this.activeCamera.up.set(0, 1, 0)
+      this.eventManager.emitEvent('cameraUpStateChange', {
+        hasCustomUp: false,
+        usingCustomUp: false
       })
     }
 

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -136,7 +136,9 @@ function makeInstance() {
     eventManager,
     adapterRef: { current: null },
     forceRender: vi.fn(),
-    handleResize: vi.fn()
+    handleResize: vi.fn(),
+    preRenderCallbacks: [],
+    postRenderCallbacks: []
   })
 
   return {

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -15,6 +15,7 @@ type CameraStub = {
   handleResize: ReturnType<typeof vi.fn>
   updateAspectRatio: ReturnType<typeof vi.fn>
   dispose: ReturnType<typeof vi.fn>
+  setUseCustomUp: ReturnType<typeof vi.fn>
   activeCamera: THREE.Camera
 }
 
@@ -51,6 +52,7 @@ function makeViewportInstance() {
     handleResize: vi.fn(),
     updateAspectRatio: vi.fn(),
     dispose: vi.fn(),
+    setUseCustomUp: vi.fn(),
     activeCamera: new THREE.PerspectiveCamera()
   }
   const sceneManager: SceneStub = {
@@ -252,7 +254,6 @@ describe('Viewport3d', () => {
       expect(overlay.onActiveCameraChange).toHaveBeenCalledWith(
         ctx.cameraManager.activeCamera
       )
-      expect(ctx.viewport.getOverlay()).toBe(overlay)
     })
 
     it('replacing an overlay detaches and disposes the prior one', () => {
@@ -264,18 +265,6 @@ describe('Viewport3d', () => {
       expect(first.detach).toHaveBeenCalledOnce()
       expect(first.dispose).toHaveBeenCalledOnce()
       expect(second.attach).toHaveBeenCalledWith(ctx.sceneManager.scene)
-      expect(ctx.viewport.getOverlay()).toBe(second)
-    })
-
-    it('removeOverlay detaches and disposes the installed overlay', () => {
-      const overlay = makeOverlay()
-      ctx.viewport.setOverlay(overlay)
-
-      ctx.viewport.removeOverlay()
-
-      expect(overlay.detach).toHaveBeenCalledOnce()
-      expect(overlay.dispose).toHaveBeenCalledOnce()
-      expect(ctx.viewport.getOverlay()).toBeNull()
     })
 
     it('tickPerFrame forwards delta to the overlay before view-helper/controls update', () => {
@@ -646,6 +635,93 @@ describe('Viewport3d', () => {
       expect(renderer.render).toHaveBeenCalledTimes(2)
       expect(view.blit).toHaveBeenCalledTimes(2)
       expect(viewport.INITIAL_RENDER_DONE).toBe(true)
+    })
+  })
+
+  describe('render callback dispatch', () => {
+    interface CallbackAccess {
+      preRenderCallbacks: Array<() => void>
+      postRenderCallbacks: Array<() => void>
+      addPreRenderCallback(cb: () => void): () => void
+      addPostRenderCallback(cb: () => void): () => void
+      runPreRenderCallbacks(): void
+      runPostRenderCallbacks(): void
+    }
+
+    it('does not skip siblings when a post-render callback disposes itself', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.postRenderCallbacks = []
+      const calls: string[] = []
+
+      const disposeA = vp.addPostRenderCallback(() => {
+        calls.push('a')
+        disposeA()
+      })
+      vp.addPostRenderCallback(() => calls.push('b'))
+
+      vp.runPostRenderCallbacks()
+
+      expect(calls).toEqual(['a', 'b'])
+    })
+
+    it('runs pre-render callbacks and stops after disposal', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.preRenderCallbacks = []
+      const cb = vi.fn()
+
+      const dispose = vp.addPreRenderCallback(cb)
+      vp.runPreRenderCallbacks()
+      dispose()
+      vp.runPreRenderCallbacks()
+
+      expect(cb).toHaveBeenCalledOnce()
+    })
+
+    it('scopes each disposer to its own registration of the same callback', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.postRenderCallbacks = []
+      const cb = vi.fn()
+
+      const disposeA = vp.addPostRenderCallback(cb)
+      vp.addPostRenderCallback(cb)
+      disposeA()
+      disposeA()
+      vp.runPostRenderCallbacks()
+
+      expect(cb).toHaveBeenCalledOnce()
+    })
+
+    it('dispatches pre -> main scene -> post within a render cycle', () => {
+      const order: string[] = []
+      Object.assign(ctx.viewport, {
+        view: {
+          renderer: { setScissorTest: vi.fn() },
+          beginRender: () => order.push('begin'),
+          blit: vi.fn()
+        },
+        renderMainScene: () => order.push('main'),
+        viewHelperManager: { render: vi.fn() }
+      })
+      const vp = ctx.viewport as unknown as CallbackAccess & {
+        renderView(): void
+      }
+      vp.preRenderCallbacks = []
+      vp.postRenderCallbacks = []
+      vp.addPreRenderCallback(() => order.push('pre'))
+      vp.addPostRenderCallback(() => order.push('post'))
+
+      vp.renderView()
+
+      expect(order).toEqual(['begin', 'pre', 'main', 'post'])
+    })
+  })
+
+  describe('setUseCustomUp', () => {
+    it('delegates to the camera manager and forces a render', () => {
+      ctx.viewport.setUseCustomUp(true)
+
+      expect(ctx.cameraManager.setUseCustomUp).toHaveBeenCalledWith(true)
+      expect(ctx.forceRender).toHaveBeenCalled()
     })
   })
 })

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -15,6 +15,7 @@ type CameraStub = {
   handleResize: ReturnType<typeof vi.fn>
   updateAspectRatio: ReturnType<typeof vi.fn>
   dispose: ReturnType<typeof vi.fn>
+  setUseCustomUp: ReturnType<typeof vi.fn>
   activeCamera: THREE.Camera
 }
 
@@ -51,6 +52,7 @@ function makeViewportInstance() {
     handleResize: vi.fn(),
     updateAspectRatio: vi.fn(),
     dispose: vi.fn(),
+    setUseCustomUp: vi.fn(),
     activeCamera: new THREE.PerspectiveCamera()
   }
   const sceneManager: SceneStub = {
@@ -248,7 +250,6 @@ describe('Viewport3d', () => {
       expect(overlay.onActiveCameraChange).toHaveBeenCalledWith(
         ctx.cameraManager.activeCamera
       )
-      expect(ctx.viewport.getOverlay()).toBe(overlay)
     })
 
     it('replacing an overlay detaches and disposes the prior one', () => {
@@ -260,18 +261,6 @@ describe('Viewport3d', () => {
       expect(first.detach).toHaveBeenCalledOnce()
       expect(first.dispose).toHaveBeenCalledOnce()
       expect(second.attach).toHaveBeenCalledWith(ctx.sceneManager.scene)
-      expect(ctx.viewport.getOverlay()).toBe(second)
-    })
-
-    it('removeOverlay detaches and disposes the installed overlay', () => {
-      const overlay = makeOverlay()
-      ctx.viewport.setOverlay(overlay)
-
-      ctx.viewport.removeOverlay()
-
-      expect(overlay.detach).toHaveBeenCalledOnce()
-      expect(overlay.dispose).toHaveBeenCalledOnce()
-      expect(ctx.viewport.getOverlay()).toBeNull()
     })
 
     it('tickPerFrame forwards delta to the overlay before view-helper/controls update', () => {
@@ -633,6 +622,93 @@ describe('Viewport3d', () => {
       expect(renderer.render).toHaveBeenCalledTimes(2)
       expect(view.blit).toHaveBeenCalledTimes(2)
       expect(viewport.INITIAL_RENDER_DONE).toBe(true)
+    })
+  })
+
+  describe('render callback dispatch', () => {
+    interface CallbackAccess {
+      preRenderCallbacks: Array<() => void>
+      postRenderCallbacks: Array<() => void>
+      addPreRenderCallback(cb: () => void): () => void
+      addPostRenderCallback(cb: () => void): () => void
+      runPreRenderCallbacks(): void
+      runPostRenderCallbacks(): void
+    }
+
+    it('does not skip siblings when a post-render callback disposes itself', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.postRenderCallbacks = []
+      const calls: string[] = []
+
+      const disposeA = vp.addPostRenderCallback(() => {
+        calls.push('a')
+        disposeA()
+      })
+      vp.addPostRenderCallback(() => calls.push('b'))
+
+      vp.runPostRenderCallbacks()
+
+      expect(calls).toEqual(['a', 'b'])
+    })
+
+    it('runs pre-render callbacks and stops after disposal', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.preRenderCallbacks = []
+      const cb = vi.fn()
+
+      const dispose = vp.addPreRenderCallback(cb)
+      vp.runPreRenderCallbacks()
+      dispose()
+      vp.runPreRenderCallbacks()
+
+      expect(cb).toHaveBeenCalledOnce()
+    })
+
+    it('scopes each disposer to its own registration of the same callback', () => {
+      const vp = ctx.viewport as unknown as CallbackAccess
+      vp.postRenderCallbacks = []
+      const cb = vi.fn()
+
+      const disposeA = vp.addPostRenderCallback(cb)
+      vp.addPostRenderCallback(cb)
+      disposeA()
+      disposeA()
+      vp.runPostRenderCallbacks()
+
+      expect(cb).toHaveBeenCalledOnce()
+    })
+
+    it('dispatches pre -> main scene -> post within a render cycle', () => {
+      const order: string[] = []
+      Object.assign(ctx.viewport, {
+        view: {
+          renderer: { setScissorTest: vi.fn() },
+          beginRender: () => order.push('begin'),
+          blit: vi.fn()
+        },
+        renderMainScene: () => order.push('main'),
+        viewHelperManager: { render: vi.fn() }
+      })
+      const vp = ctx.viewport as unknown as CallbackAccess & {
+        renderView(): void
+      }
+      vp.preRenderCallbacks = []
+      vp.postRenderCallbacks = []
+      vp.addPreRenderCallback(() => order.push('pre'))
+      vp.addPostRenderCallback(() => order.push('post'))
+
+      vp.renderView()
+
+      expect(order).toEqual(['begin', 'pre', 'main', 'post'])
+    })
+  })
+
+  describe('setUseCustomUp', () => {
+    it('delegates to the camera manager and forces a render', () => {
+      ctx.viewport.setUseCustomUp(true)
+
+      expect(ctx.cameraManager.setUseCustomUp).toHaveBeenCalledWith(true)
+      expect(ctx.forceRender).toHaveBeenCalled()
     })
   })
 })

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -151,14 +151,14 @@ describe('Viewport3d', () => {
       expect(ctx.viewport.isActive()).toBe(false)
     })
 
-    it('does not consult recording or animation state — that is a Load3d concern', () => {
+    it('is active from mouse presence alone — recording and animation are Load3d concerns', () => {
       Object.assign(ctx.viewport, {
         STATUS_MOUSE_ON_NODE: false,
-        STATUS_MOUSE_ON_SCENE: false,
+        STATUS_MOUSE_ON_SCENE: true,
         STATUS_MOUSE_ON_VIEWER: false,
         INITIAL_RENDER_DONE: true
       })
-      expect(() => ctx.viewport.isActive()).not.toThrow()
+      expect(ctx.viewport.isActive()).toBe(true)
     })
   })
 

--- a/src/extensions/core/load3d/Viewport3d.ts
+++ b/src/extensions/core/load3d/Viewport3d.ts
@@ -223,7 +223,9 @@ export class Viewport3d {
 
   private renderView(): void {
     this.view.beginRender()
+    this.runPreRenderCallbacks()
     this.renderMainScene()
+    this.runPostRenderCallbacks()
 
     this.renderer.setScissorTest(false)
     this.viewHelperManager.render(
@@ -232,6 +234,35 @@ export class Viewport3d {
     )
 
     this.view.blit()
+  }
+
+  private readonly preRenderCallbacks: Array<() => void> = []
+  private readonly postRenderCallbacks: Array<() => void> = []
+
+  addPreRenderCallback(cb: () => void): () => void {
+    const registered = () => cb()
+    this.preRenderCallbacks.push(registered)
+    return () => {
+      const i = this.preRenderCallbacks.indexOf(registered)
+      if (i >= 0) this.preRenderCallbacks.splice(i, 1)
+    }
+  }
+
+  addPostRenderCallback(cb: () => void): () => void {
+    const registered = () => cb()
+    this.postRenderCallbacks.push(registered)
+    return () => {
+      const i = this.postRenderCallbacks.indexOf(registered)
+      if (i >= 0) this.postRenderCallbacks.splice(i, 1)
+    }
+  }
+
+  private runPreRenderCallbacks(): void {
+    for (const cb of [...this.preRenderCallbacks]) cb()
+  }
+
+  private runPostRenderCallbacks(): void {
+    for (const cb of [...this.postRenderCallbacks]) cb()
   }
 
   protected tickPerFrame(delta: number): void {
@@ -458,6 +489,11 @@ export class Viewport3d {
 
   getCameraState(): CameraState {
     return this.cameraManager.getCameraState()
+  }
+
+  setUseCustomUp(use: boolean): void {
+    this.cameraManager.setUseCustomUp(use)
+    this.forceRender()
   }
 
   setTargetSize(width: number, height: number): void {

--- a/src/extensions/core/load3d/createViewport3d.ts
+++ b/src/extensions/core/load3d/createViewport3d.ts
@@ -1,0 +1,71 @@
+import type * as THREE from 'three'
+
+import { RendererView } from '@/renderer/three/RendererView'
+
+import { CameraManager } from './CameraManager'
+import { ControlsManager } from './ControlsManager'
+import { EventManager } from './EventManager'
+import { LightingManager } from './LightingManager'
+import { SceneManager } from './SceneManager'
+import { ViewHelperManager } from './ViewHelperManager'
+import { Viewport3d } from './Viewport3d'
+import type { Viewport3dDeps } from './Viewport3d'
+import type { Load3DOptions } from './interfaces'
+
+function buildViewport3dDeps(container: HTMLElement): Viewport3dDeps {
+  const view = new RendererView(container)
+  const renderer = view.renderer
+  const eventManager = new EventManager()
+
+  let cameraManager: CameraManager
+  let controlsManager: ControlsManager
+
+  const getActiveCamera = (): THREE.Camera => cameraManager.activeCamera
+  const getControls = () => controlsManager.controls
+
+  const sceneManager = new SceneManager(
+    view,
+    getActiveCamera,
+    getControls,
+    eventManager
+  )
+
+  cameraManager = new CameraManager(renderer, eventManager)
+  controlsManager = new ControlsManager(
+    container,
+    cameraManager.activeCamera,
+    eventManager
+  )
+  cameraManager.setControls(controlsManager.controls)
+
+  const lightingManager = new LightingManager(sceneManager.scene, eventManager)
+  const viewHelperManager = new ViewHelperManager(
+    renderer,
+    getActiveCamera,
+    getControls,
+    eventManager
+  )
+
+  return {
+    view,
+    eventManager,
+    sceneManager,
+    cameraManager,
+    controlsManager,
+    lightingManager,
+    viewHelperManager
+  }
+}
+
+export function createViewport3d(
+  container: HTMLElement,
+  options?: Load3DOptions
+): Viewport3d {
+  const viewport = new Viewport3d(
+    container,
+    buildViewport3dDeps(container),
+    options
+  )
+  viewport.start()
+  return viewport
+}

--- a/src/extensions/core/load3d/createViewport3d.ts
+++ b/src/extensions/core/load3d/createViewport3d.ts
@@ -31,11 +31,7 @@ function buildViewport3dDeps(container: HTMLElement): Viewport3dDeps {
   )
 
   cameraManager = new CameraManager(renderer, eventManager)
-  controlsManager = new ControlsManager(
-    container,
-    cameraManager.activeCamera,
-    eventManager
-  )
+  controlsManager = new ControlsManager(container, cameraManager.activeCamera)
   cameraManager.setControls(controlsManager.controls)
 
   const lightingManager = new LightingManager(sceneManager.scene, eventManager)
@@ -43,6 +39,7 @@ function buildViewport3dDeps(container: HTMLElement): Viewport3dDeps {
     renderer,
     getActiveCamera,
     getControls,
+    () => cameraManager.getCameraState(),
     eventManager
   )
 

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -82,6 +82,8 @@ export interface CameraConfig {
   cameraType: CameraType
   fov: number
   state?: CameraState
+  hasCustomUp?: boolean
+  useCustomUp?: boolean
 }
 
 export interface LightConfig {
@@ -159,6 +161,7 @@ export interface CameraManagerInterface extends BaseManager {
   setFOV(fov: number): void
   setCameraState(state: CameraState): void
   getCameraState(): CameraState
+  setUseCustomUp(use: boolean): void
   handleResize(width: number, height: number): void
   setControls(controls: OrbitControls): void
 }

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -78,13 +78,15 @@ export interface ModelConfig {
   gizmo?: GizmoConfig
 }
 
-export interface CameraConfig {
+type CustomUpConfig =
+  | { hasCustomUp?: false }
+  | { hasCustomUp: true; useCustomUp: boolean }
+
+export type CameraConfig = {
   cameraType: CameraType
   fov: number
   state?: CameraState
-  hasCustomUp?: boolean
-  useCustomUp?: boolean
-}
+} & CustomUpConfig
 
 export interface LightConfig {
   intensity: number

--- a/src/extensions/core/load3d/nodeTypes.ts
+++ b/src/extensions/core/load3d/nodeTypes.ts
@@ -24,3 +24,6 @@ export const isLoad3dResultViewerNode = (nodeType: string): boolean =>
 
 export const isLoad3dNode = (nodeType: string): boolean =>
   LOAD3D_ALL_NODES.has(nodeType)
+
+export const isThreeJsNode = (nodeType: string): boolean =>
+  isLoad3dNode(nodeType) || nodeType === 'CreateCameraInfo'

--- a/src/extensions/core/load3dLazy.ts
+++ b/src/extensions/core/load3dLazy.ts
@@ -15,7 +15,7 @@ import { useExtensionStore } from '@/stores/extensionStore'
 
 import type { ComfyExtension } from '@/types/comfy'
 
-import { isLoad3dNode } from './load3d/nodeTypes'
+import { isLoad3dNode, isThreeJsNode } from './load3d/nodeTypes'
 
 let load3dExtensionsLoaded = false
 let load3dExtensionsLoading: Promise<ComfyExtension[]> | null = null
@@ -39,7 +39,8 @@ async function loadLoad3dExtensions(): Promise<ComfyExtension[]> {
       import('./load3d'),
       import('./load3dAdvanced'),
       import('./load3dPreviewExtensions'),
-      import('./saveMesh')
+      import('./saveMesh'),
+      import('./cameraInfo')
     ])
     load3dExtensionsLoaded = true
     return useExtensionStore().enabledExtensions.filter(
@@ -58,6 +59,8 @@ useExtensionService().registerExtension({
     nodeType: typeof LGraphNode,
     nodeData: ComfyNodeDef
   ) {
+    if (!isThreeJsNode(nodeData.name)) return
+
     if (isLoad3dNode(nodeData.name)) {
       // Inject mesh_upload spec flags so WidgetSelect.vue can detect
       // Load3D's model_file as a mesh upload widget without hardcoding.
@@ -68,14 +71,14 @@ useExtensionService().registerExtension({
           modelFile[1].upload_subfolder = '3d'
         }
       }
+    }
 
-      // Load the 3D extensions and replay their beforeRegisterNodeDef hooks,
-      // since invokeExtensionsAsync already captured the extensions snapshot
-      // before these new extensions were registered.
-      const newExtensions = await loadLoad3dExtensions()
-      for (const ext of newExtensions) {
-        await ext.beforeRegisterNodeDef?.(nodeType, nodeData, app)
-      }
+    // Load the 3D extensions and replay their beforeRegisterNodeDef hooks,
+    // since invokeExtensionsAsync already captured the extensions snapshot
+    // before these new extensions were registered.
+    const newExtensions = await loadLoad3dExtensions()
+    for (const ext of newExtensions) {
+      await ext.beforeRegisterNodeDef?.(nodeType, nodeData, app)
     }
   }
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2052,6 +2052,19 @@
   },
   "load3d": {
     "switchCamera": "Switch Camera",
+    "useCustomUp": "Restore camera up from input",
+    "useNaturalUp": "Reset camera up to Y",
+    "showGizmos": "Show gizmos",
+    "hideGizmos": "Hide gizmos",
+    "lookThrough": "Camera view",
+    "exitLookThrough": "Exit camera view",
+    "transformGizmo": {
+      "label": "Edit",
+      "none": "None",
+      "target": "Target",
+      "cameraTranslate": "Cam pos",
+      "cameraRotate": "Cam rot"
+    },
     "showGrid": "Show Grid",
     "backgroundColor": "Background Color",
     "lightIntensity": "Light Intensity",
@@ -2254,6 +2267,7 @@
     "cannotCreateSubgraph": "Cannot create subgraph",
     "failedToConvertToSubgraph": "Failed to convert items to subgraph",
     "failedToInitializeLoad3dViewer": "Failed to initialize 3D Viewer",
+    "failedToInitializeCameraInfoViewer": "Failed to initialize Camera Info viewer. Try reloading the page.",
     "failedToLoadBackgroundImage": "Failed to load background image",
     "failedToLoadModel": "Failed to load 3D model",
     "modelLoadedSuccessfully": "3D model loaded successfully",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2165,6 +2165,19 @@
   },
   "load3d": {
     "switchCamera": "Switch Camera",
+    "useCustomUp": "Restore camera up from input",
+    "useNaturalUp": "Reset camera up to Y",
+    "showGizmos": "Show gizmos",
+    "hideGizmos": "Hide gizmos",
+    "lookThrough": "Camera view",
+    "exitLookThrough": "Exit camera view",
+    "transformGizmo": {
+      "label": "Edit",
+      "none": "None",
+      "target": "Target",
+      "cameraTranslate": "Cam pos",
+      "cameraRotate": "Cam rot"
+    },
     "showGrid": "Show Grid",
     "backgroundColor": "Background Color",
     "lightIntensity": "Light Intensity",
@@ -2404,6 +2417,7 @@
     "cannotCreateSubgraph": "Cannot create subgraph",
     "failedToConvertToSubgraph": "Failed to convert items to subgraph",
     "failedToInitializeLoad3dViewer": "Failed to initialize 3D Viewer",
+    "failedToInitializeCameraInfoViewer": "Failed to initialize Camera Info viewer. Try reloading the page.",
     "failedToLoadBackgroundImage": "Failed to load background image",
     "failedToLoadModel": "Failed to load 3D model",
     "modelLoadedSuccessfully": "3D model loaded successfully",

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -57,6 +57,9 @@ const Load3D = defineAsyncComponent(
 const Load3DAdvanced = defineAsyncComponent(
   () => import('@/components/load3d/Load3DAdvanced.vue')
 )
+const CameraInfo = defineAsyncComponent(
+  () => import('@/components/cameraInfo/CameraInfo.vue')
+)
 const WidgetImageCrop = defineAsyncComponent(
   () => import('@/components/imagecrop/WidgetImageCrop.vue')
 )
@@ -198,6 +201,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     }
   ],
   [
+    'cameraInfo',
+    {
+      component: CameraInfo,
+      aliases: ['CAMERA_INFO_STATE'],
+      essential: false
+    }
+  ],
+  [
     'imagecrop',
     {
       component: WidgetImageCrop,
@@ -289,6 +300,7 @@ const EXPANDING_TYPES = [
   'textPreview',
   'load3D',
   'load3DAdvanced',
+  'cameraInfo',
   'curve',
   'painter',
   'imagecompare',

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -57,6 +57,9 @@ const Load3D = defineAsyncComponent(
 const Load3DAdvanced = defineAsyncComponent(
   () => import('@/components/load3d/Load3DAdvanced.vue')
 )
+const CameraInfo = defineAsyncComponent(
+  () => import('@/components/cameraInfo/CameraInfo.vue')
+)
 const WidgetImageCrop = defineAsyncComponent(
   () => import('@/components/imagecrop/WidgetImageCrop.vue')
 )
@@ -205,6 +208,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     }
   ],
   [
+    'cameraInfo',
+    {
+      component: CameraInfo,
+      aliases: ['CAMERA_INFO_STATE'],
+      essential: false
+    }
+  ],
+  [
     'imagecrop',
     {
       component: WidgetImageCrop,
@@ -312,6 +323,7 @@ const EXPANDING_TYPES = [
   'textPreview',
   'load3D',
   'load3DAdvanced',
+  'cameraInfo',
   'curve',
   'painter',
   'compositor',


### PR DESCRIPTION
## Summary
Vue viewport widget for the CreateCameraInfo node, bound to the CAMERA_INFO_STATE input. It renders the configured camera in a Load3D-style 3D scene so the camera can be posed directly instead of by typing numbers into the yaw/pitch/position/quaternion widgets; every drag writes back to those widgets, which stay the source of truth.

- Editing gizmos per mode: orbit (yaw/pitch/distance rings), look_at / quaternion (position + rotation via TransformControls), plus target and roll handles.
- Corner preview of what the subject camera sees, drawn as an extra pass after the main scene.
- "Camera view" (look-through) renders the main viewport through the subject camera; while looking through, left-drag rotates the facing (quaternion mouse-look, look_at target-rotate, orbit revolve) and the wheel dollies (perspective) / zooms (ortho). Pointer + wheel input is coalesced to one update per animation frame.

Shared viewer changes (load3d):
- Viewport3d becomes the reusable base viewer; createViewport3d wires only its core managers, so the camera editor can reuse it without Load3d's model-loader / HDRI / recording.
- addPostRenderCallback: a per-frame hook to draw extra passes after the main scene (the corner preview) — overlay objects render inline with the scene and can't express a second pass.
- Custom camera up: a camera_info built from a quaternion carries an arbitrary orientation, so its up vector is world-Y rotated by that quaternion, not world-Y. Load3D's OrbitControls forced world-Y up, so feeding in such a camera snapped the view upright and stopped matching the source. CameraManager now derives the up from the incoming quaternion and applies it, with a CameraControls toggle (setUseCustomUp) to switch back to natural Y-up for comfortable orbiting.

BE https://github.com/Comfy-Org/ComfyUI/pull/14964

## Screenshots (if applicable)

https://github.com/user-attachments/assets/e55cf823-c4b5-4783-a964-b79aa374420e

