### PR TITLE
fix: load mask editor layers from the saved image's subfolder

### DIFF
--- a/browser_tests/fixtures/helpers/MaskEditorHelper.ts
+++ b/browser_tests/fixtures/helpers/MaskEditorHelper.ts
@@ -58,6 +58,17 @@ class MaskEditorHelper {
     return dialog
   }
 
+  async reopenDialog(): Promise<Locator> {
+    const imagePreview = this.page.locator('.image-preview').first()
+    await imagePreview.getByRole('region').hover()
+    await this.page.getByLabel('Edit or mask image').click()
+
+    const dialog = this.page.locator('.mask-editor-dialog')
+    await expect(dialog).toBeVisible()
+
+    return dialog
+  }
+
   async drawStrokeOnPointerZone(dialog: Locator) {
     const pointerZone = dialog.getByTestId('pointer-zone')
     await expect(pointerZone).toBeVisible()

--- a/browser_tests/tests/maskEditorLoadSave.spec.ts
+++ b/browser_tests/tests/maskEditorLoadSave.spec.ts
@@ -72,12 +72,15 @@ test.describe('Mask Editor load/save', { tag: '@vue-nodes' }, () => {
   }) => {
     const dialog = await maskEditor.openDialog()
     await maskEditor.drawStrokeAndExpectPixels(dialog)
+    const savedMask = await maskEditor.getCanvasSnapshot(MASK_CANVAS_INDEX)
 
     await dialog.getByRole('button', { name: 'Save' }).click()
     await expect(dialog).toBeHidden()
 
     await maskEditor.reopenDialog()
-    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBeGreaterThan(0)
+    await expect
+      .poll(() => maskEditor.getCanvasSnapshot(MASK_CANVAS_INDEX))
+      .toBe(savedMask)
   })
 
   test('Save failure keeps dialog open', async ({ comfyPage, maskEditor }) => {

--- a/browser_tests/tests/maskEditorLoadSave.spec.ts
+++ b/browser_tests/tests/maskEditorLoadSave.spec.ts
@@ -67,6 +67,19 @@ test.describe('Mask Editor load/save', { tag: '@vue-nodes' }, () => {
     await expect(dialog).toBeVisible()
   })
 
+  test('Reopening the editor after save restores the drawn mask', async ({
+    maskEditor
+  }) => {
+    const dialog = await maskEditor.openDialog()
+    await maskEditor.drawStrokeAndExpectPixels(dialog)
+
+    await dialog.getByRole('button', { name: 'Save' }).click()
+    await expect(dialog).toBeHidden()
+
+    await maskEditor.reopenDialog()
+    await expect.poll(() => maskEditor.pollMaskPixelCount()).toBeGreaterThan(0)
+  })
+
   test('Save failure keeps dialog open', async ({ comfyPage, maskEditor }) => {
     const dialog = await maskEditor.openDialog()
     await maskEditor.drawStrokeAndExpectPixels(dialog)

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -1,0 +1,145 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useMaskEditorLoader } from './useMaskEditorLoader'
+
+const mockDataStore: Record<string, unknown> = {
+  inputData: null,
+  sourceNode: null,
+  setLoading: vi.fn()
+}
+
+vi.mock('@/stores/maskEditorDataStore', () => ({
+  useMaskEditorDataStore: vi.fn(() => mockDataStore)
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: vi.fn(() => ({
+    getNodeOutputs: vi.fn(() => undefined)
+  }))
+}))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn(),
+    apiURL: vi.fn((route: string) => `http://localhost:8188/api${route}`)
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    getPreviewFormatParam: vi.fn(() => ''),
+    getRandParam: vi.fn(() => '')
+  }
+}))
+
+const requestedUrls: string[] = []
+let failUrlPattern: RegExp | null = null
+
+class MockImage {
+  crossOrigin = ''
+  onload: ((ev: Event) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  private _src = ''
+  get src() {
+    return this._src
+  }
+  set src(value: string) {
+    this._src = value
+    requestedUrls.push(value)
+    queueMicrotask(() => {
+      if (failUrlPattern?.test(value)) this.onerror?.(new Event('error'))
+      else this.onload?.(new Event('load'))
+    })
+  }
+}
+
+function createLoadImageNode(widgetValue: string): LGraphNode {
+  return fromAny<LGraphNode, unknown>({
+    id: 7,
+    type: 'LoadImage',
+    imgs: [{ src: 'http://localhost:8188/api/view?filename=whatever.png' }],
+    images: undefined,
+    widgets: [{ name: 'image', value: widgetValue }]
+  })
+}
+
+function subfolderOf(url: string): string | null {
+  return new URL(url).searchParams.get('subfolder')
+}
+
+describe('useMaskEditorLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requestedUrls.length = 0
+    failUrlPattern = null
+    mockDataStore.inputData = null
+    mockDataStore.sourceNode = null
+    vi.stubGlobal('Image', MockImage)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads layer files from the input root for saves without a subfolder prefix', async () => {
+    const node = createLoadImageNode('clipspace-painted-masked-123.png [input]')
+
+    await useMaskEditorLoader().loadFromNode(node)
+
+    const layerUrls = requestedUrls.filter((url) =>
+      url.includes('clipspace-mask-123.png')
+    )
+    expect(layerUrls.length).toBeGreaterThan(0)
+    for (const url of layerUrls) {
+      expect(subfolderOf(url)).toBeNull()
+    }
+    expect(mockDataStore.inputData).toMatchObject({
+      sourceRef: { filename: 'clipspace-mask-123.png', type: 'input' },
+      nodeId: 7
+    })
+  })
+
+  it('loads layer files from the clipspace subfolder for legacy saves', async () => {
+    const node = createLoadImageNode(
+      'clipspace/clipspace-painted-masked-123.png [input]'
+    )
+
+    await useMaskEditorLoader().loadFromNode(node)
+
+    const layerUrls = requestedUrls.filter((url) =>
+      url.includes('clipspace-mask-123.png')
+    )
+    expect(layerUrls.length).toBeGreaterThan(0)
+    for (const url of layerUrls) {
+      expect(subfolderOf(url)).toBe('clipspace')
+    }
+  })
+
+  it('falls back to the node image when layer files are missing', async () => {
+    failUrlPattern = /clipspace-(mask|paint)-123\.png/
+    const node = createLoadImageNode('clipspace-painted-masked-123.png [input]')
+
+    await useMaskEditorLoader().loadFromNode(node)
+
+    expect(mockDataStore.inputData).toMatchObject({
+      sourceRef: { filename: 'clipspace-painted-masked-123.png' },
+      paintLayer: undefined,
+      nodeId: 7
+    })
+  })
+
+  it('still fails when the node image itself cannot be loaded', async () => {
+    failUrlPattern = /./
+    const node = createLoadImageNode('some-regular-image.png [input]')
+
+    await expect(useMaskEditorLoader().loadFromNode(node)).rejects.toThrow()
+    expect(mockDataStore.setLoading).toHaveBeenLastCalledWith(
+      false,
+      expect.any(String)
+    )
+  })
+})

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -2,7 +2,10 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { api } from '@/scripts/api'
 import { useMaskEditorLoader } from './useMaskEditorLoader'
+
+// ---- Module Mocks ----
 
 const mockDataStore: Record<string, unknown> = {
   inputData: null,
@@ -20,7 +23,13 @@ vi.mock('@/stores/nodeOutputStore', () => ({
   }))
 }))
 
-vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
+const distribution = vi.hoisted(() => ({ isCloud: false }))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distribution.isCloud
+  }
+}))
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -36,6 +45,9 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+// Mock Image constructor so the loader's image fetches resolve without a
+// network. Records every requested URL; URLs matching failUrlPattern reject
+// like a 404 would (reset per test in beforeEach).
 const requestedUrls: string[] = []
 let failUrlPattern: RegExp | null = null
 
@@ -71,11 +83,16 @@ function subfolderOf(url: string): string | null {
   return new URL(url).searchParams.get('subfolder')
 }
 
+function requestedLayerUrls(layerFilename: string): string[] {
+  return requestedUrls.filter((url) => url.includes(layerFilename))
+}
+
 describe('useMaskEditorLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     requestedUrls.length = 0
     failUrlPattern = null
+    distribution.isCloud = false
     mockDataStore.inputData = null
     mockDataStore.sourceNode = null
     vi.stubGlobal('Image', MockImage)
@@ -90,12 +107,15 @@ describe('useMaskEditorLoader', () => {
 
     await useMaskEditorLoader().loadFromNode(node)
 
-    const layerUrls = requestedUrls.filter((url) =>
-      url.includes('clipspace-mask-123.png')
-    )
-    expect(layerUrls.length).toBeGreaterThan(0)
-    for (const url of layerUrls) {
-      expect(subfolderOf(url)).toBeNull()
+    for (const layerFilename of [
+      'clipspace-mask-123.png',
+      'clipspace-paint-123.png'
+    ]) {
+      const layerUrls = requestedLayerUrls(layerFilename)
+      expect(layerUrls.length).toBeGreaterThan(0)
+      for (const url of layerUrls) {
+        expect(subfolderOf(url)).toBeNull()
+      }
     }
     expect(mockDataStore.inputData).toMatchObject({
       sourceRef: { filename: 'clipspace-mask-123.png', type: 'input' },
@@ -110,12 +130,40 @@ describe('useMaskEditorLoader', () => {
 
     await useMaskEditorLoader().loadFromNode(node)
 
-    const layerUrls = requestedUrls.filter((url) =>
-      url.includes('clipspace-mask-123.png')
-    )
-    expect(layerUrls.length).toBeGreaterThan(0)
-    for (const url of layerUrls) {
-      expect(subfolderOf(url)).toBe('clipspace')
+    for (const layerFilename of [
+      'clipspace-mask-123.png',
+      'clipspace-paint-123.png'
+    ]) {
+      const layerUrls = requestedLayerUrls(layerFilename)
+      expect(layerUrls.length).toBeGreaterThan(0)
+      for (const url of layerUrls) {
+        expect(subfolderOf(url)).toBe('clipspace')
+      }
+    }
+  })
+
+  it('keeps the clipspace subfolder for cloud-resolved layer files', async () => {
+    distribution.isCloud = true
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          painted_masked: 'hash-painted-masked.png',
+          painted: 'hash-painted.png',
+          paint: 'hash-paint.png',
+          mask: 'hash-mask.png'
+        })
+    } as Response)
+    const node = createLoadImageNode('clipspace-painted-masked-123.png [input]')
+
+    await useMaskEditorLoader().loadFromNode(node)
+
+    for (const layerFilename of ['hash-painted-masked.png', 'hash-paint.png']) {
+      const layerUrls = requestedLayerUrls(layerFilename)
+      expect(layerUrls.length).toBeGreaterThan(0)
+      for (const url of layerUrls) {
+        expect(subfolderOf(url)).toBe('clipspace')
+      }
     }
   })
 

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -53,10 +53,10 @@ function imageLayerFilenamesIfApplicable(
   }
 }
 
-function toRef(filename: string): ImageRef {
+function toRef(filename: string, subfolder: string): ImageRef {
   return {
     filename,
-    subfolder: 'clipspace',
+    subfolder,
     type: 'input'
   }
 }
@@ -150,34 +150,68 @@ export function useMaskEditorLoader() {
         }
       }
 
-      const baseImageUrl = imageLayerFilenames?.maskedImage
-        ? mkFileUrl({ ref: toRef(imageLayerFilenames.maskedImage) })
-        : nodeImageUrl
+      // Layer files live next to the painted-masked image the widget points
+      // at: the input root for saves under the unified upload contract
+      // (#12318), or the clipspace subfolder for saves made before it.
+      const layerSubfolder = nodeImageRef.subfolder ?? ''
 
-      const sourceRef = imageLayerFilenames?.maskedImage
-        ? parseImageRef(baseImageUrl)
-        : nodeImageRef
+      const layeredBaseUrl = imageLayerFilenames?.maskedImage
+        ? mkFileUrl({
+            ref: toRef(imageLayerFilenames.maskedImage, layerSubfolder)
+          })
+        : undefined
+      const baseImageUrl = layeredBaseUrl ?? nodeImageUrl
 
       let paintLayerUrl: string | null = null
       if (maskLayersFromApi?.paint) {
-        paintLayerUrl = mkFileUrl({ ref: toRef(maskLayersFromApi.paint) })
+        paintLayerUrl = mkFileUrl({
+          ref: toRef(maskLayersFromApi.paint, layerSubfolder)
+        })
       } else if (imageLayerFilenames?.paint) {
-        paintLayerUrl = mkFileUrl({ ref: toRef(imageLayerFilenames.paint) })
+        paintLayerUrl = mkFileUrl({
+          ref: toRef(imageLayerFilenames.paint, layerSubfolder)
+        })
       }
 
-      const [baseLayer, maskLayer, paintLayer] = await Promise.all([
-        loadImageLayer(baseImageUrl, 'rgb'),
-        loadImageLayer(baseImageUrl, 'a'),
-        paintLayerUrl
-          ? loadPaintLayer(paintLayerUrl)
-          : Promise.resolve(undefined)
-      ])
+      const loadLayers = (baseUrl: string, paintUrl: string | null) =>
+        Promise.all([
+          loadImageLayer(baseUrl, 'rgb'),
+          loadImageLayer(baseUrl, 'a'),
+          paintUrl ? loadPaintLayer(paintUrl) : Promise.resolve(undefined)
+        ])
+
+      const loadInputData = async () => {
+        try {
+          const [baseLayer, maskLayer, paintLayer] = await loadLayers(
+            baseImageUrl,
+            paintLayerUrl
+          )
+          return {
+            baseLayer,
+            maskLayer,
+            paintLayer,
+            sourceRef: layeredBaseUrl
+              ? parseImageRef(baseImageUrl)
+              : nodeImageRef
+          }
+        } catch (error) {
+          if (!layeredBaseUrl) throw error
+          console.warn(
+            '[MaskEditorLoader] Failed to load editor layer files, falling back to the node image',
+            error
+          )
+          const [baseLayer, maskLayer] = await loadLayers(nodeImageUrl, null)
+          return {
+            baseLayer,
+            maskLayer,
+            paintLayer: undefined,
+            sourceRef: nodeImageRef
+          }
+        }
+      }
 
       dataStore.inputData = {
-        baseLayer,
-        maskLayer,
-        paintLayer,
-        sourceRef,
+        ...(await loadInputData()),
         nodeId: node.id
       }
 

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -150,10 +150,14 @@ export function useMaskEditorLoader() {
         }
       }
 
-      // Layer files live next to the painted-masked image the widget points
-      // at: the input root for saves under the unified upload contract
-      // (#12318), or the clipspace subfolder for saves made before it.
-      const layerSubfolder = nodeImageRef.subfolder ?? ''
+      // Pattern-matched layer files live next to the painted-masked image the
+      // widget points at: the input root for saves under the unified upload
+      // contract (#12318), or the clipspace subfolder for saves made before
+      // it. Cloud resolves the hash filenames from its mask-layers API
+      // server-side, so its refs keep the subfolder they always used.
+      const layerSubfolder = maskLayersFromApi
+        ? 'clipspace'
+        : (nodeImageRef.subfolder ?? '')
 
       const layeredBaseUrl = imageLayerFilenames?.maskedImage
         ? mkFileUrl({


### PR DESCRIPTION
## Summary

Since #12318 the mask editor uploads its layer files to the input root, but the loader still looked for them in the `clipspace/` subfolder, so reopening the editor after saving a mask silently failed (four 404s, `[MaskEditorContent] Initialization failed`, dialog never opens). Affects v1.47.3+.

## Changes

- **What**: `useMaskEditorLoader` derives the layer-file subfolder from the image the widget references (input root for saves under the unified upload contract, `clipspace/` for saves made before #12318) instead of hardcoding `clipspace`. When layer files are missing entirely, it falls back to loading the node image (mask restored from its alpha channel) so the editor still opens instead of failing silently.

## Review Focus

- The cloud path (`/files/mask-layers`) now also resolves layer refs with the widget ref's subfolder instead of hardcoded `clipspace`. Verified against a local OSS backend (save → reopen round-trip, plus masks saved by 1.45.x with `clipspace/`-prefixed widget values and by 1.47.x with root-stored files); not verified against cloud.
- Repro/verification: unit tests and the new e2e round-trip test fail on `main` and pass with this change.
