### PR TITLE
feat: 3/x add partner node access controls

### DIFF
--- a/browser_tests/tests/dialogs/partnerNodeAllowlist.spec.ts
+++ b/browser_tests/tests/dialogs/partnerNodeAllowlist.spec.ts
@@ -1,0 +1,142 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import type { ListAssetsResponse } from '@comfyorg/ingest-types'
+
+import type { PartnerNodePolicyResponse } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { WORKSPACE_FEATURE_FLAG } from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+function partnerNode(
+  name: string,
+  displayName: string,
+  provider: string
+): ComfyNodeDef {
+  return {
+    name,
+    display_name: displayName,
+    category: `partner/image/${provider}`,
+    python_module: `comfy_api_nodes.${provider.toLocaleLowerCase()}`,
+    description: '',
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: false,
+    api_node: true
+  }
+}
+
+async function openAllowlist(page: Page) {
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+
+  const dialog = page.getByTestId('settings-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('nav').getByRole('button', { name: 'Workspace' }).click()
+
+  const content = dialog.getByRole('main')
+  await content.getByRole('tab', { name: 'Allowlist' }).click()
+  await expect(
+    content.getByRole('heading', { name: 'Partner nodes' })
+  ).toBeVisible()
+  return content
+}
+
+test.describe('Partner node allowlist', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('switches to restricted access and saves provider controls', async ({
+    page
+  }) => {
+    await new CloudWorkspaceMockHelper(page).setup()
+
+    await page.route('**/api/features', (route) =>
+      route.fulfill(
+        jsonRoute({
+          ...WORKSPACE_FEATURE_FLAG,
+          partner_node_governance_enabled: true
+        } satisfies RemoteConfig)
+      )
+    )
+    await page.route('**/api/object_info', (route) =>
+      route.fulfill(
+        jsonRoute({
+          FluxFill: partnerNode('FluxFill', 'Flux Fill', 'BFL'),
+          FluxExpand: partnerNode('FluxExpand', 'Flux Expand', 'BFL'),
+          VeoVideo: partnerNode('VeoVideo', 'Veo Video', 'Google')
+        })
+      )
+    )
+    await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
+      route.fulfill(
+        jsonRoute({
+          assets: [],
+          total: 0,
+          has_more: false
+        } satisfies ListAssetsResponse)
+      )
+    )
+
+    let policy: PartnerNodePolicyResponse = {
+      enforcement_enabled: false,
+      nodes: { FluxFill: false, FluxExpand: true, VeoVideo: true }
+    } satisfies PartnerNodePolicyResponse
+    const updates: unknown[] = []
+    await page.route('**/api/workspace/partner-node-policy', (route) => {
+      if (route.request().method() === 'PUT') {
+        policy = route.request().postDataJSON() as PartnerNodePolicyResponse
+        updates.push(policy)
+      }
+      return route.fulfill(jsonRoute(policy))
+    })
+
+    const content = await openAllowlist(page)
+    await expect(
+      content.getByRole('button', { name: 'Unrestricted' })
+    ).toHaveAttribute('aria-pressed', 'true')
+    await expect(
+      content.getByRole('switch', { name: 'Allow all nodes from BFL' })
+    ).toBeDisabled()
+
+    await content
+      .getByRole('button', { name: 'Restricted', exact: true })
+      .click()
+    const confirmDialog = page.getByRole('dialog')
+    await expect(
+      confirmDialog.getByText('Switch to restricted access?')
+    ).toBeVisible()
+    await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+    const bflToggle = content.getByRole('switch', {
+      name: 'Allow all nodes from BFL'
+    })
+    await expect(bflToggle).toBeEnabled()
+    await bflToggle.click()
+
+    await expect.poll(() => updates).toHaveLength(2)
+    expect(updates).toEqual([
+      {
+        enforcement_enabled: true,
+        nodes: { FluxFill: false, FluxExpand: true, VeoVideo: true }
+      },
+      {
+        enforcement_enabled: true,
+        nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+      }
+    ] satisfies PartnerNodePolicyResponse[])
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2919,7 +2919,43 @@
     "tabs": {
       "dashboard": "Dashboard",
       "planCredits": "Plan & Credits",
-      "membersCount": "Members ({count})"
+      "membersCount": "Members ({count})",
+      "allowlist": "Allowlist"
+    },
+    "allowlist": {
+      "title": "Partner nodes",
+      "description": "Control which partner node providers members can use in this workspace.",
+      "searchPlaceholder": "Search partner nodes...",
+      "loading": "Loading partner node policy...",
+      "loadError": "Partner node policy could not be loaded.",
+      "retry": "Try again",
+      "empty": "No partner nodes are available.",
+      "noMatches": "No partner nodes match your search.",
+      "allowedCount": "{enabled} of {total} allowed",
+      "providerToggle": "Allow all nodes from {provider}",
+      "enableAll": "Enable all",
+      "disableAll": "Disable all",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "saveError": "Partner node policy could not be saved.",
+      "table": {
+        "label": "Partner node provider access",
+        "provider": "Provider",
+        "allowed": "Allowed nodes",
+        "lastModified": "Last modified",
+        "access": "Access",
+        "notAvailable": "Not available"
+      },
+      "mode": {
+        "title": "Partner node access",
+        "description": "Choose whether all providers are available or only selected providers.",
+        "unrestricted": "Unrestricted",
+        "restricted": "Restricted",
+        "restrictedConfirmTitle": "Switch to restricted access?",
+        "restrictedConfirmMessage": "Only enabled partner node providers will remain available to workspace members.",
+        "unrestrictedConfirmTitle": "Switch to unrestricted access?",
+        "unrestrictedConfirmMessage": "All partner node providers will become available to workspace members."
+      }
     },
     "dashboard": {
       "placeholder": "Dashboard workspace settings"

--- a/src/platform/workspace/api/partnerNodePolicyApi.test.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getPartnerNodePolicy,
-  PartnerNodePolicyApiError
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 
 const mockFetchApi = vi.fn()
@@ -66,5 +67,55 @@ describe('partnerNodePolicyApi', () => {
     await expect(getPartnerNodePolicy()).rejects.toMatchObject({
       name: 'ZodError'
     })
+  })
+
+  it('serializes and validates a whole-policy update', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        enforcement_enabled: false,
+        nodes: { AllowedNode: true, DisabledNode: true }
+      })
+    )
+
+    await expect(
+      updatePartnerNodePolicy({
+        enforcementEnabled: false,
+        nodes: { AllowedNode: true, DisabledNode: true }
+      })
+    ).resolves.toEqual({
+      enforcementEnabled: false,
+      nodes: { AllowedNode: true, DisabledNode: true }
+    })
+    expect(mockFetchApi).toHaveBeenCalledWith(
+      '/workspace/partner-node-policy',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          enforcement_enabled: false,
+          nodes: { AllowedNode: true, DisabledNode: true }
+        })
+      }
+    )
+  })
+
+  it('preserves update failures for the editor', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({}, { status: 409, statusText: 'Conflict' })
+    )
+
+    await expect(
+      updatePartnerNodePolicy({ enforcementEnabled: false, nodes: {} })
+    ).rejects.toEqual(new PartnerNodePolicyApiError(409, 'Conflict'))
+  })
+
+  it('rejects malformed update responses', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({ enforcement_enabled: false, nodes: [] })
+    )
+
+    await expect(
+      updatePartnerNodePolicy({ enforcementEnabled: false, nodes: {} })
+    ).rejects.toMatchObject({ name: 'ZodError' })
   })
 })

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -2,10 +2,16 @@ import { z } from 'zod'
 
 import { api } from '@/scripts/api'
 
+const PARTNER_NODE_POLICY_PATH = '/workspace/partner-node-policy'
+
 const partnerNodePolicyResponseSchema = z.object({
   enforcement_enabled: z.boolean(),
   nodes: z.record(z.string(), z.boolean())
 })
+
+export type PartnerNodePolicyResponse = z.infer<
+  typeof partnerNodePolicyResponseSchema
+>
 
 export interface PartnerNodePolicy {
   enforcementEnabled: boolean
@@ -22,18 +28,40 @@ export class PartnerNodePolicyApiError extends Error {
   }
 }
 
+function parsePartnerNodePolicy(data: unknown): PartnerNodePolicy {
+  const policy = partnerNodePolicyResponseSchema.parse(data)
+  return {
+    enforcementEnabled: policy.enforcement_enabled,
+    nodes: policy.nodes
+  }
+}
+
+function throwResponseError(response: Response): never {
+  throw new PartnerNodePolicyApiError(response.status, response.statusText)
+}
+
 export async function getPartnerNodePolicy(): Promise<PartnerNodePolicy | null> {
-  const response = await api.fetchApi('/workspace/partner-node-policy', {
+  const response = await api.fetchApi(PARTNER_NODE_POLICY_PATH, {
     cache: 'no-store'
   })
   if (response.status === 404) return null
-  if (!response.ok) {
-    throw new PartnerNodePolicyApiError(response.status, response.statusText)
-  }
+  if (!response.ok) throwResponseError(response)
 
-  const data = partnerNodePolicyResponseSchema.parse(await response.json())
-  return {
-    enforcementEnabled: data.enforcement_enabled,
-    nodes: data.nodes
-  }
+  return parsePartnerNodePolicy(await response.json())
+}
+
+export async function updatePartnerNodePolicy(
+  policy: PartnerNodePolicy
+): Promise<PartnerNodePolicy> {
+  const response = await api.fetchApi(PARTNER_NODE_POLICY_PATH, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      enforcement_enabled: policy.enforcementEnabled,
+      nodes: policy.nodes
+    })
+  })
+  if (!response.ok) throwResponseError(response)
+
+  return parsePartnerNodePolicy(await response.json())
 }

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.test.ts
@@ -1,0 +1,420 @@
+import { render, screen, waitFor, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent, nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { PartnerNodePolicyStatus } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+
+import PartnerNodeAllowlistPanel from './PartnerNodeAllowlistPanel.vue'
+
+const mockSavePolicy = vi.fn()
+const mockLoadPolicy = vi.fn()
+const mockConfirm = vi.fn()
+
+const state = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    governedWorkspaceId: ref<string | null>('workspace-one'),
+    partnerNodes: ref([
+      { id: 'FluxFill', name: 'Flux Fill', provider: 'BFL' },
+      { id: 'FluxExpand', name: 'Flux Expand', provider: 'BFL' },
+      { id: 'VeoVideo', name: 'Veo Video', provider: 'Google' }
+    ]),
+    policy: ref<PartnerNodePolicy | null>({
+      enforcementEnabled: true,
+      nodes: {
+        FluxFill: false,
+        FluxExpand: true,
+        VeoVideo: true,
+        RetiredNode: false
+      }
+    }),
+    status: ref<PartnerNodePolicyStatus>('configured')
+  }
+})
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    ...state,
+    savePolicy: mockSavePolicy,
+    loadPolicy: mockLoadPolicy
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ confirm: mockConfirm })
+}))
+
+const SearchInputStub = defineComponent({
+  name: 'SearchInput',
+  props: {
+    modelValue: { type: String, required: true },
+    placeholder: String,
+    disabled: Boolean
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <input
+      :value="modelValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  `
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function renderPanel() {
+  return render(PartnerNodeAllowlistPanel, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        SearchInput: SearchInputStub
+      }
+    }
+  })
+}
+
+describe('PartnerNodeAllowlistPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.governedWorkspaceId.value = 'workspace-one'
+    state.partnerNodes.value = [
+      { id: 'FluxFill', name: 'Flux Fill', provider: 'BFL' },
+      { id: 'FluxExpand', name: 'Flux Expand', provider: 'BFL' },
+      { id: 'VeoVideo', name: 'Veo Video', provider: 'Google' }
+    ]
+    state.policy.value = {
+      enforcementEnabled: true,
+      nodes: {
+        FluxFill: false,
+        FluxExpand: true,
+        VeoVideo: true,
+        RetiredNode: false
+      }
+    }
+    state.status.value = 'configured'
+    mockSavePolicy.mockResolvedValue(true)
+    mockConfirm.mockResolvedValue(true)
+  })
+
+  it('shows restricted provider access and expandable node details', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    expect(screen.getByRole('button', { name: 'Restricted' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByText('1 of 2 allowed')).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Allow all nodes from BFL' })
+    ).not.toBeChecked()
+
+    await user.click(screen.getByRole('button', { name: 'BFL' }))
+
+    expect(screen.getByText('Flux Fill')).toBeInTheDocument()
+    expect(screen.getByText('FluxFill')).toBeInTheDocument()
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+
+  it('auto-saves a whole provider while preserving hidden policy entries', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(
+      screen.getByRole('switch', { name: 'Allow all nodes from BFL' })
+    )
+
+    await waitFor(() =>
+      expect(mockSavePolicy).toHaveBeenCalledWith({
+        enforcementEnabled: true,
+        nodes: {
+          FluxFill: true,
+          FluxExpand: true,
+          VeoVideo: true,
+          RetiredNode: false
+        }
+      })
+    )
+  })
+
+  it('confirms before entering restricted mode', async () => {
+    const user = userEvent.setup()
+    state.policy.value = {
+      enforcementEnabled: false,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    }
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Restricted' }))
+
+    expect(mockConfirm).toHaveBeenCalledWith({
+      title: 'Switch to restricted access?',
+      message:
+        'Only enabled partner node providers will remain available to workspace members.'
+    })
+    expect(mockSavePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: true,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    })
+  })
+
+  it('keeps the current mode when restricted mode is cancelled', async () => {
+    const user = userEvent.setup()
+    mockConfirm.mockResolvedValue(false)
+    state.policy.value = {
+      enforcementEnabled: false,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    }
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Restricted' }))
+
+    expect(mockSavePolicy).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Unrestricted' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('ignores a mode confirmation after the workspace changes', async () => {
+    const user = userEvent.setup()
+    let confirmMode: (confirmed: boolean) => void = () => undefined
+    mockConfirm.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          confirmMode = resolve
+        })
+    )
+    state.policy.value = {
+      enforcementEnabled: false,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    }
+    renderPanel()
+
+    const clickMode = user.click(
+      screen.getByRole('button', { name: 'Restricted' })
+    )
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalledOnce())
+
+    state.governedWorkspaceId.value = 'workspace-two'
+    await nextTick()
+    confirmMode(true)
+    await clickMode
+
+    expect(mockSavePolicy).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Unrestricted' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('confirms unrestricted mode when a provider remains disabled', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Unrestricted' }))
+
+    expect(mockConfirm).toHaveBeenCalledWith({
+      title: 'Switch to unrestricted access?',
+      message:
+        'All partner node providers will become available to workspace members.'
+    })
+    expect(mockSavePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: false,
+      nodes: {
+        FluxFill: false,
+        FluxExpand: true,
+        VeoVideo: true,
+        RetiredNode: false
+      }
+    })
+  })
+
+  it('switches directly to unrestricted mode when every provider is enabled', async () => {
+    const user = userEvent.setup()
+    state.policy.value = {
+      enforcementEnabled: true,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    }
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Unrestricted' }))
+
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(mockSavePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: false,
+      nodes: { FluxFill: true, FluxExpand: true, VeoVideo: true }
+    })
+  })
+
+  it('disables all providers in one update', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Disable all' }))
+
+    expect(mockSavePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: true,
+      nodes: {
+        FluxFill: false,
+        FluxExpand: false,
+        VeoVideo: false,
+        RetiredNode: false
+      }
+    })
+  })
+
+  it('makes the provider table read-only in unrestricted mode', () => {
+    state.policy.value = {
+      enforcementEnabled: false,
+      nodes: { FluxFill: false, FluxExpand: true, VeoVideo: true }
+    }
+    renderPanel()
+
+    expect(
+      screen.getByRole('switch', { name: 'Allow all nodes from BFL' })
+    ).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Disable all' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('filters by provider and node identity', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.type(
+      screen.getByPlaceholderText('Search partner nodes...'),
+      'veo'
+    )
+
+    const table = screen.getByRole('table', {
+      name: 'Partner node provider access'
+    })
+    expect(within(table).getByRole('button', { name: 'Google' })).toBeVisible()
+    expect(
+      within(table).queryByRole('button', { name: 'BFL' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('reverses provider sort order from the column header', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    const providerButtons = () =>
+      screen
+        .getAllByRole('button')
+        .filter((button) =>
+          ['BFL', 'Google'].includes(button.textContent ?? '')
+        )
+    expect(providerButtons().map((button) => button.textContent)).toEqual([
+      'BFL',
+      'Google'
+    ])
+
+    await user.click(screen.getByRole('columnheader', { name: 'Provider' }))
+
+    expect(providerButtons().map((button) => button.textContent)).toEqual([
+      'Google',
+      'BFL'
+    ])
+  })
+
+  it('offers retry when the policy is unavailable', async () => {
+    const user = userEvent.setup()
+    state.status.value = 'unavailable'
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(mockLoadPolicy).toHaveBeenCalledOnce()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Partner node policy could not be loaded.'
+    )
+  })
+
+  it('keeps draft changes and retries a save failure', async () => {
+    const user = userEvent.setup()
+    mockSavePolicy.mockRejectedValueOnce(new Error('Conflict'))
+    renderPanel()
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Allow all nodes from BFL'
+    })
+    await user.click(toggle)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Partner node policy could not be saved.'
+    )
+    expect(toggle).toBeChecked()
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(mockSavePolicy).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears a save error after reverting to the saved policy', async () => {
+    const user = userEvent.setup()
+    mockSavePolicy.mockRejectedValueOnce(new Error('Conflict'))
+    renderPanel()
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Allow all nodes from Google'
+    })
+    await user.click(toggle)
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Partner node policy could not be saved.'
+    )
+
+    await user.click(toggle)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(mockSavePolicy).toHaveBeenCalledOnce()
+  })
+
+  it('releases the new workspace when a previous save fails', async () => {
+    const user = userEvent.setup()
+    let rejectSave: (reason?: unknown) => void = () => undefined
+    mockSavePolicy.mockImplementation(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          rejectSave = reject
+        })
+    )
+    renderPanel()
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Allow all nodes from BFL'
+    })
+    await user.click(toggle)
+    expect(toggle).toBeDisabled()
+
+    state.governedWorkspaceId.value = 'workspace-two'
+    await nextTick()
+
+    expect(toggle).not.toBeDisabled()
+
+    rejectSave(new Error('Conflict'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.vue
@@ -1,0 +1,475 @@
+<template>
+  <div class="grow overflow-auto pt-6">
+    <div
+      class="flex size-full min-h-0 flex-col gap-5 rounded-2xl border border-interface-stroke p-6"
+    >
+      <div>
+        <h2 class="m-0 text-base font-semibold text-base-foreground">
+          {{ $t('workspacePanel.allowlist.title') }}
+        </h2>
+        <p class="mt-1 mb-0 text-sm text-muted-foreground">
+          {{ $t('workspacePanel.allowlist.description') }}
+        </p>
+      </div>
+
+      <div
+        v-if="isReady"
+        class="flex flex-col gap-3 rounded-xl border border-interface-stroke/60 p-4"
+      >
+        <div>
+          <div class="text-sm font-medium text-base-foreground">
+            {{ $t('workspacePanel.allowlist.mode.title') }}
+          </div>
+          <div class="mt-0.5 text-xs text-muted-foreground">
+            {{ $t('workspacePanel.allowlist.mode.description') }}
+          </div>
+        </div>
+        <div
+          role="group"
+          :aria-label="$t('workspacePanel.allowlist.mode.title')"
+          class="grid w-full max-w-md grid-cols-2 rounded-lg bg-secondary-background p-1"
+        >
+          <button
+            type="button"
+            :aria-pressed="!isRestricted"
+            :disabled="isSaving"
+            class="h-9 cursor-pointer rounded-md border-0 bg-transparent px-4 text-sm text-muted-foreground transition-colors hover:bg-interface-menu-component-surface-selected/50 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-interface-menu-component-surface-selected aria-pressed:text-base-foreground"
+            @click="requestMode('unrestricted')"
+          >
+            {{ $t('workspacePanel.allowlist.mode.unrestricted') }}
+          </button>
+          <button
+            type="button"
+            :aria-pressed="isRestricted"
+            :disabled="isSaving"
+            class="h-9 cursor-pointer rounded-md border-0 bg-transparent px-4 text-sm text-muted-foreground transition-colors hover:bg-interface-menu-component-surface-selected/50 disabled:cursor-not-allowed disabled:opacity-50 aria-pressed:bg-interface-menu-component-surface-selected aria-pressed:text-base-foreground"
+            @click="requestMode('restricted')"
+          >
+            {{ $t('workspacePanel.allowlist.mode.restricted') }}
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-if="status === 'loading'"
+        role="status"
+        class="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground"
+      >
+        <i class="icon-[lucide--loader-circle] size-4 animate-spin" />
+        {{ $t('workspacePanel.allowlist.loading') }}
+      </div>
+
+      <div
+        v-else-if="status === 'error' || status === 'unavailable'"
+        role="alert"
+        class="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground"
+      >
+        <span>{{ $t('workspacePanel.allowlist.loadError') }}</span>
+        <Button variant="muted-textonly" @click="loadPolicy">
+          {{ $t('workspacePanel.allowlist.retry') }}
+        </Button>
+      </div>
+
+      <div
+        v-else-if="isReady && partnerNodes.length === 0"
+        class="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+      >
+        {{ $t('workspacePanel.allowlist.empty') }}
+      </div>
+
+      <template v-else-if="isReady">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <SearchInput
+            v-model="searchQuery"
+            :placeholder="$t('workspacePanel.allowlist.searchPlaceholder')"
+            size="lg"
+            class="w-64"
+            :disabled="isSaving"
+          />
+          <div v-if="isRestricted" class="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              :disabled="isSaving || allProvidersEnabled"
+              @click="setAllProviders(true)"
+            >
+              {{ $t('workspacePanel.allowlist.enableAll') }}
+            </Button>
+            <Button
+              variant="secondary"
+              :disabled="isSaving || allProvidersDisabled"
+              @click="setAllProviders(false)"
+            >
+              {{ $t('workspacePanel.allowlist.disableAll') }}
+            </Button>
+          </div>
+        </div>
+
+        <div class="min-h-0 flex-1 overflow-auto">
+          <div
+            v-if="groups.length === 0"
+            class="flex min-h-32 items-center justify-center text-sm text-muted-foreground"
+          >
+            {{ $t('workspacePanel.allowlist.noMatches') }}
+          </div>
+
+          <div
+            v-else
+            role="table"
+            :aria-label="$t('workspacePanel.allowlist.table.label')"
+            class="min-w-2xl overflow-hidden rounded-xl border border-interface-stroke/60"
+          >
+            <div
+              role="row"
+              class="grid min-h-11 grid-cols-[minmax(14rem,1fr)_10rem_10rem_5rem] items-center border-b border-interface-stroke/60 bg-secondary-background px-4 text-xs font-medium text-muted-foreground"
+            >
+              <button
+                role="columnheader"
+                type="button"
+                class="flex h-full cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-left text-inherit hover:text-base-foreground"
+                @click="toggleSortDirection"
+              >
+                {{ $t('workspacePanel.allowlist.table.provider') }}
+                <i
+                  :class="
+                    sortDirection === 'asc'
+                      ? 'icon-[lucide--arrow-up] size-3.5'
+                      : 'icon-[lucide--arrow-down] size-3.5'
+                  "
+                />
+              </button>
+              <div role="columnheader">
+                {{ $t('workspacePanel.allowlist.table.allowed') }}
+              </div>
+              <div role="columnheader">
+                {{ $t('workspacePanel.allowlist.table.lastModified') }}
+              </div>
+              <div role="columnheader" class="text-right">
+                {{ $t('workspacePanel.allowlist.table.access') }}
+              </div>
+            </div>
+
+            <section
+              v-for="group in groups"
+              :key="group.provider"
+              role="rowgroup"
+              class="border-b border-interface-stroke/40 last:border-b-0"
+            >
+              <div
+                role="row"
+                class="grid min-h-14 grid-cols-[minmax(14rem,1fr)_10rem_10rem_5rem] items-center px-4"
+              >
+                <div role="cell" class="min-w-0">
+                  <button
+                    type="button"
+                    :aria-expanded="expandedProviders.has(group.provider)"
+                    class="group flex h-full min-w-0 cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left text-sm font-medium text-base-foreground hover:text-muted-foreground"
+                    @click="toggleProviderExpanded(group.provider)"
+                  >
+                    <i
+                      class="icon-[lucide--chevron-right] size-4 shrink-0 transition-transform group-aria-expanded:rotate-90"
+                    />
+                    <span class="truncate">{{ group.provider }}</span>
+                  </button>
+                </div>
+                <div role="cell" class="text-sm text-muted-foreground">
+                  {{
+                    $t('workspacePanel.allowlist.allowedCount', {
+                      enabled: group.enabledCount,
+                      total: group.allNodes.length
+                    })
+                  }}
+                </div>
+                <div role="cell" class="text-sm text-muted-foreground">
+                  {{ $t('workspacePanel.allowlist.table.notAvailable') }}
+                </div>
+                <div role="cell" class="flex justify-end">
+                  <button
+                    type="button"
+                    role="switch"
+                    :aria-checked="group.enabledCount === group.allNodes.length"
+                    :disabled="!isRestricted || isSaving"
+                    :aria-label="
+                      $t('workspacePanel.allowlist.providerToggle', {
+                        provider: group.provider
+                      })
+                    "
+                    :class="
+                      cn(
+                        'focus-visible:ring-ring relative h-5 w-9 cursor-pointer rounded-full border-0 p-0 transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+                        group.enabledCount === group.allNodes.length
+                          ? 'bg-primary-background'
+                          : 'bg-tertiary-background'
+                      )
+                    "
+                    @click="
+                      setProviderEnabled(
+                        group,
+                        group.enabledCount !== group.allNodes.length
+                      )
+                    "
+                  >
+                    <span
+                      :class="
+                        cn(
+                          'block size-4 translate-x-0.5 rounded-full bg-base-foreground transition-transform',
+                          group.enabledCount === group.allNodes.length &&
+                            'translate-x-4'
+                        )
+                      "
+                    />
+                  </button>
+                </div>
+              </div>
+
+              <div
+                v-if="expandedProviders.has(group.provider)"
+                class="border-t border-interface-stroke/40 bg-secondary-background/40 py-1"
+              >
+                <div
+                  v-for="node in group.nodes"
+                  :key="node.id"
+                  role="row"
+                  class="grid min-h-10 grid-cols-[minmax(14rem,1fr)_10rem_10rem_5rem] items-center px-4 text-sm"
+                >
+                  <div role="cell" class="min-w-0 pl-6 text-muted-foreground">
+                    <div class="truncate">{{ node.name }}</div>
+                    <div v-if="node.name !== node.id" class="truncate text-xs">
+                      {{ node.id }}
+                    </div>
+                  </div>
+                  <div role="cell" class="text-xs text-muted-foreground">
+                    {{
+                      draftNodes[node.id]
+                        ? $t('workspacePanel.allowlist.enabled')
+                        : $t('workspacePanel.allowlist.disabled')
+                    }}
+                  </div>
+                  <div role="cell" />
+                  <div role="cell" />
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div
+          v-if="saveError"
+          role="alert"
+          class="text-destructive flex min-h-10 items-center justify-end gap-3 text-sm"
+        >
+          <span>{{ $t('workspacePanel.allowlist.saveError') }}</span>
+          <Button
+            variant="muted-textonly"
+            :disabled="isSaving"
+            @click="persistDraft"
+          >
+            {{ $t('workspacePanel.allowlist.retry') }}
+          </Button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { storeToRefs } from 'pinia'
+import { computed, ref, shallowRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import SearchInput from '@/components/ui/search-input/SearchInput.vue'
+import type { PartnerNodeCatalogItem } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useDialogService } from '@/services/dialogService'
+
+interface PartnerNodeGroup {
+  provider: string
+  nodes: PartnerNodeCatalogItem[]
+  allNodes: PartnerNodeCatalogItem[]
+  enabledCount: number
+}
+
+type AccessMode = 'unrestricted' | 'restricted'
+type SortDirection = 'asc' | 'desc'
+
+const { t } = useI18n()
+const governanceStore = usePartnerNodeGovernanceStore()
+const { governedWorkspaceId, partnerNodes, policy, status } =
+  storeToRefs(governanceStore)
+const dialogService = useDialogService()
+
+const searchQuery = ref('')
+const draftNodes = ref<Record<string, boolean>>({})
+const draftEnforcementEnabled = ref(false)
+const expandedProviders = shallowRef(new Set<string>())
+const sortDirection = ref<SortDirection>('asc')
+const isSaving = ref(false)
+const saveError = ref(false)
+let saveGeneration = 0
+
+const isReady = computed(
+  () => status.value === 'configured' || status.value === 'unconfigured'
+)
+const isRestricted = computed(() => draftEnforcementEnabled.value)
+const allProvidersEnabled = computed(() =>
+  partnerNodes.value.every((node) => draftNodes.value[node.id] === true)
+)
+const allProvidersDisabled = computed(() =>
+  partnerNodes.value.every((node) => draftNodes.value[node.id] === false)
+)
+
+function originalNodeValue(nodeId: string): boolean {
+  return policy.value ? policy.value.nodes[nodeId] === true : true
+}
+
+function resetDraft(): void {
+  draftEnforcementEnabled.value = policy.value?.enforcementEnabled ?? false
+  draftNodes.value = Object.fromEntries(
+    partnerNodes.value.map((node) => [node.id, originalNodeValue(node.id)])
+  )
+  saveError.value = false
+}
+
+watch([governedWorkspaceId, policy], resetDraft, { immediate: true })
+
+watch(partnerNodes, (nodes) => {
+  draftNodes.value = Object.fromEntries(
+    nodes.map((node) => [
+      node.id,
+      draftNodes.value[node.id] ?? originalNodeValue(node.id)
+    ])
+  )
+})
+
+watch(
+  governedWorkspaceId,
+  () => {
+    saveGeneration += 1
+    isSaving.value = false
+  },
+  { flush: 'sync' }
+)
+
+const hasChanges = computed(
+  () =>
+    draftEnforcementEnabled.value !==
+      (policy.value?.enforcementEnabled ?? false) ||
+    partnerNodes.value.some(
+      (node) => draftNodes.value[node.id] !== originalNodeValue(node.id)
+    )
+)
+
+const groups = computed<PartnerNodeGroup[]>(() => {
+  const query = searchQuery.value.trim().toLocaleLowerCase()
+  const byProvider = new Map<string, PartnerNodeCatalogItem[]>()
+  for (const node of partnerNodes.value) {
+    const nodes = byProvider.get(node.provider) ?? []
+    nodes.push(node)
+    byProvider.set(node.provider, nodes)
+  }
+
+  return [...byProvider.entries()]
+    .map(([provider, allNodes]) => {
+      const providerMatches = provider.toLocaleLowerCase().includes(query)
+      const nodes = allNodes
+        .filter(
+          (node) =>
+            !query ||
+            providerMatches ||
+            [node.name, node.id].some((value) =>
+              value.toLocaleLowerCase().includes(query)
+            )
+        )
+        .sort((left, right) => left.name.localeCompare(right.name))
+      return {
+        provider,
+        nodes,
+        allNodes,
+        enabledCount: allNodes.filter(
+          (node) => draftNodes.value[node.id] === true
+        ).length
+      }
+    })
+    .filter((group) => group.nodes.length > 0)
+    .sort((left, right) => {
+      const result = left.provider.localeCompare(right.provider)
+      return sortDirection.value === 'asc' ? result : -result
+    })
+})
+
+function toggleProviderExpanded(provider: string): void {
+  const nextExpandedProviders = new Set(expandedProviders.value)
+  if (nextExpandedProviders.has(provider)) {
+    nextExpandedProviders.delete(provider)
+  } else {
+    nextExpandedProviders.add(provider)
+  }
+  expandedProviders.value = nextExpandedProviders
+}
+
+function toggleSortDirection(): void {
+  sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+}
+
+async function persistDraft(): Promise<void> {
+  if (!hasChanges.value) {
+    saveError.value = false
+    return
+  }
+  if (isSaving.value) return
+
+  const generation = saveGeneration
+  isSaving.value = true
+  saveError.value = false
+  try {
+    await governanceStore.savePolicy({
+      enforcementEnabled: draftEnforcementEnabled.value,
+      nodes: {
+        ...(policy.value?.nodes ?? {}),
+        ...draftNodes.value
+      }
+    })
+  } catch {
+    if (generation === saveGeneration) saveError.value = true
+  } finally {
+    if (generation === saveGeneration) isSaving.value = false
+  }
+}
+
+async function requestMode(mode: AccessMode): Promise<void> {
+  if ((mode === 'restricted') === isRestricted.value || isSaving.value) return
+
+  const generation = saveGeneration
+  const needsConfirmation =
+    mode === 'restricted' ||
+    partnerNodes.value.some((node) => draftNodes.value[node.id] !== true)
+  if (needsConfirmation) {
+    const confirmed = await dialogService.confirm({
+      title: t(`workspacePanel.allowlist.mode.${mode}ConfirmTitle`),
+      message: t(`workspacePanel.allowlist.mode.${mode}ConfirmMessage`)
+    })
+    if (!confirmed || generation !== saveGeneration) return
+  }
+
+  draftEnforcementEnabled.value = mode === 'restricted'
+  await persistDraft()
+}
+
+async function setProviderEnabled(
+  group: PartnerNodeGroup,
+  enabled: boolean
+): Promise<void> {
+  for (const node of group.allNodes) draftNodes.value[node.id] = enabled
+  await persistDraft()
+}
+
+async function setAllProviders(enabled: boolean): Promise<void> {
+  for (const node of partnerNodes.value) draftNodes.value[node.id] = enabled
+  await persistDraft()
+}
+
+function loadPolicy(): void {
+  void governanceStore.loadPolicy()
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -9,18 +10,26 @@ import WorkspacePanelContent from './WorkspacePanelContent.vue'
 const mockFetchMembers = vi.fn()
 const mockFetchPendingInvites = vi.fn()
 
-const { mockHasTeamPlan, mockIsPlanLoading, mockMembers, mockWorkspaceType } =
-  vi.hoisted(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-    const { ref } = require('vue') as typeof import('vue')
+const {
+  mockGovernedWorkspaceId,
+  mockHasTeamPlan,
+  mockIsPlanLoading,
+  mockMembers,
+  mockWorkspaceRole,
+  mockWorkspaceType
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
 
-    return {
-      mockHasTeamPlan: ref(true),
-      mockIsPlanLoading: ref(false),
-      mockMembers: ref<WorkspaceMember[]>([]),
-      mockWorkspaceType: ref<'personal' | 'team'>('team')
-    }
-  })
+  return {
+    mockGovernedWorkspaceId: ref<string | null>('workspace-one'),
+    mockHasTeamPlan: ref(true),
+    mockIsPlanLoading: ref(false),
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
+    mockWorkspaceType: ref<'personal' | 'team'>('team')
+  }
+})
 
 vi.mock('@/platform/workspace/composables/useTeamPlan', () => ({
   useTeamPlan: () => ({
@@ -51,15 +60,19 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => {
 })
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-  const { ref } = require('vue') as typeof import('vue')
   return {
     useWorkspaceUI: () => ({
       workspaceType: mockWorkspaceType,
-      workspaceRole: ref('owner')
+      workspaceRole: mockWorkspaceRole
     })
   }
 })
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    governedWorkspaceId: mockGovernedWorkspaceId
+  })
+}))
 
 vi.mock(
   '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue',
@@ -85,6 +98,11 @@ vi.mock(
   })
 )
 
+vi.mock(
+  '@/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.vue',
+  () => ({ default: { template: '<div />' } })
+)
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -104,8 +122,9 @@ function createMember(id: string): WorkspaceMember {
   }
 }
 
-function renderComponent() {
+function renderComponent(defaultTab?: string) {
   return render(WorkspacePanelContent, {
+    props: { defaultTab },
     global: {
       plugins: [i18n],
       stubs: { WorkspaceProfilePic: true }
@@ -117,6 +136,8 @@ describe('WorkspacePanelContent billing banner', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMembers.value = []
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -138,6 +159,8 @@ describe('WorkspacePanelContent members tab label', () => {
     mockHasTeamPlan.value = true
     mockIsPlanLoading.value = false
     mockMembers.value = []
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -183,5 +206,67 @@ describe('WorkspacePanelContent members tab label', () => {
     renderComponent()
     expect(mockFetchMembers).not.toHaveBeenCalled()
     expect(mockFetchPendingInvites).not.toHaveBeenCalled()
+  })
+})
+
+describe('WorkspacePanelContent allowlist tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockWorkspaceRole.value = 'owner'
+    mockWorkspaceType.value = 'team'
+  })
+
+  it('shows the allowlist for an eligible workspace owner', () => {
+    renderComponent()
+
+    expect(
+      screen.getByRole('tab', { name: 'workspacePanel.tabs.allowlist' })
+    ).toBeInTheDocument()
+  })
+
+  it('hides the allowlist from workspace members', () => {
+    mockWorkspaceRole.value = 'member'
+    renderComponent()
+
+    expect(
+      screen.queryByRole('tab', { name: 'workspacePanel.tabs.allowlist' })
+    ).toBeNull()
+  })
+
+  it('hides the allowlist when governance is ineligible', () => {
+    mockGovernedWorkspaceId.value = null
+    renderComponent()
+
+    expect(
+      screen.queryByRole('tab', { name: 'workspacePanel.tabs.allowlist' })
+    ).toBeNull()
+  })
+
+  it('falls back when allowlist access is unavailable on mount', () => {
+    mockWorkspaceRole.value = 'member'
+    renderComponent('allowlist')
+
+    expect(
+      screen.getByRole('tab', { name: 'workspacePanel.tabs.planCredits' })
+    ).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('falls back to a valid tab when allowlist access is lost', async () => {
+    renderComponent('allowlist')
+
+    expect(
+      screen.getByRole('tab', { name: 'workspacePanel.tabs.allowlist' })
+    ).toHaveAttribute('aria-selected', 'true')
+
+    mockWorkspaceRole.value = 'member'
+    await nextTick()
+
+    expect(
+      screen.queryByRole('tab', { name: 'workspacePanel.tabs.allowlist' })
+    ).toBeNull()
+    expect(
+      screen.getByRole('tab', { name: 'workspacePanel.tabs.planCredits' })
+    ).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -39,6 +39,18 @@
               : $t('workspacePanel.members.header')
           }}
         </TabsTrigger>
+        <TabsTrigger
+          v-if="showAllowlistTab"
+          value="allowlist"
+          :class="
+            cn(
+              tabTriggerBase,
+              activeTab === 'allowlist' ? tabTriggerActive : tabTriggerInactive
+            )
+          "
+        >
+          {{ $t('workspacePanel.tabs.allowlist') }}
+        </TabsTrigger>
       </TabsList>
 
       <BillingStatusBanner class="mt-4" />
@@ -49,13 +61,16 @@
       <TabsContent value="members" class="mt-4">
         <MembersPanelContent :key="workspaceRole" />
       </TabsContent>
+      <TabsContent v-if="showAllowlistTab" value="allowlist" class="mt-4">
+        <PartnerNodeAllowlistPanel />
+      </TabsContent>
     </TabsRoot>
   </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { whenever } from '@vueuse/core'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
@@ -63,9 +78,11 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import BillingStatusBanner from '@/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
+import PartnerNodeAllowlistPanel from '@/platform/workspace/components/dialogs/settings/PartnerNodeAllowlistPanel.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -86,7 +103,21 @@ const { fetchMembers, fetchPendingInvites } = workspaceStore
 
 const { workspaceRole } = useWorkspaceUI()
 const { hasTeamPlan, isPlanLoading } = useTeamPlan()
+const { governedWorkspaceId } = storeToRefs(usePartnerNodeGovernanceStore())
+const showAllowlistTab = computed(
+  () => !!governedWorkspaceId.value && workspaceRole.value === 'owner'
+)
 const activeTab = ref(defaultTab)
+
+watch(
+  showAllowlistTab,
+  (isVisible) => {
+    if (!isVisible && activeTab.value === 'allowlist') {
+      activeTab.value = defaultTab === 'allowlist' ? 'plan' : defaultTab
+    }
+  },
+  { immediate: true }
+)
 
 const showMembersTabCount = computed(
   () => hasTeamPlan.value && members.value.length > 1

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -12,6 +12,7 @@ import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
+const mockUpdatePartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockFlags = vi.hoisted(() => ({
   teamWorkspacesEnabled: true,
   partnerNodeGovernanceEnabled: true
@@ -27,7 +28,8 @@ vi.mock(
     const actual = await importOriginal<typeof PartnerNodePolicyApi>()
     return {
       ...actual,
-      getPartnerNodePolicy: mockGetPartnerNodePolicy
+      getPartnerNodePolicy: mockGetPartnerNodePolicy,
+      updatePartnerNodePolicy: mockUpdatePartnerNodePolicy
     }
   }
 )
@@ -87,6 +89,9 @@ describe('partnerNodeGovernanceStore', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.partnerNodeGovernanceEnabled = true
     mockGetPartnerNodePolicy.mockResolvedValue(null)
+    mockUpdatePartnerNodePolicy.mockImplementation(
+      async (policy: PartnerNodePolicy) => policy
+    )
     activateWorkspace('workspace-one')
     useNodeDefStore().updateNodeDefs([
       nodeDef('AllowedNode'),
@@ -272,5 +277,111 @@ describe('partnerNodeGovernanceStore', () => {
 
     expect(store.governedWorkspaceId).toBe('workspace-two')
     expect(store.isNodeDisabled('DisabledNode')).toBe(false)
+  })
+
+  it('saves and installs the validated whole policy', async () => {
+    store = await createLoadedStore()
+    const nextPolicy = {
+      enforcementEnabled: false,
+      nodes: { AllowedNode: true, DisabledNode: true }
+    } satisfies PartnerNodePolicy
+
+    await expect(store.savePolicy(nextPolicy)).resolves.toBe(true)
+
+    expect(mockUpdatePartnerNodePolicy).toHaveBeenCalledWith(nextPolicy)
+    expect(store.policy).toEqual(nextPolicy)
+    expect(store.status).toBe('configured')
+  })
+
+  it('does not install a save response after switching workspaces', async () => {
+    store = await createLoadedStore()
+    let resolveSave!: (policy: PartnerNodePolicy) => void
+    mockUpdatePartnerNodePolicy.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSave = resolve
+      })
+    )
+
+    const save = store.savePolicy({
+      enforcementEnabled: false,
+      nodes: { AllowedNode: true }
+    })
+    activateWorkspace('workspace-two')
+    await vi.waitFor(() =>
+      expect(store?.governedWorkspaceId).toBe('workspace-two')
+    )
+    resolveSave({
+      enforcementEnabled: false,
+      nodes: { AllowedNode: true }
+    })
+
+    await expect(save).resolves.toBe(false)
+    await vi.waitFor(() => expect(store?.status).toBe('unconfigured'))
+    expect(store.policy).toBeNull()
+  })
+
+  it('does not install a save response after switching away and back', async () => {
+    store = await createLoadedStore()
+    let resolveSave!: (policy: PartnerNodePolicy) => void
+    mockUpdatePartnerNodePolicy.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSave = resolve
+      })
+    )
+
+    const save = store.savePolicy({
+      enforcementEnabled: true,
+      nodes: { AllowedNode: true }
+    })
+    activateWorkspace('workspace-two')
+    await vi.waitFor(() =>
+      expect(store?.governedWorkspaceId).toBe('workspace-two')
+    )
+    activateWorkspace('workspace-one')
+    await vi.waitFor(() =>
+      expect(store?.governedWorkspaceId).toBe('workspace-one')
+    )
+    resolveSave({
+      enforcementEnabled: true,
+      nodes: { AllowedNode: true }
+    })
+
+    await expect(save).resolves.toBe(false)
+    await vi.waitFor(() => expect(store?.status).toBe('unconfigured'))
+    expect(store.policy).toBeNull()
+  })
+
+  it('ignores a stale save rejection after switching workspaces', async () => {
+    store = await createLoadedStore()
+    let rejectSave!: (error: Error) => void
+    mockUpdatePartnerNodePolicy.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectSave = reject
+      })
+    )
+
+    const save = store.savePolicy({
+      enforcementEnabled: true,
+      nodes: { AllowedNode: true }
+    })
+    activateWorkspace('workspace-two')
+    await vi.waitFor(() =>
+      expect(store?.governedWorkspaceId).toBe('workspace-two')
+    )
+    rejectSave(new Error('Conflict'))
+
+    await expect(save).resolves.toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('refuses to save before governance is ready', async () => {
+    mockFlags.partnerNodeGovernanceEnabled = false
+    store = usePartnerNodeGovernanceStore()
+    await nextTick()
+
+    await expect(
+      store.savePolicy({ enforcementEnabled: false, nodes: {} })
+    ).rejects.toThrow('Partner node governance is not ready')
+    expect(mockUpdatePartnerNodePolicy).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -4,7 +4,8 @@ import { computed, ref, shallowRef, watch } from 'vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   getPartnerNodePolicy,
-  PartnerNodePolicyApiError
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -36,6 +37,7 @@ export const usePartnerNodeGovernanceStore = defineStore(
     const status = ref<PartnerNodePolicyStatus>('inactive')
     const error = shallowRef<Error | null>(null)
     let loadVersion = 0
+    let workspaceVersion = 0
 
     const governedWorkspaceId = computed(() => {
       const workspace = workspaceStore.activeWorkspace
@@ -124,7 +126,47 @@ export const usePartnerNodeGovernanceStore = defineStore(
       }
     }
 
-    watch(governedWorkspaceId, () => void loadPolicy(), { immediate: true })
+    async function savePolicy(nextPolicy: PartnerNodePolicy): Promise<boolean> {
+      const workspaceId = governedWorkspaceId.value
+      const version = workspaceVersion
+      if (!workspaceId || policyWorkspaceId.value !== workspaceId) {
+        throw new Error('Partner node governance is not ready')
+      }
+
+      let savedPolicy: PartnerNodePolicy
+      try {
+        savedPolicy = await updatePartnerNodePolicy(nextPolicy)
+      } catch (saveError) {
+        if (
+          workspaceVersion !== version ||
+          governedWorkspaceId.value !== workspaceId
+        ) {
+          return false
+        }
+        throw saveError
+      }
+      if (
+        workspaceVersion !== version ||
+        governedWorkspaceId.value !== workspaceId
+      ) {
+        return false
+      }
+
+      policy.value = savedPolicy
+      policyWorkspaceId.value = workspaceId
+      status.value = 'configured'
+      error.value = null
+      return true
+    }
+
+    watch(
+      governedWorkspaceId,
+      () => {
+        workspaceVersion++
+        void loadPolicy()
+      },
+      { immediate: true, flush: 'sync' }
+    )
 
     return {
       policy,
@@ -133,7 +175,8 @@ export const usePartnerNodeGovernanceStore = defineStore(
       governedWorkspaceId,
       partnerNodes,
       isNodeDisabled,
-      loadPolicy
+      loadPolicy,
+      savePolicy
     }
   }
 )


### PR DESCRIPTION
## Summary

- Adds an owner-only Allowlist tab for eligible Team workspaces, with Unrestricted and Restricted modes, confirmation before broad access changes, search, sorting, node details, and provider or bulk controls.
- Auto-saves validated whole-policy updates, preserves entries absent from the current catalog, keeps controls read-only in Unrestricted mode, and ignores stale responses after workspace changes.
- This slice is the configuration surface only. Runtime discovery and queue enforcement remain in later stacked PRs.

## Verification

| Before | After |
|---|---|
| <img width="1280" height="720" alt="Unrestricted mode with provider controls read-only" src="https://github.com/user-attachments/assets/aee63577-dad1-49ad-9393-2ae18945f2e8" /> | <img width="1280" height="720" alt="Restricted mode with provider controls enabled" src="https://github.com/user-attachments/assets/09c03184-1fec-4c6f-8be8-b16206c7fae9" /> |

https://github.com/user-attachments/assets/e9be7cc6-751a-4d46-bc7b-bc7e00cdf4dd
| Timestamp | Screenshot | Highlight |
|---|---|---|
| `00:00.50` | <img width="800" height="450" alt="Unrestricted access baseline" src="https://github.com/user-attachments/assets/4494801e-77a5-4f63-a37b-93aae0d394be" /> | Unrestricted mode is selected and provider controls are read-only. |
| `00:01.50` | <img width="800" height="450" alt="Restricted access confirmation" src="https://github.com/user-attachments/assets/bd1ff1da-1054-4ee3-9674-a2ecc3508730" /> | A confirmation dialog warns that only enabled providers will remain available. |
| `00:03.50` | <img width="800" height="450" alt="Restricted access provider controls" src="https://github.com/user-attachments/assets/90451c89-f66d-41f8-aef9-f1677e150c66" /> | Restricted mode enables provider controls and the BFL update leaves both providers allowed. |

The mocked Cloud flow observed these whole-policy writes at `/api/workspace/partner-node-policy`:

- Mode change: `{"enforcement_enabled":true,"nodes":{"FluxFill":false,"FluxExpand":true,"VeoVideo":true}}`
- Provider change: `{"enforcement_enabled":true,"nodes":{"FluxFill":true,"FluxExpand":true,"VeoVideo":true}}`

Created by Codex