### PR TITLE
feat: 4/x filter disabled partner nodes from discovery

### DIFF
--- a/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
@@ -71,6 +71,8 @@ async function setupGovernedWorkspace(page: Page) {
 }
 
 test.describe('Partner node governance discovery', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
   test('hides disabled nodes from search', async ({ page }) => {
     await setupGovernedWorkspace(page)
     await page.goto(APP_URL)

--- a/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import type { ListAssetsResponse } from '@comfyorg/ingest-types'
+
+import type { PartnerNodePolicyResponse } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { WORKSPACE_FEATURE_FLAG } from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+function partnerNode(name: string): ComfyNodeDef {
+  return {
+    name,
+    display_name: name,
+    category: 'partner/image/Acme',
+    python_module: 'comfy_api_nodes.acme',
+    description: '',
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: false,
+    api_node: true
+  }
+}
+
+async function setupGovernedWorkspace(page: Page) {
+  await new CloudWorkspaceMockHelper(page).setup()
+  await page.route('**/api/features', (route) =>
+    route.fulfill(
+      jsonRoute({
+        ...WORKSPACE_FEATURE_FLAG,
+        partner_node_governance_enabled: true
+      } satisfies RemoteConfig)
+    )
+  )
+  await page.route('**/api/object_info', (route) =>
+    route.fulfill(
+      jsonRoute({
+        AllowedPartnerNode: partnerNode('AllowedPartnerNode'),
+        DisabledPartnerNode: partnerNode('DisabledPartnerNode')
+      })
+    )
+  )
+  await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
+    route.fulfill(
+      jsonRoute({
+        assets: [],
+        total: 0,
+        has_more: false
+      } satisfies ListAssetsResponse)
+    )
+  )
+  await page.route('**/api/workspace/partner-node-policy', (route) =>
+    route.fulfill(
+      jsonRoute({
+        enforcement_enabled: true,
+        nodes: {
+          AllowedPartnerNode: true,
+          DisabledPartnerNode: false
+        }
+      } satisfies PartnerNodePolicyResponse)
+    )
+  )
+}
+
+test.describe('Partner node governance discovery', { tag: '@cloud' }, () => {
+  test('hides disabled nodes from search', async ({ page }) => {
+    await setupGovernedWorkspace(page)
+    await page.goto(APP_URL)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+
+    await page.evaluate(async () => {
+      await window.app!.extensionManager.setting.set(
+        'Comfy.NodeSearchBoxImpl',
+        'default'
+      )
+      await window.app!.extensionManager.command.execute(
+        'Workspace.SearchBox.Toggle'
+      )
+    })
+    const search = page.getByRole('search')
+    await expect(search).toBeVisible()
+    await search.getByRole('combobox').fill('PartnerNode')
+
+    await expect(search.getByText('AllowedPartnerNode')).toBeVisible()
+    await expect(search.getByText('DisabledPartnerNode')).toHaveCount(0)
+  })
+})

--- a/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceDiscovery.spec.ts
@@ -45,7 +45,7 @@ async function setupGovernedWorkspace(page: Page) {
       jsonRoute({
         AllowedPartnerNode: partnerNode('AllowedPartnerNode'),
         DisabledPartnerNode: partnerNode('DisabledPartnerNode')
-      })
+      } satisfies Record<string, ComfyNodeDef>)
     )
   )
   await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>

--- a/src/extensions/core/cloudPartnerNodeGovernance.test.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const registerExtension = vi.hoisted(() => vi.fn())
+const usePartnerNodeGovernanceStore = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({ registerExtension })
+}))
+
+describe('cloudPartnerNodeGovernance', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('initializes governance during Cloud setup', async () => {
+    await import('./cloudPartnerNodeGovernance')
+
+    expect(registerExtension).toHaveBeenCalledOnce()
+    const extension = registerExtension.mock.calls[0]?.[0] as {
+      name: string
+      setup: () => void
+    }
+    expect(extension.name).toBe('Comfy.Cloud.PartnerNodeGovernance')
+
+    extension.setup()
+
+    expect(usePartnerNodeGovernanceStore).toHaveBeenCalledOnce()
+  })
+})

--- a/src/extensions/core/cloudPartnerNodeGovernance.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.ts
@@ -1,0 +1,10 @@
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useExtensionService } from '@/services/extensionService'
+
+useExtensionService().registerExtension({
+  name: 'Comfy.Cloud.PartnerNodeGovernance',
+
+  setup: () => {
+    usePartnerNodeGovernanceStore()
+  }
+})

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -38,6 +38,7 @@ if (isCloud) {
   await import('./cloudRemoteConfig')
   await import('./cloudBadges')
   await import('./cloudSessionCookie')
+  await import('./cloudPartnerNodeGovernance')
 }
 
 // Feedback button for cloud and nightly builds

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4499,7 +4499,8 @@
     "hideDevOnly": "Hide Dev-Only Nodes",
     "hideDevOnlyDescription": "Hides nodes marked as dev-only unless dev mode is enabled",
     "hideSubgraph": "Hide Subgraph Nodes",
-    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search"
+    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search",
+    "workspacePartnerNodeGovernance": "Workspace partner-node governance"
   },
   "secrets": {
     "title": "API Keys & Secrets",

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -203,6 +203,35 @@ describe('partnerNodeGovernanceStore', () => {
     expect(LegacyGovernedNode.skip_list).toBe(false)
   })
 
+  it('removes discovery restrictions when disposed', async () => {
+    class LegacyGovernedNode extends LGraphNode {}
+    LiteGraph.registered_node_types.LegacyGovernedNode = LegacyGovernedNode
+    useNodeDefStore().addNodeDef(nodeDef('LegacyGovernedNode'))
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      nodes: { LegacyGovernedNode: false }
+    } satisfies PartnerNodePolicy)
+    store = await createLoadedStore()
+    const nodeDefStore = useNodeDefStore()
+
+    expect(LegacyGovernedNode.skip_list).toBe(true)
+    expect(
+      nodeDefStore.nodeDefFilters.some(
+        ({ id }) => id === 'workspace.partner-node-governance'
+      )
+    ).toBe(true)
+
+    store.$dispose()
+    store = undefined
+
+    expect(LegacyGovernedNode.skip_list).toBe(false)
+    expect(
+      nodeDefStore.nodeDefFilters.some(
+        ({ id }) => id === 'workspace.partner-node-governance'
+      )
+    ).toBe(false)
+  })
+
   it('fails closed for a 503 from an enforcing workspace', async () => {
     mockGetPartnerNodePolicy.mockRejectedValue(
       new PartnerNodePolicyApiError(503, 'Service Unavailable')

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type * as PartnerNodePolicyApi from '@/platform/workspace/api/partnerNodePolicyApi'
 import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
@@ -106,6 +107,7 @@ describe('partnerNodeGovernanceStore', () => {
   })
 
   afterEach(() => {
+    delete LiteGraph.registered_node_types.LegacyGovernedNode
     store?.$dispose()
     store = undefined
   })
@@ -158,6 +160,47 @@ describe('partnerNodeGovernanceStore', () => {
     expect(store.isNodeDisabled('DisabledNode')).toBe(true)
     expect(store.isNodeDisabled('UnreviewedNode')).toBe(true)
     expect(store.isNodeDisabled('CoreNode')).toBe(false)
+  })
+
+  it('filters disabled nodes out of discovery', async () => {
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      nodes: { AllowedNode: true, DisabledNode: false }
+    } satisfies PartnerNodePolicy)
+
+    store = await createLoadedStore()
+    const nodeDefStore = useNodeDefStore()
+
+    expect(nodeDefStore.visibleNodeDefs.map((node) => node.name)).toEqual([
+      'AllowedNode',
+      'CoreNode'
+    ])
+    expect(nodeDefStore.nodeSearchService.searchNode('DisabledNode')).toEqual(
+      []
+    )
+  })
+
+  it('keeps the litegraph legacy menu in sync with policy changes', async () => {
+    class LegacyGovernedNode extends LGraphNode {}
+    LiteGraph.registered_node_types.LegacyGovernedNode = LegacyGovernedNode
+    useNodeDefStore().addNodeDef(nodeDef('LegacyGovernedNode'))
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      nodes: { LegacyGovernedNode: false }
+    } satisfies PartnerNodePolicy)
+
+    store = await createLoadedStore()
+
+    expect(LegacyGovernedNode.skip_list).toBe(true)
+
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: false,
+      nodes: { LegacyGovernedNode: false }
+    } satisfies PartnerNodePolicy)
+    await store.loadPolicy()
+    await nextTick()
+
+    expect(LegacyGovernedNode.skip_list).toBe(false)
   })
 
   it('fails closed for a 503 from an enforcing workspace', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { t } from '@/i18n'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
   getPartnerNodePolicy,
@@ -77,7 +78,7 @@ export const usePartnerNodeGovernanceStore = defineStore(
 
     nodeDefStore.registerNodeDefFilter({
       id: DISCOVERY_FILTER_ID,
-      name: 'Workspace partner-node governance',
+      name: t('nodeFilters.workspacePartnerNodeGovernance'),
       predicate: (nodeDef) => !isNodeDisabled(nodeDef.name)
     })
 

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -1,5 +1,12 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
+import {
+  computed,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  watch,
+  watchEffect
+} from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { t } from '@/i18n'
@@ -100,6 +107,17 @@ export const usePartnerNodeGovernanceStore = defineStore(
 
         if (legacyHiddenNodeTypes.delete(nodeDef.name)) {
           nodeType.skip_list = nodeDef.dev_only && !showDevOnly
+        }
+      }
+    })
+
+    onScopeDispose(() => {
+      nodeDefStore.unregisterNodeDefFilter(DISCOVERY_FILTER_ID)
+      for (const nodeName of legacyHiddenNodeTypes) {
+        const nodeDef = nodeDefStore.nodeDefsByName[nodeName]
+        const nodeType = LiteGraph.registered_node_types[nodeName]
+        if (nodeDef && nodeType) {
+          nodeType.skip_list = nodeDef.dev_only && !nodeDefStore.showDevOnly
         }
       }
     })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
   getPartnerNodePolicy,
   PartnerNodePolicyApiError,
@@ -24,6 +25,8 @@ export type PartnerNodePolicyStatus =
   | 'configured'
   | 'unavailable'
   | 'error'
+
+const DISCOVERY_FILTER_ID = 'workspace.partner-node-governance'
 
 export const usePartnerNodeGovernanceStore = defineStore(
   'partnerNodeGovernance',
@@ -71,6 +74,34 @@ export const usePartnerNodeGovernanceStore = defineStore(
         policy.value.nodes[nodeType] !== true
       )
     }
+
+    nodeDefStore.registerNodeDefFilter({
+      id: DISCOVERY_FILTER_ID,
+      name: 'Workspace partner-node governance',
+      predicate: (nodeDef) => !isNodeDisabled(nodeDef.name)
+    })
+
+    const legacyHiddenNodeTypes = new Set<string>()
+    watchEffect(() => {
+      const showDevOnly = nodeDefStore.showDevOnly
+      for (const nodeDef of Object.values(nodeDefStore.nodeDefsByName)) {
+        if (!nodeDef.api_node) continue
+        const nodeType = LiteGraph.registered_node_types[nodeDef.name]
+        if (!nodeType) continue
+
+        if (isNodeDisabled(nodeDef.name)) {
+          if (!nodeType.skip_list) {
+            nodeType.skip_list = true
+            legacyHiddenNodeTypes.add(nodeDef.name)
+          }
+          continue
+        }
+
+        if (legacyHiddenNodeTypes.delete(nodeDef.name)) {
+          nodeType.skip_list = nodeDef.dev_only && !showDevOnly
+        }
+      }
+    })
 
     async function loadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -1,6 +1,7 @@
+import axios from 'axios'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { promoteValueWidgetViaSubgraphInput } from '@/core/graph/subgraph/promotionUtils'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -10,7 +11,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import type { NodeDefFilter } from '@/stores/nodeDefStore'
 
 describe('useNodeDefStore', () => {
@@ -19,6 +20,10 @@ describe('useNodeDefStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useNodeDefStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   const createMockNodeDef = (
@@ -283,6 +288,30 @@ describe('useNodeDefStore', () => {
         'normal',
         'FakeSubgraph'
       ])
+    })
+  })
+
+  describe('node frequency visibility', () => {
+    it('excludes node definitions hidden by registered filters', async () => {
+      vi.spyOn(axios, 'get').mockResolvedValue({
+        data: { HiddenNode: 2, VisibleNode: 1 }
+      })
+      store.updateNodeDefs([
+        createMockNodeDef({ name: 'HiddenNode' }),
+        createMockNodeDef({ name: 'VisibleNode' })
+      ])
+      store.registerNodeDefFilter({
+        id: 'test.hide-node',
+        name: 'Hide node',
+        predicate: (nodeDef) => nodeDef.name !== 'HiddenNode'
+      })
+
+      const frequencyStore = useNodeFrequencyStore()
+      await frequencyStore.loadNodeFrequencies()
+
+      expect(frequencyStore.topNodeDefs.map((nodeDef) => nodeDef.name)).toEqual(
+        ['VisibleNode']
+      )
     })
   })
 

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -562,9 +562,15 @@ export const useNodeFrequencyStore = defineStore('nodeFrequency', () => {
 
   const nodeDefStore = useNodeDefStore()
   const topNodeDefs = computed<ComfyNodeDefImpl[]>(() => {
+    const visibleNodeNames = new Set(
+      nodeDefStore.visibleNodeDefs.map((nodeDef) => nodeDef.name)
+    )
     return nodeNamesByFrequency.value
       .map((nodeName: string) => nodeDefStore.nodeDefsByName[nodeName])
-      .filter((nodeDef: ComfyNodeDefImpl) => nodeDef !== undefined)
+      .filter(
+        (nodeDef): nodeDef is ComfyNodeDefImpl =>
+          nodeDef !== undefined && visibleNodeNames.has(nodeDef.name)
+      )
       .slice(0, topNodeDefLimit.value)
   })
 


### PR DESCRIPTION
## Summary

Superseded by #13879. This branch preserves the earlier node-level discovery slice stacked on #13745: in Cloud builds, an enforcing workspace policy removes disabled API nodes from node search, Node Library surfaces, frequent-node suggestions, and the legacy LiteGraph add-node menu. The replacement provider-governance design does not carry this discovery filter forward.

## Verification

| Before: disabled Flux Fill remains visible | After: Flux Fill is filtered and Flux Expand remains |
|---|---|
| <img width="720" alt="Disabled Flux Fill still visible in node search" src="https://github.com/user-attachments/assets/1e496dba-0f3d-45e3-8d66-d684350ab36c" /> | <img width="720" alt="Flux Fill filtered while Flux Expand remains" src="https://github.com/user-attachments/assets/1f3c163a-c2f9-4dbf-aae5-5cecc0fa1782" /> |

https://github.com/user-attachments/assets/7ffe59b3-e4b3-471a-99da-a0672b212545
| Timestamp | Screenshot | Highlight |
|---|---|---|
| `00:02.50` | <img width="480" alt="Disabled Flux Fill visible before filtering" src="https://github.com/user-attachments/assets/03350294-e42a-47cf-8604-957861498a05" /> | Baseline search shows both Flux Fill and Flux Expand. |
| `00:04.50` | <img width="480" alt="Disabled Flux Fill removed after filtering" src="https://github.com/user-attachments/assets/8076bc7f-37f7-41b7-ba88-1f66333f2091" /> | Governed search removes Flux Fill while Flux Expand remains available. |

- Observable proof: the disabled Flux Fill result disappears while the allowed Flux Expand result remains.
- Current-head proof: the Cloud Playwright flow loads an enforcing policy, observes the allowed node, and observes no disabled-node result. Store regressions cover frequent-node filtering, legacy-menu synchronization, and cleanup on disposal.

Created by Codex