### PR TITLE
feat: 5/x block disabled partner nodes from queue

### DIFF
--- a/browser_tests/fixtures/partnerNodeGovernanceFixture.ts
+++ b/browser_tests/fixtures/partnerNodeGovernanceFixture.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test'
+
+import type { ListAssetsResponse } from '@comfyorg/ingest-types'
+
+import type { PartnerNodePolicyResponse } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { PromptResponse } from '@/schemas/apiSchema'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+import { comfyPageFixture as base } from '@e2e/fixtures/ComfyPage'
+import { WORKSPACE_FEATURE_FLAG } from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const DISABLED_NODE = 'DisabledPartnerNode'
+
+interface PartnerNodeGovernanceFixture {
+  promptRequestCount: () => number
+}
+
+function disabledPartnerNode(): ComfyNodeDef {
+  return {
+    name: DISABLED_NODE,
+    display_name: 'Disabled Partner Node',
+    category: 'partner/image/Acme',
+    python_module: 'comfy_api_nodes.acme',
+    description: '',
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: true,
+    api_node: true
+  }
+}
+
+async function setupGovernedWorkspace(page: Page) {
+  await new CloudWorkspaceMockHelper(page).setup()
+  await page.route('**/api/features', (route) =>
+    route.fulfill(
+      jsonRoute({
+        ...WORKSPACE_FEATURE_FLAG,
+        partner_node_governance_enabled: true
+      } satisfies RemoteConfig)
+    )
+  )
+  await page.route('**/api/object_info', (route) =>
+    route.fulfill(jsonRoute({ [DISABLED_NODE]: disabledPartnerNode() }))
+  )
+  await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
+    route.fulfill(
+      jsonRoute({
+        assets: [],
+        total: 0,
+        has_more: false
+      } satisfies ListAssetsResponse)
+    )
+  )
+  await page.route('**/api/workspace/partner-node-policy', (route) =>
+    route.fulfill(
+      jsonRoute({
+        enforcement_enabled: true,
+        nodes: { [DISABLED_NODE]: false }
+      } satisfies PartnerNodePolicyResponse)
+    )
+  )
+}
+
+export const partnerNodeGovernanceTest = base.extend<{
+  partnerNodeGovernance: PartnerNodeGovernanceFixture
+}>({
+  partnerNodeGovernance: async ({ page }, use) => {
+    await setupGovernedWorkspace(page)
+    let promptRequests = 0
+    await page.route('**/api/prompt', (route) => {
+      promptRequests++
+      return route.fulfill(
+        jsonRoute({
+          prompt_id: 'unexpected-prompt',
+          node_errors: {},
+          error: ''
+        } satisfies PromptResponse)
+      )
+    })
+
+    await page.goto(APP_URL)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+    await page.evaluate((nodeType) => {
+      const node = window.LiteGraph!.createNode(nodeType)
+      if (!node) throw new Error(`Failed to create ${nodeType}`)
+      window.app!.rootGraph.add(node)
+    }, DISABLED_NODE)
+
+    await use({ promptRequestCount: () => promptRequests })
+  }
+})

--- a/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from '@playwright/test'
+
+import { partnerNodeGovernanceTest as test } from '@e2e/fixtures/partnerNodeGovernanceFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+test.describe('Partner node governance workbench', { tag: '@cloud' }, () => {
+  test('blocks queueing a disabled partner node', async ({
+    page,
+    partnerNodeGovernance
+  }) => {
+    await page.getByTestId(TestIds.topbar.queueButton).click()
+
+    await expect(page.getByRole('alert')).toContainText(
+      'Workflow blocked by workspace policy'
+    )
+    expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
+  })
+})

--- a/src/extensions/core/cloudPartnerNodeGovernance.test.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.test.ts
@@ -1,10 +1,58 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const registerExtension = vi.hoisted(() => vi.fn())
-const usePartnerNodeGovernanceStore = vi.hoisted(() => vi.fn())
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import type { ComfyApp } from '@/scripts/app'
+import type { QueuePromptGuard } from '@/services/queuePromptGuardService'
+import type { ComfyExtension } from '@/types/comfy'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+
+const {
+  addToast,
+  governanceStore,
+  isNodeDisabled,
+  loadPolicy,
+  registerQueuePromptGuard,
+  registerExtension,
+  usePartnerNodeGovernanceStore
+} = vi.hoisted(() => {
+  const isNodeDisabled = vi.fn()
+  const loadPolicy = vi.fn<() => Promise<void>>().mockResolvedValue()
+  const governanceStore = {
+    status: 'configured',
+    isNodeDisabled,
+    loadPolicy
+  }
+  return {
+    addToast: vi.fn(),
+    governanceStore,
+    isNodeDisabled,
+    loadPolicy,
+    registerQueuePromptGuard: vi.fn<
+      (id: string, guard: QueuePromptGuard) => () => void
+    >(() => () => {}),
+    registerExtension: vi.fn<(extension: ComfyExtension) => void>(),
+    usePartnerNodeGovernanceStore: vi.fn(() => governanceStore)
+  }
+})
 
 vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
   usePartnerNodeGovernanceStore
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: addToast })
+}))
+
+vi.mock('@/services/queuePromptGuardService', () => ({
+  registerQueuePromptGuard
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -13,22 +61,189 @@ vi.mock('@/services/extensionService', () => ({
 
 describe('cloudPartnerNodeGovernance', () => {
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.resetModules()
     vi.clearAllMocks()
+    governanceStore.status = 'configured'
+    loadPolicy.mockResolvedValue()
   })
 
-  it('initializes governance during Cloud setup', async () => {
+  async function loadExtension(): Promise<ComfyExtension> {
     await import('./cloudPartnerNodeGovernance')
+    const extension = registerExtension.mock.calls[0]?.[0]
+    if (!extension)
+      throw new Error('Expected governance extension registration')
+    return extension
+  }
 
-    expect(registerExtension).toHaveBeenCalledOnce()
-    const extension = registerExtension.mock.calls[0]?.[0] as {
-      name: string
-      setup: () => void
+  async function loadGuard(): Promise<QueuePromptGuard> {
+    const extension = await loadExtension()
+    extension.setup?.(fromPartial<ComfyApp>({}))
+    const guard = registerQueuePromptGuard.mock.calls[0]?.[1]
+    if (!guard) throw new Error('Expected queue guard registration')
+    return guard
+  }
+
+  function disabledPartnerNode(): LGraphNode {
+    return new LGraphNode('DisabledPartnerNode', 'DisabledPartnerNode')
+  }
+
+  function outputNode(title: string): LGraphNode {
+    class OutputNode extends LGraphNode {
+      static override nodeData = { output_node: true }
     }
+
+    return new OutputNode(title, title)
+  }
+
+  function connectNodes(graph: LGraph, source: LGraphNode, target: LGraphNode) {
+    source.addOutput('output', '*')
+    target.addInput('input', '*')
+    graph.add(source)
+    graph.add(target)
+    source.connect(0, target, 0)
+  }
+
+  it('initializes governance during Cloud setup', async () => {
+    const extension = await loadExtension()
     expect(extension.name).toBe('Comfy.Cloud.PartnerNodeGovernance')
 
-    extension.setup()
+    extension.setup?.(fromPartial<ComfyApp>({}))
 
     expect(usePartnerNodeGovernanceStore).toHaveBeenCalledOnce()
+    expect(registerQueuePromptGuard).toHaveBeenCalledOnce()
+  })
+
+  it('waits for the initial policy load before checking the graph', async () => {
+    let resolvePolicy!: () => void
+    loadPolicy.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePolicy = resolve
+      })
+    )
+    governanceStore.status = 'loading'
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    const result = guard({ rootGraph: graph })
+
+    expect(loadPolicy).toHaveBeenCalledOnce()
+    expect(isNodeDisabled).not.toHaveBeenCalled()
+    resolvePolicy()
+    await expect(result).resolves.toBe(false)
+  })
+
+  it('blocks queueing when the graph contains a disabled partner node', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({ rootGraph: graph })
+
+    expect(result).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Workflow blocked by workspace policy',
+      detail:
+        'Remove disabled partner nodes from this workflow or ask a workspace owner to update the policy.',
+      life: 6000
+    })
+  })
+
+  it.each([
+    ['muted', LGraphEventMode.NEVER],
+    ['bypassed', LGraphEventMode.BYPASS]
+  ])(
+    'allows queueing when the disabled partner node is %s',
+    async (_label, mode) => {
+      const graph = new LGraph()
+      const node = disabledPartnerNode()
+      node.mode = mode
+      graph.add(node)
+      isNodeDisabled.mockImplementation(
+        (nodeType) => nodeType === 'DisabledPartnerNode'
+      )
+      const guard = await loadGuard()
+
+      expect(await guard({ rootGraph: graph })).toBe(true)
+      expect(addToast).not.toHaveBeenCalled()
+    }
+  )
+
+  it('allows queueing when the disabled partner node is inside a muted subgraph', async () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    subgraph.add(disabledPartnerNode())
+    const host = createTestSubgraphNode(subgraph)
+    host.mode = LGraphEventMode.NEVER
+    rootGraph.add(host)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph })).toBe(true)
+    expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('blocks queueing when the disabled partner node is inside an active subgraph', async () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    subgraph.add(disabledPartnerNode())
+    rootGraph.add(createTestSubgraphNode(subgraph))
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph })).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+  })
+
+  it('allows partial execution when a disabled node is on another output branch', async () => {
+    const graph = new LGraph()
+    const allowedSource = new LGraphNode('AllowedNode', 'AllowedNode')
+    const allowedOutput = outputNode('AllowedOutput')
+    const disabledSource = disabledPartnerNode()
+    const unrelatedOutput = outputNode('UnrelatedOutput')
+    connectNodes(graph, allowedSource, allowedOutput)
+    connectNodes(graph, disabledSource, unrelatedOutput)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({
+      rootGraph: graph,
+      queueNodeIds: [createNodeExecutionId([allowedOutput.id])]
+    })
+
+    expect(result).toBe(true)
+    expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('blocks partial execution when a disabled node is an upstream dependency', async () => {
+    const graph = new LGraph()
+    const disabledSource = disabledPartnerNode()
+    const selectedOutput = outputNode('SelectedOutput')
+    connectNodes(graph, disabledSource, selectedOutput)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({
+      rootGraph: graph,
+      queueNodeIds: [createNodeExecutionId([selectedOutput.id])]
+    })
+
+    expect(result).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
   })
 })

--- a/src/extensions/core/cloudPartnerNodeGovernance.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.ts
@@ -1,10 +1,121 @@
+import { t } from '@/i18n'
+import type {
+  ExecutableLGraphNode,
+  LGraph,
+  LGraphNode,
+  Subgraph
+} from '@/lib/litegraph/src/litegraph'
+import { ExecutableNodeDTO } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useExtensionService } from '@/services/extensionService'
+import { registerQueuePromptGuard } from '@/services/queuePromptGuardService'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+import { isOutputNode } from '@/utils/nodeFilterUtil'
+
+const QUEUE_GUARD_ID = 'workspace.partner-node-governance'
+
+function isExcludedFromPrompt(node: Pick<LGraphNode, 'mode'>): boolean {
+  return (
+    node.mode === LGraphEventMode.NEVER || node.mode === LGraphEventMode.BYPASS
+  )
+}
+
+function createExecutableNodeMap(
+  graph: LGraph
+): Map<string, ExecutableLGraphNode> {
+  const nodesByExecutionId = new Map<string, ExecutableLGraphNode>()
+  for (const node of graph.computeExecutionOrder(false)) {
+    const nodeDto = new ExecutableNodeDTO(node, [], nodesByExecutionId)
+    nodesByExecutionId.set(nodeDto.id, nodeDto)
+    if (isExcludedFromPrompt(node)) continue
+
+    for (const innerNode of nodeDto.getInnerNodes()) {
+      nodesByExecutionId.set(innerNode.id, innerNode)
+    }
+  }
+  return nodesByExecutionId
+}
+
+function hasDisabledPartnerNodeInPartialExecution(
+  graph: LGraph,
+  queueNodeIds: readonly NodeExecutionId[],
+  isNodeDisabled: (nodeType: string) => boolean
+): boolean {
+  const nodesByExecutionId = createExecutableNodeMap(graph)
+  const visited = new Set<string>()
+
+  function hasDisabledDependency(executionId: string): boolean {
+    if (visited.has(executionId)) return false
+    visited.add(executionId)
+
+    const node = nodesByExecutionId.get(executionId)
+    if (!node || node.isVirtualNode || isExcludedFromPrompt(node)) return false
+    if (node.type && isNodeDisabled(node.type)) return true
+
+    return node.inputs.some((_input, index) => {
+      const resolvedInput = node.resolveInput(index)
+      return (
+        !!resolvedInput &&
+        !resolvedInput.widgetInfo &&
+        hasDisabledDependency(resolvedInput.origin_id)
+      )
+    })
+  }
+
+  return queueNodeIds.some((executionId) => {
+    const node = getNodeByExecutionId(graph, executionId)
+    return !!node && isOutputNode(node) && hasDisabledDependency(executionId)
+  })
+}
+
+function hasDisabledPartnerNode(
+  graph: LGraph | Subgraph,
+  isNodeDisabled: (nodeType: string) => boolean
+): boolean {
+  return graph.nodes.some((node) => {
+    if (isExcludedFromPrompt(node)) return false
+    if (
+      node.isSubgraphNode?.() &&
+      node.subgraph &&
+      hasDisabledPartnerNode(node.subgraph, isNodeDisabled)
+    ) {
+      return true
+    }
+    return !!node.type && isNodeDisabled(node.type)
+  })
+}
 
 useExtensionService().registerExtension({
   name: 'Comfy.Cloud.PartnerNodeGovernance',
 
   setup: () => {
     usePartnerNodeGovernanceStore()
+    registerQueuePromptGuard(QUEUE_GUARD_ID, async (context) => {
+      const governanceStore = usePartnerNodeGovernanceStore()
+      if (governanceStore.status === 'loading') {
+        await governanceStore.loadPolicy()
+      }
+      const isNodeDisabled = (nodeType: string) =>
+        governanceStore.isNodeDisabled(nodeType)
+      const isBlocked = context.queueNodeIds?.length
+        ? hasDisabledPartnerNodeInPartialExecution(
+            context.rootGraph,
+            context.queueNodeIds,
+            isNodeDisabled
+          )
+        : hasDisabledPartnerNode(context.rootGraph, isNodeDisabled)
+      if (!isBlocked) return true
+
+      useToastStore().add({
+        severity: 'error',
+        summary: t('workspacePanel.allowlist.runBlocked.summary'),
+        detail: t('workspacePanel.allowlist.runBlocked.detail'),
+        life: 6000
+      })
+      return false
+    })
   }
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2955,6 +2955,10 @@
         "restrictedConfirmMessage": "Only enabled partner node providers will remain available to workspace members.",
         "unrestrictedConfirmTitle": "Switch to unrestricted access?",
         "unrestrictedConfirmMessage": "All partner node providers will become available to workspace members."
+      },
+      "runBlocked": {
+        "summary": "Workflow blocked by workspace policy",
+        "detail": "Remove disabled partner nodes from this workflow or ask a workspace owner to update the policy."
       }
     },
     "dashboard": {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -263,6 +263,23 @@ describe('partnerNodeGovernanceStore', () => {
     expect(store.isNodeDisabled('DisabledNode')).toBe(false)
   })
 
+  it('reuses the in-flight policy load', async () => {
+    let resolveLoad!: (policy: PartnerNodePolicy | null) => void
+    mockGetPartnerNodePolicy.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve
+      })
+    )
+
+    store = usePartnerNodeGovernanceStore()
+    const pendingLoad = store.loadPolicy()
+
+    expect(mockGetPartnerNodePolicy).toHaveBeenCalledOnce()
+    resolveLoad(null)
+    await pendingLoad
+    expect(store.status).toBe('unconfigured')
+  })
+
   it('stays fail-closed while retrying an unavailable policy', async () => {
     mockGetPartnerNodePolicy.mockRejectedValueOnce(
       new PartnerNodePolicyApiError(503, 'Service Unavailable')

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -49,6 +49,8 @@ export const usePartnerNodeGovernanceStore = defineStore(
     const error = shallowRef<Error | null>(null)
     let loadVersion = 0
     let workspaceVersion = 0
+    let loadPromise: Promise<void> | null = null
+    let loadPromiseWorkspaceId: string | null = null
 
     const governedWorkspaceId = computed(() => {
       const workspace = workspaceStore.activeWorkspace
@@ -122,7 +124,7 @@ export const usePartnerNodeGovernanceStore = defineStore(
       }
     })
 
-    async function loadPolicy(): Promise<void> {
+    async function performLoadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value
       const version = ++loadVersion
       if (!workspaceId) {
@@ -174,6 +176,24 @@ export const usePartnerNodeGovernanceStore = defineStore(
         }
         if (status.value !== 'unavailable') status.value = 'error'
       }
+    }
+
+    function loadPolicy(): Promise<void> {
+      const workspaceId = governedWorkspaceId.value
+      if (loadPromise && loadPromiseWorkspaceId === workspaceId) {
+        return loadPromise
+      }
+
+      const currentLoad = performLoadPolicy()
+      loadPromise = currentLoad
+      loadPromiseWorkspaceId = workspaceId
+      void currentLoad.finally(() => {
+        if (loadPromise === currentLoad) {
+          loadPromise = null
+          loadPromiseWorkspaceId = null
+        }
+      })
+      return currentLoad
     }
 
     async function savePolicy(nextPolicy: PartnerNodePolicy): Promise<boolean> {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -34,6 +34,8 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { registerQueuePromptGuard } from '@/services/queuePromptGuardService'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 const {
   mockApiKeyAuthStore,
@@ -211,6 +213,167 @@ describe('ComfyApp', () => {
       })
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
+
+    it('blocks before adding a disallowed prompt to the client queue', async () => {
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.before-queue',
+        () => false
+      )
+      const dispatchEvent = vi
+        .spyOn(api, 'dispatchCustomEvent')
+        .mockImplementation(() => true)
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+
+      try {
+        await expect(app.queuePrompt(0)).resolves.toBe(false)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(mockAuthStore.getAuthToken).not.toHaveBeenCalled()
+      expect(dispatchEvent).not.toHaveBeenCalled()
+      expect(queuePrompt).not.toHaveBeenCalled()
+    })
+
+    it('passes partial execution targets to queue guards', async () => {
+      prepareEmptyPromptQueue()
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        node_errors: {},
+        error: ''
+      })
+      const queueNodeIds = [createNodeExecutionId([1])]
+      const guard = vi.fn(() => true)
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.partial-targets',
+        guard
+      )
+
+      try {
+        await app.queuePrompt(0, 1, queueNodeIds)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(guard).toHaveBeenCalledTimes(2)
+      expect(guard).toHaveBeenNthCalledWith(1, {
+        rootGraph: app.rootGraph,
+        queueNodeIds
+      })
+      expect(guard).toHaveBeenNthCalledWith(2, {
+        rootGraph: app.rootGraph,
+        queueNodeIds
+      })
+    })
+
+    it('checks again after deferred authentication resolves', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      let resolveAuth: (token: string | undefined) => void = () => {}
+      mockAuthStore.getAuthToken.mockReturnValue(
+        new Promise((resolve) => {
+          resolveAuth = resolve
+        })
+      )
+      let guardCalls = 0
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.after-auth',
+        () => ++guardCalls === 1
+      )
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+
+      try {
+        const result = app.queuePrompt(0)
+        await vi.waitFor(() => {
+          expect(mockAuthStore.getAuthToken).toHaveBeenCalledOnce()
+        })
+        resolveAuth(undefined)
+
+        await expect(result).resolves.toBe(false)
+      } finally {
+        unregisterGuard()
+      }
+      expect(guardCalls).toBe(2)
+      expect(queuePrompt).not.toHaveBeenCalled()
+    })
+
+    it('dispatches queued progress when a later batch item is blocked', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        node_errors: {},
+        error: ''
+      })
+      const dispatchEvent = vi
+        .spyOn(api, 'dispatchCustomEvent')
+        .mockImplementation(() => true)
+      let guardCalls = 0
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.partial-batch',
+        () => ++guardCalls < 3
+      )
+
+      try {
+        await expect(app.queuePrompt(0, 2)).resolves.toBe(false)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(api.queuePrompt).toHaveBeenCalledOnce()
+      expect(dispatchEvent).toHaveBeenCalledWith('promptQueued', {
+        number: 0,
+        batchCount: 1,
+        requestId: 1
+      })
+    })
+
+    it('continues processing queued requests after one is blocked', async () => {
+      prepareEmptyPromptQueue()
+      let resolveAuth: (token: string | undefined) => void = () => {}
+      mockAuthStore.getAuthToken.mockReturnValue(
+        new Promise((resolve) => {
+          resolveAuth = resolve
+        })
+      )
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'allowed-job',
+        node_errors: {},
+        error: ''
+      })
+      const allowedTargets = [createNodeExecutionId([1])]
+      const blockedTargets = [createNodeExecutionId([2])]
+      let blockedChecks = 0
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.queued-requests',
+        ({ queueNodeIds }) =>
+          queueNodeIds !== blockedTargets || ++blockedChecks === 1
+      )
+
+      try {
+        const firstQueue = app.queuePrompt(0, 1, allowedTargets)
+        await vi.waitFor(() => {
+          expect(mockAuthStore.getAuthToken).toHaveBeenCalledOnce()
+        })
+        await expect(app.queuePrompt(1, 1, blockedTargets)).resolves.toBe(false)
+        resolveAuth(undefined)
+
+        await expect(firstQueue).resolves.toBe(true)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(api.queuePrompt).toHaveBeenCalledOnce()
+      expect(api.queuePrompt).toHaveBeenCalledWith(
+        0,
+        expect.any(Object),
+        expect.objectContaining({ partialExecutionTargets: allowedTargets })
+      )
+    })
 
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -68,6 +68,7 @@ import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreco
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
+import { runQueuePromptGuards } from '@/services/queuePromptGuardService'
 import { useSubgraphService } from '@/services/subgraphService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useCommandStore } from '@/stores/commandStore'
@@ -1624,11 +1625,22 @@ export class ComfyApp {
     })
   }
 
+  private async isQueuePromptAllowed(
+    queueNodeIds?: readonly NodeExecutionId[]
+  ): Promise<boolean> {
+    return await runQueuePromptGuards({
+      rootGraph: this.rootGraph,
+      queueNodeIds
+    })
+  }
+
   async queuePrompt(
     number: number,
     batchCount: number = 1,
     queueNodeIds?: NodeExecutionId[]
   ): Promise<boolean> {
+    if (!(await this.isQueuePromptAllowed(queueNodeIds))) return false
+
     const requestId = this.nextQueueRequestId++
     this.queueItems.push({ number, batchCount, queueNodeIds, requestId })
     api.dispatchCustomEvent('promptQueueing', {
@@ -1662,6 +1674,11 @@ export class ComfyApp {
 
         const isPartialExecution = !!queueNodeIds?.length
         for (let i = 0; i < batchCount; i++) {
+          if (!(await this.isQueuePromptAllowed(queueNodeIds))) {
+            queueResultOverride = false
+            break
+          }
+
           // Allow widgets to run callbacks before a prompt has been queued
           // e.g. random seed before every gen
           forEachNode(this.rootGraph, (node) => {

--- a/src/services/queuePromptGuardService.test.ts
+++ b/src/services/queuePromptGuardService.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+
+import {
+  registerQueuePromptGuard,
+  runQueuePromptGuards
+} from './queuePromptGuardService'
+
+const addToast = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: addToast })
+}))
+
+describe('queuePromptGuardService', () => {
+  const unregisterGuards: Array<() => void> = []
+
+  afterEach(() => {
+    unregisterGuards.splice(0).forEach((unregister) => unregister())
+    vi.restoreAllMocks()
+  })
+
+  it('fails closed while continuing after guards throw or reject', async () => {
+    const error = new Error('Invalid graph')
+    const successfulGuard = vi.fn(() => true)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    unregisterGuards.push(
+      registerQueuePromptGuard('test.throw', () => {
+        throw error
+      }),
+      registerQueuePromptGuard('test.reject', async () => {
+        await Promise.resolve()
+        throw error
+      }),
+      registerQueuePromptGuard('test.success', successfulGuard)
+    )
+
+    await expect(
+      runQueuePromptGuards({ rootGraph: {} as LGraph })
+    ).resolves.toBe(false)
+
+    expect(successfulGuard).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledTimes(2)
+    expect(addToast).toHaveBeenCalledOnce()
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Failed to queue'
+    })
+  })
+})

--- a/src/services/queuePromptGuardService.ts
+++ b/src/services/queuePromptGuardService.ts
@@ -1,0 +1,52 @@
+import { t } from '@/i18n'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+
+export interface QueuePromptGuardContext {
+  readonly rootGraph: LGraph
+  readonly queueNodeIds?: readonly NodeExecutionId[]
+}
+
+export type QueuePromptGuard = (
+  context: QueuePromptGuardContext
+) => boolean | Promise<boolean>
+
+const guards = new Map<string, QueuePromptGuard>()
+
+async function runGuard(
+  guard: QueuePromptGuard,
+  context: QueuePromptGuardContext
+): Promise<'allowed' | 'blocked' | 'failed'> {
+  try {
+    return (await guard(context)) === false ? 'blocked' : 'allowed'
+  } catch (error) {
+    console.error('Queue prompt guard failed; blocking prompt', error)
+    return 'failed'
+  }
+}
+
+export function registerQueuePromptGuard(
+  id: string,
+  guard: QueuePromptGuard
+): () => void {
+  guards.set(id, guard)
+  return () => {
+    if (guards.get(id) === guard) guards.delete(id)
+  }
+}
+
+export async function runQueuePromptGuards(
+  context: QueuePromptGuardContext
+): Promise<boolean> {
+  const results = await Promise.all(
+    [...guards.values()].map((guard) => runGuard(guard, context))
+  )
+  if (results.includes('failed')) {
+    useToastStore().add({
+      severity: 'error',
+      summary: t('toastMessages.failedToQueue')
+    })
+  }
+  return results.every((result) => result === 'allowed')
+}


### PR DESCRIPTION
## Summary

Stacked on #13748. Adds a frontend queue guard that blocks Run when any active prompt path contains a partner node disabled by workspace policy. It rechecks after deferred authentication and before each batch item, while muted or bypassed nodes and muted subgraphs remain queueable to match prompt serialization. Backend enforcement remains authoritative.

## Verification

| Before: the disabled partner node reaches the queue | After: the same Run action is blocked by workspace policy |
|---|---|
| <img width="720" alt="Before: disabled partner node reaches the queue" src="https://github.com/user-attachments/assets/b6509ef7-ccaf-423b-a8bf-2e9696b2b000" /> | <img width="720" alt="After: workflow blocked by workspace policy" src="https://github.com/user-attachments/assets/83e72142-c7a8-4dc1-a749-10e85cc08731" /> |

https://github.com/user-attachments/assets/956e1e1b-7ea0-4695-9c93-294eeb464c7f

| Timestamp | Screenshot | Highlight |
|---|---|---|
| `00:01.67` | <img width="480" alt="Before: Run reaches the queue" src="https://github.com/user-attachments/assets/b6509ef7-ccaf-423b-a8bf-2e9696b2b000" /> | The active disabled node still produces a queued job before the guard. |
| `00:06.17` | <img width="480" alt="After: Run blocked by policy" src="https://github.com/user-attachments/assets/83e72142-c7a8-4dc1-a749-10e85cc08731" /> | The same Run action shows the policy block instead of queueing. |

- Boundary proof: the cloud Playwright flow intercepts `/api/prompt` and confirms zero requests after Run.
- Serializer alignment: current-head regressions allow muted or bypassed nodes and muted subgraphs while blocking active nested disabled nodes.

- Partial execution checks only the selected output dependencies, so disabled nodes on unrelated branches do not block the run.

Created by Codex
