### PR TITLE
feat: fetch dynamic partner-node price badges from Comfy API

### DIFF
--- a/src/scripts/app.getNodeDefs.pendingPricing.test.ts
+++ b/src/scripts/app.getNodeDefs.pendingPricing.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import { api } from '@/scripts/api'
+import { app as comfyApp } from '@/scripts/app'
+import { startPriceBadgeFetch } from '@/services/priceBadgeService'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getNodeDefs: vi.fn(),
+    apiURL: vi.fn((path: string) => path),
+    addEventListener: vi.fn(),
+    getUserData: vi.fn(),
+    storeUserData: vi.fn()
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key),
+  te: vi.fn(() => false)
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn()
+}))
+
+vi.mock('@/config/comfyApi', () => ({
+  getComfyApiBaseUrl: () => 'https://api.example.com'
+}))
+
+vi.mock('@/stores/systemStatsStore', () => ({
+  useSystemStatsStore: () => ({
+    isInitialized: true,
+    error: null,
+    systemStats: { system: { comfyui_version: '0.3.50' } }
+  })
+}))
+
+// This case lives in its own file: the price badge fetch is a session
+// singleton, so proving that a stalled fetch cannot delay getNodeDefs needs
+// a module registry where no other test has already settled it. The
+// resolved-fetch counterpart lives in app.getNodeDefs.test.ts.
+describe('ComfyApp.getNodeDefs with pending pricing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  test('pricing pending past its budget does not delay node defs', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise(() => {})) // stalls forever
+    )
+    const mockNodeDefs: Record<string, ComfyNodeDefV1> = {
+      TestNode: {
+        name: 'TestNode',
+        display_name: 'Test Node',
+        category: 'api node',
+        description: '',
+        input: {},
+        output: [],
+        output_node: false,
+        python_module: 'test.module'
+      }
+    }
+    vi.mocked(api.getNodeDefs).mockResolvedValue(mockNodeDefs)
+
+    // Prefetch (as app.setup() does), then let the whole fetch budget
+    // elapse while pricing stalls.
+    startPriceBadgeFetch()
+    await vi.advanceTimersByTimeAsync(3000)
+
+    // Node defs must resolve without waiting on any new timer: with fake
+    // timers a fresh race timer would never fire and this await would hang.
+    const result = await comfyApp.getNodeDefs()
+
+    expect(result.TestNode.price_badge).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/scripts/app.getNodeDefs.priceBadges.test.ts
+++ b/src/scripts/app.getNodeDefs.priceBadges.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import { api } from '@/scripts/api'
+import { app as comfyApp } from '@/scripts/app'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getNodeDefs: vi.fn(),
+    apiURL: vi.fn((path: string) => path),
+    addEventListener: vi.fn(),
+    getUserData: vi.fn(),
+    storeUserData: vi.fn()
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  st: vi.fn((_key: string, fallback: string) => fallback),
+  t: vi.fn((key: string) => key),
+  te: vi.fn(() => false)
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn()
+}))
+
+vi.mock('@/config/comfyApi', () => ({
+  getComfyApiBaseUrl: () => 'https://api.example.com'
+}))
+
+vi.mock('@/stores/systemStatsStore', () => ({
+  useSystemStatsStore: () => ({
+    isInitialized: true,
+    error: null,
+    systemStats: { system: { comfyui_version: '0.3.50' } }
+  })
+}))
+
+// This case lives in its own file: the price badge fetch is a session
+// singleton settled by the first getNodeDefs() call, so asserting on a
+// resolved badge map needs a module registry where no other test has
+// already settled it. The pending-fetch counterpart lives in
+// app.getNodeDefs.pendingPricing.test.ts.
+describe('ComfyApp.getNodeDefs price badges', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('returned defs carry the remotely fetched price badge', async () => {
+    const priceBadge = {
+      engine: 'jsonata',
+      depends_on: {
+        widgets: [{ name: 'resolution', type: 'COMBO' }],
+        inputs: [],
+        input_groups: []
+      },
+      expr: '{"type":"usd","usd":0.1}'
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ PricedNode: priceBadge })
+      })
+    )
+    const mockNodeDefs: Record<string, ComfyNodeDefV1> = {
+      PricedNode: {
+        name: 'PricedNode',
+        display_name: 'Priced Node',
+        category: 'api node',
+        description: '',
+        input: { required: { resolution: [['1080p', '720p'], {}] } },
+        output: [],
+        output_node: false,
+        python_module: 'test.module'
+      } as unknown as ComfyNodeDefV1
+    }
+    vi.mocked(api.getNodeDefs).mockResolvedValue(mockNodeDefs)
+
+    const result = await comfyApp.getNodeDefs()
+
+    expect(result.PricedNode.price_badge).toMatchObject({
+      expr: priceBadge.expr
+    })
+  })
+})

--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { st } from '@/i18n'
 import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
@@ -20,6 +20,86 @@ vi.mock('@/i18n', () => ({
   t: vi.fn((key: string) => key),
   te: vi.fn(() => false)
 }))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn()
+}))
+
+vi.mock('@/config/comfyApi', () => ({
+  getComfyApiBaseUrl: () => 'https://api.example.com'
+}))
+
+vi.mock('@/stores/systemStatsStore', () => ({
+  useSystemStatsStore: () => ({
+    isInitialized: true,
+    error: null,
+    systemStats: { system: { comfyui_version: '0.3.50' } }
+  })
+}))
+
+// getNodeDefs triggers the price badge fetch chain; keep it off the network.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({})
+    })
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+// This describe must run first: the price badge fetch is a session singleton
+// kicked off by the first getNodeDefs() call, so the badge fetch stub has to
+// be in place before any other test touches getNodeDefs. The pending-fetch
+// counterpart lives in app.getNodeDefs.pendingPricing.test.ts for the same
+// reason (it needs a fresh module registry).
+describe('ComfyApp.getNodeDefs price badges', () => {
+  test('returned defs carry the remotely fetched price badge', async () => {
+    const priceBadge = {
+      engine: 'jsonata',
+      depends_on: {
+        widgets: [{ name: 'resolution', type: 'COMBO' }],
+        inputs: [],
+        input_groups: []
+      },
+      expr: '{"type":"usd","usd":0.1}'
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ PricedNode: priceBadge })
+      })
+    )
+    const mockNodeDefs: Record<string, ComfyNodeDefV1> = {
+      PricedNode: {
+        name: 'PricedNode',
+        display_name: 'Priced Node',
+        category: 'api node',
+        description: '',
+        input: { required: { resolution: [['1080p', '720p'], {}] } },
+        output: [],
+        output_node: false,
+        python_module: 'test.module'
+      } as unknown as ComfyNodeDefV1
+    }
+    vi.mocked(api.getNodeDefs).mockResolvedValue(mockNodeDefs)
+
+    const result = await comfyApp.getNodeDefs()
+
+    expect(result.PricedNode.price_badge).toMatchObject({
+      expr: priceBadge.expr
+    })
+  })
+})
 
 describe('ComfyApp.getNodeDefs', () => {
   beforeEach(() => {

--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -39,6 +39,9 @@ vi.mock('@/stores/systemStatsStore', () => ({
 }))
 
 // getNodeDefs triggers the price badge fetch chain; keep it off the network.
+// Badge assertions live in app.getNodeDefs.priceBadges.test.ts and
+// app.getNodeDefs.pendingPricing.test.ts, each in its own file because the
+// badge fetch is a session singleton settled by the first getNodeDefs() call.
 beforeEach(() => {
   vi.stubGlobal(
     'fetch',
@@ -52,53 +55,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
-  vi.useRealTimers()
-})
-
-// This describe must run first: the price badge fetch is a session singleton
-// kicked off by the first getNodeDefs() call, so the badge fetch stub has to
-// be in place before any other test touches getNodeDefs. The pending-fetch
-// counterpart lives in app.getNodeDefs.pendingPricing.test.ts for the same
-// reason (it needs a fresh module registry).
-describe('ComfyApp.getNodeDefs price badges', () => {
-  test('returned defs carry the remotely fetched price badge', async () => {
-    const priceBadge = {
-      engine: 'jsonata',
-      depends_on: {
-        widgets: [{ name: 'resolution', type: 'COMBO' }],
-        inputs: [],
-        input_groups: []
-      },
-      expr: '{"type":"usd","usd":0.1}'
-    }
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ PricedNode: priceBadge })
-      })
-    )
-    const mockNodeDefs: Record<string, ComfyNodeDefV1> = {
-      PricedNode: {
-        name: 'PricedNode',
-        display_name: 'Priced Node',
-        category: 'api node',
-        description: '',
-        input: { required: { resolution: [['1080p', '720p'], {}] } },
-        output: [],
-        output_node: false,
-        python_module: 'test.module'
-      } as unknown as ComfyNodeDefV1
-    }
-    vi.mocked(api.getNodeDefs).mockResolvedValue(mockNodeDefs)
-
-    const result = await comfyApp.getNodeDefs()
-
-    expect(result.PricedNode.price_badge).toMatchObject({
-      expr: priceBadge.expr
-    })
-  })
 })
 
 describe('ComfyApp.getNodeDefs', () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -68,6 +68,10 @@ import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreco
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
+import {
+  overlayPriceBadges,
+  startPriceBadgeFetch
+} from '@/services/priceBadgeService'
 import { useSubgraphService } from '@/services/subgraphService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useCommandStore } from '@/stores/commandStore'
@@ -898,6 +902,10 @@ export class ComfyApp {
 
     this.canvasElRef.value = canvasEl
 
+    // Kick off the price badge fetch early so it runs concurrently with
+    // extension loading and the /object_info request (see getNodeDefs).
+    startPriceBadgeFetch()
+
     await useWorkspaceStore().workflow.syncWorkflows()
     //Doesn't need to block. Blueprints will load async
     void useSubgraphStore().fetchSubgraphs()
@@ -1086,7 +1094,11 @@ export class ComfyApp {
       }
     }
 
-    return _.mapValues(await api.getNodeDefs(), (def) => translateNodeDef(def))
+    const defs = _.mapValues(await api.getNodeDefs(), (def) =>
+      translateNodeDef(def)
+    )
+    await overlayPriceBadges(defs)
+    return defs
   }
 
   /**

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -69,7 +69,7 @@ import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
 import {
-  overlayPriceBadges,
+  applyPriceBadges,
   startPriceBadgeFetch
 } from '@/services/priceBadgeService'
 import { useSubgraphService } from '@/services/subgraphService'
@@ -1097,7 +1097,7 @@ export class ComfyApp {
     const defs = _.mapValues(await api.getNodeDefs(), (def) =>
       translateNodeDef(def)
     )
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     return defs
   }
 

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -9,7 +9,9 @@ const mockSystemStatsStore = vi.hoisted(() => ({
   error: null as Error | null,
   systemStats: {
     system: { comfyui_version: '0.3.50' }
-  } as { system: { comfyui_version?: string } } | null
+  } as {
+    system: { comfyui_version?: string; argv?: string[] }
+  } | null
 }))
 
 vi.mock('@sentry/vue', () => ({
@@ -125,6 +127,22 @@ describe('priceBadgeService', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
     )
+  })
+
+  it('never fetches when --disable-api-nodes is among the server args', async () => {
+    mockSystemStatsStore.systemStats = {
+      system: {
+        comfyui_version: '0.3.50',
+        argv: ['main.py', '--disable-api-nodes', '--listen']
+      }
+    }
+    const fetchMock = mockFetchResponse({ PartnerNode: validBadge })
+    vi.stubGlobal('fetch', fetchMock)
+    const { applyPriceBadges } = await importService()
+    const defs = makeDefs()
+    await applyPriceBadges(defs)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
   it('falls back to nightly when the version is unavailable', async () => {

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -155,7 +155,7 @@ describe('priceBadgeService', () => {
   })
 
   it('falls back to nightly when the version is unavailable', async () => {
-    mockSystemStatsStore.systemStats = null
+    mockSystemStatsStore.systemStats = { system: {} }
     const fetchMock = mockFetchResponse({})
     vi.stubGlobal('fetch', fetchMock)
     const { applyPriceBadges } = await importService()
@@ -163,6 +163,21 @@ describe('priceBadgeService', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('comfyui_version=nightly')
     )
+  })
+
+  // Without stats we can't tell whether --disable-api-nodes is set; its
+  // no-external-requests promise must fail closed.
+  it('never fetches when the system stats request fails', async () => {
+    mockSystemStatsStore.isInitialized = false
+    mockSystemStatsStore.error = new Error('system_stats unavailable')
+    mockSystemStatsStore.systemStats = null
+    const fetchMock = mockFetchResponse({ PartnerNode: validBadge })
+    vi.stubGlobal('fetch', fetchMock)
+    const { applyPriceBadges } = await importService()
+    const defs = makeDefs()
+    await applyPriceBadges(defs)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
   // The wire schema is declarative Zod; one representative per rejection

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+const mockSystemStatsStore = vi.hoisted(() => ({
+  isInitialized: true,
+  error: null as Error | null,
+  systemStats: {
+    system: { comfyui_version: '0.3.50' }
+  } as { system: { comfyui_version?: string } } | null
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn()
+}))
+
+vi.mock('@/config/comfyApi', () => ({
+  getComfyApiBaseUrl: () => 'https://api.example.com'
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+vi.mock('@/stores/systemStatsStore', () => ({
+  useSystemStatsStore: () => mockSystemStatsStore
+}))
+
+const validBadge = {
+  engine: 'jsonata',
+  depends_on: {
+    widgets: [{ name: 'resolution', type: 'COMBO' }],
+    inputs: [],
+    input_groups: []
+  },
+  expr: '{"type":"usd","usd":0.1}'
+}
+
+function makeDefs(): Record<string, ComfyNodeDef> {
+  return {
+    PartnerNode: {
+      name: 'PartnerNode',
+      display_name: 'Partner Node',
+      description: '',
+      category: 'api node',
+      output_node: false,
+      python_module: 'nodes',
+      input: {
+        required: {
+          resolution: [['1080p', '720p'], {}],
+          seed: ['INT', {}]
+        }
+      }
+    } as unknown as ComfyNodeDef,
+    OtherNode: {
+      name: 'OtherNode',
+      display_name: 'Other Node',
+      description: '',
+      category: 'other',
+      output_node: false,
+      python_module: 'nodes',
+      input: { required: {} }
+    } as unknown as ComfyNodeDef
+  }
+}
+
+function mockFetchResponse(body: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body)
+  })
+}
+
+async function importService() {
+  return await import('@/services/priceBadgeService')
+}
+
+describe('priceBadgeService', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockSystemStatsStore.isInitialized = true
+    mockSystemStatsStore.error = null
+    mockSystemStatsStore.systemStats = {
+      system: { comfyui_version: '0.3.50' }
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('overlays a valid badge onto a matching def', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toMatchObject({
+      expr: validBadge.expr
+    })
+    expect(defs['OtherNode'].price_badge).toBeUndefined()
+  })
+
+  it('requests with comfyui_version and platform query params', async () => {
+    const fetchMock = mockFetchResponse({})
+    vi.stubGlobal('fetch', fetchMock)
+    const { overlayPriceBadges } = await importService()
+    await overlayPriceBadges(makeDefs())
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
+    )
+  })
+
+  it('falls back to nightly when the version is unavailable', async () => {
+    mockSystemStatsStore.systemStats = null
+    const fetchMock = mockFetchResponse({})
+    vi.stubGlobal('fetch', fetchMock)
+    const { overlayPriceBadges } = await importService()
+    await overlayPriceBadges(makeDefs())
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('comfyui_version=nightly')
+    )
+  })
+
+  it('ignores badges for nodes missing from the defs', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ UnknownNode: validBadge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('skips a badge whose widget dependency has no matching def input', async () => {
+    const badBadge = {
+      ...validBadge,
+      depends_on: {
+        widgets: [{ name: 'missing_widget', type: 'COMBO' }],
+        inputs: [],
+        input_groups: []
+      }
+    }
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('skips a badge whose widget type mismatches the def input type', async () => {
+    const badBadge = {
+      ...validBadge,
+      depends_on: {
+        widgets: [{ name: 'seed', type: 'STRING' }],
+        inputs: [],
+        input_groups: []
+      }
+    }
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('validates dotted dependencies against the first segment', async () => {
+    const badge = {
+      ...validBadge,
+      depends_on: {
+        widgets: [],
+        inputs: ['resolution.width'],
+        input_groups: []
+      }
+    }
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeDefined()
+  })
+
+  it('fails open on HTTP error', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse(null, false, 500))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('fails open on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('fails open when the response does not match the schema', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchResponse({ PartnerNode: { engine: 'python', expr: 42 } })
+    )
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('drops the result for the whole session when the fetch loses the race', async () => {
+    vi.useFakeTimers()
+    let resolveFetch!: (value: unknown) => void
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+    )
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    const overlay = overlayPriceBadges(defs)
+    await vi.advanceTimersByTimeAsync(3000)
+    await overlay
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+
+    // Late arrival must not apply on a later overlay call either.
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ PartnerNode: validBadge })
+    })
+    const defs2 = makeDefs()
+    await overlayPriceBadges(defs2)
+    expect(defs2['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('reuses the same fetch across overlay calls', async () => {
+    const fetchMock = mockFetchResponse({ PartnerNode: validBadge })
+    vi.stubGlobal('fetch', fetchMock)
+    const { overlayPriceBadges, startPriceBadgeFetch } = await importService()
+    startPriceBadgeFetch()
+    await overlayPriceBadges(makeDefs())
+    await overlayPriceBadges(makeDefs())
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -346,20 +346,87 @@ describe('priceBadgeService', () => {
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
-  it('validates dotted dependencies against the first segment', async () => {
-    const badge = {
-      ...validBadge,
-      depends_on: {
-        widgets: [],
-        inputs: ['resolution.width'],
-        input_groups: []
-      }
+  describe('input and input_group dependency validation', () => {
+    // Def with a plain combo (resolution), a plain INT (seed), a dynamic
+    // combo (model), and a top-level autogrow group (videos).
+    function makeDynamicDefs(): Record<string, ComfyNodeDef> {
+      const defs = makeDefs()
+      const required = (
+        defs['PartnerNode'] as unknown as {
+          input: { required: Record<string, unknown> }
+        }
+      ).input.required
+      required['model'] = ['COMFY_DYNAMICCOMBO_V3', { options: [] }]
+      required['videos'] = ['COMFY_AUTOGROW_V3', { template: {} }]
+      return defs
     }
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
-    expect(defs['PartnerNode'].price_badge).toBeDefined()
+
+    it.for([
+      {
+        case: 'accepts an input matching a def key exactly',
+        depends: { inputs: ['seed'] },
+        applied: true
+      },
+      {
+        case: 'rejects a dotted input whose parent is not a dynamic input',
+        depends: { inputs: ['resolution.width'] },
+        applied: false
+      },
+      {
+        case: 'accepts a dotted input under a dynamic combo',
+        depends: { inputs: ['model.style_reference'] },
+        applied: true
+      },
+      {
+        case: 'accepts a group matching a top-level autogrow def key',
+        depends: { input_groups: ['videos'] },
+        applied: true
+      },
+      {
+        case: 'accepts a dotted group under a dynamic combo',
+        depends: { input_groups: ['model.images'] },
+        applied: true
+      },
+      {
+        case: 'rejects a group with no matching def input',
+        depends: { input_groups: ['missing_group'] },
+        applied: false
+      },
+      {
+        case: 'rejects a dotted group whose parent is not a dynamic input',
+        depends: { input_groups: ['seed.videos'] },
+        applied: false
+      },
+      {
+        case: 'rejects a dotted widget whose parent is not a dynamic input',
+        depends: { widgets: [{ name: 'resolution.width', type: 'INT' }] },
+        applied: false
+      },
+      {
+        case: 'accepts a dotted widget under a dynamic combo',
+        depends: { widgets: [{ name: 'model.duration', type: 'COMBO' }] },
+        applied: true
+      }
+    ])('$case', async ({ depends, applied }) => {
+      const badge = {
+        ...validBadge,
+        depends_on: {
+          widgets: [],
+          inputs: [],
+          input_groups: [],
+          ...depends
+        }
+      }
+      vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
+      const { applyPriceBadges } = await importService()
+      const defs = makeDynamicDefs()
+      await applyPriceBadges(defs)
+      if (applied) {
+        expect(defs['PartnerNode'].price_badge).toBeDefined()
+      } else {
+        expect(defs['PartnerNode'].price_badge).toBeUndefined()
+      }
+    })
   })
 
   it('fails open on HTTP error', async () => {

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -95,11 +95,11 @@ describe('priceBadgeService', () => {
     vi.useRealTimers()
   })
 
-  it('overlays a valid badge onto a matching def', async () => {
+  it('applies a valid badge to a matching def', async () => {
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toMatchObject({
       expr: validBadge.expr
     })
@@ -109,8 +109,8 @@ describe('priceBadgeService', () => {
   it('requests with comfyui_version and platform query params', async () => {
     const fetchMock = mockFetchResponse({})
     vi.stubGlobal('fetch', fetchMock)
-    const { overlayPriceBadges } = await importService()
-    await overlayPriceBadges(makeDefs())
+    const { applyPriceBadges } = await importService()
+    await applyPriceBadges(makeDefs())
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
     )
@@ -120,8 +120,8 @@ describe('priceBadgeService', () => {
     mockApiBase.url = 'https://api.example.com/'
     const fetchMock = mockFetchResponse({})
     vi.stubGlobal('fetch', fetchMock)
-    const { overlayPriceBadges } = await importService()
-    await overlayPriceBadges(makeDefs())
+    const { applyPriceBadges } = await importService()
+    await applyPriceBadges(makeDefs())
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
     )
@@ -131,8 +131,8 @@ describe('priceBadgeService', () => {
     mockSystemStatsStore.systemStats = null
     const fetchMock = mockFetchResponse({})
     vi.stubGlobal('fetch', fetchMock)
-    const { overlayPriceBadges } = await importService()
-    await overlayPriceBadges(makeDefs())
+    const { applyPriceBadges } = await importService()
+    await applyPriceBadges(makeDefs())
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('comfyui_version=nightly')
     )
@@ -140,7 +140,7 @@ describe('priceBadgeService', () => {
 
   it('preserves an existing baked-in badge on nodes absent from the map', async () => {
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
     const bakedIn = {
       engine: 'jsonata',
@@ -149,7 +149,7 @@ describe('priceBadgeService', () => {
     }
     defs['OtherNode'].price_badge =
       bakedIn as unknown as (typeof defs)['OtherNode']['price_badge']
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     // Absent from the map: untouched, same object identity.
     expect(defs['OtherNode'].price_badge).toBe(bakedIn)
     // Present in the map: replaced.
@@ -166,9 +166,9 @@ describe('priceBadgeService', () => {
         OtherNode: { expr: 'missing engine and depends_on' }
       })
     )
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeDefined()
     expect(defs['OtherNode'].price_badge).toBeUndefined()
   })
@@ -211,9 +211,9 @@ describe('priceBadgeService', () => {
           }
         })
       )
-      const { overlayPriceBadges } = await importService()
+      const { applyPriceBadges } = await importService()
       const defs = makeDefs()
-      await overlayPriceBadges(defs)
+      await applyPriceBadges(defs)
       expect(defs['PartnerNode'].price_badge).toBeUndefined()
       expect(defs['OtherNode'].price_badge).toBeDefined()
     }
@@ -225,9 +225,9 @@ describe('priceBadgeService', () => {
     ['string', 'nope']
   ] as const)('fails open when the response body is %s', async ([, body]) => {
     vi.stubGlobal('fetch', mockFetchResponse(body))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -241,16 +241,16 @@ describe('priceBadgeService', () => {
       }
     }
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
     // /object_info is unvalidated; a non-string, non-array tuple head must not
-    // crash the overlay (fail open for this node only).
+    // crash the apply (fail open for this node only).
     ;(
       defs['PartnerNode'] as unknown as {
         input: { required: Record<string, unknown> }
       }
     ).input.required['broken'] = [42, {}]
-    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -259,9 +259,9 @@ describe('priceBadgeService', () => {
       'fetch',
       mockFetchResponse({ PartnerNode: { ...validBadge, engine: 'python' } })
     )
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -275,7 +275,7 @@ describe('priceBadgeService', () => {
       }
     }
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
     // Socket type INT, but the runtime widget (and core's serialized badge
     // dependency type) is the widgetType override.
@@ -284,15 +284,15 @@ describe('priceBadgeService', () => {
         input: { required: Record<string, unknown> }
       }
     ).input.required['strength'] = ['INT', { widgetType: 'STRING' }]
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeDefined()
   })
 
   it('ignores badges for nodes missing from the defs', async () => {
     vi.stubGlobal('fetch', mockFetchResponse({ UnknownNode: validBadge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -306,9 +306,9 @@ describe('priceBadgeService', () => {
       }
     }
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -322,9 +322,9 @@ describe('priceBadgeService', () => {
       }
     }
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -338,25 +338,25 @@ describe('priceBadgeService', () => {
       }
     }
     vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeDefined()
   })
 
   it('fails open on HTTP error', async () => {
     vi.stubGlobal('fetch', mockFetchResponse(null, false, 500))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
   it('fails open on network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -365,9 +365,9 @@ describe('priceBadgeService', () => {
       'fetch',
       mockFetchResponse({ PartnerNode: { engine: 'python', expr: 42 } })
     )
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    await overlayPriceBadges(defs)
+    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 
@@ -382,25 +382,25 @@ describe('priceBadgeService', () => {
         })
       )
     )
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs = makeDefs()
-    const overlay = overlayPriceBadges(defs)
+    const applying = applyPriceBadges(defs)
     await vi.advanceTimersByTimeAsync(3000)
-    await overlay
+    await applying
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
 
-    // Late arrival must not apply on a later overlay call either.
+    // Late arrival must not apply on a later apply call either.
     resolveFetch({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ PartnerNode: validBadge })
     })
     const defs2 = makeDefs()
-    await overlayPriceBadges(defs2)
+    await applyPriceBadges(defs2)
     expect(defs2['PartnerNode'].price_badge).toBeUndefined()
   })
 
-  it('never applies badges on a concurrent overlay once the session lost the race', async () => {
+  it('never applies badges on a concurrent apply call once the session lost the race', async () => {
     vi.useFakeTimers()
     let resolveFetch!: (value: unknown) => void
     vi.stubGlobal(
@@ -411,35 +411,35 @@ describe('priceBadgeService', () => {
         })
       )
     )
-    const { overlayPriceBadges } = await importService()
+    const { applyPriceBadges } = await importService()
     const defs1 = makeDefs()
     const defs2 = makeDefs()
-    const overlay1 = overlayPriceBadges(defs1)
+    const apply1 = applyPriceBadges(defs1)
     await vi.advanceTimersByTimeAsync(1000)
-    const overlay2 = overlayPriceBadges(defs2)
-    // overlay1's timer fires at 2500ms and marks the session lost;
-    // overlay2's timer would fire at 3500ms.
+    const apply2 = applyPriceBadges(defs2)
+    // apply1's timer fires at 2500ms and marks the session lost;
+    // apply2's timer would fire at 3500ms.
     await vi.advanceTimersByTimeAsync(1600)
-    await overlay1
-    // The fetch resolves after the session is lost but before overlay2's
-    // timeout: overlay2 must still not apply.
+    await apply1
+    // The fetch resolves after the session is lost but before apply2's
+    // timeout: apply2 must still not apply.
     resolveFetch({
       ok: true,
       status: 200,
       json: () => Promise.resolve({ PartnerNode: validBadge })
     })
-    await overlay2
+    await apply2
     expect(defs1['PartnerNode'].price_badge).toBeUndefined()
     expect(defs2['PartnerNode'].price_badge).toBeUndefined()
   })
 
-  it('reuses the same fetch across overlay calls', async () => {
+  it('reuses the same fetch across apply calls', async () => {
     const fetchMock = mockFetchResponse({ PartnerNode: validBadge })
     vi.stubGlobal('fetch', fetchMock)
-    const { overlayPriceBadges, startPriceBadgeFetch } = await importService()
+    const { applyPriceBadges, startPriceBadgeFetch } = await importService()
     startPriceBadgeFetch()
-    await overlayPriceBadges(makeDefs())
-    await overlayPriceBadges(makeDefs())
+    await applyPriceBadges(makeDefs())
+    await applyPriceBadges(makeDefs())
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 
+const mockApiBase = vi.hoisted(() => ({ url: 'https://api.example.com' }))
+
 const mockSystemStatsStore = vi.hoisted(() => ({
   isInitialized: true,
   error: null as Error | null,
@@ -16,7 +18,7 @@ vi.mock('@sentry/vue', () => ({
 }))
 
 vi.mock('@/config/comfyApi', () => ({
-  getComfyApiBaseUrl: () => 'https://api.example.com'
+  getComfyApiBaseUrl: () => mockApiBase.url
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -80,6 +82,7 @@ async function importService() {
 describe('priceBadgeService', () => {
   beforeEach(() => {
     vi.resetModules()
+    mockApiBase.url = 'https://api.example.com'
     mockSystemStatsStore.isInitialized = true
     mockSystemStatsStore.error = null
     mockSystemStatsStore.systemStats = {
@@ -113,6 +116,17 @@ describe('priceBadgeService', () => {
     )
   })
 
+  it('normalizes a trailing slash on the API base URL', async () => {
+    mockApiBase.url = 'https://api.example.com/'
+    const fetchMock = mockFetchResponse({})
+    vi.stubGlobal('fetch', fetchMock)
+    const { overlayPriceBadges } = await importService()
+    await overlayPriceBadges(makeDefs())
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
+    )
+  })
+
   it('falls back to nightly when the version is unavailable', async () => {
     mockSystemStatsStore.systemStats = null
     const fetchMock = mockFetchResponse({})
@@ -122,6 +136,156 @@ describe('priceBadgeService', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('comfyui_version=nightly')
     )
+  })
+
+  it('preserves an existing baked-in badge on nodes absent from the map', async () => {
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    const bakedIn = {
+      engine: 'jsonata',
+      depends_on: { widgets: [], inputs: [], input_groups: [] },
+      expr: '{"type":"usd","usd":9.99}'
+    }
+    defs['OtherNode'].price_badge =
+      bakedIn as unknown as (typeof defs)['OtherNode']['price_badge']
+    await overlayPriceBadges(defs)
+    // Absent from the map: untouched, same object identity.
+    expect(defs['OtherNode'].price_badge).toBe(bakedIn)
+    // Present in the map: replaced.
+    expect(defs['PartnerNode'].price_badge).toMatchObject({
+      expr: validBadge.expr
+    })
+  })
+
+  it('skips only the malformed badge, applying valid siblings', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchResponse({
+        PartnerNode: validBadge,
+        OtherNode: { expr: 'missing engine and depends_on' }
+      })
+    )
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeDefined()
+    expect(defs['OtherNode'].price_badge).toBeUndefined()
+  })
+
+  it.for([
+    ['engine', () => ({ ...validBadge, engine: undefined })],
+    ['depends_on', () => ({ ...validBadge, depends_on: undefined })],
+    ['expr', () => ({ ...validBadge, expr: undefined })],
+    [
+      'depends_on.widgets',
+      () => ({
+        ...validBadge,
+        depends_on: { inputs: [], input_groups: [] }
+      })
+    ],
+    [
+      'depends_on.inputs',
+      () => ({
+        ...validBadge,
+        depends_on: { widgets: validBadge.depends_on.widgets, input_groups: [] }
+      })
+    ],
+    [
+      'depends_on.input_groups',
+      () => ({
+        ...validBadge,
+        depends_on: { widgets: validBadge.depends_on.widgets, inputs: [] }
+      })
+    ]
+  ] as const)(
+    'rejects a badge missing required field %s, applying valid siblings',
+    async ([, makeBadge]) => {
+      vi.stubGlobal(
+        'fetch',
+        mockFetchResponse({
+          PartnerNode: makeBadge(),
+          OtherNode: {
+            ...validBadge,
+            depends_on: { widgets: [], inputs: [], input_groups: [] }
+          }
+        })
+      )
+      const { overlayPriceBadges } = await importService()
+      const defs = makeDefs()
+      await overlayPriceBadges(defs)
+      expect(defs['PartnerNode'].price_badge).toBeUndefined()
+      expect(defs['OtherNode'].price_badge).toBeDefined()
+    }
+  )
+
+  it.for([
+    ['null', null],
+    ['array', [validBadge]],
+    ['string', 'nope']
+  ] as const)('fails open when the response body is %s', async ([, body]) => {
+    vi.stubGlobal('fetch', mockFetchResponse(body))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('skips a badge whose def input spec is malformed, without throwing', async () => {
+    const badge = {
+      ...validBadge,
+      depends_on: {
+        widgets: [{ name: 'broken', type: 'INT' }],
+        inputs: [],
+        input_groups: []
+      }
+    }
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    // /object_info is unvalidated; a non-string, non-array tuple head must not
+    // crash the overlay (fail open for this node only).
+    ;(
+      defs['PartnerNode'] as unknown as {
+        input: { required: Record<string, unknown> }
+      }
+    ).input.required['broken'] = [42, {}]
+    await expect(overlayPriceBadges(defs)).resolves.toBeUndefined()
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('skips a badge with an unknown engine', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchResponse({ PartnerNode: { ...validBadge, engine: 'python' } })
+    )
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('honors a widgetType override on the def input spec', async () => {
+    const badge = {
+      ...validBadge,
+      depends_on: {
+        widgets: [{ name: 'strength', type: 'STRING' }],
+        inputs: [],
+        input_groups: []
+      }
+    }
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
+    const { overlayPriceBadges } = await importService()
+    const defs = makeDefs()
+    // Socket type INT, but the runtime widget (and core's serialized badge
+    // dependency type) is the widgetType override.
+    ;(
+      defs['PartnerNode'] as unknown as {
+        input: { required: Record<string, unknown> }
+      }
+    ).input.required['strength'] = ['INT', { widgetType: 'STRING' }]
+    await overlayPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeDefined()
   })
 
   it('ignores badges for nodes missing from the defs', async () => {
@@ -233,6 +397,39 @@ describe('priceBadgeService', () => {
     })
     const defs2 = makeDefs()
     await overlayPriceBadges(defs2)
+    expect(defs2['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('never applies badges on a concurrent overlay once the session lost the race', async () => {
+    vi.useFakeTimers()
+    let resolveFetch!: (value: unknown) => void
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+    )
+    const { overlayPriceBadges } = await importService()
+    const defs1 = makeDefs()
+    const defs2 = makeDefs()
+    const overlay1 = overlayPriceBadges(defs1)
+    await vi.advanceTimersByTimeAsync(1000)
+    const overlay2 = overlayPriceBadges(defs2)
+    // overlay1's timer fires at 2500ms and marks the session lost;
+    // overlay2's timer would fire at 3500ms.
+    await vi.advanceTimersByTimeAsync(1600)
+    await overlay1
+    // The fetch resolves after the session is lost but before overlay2's
+    // timeout: overlay2 must still not apply.
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ PartnerNode: validBadge })
+    })
+    await overlay2
+    expect(defs1['PartnerNode'].price_badge).toBeUndefined()
     expect(defs2['PartnerNode'].price_badge).toBeUndefined()
   })
 

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -175,6 +175,12 @@ describe('priceBadgeService', () => {
     {
       case: 'an unknown engine',
       badge: { ...validBadge, engine: 'python' }
+    },
+    {
+      // The wire schema is deliberately stricter than the canonical
+      // zPriceBadge, which allows an empty expr.
+      case: 'an empty expression',
+      badge: { ...validBadge, expr: '' }
     }
   ])('skips a badge with $case, applying valid siblings', async ({ badge }) => {
     vi.stubGlobal(

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -502,8 +502,8 @@ describe('priceBadgeService', () => {
     const apply1 = applyPriceBadges(defs1)
     await vi.advanceTimersByTimeAsync(1000)
     const apply2 = applyPriceBadges(defs2)
-    // apply1's timer fires at 2500ms and marks the session lost;
-    // apply2's timer would fire at 3500ms.
+    // The deadline is anchored at the prefetch, so both apply calls' timers
+    // fire at 2500ms and mark the session lost.
     await vi.advanceTimersByTimeAsync(1600)
     await apply1
     // The fetch resolves after the session is lost but before apply2's
@@ -516,6 +516,36 @@ describe('priceBadgeService', () => {
     await apply2
     expect(defs1['PartnerNode'].price_badge).toBeUndefined()
     expect(defs2['PartnerNode'].price_badge).toBeUndefined()
+  })
+
+  it('measures the race deadline from the prefetch, not from apply', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise(() => {})) // never settles
+    )
+    const { applyPriceBadges, startPriceBadgeFetch } = await importService()
+    startPriceBadgeFetch()
+    await vi.advanceTimersByTimeAsync(3000)
+    const defs = makeDefs()
+    // The budget is already spent: apply must return without waiting on a
+    // fresh timer.
+    await applyPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('applies a result that settled before apply, even past the deadline', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
+    const { applyPriceBadges, startPriceBadgeFetch } = await importService()
+    startPriceBadgeFetch()
+    await vi.advanceTimersByTimeAsync(10_000)
+    const defs = makeDefs()
+    await applyPriceBadges(defs)
+    expect(defs['PartnerNode'].price_badge).toMatchObject({
+      expr: validBadge.expr
+    })
   })
 
   it('reuses the same fetch across apply calls', async () => {

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -41,6 +41,12 @@ const validBadge = {
   expr: '{"type":"usd","usd":0.1}'
 }
 
+// Valid badge with no dependencies: passes def validation on any node.
+const emptyDependsBadge = {
+  ...validBadge,
+  depends_on: { widgets: [], inputs: [], input_groups: [] }
+}
+
 function makeDefs(): Record<string, ComfyNodeDef> {
   return {
     PartnerNode: {
@@ -97,28 +103,31 @@ describe('priceBadgeService', () => {
     vi.useRealTimers()
   })
 
-  it('applies a valid badge to a matching def', async () => {
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
+  it('applies matching badges, leaves other nodes untouched, ignores unknown ones', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchResponse({ PartnerNode: validBadge, UnknownNode: validBadge })
+    )
     const { applyPriceBadges } = await importService()
     const defs = makeDefs()
+    const existingBadge = {
+      engine: 'jsonata',
+      depends_on: { widgets: [], inputs: [], input_groups: [] },
+      expr: '{"type":"usd","usd":9.99}'
+    }
+    defs['OtherNode'].price_badge =
+      existingBadge as unknown as (typeof defs)['OtherNode']['price_badge']
     await applyPriceBadges(defs)
+    // Present in the map: applied.
     expect(defs['PartnerNode'].price_badge).toMatchObject({
       expr: validBadge.expr
     })
-    expect(defs['OtherNode'].price_badge).toBeUndefined()
+    // Absent from the map: untouched, same object identity.
+    expect(defs['OtherNode'].price_badge).toBe(existingBadge)
+    // In the map but not in the defs: ignored without throwing.
   })
 
-  it('requests with comfyui_version and platform query params', async () => {
-    const fetchMock = mockFetchResponse({})
-    vi.stubGlobal('fetch', fetchMock)
-    const { applyPriceBadges } = await importService()
-    await applyPriceBadges(makeDefs())
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.example.com/nodes/pricing/badges?comfyui_version=0.3.50&platform=local'
-    )
-  })
-
-  it('normalizes a trailing slash on the API base URL', async () => {
+  it('requests the versioned endpoint, normalizing a trailing base slash', async () => {
     mockApiBase.url = 'https://api.example.com/'
     const fetchMock = mockFetchResponse({})
     vi.stubGlobal('fetch', fetchMock)
@@ -156,131 +165,27 @@ describe('priceBadgeService', () => {
     )
   })
 
-  it('preserves an existing baked-in badge on nodes absent from the map', async () => {
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: validBadge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    const bakedIn = {
-      engine: 'jsonata',
-      depends_on: { widgets: [], inputs: [], input_groups: [] },
-      expr: '{"type":"usd","usd":9.99}'
+  // The wire schema is declarative Zod; one representative per rejection
+  // reason is enough at the service boundary.
+  it.for([
+    {
+      case: 'a missing required field',
+      badge: { expr: 'missing engine and depends_on' }
+    },
+    {
+      case: 'an unknown engine',
+      badge: { ...validBadge, engine: 'python' }
     }
-    defs['OtherNode'].price_badge =
-      bakedIn as unknown as (typeof defs)['OtherNode']['price_badge']
-    await applyPriceBadges(defs)
-    // Absent from the map: untouched, same object identity.
-    expect(defs['OtherNode'].price_badge).toBe(bakedIn)
-    // Present in the map: replaced.
-    expect(defs['PartnerNode'].price_badge).toMatchObject({
-      expr: validBadge.expr
-    })
-  })
-
-  it('skips only the malformed badge, applying valid siblings', async () => {
+  ])('skips a badge with $case, applying valid siblings', async ({ badge }) => {
     vi.stubGlobal(
       'fetch',
-      mockFetchResponse({
-        PartnerNode: validBadge,
-        OtherNode: { expr: 'missing engine and depends_on' }
-      })
-    )
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
-    expect(defs['PartnerNode'].price_badge).toBeDefined()
-    expect(defs['OtherNode'].price_badge).toBeUndefined()
-  })
-
-  it.for([
-    ['engine', () => ({ ...validBadge, engine: undefined })],
-    ['depends_on', () => ({ ...validBadge, depends_on: undefined })],
-    ['expr', () => ({ ...validBadge, expr: undefined })],
-    [
-      'depends_on.widgets',
-      () => ({
-        ...validBadge,
-        depends_on: { inputs: [], input_groups: [] }
-      })
-    ],
-    [
-      'depends_on.inputs',
-      () => ({
-        ...validBadge,
-        depends_on: { widgets: validBadge.depends_on.widgets, input_groups: [] }
-      })
-    ],
-    [
-      'depends_on.input_groups',
-      () => ({
-        ...validBadge,
-        depends_on: { widgets: validBadge.depends_on.widgets, inputs: [] }
-      })
-    ]
-  ] as const)(
-    'rejects a badge missing required field %s, applying valid siblings',
-    async ([, makeBadge]) => {
-      vi.stubGlobal(
-        'fetch',
-        mockFetchResponse({
-          PartnerNode: makeBadge(),
-          OtherNode: {
-            ...validBadge,
-            depends_on: { widgets: [], inputs: [], input_groups: [] }
-          }
-        })
-      )
-      const { applyPriceBadges } = await importService()
-      const defs = makeDefs()
-      await applyPriceBadges(defs)
-      expect(defs['PartnerNode'].price_badge).toBeUndefined()
-      expect(defs['OtherNode'].price_badge).toBeDefined()
-    }
-  )
-
-  it.for([
-    ['null', null],
-    ['array', [validBadge]],
-    ['string', 'nope']
-  ] as const)('fails open when the response body is %s', async ([, body]) => {
-    vi.stubGlobal('fetch', mockFetchResponse(body))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('skips a badge whose def input spec is malformed, without throwing', async () => {
-    const badge = {
-      ...validBadge,
-      depends_on: {
-        widgets: [{ name: 'broken', type: 'INT' }],
-        inputs: [],
-        input_groups: []
-      }
-    }
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    // /object_info is unvalidated; a non-string, non-array tuple head must not
-    // crash the apply (fail open for this node only).
-    ;(
-      defs['PartnerNode'] as unknown as {
-        input: { required: Record<string, unknown> }
-      }
-    ).input.required['broken'] = [42, {}]
-    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('skips a badge with an unknown engine', async () => {
-    vi.stubGlobal(
-      'fetch',
-      mockFetchResponse({ PartnerNode: { ...validBadge, engine: 'python' } })
+      mockFetchResponse({ PartnerNode: badge, OtherNode: emptyDependsBadge })
     )
     const { applyPriceBadges } = await importService()
     const defs = makeDefs()
     await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
+    expect(defs['OtherNode'].price_badge).toBeDefined()
   })
 
   it('honors a widgetType override on the def input spec', async () => {
@@ -306,45 +211,43 @@ describe('priceBadgeService', () => {
     expect(defs['PartnerNode'].price_badge).toBeDefined()
   })
 
-  it('ignores badges for nodes missing from the defs', async () => {
-    vi.stubGlobal('fetch', mockFetchResponse({ UnknownNode: validBadge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('skips a badge whose widget dependency has no matching def input', async () => {
-    const badBadge = {
-      ...validBadge,
-      depends_on: {
-        widgets: [{ name: 'missing_widget', type: 'COMBO' }],
-        inputs: [],
-        input_groups: []
-      }
+  it.for([
+    {
+      case: 'has no matching def input',
+      widget: { name: 'missing_widget', type: 'COMBO' }
+    },
+    {
+      case: 'type mismatches the def input type',
+      widget: { name: 'seed', type: 'STRING' }
+    },
+    {
+      // /object_info is unvalidated; a non-string, non-array tuple head
+      // must not crash the apply (fail open for this node only).
+      case: 'def input spec is malformed',
+      widget: { name: 'broken', type: 'INT' },
+      brokenInput: true
     }
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('skips a badge whose widget type mismatches the def input type', async () => {
-    const badBadge = {
-      ...validBadge,
-      depends_on: {
-        widgets: [{ name: 'seed', type: 'STRING' }],
-        inputs: [],
-        input_groups: []
+  ])(
+    'skips a badge whose widget dependency $case',
+    async ({ widget, brokenInput }) => {
+      const badge = {
+        ...validBadge,
+        depends_on: { widgets: [widget], inputs: [], input_groups: [] }
       }
+      vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badge }))
+      const { applyPriceBadges } = await importService()
+      const defs = makeDefs()
+      if (brokenInput) {
+        ;(
+          defs['PartnerNode'] as unknown as {
+            input: { required: Record<string, unknown> }
+          }
+        ).input.required['broken'] = [42, {}]
+      }
+      await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
+      expect(defs['PartnerNode'].price_badge).toBeUndefined()
     }
-    vi.stubGlobal('fetch', mockFetchResponse({ PartnerNode: badBadge }))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
+  )
 
   describe('input and input_group dependency validation', () => {
     // Def with a plain combo (resolution), a plain INT (seed), a dynamic
@@ -429,30 +332,24 @@ describe('priceBadgeService', () => {
     })
   })
 
-  it('fails open on HTTP error', async () => {
-    vi.stubGlobal('fetch', mockFetchResponse(null, false, 500))
+  it.for([
+    {
+      case: 'HTTP error',
+      makeFetch: () => mockFetchResponse(null, false, 500)
+    },
+    {
+      case: 'network error',
+      makeFetch: () => vi.fn().mockRejectedValue(new Error('offline'))
+    },
+    {
+      case: 'invalid top-level body',
+      makeFetch: () => mockFetchResponse(['not', 'a', 'map'])
+    }
+  ])('fails open on $case', async ({ makeFetch }) => {
+    vi.stubGlobal('fetch', makeFetch())
     const { applyPriceBadges } = await importService()
     const defs = makeDefs()
     await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('fails open on network error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await expect(applyPriceBadges(defs)).resolves.toBeUndefined()
-    expect(defs['PartnerNode'].price_badge).toBeUndefined()
-  })
-
-  it('fails open when the response does not match the schema', async () => {
-    vi.stubGlobal(
-      'fetch',
-      mockFetchResponse({ PartnerNode: { engine: 'python', expr: 42 } })
-    )
-    const { applyPriceBadges } = await importService()
-    const defs = makeDefs()
-    await applyPriceBadges(defs)
     expect(defs['PartnerNode'].price_badge).toBeUndefined()
   })
 

--- a/src/services/priceBadgeService.test.ts
+++ b/src/services/priceBadgeService.test.ts
@@ -127,6 +127,28 @@ describe('priceBadgeService', () => {
     // In the map but not in the defs: ignored without throwing.
   })
 
+  it('never resolves badge names to inherited keys or mutates builtins', async () => {
+    // JSON.parse is required for fidelity: an object literal's __proto__
+    // sets the prototype instead of creating the own key that
+    // response.json() produces.
+    const payload: unknown = JSON.parse(
+      JSON.stringify({ OtherNode: emptyDependsBadge }).replace(
+        '{',
+        `{"__proto__":${JSON.stringify(emptyDependsBadge)},` +
+          `"constructor":${JSON.stringify(emptyDependsBadge)},` +
+          `"toString":${JSON.stringify(emptyDependsBadge)},`
+      )
+    )
+    vi.stubGlobal('fetch', mockFetchResponse(payload))
+    const { applyPriceBadges } = await importService()
+    const defs = makeDefs()
+    await applyPriceBadges(defs)
+    expect(Object.hasOwn(Object.prototype, 'price_badge')).toBe(false)
+    expect(Object.hasOwn(Object, 'price_badge')).toBe(false)
+    expect(Object.hasOwn(Object.prototype.toString, 'price_badge')).toBe(false)
+    expect(defs['OtherNode'].price_badge).toBeDefined()
+  })
+
   it('requests the versioned endpoint, normalizing a trailing base slash', async () => {
     mockApiBase.url = 'https://api.example.com/'
     const fetchMock = mockFetchResponse({})

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -1,0 +1,170 @@
+import { captureException, captureMessage } from '@sentry/vue'
+import { until } from '@vueuse/core'
+import { z } from 'zod'
+
+import { getComfyApiBaseUrl } from '@/config/comfyApi'
+import { isCloud } from '@/platform/distribution/types'
+import type { ComfyNodeDef, PriceBadge } from '@/schemas/nodeDefSchema'
+import { useSystemStatsStore } from '@/stores/systemStatsStore'
+
+const zWidgetDependency = z.object({
+  name: z.string(),
+  type: z.string()
+})
+
+const zPriceBadgeDepends = z.object({
+  widgets: z.array(zWidgetDependency).optional().default([]),
+  inputs: z.array(z.string()).optional().default([]),
+  input_groups: z.array(z.string()).optional().default([])
+})
+
+const zRemotePriceBadge = z.object({
+  engine: z.literal('jsonata').optional().default('jsonata'),
+  depends_on: zPriceBadgeDepends
+    .optional()
+    .default({ widgets: [], inputs: [], input_groups: [] }),
+  expr: z.string()
+})
+
+const zPriceBadgeMap = z.record(zRemotePriceBadge)
+
+type PriceBadgeMap = Record<string, PriceBadge>
+
+const DEF_LOAD_RACE_TIMEOUT_MS = 2500
+
+let badgeMapPromise: Promise<PriceBadgeMap | null> | null = null
+let raceLostForSession = false
+
+async function resolveComfyUIVersion(): Promise<string> {
+  const systemStatsStore = useSystemStatsStore()
+  await until(
+    () => systemStatsStore.isInitialized || !!systemStatsStore.error
+  ).toBe(true)
+  return systemStatsStore.systemStats?.system?.comfyui_version || 'nightly'
+}
+
+async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
+  try {
+    const version = await resolveComfyUIVersion()
+    const url = `${getComfyApiBaseUrl()}/nodes/pricing/badges`
+    const params = new URLSearchParams({
+      comfyui_version: version,
+      platform: isCloud ? 'cloud' : 'local'
+    })
+    const response = await fetch(`${url}?${params}`)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    const parsed = zPriceBadgeMap.safeParse(await response.json())
+    if (!parsed.success) {
+      throw new Error(`invalid response: ${parsed.error.message}`)
+    }
+    return parsed.data
+  } catch (error) {
+    console.warn(
+      '[pricing/badges] fetch failed; no core-node badges this session:',
+      error
+    )
+    captureException(error, {
+      level: 'warning',
+      tags: {
+        api_endpoint: '/nodes/pricing/badges',
+        error_type: 'price_badge_fetch_error'
+      }
+    })
+    return null
+  }
+}
+
+/**
+ * Kick off the price badge fetch chain (system_stats version -> badge map).
+ * Idempotent; safe to call before node defs load so the fetch runs
+ * concurrently with /object_info.
+ */
+export function startPriceBadgeFetch(): void {
+  badgeMapPromise ??= fetchPriceBadgeMap()
+}
+
+type WidgetTypeBucket = 'number' | 'boolean' | 'string'
+
+function bucketOfType(type: string): WidgetTypeBucket {
+  const upper = type.toUpperCase()
+  if (upper === 'INT' || upper === 'FLOAT') return 'number'
+  if (upper === 'BOOLEAN') return 'boolean'
+  return 'string'
+}
+
+function declaredInputBucket(spec: unknown): WidgetTypeBucket {
+  if (!Array.isArray(spec) || Array.isArray(spec[0])) return 'string'
+  return bucketOfType(String(spec[0]))
+}
+
+function validateBadgeAgainstDef(
+  badge: PriceBadge,
+  def: ComfyNodeDef
+): string | null {
+  const inputs = { ...def.input?.required, ...def.input?.optional }
+  for (const widget of badge.depends_on.widgets) {
+    const [parent] = widget.name.split('.')
+    const spec = inputs[parent]
+    if (!spec) return `widget '${widget.name}' has no def input '${parent}'`
+    const isNested = widget.name.includes('.')
+    if (!isNested && bucketOfType(widget.type) !== declaredInputBucket(spec)) {
+      return `widget '${widget.name}' type '${widget.type}' does not match def input type`
+    }
+  }
+  for (const name of [
+    ...badge.depends_on.inputs,
+    ...badge.depends_on.input_groups
+  ]) {
+    const [parent] = name.split('.')
+    if (!inputs[parent])
+      return `dependency '${name}' has no def input '${parent}'`
+  }
+  return null
+}
+
+/**
+ * Overlay remotely fetched price badges onto node defs, in place.
+ *
+ * Awaits the badge fetch for at most DEF_LOAD_RACE_TIMEOUT_MS; on timeout the
+ * result is dropped for the whole session so badge state stays deterministic
+ * (compiled-rule and label caches are keyed by node name and never
+ * invalidated). Badges that fail validation against the def are skipped per
+ * node: no badge beats a wrong one.
+ */
+export async function overlayPriceBadges(
+  defs: Record<string, ComfyNodeDef>
+): Promise<void> {
+  if (raceLostForSession) return
+  startPriceBadgeFetch()
+  const result = await Promise.race([
+    badgeMapPromise,
+    new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DEF_LOAD_RACE_TIMEOUT_MS)
+    )
+  ])
+  if (result === 'timeout') {
+    raceLostForSession = true
+    console.warn(
+      '[pricing/badges] fetch lost the def-load race; no core-node badges this session'
+    )
+    captureMessage('price badge fetch lost def-load race', {
+      level: 'warning'
+    })
+    return
+  }
+  if (!result) return
+  for (const [name, badge] of Object.entries(result)) {
+    const def = defs[name]
+    if (!def) continue
+    const problem = validateBadgeAgainstDef(badge, def)
+    if (problem) {
+      console.warn(
+        `[pricing/badges] skipping overlay for '${name}': ${problem}`
+      )
+      continue
+    }
+    def.price_badge = badge
+  }
+}

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -25,11 +25,13 @@ const zPriceBadgeDepends = z.object({
 
 // Stricter than the canonical zPriceBadge: the wire contract always carries
 // the full shape, so nothing is defaulted and unknown engines are rejected.
+// `satisfies` ties the output to the canonical PriceBadge type so a change
+// to it surfaces here as a compile error.
 const zRemotePriceBadge = z.object({
   engine: z.literal('jsonata'),
   depends_on: zPriceBadgeDepends,
   expr: z.string().min(1)
-})
+}) satisfies z.ZodType<PriceBadge>
 
 const zPriceBadgeMap = z.record(z.unknown())
 

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -165,7 +165,7 @@ function validateBadgeAgainstDef(
 }
 
 /**
- * Overlay remotely fetched price badges onto node defs, in place.
+ * Apply remotely fetched price badges to node defs, mutating them in place.
  *
  * Awaits the badge fetch for at most DEF_LOAD_RACE_TIMEOUT_MS; on timeout the
  * result is dropped for the whole session so badge state stays deterministic
@@ -173,7 +173,7 @@ function validateBadgeAgainstDef(
  * invalidated). Badges that fail validation against the def are skipped per
  * node: no badge beats a wrong one.
  */
-export async function overlayPriceBadges(
+export async function applyPriceBadges(
   defs: Record<string, ComfyNodeDef>
 ): Promise<void> {
   if (raceLostForSession) return
@@ -194,7 +194,7 @@ export async function overlayPriceBadges(
     })
     return
   }
-  // A concurrent overlay call may have timed out and marked the session lost
+  // A concurrent apply call may have timed out and marked the session lost
   // while we were awaiting; honor the all-or-nothing session invariant.
   if (raceLostForSession) return
   if (!result) return
@@ -203,9 +203,7 @@ export async function overlayPriceBadges(
     if (!def) continue
     const problem = validateBadgeAgainstDef(badge, def)
     if (problem) {
-      console.warn(
-        `[pricing/badges] skipping overlay for '${name}': ${problem}`
-      )
+      console.warn(`[pricing/badges] skipping badge for '${name}': ${problem}`)
       continue
     }
     def.price_badge = badge

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -4,7 +4,12 @@ import { z } from 'zod'
 
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import { isCloud } from '@/platform/distribution/types'
-import type { ComfyNodeDef, PriceBadge } from '@/schemas/nodeDefSchema'
+import type {
+  ComfyNodeDef,
+  InputSpec,
+  PriceBadge
+} from '@/schemas/nodeDefSchema'
+import { getInputSpecType } from '@/schemas/nodeDefSchema'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 
 const zWidgetDependency = z.object({
@@ -13,20 +18,20 @@ const zWidgetDependency = z.object({
 })
 
 const zPriceBadgeDepends = z.object({
-  widgets: z.array(zWidgetDependency).optional().default([]),
-  inputs: z.array(z.string()).optional().default([]),
-  input_groups: z.array(z.string()).optional().default([])
+  widgets: z.array(zWidgetDependency),
+  inputs: z.array(z.string()),
+  input_groups: z.array(z.string())
 })
 
+// Stricter than the canonical zPriceBadge: the wire contract always carries
+// the full shape, so nothing is defaulted and unknown engines are rejected.
 const zRemotePriceBadge = z.object({
-  engine: z.literal('jsonata').optional().default('jsonata'),
-  depends_on: zPriceBadgeDepends
-    .optional()
-    .default({ widgets: [], inputs: [], input_groups: [] }),
-  expr: z.string()
+  engine: z.literal('jsonata'),
+  depends_on: zPriceBadgeDepends,
+  expr: z.string().min(1)
 })
 
-const zPriceBadgeMap = z.record(zRemotePriceBadge)
+const zPriceBadgeMap = z.record(z.unknown())
 
 type PriceBadgeMap = Record<string, PriceBadge>
 
@@ -46,12 +51,12 @@ async function resolveComfyUIVersion(): Promise<string> {
 async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
   try {
     const version = await resolveComfyUIVersion()
-    const url = `${getComfyApiBaseUrl()}/nodes/pricing/badges`
+    const base = getComfyApiBaseUrl().replace(/\/+$/, '')
     const params = new URLSearchParams({
       comfyui_version: version,
       platform: isCloud ? 'cloud' : 'local'
     })
-    const response = await fetch(`${url}?${params}`)
+    const response = await fetch(`${base}/nodes/pricing/badges?${params}`)
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
     }
@@ -59,7 +64,19 @@ async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
     if (!parsed.success) {
       throw new Error(`invalid response: ${parsed.error.message}`)
     }
-    return parsed.data
+    const map: PriceBadgeMap = {}
+    for (const [name, rawBadge] of Object.entries(parsed.data)) {
+      const badge = zRemotePriceBadge.safeParse(rawBadge)
+      if (!badge.success) {
+        console.warn(
+          `[pricing/badges] skipping malformed badge for '${name}':`,
+          badge.error.message
+        )
+        continue
+      }
+      map[name] = badge.data
+    }
+    return map
   } catch (error) {
     console.warn(
       '[pricing/badges] fetch failed; no core-node badges this session:',
@@ -94,9 +111,26 @@ function bucketOfType(type: string): WidgetTypeBucket {
   return 'string'
 }
 
-function declaredInputBucket(spec: unknown): WidgetTypeBucket {
-  if (!Array.isArray(spec) || Array.isArray(spec[0])) return 'string'
-  return bucketOfType(String(spec[0]))
+/**
+ * Bucket the declared type of a def input spec, or null when the spec is
+ * malformed. /object_info arrives unvalidated, so the tuple head must be
+ * narrowed before it reaches the canonical parser.
+ */
+function declaredInputBucket(spec: unknown): WidgetTypeBucket | null {
+  if (!Array.isArray(spec)) return null
+  // A widgetType override is what the runtime widget is constructed as.
+  const options = spec[1]
+  const widgetType =
+    options !== null &&
+    typeof options === 'object' &&
+    'widgetType' in options &&
+    typeof options.widgetType === 'string'
+      ? options.widgetType
+      : undefined
+  if (widgetType) return bucketOfType(widgetType)
+  const head: unknown = spec[0]
+  if (typeof head !== 'string' && !Array.isArray(head)) return null
+  return bucketOfType(getInputSpecType(spec as InputSpec))
 }
 
 function validateBadgeAgainstDef(
@@ -109,8 +143,14 @@ function validateBadgeAgainstDef(
     const spec = inputs[parent]
     if (!spec) return `widget '${widget.name}' has no def input '${parent}'`
     const isNested = widget.name.includes('.')
-    if (!isNested && bucketOfType(widget.type) !== declaredInputBucket(spec)) {
-      return `widget '${widget.name}' type '${widget.type}' does not match def input type`
+    if (!isNested) {
+      const declared = declaredInputBucket(spec)
+      if (declared === null) {
+        return `widget '${widget.name}' def input spec is malformed`
+      }
+      if (bucketOfType(widget.type) !== declared) {
+        return `widget '${widget.name}' type '${widget.type}' does not match def input type`
+      }
     }
   }
   for (const name of [
@@ -154,6 +194,9 @@ export async function overlayPriceBadges(
     })
     return
   }
+  // A concurrent overlay call may have timed out and marked the session lost
+  // while we were awaiting; honor the all-or-nothing session invariant.
+  if (raceLostForSession) return
   if (!result) return
   for (const [name, badge] of Object.entries(result)) {
     const def = defs[name]

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -276,7 +276,9 @@ export async function applyPriceBadges(
   if (raceLostForSession) return
   if (!result) return
   for (const [name, badge] of Object.entries(result)) {
-    const def = defs[name]
+    // Own-key check: names like 'constructor' or 'toString' would otherwise
+    // resolve to inherited builtins and let remote data mutate them.
+    const def = Object.hasOwn(defs, name) ? defs[name] : undefined
     if (!def) continue
     const problem = validateBadgeAgainstDef(badge, def)
     if (problem) {

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -49,18 +49,23 @@ async function resolveSystemStats() {
   await until(
     () => systemStatsStore.isInitialized || !!systemStatsStore.error
   ).toBe(true)
-  return systemStatsStore.systemStats
+  return systemStatsStore.error ? null : systemStatsStore.systemStats
 }
 
 async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
   try {
     const stats = await resolveSystemStats()
-    // --disable-api-nodes promises no frontend internet access; honor it
-    // (same contract as releaseStore).
-    if (stats?.system?.argv?.includes('--disable-api-nodes')) {
+    // Without stats we can't tell whether --disable-api-nodes is set, so
+    // its no-external-requests promise must fail closed: no fetch.
+    if (!stats) {
       return null
     }
-    const version = stats?.system?.comfyui_version || 'nightly'
+    // --disable-api-nodes promises no frontend internet access; honor it
+    // (same contract as releaseStore).
+    if (stats.system?.argv?.includes('--disable-api-nodes')) {
+      return null
+    }
+    const version = stats.system?.comfyui_version || 'nightly'
     const base = getComfyApiBaseUrl().replace(/\/+$/, '')
     const params = new URLSearchParams({
       comfyui_version: version,

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -42,17 +42,23 @@ const DEF_LOAD_RACE_TIMEOUT_MS = 2500
 let badgeMapPromise: Promise<PriceBadgeMap | null> | null = null
 let raceLostForSession = false
 
-async function resolveComfyUIVersion(): Promise<string> {
+async function resolveSystemStats() {
   const systemStatsStore = useSystemStatsStore()
   await until(
     () => systemStatsStore.isInitialized || !!systemStatsStore.error
   ).toBe(true)
-  return systemStatsStore.systemStats?.system?.comfyui_version || 'nightly'
+  return systemStatsStore.systemStats
 }
 
 async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
   try {
-    const version = await resolveComfyUIVersion()
+    const stats = await resolveSystemStats()
+    // --disable-api-nodes promises no frontend internet access; honor it
+    // (same contract as releaseStore).
+    if (stats?.system?.argv?.includes('--disable-api-nodes')) {
+      return null
+    }
+    const version = stats?.system?.comfyui_version || 'nightly'
     const base = getComfyApiBaseUrl().replace(/\/+$/, '')
     const params = new URLSearchParams({
       comfyui_version: version,

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -40,6 +40,8 @@ type PriceBadgeMap = Record<string, PriceBadge>
 const DEF_LOAD_RACE_TIMEOUT_MS = 2500
 
 let badgeMapPromise: Promise<PriceBadgeMap | null> | null = null
+let badgeMapSettled = false
+let fetchDeadline = 0
 let raceLostForSession = false
 
 async function resolveSystemStats() {
@@ -104,10 +106,17 @@ async function fetchPriceBadgeMap(): Promise<PriceBadgeMap | null> {
 /**
  * Kick off the price badge fetch chain (system_stats version -> badge map).
  * Idempotent; safe to call before node defs load so the fetch runs
- * concurrently with /object_info.
+ * concurrently with /object_info. The def-load race deadline is anchored
+ * here, so time spent fetching before defs arrive counts against the
+ * budget instead of delaying node registration.
  */
 export function startPriceBadgeFetch(): void {
-  badgeMapPromise ??= fetchPriceBadgeMap()
+  if (badgeMapPromise) return
+  fetchDeadline = Date.now() + DEF_LOAD_RACE_TIMEOUT_MS
+  badgeMapPromise = fetchPriceBadgeMap()
+  void badgeMapPromise.finally(() => {
+    badgeMapSettled = true
+  })
 }
 
 type WidgetTypeBucket = 'number' | 'boolean' | 'string'
@@ -206,35 +215,56 @@ function validateBadgeAgainstDef(
   return null
 }
 
+function markRaceLost(): void {
+  if (raceLostForSession) return
+  raceLostForSession = true
+  console.warn(
+    '[pricing/badges] fetch lost the def-load race; no core-node badges this session'
+  )
+  captureMessage('price badge fetch lost def-load race', {
+    level: 'warning'
+  })
+}
+
 /**
  * Apply remotely fetched price badges to node defs, mutating them in place.
  *
- * Awaits the badge fetch for at most DEF_LOAD_RACE_TIMEOUT_MS; on timeout the
- * result is dropped for the whole session so badge state stays deterministic
- * (compiled-rule and label caches are keyed by node name and never
- * invalidated). Badges that fail validation against the def are skipped per
- * node: no badge beats a wrong one.
+ * The fetch gets a DEF_LOAD_RACE_TIMEOUT_MS budget measured from
+ * startPriceBadgeFetch(), not from here, so it never delays node
+ * registration by more than what remains of that budget once /object_info
+ * has resolved — typically nothing, since the prefetch runs concurrently
+ * with extension loading and /object_info. A result that settled before
+ * apply is used even past the deadline (it costs no extra wait). On
+ * timeout the result is dropped for the whole session so badge state stays
+ * deterministic (compiled-rule and label caches are keyed by node name and
+ * never invalidated). Badges that fail validation against the def are
+ * skipped per node: no badge beats a wrong one.
  */
 export async function applyPriceBadges(
   defs: Record<string, ComfyNodeDef>
 ): Promise<void> {
   if (raceLostForSession) return
   startPriceBadgeFetch()
-  const result = await Promise.race([
-    badgeMapPromise,
-    new Promise<'timeout'>((resolve) =>
-      setTimeout(() => resolve('timeout'), DEF_LOAD_RACE_TIMEOUT_MS)
-    )
-  ])
-  if (result === 'timeout') {
-    raceLostForSession = true
-    console.warn(
-      '[pricing/badges] fetch lost the def-load race; no core-node badges this session'
-    )
-    captureMessage('price badge fetch lost def-load race', {
-      level: 'warning'
-    })
-    return
+  let result: PriceBadgeMap | null
+  if (badgeMapSettled) {
+    result = await badgeMapPromise!
+  } else {
+    const remaining = fetchDeadline - Date.now()
+    if (remaining <= 0) {
+      markRaceLost()
+      return
+    }
+    const raced = await Promise.race([
+      badgeMapPromise,
+      new Promise<'timeout'>((resolve) =>
+        setTimeout(() => resolve('timeout'), remaining)
+      )
+    ])
+    if (raced === 'timeout') {
+      markRaceLost()
+      return
+    }
+    result = raced ?? null
   }
   // A concurrent apply call may have timed out and marked the session lost
   // while we were awaiting; honor the all-or-nothing session invariant.

--- a/src/services/priceBadgeService.ts
+++ b/src/services/priceBadgeService.ts
@@ -141,18 +141,52 @@ function declaredInputBucket(spec: unknown): WidgetTypeBucket | null {
   return bucketOfType(getInputSpecType(spec as InputSpec))
 }
 
+/**
+ * Dynamic container inputs (DynamicCombo, Autogrow, ... — all COMFY_*_V3
+ * io types) are the only inputs that expand into dotted runtime slot names
+ * like 'model.images.image_1'.
+ */
+function isDynamicContainerSpec(spec: unknown): boolean {
+  return (
+    Array.isArray(spec) &&
+    typeof spec[0] === 'string' &&
+    spec[0].startsWith('COMFY_')
+  )
+}
+
+/**
+ * Check a dependency name against def inputs. An undotted name must be an
+ * exact def input key; a dotted name references a runtime-expanded slot,
+ * which cannot be resolved statically, so its first segment must be a
+ * dynamic container input.
+ */
+function dependencyProblem(
+  name: string,
+  inputs: Record<string, unknown>
+): string | null {
+  const dotIndex = name.indexOf('.')
+  if (dotIndex === -1) {
+    return inputs[name] ? null : `has no def input '${name}'`
+  }
+  const parent = name.slice(0, dotIndex)
+  const spec = inputs[parent]
+  if (!spec) return `has no def input '${parent}'`
+  if (!isDynamicContainerSpec(spec)) {
+    return `parent def input '${parent}' is not a dynamic input`
+  }
+  return null
+}
+
 function validateBadgeAgainstDef(
   badge: PriceBadge,
   def: ComfyNodeDef
 ): string | null {
   const inputs = { ...def.input?.required, ...def.input?.optional }
   for (const widget of badge.depends_on.widgets) {
-    const [parent] = widget.name.split('.')
-    const spec = inputs[parent]
-    if (!spec) return `widget '${widget.name}' has no def input '${parent}'`
-    const isNested = widget.name.includes('.')
-    if (!isNested) {
-      const declared = declaredInputBucket(spec)
+    const problem = dependencyProblem(widget.name, inputs)
+    if (problem) return `widget '${widget.name}' ${problem}`
+    if (!widget.name.includes('.')) {
+      const declared = declaredInputBucket(inputs[widget.name])
       if (declared === null) {
         return `widget '${widget.name}' def input spec is malformed`
       }
@@ -161,13 +195,13 @@ function validateBadgeAgainstDef(
       }
     }
   }
-  for (const name of [
-    ...badge.depends_on.inputs,
-    ...badge.depends_on.input_groups
-  ]) {
-    const [parent] = name.split('.')
-    if (!inputs[parent])
-      return `dependency '${name}' has no def input '${parent}'`
+  for (const name of badge.depends_on.inputs) {
+    const problem = dependencyProblem(name, inputs)
+    if (problem) return `input '${name}' ${problem}`
+  }
+  for (const name of badge.depends_on.input_groups) {
+    const problem = dependencyProblem(name, inputs)
+    if (problem) return `input group '${name}' ${problem}`
   }
   return null
 }


### PR DESCRIPTION
## Summary

Fetch partner (API) node price badges dynamically from the Comfy API instead of relying only on badge data baked into ComfyUI core releases, so pricing changes no longer require a core release.

## Changes

- **What**: New `priceBadgeService` fetches `GET {comfy_api_base_url}/nodes/pricing/badges?comfyui_version=<v>&platform=<cloud|local>` (server resolves the badge set for the client's core version and platform) and overlays the result onto node defs inside `ComfyApp.getNodeDefs()` — the single funnel both LiteGraph registration and the Vue node-def store go through. The fetch is kicked off early in `app.setup()` so it runs concurrently with extension loading and `/object_info`.

Behavior details:

- ComfyUI version comes from `/system_stats`; falls back to `"nightly"` (server treats it as latest) when unavailable.
- **Fail open**: on fetch error, schema-invalid response, or losing a bounded (2.5s) race against def load, defs are left untouched for the session — you get exactly the badges `/object_info` shipped.
- Per-node validation before overlay: referenced widgets/inputs/input groups must exist on the def (dotted names validated by first segment) and widget types must bucket-match. An invalid badge is skipped for that node — no badge beats a wrong one.
- Nodes absent from the response are untouched, so third-party custom-node badges from `/object_info` are preserved.
- Plain cache-friendly GET: the browser HTTP cache revalidates via ETag/304 per the endpoint's `Cache-Control: public, max-age=300`.

Server side: Comfy-Org/cloud#5081 (verified against its ephemeral env, including CORS, ETag/304 revalidation, and resolution parity with the authoritative data).

## Review Focus

- Overlay placement in `ComfyApp.getNodeDefs()` (`src/scripts/app.ts`) — chosen because it covers both `registerNodes()` and the node-refresh path before any consumer (including `useNodePricing`'s per-node compiled-rule caches) sees defs.
- Race-loss handling: if the badge fetch loses the def-load race once, the result is dropped for the whole session to keep badge state deterministic (pricing rule caches are keyed by node name and never invalidated).
- The display toggle `Comfy.NodeBadge.ShowApiPricing` is deliberately not gating the fetch: it already gates rendering in `useNodeBadge`, and always fetching keeps mid-session toggling working.
