### PR TITLE
feat: import AVIF workflow metadata from XMP

### DIFF
--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -420,7 +420,7 @@ function buildXmpPacket(workflow: string, prompt?: string): string {
     '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
     '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
     '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
-    `    <rdf:Description xmlns:comfy="https://example.com/comfyui/metadata/1.0/" rdf:about=""${promptAttribute}>`,
+    `    <rdf:Description xmlns:comfy="https://github.com/Comfy-Org/ComfyUI" rdf:about=""${promptAttribute}>`,
     `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
     '    </rdf:Description>',
     '  </rdf:RDF>',

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -177,18 +177,66 @@ const buildIinfBox = (infeBoxes: Uint8Array[]): Uint8Array => {
   return buf
 }
 
+type IlocIntegerSize = 0 | 4 | 8
+
+interface IlocFieldSizes {
+  offset: IlocIntegerSize
+  length: IlocIntegerSize
+  baseOffset: IlocIntegerSize
+}
+
+interface TestIlocItem {
+  itemId: number
+  baseOffset: number
+  extents: { extentOffset: number; extentLength: number }[]
+}
+
+const defaultIlocFieldSizes: IlocFieldSizes = {
+  offset: 4,
+  length: 4,
+  baseOffset: 0
+}
+
+function setIlocInteger(
+  dataView: DataView,
+  offset: number,
+  value: number,
+  size: IlocIntegerSize
+) {
+  if (size === 0) return
+  if (size === 4) {
+    setU32BE(dataView, offset, value)
+    return
+  }
+  dataView.setBigUint64(offset, BigInt(value), false)
+}
+
 const buildIlocBox = (
-  items: { itemId: number; extentOffset: number; extentLength: number }[]
+  items: TestIlocItem[],
+  fieldSizes: IlocFieldSizes = defaultIlocFieldSizes
 ): Uint8Array => {
-  const perItemSize = 2 + 2 + 0 + 2 + (4 + 4)
-  const bodySize = 4 + 1 + 1 + 2 + items.length * perItemSize
+  const bodySize =
+    4 +
+    1 +
+    1 +
+    2 +
+    items.reduce(
+      (size, item) =>
+        size +
+        2 +
+        2 +
+        fieldSizes.baseOffset +
+        2 +
+        item.extents.length * (fieldSizes.offset + fieldSizes.length),
+      0
+    )
   const totalSize = 8 + bodySize
   const buf = new Uint8Array(totalSize)
   const dv = new DataView(buf.buffer)
   setU32BE(dv, 0, totalSize)
   buf.set(new TextEncoder().encode('iloc'), 4)
-  buf[12] = 0x44
-  buf[13] = 0x00
+  buf[12] = (fieldSizes.offset << 4) | fieldSizes.length
+  buf[13] = fieldSizes.baseOffset << 4
   setU16BE(dv, 14, items.length)
   let p = 16
   for (const it of items) {
@@ -196,12 +244,16 @@ const buildIlocBox = (
     p += 2
     setU16BE(dv, p, 0)
     p += 2
-    setU16BE(dv, p, 1)
+    setIlocInteger(dv, p, it.baseOffset, fieldSizes.baseOffset)
+    p += fieldSizes.baseOffset
+    setU16BE(dv, p, it.extents.length)
     p += 2
-    setU32BE(dv, p, it.extentOffset)
-    p += 4
-    setU32BE(dv, p, it.extentLength)
-    p += 4
+    for (const extent of it.extents) {
+      setIlocInteger(dv, p, extent.extentOffset, fieldSizes.offset)
+      p += fieldSizes.offset
+      setIlocInteger(dv, p, extent.extentLength, fieldSizes.length)
+      p += fieldSizes.length
+    }
   }
   return buf
 }
@@ -235,6 +287,8 @@ interface BuildAvifOpts {
   exifEntries?: string[]
   xmp?: string
   includeExif?: boolean
+  ilocFieldSizes?: IlocFieldSizes
+  splitXmpAcrossExtents?: boolean
   endian?: 'II' | 'MM'
   itemType?: string
   ftypBrand?: string
@@ -248,6 +302,8 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     exifEntries = [],
     xmp,
     includeExif = true,
+    ilocFieldSizes = defaultIlocFieldSizes,
+    splitXmpAcrossExtents = false,
     endian = 'II',
     itemType = 'Exif',
     ftypBrand = 'avif',
@@ -266,20 +322,28 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     itemType: string
     contentType?: string
     data: Uint8Array
+    extentLengths: number[]
   }[] = []
   if (includeExif) {
+    const data = buildExifBlob(exifEntries, endian)
     items.push({
       itemId: items.length + 1,
       itemType,
-      data: buildExifBlob(exifEntries, endian)
+      data,
+      extentLengths: [data.length]
     })
   }
   if (xmp !== undefined) {
+    const data = new TextEncoder().encode(xmp)
+    const firstExtentLength = Math.floor(data.length / 2)
     items.push({
       itemId: items.length + 1,
       itemType: 'mime',
       contentType: 'application/rdf+xml',
-      data: new TextEncoder().encode(xmp)
+      data,
+      extentLengths: splitXmpAcrossExtents
+        ? [firstExtentLength, data.length - firstExtentLength]
+        : [data.length]
     })
   }
 
@@ -289,25 +353,34 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     )
   )
   const placeholderIloc = buildIlocBox(
-    items.map(({ itemId, data }) => ({
+    items.map(({ itemId, extentLengths }) => ({
       itemId,
-      extentOffset: 0,
-      extentLength: data.length
-    }))
+      baseOffset: 0,
+      extents: extentLengths.map((extentLength) => ({
+        extentOffset: 0,
+        extentLength
+      }))
+    })),
+    ilocFieldSizes
   )
   const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : placeholderIloc.length)
   let itemOffset = ftyp.length + metaSize
-  const itemLocations = items.map(({ itemId, data }) => {
+  const itemLocations = items.map(({ itemId, data, extentLengths }) => {
+    let extentOffset = ilocFieldSizes.offset === 0 ? 0 : itemOffset
     const location = {
       itemId,
-      extentOffset: itemOffset,
-      extentLength: data.length
+      baseOffset: ilocFieldSizes.offset === 0 ? itemOffset : 0,
+      extents: extentLengths.map((extentLength) => {
+        const extent = { extentOffset, extentLength }
+        extentOffset += extentLength
+        return extent
+      })
     }
     itemOffset += data.length
     return location
   })
 
-  const finalIloc = buildIlocBox(itemLocations)
+  const finalIloc = buildIlocBox(itemLocations, ilocFieldSizes)
   const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
   const meta = buildMetaBox(finalInner)
 
@@ -328,13 +401,50 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
   return buf.slice().buffer as ArrayBuffer
 }
 
+function escapeXmlText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replaceAll('"', '&quot;')
+}
+
 function buildXmpPacket(workflow: string, prompt?: string): string {
-  const promptProperty = prompt ? `<pm:prompt>${prompt}</pm:prompt>` : ''
-  return `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:pm="https://ai-foundry.dev/ns/pixelmeta/1.0/" rdf:about="">${promptProperty}<pm:workflow>${workflow}</pm:workflow></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>`
+  const promptAttribute =
+    prompt === undefined ? '' : ` comfy:prompt="${escapeXmlAttribute(prompt)}"`
+
+  return [
+    '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
+    '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
+    '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
+    `    <rdf:Description xmlns:comfy="https://example.com/comfyui/metadata/1.0/" rdf:about=""${promptAttribute}>`,
+    `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
+    '    </rdf:Description>',
+    '  </rdf:RDF>',
+    '</x:xmpmeta>',
+    '<?xpacket end="w"?>'
+  ].join('\n')
 }
 
 const fileFromBuffer = (buffer: ArrayBuffer, name = 'test.avif'): File =>
   new File([buffer], name, { type: 'image/avif' })
+
+const ilocWidthCases: {
+  name: string
+  fieldSizes: IlocFieldSizes
+}[] = [
+  {
+    name: 'zero-byte extent offsets',
+    fieldSizes: { offset: 0, length: 4, baseOffset: 4 }
+  },
+  {
+    name: 'eight-byte extent offsets and lengths',
+    fieldSizes: { offset: 8, length: 8, baseOffset: 0 }
+  }
+]
 
 describe('getFromAvifFile', () => {
   beforeEach(() => {
@@ -469,7 +579,7 @@ describe('getFromAvifFile', () => {
     expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
   })
 
-  it('imports workflow and prompt from a standard XMP item', async () => {
+  it('imports workflow element and prompt attribute from an XMP item', async () => {
     const workflow = '{"nodes":[],"version":1}'
     const prompt = '{"1":{"class_type":"KSampler"}}'
     const file = fileFromBuffer(
@@ -482,6 +592,36 @@ describe('getFromAvifFile', () => {
     const result = await getWorkflowDataFromFile(file)
 
     expect(result).toEqual({ workflow, prompt })
+  })
+
+  it.each(ilocWidthCases)('imports XMP with $name', async ({ fieldSizes }) => {
+    const workflow = '{"nodes":[],"version":1}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        ilocFieldSizes: fieldSizes,
+        xmp: buildXmpPacket(workflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(workflow)
+  })
+
+  it('joins multiple iloc extents before parsing XMP', async () => {
+    const workflow = '{"nodes":[],"source":"split-extents"}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        splitXmpAcrossExtents: true,
+        xmp: buildXmpPacket(workflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(workflow)
   })
 
   it('prefers valid XMP values while retaining EXIF-only metadata', async () => {

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -500,4 +500,34 @@ describe('getFromAvifFile', () => {
     expect(result.workflow).toBe(xmpWorkflow)
     expect(result.prompt).toBe(prompt)
   })
+
+  it('retains EXIF metadata when the XMP packet is malformed', async () => {
+    const workflow = '{"source":"exif"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${workflow}`, `prompt:${prompt}`],
+        xmp: '<x:xmpmeta'
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('retains EXIF metadata when XMP JSON is malformed', async () => {
+    const workflow = '{"source":"exif"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${workflow}`, `prompt:${prompt}`],
+        xmp: buildXmpPacket('{invalid-workflow', '{invalid-prompt')
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
 })

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -412,16 +412,23 @@ function escapeXmlAttribute(value: string): string {
   return escapeXmlText(value).replaceAll('"', '&quot;')
 }
 
-function buildXmpPacket(workflow: string, prompt?: string): string {
+function buildXmpPacket(
+  workflow: string,
+  prompt?: string,
+  namespace = 'https://github.com/Comfy-Org/ComfyUI',
+  prefix = 'comfy'
+): string {
   const promptAttribute =
-    prompt === undefined ? '' : ` comfy:prompt="${escapeXmlAttribute(prompt)}"`
+    prompt === undefined
+      ? ''
+      : ` ${prefix}:prompt="${escapeXmlAttribute(prompt)}"`
 
   return [
     '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
     '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
     '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
-    `    <rdf:Description xmlns:comfy="https://github.com/Comfy-Org/ComfyUI" rdf:about=""${promptAttribute}>`,
-    `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
+    `    <rdf:Description xmlns:${prefix}="${namespace}" rdf:about=""${promptAttribute}>`,
+    `      <${prefix}:workflow>${escapeXmlText(workflow)}</${prefix}:workflow>`,
     '    </rdf:Description>',
     '  </rdf:RDF>',
     '</x:xmpmeta>',
@@ -592,6 +599,47 @@ describe('getFromAvifFile', () => {
     const result = await getWorkflowDataFromFile(file)
 
     expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('imports ComfyUI XMP metadata with a different namespace prefix', async () => {
+    const workflow = '{"nodes":[],"version":1}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        xmp: buildXmpPacket(
+          workflow,
+          prompt,
+          'https://github.com/Comfy-Org/ComfyUI',
+          'alternate'
+        )
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('ignores prompt and workflow from a different XMP namespace', async () => {
+    const exifWorkflow = '{"source":"exif"}'
+    const exifPrompt = '{"1":{"class_type":"EXIF"}}'
+    const xmpWorkflow = '{"source":"unrelated-xmp"}'
+    const xmpPrompt = '{"1":{"class_type":"Unrelated"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${exifWorkflow}`, `prompt:${exifPrompt}`],
+        xmp: buildXmpPacket(
+          xmpWorkflow,
+          xmpPrompt,
+          'https://example.com/unrelated-xmp'
+        )
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow: exifWorkflow, prompt: exifPrompt })
   })
 
   it.each(ilocWidthCases)('imports XMP with $name', async ({ fieldSizes }) => {

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -10,6 +10,7 @@ import {
   mockFileReaderError
 } from './__fixtures__/helpers'
 import { getFromAvifFile } from './avif'
+import { getWorkflowDataFromFile } from './parser'
 
 const fixturePath = path.resolve(__dirname, '__fixtures__/with_metadata.avif')
 const nanFixturePath = path.resolve(
@@ -137,9 +138,14 @@ const buildExifBlob = (
 const buildInfeBox = (
   itemId: number,
   itemType: string,
-  version = 2
+  version = 2,
+  contentType?: string
 ): Uint8Array => {
-  const bodySize = 4 + 2 + 2 + 4 + 1 + 1
+  const itemName = itemType === 'mime' ? 'XMP' : ''
+  const itemInfo = new TextEncoder().encode(
+    `${itemName}\0${contentType === undefined ? '' : `${contentType}\0`}`
+  )
+  const bodySize = 4 + 2 + 2 + 4 + itemInfo.length
   const totalSize = 8 + bodySize
   const buf = new Uint8Array(totalSize)
   const dv = new DataView(buf.buffer)
@@ -150,6 +156,7 @@ const buildInfeBox = (
     setU16BE(dv, 12, itemId)
     setU16BE(dv, 14, 0)
     buf.set(new TextEncoder().encode(itemType.padEnd(4).slice(0, 4)), 16)
+    buf.set(itemInfo, 20)
   }
   return buf
 }
@@ -226,6 +233,8 @@ const buildFtypBox = (majorBrand = 'avif'): Uint8Array => {
 
 interface BuildAvifOpts {
   exifEntries?: string[]
+  xmp?: string
+  includeExif?: boolean
   endian?: 'II' | 'MM'
   itemType?: string
   ftypBrand?: string
@@ -237,6 +246,8 @@ interface BuildAvifOpts {
 const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
   const {
     exifEntries = [],
+    xmp,
+    includeExif = true,
     endian = 'II',
     itemType = 'Exif',
     ftypBrand = 'avif',
@@ -250,31 +261,76 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     return ftyp.slice().buffer as ArrayBuffer
   }
 
-  const exifData = buildExifBlob(exifEntries, endian)
-  const infe = buildInfeBox(1, itemType, infeVersion)
-  const iinf = buildIinfBox([infe])
+  const items: {
+    itemId: number
+    itemType: string
+    contentType?: string
+    data: Uint8Array
+  }[] = []
+  if (includeExif) {
+    items.push({
+      itemId: items.length + 1,
+      itemType,
+      data: buildExifBlob(exifEntries, endian)
+    })
+  }
+  if (xmp !== undefined) {
+    items.push({
+      itemId: items.length + 1,
+      itemType: 'mime',
+      contentType: 'application/rdf+xml',
+      data: new TextEncoder().encode(xmp)
+    })
+  }
 
-  const realIloc = buildIlocBox([
-    { itemId: 1, extentOffset: 0, extentLength: exifData.length }
-  ])
-  const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : realIloc.length)
-  const exifOffset = ftyp.length + metaSize
+  const iinf = buildIinfBox(
+    items.map(({ itemId, itemType, contentType }) =>
+      buildInfeBox(itemId, itemType, infeVersion, contentType)
+    )
+  )
+  const placeholderIloc = buildIlocBox(
+    items.map(({ itemId, data }) => ({
+      itemId,
+      extentOffset: 0,
+      extentLength: data.length
+    }))
+  )
+  const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : placeholderIloc.length)
+  let itemOffset = ftyp.length + metaSize
+  const itemLocations = items.map(({ itemId, data }) => {
+    const location = {
+      itemId,
+      extentOffset: itemOffset,
+      extentLength: data.length
+    }
+    itemOffset += data.length
+    return location
+  })
 
-  const finalIloc = buildIlocBox([
-    { itemId: 1, extentOffset: exifOffset, extentLength: exifData.length }
-  ])
+  const finalIloc = buildIlocBox(itemLocations)
   const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
   const meta = buildMetaBox(finalInner)
 
-  const total = ftyp.length + meta.length + exifData.length
+  const total =
+    ftyp.length +
+    meta.length +
+    items.reduce((length, item) => length + item.data.length, 0)
   const buf = new Uint8Array(total)
   let p = 0
   buf.set(ftyp, p)
   p += ftyp.length
   buf.set(meta, p)
   p += meta.length
-  buf.set(exifData, p)
+  for (const item of items) {
+    buf.set(item.data, p)
+    p += item.data.length
+  }
   return buf.slice().buffer as ArrayBuffer
+}
+
+function buildXmpPacket(workflow: string, prompt?: string): string {
+  const promptProperty = prompt ? `<pm:prompt>${prompt}</pm:prompt>` : ''
+  return `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:pm="https://ai-foundry.dev/ns/pixelmeta/1.0/" rdf:about="">${promptProperty}<pm:workflow>${workflow}</pm:workflow></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>`
 }
 
 const fileFromBuffer = (buffer: ArrayBuffer, name = 'test.avif'): File =>
@@ -411,5 +467,37 @@ describe('getFromAvifFile', () => {
 
     expect(result.prompt).toBe(JSON.stringify(JSON.parse(prompt)))
     expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
+  })
+
+  it('imports workflow and prompt from a standard XMP item', async () => {
+    const workflow = '{"nodes":[],"version":1}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        xmp: buildXmpPacket(workflow, prompt)
+      })
+    )
+
+    const result = await getWorkflowDataFromFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('prefers valid XMP values while retaining EXIF-only metadata', async () => {
+    const exifWorkflow = '{"source":"exif"}'
+    const xmpWorkflow = '{"source":"xmp"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${exifWorkflow}`, `prompt:${prompt}`],
+        xmp: buildXmpPacket(xmpWorkflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(xmpWorkflow)
+    expect(result.prompt).toBe(prompt)
   })
 })

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -413,16 +413,23 @@ function escapeXmlAttribute(value: string): string {
   return escapeXmlText(value).replaceAll('"', '&quot;')
 }
 
-function buildXmpPacket(workflow: string, prompt?: string): string {
+function buildXmpPacket(
+  workflow: string,
+  prompt?: string,
+  namespace = 'https://github.com/Comfy-Org/ComfyUI',
+  prefix = 'comfy'
+): string {
   const promptAttribute =
-    prompt === undefined ? '' : ` comfy:prompt="${escapeXmlAttribute(prompt)}"`
+    prompt === undefined
+      ? ''
+      : ` ${prefix}:prompt="${escapeXmlAttribute(prompt)}"`
 
   return [
     '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
     '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
     '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
-    `    <rdf:Description xmlns:comfy="https://github.com/Comfy-Org/ComfyUI" rdf:about=""${promptAttribute}>`,
-    `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
+    `    <rdf:Description xmlns:${prefix}="${namespace}" rdf:about=""${promptAttribute}>`,
+    `      <${prefix}:workflow>${escapeXmlText(workflow)}</${prefix}:workflow>`,
     '    </rdf:Description>',
     '  </rdf:RDF>',
     '</x:xmpmeta>',
@@ -593,6 +600,47 @@ describe('getFromAvifFile', () => {
     const result = await getWorkflowDataFromFile(file)
 
     expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('imports ComfyUI XMP metadata with a different namespace prefix', async () => {
+    const workflow = '{"nodes":[],"version":1}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        xmp: buildXmpPacket(
+          workflow,
+          prompt,
+          'https://github.com/Comfy-Org/ComfyUI',
+          'alternate'
+        )
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('ignores prompt and workflow from a different XMP namespace', async () => {
+    const exifWorkflow = '{"source":"exif"}'
+    const exifPrompt = '{"1":{"class_type":"EXIF"}}'
+    const xmpWorkflow = '{"source":"unrelated-xmp"}'
+    const xmpPrompt = '{"1":{"class_type":"Unrelated"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${exifWorkflow}`, `prompt:${exifPrompt}`],
+        xmp: buildXmpPacket(
+          xmpWorkflow,
+          xmpPrompt,
+          'https://example.com/unrelated-xmp'
+        )
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow: exifWorkflow, prompt: exifPrompt })
   })
 
   it.each(ilocWidthCases)('imports XMP with $name', async ({ fieldSizes }) => {

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -10,6 +10,7 @@ import {
   mockFileReaderError
 } from './__fixtures__/helpers'
 import { getFromAvifFile } from './avif'
+import { getWorkflowDataFromFile } from './parser'
 
 const fixturePath = path.resolve(__dirname, '__fixtures__/with_metadata.avif')
 const nanFixturePath = path.resolve(
@@ -138,9 +139,14 @@ const buildExifBlob = (
 const buildInfeBox = (
   itemId: number,
   itemType: string,
-  version = 2
+  version = 2,
+  contentType?: string
 ): Uint8Array => {
-  const bodySize = 4 + 2 + 2 + 4 + 1 + 1
+  const itemName = itemType === 'mime' ? 'XMP' : ''
+  const itemInfo = new TextEncoder().encode(
+    `${itemName}\0${contentType === undefined ? '' : `${contentType}\0`}`
+  )
+  const bodySize = 4 + 2 + 2 + 4 + itemInfo.length
   const totalSize = 8 + bodySize
   const buf = new Uint8Array(totalSize)
   const dv = new DataView(buf.buffer)
@@ -151,6 +157,7 @@ const buildInfeBox = (
     setU16BE(dv, 12, itemId)
     setU16BE(dv, 14, 0)
     buf.set(new TextEncoder().encode(itemType.padEnd(4).slice(0, 4)), 16)
+    buf.set(itemInfo, 20)
   }
   return buf
 }
@@ -227,6 +234,8 @@ const buildFtypBox = (majorBrand = 'avif'): Uint8Array => {
 
 interface BuildAvifOpts {
   exifEntries?: string[]
+  xmp?: string
+  includeExif?: boolean
   endian?: 'II' | 'MM'
   itemType?: string
   ftypBrand?: string
@@ -238,6 +247,8 @@ interface BuildAvifOpts {
 const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
   const {
     exifEntries = [],
+    xmp,
+    includeExif = true,
     endian = 'II',
     itemType = 'Exif',
     ftypBrand = 'avif',
@@ -251,31 +262,76 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     return ftyp.slice().buffer as ArrayBuffer
   }
 
-  const exifData = buildExifBlob(exifEntries, endian)
-  const infe = buildInfeBox(1, itemType, infeVersion)
-  const iinf = buildIinfBox([infe])
+  const items: {
+    itemId: number
+    itemType: string
+    contentType?: string
+    data: Uint8Array
+  }[] = []
+  if (includeExif) {
+    items.push({
+      itemId: items.length + 1,
+      itemType,
+      data: buildExifBlob(exifEntries, endian)
+    })
+  }
+  if (xmp !== undefined) {
+    items.push({
+      itemId: items.length + 1,
+      itemType: 'mime',
+      contentType: 'application/rdf+xml',
+      data: new TextEncoder().encode(xmp)
+    })
+  }
 
-  const realIloc = buildIlocBox([
-    { itemId: 1, extentOffset: 0, extentLength: exifData.length }
-  ])
-  const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : realIloc.length)
-  const exifOffset = ftyp.length + metaSize
+  const iinf = buildIinfBox(
+    items.map(({ itemId, itemType, contentType }) =>
+      buildInfeBox(itemId, itemType, infeVersion, contentType)
+    )
+  )
+  const placeholderIloc = buildIlocBox(
+    items.map(({ itemId, data }) => ({
+      itemId,
+      extentOffset: 0,
+      extentLength: data.length
+    }))
+  )
+  const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : placeholderIloc.length)
+  let itemOffset = ftyp.length + metaSize
+  const itemLocations = items.map(({ itemId, data }) => {
+    const location = {
+      itemId,
+      extentOffset: itemOffset,
+      extentLength: data.length
+    }
+    itemOffset += data.length
+    return location
+  })
 
-  const finalIloc = buildIlocBox([
-    { itemId: 1, extentOffset: exifOffset, extentLength: exifData.length }
-  ])
+  const finalIloc = buildIlocBox(itemLocations)
   const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
   const meta = buildMetaBox(finalInner)
 
-  const total = ftyp.length + meta.length + exifData.length
+  const total =
+    ftyp.length +
+    meta.length +
+    items.reduce((length, item) => length + item.data.length, 0)
   const buf = new Uint8Array(total)
   let p = 0
   buf.set(ftyp, p)
   p += ftyp.length
   buf.set(meta, p)
   p += meta.length
-  buf.set(exifData, p)
+  for (const item of items) {
+    buf.set(item.data, p)
+    p += item.data.length
+  }
   return buf.slice().buffer as ArrayBuffer
+}
+
+function buildXmpPacket(workflow: string, prompt?: string): string {
+  const promptProperty = prompt ? `<pm:prompt>${prompt}</pm:prompt>` : ''
+  return `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:pm="https://ai-foundry.dev/ns/pixelmeta/1.0/" rdf:about="">${promptProperty}<pm:workflow>${workflow}</pm:workflow></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>`
 }
 
 const fileFromBuffer = (buffer: ArrayBuffer, name = 'test.avif'): File =>
@@ -412,5 +468,37 @@ describe('getFromAvifFile', () => {
 
     expect(result.prompt).toBe(JSON.stringify(JSON.parse(prompt)))
     expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
+  })
+
+  it('imports workflow and prompt from a standard XMP item', async () => {
+    const workflow = '{"nodes":[],"version":1}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        xmp: buildXmpPacket(workflow, prompt)
+      })
+    )
+
+    const result = await getWorkflowDataFromFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('prefers valid XMP values while retaining EXIF-only metadata', async () => {
+    const exifWorkflow = '{"source":"exif"}'
+    const xmpWorkflow = '{"source":"xmp"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${exifWorkflow}`, `prompt:${prompt}`],
+        xmp: buildXmpPacket(xmpWorkflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(xmpWorkflow)
+    expect(result.prompt).toBe(prompt)
   })
 })

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -501,4 +501,34 @@ describe('getFromAvifFile', () => {
     expect(result.workflow).toBe(xmpWorkflow)
     expect(result.prompt).toBe(prompt)
   })
+
+  it('retains EXIF metadata when the XMP packet is malformed', async () => {
+    const workflow = '{"source":"exif"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${workflow}`, `prompt:${prompt}`],
+        xmp: '<x:xmpmeta'
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
+
+  it('retains EXIF metadata when XMP JSON is malformed', async () => {
+    const workflow = '{"source":"exif"}'
+    const prompt = '{"1":{"class_type":"KSampler"}}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        exifEntries: [`workflow:${workflow}`, `prompt:${prompt}`],
+        xmp: buildXmpPacket('{invalid-workflow', '{invalid-prompt')
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result).toEqual({ workflow, prompt })
+  })
 })

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -178,18 +178,66 @@ const buildIinfBox = (infeBoxes: Uint8Array[]): Uint8Array => {
   return buf
 }
 
+type IlocIntegerSize = 0 | 4 | 8
+
+interface IlocFieldSizes {
+  offset: IlocIntegerSize
+  length: IlocIntegerSize
+  baseOffset: IlocIntegerSize
+}
+
+interface TestIlocItem {
+  itemId: number
+  baseOffset: number
+  extents: { extentOffset: number; extentLength: number }[]
+}
+
+const defaultIlocFieldSizes: IlocFieldSizes = {
+  offset: 4,
+  length: 4,
+  baseOffset: 0
+}
+
+function setIlocInteger(
+  dataView: DataView,
+  offset: number,
+  value: number,
+  size: IlocIntegerSize
+) {
+  if (size === 0) return
+  if (size === 4) {
+    setU32BE(dataView, offset, value)
+    return
+  }
+  dataView.setBigUint64(offset, BigInt(value), false)
+}
+
 const buildIlocBox = (
-  items: { itemId: number; extentOffset: number; extentLength: number }[]
+  items: TestIlocItem[],
+  fieldSizes: IlocFieldSizes = defaultIlocFieldSizes
 ): Uint8Array => {
-  const perItemSize = 2 + 2 + 0 + 2 + (4 + 4)
-  const bodySize = 4 + 1 + 1 + 2 + items.length * perItemSize
+  const bodySize =
+    4 +
+    1 +
+    1 +
+    2 +
+    items.reduce(
+      (size, item) =>
+        size +
+        2 +
+        2 +
+        fieldSizes.baseOffset +
+        2 +
+        item.extents.length * (fieldSizes.offset + fieldSizes.length),
+      0
+    )
   const totalSize = 8 + bodySize
   const buf = new Uint8Array(totalSize)
   const dv = new DataView(buf.buffer)
   setU32BE(dv, 0, totalSize)
   buf.set(new TextEncoder().encode('iloc'), 4)
-  buf[12] = 0x44
-  buf[13] = 0x00
+  buf[12] = (fieldSizes.offset << 4) | fieldSizes.length
+  buf[13] = fieldSizes.baseOffset << 4
   setU16BE(dv, 14, items.length)
   let p = 16
   for (const it of items) {
@@ -197,12 +245,16 @@ const buildIlocBox = (
     p += 2
     setU16BE(dv, p, 0)
     p += 2
-    setU16BE(dv, p, 1)
+    setIlocInteger(dv, p, it.baseOffset, fieldSizes.baseOffset)
+    p += fieldSizes.baseOffset
+    setU16BE(dv, p, it.extents.length)
     p += 2
-    setU32BE(dv, p, it.extentOffset)
-    p += 4
-    setU32BE(dv, p, it.extentLength)
-    p += 4
+    for (const extent of it.extents) {
+      setIlocInteger(dv, p, extent.extentOffset, fieldSizes.offset)
+      p += fieldSizes.offset
+      setIlocInteger(dv, p, extent.extentLength, fieldSizes.length)
+      p += fieldSizes.length
+    }
   }
   return buf
 }
@@ -236,6 +288,8 @@ interface BuildAvifOpts {
   exifEntries?: string[]
   xmp?: string
   includeExif?: boolean
+  ilocFieldSizes?: IlocFieldSizes
+  splitXmpAcrossExtents?: boolean
   endian?: 'II' | 'MM'
   itemType?: string
   ftypBrand?: string
@@ -249,6 +303,8 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     exifEntries = [],
     xmp,
     includeExif = true,
+    ilocFieldSizes = defaultIlocFieldSizes,
+    splitXmpAcrossExtents = false,
     endian = 'II',
     itemType = 'Exif',
     ftypBrand = 'avif',
@@ -267,20 +323,28 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     itemType: string
     contentType?: string
     data: Uint8Array
+    extentLengths: number[]
   }[] = []
   if (includeExif) {
+    const data = buildExifBlob(exifEntries, endian)
     items.push({
       itemId: items.length + 1,
       itemType,
-      data: buildExifBlob(exifEntries, endian)
+      data,
+      extentLengths: [data.length]
     })
   }
   if (xmp !== undefined) {
+    const data = new TextEncoder().encode(xmp)
+    const firstExtentLength = Math.floor(data.length / 2)
     items.push({
       itemId: items.length + 1,
       itemType: 'mime',
       contentType: 'application/rdf+xml',
-      data: new TextEncoder().encode(xmp)
+      data,
+      extentLengths: splitXmpAcrossExtents
+        ? [firstExtentLength, data.length - firstExtentLength]
+        : [data.length]
     })
   }
 
@@ -290,25 +354,34 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
     )
   )
   const placeholderIloc = buildIlocBox(
-    items.map(({ itemId, data }) => ({
+    items.map(({ itemId, extentLengths }) => ({
       itemId,
-      extentOffset: 0,
-      extentLength: data.length
-    }))
+      baseOffset: 0,
+      extents: extentLengths.map((extentLength) => ({
+        extentOffset: 0,
+        extentLength
+      }))
+    })),
+    ilocFieldSizes
   )
   const metaSize = 8 + 4 + iinf.length + (omitIloc ? 0 : placeholderIloc.length)
   let itemOffset = ftyp.length + metaSize
-  const itemLocations = items.map(({ itemId, data }) => {
+  const itemLocations = items.map(({ itemId, data, extentLengths }) => {
+    let extentOffset = ilocFieldSizes.offset === 0 ? 0 : itemOffset
     const location = {
       itemId,
-      extentOffset: itemOffset,
-      extentLength: data.length
+      baseOffset: ilocFieldSizes.offset === 0 ? itemOffset : 0,
+      extents: extentLengths.map((extentLength) => {
+        const extent = { extentOffset, extentLength }
+        extentOffset += extentLength
+        return extent
+      })
     }
     itemOffset += data.length
     return location
   })
 
-  const finalIloc = buildIlocBox(itemLocations)
+  const finalIloc = buildIlocBox(itemLocations, ilocFieldSizes)
   const finalInner = omitIloc ? [iinf] : [iinf, finalIloc]
   const meta = buildMetaBox(finalInner)
 
@@ -329,13 +402,50 @@ const buildAvifFile = (opts: BuildAvifOpts = {}): ArrayBuffer => {
   return buf.slice().buffer as ArrayBuffer
 }
 
+function escapeXmlText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replaceAll('"', '&quot;')
+}
+
 function buildXmpPacket(workflow: string, prompt?: string): string {
-  const promptProperty = prompt ? `<pm:prompt>${prompt}</pm:prompt>` : ''
-  return `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:pm="https://ai-foundry.dev/ns/pixelmeta/1.0/" rdf:about="">${promptProperty}<pm:workflow>${workflow}</pm:workflow></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>`
+  const promptAttribute =
+    prompt === undefined ? '' : ` comfy:prompt="${escapeXmlAttribute(prompt)}"`
+
+  return [
+    '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
+    '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
+    '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
+    `    <rdf:Description xmlns:comfy="https://example.com/comfyui/metadata/1.0/" rdf:about=""${promptAttribute}>`,
+    `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
+    '    </rdf:Description>',
+    '  </rdf:RDF>',
+    '</x:xmpmeta>',
+    '<?xpacket end="w"?>'
+  ].join('\n')
 }
 
 const fileFromBuffer = (buffer: ArrayBuffer, name = 'test.avif'): File =>
   new File([buffer], name, { type: 'image/avif' })
+
+const ilocWidthCases: {
+  name: string
+  fieldSizes: IlocFieldSizes
+}[] = [
+  {
+    name: 'zero-byte extent offsets',
+    fieldSizes: { offset: 0, length: 4, baseOffset: 4 }
+  },
+  {
+    name: 'eight-byte extent offsets and lengths',
+    fieldSizes: { offset: 8, length: 8, baseOffset: 0 }
+  }
+]
 
 describe('getFromAvifFile', () => {
   beforeEach(() => {
@@ -470,7 +580,7 @@ describe('getFromAvifFile', () => {
     expect(result.workflow).toBe(JSON.stringify(JSON.parse(workflow)))
   })
 
-  it('imports workflow and prompt from a standard XMP item', async () => {
+  it('imports workflow element and prompt attribute from an XMP item', async () => {
     const workflow = '{"nodes":[],"version":1}'
     const prompt = '{"1":{"class_type":"KSampler"}}'
     const file = fileFromBuffer(
@@ -483,6 +593,36 @@ describe('getFromAvifFile', () => {
     const result = await getWorkflowDataFromFile(file)
 
     expect(result).toEqual({ workflow, prompt })
+  })
+
+  it.each(ilocWidthCases)('imports XMP with $name', async ({ fieldSizes }) => {
+    const workflow = '{"nodes":[],"version":1}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        ilocFieldSizes: fieldSizes,
+        xmp: buildXmpPacket(workflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(workflow)
+  })
+
+  it('joins multiple iloc extents before parsing XMP', async () => {
+    const workflow = '{"nodes":[],"source":"split-extents"}'
+    const file = fileFromBuffer(
+      buildAvifFile({
+        includeExif: false,
+        splitXmpAcrossExtents: true,
+        xmp: buildXmpPacket(workflow)
+      })
+    )
+
+    const result = await getFromAvifFile(file)
+
+    expect(result.workflow).toBe(workflow)
   })
 
   it('prefers valid XMP values while retaining EXIF-only metadata', async () => {

--- a/src/scripts/metadata/avif.test.ts
+++ b/src/scripts/metadata/avif.test.ts
@@ -421,7 +421,7 @@ function buildXmpPacket(workflow: string, prompt?: string): string {
     '<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>',
     '<x:xmpmeta xmlns:x="adobe:ns:meta/">',
     '  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">',
-    `    <rdf:Description xmlns:comfy="https://example.com/comfyui/metadata/1.0/" rdf:about=""${promptAttribute}>`,
+    `    <rdf:Description xmlns:comfy="https://github.com/Comfy-Org/ComfyUI" rdf:about=""${promptAttribute}>`,
     `      <comfy:workflow>${escapeXmlText(workflow)}</comfy:workflow>`,
     '    </rdf:Description>',
     '  </rdf:RDF>',

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -57,7 +57,7 @@ const parseInfeBox = (
     const { str: item_name, length: name_len } = readNullTerminatedString(
       dataView,
       offset,
-      dataView.byteLength
+      end
     )
     offset += name_len
 
@@ -118,6 +118,23 @@ const parseIinfBox = (
   }
 }
 
+function readIlocInteger(
+  dataView: DataView,
+  offset: number,
+  size: number
+): number {
+  if (size === 0) return 0
+  if (size === 4) return dataView.getUint32(offset)
+  if (size === 8) {
+    const value = dataView.getBigUint64(offset)
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error('iloc integer exceeds JavaScript safe integer range')
+    }
+    return Number(value)
+  }
+  throw new Error(`Unsupported iloc integer size: ${size}`)
+}
+
 const parseIlocBox = (
   dataView: DataView,
   range: IsobmffBoxContentRange
@@ -154,7 +171,7 @@ const parseIlocBox = (
     const data_reference_index = dataView.getUint16(offset)
     offset += 2
 
-    const base_offset = base_offset_size > 0 ? dataView.getUint32(offset) : 0 // Simplified
+    const base_offset = readIlocInteger(dataView, offset, base_offset_size)
     offset += base_offset_size
 
     const extent_count = dataView.getUint16(offset)
@@ -163,11 +180,12 @@ const parseIlocBox = (
     const extents = []
     for (let j = 0; j < extent_count; j++) {
       if ((version === 1 || version === 2) && index_size > 0) {
+        readIlocInteger(dataView, offset, index_size)
         offset += index_size
       }
-      const extent_offset = dataView.getUint32(offset) // Simplified
+      const extent_offset = readIlocInteger(dataView, offset, offset_size)
       offset += offset_size
-      const extent_length = dataView.getUint32(offset) // Simplified
+      const extent_length = readIlocInteger(dataView, offset, length_size)
       offset += length_size
       extents.push({ extent_offset, extent_length })
     }
@@ -271,7 +289,9 @@ function setXmpMetadataValue(
   localName: string,
   value: string
 ) {
-  const metadataKey = localName.toLowerCase()
+  const metadataKey = localName
+    .slice(localName.lastIndexOf(':') + 1)
+    .toLowerCase()
 
   try {
     if (metadataKey === ComfyMetadataTags.PROMPT.toLowerCase()) {

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -12,6 +12,8 @@ import {
 } from '@/types/metadataTypes'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
 
+const COMFYUI_XMP_NAMESPACE = 'https://github.com/Comfy-Org/ComfyUI'
+
 const readNullTerminatedString = (
   dataView: DataView,
   start: number,
@@ -286,9 +288,12 @@ function getIlocItemData(
 
 function setXmpMetadataValue(
   metadata: ComfyMetadata,
+  namespaceUri: string | null,
   localName: string,
   value: string
 ) {
+  if (namespaceUri !== COMFYUI_XMP_NAMESPACE) return
+
   const metadataKey = localName
     .slice(localName.lastIndexOf(':') + 1)
     .toLowerCase()
@@ -302,6 +307,25 @@ function setXmpMetadataValue(
   } catch (error) {
     console.error(`Failed to parse XMP ${metadataKey} metadata`, error)
   }
+}
+
+function getAttributeNamespaceUri(
+  element: Element,
+  attribute: Attr
+): string | null {
+  if (attribute.namespaceURI) return attribute.namespaceURI
+
+  const prefixSeparator = attribute.name.indexOf(':')
+  if (prefixSeparator <= 0) return null
+
+  const namespaceAttribute = `xmlns:${attribute.name.slice(0, prefixSeparator)}`
+  let namespaceOwner: Element | null = element
+  while (namespaceOwner) {
+    const namespaceUri = namespaceOwner.getAttribute(namespaceAttribute)
+    if (namespaceUri) return namespaceUri
+    namespaceOwner = namespaceOwner.parentElement
+  }
+  return null
 }
 
 function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
@@ -324,10 +348,20 @@ function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
       attributeIndex++
     ) {
       const attribute = element.attributes[attributeIndex]
-      setXmpMetadataValue(metadata, attribute.localName, attribute.value)
+      setXmpMetadataValue(
+        metadata,
+        getAttributeNamespaceUri(element, attribute),
+        attribute.localName,
+        attribute.value
+      )
     }
 
-    setXmpMetadataValue(metadata, element.localName, element.textContent ?? '')
+    setXmpMetadataValue(
+      metadata,
+      element.namespaceURI,
+      element.localName,
+      element.textContent ?? ''
+    )
   }
 
   return metadata

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -230,23 +230,37 @@ function getIlocItemData(
   )
     return null
 
-  const totalLength = item.extents.reduce(
-    (length, extent) => length + extent.extent_length,
-    0
-  )
-  const itemData = new Uint8Array(totalLength)
-  let destinationOffset = 0
+  const sourceRanges: { offset: number; length: number }[] = []
+  let totalLength = 0
 
   for (const extent of item.extents) {
     const sourceOffset = item.base_offset + extent.extent_offset
     const sourceEnd = sourceOffset + extent.extent_length
-    if (sourceOffset < 0 || sourceEnd > buffer.byteLength) return null
+    totalLength += extent.extent_length
 
+    if (
+      !Number.isSafeInteger(sourceOffset) ||
+      !Number.isSafeInteger(sourceEnd) ||
+      !Number.isSafeInteger(totalLength) ||
+      sourceOffset < 0 ||
+      sourceEnd < sourceOffset ||
+      sourceEnd > buffer.byteLength ||
+      totalLength > buffer.byteLength
+    )
+      return null
+
+    sourceRanges.push({ offset: sourceOffset, length: extent.extent_length })
+  }
+
+  const itemData = new Uint8Array(totalLength)
+  let destinationOffset = 0
+
+  for (const sourceRange of sourceRanges) {
     itemData.set(
-      new Uint8Array(buffer, sourceOffset, extent.extent_length),
+      new Uint8Array(buffer, sourceRange.offset, sourceRange.length),
       destinationOffset
     )
-    destinationOffset += extent.extent_length
+    destinationOffset += sourceRange.length
   }
 
   return itemData

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -27,7 +27,11 @@ const readNullTerminatedString = (
   return { str, length: length + 1 } // Include null terminator
 }
 
-const parseInfeBox = (dataView: DataView, start: number): AvifInfeBox => {
+const parseInfeBox = (
+  dataView: DataView,
+  start: number,
+  end: number
+): AvifInfeBox => {
   const version = dataView.getUint8(start)
   const flags = dataView.getUint32(start) & 0xffffff
   let offset = start + 4
@@ -57,11 +61,10 @@ const parseInfeBox = (dataView: DataView, start: number): AvifInfeBox => {
     )
     offset += name_len
 
-    const content_type = readNullTerminatedString(
-      dataView,
-      offset,
-      dataView.byteLength
-    ).str
+    const content_type =
+      item_type === 'mime'
+        ? readNullTerminatedString(dataView, offset, end).str
+        : undefined
 
     return {
       box_header: { size: 0, type: 'infe' }, // Size is dynamic
@@ -99,7 +102,7 @@ const parseIinfBox = (
     )
 
     if (boxType === 'infe') {
-      const infe = parseInfeBox(dataView, offset + 8)
+      const infe = parseInfeBox(dataView, offset + 8, offset + boxSize)
       infe.box_header.size = boxSize
       entries.push(infe)
     }
@@ -144,9 +147,9 @@ const parseIlocBox = (
       version < 2 ? dataView.getUint16(offset) : dataView.getUint32(offset)
     offset += version < 2 ? 2 : 4
 
-    if (version === 1 || version === 2) {
-      offset += 2 // construction_method
-    }
+    const construction_method =
+      version === 1 || version === 2 ? dataView.getUint16(offset) & 0x000f : 0
+    if (version === 1 || version === 2) offset += 2
 
     const data_reference_index = dataView.getUint16(offset)
     offset += 2
@@ -170,6 +173,7 @@ const parseIlocBox = (
     }
     items.push({
       item_ID,
+      construction_method,
       data_reference_index,
       base_offset,
       extent_count,
@@ -215,6 +219,86 @@ function findBox(
   return null
 }
 
+function getIlocItemData(
+  buffer: ArrayBuffer,
+  item: AvifIlocBox['items'][number]
+): Uint8Array | null {
+  if (
+    item.construction_method !== 0 ||
+    item.data_reference_index !== 0 ||
+    item.extents.length === 0
+  )
+    return null
+
+  const totalLength = item.extents.reduce(
+    (length, extent) => length + extent.extent_length,
+    0
+  )
+  const itemData = new Uint8Array(totalLength)
+  let destinationOffset = 0
+
+  for (const extent of item.extents) {
+    const sourceOffset = item.base_offset + extent.extent_offset
+    const sourceEnd = sourceOffset + extent.extent_length
+    if (sourceOffset < 0 || sourceEnd > buffer.byteLength) return null
+
+    itemData.set(
+      new Uint8Array(buffer, sourceOffset, extent.extent_length),
+      destinationOffset
+    )
+    destinationOffset += extent.extent_length
+  }
+
+  return itemData
+}
+
+function setXmpMetadataValue(
+  metadata: ComfyMetadata,
+  localName: string,
+  value: string
+) {
+  const metadataKey = localName.toLowerCase()
+
+  try {
+    if (metadataKey === ComfyMetadataTags.PROMPT.toLowerCase()) {
+      metadata.prompt = parseJsonWithNonFinite<ComfyApiWorkflow>(value)
+    } else if (metadataKey === ComfyMetadataTags.WORKFLOW.toLowerCase()) {
+      metadata.workflow = parseJsonWithNonFinite<ComfyWorkflowJSON>(value)
+    }
+  } catch (error) {
+    console.error(`Failed to parse XMP ${metadataKey} metadata`, error)
+  }
+}
+
+function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
+  const metadata: ComfyMetadata = {}
+  const xmpText = new TextDecoder('utf-8').decode(itemData)
+  const xmpDocument = new DOMParser().parseFromString(
+    xmpText,
+    'application/xml'
+  )
+  if (xmpDocument.getElementsByTagName('parsererror').length > 0)
+    return metadata
+
+  const elements = xmpDocument.getElementsByTagName('*')
+  for (let elementIndex = 0; elementIndex < elements.length; elementIndex++) {
+    const element = elements[elementIndex]
+
+    for (
+      let attributeIndex = 0;
+      attributeIndex < element.attributes.length;
+      attributeIndex++
+    ) {
+      const attribute = element.attributes[attributeIndex]
+      setXmpMetadataValue(metadata, attribute.localName, attribute.value)
+    }
+
+    setXmpMetadataValue(metadata, element.localName, element.textContent ?? '')
+  }
+
+  return metadata
+}
+
 function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   const metadata: ComfyMetadata = {}
   const dataView = new DataView(buffer)
@@ -241,7 +325,11 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   const iinf = parseIinfBox(dataView, iinfBoxRange)
 
   const exifInfe = iinf.entries.find((e) => e.item_type === 'Exif')
-  if (!exifInfe) return {}
+  const xmpInfe = iinf.entries.find(
+    (entry) =>
+      entry.item_type === 'mime' && entry.content_type === 'application/rdf+xml'
+  )
+  if (!exifInfe && !xmpInfe) return {}
 
   const ilocBoxRange = findBox(
     dataView,
@@ -251,36 +339,31 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   )
   const iloc = parseIlocBox(dataView, ilocBoxRange)
 
-  const exifIloc = iloc.items.find((i) => i.item_ID === exifInfe.item_ID)
-  if (!exifIloc || exifIloc.extents.length === 0) return {}
-
-  const exifExtent = exifIloc.extents[0]
-  const itemData = new Uint8Array(
-    buffer,
-    exifExtent.extent_offset,
-    exifExtent.extent_length
-  )
+  const exifIloc = exifInfe
+    ? iloc.items.find((item) => item.item_ID === exifInfe.item_ID)
+    : undefined
+  const exifData = exifIloc ? getIlocItemData(buffer, exifIloc) : null
 
   let tiffHeaderOffset = -1
-  for (let i = 0; i < itemData.length - 4; i++) {
+  for (let i = 0; exifData && i < exifData.length - 4; i++) {
     if (
-      (itemData[i] === 0x4d &&
-        itemData[i + 1] === 0x4d &&
-        itemData[i + 2] === 0x00 &&
-        itemData[i + 3] === 0x2a) || // MM*
-      (itemData[i] === 0x49 &&
-        itemData[i + 1] === 0x49 &&
-        itemData[i + 2] === 0x2a &&
-        itemData[i + 3] === 0x00) // II*
+      (exifData[i] === 0x4d &&
+        exifData[i + 1] === 0x4d &&
+        exifData[i + 2] === 0x00 &&
+        exifData[i + 3] === 0x2a) || // MM*
+      (exifData[i] === 0x49 &&
+        exifData[i + 1] === 0x49 &&
+        exifData[i + 2] === 0x2a &&
+        exifData[i + 3] === 0x00) // II*
     ) {
       tiffHeaderOffset = i
       break
     }
   }
 
-  if (tiffHeaderOffset !== -1) {
-    const exifData = itemData.subarray(tiffHeaderOffset)
-    const data: Record<string, any> = parseExifData(exifData)
+  if (exifData && tiffHeaderOffset !== -1) {
+    const tiffData = exifData.subarray(tiffHeaderOffset)
+    const data: Record<string, any> = parseExifData(tiffData)
     for (const key in data) {
       const value = data[key]
       if (typeof value === 'string') {
@@ -321,9 +404,15 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
         }
       }
     }
-  } else {
+  } else if (exifInfe) {
     console.log('Warning: TIFF header not found in EXIF data.')
   }
+
+  const xmpIloc = xmpInfe
+    ? iloc.items.find((item) => item.item_ID === xmpInfe.item_ID)
+    : undefined
+  const xmpData = xmpIloc ? getIlocItemData(buffer, xmpIloc) : null
+  if (xmpData) Object.assign(metadata, parseXmpMetadata(xmpData))
 
   return metadata
 }

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -59,7 +59,7 @@ const parseInfeBox = (
     const { str: item_name, length: name_len } = readNullTerminatedString(
       dataView,
       offset,
-      dataView.byteLength
+      end
     )
     offset += name_len
 
@@ -120,6 +120,23 @@ const parseIinfBox = (
   }
 }
 
+function readIlocInteger(
+  dataView: DataView,
+  offset: number,
+  size: number
+): number {
+  if (size === 0) return 0
+  if (size === 4) return dataView.getUint32(offset)
+  if (size === 8) {
+    const value = dataView.getBigUint64(offset)
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error('iloc integer exceeds JavaScript safe integer range')
+    }
+    return Number(value)
+  }
+  throw new Error(`Unsupported iloc integer size: ${size}`)
+}
+
 const parseIlocBox = (
   dataView: DataView,
   range: IsobmffBoxContentRange
@@ -156,7 +173,7 @@ const parseIlocBox = (
     const data_reference_index = dataView.getUint16(offset)
     offset += 2
 
-    const base_offset = base_offset_size > 0 ? dataView.getUint32(offset) : 0 // Simplified
+    const base_offset = readIlocInteger(dataView, offset, base_offset_size)
     offset += base_offset_size
 
     const extent_count = dataView.getUint16(offset)
@@ -165,11 +182,12 @@ const parseIlocBox = (
     const extents = []
     for (let j = 0; j < extent_count; j++) {
       if ((version === 1 || version === 2) && index_size > 0) {
+        readIlocInteger(dataView, offset, index_size)
         offset += index_size
       }
-      const extent_offset = dataView.getUint32(offset) // Simplified
+      const extent_offset = readIlocInteger(dataView, offset, offset_size)
       offset += offset_size
-      const extent_length = dataView.getUint32(offset) // Simplified
+      const extent_length = readIlocInteger(dataView, offset, length_size)
       offset += length_size
       extents.push({ extent_offset, extent_length })
     }
@@ -273,7 +291,9 @@ function setXmpMetadataValue(
   localName: string,
   value: string
 ) {
-  const metadataKey = localName.toLowerCase()
+  const metadataKey = localName
+    .slice(localName.lastIndexOf(':') + 1)
+    .toLowerCase()
 
   try {
     if (metadataKey === ComfyMetadataTags.PROMPT.toLowerCase()) {

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -29,7 +29,11 @@ const readNullTerminatedString = (
   return { str, length: length + 1 } // Include null terminator
 }
 
-const parseInfeBox = (dataView: DataView, start: number): AvifInfeBox => {
+const parseInfeBox = (
+  dataView: DataView,
+  start: number,
+  end: number
+): AvifInfeBox => {
   const version = dataView.getUint8(start)
   const flags = dataView.getUint32(start) & 0xffffff
   let offset = start + 4
@@ -59,11 +63,10 @@ const parseInfeBox = (dataView: DataView, start: number): AvifInfeBox => {
     )
     offset += name_len
 
-    const content_type = readNullTerminatedString(
-      dataView,
-      offset,
-      dataView.byteLength
-    ).str
+    const content_type =
+      item_type === 'mime'
+        ? readNullTerminatedString(dataView, offset, end).str
+        : undefined
 
     return {
       box_header: { size: 0, type: 'infe' }, // Size is dynamic
@@ -101,7 +104,7 @@ const parseIinfBox = (
     )
 
     if (boxType === 'infe') {
-      const infe = parseInfeBox(dataView, offset + 8)
+      const infe = parseInfeBox(dataView, offset + 8, offset + boxSize)
       infe.box_header.size = boxSize
       entries.push(infe)
     }
@@ -146,9 +149,9 @@ const parseIlocBox = (
       version < 2 ? dataView.getUint16(offset) : dataView.getUint32(offset)
     offset += version < 2 ? 2 : 4
 
-    if (version === 1 || version === 2) {
-      offset += 2 // construction_method
-    }
+    const construction_method =
+      version === 1 || version === 2 ? dataView.getUint16(offset) & 0x000f : 0
+    if (version === 1 || version === 2) offset += 2
 
     const data_reference_index = dataView.getUint16(offset)
     offset += 2
@@ -172,6 +175,7 @@ const parseIlocBox = (
     }
     items.push({
       item_ID,
+      construction_method,
       data_reference_index,
       base_offset,
       extent_count,
@@ -217,6 +221,86 @@ function findBox(
   return null
 }
 
+function getIlocItemData(
+  buffer: ArrayBuffer,
+  item: AvifIlocBox['items'][number]
+): Uint8Array | null {
+  if (
+    item.construction_method !== 0 ||
+    item.data_reference_index !== 0 ||
+    item.extents.length === 0
+  )
+    return null
+
+  const totalLength = item.extents.reduce(
+    (length, extent) => length + extent.extent_length,
+    0
+  )
+  const itemData = new Uint8Array(totalLength)
+  let destinationOffset = 0
+
+  for (const extent of item.extents) {
+    const sourceOffset = item.base_offset + extent.extent_offset
+    const sourceEnd = sourceOffset + extent.extent_length
+    if (sourceOffset < 0 || sourceEnd > buffer.byteLength) return null
+
+    itemData.set(
+      new Uint8Array(buffer, sourceOffset, extent.extent_length),
+      destinationOffset
+    )
+    destinationOffset += extent.extent_length
+  }
+
+  return itemData
+}
+
+function setXmpMetadataValue(
+  metadata: ComfyMetadata,
+  localName: string,
+  value: string
+) {
+  const metadataKey = localName.toLowerCase()
+
+  try {
+    if (metadataKey === ComfyMetadataTags.PROMPT.toLowerCase()) {
+      metadata.prompt = parseJsonWithNonFinite<ComfyApiWorkflow>(value)
+    } else if (metadataKey === ComfyMetadataTags.WORKFLOW.toLowerCase()) {
+      metadata.workflow = parseJsonWithNonFinite<ComfyWorkflowJSON>(value)
+    }
+  } catch (error) {
+    console.error(`Failed to parse XMP ${metadataKey} metadata`, error)
+  }
+}
+
+function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
+  const metadata: ComfyMetadata = {}
+  const xmpText = new TextDecoder('utf-8').decode(itemData)
+  const xmpDocument = new DOMParser().parseFromString(
+    xmpText,
+    'application/xml'
+  )
+  if (xmpDocument.getElementsByTagName('parsererror').length > 0)
+    return metadata
+
+  const elements = xmpDocument.getElementsByTagName('*')
+  for (let elementIndex = 0; elementIndex < elements.length; elementIndex++) {
+    const element = elements[elementIndex]
+
+    for (
+      let attributeIndex = 0;
+      attributeIndex < element.attributes.length;
+      attributeIndex++
+    ) {
+      const attribute = element.attributes[attributeIndex]
+      setXmpMetadataValue(metadata, attribute.localName, attribute.value)
+    }
+
+    setXmpMetadataValue(metadata, element.localName, element.textContent ?? '')
+  }
+
+  return metadata
+}
+
 function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   const metadata: ComfyMetadata = {}
   const dataView = new DataView(buffer)
@@ -243,7 +327,11 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   const iinf = parseIinfBox(dataView, iinfBoxRange)
 
   const exifInfe = iinf.entries.find((e) => e.item_type === 'Exif')
-  if (!exifInfe) return {}
+  const xmpInfe = iinf.entries.find(
+    (entry) =>
+      entry.item_type === 'mime' && entry.content_type === 'application/rdf+xml'
+  )
+  if (!exifInfe && !xmpInfe) return {}
 
   const ilocBoxRange = findBox(
     dataView,
@@ -253,36 +341,31 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
   )
   const iloc = parseIlocBox(dataView, ilocBoxRange)
 
-  const exifIloc = iloc.items.find((i) => i.item_ID === exifInfe.item_ID)
-  if (!exifIloc || exifIloc.extents.length === 0) return {}
-
-  const exifExtent = exifIloc.extents[0]
-  const itemData = new Uint8Array(
-    buffer,
-    exifExtent.extent_offset,
-    exifExtent.extent_length
-  )
+  const exifIloc = exifInfe
+    ? iloc.items.find((item) => item.item_ID === exifInfe.item_ID)
+    : undefined
+  const exifData = exifIloc ? getIlocItemData(buffer, exifIloc) : null
 
   let tiffHeaderOffset = -1
-  for (let i = 0; i < itemData.length - 4; i++) {
+  for (let i = 0; exifData && i < exifData.length - 4; i++) {
     if (
-      (itemData[i] === 0x4d &&
-        itemData[i + 1] === 0x4d &&
-        itemData[i + 2] === 0x00 &&
-        itemData[i + 3] === 0x2a) || // MM*
-      (itemData[i] === 0x49 &&
-        itemData[i + 1] === 0x49 &&
-        itemData[i + 2] === 0x2a &&
-        itemData[i + 3] === 0x00) // II*
+      (exifData[i] === 0x4d &&
+        exifData[i + 1] === 0x4d &&
+        exifData[i + 2] === 0x00 &&
+        exifData[i + 3] === 0x2a) || // MM*
+      (exifData[i] === 0x49 &&
+        exifData[i + 1] === 0x49 &&
+        exifData[i + 2] === 0x2a &&
+        exifData[i + 3] === 0x00) // II*
     ) {
       tiffHeaderOffset = i
       break
     }
   }
 
-  if (tiffHeaderOffset !== -1) {
-    const exifData = itemData.subarray(tiffHeaderOffset)
-    const data: Record<string, any> = parseExifData(exifData)
+  if (exifData && tiffHeaderOffset !== -1) {
+    const tiffData = exifData.subarray(tiffHeaderOffset)
+    const data: Record<string, any> = parseExifData(tiffData)
     for (const key in data) {
       const value = data[key]
       if (typeof value === 'string') {
@@ -323,9 +406,15 @@ function parseAvifMetadata(buffer: ArrayBuffer): ComfyMetadata {
         }
       }
     }
-  } else {
+  } else if (exifInfe) {
     console.log('Warning: TIFF header not found in EXIF data.')
   }
+
+  const xmpIloc = xmpInfe
+    ? iloc.items.find((item) => item.item_ID === xmpInfe.item_ID)
+    : undefined
+  const xmpData = xmpIloc ? getIlocItemData(buffer, xmpIloc) : null
+  if (xmpData) Object.assign(metadata, parseXmpMetadata(xmpData))
 
   return metadata
 }

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -14,6 +14,8 @@ import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
 
 import { readFileAsArrayBuffer } from './readFile'
 
+const COMFYUI_XMP_NAMESPACE = 'https://github.com/Comfy-Org/ComfyUI'
+
 const readNullTerminatedString = (
   dataView: DataView,
   start: number,
@@ -288,9 +290,12 @@ function getIlocItemData(
 
 function setXmpMetadataValue(
   metadata: ComfyMetadata,
+  namespaceUri: string | null,
   localName: string,
   value: string
 ) {
+  if (namespaceUri !== COMFYUI_XMP_NAMESPACE) return
+
   const metadataKey = localName
     .slice(localName.lastIndexOf(':') + 1)
     .toLowerCase()
@@ -304,6 +309,25 @@ function setXmpMetadataValue(
   } catch (error) {
     console.error(`Failed to parse XMP ${metadataKey} metadata`, error)
   }
+}
+
+function getAttributeNamespaceUri(
+  element: Element,
+  attribute: Attr
+): string | null {
+  if (attribute.namespaceURI) return attribute.namespaceURI
+
+  const prefixSeparator = attribute.name.indexOf(':')
+  if (prefixSeparator <= 0) return null
+
+  const namespaceAttribute = `xmlns:${attribute.name.slice(0, prefixSeparator)}`
+  let namespaceOwner: Element | null = element
+  while (namespaceOwner) {
+    const namespaceUri = namespaceOwner.getAttribute(namespaceAttribute)
+    if (namespaceUri) return namespaceUri
+    namespaceOwner = namespaceOwner.parentElement
+  }
+  return null
 }
 
 function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
@@ -326,10 +350,20 @@ function parseXmpMetadata(itemData: Uint8Array): ComfyMetadata {
       attributeIndex++
     ) {
       const attribute = element.attributes[attributeIndex]
-      setXmpMetadataValue(metadata, attribute.localName, attribute.value)
+      setXmpMetadataValue(
+        metadata,
+        getAttributeNamespaceUri(element, attribute),
+        attribute.localName,
+        attribute.value
+      )
     }
 
-    setXmpMetadataValue(metadata, element.localName, element.textContent ?? '')
+    setXmpMetadataValue(
+      metadata,
+      element.namespaceURI,
+      element.localName,
+      element.textContent ?? ''
+    )
   }
 
   return metadata

--- a/src/scripts/metadata/avif.ts
+++ b/src/scripts/metadata/avif.ts
@@ -232,23 +232,37 @@ function getIlocItemData(
   )
     return null
 
-  const totalLength = item.extents.reduce(
-    (length, extent) => length + extent.extent_length,
-    0
-  )
-  const itemData = new Uint8Array(totalLength)
-  let destinationOffset = 0
+  const sourceRanges: { offset: number; length: number }[] = []
+  let totalLength = 0
 
   for (const extent of item.extents) {
     const sourceOffset = item.base_offset + extent.extent_offset
     const sourceEnd = sourceOffset + extent.extent_length
-    if (sourceOffset < 0 || sourceEnd > buffer.byteLength) return null
+    totalLength += extent.extent_length
 
+    if (
+      !Number.isSafeInteger(sourceOffset) ||
+      !Number.isSafeInteger(sourceEnd) ||
+      !Number.isSafeInteger(totalLength) ||
+      sourceOffset < 0 ||
+      sourceEnd < sourceOffset ||
+      sourceEnd > buffer.byteLength ||
+      totalLength > buffer.byteLength
+    )
+      return null
+
+    sourceRanges.push({ offset: sourceOffset, length: extent.extent_length })
+  }
+
+  const itemData = new Uint8Array(totalLength)
+  let destinationOffset = 0
+
+  for (const sourceRange of sourceRanges) {
     itemData.set(
-      new Uint8Array(buffer, sourceOffset, extent.extent_length),
+      new Uint8Array(buffer, sourceRange.offset, sourceRange.length),
       destinationOffset
     )
-    destinationOffset += extent.extent_length
+    destinationOffset += sourceRange.length
   }
 
   return itemData

--- a/src/types/metadataTypes.ts
+++ b/src/types/metadataTypes.ts
@@ -119,6 +119,7 @@ type AvifIlocItemExtent = {
 
 type AvifIlocItem = {
   item_ID: number
+  construction_method: number
   data_reference_index: number
   base_offset: number
   extent_count: number


### PR DESCRIPTION
## Summary

Dragging an AVIF that stores ComfyUI workflow or prompt metadata in an XMP MIME item currently accepts the image but does not restore its workflow. This extends the reader introduced by [Add the ability to parse workflows from AVIF images](https://github.com/Comfy-Org/ComfyUI_frontend/pull/4420) to import that metadata while preserving existing EXIF behavior.

## Changes

- Recognize `infe` items with type `mime` and content type `application/rdf+xml`, resolve their declared 0/4/8-byte `iloc` fields and extents, and read `workflow` and `prompt` from RDF elements or attributes in the canonical ComfyUI XMP namespace.
- Match the namespace URI rather than its XML prefix, and ignore identically named properties from unrelated namespaces.
- Parse EXIF first, then replace only matching keys whose XMP values contain syntactically valid JSON. Absent, malformed, or non-ComfyUI XMP leaves EXIF metadata intact.
- Validate extent ranges before allocation and join multiple extents before decoding the XMP packet.

## Review Focus

- XMP item extraction is limited to self-contained file offsets (`construction_method=0`, `data_reference_index=0`). `idat`-stored items using construction method 1 remain out of scope.
- XMP overrides EXIF per key; semantic workflow validation remains in the shared loading path rather than this format reader.
- Extent validation remains bounded by the selected file; this change does not introduce an arbitrary metadata-size limit.

## Testing

- `pnpm test:unit src/scripts/metadata/avif.test.ts --maxWorkers=2` — 27/27 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check` for the changed files
- `pnpm knip`
- Encoded and decoded a libavif 1.4.2 canary containing a 460-byte XMP item; the existing AVIF reader returned its exact workflow and prompt.