### PR TITLE
feat: 4/x attribute RUM workflow vitals to origin views

### DIFF
--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -2,12 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const { addDurationVital } = vi.hoisted(() => ({
-  addDurationVital: vi.fn()
+const { addDurationVital, getInternalContext } = vi.hoisted(() => ({
+  addDurationVital: vi.fn(),
+  getInternalContext: vi.fn()
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addDurationVital }
+  datadogRum: { addDurationVital, getInternalContext }
 }))
 
 afterEach(() => {
@@ -19,6 +20,7 @@ describe('DatadogRumTelemetryProvider', () => {
   it.for(['success', 'failure'] as const)(
     'records a workflow vital with a %s outcome',
     (outcome) => {
+      getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
       vi.spyOn(performance, 'now').mockReturnValue(142)
 
       new DatadogRumTelemetryProvider().trackExecutionOutcome({
@@ -26,10 +28,12 @@ describe('DatadogRumTelemetryProvider', () => {
         outcome
       })
 
+      expect(getInternalContext).toHaveBeenCalledWith(42)
       expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
         startTime: performance.timeOrigin + 42,
         duration: 100,
         context: {
+          origin_view_id: 'view-a',
           outcome,
           product: 'cloud_generation'
         }

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -7,12 +7,14 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     startTime,
     outcome
   }: ExecutionOutcomeMetadata): void {
+    const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     datadogRum.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
       duration: performance.now() - startTime,
       context: {
         outcome,
-        product: 'cloud_generation'
+        product: 'cloud_generation',
+        ...(originViewId && { origin_view_id: originViewId })
       }
     })
   }


### PR DESCRIPTION
## Stack

1. [#13767 — feat: 3/x record RUM workflow execution vitals](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13767)
2. [#13764 — feat: 4/x attribute RUM workflow vitals to origin views](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13764)

## Summary

Attributes each `workflow_execution` vital to the native Datadog view where the workflow began. The stateless provider resolves historical RUM context with the workflow start time and adds `origin_view_id` when Datadog returns a view ID.

## Verification

- The provider regression test calls `getInternalContext(42)` and observes `origin_view_id: 'view-a'` in the authoritative `DD_RUM.addDurationVital('workflow_execution', ...)` payload.
- Manual Cloud console verification recorded for this head confirmed that current and historical timestamps resolve to distinct Datadog views.
- Merge blocker: GitHub currently reports this branch conflicts with #13767, so it requires a rebase before merge.

Created by Codex