### PR TITLE
feat: 1/x add partner node governance feature flag

### DIFF
--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -194,6 +194,16 @@ describe('useFeatureFlags', () => {
 
       expect(flags.partnerNodeGovernanceEnabled).toBe(true)
     })
+
+    it('defaults to false when the remote flag is unset', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+
+      expect(flags.partnerNodeGovernanceEnabled).toBe(false)
+    })
   })
 
   describe('dev override via localStorage', () => {

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -182,6 +182,20 @@ describe('useFeatureFlags', () => {
     })
   })
 
+  describe('partnerNodeGovernanceEnabled', () => {
+    afterEach(() => {
+      remoteConfig.value = {}
+    })
+
+    it('uses the workspace eligibility flag', () => {
+      remoteConfig.value = { partner_node_governance_enabled: true }
+
+      const { flags } = useFeatureFlags()
+
+      expect(flags.partnerNodeGovernanceEnabled).toBe(true)
+    })
+  })
+
   describe('dev override via localStorage', () => {
     afterEach(() => {
       localStorage.clear()

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -24,6 +24,7 @@ export enum ServerFeatureFlag {
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
   TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
+  PARTNER_NODE_GOVERNANCE_ENABLED = 'partner_node_governance_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
   NODE_REPLACEMENTS = 'node_replacements',
   NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
@@ -132,6 +133,13 @@ export function useFeatureFlags() {
         ServerFeatureFlag.TEAM_WORKSPACES_ENABLED,
         remoteConfig.value.team_workspaces_enabled,
         cachedTeamWorkspacesEnabled
+      )
+    },
+    get partnerNodeGovernanceEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.PARTNER_NODE_GOVERNANCE_ENABLED,
+        remoteConfig.value.partner_node_governance_enabled,
+        false
       )
     },
     get userSecretsEnabled() {

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -107,6 +107,7 @@ export type RemoteConfig = {
   manager_survey_url?: string
   linear_toggle_enabled?: boolean
   team_workspaces_enabled?: boolean
+  partner_node_governance_enabled?: boolean
   user_secrets_enabled?: boolean
   node_library_essentials_enabled?: boolean
   free_tier_credits?: number


### PR DESCRIPTION
## Summary

Adds the rollout eligibility flag for workspace partner-node governance.

## Changes

- Adds `partner_node_governance_enabled` to remote config typing.
- Exposes `partnerNodeGovernanceEnabled` through `useFeatureFlags`, defaulting to `false`.

## Impact

This PR does not load policy or change node behavior. The policy API and store are stacked in #13743.

## Validation

- `pnpm test:unit src/composables/useFeatureFlags.test.ts` (26 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`

Created by Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive feature-flag plumbing with safe defaults; no runtime behavior or policy changes in this PR.
> 
> **Overview**
> Introduces **`partner_node_governance_enabled`** as a workspace rollout eligibility switch for upcoming partner-node governance work. This change only wires the flag; it does not load policy or alter node behavior (follow-up PRs handle that).
> 
> **Remote config** gains optional `partner_node_governance_enabled`. **`useFeatureFlags`** exposes **`partnerNodeGovernanceEnabled`**, resolved via the usual `resolveFlag` path (dev override → remote config → server feature) with a default of **`false`**. Unit tests cover the remote-config-on and default-off cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d862f60c8ce56d5b4a194c8b5697f3b5c07959a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->