### PR TITLE
feat: compress large images to previews in the mask editor

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -51,7 +51,7 @@
   },
   "src/composables/maskeditor/useMaskEditorSaver.ts": {
     "comfy/no-new-error-throw": {
-      "count": 5
+      "count": 8
     }
   },
   "src/composables/painter/usePainter.ts": {

--- a/src/composables/maskeditor/previewCompressionParams.test.ts
+++ b/src/composables/maskeditor/previewCompressionParams.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { previewCompressionParams } from './previewCompressionParams'
+
+describe('previewCompressionParams', () => {
+  it('returns no params when compression is disabled and no preview format is set', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: false,
+        previewFormat: '',
+        maxSize: 4096
+      })
+    ).toBe('')
+  })
+
+  it('keeps the global preview format when compression is disabled', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: false,
+        previewFormat: 'jpeg;80',
+        maxSize: 4096
+      })
+    ).toBe('&preview=jpeg;80')
+  })
+
+  it('adds max_size and a default format when compression is enabled', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: true,
+        previewFormat: '',
+        maxSize: 4096
+      })
+    ).toBe('&preview=webp;90&max_size=4096')
+  })
+
+  it('respects the global preview format when compression is enabled', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: true,
+        previewFormat: 'jpeg;80',
+        maxSize: 2048
+      })
+    ).toBe('&preview=jpeg;80&max_size=2048')
+  })
+
+  it('clamps out-of-range max sizes into the 512-8192 range', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: true,
+        previewFormat: '',
+        maxSize: 0
+      })
+    ).toBe('&preview=webp;90&max_size=512')
+    expect(
+      previewCompressionParams({
+        compressionEnabled: true,
+        previewFormat: '',
+        maxSize: 100000
+      })
+    ).toBe('&preview=webp;90&max_size=8192')
+  })
+
+  it('rounds fractional max sizes to an integer', () => {
+    expect(
+      previewCompressionParams({
+        compressionEnabled: true,
+        previewFormat: '',
+        maxSize: 1536.4
+      })
+    ).toBe('&preview=webp;90&max_size=1536')
+  })
+})

--- a/src/composables/maskeditor/previewCompressionParams.ts
+++ b/src/composables/maskeditor/previewCompressionParams.ts
@@ -1,0 +1,23 @@
+import { clamp } from 'es-toolkit'
+
+const DEFAULT_PREVIEW_FORMAT = 'webp;90'
+const MIN_PREVIEW_SIZE = 512
+const MAX_PREVIEW_SIZE = 8192
+
+export function previewCompressionParams(options: {
+  compressionEnabled: boolean
+  previewFormat: string
+  maxSize: number
+}): string {
+  const { compressionEnabled, previewFormat, maxSize } = options
+  if (!compressionEnabled) {
+    return previewFormat ? `&preview=${previewFormat}` : ''
+  }
+  const format = previewFormat || DEFAULT_PREVIEW_FORMAT
+  const clampedSize = clamp(
+    Math.round(maxSize),
+    MIN_PREVIEW_SIZE,
+    MAX_PREVIEW_SIZE
+  )
+  return `&preview=${format}&max_size=${clampedSize}`
+}

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -31,6 +31,12 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn(() => false)
+  }))
+}))
+
 vi.mock('@/scripts/api', () => ({
   api: {
     fetchApi: vi.fn(),

--- a/src/composables/maskeditor/useMaskEditorLoader.test.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.test.ts
@@ -34,6 +34,12 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn(() => false)
+  }))
+}))
+
 vi.mock('@/scripts/api', () => ({
   api: {
     fetchApi: vi.fn(),

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -3,9 +3,11 @@ import type { ImageRef, ImageLayer } from '@/stores/maskEditorDataStore'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { parseImageWidgetValue } from '@/utils/imageUtil'
+import { previewCompressionParams } from './previewCompressionParams'
 
 export function extractWidgetStringValue(value: unknown): string | undefined {
   if (typeof value === 'string') return value
@@ -61,7 +63,7 @@ function toRef(filename: string, subfolder: string): ImageRef {
   }
 }
 
-function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
+function mkFileUrl(props: { ref: ImageRef }): string {
   const params = new URLSearchParams()
   params.set('filename', props.ref.filename)
   if (props.ref.subfolder) {
@@ -71,10 +73,15 @@ function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
     params.set('type', props.ref.type)
   }
 
+  const settingStore = useSettingStore()
   const pathPlusQueryParams = api.apiURL(
     '/view?' +
       params.toString() +
-      app.getPreviewFormatParam() +
+      previewCompressionParams({
+        compressionEnabled: settingStore.get('Comfy.Image.PreviewCompression'),
+        previewFormat: settingStore.get('Comfy.PreviewFormat'),
+        maxSize: settingStore.get('Comfy.Image.PreviewMaxSize')
+      }) +
       app.getRandParam()
   )
   const imageElement = new Image()

--- a/src/composables/maskeditor/useMaskEditorLoader.ts
+++ b/src/composables/maskeditor/useMaskEditorLoader.ts
@@ -4,9 +4,11 @@ import type { ImageRef, ImageLayer } from '@/stores/maskEditorDataStore'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { parseImageWidgetValue } from '@/utils/imageUtil'
+import { previewCompressionParams } from './previewCompressionParams'
 
 export function extractWidgetStringValue(value: unknown): string | undefined {
   if (typeof value === 'string') return value
@@ -62,7 +64,7 @@ function toRef(filename: string, subfolder: string): ImageRef {
   }
 }
 
-function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
+function mkFileUrl(props: { ref: ImageRef }): string {
   const params = new URLSearchParams()
   params.set('filename', props.ref.filename)
   if (props.ref.subfolder) {
@@ -72,10 +74,15 @@ function mkFileUrl(props: { ref: ImageRef; preview?: boolean }): string {
     params.set('type', props.ref.type)
   }
 
+  const settingStore = useSettingStore()
   const pathPlusQueryParams = api.apiURL(
     '/view?' +
       params.toString() +
-      app.getPreviewFormatParam() +
+      previewCompressionParams({
+        compressionEnabled: settingStore.get('Comfy.Image.PreviewCompression'),
+        previewFormat: settingStore.get('Comfy.PreviewFormat'),
+        maxSize: settingStore.get('Comfy.Image.PreviewMaxSize')
+      }) +
       app.getRandParam()
   )
   const imageElement = new Image()

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -75,6 +75,18 @@ vi.mock('@/scripts/app', () => ({
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
 
+const mockSettings = vi.hoisted(() => ({ previewCompression: false }))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn((key: string) =>
+      key === 'Comfy.Image.PreviewCompression'
+        ? mockSettings.previewCompression
+        : undefined
+    )
+  }))
+}))
+
 vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => ({
     nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
@@ -93,6 +105,7 @@ describe('useMaskEditorSaver', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
+    mockSettings.previewCompression = false
 
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
@@ -200,5 +213,72 @@ describe('useMaskEditorSaver', () => {
     expect(body).toBeInstanceOf(FormData)
     expect(body.get('type')).toBe('input')
     expect(body.get('subfolder')).toBeNull()
+  })
+
+  it('composites on the server via /upload/mask when preview compression is enabled', async () => {
+    mockSettings.previewCompression = true
+    const fetchApiMock = vi.mocked(api.fetchApi)
+
+    const { save } = useMaskEditorSaver()
+    await save()
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(1)
+    const [route, init] = fetchApiMock.mock.calls[0]
+    expect(route).toBe('/upload/mask')
+
+    const body = init?.body as FormData
+    expect(body).toBeInstanceOf(FormData)
+    expect(body.get('original_ref')).toBe(
+      JSON.stringify({ filename: 'original.png', subfolder: '', type: 'input' })
+    )
+    expect(body.get('image')).toBeInstanceOf(Blob)
+    expect(body.get('paint')).toBeInstanceOf(Blob)
+    expect(String(body.get('paint_filename'))).toMatch(/^clipspace-paint-/)
+    expect(String(body.get('painted_filename'))).toMatch(/^clipspace-painted-/)
+    expect(String(body.get('painted_masked_filename'))).toMatch(
+      /^clipspace-painted-masked-/
+    )
+  })
+
+  it('updates layer refs from the server composite response', async () => {
+    mockSettings.previewCompression = true
+
+    const { save } = useMaskEditorSaver()
+    await save()
+
+    const outputData = mockDataStore.outputData as {
+      maskedImage: { ref: { filename: string; subfolder: string } }
+      paintedMaskedImage: { ref: { subfolder: string; type: string } }
+    }
+    expect(outputData.maskedImage.ref.filename).toBe(
+      'clipspace-painted-masked-123.png'
+    )
+    expect(outputData.paintedMaskedImage.ref.subfolder).toBe('clipspace')
+    expect(outputData.paintedMaskedImage.ref.type).toBe('input')
+  })
+
+  it('throws an actionable error when the composite response is not valid JSON', async () => {
+    mockSettings.previewCompression = true
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new Error('Unexpected end of JSON input'))
+    } as Response)
+
+    const { save } = useMaskEditorSaver()
+    await expect(save()).rejects.toThrow(/Invalid composite upload response/)
+  })
+
+  it('throws an error when the server composite request fails', async () => {
+    mockSettings.previewCompression = true
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error')
+    } as Response)
+
+    const { save } = useMaskEditorSaver()
+    await expect(save()).rejects.toThrow(
+      /Failed to composite mask layers on server \(500: Internal Server Error\)/
+    )
   })
 })

--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -105,6 +105,18 @@ vi.mock('@/scripts/app', () => ({
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
 
+const mockSettings = vi.hoisted(() => ({ previewCompression: false }))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn((key: string) =>
+      key === 'Comfy.Image.PreviewCompression'
+        ? mockSettings.previewCompression
+        : undefined
+    )
+  }))
+}))
+
 vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => ({
     nodeIdToNodeLocatorId: vi.fn((id: string | number) => String(id)),
@@ -121,6 +133,10 @@ describe('useMaskEditorSaver', () => {
   const originalCreateElement = document.createElement.bind(document)
 
   beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    mockSettings.previewCompression = false
+
     app.nodeOutputs = {}
     app.nodePreviewImages = {}
 
@@ -327,5 +343,72 @@ describe('useMaskEditorSaver', () => {
         expect(pixels[i + 2]).toBe(imgPixels[i + 2])
       }
     }
+  })
+
+  it('composites on the server via /upload/mask when preview compression is enabled', async () => {
+    mockSettings.previewCompression = true
+    const fetchApiMock = vi.mocked(api.fetchApi)
+
+    const { save } = useMaskEditorSaver()
+    await save()
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(1)
+    const [route, init] = fetchApiMock.mock.calls[0]
+    expect(route).toBe('/upload/mask')
+
+    const body = init?.body as FormData
+    expect(body).toBeInstanceOf(FormData)
+    expect(body.get('original_ref')).toBe(
+      JSON.stringify({ filename: 'original.png', subfolder: '', type: 'input' })
+    )
+    expect(body.get('image')).toBeInstanceOf(Blob)
+    expect(body.get('paint')).toBeInstanceOf(Blob)
+    expect(String(body.get('paint_filename'))).toMatch(/^clipspace-paint-/)
+    expect(String(body.get('painted_filename'))).toMatch(/^clipspace-painted-/)
+    expect(String(body.get('painted_masked_filename'))).toMatch(
+      /^clipspace-painted-masked-/
+    )
+  })
+
+  it('updates layer refs from the server composite response', async () => {
+    mockSettings.previewCompression = true
+
+    const { save } = useMaskEditorSaver()
+    await save()
+
+    const outputData = mockDataStore.outputData as {
+      maskedImage: { ref: { filename: string; subfolder: string } }
+      paintedMaskedImage: { ref: { subfolder: string; type: string } }
+    }
+    expect(outputData.maskedImage.ref.filename).toBe(
+      'clipspace-painted-masked-123.png'
+    )
+    expect(outputData.paintedMaskedImage.ref.subfolder).toBe('clipspace')
+    expect(outputData.paintedMaskedImage.ref.type).toBe('input')
+  })
+
+  it('throws an actionable error when the composite response is not valid JSON', async () => {
+    mockSettings.previewCompression = true
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new Error('Unexpected end of JSON input'))
+    } as Response)
+
+    const { save } = useMaskEditorSaver()
+    await expect(save()).rejects.toThrow(/Invalid composite upload response/)
+  })
+
+  it('throws an error when the server composite request fails', async () => {
+    mockSettings.previewCompression = true
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error')
+    } as Response)
+
+    const { save } = useMaskEditorSaver()
+    await expect(save()).rejects.toThrow(
+      /Failed to composite mask layers on server \(500: Internal Server Error\)/
+    )
   })
 })

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -1,5 +1,7 @@
 import type { UploadImageResponse } from '@comfyorg/ingest-types'
 
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -49,7 +51,11 @@ export function useMaskEditorSaver() {
 
       await updateNodePreview(sourceNode, outputData)
 
-      await uploadAllLayers(outputData)
+      if (shouldCompositeOnServer()) {
+        await uploadLayersWithServerComposite(outputData)
+      } else {
+        await uploadAllLayers(outputData)
+      }
 
       updateNodeWithServerReferences(sourceNode, outputData)
 
@@ -207,6 +213,77 @@ export function useMaskEditorSaver() {
     const ref = createFileRef(filename)
 
     return { canvas, blob, ref }
+  }
+
+  function shouldCompositeOnServer(): boolean {
+    return (
+      !isCloud &&
+      useSettingStore().get('Comfy.Image.PreviewCompression') &&
+      !!dataStore.inputData?.sourceRef
+    )
+  }
+
+  async function uploadLayersWithServerComposite(
+    outputData: EditorOutputData
+  ): Promise<void> {
+    const sourceRef = dataStore.inputData!.sourceRef
+    const formData = new FormData()
+    formData.append(
+      'image',
+      outputData.maskedImage.blob,
+      outputData.maskedImage.ref.filename
+    )
+    formData.append('type', 'input')
+    formData.append('original_ref', JSON.stringify(sourceRef))
+    formData.append(
+      'paint',
+      outputData.paintLayer.blob,
+      outputData.paintLayer.ref.filename
+    )
+    formData.append('paint_filename', outputData.paintLayer.ref.filename)
+    formData.append('painted_filename', outputData.paintedImage.ref.filename)
+    formData.append(
+      'painted_masked_filename',
+      outputData.paintedMaskedImage.ref.filename
+    )
+
+    const response = await api.fetchApi('/upload/mask', {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(
+        `Failed to composite mask layers on server (${response.status}${body ? `: ${body}` : ''})`
+      )
+    }
+
+    let data: UploadImageResponse
+    try {
+      data = await response.json()
+    } catch (error) {
+      throw new Error(
+        `Invalid composite upload response: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error }
+      )
+    }
+    if (!data?.name) {
+      throw new Error('Composite upload response missing file name')
+    }
+
+    const subfolder = data.subfolder || ''
+    const type = data.type || 'input'
+    outputData.maskedImage.ref = { filename: data.name, subfolder, type }
+    for (const layer of [
+      outputData.paintLayer,
+      outputData.paintedImage,
+      outputData.paintedMaskedImage
+    ]) {
+      layer.ref = { ...layer.ref, subfolder, type }
+    }
   }
 
   async function uploadAllLayers(outputData: EditorOutputData): Promise<void> {

--- a/src/composables/maskeditor/useMaskEditorSaver.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.ts
@@ -1,6 +1,8 @@
 import type { UploadImageResponse } from '@comfyorg/ingest-types'
 
 import { writeImageWidgetValue } from '@/composables/maskeditor/imageWidgetAdapter'
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
@@ -51,7 +53,11 @@ export function useMaskEditorSaver() {
 
       await updateNodePreview(sourceNode, outputData)
 
-      await uploadAllLayers(outputData)
+      if (shouldCompositeOnServer()) {
+        await uploadLayersWithServerComposite(outputData)
+      } else {
+        await uploadAllLayers(outputData)
+      }
 
       updateNodeWithServerReferences(sourceNode, outputData)
 
@@ -202,6 +208,77 @@ export function useMaskEditorSaver() {
     const ref = createFileRef(filename)
 
     return { canvas, blob, ref }
+  }
+
+  function shouldCompositeOnServer(): boolean {
+    return (
+      !isCloud &&
+      useSettingStore().get('Comfy.Image.PreviewCompression') &&
+      !!dataStore.inputData?.sourceRef
+    )
+  }
+
+  async function uploadLayersWithServerComposite(
+    outputData: EditorOutputData
+  ): Promise<void> {
+    const sourceRef = dataStore.inputData!.sourceRef
+    const formData = new FormData()
+    formData.append(
+      'image',
+      outputData.maskedImage.blob,
+      outputData.maskedImage.ref.filename
+    )
+    formData.append('type', 'input')
+    formData.append('original_ref', JSON.stringify(sourceRef))
+    formData.append(
+      'paint',
+      outputData.paintLayer.blob,
+      outputData.paintLayer.ref.filename
+    )
+    formData.append('paint_filename', outputData.paintLayer.ref.filename)
+    formData.append('painted_filename', outputData.paintedImage.ref.filename)
+    formData.append(
+      'painted_masked_filename',
+      outputData.paintedMaskedImage.ref.filename
+    )
+
+    const response = await api.fetchApi('/upload/mask', {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(
+        `Failed to composite mask layers on server (${response.status}${body ? `: ${body}` : ''})`
+      )
+    }
+
+    let data: UploadImageResponse
+    try {
+      data = await response.json()
+    } catch (error) {
+      throw new Error(
+        `Invalid composite upload response: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error }
+      )
+    }
+    if (!data?.name) {
+      throw new Error('Composite upload response missing file name')
+    }
+
+    const subfolder = data.subfolder || ''
+    const type = data.type || 'input'
+    outputData.maskedImage.ref = { filename: data.name, subfolder, type }
+    for (const layer of [
+      outputData.paintLayer,
+      outputData.paintedImage,
+      outputData.paintedMaskedImage
+    ]) {
+      layer.ref = { ...layer.ref, subfolder, type }
+    }
   }
 
   async function uploadAllLayers(outputData: EditorOutputData): Promise<void> {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -210,6 +210,14 @@
   "Comfy_Locale": {
     "name": "Language"
   },
+  "Comfy_Image_PreviewCompression": {
+    "name": "Load large images as compressed previews",
+    "tooltip": "When enabled, image editors (currently the mask editor) load images as compressed, downscaled previews. This greatly improves performance with very large images; edits are applied to the original at full resolution on save. Downscaling requires the assets system on the server (--enable-assets); without it images are only recompressed at full resolution."
+  },
+  "Comfy_Image_PreviewMaxSize": {
+    "name": "Compressed preview maximum size",
+    "tooltip": "Maximum size in pixels for the longest edge of a compressed preview. Images whose longest edge exceeds this are downscaled proportionally until it fits; the aspect ratio is preserved and images are never upscaled."
+  },
   "Comfy_MaskEditor_BrushAdjustmentSpeed": {
     "name": "Brush adjustment speed multiplier",
     "tooltip": "Controls how quickly the brush size and hardness change when adjusting. Higher values mean faster changes."

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -521,6 +521,31 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: ''
   },
   {
+    id: 'Comfy.Image.PreviewCompression',
+    category: ['Comfy', 'Preview', 'PreviewCompression'],
+    name: 'Load large images as compressed previews',
+    tooltip:
+      'When enabled, image editors (currently the mask editor) load images as compressed, downscaled previews. This greatly improves performance with very large images; edits are applied to the original at full resolution on save. Downscaling requires the assets system on the server (--enable-assets); without it images are only recompressed at full resolution.',
+    type: 'boolean',
+    defaultValue: false,
+    versionAdded: '1.48.0'
+  },
+  {
+    id: 'Comfy.Image.PreviewMaxSize',
+    category: ['Comfy', 'Preview', 'PreviewMaxSize'],
+    name: 'Compressed preview maximum size',
+    tooltip:
+      'Maximum size in pixels for the longest edge of a compressed preview. Images whose longest edge exceeds this are downscaled proportionally until it fits; the aspect ratio is preserved and images are never upscaled.',
+    type: 'slider',
+    attrs: {
+      min: 512,
+      max: 8192,
+      step: 256
+    },
+    defaultValue: 4096,
+    versionAdded: '1.48.0'
+  },
+  {
     id: 'Comfy.DisableSliders',
     category: ['LiteGraph', 'Node Widget', 'DisableSliders'],
     name: 'Disable node widget sliders',

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -519,6 +519,31 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: ''
   },
   {
+    id: 'Comfy.Image.PreviewCompression',
+    category: ['Comfy', 'Preview', 'PreviewCompression'],
+    name: 'Load large images as compressed previews',
+    tooltip:
+      'When enabled, image editors (currently the mask editor) load images as compressed, downscaled previews. This greatly improves performance with very large images; edits are applied to the original at full resolution on save. Downscaling requires the assets system on the server (--enable-assets); without it images are only recompressed at full resolution.',
+    type: 'boolean',
+    defaultValue: false,
+    versionAdded: '1.48.0'
+  },
+  {
+    id: 'Comfy.Image.PreviewMaxSize',
+    category: ['Comfy', 'Preview', 'PreviewMaxSize'],
+    name: 'Compressed preview maximum size',
+    tooltip:
+      'Maximum size in pixels for the longest edge of a compressed preview. Images whose longest edge exceeds this are downscaled proportionally until it fits; the aspect ratio is preserved and images are never upscaled.',
+    type: 'slider',
+    attrs: {
+      min: 512,
+      max: 8192,
+      step: 256
+    },
+    defaultValue: 4096,
+    versionAdded: '1.48.0'
+  },
+  {
     id: 'Comfy.DisableSliders',
     category: ['LiteGraph', 'Node Widget', 'DisableSliders'],
     name: 'Disable node widget sliders',

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -438,6 +438,8 @@ const zSettings = z.object({
   'Comfy-Desktop.UV.TorchInstallMirror': z.string(),
   'Comfy.MaskEditor.BrushAdjustmentSpeed': z.number(),
   'Comfy.MaskEditor.UseDominantAxis': z.boolean(),
+  'Comfy.Image.PreviewCompression': z.boolean(),
+  'Comfy.Image.PreviewMaxSize': z.number(),
   'Comfy.Load3D.ShowGrid': z.boolean(),
   'Comfy.Load3D.BackgroundColor': z.string(),
   'Comfy.Load3D.LightIntensity': z.number(),

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -441,6 +441,8 @@ const zSettings = z.object({
   'Comfy-Desktop.UV.TorchInstallMirror': z.string(),
   'Comfy.MaskEditor.BrushAdjustmentSpeed': z.number(),
   'Comfy.MaskEditor.UseDominantAxis': z.boolean(),
+  'Comfy.Image.PreviewCompression': z.boolean(),
+  'Comfy.Image.PreviewMaxSize': z.number(),
   'Comfy.Load3D.ShowGrid': z.boolean(),
   'Comfy.Load3D.BackgroundColor': z.string(),
   'Comfy.Load3D.LightIntensity': z.number(),


### PR DESCRIPTION
## Summary
Loading a very large image into the mask editor could freeze the browser while it decoded and rendered the full-resolution bitmap. Add an opt-in setting that loads images as downscaled, compressed previews instead, and composite edits back onto the original at full resolution when saving.

- Add Comfy.Image.PreviewCompression (boolean, default off) and Comfy.Image.PreviewMaxSize (slider, 512-8192, default 4096) settings, with schema and i18n entries.
- useMaskEditorLoader appends preview/max_size to the /view URL when the setting is on, built by a new previewCompressionParams helper that clamps max_size to 512-8192 (unit tested).
- When compression is on, useMaskEditorSaver uploads the small mask and paint layers to /upload/mask so the server composites them onto the original at full resolution, instead of uploading four full-size canvas layers via /upload/image. OSS only; cloud keeps the existing path.

Some notes:

1. Currently this approach is only introduced for the mask editor. If it proves viable, it can be extended to other components, e.g. painter, create bbox, or image preview itself (on Load Image), etc.
2. Right now we composite at the original resolution on the backend. We could consider whether to composite using the compressed image instead. I am not not doing that currently because compositing on the compressed image would degrade the output to the preview resolution instead of preserving the user's original detail, but compositing at full resolution consumes server runtime, this needs team discussion.

BE PR https://github.com/Comfy-Org/ComfyUI/pull/14976
Cloud PR https://github.com/Comfy-Org/cloud/pull/5184

## Screenshots (if applicable)


https://github.com/user-attachments/assets/e130ce13-4075-4f33-bab5-5f6150babac6

