### PR TITLE
feat: 3/x record RUM workflow execution vitals

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -41,6 +41,16 @@ interface GtagFunction {
   (...args: unknown[]): void
 }
 
+interface DatadogRumDurationVitalOptions {
+  startTime: number
+  duration: number
+  context?: Record<string, unknown>
+}
+
+interface DatadogRumClient {
+  addDurationVital(name: string, options: DatadogRumDurationVitalOptions): void
+}
+
 type SyftDataTraits = Record<string, string | number | null | undefined>
 
 interface SyftDataPendingFetch {
@@ -101,6 +111,7 @@ interface Window {
   }
   dataLayer?: Array<Record<string, unknown>>
   gtag?: GtagFunction
+  DD_RUM?: DatadogRumClient
   syft?: SyftDataClient | SyftDisabledClient
   syftc?: { sourceId?: string; enabled?: boolean }
   ire_o?: string

--- a/global.d.ts
+++ b/global.d.ts
@@ -41,16 +41,6 @@ interface GtagFunction {
   (...args: unknown[]): void
 }
 
-interface DatadogRumDurationVitalOptions {
-  startTime: number
-  duration: number
-  context?: Record<string, unknown>
-}
-
-interface DatadogRumClient {
-  addDurationVital(name: string, options: DatadogRumDurationVitalOptions): void
-}
-
 type SyftDataTraits = Record<string, string | number | null | undefined>
 
 interface SyftDataPendingFetch {
@@ -111,7 +101,6 @@ interface Window {
   }
   dataLayer?: Array<Record<string, unknown>>
   gtag?: GtagFunction
-  DD_RUM?: DatadogRumClient
   syft?: SyftDataClient | SyftDisabledClient
   syftc?: { sourceId?: string; enabled?: boolean }
   ire_o?: string

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
+
+const addDurationVital = vi.fn()
+
+function installDatadogRum(): void {
+  Object.defineProperty(window, 'DD_RUM', {
+    configurable: true,
+    value: { addDurationVital }
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  Reflect.deleteProperty(window, 'DD_RUM')
+})
+
+describe('DatadogRumTelemetryProvider', () => {
+  it('records a workflow vital with its duration and outcome', () => {
+    installDatadogRum()
+    vi.spyOn(performance, 'now').mockReturnValue(142)
+
+    new DatadogRumTelemetryProvider().trackExecutionOutcome({
+      startTime: 42,
+      outcome: 'success'
+    })
+
+    expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
+      startTime: performance.timeOrigin + 42,
+      duration: 100,
+      context: {
+        outcome: 'success',
+        product: 'cloud_generation'
+      }
+    })
+  })
+
+  it('does nothing when Datadog RUM is unavailable', () => {
+    expect(() =>
+      new DatadogRumTelemetryProvider().trackExecutionOutcome({
+        startTime: 42,
+        outcome: 'failure'
+      })
+    ).not.toThrow()
+  })
+})

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -2,47 +2,38 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const addDurationVital = vi.fn()
+const { addDurationVital } = vi.hoisted(() => ({
+  addDurationVital: vi.fn()
+}))
 
-function installDatadogRum(): void {
-  Object.defineProperty(window, 'DD_RUM', {
-    configurable: true,
-    value: { addDurationVital }
-  })
-}
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: { addDurationVital }
+}))
 
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
-  Reflect.deleteProperty(window, 'DD_RUM')
 })
 
 describe('DatadogRumTelemetryProvider', () => {
-  it('records a workflow vital with its duration and outcome', () => {
-    installDatadogRum()
-    vi.spyOn(performance, 'now').mockReturnValue(142)
+  it.for(['success', 'failure'] as const)(
+    'records a workflow vital with a %s outcome',
+    (outcome) => {
+      vi.spyOn(performance, 'now').mockReturnValue(142)
 
-    new DatadogRumTelemetryProvider().trackExecutionOutcome({
-      startTime: 42,
-      outcome: 'success'
-    })
-
-    expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
-      startTime: performance.timeOrigin + 42,
-      duration: 100,
-      context: {
-        outcome: 'success',
-        product: 'cloud_generation'
-      }
-    })
-  })
-
-  it('does nothing when Datadog RUM is unavailable', () => {
-    expect(() =>
       new DatadogRumTelemetryProvider().trackExecutionOutcome({
         startTime: 42,
-        outcome: 'failure'
+        outcome
       })
-    ).not.toThrow()
-  })
+
+      expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
+        startTime: performance.timeOrigin + 42,
+        duration: 100,
+        context: {
+          outcome,
+          product: 'cloud_generation'
+        }
+      })
+    }
+  )
 })

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,29 +1,11 @@
 import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
 
-interface DatadogRumDurationVitalOptions {
-  startTime: number
-  duration: number
-  context?: Record<string, unknown>
-}
-
-interface DatadogRumClient {
-  addDurationVital(name: string, options: DatadogRumDurationVitalOptions): void
-}
-
-interface WindowWithDatadogRum extends Window {
-  DD_RUM?: DatadogRumClient
-}
-
-function getDatadogRum(): DatadogRumClient | undefined {
-  return (window as WindowWithDatadogRum).DD_RUM
-}
-
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
   trackExecutionOutcome({
     startTime,
     outcome
   }: ExecutionOutcomeMetadata): void {
-    getDatadogRum()?.addDurationVital('workflow_execution', {
+    window.DD_RUM?.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
       duration: performance.now() - startTime,
       context: {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,3 +1,35 @@
-import type { TelemetryProvider } from '../../types'
+import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
 
-export class DatadogRumTelemetryProvider implements TelemetryProvider {}
+interface DatadogRumDurationVitalOptions {
+  startTime: number
+  duration: number
+  context?: Record<string, unknown>
+}
+
+interface DatadogRumClient {
+  addDurationVital(name: string, options: DatadogRumDurationVitalOptions): void
+}
+
+interface WindowWithDatadogRum extends Window {
+  DD_RUM?: DatadogRumClient
+}
+
+function getDatadogRum(): DatadogRumClient | undefined {
+  return (window as WindowWithDatadogRum).DD_RUM
+}
+
+export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackExecutionOutcome({
+    startTime,
+    outcome
+  }: ExecutionOutcomeMetadata): void {
+    getDatadogRum()?.addDurationVital('workflow_execution', {
+      startTime: performance.timeOrigin + startTime,
+      duration: performance.now() - startTime,
+      context: {
+        outcome,
+        product: 'cloud_generation'
+      }
+    })
+  }
+}

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,3 +1,5 @@
+import { datadogRum } from '@datadog/browser-rum'
+
 import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
@@ -5,7 +7,7 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     startTime,
     outcome
   }: ExecutionOutcomeMetadata): void {
-    window.DD_RUM?.addDurationVital('workflow_execution', {
+    datadogRum.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
       duration: performance.now() - startTime,
       context: {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1677,6 +1677,7 @@ export class ComfyApp {
           // user switches tabs while the request is in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const startTime = performance.now()
           const p = await this.graphToPrompt(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           try {
@@ -1696,6 +1697,7 @@ export class ComfyApp {
                   id: res.prompt_id,
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
+                  startTime,
                   workflow: queuedWorkflow
                 })
               }

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -21,6 +21,7 @@ const {
   mockOpenWorkflows,
   mockShowTextPreview,
   mockTrackExecutionError,
+  mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
   mockTrackSharedWorkflowRun
 } = await vi.hoisted(async () => {
@@ -33,6 +34,7 @@ const {
     mockOpenWorkflows: shallowRef<{ path: string }[]>([]),
     mockShowTextPreview: vi.fn(),
     mockTrackExecutionError: vi.fn(),
+    mockTrackExecutionOutcome: vi.fn(),
     mockTrackExecutionSuccess: vi.fn(),
     mockTrackSharedWorkflowRun: vi.fn()
   }
@@ -92,6 +94,7 @@ vi.mock('@/platform/distribution/types', async () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackExecutionError: mockTrackExecutionError,
+    trackExecutionOutcome: mockTrackExecutionOutcome,
     trackExecutionSuccess: mockTrackExecutionSuccess,
     trackSharedWorkflowRun: mockTrackSharedWorkflowRun
   })
@@ -614,6 +617,7 @@ describe('useExecutionStore - workflowStatus', () => {
       nodes: ['1'],
       id: jobId,
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+      startTime: 42,
       workflow
     })
   }
@@ -631,6 +635,7 @@ describe('useExecutionStore - workflowStatus', () => {
     callStoreJob('job-1', workflowA)
     fireExecutionStart('job-1')
 
+    expect(mockTrackExecutionOutcome).not.toHaveBeenCalled()
     expect(store.getWorkflowStatus(workflowA)).toBe('running')
   })
 
@@ -648,6 +653,11 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionSuccess('job-1')
 
     callStoreJob('job-1', workflowA)
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledOnce()
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'success'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
   })
 
@@ -656,6 +666,10 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionError('job-1')
 
     callStoreJob('job-1', workflowA)
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'failure'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
   })
 
@@ -672,6 +686,10 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionStart('job-1')
     fireExecutionSuccess('job-1')
 
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'success'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
   })
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -659,6 +659,7 @@ describe('useExecutionStore - workflowStatus', () => {
       outcome: 'success'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
+    expect(store.queuedJobs['job-1']).toBeUndefined()
   })
 
   it('flushes terminal failed when WS errors before storeJob', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -51,6 +51,7 @@ interface QueuedJob {
    * value is a boolean indicating if the node has been executed.
    */
   nodes: Record<string, boolean>
+  startTime?: number
   /**
    * The workflow that is queued to be executed
    */
@@ -177,6 +178,19 @@ export const useExecutionStore = defineStore('execution', () => {
     mutateStatus((m) => m.set(workflow, status))
   }
 
+  function trackExecutionOutcome(
+    jobId: string,
+    status: WorkflowExecutionStatus
+  ) {
+    if (status === 'running') return
+    const startTime = queuedJobs.value[jobId]?.startTime
+    if (startTime === undefined) return
+    useTelemetry()?.trackExecutionOutcome({
+      startTime,
+      outcome: status === 'completed' ? 'success' : 'failure'
+    })
+  }
+
   function setWorkflowStatus(jobId: string, status: WorkflowExecutionStatus) {
     const workflow = jobIdToWorkflow.get(jobId)
     if (!workflow) {
@@ -184,6 +198,7 @@ export const useExecutionStore = defineStore('execution', () => {
       return
     }
     applyWorkflowStatus(workflow, status)
+    trackExecutionOutcome(jobId, status)
   }
 
   function clearWorkflowStatus(workflow: ComfyWorkflow) {
@@ -718,11 +733,13 @@ export const useExecutionStore = defineStore('execution', () => {
     nodes,
     id,
     promptOutput,
+    startTime,
     workflow
   }: {
     nodes: string[]
     id: JobId
     promptOutput: ComfyApiWorkflow
+    startTime?: number
     workflow: ComfyWorkflow
   }) {
     queuedJobs.value[id] ??= { nodes: {} }
@@ -735,6 +752,7 @@ export const useExecutionStore = defineStore('execution', () => {
       ...queuedJob.nodes
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
+    queuedJob.startTime = startTime
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
     queuedJob.shareId = workflow?.shareId
@@ -761,6 +779,7 @@ export const useExecutionStore = defineStore('execution', () => {
     // Don't let a stale 'running' overwrite a terminal status already set.
     if (pending === 'running' && workflowStatus.value.has(workflow)) return
     applyWorkflowStatus(workflow, pending)
+    trackExecutionOutcome(jobId, pending)
   }
 
   // ~0.65 MB at capacity (32 char GUID key + 50 char path value)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -780,6 +780,9 @@ export const useExecutionStore = defineStore('execution', () => {
     if (pending === 'running' && workflowStatus.value.has(workflow)) return
     applyWorkflowStatus(workflow, pending)
     trackExecutionOutcome(jobId, pending)
+    if (pending === 'running' || activeJobId.value === jobId) return
+    delete queuedJobs.value[jobId]
+    jobIdToWorkflow.delete(jobId)
   }
 
   // ~0.65 MB at capacity (32 char GUID key + 50 char path value)


### PR DESCRIPTION
## Stack

1. [#13767 — feat: 3/x record RUM workflow execution vitals](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13767)
2. [#13764 — feat: 4/x attribute RUM workflow vitals to origin views](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13764)

## Summary

Records one `workflow_execution` Datadog RUM duration vital when a queued Cloud workflow reaches a terminal state. Timing starts before prompt construction, and the existing pending-status path preserves outcomes that arrive before the queue response. Running jobs and jobs without a start time emit no outcome; the provider remains stateless and safely no-ops when RUM is unavailable.

## Verification

- The execution-store regression test drives completed and failed transitions, including a terminal WebSocket event received before `storeJob`, and observes one `trackExecutionOutcome` call only after a terminal state.
- The provider test observes the authoritative `DD_RUM.addDurationVital('workflow_execution', ...)` payload with an absolute start time, measured duration, `outcome`, and `product: cloud_generation`.

Created by Codex