### PR TITLE
ci: make Codecov patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+
 comment:
   layout: 'header, diff, flags, files'
   behavior: default


### PR DESCRIPTION
## Summary

Make Codecov patch coverage informational so the critical Vitest thresholds remain the coverage merge gate.

## Changes

- **What**: Configure the default `codecov/patch` status as informational. Patch coverage remains visible, but uncovered non-critical lines no longer produce a failed check like #13750.

## verification
https://github.com/Comfy-Org/ComfyUI_frontend/pull/13775#issuecomment-5008201405

## Review Focus

Critical coverage is still enforced by the required `CI: Tests Unit` job. This only changes the external Codecov status from blocking-style failure to informational reporting.

Validated with Codecov's YAML validator, `pnpm exec oxfmt --check codecov.yml`, and the pre-push `knip` hook.

Created by Codex