### PR TITLE
fix(widgets): reconcile widget store entry when widget type changes

### DIFF
--- a/src/stores/widgetValueStore.test.ts
+++ b/src/stores/widgetValueStore.test.ts
@@ -112,6 +112,21 @@ describe('useWidgetValueStore', () => {
       expect(second.value).toBe(99)
     })
 
+    it('replaces a stale entry when the widget type changes', () => {
+      const store = useWidgetValueStore()
+      const first = store.registerWidget(seedA, state('number', 5))!
+      first.value = 42
+
+      // After a subgraph convert the graphId:nodeId:name key can be reused by a
+      // different widget. A type mismatch means it is not the same widget, so
+      // the live type/value must win rather than the stale entry (BUG: a text
+      // widget rendered as int until reload).
+      const reconciled = store.registerWidget(seedA, state('string', 'hello'))!
+      expect(reconciled.type).toBe('string')
+      expect(reconciled.value).toBe('hello')
+      expect(store.getWidget(seedA)?.type).toBe('string')
+    })
+
     it('registers a widget with all properties', () => {
       const store = useWidgetValueStore()
       const registered = store.registerWidget(

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -37,7 +37,9 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     }
 
     const existing = getWidget(widgetId)
-    if (existing) return existing as WidgetState<TValue>
+    if (existing && existing.type === init.type) {
+      return existing as WidgetState<TValue>
+    }
 
     const { graphId, nodeId, name } = parseWidgetId(widgetId)
     const state: WidgetState<TValue> = {


### PR DESCRIPTION
## Summary

On subgraph convert, a widget could render with the wrong type (a multiline text widget appeared as an int widget until a page reload) because the widget value store returned a stale entry keyed by `graphId:nodeId:name`.

## Changes

- **What**: `registerWidget` returned the existing store entry unconditionally (idempotent to preserve edited values across re-render). But when a subgraph convert reuses the same `graphId:nodeId:name` key for a *different* widget, the stale entry won — wrong type, wrong value, only corrected by a reload that rehydrates the store from serialized data. Now the idempotent return applies only when `existing.type === init.type`; on a type mismatch the id belongs to a different widget, so the store overwrites with the live type/value. Same-type re-registration still preserves edited values (unchanged behavior).
- **Breaking**: none.

## Review Focus

- @drjkl @AustinMroz — this changes the idempotency semantic in the #12617 widget store (#13073 collision class). The discriminator is `type`; please sanity-check that no legitimate re-registration changes `type` for the same logical widget. Reload already produces the correct result, which is the evidence the in-memory path diverges here.
- Stacked on #13773 (base = `fix/widget-store-custom-node-widgets`). Rebase to `main` once that lands.

QA source: staging 1.47 — "multiline text widget converts to int inside/outside nested subgraph; refresh fixes it", working on 1.45.21.