### PR TITLE
fix: avoid large option lists in node previews

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.test.ts
@@ -59,22 +59,34 @@ function renderedComboWidget(
 }
 
 describe('LGraphNodePreview', () => {
-  it('leads the combo options with the provided widget value', () => {
+  it('keeps only the provided combo value for the preview', () => {
     const widget = renderedComboWidget({
       widgetValues: { ckpt_name: 'sd_xl_base_1.0.safetensors' }
     })
 
-    expect(widget?.options?.values).toEqual([
-      'sd_xl_base_1.0.safetensors',
-      'a.safetensors',
-      'b.safetensors'
-    ])
+    expect(widget?.options?.values).toEqual(['sd_xl_base_1.0.safetensors'])
   })
 
-  it('keeps the combo options untouched when no value is provided', () => {
+  it('keeps only the first combo value when no value is provided', () => {
     const widget = renderedComboWidget()
 
-    expect(widget?.options?.values).toEqual(['a.safetensors', 'b.safetensors'])
+    expect(widget?.options?.values).toEqual(['a.safetensors'])
+  })
+
+  it('does not retain a large combo option list in the preview', () => {
+    const options = Array.from(
+      { length: 10_000 },
+      (_, index) => `input/image-${index}.png`
+    )
+    const widget = renderedWidgets(
+      fromPartial<ComfyNodeDefV2>({
+        name: 'LoadImage',
+        inputs: { image: { type: 'COMBO', options } },
+        outputs: []
+      })
+    ).find((item) => item.name === 'image')
+
+    expect(widget?.options?.values).toEqual([options[0]])
   })
 
   it('uses the input default when defined and empty string otherwise', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNodePreview.vue
@@ -67,24 +67,17 @@ const nodeData = computed<VueNodeData>(() => {
         input.type === 'COMBO' && Array.isArray(input.options)
           ? input.options
           : undefined
-      // Preview nodes have no widget-value store entry, so combo widgets
-      // render their first option; lead with the requested value to show it.
       const leadValue = widgetValues?.[name]
+      const value = leadValue ?? input.default ?? comboValues?.[0] ?? ''
       return {
         nodeId: toNodeId('-1'),
         name,
         type: input.widgetType || input.type,
-        value:
-          input.default !== undefined
-            ? input.default
-            : (comboValues?.[0] ?? ''),
+        value,
         options: {
           hidden: input.hidden,
           advanced: input.advanced,
-          values:
-            leadValue && comboValues
-              ? [leadValue, ...comboValues.filter((o) => o !== leadValue)]
-              : comboValues
+          values: comboValues?.length ? [value] : comboValues
         } satisfies IWidgetOptions
       }
     })


### PR DESCRIPTION
## Summary

Prevent inert node previews from materializing full combo option lists, which freezes node search when LoadImage exposes a very large input file list.

## Changes

- **What**: Keep only the value displayed by a combo widget in preview-only node data instead of retaining every option.
- **Tests**: Add a 10,000-option LoadImage regression case and update existing preview expectations.

## Review Focus

The real canvas node and its dropdown options are unchanged. Only the non-interactive preview data is reduced to the selected, default, or first combo value.

Fixes https://github.com/Comfy-Org/ComfyUI/issues/14872

## Validation

- Related preview/search/widget tests: 89 passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed (3 unrelated existing warnings)
- `pnpm format:check`: passed
- `pnpm knip`: passed
- Repository pre-commit and pre-push hooks: passed

Disclosure: Codex assisted with source tracing and implementation. I reviewed the diff and ran the checks listed above.