### PR TITLE
fix: QA quick-wins — stale keybinding warning + 404 links (Contact/Terms/Privacy)

### DIFF
--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -1,0 +1,77 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingService } from '@/platform/keybindings/keybindingService'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
+
+const settings = vi.hoisted(() => ({
+  values: {} as Record<string, unknown>
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn((key: string) => settings.values[key] ?? [])
+  }))
+}))
+
+describe('keybindingService - registerUserKeybindings', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    settings.values = {}
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('does not warn when unset binding targets a command that no longer exists', () => {
+    // A command removed from the app (e.g. ConvertSelectedNodesToGroupNode,
+    // removed in #12931) can still linger in the persisted UnsetBindings.
+    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+      {
+        commandId: 'ConvertSelectedNodesToGroupNode',
+        combo: { key: 'g', ctrl: true, alt: false, shift: false }
+      }
+    ]
+
+    useKeybindingService().registerUserKeybindings()
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Trying to unset non-exist keybinding')
+    )
+  })
+
+  it('still unsets bindings for commands that are registered', () => {
+    const commandStore = useCommandStore()
+    commandStore.registerCommand({
+      id: 'Comfy.Test.Registered',
+      function: vi.fn()
+    })
+
+    const keybindingStore = useKeybindingStore()
+    const combo = { key: 'g', ctrl: true, alt: false, shift: false }
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({ commandId: 'Comfy.Test.Registered', combo })
+    )
+
+    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+      { commandId: 'Comfy.Test.Registered', combo }
+    ]
+
+    useKeybindingService().registerUserKeybindings()
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Trying to unset non-exist keybinding')
+    )
+    expect(
+      keybindingStore.getKeybindingByCommandId('Comfy.Test.Registered')
+    ).toBeUndefined()
+  })
+})

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -121,6 +121,9 @@ export function useKeybindingService() {
   function registerUserKeybindings() {
     const unsetBindings = settingStore.get('Comfy.Keybinding.UnsetBindings')
     for (const keybinding of unsetBindings) {
+      if (!commandStore.isRegistered(keybinding.commandId)) {
+        continue
+      }
       keybindingStore.unsetKeybinding(new KeybindingImpl(keybinding))
     }
     const newBindings = settingStore.get('Comfy.Keybinding.NewBindings')

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -534,7 +534,7 @@ function handleSubscribe(tierKey: CheckoutTierKey) {
 }
 
 function handleContactUs() {
-  window.open('https://www.comfy.org/discord', '_blank')
+  window.open('https://discord.com/invite/comfyorg', '_blank')
 }
 
 function handleViewEnterprise() {

--- a/src/platform/workspace/components/SubscriptionTermsNote.vue
+++ b/src/platform/workspace/components/SubscriptionTermsNote.vue
@@ -3,7 +3,7 @@
     <i18n-t keypath="subscription.preview.termsAgreement" tag="span">
       <template #terms>
         <a
-          href="https://www.comfy.org/terms"
+          href="https://www.comfy.org/terms-of-service"
           target="_blank"
           rel="noopener noreferrer"
           class="underline hover:text-base-foreground"
@@ -13,7 +13,7 @@
       </template>
       <template #privacy>
         <a
-          href="https://www.comfy.org/privacy"
+          href="https://www.comfy.org/privacy-policy"
           target="_blank"
           rel="noopener noreferrer"
           class="underline hover:text-base-foreground"


### PR DESCRIPTION
## Summary

Three low-risk QA findings from the 1.47 staging pass, each with a regression test where applicable.

## Changes

- **BUG-016 / L-2** (P3, regression): removed commands (e.g. `ConvertSelectedNodesToGroupNode`, removed in #12931) linger in persisted `UnsetBindings`, so `registerUserKeybindings` unset a non-existent binding and logged `Trying to unset non-exist keybinding`. Skip unregistered commands in `keybindingService.ts`. New unit test `keybindingService.registerUserKeybindings.test.ts` (fails without the fix).
- **BUG-014 / D-8** (P2): pricing "Contact us" pointed to `www.comfy.org/discord` (404). Now `discord.com/invite/comfyorg` (verified 200). `PricingTableWorkspace.vue`.
- **BUG-015 / D-9** (P2): subscription-confirmation "Terms" / "Privacy policy" pointed to `/terms` + `/privacy` (404). Now `/terms-of-service` + `/privacy-policy` (200), matching the cloud onboarding views. `SubscriptionTermsNote.vue`.

## Review Focus

- Out-of-scope 404s spotted but NOT changed here (separate follow-up): the canonical `useExternalLink.ts` discord link and `SignInContent.vue` privacy link also 404.

QA source: Denys FE-1.47 findings (D-8, D-9, L-2). Tracker: https://app.notion.com/p/3a06d73d365081cbbbd2d5198475fffb