### PR TITLE
test(e2e): custom-node empty-name widget doesn't blank the node grid (#13773)

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/emptyNameWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/emptyNameWidget.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 const HOST_NODE_TYPE = 'KSampler'
@@ -21,35 +20,21 @@ test.describe(
   { tag: ['@vue-nodes', '@widget'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
-      // Emulate a custom node registering an extra, un-keyable widget: a
-      // `nodeCreated` extension hook pushes a widget with an empty name onto the
-      // host node, alongside its normal schema widgets.
-      await comfyPage.page.evaluate((hostType) => {
-        window.app!.registerExtension({
-          name: 'TestExtension.EmptyNameWidget',
-          nodeCreated(node) {
-            if (node.type !== hostType) return
-            node.addWidget('text', '', '', () => {})
-          }
-        })
-      }, HOST_NODE_TYPE)
-
+      // Emulate a custom node registering an extra, un-keyable widget
       await comfyPage.nodeOps.clearGraph()
-      await comfyPage.nodeOps.addNode(HOST_NODE_TYPE, undefined, {
+      await comfyPage.nodeOps.addNode(HOST_NODE_TITLE, undefined, {
         x: 400,
         y: 200
       })
-      await comfyPage.vueNodes.waitForNodes()
+      await comfyPage.page.evaluate(() =>
+        graph!.nodes[0].addWidget('text', '', '', () => {})
+      )
     })
-
-    function getNode(comfyPage: ComfyPage) {
-      return comfyPage.vueNodes.getNodeByTitle(HOST_NODE_TITLE)
-    }
 
     test('renders schema widgets despite an un-keyable sibling', async ({
       comfyPage
     }) => {
-      const node = getNode(comfyPage)
+      const node = comfyPage.vueNodes.getNodeByTitle(HOST_NODE_TITLE)
       await expect(node).toBeVisible()
 
       // Precondition: the un-keyable empty-name widget really is on the node, so

--- a/browser_tests/tests/vueNodes/widgets/emptyNameWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/emptyNameWidget.spec.ts
@@ -1,0 +1,76 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+const HOST_NODE_TYPE = 'KSampler'
+const HOST_NODE_TITLE = 'KSampler'
+
+/**
+ * Regression for #13773: a custom node that registers a client-side widget with
+ * an empty/placeholder name produces an un-keyable widget id (empty name
+ * segment). Before the fix, `parseWidgetId` threw on that id, which tripped the
+ * Vue `NodeWidgets` error boundary and blanked the node's ENTIRE widget grid
+ * (e.g. rgthree Power Lora Loader rendered no widgets). The un-storable widget
+ * must not take down its schema-declared siblings.
+ */
+test.describe(
+  'Empty-name custom widget',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      // Emulate a custom node registering an extra, un-keyable widget: a
+      // `nodeCreated` extension hook pushes a widget with an empty name onto the
+      // host node, alongside its normal schema widgets.
+      await comfyPage.page.evaluate((hostType) => {
+        window.app!.registerExtension({
+          name: 'TestExtension.EmptyNameWidget',
+          nodeCreated(node) {
+            if (node.type !== hostType) return
+            node.addWidget('text', '', '', () => {})
+          }
+        })
+      }, HOST_NODE_TYPE)
+
+      await comfyPage.nodeOps.clearGraph()
+      await comfyPage.nodeOps.addNode(HOST_NODE_TYPE, undefined, {
+        x: 400,
+        y: 200
+      })
+      await comfyPage.vueNodes.waitForNodes()
+    })
+
+    function getNode(comfyPage: ComfyPage) {
+      return comfyPage.vueNodes.getNodeByTitle(HOST_NODE_TITLE)
+    }
+
+    test('renders schema widgets despite an un-keyable sibling', async ({
+      comfyPage
+    }) => {
+      const node = getNode(comfyPage)
+      await expect(node).toBeVisible()
+
+      // Precondition: the un-keyable empty-name widget really is on the node, so
+      // this test exercises the regression rather than passing vacuously.
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate((type) => {
+            const host = window.app!.graph.nodes.find((n) => n.type === type)
+            return host?.widgets?.some((w) => w.name === '') ?? false
+          }, HOST_NODE_TYPE)
+        )
+        .toBe(true)
+
+      // The widget grid must render (v-else branch), not the error boundary.
+      await expect(node.getByTestId(TestIds.widgets.container)).toBeVisible()
+      await expect(node.locator('.node-error')).toHaveCount(0)
+
+      // Schema-declared siblings must still render and be interactable.
+      await expect(node.getByLabel('seed', { exact: true })).toBeVisible()
+      await expect(node.getByLabel('steps', { exact: true })).toBeVisible()
+      await expect(node.getByLabel('cfg', { exact: true })).toBeVisible()
+    })
+  }
+)


### PR DESCRIPTION
## Summary

Playwright regression for #13773: a custom node that registers a client-side widget with an empty/placeholder name (an un-keyable widget id) must not trip the Vue `NodeWidgets` error boundary and blank the node's entire widget grid.

## Changes

- **What**: `browser_tests/tests/vueNodes/widgets/emptyNameWidget.spec.ts` — a `registerExtension` `nodeCreated` hook adds an empty-name widget to a KSampler, then asserts the widget grid renders (not `.node-error`) and the schema siblings (seed/steps/cfg) stay visible. Behavioral, retrying assertions, no `waitForTimeout`; a precondition poll confirms the empty-name widget is actually present so the test can't pass vacuously.
- **Breaking**: none (test only).

## Review Focus

- Stacked on #13773 (base = `fix/widget-store-custom-node-widgets`); retarget to `main` when that merges.
- Draft: written to pass with the #13773 fix and fail without it, but could not be run locally (no browser binary / local ComfyUI backend in the dev env). Relying on CI to validate — will iterate if the fixture selectors need adjustment.

Locks in the defensive guard from #13773 regardless of the exact custom-node trigger.