### PR TITLE
feat(assets): classify jobs cursor rejection via structured errorCode

### DIFF
--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -143,19 +143,34 @@ describe('fetchJobs', () => {
       await expect(fetchHistory(mockFetch)).rejects.toThrow('Network error')
     })
 
-    it('throws a JobsApiError carrying status and body on non-ok response', async () => {
+    it('throws a JobsApiError carrying status, body, and parsed errorCode on non-ok response', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 400,
         text: () =>
-          Promise.resolve('{"error":"Invalid cursor","code":"INVALID_CURSOR"}')
+          Promise.resolve(
+            '{"code":"INVALID_CURSOR","message":"Invalid pagination cursor"}'
+          )
       })
 
       await expect(fetchHistory(mockFetch)).rejects.toBeInstanceOf(JobsApiError)
       await expect(fetchHistory(mockFetch)).rejects.toMatchObject({
         status: 400,
+        errorCode: 'INVALID_CURSOR',
         message: expect.stringContaining('INVALID_CURSOR')
       })
+    })
+
+    it('leaves errorCode undefined when the body is not the structured error shape', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve('<html>Bad Gateway</html>')
+      })
+
+      const err = await fetchHistory(mockFetch).catch((e) => e)
+      expect(err).toBeInstanceOf(JobsApiError)
+      expect(err.errorCode).toBeUndefined()
     })
 
     it('truncates oversized error bodies to 200 chars in the thrown message', async () => {

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -173,6 +173,19 @@ describe('fetchJobs', () => {
       expect(err.errorCode).toBeUndefined()
     })
 
+    it('leaves errorCode undefined for an oversized body rather than parsing it', async () => {
+      const oversized = `{"code":"INVALID_CURSOR","pad":"${'x'.repeat(20_000)}"}`
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(oversized)
+      })
+
+      const err = await fetchHistory(mockFetch).catch((e) => e)
+      expect(err).toBeInstanceOf(JobsApiError)
+      expect(err.errorCode).toBeUndefined()
+    })
+
     it('truncates oversized error bodies to 200 chars in the thrown message', async () => {
       const oversized = 'x'.repeat(500)
       const mockFetch = vi.fn().mockResolvedValue({

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -32,9 +32,14 @@ export type JobsPageRequest =
 
 const MAX_ERROR_BODY_LENGTH = 200
 
+// Cap synchronous JSON.parse so an oversized error body can't block the UI
+// thread; the structured error is a few hundred bytes at most.
+const MAX_ERROR_PARSE_LENGTH = 10_000
+
 const zJobsErrorBody = z.object({ code: z.string() })
 
 function parseErrorCode(body: string): string | undefined {
+  if (body.length > MAX_ERROR_PARSE_LENGTH) return undefined
   try {
     return zJobsErrorBody.safeParse(JSON.parse(body)).data?.code
   } catch {

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -6,6 +6,8 @@
  * All distributions use the /jobs endpoint.
  */
 
+import { z } from 'zod'
+
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { JobId } from '@/schemas/apiSchema'
@@ -30,26 +32,38 @@ export type JobsPageRequest =
 
 const MAX_ERROR_BODY_LENGTH = 200
 
-/**
- * Non-ok response from the jobs API. Carries the HTTP status so callers can
- * tell a rejected cursor (400 INVALID_CURSOR) apart from transient failures.
- */
-export class JobsApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number
-  ) {
-    super(message)
-    this.name = 'JobsApiError'
+const zJobsErrorBody = z.object({ code: z.string() })
+
+function parseErrorCode(body: string): string | undefined {
+  try {
+    return zJobsErrorBody.safeParse(JSON.parse(body)).data?.code
+  } catch {
+    return undefined
   }
 }
 
-function jobsApiErrorMessage(status: number, body: string): string {
-  const truncated =
-    body.length > MAX_ERROR_BODY_LENGTH
-      ? `${body.slice(0, MAX_ERROR_BODY_LENGTH)}…`
-      : body
-  return `[Jobs API] Failed to fetch jobs: ${status} ${truncated}`.trim()
+/**
+ * Non-ok response from the jobs API. Carries the HTTP status and the parsed
+ * machine-readable `errorCode` (from the JSON error body) so callers can tell a
+ * rejected cursor (`INVALID_CURSOR`) apart from other 400s and transient
+ * failures. `errorCode` is undefined when the body isn't the structured error
+ * shape (e.g. a proxy error page).
+ */
+export class JobsApiError extends Error {
+  readonly errorCode?: string
+
+  constructor(
+    readonly status: number,
+    body: string
+  ) {
+    const truncated =
+      body.length > MAX_ERROR_BODY_LENGTH
+        ? `${body.slice(0, MAX_ERROR_BODY_LENGTH)}…`
+        : body
+    super(`[Jobs API] Failed to fetch jobs: ${status} ${truncated}`.trim())
+    this.name = 'JobsApiError'
+    this.errorCode = parseErrorCode(body)
+  }
 }
 
 interface FetchJobsRawResult {
@@ -91,7 +105,7 @@ async function fetchJobsRaw(
   const res = await fetchApi(url)
   if (!res.ok) {
     const body = await res.text().catch(() => '')
-    throw new JobsApiError(jobsApiErrorMessage(res.status, body), res.status)
+    throw new JobsApiError(res.status, body)
   }
   const parsed = zJobsListResponse.safeParse(await res.json())
   if (!parsed.success) {

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -623,7 +623,9 @@ describe('assetsStore - Refactored (Option A)', () => {
             nextCursor: 'cursor-stale'
           })
         )
-        .mockRejectedValueOnce(new JobsApiError('INVALID_CURSOR', 400))
+        .mockRejectedValueOnce(
+          new JobsApiError(400, '{"code":"INVALID_CURSOR"}')
+        )
         .mockResolvedValueOnce(
           mockHistoryPage(
             Array.from({ length: 10 }, (_, i) => createMockJobItem(10 + i)),
@@ -675,7 +677,9 @@ describe('assetsStore - Refactored (Option A)', () => {
             nextCursor: 'cursor-stale'
           })
         )
-        .mockRejectedValueOnce(new JobsApiError('INVALID_CURSOR', 400))
+        .mockRejectedValueOnce(
+          new JobsApiError(400, '{"code":"INVALID_CURSOR"}')
+        )
         .mockRejectedValueOnce(new Error('network down'))
 
       await store.updateHistory()
@@ -726,7 +730,9 @@ describe('assetsStore - Refactored (Option A)', () => {
             nextCursor: 'cursor-stale'
           })
         )
-        .mockRejectedValueOnce(new JobsApiError('INVALID_CURSOR', 400))
+        .mockRejectedValueOnce(
+          new JobsApiError(400, '{"code":"INVALID_CURSOR"}')
+        )
         .mockResolvedValueOnce(mockHistoryPage(serverStateAfterDeletions))
 
       await store.updateHistory()
@@ -762,14 +768,43 @@ describe('assetsStore - Refactored (Option A)', () => {
       await store.loadMoreHistory()
 
       // No offset fallback for transient failures, just a recorded error.
-      // Asserting the concrete 500 guards the recover-vs-not classification:
-      // only a 400 should drop to the offset fallback.
+      // Only an INVALID_CURSOR error should drop to the offset fallback; a 500
+      // with no such code must preserve the cursor.
       expect(fetchHistoryPage).toHaveBeenCalledTimes(2)
       expect(store.historyError).toBeInstanceOf(JobsApiError)
       expect(store.historyError).toMatchObject({ status: 500 })
       expect(store.hasMoreHistory).toBe(true)
 
       // The still-valid cursor is retried on the next attempt
+      vi.mocked(fetchHistoryPage).mockResolvedValueOnce(mockHistoryPage([]))
+      await store.loadMoreHistory()
+      expect(fetchHistoryPage).toHaveBeenLastCalledWith(
+        expect.any(Function),
+        200,
+        { after: 'cursor-1' }
+      )
+    })
+
+    it('preserves the cursor for a 400 that is not an INVALID_CURSOR rejection', async () => {
+      vi.mocked(fetchHistoryPage)
+        .mockResolvedValueOnce(
+          mockHistoryPage(
+            Array.from({ length: 10 }, (_, i) => createMockJobItem(i)),
+            { hasMore: true, nextCursor: 'cursor-1' }
+          )
+        )
+        .mockRejectedValueOnce(
+          new JobsApiError(400, '{"code":"INVALID_STATUS_FILTER"}')
+        )
+
+      await store.updateHistory()
+      await store.loadMoreHistory()
+
+      // A non-cursor 400 must not reset the walk to the offset fallback.
+      expect(fetchHistoryPage).toHaveBeenCalledTimes(2)
+      expect(store.historyError).toBeInstanceOf(JobsApiError)
+      expect(store.hasMoreHistory).toBe(true)
+
       vi.mocked(fetchHistoryPage).mockResolvedValueOnce(mockHistoryPage([]))
       await store.loadMoreHistory()
       expect(fetchHistoryPage).toHaveBeenLastCalledWith(
@@ -861,7 +896,7 @@ describe('assetsStore - Refactored (Option A)', () => {
       )
       await store.updateHistory()
 
-      rejectStale!(new JobsApiError('INVALID_CURSOR', 400))
+      rejectStale!(new JobsApiError(400, '{"code":"INVALID_CURSOR"}'))
       await staleLoad
 
       // The superseded walk neither nulled the fresh cursor nor fired an

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -814,6 +814,36 @@ describe('assetsStore - Refactored (Option A)', () => {
       )
     })
 
+    it('preserves the cursor for an INVALID_CURSOR code carried by a non-400 status', async () => {
+      vi.mocked(fetchHistoryPage)
+        .mockResolvedValueOnce(
+          mockHistoryPage(
+            Array.from({ length: 10 }, (_, i) => createMockJobItem(i)),
+            { hasMore: true, nextCursor: 'cursor-1' }
+          )
+        )
+        .mockRejectedValueOnce(
+          new JobsApiError(500, '{"code":"INVALID_CURSOR"}')
+        )
+
+      await store.updateHistory()
+      await store.loadMoreHistory()
+
+      // A rejected cursor is only ever a 400; the same code on a 500 is a real
+      // server error and must not reset the walk to the offset fallback.
+      expect(fetchHistoryPage).toHaveBeenCalledTimes(2)
+      expect(store.historyError).toMatchObject({ status: 500 })
+      expect(store.hasMoreHistory).toBe(true)
+
+      vi.mocked(fetchHistoryPage).mockResolvedValueOnce(mockHistoryPage([]))
+      await store.loadMoreHistory()
+      expect(fetchHistoryPage).toHaveBeenLastCalledWith(
+        expect.any(Function),
+        200,
+        { after: 'cursor-1' }
+      )
+    })
+
     it('treats a cursorless empty page as terminal even if the server claims more', async () => {
       vi.mocked(fetchHistoryPage).mockResolvedValueOnce(
         mockHistoryPage([], { hasMore: true })

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -762,7 +762,7 @@ describe('assetsStore - Refactored (Option A)', () => {
             { hasMore: true, nextCursor: 'cursor-1' }
           )
         )
-        .mockRejectedValueOnce(new JobsApiError('server error', 500))
+        .mockRejectedValueOnce(new JobsApiError(500, 'server error'))
 
       await store.updateHistory()
       await store.loadMoreHistory()

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -208,7 +208,7 @@ export const useAssetsStore = defineStore('assets', () => {
   let hadCursorThisWalk = false
 
   const isRejectedCursorError = (err: unknown): boolean =>
-    err instanceof JobsApiError && err.status === 400
+    err instanceof JobsApiError && err.errorCode === 'INVALID_CURSOR'
 
   const fetchHistoryPageWithCursorRecovery = async (
     after: string | null,

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -208,7 +208,9 @@ export const useAssetsStore = defineStore('assets', () => {
   let hadCursorThisWalk = false
 
   const isRejectedCursorError = (err: unknown): boolean =>
-    err instanceof JobsApiError && err.errorCode === 'INVALID_CURSOR'
+    err instanceof JobsApiError &&
+    err.status === 400 &&
+    err.errorCode === 'INVALID_CURSOR'
 
   const fetchHistoryPageWithCursorRecovery = async (
     after: string | null,


### PR DESCRIPTION
## ELI-5

When you scroll the Generated tab, the app pages through your job history with a
"cursor". If that cursor goes stale (e.g. after a server restart) the server
rejects the page with a 400 and the app restarts the walk from the beginning so
you don't get skipped or duplicated rows. Today the app treats *any* 400 on that
request as "stale cursor". That's fine right now because a rejected cursor is the
only 400 the endpoint can return — but if the endpoint ever starts returning 400
for other reasons, an unrelated error would wrongly nuke your loaded history back
to the top. This teaches the app to read the server's actual machine-readable
error code and only reset when it really is a rejected cursor.

## Summary

Classify a rejected jobs pagination cursor by the server's structured error code
instead of the bare HTTP 400 status, so future non-cursor 400s don't trigger the
history offset fallback.

## Changes

- **What**:
  - `JobsApiError` now parses the machine-readable `code` from the JSON error
    body and exposes it as `errorCode` (undefined when the body isn't the
    structured error shape, e.g. a proxy error page).
  - `assetsStore.isRejectedCursorError` narrows from `status === 400` to
    `errorCode === 'INVALID_CURSOR'`.
  - Recovery tests construct errors with realistic JSON bodies; added coverage
    for a non-JSON body (no `errorCode`) and a non-cursor 400 (cursor preserved).
- **Breaking**: none — behavior is identical for today's traffic (see below).

## Review Focus

- **Server contract confirmed first.** The `/jobs` list endpoint returns its
  errors as a structured JSON body carrying a machine-readable `code` field, and
  emits `INVALID_CURSOR` for a rejected pagination cursor. That endpoint's only
  400 today is the rejected cursor, so old (`status === 400`) and new
  (`errorCode === 'INVALID_CURSOR'`) conditions cannot disagree for current
  traffic — no behavior change now. The narrowing is defense-in-depth for when
  the endpoint gains other 400 cases, and is strictly more correct: an unrelated
  400 or a non-JSON proxy 400 no longer resets the walk to offset 0.
- **Judgment call:** the deferred review note suggested parsing the code in
  `fetchJobsRaw`. I parse it in the `JobsApiError` constructor instead — the body
  already flows in there, so the single throw site is unchanged and the parsing
  lives with the field it populates. Same observable result.
- Stacked on the cursor-pagination PR (its branch is the base) since
  `JobsApiError` / `isRejectedCursorError` only exist there; GitHub retargets to
  `main` once that merges.

## Verification

- `vitest run` on `fetchJobs.test.ts` + `assetsStore.test.ts`: 124 passed.
- eslint + oxfmt clean on the four changed files.
- Type-check introduces zero new errors (identical error count with the change
  stashed vs applied, against the base branch).
