### PR TITLE
fix: repoint remaining comfy.org 404 links to live pages

### DIFF
--- a/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
+++ b/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
@@ -108,7 +108,7 @@
         </ul>
 
         <div class="mt-4">
-          <a href="https://comfy.org/privacy" target="_blank">
+          <a href="https://comfy.org/privacy-policy" target="_blank">
             {{ $t('install.settings.dataCollectionDialog.viewFullPolicy') }}
           </a>
         </div>

--- a/apps/desktop-ui/src/views/MetricsConsentView.vue
+++ b/apps/desktop-ui/src/views/MetricsConsentView.vue
@@ -13,7 +13,7 @@
         <p class="text-neutral-400">
           {{ $t('install.moreInfo') }}
           <a
-            href="https://comfy.org/privacy"
+            href="https://comfy.org/privacy-policy"
             target="_blank"
             class="text-blue-400 underline hover:text-blue-300"
           >

--- a/browser_tests/tests/dialogs/signInDialog.spec.ts
+++ b/browser_tests/tests/dialogs/signInDialog.spec.ts
@@ -68,7 +68,7 @@ test.describe('Sign In dialog', { tag: '@ui' }, () => {
     await expect(dialog.privacyLink).toBeVisible()
     await expect(dialog.privacyLink).toHaveAttribute(
       'href',
-      'https://www.comfy.org/privacy'
+      'https://www.comfy.org/privacy-policy'
     )
   })
 

--- a/browser_tests/tests/helpCenter.spec.ts
+++ b/browser_tests/tests/helpCenter.spec.ts
@@ -77,15 +77,15 @@ test.describe('Help Center', () => {
       expect(url.pathname).toBe('/')
     })
 
-    test('Discord item opens comfy.org/discord in a new tab', async ({
+    test('Discord item opens the Discord invite in a new tab', async ({
       helpCenter
     }) => {
       const url = await waitForPopup(helpCenter.page, () =>
         helpCenter.menuItem('discord').click()
       )
 
-      expect(url.hostname).toBe('www.comfy.org')
-      expect(url.pathname).toBe('/discord')
+      expect(url.hostname).toBe('discord.com')
+      expect(url.pathname).toBe('/invite/comfyorg')
     })
 
     test('Github item opens the ComfyUI repo in a new tab', async ({

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -126,7 +126,7 @@
         </a>
         {{ t('auth.login.andText') }}
         <a
-          href="https://www.comfy.org/privacy"
+          href="https://www.comfy.org/privacy-policy"
           target="_blank"
           class="cursor-pointer text-blue-500"
         >

--- a/src/composables/useExternalLink.test.ts
+++ b/src/composables/useExternalLink.test.ts
@@ -42,7 +42,7 @@ describe('useExternalLink', () => {
       const { staticUrls } = useExternalLink()
 
       // Static URLs
-      expect(staticUrls.discord).toBe('https://www.comfy.org/discord')
+      expect(staticUrls.discord).toBe('https://discord.com/invite/comfyorg')
       expect(staticUrls.github).toBe('https://github.com/Comfy-Org/ComfyUI')
       expect(staticUrls.githubIssues).toBe(
         'https://github.com/Comfy-Org/ComfyUI/issues'

--- a/src/composables/useExternalLink.ts
+++ b/src/composables/useExternalLink.ts
@@ -84,7 +84,7 @@ export function useExternalLink() {
 
   const staticUrls = {
     // Static external URLs
-    discord: 'https://www.comfy.org/discord',
+    discord: 'https://discord.com/invite/comfyorg',
     github: 'https://github.com/Comfy-Org/ComfyUI',
     githubIssues: 'https://github.com/Comfy-Org/ComfyUI/issues',
     githubFrontend: 'https://github.com/Comfy-Org/ComfyUI_frontend',

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -482,7 +482,7 @@ describe('MembersPanelContent', () => {
         screen.getByText('workspacePanel.members.contactUs')
       )
       expect(openSpy).toHaveBeenCalledWith(
-        'https://www.comfy.org/discord',
+        'https://discord.com/invite/comfyorg',
         '_blank',
         'noopener,noreferrer'
       )


### PR DESCRIPTION
## Summary

Follow-up to #13777: repoints the remaining comfy.org 404 link targets it called out as out-of-scope (canonical Discord URL and privacy links).

## Changes

- **What**:
  - `useExternalLink.ts` `staticUrls.discord`: `www.comfy.org/discord` (404) → `discord.com/invite/comfyorg` (200). Consumers: help center Discord item, About panel badge, Members panel "Contact us", `Comfy.Help.OpenComfyOrgDiscord` menu command.
  - `SignInContent.vue` privacy link and desktop-ui `DesktopSettingsConfiguration.vue` / `MetricsConsentView.vue`: `comfy.org/privacy` (404) → `comfy.org/privacy-policy` (200), matching the cloud onboarding views.
  - Updated existing unit assertions (`useExternalLink.test.ts`, `MembersPanelContent.test.ts`) and e2e assertions (`helpCenter.spec.ts`, `signInDialog.spec.ts`).

## Review Focus

- URL targets verified via curl: `comfy.org/discord`, `comfy.org/terms`, `comfy.org/privacy` all 404; `discord.com/invite/comfyorg`, `comfy.org/privacy-policy`, `comfy.org/terms-of-service` all 200. The invite URL is the same one `apps/website` uses in its own footer (`src/config/routes.ts`).
- Website-side redirects for the old paths exist as separate open PRs (#12684 `/discord`, #12415 `/privacy`); this PR fixes the frontend regardless of when those land.

QA source: Denys FE-1.47 findings (Cloud #8, #9).

https://claude.ai/code/session_01DYVWQGmLzKUoHhMVzUVpVM
