### PR TITLE
fix: use destructive token for Delete Workspace menu items

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
@@ -66,7 +66,9 @@ const menuItems = computed<MenuItem[]>(() => {
     items.push({
       label: t('workspacePanel.menu.deleteWorkspace'),
       icon: 'pi pi-trash',
-      class: isDeleteDisabled.value ? 'text-danger/50' : 'text-danger',
+      class: isDeleteDisabled.value
+        ? 'text-destructive-background/50'
+        : 'text-destructive-background',
       disabled: isDeleteDisabled.value,
       tooltip: deleteTooltip.value,
       command: isDeleteDisabled.value

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -92,8 +92,8 @@ export function useWorkspaceMenuItems() {
       items.push({
         label: t('workspacePanel.menu.deleteWorkspace'),
         class: isDeleteDisabled.value
-          ? 'data-disabled:cursor-not-allowed data-disabled:text-danger/50 data-disabled:pointer-events-auto'
-          : 'text-danger',
+          ? 'data-disabled:cursor-not-allowed data-disabled:text-destructive-background/50 data-disabled:pointer-events-auto'
+          : 'text-destructive-background',
         disabled: isDeleteDisabled.value,
         tooltip: deleteTooltip.value,
         command: isDeleteDisabled.value ? undefined : deleteWorkspace


### PR DESCRIPTION
## Summary

The "Delete Workspace" items in both workspace overflow menus (Plan & Credits and the Members-panel workspace menu) render in the default foreground instead of red.

## Changes

- **What**: `text-danger` is a dead utility — the design system defines only `--color-danger-100`/`--color-danger-200`, no bare `--color-danger`, so Tailwind 4 generates no CSS for `text-danger` (confirmed against the compiled dev bundle: `.text-danger-100`/`.text-danger-200` exist, bare `.text-danger` does not). Repointed both Delete Workspace items (enabled + disabled/50 states) to `text-destructive-background`, the `semantic/destructive/background` token.

## Screenshots

Same menu (workspace ⋯ overflow), rendered in Storybook with each class:

| AS IS (`text-danger`, no-op) | TO BE (`text-destructive-background`) |
|---|---|
| ![as-is](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/qa147-13784/as-is.png) | ![to-be](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/qa147-13784/to-be.png) |

## Review Focus

- 9 other `text-danger` usages remain in `src/` (invite-form validation text, survey errors, etc.) and are equally no-op — left out of scope here since each needs its own token decision.

QA source: Denys FE-1.47 findings (Cloud #11).

https://claude.ai/code/session_01DYVWQGmLzKUoHhMVzUVpVM
