### PR TITLE
fix: derive Plan & Credits plan identity from the plan, not the workspace type

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -585,6 +585,24 @@ describe('useBillingContext', () => {
       expect(isTeamPlan.value).toBe(true)
     })
 
+    it('is true for a per-credit Team plan in a personal workspace before its credit stop is populated', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockBillingControlEnabled.value = true
+      mockIsPersonal.value = true
+      mockBillingStatus.value = {
+        is_active: true,
+        has_funds: true,
+        subscription_status: 'active',
+        subscription_duration: 'ANNUAL',
+        plan_slug: 'team_per_credit_annual'
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
     it('is true for a legacy team sub, identified by slug rather than credit stop', async () => {
       mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -30,6 +30,15 @@ import { useWorkspaceBilling } from '@/platform/workspace/composables/useWorkspa
 // carries a team_credit_stop. The hyphen prefix alone separates the two, so a
 // new sub is never misrouted even before its credit stop is populated.
 const LEGACY_TEAM_PLAN_SLUG_PREFIX = 'team-'
+const PER_CREDIT_TEAM_PLAN_SLUG_PREFIX = 'team_per_credit_'
+
+function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
+  const normalizedSlug = planSlug?.toLowerCase()
+  return (
+    normalizedSlug?.startsWith(LEGACY_TEAM_PLAN_SLUG_PREFIX) === true ||
+    normalizedSlug?.startsWith(PER_CREDIT_TEAM_PLAN_SLUG_PREFIX) === true
+  )
+}
 
 /**
  * Unified billing context that selects the billing implementation by build/flag.
@@ -161,10 +170,7 @@ function useBillingContextInternal(): BillingContext {
     () =>
       type.value === 'workspace' &&
       (currentTeamCreditStop.value !== null ||
-        (currentPlanSlug.value
-          ?.toLowerCase()
-          .startsWith(LEGACY_TEAM_PLAN_SLUG_PREFIX) ??
-          false))
+        isTeamPlanSlug(currentPlanSlug.value))
   )
 
   const billingStatus = computed(() =>

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -105,19 +105,31 @@ const personalUiConfig: MenuUiConfig = {
 }
 const mockUiConfig = ref<MenuUiConfig>(ownerUiConfig)
 
+const mockSubscriptionTier = ref<SubscriptionInfo['tier']>('PRO')
+const mockPlanSlug = ref('team-monthly')
+
 const mockSubscription = computed<SubscriptionInfo | null>(() =>
   mockHasSubscription.value
     ? {
         isActive: true,
-        tier: 'PRO',
+        tier: mockSubscriptionTier.value,
         duration: mockSubscriptionDuration.value,
-        planSlug: 'team-monthly',
+        planSlug: mockPlanSlug.value,
         renewalDate: RENEWAL_DATE_ISO,
         endDate: END_DATE_ISO,
         isCancelled: mockSubscriptionStatus.value === 'canceled',
         hasFunds: true
       }
     : null
+)
+
+// Mirrors useBillingContext's plan-identity derivation: a credit stop or a
+// legacy `team-` slug marks a team plan.
+const mockIsTeamPlan = computed(
+  () =>
+    !mockIsInPersonalWorkspace.value &&
+    (mockCurrentTeamCreditStop.value !== null ||
+      (mockSubscription.value?.planSlug?.startsWith('team-') ?? false))
 )
 
 const mockInitialize = vi.fn()
@@ -128,6 +140,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
+    isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     teamCreditStops: mockTeamCreditStops,
     currentTeamCreditStop: mockCurrentTeamCreditStop,
@@ -284,6 +297,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ]
     mockUserEmail.value = 'me@example.com'
     mockUiConfig.value = ownerUiConfig
+    mockSubscriptionTier.value = 'PRO'
+    mockPlanSlug.value = 'team-monthly'
     mockSubscriptionDuration.value = 'MONTHLY'
     mockTeamCreditStops.value = teamCreditStops
     mockCurrentTeamCreditStop.value = {
@@ -554,6 +569,23 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Leave Workspace' })
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the personal plan identity when a team workspace holds a personal subscription', () => {
+    mockSubscriptionTier.value = 'STANDARD'
+    mockPlanSlug.value = 'standard-annual'
+    mockSubscriptionDuration.value = 'ANNUAL'
+    mockCurrentTeamCreditStop.value = null
+    renderComponent()
+
+    expect(screen.getByText('Standard Yearly')).toBeInTheDocument()
+    expect(screen.queryByText('Team')).not.toBeInTheDocument()
+    // Standard yearly per-month price, without the per-member team unit.
+    expect(screen.getByText('$16')).toBeInTheDocument()
+    expect(screen.getByText('USD / mo')).toBeInTheDocument()
+    expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
+    expect(screen.getByText('RTX 6000 Pro (96GB VRAM)')).toBeInTheDocument()
+    expect(screen.queryByText('Invite members')).not.toBeInTheDocument()
   })
 
   it('lists the four team perks under the Pro-inclusive heading', () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -107,6 +107,7 @@ const mockUiConfig = ref<MenuUiConfig>(ownerUiConfig)
 
 const mockSubscriptionTier = ref<SubscriptionInfo['tier']>('PRO')
 const mockPlanSlug = ref('team-monthly')
+const mockHasTeamPlan = ref(true)
 
 const mockSubscription = computed<SubscriptionInfo | null>(() =>
   mockHasSubscription.value
@@ -122,14 +123,8 @@ const mockSubscription = computed<SubscriptionInfo | null>(() =>
       }
     : null
 )
-
-// Mirrors useBillingContext's plan-identity derivation: a credit stop or a
-// legacy `team-` slug marks a team plan.
 const mockIsTeamPlan = computed(
-  () =>
-    !mockIsInPersonalWorkspace.value &&
-    (mockCurrentTeamCreditStop.value !== null ||
-      (mockSubscription.value?.planSlug?.startsWith('team-') ?? false))
+  () => mockHasSubscription.value && mockHasTeamPlan.value
 )
 
 const mockInitialize = vi.fn()
@@ -299,6 +294,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
     mockPlanSlug.value = 'team-monthly'
+    mockHasTeamPlan.value = true
     mockSubscriptionDuration.value = 'MONTHLY'
     mockTeamCreditStops.value = teamCreditStops
     mockCurrentTeamCreditStop.value = {
@@ -574,18 +570,35 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('shows the personal plan identity when a team workspace holds a personal subscription', () => {
     mockSubscriptionTier.value = 'STANDARD'
     mockPlanSlug.value = 'standard-annual'
+    mockHasTeamPlan.value = false
     mockSubscriptionDuration.value = 'ANNUAL'
     mockCurrentTeamCreditStop.value = null
     renderComponent()
 
     expect(screen.getByText('Standard Yearly')).toBeInTheDocument()
     expect(screen.queryByText('Team')).not.toBeInTheDocument()
-    // Standard yearly per-month price, without the per-member team unit.
     expect(screen.getByText('$16')).toBeInTheDocument()
     expect(screen.getByText('USD / mo')).toBeInTheDocument()
     expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
     expect(screen.getByText('RTX 6000 Pro (96GB VRAM)')).toBeInTheDocument()
     expect(screen.queryByText('Invite members')).not.toBeInTheDocument()
+  })
+
+  it('shows the Team plan identity when a personal workspace holds a Team subscription', () => {
+    mockIsInPersonalWorkspace.value = true
+    renderComponent()
+
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Pro' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('$665')).toBeInTheDocument()
+    expect(screen.getByText('USD / mo')).toBeInTheDocument()
+    expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
+    expect(screen.getByText('Invite members')).toBeInTheDocument()
+    expect(
+      screen.queryByText('RTX 6000 Pro (96GB VRAM)')
+    ).not.toBeInTheDocument()
   })
 
   it('lists the four team perks under the Pro-inclusive heading', () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -344,6 +344,7 @@ const isSettingUp = computed(() => billingOperationStore.isSettingUp)
 const {
   isActiveSubscription,
   isFreeTier: isFreeTierPlan,
+  isTeamPlan,
   subscription,
   isLoading,
   error,
@@ -376,7 +377,7 @@ const isPersonalFree = computed(
 )
 
 const isTeamActive = computed(
-  () => !isInPersonalWorkspace.value && isActiveSubscription.value
+  () => isTeamPlan.value && isActiveSubscription.value
 )
 
 const isMemberView = computed(
@@ -440,9 +441,7 @@ const subscriptionTierName = computed(() => {
 })
 
 const planDisplayName = computed(() =>
-  isInPersonalWorkspace.value
-    ? subscriptionTierName.value
-    : t('subscription.teamPlanName')
+  isTeamPlan.value ? t('subscription.teamPlanName') : subscriptionTierName.value
 )
 
 const tierKey = computed(() => {

--- a/src/platform/workspace/composables/useWorkspacePlanPricing.ts
+++ b/src/platform/workspace/composables/useWorkspacePlanPricing.ts
@@ -1,4 +1,3 @@
-import { storeToRefs } from 'pinia'
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -8,7 +7,6 @@ import {
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { formatUsdCents } from '@/utils/numberUtil'
 
 /**
@@ -24,8 +22,7 @@ import { formatUsdCents } from '@/utils/numberUtil'
  */
 export function useWorkspacePlanPricing() {
   const { t, locale } = useI18n()
-  const { isInPersonalWorkspace } = storeToRefs(useTeamWorkspaceStore())
-  const { subscription, teamCreditStops, currentTeamCreditStop } =
+  const { subscription, teamCreditStops, currentTeamCreditStop, isTeamPlan } =
     useBillingContext()
 
   const isYearly = computed(() => subscription.value?.duration === 'ANNUAL')
@@ -39,7 +36,7 @@ export function useWorkspacePlanPricing() {
   })
 
   const subscribedStop = computed(() => {
-    if (isInPersonalWorkspace.value) return null
+    if (!isTeamPlan.value) return null
     const id = currentTeamCreditStop.value?.id
     const stops = teamCreditStops.value?.stops
     if (!id || !stops) return null
@@ -48,7 +45,6 @@ export function useWorkspacePlanPricing() {
 
   const hasStaleCreditStop = computed(
     () =>
-      !isInPersonalWorkspace.value &&
       !!currentTeamCreditStop.value &&
       !!teamCreditStops.value &&
       subscribedStop.value === null
@@ -68,7 +64,7 @@ export function useWorkspacePlanPricing() {
   })
 
   const priceUnitLabel = computed(() =>
-    teamMonthlyCostCents.value !== null || isInPersonalWorkspace.value
+    teamMonthlyCostCents.value !== null || !isTeamPlan.value
       ? t('subscription.usdPerMonth')
       : t('subscription.usdPerMonthPerMember')
   )


### PR DESCRIPTION
## Symptom

Settings → Workspace → Plan & Credits used the selected workspace type as the displayed plan identity.

- A personal workspace with an active Team subscription still displayed the personal `Pro` plan, personal pricing, and personal benefits.
- The reciprocal case was also incorrect: a team workspace with a personal subscription displayed the Team identity.
- Immediately after a Personal → Team upgrade, the panel could continue to show the personal plan until `team_credit_stop` was populated.

Expected behavior: the panel must always display the user's current subscription plan, regardless of whether the selected workspace is personal or team. Workspace type and subscription plan are independent.

## Cause

`SubscriptionPanelContentWorkspace` and `useWorkspacePlanPricing` used `isInPersonalWorkspace` as a proxy for subscription identity. That assumption is invalid for cross-workspace combinations, so the plan name, price unit, and benefits could all come from the workspace type instead of the active subscription.

`isTeamPlan` also relied on `team_credit_stop` for current `team_per_credit_*` subscriptions. Because that field can be populated after the plan slug, the subscription could temporarily be misclassified during provisioning.

## Fix

- Derive the plan name, price and unit, and benefits from the subscription-derived `isTeamPlan` state.
- Treat `team_per_credit_*` slugs as Team plans even when `team_credit_stop` has not been populated yet.
- Keep workspace type limited to workspace-specific behavior.
- Add regression coverage for both combinations and the provisioning transition:
  - Personal workspace + Team subscription → Team plan
  - Team workspace + personal subscription → subscribed personal tier
  - Personal workspace + `team_per_credit_*` Team subscription with no credit stop yet → Team plan

This change does not modify `billing_control_enabled`, billing routing, or feature gating.

## Result

- Personal workspace + Team subscription now displays the Team identity, Team price, and Team benefits.
- Team workspace + personal subscription now displays the subscribed personal tier, its price unit, and its benefits.
- Newly upgraded `team_per_credit_*` subscriptions are identified as Team as soon as the plan slug is available, before the credit stop resolves.
- Workspace membership, permissions, and subscription state mutations are unchanged.

### RED / GREEN

| State | Revision | Result |
| --- | --- | --- |
| RED | [`509a4e4`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/509a4e423d051abf82c0e601f6903f9a8233bb03) with the new regression test applied | Fails because the Team heading is missing; the same personal workspace + Team subscription renders `Pro / $100` and personal benefits. |
| GREEN | [`6d73a02`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/6d73a02ed6d9150a3bef033c20b8ceaa9ce1c94d) | The regression test passes, and the reciprocal team workspace + personal subscription case remains covered. |
| RED — provisioning lag | [`f078477`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/f0784776d2d058449a184c6030e72f9651600c80) | Fails because `team_per_credit_annual` is not recognized as Team until `team_credit_stop` is populated. |
| GREEN — provisioning lag | [`92790d6`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/92790d6110e44d49e97dd243a5a0703d4fbab9ae) | The regression test passes; Team identity is derived from the plan slug during credit-stop provisioning. |

### AS IS / TO BE

Both captures use the same mocked personal workspace, active Team subscription, credits, renewal date, theme, and viewport.

| AS IS — `509a4e4` | TO BE — `6d73a02` |
| --- | --- |
| ![AS IS — personal workspace incorrectly displays Pro](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/qa147-13784/qa147-13785-personal-workspace-team-plan-as-is.png) | ![TO BE — personal workspace correctly displays Team](https://raw.githubusercontent.com/dante01yoon/ComfyUI_frontend/assets/qa147-13784/qa147-13785-personal-workspace-team-plan-to-be.png) |
| Workspace type incorrectly overrides the subscription identity. | Displayed identity comes from the current subscription state. |

### Validation

- Component tests: 24 passed, including both cross-workspace plan combinations.
- Billing-context tests: 39 passed, including a personal workspace with a `team_per_credit_*` plan before `team_credit_stop` is populated.
- Focused billing/workspace regression suite: 88 passed.
- `pnpm typecheck`, `pnpm lint`, `pnpm knip`, and full-repository `pnpm format:check` passed.
- A committed browser test is not practical for this presentation-only mapping because it would need to restub unrelated cloud boot, auth, workspace, and billing endpoints and would primarily test mocks. The component test directly exercises both relevant combinations; a temporary Playwright harness was used only to capture the identical AS IS / TO BE states above.

QA source: [FE-1.47 staging findings](https://app.notion.com/p/comfy-org/Findings-FE-1-47-testing-on-stagingcloud-and-local-Denys-39e6d73d365080578d89f00753548b46?source=copy_link)
