### PR TITLE
fix: render nested dropdown menus above modal overlays

### DIFF
--- a/src/components/common/DropdownItem.vue
+++ b/src/components/common/DropdownItem.vue
@@ -10,6 +10,7 @@ import {
 } from 'reka-ui'
 import { useI18n } from 'vue-i18n'
 import { toValue } from 'vue'
+import type { StyleValue } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -19,7 +20,12 @@ defineOptions({
   inheritAttrs: false
 })
 
-defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
+defineProps<{
+  itemClass: string
+  contentClass: string
+  contentStyle?: StyleValue
+  item: MenuItem
+}>()
 </script>
 <template>
   <DropdownMenuSeparator
@@ -37,6 +43,7 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
     <DropdownMenuPortal>
       <DropdownMenuSubContent
         :class="contentClass"
+        :style="contentStyle"
         :side-offset="2"
         :align-offset="-5"
       >
@@ -46,6 +53,7 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
           :item="subitem"
           :item-class
           :content-class
+          :content-style
         />
       </DropdownMenuSubContent>
     </DropdownMenuPortal>

--- a/src/components/common/DropdownMenu.vue
+++ b/src/components/common/DropdownMenu.vue
@@ -72,6 +72,7 @@ const contentStyle = useModalLiftedZIndex(open)
             :key="toValue(item.label) ?? index"
             :item-class
             :content-class
+            :content-style
             :item
           />
         </slot>

--- a/src/components/common/DropdownMenu.zindex.test.ts
+++ b/src/components/common/DropdownMenu.zindex.test.ts
@@ -1,7 +1,8 @@
 import { ZIndex } from '@primeuix/utils/zindex'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import type { MenuItem } from 'primevue/menuitem'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
@@ -14,9 +15,9 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function renderMenu() {
+function renderMenu(entries: MenuItem[] = [{ label: 'Item A' }]) {
   return render(DropdownMenu, {
-    props: { entries: [{ label: 'Item A' }] },
+    props: { entries },
     global: { plugins: [i18n], directives: { tooltip: {} } }
   })
 }
@@ -52,5 +53,33 @@ describe('DropdownMenu z-index', () => {
     const menu = await screen.findByRole('menu')
     expect(menu.style.zIndex).toBe('')
     expect(menu.className).toContain('z-1700')
+  })
+
+  it('opens a nested menu above a registered dialog', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    const dialogZ = Number(openModal.style.zIndex)
+    const command = vi.fn()
+    const user = userEvent.setup()
+    renderMenu([
+      {
+        label: 'Change role',
+        items: [
+          { label: 'Owner', command },
+          { label: 'Member', command }
+        ]
+      }
+    ])
+
+    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('menuitem', { name: 'Change role' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Owner' })).toBeVisible()
+    expect(screen.getByRole('menuitem', { name: 'Member' })).toBeVisible()
+    const submenu = screen
+      .getAllByRole('menu')
+      .find((menu) => within(menu).queryByRole('menuitem', { name: 'Owner' }))
+    expect(submenu).toBeDefined()
+    expect(Number(submenu?.style.zIndex)).toBeGreaterThan(dialogZ)
   })
 })


### PR DESCRIPTION
## Summary

Propagate the shared dropdown's modal-aware z-index to nested submenu portals so Settings → Workspace → Members → Change role renders above the dimmed overlay.

## Changes

- **What**: Pass `contentStyle` through recursive `DropdownItem` instances, apply it to every `DropdownMenuSubContent`, and add regression coverage for a nested menu opened over an active modal.

## AS IS / TO BE

Rendered Cloud app at 1404 × 902 with identical four-member workspace data.

### AS IS

At `af68bb13b2`, the Owner / Member submenu is portaled below the Settings modal and is hidden behind the dimmed layer.

![AS IS - role submenu hidden behind the Settings modal](https://github.com/user-attachments/assets/2a70223c-4f7b-4072-ae55-042e47a263ed)

### TO BE

At `f03d77fed4`, the same submenu inherits the modal-aware stacking value and renders above the overlay.

![TO BE - role submenu rendered above the Settings modal](https://github.com/user-attachments/assets/2c1cc255-1b1d-4bd2-a748-7fc284fb1260)

## Review Focus

- Root and nested body portals share the same modal-aware stacking value while menus outside dialogs keep the existing static `z-1700` behavior.
- Reka UI portal, collision-flip, keyboard, and pointer behavior remain unchanged.
- QA finding: https://app.notion.com/p/comfy-org/Findings-FE-1-47-testing-on-stagingcloud-and-local-Denys-39e6d73d365080578d89f00753548b46?source=copy_link
- Design: https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=3067-9962&m=dev

Validation:
- `pnpm test:unit src/components/common/DropdownMenu.zindex.test.ts`
- `pnpm test:browser:local browser_tests/tests/dialogs/memberRoleChange.spec.ts --project=cloud`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`