### PR TITLE
feat: rescan missing models when refreshing node definitions

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -6,6 +6,7 @@ import { useCoreCommands } from '@/composables/useCoreCommands'
 import { useExternalLink } from '@/composables/useExternalLink'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type * as DistributionModule from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -78,6 +79,23 @@ vi.mock('@/stores/modelStore', async (importOriginal) => {
     useModelStore: () => ({ refresh: mockModelStoreRefresh })
   }
 })
+
+const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
+vi.mock('@/platform/distribution/types', async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionModule>()),
+  get isCloud() {
+    return mockDistributionState.isCloud
+  }
+}))
+
+const mockMissingModelStoreRefresh = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+)
+vi.mock('@/platform/missingModel/missingModelStore', () => ({
+  useMissingModelStore: () => ({
+    refreshMissingModels: mockMissingModelStoreRefresh
+  })
+}))
 
 vi.mock('@/platform/settings/settingStore')
 
@@ -292,6 +310,10 @@ describe('useCoreCommands', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockDistributionState.isCloud = false
+    vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
+    mockModelStoreRefresh.mockResolvedValue(undefined)
+    mockMissingModelStoreRefresh.mockResolvedValue(undefined)
 
     // Set up Pinia
     setActivePinia(createPinia())
@@ -587,11 +609,56 @@ describe('useCoreCommands', () => {
       expect(app.openClipspace).toHaveBeenCalled()
     })
 
-    it('Comfy.RefreshNodeDefinitions refreshes combos and the model library', async () => {
+    it('Comfy.RefreshNodeDefinitions rescans missing models after refreshing combos', async () => {
+      const order: string[] = []
+      let resolveComboRefresh: () => void = () => {}
+      vi.mocked(app.refreshComboInNodes).mockImplementation(async () => {
+        order.push('combo:start')
+        await new Promise<void>((resolve) => {
+          resolveComboRefresh = resolve
+        })
+        order.push('combo:end')
+      })
+      mockModelStoreRefresh.mockImplementation(async () => {
+        order.push('models')
+      })
+      mockMissingModelStoreRefresh.mockImplementation(async () => {
+        order.push('missing')
+      })
+
+      const commandPromise = findCmd('Comfy.RefreshNodeDefinitions').function()
+
+      expect(mockMissingModelStoreRefresh).not.toHaveBeenCalled()
+      resolveComboRefresh()
+      await commandPromise
+
+      expect(app.refreshComboInNodes).toHaveBeenCalled()
+      expect(mockModelStoreRefresh).toHaveBeenCalled()
+      expect(mockMissingModelStoreRefresh).toHaveBeenCalledWith({
+        reloadDefs: false
+      })
+      expect(order.indexOf('missing')).toBeGreaterThan(
+        order.indexOf('combo:end')
+      )
+    })
+
+    it('Comfy.RefreshNodeDefinitions skips the rescan when combo refresh fails', async () => {
+      vi.mocked(app.refreshComboInNodes).mockRejectedValue(new Error('boom'))
+
+      await expect(
+        findCmd('Comfy.RefreshNodeDefinitions').function()
+      ).rejects.toThrow('boom')
+      expect(mockMissingModelStoreRefresh).not.toHaveBeenCalled()
+    })
+
+    it('Comfy.RefreshNodeDefinitions skips missing model refresh on cloud', async () => {
+      mockDistributionState.isCloud = true
+
       await findCmd('Comfy.RefreshNodeDefinitions').function()
 
       expect(app.refreshComboInNodes).toHaveBeenCalled()
       expect(mockModelStoreRefresh).toHaveBeenCalled()
+      expect(mockMissingModelStoreRefresh).not.toHaveBeenCalled()
     })
   })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -22,6 +22,8 @@ import {
 import type { Point } from '@/lib/litegraph/src/litegraph'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import { isCloud } from '@/platform/distribution/types'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { buildSupportUrl } from '@/platform/support/config'
 import { useTelemetry } from '@/platform/telemetry'
@@ -85,6 +87,7 @@ export function useCoreCommands(): ComfyCommand[] {
   const canvasStore = useCanvasStore()
   const executionStore = useExecutionStore()
   const modelStore = useModelStore()
+  const missingModelStore = useMissingModelStore()
   const telemetry = useTelemetry()
   const { trackRunButton } = useRunButtonTelemetry()
   const { staticUrls, buildDocsUrl } = useExternalLink()
@@ -311,6 +314,9 @@ export function useCoreCommands(): ComfyCommand[] {
       category: 'essentials' as const,
       function: async () => {
         await Promise.all([app.refreshComboInNodes(), modelStore.refresh()])
+        if (!isCloud) {
+          await missingModelStore.refreshMissingModels({ reloadDefs: false })
+        }
       }
     },
     {

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -201,21 +201,39 @@ describe('missingModelPipeline', () => {
     it('reloads node definitions before scanning the current graph', async () => {
       const order: string[] = []
       const graph = createGraph()
+      let resolveReload: () => void = () => {}
       const reloadNodeDefs = vi.fn(async () => {
-        order.push('reload')
+        order.push('reload:start')
+        await new Promise<void>((resolve) => {
+          resolveReload = resolve
+        })
+        order.push('reload:end')
       })
       mockHandles.scanAllModelCandidates.mockImplementation(() => {
         order.push('scan')
         return []
       })
 
-      await refreshMissingModelPipeline({
+      const refreshPromise = refreshMissingModelPipeline({
         graph,
         reloadNodeDefs,
         missingModelStore: mockHandles.missingModelStore
       })
 
-      expect(order).toEqual(['reload', 'scan'])
+      expect(order).toEqual(['reload:start'])
+      resolveReload()
+      await refreshPromise
+
+      expect(order).toEqual(['reload:start', 'reload:end', 'scan'])
+    })
+
+    it('scans the current graph when node definition reload is omitted', async () => {
+      await refreshMissingModelPipeline({
+        graph: createGraph(),
+        missingModelStore: mockHandles.missingModelStore
+      })
+
+      expect(mockHandles.scanAllModelCandidates).toHaveBeenCalled()
     })
 
     it('reuses active workflow model metadata when refreshing the current graph', async () => {

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -45,7 +45,7 @@ interface RunMissingModelPipelineOptions {
 
 interface RefreshMissingModelPipelineOptions {
   graph: LGraph
-  reloadNodeDefs: () => Promise<void>
+  reloadNodeDefs?: () => Promise<void>
   missingModelStore: MissingModelPipelineStore
   silent?: boolean
 }
@@ -228,7 +228,7 @@ export async function refreshMissingModelPipeline({
   missingModelStore,
   silent = true
 }: RefreshMissingModelPipelineOptions): Promise<MissingModelPipelineResult> {
-  await reloadNodeDefs()
+  await reloadNodeDefs?.()
   const graphData: MissingModelWorkflowData = graph.serialize()
   const activeWorkflowState =
     useWorkspaceStore().workflow.activeWorkflow?.activeState

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -112,6 +112,24 @@ describe('missingModelStore', () => {
       expect(store.isRefreshingMissingModels).toBe(false)
     })
 
+    it('forwards the node definition reload option to the app', async () => {
+      const store = useMissingModelStore()
+      const refreshSpy = vi
+        .spyOn(app, 'refreshMissingModels')
+        .mockResolvedValue({
+          missingModels: [],
+          confirmedCandidates: []
+        })
+
+      await store.refreshMissingModels({ reloadDefs: false })
+
+      expect(refreshSpy).toHaveBeenCalledWith({
+        silent: true,
+        reloadDefs: false
+      })
+      expect(store.isRefreshingMissingModels).toBe(false)
+    })
+
     it('ignores overlapping refresh requests', async () => {
       const store = useMissingModelStore()
       let resolveRefresh: () => void = () => {}

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -260,12 +260,15 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     return error instanceof Error && error.name === 'AbortError'
   }
 
-  async function refreshMissingModels() {
+  async function refreshMissingModels(options: { reloadDefs?: boolean } = {}) {
     if (isRefreshingMissingModels.value) return
 
     isRefreshingMissingModels.value = true
     try {
-      await app.refreshMissingModels({ silent: true })
+      await app.refreshMissingModels({
+        silent: true,
+        reloadDefs: options.reloadDefs
+      })
     } catch (error) {
       if (isAbortError(error)) return
 

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -382,6 +382,29 @@ describe('ComfyApp', () => {
       await mockRefreshMissingModelPipeline.mock.calls[0][0].reloadNodeDefs()
       expect(app.reloadNodeDefs).toHaveBeenCalled()
     })
+
+    it('omits the node definition reload when reloadDefs is false', async () => {
+      const graph = {
+        nodes: [],
+        serialize: vi.fn(() => createWorkflowGraphData())
+      }
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.spyOn(app, 'reloadNodeDefs').mockResolvedValue()
+      mockRefreshMissingModelPipeline.mockResolvedValue({
+        missingModels: [],
+        confirmedCandidates: []
+      })
+
+      await app.refreshMissingModels({ reloadDefs: false })
+
+      expect(mockRefreshMissingModelPipeline).toHaveBeenCalledWith({
+        graph,
+        reloadNodeDefs: undefined,
+        missingModelStore: useMissingModelStore(),
+        silent: true
+      })
+      expect(app.reloadNodeDefs).not.toHaveBeenCalled()
+    })
   })
 
   describe('handleFileList', () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1528,11 +1528,12 @@ export class ComfyApp {
   }
 
   async refreshMissingModels(
-    options: { silent?: boolean } = {}
+    options: { silent?: boolean; reloadDefs?: boolean } = {}
   ): Promise<MissingModelPipelineResult> {
     return refreshMissingModelPipeline({
       graph: this.rootGraph,
-      reloadNodeDefs: () => this.reloadNodeDefs(),
+      reloadNodeDefs:
+        options.reloadDefs === false ? undefined : () => this.reloadNodeDefs(),
       missingModelStore: useMissingModelStore(),
       silent: options.silent ?? true
     })


### PR DESCRIPTION
## Summary

Make the `Comfy.RefreshNodeDefinitions` command ('r' key, Node Library refresh button, Manager apply-changes) re-run missing-model detection after reloading node definitions, so resolved models clear their error state without extra steps.

## Changes

- **What**: On local OSS, missing-model re-detection currently only runs on workflow load or via the right-side-panel Refresh button — after installing a model, pressing 'r' refreshes combo options but the stale missing-model error group persists until the user finds the panel button or reloads the page. The command now runs the missing-model rescan sequentially after the definition reload completes (ordering matters: the scan's missing/resolved verdict reads the freshly reloaded combo options).
  - `refreshMissingModelPipeline` gains an optional `reloadNodeDefs` callback, and `app.refreshMissingModels` / `missingModelStore.refreshMissingModels` accept `reloadDefs: false` to skip the pipeline's internal definition reload — the command path already reloaded defs via `refreshComboInNodes()`, so this avoids fetching `/object_info` twice.
  - The rescan reuses the store's `isRefreshingMissingModels` guard and error toast, and runs silently (no error overlay auto-open). The panel Refresh button path is behavior-preserving (`reloadDefs` defaults to reloading).
  - Cloud is excluded (`!isCloud`): cloud intentionally hides the manual missing-model refresh affordance and resolves candidates through async asset verification instead of combo options, so the rescan would add cost without benefit there.
- **Breaking**: None. `app.refreshMissingModels` is widened with an optional key; the default path is unchanged.

## Review Focus

- The command relies on `refreshComboInNodes()` internally delegating to `reloadNodeDefs()`; the `reloadDefs: false` skip is only correct while that holds.
- If a rescan is already in flight (panel button), a concurrent 'r' rescan is silently coalesced by the existing guard — same semantics as the panel button.

## Tests

- Command: rescan ordering (starts only after combo refresh resolves), cloud gate, combo-refresh rejection skips the rescan.
- App layer: `reloadDefs: false` maps to an omitted pipeline reload; default path still reloads.
- Pipeline: scan runs with the reload callback omitted; reload is awaited before scanning.
- Store: option forwarding and unchanged default/guard/toast behavior.

## Screenshots

https://github.com/user-attachments/assets/f01f6109-474e-4808-9ff9-a933e364994b


