### PR TITLE
test: mock workspace personal plan price

### DIFF
--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -1,12 +1,13 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { SubscriptionInfo } from '@/composables/billing/types'
 import enMessages from '@/locales/en/main.json'
+import * as tierPricing from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
   CurrentTeamCreditStop,
   TeamCreditStops
@@ -270,6 +271,10 @@ function renderComponent() {
 }
 
 describe('SubscriptionPanelContentWorkspace', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockSubscriptionStatus.value = 'active'
@@ -568,6 +573,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
   })
 
   it('shows the personal plan identity when a team workspace holds a personal subscription', () => {
+    const getTierPriceSpy = vi
+      .spyOn(tierPricing, 'getTierPrice')
+      .mockReturnValue(42)
     mockSubscriptionTier.value = 'STANDARD'
     mockPlanSlug.value = 'standard-annual'
     mockHasTeamPlan.value = false
@@ -577,6 +585,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
     expect(screen.getByText('Standard Yearly')).toBeInTheDocument()
     expect(screen.queryByText('Team')).not.toBeInTheDocument()
+    expect(getTierPriceSpy).toHaveBeenCalledWith('standard', true)
     expect(screen.getByText('$42')).toBeInTheDocument()
     expect(screen.getByText('USD / mo')).toBeInTheDocument()
     expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -577,7 +577,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
     expect(screen.getByText('Standard Yearly')).toBeInTheDocument()
     expect(screen.queryByText('Team')).not.toBeInTheDocument()
-    expect(screen.getByText('$16')).toBeInTheDocument()
+    expect(screen.getByText('$42')).toBeInTheDocument()
     expect(screen.getByText('USD / mo')).toBeInTheDocument()
     expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
     expect(screen.getByText('RTX 6000 Pro (96GB VRAM)')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Follow-up to #13785 addressing [this review comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13785#discussion_r3608846089): isolate the workspace plan identity regression test from the live tier price catalog.

## Symptom

The reciprocal workspace scenario asserted the catalog-backed `$16` value, so unrelated pricing changes could fail a plan-identity test.

## Cause

The test exercised `getTierPrice` without mocking it even though its purpose is to verify personal-plan identity and the non-member price label.

## Fix

- Mock `getTierPrice` with the sentinel value `42` for this scenario.
- Assert the component requests `('standard', true)` and renders `$42`.
- Restore spies after every test to prevent leakage.

## Result

The regression test now verifies the price lookup contract without depending on a catalog value. No production behavior changes.

## Red / Green

| Stage | Commit | Result |
| --- | --- | --- |
| RED | [`edf37f5`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/edf37f55331357025bc878c2b2f58291c22fde8f) | Failed because the unmocked catalog rendered `$16` instead of the sentinel `$42`. |
| GREEN | [`58420ef`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/58420efda277e33fb140bb0ec3df88d5d40bf0b8) | Passed after mocking and verifying the price lookup. |

## Validation

- `pnpm test:unit src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts` — 24 passed
- `pnpm typecheck`
- `pnpm lint` — 0 errors (44 existing warnings)
- `pnpm knip`
- `pnpm format:check`
- GitHub CI — 49 passed, 10 skipped, 0 failed

## Review Focus

Test-only follow-up; one test file changed.

## Screenshots

Not applicable; this PR changes no production UI behavior.
