### PR TITLE
[backport cloud/1.47] fix: derive Plan & Credits plan identity from the plan, not the workspace type

### DIFF
--- a/src/composables/billing/types.ts
+++ b/src/composables/billing/types.ts
@@ -112,6 +112,7 @@ export interface BillingContext extends BillingState, BillingActions {
    * (legacy) per-member tier plan, which keeps the old team pricing table.
    */
   isLegacyTeamPlan: ComputedRef<boolean>
+  isTeamPlan: ComputedRef<boolean>
   getMaxSeats: (tierKey: TierKey) => number
   canRunWorkflows: ComputedRef<boolean>
 }

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -555,4 +555,119 @@ describe('useBillingContext', () => {
       expect(isLegacyTeamPlan.value).toBe(true)
     })
   })
+
+  describe('isTeamPlan', () => {
+    it('is false for a personal workspace', () => {
+      const { isTeamPlan } = useBillingContext()
+      expect(isTeamPlan.value).toBe(false)
+    })
+
+    it('is true for a credit-slider team sub, which carries a credit stop', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsPersonal.value = false
+      mockBillingStatus.value = {
+        is_active: true,
+        has_funds: true,
+        plan_slug: 'team_per_credit_monthly',
+        team_credit_stop: {
+          id: 'team_700',
+          credits_monthly: 700,
+          stop_usd: 332
+        }
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
+    it('is true for a per-credit Team plan in a personal workspace before its credit stop is populated', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockConsolidatedBillingEnabled.value = true
+      mockIsPersonal.value = true
+      mockBillingStatus.value = {
+        is_active: true,
+        has_funds: true,
+        subscription_status: 'active',
+        subscription_duration: 'ANNUAL',
+        plan_slug: 'team_per_credit_annual'
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
+    it('is true for a legacy team sub, identified by slug rather than credit stop', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsPersonal.value = false
+      mockBillingStatus.value = {
+        is_active: true,
+        has_funds: true,
+        subscription_tier: 'STANDARD',
+        plan_slug: 'team-standard-annual'
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
+    it('stays true for an inactive per-credit Team plan', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsPersonal.value = false
+      mockBillingStatus.value = {
+        is_active: false,
+        has_funds: true,
+        billing_status: 'inactive',
+        plan_slug: 'team_per_credit_monthly',
+        team_credit_stop: {
+          id: 'team_700',
+          credits_monthly: 700,
+          stop_usd: 332
+        }
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
+    it('stays true for a legacy team plan whose payment failed', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsPersonal.value = false
+      mockBillingStatus.value = {
+        is_active: false,
+        has_funds: true,
+        billing_status: 'payment_failed',
+        subscription_tier: 'STANDARD',
+        plan_slug: 'team-standard-annual'
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(true)
+    })
+
+    it('is false for a team workspace on a personal-tier plan', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsPersonal.value = false
+      mockBillingStatus.value = {
+        is_active: true,
+        has_funds: true,
+        subscription_tier: 'PRO',
+        plan_slug: 'pro-monthly'
+      }
+
+      const { initialize, isTeamPlan } = useBillingContext()
+      await initialize()
+
+      expect(isTeamPlan.value).toBe(false)
+    })
+  })
 })

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -30,6 +30,15 @@ import { useWorkspaceBilling } from '@/platform/workspace/composables/useWorkspa
 // carries a team_credit_stop. The hyphen prefix alone separates the two, so a
 // new sub is never misrouted even before its credit stop is populated.
 const LEGACY_TEAM_PLAN_SLUG_PREFIX = 'team-'
+const PER_CREDIT_TEAM_PLAN_SLUG_PREFIX = 'team_per_credit_'
+
+function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
+  const normalizedSlug = planSlug?.toLowerCase()
+  return (
+    normalizedSlug?.startsWith(LEGACY_TEAM_PLAN_SLUG_PREFIX) === true ||
+    normalizedSlug?.startsWith(PER_CREDIT_TEAM_PLAN_SLUG_PREFIX) === true
+  )
+}
 
 /**
  * Unified billing context that selects the billing implementation by build/flag.
@@ -150,6 +159,13 @@ function useBillingContextInternal(): BillingContext {
         ?.toLowerCase()
         .startsWith(LEGACY_TEAM_PLAN_SLUG_PREFIX) ??
         false)
+  )
+
+  const isTeamPlan = computed(
+    () =>
+      type.value === 'workspace' &&
+      (currentTeamCreditStop.value !== null ||
+        isTeamPlanSlug(currentPlanSlug.value))
   )
 
   const billingStatus = computed(() =>
@@ -311,6 +327,7 @@ function useBillingContextInternal(): BillingContext {
     canRunWorkflows,
     isFreeTier,
     isLegacyTeamPlan,
+    isTeamPlan,
     billingStatus,
     subscriptionStatus,
     tier,

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -105,19 +105,26 @@ const personalUiConfig: MenuUiConfig = {
 }
 const mockUiConfig = ref<MenuUiConfig>(ownerUiConfig)
 
+const mockSubscriptionTier = ref<SubscriptionInfo['tier']>('PRO')
+const mockPlanSlug = ref('team-monthly')
+const mockHasTeamPlan = ref(true)
+
 const mockSubscription = computed<SubscriptionInfo | null>(() =>
   mockHasSubscription.value
     ? {
         isActive: true,
-        tier: 'PRO',
+        tier: mockSubscriptionTier.value,
         duration: mockSubscriptionDuration.value,
-        planSlug: 'team-monthly',
+        planSlug: mockPlanSlug.value,
         renewalDate: RENEWAL_DATE_ISO,
         endDate: END_DATE_ISO,
         isCancelled: mockSubscriptionStatus.value === 'canceled',
         hasFunds: true
       }
     : null
+)
+const mockIsTeamPlan = computed(
+  () => mockHasSubscription.value && mockHasTeamPlan.value
 )
 
 const mockInitialize = vi.fn()
@@ -128,6 +135,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
+    isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     teamCreditStops: mockTeamCreditStops,
     currentTeamCreditStop: mockCurrentTeamCreditStop,
@@ -284,6 +292,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ]
     mockUserEmail.value = 'me@example.com'
     mockUiConfig.value = ownerUiConfig
+    mockSubscriptionTier.value = 'PRO'
+    mockPlanSlug.value = 'team-monthly'
+    mockHasTeamPlan.value = true
     mockSubscriptionDuration.value = 'MONTHLY'
     mockTeamCreditStops.value = teamCreditStops
     mockCurrentTeamCreditStop.value = {
@@ -553,6 +564,40 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).toBeDisabled()
     expect(
       screen.queryByRole('button', { name: 'Leave Workspace' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the personal plan identity when a team workspace holds a personal subscription', () => {
+    mockSubscriptionTier.value = 'STANDARD'
+    mockPlanSlug.value = 'standard-annual'
+    mockHasTeamPlan.value = false
+    mockSubscriptionDuration.value = 'ANNUAL'
+    mockCurrentTeamCreditStop.value = null
+    renderComponent()
+
+    expect(screen.getByText('Standard Yearly')).toBeInTheDocument()
+    expect(screen.queryByText('Team')).not.toBeInTheDocument()
+    expect(screen.getByText('$16')).toBeInTheDocument()
+    expect(screen.getByText('USD / mo')).toBeInTheDocument()
+    expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
+    expect(screen.getByText('RTX 6000 Pro (96GB VRAM)')).toBeInTheDocument()
+    expect(screen.queryByText('Invite members')).not.toBeInTheDocument()
+  })
+
+  it('shows the Team plan identity when a personal workspace holds a Team subscription', () => {
+    mockIsInPersonalWorkspace.value = true
+    renderComponent()
+
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Pro' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('$665')).toBeInTheDocument()
+    expect(screen.getByText('USD / mo')).toBeInTheDocument()
+    expect(screen.queryByText('USD / mo / member')).not.toBeInTheDocument()
+    expect(screen.getByText('Invite members')).toBeInTheDocument()
+    expect(
+      screen.queryByText('RTX 6000 Pro (96GB VRAM)')
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -344,6 +344,7 @@ const isSettingUp = computed(() => billingOperationStore.isSettingUp)
 const {
   isActiveSubscription,
   isFreeTier: isFreeTierPlan,
+  isTeamPlan,
   subscription,
   isLoading,
   error,
@@ -376,7 +377,7 @@ const isPersonalFree = computed(
 )
 
 const isTeamActive = computed(
-  () => !isInPersonalWorkspace.value && isActiveSubscription.value
+  () => isTeamPlan.value && isActiveSubscription.value
 )
 
 const isMemberView = computed(
@@ -440,9 +441,7 @@ const subscriptionTierName = computed(() => {
 })
 
 const planDisplayName = computed(() =>
-  isInPersonalWorkspace.value
-    ? subscriptionTierName.value
-    : t('subscription.teamPlanName')
+  isTeamPlan.value ? t('subscription.teamPlanName') : subscriptionTierName.value
 )
 
 const tierKey = computed(() => {

--- a/src/platform/workspace/composables/useWorkspacePlanPricing.ts
+++ b/src/platform/workspace/composables/useWorkspacePlanPricing.ts
@@ -1,4 +1,3 @@
-import { storeToRefs } from 'pinia'
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -8,7 +7,6 @@ import {
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { formatUsdCents } from '@/utils/numberUtil'
 
 /**
@@ -24,8 +22,7 @@ import { formatUsdCents } from '@/utils/numberUtil'
  */
 export function useWorkspacePlanPricing() {
   const { t, locale } = useI18n()
-  const { isInPersonalWorkspace } = storeToRefs(useTeamWorkspaceStore())
-  const { subscription, teamCreditStops, currentTeamCreditStop } =
+  const { subscription, teamCreditStops, currentTeamCreditStop, isTeamPlan } =
     useBillingContext()
 
   const isYearly = computed(() => subscription.value?.duration === 'ANNUAL')
@@ -39,7 +36,7 @@ export function useWorkspacePlanPricing() {
   })
 
   const subscribedStop = computed(() => {
-    if (isInPersonalWorkspace.value) return null
+    if (!isTeamPlan.value) return null
     const id = currentTeamCreditStop.value?.id
     const stops = teamCreditStops.value?.stops
     if (!id || !stops) return null
@@ -48,7 +45,6 @@ export function useWorkspacePlanPricing() {
 
   const hasStaleCreditStop = computed(
     () =>
-      !isInPersonalWorkspace.value &&
       !!currentTeamCreditStop.value &&
       !!teamCreditStops.value &&
       subscribedStop.value === null
@@ -68,7 +64,7 @@ export function useWorkspacePlanPricing() {
   })
 
   const priceUnitLabel = computed(() =>
-    teamMonthlyCostCents.value !== null || isInPersonalWorkspace.value
+    teamMonthlyCostCents.value !== null || !isTeamPlan.value
       ? t('subscription.usdPerMonth')
       : t('subscription.usdPerMonthPerMember')
   )

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -30,6 +30,7 @@ export function useBillingContext(): BillingContext {
     canRunWorkflows: computed(() => false),
     isFreeTier: computed(() => false),
     isLegacyTeamPlan: computed(() => false),
+    isTeamPlan: computed(() => false),
     billingStatus: computed(() => null),
     subscriptionStatus: computed(() => null),
     tier: computed(() => null),


### PR DESCRIPTION
## Summary

Backports #13785 to `cloud/1.47` after resolving the billing-context cherry-pick conflicts.

## Changes

- **What**: Preserves subscription-derived plan identity and adapts the required `isTeamPlan` contract to the release branch.

## Review Focus

Review the manual conflict resolution in the billing context, its type contract, Storybook mock, and behavioral tests.

Validation: 63 focused tests, typecheck, lint, format, and knip checks passed.