### PR TITLE
[backport cloud/1.45] style: use neutral credits info button

### DIFF
--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -110,17 +110,18 @@
         >
           <span class="flex items-center gap-1 text-text-primary">
             {{ $t('subscription.additionalCredits') }}
-            <button
+            <Button
               v-tooltip="{
                 value: $t('subscription.additionalCreditsTooltip'),
                 showDelay: 300
               }"
-              type="button"
+              variant="muted-textonly"
+              size="icon-sm"
               :aria-label="$t('subscription.additionalCreditsInfo')"
-              class="flex items-center text-muted"
+              class="text-muted"
             >
               <i class="icon-[lucide--info] size-4" />
-            </button>
+            </Button>
             <span
               v-if="isSpendingAdditional"
               class="flex h-3.5 items-center rounded-full bg-base-foreground px-1 text-2xs/none font-semibold text-base-background uppercase"


### PR DESCRIPTION
## Summary

Backports #13461, **style: use neutral credits info button**, to `cloud/1.45`.

Main already uses the shared neutral icon button for the Additional Credits tooltip. The release branch still rendered a native `<button>`, so browser-default background and padding appeared in Settings → Workspace → Plan & Credits.

## Changes

- Replace the native tooltip trigger with the shared `Button` using `muted-textonly` and `icon-sm`
- Preserve the existing tooltip and accessible label
- No dependencies

## Review Focus

Confirm this remains a visual-only change: the native button background is removed and the tooltip interaction is unchanged.

Before/after screenshots are available in the source PR: #13461.

## Testing

- `pnpm test:unit src/platform/cloud/subscription/components/CreditsTile.test.ts` (18 passed)
- `pnpm format:check src/platform/cloud/subscription/components/CreditsTile.vue`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
