### PR TITLE
1.47 bugfixes

### DIFF
--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -379,12 +379,14 @@ export function demotePromotedInput(
   )
   const linkedInput = hostInput?._subgraphSlot
   if (!linkedInput) return false
+  const hostWidgetId = hostInput.widgetId
 
   if (hostInput.link != null) {
     linkedInput.disconnect()
   } else {
     subgraphNode.subgraph.removeInput(linkedInput)
   }
+  if (hostWidgetId) useWidgetValueStore().deleteWidget(hostWidgetId)
   return true
 }
 

--- a/src/extensions/core/groupNode.test.ts
+++ b/src/extensions/core/groupNode.test.ts
@@ -105,3 +105,28 @@ describe('GroupNodeConfig.getLinks', () => {
     expect(config.externalFrom[0][1]).toBe('IMAGE')
   })
 })
+
+describe('GroupNodeConfig.processInputSlots', () => {
+  it('maps exposed inputs by name instead of definition index', () => {
+    const config = new GroupNodeConfig('group', {
+      nodes: [{ index: 0, type: 'KSampler' }],
+      links: [],
+      external: []
+    })
+    const inputMap: Record<string, number> = {}
+
+    config.processInputSlots(
+      {
+        model: ['MODEL'],
+        latent_image: ['LATENT']
+      },
+      { index: 0, type: 'KSampler' },
+      ['model', 'latent_image'],
+      {},
+      inputMap,
+      {}
+    )
+
+    expect(inputMap).toEqual({ model: 0, latent_image: 1 })
+  })
+})

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -566,7 +566,7 @@ export class GroupNodeConfig {
     node: GroupNodeData,
     slots: string[],
     linksTo: Record<number, GroupNodeLink>,
-    inputMap: Record<number, number>,
+    inputMap: Record<string, number>,
     seenInputs: Record<string, number>
   ) {
     const nodeIdx = node.index ?? -1
@@ -593,7 +593,7 @@ export class GroupNodeConfig {
         // @ts-expect-error legacy dynamic input assignment
         this.nodeDef.input.required[name] = config
       }
-      inputMap[i] = this.inputCount++
+      inputMap[inputName] = this.inputCount++
     }
   }
 
@@ -603,7 +603,7 @@ export class GroupNodeConfig {
     slots: string[],
     converted: Map<number, string>,
     linksTo: Record<number, GroupNodeLink>,
-    inputMap: Record<number, number>,
+    inputMap: Record<string, number>,
     seenInputs: Record<string, number>
   ) {
     // Add converted widgets sorted into their index order (ordered as they were converted) so link ids match up
@@ -645,7 +645,7 @@ export class GroupNodeConfig {
       }
       this.oldToNewWidgetMap[nodeIndex][inputName] = name
 
-      inputMap[slots.length + i] = this.inputCount++
+      inputMap[inputName] = this.inputCount++
     }
   }
 
@@ -668,7 +668,7 @@ export class GroupNodeConfig {
     )
     const nodeIndex = node.index ?? -1
     const linksTo = this.linksTo[nodeIndex] ?? {}
-    const inputMap: Record<number, number> = (this.oldToNewInputMap[nodeIndex] =
+    const inputMap: Record<string, number> = (this.oldToNewInputMap[nodeIndex] =
       {})
     this.processInputSlots(
       inputs as unknown as Record<string, unknown[]>,
@@ -917,15 +917,18 @@ export class GroupNodeHandler {
           : null
         if (!newNode) continue
         const map = oldToNewInputMap[Number(innerNodeIndex)]
-        for (const innerInputId in map) {
-          const groupSlotId = map[Number(innerInputId)]
+        for (const innerInputName in map) {
+          const groupSlotId = map[innerInputName]
           if (groupSlotId == null) continue
           const slot = node.inputs[groupSlotId]
           if (slot.link == null) continue
           const link = app.rootGraph.links[slot.link]
           if (!link) continue
           const originNode = app.rootGraph.getNodeById(link.origin_id)
-          originNode?.connect(link.origin_slot, newNode, +innerInputId)
+          const innerInputId = newNode.findInputSlot(innerInputName)
+          if (innerInputId !== -1) {
+            originNode?.connect(link.origin_slot, newNode, innerInputId)
+          }
         }
       }
     }

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -920,9 +920,9 @@ export class GroupNodeHandler {
         for (const innerInputName in map) {
           const groupSlotId = map[innerInputName]
           if (groupSlotId == null) continue
-          const slot = node.inputs[groupSlotId]
-          if (slot.link == null) continue
-          const link = app.rootGraph.links[slot.link]
+          const slotLink = node.inputs?.[groupSlotId]?.link
+          if (slotLink == null) continue
+          const link = app.rootGraph.links[slotLink]
           if (!link) continue
           const originNode = app.rootGraph.getNodeById(link.origin_id)
           const innerInputId = newNode.findInputSlot(innerInputName)

--- a/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { flushProxyWidgetMigration } from '@/core/graph/subgraph/migration/proxyWidgetMigration'
 import { autoExposeKnownPreviewNodes } from '@/core/graph/subgraph/promotionUtils'
-import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import {
   LGraph,
   LGraphCanvas,
@@ -26,6 +25,8 @@ import type {
 } from '@/lib/litegraph/src/types/serialisation'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
+
+import { registerTestSubgraphNodeTypes } from './subgraph/__fixtures__/subgraphHelpers'
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({})
@@ -208,29 +209,6 @@ describe('_deserializeItems paste-time migration & auto-expose', () => {
     registeredTypesToCleanup.length = 0
   })
 
-  function registerSubgraphNodeTypeOnCreate(rootGraph: LGraph): void {
-    rootGraph.events.addEventListener('subgraph-created', (e) => {
-      const { subgraph } = e.detail
-      class TestSubgraphNode extends SubgraphNode {
-        constructor() {
-          super(rootGraph, subgraph as Subgraph, {
-            id: -1,
-            type: subgraph.id,
-            pos: [0, 0],
-            size: [100, 100],
-            inputs: [],
-            outputs: [],
-            flags: {},
-            order: 0,
-            mode: 0
-          })
-        }
-      }
-      LiteGraph.registerNodeType(subgraph.id, TestSubgraphNode)
-      registeredTypesToCleanup.push(subgraph.id)
-    })
-  }
-
   function createCanvas(graph: LGraph): LGraphCanvas {
     const el = document.createElement('canvas')
     el.width = 800
@@ -309,7 +287,7 @@ describe('_deserializeItems paste-time migration & auto-expose', () => {
       })
 
     const rootGraph = new LGraph()
-    registerSubgraphNodeTypeOnCreate(rootGraph)
+    registerTestSubgraphNodeTypes(rootGraph)
     const canvas = createCanvas(rootGraph)
 
     const subgraphId = createUuidv4()
@@ -385,7 +363,7 @@ describe('_deserializeItems paste-time migration & auto-expose', () => {
       autoExposeKnownPreviewNodes(hostNode)
 
     const rootGraph = new LGraph()
-    registerSubgraphNodeTypeOnCreate(rootGraph)
+    registerTestSubgraphNodeTypes(rootGraph)
     const canvas = createCanvas(rootGraph)
 
     const subgraphId = createUuidv4()

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -350,7 +350,13 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         }
 
         if (input._widget) this.ensureWidgetRemoved(input._widget)
-        if (input.widgetId) useWidgetValueStore().deleteWidget(input.widgetId)
+        if (input.widgetId) {
+          const id = input.widgetId
+          queueMicrotask(() => {
+            if (this.inputs.some((input) => input.widgetId === id)) return
+            useWidgetValueStore().deleteWidget(id)
+          })
+        }
 
         delete input.pos
         delete input.widget

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { fromAny } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import type {
   ISlotType,
@@ -9,7 +9,11 @@ import type {
   Subgraph,
   TWidgetType
 } from '@/lib/litegraph/src/litegraph'
-import { BaseWidget, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  BaseWidget,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
 import { NumberWidget } from '@/lib/litegraph/src/widgets/NumberWidget'
 import {
   appendQuarantine,
@@ -32,6 +36,7 @@ import {
   createTestRootGraph,
   createTestSubgraph,
   createTestSubgraphNode,
+  registerTestSubgraphNodeTypes,
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
 
@@ -169,6 +174,42 @@ describe('SubgraphWidgetPromotion', () => {
           value: 42
         }
       )
+    })
+
+    it('preserves the host value when its source is converted to a nested subgraph', async () => {
+      const rootGraph = createTestRootGraph()
+      const subgraph = createTestSubgraph({
+        rootGraph,
+        inputs: [{ name: 'value', type: 'STRING' }]
+      })
+      const sourceType = 'test/nested-conversion-source'
+
+      class SourceNode extends LGraphNode {
+        constructor() {
+          super('Source')
+          const input = this.addInput('value', 'STRING')
+          input.widget = { name: 'value' }
+          this.addWidget('text', 'value', 'source value', () => {})
+        }
+      }
+      LiteGraph.registerNodeType(sourceType, SourceNode)
+      onTestFinished(() => LiteGraph.unregisterNodeType(sourceType))
+      registerTestSubgraphNodeTypes(rootGraph)
+
+      const source = LiteGraph.createNode(sourceType)
+      if (!source) throw new Error('Failed to create source node')
+      subgraph.add(source)
+      const link = subgraph.inputNode.slots[0].connect(source.inputs[0], source)
+      if (!link) throw new Error('Failed to connect promoted input')
+
+      const host = createTestSubgraphNode(subgraph)
+      rootGraph.add(host)
+      writePromotedWidgetValue(host, 0, 'host value')
+
+      subgraph.convertToSubgraph(new Set([source]))
+      await Promise.resolve()
+
+      expect(promotedWidgetStateByName(host, 'value').value).toBe('host value')
     })
 
     it('should promote all widget types', () => {

--- a/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
+++ b/src/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers.ts
@@ -5,7 +5,7 @@
  * These functions provide consistent ways to create test subgraphs, nodes, and
  * verify their behavior.
  */
-import { expect } from 'vitest'
+import { expect, onTestFinished } from 'vitest'
 
 import type {
   ExportedSubgraph,
@@ -285,6 +285,35 @@ export function createTestSubgraphNode(
   }
 
   return new SubgraphNode(parentGraph, subgraph, instanceData)
+}
+
+export function registerTestSubgraphNodeTypes(rootGraph: LGraph): void {
+  const registeredTypes: string[] = []
+
+  rootGraph.events.addEventListener('subgraph-created', (event) => {
+    const subgraph = event.detail.subgraph
+    class TestSubgraphNode extends SubgraphNode {
+      constructor() {
+        super(rootGraph, subgraph, {
+          id: -1,
+          type: subgraph.id,
+          pos: [0, 0],
+          size: [100, 100],
+          inputs: [],
+          outputs: [],
+          flags: {},
+          order: 0,
+          mode: 0
+        })
+      }
+    }
+    LiteGraph.registerNodeType(subgraph.id, TestSubgraphNode)
+    registeredTypes.push(subgraph.id)
+  })
+
+  onTestFinished(() => {
+    for (const type of registeredTypes) LiteGraph.unregisterNodeType(type)
+  })
 }
 
 export function createBoundaryLinkedSubgraph({


### PR DESCRIPTION
Fix multiple blocking bugs introduced in 1.47

- When converting groupNodes to subgraphs, use inputNames instead of slotIds since slotIds are not reliable
- When converting a node inside a subgraph into a nested subgraph, maintain value of host widgets on parent subgraph node.