### PR TITLE
fix(workspace): derive Members access from Team plan

### DIFF
--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -9,7 +9,8 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 // `/api/features` is the remote-config source: production builds resolve the
 // workspaces flag from it (the `ff:` localStorage override is dev-only).
 export const WORKSPACE_FEATURE_FLAG: RemoteConfig = {
-  team_workspaces_enabled: true
+  team_workspaces_enabled: true,
+  billing_control_enabled: true
 }
 
 export const TEAM_WORKSPACE: WorkspaceWithRole = {

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -67,21 +67,21 @@ export const DEFAULT_TEAM_MEMBERS: Member[] = [
   MEMBER_JOHN
 ]
 
+const TEAM_PLAN_SLUG = 'team-pro-monthly'
+
 export const TEAM_BILLING_STATUS: BillingStatusResponse = {
   is_active: true,
   subscription_status: 'active',
   subscription_tier: 'PRO',
   subscription_duration: 'MONTHLY',
-  plan_slug: 'pro-monthly',
+  plan_slug: TEAM_PLAN_SLUG,
   billing_status: 'paid',
   has_funds: true,
   renewal_date: '2099-02-20T00:00:00Z'
 }
 
-// `max_seats > 1` on the current plan is what flips `isOnTeamPlan`, which gates
-// the whole role-management UI.
 export const TEAM_PRO_PLAN: Plan = {
-  slug: 'pro-monthly',
+  slug: TEAM_PLAN_SLUG,
   tier: 'PRO',
   duration: 'MONTHLY',
   price_cents: 10000,

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -1,6 +1,9 @@
 import type { Page, Route } from '@playwright/test'
 
-import type { Member } from '@/platform/workspace/api/workspaceApi'
+import type {
+  Member,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
 
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import {
@@ -41,18 +44,22 @@ export class CloudWorkspaceMockHelper {
   constructor(private readonly page: Page) {}
 
   async setup(
-    members: Member[] = DEFAULT_TEAM_MEMBERS
+    members: Member[] = DEFAULT_TEAM_MEMBERS,
+    activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE
   ): Promise<MemberMockState> {
-    const state = await this.mockBoot(members)
+    const state = await this.mockBoot(members, activeWorkspace)
     await new CloudAuthHelper(this.page).mockAuth()
-    await this.page.addInitScript(() => {
+    await this.page.addInitScript((workspaceId) => {
       localStorage.setItem('Comfy.userId', 'test-user-e2e')
-      localStorage.setItem('Comfy.Workspace.LastWorkspaceId', 'ws-team')
-    })
+      localStorage.setItem('Comfy.Workspace.LastWorkspaceId', workspaceId)
+    }, activeWorkspace.id)
     return state
   }
 
-  private async mockBoot(members: Member[]): Promise<MemberMockState> {
+  private async mockBoot(
+    members: Member[],
+    activeWorkspace: WorkspaceWithRole
+  ): Promise<MemberMockState> {
     const state: MemberMockState = {
       members: members.map((m) => ({ ...m })),
       patches: []
@@ -93,11 +100,11 @@ export class CloudWorkspaceMockHelper {
     await page.route('**/api/auth/session', (r) =>
       r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
     )
-    await mockWorkspaceTokenMint(page, TEAM_WORKSPACE)
+    await mockWorkspaceTokenMint(page, activeWorkspace)
     await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
 
     await page.route('**/api/workspaces', (r) =>
-      r.fulfill(jsonRoute({ workspaces: [TEAM_WORKSPACE] }))
+      r.fulfill(jsonRoute({ workspaces: [activeWorkspace] }))
     )
 
     await page.route('**/api/workspace/members**', (route: Route) => {

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -140,7 +140,10 @@ export class CloudWorkspaceMockHelper {
     )
     await page.route('**/api/billing/plans', (r) =>
       r.fulfill(
-        jsonRoute({ current_plan_slug: 'pro-monthly', plans: [TEAM_PRO_PLAN] })
+        jsonRoute({
+          current_plan_slug: TEAM_PRO_PLAN.slug,
+          plans: [TEAM_PRO_PLAN]
+        })
       )
     )
 

--- a/browser_tests/tests/dialogs/memberRoleChange.spec.ts
+++ b/browser_tests/tests/dialogs/memberRoleChange.spec.ts
@@ -6,11 +6,13 @@ import type { Member } from '@/platform/workspace/api/workspaceApi'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import {
   CREATOR,
+  DEFAULT_TEAM_MEMBERS,
   MEMBER_JANE,
   MEMBER_JOHN,
   VIEWER
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 // Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
 // against fully mocked endpoints; `comfyPage` would try to reach the OSS
@@ -69,6 +71,39 @@ async function openChangeRoleSubmenu(page: Page) {
     page.getByRole('menuitemradio', { name: 'Owner', exact: true })
   ).toBeVisible()
 }
+
+test.describe('Members plan gating', { tag: '@cloud' }, () => {
+  test('personal workspace with a Team plan gets member management', async ({
+    page
+  }) => {
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      workspace('personal', 'owner')
+    )
+    const content = await openMembersTab(page)
+
+    const inviteButton = content.getByRole('button', {
+      name: 'Invite member'
+    })
+    await expect(inviteButton).toBeEnabled()
+    await expect(
+      content.getByRole('button', { name: 'Role', exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByText(MEMBER_JANE.email, { exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Upgrade to Team' })
+    ).toHaveCount(0)
+
+    await inviteButton.click()
+    await expect(
+      page.getByRole('heading', {
+        name: 'Invite members to this workspace'
+      })
+    ).toBeVisible()
+  })
+})
 
 test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
   test.describe.configure({ timeout: 60_000 })

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -25,7 +25,8 @@ const {
   mockOriginalOwnerId,
   mockFilteredMembers,
   mockFilteredPendingInvites,
-  mockIsPersonalWorkspace,
+  mockHasTeamPlan,
+  mockIsPlanLoading,
   mockIsOnTeamPlan,
   mockHasMultipleMembers,
   mockShowSearch,
@@ -51,7 +52,8 @@ const {
     mockIsInviteDisabled: ref(false),
     mockFilteredMembers: ref<WorkspaceMember[]>([]),
     mockFilteredPendingInvites: ref<PendingInvite[]>([]),
-    mockIsPersonalWorkspace: ref(false),
+    mockHasTeamPlan: ref(true),
+    mockIsPlanLoading: ref(false),
     mockIsOnTeamPlan: ref(true),
     mockActiveView: ref<'active' | 'pending'>('active'),
     mockSearchQuery: ref(''),
@@ -86,7 +88,10 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     searchQuery: mockSearchQuery,
     activeView: mockActiveView,
     maxSeats: computed(() => 20),
+    hasTeamPlan: mockHasTeamPlan,
+    isPlanLoading: mockIsPlanLoading,
     isOnTeamPlan: mockIsOnTeamPlan,
+    hasLapsedTeamPlan: computed(() => false),
     hasMultipleMembers: mockHasMultipleMembers,
     showSearch: mockShowSearch,
     showViewTabs: mockShowViewTabs,
@@ -111,7 +116,6 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
           mockFilteredMembers.value.map((m) => [m.id, mockMemberMenuItems()])
         )
     ),
-    isPersonalWorkspace: mockIsPersonalWorkspace,
     members: mockMembers,
     pendingInvites: mockPendingInvites,
     permissions: mockPermissions,
@@ -205,7 +209,8 @@ describe('MembersPanelContent', () => {
     mockOriginalOwnerId.value = null
     mockFilteredMembers.value = []
     mockFilteredPendingInvites.value = []
-    mockIsPersonalWorkspace.value = false
+    mockHasTeamPlan.value = true
+    mockIsPlanLoading.value = false
     mockIsOnTeamPlan.value = true
     mockHasMultipleMembers.value = true
     mockShowSearch.value = true
@@ -239,9 +244,9 @@ describe('MembersPanelContent', () => {
     }
   })
 
-  describe('personal workspace', () => {
+  describe('personal plan', () => {
     beforeEach(() => {
-      mockIsPersonalWorkspace.value = true
+      mockHasTeamPlan.value = false
       mockIsOnTeamPlan.value = false
       mockHasMultipleMembers.value = false
       mockShowSearch.value = false
@@ -275,7 +280,7 @@ describe('MembersPanelContent', () => {
     })
   })
 
-  describe('team workspace - member list', () => {
+  describe('Team plan member list', () => {
     it('shows the Role column header and member roles', () => {
       mockFilteredMembers.value = [
         createMember({ role: 'owner', email: 'boss@test.com' }),
@@ -301,6 +306,9 @@ describe('MembersPanelContent', () => {
       renderComponent()
       expect(screen.getByText('Alice')).toBeTruthy()
       expect(screen.getByText('Bob')).toBeTruthy()
+      expect(
+        screen.queryByText('workspacePanel.members.upsellBanner')
+      ).toBeNull()
     })
 
     it('shows more options button for non-current members', () => {
@@ -431,6 +439,7 @@ describe('MembersPanelContent', () => {
 
   describe('not on team plan', () => {
     beforeEach(() => {
+      mockHasTeamPlan.value = false
       mockIsOnTeamPlan.value = false
       mockShowSearch.value = false
       mockShowViewTabs.value = false
@@ -444,6 +453,7 @@ describe('MembersPanelContent', () => {
     })
 
     it('hides the upsell banner when on a team plan', () => {
+      mockHasTeamPlan.value = true
       mockIsOnTeamPlan.value = true
       renderComponent()
       expect(
@@ -469,10 +479,18 @@ describe('MembersPanelContent', () => {
       renderComponent()
       expect(screen.queryByText('workspacePanel.members.contactUs')).toBeNull()
     })
+
+    it('does not show an upgrade banner while plan state is loading', () => {
+      mockIsPlanLoading.value = true
+      renderComponent()
+      expect(
+        screen.queryByText('workspacePanel.members.upsellBanner')
+      ).toBeNull()
+    })
   })
 
   describe('contact us footer', () => {
-    it('opens discord in a new tab for team workspaces on a team plan', async () => {
+    it('opens discord in a new tab on a Team plan', async () => {
       const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
       renderComponent()
       expect(
@@ -489,10 +507,9 @@ describe('MembersPanelContent', () => {
       openSpy.mockRestore()
     })
 
-    it('is hidden in personal workspaces', () => {
-      mockIsPersonalWorkspace.value = true
+    it('is shown whenever the active plan is Team', () => {
       renderComponent()
-      expect(screen.queryByText('workspacePanel.members.contactUs')).toBeNull()
+      expect(screen.getByText('workspacePanel.members.contactUs')).toBeTruthy()
     })
   })
 

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -8,7 +8,7 @@
         <div class="flex min-w-0 flex-1 items-baseline gap-2">
           <span class="text-base font-semibold text-base-foreground">
             <template v-if="activeView === 'active'">
-              <template v-if="isOnTeamPlan && !isPersonalWorkspace">
+              <template v-if="isOnTeamPlan">
                 {{
                   $t('workspacePanel.members.membersCount', {
                     count: members.length,
@@ -140,8 +140,7 @@
         <div class="min-h-0 flex-1 overflow-y-auto">
           <!-- Active Members -->
           <template v-if="activeView === 'active'">
-            <!-- Personal Workspace: show only current user -->
-            <template v-if="isPersonalWorkspace">
+            <template v-if="!hasTeamPlan">
               <MemberListItem
                 :member="personalWorkspaceMember"
                 :is-current-user="true"
@@ -150,7 +149,6 @@
               />
             </template>
 
-            <!-- Team Workspace: sorted list -->
             <template v-else>
               <MemberListItem
                 v-for="(member, index) in filteredMembers"
@@ -188,15 +186,12 @@
     </div>
     <!-- Upsell Banner -->
     <MemberUpsellBanner
-      v-if="!isOnTeamPlan"
+      v-if="!isPlanLoading && !isOnTeamPlan"
       :reactivate="hasLapsedTeamPlan"
       @show-plans="showTeamPlans()"
     />
     <!-- Need More Members Footer -->
-    <div
-      v-if="isOnTeamPlan && !isPersonalWorkspace"
-      class="flex items-center pt-2"
-    >
+    <div v-if="isOnTeamPlan" class="flex items-center pt-2">
       <p class="text-sm text-muted-foreground">
         {{ $t('workspacePanel.members.needMoreMembers') }}
       </p>
@@ -227,8 +222,10 @@ const {
   searchQuery,
   activeView,
   maxSeats,
+  hasTeamPlan,
   isOnTeamPlan,
   hasLapsedTeamPlan,
+  isPlanLoading,
   hasMultipleMembers,
   showSearch,
   showViewTabs,
@@ -240,7 +237,6 @@ const {
   filteredMembers,
   filteredPendingInvites,
   memberMenus,
-  isPersonalWorkspace,
   members,
   pendingInvites,
   permissions,

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -9,15 +9,25 @@ import WorkspacePanelContent from './WorkspacePanelContent.vue'
 const mockFetchMembers = vi.fn()
 const mockFetchPendingInvites = vi.fn()
 
-const { mockMembers, mockWorkspaceType } = vi.hoisted(() => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-  const { ref } = require('vue') as typeof import('vue')
+const { mockHasTeamPlan, mockIsPlanLoading, mockMembers, mockWorkspaceType } =
+  vi.hoisted(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+    const { ref } = require('vue') as typeof import('vue')
 
-  return {
-    mockMembers: ref<WorkspaceMember[]>([]),
-    mockWorkspaceType: ref<'personal' | 'team'>('team')
-  }
-})
+    return {
+      mockHasTeamPlan: ref(true),
+      mockIsPlanLoading: ref(false),
+      mockMembers: ref<WorkspaceMember[]>([]),
+      mockWorkspaceType: ref<'personal' | 'team'>('team')
+    }
+  })
+
+vi.mock('@/platform/workspace/composables/useTeamPlan', () => ({
+  useTeamPlan: () => ({
+    hasTeamPlan: mockHasTeamPlan,
+    isPlanLoading: mockIsPlanLoading
+  })
+}))
 
 vi.mock('pinia', async (importOriginal) => {
   const actual = await importOriginal()
@@ -125,11 +135,13 @@ describe('WorkspacePanelContent billing banner', () => {
 describe('WorkspacePanelContent members tab label', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockHasTeamPlan.value = true
+    mockIsPlanLoading.value = false
     mockMembers.value = []
     mockWorkspaceType.value = 'team'
   })
 
-  it('shows the counted label for team workspaces with multiple members', () => {
+  it('shows the counted label for Team plans with multiple members', () => {
     mockMembers.value = [createMember('1'), createMember('2')]
     renderComponent()
     expect(screen.getByText(/workspacePanel\.tabs\.membersCount/)).toBeTruthy()
@@ -142,17 +154,34 @@ describe('WorkspacePanelContent members tab label', () => {
     expect(screen.queryByText(/workspacePanel\.tabs\.membersCount/)).toBeNull()
   })
 
-  it('shows the plain Members label for personal workspaces', () => {
+  it('shows the plain Members label for a personal plan', () => {
     mockWorkspaceType.value = 'personal'
+    mockHasTeamPlan.value = false
     mockMembers.value = [createMember('1'), createMember('2')]
     renderComponent()
     expect(screen.getByText('workspacePanel.members.header')).toBeTruthy()
     expect(screen.queryByText(/workspacePanel\.tabs\.membersCount/)).toBeNull()
   })
 
-  it('fetches members and pending invites on mount', () => {
+  it('fetches members and pending invites for a Team plan', () => {
+    mockWorkspaceType.value = 'personal'
     renderComponent()
     expect(mockFetchMembers).toHaveBeenCalled()
     expect(mockFetchPendingInvites).toHaveBeenCalled()
+  })
+
+  it('does not fetch member data for a personal plan', () => {
+    mockWorkspaceType.value = 'team'
+    mockHasTeamPlan.value = false
+    renderComponent()
+    expect(mockFetchMembers).not.toHaveBeenCalled()
+    expect(mockFetchPendingInvites).not.toHaveBeenCalled()
+  })
+
+  it('waits for billing initialization before fetching member data', () => {
+    mockIsPlanLoading.value = true
+    renderComponent()
+    expect(mockFetchMembers).not.toHaveBeenCalled()
+    expect(mockFetchPendingInvites).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -55,7 +55,8 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
+import { whenever } from '@vueuse/core'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 
@@ -91,12 +92,9 @@ const showMembersTabCount = computed(
   () => hasTeamPlan.value && members.value.length > 1
 )
 
-watch(
-  [hasTeamPlan, isPlanLoading],
-  ([hasPlan, isLoading]) => {
-    if (!hasPlan || isLoading) return
-    void Promise.allSettled([fetchMembers(), fetchPendingInvites()])
-  },
+whenever(
+  () => hasTeamPlan.value && !isPlanLoading.value,
+  () => Promise.allSettled([fetchMembers(), fetchPendingInvites()]),
   { immediate: true }
 )
 </script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -55,7 +55,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 
@@ -63,6 +63,7 @@ import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfil
 import BillingStatusBanner from '@/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
+import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -82,17 +83,20 @@ const workspaceStore = useTeamWorkspaceStore()
 const { workspaceName, members } = storeToRefs(workspaceStore)
 const { fetchMembers, fetchPendingInvites } = workspaceStore
 
-const { workspaceType, workspaceRole } = useWorkspaceUI()
-const isPersonalWorkspace = computed(() => workspaceType.value === 'personal')
+const { workspaceRole } = useWorkspaceUI()
+const { hasTeamPlan, isPlanLoading } = useTeamPlan()
 const activeTab = ref(defaultTab)
 
-// Per design, the tab counts members only when there is more than the owner
 const showMembersTabCount = computed(
-  () => !isPersonalWorkspace.value && members.value.length > 1
+  () => hasTeamPlan.value && members.value.length > 1
 )
 
-onMounted(() => {
-  fetchMembers()
-  fetchPendingInvites()
-})
+watch(
+  [hasTeamPlan, isPlanLoading],
+  ([hasPlan, isLoading]) => {
+    if (!hasPlan || isLoading) return
+    void Promise.allSettled([fetchMembers(), fetchPendingInvites()])
+  },
+  { immediate: true }
+)
 </script>

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -259,13 +259,15 @@ const {
   mockMembers,
   mockPendingInvites,
   mockOriginalOwnerId,
-  mockIsInPersonalWorkspace,
-  mockIsWorkspaceSubscribed,
   mockTotalMemberSlots,
   mockIsInviteLimitReached,
   mockPermissions,
   mockUiConfig,
   mockIsActiveSubscription,
+  mockIsInitialized,
+  mockIsTeamPlan,
+  mockSubscriptionStatus,
+  mockWorkspaceRole,
   mockSubscription
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
@@ -275,8 +277,6 @@ const {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
     mockOriginalOwnerId: ref<string | null>(null),
-    mockIsInPersonalWorkspace: ref(false),
-    mockIsWorkspaceSubscribed: ref(true),
     mockTotalMemberSlots: ref(0),
     mockIsInviteLimitReached: ref(false),
     mockPermissions: ref({
@@ -303,6 +303,10 @@ const {
       workspaceMenuDisabledTooltip: null as string | null
     }),
     mockIsActiveSubscription: ref(true),
+    mockIsInitialized: ref(true),
+    mockIsTeamPlan: ref(true),
+    mockSubscriptionStatus: ref<string | null>('active'),
+    mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
     mockSubscription: ref<{ tier: string; isCancelled?: boolean } | null>({
       tier: 'PRO',
       isCancelled: false
@@ -334,8 +338,6 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
     originalOwnerId: mockOriginalOwnerId,
     totalMemberSlots: mockTotalMemberSlots,
     isInviteLimitReached: mockIsInviteLimitReached,
-    isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
     resendInvite: mockResendInvite
   })
 }))
@@ -343,7 +345,8 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: mockPermissions,
-    uiConfig: mockUiConfig
+    uiConfig: mockUiConfig,
+    workspaceRole: mockWorkspaceRole
   })
 }))
 
@@ -365,7 +368,10 @@ vi.mock(
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: mockIsActiveSubscription,
+    isInitialized: mockIsInitialized,
+    isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
+    subscriptionStatus: mockSubscriptionStatus,
     getMaxSeats: (tierKey: string) => {
       const seats: Record<string, number> = {
         free: 1,
@@ -401,12 +407,37 @@ describe('useMembersPanel', () => {
     mockMembers.value = []
     mockPendingInvites.value = []
     mockOriginalOwnerId.value = null
-    mockIsInPersonalWorkspace.value = false
-    mockIsWorkspaceSubscribed.value = true
     mockTotalMemberSlots.value = 0
     mockIsInviteLimitReached.value = false
     mockIsActiveSubscription.value = true
+    mockIsInitialized.value = true
+    mockIsTeamPlan.value = true
+    mockSubscriptionStatus.value = 'active'
+    mockWorkspaceRole.value = 'owner'
     mockSubscription.value = { tier: 'PRO', isCancelled: false }
+    mockPermissions.value = {
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canManageMembers: true,
+      canLeaveWorkspace: true,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true,
+      canTopUp: true
+    }
+    mockUiConfig.value = {
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showRoleColumn: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: 'delete',
+      workspaceMenuDisabledTooltip: null
+    }
   })
 
   // Lazy import so mocks are in place
@@ -416,21 +447,61 @@ describe('useMembersPanel', () => {
   }
 
   describe('team plan detection', () => {
-    it('is on the team plan for a subscribed team workspace', async () => {
+    it('is on the team plan when billing reports an active Team plan', async () => {
       const panel = await setup()
+      expect(panel.hasTeamPlan.value).toBe(true)
       expect(panel.isOnTeamPlan.value).toBe(true)
     })
 
-    it('is off the team plan in a personal workspace', async () => {
-      mockIsInPersonalWorkspace.value = true
+    it('is off the team plan when billing reports a personal plan', async () => {
+      mockIsTeamPlan.value = false
       const panel = await setup()
       expect(panel.isOnTeamPlan.value).toBe(false)
     })
 
-    it('is off the team plan when the team workspace is not subscribed', async () => {
-      mockIsWorkspaceSubscribed.value = false
+    it('is off the team plan when the subscription is inactive', async () => {
+      mockIsActiveSubscription.value = false
       const panel = await setup()
       expect(panel.isOnTeamPlan.value).toBe(false)
+    })
+
+    it('enables Team member capabilities over personal workspace defaults', async () => {
+      mockPermissions.value = {
+        ...mockPermissions.value,
+        canViewOtherMembers: false,
+        canViewPendingInvites: false,
+        canInviteMembers: false,
+        canManageInvites: false,
+        canManageMembers: false
+      }
+      mockUiConfig.value = {
+        ...mockUiConfig.value,
+        showMembersList: false,
+        showPendingTab: false,
+        showSearch: false,
+        showRoleColumn: false,
+        membersGridCols: 'grid-cols-1',
+        headerGridCols: 'grid-cols-1'
+      }
+
+      const panel = await setup()
+
+      expect(panel.permissions.value.canInviteMembers).toBe(true)
+      expect(panel.permissions.value.canManageMembers).toBe(true)
+      expect(panel.uiConfig.value.showMembersList).toBe(true)
+      expect(panel.uiConfig.value.showPendingTab).toBe(true)
+      expect(panel.uiConfig.value.showRoleColumn).toBe(true)
+    })
+
+    it('uses the single-user member layout for a personal plan', async () => {
+      mockIsTeamPlan.value = false
+
+      const panel = await setup()
+
+      expect(panel.permissions.value.canInviteMembers).toBe(false)
+      expect(panel.uiConfig.value.showMembersList).toBe(false)
+      expect(panel.uiConfig.value.showPendingTab).toBe(false)
+      expect(panel.uiConfig.value.membersGridCols).toBe('grid-cols-1')
     })
 
     it('caps members at the flat team maximum regardless of tier', async () => {
@@ -681,12 +752,12 @@ describe('useMembersPanel', () => {
       expect(panel.showViewTabs.value).toBe(true)
     })
 
-    it('hides view tabs when the team workspace is not subscribed', async () => {
-      mockIsWorkspaceSubscribed.value = false
+    it('hides Team member controls for a personal plan', async () => {
+      mockIsTeamPlan.value = false
       mockMembers.value = [createMember(), createMember({ id: '2' })]
       const panel = await setup()
       expect(panel.showViewTabs.value).toBe(false)
-      expect(panel.showSearch.value).toBe(true)
+      expect(panel.showSearch.value).toBe(false)
     })
   })
 
@@ -699,7 +770,7 @@ describe('useMembersPanel', () => {
     })
 
     it('opens the upsell dialog when not on a team plan', async () => {
-      mockIsWorkspaceSubscribed.value = false
+      mockIsTeamPlan.value = false
       const panel = await setup()
       panel.handleInviteMember()
       expect(mockShowInviteMemberUpsellDialog).toHaveBeenCalled()
@@ -731,7 +802,7 @@ describe('useMembersPanel', () => {
     })
 
     it('disables the invite button when not on a team plan', async () => {
-      mockIsWorkspaceSubscribed.value = false
+      mockIsTeamPlan.value = false
       const panel = await setup()
       expect(panel.isInviteDisabled.value).toBe(true)
     })
@@ -744,24 +815,29 @@ describe('useMembersPanel', () => {
       expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
     })
 
-    it('shows a disabled invite button in a personal workspace', async () => {
-      mockIsInPersonalWorkspace.value = true
+    it('enables invite for a Team-plan owner over personal defaults', async () => {
       mockPermissions.value = {
         ...mockPermissions.value,
         canInviteMembers: false
       }
       const panel = await setup()
       expect(panel.showInviteButton.value).toBe(true)
-      expect(panel.isInviteDisabled.value).toBe(true)
+      expect(panel.isInviteDisabled.value).toBe(false)
     })
 
-    it('hides the invite button for members without invite permission', async () => {
-      mockPermissions.value = {
-        ...mockPermissions.value,
-        canInviteMembers: false
-      }
+    it('hides the invite button for workspace members', async () => {
+      mockWorkspaceRole.value = 'member'
       const panel = await setup()
       expect(panel.showInviteButton.value).toBe(false)
+    })
+
+    it('keeps invite disabled while billing is initializing', async () => {
+      mockIsInitialized.value = false
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(true)
+      panel.handleInviteMember()
+      expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
+      expect(mockShowInviteMemberUpsellDialog).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -105,17 +105,79 @@ export function useMembersPanel() {
     pendingInvites,
     originalOwnerId,
     totalMemberSlots,
-    isInviteLimitReached,
-    isInPersonalWorkspace: isPersonalWorkspace
+    isInviteLimitReached
   } = storeToRefs(workspaceStore)
   const { resendInvite } = workspaceStore
-  const { permissions, uiConfig } = useWorkspaceUI()
-  const { isOnTeamPlan, isCancelled, hasLapsedTeamPlan } = useTeamPlan()
+  const {
+    permissions: workspacePermissions,
+    uiConfig: workspaceUiConfig,
+    workspaceRole
+  } = useWorkspaceUI()
+  const {
+    hasTeamPlan,
+    isOnTeamPlan,
+    isCancelled,
+    hasLapsedTeamPlan,
+    isPlanLoading
+  } = useTeamPlan()
   const subscriptionDialog = useSubscriptionDialog()
 
   // The team plan caps members at a flat MAX_WORKSPACE_MEMBERS, independent of
   // the subscription tier.
   const maxSeats = computed(() => MAX_WORKSPACE_MEMBERS)
+
+  const permissions = computed(() => {
+    const canManageMembers =
+      hasTeamPlan.value && workspaceRole.value === 'owner'
+
+    return {
+      ...workspacePermissions.value,
+      canViewOtherMembers: hasTeamPlan.value,
+      canViewPendingInvites: canManageMembers,
+      canInviteMembers: canManageMembers,
+      canManageInvites: canManageMembers,
+      canManageMembers
+    }
+  })
+
+  const uiConfig = computed(() => {
+    if (!hasTeamPlan.value) {
+      return {
+        ...workspaceUiConfig.value,
+        showMembersList: false,
+        showPendingTab: false,
+        showSearch: false,
+        showRoleColumn: false,
+        membersGridCols: 'grid-cols-1',
+        pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+        headerGridCols: 'grid-cols-1'
+      }
+    }
+
+    if (workspaceRole.value === 'owner') {
+      return {
+        ...workspaceUiConfig.value,
+        showMembersList: true,
+        showPendingTab: true,
+        showSearch: true,
+        showRoleColumn: true,
+        membersGridCols: 'grid-cols-[50%_40%_10%]',
+        pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+        headerGridCols: 'grid-cols-[50%_40%_10%]'
+      }
+    }
+
+    return {
+      ...workspaceUiConfig.value,
+      showMembersList: true,
+      showPendingTab: false,
+      showSearch: true,
+      showRoleColumn: true,
+      membersGridCols: 'grid-cols-[1fr_auto]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[1fr_auto]'
+    }
+  })
 
   const hasMultipleMembers = computed(() => members.value.length > 1)
 
@@ -129,9 +191,7 @@ export function useMembersPanel() {
       (hasMultipleMembers.value || pendingInvites.value.length > 0)
   )
 
-  const showInviteButton = computed(
-    () => permissions.value.canInviteMembers || isPersonalWorkspace.value
-  )
+  const showInviteButton = computed(() => workspaceRole.value === 'owner')
 
   // Plan seat limit, with the flat backend cap (isInviteLimitReached) as backstop
   const isMemberLimitReached = computed(
@@ -141,7 +201,11 @@ export function useMembersPanel() {
   // Invite is allowed only on an active (non-cancelled) team plan that is under
   // the member cap.
   const isInviteDisabled = computed(
-    () => !isOnTeamPlan.value || isCancelled.value || isMemberLimitReached.value
+    () =>
+      isPlanLoading.value ||
+      !isOnTeamPlan.value ||
+      isCancelled.value ||
+      isMemberLimitReached.value
   )
 
   const inviteTooltip = computed(() => {
@@ -151,6 +215,7 @@ export function useMembersPanel() {
   })
 
   function handleInviteMember() {
+    if (isPlanLoading.value) return
     if (!isOnTeamPlan.value) {
       void showInviteMemberUpsellDialog()
       return
@@ -286,8 +351,10 @@ export function useMembersPanel() {
     sortField,
     sortDirection,
     maxSeats,
+    hasTeamPlan,
     isOnTeamPlan,
     hasLapsedTeamPlan,
+    isPlanLoading,
     hasMultipleMembers,
     showSearch,
     showViewTabs,
@@ -300,7 +367,6 @@ export function useMembersPanel() {
     filteredPendingInvites,
     memberMenuItems,
     memberMenus,
-    isPersonalWorkspace,
     members,
     pendingInvites,
     permissions,

--- a/src/platform/workspace/composables/useTeamPlan.test.ts
+++ b/src/platform/workspace/composables/useTeamPlan.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
-  mockIsInPersonalWorkspace,
-  mockIsWorkspaceSubscribed,
+  mockIsActiveSubscription,
+  mockIsInitialized,
+  mockIsTeamPlan,
   mockSubscription,
   mockSubscriptionStatus
 } = vi.hoisted(() => {
@@ -10,8 +11,9 @@ const {
   const { ref } = require('vue') as typeof import('vue')
 
   return {
-    mockIsInPersonalWorkspace: ref(false),
-    mockIsWorkspaceSubscribed: ref(true),
+    mockIsActiveSubscription: ref(true),
+    mockIsInitialized: ref(true),
+    mockIsTeamPlan: ref(true),
     mockSubscription: ref<{ isCancelled?: boolean } | null>({
       isCancelled: false
     }),
@@ -19,23 +21,11 @@ const {
   }
 })
 
-vi.mock('pinia', async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...(actual as object),
-    storeToRefs: (store: Record<string, unknown>) => store
-  }
-})
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
-  })
-}))
-
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
+    isActiveSubscription: mockIsActiveSubscription,
+    isInitialized: mockIsInitialized,
+    isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     subscriptionStatus: mockSubscriptionStatus
   })
@@ -49,25 +39,28 @@ async function setup() {
 describe('useTeamPlan', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockIsInPersonalWorkspace.value = false
-    mockIsWorkspaceSubscribed.value = true
+    mockIsActiveSubscription.value = true
+    mockIsInitialized.value = true
+    mockIsTeamPlan.value = true
     mockSubscription.value = { isCancelled: false }
     mockSubscriptionStatus.value = 'active'
   })
 
-  it('is on the team plan for a subscribed team workspace', async () => {
+  it('enables Team features from the active plan identity', async () => {
     const plan = await setup()
+    expect(plan.hasTeamPlan.value).toBe(true)
     expect(plan.isOnTeamPlan.value).toBe(true)
   })
 
-  it('is off the team plan in a personal workspace', async () => {
-    mockIsInPersonalWorkspace.value = true
+  it('does not enable Team features for a personal plan', async () => {
+    mockIsTeamPlan.value = false
     const plan = await setup()
+    expect(plan.hasTeamPlan.value).toBe(false)
     expect(plan.isOnTeamPlan.value).toBe(false)
   })
 
-  it('is off the team plan when the team workspace is not subscribed', async () => {
-    mockIsWorkspaceSubscribed.value = false
+  it('does not enable Team features for an inactive subscription', async () => {
+    mockIsActiveSubscription.value = false
     const plan = await setup()
     expect(plan.isOnTeamPlan.value).toBe(false)
   })
@@ -77,6 +70,7 @@ describe('useTeamPlan', () => {
     expect(plan.isCancelled.value).toBe(false)
     mockSubscription.value = { isCancelled: true }
     expect(plan.isCancelled.value).toBe(true)
+    expect(plan.isOnTeamPlan.value).toBe(false)
   })
 
   it('treats a missing subscription as not cancelled', async () => {
@@ -85,12 +79,7 @@ describe('useTeamPlan', () => {
     expect(plan.isCancelled.value).toBe(false)
   })
 
-  it('does not flag a lapsed plan while the team subscription is active', async () => {
-    const plan = await setup()
-    expect(plan.hasLapsedTeamPlan.value).toBe(false)
-  })
-
-  it('flags a lapsed plan when the team subscription is cancelled or ended', async () => {
+  it('flags a cancelled or ended Team plan as lapsed', async () => {
     const plan = await setup()
     mockSubscriptionStatus.value = 'canceled'
     expect(plan.hasLapsedTeamPlan.value).toBe(true)
@@ -98,10 +87,18 @@ describe('useTeamPlan', () => {
     expect(plan.hasLapsedTeamPlan.value).toBe(true)
   })
 
-  it('does not flag a lapsed plan in a personal workspace', async () => {
-    mockIsInPersonalWorkspace.value = true
-    mockSubscriptionStatus.value = 'canceled'
+  it('does not flag a personal plan as a lapsed Team plan', async () => {
+    mockIsTeamPlan.value = false
+    mockSubscriptionStatus.value = 'ended'
     const plan = await setup()
     expect(plan.hasLapsedTeamPlan.value).toBe(false)
+  })
+
+  it('reports loading until billing initialization completes', async () => {
+    mockIsInitialized.value = false
+    const plan = await setup()
+    expect(plan.isPlanLoading.value).toBe(true)
+    mockIsInitialized.value = true
+    expect(plan.isPlanLoading.value).toBe(false)
   })
 })

--- a/src/platform/workspace/composables/useTeamPlan.ts
+++ b/src/platform/workspace/composables/useTeamPlan.ts
@@ -1,35 +1,33 @@
-import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
-/**
- * Team-plan state for the active workspace. The team plan is tier-independent
- * (no standard/creator/pro): "on the team plan" simply means a team workspace
- * that is subscribed to it.
- */
 export function useTeamPlan() {
-  const { subscription, subscriptionStatus } = useBillingContext()
-  const { isInPersonalWorkspace, isWorkspaceSubscribed } = storeToRefs(
-    useTeamWorkspaceStore()
-  )
+  const {
+    isActiveSubscription,
+    isInitialized,
+    isTeamPlan,
+    subscription,
+    subscriptionStatus
+  } = useBillingContext()
 
-  const isTeamWorkspace = computed(() => !isInPersonalWorkspace.value)
-
-  const isOnTeamPlan = computed(
-    () => isTeamWorkspace.value && isWorkspaceSubscribed.value
-  )
   const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
-
-  const isSubscriptionLapsed = computed(
-    () =>
-      subscriptionStatus.value === 'canceled' ||
-      subscriptionStatus.value === 'ended'
+  const isOnTeamPlan = computed(
+    () => isTeamPlan.value && isActiveSubscription.value && !isCancelled.value
   )
   const hasLapsedTeamPlan = computed(
-    () => isTeamWorkspace.value && isSubscriptionLapsed.value
+    () =>
+      isTeamPlan.value &&
+      (subscriptionStatus.value === 'canceled' ||
+        subscriptionStatus.value === 'ended')
   )
+  const isPlanLoading = computed(() => !isInitialized.value)
 
-  return { isOnTeamPlan, isCancelled, hasLapsedTeamPlan }
+  return {
+    hasTeamPlan: isTeamPlan,
+    isOnTeamPlan,
+    isCancelled,
+    hasLapsedTeamPlan,
+    isPlanLoading
+  }
 }

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -674,14 +674,18 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[0].name).toBe('User One')
     })
 
-    it('fetchMembers returns empty for personal workspace', async () => {
+    it('fetchMembers supports a personal workspace with Team entitlement', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [],
+        pagination: { offset: 0, limit: 50, total: 0 }
+      })
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
       const result = await store.fetchMembers()
 
       expect(result).toEqual([])
-      expect(mockWorkspaceApi.listMembers).not.toHaveBeenCalled()
+      expect(mockWorkspaceApi.listMembers).toHaveBeenCalled()
     })
 
     it('removeMember removes from local list', async () => {
@@ -1004,13 +1008,15 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.listMembers).toHaveBeenCalledTimes(1)
     })
 
-    it('does not load members for a personal workspace', async () => {
+    it('loads members for an entitled personal workspace', async () => {
+      mockMembersResponse()
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
       await store.ensureMembersLoaded()
 
-      expect(mockWorkspaceApi.listMembers).not.toHaveBeenCalled()
+      expect(mockWorkspaceApi.listMembers).toHaveBeenCalledTimes(1)
+      expect(store.members).toHaveLength(1)
     })
 
     it('logs a failed request and retries on the next call', async () => {
@@ -1158,6 +1164,17 @@ describe('useTeamWorkspaceStore', () => {
   })
 
   describe('invite actions', () => {
+    it('fetchPendingInvites supports a personal workspace with Team entitlement', async () => {
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: [] })
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      const result = await store.fetchPendingInvites()
+
+      expect(result).toEqual([])
+      expect(mockWorkspaceApi.listInvites).toHaveBeenCalled()
+    })
+
     it('fetchPendingInvites updates active workspace invites', async () => {
       const mockInvites = [
         {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -546,7 +546,6 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     params?: ListMembersParams
   ): Promise<WorkspaceMember[]> {
     if (!activeWorkspaceId.value) return []
-    if (activeWorkspace.value?.type === 'personal') return []
 
     const response = await workspaceApi.listMembers(params)
     const members = response.members.map(mapApiMemberToWorkspaceMember)
@@ -554,20 +553,19 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     return members
   }
 
-  // Tracks which team workspaces have already loaded their members so the
+  // Tracks which workspaces have already loaded their members so the
   // lifecycle gate resolves without redundant or duplicate fetches.
   const loadedMemberWorkspaceIds = new Set<string>()
   let inFlightMembersWorkspaceId: string | null = null
 
   /**
-   * Load the active team workspace's members once. No-ops for personal or
-   * already-loaded workspaces and dedupes concurrent calls. A failed request is
-   * logged and leaves the workspace unloaded so a later call retries.
+   * Load the active workspace's members once. No-ops for already-loaded
+   * workspaces and dedupes concurrent calls. A failed request is logged and
+   * leaves the workspace unloaded so a later call retries.
    */
   async function ensureMembersLoaded(): Promise<void> {
     const workspaceId = activeWorkspaceId.value
     if (!workspaceId) return
-    if (activeWorkspace.value?.type === 'personal') return
     if (loadedMemberWorkspaceIds.has(workspaceId)) return
     if (inFlightMembersWorkspaceId === workspaceId) return
 
@@ -626,7 +624,6 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    */
   async function fetchPendingInvites(): Promise<PendingInvite[]> {
     if (!activeWorkspaceId.value) return []
-    if (activeWorkspace.value?.type === 'personal') return []
 
     const response = await workspaceApi.listInvites()
     const invites = response.invites.map(mapApiInviteToPendingInvite)


### PR DESCRIPTION
## Summary

Make Members eligibility follow the active billing plan instead of the personal/team workspace type. A personal workspace on a Team plan now gets the same Members experience as a team workspace on the same plan.

## Root cause

The Members surface had three independent workspace-type gates:

- `useTeamPlan` treated “team workspace + subscribed” as the Team-plan signal, so a personal workspace was always classified as not being on Team even when billing reported a Team plan.
- `useMembersPanel` inherited the personal-workspace permission and layout defaults, which forced the single-user row, disabled Invite, and rendered the Team upgrade banner.
- Member and pending-invite loading short-circuited for personal workspaces, so valid Team-plan members could not be fetched even if the UI gate was corrected.

## How this fixes it

- Derive `hasTeamPlan`, active Team-plan, cancelled/lapsed, and loading states from billing plan identity plus subscription state.
- Overlay Members permissions and table layout from the plan and workspace role. Team-plan owners can invite and manage members regardless of workspace type; personal plans keep the single-user experience.
- Wait for billing initialization before deciding whether to fetch members/invites or show an upgrade state.
- Remove the store-level personal-workspace short-circuits for member and invite APIs.
- Keep workspace-container actions such as delete/leave governed by workspace type; only the Members entitlement moves to plan-based logic.

## Before / After

### Before

A personal workspace with a Team plan was treated as a personal plan: Invite was disabled and the UI asked the user to upgrade to Team.

<img width="1400" alt="Before: Personal Workspace on Team plan incorrectly shows disabled Invite and Upgrade to Team" src="https://github.com/user-attachments/assets/f0d7a99c-6d7b-4cac-b3c0-9d3c9266830f" />

### After

The same personal-workspace + Team-plan scenario loads the Team member list and enables owner member-management actions.

<img width="1400" alt="After: Personal Workspace on Team plan shows member list, Invite, roles, and member actions" src="https://github.com/user-attachments/assets/7e2fbcd7-d8e3-4ae8-a9df-ad59974ecf52" />

## Review Focus

- Team-plan owners receive member management regardless of workspace type.
- Personal plans remain single-user.
- Loading, cancelled, and lapsed states do not briefly expose an incorrect upgrade or invite state.
- Workspace delete/leave behavior remains workspace-type based.

## Validation

- 168 focused Vitest tests passed.
- `pnpm typecheck` passed.
- `pnpm lint` passed.
- `pnpm knip` passed.
- Cloud Playwright: 7/7 tests passed in `memberRoleChange.spec.ts`, including personal workspace + Team plan regression coverage.
- Pre-commit style, format, lint, and type checks passed.