### PR TITLE
test: guard error copy against escaping slashes in received values

### DIFF
--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -173,12 +173,12 @@ describe('errorMessageResolver', () => {
       }),
       nodeDisplayName: 'WanVideo Lora Select Multi'
     })
-    const interpolatedCopy = [result.displayDetails, result.toastMessage].join(
-      ' '
-    )
+    const htmlEntityPattern = /&(?:#x?[0-9a-f]+|[a-z]+);/i
 
-    expect(interpolatedCopy).toContain(receivedValue)
-    expect(interpolatedCopy).not.toMatch(/&(?:amp|lt|gt|#x2F|#39|#x27);/)
+    expect(result.displayDetails).toContain(receivedValue)
+    expect(result.displayDetails).not.toMatch(htmlEntityPattern)
+    expect(result.toastMessage).toContain(receivedValue)
+    expect(result.toastMessage).not.toMatch(htmlEntityPattern)
   })
 
   it('uses catalog fallbacks when required_input_missing lacks node or input labels', () => {

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -160,6 +160,27 @@ describe('errorMessageResolver', () => {
     expect(result.displayDetails).not.toMatch(/&(?:amp|lt|gt);/)
   })
 
+  it('preserves slashes and ampersands in received values for value_not_in_list', () => {
+    expect(
+      te('errorCatalog.validationErrors.value_not_in_list.detailsWithValue')
+    ).toBe(true)
+    const receivedValue =
+      "Wan22_FunReward/Wan2.2-Fun-A14B-InP-HIGH-MPS_resized_dynamic_avg_rank_21_bf16.safetensors & Bob's model"
+    const result = resolveRunErrorMessage({
+      kind: 'node_validation',
+      error: nodeValidationError('value_not_in_list', 'lora_0', 'lora_0', {
+        received_value: receivedValue
+      }),
+      nodeDisplayName: 'WanVideo Lora Select Multi'
+    })
+    const interpolatedCopy = [result.displayDetails, result.toastMessage].join(
+      ' '
+    )
+
+    expect(interpolatedCopy).toContain(receivedValue)
+    expect(interpolatedCopy).not.toMatch(/&(?:amp|lt|gt|#x2F|#39|#x27);/)
+  })
+
   it('uses catalog fallbacks when required_input_missing lacks node or input labels', () => {
     expect(
       resolveRunErrorMessage({


### PR DESCRIPTION
## ELI-5

When a workflow error mentions a model whose name has a folder in it (like `MyLoras/model.safetensors`), the Error tab used to show the slash as the gibberish code `&#x2F;`, making it look like the frontend mangled the path when it didn't. That specific double-escaping was already fixed on `main` in #13684 (which made the error-catalog translations escape once, at the Vue render boundary). This PR adds a regression test that pins the exact reported scenario — a `value_not_in_list` error whose `received_value` contains `/`, `&`, and `'` — so the fix can't silently regress.

## Summary

Adds a regression test asserting the error-catalog resolver produces no HTML entities when a validation error's `received_value` contains special characters (`/`, `&`, `'`).

## Changes

- **What**: One new test in `errorMessageResolver.test.ts` covering the `value_not_in_list` path with a subfolder model path in `received_value`. No product code change — the underlying fix already landed in #13684.

## Review Focus

**Why no product change.** The reported bug (model paths rendering `/` as `&#x2F;` in the Error tab / toasts) was real, but it was already fixed on `main` by #13684 before this branch was cut. That PR kept `escapeParameter: true` global and opted out per-site with `t(key, params, { escapeParameter: false })` in `catalogI18n.ts` — which is exactly the code path that builds the `receivedValue`-bearing copy (`detailsWithValue` / `toastMessageWithValue`). So `receivedValue` already renders `/`, `&`, and `'` literally. Removing the global `escapeParameter` (an alternative approach) was deliberately **not** done: #13684 chose the global-on + per-site-opt-out design and even aligned the shared test fixture to `escapeParameter: true`, so flipping the global now would undo that design and risk re-escaping at the sites that rely on it.

**Coverage gap this fills.** #13684's special-character tests cover node names (execution) and model names (missing-model), plus numeric `received_value` cases — but none exercise a *string* `received_value` containing `/` (the exact `&#x2F;` symptom). This test closes that gap.

**Test is not vacuous.** Verified locally: with #13684's `{ escapeParameter: false }` opt-out temporarily removed, this test fails with `Wan22_FunReward&amp;amp;#x2F;...` (the reported symptom); with it in place, it passes. A `te(...)` key-existence guard ensures the assertion exercises the real i18n interpolation branch rather than the raw-string fallback.

**v-html audit (per the acceptance criteria).** Audited every `v-html` site plus the one PrimeVue `escape: false` tooltip. None render vue-i18n `t(key, params)` output with user-controlled interpolated params: they render DOMPurify-sanitized markdown, parameterless translated strings, static entity/icon HTML, locally-escaped search highlighting of node names, or (the tooltip) raw string-literal HTML built outside vue-i18n. So no site depends on `escapeParameter` for its safety, and none is affected by the resolver's per-site opt-out.
