### PR TITLE
test: add mocked billing E2E coverage

### DIFF
--- a/browser_tests/fixtures/cloudBillingApiFixture.ts
+++ b/browser_tests/fixtures/cloudBillingApiFixture.ts
@@ -1,0 +1,401 @@
+import { test as base } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
+
+import type {
+  BillingBalanceResponse,
+  BillingOpStatusResponse,
+  BillingPlansResponse,
+  BillingStatusResponse,
+  CancelSubscriptionRequest,
+  CancelSubscriptionResponse,
+  CreateTopupRequest,
+  CreateTopupResponse,
+  ErrorResponse,
+  PreviewSubscribeRequest as GeneratedPreviewSubscribeRequest,
+  PreviewSubscribeResponse,
+  ResubscribeRequest,
+  ResubscribeResponse,
+  SubscribeRequest,
+  SubscribeResponse
+} from '@comfyorg/ingest-types'
+
+import {
+  BILLING_RENEWAL_DATE,
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_BILLING_STATUS,
+  DEFAULT_CANCEL_RESPONSE,
+  DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+  DEFAULT_RESUBSCRIBE_RESPONSE,
+  DEFAULT_SUBSCRIBE_RESPONSE,
+  DEFAULT_TOPUP_RESPONSE,
+  SUCCEEDED_BILLING_OPERATION
+} from '@e2e/fixtures/data/cloudWorkspace'
+
+const BILLING_ROUTE_PATTERN = '**/api/billing/**'
+
+export type PreviewSubscribeRequest = GeneratedPreviewSubscribeRequest &
+  Pick<SubscribeRequest, 'team_credit_stop_id' | 'billing_cycle'>
+
+export interface BillingMutationRequests {
+  previewSubscribe: PreviewSubscribeRequest[]
+  subscribe: SubscribeRequest[]
+  topup: CreateTopupRequest[]
+  cancel: CancelSubscriptionRequest[]
+  resubscribe: ResubscribeRequest[]
+}
+
+export interface CloudBillingState {
+  status: BillingStatusResponse
+  balance: BillingBalanceResponse
+  plans: BillingPlansResponse
+}
+
+export interface BillingHttpFailure {
+  status: number
+  message: string
+  code?: string
+}
+
+export interface CloudBillingSetupOptions {
+  status?: BillingStatusResponse
+  balance?: BillingBalanceResponse
+  plans?: BillingPlansResponse
+  previewResponse?: PreviewSubscribeResponse
+  subscribeResponse?: SubscribeResponse
+  topupResponse?: CreateTopupResponse
+  cancelResponse?: CancelSubscriptionResponse
+  resubscribeResponse?: ResubscribeResponse
+  operationResponses?: Record<string, readonly BillingOpStatusResponse[]>
+  failures?: Partial<Record<keyof BillingMutationRequests, BillingHttpFailure>>
+}
+
+type PendingMutation =
+  | { type: 'subscribe'; request: SubscribeRequest }
+  | { type: 'topup'; amountCents: number }
+  | { type: 'cancel'; cancelAt: string }
+  | { type: 'resubscribe' }
+
+export class CloudBillingApiMock {
+  readonly requests: BillingMutationRequests = {
+    previewSubscribe: [],
+    subscribe: [],
+    topup: [],
+    cancel: [],
+    resubscribe: []
+  }
+
+  private _state: CloudBillingState | null = null
+  private previewResponse = structuredClone(DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE)
+  private subscribeResponse = structuredClone(DEFAULT_SUBSCRIBE_RESPONSE)
+  private topupResponse = structuredClone(DEFAULT_TOPUP_RESPONSE)
+  private cancelResponse = structuredClone(DEFAULT_CANCEL_RESPONSE)
+  private resubscribeResponse = structuredClone(DEFAULT_RESUBSCRIBE_RESPONSE)
+  private failures: CloudBillingSetupOptions['failures'] = {}
+  private readonly operationResponses = new Map<
+    string,
+    readonly BillingOpStatusResponse[]
+  >()
+  private readonly operationPolls = new Map<string, number>()
+  private readonly pendingMutations = new Map<string, PendingMutation>()
+  private readonly appliedOperations = new Set<string>()
+  private readonly routeHandler: (route: Route) => Promise<void>
+
+  constructor(private readonly page: Page) {
+    this.routeHandler = this.handleRoute.bind(this)
+  }
+
+  get state(): CloudBillingState {
+    if (!this._state) {
+      throw new Error('Call billingApi.setup() before reading billing state')
+    }
+    return this._state
+  }
+
+  async setup(
+    options: CloudBillingSetupOptions = {}
+  ): Promise<CloudBillingState> {
+    if (this._state) {
+      throw new Error('billingApi.setup() can only be called once per test')
+    }
+
+    this._state = {
+      status: structuredClone(options.status ?? DEFAULT_BILLING_STATUS),
+      balance: structuredClone(options.balance ?? DEFAULT_BILLING_BALANCE),
+      plans: structuredClone(options.plans ?? DEFAULT_BILLING_PLANS)
+    }
+    this.previewResponse = structuredClone(
+      options.previewResponse ?? DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE
+    )
+    this.subscribeResponse = structuredClone(
+      options.subscribeResponse ?? DEFAULT_SUBSCRIBE_RESPONSE
+    )
+    this.topupResponse = structuredClone(
+      options.topupResponse ?? DEFAULT_TOPUP_RESPONSE
+    )
+    this.cancelResponse = structuredClone(
+      options.cancelResponse ?? DEFAULT_CANCEL_RESPONSE
+    )
+    this.resubscribeResponse = structuredClone(
+      options.resubscribeResponse ?? DEFAULT_RESUBSCRIBE_RESPONSE
+    )
+    this.failures = structuredClone(options.failures ?? {})
+
+    for (const [operationId, responses] of Object.entries(
+      options.operationResponses ?? {}
+    )) {
+      this.operationResponses.set(operationId, structuredClone(responses))
+    }
+
+    await this.page.route(BILLING_ROUTE_PATTERN, this.routeHandler)
+    return this._state
+  }
+
+  async dispose(): Promise<void> {
+    if (!this._state) return
+    await this.page.unroute(BILLING_ROUTE_PATTERN, this.routeHandler)
+  }
+
+  private async handleRoute(route: Route): Promise<void> {
+    const request = route.request()
+    const method = request.method().toUpperCase()
+    const pathname = new URL(request.url()).pathname
+
+    if (method === 'GET' && pathname.endsWith('/api/billing/status')) {
+      await route.fulfill({ json: this.state.status })
+      return
+    }
+    if (method === 'GET' && pathname.endsWith('/api/billing/balance')) {
+      await route.fulfill({ json: this.state.balance })
+      return
+    }
+    if (method === 'GET' && pathname.endsWith('/api/billing/plans')) {
+      await route.fulfill({ json: this.state.plans })
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/preview-subscribe')
+    ) {
+      await this.handlePreviewSubscribe(route)
+      return
+    }
+    if (method === 'POST' && pathname.endsWith('/api/billing/subscribe')) {
+      await this.handleSubscribe(route)
+      return
+    }
+    if (method === 'POST' && pathname.endsWith('/api/billing/topup')) {
+      await this.handleTopup(route)
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/subscription/cancel')
+    ) {
+      await this.handleCancel(route)
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/subscription/resubscribe')
+    ) {
+      await this.handleResubscribe(route)
+      return
+    }
+    if (method === 'GET' && pathname.includes('/api/billing/ops/')) {
+      await this.handleOperation(route, pathname)
+      return
+    }
+
+    await route.fallback()
+  }
+
+  private async handlePreviewSubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as PreviewSubscribeRequest
+    this.requests.previewSubscribe.push(request)
+    if (await this.failIfConfigured(route, 'previewSubscribe')) return
+    await route.fulfill({ json: this.previewResponse })
+  }
+
+  private async handleSubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as SubscribeRequest
+    this.requests.subscribe.push(request)
+    if (await this.failIfConfigured(route, 'subscribe')) return
+
+    if (this.subscribeResponse.status === 'subscribed') {
+      this.applySubscribe(request)
+    } else {
+      this.pendingMutations.set(this.subscribeResponse.billing_op_id, {
+        type: 'subscribe',
+        request
+      })
+    }
+    await route.fulfill({ json: this.subscribeResponse })
+  }
+
+  private async handleTopup(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as CreateTopupRequest
+    this.requests.topup.push(request)
+    if (await this.failIfConfigured(route, 'topup')) return
+
+    const response: CreateTopupResponse = {
+      ...this.topupResponse,
+      amount_cents: request.amount_cents
+    }
+    if (response.status === 'completed') {
+      this.applyTopup(request.amount_cents)
+    } else if (response.status === 'pending') {
+      this.pendingMutations.set(response.billing_op_id, {
+        type: 'topup',
+        amountCents: request.amount_cents
+      })
+    }
+    await route.fulfill({ json: response })
+  }
+
+  private async handleCancel(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as CancelSubscriptionRequest
+    this.requests.cancel.push(request)
+    if (await this.failIfConfigured(route, 'cancel')) return
+
+    this.pendingMutations.set(this.cancelResponse.billing_op_id, {
+      type: 'cancel',
+      cancelAt: this.cancelResponse.cancel_at
+    })
+    await route.fulfill({ json: this.cancelResponse })
+  }
+
+  private async handleResubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as ResubscribeRequest
+    this.requests.resubscribe.push(request)
+    if (await this.failIfConfigured(route, 'resubscribe')) return
+
+    if (this.resubscribeResponse.status === 'active') {
+      this.applyResubscribe()
+    } else {
+      this.pendingMutations.set(this.resubscribeResponse.billing_op_id, {
+        type: 'resubscribe'
+      })
+    }
+    await route.fulfill({ json: this.resubscribeResponse })
+  }
+
+  private async handleOperation(route: Route, pathname: string): Promise<void> {
+    const operationId = decodeURIComponent(pathname.split('/').at(-1) ?? '')
+    const responses = this.operationResponses.get(operationId)
+    const poll = this.operationPolls.get(operationId) ?? 0
+    const configuredResponse = responses?.at(
+      Math.min(poll, responses.length - 1)
+    )
+    const response: BillingOpStatusResponse = {
+      ...(configuredResponse ?? SUCCEEDED_BILLING_OPERATION),
+      id: operationId
+    }
+    this.operationPolls.set(operationId, poll + 1)
+
+    if (response.status === 'succeeded') {
+      this.applyPendingMutation(operationId)
+    }
+    await route.fulfill({ json: response })
+  }
+
+  private async failIfConfigured(
+    route: Route,
+    mutation: keyof BillingMutationRequests
+  ): Promise<boolean> {
+    const failure = this.failures?.[mutation]
+    if (!failure) return false
+
+    const body: ErrorResponse = {
+      code: failure.code ?? 'billing_mock_error',
+      message: failure.message
+    }
+    await route.fulfill({ status: failure.status, json: body })
+    return true
+  }
+
+  private applyPendingMutation(operationId: string): void {
+    if (this.appliedOperations.has(operationId)) return
+    const mutation = this.pendingMutations.get(operationId)
+    if (!mutation) return
+
+    if (mutation.type === 'subscribe') this.applySubscribe(mutation.request)
+    if (mutation.type === 'topup') this.applyTopup(mutation.amountCents)
+    if (mutation.type === 'cancel') this.applyCancel(mutation.cancelAt)
+    if (mutation.type === 'resubscribe') this.applyResubscribe()
+    this.appliedOperations.add(operationId)
+  }
+
+  private applySubscribe(request: SubscribeRequest): void {
+    const plan = this.state.plans.plans.find(
+      ({ slug }) => slug === request.plan_slug
+    )
+    const stop = this.state.plans.team_credit_stops?.stops.find(
+      ({ id }) => id === request.team_credit_stop_id
+    )
+
+    this.state.status = {
+      ...this.state.status,
+      is_active: true,
+      subscription_status: 'active',
+      subscription_tier: plan?.tier ?? this.state.status.subscription_tier,
+      subscription_duration:
+        plan?.duration ?? this.state.status.subscription_duration,
+      plan_slug: request.plan_slug,
+      billing_status: 'paid',
+      renewal_date: this.state.status.renewal_date ?? BILLING_RENEWAL_DATE,
+      team_credit_stop:
+        plan?.tier === 'TEAM' && stop
+          ? {
+              id: stop.id,
+              credits_monthly: stop.credits,
+              stop_usd: stop.yearly.list_price_cents / 100
+            }
+          : null
+    }
+    this.state.plans.current_plan_slug = request.plan_slug
+  }
+
+  private applyTopup(amountCents: number): void {
+    const balance = this.state.balance
+    this.state.balance = {
+      ...balance,
+      amount_micros: balance.amount_micros + amountCents,
+      effective_balance_micros:
+        (balance.effective_balance_micros ?? balance.amount_micros) +
+        amountCents,
+      prepaid_balance_micros:
+        (balance.prepaid_balance_micros ?? 0) + amountCents
+    }
+    this.state.status = { ...this.state.status, has_funds: true }
+  }
+
+  private applyCancel(cancelAt: string): void {
+    this.state.status = {
+      ...this.state.status,
+      is_active: true,
+      subscription_status: 'canceled',
+      cancel_at: cancelAt
+    }
+  }
+
+  private applyResubscribe(): void {
+    const status = { ...this.state.status }
+    delete status.cancel_at
+    this.state.status = {
+      ...status,
+      is_active: true,
+      subscription_status: 'active'
+    }
+  }
+}
+
+export const cloudBillingApiFixture = base.extend<{
+  billingApi: CloudBillingApiMock
+}>({
+  billingApi: async ({ page }, use) => {
+    const billingApi = new CloudBillingApiMock(page)
+    await use(billingApi)
+    await billingApi.dispose()
+  }
+})

--- a/browser_tests/fixtures/cloudBillingApiFixture.ts
+++ b/browser_tests/fixtures/cloudBillingApiFixture.ts
@@ -45,6 +45,8 @@ export interface BillingMutationRequests {
   resubscribe: ResubscribeRequest[]
 }
 
+export type BillingQuery = 'status' | 'balance' | 'plans'
+
 export interface CloudBillingState {
   status: BillingStatusResponse
   balance: BillingBalanceResponse
@@ -66,8 +68,10 @@ export interface CloudBillingSetupOptions {
   topupResponse?: CreateTopupResponse
   cancelResponse?: CancelSubscriptionResponse
   resubscribeResponse?: ResubscribeResponse
+  postSubscribeBalance?: BillingBalanceResponse
   operationResponses?: Record<string, readonly BillingOpStatusResponse[]>
   failures?: Partial<Record<keyof BillingMutationRequests, BillingHttpFailure>>
+  queryFailures?: Partial<Record<BillingQuery, BillingHttpFailure>>
 }
 
 type PendingMutation =
@@ -84,14 +88,15 @@ export class CloudBillingApiMock {
     cancel: [],
     resubscribe: []
   }
-
   private _state: CloudBillingState | null = null
   private previewResponse = structuredClone(DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE)
   private subscribeResponse = structuredClone(DEFAULT_SUBSCRIBE_RESPONSE)
   private topupResponse = structuredClone(DEFAULT_TOPUP_RESPONSE)
   private cancelResponse = structuredClone(DEFAULT_CANCEL_RESPONSE)
   private resubscribeResponse = structuredClone(DEFAULT_RESUBSCRIBE_RESPONSE)
+  private postSubscribeBalance: BillingBalanceResponse | null = null
   private failures: CloudBillingSetupOptions['failures'] = {}
+  private readonly queryFailures = new Map<BillingQuery, BillingHttpFailure>()
   private readonly operationResponses = new Map<
     string,
     readonly BillingOpStatusResponse[]
@@ -139,7 +144,16 @@ export class CloudBillingApiMock {
     this.resubscribeResponse = structuredClone(
       options.resubscribeResponse ?? DEFAULT_RESUBSCRIBE_RESPONSE
     )
+    this.postSubscribeBalance = options.postSubscribeBalance
+      ? structuredClone(options.postSubscribeBalance)
+      : null
     this.failures = structuredClone(options.failures ?? {})
+
+    for (const [query, failure] of Object.entries(
+      options.queryFailures ?? {}
+    )) {
+      this.queryFailures.set(query as BillingQuery, structuredClone(failure))
+    }
 
     for (const [operationId, responses] of Object.entries(
       options.operationResponses ?? {}
@@ -149,6 +163,21 @@ export class CloudBillingApiMock {
 
     await this.page.route(BILLING_ROUTE_PATTERN, this.routeHandler)
     return this._state
+  }
+
+  setBalance(balance: BillingBalanceResponse): void {
+    this.state.balance = structuredClone(balance)
+  }
+
+  setQueryFailure(
+    query: BillingQuery,
+    failure: BillingHttpFailure | null
+  ): void {
+    if (failure) {
+      this.queryFailures.set(query, structuredClone(failure))
+      return
+    }
+    this.queryFailures.delete(query)
   }
 
   async dispose(): Promise<void> {
@@ -162,15 +191,15 @@ export class CloudBillingApiMock {
     const pathname = new URL(request.url()).pathname
 
     if (method === 'GET' && pathname.endsWith('/api/billing/status')) {
-      await route.fulfill({ json: this.state.status })
+      await this.handleQuery(route, 'status', this.state.status)
       return
     }
     if (method === 'GET' && pathname.endsWith('/api/billing/balance')) {
-      await route.fulfill({ json: this.state.balance })
+      await this.handleQuery(route, 'balance', this.state.balance)
       return
     }
     if (method === 'GET' && pathname.endsWith('/api/billing/plans')) {
-      await route.fulfill({ json: this.state.plans })
+      await this.handleQuery(route, 'plans', this.state.plans)
       return
     }
     if (
@@ -208,6 +237,26 @@ export class CloudBillingApiMock {
     }
 
     await route.fallback()
+  }
+
+  private async handleQuery(
+    route: Route,
+    query: BillingQuery,
+    response:
+      | BillingStatusResponse
+      | BillingBalanceResponse
+      | BillingPlansResponse
+  ): Promise<void> {
+    const failure = this.queryFailures.get(query)
+    if (failure) {
+      const body: ErrorResponse = {
+        code: failure.code ?? 'billing_mock_error',
+        message: failure.message
+      }
+      await route.fulfill({ status: failure.status, json: body })
+      return
+    }
+    await route.fulfill({ json: response })
   }
 
   private async handlePreviewSubscribe(route: Route): Promise<void> {
@@ -354,6 +403,9 @@ export class CloudBillingApiMock {
           : null
     }
     this.state.plans.current_plan_slug = request.plan_slug
+    if (this.postSubscribeBalance) {
+      this.state.balance = structuredClone(this.postSubscribeBalance)
+    }
   }
 
   private applyTopup(amountCents: number): void {

--- a/browser_tests/fixtures/components/SubscriptionCheckoutDialog.ts
+++ b/browser_tests/fixtures/components/SubscriptionCheckoutDialog.ts
@@ -1,0 +1,61 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { BaseDialog } from '@e2e/fixtures/components/BaseDialog'
+
+export class SubscriptionCheckoutDialog extends BaseDialog {
+  readonly heading: Locator
+  readonly personalPlansButton: Locator
+  readonly teamPlansButton: Locator
+  readonly monthlyButton: Locator
+  readonly yearlyButton: Locator
+  readonly paymentPreviewHeading: Locator
+  readonly upgradePreviewHeading: Locator
+  readonly scheduledChangeHeading: Locator
+  readonly backToPlansButton: Locator
+  readonly termsLink: Locator
+  readonly privacyPolicyLink: Locator
+  readonly successHeading: Locator
+  readonly successContent: Locator
+
+  constructor(page: Page) {
+    super(page)
+    this.heading = this.root.getByRole('heading', { name: 'Choose a Plan' })
+    this.personalPlansButton = this.root.getByRole('button', {
+      name: 'For Personal'
+    })
+    this.teamPlansButton = this.root.getByRole('button', {
+      name: 'For Teams'
+    })
+    this.monthlyButton = this.root.getByRole('button', { name: 'Monthly' })
+    this.yearlyButton = this.root.getByRole('button', { name: /^Yearly\b/ })
+    this.paymentPreviewHeading = this.root.getByRole('heading', {
+      name: 'Confirm your payment'
+    })
+    this.upgradePreviewHeading = this.root.getByRole('heading', {
+      name: 'Confirm your upgrade'
+    })
+    this.scheduledChangeHeading = this.root.getByRole('heading', {
+      name: 'Review your scheduled change'
+    })
+    this.backToPlansButton = this.root.getByRole('button', {
+      name: 'Back to all plans'
+    })
+    this.termsLink = this.root.getByRole('link', { name: 'Terms' })
+    this.privacyPolicyLink = this.root.getByRole('link', {
+      name: 'Privacy Policy'
+    })
+    this.successHeading = this.root.getByRole('heading', {
+      name: "You're all set"
+    })
+    this.successContent = this.successHeading.locator('..')
+  }
+
+  personalPlanButton(label: string): Locator {
+    return this.root.getByRole('button', { name: label, exact: true })
+  }
+
+  async selectBillingCycle(cycle: 'monthly' | 'yearly'): Promise<void> {
+    const button = cycle === 'monthly' ? this.monthlyButton : this.yearlyButton
+    await button.click()
+  }
+}

--- a/browser_tests/fixtures/components/TopUpCreditsDialog.ts
+++ b/browser_tests/fixtures/components/TopUpCreditsDialog.ts
@@ -11,6 +11,7 @@ export class TopUpCreditsDialog extends BaseDialog {
   readonly preset50: Locator
   readonly preset100: Locator
   readonly payAmountInput: Locator
+  readonly contactUsLink: Locator
   readonly pricingLink: Locator
 
   constructor(page: Page) {
@@ -38,6 +39,7 @@ export class TopUpCreditsDialog extends BaseDialog {
     this.payAmountInput = this.root
       .getByTestId('top-up-pay-amount')
       .locator('input')
+    this.contactUsLink = this.root.getByRole('link', { name: 'Contact us' })
     this.pricingLink = this.root.getByRole('link', {
       name: 'View pricing details'
     })

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,7 +1,19 @@
 import type {
+  BillingBalanceResponse,
+  BillingOpStatusResponse,
+  BillingPlansResponse,
   BillingStatusResponse,
-  Member,
+  CancelSubscriptionResponse,
+  CreateTopupResponse,
   Plan,
+  PreviewSubscribeResponse,
+  ResubscribeResponse,
+  SubscribeResponse,
+  TeamCreditStops
+} from '@comfyorg/ingest-types'
+
+import type {
+  Member,
   WorkspaceWithRole
 } from '@/platform/workspace/api/workspaceApi'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
@@ -68,7 +80,36 @@ export const DEFAULT_TEAM_MEMBERS: Member[] = [
   MEMBER_JOHN
 ]
 
+export const BILLING_RENEWAL_DATE = '2099-02-20T00:00:00Z'
+export const BILLING_OPERATION_STARTED_AT = '2099-01-20T00:00:00Z'
+export const BILLING_OPERATION_COMPLETED_AT = '2099-01-20T00:00:01Z'
+
 const TEAM_PLAN_SLUG = 'team-pro-monthly'
+
+function billingPlan(
+  slug: string,
+  tier: Plan['tier'],
+  duration: Plan['duration'],
+  priceCents: number,
+  creditsCents: number,
+  maxSeats: number,
+  seatCount: number
+): Plan {
+  return {
+    slug,
+    tier,
+    duration,
+    price_cents: priceCents,
+    credits_cents: creditsCents,
+    max_seats: maxSeats,
+    availability: { available: true },
+    seat_summary: {
+      seat_count: seatCount,
+      total_cost_cents: priceCents * seatCount,
+      total_credits_cents: creditsCents * seatCount
+    }
+  }
+}
 
 export const TEAM_BILLING_STATUS: BillingStatusResponse = {
   is_active: true,
@@ -78,20 +119,195 @@ export const TEAM_BILLING_STATUS: BillingStatusResponse = {
   plan_slug: TEAM_PLAN_SLUG,
   billing_status: 'paid',
   has_funds: true,
-  renewal_date: '2099-02-20T00:00:00Z'
+  renewal_date: BILLING_RENEWAL_DATE,
+  team_credit_stop: null
 }
 
 export const TEAM_PRO_PLAN: Plan = {
   slug: TEAM_PLAN_SLUG,
   tier: 'PRO',
   duration: 'MONTHLY',
-  price_cents: 10000,
-  credits_cents: 21100,
+  price_cents: 10_000,
+  credits_cents: 21_100,
   max_seats: 30,
   availability: { available: true },
   seat_summary: {
     seat_count: 4,
-    total_cost_cents: 40000,
+    total_cost_cents: 40_000,
     total_credits_cents: 0
   }
+}
+
+export const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
+  is_active: false,
+  subscription_tier: 'FREE',
+  billing_status: 'inactive',
+  has_funds: true,
+  team_credit_stop: null
+}
+
+export const PERSONAL_BILLING_STATUS: BillingStatusResponse = {
+  is_active: true,
+  subscription_status: 'active',
+  subscription_tier: 'STANDARD',
+  subscription_duration: 'ANNUAL',
+  plan_slug: 'standard-annual',
+  billing_status: 'paid',
+  has_funds: true,
+  renewal_date: BILLING_RENEWAL_DATE,
+  team_credit_stop: null
+}
+
+export const TEAM_CREDIT_BILLING_STATUS: BillingStatusResponse = {
+  is_active: true,
+  subscription_status: 'active',
+  subscription_tier: 'TEAM',
+  subscription_duration: 'ANNUAL',
+  plan_slug: 'team_per_credit_annual',
+  billing_status: 'paid',
+  has_funds: true,
+  renewal_date: BILLING_RENEWAL_DATE,
+  team_credit_stop: {
+    id: 'team_700',
+    credits_monthly: 147_700,
+    stop_usd: 700
+  }
+}
+
+export const CANCELLED_TEAM_BILLING_STATUS: BillingStatusResponse = {
+  ...TEAM_CREDIT_BILLING_STATUS,
+  subscription_status: 'canceled',
+  cancel_at: BILLING_RENEWAL_DATE
+}
+
+export const DEFAULT_BILLING_BALANCE: BillingBalanceResponse = {
+  amount_micros: 2_500,
+  currency: 'usd',
+  effective_balance_micros: 2_500,
+  cloud_credit_balance_micros: 2_000,
+  prepaid_balance_micros: 500
+}
+
+export const PERSONAL_STANDARD_ANNUAL_PLAN = billingPlan(
+  'standard-annual',
+  'STANDARD',
+  'ANNUAL',
+  19_200,
+  4_200,
+  1,
+  1
+)
+
+const PERSONAL_PLANS: Plan[] = [
+  billingPlan('standard-monthly', 'STANDARD', 'MONTHLY', 2_000, 4_200, 1, 1),
+  PERSONAL_STANDARD_ANNUAL_PLAN,
+  billingPlan('creator-monthly', 'CREATOR', 'MONTHLY', 3_500, 7_400, 5, 1),
+  billingPlan('creator-annual', 'CREATOR', 'ANNUAL', 33_600, 7_400, 5, 1),
+  billingPlan('pro-monthly', 'PRO', 'MONTHLY', 10_000, 21_100, 20, 1),
+  billingPlan('pro-annual', 'PRO', 'ANNUAL', 96_000, 21_100, 20, 1)
+]
+
+export const DEFAULT_TEAM_CREDIT_STOPS: TeamCreditStops = {
+  default_stop_index: 0,
+  stops: [
+    {
+      id: 'team_700',
+      credits: 147_700,
+      monthly: { list_price_cents: 70_000, price_cents: 66_500 },
+      yearly: { list_price_cents: 70_000, price_cents: 63_000 }
+    }
+  ]
+}
+
+const TEAM_PLANS: Plan[] = [
+  billingPlan('team_per_credit_monthly', 'TEAM', 'MONTHLY', 66_500, 0, 30, 1),
+  billingPlan('team_per_credit_annual', 'TEAM', 'ANNUAL', 756_000, 0, 30, 1)
+]
+
+export const DEFAULT_BILLING_PLANS: BillingPlansResponse = {
+  plans: [...PERSONAL_PLANS, ...TEAM_PLANS],
+  team_credit_stops: DEFAULT_TEAM_CREDIT_STOPS
+}
+
+export const DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE: PreviewSubscribeResponse = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: BILLING_OPERATION_COMPLETED_AT,
+  is_immediate: true,
+  cost_today_cents: PERSONAL_STANDARD_ANNUAL_PLAN.price_cents,
+  cost_next_period_cents: PERSONAL_STANDARD_ANNUAL_PLAN.price_cents,
+  credits_today_cents: PERSONAL_STANDARD_ANNUAL_PLAN.credits_cents,
+  credits_next_period_cents: PERSONAL_STANDARD_ANNUAL_PLAN.credits_cents,
+  new_plan: PERSONAL_STANDARD_ANNUAL_PLAN
+}
+
+export const SCHEDULED_PREVIEW_SUBSCRIBE_RESPONSE: PreviewSubscribeResponse = {
+  ...DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+  transition_type: 'downgrade',
+  effective_at: BILLING_RENEWAL_DATE,
+  is_immediate: false,
+  cost_today_cents: 0,
+  credits_today_cents: 0
+}
+
+export const DEFAULT_SUBSCRIBE_RESPONSE: SubscribeResponse = {
+  billing_op_id: 'billing-op-subscribe',
+  status: 'subscribed',
+  effective_at: BILLING_OPERATION_COMPLETED_AT
+}
+
+export const PENDING_SUBSCRIBE_RESPONSE: SubscribeResponse = {
+  ...DEFAULT_SUBSCRIBE_RESPONSE,
+  status: 'pending_payment'
+}
+
+export const DEFAULT_TOPUP_RESPONSE: CreateTopupResponse = {
+  billing_op_id: 'billing-op-topup',
+  topup_id: 'topup-1',
+  status: 'completed',
+  amount_cents: 2_500
+}
+
+export const PENDING_TOPUP_RESPONSE: CreateTopupResponse = {
+  ...DEFAULT_TOPUP_RESPONSE,
+  status: 'pending'
+}
+
+export const FAILED_TOPUP_RESPONSE: CreateTopupResponse = {
+  ...DEFAULT_TOPUP_RESPONSE,
+  status: 'failed'
+}
+
+export const DEFAULT_CANCEL_RESPONSE: CancelSubscriptionResponse = {
+  billing_op_id: 'billing-op-cancel',
+  cancel_at: BILLING_RENEWAL_DATE
+}
+
+export const DEFAULT_RESUBSCRIBE_RESPONSE: ResubscribeResponse = {
+  billing_op_id: 'billing-op-resubscribe',
+  status: 'active'
+}
+
+export const PENDING_RESUBSCRIBE_RESPONSE: ResubscribeResponse = {
+  ...DEFAULT_RESUBSCRIBE_RESPONSE,
+  status: 'pending'
+}
+
+export const PENDING_BILLING_OPERATION: BillingOpStatusResponse = {
+  id: 'billing-op',
+  status: 'pending',
+  started_at: BILLING_OPERATION_STARTED_AT
+}
+
+export const SUCCEEDED_BILLING_OPERATION: BillingOpStatusResponse = {
+  ...PENDING_BILLING_OPERATION,
+  status: 'succeeded',
+  completed_at: BILLING_OPERATION_COMPLETED_AT
+}
+
+export const FAILED_BILLING_OPERATION: BillingOpStatusResponse = {
+  ...PENDING_BILLING_OPERATION,
+  status: 'failed',
+  error_message: 'Mock billing operation failed',
+  completed_at: BILLING_OPERATION_COMPLETED_AT
 }

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -26,6 +26,10 @@ interface MemberMockState {
   patches: RoleChangeRequest[]
 }
 
+export interface CloudWorkspaceMockOptions {
+  mockBilling?: boolean
+}
+
 const jsonRoute = (body: unknown) => ({
   status: 200,
   contentType: 'application/json',
@@ -45,9 +49,10 @@ export class CloudWorkspaceMockHelper {
 
   async setup(
     members: Member[] = DEFAULT_TEAM_MEMBERS,
-    activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE
+    activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE,
+    { mockBilling = true }: CloudWorkspaceMockOptions = {}
   ): Promise<MemberMockState> {
-    const state = await this.mockBoot(members, activeWorkspace)
+    const state = await this.mockBoot(members, activeWorkspace, mockBilling)
     await new CloudAuthHelper(this.page).mockAuth()
     await this.page.addInitScript((workspaceId) => {
       localStorage.setItem('Comfy.userId', 'test-user-e2e')
@@ -58,7 +63,8 @@ export class CloudWorkspaceMockHelper {
 
   private async mockBoot(
     members: Member[],
-    activeWorkspace: WorkspaceWithRole
+    activeWorkspace: WorkspaceWithRole,
+    mockBilling: boolean
   ): Promise<MemberMockState> {
     const state: MemberMockState = {
       members: members.map((m) => ({ ...m })),
@@ -131,28 +137,30 @@ export class CloudWorkspaceMockHelper {
       r.fulfill(jsonRoute({ invites: [] }))
     )
 
-    await page.route('**/api/billing/status', (r) =>
-      r.fulfill(jsonRoute(TEAM_BILLING_STATUS))
-    )
-    await page.route('**/api/billing/balance', (r) =>
-      r.fulfill(
-        jsonRoute({
-          amount_micros: 6000,
-          currency: 'usd',
-          effective_balance_micros: 6000,
-          cloud_credit_balance_micros: 5000,
-          prepaid_balance_micros: 1000
-        })
+    if (mockBilling) {
+      await page.route('**/api/billing/status', (r) =>
+        r.fulfill(jsonRoute(TEAM_BILLING_STATUS))
       )
-    )
-    await page.route('**/api/billing/plans', (r) =>
-      r.fulfill(
-        jsonRoute({
-          current_plan_slug: TEAM_PRO_PLAN.slug,
-          plans: [TEAM_PRO_PLAN]
-        })
+      await page.route('**/api/billing/balance', (r) =>
+        r.fulfill(
+          jsonRoute({
+            amount_micros: 6000,
+            currency: 'usd',
+            effective_balance_micros: 6000,
+            cloud_credit_balance_micros: 5000,
+            prepaid_balance_micros: 1000
+          })
+        )
       )
-    )
+      await page.route('**/api/billing/plans', (r) =>
+        r.fulfill(
+          jsonRoute({
+            current_plan_slug: TEAM_PRO_PLAN.slug,
+            plans: [TEAM_PRO_PLAN]
+          })
+        )
+      )
+    }
 
     return state
   }

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -50,15 +50,51 @@ const toWorkspaceStatus = (
 
 const mockBalance: BillingBalanceResponse = {
   amount_micros: 6000, // -> 12,660 credits
+  cloud_credit_balance_micros: 5000,
   currency: 'usd',
-  effective_balance_micros: 6000
+  effective_balance_micros: 6000,
+  prepaid_balance_micros: 1000
+}
+
+const activeProSubscription: CloudSubscriptionStatusResponse = {
+  is_active: true,
+  subscription_tier: 'PRO',
+  subscription_duration: 'MONTHLY',
+  renewal_date: '2099-02-20T10:00:00Z',
+  end_date: null
+}
+
+const legacyBillingConfig: RemoteConfig = {
+  team_workspaces_enabled: false,
+  billing_control_enabled: false,
+  subscription_required: true
+}
+
+const workspaceBillingConfig: RemoteConfig = {
+  team_workspaces_enabled: true,
+  billing_control_enabled: true,
+  subscription_required: true
+}
+
+interface BillingBackendRequestCounts {
+  legacyBalance: number
+  legacyStatus: number
+  workspaceBalance: number
+  workspaceStatus: number
 }
 
 async function mockCloudBoot(
   page: Page,
   subscriptionStatus: CloudSubscriptionStatusResponse,
   remoteConfig: RemoteConfig = { team_workspaces_enabled: false }
-) {
+): Promise<BillingBackendRequestCounts> {
+  const billingRequests: BillingBackendRequestCounts = {
+    legacyBalance: 0,
+    legacyStatus: 0,
+    workspaceBalance: 0,
+    workspaceStatus: 0
+  }
+
   await page.route('**/api/features', (r) => r.fulfill(jsonRoute(remoteConfig)))
   await page.route('**/api/system_stats', (r) =>
     r.fulfill(jsonRoute(mockSystemStats))
@@ -105,24 +141,30 @@ async function mockCloudBoot(
   )
 
   // Legacy backend (team_workspaces_enabled: false).
-  await page.route('**/customers/cloud-subscription-status', (r) =>
-    r.fulfill(jsonRoute(subscriptionStatus))
-  )
-  await page.route('**/customers/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  await page.route('**/customers/cloud-subscription-status', (r) => {
+    billingRequests.legacyStatus += 1
+    return r.fulfill(jsonRoute(subscriptionStatus))
+  })
+  await page.route('**/customers/balance', (r) => {
+    billingRequests.legacyBalance += 1
+    return r.fulfill(jsonRoute(mockBalance))
+  })
 
   // Workspace backend (team_workspaces_enabled: true) — a personal workspace
   // now routes through `/api/billing/*`.
-  await page.route('**/api/billing/status', (r) =>
-    r.fulfill(jsonRoute(toWorkspaceStatus(subscriptionStatus)))
-  )
-  await page.route('**/api/billing/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  await page.route('**/api/billing/status', (r) => {
+    billingRequests.workspaceStatus += 1
+    return r.fulfill(jsonRoute(toWorkspaceStatus(subscriptionStatus)))
+  })
+  await page.route('**/api/billing/balance', (r) => {
+    billingRequests.workspaceBalance += 1
+    return r.fulfill(jsonRoute(mockBalance))
+  })
   await page.route('**/api/billing/plans', (r) =>
     r.fulfill(jsonRoute({ plans: [] }))
   )
+
+  return billingRequests
 }
 
 async function bootApp(page: Page) {
@@ -140,6 +182,104 @@ async function bootApp(page: Page) {
 }
 
 test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
+  test('TB-17 keeps the balance consistent from the popover to Plan & Credits', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
+
+    const billingRequests = await mockCloudBoot(
+      page,
+      activeProSubscription,
+      workspaceBillingConfig
+    )
+    await bootApp(page)
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    const popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByText('12,660', { exact: true })).toBeVisible()
+
+    await popover.getByTestId('manage-plan-menu-item').click()
+
+    const dialog = page.getByTestId('settings-dialog')
+    await expect(dialog).toBeVisible()
+    const content = dialog.getByRole('main')
+    await expect(
+      content.getByRole('tab', { name: 'Plan & Credits' })
+    ).toBeVisible()
+    await expect(content.getByText('Total credits')).toBeVisible()
+    await expect(content.getByText('12,660', { exact: true })).toBeVisible()
+    expect(billingRequests.workspaceStatus).toBeGreaterThanOrEqual(1)
+    expect(billingRequests.workspaceBalance).toBeGreaterThanOrEqual(1)
+    expect(billingRequests.legacyStatus).toBe(0)
+    expect(billingRequests.legacyBalance).toBe(0)
+  })
+
+  test('TB-18 keeps the legacy Plan & Credits surface functional with billing flags off', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
+
+    const billingRequests = await mockCloudBoot(
+      page,
+      activeProSubscription,
+      legacyBillingConfig
+    )
+    await bootApp(page)
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    const popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+    await popover.getByTestId('manage-plan-menu-item').click()
+
+    const dialog = page.getByTestId('settings-dialog')
+    await expect(dialog).toBeVisible()
+    await expect(
+      dialog.getByRole('button', { name: 'Plan & Credits' })
+    ).toBeVisible()
+
+    const content = dialog.getByRole('main')
+    await expect(
+      content.getByText('Subscription', { exact: true })
+    ).toBeVisible()
+    await expect(content.getByText('Pro', { exact: true })).toBeVisible()
+    await expect(content.getByText('$100', { exact: true })).toBeVisible()
+    await expect(content.getByText('12,660', { exact: true })).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Manage subscription' })
+    ).toBeVisible()
+    expect(billingRequests.legacyStatus).toBeGreaterThanOrEqual(1)
+    expect(billingRequests.legacyBalance).toBeGreaterThanOrEqual(1)
+    expect(billingRequests.workspaceStatus).toBe(0)
+    expect(billingRequests.workspaceBalance).toBe(0)
+  })
+
+  test('TB-19 keeps workspace-only controls and team pricing out of the legacy path', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
+
+    await mockCloudBoot(page, activeProSubscription, legacyBillingConfig)
+    await bootApp(page)
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    const popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByTestId('workspace-switcher-trigger')).toHaveCount(
+      0
+    )
+    await expect(
+      popover.getByTestId('workspace-settings-menu-item')
+    ).toHaveCount(0)
+
+    await popover.getByTestId('plans-pricing-menu-item').click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Plans for Personal Workspace' })
+    ).toBeVisible()
+    await expect(page.getByRole('button', { name: 'For Teams' })).toHaveCount(0)
+  })
+
   test('avatar popover renders tier badge and balance from the facade', async ({
     page
   }) => {

--- a/browser_tests/tests/billingPartnerNodeLifecycle.spec.ts
+++ b/browser_tests/tests/billingPartnerNodeLifecycle.spec.ts
@@ -1,0 +1,331 @@
+import { expect } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
+import type {
+  BillingBalanceResponse,
+  ListWorkspaceInvitesResponse,
+  PromptRequest
+} from '@comfyorg/ingest-types'
+
+import type { PromptResponse } from '@/schemas/apiSchema'
+import { zJobsListResponse } from '@/platform/remote/comfyui/jobs/jobTypes'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+import { cloudBillingApiFixture } from '@e2e/fixtures/cloudBillingApiFixture'
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_TEAM_MEMBERS,
+  PERSONAL_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const API_NODE_TYPE = 'DevToolsNodeWithPriceBadge'
+const JOB_ID = 'partner-run-job'
+const PROMPT_ROUTE_PATTERN = /\/api\/prompt$/
+const PERSONAL_WORKSPACE = workspace('personal', 'owner')
+
+const POST_RUN_BALANCE: BillingBalanceResponse = {
+  ...DEFAULT_BILLING_BALANCE,
+  amount_micros: 2_000,
+  effective_balance_micros: 2_000,
+  cloud_credit_balance_micros: 1_500
+}
+
+const EMPTY_INVITES: ListWorkspaceInvitesResponse = { invites: [] }
+
+const API_NODE_DEFS: Record<string, ComfyNodeDef> = {
+  [API_NODE_TYPE]: {
+    name: API_NODE_TYPE,
+    display_name: 'Node With Price Badge',
+    description: 'An API node with a price badge',
+    category: 'api node',
+    python_module: 'comfy_api_nodes',
+    input: {
+      required: {
+        price: [['1x', '2x', '3x'], { default: '1x' }]
+      }
+    },
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: true,
+    api_node: true,
+    price_badge: {
+      engine: 'jsonata',
+      depends_on: {
+        widgets: [{ name: 'price', type: 'COMBO' }],
+        inputs: [],
+        input_groups: []
+      },
+      expr: "{'type':'text','text':'1 credit/Run'}"
+    }
+  }
+}
+
+const EMPTY_JOBS = zJobsListResponse.parse({
+  jobs: [],
+  pagination: {
+    offset: 0,
+    limit: 200,
+    total: 0,
+    has_more: false
+  }
+})
+
+interface PartnerApp {
+  comfyPage: ComfyPage
+  partnerNodeId: string
+}
+
+async function mockGraphApi(page: Page): Promise<void> {
+  const promptStatus: PromptResponse = {
+    exec_info: { queue_remaining: 0 },
+    error: ''
+  }
+
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute(promptStatus))
+  })
+  await page.route('**/api/object_info', (route) =>
+    route.fulfill(jsonRoute(API_NODE_DEFS))
+  )
+  await page.route('**/api/jobs**', (route) =>
+    route.fulfill(jsonRoute(EMPTY_JOBS))
+  )
+  await page.route('**/api/workspace/invites', (route) =>
+    route.fulfill(jsonRoute(EMPTY_INVITES))
+  )
+}
+
+async function mockPromptPost(
+  page: Page,
+  response: PromptResponse,
+  status = 200
+) {
+  const handler = async (route: Route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback()
+      return
+    }
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+  }
+  await page.route(PROMPT_ROUTE_PATTERN, handler)
+  return handler
+}
+
+const test = cloudBillingApiFixture.extend<{
+  partnerApp: PartnerApp
+}>({
+  partnerApp: async ({ billingApi, page, request }, use) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      balance: DEFAULT_BILLING_BALANCE
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      PERSONAL_WORKSPACE,
+      { mockBilling: false }
+    )
+    await mockGraphApi(page)
+
+    await page.goto(APP_URL)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+
+    const comfyPage = new ComfyPage(page, request)
+    await comfyPage.workflow.waitForActiveWorkflow()
+    await comfyPage.workflow.waitForWorkflowIdle()
+    const partnerNode = await comfyPage.nodeOps.addNode(
+      API_NODE_TYPE,
+      undefined,
+      { x: 100, y: 100 }
+    )
+
+    await use({
+      comfyPage,
+      partnerNodeId: String(partnerNode.id)
+    })
+  }
+})
+
+test.describe('Billing partner-node lifecycle', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-03 queues an API node and renders the refreshed post-run balance', async ({
+    billingApi,
+    page,
+    partnerApp
+  }) => {
+    const { comfyPage, partnerNodeId } = partnerApp
+    const currentUserButton = page.getByRole('button', {
+      name: 'Current user'
+    })
+    const popover = page.locator('.current-user-popover')
+
+    await currentUserButton.click()
+    await expect(popover.getByText('5,275', { exact: true })).toBeVisible()
+    await currentUserButton.click()
+    await expect(popover).toBeHidden()
+
+    const response: PromptResponse = {
+      prompt_id: JOB_ID,
+      node_errors: {},
+      error: ''
+    }
+    const promptPostHandler = await mockPromptPost(page, response)
+
+    const promptRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' && PROMPT_ROUTE_PATTERN.test(request.url())
+    )
+    const promptResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        PROMPT_ROUTE_PATTERN.test(response.url())
+    )
+    await comfyPage.actionbar.queueButton.primaryButton.click()
+
+    const promptRequest = (await promptRequestPromise).postDataJSON() as
+      | PromptRequest
+      | undefined
+    await promptResponsePromise
+    await page.unroute(PROMPT_ROUTE_PATTERN, promptPostHandler)
+    expect(promptRequest?.prompt).toBeDefined()
+    expect(Object.values(promptRequest?.prompt ?? {})).toContainEqual(
+      expect.objectContaining({
+        class_type: API_NODE_TYPE,
+        inputs: expect.objectContaining({ price: '1x' })
+      })
+    )
+    expect(promptRequest?.extra_data).toEqual(
+      expect.objectContaining({
+        comfy_usage_source: 'comfyui-frontend',
+        extra_pnginfo: expect.objectContaining({
+          workflow: expect.any(Object)
+        })
+      })
+    )
+
+    await comfyPage.nextFrame()
+    const cancelRunButton = page.getByRole('button', {
+      name: 'Cancel current run'
+    })
+    await page.evaluate(
+      ({ jobId, nodeId }) => {
+        window.app!.api.dispatchCustomEvent('execution_start', {
+          prompt_id: jobId,
+          timestamp: Date.now()
+        })
+        window.app!.api.dispatchCustomEvent('executing', nodeId)
+      },
+      { jobId: JOB_ID, nodeId: partnerNodeId }
+    )
+    await expect(cancelRunButton).toBeEnabled()
+    await page.evaluate(
+      ({ jobId, nodeId }) => {
+        window.app!.api.dispatchCustomEvent('executed', {
+          prompt_id: jobId,
+          node: nodeId,
+          display_node: nodeId,
+          output: {}
+        })
+        window.app!.api.dispatchCustomEvent('execution_success', {
+          prompt_id: jobId,
+          timestamp: Date.now()
+        })
+      },
+      { jobId: JOB_ID, nodeId: partnerNodeId }
+    )
+    await expect(cancelRunButton).toBeDisabled()
+    billingApi.setBalance(POST_RUN_BALANCE)
+
+    const balanceRefresh = page.waitForResponse((response) => {
+      const request = response.request()
+      return (
+        request.method() === 'GET' &&
+        new URL(response.url()).pathname.endsWith('/api/billing/balance') &&
+        response.status() === 200
+      )
+    })
+    await currentUserButton.click()
+    await balanceRefresh
+    await expect(popover.getByText('4,220', { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Plans for Personal Workspace' })
+    ).toBeHidden()
+    await expect(page.getByTestId(TestIds.dialogs.errorOverlay)).toBeHidden()
+  })
+
+  test('TB-03 keeps insufficient-credit recovery visible when billing refresh fails', async ({
+    billingApi,
+    page,
+    partnerApp
+  }) => {
+    const { comfyPage } = partnerApp
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+    billingApi.setQueryFailure('status', {
+      status: 503,
+      message: 'Billing status unavailable'
+    })
+    billingApi.setQueryFailure('balance', {
+      status: 503,
+      message: 'Billing balance unavailable'
+    })
+
+    const response: PromptResponse = {
+      node_errors: {},
+      error: {
+        type: 'PAYMENT_REQUIRED',
+        message: 'Insufficient credits to queue workflows',
+        details: ''
+      }
+    }
+    const promptPostHandler = await mockPromptPost(page, response, 429)
+
+    const promptResponsePromise = page.waitForResponse(
+      (promptResponse) =>
+        promptResponse.request().method() === 'POST' &&
+        PROMPT_ROUTE_PATTERN.test(promptResponse.url())
+    )
+    const statusFailure = page.waitForResponse(
+      (billingResponse) =>
+        billingResponse.request().method() === 'GET' &&
+        new URL(billingResponse.url()).pathname.endsWith(
+          '/api/billing/status'
+        ) &&
+        billingResponse.status() === 503
+    )
+    const balanceFailure = page.waitForResponse(
+      (billingResponse) =>
+        billingResponse.request().method() === 'GET' &&
+        new URL(billingResponse.url()).pathname.endsWith(
+          '/api/billing/balance'
+        ) &&
+        billingResponse.status() === 503
+    )
+    await comfyPage.actionbar.queueButton.primaryButton.click()
+    await Promise.all([promptResponsePromise, statusFailure, balanceFailure])
+    await page.unroute(PROMPT_ROUTE_PATTERN, promptPostHandler)
+
+    const topUpDialog = new TopUpCreditsDialog(page)
+    await expect(topUpDialog.insufficientHeading).toBeVisible()
+    await expect(topUpDialog.root).toContainText(
+      "You don't have enough credits to run this workflow"
+    )
+    await expect(page.getByTestId(TestIds.dialogs.errorOverlay)).toBeHidden()
+    await expect(page.getByTestId(TestIds.dialogs.errorDialog)).toBeHidden()
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/browser_tests/tests/dialogs/billingActivity.spec.ts
+++ b/browser_tests/tests/dialogs/billingActivity.spec.ts
@@ -1,0 +1,109 @@
+import type {
+  BillingEventsResponse,
+  ErrorResponse
+} from '@comfyorg/ingest-types'
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const API_USAGE_EVENTS: BillingEventsResponse = {
+  total: 1,
+  events: [
+    {
+      event_type: 'api_usage_completed',
+      event_id: 'usage-event-1',
+      params: {
+        api_name: 'Comfy API',
+        model: 'flux-1.1-pro',
+        amount: 420,
+        run_id: 'run-e2e-42'
+      },
+      createdAt: '2099-01-18T12:34:00Z'
+    }
+  ],
+  page: 1,
+  limit: 7,
+  totalPages: 1
+}
+
+const BILLING_EVENTS_FAILURE: ErrorResponse = {
+  code: 'billing_events_unavailable',
+  message: 'Billing events are temporarily unavailable'
+}
+
+async function openBillingActivity(page: Page): Promise<Locator> {
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+  await settings.locator('nav').getByRole('button', { name: 'Credits' }).click()
+
+  const content = settings.getByRole('main')
+  await expect(content.getByRole('heading', { name: 'Activity' })).toBeVisible()
+  return content
+}
+
+test.describe('Billing activity', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test.describe('with an API usage event', () => {
+    let content: Locator
+
+    test.beforeEach(async ({ page }) => {
+      await new CloudWorkspaceMockHelper(page).setup()
+      await page.route('**/api/billing/events**', (route) =>
+        route.fulfill({ json: API_USAGE_EVENTS })
+      )
+      content = await openBillingActivity(page)
+    })
+
+    test('TB-04 shows the completed run in Activity', async ({ page }) => {
+      const eventRow = content.getByRole('row').filter({ hasText: 'Comfy API' })
+
+      await expect(
+        eventRow.getByText('API Usage', { exact: true })
+      ).toBeVisible()
+      await expect(
+        eventRow.getByText('Comfy API', { exact: true })
+      ).toBeVisible()
+      await expect(eventRow.getByText('Model: flux-1.1-pro')).toBeVisible()
+      await expect(eventRow).toContainText('Jan 18')
+
+      await eventRow.getByRole('button', { name: 'Additional Info' }).hover()
+      const tooltip = page.getByRole('tooltip')
+      await expect(tooltip).toContainText('Amount: 420')
+      await expect(tooltip).toContainText('Run Id: run-e2e-42')
+    })
+  })
+
+  test.describe('when billing events are unavailable', () => {
+    let content: Locator
+
+    test.beforeEach(async ({ page }) => {
+      await new CloudWorkspaceMockHelper(page).setup()
+      await page.route('**/api/billing/events**', (route) =>
+        route.fulfill({ status: 503, json: BILLING_EVENTS_FAILURE })
+      )
+      content = await openBillingActivity(page)
+    })
+
+    test('shows the localized Activity error', async () => {
+      await expect(
+        content.getByText(
+          'Something went wrong while loading activity. Please refresh and try again.'
+        )
+      ).toBeVisible()
+    })
+  })
+})

--- a/browser_tests/tests/dialogs/billingCreditConsumption.spec.ts
+++ b/browser_tests/tests/dialogs/billingCreditConsumption.spec.ts
@@ -1,0 +1,273 @@
+import type {
+  BillingBalanceResponse,
+  BillingPlansResponse
+} from '@comfyorg/ingest-types'
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+import type { operations } from '@/types/comfyRegistryTypes'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import {
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_TEAM_MEMBERS,
+  PERSONAL_BILLING_STATUS,
+  TEAM_CREDIT_BILLING_STATUS,
+  TEAM_WORKSPACE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+type CustomerBalanceResponse = NonNullable<
+  operations['GetCustomerBalance']['responses']['200']['content']['application/json']
+>
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const PERSONAL_WORKSPACE = workspace('personal', 'owner')
+
+function balance(
+  monthlyCents: number,
+  prepaidCents: number
+): BillingBalanceResponse {
+  const amountCents = monthlyCents + prepaidCents
+  return {
+    amount_micros: amountCents,
+    currency: 'usd',
+    effective_balance_micros: amountCents,
+    cloud_credit_balance_micros: monthlyCents,
+    prepaid_balance_micros: prepaidCents
+  }
+}
+
+const TEAM_BALANCE_BEFORE_RUN = balance(50_000, 1_000)
+const TEAM_BALANCE_AFTER_RUN = balance(49_000, 1_000)
+const PERSONAL_BALANCE: CustomerBalanceResponse = {
+  amount_micros: 100_000,
+  currency: 'usd',
+  effective_balance_micros: 100_000,
+  cloud_credit_balance_micros: 90_000,
+  prepaid_balance_micros: 10_000
+}
+const PERSONAL_STATUS: CloudSubscriptionStatusResponse = {
+  is_active: true,
+  subscription_tier: 'PRO',
+  subscription_duration: 'MONTHLY',
+  renewal_date: '2099-02-20T00:00:00Z',
+  end_date: null
+}
+
+const ACTIVE_TEAM_PLANS = {
+  ...DEFAULT_BILLING_PLANS,
+  current_plan_slug: TEAM_CREDIT_BILLING_STATUS.plan_slug
+} satisfies BillingPlansResponse
+
+const ACTIVE_PERSONAL_PLANS = {
+  ...DEFAULT_BILLING_PLANS,
+  current_plan_slug: PERSONAL_BILLING_STATUS.plan_slug
+} satisfies BillingPlansResponse
+
+async function mockPersonalBilling(page: Page): Promise<void> {
+  await page.route('**/customers/cloud-subscription-status', (route) =>
+    route.fulfill({ json: PERSONAL_STATUS })
+  )
+  await page.route('**/customers/balance', (route) =>
+    route.fulfill({ json: PERSONAL_BALANCE })
+  )
+}
+
+async function openPlanAndCredits(
+  page: Page,
+  activeWorkspace: WorkspaceWithRole
+): Promise<Locator> {
+  const workspaceResponse = page.waitForResponse((response) => {
+    const request = response.request()
+    return (
+      request.method() === 'GET' &&
+      new URL(response.url()).pathname.endsWith('/api/workspaces')
+    )
+  })
+  await page.goto(APP_URL)
+  await workspaceResponse
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+  await settings
+    .locator('nav')
+    .getByRole('button', { name: 'Workspace' })
+    .click()
+
+  const content = settings.getByRole('main')
+  const planTab = content.getByRole('tab', { name: 'Plan & Credits' })
+  await planTab.click()
+  await expect(planTab).toHaveAttribute('data-state', 'active')
+  await expect(
+    content.getByRole('heading', { name: activeWorkspace.name })
+  ).toBeVisible()
+  return content
+}
+
+function creditsTile(content: Locator): Locator {
+  return content
+    .getByText('Total credits', { exact: true })
+    .locator('xpath=../..')
+}
+
+test.describe('Billing credit consumption', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-11 refreshes the active Team pool from a mocked post-run balance', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: TEAM_CREDIT_BILLING_STATUS,
+      balance: TEAM_BALANCE_BEFORE_RUN,
+      plans: ACTIVE_TEAM_PLANS
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    await mockPersonalBilling(page)
+    const content = await openPlanAndCredits(page, TEAM_WORKSPACE)
+    const tile = creditsTile(content)
+
+    await expect(tile.getByText('107,610', { exact: true })).toBeVisible()
+    await expect(tile.getByText('105,500 left of 147,700')).toBeVisible()
+    await expect(tile.getByText('211,000', { exact: true })).toHaveCount(0)
+
+    billingApi.setBalance(TEAM_BALANCE_AFTER_RUN)
+    await tile.getByRole('button', { name: 'Refresh credits' }).click()
+
+    await expect(
+      content.getByRole('heading', { name: TEAM_WORKSPACE.name })
+    ).toBeVisible()
+    await expect(tile.getByText('105,500', { exact: true })).toBeVisible()
+    await expect(tile.getByText('44,310 used')).toBeVisible()
+    await expect(tile.getByText('103,390 left of 147,700')).toBeVisible()
+    await expect(tile.getByText('2,110', { exact: true })).toBeVisible()
+  })
+
+  test('TB-15 shows monthly credits draining before additional credits', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      balance: balance(1_500, 500),
+      plans: ACTIVE_PERSONAL_PLANS
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      PERSONAL_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page, PERSONAL_WORKSPACE)
+    const tile = creditsTile(content)
+
+    await expect(tile.getByText('4,220', { exact: true })).toBeVisible()
+    await expect(tile.getByText('3,165 left of 4,200')).toBeVisible()
+    await expect(tile.getByText('1,055', { exact: true })).toBeVisible()
+
+    billingApi.setBalance(balance(1_000, 500))
+    await tile.getByRole('button', { name: 'Refresh credits' }).click()
+
+    await expect(tile.getByText('3,165', { exact: true })).toBeVisible()
+    await expect(tile.getByText('2,090 used')).toBeVisible()
+    await expect(tile.getByText('2,110 left of 4,200')).toBeVisible()
+    await expect(tile.getByText('1,055', { exact: true })).toBeVisible()
+    await expect(tile.getByText('In use')).toHaveCount(0)
+
+    billingApi.setBalance(balance(0, 400))
+    await tile.getByRole('button', { name: 'Refresh credits' }).click()
+
+    await expect(tile.getByText('844', { exact: true })).toHaveCount(2)
+    await expect(tile.getByText('0 left of 4,200')).toBeVisible()
+    await expect(
+      tile.getByText(/Monthly credits are used up\. Refills Feb \d{1,2}/)
+    ).toBeVisible()
+    await expect(tile.getByText('In use')).toBeVisible()
+  })
+
+  test('keeps the last known credits visible when a balance refresh fails', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      balance: balance(1_500, 500),
+      plans: ACTIVE_PERSONAL_PLANS
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      PERSONAL_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page, PERSONAL_WORKSPACE)
+    const tile = creditsTile(content)
+    await expect(tile.getByText('4,220', { exact: true })).toBeVisible()
+
+    billingApi.setBalance(balance(1_000, 500))
+    billingApi.setQueryFailure('balance', {
+      status: 503,
+      message: 'Billing balance unavailable'
+    })
+    await tile.getByRole('button', { name: 'Refresh credits' }).click()
+
+    await expect(tile.getByText('4,220', { exact: true })).toBeVisible()
+    await expect(
+      page.locator('.p-toast-message-error').filter({
+        hasText: 'Billing balance unavailable'
+      })
+    ).toBeVisible()
+
+    billingApi.setQueryFailure('balance', null)
+    await tile.getByRole('button', { name: 'Refresh credits' }).click()
+
+    await expect(tile.getByText('3,165', { exact: true })).toBeVisible()
+  })
+
+  test('shows a retry state instead of a false plan when billing status is unavailable', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: TEAM_CREDIT_BILLING_STATUS,
+      balance: TEAM_BALANCE_BEFORE_RUN,
+      plans: ACTIVE_TEAM_PLANS,
+      queryFailures: {
+        status: { status: 503, message: 'Billing status unavailable' }
+      }
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page, TEAM_WORKSPACE)
+
+    await expect(
+      content.getByText("We couldn't load your plan details.")
+    ).toBeVisible()
+    await expect(content.getByText('$0', { exact: true })).toHaveCount(0)
+
+    billingApi.setQueryFailure('status', null)
+    await content.getByRole('button', { name: 'Try again' }).click()
+
+    const tile = creditsTile(content)
+    await expect(
+      content.getByRole('heading', { name: 'Team', exact: true })
+    ).toBeVisible()
+    await expect(tile.getByText('107,610', { exact: true })).toBeVisible()
+  })
+})

--- a/browser_tests/tests/dialogs/billingStatusBanner.spec.ts
+++ b/browser_tests/tests/dialogs/billingStatusBanner.spec.ts
@@ -1,0 +1,217 @@
+import type {
+  BillingBalanceResponse,
+  BillingStatusResponse as GeneratedBillingStatusResponse
+} from '@comfyorg/ingest-types'
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import type {
+  BillingStatusResponse as WorkspaceBillingStatusResponse,
+  Member,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import {
+  CANCELLED_TEAM_BILLING_STATUS,
+  CREATOR,
+  DEFAULT_TEAM_MEMBERS,
+  TEAM_CREDIT_BILLING_STATUS,
+  TEAM_WORKSPACE,
+  VIEWER
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const EMPTY_BALANCE: BillingBalanceResponse = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0,
+  cloud_credit_balance_micros: 0,
+  prepaid_balance_micros: 0
+}
+
+type PausedBillingStatusResponse = Omit<
+  GeneratedBillingStatusResponse,
+  'billing_status'
+> &
+  Pick<WorkspaceBillingStatusResponse, 'billing_status'>
+
+const OUT_OF_CREDITS_STATUS: GeneratedBillingStatusResponse = {
+  ...TEAM_CREDIT_BILLING_STATUS,
+  has_funds: false
+}
+
+const PAUSED_STATUS: PausedBillingStatusResponse = {
+  ...TEAM_CREDIT_BILLING_STATUS,
+  is_active: false,
+  billing_status: 'paused'
+}
+
+function viewerIsOriginalOwner(): Member[] {
+  return DEFAULT_TEAM_MEMBERS.map((member) => {
+    if (member.id === CREATOR.id) {
+      return { ...member, is_original_owner: false }
+    }
+    if (member.id === VIEWER.id) {
+      return { ...member, is_original_owner: true }
+    }
+    return { ...member }
+  })
+}
+
+function viewerIsMember(): {
+  members: Member[]
+  workspace: WorkspaceWithRole
+} {
+  return {
+    members: DEFAULT_TEAM_MEMBERS.map((member) =>
+      member.id === VIEWER.id
+        ? { ...member, role: 'member' as const }
+        : { ...member }
+    ),
+    workspace: { ...TEAM_WORKSPACE, role: 'member' }
+  }
+}
+
+async function openWorkspaceSettings(page: Page): Promise<Locator> {
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+  await settings
+    .locator('nav')
+    .getByRole('button', { name: 'Workspace' })
+    .click()
+
+  const content = settings.getByRole('main')
+  await expect(content.getByRole('status')).toBeVisible()
+  return content
+}
+
+test.describe('Workspace billing status banner', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-22 lets the original owner add credits from an exhausted workspace', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: OUT_OF_CREDITS_STATUS,
+      balance: EMPTY_BALANCE
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      viewerIsOriginalOwner(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openWorkspaceSettings(page)
+    const banner = content.getByRole('status')
+
+    await expect(banner).toContainText('Out of credits')
+    await expect(banner).toContainText(
+      'Add more credits to continue generating'
+    )
+    await banner.getByRole('button', { name: 'Add credits' }).click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Add more credits' })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: '$50', exact: true })
+    ).toBeVisible()
+  })
+
+  test('TB-22 directs an exhausted member to workspace admins without a billing action', async ({
+    billingApi,
+    page
+  }) => {
+    const { members, workspace } = viewerIsMember()
+    await billingApi.setup({
+      status: OUT_OF_CREDITS_STATUS,
+      balance: EMPTY_BALANCE
+    })
+    await new CloudWorkspaceMockHelper(page).setup(members, workspace, {
+      mockBilling: false
+    })
+    const content = await openWorkspaceSettings(page)
+    const banner = content.getByRole('status')
+
+    await expect(banner).toContainText('Out of credits')
+    await expect(banner).toContainText(
+      'Your workspace admins need to add more credits'
+    )
+    await expect(
+      banner.getByRole('button', { name: 'Add credits' })
+    ).toHaveCount(0)
+    await expect(banner.getByRole('button', { name: 'Dismiss' })).toBeVisible()
+  })
+
+  test('TB-22 gives a paused owner the payment recovery action', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup()
+    await new CloudWorkspaceMockHelper(page).setup(
+      viewerIsOriginalOwner(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    await page.route('**/api/billing/status', (route) =>
+      route.fulfill({ json: PAUSED_STATUS })
+    )
+    const content = await openWorkspaceSettings(page)
+    const banner = content.getByRole('status')
+
+    await expect(banner).toContainText('Subscription paused')
+    await expect(banner).toContainText('Update payment to resume')
+    await expect(
+      banner.getByRole('button', { name: 'Update payment' })
+    ).toBeVisible()
+  })
+
+  test('TB-22 limits ending-plan reactivation to the original owner', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: CANCELLED_TEAM_BILLING_STATUS })
+    const workspaceState = await new CloudWorkspaceMockHelper(page).setup(
+      viewerIsOriginalOwner(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    let content = await openWorkspaceSettings(page)
+    let banner = content.getByRole('status')
+
+    await expect(banner).toContainText(
+      /Your team plan ends on February \d{1,2}, 2099/
+    )
+    await expect(
+      banner.getByRole('button', { name: 'Reactivate plan' })
+    ).toBeVisible()
+
+    workspaceState.members.splice(
+      0,
+      workspaceState.members.length,
+      ...DEFAULT_TEAM_MEMBERS.map((member) => ({ ...member }))
+    )
+    await page.reload()
+    content = await openWorkspaceSettings(page)
+    banner = content.getByRole('status')
+
+    await expect(banner).toContainText(
+      /Your team plan ends on February \d{1,2}, 2099/
+    )
+    await expect(
+      banner.getByRole('button', { name: 'Reactivate plan' })
+    ).toHaveCount(0)
+  })
+})

--- a/browser_tests/tests/dialogs/billingTopUp.spec.ts
+++ b/browser_tests/tests/dialogs/billingTopUp.spec.ts
@@ -1,0 +1,311 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page, Request } from '@playwright/test'
+
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_TEAM_MEMBERS,
+  FAILED_BILLING_OPERATION,
+  PERSONAL_BILLING_STATUS,
+  PENDING_BILLING_OPERATION,
+  PENDING_TOPUP_RESPONSE,
+  TEAM_CREDIT_BILLING_STATUS,
+  TEAM_WORKSPACE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const PERSONAL_WORKSPACE = workspace('personal', 'owner')
+
+interface BillingRequestCounts {
+  balance: number
+  status: number
+  operations: number
+}
+
+function trackBillingRequests(page: Page): BillingRequestCounts {
+  const counts: BillingRequestCounts = {
+    balance: 0,
+    status: 0,
+    operations: 0
+  }
+
+  page.on('request', (request: Request) => {
+    if (request.method() !== 'GET') return
+
+    const pathname = new URL(request.url()).pathname
+    if (pathname.endsWith('/api/billing/balance')) counts.balance += 1
+    if (pathname.endsWith('/api/billing/status')) counts.status += 1
+    if (pathname.includes('/api/billing/ops/')) counts.operations += 1
+  })
+
+  return counts
+}
+
+async function bootTopUpDialog(
+  page: Page,
+  activeWorkspace: WorkspaceWithRole = PERSONAL_WORKSPACE
+): Promise<TopUpCreditsDialog> {
+  await new CloudWorkspaceMockHelper(page).setup(
+    DEFAULT_TEAM_MEMBERS,
+    activeWorkspace,
+    { mockBilling: false }
+  )
+
+  const initialBillingResponses = ['status', 'balance', 'plans'].map(
+    (endpoint) =>
+      page.waitForResponse((response) => {
+        const request = response.request()
+        return (
+          request.method() === 'GET' &&
+          new URL(request.url()).pathname.endsWith(`/api/billing/${endpoint}`)
+        )
+      })
+  )
+
+  await page.goto(APP_URL)
+  await Promise.all(initialBillingResponses)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  const dialog = new TopUpCreditsDialog(page)
+  await dialog.open()
+  await expect(dialog.heading).toBeVisible()
+  return dialog
+}
+
+async function expectWorkspaceCredits(
+  page: Page,
+  workspaceName: string
+): Promise<Locator> {
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+
+  const content = settings.getByRole('main')
+  await expect(
+    content.getByRole('heading', { name: workspaceName })
+  ).toBeVisible()
+  await expect(
+    content.getByRole('tab', { name: 'Plan & Credits' })
+  ).toHaveAttribute('data-state', 'active')
+  await expect(content.getByText('Total credits')).toBeVisible()
+  return content
+}
+
+test.describe('Billing top-up flows', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-05 personal preset posts exact cents and refreshes Plan & Credits', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+
+    await dialog.preset10.click()
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    const content = await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 1_000 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 3_500,
+      effective_balance_micros: 3_500,
+      prepaid_balance_micros: 1_500
+    })
+    expect(counts.balance).toBeGreaterThanOrEqual(1)
+    expect(counts.status).toBeGreaterThanOrEqual(1)
+    await expect(content.getByText('7,385', { exact: true })).toBeVisible()
+  })
+
+  test('TB-05 custom dollar amount posts exact cents', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const dialog = await bootTopUpDialog(page)
+
+    await dialog.payAmountInput.click()
+    await dialog.payAmountInput.press('ControlOrMeta+A')
+    await dialog.payAmountInput.pressSequentially('37')
+    await expect(dialog.payAmountInput).toHaveValue('37')
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 3_700 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 6_200,
+      effective_balance_micros: 6_200,
+      prepaid_balance_micros: 4_200
+    })
+  })
+
+  test('TB-24 links the ceiling warning to the enterprise page', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const dialog = await bootTopUpDialog(page)
+
+    await dialog.payAmountInput.fill('10001')
+
+    await expect(dialog.payAmountInput).toHaveValue('10,000')
+    await expect(dialog.contactUsLink).toBeVisible()
+    await expect(dialog.contactUsLink).toHaveAttribute(
+      'href',
+      'https://www.comfy.org/cloud/enterprise'
+    )
+    await expect(dialog.contactUsLink).toHaveAttribute('target', '_blank')
+  })
+
+  test('TB-13 team owner top-up returns to the active workspace credit pool', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: TEAM_CREDIT_BILLING_STATUS,
+      plans: {
+        ...DEFAULT_BILLING_PLANS,
+        current_plan_slug: TEAM_CREDIT_BILLING_STATUS.plan_slug
+      }
+    })
+    const dialog = await bootTopUpDialog(page, TEAM_WORKSPACE)
+
+    await dialog.preset100.click()
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    const content = await expectWorkspaceCredits(page, TEAM_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 10_000 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 12_500,
+      effective_balance_micros: 12_500,
+      prepaid_balance_micros: 10_500
+    })
+    await expect(content.getByText('26,375', { exact: true })).toBeVisible()
+  })
+
+  test('TB-16 pending top-up polls to success and applies one balance increment', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      topupResponse: PENDING_TOPUP_RESPONSE,
+      operationResponses: {
+        'billing-op-topup': [
+          PENDING_BILLING_OPERATION,
+          {
+            ...PENDING_BILLING_OPERATION,
+            status: 'succeeded',
+            completed_at: '2099-01-20T00:00:01Z'
+          }
+        ]
+      }
+    })
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+    counts.operations = 0
+
+    await dialog.preset25.click()
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    await expect(
+      page.getByText('Processing payment — adding credits...')
+    ).toBeVisible()
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    await expect(page.getByText('Credits added successfully')).toBeVisible()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 2_500 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 5_000,
+      effective_balance_micros: 5_000,
+      prepaid_balance_micros: 3_000
+    })
+    expect(counts.operations).toBe(2)
+    expect(counts.balance).toBeGreaterThanOrEqual(1)
+    expect(counts.status).toBeGreaterThanOrEqual(1)
+  })
+
+  test('TB-16 HTTP rejection keeps the balance unchanged and supports retry', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      failures: {
+        topup: { status: 402, message: 'Card declined' }
+      }
+    })
+    const initialBalance = structuredClone(billingApi.state.balance)
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+
+    await dialog.preset25.click()
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    const errorToast = page.locator('.p-toast-message-error').filter({
+      hasText: 'Purchase Failed'
+    })
+    await expect(errorToast).toContainText('Purchase Failed')
+    await expect(errorToast).toContainText('Card declined')
+    await expect(dialog.heading).toBeVisible()
+    await expect(
+      dialog.root.getByRole('button', { name: 'Add credits' })
+    ).toBeEnabled()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 2_500 }])
+    expect(billingApi.state.balance).toEqual(initialBalance)
+    expect(counts.balance).toBe(0)
+    expect(counts.status).toBe(0)
+  })
+
+  test('TB-16 failed operation keeps the balance unchanged and surfaces the operation error', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      topupResponse: PENDING_TOPUP_RESPONSE,
+      operationResponses: {
+        'billing-op-topup': [FAILED_BILLING_OPERATION]
+      }
+    })
+    const initialBalance = structuredClone(billingApi.state.balance)
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+    counts.operations = 0
+
+    await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+
+    const errorToast = page.locator('.p-toast-message-error').filter({
+      hasText: 'Top-up failed'
+    })
+    await expect(errorToast).toContainText('Top-up failed')
+    await expect(errorToast).toContainText('Mock billing operation failed')
+    await expect(dialog.heading).toBeVisible()
+    await expect(
+      dialog.root.getByRole('button', { name: 'Add credits' })
+    ).toBeEnabled()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 5_000 }])
+    expect(billingApi.state.balance).toEqual(initialBalance)
+    expect(counts.operations).toBe(1)
+    expect(counts.balance).toBe(0)
+    expect(counts.status).toBe(0)
+  })
+})

--- a/browser_tests/tests/dialogs/pricingTableResponsive.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableResponsive.spec.ts
@@ -1,0 +1,152 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const BOOT_FEATURES = {
+  team_workspaces_enabled: true,
+  billing_control_enabled: true
+} satisfies RemoteConfig
+const BOOT_SETTINGS = {
+  'Comfy.Assets.UseAssetAPI': false,
+  'Comfy.TutorialCompleted': true,
+  'Comfy.RightSidePanel.ShowErrorsTab': false
+}
+
+interface HorizontalLayout {
+  document: {
+    clientWidth: number
+    scrollWidth: number
+  }
+  viewportWidth: number
+  dialog: {
+    left: number
+    right: number
+  }
+  pricing: {
+    clientWidth: number
+    left: number
+    right: number
+    scrollWidth: number
+  }
+  interactive: {
+    left: number
+    right: number
+  }
+}
+
+async function mockGraphBootExtras(page: Page) {
+  await page.route('**/api/settings/**', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({}))
+  })
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+  })
+  await page.route('**/api/queue', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ queue_running: [], queue_pending: [] }))
+  })
+}
+
+async function setupCloudPricing(page: Page) {
+  await mockCloudBoot(page, {
+    features: BOOT_FEATURES,
+    settings: BOOT_SETTINGS
+  })
+  await mockGraphBootExtras(page)
+  await mockWorkspace(page, workspace('personal', 'owner'), [])
+  await bootCloud(page)
+}
+
+async function getHorizontalLayout(
+  pricingContent: Locator
+): Promise<HorizontalLayout> {
+  return pricingContent.evaluate((element) => {
+    const dialog = element.closest('[role="dialog"]')
+    if (!(dialog instanceof HTMLElement)) {
+      throw new Error('Pricing content is not inside a dialog')
+    }
+
+    const dialogRect = dialog.getBoundingClientRect()
+    const pricingRect = element.getBoundingClientRect()
+    const interactiveRects = Array.from(
+      element.querySelectorAll<HTMLElement>('a, button, input')
+    )
+      .map((interactive) => interactive.getBoundingClientRect())
+      .filter((rect) => rect.width > 0 && rect.height > 0)
+
+    return {
+      document: {
+        clientWidth: document.documentElement.clientWidth,
+        scrollWidth: document.documentElement.scrollWidth
+      },
+      viewportWidth: window.innerWidth,
+      dialog: {
+        left: dialogRect.left,
+        right: dialogRect.right
+      },
+      pricing: {
+        clientWidth: element.clientWidth,
+        left: pricingRect.left,
+        right: pricingRect.right,
+        scrollWidth: element.scrollWidth
+      },
+      interactive: {
+        left: Math.min(...interactiveRects.map((rect) => rect.left)),
+        right: Math.max(...interactiveRects.map((rect) => rect.right))
+      }
+    }
+  })
+}
+
+test.describe('Responsive pricing table', { tag: '@cloud' }, () => {
+  for (const viewport of [
+    { width: 576, height: 900 },
+    { width: 390, height: 844 }
+  ]) {
+    test(`TB-20 fits a ${viewport.width}px viewport without horizontal overflow`, async ({
+      billingApi,
+      page
+    }) => {
+      test.slow()
+      await page.setViewportSize(viewport)
+      await billingApi.setup()
+      await setupCloudPricing(page)
+
+      await page.goto(`${APP_URL}/?pricing=1`)
+
+      const heading = page.getByRole('heading', { name: 'Choose a Plan' })
+      await expect(heading).toBeVisible({ timeout: 45_000 })
+
+      const pricingContent = page.getByRole('dialog').filter({ has: heading })
+      const layout = await getHorizontalLayout(pricingContent)
+
+      expect.soft(layout.dialog.left).toBeGreaterThanOrEqual(0)
+      expect.soft(layout.dialog.right).toBeLessThanOrEqual(layout.viewportWidth)
+      expect
+        .soft(layout.pricing.left)
+        .toBeGreaterThanOrEqual(layout.dialog.left)
+      expect.soft(layout.pricing.right).toBeLessThanOrEqual(layout.dialog.right)
+      expect
+        .soft(layout.interactive.left)
+        .toBeGreaterThanOrEqual(layout.pricing.left)
+      expect
+        .soft(layout.interactive.right)
+        .toBeLessThanOrEqual(layout.pricing.right)
+      expect
+        .soft(layout.pricing.scrollWidth)
+        .toBeLessThanOrEqual(layout.pricing.clientWidth)
+      expect
+        .soft(layout.document.scrollWidth)
+        .toBeLessThanOrEqual(layout.document.clientWidth)
+    })
+  }
+})

--- a/browser_tests/tests/dialogs/subscriptionCheckout.spec.ts
+++ b/browser_tests/tests/dialogs/subscriptionCheckout.spec.ts
@@ -1,0 +1,244 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type { BillingStatusResponse } from '@comfyorg/ingest-types'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { SubscriptionCheckoutDialog } from '@e2e/fixtures/components/SubscriptionCheckoutDialog'
+import {
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_BILLING_STATUS,
+  DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+  DEFAULT_SUBSCRIBE_RESPONSE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import {
+  member,
+  mockWorkspace,
+  workspace
+} from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const FEATURES = {
+  team_workspaces_enabled: true,
+  billing_control_enabled: true
+} satisfies RemoteConfig
+const SETTINGS = {
+  'Comfy.Assets.UseAssetAPI': false,
+  'Comfy.TutorialCompleted': true,
+  'Comfy.RightSidePanel.ShowErrorsTab': false
+}
+
+async function mockGraphBoot(page: Page): Promise<void> {
+  await page.route('**/api/settings/**', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({}))
+  })
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+  })
+  await page.route('**/api/queue', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ queue_running: [], queue_pending: [] }))
+  })
+}
+
+async function openCheckout(
+  page: Page,
+  planMode: '1' | 'team' = '1',
+  workspaceType: 'personal' | 'team' = 'personal'
+): Promise<SubscriptionCheckoutDialog> {
+  const activeWorkspace = workspace(workspaceType, 'owner')
+  const members =
+    workspaceType === 'team'
+      ? [
+          member({
+            email: 'e2e@test.comfy.org',
+            role: 'owner',
+            is_original_owner: true
+          })
+        ]
+      : []
+
+  await mockCloudBoot(page, { features: FEATURES, settings: SETTINGS })
+  await mockGraphBoot(page)
+  await mockWorkspace(page, activeWorkspace, members)
+  await page.route('**/api/workspace/invites', (route) =>
+    route.fulfill(jsonRoute({ invites: [] }))
+  )
+  await bootCloud(page)
+  await page.goto(`${APP_URL}/?pricing=${planMode}`)
+
+  const dialog = new SubscriptionCheckoutDialog(page)
+  await expect(dialog.heading).toBeVisible({ timeout: 45_000 })
+  return dialog
+}
+
+async function chooseStandardYearly(
+  dialog: SubscriptionCheckoutDialog
+): Promise<void> {
+  await dialog.personalPlanButton('Subscribe to Standard Yearly').click()
+  await expect(dialog.paymentPreviewHeading).toBeVisible()
+}
+
+async function completeStandardCheckout(
+  dialog: SubscriptionCheckoutDialog
+): Promise<void> {
+  await chooseStandardYearly(dialog)
+  await dialog.personalPlanButton('Subscribe to Standard').click()
+  await expect(dialog.successHeading).toBeVisible()
+}
+
+async function openWorkspaceSettings(page: Page) {
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+  await settings
+    .locator('nav')
+    .getByRole('button', { name: 'Workspace' })
+    .click()
+  return settings.getByRole('main')
+}
+
+test.describe('Subscription checkout', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-23 exposes the Terms and Privacy destinations before confirmation', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup()
+    const dialog = await openCheckout(page)
+
+    await chooseStandardYearly(dialog)
+
+    await expect(dialog.termsLink).toHaveAttribute(
+      'href',
+      'https://www.comfy.org/terms-of-service'
+    )
+    await expect(dialog.termsLink).toHaveAttribute('target', '_blank')
+    await expect(dialog.privacyPolicyLink).toHaveAttribute(
+      'href',
+      'https://www.comfy.org/privacy-policy'
+    )
+    await expect(dialog.privacyPolicyLink).toHaveAttribute('target', '_blank')
+    expect(billingApi.requests.previewSubscribe).toEqual([
+      expect.objectContaining({ plan_slug: 'standard-annual' })
+    ])
+  })
+
+  test('TB-25 shows the selected plan, monthly amount, and credits after subscribe', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup()
+    const dialog = await openCheckout(page)
+
+    await completeStandardCheckout(dialog)
+
+    await expect(
+      dialog.successContent.getByText('Standard', { exact: true })
+    ).toBeVisible()
+    await expect(
+      dialog.successContent.getByText('$16', { exact: true })
+    ).toBeVisible()
+    await expect(dialog.successContent.getByText('4,200 / month')).toBeVisible()
+    expect(billingApi.requests.subscribe).toEqual([
+      expect.objectContaining({ plan_slug: 'standard-annual' })
+    ])
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        is_active: true,
+        plan_slug: 'standard-annual',
+        subscription_duration: 'ANNUAL',
+        subscription_tier: 'STANDARD'
+      })
+    )
+  })
+
+  test('TB-21 keeps plan price, cadence, and renewal date consistent in settings', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: {
+        ...DEFAULT_BILLING_STATUS,
+        renewal_date: '2099-02-20T12:00:00Z'
+      }
+    })
+    const dialog = await openCheckout(page)
+
+    await completeStandardCheckout(dialog)
+    await dialog.root
+      .getByRole('button', { name: 'Close', exact: true })
+      .last()
+      .click()
+    await expect(dialog.root).toBeHidden()
+
+    const content = await openWorkspaceSettings(page)
+    await expect(
+      content.getByText('Standard Yearly', { exact: true })
+    ).toBeVisible()
+    await expect(content.getByText('$16', { exact: true })).toBeVisible()
+    await expect(content.getByText('USD / mo', { exact: true })).toBeVisible()
+    await expect(content.getByText('Renews on Feb 20, 2099')).toBeVisible()
+  })
+
+  test('TB-14 keeps a team plan change recoverable when subscribe is rejected', async ({
+    billingApi,
+    page
+  }) => {
+    const teamStatus: BillingStatusResponse = {
+      is_active: true,
+      subscription_status: 'active',
+      subscription_tier: 'TEAM',
+      subscription_duration: 'MONTHLY',
+      plan_slug: 'team_per_credit_monthly',
+      billing_status: 'paid',
+      has_funds: true,
+      renewal_date: '2099-02-20T00:00:00Z',
+      team_credit_stop: {
+        id: 'team_700',
+        credits_monthly: 147_700,
+        stop_usd: 700
+      }
+    }
+    await billingApi.setup({
+      status: teamStatus,
+      plans: {
+        ...DEFAULT_BILLING_PLANS,
+        current_plan_slug: 'team_per_credit_monthly'
+      },
+      previewResponse: DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+      subscribeResponse: DEFAULT_SUBSCRIBE_RESPONSE,
+      failures: {
+        subscribe: { status: 500, message: 'Plan change unavailable' }
+      }
+    })
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+    const dialog = await openCheckout(page, 'team', 'team')
+
+    await dialog.personalPlanButton('Change plan').click()
+    await expect(dialog.paymentPreviewHeading).toBeVisible()
+    await dialog.personalPlanButton('Subscribe to Team Plan').click()
+
+    await expect(page.getByText('Plan change unavailable')).toBeVisible()
+    await expect(dialog.paymentPreviewHeading).toBeVisible()
+    await expect(dialog.backToPlansButton).toBeEnabled()
+    expect(billingApi.requests.subscribe).toEqual([
+      expect.objectContaining({
+        plan_slug: 'team_per_credit_annual',
+        team_credit_stop_id: 'team_700',
+        billing_cycle: 'yearly'
+      })
+    ])
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/browser_tests/tests/dialogs/subscriptionLifecycle.spec.ts
+++ b/browser_tests/tests/dialogs/subscriptionLifecycle.spec.ts
@@ -1,0 +1,296 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+import type { BillingPlansResponse } from '@comfyorg/ingest-types'
+
+import type { Member } from '@/platform/workspace/api/workspaceApi'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import {
+  BILLING_RENEWAL_DATE,
+  CANCELLED_TEAM_BILLING_STATUS,
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_TEAM_MEMBERS,
+  PENDING_BILLING_OPERATION,
+  SUCCEEDED_BILLING_OPERATION,
+  TEAM_BILLING_STATUS,
+  TEAM_PRO_PLAN,
+  TEAM_WORKSPACE,
+  VIEWER
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const ACTIVE_TEAM_PLANS = {
+  ...DEFAULT_BILLING_PLANS,
+  current_plan_slug: TEAM_PRO_PLAN.slug,
+  plans: [TEAM_PRO_PLAN, ...DEFAULT_BILLING_PLANS.plans]
+} satisfies BillingPlansResponse
+
+const CANCELLED_TEAM_PLANS = {
+  ...DEFAULT_BILLING_PLANS,
+  current_plan_slug: CANCELLED_TEAM_BILLING_STATUS.plan_slug
+} satisfies BillingPlansResponse
+
+function originalOwnerMembers(): Member[] {
+  return DEFAULT_TEAM_MEMBERS.map((member) =>
+    member.id === VIEWER.id
+      ? {
+          ...member,
+          joined_at: '2024-01-01T00:00:00Z',
+          is_original_owner: true
+        }
+      : { ...member, is_original_owner: false }
+  )
+}
+
+function formattedEndDate(): string {
+  return new Date(BILLING_RENEWAL_DATE).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+}
+
+async function openPlanAndCredits(page: Page): Promise<Locator> {
+  const workspaceResponse = page.waitForResponse((response) => {
+    const request = response.request()
+    return (
+      request.method() === 'GET' &&
+      new URL(response.url()).pathname.endsWith('/api/workspaces')
+    )
+  })
+  await page.goto(APP_URL)
+  await workspaceResponse
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+  await settings
+    .locator('nav')
+    .getByRole('button', { name: 'Workspace' })
+    .click()
+
+  const content = settings.getByRole('main')
+  const planTab = content.getByRole('tab', { name: 'Plan & Credits' })
+  await planTab.click()
+  await expect(planTab).toHaveAttribute('data-state', 'active')
+  await expect(
+    content.getByRole('heading', { name: TEAM_WORKSPACE.name })
+  ).toBeVisible()
+  return content
+}
+
+async function openCancelSubscriptionDialog(
+  page: Page,
+  content: Locator
+): Promise<Locator> {
+  await content.getByRole('button', { name: 'More Options' }).click()
+  await page.getByRole('menuitem', { name: 'Cancel plan' }).click()
+
+  const dialog = page.getByRole('dialog').filter({
+    has: page.getByRole('heading', { name: 'Cancel subscription' })
+  })
+  await expect(dialog).toBeVisible()
+  return dialog
+}
+
+test.describe('Workspace subscription lifecycle', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-26 original owner can cancel while access remains active through the end date', async ({
+    billingApi,
+    page
+  }) => {
+    const operationRequests: string[] = []
+    page.on('request', (request) => {
+      const pathname = new URL(request.url()).pathname
+      if (
+        request.method() === 'GET' &&
+        pathname.includes('/api/billing/ops/')
+      ) {
+        operationRequests.push(pathname)
+      }
+    })
+
+    await billingApi.setup({
+      status: TEAM_BILLING_STATUS,
+      plans: ACTIVE_TEAM_PLANS,
+      operationResponses: {
+        'billing-op-cancel': [
+          PENDING_BILLING_OPERATION,
+          SUCCEEDED_BILLING_OPERATION
+        ]
+      }
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      originalOwnerMembers(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page)
+    const cancelDialog = await openCancelSubscriptionDialog(page, content)
+
+    await cancelDialog
+      .getByRole('button', { name: 'Cancel subscription' })
+      .click()
+
+    await expect(cancelDialog).toBeHidden()
+    expect(billingApi.requests.cancel).toHaveLength(1)
+    expect(operationRequests).toHaveLength(2)
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        is_active: true,
+        subscription_status: 'canceled',
+        cancel_at: BILLING_RENEWAL_DATE
+      })
+    )
+    await expect(
+      content.getByText('Your subscription has been canceled', { exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByText(`Ends on ${formattedEndDate()}`, { exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Reactivate plan' }).last()
+    ).toBeVisible()
+  })
+
+  test('TB-26 non-original owner cannot cancel or reactivate the team plan', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: TEAM_BILLING_STATUS,
+      plans: ACTIVE_TEAM_PLANS
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    let content = await openPlanAndCredits(page)
+
+    await content.getByRole('button', { name: 'More Options' }).click()
+    await expect(
+      page.getByRole('menuitem', { name: 'Edit workspace details' })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: 'Cancel plan' })
+    ).toHaveCount(0)
+
+    billingApi.state.status = structuredClone(CANCELLED_TEAM_BILLING_STATUS)
+    billingApi.state.plans = structuredClone(CANCELLED_TEAM_PLANS)
+    content = await openPlanAndCredits(page)
+
+    await expect(
+      content.getByText('Your subscription has been canceled', { exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Reactivate plan' })
+    ).toHaveCount(0)
+  })
+
+  test('TB-27 reactivation restores the same workspace plan and removes ending UI', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: CANCELLED_TEAM_BILLING_STATUS,
+      plans: CANCELLED_TEAM_PLANS
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      originalOwnerMembers(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page)
+    const planSlug = billingApi.state.status.plan_slug
+    const planHeading = content.getByRole('heading', {
+      name: 'Team',
+      exact: true
+    })
+    const planPrice = content.getByText('$630', { exact: true })
+
+    await expect(planHeading).toBeVisible()
+    await expect(planPrice).toBeVisible()
+
+    await content
+      .getByRole('button', { name: 'Reactivate plan' })
+      .last()
+      .click()
+
+    await expect(page.locator('.p-toast-message-success')).toContainText(
+      'Subscription reactivated successfully'
+    )
+    expect(billingApi.requests.resubscribe).toHaveLength(1)
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        is_active: true,
+        subscription_status: 'active',
+        plan_slug: planSlug
+      })
+    )
+    expect(billingApi.state.status.cancel_at).toBeUndefined()
+    await expect(
+      content.getByText('Your subscription has been canceled', { exact: true })
+    ).toHaveCount(0)
+    await expect(content.getByText(/^Ends on /)).toHaveCount(0)
+    await expect(
+      content.getByRole('button', { name: 'Reactivate plan' })
+    ).toHaveCount(0)
+    await expect(
+      content.getByRole('heading', { name: TEAM_WORKSPACE.name })
+    ).toBeVisible()
+    await expect(planHeading).toBeVisible()
+    await expect(planPrice).toBeVisible()
+  })
+
+  test('TB-27 failed reactivation keeps the canceled plan recoverable', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: CANCELLED_TEAM_BILLING_STATUS,
+      plans: CANCELLED_TEAM_PLANS,
+      failures: {
+        resubscribe: {
+          status: 503,
+          message: 'Reactivate service unavailable'
+        }
+      }
+    })
+    const canceledStatus = structuredClone(billingApi.state.status)
+    await new CloudWorkspaceMockHelper(page).setup(
+      originalOwnerMembers(),
+      TEAM_WORKSPACE,
+      { mockBilling: false }
+    )
+    const content = await openPlanAndCredits(page)
+    const reactivateButton = content
+      .getByRole('button', { name: 'Reactivate plan' })
+      .last()
+
+    await reactivateButton.click()
+
+    const errorToast = page.locator('.p-toast-message-error').filter({
+      hasText: 'Reactivate service unavailable'
+    })
+    await expect(errorToast).toContainText('Reactivate service unavailable')
+    await expect(reactivateButton).toBeEnabled()
+    expect(billingApi.requests.resubscribe).toHaveLength(1)
+    expect(billingApi.state.status).toEqual(canceledStatus)
+    await expect(
+      content.getByText('Your subscription has been canceled', { exact: true })
+    ).toBeVisible()
+    await expect(
+      content.getByText(`Ends on ${formattedEndDate()}`, { exact: true })
+    ).toBeVisible()
+  })
+})

--- a/browser_tests/tests/dialogs/subscriptionTransitions.spec.ts
+++ b/browser_tests/tests/dialogs/subscriptionTransitions.spec.ts
@@ -1,0 +1,316 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type {
+  BillingStatusResponse,
+  PreviewSubscribeResponse
+} from '@comfyorg/ingest-types'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { SubscriptionCheckoutDialog } from '@e2e/fixtures/components/SubscriptionCheckoutDialog'
+import {
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+  DEFAULT_SUBSCRIBE_RESPONSE,
+  PENDING_BILLING_OPERATION,
+  SUCCEEDED_BILLING_OPERATION
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import {
+  member,
+  mockWorkspace,
+  workspace
+} from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const FEATURES = {
+  team_workspaces_enabled: true,
+  billing_control_enabled: true
+} satisfies RemoteConfig
+const SETTINGS = {
+  'Comfy.Assets.UseAssetAPI': false,
+  'Comfy.TutorialCompleted': true,
+  'Comfy.RightSidePanel.ShowErrorsTab': false
+}
+
+function plan(slug: string) {
+  const selected = DEFAULT_BILLING_PLANS.plans.find(
+    (candidate) => candidate.slug === slug
+  )
+  if (!selected) throw new Error(`Missing billing plan fixture: ${slug}`)
+  return structuredClone(selected)
+}
+
+function preview(
+  slug: string,
+  overrides: Partial<PreviewSubscribeResponse> = {}
+): PreviewSubscribeResponse {
+  const selected = plan(slug)
+  return {
+    ...DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+    cost_today_cents: selected.price_cents,
+    cost_next_period_cents: selected.price_cents,
+    credits_today_cents: selected.credits_cents,
+    credits_next_period_cents: selected.credits_cents,
+    new_plan: selected,
+    ...overrides
+  }
+}
+
+async function mockGraphBoot(page: Page): Promise<void> {
+  await page.route('**/api/settings/**', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({}))
+  })
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+  })
+  await page.route('**/api/queue', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ queue_running: [], queue_pending: [] }))
+  })
+}
+
+async function openCheckout(
+  page: Page,
+  options: { planMode?: '1' | 'team'; workspaceType?: 'personal' | 'team' } = {}
+): Promise<SubscriptionCheckoutDialog> {
+  const { planMode = '1', workspaceType = 'personal' } = options
+  const activeWorkspace = workspace(workspaceType, 'owner')
+  const members =
+    workspaceType === 'team'
+      ? [
+          member({
+            email: 'e2e@test.comfy.org',
+            role: 'owner',
+            is_original_owner: true
+          })
+        ]
+      : []
+
+  await mockCloudBoot(page, { features: FEATURES, settings: SETTINGS })
+  await mockGraphBoot(page)
+  await mockWorkspace(page, activeWorkspace, members)
+  await page.route('**/api/workspace/invites', (route) =>
+    route.fulfill(jsonRoute({ invites: [] }))
+  )
+  await bootCloud(page)
+  await page.goto(`${APP_URL}/?pricing=${planMode}`)
+
+  const dialog = new SubscriptionCheckoutDialog(page)
+  await expect(dialog.heading).toBeVisible({ timeout: 45_000 })
+  return dialog
+}
+
+async function confirmNewPlan(
+  dialog: SubscriptionCheckoutDialog,
+  pricingButton: string,
+  confirmButton: string
+): Promise<void> {
+  await dialog.personalPlanButton(pricingButton).click()
+  await expect(dialog.paymentPreviewHeading).toBeVisible()
+  await dialog.personalPlanButton(confirmButton).click()
+  await expect(dialog.successHeading).toBeVisible()
+}
+
+test.describe('Subscription transitions', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-01 completes a mocked monthly personal subscription and refreshes status', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ previewResponse: preview('creator-monthly') })
+    const dialog = await openCheckout(page)
+
+    await dialog.selectBillingCycle('monthly')
+    await confirmNewPlan(dialog, 'Subscribe to Creator', 'Subscribe to Creator')
+
+    expect(billingApi.requests.previewSubscribe).toEqual([
+      expect.objectContaining({ plan_slug: 'creator-monthly' })
+    ])
+    expect(billingApi.requests.subscribe).toEqual([
+      expect.objectContaining({ plan_slug: 'creator-monthly' })
+    ])
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        subscription_tier: 'CREATOR',
+        subscription_duration: 'MONTHLY',
+        plan_slug: 'creator-monthly'
+      })
+    )
+  })
+
+  test('TB-01 keeps the annual selection in preview and subscribe requests', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ previewResponse: preview('pro-annual') })
+    const dialog = await openCheckout(page)
+
+    await confirmNewPlan(dialog, 'Subscribe to Pro Yearly', 'Subscribe to Pro')
+
+    await expect(dialog.root.getByText('$80', { exact: true })).toBeVisible()
+    expect(billingApi.requests.previewSubscribe[0]).toEqual(
+      expect.objectContaining({ plan_slug: 'pro-annual' })
+    )
+    expect(billingApi.requests.subscribe[0]).toEqual(
+      expect.objectContaining({ plan_slug: 'pro-annual' })
+    )
+  })
+
+  test('TB-06 sends the selected annual Team stop and shows the refreshed Team plan', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup()
+    const dialog = await openCheckout(page, { planMode: 'team' })
+
+    await confirmNewPlan(
+      dialog,
+      'Subscribe to Team Yearly',
+      'Subscribe to Team Plan'
+    )
+
+    await expect(
+      dialog.successContent.getByText('Team Plan', { exact: true })
+    ).toBeVisible()
+    await expect(
+      dialog.successContent.getByText('$630', { exact: true })
+    ).toBeVisible()
+    await expect(
+      dialog.successContent.getByText('147,700 / month')
+    ).toBeVisible()
+    expect(billingApi.requests.subscribe[0]).toEqual(
+      expect.objectContaining({
+        plan_slug: 'team_per_credit_annual',
+        team_credit_stop_id: 'team_700',
+        billing_cycle: 'yearly'
+      })
+    )
+    expect(billingApi.state.status.team_credit_stop).toEqual(
+      expect.objectContaining({ id: 'team_700', credits_monthly: 147_700 })
+    )
+  })
+
+  test('TB-06 keeps a Team workspace monthly selection in the mutation contract', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup()
+    const dialog = await openCheckout(page, {
+      planMode: 'team',
+      workspaceType: 'team'
+    })
+
+    await dialog.selectBillingCycle('monthly')
+    await confirmNewPlan(
+      dialog,
+      'Subscribe to Team Monthly',
+      'Subscribe to Team Plan'
+    )
+
+    expect(billingApi.requests.subscribe[0]).toEqual(
+      expect.objectContaining({
+        plan_slug: 'team_per_credit_monthly',
+        team_credit_stop_id: 'team_700',
+        billing_cycle: 'monthly'
+      })
+    )
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        subscription_tier: 'TEAM',
+        subscription_duration: 'MONTHLY'
+      })
+    )
+  })
+
+  test('TB-09 advances a pending subscription only after its billing operation succeeds', async ({
+    billingApi,
+    page
+  }) => {
+    const operationId = 'billing-op-pending-subscribe'
+    await billingApi.setup({
+      previewResponse: preview('standard-monthly'),
+      subscribeResponse: {
+        ...DEFAULT_SUBSCRIBE_RESPONSE,
+        billing_op_id: operationId,
+        status: 'pending_payment'
+      },
+      operationResponses: {
+        [operationId]: [
+          { ...PENDING_BILLING_OPERATION, id: operationId },
+          { ...SUCCEEDED_BILLING_OPERATION, id: operationId }
+        ]
+      }
+    })
+    const dialog = await openCheckout(page)
+
+    await dialog.selectBillingCycle('monthly')
+    await confirmNewPlan(
+      dialog,
+      'Subscribe to Standard',
+      'Subscribe to Standard'
+    )
+
+    expect(billingApi.requests.subscribe).toHaveLength(1)
+    expect(billingApi.requests.previewSubscribe[0]).toEqual(
+      expect.objectContaining({ plan_slug: 'standard-monthly' })
+    )
+    expect(billingApi.state.status).toEqual(
+      expect.objectContaining({
+        is_active: true,
+        plan_slug: 'standard-monthly',
+        subscription_status: 'active'
+      })
+    )
+  })
+
+  test('TB-09 confirms an immediate upgrade from the backend preview', async ({
+    billingApi,
+    page
+  }) => {
+    const currentStatus: BillingStatusResponse = {
+      is_active: true,
+      subscription_status: 'active',
+      subscription_tier: 'STANDARD',
+      subscription_duration: 'MONTHLY',
+      plan_slug: 'standard-monthly',
+      billing_status: 'paid',
+      has_funds: true,
+      renewal_date: '2099-02-20T00:00:00Z',
+      team_credit_stop: null
+    }
+    const upgradePreview = preview('pro-annual', {
+      transition_type: 'upgrade',
+      current_plan: plan('standard-monthly'),
+      is_immediate: true
+    })
+    await billingApi.setup({
+      status: currentStatus,
+      plans: {
+        ...DEFAULT_BILLING_PLANS,
+        current_plan_slug: 'standard-monthly'
+      },
+      previewResponse: upgradePreview
+    })
+    const dialog = await openCheckout(page)
+
+    await dialog.personalPlanButton('Change to Pro Yearly').click()
+    await expect(dialog.upgradePreviewHeading).toBeVisible()
+    await expect(dialog.root.getByText('Total due today')).toBeVisible()
+    await dialog.personalPlanButton('Confirm upgrade').click()
+
+    await expect(dialog.successHeading).toBeVisible()
+    expect(billingApi.requests.previewSubscribe[0]).toEqual(
+      expect.objectContaining({ plan_slug: 'pro-annual' })
+    )
+    expect(billingApi.requests.subscribe[0]).toEqual(
+      expect.objectContaining({ plan_slug: 'pro-annual' })
+    )
+    expect(billingApi.state.status.plan_slug).toBe('pro-annual')
+  })
+})

--- a/browser_tests/tests/dialogs/subscriptionTransitions.spec.ts
+++ b/browser_tests/tests/dialogs/subscriptionTransitions.spec.ts
@@ -1,16 +1,19 @@
 import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import type {
+  BillingBalanceResponse,
   BillingStatusResponse,
   PreviewSubscribeResponse
 } from '@comfyorg/ingest-types'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import { creditsToCents } from '@/base/credits/comfyCredits'
 
 import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
 import { SubscriptionCheckoutDialog } from '@e2e/fixtures/components/SubscriptionCheckoutDialog'
 import {
   DEFAULT_BILLING_PLANS,
+  DEFAULT_BILLING_STATUS,
   DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
   DEFAULT_SUBSCRIBE_RESPONSE,
   PENDING_BILLING_OPERATION,
@@ -33,6 +36,22 @@ const SETTINGS = {
   'Comfy.Assets.UseAssetAPI': false,
   'Comfy.TutorialCompleted': true,
   'Comfy.RightSidePanel.ShowErrorsTab': false
+}
+const EMPTY_BILLING_BALANCE: BillingBalanceResponse = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0,
+  cloud_credit_balance_micros: 0,
+  prepaid_balance_micros: 0
+}
+const CREATOR_MONTHLY_CREDITS = 7_400
+const creatorMonthlyGrantCents = creditsToCents(CREATOR_MONTHLY_CREDITS)
+const CREATOR_MONTHLY_GRANT: BillingBalanceResponse = {
+  amount_micros: creatorMonthlyGrantCents,
+  currency: 'usd',
+  effective_balance_micros: creatorMonthlyGrantCents,
+  cloud_credit_balance_micros: creatorMonthlyGrantCents,
+  prepaid_balance_micros: 0
 }
 
 function plan(slug: string) {
@@ -116,6 +135,16 @@ async function confirmNewPlan(
   await expect(dialog.successHeading).toBeVisible()
 }
 
+async function closeCheckout(
+  dialog: SubscriptionCheckoutDialog
+): Promise<void> {
+  await dialog.root
+    .getByRole('button', { name: 'Close', exact: true })
+    .last()
+    .click()
+  await expect(dialog.root).toBeHidden()
+}
+
 test.describe('Subscription transitions', { tag: '@cloud' }, () => {
   test.describe.configure({ timeout: 60_000 })
 
@@ -160,6 +189,70 @@ test.describe('Subscription transitions', { tag: '@cloud' }, () => {
     expect(billingApi.requests.subscribe[0]).toEqual(
       expect.objectContaining({ plan_slug: 'pro-annual' })
     )
+  })
+
+  test('TB-02 refreshes the granted credits after subscription purchase', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: DEFAULT_BILLING_STATUS,
+      balance: EMPTY_BILLING_BALANCE,
+      postSubscribeBalance: CREATOR_MONTHLY_GRANT,
+      previewResponse: preview('creator-monthly')
+    })
+    const dialog = await openCheckout(page)
+
+    await dialog.selectBillingCycle('monthly')
+    await confirmNewPlan(dialog, 'Subscribe to Creator', 'Subscribe to Creator')
+    await closeCheckout(dialog)
+    await page.getByRole('button', { name: 'Current user' }).click()
+
+    const popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByText('7,400', { exact: true })).toBeVisible()
+    await popover.getByTestId('manage-plan-menu-item').click()
+
+    const settings = page.getByTestId('settings-dialog')
+    await expect(settings).toBeVisible()
+    const content = settings.getByRole('main')
+    await expect(content.getByText('Total credits')).toBeVisible()
+    await expect(content.getByText('7,400', { exact: true })).toBeVisible()
+  })
+
+  test('TB-02 keeps a completed subscription out of retry state when balance refresh fails', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: DEFAULT_BILLING_STATUS,
+      balance: EMPTY_BILLING_BALANCE,
+      postSubscribeBalance: CREATOR_MONTHLY_GRANT,
+      previewResponse: preview('creator-monthly')
+    })
+    const dialog = await openCheckout(page)
+
+    await dialog.selectBillingCycle('monthly')
+    await dialog.personalPlanButton('Subscribe to Creator').click()
+    await expect(dialog.paymentPreviewHeading).toBeVisible()
+    billingApi.setQueryFailure('balance', {
+      status: 503,
+      message: 'Billing balance temporarily unavailable'
+    })
+    await dialog.personalPlanButton('Subscribe to Creator').click()
+
+    await expect.poll(() => billingApi.requests.subscribe.length).toBe(1)
+    expect(
+      billingApi.state.status,
+      'the mocked subscription write should already be complete'
+    ).toEqual(
+      expect.objectContaining({
+        is_active: true,
+        plan_slug: 'creator-monthly'
+      })
+    )
+    await expect(dialog.successHeading).toBeVisible()
+    await expect(dialog.personalPlanButton('Subscribe to Creator')).toBeHidden()
   })
 
   test('TB-06 sends the selected annual Team stop and shows the refreshed Team plan', async ({

--- a/browser_tests/tests/dialogs/workspaceMemberLifecycle.spec.ts
+++ b/browser_tests/tests/dialogs/workspaceMemberLifecycle.spec.ts
@@ -1,0 +1,251 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page, Route } from '@playwright/test'
+import type {
+  CreateInviteRequest,
+  ErrorResponse,
+  PendingInvite
+} from '@comfyorg/ingest-types'
+
+import type {
+  Member,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import {
+  CREATOR,
+  DEFAULT_TEAM_MEMBERS,
+  TEAM_WORKSPACE,
+  VIEWER
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const MAX_TEAM_MEMBERS = 30
+
+async function openMembersTab(
+  page: Page,
+  expectedMemberCount: number
+): Promise<Locator> {
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const dialog = page.getByTestId('settings-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('nav').getByRole('button', { name: 'Workspace' }).click()
+
+  const content = dialog.getByRole('main')
+  await content.getByRole('tab', { name: /Members/ }).click()
+  await expect(
+    content.getByText(`${expectedMemberCount} of ${MAX_TEAM_MEMBERS} members`, {
+      exact: true
+    })
+  ).toBeVisible()
+  return content
+}
+
+function membersAtCapacity(): Member[] {
+  return [
+    CREATOR,
+    VIEWER,
+    ...Array.from(
+      { length: MAX_TEAM_MEMBERS - 2 },
+      (_, index): Member => ({
+        id: `u-capacity-${index}`,
+        name: `Capacity Member ${index}`,
+        email: `capacity-${index}@test.comfy.org`,
+        joined_at: `2025-02-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+        role: 'member',
+        is_original_owner: false
+      })
+    )
+  ]
+}
+
+async function fulfillJson<T>(
+  route: Route,
+  body: T,
+  status = 200
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body)
+  })
+}
+
+test.describe('Workspace member request contracts', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('TB-07 invite UI posts one email and displays the returned pending invite', async ({
+    page
+  }) => {
+    const email = 'new.member@test.comfy.org'
+    const inviteResponse: PendingInvite = {
+      id: 'invite-new-member',
+      email,
+      token: 'invite-token',
+      invited_at: '2025-02-01T00:00:00Z',
+      expires_at: '2099-02-08T00:00:00Z'
+    }
+    let inviteRequest: CreateInviteRequest | undefined
+
+    await new CloudWorkspaceMockHelper(page).setup()
+    await page.route('**/api/workspace/invites', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback()
+      inviteRequest = route.request().postDataJSON() as CreateInviteRequest
+      await fulfillJson(route, inviteResponse)
+    })
+    const content = await openMembersTab(page, DEFAULT_TEAM_MEMBERS.length)
+
+    await content
+      .getByRole('button', { name: 'Invite member', exact: true })
+      .click()
+    await page.getByPlaceholder('Enter emails separated by commas').fill(email)
+    await page
+      .getByPlaceholder('Enter emails separated by commas')
+      .press('Enter')
+    await page.getByRole('button', { name: 'Invite', exact: true }).click()
+
+    await expect(
+      page.getByText(`An invite was sent to ${email}`, { exact: true })
+    ).toBeVisible()
+    expect(inviteRequest).toEqual({ email })
+
+    await page
+      .getByRole('button', { name: 'Close', exact: true })
+      .filter({ hasText: 'Close' })
+      .click()
+    await content.getByRole('button', { name: 'Pending (1)' }).click()
+    await expect(
+      content.getByText('1 pending invite', { exact: true })
+    ).toBeVisible()
+    await expect(content.getByText(email, { exact: true })).toBeVisible()
+  })
+
+  test('TB-08 member UI shows the team seat count and disables invites at capacity', async ({
+    page
+  }) => {
+    await new CloudWorkspaceMockHelper(page).setup(membersAtCapacity())
+    const content = await openMembersTab(page, MAX_TEAM_MEMBERS)
+
+    await expect(
+      content.getByRole('button', { name: 'Invite member', exact: true })
+    ).toBeDisabled()
+  })
+
+  test('TB-08 removal UI sends DELETE and removes the targeted member row', async ({
+    page
+  }) => {
+    const removedMember = DEFAULT_TEAM_MEMBERS.at(-1)
+    if (!removedMember) throw new Error('Expected a removable team member')
+
+    await new CloudWorkspaceMockHelper(page).setup()
+    await page.route(
+      `**/api/workspace/members/${removedMember.id}`,
+      async (route) => {
+        if (route.request().method() !== 'DELETE') return route.fallback()
+        await route.fulfill({ status: 204 })
+      }
+    )
+    const content = await openMembersTab(page, DEFAULT_TEAM_MEMBERS.length)
+    const row = content.getByTestId(`member-row-${removedMember.id}`)
+    const removeRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === 'DELETE' &&
+        new URL(request.url()).pathname.endsWith(
+          `/api/workspace/members/${removedMember.id}`
+        )
+    )
+
+    await row.getByRole('button', { name: 'More Options' }).click()
+    await page.getByRole('menuitem', { name: 'Remove member' }).click()
+    await page
+      .getByRole('button', { name: 'Remove member', exact: true })
+      .click()
+
+    const removeRequest = await removeRequestPromise
+    expect(removeRequest.method()).toBe('DELETE')
+    await expect(
+      page.getByText('Member removed', { exact: true })
+    ).toBeVisible()
+    await expect(row).toHaveCount(0)
+    await expect(
+      content.getByText(
+        `${DEFAULT_TEAM_MEMBERS.length - 1} of ${MAX_TEAM_MEMBERS} members`,
+        { exact: true }
+      )
+    ).toBeVisible()
+  })
+
+  test('TB-10 member role UI omits invite and member-removal controls', async ({
+    page
+  }) => {
+    const memberWorkspace: WorkspaceWithRole = {
+      ...TEAM_WORKSPACE,
+      role: 'member'
+    }
+    const members = DEFAULT_TEAM_MEMBERS.map((member) =>
+      member.id === VIEWER.id ? { ...member, role: 'member' as const } : member
+    )
+
+    await new CloudWorkspaceMockHelper(page).setup(members, memberWorkspace)
+    const content = await openMembersTab(page, members.length)
+
+    await expect(
+      content.getByRole('button', { name: 'Invite member', exact: true })
+    ).toHaveCount(0)
+    await expect(
+      content
+        .locator('[data-testid^="member-row-"]')
+        .getByRole('button', { name: 'More Options' })
+    ).toHaveCount(0)
+    await expect(content.getByRole('button', { name: /^Pending/ })).toHaveCount(
+      0
+    )
+  })
+
+  test('TB-07 failed invite request keeps the email retryable', async ({
+    page
+  }) => {
+    const email = 'retry.member@test.comfy.org'
+    const errorResponse: ErrorResponse = {
+      code: 'invite_service_unavailable',
+      message: 'Invite service unavailable'
+    }
+
+    await new CloudWorkspaceMockHelper(page).setup()
+    await page.route('**/api/workspace/invites', async (route) => {
+      if (route.request().method() !== 'POST') return route.fallback()
+      await fulfillJson(route, errorResponse, 503)
+    })
+    const content = await openMembersTab(page, DEFAULT_TEAM_MEMBERS.length)
+
+    await content
+      .getByRole('button', { name: 'Invite member', exact: true })
+      .click()
+    const emailInput = page.getByPlaceholder('Enter emails separated by commas')
+    await emailInput.fill(email)
+    await emailInput.press('Enter')
+    await page.getByRole('button', { name: 'Invite', exact: true }).click()
+
+    await expect(
+      page.getByText("Couldn't send 1 invite. Try again.", { exact: true })
+    ).toBeVisible()
+    await expect(page.getByText(email, { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('heading', {
+        name: 'Invite members to this workspace'
+      })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Invite', exact: true })
+    ).toBeEnabled()
+  })
+})


### PR DESCRIPTION
## Summary

Adds mocked billing E2E coverage for the Team Billing QA matrix without changing production code.

## Changes

- Adds 45 E2E tests across subscription checkout and transitions, partner-node execution, credit consumption, Activity, top-ups, billing status banners, cancellation/reactivation, workspace members, legacy/workspace routing, and responsive pricing.
- Adds the previously missing frontend coverage for TB-02, TB-03, TB-04, TB-11, and TB-15, including normal external-system responses and billing failure UI.
- Extends the typed billing mock with post-subscription balances, mutable balances, and GET failure responses.
- TB-01 through TB-27 are now represented; TB-12 remains covered by the existing suite. TB-04 covers the reachable ComfyUI Activity UI, while external staging-platform propagation remains a platform/manual check.

## Review Focus

- Frontend state transitions and rendered UI after mocked billing operations.
- Typed API-node request payloads and workspace-scoped credit balances.
- Four assertions intentionally expose existing product behavior; no production fix is included:
  - TB-02: a successful subscribe followed by a balance `503` remains on the confirmation/retry state instead of showing completion.
  - TB-04: Activity does not make its initial events request, so both the event row and request-failure UI remain behind the loading state.
  - TB-24: entering `$10,001` clamps to `$10,000`, but the expected **Contact us** link is not rendered.

Validation:
- Browser TypeScript, changed-file ESLint/Oxlint, oxfmt, and diff checks pass.
- Cloud Playwright: 43 passed, 4 failed for the intentional product-gap assertions above.
