### PR TITLE
[backport cloud/1.45] fix(billing): honor both billing routing flags

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -20,6 +20,7 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 const {
   mockTeamWorkspacesEnabled,
   mockConsolidatedBillingEnabled,
+  mockBillingControlEnabled,
   mockIsPersonal,
   mockPlans,
   mockPurchaseCredits,
@@ -28,6 +29,7 @@ const {
 } = vi.hoisted(() => ({
   mockTeamWorkspacesEnabled: { value: false },
   mockConsolidatedBillingEnabled: { value: false },
+  mockBillingControlEnabled: { value: false },
   mockIsPersonal: { value: true },
   mockPlans: { value: [] as Plan[] },
   mockPurchaseCredits: vi.fn(),
@@ -68,6 +70,13 @@ vi.mock('@/composables/useFeatureFlags', async () => {
       consolidatedBillingEnabledRef.value = value
     }
   })
+  const billingControlEnabledRef = ref(mockBillingControlEnabled.value)
+  Object.defineProperty(mockBillingControlEnabled, 'value', {
+    get: () => billingControlEnabledRef.value,
+    set: (value: boolean) => {
+      billingControlEnabledRef.value = value
+    }
+  })
   return {
     useFeatureFlags: () => ({
       flags: {
@@ -76,6 +85,9 @@ vi.mock('@/composables/useFeatureFlags', async () => {
         },
         get consolidatedBillingEnabled() {
           return mockConsolidatedBillingEnabled.value
+        },
+        get billingControlEnabled() {
+          return mockBillingControlEnabled.value
         }
       }
     })
@@ -166,6 +178,7 @@ describe('useBillingContext', () => {
     vi.clearAllMocks()
     mockTeamWorkspacesEnabled.value = false
     mockConsolidatedBillingEnabled.value = false
+    mockBillingControlEnabled.value = false
     mockIsPersonal.value = true
     mockPlans.value = []
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
@@ -177,7 +190,7 @@ describe('useBillingContext', () => {
     expect(type.value).toBe('legacy')
   })
 
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
+  it('keeps personal on legacy when both billing rollouts are disabled', () => {
     mockTeamWorkspacesEnabled.value = true
     mockConsolidatedBillingEnabled.value = false
     mockIsPersonal.value = true
@@ -189,6 +202,15 @@ describe('useBillingContext', () => {
   it('selects workspace type for personal when consolidated billing is enabled', () => {
     mockTeamWorkspacesEnabled.value = true
     mockConsolidatedBillingEnabled.value = true
+    mockIsPersonal.value = true
+
+    const { type } = useBillingContext()
+    expect(type.value).toBe('workspace')
+  })
+
+  it('selects workspace type for personal when billing control is enabled', () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockBillingControlEnabled.value = true
     mockIsPersonal.value = true
 
     const { type } = useBillingContext()

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -44,7 +44,7 @@ function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
  *
  * - Team workspaces disabled (OSS/Desktop): legacy billing via /customers/*
  * - Team workspaces enabled: workspace billing via /api/billing/* for team
- *   workspaces, and for personal workspaces once consolidated billing is
+ *   workspaces, and for personal workspaces once either billing rollout is
  *   enabled; personal workspaces otherwise stay on legacy billing
  *
  * The context automatically initializes when the workspace changes and provides
@@ -207,9 +207,9 @@ function useBillingContextInternal(): BillingContext {
     error.value = null
   }
 
-  // type flips when the team-workspaces or consolidated-billing flag resolves
-  // from authenticated config, swapping the active backend. Reset then reinit
-  // on every workspace-id or type change.
+  // type flips when the team-workspaces or either billing flag resolves from
+  // authenticated config, swapping the active backend. Reset then reinit on
+  // every workspace-id or type change.
   watch(
     [() => store.activeWorkspace?.id, () => type.value],
     async ([newWorkspaceId]) => {

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -5,7 +5,8 @@ import { useBillingRouting } from './useBillingRouting'
 const { mockFlags, mockActiveWorkspace } = vi.hoisted(() => ({
   mockFlags: {
     teamWorkspacesEnabled: false,
-    consolidatedBillingEnabled: false
+    consolidatedBillingEnabled: false,
+    billingControlEnabled: false
   },
   mockActiveWorkspace: {
     value: null as { id: string; type: 'personal' | 'team' } | null
@@ -31,6 +32,7 @@ describe('useBillingRouting', () => {
   beforeEach(() => {
     mockFlags.teamWorkspacesEnabled = false
     mockFlags.consolidatedBillingEnabled = false
+    mockFlags.billingControlEnabled = false
     mockActiveWorkspace.value = personal
   })
 
@@ -44,7 +46,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(false)
   })
 
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
+  it('keeps personal on legacy when both billing rollouts are disabled', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = false
     mockActiveWorkspace.value = personal
@@ -57,6 +59,17 @@ describe('useBillingRouting', () => {
   it('moves personal to workspace billing when consolidated billing is enabled', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
+    mockActiveWorkspace.value = personal
+
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+
+    expect(type.value).toBe('workspace')
+    expect(shouldUseWorkspaceBilling.value).toBe(true)
+  })
+
+  it('moves personal to workspace billing when billing control is enabled', () => {
+    mockFlags.teamWorkspacesEnabled = true
+    mockFlags.billingControlEnabled = true
     mockActiveWorkspace.value = personal
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -8,8 +8,9 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * stay legacy until `consolidatedBillingEnabled`; team workspaces are always
- * workspace-scoped. The routing matrix is covered in useBillingRouting.test.ts.
+ * stay legacy until either billing rollout is enabled; team workspaces are
+ * always workspace-scoped. The routing matrix is covered in
+ * useBillingRouting.test.ts.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
@@ -23,7 +24,11 @@ export function useBillingRouting() {
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return 'legacy'
 
-    if (workspaceType === 'personal' && !flags.consolidatedBillingEnabled) {
+    if (
+      workspaceType === 'personal' &&
+      !flags.consolidatedBillingEnabled &&
+      !flags.billingControlEnabled
+    ) {
       return 'legacy'
     }
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -103,9 +103,9 @@ export const useSubscriptionDialog = () => {
     }
 
     // Jun-5 model: a single unified pricing table (personal/team plan toggle on
-    // one workspace) for workspaces on the consolidated billing flow. Replaces
-    // the old personal-vs-team workspace fork. Personal workspaces still on the
-    // legacy flow (consolidated billing disabled) get the legacy table.
+    // one workspace) for workspaces on the workspace-scoped billing flow.
+    // Replaces the old personal-vs-team workspace fork. Personal workspaces
+    // still on the legacy flow get the legacy table.
     if (shouldUseWorkspaceBilling.value) {
       // Existing per-member (legacy) team subscribers keep the old tier-based
       // team table; the unified credit-slider table is for everyone else.


### PR DESCRIPTION
## Summary

Routes personal workspaces to workspace-scoped billing when either independent billing rollout is enabled.

## Changes

- **What**: Uses `consolidatedBillingEnabled || billingControlEnabled` for personal-workspace billing routing while team workspaces remain workspace-scoped.
- **Tests**: Adds unit coverage for both rollout paths and validates the billing-control-only Members E2E alongside the consolidated-only pricing E2E.

## Review Focus

Final-branch validation after #13813 and #13819 exposed that restoring consolidated-only routing broke users in the billing-control rollout. The backend defines both flags as independent gates for workspace-scoped billing, so either must enable the route.

## Screenshots (if applicable)

Not applicable; this corrects routing without visual changes.