### PR TITLE
fix(workspace): standardize invite actions

### DIFF
--- a/src/platform/workspace/components/InviteMembersForm.test.ts
+++ b/src/platform/workspace/components/InviteMembersForm.test.ts
@@ -80,14 +80,16 @@ describe('InviteMembersForm', () => {
     )
   })
 
-  it('turns comma- and enter-delimited input into chips', async () => {
+  it('turns comma-, whitespace-, and enter-delimited input into chips', async () => {
     const { user } = renderForm()
 
-    await user.type(emailInput(), 'a@b.com,')
-    await user.type(emailInput(), 'c@d.com{Enter}')
+    await user.type(emailInput(), 'a@b.com ')
+    await user.type(emailInput(), 'c@d.com,')
+    await user.type(emailInput(), 'e@f.com{Enter}')
 
     expect(screen.getByText('a@b.com')).toBeInTheDocument()
     expect(screen.getByText('c@d.com')).toBeInTheDocument()
+    expect(screen.getByText('e@f.com')).toBeInTheDocument()
   })
 
   it('disables submit with no chips and flags invalid emails', async () => {
@@ -107,7 +109,7 @@ describe('InviteMembersForm', () => {
   it('creates an invite per email, tracks telemetry, and emits submitted', async () => {
     const { user, emitted } = renderForm()
 
-    await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
+    await user.type(emailInput(), 'A@B.com C@D.com{Enter}')
     await user.click(submitButton())
 
     await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
@@ -120,14 +122,18 @@ describe('InviteMembersForm', () => {
     expect(emitted().submitted).toEqual([[['a@b.com', 'c@d.com']]])
   })
 
-  it('keeps failed emails as chips, toasts, and emits the invited subset on partial failure', async () => {
+  it('keeps failed emails for retry and emits all invited emails after recovery', async () => {
+    let shouldFail = true
     mockCreateInvite.mockImplementation(async (email: string) => {
-      if (email === 'fail@x.com') throw new Error('nope')
+      if (email === 'fail@x.com' && shouldFail) {
+        shouldFail = false
+        throw new Error('nope')
+      }
       return pendingInviteFor(email)
     })
     const { user, emitted } = renderForm()
 
-    await user.type(emailInput(), 'ok@x.com,fail@x.com{Enter}')
+    await user.type(emailInput(), 'ok@x.com fail@x.com{Enter}')
     await user.click(submitButton())
 
     await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
@@ -136,8 +142,18 @@ describe('InviteMembersForm', () => {
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
-    expect(emitted().submitted).toEqual([[['ok@x.com']]])
+    expect(emitted().submitted).toBeUndefined()
     expect(mockTrackInviteSent).toHaveBeenCalledWith({
+      source: 'post_upgrade_success',
+      count: 1
+    })
+
+    await user.click(submitButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(3))
+    expect(emitted().submitted).toEqual([[['ok@x.com', 'fail@x.com']]])
+    expect(mockTrackInviteSent).toHaveBeenCalledTimes(2)
+    expect(mockTrackInviteSent).toHaveBeenLastCalledWith({
       source: 'post_upgrade_success',
       count: 1
     })

--- a/src/platform/workspace/components/InviteMembersForm.vue
+++ b/src/platform/workspace/components/InviteMembersForm.vue
@@ -7,7 +7,7 @@
       :delimiter="EMAIL_DELIMITER"
       :convert-value="normalizeEmail"
       :model-value="emails"
-      class="min-h-10 w-full bg-tertiary-background px-3 focus-within:bg-tertiary-background hover:bg-tertiary-background-hover"
+      :class="tagsInputClass"
       @update:model-value="onEmailsUpdate"
     >
       <TagsInputItem
@@ -111,7 +111,8 @@ const {
   cancelLabel,
   maxSeats = Number.POSITIVE_INFINITY,
   showSubmit = true,
-  autoFocus = false
+  autoFocus = false,
+  tagsInputClass = 'min-h-10 w-full bg-tertiary-background px-3 focus-within:bg-tertiary-background hover:bg-tertiary-background-hover'
 } = defineProps<{
   submitLabel: string
   placeholder: string
@@ -124,6 +125,7 @@ const {
   /** Focus the email input on mount. Off by default so an embedding dialog
    *  keeps control of its own focus order. */
   autoFocus?: boolean
+  tagsInputClass?: string
 }>()
 
 const emit = defineEmits<{
@@ -137,6 +139,7 @@ const telemetry = useTelemetry()
 const workspaceStore = useTeamWorkspaceStore()
 
 const emails = ref<string[]>([])
+const invitedEmails = ref<string[]>([])
 const loading = ref(false)
 
 const invalidEmailsHintId = useId()
@@ -168,12 +171,8 @@ function onEmailsUpdate(value: string[]) {
 }
 
 async function onSubmit() {
-  if (loading.value) return
+  if (loading.value || !canSubmit.value) return
   loading.value = true
-  if (!canSubmit.value) {
-    loading.value = false
-    return
-  }
   try {
     const emailSnapshot = [...emails.value]
     const results = await Promise.allSettled(
@@ -182,17 +181,22 @@ async function onSubmit() {
     const failedEmails = emailSnapshot.filter(
       (_, index) => results[index].status === 'rejected'
     )
-    const invitedCount = emailSnapshot.length - failedEmails.length
+    const successfulEmails = emailSnapshot.filter(
+      (_, index) => results[index].status === 'fulfilled'
+    )
 
-    if (invitedCount > 0) {
-      telemetry?.trackWorkspaceInviteSent({ source, count: invitedCount })
-      emit(
-        'submitted',
-        emailSnapshot.filter((email) => !failedEmails.includes(email))
-      )
+    if (successfulEmails.length > 0) {
+      invitedEmails.value.push(...successfulEmails)
+      telemetry?.trackWorkspaceInviteSent({
+        source,
+        count: successfulEmails.length
+      })
     }
 
-    if (failedEmails.length === 0) return
+    if (failedEmails.length === 0) {
+      emit('submitted', [...invitedEmails.value])
+      return
+    }
 
     emails.value = failedEmails
     toast.add({

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -7,15 +7,25 @@ import InviteMemberDialogContent from './InviteMemberDialogContent.vue'
 
 import type { PendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 
-const { mockCreateInvite, mockCloseDialog, mockToastAdd } = vi.hoisted(() => ({
-  mockCreateInvite: vi.fn(),
-  mockCloseDialog: vi.fn(),
-  mockToastAdd: vi.fn()
-}))
+const { mockCreateInvite, mockCloseDialog, mockToastAdd, mockTrackInviteSent } =
+  vi.hoisted(() => ({
+    mockCreateInvite: vi.fn(),
+    mockCloseDialog: vi.fn(),
+    mockToastAdd: vi.fn(),
+    mockTrackInviteSent: vi.fn()
+  }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  MAX_WORKSPACE_MEMBERS: 30,
   useTeamWorkspaceStore: () => ({
-    createInvite: mockCreateInvite
+    createInvite: mockCreateInvite,
+    totalMemberSlots: 0
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackWorkspaceInviteSent: mockTrackInviteSent
   })
 }))
 
@@ -72,14 +82,16 @@ describe('InviteMemberDialogContent', () => {
     )
   })
 
-  it('turns comma- and enter-delimited input into chips', async () => {
+  it('turns comma-, whitespace-, and enter-delimited input into chips', async () => {
     const { user } = renderDialog()
 
-    await user.type(emailInput(), 'a@b.com,')
-    await user.type(emailInput(), 'c@d.com{Enter}')
+    await user.type(emailInput(), 'a@b.com ')
+    await user.type(emailInput(), 'c@d.com,')
+    await user.type(emailInput(), 'e@f.com{Enter}')
 
     expect(screen.getByText('a@b.com')).toBeInTheDocument()
     expect(screen.getByText('c@d.com')).toBeInTheDocument()
+    expect(screen.getByText('e@f.com')).toBeInTheDocument()
   })
 
   it('splits a pasted comma-separated list into chips', async () => {
@@ -128,6 +140,10 @@ describe('InviteMemberDialogContent', () => {
     expect(mockCreateInvite).toHaveBeenCalledTimes(2)
     expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
     expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    expect(mockTrackInviteSent).toHaveBeenCalledWith({
+      source: 'settings_members',
+      count: 2
+    })
 
     const closeButton = screen
       .getAllByRole('button', { name: 'g.close' })
@@ -153,6 +169,10 @@ describe('InviteMemberDialogContent', () => {
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
+    expect(mockTrackInviteSent).toHaveBeenCalledWith({
+      source: 'settings_members',
+      count: 1
+    })
     expect(inviteButton()).toBeEnabled()
   })
 
@@ -172,6 +192,7 @@ describe('InviteMemberDialogContent', () => {
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
+    expect(mockTrackInviteSent).not.toHaveBeenCalled()
     expect(inviteButton()).toBeEnabled()
   })
 

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.vue
@@ -19,48 +19,17 @@
 
     <template v-if="step === 'form'">
       <div class="flex flex-col gap-2 p-4">
-        <TagsInput
-          always-editing
-          add-on-paste
-          add-on-blur
-          :delimiter="EMAIL_DELIMITER"
-          :convert-value="trimEmail"
-          :model-value="emails"
-          class="min-h-10 w-full bg-secondary-background"
-          @update:model-value="onEmailsUpdate"
-        >
-          <TagsInputItem
-            v-for="email in emails"
-            :key="email"
-            :value="email"
-            :class="
-              cn(
-                'rounded-full',
-                !EMAIL_REGEX.test(email) && 'bg-danger/20 text-danger'
-              )
-            "
-          >
-            <TagsInputItemText />
-            <TagsInputItemDelete />
-          </TagsInputItem>
-          <TagsInputInput
-            auto-focus
-            class="text-sm"
-            :placeholder="
-              emails.length === 0
-                ? $t('workspacePanel.inviteMemberDialog.placeholder')
-                : undefined
-            "
-          />
-        </TagsInput>
-        <p v-if="invalidEmails.length > 0" class="text-danger m-0 text-xs">
-          {{
-            $t(
-              'workspacePanel.inviteMemberDialog.invalidEmailCount',
-              invalidEmails.length
-            )
-          }}
-        </p>
+        <InviteMembersForm
+          ref="inviteForm"
+          auto-focus
+          :show-submit="false"
+          source="settings_members"
+          :submit-label="$t('workspacePanel.invite')"
+          :placeholder="$t('workspacePanel.inviteMemberDialog.placeholder')"
+          :max-seats="invitableSeats"
+          tags-input-class="min-h-10 w-full bg-secondary-background"
+          @submitted="onInvited"
+        />
       </div>
 
       <div class="flex items-center justify-end gap-4 p-4">
@@ -72,7 +41,7 @@
           size="lg"
           :loading
           :disabled="!canSubmit"
-          @click="onInvite"
+          @click="handleInvite"
         >
           {{ $t('workspacePanel.invite') }}
         </Button>
@@ -102,78 +71,39 @@
 </template>
 
 <script setup lang="ts">
-import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
-import TagsInputInput from '@/components/ui/tags-input/TagsInputInput.vue'
-import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'
-import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.vue'
-import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import InviteMembersForm from '@/platform/workspace/components/InviteMembersForm.vue'
+import {
+  MAX_WORKSPACE_MEMBERS,
+  useTeamWorkspaceStore
+} from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogStore } from '@/stores/dialogStore'
-import { cn } from '@comfyorg/tailwind-utils'
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const EMAIL_DELIMITER = /[,\s]+/
 
 const dialogStore = useDialogStore()
-const toast = useToast()
-const { t } = useI18n()
 const workspaceStore = useTeamWorkspaceStore()
 
 const step = ref<'form' | 'invited'>('form')
-const emails = ref<string[]>([])
 const invitedEmails = ref<string[]>([])
-const loading = ref(false)
+const inviteForm = ref<InstanceType<typeof InviteMembersForm>>()
 
-const invalidEmails = computed(() =>
-  emails.value.filter((email) => !EMAIL_REGEX.test(email))
+const invitableSeats = computed(() =>
+  Math.max(0, MAX_WORKSPACE_MEMBERS - workspaceStore.totalMemberSlots)
 )
-const canSubmit = computed(
-  () => emails.value.length > 0 && invalidEmails.value.length === 0
-)
-
-function trimEmail(value: string) {
-  return value.trim()
-}
-
-function onEmailsUpdate(value: string[]) {
-  emails.value = value.filter((email) => email.length > 0)
-}
+const canSubmit = computed(() => inviteForm.value?.canSubmit ?? false)
+const loading = computed(() => inviteForm.value?.loading ?? false)
 
 function onClose() {
   dialogStore.closeDialog({ key: 'invite-member' })
 }
 
-async function onInvite() {
-  if (!canSubmit.value || loading.value) return
-  loading.value = true
-  try {
-    const submitted = [...emails.value]
-    const results = await Promise.allSettled(
-      submitted.map((email) => workspaceStore.createInvite(email))
-    )
-    const failedEmails = submitted.filter(
-      (_, index) => results[index].status === 'rejected'
-    )
-    if (failedEmails.length === 0) {
-      invitedEmails.value = submitted
-      step.value = 'invited'
-      return
-    }
-    emails.value = failedEmails
-    toast.add({
-      severity: 'error',
-      summary: t(
-        'workspacePanel.inviteMemberDialog.failedCount',
-        failedEmails.length
-      )
-    })
-  } finally {
-    loading.value = false
-  }
+function handleInvite() {
+  void inviteForm.value?.submit()?.catch(console.error)
+}
+
+function onInvited(emails: string[]) {
+  invitedEmails.value = emails
+  step.value = 'invited'
 }
 </script>

--- a/src/platform/workspace/utils/inviteEmails.ts
+++ b/src/platform/workspace/utils/inviteEmails.ts
@@ -1,8 +1,6 @@
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-/** Split pasted/typed input on commas and newlines only, so addresses with
- *  surrounding whitespace (e.g. Outlook `"Alice B" <a@b.com>`) stay intact. */
-export const EMAIL_DELIMITER = /[,\n]+/
+export const EMAIL_DELIMITER = /[,\s]+/
 
 export function normalizeEmail(value: string): string {
   return value.trim().toLowerCase()


### PR DESCRIPTION
## Summary

Standardize workspace invites across Settings and the post-upgrade flow. The two surfaces were implemented separately, so delimiter parsing, telemetry, seat limits, and partial-failure behavior drifted.

## Changes

- **What**: Reuse `InviteMembersForm` in Settings and accept commas or whitespace in both flows.
- **What**: Keep failed addresses available for retry and emit the complete invited list only after recovery.
- **What**: Share normalization, validation, deduplication, seat limits, accessibility feedback, and source-specific telemetry.
- **Dependencies**: None.

## Review Focus

- Mixed comma/space input produces the same chips in both invite surfaces.
- Partial success does not hide failed addresses or transition early.
- Settings keeps its existing layout while delegating behavior to the shared form.

Validation: 32 focused Vitest tests, Vue typecheck, ESLint, Oxlint, formatting, Knip, and real-app visual QA.

## Screenshots

Captured in the local cloud app with production components and client-side Team state; no Storybook.

### Settings — empty

<img width="1920" height="902" alt="clipboard" src="https://github.com/user-attachments/assets/54cefe2c-51af-4730-947f-beb12d6ddf86" />

### Settings — comma and whitespace

<img width="1920" height="902" alt="clipboard" src="https://github.com/user-attachments/assets/a5b89b24-96fe-44b9-ba02-2cefd14a3d5f" />

### Post-upgrade — empty

<img width="1920" height="902" alt="clipboard" src="https://github.com/user-attachments/assets/1b345c8e-3b39-432c-9a5e-0d6e672d64e5" />

### Post-upgrade — comma and whitespace

<img width="1920" height="902" alt="clipboard" src="https://github.com/user-attachments/assets/448c2cc5-37c3-456f-9c95-adf7861f268b" />
