### PR TITLE
fix: scope creator protection to personal workspaces

### DIFF
--- a/browser_tests/tests/dialogs/memberRoleChange.spec.ts
+++ b/browser_tests/tests/dialogs/memberRoleChange.spec.ts
@@ -22,11 +22,10 @@ import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
  * Member role change (Settings ▸ Workspace ▸ Members) — Figma 2993-15512.
  *
  * The viewer is a promoted owner (not the workspace creator), so the spec can
- * distinguish the creator guard from the self guard: the creator row and the
- * viewer's own row hide the row menu, every other row exposes
- * "Change role ›" (Owner / Member) plus "Remove member". Promoting a member
- * sends PATCH /api/workspace/members/:id {role}, flips the Role column,
- * re-sorts the row under the creator, and the promoted owner stays demotable.
+ * distinguish personal-workspace creator protection from the self guard.
+ * Promoting a member sends PATCH /api/workspace/members/:id {role}, flips the
+ * Role column, re-sorts the row under the creator, and the promoted owner stays
+ * demotable.
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
@@ -92,6 +91,7 @@ test.describe('Members plan gating', { tag: '@cloud' }, () => {
     await expect(
       content.getByText(MEMBER_JANE.email, { exact: true })
     ).toBeVisible()
+    await expect(menuButton(memberRow(content, CREATOR.email))).toHaveCount(0)
     await expect(
       content.getByRole('button', { name: 'Upgrade to Team' })
     ).toHaveCount(0)
@@ -108,19 +108,19 @@ test.describe('Members plan gating', { tag: '@cloud' }, () => {
 test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
   test.describe.configure({ timeout: 60_000 })
 
-  test('row menus respect creator and self guards', async ({ page }) => {
+  test('row menus protect only the current user in an additional workspace', async ({
+    page
+  }) => {
     await new CloudWorkspaceMockHelper(page).setup()
     const content = await openMembersTab(page)
 
-    // US8/US9 — no row actions on the creator row (Liz) nor on the viewer's
-    // own row; the two plain members each expose a menu.
     await expect(
       menuButton(memberRow(content, MEMBER_JOHN.email))
     ).toBeVisible()
     await expect(
       menuButton(memberRow(content, MEMBER_JANE.email))
     ).toBeVisible()
-    await expect(menuButton(memberRow(content, CREATOR.email))).toHaveCount(0)
+    await expect(menuButton(memberRow(content, CREATOR.email))).toBeVisible()
     await expect(menuButton(memberRow(content, VIEWER.email))).toHaveCount(0)
 
     // US1/US12 — the row menu exposes Change role and the FE-768 remove flow.
@@ -181,9 +181,7 @@ test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
       page.getByText('Manage members, payment methods, and workspace settings')
     ).toBeVisible()
     await expect(
-      page.getByText(
-        'Promote and demote other owners (except the workspace creator).'
-      )
+      page.getByText('Promote and demote other owners.')
     ).toBeVisible()
 
     await page.getByRole('button', { name: 'Cancel', exact: true }).click()

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -17,15 +17,8 @@ import {
   workspace
 } from '@e2e/fixtures/utils/workspaceMocks'
 
-/**
- * The `?pricing=` deep link opens the pricing table on app load, gated to the
- * original owner (canManageSubscriptionLifecycle). Drives a raw `page` so the
- * cloud app boots against fully mocked endpoints, like the survey-gate spec.
- */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
-// CloudAuthHelper.mockAuth() signs in as this email; the original-owner gate
-// matches it against the members self-row.
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
 // consolidated_billing_enabled routes personal workspaces to the unified
@@ -100,10 +93,15 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     ).toHaveAttribute('aria-pressed', 'true')
   })
 
-  test('opens for a team original owner', async ({ page }) => {
+  test('opens for a promoted team owner', async ({ page }) => {
     test.slow()
     await setupCloudApp(page, workspace('team', 'owner'), [
-      member({ email: SELF_EMAIL, role: 'owner', is_original_owner: true })
+      member({
+        email: 'creator@test.comfy.org',
+        role: 'owner',
+        is_original_owner: true
+      }),
+      member({ email: SELF_EMAIL, role: 'owner' })
     ])
 
     await page.goto(`${APP_URL}/?pricing=1`)

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2987,7 +2987,7 @@
       "promoteIntro": "They'll be able to:",
       "promotePermissionCredits": "Add additional credits",
       "promotePermissionManage": "Manage members, payment methods, and workspace settings",
-      "promotePermissionRoles": "Promote and demote other owners (except the workspace creator).",
+      "promotePermissionRoles": "Promote and demote other owners.",
       "promoteConfirm": "Make owner",
       "demoteTitle": "Demote {name} to member?",
       "demoteMessage": "They'll lose admin access.",

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -40,29 +40,18 @@ vi.mock(
 )
 
 const mockPermissions = vi.hoisted(() => ({
-  value: { canManageSubscriptionLifecycle: true }
+  value: { canManageSubscription: true }
 }))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({ permissions: mockPermissions })
 }))
 
-const mockFetchMembers = vi.hoisted(() => vi.fn().mockResolvedValue([]))
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    fetchMembers: mockFetchMembers
-  })
-}))
-
 describe('usePricingTableUrlLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRouteQuery.value = {}
-    mockPermissions.value = { canManageSubscriptionLifecycle: true }
-    // clearAllMocks resets calls, not implementations, so restore the default
-    // (a test overrides fetchMembers to flip the gate mid-await).
-    mockFetchMembers.mockResolvedValue([])
+    mockPermissions.value = { canManageSubscription: true }
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -80,7 +69,7 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).not.toHaveBeenCalled()
   })
 
-  it('opens the pricing table for an original owner', async () => {
+  it('opens the pricing table for an owner', async () => {
     mockRouteQuery.value = { pricing: '1' }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
@@ -91,22 +80,6 @@ describe('usePricingTableUrlLoader', () => {
       planMode: undefined
     })
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
-  })
-
-  it('reads the gate only after members finish loading', async () => {
-    mockRouteQuery.value = { pricing: '1' }
-    // The original owner becomes known only once the members list resolves;
-    // proves the loader awaits fetchMembers before reading the gate.
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
-    mockFetchMembers.mockImplementation(async () => {
-      mockPermissions.value = { canManageSubscriptionLifecycle: true }
-      return []
-    })
-
-    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
-    await loadPricingTableFromUrl()
-
-    expect(mockShowPricingTable).toHaveBeenCalledOnce()
   })
 
   it('opens on the team tab for ?pricing=team', async () => {
@@ -133,9 +106,9 @@ describe('usePricingTableUrlLoader', () => {
     })
   })
 
-  it('is a silent no-op for a member or promoted owner', async () => {
+  it('is a silent no-op for a member', async () => {
     mockRouteQuery.value = { pricing: '1' }
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+    mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
@@ -145,7 +118,7 @@ describe('usePricingTableUrlLoader', () => {
 
   it('denies, strips, and clears together when the user is not eligible', async () => {
     mockRouteQuery.value = { pricing: '1', other: 'param' }
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+    mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
@@ -207,21 +180,5 @@ describe('usePricingTableUrlLoader', () => {
       reason: 'deep_link',
       planMode: undefined
     })
-  })
-
-  it('strips and clears, then propagates a members-fetch failure', async () => {
-    mockRouteQuery.value = { pricing: '1' }
-    mockFetchMembers.mockRejectedValue(new Error('listMembers failed'))
-
-    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
-    await expect(loadPricingTableFromUrl()).rejects.toThrow(
-      'listMembers failed'
-    )
-
-    expect(mockShowPricingTable).not.toHaveBeenCalled()
-    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
-    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
-      'pricing'
-    )
   })
 })

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -8,7 +8,6 @@ import {
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
 
@@ -16,15 +15,11 @@ const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
  * Opens the pricing table from a `?pricing=` deep link, to send pilot users
  * straight to subscribe. Values: `1` (default tab), `team`, `personal`.
  *
- * Gated to the original owner (`canManageSubscriptionLifecycle`); a member or
- * promoted owner is a silent no-op with the param stripped. Survives the login
- * redirect via the preserved-query system, like the invite URL loader.
  */
 export function usePricingTableUrlLoader() {
   const route = useRoute()
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
-  const workspaceStore = useTeamWorkspaceStore()
   const { permissions } = useWorkspaceUI()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
@@ -52,11 +47,7 @@ export function usePricingTableUrlLoader() {
     // gets stripped above.
     if (typeof param !== 'string' || !param) return
 
-    // Load members before reading the gate so the original-owner self-row is
-    // present. fetchMembers always awaits the request; ensureMembersLoaded can
-    // early-return on a cached/in-flight load and let the gate read empty members.
-    await workspaceStore.fetchMembers()
-    if (!permissions.value.canManageSubscriptionLifecycle) return
+    if (!permissions.value.canManageSubscription) return
 
     const planMode =
       param === 'team' || param === 'personal' ? param : undefined

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -113,11 +113,7 @@
         button-variant="subscribe"
       />
       <Button
-        v-if="
-          showSubscribeAction &&
-          !isPersonalWorkspace &&
-          (!isCancelled || permissions.canManageSubscriptionLifecycle)
-        "
+        v-if="showSubscribeAction && !isPersonalWorkspace"
         variant="primary"
         size="sm"
         @click="handleOpenPlansAndPricing"

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -550,7 +550,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowEditWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('offers a subscribed personal workspace Edit, Cancel plan, and a locked Delete', () => {
+  it('offers a subscribed personal workspace Edit and Cancel but not Delete', () => {
     mockIsInPersonalWorkspace.value = true
     mockIsActiveSubscription.value = true
     mockHasSubscription.value = true
@@ -565,8 +565,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Cancel plan' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Delete Workspace' })
-    ).toBeDisabled()
+      screen.queryByRole('button', { name: 'Delete Workspace' })
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Leave Workspace' })
     ).not.toBeInTheDocument()
@@ -656,7 +656,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('offers a promoted owner Edit and Leave (no Cancel or Delete)', () => {
+  it('offers a promoted owner Edit, Leave, and subscription-locked Delete', () => {
     renderComponent()
 
     expect(
@@ -669,8 +669,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.queryByRole('button', { name: 'Cancel plan' })
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Delete Workspace' })
-    ).not.toBeInTheDocument()
+      screen.getByRole('button', { name: 'Delete Workspace' })
+    ).toBeDisabled()
   })
 
   it('offers the original owner Edit, Cancel plan, and a subscription-locked Delete', async () => {
@@ -685,15 +685,14 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Delete Workspace' })
     ).toBeDisabled()
     expect(
-      screen.queryByRole('button', { name: 'Leave Workspace' })
-    ).not.toBeInTheDocument()
+      screen.getByRole('button', { name: 'Leave Workspace' })
+    ).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Cancel plan' }))
     expect(mockShowCancelSubscriptionDialog).toHaveBeenCalledOnce()
   })
 
-  it('enables Delete for the original owner once the plan is cancelled', () => {
-    mockUserEmail.value = 'creator@example.com'
+  it('enables Delete for an owner once the plan is cancelled', () => {
     mockSubscriptionStatus.value = 'canceled'
     renderComponent()
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -53,19 +53,6 @@ const mockIsActiveSubscription = ref(true)
 const mockIsInPersonalWorkspace = ref(false)
 const mockIsWorkspaceSubscribed = ref(true)
 const mockCanManageSubscription = ref(true)
-const mockMembers = ref([
-  {
-    id: 'member-1',
-    email: 'creator@example.com',
-    joinDate: new Date('2026-01-01T00:00:00Z')
-  },
-  {
-    id: 'member-2',
-    email: 'me@example.com',
-    joinDate: new Date('2026-02-01T00:00:00Z')
-  }
-])
-const mockUserEmail = ref<string | null>('me@example.com')
 const mockTeamCreditStops = ref<TeamCreditStops | null>(teamCreditStops)
 const mockCurrentTeamCreditStop = ref<CurrentTeamCreditStop | null>({
   id: 'team_700',
@@ -152,23 +139,9 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
-    members: mockMembers
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
   })
 }))
-
-// Mirrors useWorkspaceUI's original-owner derivation (earliest join date, ties
-// broken by member id) so member/email toggles still drive owner-only menus.
-const mockIsOriginalOwner = computed(() => {
-  if (mockIsInPersonalWorkspace.value) return true
-  const email = mockUserEmail.value?.toLowerCase()
-  if (!email || mockMembers.value.length === 0) return false
-  const original = [...mockMembers.value].sort(
-    (a, b) =>
-      a.joinDate.getTime() - b.joinDate.getTime() || a.id.localeCompare(b.id)
-  )[0]
-  return original.email.toLowerCase() === email
-})
 
 const mockIsTeamPlanCancelled = computed(
   () =>
@@ -190,7 +163,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
-    isOriginalOwner: mockIsOriginalOwner,
     isTeamPlanCancelled: mockIsTeamPlanCancelled,
     isDeleteDisabled: mockIsDeleteDisabled,
     deleteDisabledTooltipKey: computed(() =>
@@ -283,19 +255,6 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsInPersonalWorkspace.value = false
     mockIsWorkspaceSubscribed.value = true
     mockCanManageSubscription.value = true
-    mockMembers.value = [
-      {
-        id: 'member-1',
-        email: 'creator@example.com',
-        joinDate: new Date('2026-01-01T00:00:00Z')
-      },
-      {
-        id: 'member-2',
-        email: 'me@example.com',
-        joinDate: new Date('2026-02-01T00:00:00Z')
-      }
-    ]
-    mockUserEmail.value = 'me@example.com'
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
     mockPlanSlug.value = 'team-monthly'
@@ -405,39 +364,16 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(screen.getByText('Invite members')).toBeInTheDocument()
   })
 
-  it('reactivates a cancelled plan as the original owner, keeping Manage billing', async () => {
+  it('reactivates a cancelled plan as a promoted owner', async () => {
     const user = userEvent.setup()
     mockSubscriptionStatus.value = 'canceled'
-    mockUserEmail.value = 'creator@example.com'
     renderComponent()
 
     expect(
-      screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
-    ).not.toBeInTheDocument()
-    expect(
       screen.getByRole('button', { name: 'Manage billing' })
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Change plan' })
-    ).not.toBeInTheDocument()
-
     await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
     expect(mockResubscribe).toHaveBeenCalledOnce()
-  })
-
-  it('hides Reactivate plan from a promoted owner on a cancelled plan', () => {
-    mockSubscriptionStatus.value = 'canceled'
-    renderComponent()
-
-    expect(
-      screen.getByRole('button', { name: 'Manage billing' })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
-    ).not.toBeInTheDocument()
   })
 
   it('shows the zero-state subscribe prompt to unsubscribed team owners', () => {
@@ -656,37 +592,19 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('offers a promoted owner Edit, Leave, and subscription-locked Delete', () => {
-    renderComponent()
-
-    expect(
-      screen.getByRole('button', { name: 'Edit workspace details' })
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Leave Workspace' })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Cancel plan' })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Delete Workspace' })
-    ).toBeDisabled()
-  })
-
-  it('offers the original owner Edit, Cancel plan, and a subscription-locked Delete', async () => {
+  it('offers a promoted owner Edit, Cancel plan, Leave, and subscription-locked Delete', async () => {
     const user = userEvent.setup()
-    mockUserEmail.value = 'creator@example.com'
     renderComponent()
 
     expect(
       screen.getByRole('button', { name: 'Edit workspace details' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Delete Workspace' })
-    ).toBeDisabled()
-    expect(
       screen.getByRole('button', { name: 'Leave Workspace' })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Delete Workspace' })
+    ).toBeDisabled()
 
     await user.click(screen.getByRole('button', { name: 'Cancel plan' }))
     expect(mockShowCancelSubscriptionDialog).toHaveBeenCalledOnce()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -195,7 +195,9 @@
                   {{ $t('subscription.manageBilling') }}
                 </Button>
                 <Button
-                  v-if="isTeamPlanCancelled && isOriginalOwner"
+                  v-if="
+                    isTeamPlanCancelled && permissions.canManageSubscription
+                  "
                   size="lg"
                   variant="primary"
                   class="rounded-lg px-4 text-sm font-normal"
@@ -335,7 +337,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
-const { permissions, isOriginalOwner, isTeamPlanCancelled } = useWorkspaceUI()
+const { permissions, isTeamPlanCancelled } = useWorkspaceUI()
 const { t, n, locale } = useI18n()
 
 const billingOperationStore = useBillingOperationStore()

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.stories.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.stories.ts
@@ -57,7 +57,6 @@ const cancelled: SubscriptionInfo = {
 const owner: Partial<WorkspaceUIMockState> = {}
 const member: Partial<WorkspaceUIMockState> = {
   canManageSubscription: false,
-  canManageSubscriptionLifecycle: false,
   canTopUp: false
 }
 
@@ -161,18 +160,4 @@ export const EndingOwner: Story = story(
     subscriptionStatus: 'canceled'
   },
   owner
-)
-
-/**
- * Reactivate is lifecycle-gated to the original owner, so a non-original owner
- * sees the notice read-only.
- */
-export const EndingNonOriginalOwner: Story = story(
-  {
-    subscription: cancelled,
-    isActiveSubscription: true,
-    billingStatus: 'paid',
-    subscriptionStatus: 'canceled'
-  },
-  { canManageSubscriptionLifecycle: false }
 )

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -29,7 +29,6 @@ const state = vi.hoisted(() => ({
   renewalDate: null as string | null,
   workspaceType: 'team' as string,
   canManageSubscription: true,
-  canManageSubscriptionLifecycle: true,
   canTopUp: true,
   showTopUpCreditsDialog: vi.fn(),
   manageSubscription: vi.fn(),
@@ -63,7 +62,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: computed(() => ({
       canManageSubscription: state.canManageSubscription,
-      canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle,
       canTopUp: state.canTopUp
     })),
     workspaceType: computed(() => state.workspaceType as WorkspaceType)
@@ -166,7 +164,6 @@ describe('BillingStatusBanner', () => {
     state.renewalDate = null
     state.workspaceType = 'team'
     state.canManageSubscription = true
-    state.canManageSubscriptionLifecycle = true
     state.canTopUp = true
     vi.clearAllMocks()
   })
@@ -298,20 +295,15 @@ describe('BillingStatusBanner', () => {
     expect(state.handleResubscribe).toHaveBeenCalledTimes(1)
   })
 
-  it('shows the ending banner read-only to a non-original owner (Reactivate is lifecycle-gated)', () => {
+  it('hides the ending banner from a member', () => {
     state.subscription = {
       hasFunds: true,
       isCancelled: true,
       endDate: '2026-08-01T00:00:00Z'
     }
-    state.canManageSubscriptionLifecycle = false
+    state.canManageSubscription = false
     renderBanner()
 
-    expect(screen.getByRole('status')).toHaveTextContent(
-      'Your team plan ends on'
-    )
-    expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -84,9 +84,6 @@ const { isResubscribing, handleResubscribe } = useResubscribe()
 const dialogService = useDialogService()
 
 const canManage = computed(() => permissions.value.canManageSubscription)
-const canManageLifecycle = computed(
-  () => permissions.value.canManageSubscriptionLifecycle
-)
 const canTopUp = computed(() => permissions.value.canTopUp)
 
 const cycleResetDate = computed(() => {
@@ -148,7 +145,7 @@ const banner = computed<BannerView | null>(() => {
         muted: true,
         title: t(`${bs}.ending.title`, { date: planEndDate.value }),
         body: t(`${bs}.ending.body`),
-        action: canManageLifecycle.value ? 'reactivate' : null,
+        action: canManage.value ? 'reactivate' : null,
         dismissible: false
       }
     default:

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
@@ -21,7 +21,6 @@ const memberConfig = {
 }
 
 const mockUiConfig = ref<Record<string, unknown>>(ownerConfig)
-const mockIsCurrentUserOriginalOwner = ref(false)
 const mockIsWorkspaceSubscribed = ref(false)
 
 const mockShowLeaveWorkspaceDialog = vi.fn()
@@ -34,8 +33,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
-    isCurrentUserOriginalOwner: mockIsCurrentUserOriginalOwner
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
   })
 }))
 
@@ -73,7 +71,6 @@ describe('WorkspaceMenuButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUiConfig.value = ownerConfig
-    mockIsCurrentUserOriginalOwner.value = false
     mockIsWorkspaceSubscribed.value = false
   })
 
@@ -88,7 +85,7 @@ describe('WorkspaceMenuButton', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('lets a non-creator owner leave', () => {
+  it('lets an owner leave', () => {
     renderComponent()
 
     expect(
@@ -99,29 +96,11 @@ describe('WorkspaceMenuButton', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows the creator a disabled Leave option', () => {
-    mockIsCurrentUserOriginalOwner.value = true
-    renderComponent()
-
-    expect(
-      screen.getByRole('button', { name: 'Leave Workspace' })
-    ).toBeDisabled()
-  })
-
-  it('opens the leave dialog when a non-creator owner clicks Leave', async () => {
+  it('opens the leave dialog when an owner clicks Leave', async () => {
     const user = userEvent.setup()
     renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
     expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
-  })
-
-  it('does not open the leave dialog for the creator', async () => {
-    const user = userEvent.setup()
-    mockIsCurrentUserOriginalOwner.value = true
-    renderComponent()
-
-    await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
-    expect(mockShowLeaveWorkspaceDialog).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
@@ -31,9 +31,7 @@ const {
   showDeleteWorkspaceDialog,
   showEditWorkspaceDialog
 } = useDialogService()
-const { isWorkspaceSubscribed, isCurrentUserOriginalOwner } = storeToRefs(
-  useTeamWorkspaceStore()
-)
+const { isWorkspaceSubscribed } = storeToRefs(useTeamWorkspaceStore())
 const { uiConfig } = useWorkspaceUI()
 
 // Disable delete when the workspace has an active subscription (prevents
@@ -77,23 +75,12 @@ const menuItems = computed<MenuItem[]>(() => {
     })
   }
 
-  // Members and non-creator owners can leave; the creator sees it disabled.
   if (action === 'leave' || action === 'delete') {
-    items.push(
-      isCurrentUserOriginalOwner.value
-        ? {
-            label: t('workspacePanel.menu.leaveWorkspace'),
-            icon: 'pi pi-sign-out',
-            class: 'opacity-50',
-            disabled: true,
-            tooltip: t('workspacePanel.menu.creatorCannotLeave')
-          }
-        : {
-            label: t('workspacePanel.menu.leaveWorkspace'),
-            icon: 'pi pi-sign-out',
-            command: () => showLeaveWorkspaceDialog()
-          }
-    )
+    items.push({
+      label: t('workspacePanel.menu.leaveWorkspace'),
+      icon: 'pi pi-sign-out',
+      command: () => showLeaveWorkspaceDialog()
+    })
   }
 
   return items

--- a/src/platform/workspace/composables/useBillingBanner.test.ts
+++ b/src/platform/workspace/composables/useBillingBanner.test.ts
@@ -46,7 +46,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', async () => {
     useWorkspaceUI: () => ({
       permissions: computed(() => ({
         canManageSubscription: true,
-        canManageSubscriptionLifecycle: true,
         canTopUp: true
       }))
     })

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -257,6 +257,7 @@ const mockShowInviteMemberUpsellDialog = vi.fn()
 
 const {
   mockMembers,
+  mockActiveWorkspace,
   mockPendingInvites,
   mockOriginalOwnerId,
   mockTotalMemberSlots,
@@ -275,6 +276,7 @@ const {
 
   return {
     mockMembers: ref<WorkspaceMember[]>([]),
+    mockActiveWorkspace: ref<{ type: 'personal' | 'team' }>({ type: 'team' }),
     mockPendingInvites: ref<PendingInvite[]>([]),
     mockOriginalOwnerId: ref<string | null>(null),
     mockTotalMemberSlots: ref(0),
@@ -333,6 +335,7 @@ vi.mock('pinia', async (importOriginal) => {
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   MAX_WORKSPACE_MEMBERS: 30,
   useTeamWorkspaceStore: () => ({
+    activeWorkspace: mockActiveWorkspace,
     members: mockMembers,
     pendingInvites: mockPendingInvites,
     originalOwnerId: mockOriginalOwnerId,
@@ -404,6 +407,7 @@ vi.mock('@/services/dialogService', () => ({
 describe('useMembersPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockActiveWorkspace.value = { type: 'team' }
     mockMembers.value = []
     mockPendingInvites.value = []
     mockOriginalOwnerId.value = null
@@ -707,13 +711,22 @@ describe('useMembersPanel', () => {
   })
 
   describe('isOriginalOwner', () => {
-    it('matches against the store originalOwnerId', async () => {
+    it('protects the original owner in a personal workspace', async () => {
+      mockActiveWorkspace.value = { type: 'personal' }
       mockOriginalOwnerId.value = 'creator-1'
       const panel = await setup()
       expect(panel.isOriginalOwner(createMember({ id: 'creator-1' }))).toBe(
         true
       )
       expect(panel.isOriginalOwner(createMember({ id: 'other' }))).toBe(false)
+    })
+
+    it('does not protect the creator of an additional workspace', async () => {
+      mockOriginalOwnerId.value = 'creator-1'
+      const panel = await setup()
+      expect(panel.isOriginalOwner(createMember({ id: 'creator-1' }))).toBe(
+        false
+      )
     })
   })
 

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -101,6 +101,7 @@ export function useMembersPanel() {
   } = useDialogService()
   const workspaceStore = useTeamWorkspaceStore()
   const {
+    activeWorkspace,
     members,
     pendingInvites,
     originalOwnerId,
@@ -271,7 +272,10 @@ export function useMembersPanel() {
   }
 
   function isOriginalOwner(member: WorkspaceMember): boolean {
-    return member.id === originalOwnerId.value
+    return (
+      activeWorkspace.value?.type === 'personal' &&
+      member.id === originalOwnerId.value
+    )
   }
 
   const filteredMembers = computed(() => {

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -21,7 +21,6 @@ export function useWorkspaceMenuItems() {
     uiConfig,
     isInPersonalWorkspace,
     isActiveSubscription,
-    isOriginalOwner,
     isTeamPlanCancelled,
     isDeleteDisabled,
     deleteDisabledTooltipKey
@@ -51,7 +50,7 @@ export function useWorkspaceMenuItems() {
 
   const canCancelPlan = computed(
     () =>
-      isOriginalOwner.value &&
+      permissions.value.canManageSubscription &&
       isActiveSubscription.value &&
       !isTeamPlanCancelled.value &&
       !isFreeTier.value

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -17,6 +17,7 @@ export function useWorkspaceMenuItems() {
   const { t } = useI18n()
   const { isFreeTier, subscription } = useBillingContext()
   const {
+    permissions,
     uiConfig,
     isInPersonalWorkspace,
     isActiveSubscription,
@@ -58,13 +59,10 @@ export function useWorkspaceMenuItems() {
 
   const canDeleteWorkspace = computed(
     () =>
-      isOriginalOwner.value &&
-      (!isInPersonalWorkspace.value || isActiveSubscription.value)
+      permissions.value.canManageSubscription && !isInPersonalWorkspace.value
   )
 
-  const canLeaveWorkspace = computed(
-    () => !isInPersonalWorkspace.value && !isOriginalOwner.value
-  )
+  const canLeaveWorkspace = computed(() => !isInPersonalWorkspace.value)
 
   const deleteTooltip = computed(() => {
     const key = deleteDisabledTooltipKey.value

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -2,15 +2,10 @@ import { ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
-import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const mockStore = vi.hoisted(() => ({
-  activeWorkspace: null as WorkspaceWithRole | null,
-  isCurrentUserOriginalOwner: false,
-  ensureMembersLoaded: vi.fn()
+  activeWorkspace: null as WorkspaceWithRole | null
 }))
-const mockMembers = vi.hoisted(() => ({ value: [] as WorkspaceMember[] }))
-const mockUserEmail = vi.hoisted(() => ({ value: null as string | null }))
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
 
@@ -24,19 +19,8 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
     },
     get isWorkspaceSubscribed() {
       return false
-    },
-    get members() {
-      return mockMembers.value
-    },
-    get isCurrentUserOriginalOwner() {
-      return mockStore.isCurrentUserOriginalOwner
-    },
-    ensureMembersLoaded: mockStore.ensureMembersLoaded
+    }
   })
-}))
-
-vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({ userEmail: ref(mockUserEmail.value) })
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -80,10 +64,6 @@ async function loadComposable() {
 
 function resetStore() {
   mockStore.activeWorkspace = null
-  mockStore.isCurrentUserOriginalOwner = false
-  mockStore.ensureMembersLoaded.mockReset()
-  mockMembers.value = []
-  mockUserEmail.value = null
   mockIsActiveSubscription.value = false
   mockIsCancelled.value = false
 }
@@ -236,111 +216,29 @@ describe('useWorkspaceUI', () => {
     })
   })
 
-  describe('isOriginalOwner', () => {
-    const earlier = new Date('2026-01-01T00:00:00Z')
-
-    function member(
-      id: string,
-      email: string,
-      joinDate: Date
-    ): WorkspaceMember {
-      return {
-        id,
-        name: id,
-        email,
-        joinDate,
-        role: 'owner',
-        isOriginalOwner: false
-      }
-    }
-
-    beforeEach(() => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-    })
-
-    it('treats the personal owner as their own original owner', async () => {
-      mockStore.activeWorkspace = personalWorkspace
-      const ui = await loadComposable()
-
-      expect(ui.isOriginalOwner.value).toBe(true)
-    })
-
-    it('names the earliest-joined member as the original owner', async () => {
-      mockMembers.value = [
-        member('m2', 'late@example.com', new Date('2026-02-01T00:00:00Z')),
-        member('m1', 'early@example.com', earlier)
-      ]
-      mockUserEmail.value = 'early@example.com'
-      const ui = await loadComposable()
-
-      expect(ui.isOriginalOwner.value).toBe(true)
-    })
-
-    it('breaks join-date ties with the member id so only one is the owner', async () => {
-      mockMembers.value = [
-        member('m-b', 'b@example.com', earlier),
-        member('m-a', 'a@example.com', earlier)
-      ]
-
-      mockUserEmail.value = 'a@example.com'
-      const owner = await loadComposable()
-      expect(owner.isOriginalOwner.value).toBe(true)
-
-      vi.resetModules()
-      mockUserEmail.value = 'b@example.com'
-      const notOwner = await loadComposable()
-      expect(notOwner.isOriginalOwner.value).toBe(false)
-    })
-  })
-
-  // Drives off the members-list self-row original-owner signal, surfaced by the
-  // store getter `isCurrentUserOriginalOwner`.
-  describe('subscription lifecycle (creator-only)', () => {
+  describe('subscription lifecycle', () => {
     it('grants lifecycle to the personal-workspace sole owner', async () => {
       mockStore.activeWorkspace = personalWorkspace
       const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
+      expect(ui.permissions.value.canManageSubscription).toBe(true)
     })
 
     it('grants lifecycle to a team owner who is the original owner', async () => {
       mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = true
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
     })
 
-    it('withholds lifecycle from a promoted (non-creator) team owner', async () => {
+    it('grants lifecycle to a promoted team owner', async () => {
       mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
-    })
-
-    it('fails closed while the members list is still loading', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
-      const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
     })
 
     it('withholds lifecycle from members', async () => {
       mockStore.activeWorkspace = teamMemberWorkspace
       const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
-    })
-
-    it('delegates member loading to the store when a team workspace becomes active', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      await loadComposable()
-      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
-    })
-
-    it('does not load members for a personal workspace', async () => {
-      mockStore.activeWorkspace = personalWorkspace
-      await loadComposable()
-      expect(mockStore.ensureMembersLoaded).not.toHaveBeenCalled()
+      expect(ui.permissions.value.canManageSubscription).toBe(false)
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -1,11 +1,9 @@
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
-import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 
 import type { WorkspaceRole, WorkspaceType } from '../api/workspaceApi'
-import type { WorkspaceMember } from '../stores/teamWorkspaceStore'
 import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
 
 /** Permission flags for workspace actions */
@@ -18,10 +16,6 @@ interface WorkspacePermissions {
   canLeaveWorkspace: boolean
   canAccessWorkspaceMenu: boolean
   canManageSubscription: boolean
-  // Creator-only subscription lifecycle: cancel / reactivate / downgrade.
-  // Any owner has `canManageSubscription` (manage payment, top-up, change
-  // commit); only the original owner gets `canManageSubscriptionLifecycle`.
-  canManageSubscriptionLifecycle: boolean
   canTopUp: boolean
 }
 
@@ -41,8 +35,7 @@ interface WorkspaceUIConfig {
 
 function getPermissions(
   type: WorkspaceType,
-  role: WorkspaceRole,
-  isOriginalOwner: boolean
+  role: WorkspaceRole
 ): WorkspacePermissions {
   if (type === 'personal') {
     return {
@@ -54,8 +47,6 @@ function getPermissions(
       canLeaveWorkspace: false,
       canAccessWorkspaceMenu: false,
       canManageSubscription: true,
-      // Personal workspace is single-member: the user is the sole owner/creator.
-      canManageSubscriptionLifecycle: true,
       canTopUp: true
     }
   }
@@ -70,7 +61,6 @@ function getPermissions(
       canLeaveWorkspace: true,
       canAccessWorkspaceMenu: true,
       canManageSubscription: true,
-      canManageSubscriptionLifecycle: isOriginalOwner,
       canTopUp: true
     }
   }
@@ -85,7 +75,6 @@ function getPermissions(
     canLeaveWorkspace: true,
     canAccessWorkspaceMenu: true,
     canManageSubscription: false,
-    canManageSubscriptionLifecycle: false,
     canTopUp: false
   }
 }
@@ -141,32 +130,14 @@ function getUIConfig(
 }
 
 /**
- * The original owner is the earliest-joined member. Ties on join date are
- * broken by the stable member id so exactly one member is the original owner.
- */
-function isOriginalOwnerByEmail(
-  members: WorkspaceMember[],
-  email: string
-): boolean {
-  if (members.length === 0) return false
-  const original = [...members].sort(
-    (a, b) =>
-      a.joinDate.getTime() - b.joinDate.getTime() || a.id.localeCompare(b.id)
-  )[0]
-  return original.email.toLowerCase() === email
-}
-
-/**
  * Internal implementation of UI configuration composable.
  */
 function useWorkspaceUIInternal() {
   const store = useTeamWorkspaceStore()
-  const { userEmail } = useCurrentUser()
   const { isActiveSubscription, subscription } = useBillingContext()
 
   const isInPersonalWorkspace = computed(() => store.isInPersonalWorkspace)
   const isWorkspaceSubscribed = computed(() => store.isWorkspaceSubscribed)
-  const members = computed(() => store.members)
 
   const workspaceType = computed<WorkspaceType>(
     () => store.activeWorkspace?.type ?? 'personal'
@@ -176,39 +147,13 @@ function useWorkspaceUIInternal() {
     () => store.activeWorkspace?.role ?? 'owner'
   )
 
-  // The original-owner signal lives on the members-list self-row, so a team
-  // workspace's members must be loaded before its lifecycle gate can resolve.
-  // The store dedupes in-flight/already-loaded requests and logs failures;
-  // until members arrive the getter fails closed.
-  watch(
-    () => store.activeWorkspace?.id,
-    () => {
-      if (store.activeWorkspace?.type === 'team') {
-        void store.ensureMembersLoaded()
-      }
-    },
-    { immediate: true }
-  )
-
   const permissions = computed<WorkspacePermissions>(() =>
-    getPermissions(
-      workspaceType.value,
-      workspaceRole.value,
-      store.isCurrentUserOriginalOwner
-    )
+    getPermissions(workspaceType.value, workspaceRole.value)
   )
 
   const uiConfig = computed<WorkspaceUIConfig>(() =>
     getUIConfig(workspaceType.value, workspaceRole.value)
   )
-
-  // Cancel / reactivate / delete are original-owner-only; personal workspaces
-  // are single-member, so the user is always their own original owner.
-  const isOriginalOwner = computed(() => {
-    if (isInPersonalWorkspace.value) return true
-    const email = userEmail.value?.toLowerCase()
-    return !!email && isOriginalOwnerByEmail(members.value, email)
-  })
 
   // Cancellation is meaningful only for team (workspace) billing; personal plans
   // use legacy billing with different semantics.
@@ -238,7 +183,6 @@ function useWorkspaceUIInternal() {
     isInPersonalWorkspace,
     isWorkspaceSubscribed,
     isActiveSubscription,
-    isOriginalOwner,
     isTeamPlanCancelled,
     isDeleteDisabled,
     deleteDisabledTooltipKey

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -800,7 +800,15 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[0].role).toBe('member')
     })
 
-    it('changeMemberRole refuses to change the flagged creator and never calls the API', async () => {
+    it('changeMemberRole allows changing a team workspace creator', async () => {
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'creator',
+        name: 'Creator',
+        email: 'creator@test.com',
+        joined_at: '2024-01-02T00:00:00Z',
+        role: 'member',
+        is_original_owner: true
+      })
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [
           {
@@ -829,11 +837,39 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
       await store.fetchMembers()
 
+      await store.changeMemberRole('creator', 'member')
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'creator',
+        'member'
+      )
+      expect(store.members.find((m) => m.id === 'creator')?.role).toBe('member')
+    })
+
+    it('changeMemberRole protects a personal workspace creator', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'creator',
+            name: 'Creator',
+            email: 'creator@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'owner',
+            is_original_owner: true
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 1 }
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockPersonalWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
       await expect(store.changeMemberRole('creator', 'member')).rejects.toThrow(
         "Cannot change the workspace creator's role"
       )
       expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
-      expect(store.members.find((m) => m.id === 'creator')?.role).toBe('owner')
     })
 
     it('originalOwnerId is the member flagged is_original_owner, even when not earliest-joined', async () => {
@@ -872,6 +908,13 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('originalOwnerId falls back to the earliest-joined member when no flag is present', async () => {
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'founder',
+        name: 'Founder',
+        email: 'founder@test.com',
+        joined_at: '2024-01-01T00:00:00Z',
+        role: 'member'
+      })
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [
           {
@@ -900,10 +943,11 @@ describe('useTeamWorkspaceStore', () => {
 
       expect(store.originalOwnerId).toBe('founder')
 
-      await expect(store.changeMemberRole('founder', 'member')).rejects.toThrow(
-        "Cannot change the workspace creator's role"
+      await store.changeMemberRole('founder', 'member')
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'founder',
+        'member'
       )
-      expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
     })
 
     it('originalOwnerId fallback skips a non-owner earliest joiner, keeping them changeable', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -602,7 +602,10 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     userId: string,
     role: WorkspaceMember['role']
   ): Promise<void> {
-    if (userId === originalOwnerId.value) {
+    if (
+      activeWorkspace.value?.type === 'personal' &&
+      userId === originalOwnerId.value
+    ) {
       throw new Error("Cannot change the workspace creator's role")
     }
     // Only the role changes; merge it onto the existing row rather than trusting

--- a/src/storybook/mocks/useWorkspaceUI.ts
+++ b/src/storybook/mocks/useWorkspaceUI.ts
@@ -6,14 +6,12 @@ import type { WorkspaceType } from '@/platform/workspace/api/workspaceApi'
 export interface WorkspaceUIMockState {
   workspaceType: WorkspaceType
   canManageSubscription: boolean
-  canManageSubscriptionLifecycle: boolean
   canTopUp: boolean
 }
 
 const defaultState: WorkspaceUIMockState = {
   workspaceType: 'team',
   canManageSubscription: true,
-  canManageSubscriptionLifecycle: true,
   canTopUp: true
 }
 
@@ -24,21 +22,11 @@ export function setWorkspaceUIMock(next: Partial<WorkspaceUIMockState>) {
   state.value = { ...defaultState, ...next }
 }
 
-/**
- * Storybook mock for `useWorkspaceUI`.
- *
- * The real composable derives permissions from `useCurrentUser` (Firebase auth)
- * and the team workspace store, neither of which is available in Storybook. This
- * stub exposes only the role surface the billing banner reads; add keys here as
- * other stories need them.
- */
 export function useWorkspaceUI() {
   return {
     workspaceType: computed(() => state.value.workspaceType),
     permissions: computed(() => ({
       canManageSubscription: state.value.canManageSubscription,
-      canManageSubscriptionLifecycle:
-        state.value.canManageSubscriptionLifecycle,
       canTopUp: state.value.canTopUp
     }))
   }


### PR DESCRIPTION
## Summary

Scope creator-specific safeguards to the original personal workspace and align subscription controls with the backend owner-role policy.

## Changes

- Preserve personal-workspace creator and deletion protections.
- Let additional-workspace creators follow ordinary owner and last-owner rules for demotion, removal, leaving, and deletion.
- Let any current owner cancel, reactivate, or otherwise manage the workspace subscription; members remain read-only.
- Keep Team → personal downgrade creator-only.

## Relationship to #13810

#13810 makes Members entitlement plan-based, allowing a personal workspace on a Team plan to collaborate. This PR handles the remaining workspace-type distinction: personal workspaces protect their creator and cannot be deleted; additional workspaces do not. Backport this after #13810, especially on `cloud/1.47`.

Backend counterpart: https://github.com/Comfy-Org/cloud/pull/5233

## Validation

- 62 focused Vitest tests passed.
- App and browser typechecks passed.
- ESLint, Oxlint, Stylelint, formatting, and Knip passed.
- Cloud Playwright coverage now exercises a promoted owner; local execution was blocked by the missing Playwright browser binary, so CI will run it.