### PR TITLE
fix: isolate workspace auth across account switches

### DIFF
--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -1,0 +1,271 @@
+import { expect } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { AssetsSidebarTab } from '@e2e/fixtures/components/SidebarTab'
+import {
+  DEFAULT_TEAM_MEMBERS,
+  TEAM_WORKSPACE,
+  WORKSPACE_FEATURE_FLAG
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { AssetsHelper, createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+import { member } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL ?? 'http://localhost:8188'
+
+const ACCOUNT_A = {
+  id: 'a',
+  uid: 'test-user-e2e',
+  email: 'e2e@test.comfy.org',
+  displayName: 'E2E Test User',
+  idToken: 'mock-firebase-id-token',
+  refreshToken: 'mock-refresh-token'
+} as const
+
+const ACCOUNT_B = {
+  id: 'b',
+  uid: 'test-user-b',
+  email: 'account-b@test.comfy.org',
+  displayName: 'Account B',
+  idToken: 'firebase-id-token-b',
+  refreshToken: 'firebase-refresh-token-b'
+} as const
+
+type MockAccount = typeof ACCOUNT_A | typeof ACCOUNT_B
+
+function accountForToken(token: string | null): MockAccount {
+  if (
+    token?.includes(ACCOUNT_B.idToken) ||
+    token?.includes(ACCOUNT_B.refreshToken)
+  ) {
+    return ACCOUNT_B
+  }
+  if (
+    token?.includes(ACCOUNT_A.idToken) ||
+    token?.includes(ACCOUNT_A.refreshToken)
+  ) {
+    return ACCOUNT_A
+  }
+  throw new Error(`Unexpected account token: ${token ?? 'missing'}`)
+}
+
+function firebaseLookupResponse(account: MockAccount) {
+  return {
+    kind: 'identitytoolkit#GetAccountInfoResponse',
+    users: [
+      {
+        localId: account.uid,
+        email: account.email,
+        displayName: account.displayName,
+        emailVerified: true,
+        providerUserInfo: [
+          {
+            providerId: 'password',
+            rawId: account.uid,
+            email: account.email,
+            displayName: account.displayName
+          }
+        ],
+        validSince: '0',
+        lastLoginAt: String(Date.now()),
+        createdAt: String(Date.now())
+      }
+    ]
+  }
+}
+
+test.describe('Cloud account switch', { tag: '@cloud' }, () => {
+  test('keeps workspace bearer and session cookie on the switched account', async ({
+    page
+  }) => {
+    await new CloudWorkspaceMockHelper(page).setup([
+      ...DEFAULT_TEAM_MEMBERS,
+      member({
+        id: ACCOUNT_B.uid,
+        name: ACCOUNT_B.displayName,
+        email: ACCOUNT_B.email,
+        role: 'member'
+      })
+    ])
+
+    await page.unroute('**/api/features')
+    await page.unroute('**/api/auth/token')
+    await page.unroute('**/api/auth/session')
+    await page.unroute('**/identitytoolkit.googleapis.com/**')
+    await page.unroute('**/securetoken.googleapis.com/**')
+
+    const features = {
+      ...WORKSPACE_FEATURE_FLAG,
+      onboarding_survey_enabled: false,
+      unified_cloud_auth: false
+    } satisfies RemoteConfig
+
+    await page.route('**/api/features', (route) =>
+      route.fulfill({ json: features })
+    )
+
+    await page.route('**/identitytoolkit.googleapis.com/**', async (route) => {
+      const request = route.request()
+      if (request.url().includes('accounts:signInWithPassword')) {
+        await route.fulfill({
+          json: {
+            kind: 'identitytoolkit#VerifyPasswordResponse',
+            localId: ACCOUNT_B.uid,
+            email: ACCOUNT_B.email,
+            displayName: ACCOUNT_B.displayName,
+            idToken: ACCOUNT_B.idToken,
+            registered: true,
+            refreshToken: ACCOUNT_B.refreshToken,
+            expiresIn: '3600'
+          }
+        })
+        return
+      }
+
+      const body = request.postDataJSON() as { idToken?: string }
+      await route.fulfill({
+        json: firebaseLookupResponse(accountForToken(body.idToken ?? null))
+      })
+    })
+
+    await page.route('**/securetoken.googleapis.com/**', async (route) => {
+      const refreshToken = new URLSearchParams(
+        route.request().postData() ?? ''
+      ).get('refresh_token')
+      const account = accountForToken(refreshToken)
+      await route.fulfill({
+        json: {
+          access_token: account.idToken,
+          expires_in: '3600',
+          token_type: 'Bearer',
+          refresh_token: account.refreshToken,
+          id_token: account.idToken,
+          user_id: account.uid,
+          project_id: 'dreamboothy-dev'
+        }
+      })
+    })
+
+    const workspaceMintOwners: string[] = []
+    await page.route('**/api/auth/token', async (route) => {
+      const authorization = await route.request().headerValue('authorization')
+      const account = accountForToken(authorization)
+      workspaceMintOwners.push(account.id)
+      const response = {
+        token: `workspace-jwt-${account.id}`,
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        workspace: {
+          id: TEAM_WORKSPACE.id,
+          name: TEAM_WORKSPACE.name,
+          type: TEAM_WORKSPACE.type
+        },
+        role: account === ACCOUNT_A ? 'owner' : 'member',
+        permissions: []
+      } satisfies WorkspaceTokenResponse
+      await route.fulfill({ json: response })
+    })
+
+    const sessionOwners: string[] = []
+    await page.route('**/api/auth/session', async (route) => {
+      const authorization = await route.request().headerValue('authorization')
+      const account = accountForToken(authorization)
+      sessionOwners.push(account.id)
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'set-cookie': `mock-cloud-session=${account.id}; Path=/; HttpOnly; SameSite=Lax`
+        },
+        json: {}
+      })
+    })
+
+    await page.route('**/customers', (route) =>
+      route.fulfill({ status: 201, json: { id: 'test-customer-id' } })
+    )
+
+    const assets = new AssetsHelper(page)
+    await assets.mockOutputHistory([
+      createMockJob({
+        id: 'account-switch-job',
+        preview_output: {
+          filename: 'account-switch.webp',
+          subfolder: '',
+          type: 'output',
+          nodeId: '9',
+          mediaType: 'images'
+        }
+      })
+    ])
+    await assets.mockEmptyCloudAssets()
+
+    let jobsAuthorization: string | null = null
+    await page.route('**/api/jobs?*', async (route) => {
+      jobsAuthorization = await route.request().headerValue('authorization')
+      await route.fallback()
+    })
+
+    let viewCookie: string | null = null
+    let viewStatus: number | null = null
+    await page.route('**/api/view?*', async (route) => {
+      viewCookie = await route.request().headerValue('cookie')
+      const bearerOwner = jobsAuthorization?.endsWith('-b') ? 'b' : 'a'
+      const cookieOwner = viewCookie?.includes('mock-cloud-session=b')
+        ? 'b'
+        : 'a'
+
+      if (bearerOwner !== cookieOwner) {
+        viewStatus = 404
+        await route.fulfill({
+          status: 404,
+          json: { code: 'FILE_NOT_FOUND' }
+        })
+        return
+      }
+
+      viewStatus = 200
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/webp',
+        path: assetPath('image32x32.webp')
+      })
+    })
+
+    await page.goto(APP_URL)
+    await expect.poll(() => workspaceMintOwners).toContain('a')
+    await expect.poll(() => sessionOwners).toContain('a')
+
+    await page.goto(`${APP_URL}/cloud/login?switchAccount=true`)
+    await page.getByRole('button', { name: 'Use email instead' }).click()
+    await page.getByLabel('Email').fill(ACCOUNT_B.email)
+    await page.getByLabel('Password').fill('password')
+    await page.getByRole('button', { name: 'Sign in' }).click()
+
+    await expect(
+      page.getByRole('button', { name: 'Current user' })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await expect(page.getByText(ACCOUNT_B.email, { exact: true })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect.poll(() => workspaceMintOwners).toContain('b')
+    await expect.poll(() => sessionOwners).toContain('b')
+
+    await new AssetsSidebarTab(page).open()
+    const card = page.locator('[data-asset-id="account-switch-job"]')
+    const image = card.getByRole('img', { name: 'account-switch.webp' })
+
+    await expect(card).toBeVisible()
+    await expect(image).toBeVisible()
+    await expect
+      .poll(() =>
+        image.evaluate((element: HTMLImageElement) => element.naturalWidth)
+      )
+      .toBeGreaterThan(0)
+    expect(jobsAuthorization).toBe('Bearer workspace-jwt-b')
+    expect(viewCookie).toContain('mock-cloud-session=b')
+    expect(viewStatus).toBe(200)
+  })
+})

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -288,72 +288,80 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
       })
     })
 
-    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
-    await expect
-      .poll(() => workspaceMintOwners, { timeout: 15_000 })
-      .toContain(ACCOUNT_A.id)
-    await expect
-      .poll(() => sessionOwners, { timeout: 15_000 })
-      .toContain(ACCOUNT_A.id)
+    await test.step('Establish account A credentials', async () => {
+      await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
+      await expect
+        .poll(() => workspaceMintOwners, { timeout: 15_000 })
+        .toContain(ACCOUNT_A.id)
+      await expect
+        .poll(() => sessionOwners, { timeout: 15_000 })
+        .toContain(ACCOUNT_A.id)
+    })
 
-    await page.evaluate(() => {
-      sessionStorage.setItem(
-        'e2e-account-switch-route',
-        '/cloud/login?switchAccount=true'
+    await test.step('Switch to account B', async () => {
+      await page.evaluate(() => {
+        sessionStorage.setItem(
+          'e2e-account-switch-route',
+          '/cloud/login?switchAccount=true'
+        )
+      })
+      await page.addInitScript(() => {
+        function applyTargetRoute() {
+          const targetRoute = sessionStorage.getItem('e2e-account-switch-route')
+          if (!targetRoute) return
+          sessionStorage.removeItem('e2e-account-switch-route')
+          window.history.replaceState(null, '', targetRoute)
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('readystatechange', applyTargetRoute, {
+            once: true
+          })
+          return
+        }
+        applyTargetRoute()
+      })
+      await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveURL(/\/cloud\/login\?switchAccount=true$/)
+      await page.getByRole('button', { name: 'Use email instead' }).click()
+      await page.getByLabel('Email').fill(ACCOUNT_B.email)
+      await page.getByLabel('Password').fill('password')
+      await page.getByRole('button', { name: 'Sign in' }).click()
+
+      await expect(
+        page.getByRole('button', { name: 'Current user' })
+      ).toBeVisible()
+      await page.getByRole('button', { name: 'Current user' }).click()
+      await expect(
+        page.getByText(ACCOUNT_B.email, { exact: true })
+      ).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect
+        .poll(() => workspaceMintOwners, { timeout: 15_000 })
+        .toContain(ACCOUNT_B.id)
+      await expect
+        .poll(() => sessionOwners, { timeout: 15_000 })
+        .toContain(ACCOUNT_B.id)
+      expect(credentialEvents.indexOf(`session:${ACCOUNT_B.id}`)).toBeLessThan(
+        credentialEvents.indexOf(`workspace:${ACCOUNT_B.id}`)
       )
     })
-    await page.addInitScript(() => {
-      function applyTargetRoute() {
-        const targetRoute = sessionStorage.getItem('e2e-account-switch-route')
-        if (!targetRoute) return
-        sessionStorage.removeItem('e2e-account-switch-route')
-        window.history.replaceState(null, '', targetRoute)
-      }
 
-      if (document.readyState === 'loading') {
-        document.addEventListener('readystatechange', applyTargetRoute, {
-          once: true
-        })
-        return
-      }
-      applyTargetRoute()
+    await test.step('Load an asset with account B credentials', async () => {
+      await new AssetsSidebarTab(page).open()
+      const card = page.locator('[data-asset-id="account-switch-job"]')
+      const image = card.getByRole('img', { name: 'account-switch.webp' })
+
+      await expect(card).toBeVisible()
+      await expect(image).toBeVisible()
+      await expect
+        .poll(() =>
+          image.evaluate((element: HTMLImageElement) => element.naturalWidth)
+        )
+        .toBeGreaterThan(0)
+      expect(jobsAuthorization).toBe(`Bearer workspace-jwt-${ACCOUNT_B.id}`)
+      expect(viewCookie).toContain(`mock-cloud-session=${ACCOUNT_B.id}`)
+      expect(viewStatus).toBe(200)
     })
-    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
-    await expect(page).toHaveURL(/\/cloud\/login\?switchAccount=true$/)
-    await page.getByRole('button', { name: 'Use email instead' }).click()
-    await page.getByLabel('Email').fill(ACCOUNT_B.email)
-    await page.getByLabel('Password').fill('password')
-    await page.getByRole('button', { name: 'Sign in' }).click()
-
-    await expect(
-      page.getByRole('button', { name: 'Current user' })
-    ).toBeVisible()
-    await page.getByRole('button', { name: 'Current user' }).click()
-    await expect(page.getByText(ACCOUNT_B.email, { exact: true })).toBeVisible()
-    await page.keyboard.press('Escape')
-    await expect
-      .poll(() => workspaceMintOwners, { timeout: 15_000 })
-      .toContain(ACCOUNT_B.id)
-    await expect
-      .poll(() => sessionOwners, { timeout: 15_000 })
-      .toContain(ACCOUNT_B.id)
-    expect(credentialEvents.indexOf(`session:${ACCOUNT_B.id}`)).toBeLessThan(
-      credentialEvents.indexOf(`workspace:${ACCOUNT_B.id}`)
-    )
-
-    await new AssetsSidebarTab(page).open()
-    const card = page.locator('[data-asset-id="account-switch-job"]')
-    const image = card.getByRole('img', { name: 'account-switch.webp' })
-
-    await expect(card).toBeVisible()
-    await expect(image).toBeVisible()
-    await expect
-      .poll(() =>
-        image.evaluate((element: HTMLImageElement) => element.naturalWidth)
-      )
-      .toBeGreaterThan(0)
-    expect(jobsAuthorization).toBe(`Bearer workspace-jwt-${ACCOUNT_B.id}`)
-    expect(viewCookie).toContain(`mock-cloud-session=${ACCOUNT_B.id}`)
-    expect(viewStatus).toBe(200)
   })
 })

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -238,7 +238,30 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await expect.poll(() => workspaceMintOwners).toContain('a')
     await expect.poll(() => sessionOwners).toContain('a')
 
-    await page.goto(`${APP_URL}/cloud/login?switchAccount=true`)
+    await page.evaluate(() => {
+      sessionStorage.setItem(
+        'e2e-account-switch-route',
+        '/cloud/login?switchAccount=true'
+      )
+    })
+    await page.addInitScript(() => {
+      function applyTargetRoute() {
+        const targetRoute = sessionStorage.getItem('e2e-account-switch-route')
+        if (!targetRoute) return
+        sessionStorage.removeItem('e2e-account-switch-route')
+        window.history.replaceState(null, '', targetRoute)
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('readystatechange', applyTargetRoute, {
+          once: true
+        })
+        return
+      }
+      applyTargetRoute()
+    })
+    await page.goto(APP_URL)
+    await expect(page).toHaveURL(/\/cloud\/login\?switchAccount=true$/)
     await page.getByRole('button', { name: 'Use email instead' }).click()
     await page.getByLabel('Email').fill(ACCOUNT_B.email)
     await page.getByLabel('Password').fill('password')

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -291,8 +291,10 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
     await expect
       .poll(() => workspaceMintOwners, { timeout: 15_000 })
-      .toContain('a')
-    await expect.poll(() => sessionOwners, { timeout: 15_000 }).toContain('a')
+      .toContain(ACCOUNT_A.id)
+    await expect
+      .poll(() => sessionOwners, { timeout: 15_000 })
+      .toContain(ACCOUNT_A.id)
 
     await page.evaluate(() => {
       sessionStorage.setItem(
@@ -331,10 +333,12 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.keyboard.press('Escape')
     await expect
       .poll(() => workspaceMintOwners, { timeout: 15_000 })
-      .toContain('b')
-    await expect.poll(() => sessionOwners, { timeout: 15_000 }).toContain('b')
-    expect(credentialEvents.indexOf('session:b')).toBeLessThan(
-      credentialEvents.indexOf('workspace:b')
+      .toContain(ACCOUNT_B.id)
+    await expect
+      .poll(() => sessionOwners, { timeout: 15_000 })
+      .toContain(ACCOUNT_B.id)
+    expect(credentialEvents.indexOf(`session:${ACCOUNT_B.id}`)).toBeLessThan(
+      credentialEvents.indexOf(`workspace:${ACCOUNT_B.id}`)
     )
 
     await new AssetsSidebarTab(page).open()
@@ -348,8 +352,8 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
         image.evaluate((element: HTMLImageElement) => element.naturalWidth)
       )
       .toBeGreaterThan(0)
-    expect(jobsAuthorization).toBe('Bearer workspace-jwt-b')
-    expect(viewCookie).toContain('mock-cloud-session=b')
+    expect(jobsAuthorization).toBe(`Bearer workspace-jwt-${ACCOUNT_B.id}`)
+    expect(viewCookie).toContain(`mock-cloud-session=${ACCOUNT_B.id}`)
     expect(viewStatus).toBe(200)
   })
 })

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -194,11 +194,13 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
       })
     })
 
+    const credentialEvents: string[] = []
     const workspaceMintOwners: string[] = []
     await page.route('**/api/auth/token', async (route) => {
       const authorization = await route.request().headerValue('authorization')
       const account = accountForToken(authorization)
       workspaceMintOwners.push(account.id)
+      credentialEvents.push(`workspace:${account.id}`)
       const response = {
         token: `workspace-jwt-${account.id}`,
         expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
@@ -217,7 +219,6 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.route('**/api/auth/session', async (route) => {
       const authorization = await route.request().headerValue('authorization')
       const account = accountForToken(authorization)
-      sessionOwners.push(account.id)
       await route.fulfill({
         status: 200,
         headers: {
@@ -225,6 +226,8 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
         },
         json: {}
       })
+      sessionOwners.push(account.id)
+      credentialEvents.push(`session:${account.id}`)
     })
 
     await page.route('**/customers', (route) =>
@@ -286,8 +289,10 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     })
 
     await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
-    await expect.poll(() => workspaceMintOwners).toContain('a')
-    await expect.poll(() => sessionOwners).toContain('a')
+    await expect
+      .poll(() => workspaceMintOwners, { timeout: 15_000 })
+      .toContain('a')
+    await expect.poll(() => sessionOwners, { timeout: 15_000 }).toContain('a')
 
     await page.evaluate(() => {
       sessionStorage.setItem(
@@ -324,8 +329,13 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.getByRole('button', { name: 'Current user' }).click()
     await expect(page.getByText(ACCOUNT_B.email, { exact: true })).toBeVisible()
     await page.keyboard.press('Escape')
-    await expect.poll(() => workspaceMintOwners).toContain('b')
-    await expect.poll(() => sessionOwners).toContain('b')
+    await expect
+      .poll(() => workspaceMintOwners, { timeout: 15_000 })
+      .toContain('b')
+    await expect.poll(() => sessionOwners, { timeout: 15_000 }).toContain('b')
+    expect(credentialEvents.indexOf('session:b')).toBeLessThan(
+      credentialEvents.indexOf('workspace:b')
+    )
 
     await new AssetsSidebarTab(page).open()
     const card = page.locator('[data-asset-id="account-switch-job"]')

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -106,6 +106,10 @@ const test = comfyPageFixture.extend({
       })
     )
 
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({ status: 204 })
+    )
+
     await page.route('**/customers/cloud-subscription-status', (route) =>
       route.fulfill({
         status: 200,

--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -77,6 +77,10 @@ const test = comfyPageFixture.extend({
       })
     )
 
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({ status: 204 })
+    )
+
     await use(page)
   }
 })

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetIdToken = vi.fn()
+const mockGetAuthHeader = vi.fn()
 const mockAuthState = vi.hoisted(() => ({
   currentUser: { uid: 'user-a' } as { uid: string } | null
 }))
+const mockFlags = vi.hoisted(() => ({ teamWorkspacesEnabled: true }))
 const originalFetch = globalThis.fetch
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -12,16 +14,14 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
-    flags: {
-      teamWorkspacesEnabled: true
-    }
+    flags: mockFlags
   })
 }))
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
     getIdToken: mockGetIdToken,
-    getAuthHeader: vi.fn(),
+    getAuthHeader: mockGetAuthHeader,
     get currentUser() {
       return mockAuthState.currentUser
     }
@@ -39,7 +39,9 @@ describe('useSessionCookie', () => {
     vi.resetModules()
     vi.restoreAllMocks()
     mockGetIdToken.mockReset()
+    mockGetAuthHeader.mockReset()
     mockAuthState.currentUser = { uid: 'user-a' }
+    mockFlags.teamWorkspacesEnabled = true
     globalThis.fetch = vi.fn()
   })
 
@@ -100,7 +102,38 @@ describe('useSessionCookie', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
   })
 
-  it('serializes a new user session after the previous user response', async () => {
+  it('confirms the current session once for workspace token admission', async () => {
+    mockGetIdToken.mockResolvedValue('firebase-id-token')
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(null, { status: 204 })
+    )
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    const { ensureSessionCookie } = useSessionCookie()
+    await ensureSessionCookie()
+    await ensureSessionCookie()
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects workspace token admission when session creation fails', async () => {
+    mockGetIdToken.mockResolvedValue('firebase-id-token')
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'session denied' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    await expect(useSessionCookie().ensureSessionCookie()).rejects.toThrow(
+      'session denied'
+    )
+  })
+
+  it('serializes strict session creation after the previous user response', async () => {
     mockGetIdToken.mockImplementation(() =>
       Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
     )
@@ -119,7 +152,7 @@ describe('useSessionCookie', () => {
     await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
 
     mockAuthState.currentUser = { uid: 'user-b' }
-    const second = useSessionCookie().createSession()
+    const second = useSessionCookie().createSessionOrThrow()
     await Promise.resolve()
     await Promise.resolve()
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
@@ -137,6 +170,88 @@ describe('useSessionCookie', () => {
     )
     expect(firstHeaders.get('Authorization')).toBe('Bearer firebase-user-a')
     expect(secondHeaders.get('Authorization')).toBe('Bearer firebase-user-b')
+  })
+
+  it('reconfirms a cached owner after another owner mutates the cookie', async () => {
+    mockGetIdToken.mockImplementation(() =>
+      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+    )
+    let resolveUserB: (value: Response) => void = () => {}
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveUserB = resolve
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    await useSessionCookie().ensureSessionCookie()
+    mockAuthState.currentUser = { uid: 'user-b' }
+    const userBSession = useSessionCookie().createSession()
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
+
+    mockAuthState.currentUser = { uid: 'user-a' }
+    const userASession = useSessionCookie().ensureSessionCookie()
+    await Promise.resolve()
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+
+    resolveUserB(new Response(null, { status: 204 }))
+    await Promise.all([userBSession, userASession])
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+    const finalHeaders = new Headers(
+      vi.mocked(globalThis.fetch).mock.calls[2][1]?.headers
+    )
+    expect(finalHeaders.get('Authorization')).toBe('Bearer firebase-user-a')
+  })
+
+  it('does not let strict Firebase creation join a weaker request', async () => {
+    mockFlags.teamWorkspacesEnabled = false
+    mockGetAuthHeader.mockResolvedValue(null)
+    mockGetIdToken.mockResolvedValue('firebase-id-token')
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(null, { status: 204 })
+    )
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    const bestEffort = useSessionCookie().createSession()
+    const strict = useSessionCookie().createSessionOrThrow()
+    await Promise.all([bestEffort, strict])
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce()
+    const headers = new Headers(
+      vi.mocked(globalThis.fetch).mock.calls[0][1]?.headers
+    )
+    expect(headers.get('Authorization')).toBe('Bearer firebase-id-token')
+  })
+
+  it('serializes session deletion after an in-flight creation', async () => {
+    mockGetIdToken.mockResolvedValue('firebase-id-token')
+    let resolveCreate: (value: Response) => void = () => {}
+    vi.mocked(globalThis.fetch)
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveCreate = resolve
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    const create = useSessionCookie().createSession()
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
+    const remove = useSessionCookie().deleteSession()
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    resolveCreate(new Response(null, { status: 204 }))
+    await Promise.all([create, remove])
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(globalThis.fetch).mock.calls[1][1]?.method).toBe('DELETE')
   })
 
   it('createSessionOrThrow fails fast on non-success responses', async () => {

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetIdToken = vi.fn()
+const mockAuthState = vi.hoisted(() => ({
+  currentUser: { uid: 'user-a' } as { uid: string } | null
+}))
 const originalFetch = globalThis.fetch
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -18,7 +21,10 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
     getIdToken: mockGetIdToken,
-    getAuthHeader: vi.fn()
+    getAuthHeader: vi.fn(),
+    get currentUser() {
+      return mockAuthState.currentUser
+    }
   })
 }))
 
@@ -33,6 +39,7 @@ describe('useSessionCookie', () => {
     vi.resetModules()
     vi.restoreAllMocks()
     mockGetIdToken.mockReset()
+    mockAuthState.currentUser = { uid: 'user-a' }
     globalThis.fetch = vi.fn()
   })
 
@@ -91,6 +98,45 @@ describe('useSessionCookie', () => {
     await Promise.all([first, second])
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('serializes a new user session after the previous user response', async () => {
+    mockGetIdToken.mockImplementation(() =>
+      Promise.resolve(`firebase-${mockAuthState.currentUser?.uid}`)
+    )
+    let resolveFirstFetch: (value: Response) => void = () => {}
+    vi.mocked(globalThis.fetch)
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveFirstFetch = resolve
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+
+    const first = useSessionCookie().createSession()
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
+
+    mockAuthState.currentUser = { uid: 'user-b' }
+    const second = useSessionCookie().createSession()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(mockGetIdToken).toHaveBeenCalledTimes(1)
+
+    resolveFirstFetch(new Response(null, { status: 204 }))
+    await Promise.all([first, second])
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    const firstHeaders = new Headers(
+      vi.mocked(globalThis.fetch).mock.calls[0][1]?.headers
+    )
+    const secondHeaders = new Headers(
+      vi.mocked(globalThis.fetch).mock.calls[1][1]?.headers
+    )
+    expect(firstHeaders.get('Authorization')).toBe('Bearer firebase-user-a')
+    expect(secondHeaders.get('Authorization')).toBe('Bearer firebase-user-b')
   })
 
   it('createSessionOrThrow fails fast on non-success responses', async () => {

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -5,10 +5,14 @@ import { useAuthStore } from '@/stores/authStore'
 
 interface InFlightCreateSession {
   ownerUid: string | null
+  usesFirebaseToken: boolean
   promise: Promise<void>
 }
 
 let inFlightCreateSession: InFlightCreateSession | null = null
+let confirmedSessionOwnerUid: string | null = null
+let sessionMutationTail = Promise.resolve()
+let pendingSessionMutations = 0
 
 /**
  * Session cookie management for cloud authentication.
@@ -53,75 +57,99 @@ export const useSessionCookie = () => {
    * (since getAuthHeader() returns workspace token which shouldn't be used for session creation).
    * When disabled, uses getAuthHeader() for backward compatibility.
    */
-  const createSession = async (): Promise<void> => {
-    if (!isCloud) return
-    const ownerUid = useAuthStore().currentUser?.uid ?? null
-    if (inFlightCreateSession?.ownerUid === ownerUid) {
+  const performCreateSession = async (
+    expectedOwnerUid: string,
+    useFirebaseToken: boolean
+  ): Promise<void> => {
+    const { flags } = useFeatureFlags()
+    const authStore = useAuthStore()
+
+    let authHeader: Record<string, string>
+
+    if (useFirebaseToken || flags.teamWorkspacesEnabled) {
+      authHeader = await getFirebaseSessionHeaderOrThrow()
+    } else {
+      const header = await authStore.getAuthHeader()
+      if (!header) {
+        throw new Error('No auth header available for session creation')
+      }
+      authHeader = header
+    }
+
+    if ((authStore.currentUser?.uid ?? null) !== expectedOwnerUid) {
+      throw new Error('Session identity changed during creation')
+    }
+
+    const response = await createSessionWithHeader(authHeader)
+
+    if (!response.ok) {
+      throw new Error(await readSessionError(response))
+    }
+  }
+
+  const establishSession = (
+    ownerUid: string,
+    forceRefresh: boolean,
+    useFirebaseToken = false
+  ): Promise<void> => {
+    if (
+      !forceRefresh &&
+      pendingSessionMutations === 0 &&
+      confirmedSessionOwnerUid === ownerUid
+    ) {
+      return Promise.resolve()
+    }
+    if (
+      inFlightCreateSession?.ownerUid === ownerUid &&
+      (!useFirebaseToken || inFlightCreateSession.usesFirebaseToken)
+    ) {
       return inFlightCreateSession.promise
     }
 
-    const previousRequest = inFlightCreateSession?.promise
+    pendingSessionMutations++
     const request: InFlightCreateSession = {
       ownerUid,
-      promise: (previousRequest
-        ? previousRequest.catch(() => {})
-        : Promise.resolve()
-      )
+      usesFirebaseToken: useFirebaseToken,
+      promise: sessionMutationTail
         .then(async () => {
-          if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) return
-          await performCreateSession(ownerUid)
+          if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
+            throw new Error('Session identity changed before creation')
+          }
+          await performCreateSession(ownerUid, useFirebaseToken)
+          confirmedSessionOwnerUid = ownerUid
+          if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
+            throw new Error('Session identity changed during creation')
+          }
         })
         .finally(() => {
+          pendingSessionMutations--
           if (inFlightCreateSession === request) {
             inFlightCreateSession = null
           }
         })
     }
     inFlightCreateSession = request
+    sessionMutationTail = request.promise.catch(() => {})
     return request.promise
   }
 
-  const performCreateSession = async (
-    expectedOwnerUid: string | null
-  ): Promise<void> => {
-    const { flags } = useFeatureFlags()
+  const currentOwnerUidOrThrow = (): string => {
+    const ownerUid = useAuthStore().currentUser?.uid
+    if (!ownerUid) {
+      throw new Error('No authenticated user available for session creation')
+    }
+    return ownerUid
+  }
+
+  const ensureSessionCookie = async (): Promise<void> => {
+    if (!isCloud) return
+    await establishSession(currentOwnerUidOrThrow(), false)
+  }
+
+  const createSession = async (): Promise<void> => {
+    if (!isCloud) return
     try {
-      const authStore = useAuthStore()
-
-      let authHeader: Record<string, string>
-
-      if (flags.teamWorkspacesEnabled) {
-        const firebaseToken = await authStore.getIdToken()
-        if (!firebaseToken) {
-          console.warn(
-            'Failed to create session cookie:',
-            'No Firebase token available for session creation'
-          )
-          return
-        }
-        authHeader = { Authorization: `Bearer ${firebaseToken}` }
-      } else {
-        const header = await authStore.getAuthHeader()
-        if (!header) {
-          console.warn(
-            'Failed to create session cookie:',
-            'No auth header available for session creation'
-          )
-          return
-        }
-        authHeader = header
-      }
-
-      if ((authStore.currentUser?.uid ?? null) !== expectedOwnerUid) return
-
-      const response = await createSessionWithHeader(authHeader)
-
-      if (!response.ok) {
-        console.warn(
-          'Failed to create session cookie:',
-          await readSessionError(response)
-        )
-      }
+      await establishSession(currentOwnerUidOrThrow(), true)
     } catch (error) {
       console.warn('Failed to create session cookie:', error)
     }
@@ -129,12 +157,7 @@ export const useSessionCookie = () => {
 
   const createSessionOrThrow = async (): Promise<void> => {
     if (!isCloud) return
-
-    const authHeader = await getFirebaseSessionHeaderOrThrow()
-    const response = await createSessionWithHeader(authHeader)
-    if (!response.ok) {
-      throw new Error(await readSessionError(response))
-    }
+    await establishSession(currentOwnerUidOrThrow(), true, true)
   }
 
   /**
@@ -143,19 +166,28 @@ export const useSessionCookie = () => {
    */
   const deleteSession = async (): Promise<void> => {
     if (!isCloud) return
+    confirmedSessionOwnerUid = null
+    inFlightCreateSession = null
 
     try {
-      const response = await fetch(api.apiURL('/auth/session'), {
-        method: 'DELETE',
-        credentials: 'include'
-      })
+      pendingSessionMutations++
+      const deleteRequest = sessionMutationTail
+        .then(async () => {
+          const response = await fetch(api.apiURL('/auth/session'), {
+            method: 'DELETE',
+            credentials: 'include'
+          })
 
-      if (!response.ok) {
-        console.warn(
-          'Failed to delete session cookie:',
-          await readSessionError(response)
-        )
-      }
+          if (!response.ok) {
+            throw new Error(await readSessionError(response))
+          }
+          confirmedSessionOwnerUid = null
+        })
+        .finally(() => {
+          pendingSessionMutations--
+        })
+      sessionMutationTail = deleteRequest.catch(() => {})
+      await deleteRequest
     } catch (error) {
       console.warn('Failed to delete session cookie:', error)
     }
@@ -164,6 +196,7 @@ export const useSessionCookie = () => {
   return {
     createSession,
     createSessionOrThrow,
+    ensureSessionCookie,
     deleteSession
   }
 }

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -3,8 +3,12 @@ import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 
-// Coalesce concurrent rotations (token-refresh bursts) into one POST.
-let inFlightCreateSession: Promise<void> | null = null
+interface InFlightCreateSession {
+  ownerUid: string | null
+  promise: Promise<void>
+}
+
+let inFlightCreateSession: InFlightCreateSession | null = null
 
 /**
  * Session cookie management for cloud authentication.
@@ -51,14 +55,35 @@ export const useSessionCookie = () => {
    */
   const createSession = async (): Promise<void> => {
     if (!isCloud) return
-    if (inFlightCreateSession) return inFlightCreateSession
-    inFlightCreateSession = performCreateSession().finally(() => {
-      inFlightCreateSession = null
-    })
-    return inFlightCreateSession
+    const ownerUid = useAuthStore().currentUser?.uid ?? null
+    if (inFlightCreateSession?.ownerUid === ownerUid) {
+      return inFlightCreateSession.promise
+    }
+
+    const previousRequest = inFlightCreateSession?.promise
+    const request: InFlightCreateSession = {
+      ownerUid,
+      promise: (previousRequest
+        ? previousRequest.catch(() => {})
+        : Promise.resolve()
+      )
+        .then(async () => {
+          if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) return
+          await performCreateSession(ownerUid)
+        })
+        .finally(() => {
+          if (inFlightCreateSession === request) {
+            inFlightCreateSession = null
+          }
+        })
+    }
+    inFlightCreateSession = request
+    return request.promise
   }
 
-  const performCreateSession = async (): Promise<void> => {
+  const performCreateSession = async (
+    expectedOwnerUid: string | null
+  ): Promise<void> => {
     const { flags } = useFeatureFlags()
     try {
       const authStore = useAuthStore()
@@ -86,6 +111,8 @@ export const useSessionCookie = () => {
         }
         authHeader = header
       }
+
+      if ((authStore.currentUser?.uid ?? null) !== expectedOwnerUid) return
 
       const response = await createSessionWithHeader(authHeader)
 

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -38,15 +38,26 @@ export const useSessionCookie = () => {
     return typeof message === 'string' ? message : response.statusText
   }
 
-  const getFirebaseSessionHeaderOrThrow = async (): Promise<
-    Record<string, string>
-  > => {
-    const firebaseToken = await useAuthStore().getIdToken()
-    if (!firebaseToken) {
-      throw new Error('No Firebase token available for session creation')
+  const getSessionHeaderOrThrow = async (
+    useFirebaseToken: boolean
+  ): Promise<Record<string, string>> => {
+    const { flags } = useFeatureFlags()
+    const authStore = useAuthStore()
+
+    if (useFirebaseToken || flags.teamWorkspacesEnabled) {
+      const firebaseToken = await authStore.getIdToken()
+      if (!firebaseToken) {
+        throw new Error('No Firebase token available for session creation')
+      }
+
+      return { Authorization: `Bearer ${firebaseToken}` }
     }
 
-    return { Authorization: `Bearer ${firebaseToken}` }
+    const authHeader = await authStore.getAuthHeader()
+    if (!authHeader) {
+      throw new Error('No auth header available for session creation')
+    }
+    return authHeader
   }
 
   /**
@@ -61,20 +72,8 @@ export const useSessionCookie = () => {
     expectedOwnerUid: string,
     useFirebaseToken: boolean
   ): Promise<void> => {
-    const { flags } = useFeatureFlags()
     const authStore = useAuthStore()
-
-    let authHeader: Record<string, string>
-
-    if (useFirebaseToken || flags.teamWorkspacesEnabled) {
-      authHeader = await getFirebaseSessionHeaderOrThrow()
-    } else {
-      const header = await authStore.getAuthHeader()
-      if (!header) {
-        throw new Error('No auth header available for session creation')
-      }
-      authHeader = header
-    }
+    const authHeader = await getSessionHeaderOrThrow(useFirebaseToken)
 
     if ((authStore.currentUser?.uid ?? null) !== expectedOwnerUid) {
       throw new Error('Session identity changed during creation')

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -59,6 +59,7 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(ok)
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+    expect(mockRemint).toHaveBeenCalledWith('tokenA')
 
     const retryHeaders = new Headers(mockFetch.mock.calls[1][1].headers)
     expect(retryHeaders.get('Authorization')).toBe('Bearer tokenB')
@@ -125,6 +126,31 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(unauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the bearer from a Request when init does not override headers', async () => {
+    mockFetch.mockResolvedValueOnce(unauthorized).mockResolvedValueOnce(ok)
+    mockRemint.mockResolvedValue('tokenB')
+    const request = new Request('https://cloud/x', {
+      headers: { Authorization: 'Bearer tokenA' }
+    })
+
+    const result = await fetchWithUnifiedRemint(request, {}, true)
+
+    expect(result).toBe(ok)
+    expect(mockRemint).toHaveBeenCalledWith('tokenA')
+    const retryHeaders = new Headers(mockFetch.mock.calls[1][1].headers)
+    expect(retryHeaders.get('Authorization')).toBe('Bearer tokenB')
+  })
+
+  it('surfaces the original 401 when the original bearer is unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(unauthorized)
+
+    const result = await fetchWithUnifiedRemint('https://cloud/x', {}, true)
+
+    expect(result).toBe(unauthorized)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockRemint).not.toHaveBeenCalled()
   })
 
   it('surfaces the original 401 when the re-mint throws a permanent auth error', async () => {
@@ -255,6 +281,7 @@ describe('attachUnifiedRemintInterceptor', () => {
     expect(res.status).toBe(200)
     expect(adapter).toHaveBeenCalledTimes(2)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+    expect(mockRemint).toHaveBeenCalledWith('tokenA')
     expect(String(adapter.mock.calls[1][0].headers.Authorization)).toBe(
       'Bearer tokenB'
     )
@@ -298,6 +325,17 @@ describe('attachUnifiedRemintInterceptor', () => {
         __skipUnifiedRemint: true
       })
     ).rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(adapter).toHaveBeenCalledTimes(1)
+    expect(mockRemint).not.toHaveBeenCalled()
+  })
+
+  it('does not re-mint when the original bearer is unavailable', async () => {
+    const { client, adapter } = makeClient([401])
+
+    await expect(client.get('https://cloud/x')).rejects.toMatchObject({
+      response: { status: 401 }
+    })
 
     expect(adapter).toHaveBeenCalledTimes(1)
     expect(mockRemint).not.toHaveBeenCalled()

--- a/src/platform/auth/unified/remintRetry.ts
+++ b/src/platform/auth/unified/remintRetry.ts
@@ -36,15 +36,30 @@ export async function shouldRemintCloudRequest(): Promise<boolean> {
  * unexpected throw (e.g. a chunk-load failure or no active Pinia), which it
  * logs. Either way `null` makes the caller surface its original 401 unchanged.
  */
-async function tryRemintToken(): Promise<string | null> {
+async function tryRemintToken(expectedToken: string): Promise<string | null> {
   try {
     const { useWorkspaceAuthStore } =
       await import('@/platform/workspace/stores/workspaceAuthStore')
-    return await useWorkspaceAuthStore().remintUnifiedOnce()
+    return await useWorkspaceAuthStore().remintUnifiedOnce(expectedToken)
   } catch (err) {
     console.warn('Unified re-mint primitive threw unexpectedly:', err)
     return null
   }
+}
+
+function bearerToken(authorization: unknown): string | undefined {
+  if (typeof authorization !== 'string') return
+  return authorization.startsWith('Bearer ')
+    ? authorization.slice('Bearer '.length)
+    : undefined
+}
+
+function fetchRequestHeaders(
+  input: RequestInfo | URL,
+  init: RequestInit
+): Headers {
+  if (init.headers !== undefined) return new Headers(init.headers)
+  return input instanceof Request ? new Headers(input.headers) : new Headers()
 }
 
 /**
@@ -76,12 +91,16 @@ export async function fetchWithUnifiedRemint(
     return response
   }
 
-  const token = await tryRemintToken()
+  const requestHeaders = fetchRequestHeaders(input, init)
+  const expectedToken = bearerToken(requestHeaders.get('Authorization'))
+  if (!expectedToken) return response
+
+  const token = await tryRemintToken(expectedToken)
   if (!token) {
     return response
   }
 
-  const headers = new Headers(init.headers)
+  const headers = requestHeaders
   headers.set('Authorization', `Bearer ${token}`)
   return fetch(input, { ...init, headers })
 }
@@ -115,7 +134,14 @@ export function attachUnifiedRemintInterceptor(client: AxiosInstance): void {
         throw error
       }
 
-      const token = await tryRemintToken()
+      const expectedToken = bearerToken(
+        new AxiosHeaders(error.config.headers).get('Authorization')
+      )
+      if (!expectedToken) {
+        throw error
+      }
+
+      const token = await tryRemintToken(expectedToken)
       if (!token) {
         throw error
       }

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -31,6 +31,14 @@ vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
   useWorkspaceAuthStore: () => mockWorkspaceAuthStore
 }))
 
+const mockEnsureSessionCookie = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/auth/session/useSessionCookie', () => ({
+  useSessionCookie: () => ({
+    ensureSessionCookie: mockEnsureSessionCookie
+  })
+}))
+
 // Mock current user (drives the original-owner self-row match by email)
 const mockCurrentUser = vi.hoisted(() => ({
   userEmail: { value: null as string | null }
@@ -144,6 +152,7 @@ describe('useTeamWorkspaceStore', () => {
     mockWorkspaceAuthStore.isAuthenticated = false
     mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(false)
     mockWorkspaceAuthStore.switchWorkspace.mockResolvedValue(undefined)
+    mockEnsureSessionCookie.mockResolvedValue(undefined)
 
     // Default mock responses
     mockWorkspaceApi.list.mockResolvedValue({
@@ -302,6 +311,9 @@ describe('useTeamWorkspaceStore', () => {
 
       const store = useTeamWorkspaceStore()
       const firstInitialization = store.initialize()
+      await vi.waitFor(() =>
+        expect(mockWorkspaceApi.list).toHaveBeenCalledOnce()
+      )
       store.resetForIdentityChange()
       const secondInitialization = store.initialize()
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -264,6 +264,60 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(1)
     })
 
+    it('can initialize the next user after identity state is reset', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      store.resetForIdentityChange()
+
+      expect(store.initState).toBe('uninitialized')
+      expect(store.workspaces).toEqual([])
+      expect(store.activeWorkspaceId).toBeNull()
+      expect(store.error).toBeNull()
+      expect(store.isFetchingWorkspaces).toBe(false)
+
+      mockWorkspaceApi.list.mockResolvedValueOnce({
+        workspaces: [mockMemberWorkspace]
+      })
+      await store.initialize()
+
+      expect(store.initState).toBe('ready')
+      expect(store.workspaces).toEqual([
+        expect.objectContaining({ id: mockMemberWorkspace.id })
+      ])
+      expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
+    })
+
+    it('does not let a previous user initialization overwrite the next user', async () => {
+      let resolveFirstList: (value: unknown) => void = () => {}
+      mockWorkspaceApi.list
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveFirstList = resolve
+          })
+        )
+        .mockResolvedValueOnce({ workspaces: [mockMemberWorkspace] })
+
+      const store = useTeamWorkspaceStore()
+      const firstInitialization = store.initialize()
+      store.resetForIdentityChange()
+      const secondInitialization = store.initialize()
+
+      await secondInitialization
+      resolveFirstList({ workspaces: [mockPersonalWorkspace] })
+      await firstInitialization
+
+      expect(store.initState).toBe('ready')
+      expect(store.workspaces).toEqual([
+        expect.objectContaining({ id: mockMemberWorkspace.id })
+      ])
+      expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
+      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledOnce()
+      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+        mockMemberWorkspace.id
+      )
+    })
+
     it('throws when no workspaces available', async () => {
       mockWorkspaceApi.list.mockResolvedValue({ workspaces: [] })
 
@@ -357,6 +411,40 @@ describe('useTeamWorkspaceStore', () => {
       ).rejects.toThrow('Workspace not found or access denied')
 
       expect(store.isSwitching).toBe(false)
+    })
+  })
+
+  describe('refreshWorkspaces', () => {
+    it('does not let a previous user refresh overwrite the next user', async () => {
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      let resolveRefresh: (value: unknown) => void = () => {}
+      mockWorkspaceApi.list.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefresh = resolve
+        })
+      )
+      const previousRefresh = store.refreshWorkspaces()
+
+      store.resetForIdentityChange()
+      mockWorkspaceApi.list.mockResolvedValueOnce({
+        workspaces: [mockMemberWorkspace]
+      })
+      await store.initialize()
+
+      resolveRefresh({ workspaces: [mockTeamWorkspace] })
+      await previousRefresh
+
+      expect(store.initState).toBe('ready')
+      expect(store.workspaces).toEqual([
+        expect.objectContaining({
+          id: mockMemberWorkspace.id,
+          role: mockMemberWorkspace.role
+        })
+      ])
+      expect(store.activeWorkspaceId).toBe(mockMemberWorkspace.id)
+      expect(store.isFetchingWorkspaces).toBe(false)
     })
   })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -254,6 +254,11 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
     for (let attempt = 0; attempt <= MAX_INIT_RETRIES; attempt++) {
       try {
+        const { useSessionCookie } =
+          await import('@/platform/auth/session/useSessionCookie')
+        await useSessionCookie().ensureSessionCookie()
+        if (isStaleIdentity(generation)) return
+
         // 1. Try to restore workspace context from session (page refresh case)
         const hasValidSession = workspaceAuthStore.initializeFromSession()
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -126,6 +126,17 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const isDeleting = ref(false)
   const isSwitching = ref(false)
   const isFetchingWorkspaces = ref(false)
+  let identityGeneration = 0
+
+  function isStaleIdentity(generation: number): boolean {
+    return generation !== identityGeneration
+  }
+
+  function isStaleWorkspace(generation: number, workspaceId: string): boolean {
+    return (
+      isStaleIdentity(generation) || activeWorkspaceId.value !== workspaceId
+    )
+  }
 
   const activeWorkspace = computed(
     () => workspaces.value.find((w) => w.id === activeWorkspaceId.value) ?? null
@@ -234,6 +245,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   async function initialize(): Promise<void> {
     if (initState.value !== 'uninitialized') return
 
+    const generation = identityGeneration
     initState.value = 'loading'
     isFetchingWorkspaces.value = true
     error.value = null
@@ -248,6 +260,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         if (hasValidSession && workspaceAuthStore.currentWorkspace) {
           // Valid session exists - fetch workspace list and verify access
           const response = await workspaceApi.list()
+          if (isStaleIdentity(generation)) return
           workspaces.value = sortWorkspaces(
             response.workspaces.map(createWorkspaceState)
           )
@@ -278,10 +291,13 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           try {
             await workspaceAuthStore.switchWorkspace(fallbackWorkspaceId)
           } catch {
+            if (isStaleIdentity(generation)) return
             console.error(
               '[teamWorkspaceStore] Token exchange failed during fallback'
             )
           }
+
+          if (isStaleIdentity(generation)) return
 
           activeWorkspaceId.value = fallbackWorkspaceId
           setLastWorkspaceId(fallbackWorkspaceId)
@@ -292,6 +308,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
         // 2. No valid session - fetch workspaces and pick default
         const response = await workspaceApi.list()
+        if (isStaleIdentity(generation)) return
         workspaces.value = sortWorkspaces(
           response.workspaces.map(createWorkspaceState)
         )
@@ -317,11 +334,14 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         try {
           await workspaceAuthStore.switchWorkspace(targetWorkspaceId)
         } catch {
+          if (isStaleIdentity(generation)) return
           // Log but don't fail initialization - API calls will fall back to Firebase token
           console.error(
             '[teamWorkspaceStore] Token exchange failed during init'
           )
         }
+
+        if (isStaleIdentity(generation)) return
 
         // 5. Set active workspace
         activeWorkspaceId.value = targetWorkspaceId
@@ -331,6 +351,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         isFetchingWorkspaces.value = false
         return
       } catch (e) {
+        if (isStaleIdentity(generation)) return
         const isNoWorkspacesError =
           e instanceof Error && e.message === 'No workspaces available'
 
@@ -349,9 +370,11 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           `[teamWorkspaceStore] Init failed (attempt ${attempt + 1}/${MAX_INIT_RETRIES + 1}), retrying in ${delay}ms: ${errorMessage}`
         )
         await new Promise((resolve) => setTimeout(resolve, delay))
+        if (isStaleIdentity(generation)) return
       }
     }
 
+    if (isStaleIdentity(generation)) return
     isFetchingWorkspaces.value = false
   }
 
@@ -359,14 +382,18 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Re-fetch workspaces from API without changing active workspace.
    */
   async function refreshWorkspaces(): Promise<void> {
+    const generation = identityGeneration
     isFetchingWorkspaces.value = true
     try {
       const response = await workspaceApi.list()
+      if (isStaleIdentity(generation)) return
       workspaces.value = sortWorkspaces(
         response.workspaces.map(createWorkspaceState)
       )
     } finally {
-      isFetchingWorkspaces.value = false
+      if (!isStaleIdentity(generation)) {
+        isFetchingWorkspaces.value = false
+      }
     }
   }
 
@@ -391,6 +418,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   async function switchWorkspace(workspaceId: string): Promise<void> {
     if (workspaceId === activeWorkspaceId.value) return
 
+    const generation = identityGeneration
     const workspaceAuthStore = useWorkspaceAuthStore()
 
     isSwitching.value = true
@@ -401,6 +429,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       if (!workspace) {
         // Workspace not in list - try refetching in case it was added
         await refreshWorkspaces()
+        if (isStaleIdentity(generation)) return
         const refreshedWorkspace = workspaces.value.find(
           (w) => w.id === workspaceId
         )
@@ -408,6 +437,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           throw new Error('Workspace not found or access denied')
         }
       }
+
+      if (isStaleIdentity(generation)) return
 
       // Clear current workspace context and persist new workspace ID
       workspaceAuthStore.clearWorkspaceContext()
@@ -417,7 +448,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       window.location.reload()
       // Code after this won't run (page reloads)
     } catch (e) {
-      isSwitching.value = false
+      if (!isStaleIdentity(generation)) {
+        isSwitching.value = false
+      }
       throw e
     }
   }
@@ -426,6 +459,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Create a new workspace and switch to it.
    */
   async function createWorkspace(name: string): Promise<WorkspaceState> {
+    const generation = identityGeneration
     const workspaceAuthStore = useWorkspaceAuthStore()
 
     isCreating.value = true
@@ -433,6 +467,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     try {
       const newWorkspace = await workspaceApi.create({ name })
       const workspaceState = createWorkspaceState(newWorkspace)
+      if (isStaleIdentity(generation)) return workspaceState
 
       // Add to local list
       workspaces.value = [...workspaces.value, workspaceState]
@@ -448,7 +483,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       // Code after this won't run (page reloads)
       return workspaceState
     } catch (e) {
-      isCreating.value = false
+      if (!isStaleIdentity(generation)) {
+        isCreating.value = false
+      }
       throw e
     }
   }
@@ -458,6 +495,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * If deleting active workspace, switches to personal.
    */
   async function deleteWorkspace(workspaceId?: string): Promise<void> {
+    const generation = identityGeneration
     const targetId = workspaceId ?? activeWorkspaceId.value
     if (!targetId) throw new Error('No workspace to delete')
 
@@ -473,6 +511,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
     try {
       await workspaceApi.delete(targetId)
+      if (isStaleIdentity(generation)) return
 
       if (targetId === activeWorkspaceId.value) {
         // Deleted active workspace - go to personal
@@ -489,7 +528,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         isDeleting.value = false
       }
     } catch (e) {
-      isDeleting.value = false
+      if (!isStaleIdentity(generation)) {
+        isDeleting.value = false
+      }
       throw e
     }
   }
@@ -501,7 +542,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     workspaceId: string,
     newName: string
   ): Promise<void> {
+    const generation = identityGeneration
     const updated = await workspaceApi.update(workspaceId, { name: newName })
+    if (isStaleIdentity(generation)) return
     updateWorkspace(workspaceId, { name: updated.name })
   }
 
@@ -520,6 +563,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Switches to personal workspace after leaving.
    */
   async function leaveWorkspace(): Promise<void> {
+    const generation = identityGeneration
     const current = activeWorkspace.value
     if (!current || current.type === 'personal') {
       throw new Error('Cannot leave personal workspace')
@@ -528,6 +572,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const workspaceAuthStore = useWorkspaceAuthStore()
 
     await workspaceApi.leave()
+    if (isStaleIdentity(generation)) return
 
     // Go to personal workspace
     const personal = personalWorkspace.value
@@ -545,18 +590,25 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   async function fetchMembers(
     params?: ListMembersParams
   ): Promise<WorkspaceMember[]> {
-    if (!activeWorkspaceId.value) return []
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
+    if (!workspaceId) return []
 
     const response = await workspaceApi.listMembers(params)
     const members = response.members.map(mapApiMemberToWorkspaceMember)
-    updateActiveWorkspace({ members })
+    if (!isStaleWorkspace(generation, workspaceId)) {
+      updateWorkspace(workspaceId, { members })
+    }
     return members
   }
 
   // Tracks which workspaces have already loaded their members so the
   // lifecycle gate resolves without redundant or duplicate fetches.
   const loadedMemberWorkspaceIds = new Set<string>()
-  let inFlightMembersWorkspaceId: string | null = null
+  let inFlightMembersRequest: {
+    generation: number
+    workspaceId: string
+  } | null = null
 
   /**
    * Load the active workspace's members once. No-ops for already-loaded
@@ -565,19 +617,30 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    */
   async function ensureMembersLoaded(): Promise<void> {
     const workspaceId = activeWorkspaceId.value
+    const generation = identityGeneration
     if (!workspaceId) return
     if (loadedMemberWorkspaceIds.has(workspaceId)) return
-    if (inFlightMembersWorkspaceId === workspaceId) return
+    if (
+      inFlightMembersRequest?.generation === generation &&
+      inFlightMembersRequest.workspaceId === workspaceId
+    ) {
+      return
+    }
 
-    inFlightMembersWorkspaceId = workspaceId
+    const request = { generation, workspaceId }
+    inFlightMembersRequest = request
     try {
       await fetchMembers()
-      loadedMemberWorkspaceIds.add(workspaceId)
+      if (!isStaleWorkspace(generation, workspaceId)) {
+        loadedMemberWorkspaceIds.add(workspaceId)
+      }
     } catch (e) {
-      console.error('Failed to load workspace members', e)
+      if (!isStaleIdentity(generation)) {
+        console.error('Failed to load workspace members', e)
+      }
     } finally {
-      if (inFlightMembersWorkspaceId === workspaceId) {
-        inFlightMembersWorkspaceId = null
+      if (inFlightMembersRequest === request) {
+        inFlightMembersRequest = null
       }
     }
   }
@@ -586,10 +649,17 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Remove a member from the current workspace.
    */
   async function removeMember(userId: string): Promise<void> {
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
+    if (!workspaceId) return
+
     await workspaceApi.removeMember(userId)
-    const current = activeWorkspace.value
+    if (isStaleWorkspace(generation, workspaceId)) {
+      return
+    }
+    const current = workspaces.value.find((w) => w.id === workspaceId)
     if (current) {
-      updateActiveWorkspace({
+      updateWorkspace(workspaceId, {
         members: current.members.filter((m) => m.id !== userId)
       })
     }
@@ -602,6 +672,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     userId: string,
     role: WorkspaceMember['role']
   ): Promise<void> {
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
+    if (!workspaceId) return
     if (userId === originalOwnerId.value) {
       throw new Error("Cannot change the workspace creator's role")
     }
@@ -609,9 +682,12 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     // the PATCH response to echo a full Member (a 204/partial body would
     // otherwise drop joined_at / is_original_owner).
     await workspaceApi.updateMemberRole(userId, role)
-    const current = activeWorkspace.value
+    if (isStaleWorkspace(generation, workspaceId)) {
+      return
+    }
+    const current = workspaces.value.find((w) => w.id === workspaceId)
     if (current) {
-      updateActiveWorkspace({
+      updateWorkspace(workspaceId, {
         members: current.members.map((m) =>
           m.id === userId ? { ...m, role } : m
         )
@@ -623,11 +699,15 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Fetch pending invites for the current workspace.
    */
   async function fetchPendingInvites(): Promise<PendingInvite[]> {
-    if (!activeWorkspaceId.value) return []
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
+    if (!workspaceId) return []
 
     const response = await workspaceApi.listInvites()
     const invites = response.invites.map(mapApiInviteToPendingInvite)
-    updateActiveWorkspace({ pendingInvites: invites })
+    if (!isStaleWorkspace(generation, workspaceId)) {
+      updateWorkspace(workspaceId, { pendingInvites: invites })
+    }
     return invites
   }
 
@@ -635,12 +715,17 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Create an invite for the current workspace.
    */
   async function createInvite(email: string): Promise<PendingInvite> {
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
     const response = await workspaceApi.createInvite({ email })
     const invite = mapApiInviteToPendingInvite(response)
 
-    const current = activeWorkspace.value
+    if (!workspaceId || isStaleWorkspace(generation, workspaceId)) {
+      return invite
+    }
+    const current = workspaces.value.find((w) => w.id === workspaceId)
     if (current) {
-      updateActiveWorkspace({
+      updateWorkspace(workspaceId, {
         pendingInvites: [...current.pendingInvites, invite]
       })
     }
@@ -652,10 +737,15 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Revoke a pending invite.
    */
   async function revokeInvite(inviteId: string): Promise<void> {
+    const generation = identityGeneration
+    const workspaceId = activeWorkspaceId.value
     await workspaceApi.revokeInvite(inviteId)
-    const current = activeWorkspace.value
+    if (!workspaceId || isStaleWorkspace(generation, workspaceId)) {
+      return
+    }
+    const current = workspaces.value.find((w) => w.id === workspaceId)
     if (current) {
-      updateActiveWorkspace({
+      updateWorkspace(workspaceId, {
         pendingInvites: current.pendingInvites.filter((i) => i.id !== inviteId)
       })
     }
@@ -671,7 +761,9 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * than show success over two live invites for the same email.
    */
   async function resendInvite(inviteId: string): Promise<PendingInvite> {
-    if (resendingInviteIds.has(inviteId)) {
+    const generation = identityGeneration
+    const resendKey = `${generation}:${inviteId}`
+    if (resendingInviteIds.has(resendKey)) {
       throw new Error('Invite resend already in progress')
     }
     const invite = activeWorkspace.value?.pendingInvites.find(
@@ -680,18 +772,20 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     if (!invite) {
       throw new Error('Invite not found')
     }
-    resendingInviteIds.add(inviteId)
+    resendingInviteIds.add(resendKey)
     try {
       const newInvite = await createInvite(invite.email)
+      if (isStaleIdentity(generation)) return newInvite
       try {
         await revokeInvite(inviteId)
       } catch (error) {
+        if (isStaleIdentity(generation)) throw error
         await fetchPendingInvites()
         throw error
       }
       return newInvite
     } finally {
-      resendingInviteIds.delete(inviteId)
+      resendingInviteIds.delete(resendKey)
     }
   }
 
@@ -702,10 +796,13 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   async function acceptInvite(
     token: string
   ): Promise<{ workspaceId: string; workspaceName: string }> {
+    const generation = identityGeneration
     const response = await workspaceApi.acceptInvite(token)
 
     // Refresh workspace list to include newly joined workspace
-    await refreshWorkspaces()
+    if (!isStaleIdentity(generation)) {
+      await refreshWorkspaces()
+    }
 
     return {
       workspaceId: response.workspace_id,
@@ -725,6 +822,21 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   function destroy(): void {
     const workspaceAuthStore = useWorkspaceAuthStore()
     workspaceAuthStore.destroy()
+  }
+
+  function resetForIdentityChange(): void {
+    identityGeneration++
+    initState.value = 'uninitialized'
+    workspaces.value = []
+    activeWorkspaceId.value = null
+    error.value = null
+    isCreating.value = false
+    isDeleting.value = false
+    isSwitching.value = false
+    isFetchingWorkspaces.value = false
+    loadedMemberWorkspaceIds.clear()
+    inFlightMembersRequest = null
+    resendingInviteIds.clear()
   }
 
   return {
@@ -759,6 +871,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     // Initialization & Cleanup
     initialize,
     destroy,
+    resetForIdentityChange,
     refreshWorkspaces,
 
     // Workspace Actions

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -2056,6 +2056,80 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
+    it('does not let an old workspace retry supersede a pending switch', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      let resolveWorkspaceB: (value: unknown) => void = () => {}
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-a-token',
+              workspace: { ...mockWorkspace, id: 'workspace-a' }
+            })
+        })
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveWorkspaceB = resolve
+          })
+        )
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-a')
+      const switchToB = store.switchWorkspace('workspace-b')
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+
+      await expect(
+        store.remintUnifiedOnce('workspace-a-token')
+      ).resolves.toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      resolveWorkspaceB({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockTokenResponse,
+            token: 'workspace-b-token',
+            workspace: { ...mockWorkspace, id: 'workspace-b' }
+          })
+      })
+      await switchToB
+
+      expect(store.getUnifiedToken()).toBe('workspace-b-token')
+    })
+
+    it('fails closed when switching workspaces fails', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockTokenResponse)
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          json: () => Promise.resolve({ message: 'try again' })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-a')
+
+      await expect(store.switchWorkspace('workspace-b')).rejects.toThrow()
+      expect(store.getUnifiedToken()).toBeUndefined()
+      await expect(
+        store.remintUnifiedOnce('workspace-token-abc')
+      ).resolves.toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
     it('bumps the rotation trigger exactly once on a refresh re-mint', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -384,6 +384,50 @@ describe('useWorkspaceAuthStore', () => {
       )
     })
 
+    it('replaces the workspace token when the same user switches workspaces', async () => {
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-a-token',
+              workspace: { ...mockWorkspace, id: 'workspace-a' }
+            })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-b-token',
+              workspace: { ...mockWorkspace, id: 'workspace-b' }
+            })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-a')
+      await store.switchWorkspace('workspace-b')
+
+      expect(mockFetch.mock.calls.map(([, init]) => init.body)).toEqual([
+        JSON.stringify({ workspace_id: 'workspace-a' }),
+        JSON.stringify({ workspace_id: 'workspace-b' })
+      ])
+      expect(store.currentWorkspace?.id).toBe('workspace-b')
+      expect(store.getWorkspaceAuthHeader()).toEqual({
+        Authorization: 'Bearer workspace-b-token'
+      })
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBe(
+        'workspace-b-token'
+      )
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.OWNER_UID)).toBe(
+        'user-a'
+      )
+    })
+
     it('sets isLoading to true during operation', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
       let resolveResponse: (value: unknown) => void
@@ -1955,18 +1999,61 @@ describe('useWorkspaceAuthStore', () => {
     it('does not bump the rotation trigger on a workspace switch', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve(mockTokenResponse)
-        })
-      )
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
 
       const store = useWorkspaceAuthStore()
       await store.switchWorkspace('workspace-123')
 
+      expect(mockEnsureSessionCookie).toHaveBeenCalledOnce()
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/api/auth/token',
+        expect.objectContaining({
+          body: JSON.stringify({ workspace_id: 'workspace-123' })
+        })
+      )
+      expect(store.getUnifiedToken()).toBe('workspace-token-abc')
+      expect(store.workspaceToken).toBeNull()
       expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+    })
+
+    it('does not retry an old workspace request with a new workspace token', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-a-token',
+              workspace: { ...mockWorkspace, id: 'workspace-a' }
+            })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-b-token',
+              workspace: { ...mockWorkspace, id: 'workspace-b' }
+            })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-a')
+      await store.switchWorkspace('workspace-b')
+
+      await expect(
+        store.remintUnifiedOnce('workspace-a-token')
+      ).resolves.toBeNull()
+      expect(store.getUnifiedToken()).toBe('workspace-b-token')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
     it('bumps the rotation trigger exactly once on a refresh re-mint', async () => {

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -2266,6 +2266,49 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
+    it('evicts an expired unified-token context past the grace window on the next mint', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const base = Date.now()
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...personalTokenResponse,
+              token: 'unified-token-1',
+              expires_at: new Date(base + 3600 * 1000).toISOString()
+            })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...personalTokenResponse,
+              token: 'unified-token-2',
+              expires_at: new Date(base + 10 * 3600 * 1000).toISOString()
+            })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+
+      // Jump well past token-1's expiry plus the retention grace window without
+      // firing the scheduled refresh timer.
+      vi.setSystemTime(base + 2 * 3600 * 1000)
+
+      // Re-minting the current token writes token-2 and prunes the stale entry.
+      expect(await store.remintUnifiedOnce('unified-token-1')).toBe(
+        'unified-token-2'
+      )
+
+      // token-1's context is gone: a late 401 replay for it now fails closed
+      // instead of resolving to the fresh token off a never-evicted entry.
+      expect(await store.remintUnifiedOnce('unified-token-1')).toBeNull()
+    })
+
     it('ignores a stale unified mint failure after account state is cleared', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-a')

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -95,7 +95,7 @@ describe('useWorkspaceAuthStore', () => {
     sessionStorage.clear()
     mockTeamWorkspacesEnabled.value = true
     mockUnifiedCloudAuthEnabled.value = false
-    mockCurrentUser.value = null
+    mockCurrentUser.value = { uid: 'user-a' }
   })
 
   afterEach(() => {
@@ -133,6 +133,7 @@ describe('useWorkspaceAuthStore', () => {
         WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
         futureExpiry.toString()
       )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, 'user-a')
 
       const store = useWorkspaceAuthStore()
       const { currentWorkspace, workspaceToken } = storeToRefs(store)
@@ -144,12 +145,52 @@ describe('useWorkspaceAuthStore', () => {
       expect(workspaceToken.value).toBe('valid-token')
     })
 
+    it('rejects session data owned by a different user', () => {
+      const futureExpiry = Date.now() + 3600 * 1000
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+        JSON.stringify(mockWorkspaceWithRole)
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'user-a-token')
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
+        futureExpiry.toString()
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, 'user-a')
+      mockCurrentUser.value = { uid: 'user-b' }
+
+      const store = useWorkspaceAuthStore()
+
+      expect(store.initializeFromSession()).toBe(false)
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBeNull()
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.OWNER_UID)
+      ).toBeNull()
+    })
+
     it('returns false when sessionStorage is empty', () => {
       const store = useWorkspaceAuthStore()
 
       const result = store.initializeFromSession()
 
       expect(result).toBe(false)
+    })
+
+    it('rejects legacy session data without an owner uid', () => {
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+        JSON.stringify(mockWorkspaceWithRole)
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'legacy-token')
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
+        (Date.now() + 3600 * 1000).toString()
+      )
+
+      const store = useWorkspaceAuthStore()
+
+      expect(store.initializeFromSession()).toBe(false)
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBeNull()
     })
 
     it('returns false and clears storage when token is expired', () => {
@@ -240,6 +281,32 @@ describe('useWorkspaceAuthStore', () => {
       expect(isAuthenticated.value).toBe(true)
     })
 
+    it('discards a token exchange that resolves after the user changes', async () => {
+      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      let resolveResponse: (value: unknown) => void = () => {}
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveResponse = resolve
+          })
+        )
+      )
+
+      const store = useWorkspaceAuthStore()
+      const switchPromise = store.switchWorkspace('workspace-123')
+      mockCurrentUser.value = { uid: 'user-b' }
+      resolveResponse({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse)
+      })
+
+      await switchPromise
+
+      expect(store.workspaceToken).toBeNull()
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBeNull()
+    })
+
     it('stores workspace data in sessionStorage', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
       vi.stubGlobal(
@@ -262,6 +329,9 @@ describe('useWorkspaceAuthStore', () => {
       )
       expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.EXPIRES_AT)).toBe(
         expectedExpiresAtMs(mockTokenResponse.expires_at)
+      )
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.OWNER_UID)).toBe(
+        'user-a'
       )
     })
 
@@ -616,6 +686,36 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
 
+    it('re-mints instead of returning a token owned by another user', async () => {
+      mockGetIdToken
+        .mockResolvedValueOnce('firebase-token-a')
+        .mockResolvedValueOnce('firebase-token-b')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockTokenResponse)
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-token-b'
+            })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-123')
+      mockCurrentUser.value = { uid: 'user-b' }
+
+      const header = await store.ensureWorkspaceAuthHeader('workspace-123')
+
+      expect(header).toEqual({ Authorization: 'Bearer workspace-token-b' })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
     it('mints a token for the preferred workspace when none exists', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
       vi.stubGlobal(
@@ -676,6 +776,51 @@ describe('useWorkspaceAuthStore', () => {
 
       expect(header).toEqual({ Authorization: 'Bearer workspace-token-abc' })
       expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not give a previous user waiter the next user token', async () => {
+      mockGetIdToken.mockImplementation(() =>
+        Promise.resolve(`firebase-${mockCurrentUser.value?.uid}`)
+      )
+      let resolvePreviousResponse: (value: unknown) => void = () => {}
+      const mockFetch = vi
+        .fn()
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolvePreviousResponse = resolve
+          })
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...mockTokenResponse,
+              token: 'workspace-token-b'
+            })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const previousHeader = store.ensureWorkspaceAuthHeader('workspace-123')
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+
+      mockCurrentUser.value = { uid: 'user-b' }
+      store.clearWorkspaceContext()
+      await store.switchWorkspace('workspace-123')
+
+      resolvePreviousResponse({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockTokenResponse,
+            token: 'workspace-token-a'
+          })
+      })
+
+      await expect(previousHeader).resolves.toBeNull()
+      expect(store.workspaceToken).toBe('workspace-token-b')
+      expect(store.currentWorkspace?.id).toBe('workspace-123')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
     it('returns null (never a downgrade) when recovery fails transiently', async () => {
@@ -821,7 +966,7 @@ describe('useWorkspaceAuthStore', () => {
       const { currentWorkspace } = storeToRefs(store)
       await store.switchWorkspace('workspace-123')
 
-      mockCurrentUser.value = { uid: 'user-1' }
+      mockCurrentUser.value = { uid: 'user-a' }
       mockGetIdToken.mockResolvedValue(undefined)
 
       const token = await store.ensureWorkspaceToken('workspace-999')
@@ -1684,6 +1829,35 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
 
+    it('re-mints when the existing unified token belongs to another user', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken
+        .mockResolvedValueOnce('firebase-token-a')
+        .mockResolvedValueOnce('firebase-token-b')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(personalTokenResponse)
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...personalTokenResponse, token: 'unified-b' })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+      mockCurrentUser.value = { uid: 'user-b' }
+
+      const result = await store.mintAtLogin()
+
+      expect(result).toBe(true)
+      expect(store.unifiedToken).toBe('unified-b')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
     it('arms a refresh at expires_at - buffer and re-mints from the parsed expiry (no hardcoded TTL)', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
@@ -1793,7 +1967,7 @@ describe('useWorkspaceAuthStore', () => {
       await store.mintAtLogin()
       expect(mockFetch).toHaveBeenCalledTimes(1)
 
-      const result = await store.remintUnifiedOnce()
+      const result = await store.remintUnifiedOnce('unified-token-1')
 
       // Exactly one re-mint attempt — the primitive does not retry.
       expect(mockFetch).toHaveBeenCalledTimes(2)
@@ -1832,7 +2006,7 @@ describe('useWorkspaceAuthStore', () => {
 
       await store.mintAtLogin()
 
-      const result = await store.remintUnifiedOnce()
+      const result = await store.remintUnifiedOnce('unified-token-1')
 
       expect(result).toBeNull()
       expect(mockToastAdd).not.toHaveBeenCalled()
@@ -1847,16 +2021,73 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
 
-      const result = await store.remintUnifiedOnce()
+      const result = await store.remintUnifiedOnce('unified-token-1')
 
       expect(result).toBeNull()
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
-    it('discards a stale concurrent mint but hands the discarded caller the winning token to retry with', async () => {
+    it('does not retry an old account request with the current account token', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken
+        .mockResolvedValueOnce('firebase-token-a')
+        .mockResolvedValueOnce('firebase-token-b')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(personalTokenResponse)
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...personalTokenResponse, token: 'unified-b' })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+      mockCurrentUser.value = { uid: 'user-b' }
+      await store.mintAtLogin()
+
+      const result = await store.remintUnifiedOnce('unified-token-1')
+
+      expect(result).toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('ignores a stale unified mint failure after account state is cleared', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-a')
+      let resolveResponse: (value: unknown) => void = () => {}
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockReturnValue(
+          new Promise((resolve) => {
+            resolveResponse = resolve
+          })
+        )
+      )
+
+      const store = useWorkspaceAuthStore()
+      const mintPromise = store.mintAtLogin()
+      store.clearWorkspaceContext()
+      resolveResponse({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: () => Promise.resolve({ message: 'old account' })
+      })
+
+      await expect(mintPromise).resolves.toBe(false)
+      expect(store.unifiedToken).toBeNull()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('coalesces concurrent re-mints and returns the winning token to every caller', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockFetch = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(personalTokenResponse)
       })
@@ -1867,36 +2098,56 @@ describe('useWorkspaceAuthStore', () => {
 
       await store.mintAtLogin()
 
-      // Re-mint A hangs (it will resolve last and must be discarded as stale).
-      let resolveStale: (value: unknown) => void = () => {}
+      let resolveRemint: (value: unknown) => void = () => {}
       mockFetch.mockReturnValueOnce(
         new Promise((resolve) => {
-          resolveStale = resolve
+          resolveRemint = resolve
         })
       )
-      const remintA = store.remintUnifiedOnce()
+      const first = store.remintUnifiedOnce('unified-token-1')
+      const second = store.remintUnifiedOnce('unified-token-1')
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
 
-      // Re-mint B starts later and resolves first with the newest token.
-      mockFetch.mockResolvedValueOnce({
+      resolveRemint({
         ok: true,
         json: () =>
           Promise.resolve({ ...personalTokenResponse, token: 'latest-token' })
       })
-      await store.remintUnifiedOnce()
 
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        'latest-token',
+        'latest-token'
+      ])
       expect(unifiedToken.value).toBe('latest-token')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
 
-      // The stale re-mint resolves last and must not clobber the latest token.
-      // It returns the slot's winning token, not its own discarded mint, so the
-      // burst's discarded caller retries with the fresh token instead of a 401.
-      resolveStale({
-        ok: true,
-        json: () =>
-          Promise.resolve({ ...personalTokenResponse, token: 'stale-token' })
-      })
+    it('reuses a same-user burst winner for a later stale 401', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(personalTokenResponse)
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...personalTokenResponse, token: 'winner-token' })
+        })
+      vi.stubGlobal('fetch', mockFetch)
 
-      expect(await remintA).toBe('latest-token')
-      expect(unifiedToken.value).toBe('latest-token')
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+
+      expect(await store.remintUnifiedOnce('unified-token-1')).toBe(
+        'winner-token'
+      )
+      expect(await store.remintUnifiedOnce('unified-token-1')).toBe(
+        'winner-token'
+      )
+      expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
     it('clears unifiedToken and stops the unified timer on clearWorkspaceContext', async () => {
@@ -1933,7 +2184,7 @@ describe('useWorkspaceAuthStore', () => {
       const { unifiedToken } = storeToRefs(store)
 
       await store.mintAtLogin()
-      await store.remintUnifiedOnce()
+      await store.remintUnifiedOnce('unified-token-1')
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
       expect(mockFetch).not.toHaveBeenCalled()
@@ -2149,7 +2400,7 @@ describe('useWorkspaceAuthStore', () => {
       const store = useWorkspaceAuthStore()
 
       await store.mintAtLogin()
-      await store.remintUnifiedOnce()
+      await store.remintUnifiedOnce('unified-token-1')
       await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
       expect(mockToastAdd).not.toHaveBeenCalled()

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -11,6 +11,7 @@ import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 const mockGetIdToken = vi.fn()
 const mockNotifyTokenRefreshed = vi.fn()
 const mockToastAdd = vi.fn()
+const mockEnsureSessionCookie = vi.fn()
 const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
   value: null
 }))
@@ -29,6 +30,12 @@ vi.mock('@/stores/authStore', () => ({
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace
+  })
+}))
+
+vi.mock('@/platform/auth/session/useSessionCookie', () => ({
+  useSessionCookie: () => ({
+    ensureSessionCookie: mockEnsureSessionCookie
   })
 }))
 
@@ -96,6 +103,7 @@ describe('useWorkspaceAuthStore', () => {
     mockTeamWorkspacesEnabled.value = true
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
+    mockEnsureSessionCookie.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -279,6 +287,47 @@ describe('useWorkspaceAuthStore', () => {
       expect(currentWorkspace.value).toEqual(mockWorkspaceWithRole)
       expect(workspaceToken.value).toBe('workspace-token-abc')
       expect(isAuthenticated.value).toBe(true)
+    })
+
+    it('waits for the matching session cookie before exchanging a workspace token', async () => {
+      let confirmSession: () => void = () => {}
+      mockEnsureSessionCookie.mockReturnValue(
+        new Promise<void>((resolve) => {
+          confirmSession = resolve
+        })
+      )
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const switchPromise = store.switchWorkspace('workspace-123')
+      await Promise.resolve()
+
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      confirmSession()
+      await switchPromise
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+      expect(store.workspaceToken).toBe('workspace-token-abc')
+    })
+
+    it('does not exchange a workspace token when session creation fails', async () => {
+      mockEnsureSessionCookie.mockRejectedValue(new Error('session denied'))
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+
+      await expect(store.switchWorkspace('workspace-123')).rejects.toThrow(
+        'session denied'
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(store.workspaceToken).toBeNull()
     })
 
     it('discards a token exchange that resolves after the user changes', async () => {

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -43,6 +43,11 @@ const MAX_SCHEDULED_REFRESH_RETRIES = 3
 
 const RECOVERY_COOLDOWN_MS = 5000
 
+// Retain expired unified-token contexts briefly so a concurrent reactive-401
+// replay for the just-rotated token still resolves, then evict them so a
+// long-lived session cannot grow the context Map unbounded.
+const ISSUED_TOKEN_CONTEXT_GRACE_MS = 5 * 60 * 1000
+
 export class WorkspaceAuthError extends Error {
   constructor(
     message: string,
@@ -115,7 +120,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   const unifiedTokenOwnerUid = ref<string | null>(null)
   const issuedUnifiedTokenContexts = new Map<
     string,
-    { ownerUid: string; targetKey: string }
+    { ownerUid: string; targetKey: string; expiresAt: number }
   >()
 
   // Timer state
@@ -732,6 +737,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }, delay)
   }
 
+  function pruneExpiredUnifiedTokenContexts(now: number): void {
+    for (const [token, context] of issuedUnifiedTokenContexts) {
+      if (context.expiresAt + ISSUED_TOKEN_CONTEXT_GRACE_MS < now) {
+        issuedUnifiedTokenContexts.delete(token)
+      }
+    }
+  }
+
   function clearUnifiedContext(): void {
     unifiedRefreshRequestId++
     stopUnifiedRefreshTimer()
@@ -775,8 +788,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     unifiedTokenOwnerUid.value = mintedToken.ownerUid
     issuedUnifiedTokenContexts.set(mintedToken.token, {
       ownerUid: mintedToken.ownerUid,
-      targetKey: unifiedTargetKey(target)
+      targetKey: unifiedTargetKey(target),
+      expiresAt: mintedToken.expiresAt
     })
+    pruneExpiredUnifiedTokenContexts(Date.now())
     unifiedTarget = target
     scheduleUnifiedRefresh(mintedToken.expiresAt)
     return true

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -57,6 +57,7 @@ interface MintedToken {
   token: string
   expiresAt: number
   workspace: WorkspaceWithRole
+  ownerUid: string
 }
 
 const PERMANENT_AUTH_ERROR_CODES = new Set([
@@ -104,6 +105,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   const currentWorkspace = shallowRef<WorkspaceWithRole | null>(null)
   const workspaceToken = ref<string | null>(null)
   const workspaceTokenExpiresAt = ref<number | null>(null)
+  const workspaceTokenOwnerUid = ref<string | null>(null)
   const isLoading = ref(false)
   const error = ref<Error | null>(null)
 
@@ -111,6 +113,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   // populated by the unified mint lifecycle below but read by no consumer until
   // the PR 3 consumer flip, so it cannot change which token requests carry.
   const unifiedToken = ref<string | null>(null)
+  const unifiedTokenOwnerUid = ref<string | null>(null)
+  const issuedUnifiedTokenOwners = new Map<string, string>()
 
   // Timer state
   let refreshTimerId: ReturnType<typeof setTimeout> | null = null
@@ -128,8 +132,16 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
   // Getters
   const isAuthenticated = computed(
-    () => currentWorkspace.value !== null && workspaceToken.value !== null
+    () => currentWorkspace.value !== null && hasValidWorkspaceToken()
   )
+
+  function currentUserUid(): string | null {
+    return useAuthStore().currentUser?.uid ?? null
+  }
+
+  function isCurrentUser(ownerUid: string): boolean {
+    return currentUserUid() === ownerUid
+  }
 
   // Private helpers
   function stopRefreshTimer(): void {
@@ -201,14 +213,21 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     return true
   }
 
-  function isStaleWorkspaceRequest(capturedRequestId: number): boolean {
-    return capturedRequestId !== refreshRequestId
+  function isStaleWorkspaceRequest(
+    capturedRequestId: number,
+    ownerUid?: string | null
+  ): boolean {
+    return (
+      capturedRequestId !== refreshRequestId ||
+      (ownerUid !== undefined && ownerUid !== null && !isCurrentUser(ownerUid))
+    )
   }
 
   function persistToSession(
     workspace: WorkspaceWithRole,
     token: string,
-    expiresAt: number
+    expiresAt: number,
+    ownerUid: string
   ): void {
     try {
       sessionStorage.setItem(
@@ -220,6 +239,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
         WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
         expiresAt.toString()
       )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, ownerUid)
     } catch {
       console.warn('Failed to persist workspace context to sessionStorage')
     }
@@ -230,6 +250,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       sessionStorage.removeItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
       sessionStorage.removeItem(WORKSPACE_STORAGE_KEYS.TOKEN)
       sessionStorage.removeItem(WORKSPACE_STORAGE_KEYS.EXPIRES_AT)
+      sessionStorage.removeItem(WORKSPACE_STORAGE_KEYS.OWNER_UID)
     } catch {
       console.warn('Failed to clear workspace context from sessionStorage')
     }
@@ -257,8 +278,16 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       const expiresAtStr = sessionStorage.getItem(
         WORKSPACE_STORAGE_KEYS.EXPIRES_AT
       )
+      const ownerUid = sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.OWNER_UID)
 
-      if (!workspaceJson || !token || !expiresAtStr) {
+      if (
+        !workspaceJson ||
+        !token ||
+        !expiresAtStr ||
+        !ownerUid ||
+        !isCurrentUser(ownerUid)
+      ) {
+        clearSessionStorage()
         return false
       }
 
@@ -280,6 +309,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       currentWorkspace.value = parseResult.data
       workspaceToken.value = token
       workspaceTokenExpiresAt.value = expiresAt
+      workspaceTokenOwnerUid.value = ownerUid
       error.value = null
 
       scheduleTokenRefresh(expiresAt)
@@ -299,6 +329,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
    * each other's gates.
    */
   async function requestToken(workspaceId?: string): Promise<MintedToken> {
+    const ownerUid = currentUserUid()
+    if (!ownerUid) {
+      throw new WorkspaceAuthError(
+        t('workspaceAuth.errors.notAuthenticated'),
+        'NOT_AUTHENTICATED'
+      )
+    }
+
     const firebaseToken = await useAuthStore().getIdToken()
     if (!firebaseToken) {
       throw new WorkspaceAuthError(
@@ -372,7 +410,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     return {
       token: data.token,
       expiresAt,
-      workspace: { ...data.workspace, role: data.role }
+      workspace: { ...data.workspace, role: data.role },
+      ownerUid
     }
   }
 
@@ -382,15 +421,17 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }
 
     const capturedRequestId = refreshRequestId
+    const capturedOwnerUid = currentUserUid()
 
     inFlightSwitchCount += 1
     isLoading.value = true
     error.value = null
 
     try {
-      const { token, expiresAt, workspace } = await requestToken(workspaceId)
+      const { token, expiresAt, workspace, ownerUid } =
+        await requestToken(workspaceId)
 
-      if (isStaleWorkspaceRequest(capturedRequestId)) {
+      if (isStaleWorkspaceRequest(capturedRequestId, ownerUid)) {
         console.warn(
           'Aborting stale workspace switch: workspace context changed before commit'
         )
@@ -403,13 +444,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       currentWorkspace.value = workspace
       workspaceToken.value = token
       workspaceTokenExpiresAt.value = expiresAt
+      workspaceTokenOwnerUid.value = ownerUid
       scheduledRefreshRetryCount = 0
       recoveryCooldownUntil = 0
 
-      persistToSession(workspace, token, expiresAt)
+      persistToSession(workspace, token, expiresAt, ownerUid)
       scheduleTokenRefresh(expiresAt)
     } catch (err) {
-      if (isStaleWorkspaceRequest(capturedRequestId)) {
+      if (isStaleWorkspaceRequest(capturedRequestId, capturedOwnerUid)) {
         console.warn(
           'Aborting stale workspace switch: workspace context changed before error commit',
           err
@@ -502,9 +544,12 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       return null
     }
 
+    const ownerUid = currentUserUid()
+    if (!ownerUid) return null
     const targetWorkspaceId = preferredWorkspaceId ?? currentWorkspace.value?.id
 
     while (true) {
+      if (!isCurrentUser(ownerUid)) return null
       if (hasValidTokenForWorkspace(targetWorkspaceId)) {
         return workspaceToken.value
       }
@@ -512,6 +557,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // Join any in-flight mint and re-check rather than launching our own.
       if (inFlightSwitchPromise) {
         await inFlightSwitchPromise.catch(() => {})
+        if (!isCurrentUser(ownerUid)) return null
         continue
       }
 
@@ -522,10 +568,12 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       try {
         await switchWorkspace(targetWorkspaceId)
       } catch (err) {
+        if (!isCurrentUser(ownerUid)) return null
         handleRecoveryFailure(err, targetWorkspaceId)
         return null
       }
 
+      if (!isCurrentUser(ownerUid)) return null
       if (hasValidTokenForWorkspace(targetWorkspaceId)) {
         return workspaceToken.value
       }
@@ -634,7 +682,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   // Mint body the unified session re-mints against: `{}` = personal (resolved
   // server-side from the Firebase identity), `{ workspace_id }` = explicit.
   type UnifiedMintBody = Record<string, never> | { workspace_id: string }
+  interface InFlightUnifiedMint {
+    ownerUid: string | null
+    targetKey: string
+    promise: Promise<boolean>
+  }
+
   let unifiedTarget: UnifiedMintBody | null = null
+  let inFlightUnifiedMint: InFlightUnifiedMint | null = null
 
   function personalWorkspaceTarget(): UnifiedMintBody {
     return {}
@@ -642,6 +697,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
   function currentUnifiedTarget(): UnifiedMintBody | null {
     return unifiedTarget
+  }
+
+  function unifiedTargetKey(target: UnifiedMintBody): string {
+    return 'workspace_id' in target ? target.workspace_id : 'personal'
   }
 
   function stopUnifiedRefreshTimer(): void {
@@ -666,27 +725,66 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     unifiedRefreshRequestId++
     stopUnifiedRefreshTimer()
     unifiedToken.value = null
+    unifiedTokenOwnerUid.value = null
+    issuedUnifiedTokenOwners.clear()
     unifiedTarget = null
+    inFlightUnifiedMint = null
   }
 
-  async function mintUnified(target: UnifiedMintBody): Promise<boolean> {
-    // Stale-guard: bump and capture the request id so a 401-driven re-mint and
-    // a timer-driven re-mint cannot clobber each other's write — the last mint
-    // to start wins.
+  async function performUnifiedMint(
+    target: UnifiedMintBody,
+    capturedOwnerUid: string | null
+  ): Promise<boolean> {
     const capturedRequestId = ++unifiedRefreshRequestId
     const workspaceId =
       'workspace_id' in target ? target.workspace_id : undefined
 
-    const { token, expiresAt } = await requestToken(workspaceId)
+    let mintedToken: MintedToken
+    try {
+      mintedToken = await requestToken(workspaceId)
+    } catch (err) {
+      if (
+        capturedRequestId !== unifiedRefreshRequestId ||
+        capturedOwnerUid === null ||
+        !isCurrentUser(capturedOwnerUid)
+      ) {
+        return false
+      }
+      throw err
+    }
 
-    if (capturedRequestId !== unifiedRefreshRequestId) {
+    if (
+      capturedRequestId !== unifiedRefreshRequestId ||
+      !isCurrentUser(mintedToken.ownerUid)
+    ) {
       return false
     }
 
-    unifiedToken.value = token
+    unifiedToken.value = mintedToken.token
+    unifiedTokenOwnerUid.value = mintedToken.ownerUid
+    issuedUnifiedTokenOwners.set(mintedToken.token, mintedToken.ownerUid)
     unifiedTarget = target
-    scheduleUnifiedRefresh(expiresAt)
+    scheduleUnifiedRefresh(mintedToken.expiresAt)
     return true
+  }
+
+  function mintUnified(target: UnifiedMintBody): Promise<boolean> {
+    const ownerUid = currentUserUid()
+    const targetKey = unifiedTargetKey(target)
+    if (
+      inFlightUnifiedMint?.ownerUid === ownerUid &&
+      inFlightUnifiedMint.targetKey === targetKey
+    ) {
+      return inFlightUnifiedMint.promise
+    }
+
+    const promise = performUnifiedMint(target, ownerUid).finally(() => {
+      if (inFlightUnifiedMint?.promise === promise) {
+        inFlightUnifiedMint = null
+      }
+    })
+    inFlightUnifiedMint = { ownerUid, targetKey, promise }
+    return promise
   }
 
   async function refreshUnified(): Promise<void> {
@@ -710,7 +808,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // Guard the toast on a live token so concurrent permanent failures across
       // the proactive + reactive paths alarm the user once, not once per caller.
       if (isPermanentAuthError(err)) {
-        if (unifiedToken.value) surfacePermanentAuthError(err)
+        if (getUnifiedToken()) surfacePermanentAuthError(err)
         clearUnifiedContext()
       } else {
         console.warn('Unified token refresh failed:', err)
@@ -722,7 +820,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     if (!flags.unifiedCloudAuthEnabled) {
       return false
     }
-    if (unifiedToken.value) {
+    if (getUnifiedToken()) {
       return true
     }
     try {
@@ -737,26 +835,33 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }
   }
 
-  const remintUnifiedOnce = async (): Promise<string | null> => {
+  const remintUnifiedOnce = async (
+    expectedToken: string
+  ): Promise<string | null> => {
     if (!flags.unifiedCloudAuthEnabled) {
       return null
     }
     const target = currentUnifiedTarget()
-    if (!target) {
+    const ownerUid = currentUserUid()
+    const currentToken = getUnifiedToken()
+    if (
+      !target ||
+      !ownerUid ||
+      !currentToken ||
+      issuedUnifiedTokenOwners.get(expectedToken) !== ownerUid
+    ) {
       return null
     }
+    if (expectedToken !== currentToken) return currentToken
     try {
-      // On a concurrent burst the stale-guard discards all but the winning
-      // mint. Return the slot's current token (the winner's, once it lands)
-      // rather than this call's own success, so a discarded caller can still
-      // retry with it instead of burning its one-shot retry on a fresh 401.
-      await mintUnified(target)
-      return unifiedToken.value ?? null
+      const minted = await mintUnified(target)
+      if (!minted) return null
+      return getUnifiedToken() ?? null
     } catch (err) {
       // Mirror refreshUnified: a permanent failure tears down the session;
       // guard the toast on a live token so a concurrent burst surfaces it once.
       if (isPermanentAuthError(err)) {
-        if (unifiedToken.value) surfacePermanentAuthError(err)
+        if (getUnifiedToken()) surfacePermanentAuthError(err)
         clearUnifiedContext()
       } else {
         console.warn('Unified reactive re-mint failed:', err)
@@ -766,7 +871,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   function getWorkspaceAuthHeader(): AuthHeader | null {
-    if (!workspaceToken.value) {
+    if (!hasValidWorkspaceToken()) {
       return null
     }
     return {
@@ -775,15 +880,27 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   function getWorkspaceToken(): string | undefined {
-    return workspaceToken.value ?? undefined
+    return hasValidWorkspaceToken()
+      ? (workspaceToken.value ?? undefined)
+      : undefined
   }
 
   function hasValidWorkspaceToken(): boolean {
     return (
       workspaceToken.value !== null &&
       workspaceTokenExpiresAt.value !== null &&
-      workspaceTokenExpiresAt.value > Date.now()
+      workspaceTokenExpiresAt.value > Date.now() &&
+      workspaceTokenOwnerUid.value !== null &&
+      isCurrentUser(workspaceTokenOwnerUid.value)
     )
+  }
+
+  function getUnifiedToken(): string | undefined {
+    return unifiedToken.value !== null &&
+      unifiedTokenOwnerUid.value !== null &&
+      isCurrentUser(unifiedTokenOwnerUid.value)
+      ? unifiedToken.value
+      : undefined
   }
 
   function clearWorkspaceContext(): void {
@@ -792,6 +909,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     currentWorkspace.value = null
     workspaceToken.value = null
     workspaceTokenExpiresAt.value = null
+    workspaceTokenOwnerUid.value = null
     scheduledRefreshRetryCount = 0
     recoveryCooldownUntil = 0
     // refreshRequestId bump above aborts any in-flight switch before it commits.
@@ -824,6 +942,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     ensureWorkspaceAuthHeader,
     ensureWorkspaceToken,
     getWorkspaceToken,
+    getUnifiedToken,
     clearWorkspaceContext
   }
 })

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -802,6 +802,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   async function switchUnifiedWorkspace(workspaceId: string): Promise<void> {
+    clearUnifiedContext()
     const { useSessionCookie } =
       await import('@/platform/auth/session/useSessionCookie')
     await useSessionCookie().ensureSessionCookie()

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -109,12 +109,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   const isLoading = ref(false)
   const error = ref<Error | null>(null)
 
-  // Unified Cloud-JWT slot (flag-gated: unified_cloud_auth). Dormant in this PR:
-  // populated by the unified mint lifecycle below but read by no consumer until
-  // the PR 3 consumer flip, so it cannot change which token requests carry.
+  // Unified Cloud-JWT slot (flag-gated: unified_cloud_auth). Kept separate from
+  // workspaceToken so the legacy and unified refresh lifecycles cannot collide.
   const unifiedToken = ref<string | null>(null)
   const unifiedTokenOwnerUid = ref<string | null>(null)
-  const issuedUnifiedTokenOwners = new Map<string, string>()
+  const issuedUnifiedTokenContexts = new Map<
+    string,
+    { ownerUid: string; targetKey: string }
+  >()
 
   // Timer state
   let refreshTimerId: ReturnType<typeof setTimeout> | null = null
@@ -473,6 +475,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   function switchWorkspace(workspaceId: string): Promise<void> {
+    if (flags.unifiedCloudAuthEnabled) {
+      return switchUnifiedWorkspace(workspaceId)
+    }
+
     const promise = performSwitchWorkspace(workspaceId)
     inFlightSwitchPromise = promise
     void promise
@@ -678,8 +684,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
   // --- Unified Cloud-JWT lifecycle (flag-gated: unified_cloud_auth) ----------
   //
-  // A parallel mint/refresh lifecycle that writes to the dormant `unifiedToken`
-  // slot. The legacy switchWorkspace/refreshToken machinery above is untouched.
+  // A parallel mint/refresh lifecycle that writes to `unifiedToken`. The legacy
+  // refresh machinery above remains isolated behind its feature flag.
   //
   // TODO(unified): call forgetRevokedActiveWorkspace on
   // ACCESS_DENIED/WORKSPACE_NOT_FOUND here too, with the PR-3 consumer flip.
@@ -731,7 +737,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     stopUnifiedRefreshTimer()
     unifiedToken.value = null
     unifiedTokenOwnerUid.value = null
-    issuedUnifiedTokenOwners.clear()
+    issuedUnifiedTokenContexts.clear()
     unifiedTarget = null
     inFlightUnifiedMint = null
   }
@@ -767,7 +773,10 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
     unifiedToken.value = mintedToken.token
     unifiedTokenOwnerUid.value = mintedToken.ownerUid
-    issuedUnifiedTokenOwners.set(mintedToken.token, mintedToken.ownerUid)
+    issuedUnifiedTokenContexts.set(mintedToken.token, {
+      ownerUid: mintedToken.ownerUid,
+      targetKey: unifiedTargetKey(target)
+    })
     unifiedTarget = target
     scheduleUnifiedRefresh(mintedToken.expiresAt)
     return true
@@ -790,6 +799,15 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     })
     inFlightUnifiedMint = { ownerUid, targetKey, promise }
     return promise
+  }
+
+  async function switchUnifiedWorkspace(workspaceId: string): Promise<void> {
+    const { useSessionCookie } =
+      await import('@/platform/auth/session/useSessionCookie')
+    await useSessionCookie().ensureSessionCookie()
+    if (!(await mintUnified({ workspace_id: workspaceId }))) {
+      throw new Error('Workspace identity changed during switch')
+    }
   }
 
   async function refreshUnified(): Promise<void> {
@@ -849,11 +867,13 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     const target = currentUnifiedTarget()
     const ownerUid = currentUserUid()
     const currentToken = getUnifiedToken()
+    const expectedContext = issuedUnifiedTokenContexts.get(expectedToken)
     if (
       !target ||
       !ownerUid ||
       !currentToken ||
-      issuedUnifiedTokenOwners.get(expectedToken) !== ownerUid
+      expectedContext?.ownerUid !== ownerUid ||
+      expectedContext.targetKey !== unifiedTargetKey(target)
     ) {
       return null
     }

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -428,6 +428,11 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     error.value = null
 
     try {
+      const { useSessionCookie } =
+        await import('@/platform/auth/session/useSessionCookie')
+      await useSessionCookie().ensureSessionCookie()
+      if (isStaleWorkspaceRequest(capturedRequestId, capturedOwnerUid)) return
+
       const { token, expiresAt, workspace, ownerUid } =
         await requestToken(workspaceId)
 

--- a/src/platform/workspace/workspaceConstants.ts
+++ b/src/platform/workspace/workspaceConstants.ts
@@ -3,6 +3,7 @@ export const WORKSPACE_STORAGE_KEYS = {
   CURRENT_WORKSPACE: 'Comfy.Workspace.Current',
   TOKEN: 'Comfy.Workspace.Token',
   EXPIRES_AT: 'Comfy.Workspace.ExpiresAt',
+  OWNER_UID: 'Comfy.Workspace.OwnerUid',
   // localStorage key (persists across browser sessions)
   LAST_WORKSPACE_ID: 'Comfy.Workspace.LastWorkspaceId'
 } as const

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -27,16 +27,28 @@ const mockGetWorkspaceToken = vi.fn().mockReturnValue(undefined)
 const mockClearWorkspaceContext = vi.fn()
 const mockMintAtLogin = vi.fn().mockResolvedValue(false)
 let mockUnifiedToken: string | null = null
+const mockResetForIdentityChange = vi.fn()
+let mockActiveWorkspaceId: string | null = null
 
 vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
   useWorkspaceAuthStore: () => ({
     getWorkspaceAuthHeader: mockWorkspaceAuthHeader,
     getWorkspaceToken: mockGetWorkspaceToken,
+    getUnifiedToken: () => mockUnifiedToken ?? undefined,
     clearWorkspaceContext: mockClearWorkspaceContext,
     mintAtLogin: mockMintAtLogin,
     get unifiedToken() {
       return mockUnifiedToken
     }
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    get activeWorkspaceId() {
+      return mockActiveWorkspaceId
+    },
+    resetForIdentityChange: mockResetForIdentityChange
   })
 }))
 
@@ -121,6 +133,7 @@ describe('auth token priority chain', () => {
     mockFeatureFlags.teamWorkspacesEnabled = false
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null
+    mockActiveWorkspaceId = null
     mockWorkspaceAuthHeader.mockReturnValue(null)
     mockGetWorkspaceToken.mockReturnValue(undefined)
     mockMintAtLogin.mockResolvedValue(false)
@@ -230,6 +243,36 @@ describe('auth token priority chain', () => {
       authStateCallback(null)
       expect(mockMintAtLogin).not.toHaveBeenCalled()
       expect(mockClearWorkspaceContext).toHaveBeenCalled()
+    })
+
+    it('clears account-scoped state before minting for a different user', () => {
+      mockClearWorkspaceContext.mockClear()
+      mockResetForIdentityChange.mockClear()
+      mockMintAtLogin.mockClear()
+      const nextUser = {
+        ...mockUser,
+        uid: 'different-user-id',
+        email: 'different@example.com'
+      } as MockUser
+
+      authStateCallback(nextUser)
+
+      expect(mockClearWorkspaceContext).toHaveBeenCalledOnce()
+      expect(mockResetForIdentityChange).toHaveBeenCalledOnce()
+      expect(mockMintAtLogin).toHaveBeenCalledOnce()
+      expect(
+        mockClearWorkspaceContext.mock.invocationCallOrder[0]
+      ).toBeLessThan(mockMintAtLogin.mock.invocationCallOrder[0])
+    })
+
+    it('keeps account-scoped state for a repeated callback with the same uid', () => {
+      mockClearWorkspaceContext.mockClear()
+      mockResetForIdentityChange.mockClear()
+
+      authStateCallback({ ...mockUser } as MockUser)
+
+      expect(mockClearWorkspaceContext).not.toHaveBeenCalled()
+      expect(mockResetForIdentityChange).not.toHaveBeenCalled()
     })
   })
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -528,6 +528,27 @@ describe('useAuthStore', () => {
       expect(token).toBeUndefined()
     })
 
+    it('discards a token that resolves after the account changes', async () => {
+      let resolveToken: (token: string) => void = () => {}
+      mockUser.getIdToken.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveToken = resolve
+        })
+      )
+      const tokenPromise = store.getIdToken()
+      const nextUser = {
+        ...mockUser,
+        uid: 'different-user-id',
+        email: 'different@example.com',
+        getIdToken: vi.fn().mockResolvedValue('different-user-token')
+      } as MockUser
+
+      authStateCallback(nextUser)
+      resolveToken('old-user-token')
+
+      await expect(tokenPromise).resolves.toBeUndefined()
+    })
+
     it('should return null for token after login and logout sequence', async () => {
       // Setup mock for login
       const mockUserCredential = { user: mockUser }

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -313,6 +313,37 @@ describe('useAuthStore', () => {
     await store.login('test@example.com', 'correct-password')
   })
 
+  describe('fetchBalance identity isolation', () => {
+    it('discards a late balance response from the previous account after an A->B switch', async () => {
+      let signalBalanceRequested: () => void = () => {}
+      const balanceRequested = new Promise<void>((resolve) => {
+        signalBalanceRequested = resolve
+      })
+      let resolveBalanceJson: (value: unknown) => void = () => {}
+      const balanceJson = new Promise((resolve) => {
+        resolveBalanceJson = resolve
+      })
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/customers/balance')) {
+          signalBalanceRequested()
+          return Promise.resolve({ ok: true, json: () => balanceJson })
+        }
+        return Promise.reject(new Error('Unexpected API call'))
+      })
+
+      // Request starts while account A is current.
+      const pending = store.fetchBalance()
+      await balanceRequested
+
+      // Firebase transitions directly to account B before the response lands.
+      authStateCallback({ ...mockUser, uid: 'account-b' } as User)
+      resolveBalanceJson({ balance: 4242 })
+
+      expect(await pending).toBeNull()
+      expect(store.balance).toBeNull()
+    })
+  })
+
   describe('login', () => {
     it('should login with valid credentials', async () => {
       const mockUserCredential = { user: mockUser }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -320,6 +320,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   const fetchBalance = async (): Promise<GetCustomerBalanceResponse | null> => {
     isFetchingBalance.value = true
+    const requestOwnerUid = currentUser.value?.uid ?? null
     try {
       const authHeader = await getAuthHeader()
       if (!authHeader) {
@@ -351,6 +352,11 @@ export const useAuthStore = defineStore('auth', () => {
       }
 
       const balanceData = await response.json()
+      // A direct A->B account switch nulls balance in onAuthStateChanged; a
+      // late-resolving request from the previous identity must not repaint it.
+      if ((currentUser.value?.uid ?? null) !== requestOwnerUid) {
+        return null
+      }
       // Update the last balance update time
       lastBalanceUpdateTime.value = new Date()
       balance.value = balanceData

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -139,11 +139,21 @@ export const useAuthStore = defineStore('auth', () => {
   void setPersistence(auth, browserLocalPersistence)
 
   onAuthStateChanged(auth, (user) => {
+    const previousUserId = currentUser.value?.uid ?? null
+    const isDirectAccountSwitch =
+      previousUserId !== null && user !== null && previousUserId !== user.uid
+
+    if (user === null || isDirectAccountSwitch) {
+      useWorkspaceAuthStore().clearWorkspaceContext()
+    }
+    if (previousUserId !== null && previousUserId !== user?.uid) {
+      useTeamWorkspaceStore().resetForIdentityChange()
+    }
+
     currentUser.value = user
     isInitialized.value = true
     if (user === null) {
       lastTokenUserId.value = null
-      useWorkspaceAuthStore().clearWorkspaceContext()
     } else if (isCloud) {
       // Mint the single Cloud JWT at login (flag-guarded inside the store; a
       // no-op when unified_cloud_auth is off).
@@ -183,10 +193,13 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const getIdToken = async (): Promise<string | undefined> => {
-    if (!currentUser.value) return
+    const user = currentUser.value
+    if (!user) return
     try {
-      return await currentUser.value.getIdToken()
+      const token = await user.getIdToken()
+      return currentUser.value?.uid === user.uid ? token : undefined
     } catch (error: unknown) {
+      if (currentUser.value?.uid !== user.uid) return
       if (
         error instanceof FirebaseError &&
         error.code === AuthErrorCodes.NETWORK_REQUEST_FAILED
@@ -222,7 +235,7 @@ export const useAuthStore = defineStore('auth', () => {
    */
   const getAuthHeader = async (): Promise<AuthHeader | null> => {
     if (flags.unifiedCloudAuthEnabled) {
-      const token = useWorkspaceAuthStore().unifiedToken
+      const token = useWorkspaceAuthStore().getUnifiedToken()
       return token ? { Authorization: `Bearer ${token}` } : null
     }
 
@@ -267,7 +280,7 @@ export const useAuthStore = defineStore('auth', () => {
    */
   const getAuthToken = async (): Promise<string | undefined> => {
     if (flags.unifiedCloudAuthEnabled) {
-      return useWorkspaceAuthStore().unifiedToken ?? undefined
+      return useWorkspaceAuthStore().getUnifiedToken()
     }
 
     if (flags.teamWorkspacesEnabled) {


### PR DESCRIPTION
## Summary

Prevent cross-account workspace credentials from surviving a direct Firebase account switch, fixing the broken asset preview reported in [Slack](https://comfy-organization.slack.com/archives/C0BHR8PMK1D/p1784434802874859).

## Root Cause

The reported flow runs through the legacy workspace-token path because `unified_cloud_auth` is currently rolled out to 0%.

Firebase can transition directly from account A to account B without emitting an intermediate signed-out state. Workspace authentication was cleared only on sign-out, so account A's workspace JWT could remain active after the UI and session cookie changed to account B.

Because both accounts belong to the same team, the workspace ID still matched and masked the stale credential:

- `/api/jobs`: account A workspace bearer
- `/api/view`: account B session cookie
- Result: `404 FILE_NOT_FOUND` and a broken asset preview

This is a pre-existing flag-off lifecycle bug, not a regression caused by the recent consolidated/unified auth work. The unified path had the same latent identity-ownership risk, so this PR hardens both paths.

## Resolution

- Clear workspace auth before publishing a direct A → B Firebase identity transition.
- Associate persisted legacy and unified tokens with their Firebase owner UID.
- Reject missing or mismatched token ownership and re-mint for the active user.
- Scope session-cookie rotation and team-workspace async state writes to the initiating UID.
- Discard late account A token, workspace, member, and invite responses after account B becomes active.
- Make unified re-mint single-flight and prevent retrying an account A request with an account B token.
- Add a Cloud browser regression test for the reported flag-off flow.

## Reproduction

### Preconditions

- `unified_cloud_auth` is disabled.
- Team workspaces are enabled.
- Account A and account B belong to the same team.
- The team has an existing output in the Assets sidebar.

### Manual steps

1. Sign in as account A.
2. Select the shared team workspace and confirm its output is visible.
3. Navigate to `/cloud/login?switchAccount=true`.
4. Select **Use email instead**.
5. Sign in directly as account B without explicitly signing out account A.
6. Confirm the current-user menu shows account B and the same team workspace.
7. Open the Assets sidebar and inspect the existing output.
8. Compare the `/api/jobs` bearer with the session cookie used by `/api/view`.

### Before this PR

The UI shows account B, but `/api/jobs` can still use account A's workspace bearer while `/api/view` uses account B's session cookie. The image request returns `404 FILE_NOT_FOUND`.

### Expected / after this PR

Both requests use account B's credentials. `/api/view` returns `200`, and the image renders normally.

### Deterministic browser reproduction

```bash
PLAYWRIGHT_LOCAL=1 \
PLAYWRIGHT_TEST_URL=http://127.0.0.1:5173 \
pnpm test:browser --project=cloud browser_tests/tests/authAccountSwitch.spec.ts
```

The test explicitly sets `unified_cloud_auth: false`, switches A → B in the same team, and asserts the B workspace bearer, B session cookie, `/api/view` 200, and `naturalWidth > 0`.

## Before / After

| Before (`main`) | After this PR |
| --- | --- |
| <img width="520" alt="Before: Account B in Team Comfy with a broken asset preview" src="https://github.com/user-attachments/assets/3eb5be05-505c-4af4-8249-528bd201cdf8" /> | <img width="520" alt="After: Account B in Team Comfy with the asset rendered" src="https://github.com/user-attachments/assets/cd88a9ce-992e-4683-8254-f8e16b9dee94" /> |

Both screenshots come from the same deterministic Cloud mock scenario and show **Account B / Team Comfy** together with the affected asset.

## Verification

The reported scenario is confirmed working after the fix using both interactive Computer Use and the automated Cloud E2E.

| Check | Before (`main`) | After this PR |
| --- | --- | --- |
| Visible user | Account B | Account B |
| Active workspace | Team Comfy | Team Comfy |
| `/api/jobs` bearer | `workspace-jwt-a` | `workspace-jwt-b` |
| Session cookie | Account B | Account B |
| `/api/view` | `404 FILE_NOT_FOUND` | `200` |
| Asset preview | Broken image | Rendered image |

Validation completed:

- Cloud account-switch E2E passed with `unified_cloud_auth: false`.
- 265 targeted unit tests passed.
- Source and browser type checks passed.
- Format and knip checks passed.
- Lint completed with no errors.

This confirms the reported behavior in the equivalent deterministic Cloud reproduction. Production verification remains pending deployment.

## Review Focus

- Credential cleanup happens before account B becomes the active application identity.
- Cached credentials cannot be restored or returned for a different Firebase UID.
- Late account A requests cannot overwrite account B state.
- Unified-auth retries remain bound to the identity that issued the original request.

## Known follow-up

This PR isolates the HTTP credential and session paths for the reported flag-off account-switch flow. An already-open realtime WebSocket does not yet reauthenticate after a cross-tab Firebase identity change; that pre-existing connection-plane lifecycle is tracked separately in [#13920](https://github.com/Comfy-Org/ComfyUI_frontend/issues/13920).
