### PR TITLE
test: enable both billing flags in workspace fixture

### DIFF
--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -10,6 +10,7 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 // workspaces flag from it (the `ff:` localStorage override is dev-only).
 export const WORKSPACE_FEATURE_FLAG: RemoteConfig = {
   team_workspaces_enabled: true,
+  consolidated_billing_enabled: true,
   billing_control_enabled: true
 }
 


### PR DESCRIPTION
## Summary

Enable both independent billing rollouts in the cloud workspace fixture so the personal Team-plan Members E2E uses workspace billing without disabling billing controls.

## Changes

- **What**: Add `consolidated_billing_enabled: true` while retaining `billing_control_enabled: true`.
- **Dependencies**: None.

## Review Focus

Confirm the fixture preserves both flag contracts. This PR is stacked on #13827 and fixes its deterministic cloud Members E2E failure.

## Validation

- `pnpm exec oxfmt --check browser_tests/fixtures/data/cloudWorkspace.ts`
- `pnpm typecheck`
- `pnpm exec playwright test --project=cloud browser_tests/tests/dialogs/memberRoleChange.spec.ts --list`
- Commit hooks: oxfmt, oxlint, ESLint, typecheck, browser typecheck
- Push hook: knip completed with the existing custom-node tag warning