### PR TITLE
[backport cloud/1.45] fix(workspace): gate billing controls by role

### DIFF
--- a/browser_tests/tests/dialogs/memberRoleChange.spec.ts
+++ b/browser_tests/tests/dialogs/memberRoleChange.spec.ts
@@ -18,16 +18,6 @@ import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
 // against fully mocked endpoints; `comfyPage` would try to reach the OSS
 // devtools backend during setup.
 
-/**
- * Member role change (Settings ▸ Workspace ▸ Members) — Figma 2993-15512.
- *
- * The viewer is a promoted owner (not the workspace creator), so the spec can
- * distinguish the creator guard from the self guard: the creator row and the
- * viewer's own row hide the row menu, every other row exposes
- * "Change role ›" (Owner / Member) plus "Remove member". Promoting a member
- * sends PATCH /api/workspace/members/:id {role}, flips the Role column,
- * re-sorts the row under the creator, and the promoted owner stays demotable.
- */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
 async function openMembersTab(page: Page): Promise<Locator> {
@@ -95,6 +85,7 @@ test.describe('Members plan gating', { tag: '@cloud' }, () => {
     await expect(
       content.getByRole('button', { name: 'Upgrade to Team' })
     ).toHaveCount(0)
+    await expect(menuButton(memberRow(content, CREATOR.email))).toHaveCount(0)
 
     await inviteButton.click()
     await expect(
@@ -108,28 +99,47 @@ test.describe('Members plan gating', { tag: '@cloud' }, () => {
 test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
   test.describe.configure({ timeout: 60_000 })
 
-  test('row menus respect creator and self guards', async ({ page }) => {
-    await new CloudWorkspaceMockHelper(page).setup()
+  test('additional workspace creator has actions while self does not', async ({
+    page
+  }) => {
+    const state = await new CloudWorkspaceMockHelper(page).setup()
     const content = await openMembersTab(page)
+    const creatorRow = memberRow(content, CREATOR.email)
 
-    // US8/US9 — no row actions on the creator row (Liz) nor on the viewer's
-    // own row; the two plain members each expose a menu.
     await expect(
       menuButton(memberRow(content, MEMBER_JOHN.email))
     ).toBeVisible()
     await expect(
       menuButton(memberRow(content, MEMBER_JANE.email))
     ).toBeVisible()
-    await expect(menuButton(memberRow(content, CREATOR.email))).toHaveCount(0)
+    await expect(menuButton(creatorRow)).toBeVisible()
     await expect(menuButton(memberRow(content, VIEWER.email))).toHaveCount(0)
 
-    // US1/US12 — the row menu exposes Change role and the FE-768 remove flow.
-    await menuButton(memberRow(content, MEMBER_JANE.email)).click()
+    await menuButton(creatorRow).click()
     await expect(
       page.getByRole('menuitem', { name: 'Change role' })
     ).toBeVisible()
     await page.getByRole('menuitem', { name: 'Remove member' }).click()
     await expect(page.getByText('Remove this member?')).toBeVisible()
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click()
+
+    await menuButton(creatorRow).click()
+    await openChangeRoleSubmenu(page)
+    await page
+      .getByRole('menuitemradio', { name: 'Member', exact: true })
+      .click()
+    await expect(
+      page.getByRole('heading', { name: 'Demote Liz to member?' })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Demote to member' }).click()
+
+    await expect(creatorRow.getByText('Member', { exact: true })).toBeVisible()
+    expect(state.patches).toEqual([
+      {
+        url: expect.stringContaining('/api/workspace/members/u-liz'),
+        role: 'member'
+      }
+    ])
   })
 
   // Skipped on cloud/1.45: confirm dialog renders on legacy PrimeVue (pre-Reka-cutover) — mask enter-transition race. Un-fixme after backporting the Reka dialog cutover.
@@ -183,9 +193,7 @@ test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
       page.getByText('Manage members, payment methods, and workspace settings')
     ).toBeVisible()
     await expect(
-      page.getByText(
-        'Promote and demote other owners (except the workspace creator).'
-      )
+      page.getByText('Promote members and demote eligible owners.')
     ).toBeVisible()
 
     await page.getByRole('button', { name: 'Cancel', exact: true }).click()

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -54,6 +54,8 @@ const mockCloseDialog = vi.hoisted(() => vi.fn())
 const mockToastAdd = vi.hoisted(() => vi.fn())
 const mockTier = vi.hoisted(() => ({ value: 'STANDARD' as string | null }))
 const mockTrackCancellation = vi.hoisted(() => vi.fn())
+const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
+const mockCanManageSubscriptionLifecycle = vi.hoisted(() => ({ value: true }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
@@ -62,6 +64,25 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     subscription: mockSubscription,
     tier: mockTier
   }))
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: mockShouldUseWorkspaceBilling
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return {
+          canManageSubscriptionLifecycle:
+            mockCanManageSubscriptionLifecycle.value
+        }
+      }
+    }
+  })
 }))
 
 vi.mock('@/platform/telemetry', () => ({
@@ -107,6 +128,8 @@ describe('CancelSubscriptionDialogContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockTier.value = 'STANDARD'
+    mockShouldUseWorkspaceBilling.value = false
+    mockCanManageSubscriptionLifecycle.value = true
   })
 
   describe('cancellation telemetry', () => {
@@ -238,6 +261,26 @@ describe('CancelSubscriptionDialogContent', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'success' })
       )
+    })
+
+    it('does not cancel after the workspace role loses permission', async () => {
+      mockSubscription.value = null
+      mockShouldUseWorkspaceBilling.value = true
+      mockCanManageSubscriptionLifecycle.value = true
+
+      renderComponent()
+      mockCanManageSubscriptionLifecycle.value = false
+      await userEvent.click(
+        screen.getByRole('button', { name: /^cancel subscription$/i })
+      )
+
+      expect(mockCancelSubscription).not.toHaveBeenCalled()
+      expect(mockTrackCancellation).not.toHaveBeenCalledWith(
+        'confirmed',
+        expect.anything()
+      )
+      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(mockCloseDialog).not.toHaveBeenCalled()
     })
 
     it('does not track cancellation failure when status refresh fails after cancellation succeeds', async () => {

--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.vue
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.vue
@@ -50,8 +50,10 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useTelemetry } from '@/platform/telemetry'
 import type { SubscriptionCancellationMetadata } from '@/platform/telemetry/types'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogStore } from '@/stores/dialogStore'
 import { parseIsoDateSafe } from '@/utils/dateTimeUtil'
 import { getErrorMessage } from '@/utils/errorUtil'
@@ -65,6 +67,8 @@ const dialogStore = useDialogStore()
 const toast = useToast()
 const { cancelSubscription, fetchStatus, subscription, tier } =
   useBillingContext()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
+const { permissions } = useWorkspaceUI()
 const telemetry = useTelemetry()
 
 const isLoading = ref(false)
@@ -119,6 +123,13 @@ function onClose() {
 }
 
 async function onConfirmCancel() {
+  if (
+    shouldUseWorkspaceBilling.value &&
+    !permissions.value.canManageSubscriptionLifecycle
+  ) {
+    return
+  }
+
   telemetry?.trackSubscriptionCancellation('confirmed', cancellationMetadata())
   isLoading.value = true
   try {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2814,7 +2814,7 @@
       "promoteIntro": "They'll be able to:",
       "promotePermissionCredits": "Add additional credits",
       "promotePermissionManage": "Manage members, payment methods, and workspace settings",
-      "promotePermissionRoles": "Promote and demote other owners (except the workspace creator).",
+      "promotePermissionRoles": "Promote members and demote eligible owners.",
       "promoteConfirm": "Make owner",
       "demoteTitle": "Demote {name} to member?",
       "demoteMessage": "They'll lose admin access.",

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import SubscriptionFooterLinks from './SubscriptionFooterLinks.vue'
+
+const state = vi.hoisted(() => ({
+  manageSubscription: vi.fn(),
+  handleLearnMoreClick: vi.fn(),
+  handleMessageSupport: vi.fn()
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    manageSubscription: state.manageSubscription
+  })
+}))
+
+vi.mock('@/composables/useExternalLink', () => ({
+  useExternalLink: () => ({
+    buildDocsUrl: vi.fn(() => 'https://docs.comfy.org/partner-nodes'),
+    docsPaths: { partnerNodesPricing: 'partner-nodes' }
+  })
+}))
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionActions',
+  () => ({
+    useSubscriptionActions: () => ({
+      isLoadingSupport: ref(false),
+      handleLearnMoreClick: state.handleLearnMoreClick,
+      handleMessageSupport: state.handleMessageSupport
+    })
+  })
+)
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      subscription: {
+        learnMore: 'Learn more',
+        partnerNodesPricingTable: 'Partner Nodes pricing',
+        messageSupport: 'Message support',
+        invoiceHistory: 'Invoice history'
+      }
+    }
+  }
+})
+
+function renderComponent(showInvoiceHistory?: boolean) {
+  return render(SubscriptionFooterLinks, {
+    props: showInvoiceHistory === undefined ? {} : { showInvoiceHistory },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: {
+          props: ['loading'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>'
+        }
+      }
+    }
+  })
+}
+
+describe('SubscriptionFooterLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps Invoice history visible by default for legacy billing', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Invoice history' }))
+
+    expect(state.manageSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('hides Invoice history without opening the payment portal', () => {
+    renderComponent(false)
+
+    expect(
+      screen.queryByRole('button', { name: 'Invoice history' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Learn more' })
+    ).toBeInTheDocument()
+    expect(state.manageSubscription).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -31,6 +31,7 @@
     </div>
 
     <Button
+      v-if="showInvoiceHistory"
       variant="muted-textonly"
       class="text-xs text-text-secondary"
       @click="handleInvoiceHistory"
@@ -47,6 +48,10 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
 
+const { showInvoiceHistory = true } = defineProps<{
+  showInvoiceHistory?: boolean
+}>()
+
 const { buildDocsUrl, docsPaths } = useExternalLink()
 
 const { manageSubscription } = useBillingContext()
@@ -55,6 +60,7 @@ const { isLoadingSupport, handleMessageSupport, handleLearnMoreClick } =
   useSubscriptionActions()
 
 async function handleInvoiceHistory() {
+  if (!showInvoiceHistory) return
   await manageSubscription()
 }
 

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -40,29 +40,18 @@ vi.mock(
 )
 
 const mockPermissions = vi.hoisted(() => ({
-  value: { canManageSubscriptionLifecycle: true }
+  value: { canManageSubscription: true }
 }))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({ permissions: mockPermissions })
 }))
 
-const mockFetchMembers = vi.hoisted(() => vi.fn().mockResolvedValue([]))
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    fetchMembers: mockFetchMembers
-  })
-}))
-
 describe('usePricingTableUrlLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRouteQuery.value = {}
-    mockPermissions.value = { canManageSubscriptionLifecycle: true }
-    // clearAllMocks resets calls, not implementations, so restore the default
-    // (a test overrides fetchMembers to flip the gate mid-await).
-    mockFetchMembers.mockResolvedValue([])
+    mockPermissions.value = { canManageSubscription: true }
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -80,7 +69,7 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).not.toHaveBeenCalled()
   })
 
-  it('opens the pricing table for an original owner', async () => {
+  it('opens the pricing table for an owner', async () => {
     mockRouteQuery.value = { pricing: '1' }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
@@ -91,22 +80,6 @@ describe('usePricingTableUrlLoader', () => {
       planMode: undefined
     })
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
-  })
-
-  it('reads the gate only after members finish loading', async () => {
-    mockRouteQuery.value = { pricing: '1' }
-    // The original owner becomes known only once the members list resolves;
-    // proves the loader awaits fetchMembers before reading the gate.
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
-    mockFetchMembers.mockImplementation(async () => {
-      mockPermissions.value = { canManageSubscriptionLifecycle: true }
-      return []
-    })
-
-    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
-    await loadPricingTableFromUrl()
-
-    expect(mockShowPricingTable).toHaveBeenCalledOnce()
   })
 
   it('opens on the team tab for ?pricing=team', async () => {
@@ -133,9 +106,9 @@ describe('usePricingTableUrlLoader', () => {
     })
   })
 
-  it('is a silent no-op for a member or promoted owner', async () => {
+  it('is a silent no-op for a member', async () => {
     mockRouteQuery.value = { pricing: '1' }
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+    mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
@@ -145,7 +118,7 @@ describe('usePricingTableUrlLoader', () => {
 
   it('denies, strips, and clears together when the user is not eligible', async () => {
     mockRouteQuery.value = { pricing: '1', other: 'param' }
-    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+    mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
@@ -207,21 +180,5 @@ describe('usePricingTableUrlLoader', () => {
       reason: 'deep_link',
       planMode: undefined
     })
-  })
-
-  it('strips and clears, then propagates a members-fetch failure', async () => {
-    mockRouteQuery.value = { pricing: '1' }
-    mockFetchMembers.mockRejectedValue(new Error('listMembers failed'))
-
-    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
-    await expect(loadPricingTableFromUrl()).rejects.toThrow(
-      'listMembers failed'
-    )
-
-    expect(mockShowPricingTable).not.toHaveBeenCalled()
-    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
-    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
-      'pricing'
-    )
   })
 })

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -8,7 +8,6 @@ import {
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
 
@@ -16,15 +15,14 @@ const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
  * Opens the pricing table from a `?pricing=` deep link, to send pilot users
  * straight to subscribe. Values: `1` (default tab), `team`, `personal`.
  *
- * Gated to the original owner (`canManageSubscriptionLifecycle`); a member or
- * promoted owner is a silent no-op with the param stripped. Survives the login
- * redirect via the preserved-query system, like the invite URL loader.
+ * Gated to workspace owners (`canManageSubscription`); a member is a silent
+ * no-op with the param stripped. Survives the login redirect via the
+ * preserved-query system, like the invite URL loader.
  */
 export function usePricingTableUrlLoader() {
   const route = useRoute()
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
-  const workspaceStore = useTeamWorkspaceStore()
   const { permissions } = useWorkspaceUI()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
@@ -52,11 +50,7 @@ export function usePricingTableUrlLoader() {
     // gets stripped above.
     if (typeof param !== 'string' || !param) return
 
-    // Load members before reading the gate so the original-owner self-row is
-    // present. fetchMembers always awaits the request; ensureMembersLoaded can
-    // early-return on a cached/in-flight load and let the gate read empty members.
-    await workspaceStore.fetchMembers()
-    if (!permissions.value.canManageSubscriptionLifecycle) return
+    if (!permissions.value.canManageSubscription) return
 
     const planMode =
       param === 'team' || param === 'personal' ? param : undefined

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -12,6 +12,8 @@ const mockTier = vi.hoisted(() => ({ value: 'FREE' as string | null }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockIsLegacyTeamPlan = vi.hoisted(() => ({ value: false }))
+const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
+const mockCurrentPlanSlug = vi.hoisted(() => ({ value: null as string | null }))
 const mockCanManageSubscription = vi.hoisted(() => ({ value: true }))
 const mockUseWorkspaceUI = vi.hoisted(() => vi.fn())
 
@@ -62,6 +64,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isFreeTier: mockIsFreeTier,
     isLegacyTeamPlan: mockIsLegacyTeamPlan,
+    isTeamPlan: mockIsTeamPlan,
+    currentPlanSlug: mockCurrentPlanSlug,
     tier: mockTier
   })
 }))
@@ -83,6 +87,8 @@ describe('useSubscriptionDialog', () => {
     mockTier.value = 'FREE'
     mockShouldUseWorkspaceBilling.value = false
     mockIsLegacyTeamPlan.value = false
+    mockIsTeamPlan.value = false
+    mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
     mockUseWorkspaceUI.mockImplementation(() => ({
       permissions: {
@@ -107,6 +113,7 @@ describe('useSubscriptionDialog', () => {
     })
 
     it('resolves useWorkspaceUI lazily when the pricing table is shown', () => {
+      mockShouldUseWorkspaceBilling.value = true
       const { showPricingTable } = useSubscriptionDialog()
       expect(mockUseWorkspaceUI).not.toHaveBeenCalled()
 
@@ -176,12 +183,38 @@ describe('useSubscriptionDialog', () => {
     it('opens the team tab when planMode is forced from a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
       mockIsInPersonalWorkspace.value = true
+      mockCurrentPlanSlug.value = 'creator-monthly'
       const { showPricingTable } = useSubscriptionDialog()
 
       showPricingTable({ planMode: 'team' })
 
       const props = mockShowLayoutDialog.mock.calls[0][0].props
       expect(props.initialPlanMode).toBe('team')
+    })
+
+    it('defaults to the team tab for a Team plan in a personal workspace', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsInPersonalWorkspace.value = true
+      mockIsTeamPlan.value = true
+      mockCurrentPlanSlug.value = 'team_per_credit_monthly'
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props.initialPlanMode).toBe('team')
+    })
+
+    it('defaults to the personal tab for a personal plan in a team workspace', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsInPersonalWorkspace.value = false
+      mockCurrentPlanSlug.value = 'creator-monthly'
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props.initialPlanMode).toBe('personal')
     })
 
     it('uses the legacy table (with onChooseTeam) on the legacy billing flow', () => {
@@ -213,7 +246,7 @@ describe('useSubscriptionDialog', () => {
       expect(props).not.toHaveProperty('onChooseTeam')
     })
 
-    it('keeps a non-legacy (credit-slider) team subscriber on the unified table', () => {
+    it('defaults an unsubscribed team workspace to the team tab', () => {
       mockShouldUseWorkspaceBilling.value = true
       mockIsInPersonalWorkspace.value = false
       mockIsLegacyTeamPlan.value = false
@@ -223,6 +256,21 @@ describe('useSubscriptionDialog', () => {
 
       const props = mockShowLayoutDialog.mock.calls[0][0].props
       expect(props.initialPlanMode).toBe('team')
+    })
+
+    it('shows the read-only member dialog in a personal workspace', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsInPersonalWorkspace.value = true
+      mockCanManageSubscription.value = false
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable({ reason: 'subscribe_to_run' })
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledTimes(1)
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props).toHaveProperty('onClose')
+      expect(props).not.toHaveProperty('reason')
+      expect(props).not.toHaveProperty('initialPlanMode')
     })
 
     it('tracks modal_opened with the caller reason and current tier', () => {
@@ -282,6 +330,25 @@ describe('useSubscriptionDialog', () => {
       expect(mockShowLayoutDialog).toHaveBeenCalledWith(
         expect.objectContaining({ key: 'free-tier-info' })
       )
+    })
+
+    it('checks workspace member permission before the personal free-tier path', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsFreeTier.value = true
+      mockIsInPersonalWorkspace.value = true
+      mockCanManageSubscription.value = false
+      const { show } = useSubscriptionDialog()
+
+      show()
+
+      expect(mockShowLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'subscription-required' })
+      )
+      expect(mockShowLayoutDialog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'free-tier-info' })
+      )
+      expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'global-settings' })
+      expect(mockTrackSubscription).not.toHaveBeenCalled()
     })
 
     it('falls back to the pricing table for a non-free-tier user', () => {
@@ -386,13 +453,18 @@ describe('useSubscriptionDialog', () => {
     it('shows pricing table and clears intent when in team workspace', () => {
       sessionStorage.setItem('comfy:resume-team-pricing', '1')
       mockIsInPersonalWorkspace.value = false
+      mockShouldUseWorkspaceBilling.value = true
+      mockCurrentPlanSlug.value = 'creator-monthly'
 
       const { resumePendingPricingFlow } = useSubscriptionDialog()
       resumePendingPricingFlow()
 
       expect(sessionStorage.getItem('comfy:resume-team-pricing')).toBeNull()
       expect(mockShowLayoutDialog).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'subscription-required' })
+        expect.objectContaining({
+          key: 'subscription-required',
+          props: expect.objectContaining({ initialPlanMode: 'team' })
+        })
       )
     })
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -23,6 +23,18 @@ export interface SubscriptionDialogOptions {
   planMode?: 'personal' | 'team'
 }
 
+function getInitialPlanMode(
+  explicitMode: SubscriptionDialogOptions['planMode'],
+  isTeamPlan: boolean,
+  hasCurrentPlan: boolean,
+  isPersonalWorkspace: boolean
+): NonNullable<SubscriptionDialogOptions['planMode']> {
+  if (explicitMode) return explicitMode
+  if (isTeamPlan) return 'team'
+  if (hasCurrentPlan) return 'personal'
+  return isPersonalWorkspace ? 'personal' : 'team'
+}
+
 export const useSubscriptionDialog = () => {
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const dialogService = useDialogService()
@@ -45,8 +57,36 @@ export const useSubscriptionDialog = () => {
     })
   }
 
+  function showInactiveMemberDialog(): boolean {
+    if (!shouldUseWorkspaceBilling.value) return false
+
+    const { permissions } = useWorkspaceUI()
+    if (permissions.value.canManageSubscription) return false
+
+    dialogStore.closeDialog({ key: 'global-settings' })
+    dialogService.showLayoutDialog({
+      key: DIALOG_KEY,
+      component: defineAsyncComponent(
+        () =>
+          import('@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue')
+      ),
+      props: { onClose: hide },
+      dialogComponentProps: {
+        style: 'width: min(360px, 95vw);',
+        pt: {
+          root: {
+            class: 'bg-transparent border-none rounded-none shadow-none'
+          },
+          content: { class: '!p-0 bg-transparent border-none shadow-none' }
+        }
+      }
+    })
+    return true
+  }
+
   function showPricingTable(options?: SubscriptionDialogOptions) {
     if (!isCloud) return
+    if (showInactiveMemberDialog()) return
 
     // Opening pricing from inside Settings (the "Subscribe" / "Upgrade to Team"
     // CTA) would stack the Reka pricing dialog behind the PrimeVue Settings
@@ -54,37 +94,6 @@ export const useSubscriptionDialog = () => {
     // non-modal so its hosted PrimeVue popover stays clickable, so it can't just
     // be raised above. Close Settings first so pricing opens cleanly on top.
     dialogStore.closeDialog({ key: 'global-settings' })
-
-    const { permissions } = useWorkspaceUI()
-
-    // Members can't manage the workspace subscription, so a blocked run shows a
-    // small read-only "ask your owner to reactivate" modal instead of the
-    // pricing table. Out-of-credits still routes everyone to the credits flow.
-    if (
-      shouldUseWorkspaceBilling.value &&
-      !workspaceStore.isInPersonalWorkspace &&
-      !permissions.value.canManageSubscription &&
-      options?.reason !== 'out_of_credits'
-    ) {
-      dialogService.showLayoutDialog({
-        key: DIALOG_KEY,
-        component: defineAsyncComponent(
-          () =>
-            import('@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue')
-        ),
-        props: { onClose: hide },
-        dialogComponentProps: {
-          style: 'width: min(360px, 95vw);',
-          pt: {
-            root: {
-              class: 'bg-transparent border-none rounded-none shadow-none'
-            },
-            content: { class: '!p-0 bg-transparent border-none shadow-none' }
-          }
-        }
-      })
-      return
-    }
 
     trackModalOpened(options?.reason)
 
@@ -113,7 +122,8 @@ export const useSubscriptionDialog = () => {
       // an import cycle (useBillingContext -> useWorkspaceBilling ->
       // useSubscriptionDialog), so a setup-time read would deref the shared
       // context before its state is constructed.
-      const { isLegacyTeamPlan } = useBillingContext()
+      const { currentPlanSlug, isLegacyTeamPlan, isTeamPlan } =
+        useBillingContext()
       if (isLegacyTeamPlan.value) {
         dialogService.showLayoutDialog({
           key: DIALOG_KEY,
@@ -142,12 +152,12 @@ export const useSubscriptionDialog = () => {
         props: {
           onClose: hide,
           reason: options?.reason,
-          // A team workspace lands on the For Teams tab; personal on For
-          // Personal. An explicit caller (e.g. an "Upgrade to Team" CTA) can
-          // override via options.planMode.
-          initialPlanMode:
-            options?.planMode ??
-            (workspaceStore.isInPersonalWorkspace ? 'personal' : 'team')
+          initialPlanMode: getInitialPlanMode(
+            options?.planMode,
+            isTeamPlan.value,
+            currentPlanSlug.value !== null,
+            workspaceStore.isInPersonalWorkspace
+          )
         },
         dialogComponentProps: {
           // Reka (the default renderer) sizes via size/contentClass; a PrimeVue
@@ -180,6 +190,8 @@ export const useSubscriptionDialog = () => {
   }
 
   function show(options?: SubscriptionDialogOptions) {
+    if (isCloud && showInactiveMemberDialog()) return
+
     // Free-tier state comes from the unified facade so it works on both the
     // legacy (/customers) and workspace (/api/billing) paths. Resolved lazily
     // (not at composable setup) to avoid the useBillingContext import cycle.
@@ -262,7 +274,10 @@ export const useSubscriptionDialog = () => {
       sessionStorage.removeItem(RESUME_PRICING_KEY)
 
       if (!workspaceStore.isInPersonalWorkspace) {
-        showPricingTable({ reason: 'team_upgrade_resume' })
+        showPricingTable({
+          reason: 'team_upgrade_resume',
+          planMode: 'team'
+        })
       }
     } catch {
       // sessionStorage may be unavailable

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -33,8 +33,8 @@ export interface Member {
   joined_at: string
   role: WorkspaceRole
   // True when this member is the workspace's original owner/creator
-  // (member.id == workspace.created_by_user_id). Gates the creator-only
-  // billing lifecycle actions (cancel / reactivate / downgrade).
+  // (member.id == workspace.created_by_user_id). Used for personal creator
+  // protections and Team-to-personal downgrade eligibility.
   // Optional: the cloud OpenAPI does not carry this field yet.
   is_original_owner?: boolean
 }

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -9,7 +9,17 @@ import enMessages from '@/locales/en/main.json'
 
 import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
 
-const showCreateWorkspaceDialog = vi.fn()
+const state = vi.hoisted(() => ({
+  isActiveSubscription: true,
+  isFreeTier: false,
+  isCancelled: false,
+  canTopUp: false,
+  canManageSubscription: false,
+  canManageSubscriptionLifecycle: false,
+  showCreateWorkspaceDialog: vi.fn(),
+  showTopUpCreditsDialog: vi.fn(),
+  showPricingTable: vi.fn()
+}))
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({
@@ -22,10 +32,12 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: ref(true),
-    isFreeTier: ref(false),
-    subscription: ref(null),
-    balance: ref(null),
+    isActiveSubscription: computed(() => state.isActiveSubscription),
+    isFreeTier: computed(() => state.isFreeTier),
+    subscription: computed(() => ({
+      isCancelled: state.isCancelled
+    })),
+    balance: ref({ amountMicros: 100 }),
     isLoading: ref(false),
     fetchBalance: vi.fn()
   })
@@ -34,8 +46,9 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: computed(() => ({
-      canTopUp: false,
-      canManageSubscription: false
+      canTopUp: state.canTopUp,
+      canManageSubscription: state.canManageSubscription,
+      canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
     }))
   })
 }))
@@ -43,7 +56,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({
-    useSubscriptionDialog: () => ({ showPricingTable: vi.fn() })
+    useSubscriptionDialog: () => ({ showPricingTable: state.showPricingTable })
   })
 )
 
@@ -53,8 +66,8 @@ vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
-    showCreateWorkspaceDialog,
-    showTopUpCreditsDialog: vi.fn()
+    showCreateWorkspaceDialog: state.showCreateWorkspaceDialog,
+    showTopUpCreditsDialog: state.showTopUpCreditsDialog
   })
 }))
 
@@ -85,7 +98,29 @@ const i18n = createI18n({
   messages: { en: enMessages }
 })
 
-function renderComponent() {
+function createWorkspaceState(
+  type: 'personal' | 'team',
+  role: 'owner' | 'member'
+) {
+  return {
+    id: `ws-${type}`,
+    name: `${type === 'personal' ? 'Personal' : 'Team'} Workspace`,
+    type,
+    role,
+    created_at: '2026-01-01T00:00:00Z',
+    joined_at: '2026-01-01T00:00:00Z',
+    isSubscribed: true,
+    subscriptionPlan: 'team-pro-monthly',
+    subscriptionTier: 'PRO',
+    members: [],
+    pendingInvites: []
+  }
+}
+
+function renderComponent(
+  type: 'personal' | 'team' = 'personal',
+  role: 'owner' | 'member' = 'member'
+) {
   return render(CurrentUserPopoverWorkspace, {
     global: {
       plugins: [
@@ -94,7 +129,8 @@ function renderComponent() {
           initialState: {
             teamWorkspace: {
               initState: 'ready',
-              activeWorkspaceId: 'ws-personal'
+              activeWorkspaceId: `ws-${type}`,
+              workspaces: [createWorkspaceState(type, role)]
             }
           }
         }),
@@ -116,6 +152,16 @@ function renderComponent() {
 }
 
 describe('CurrentUserPopoverWorkspace', () => {
+  beforeEach(() => {
+    state.isActiveSubscription = true
+    state.isFreeTier = false
+    state.isCancelled = false
+    state.canTopUp = false
+    state.canManageSubscription = false
+    state.canManageSubscriptionLifecycle = false
+    vi.clearAllMocks()
+  })
+
   it('toggles the workspace switcher panel from the selector row', async () => {
     const user = userEvent.setup()
     renderComponent()
@@ -152,10 +198,43 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByTestId('workspace-switcher-trigger'))
     await user.click(screen.getByTestId('stub-create-workspace'))
 
-    expect(showCreateWorkspaceDialog).toHaveBeenCalled()
+    expect(state.showCreateWorkspaceDialog).toHaveBeenCalled()
     expect(emitted('close')).toHaveLength(1)
     expect(
       screen.queryByTestId('workspace-switcher-panel')
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps a Personal workspace Team-plan member read-only', () => {
+    renderComponent('personal', 'member')
+
+    expect(screen.getByText('211')).toBeInTheDocument()
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('plans-pricing-menu-item')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('manage-plan-menu-item')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps billing controls and resubscribe available to a promoted owner', async () => {
+    const user = userEvent.setup()
+    state.isCancelled = true
+    state.canTopUp = true
+    state.canManageSubscription = true
+    state.canManageSubscriptionLifecycle = true
+    renderComponent('team', 'owner')
+
+    expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
+    expect(screen.getByTestId('plans-pricing-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('manage-plan-menu-item')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
+
+    expect(state.showPricingTable).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -89,7 +89,6 @@
       >
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
-      <!-- Add Credits (subscribed + personal or workspace owner only, paid tier) -->
       <Button
         v-else-if="isActiveSubscription && permissions.canTopUp"
         variant="secondary"
@@ -113,11 +112,7 @@
         button-variant="gradient"
       />
       <Button
-        v-if="
-          showSubscribeAction &&
-          !isPersonalWorkspace &&
-          (!isCancelled || permissions.canManageSubscriptionLifecycle)
-        "
+        v-if="showSubscribeAction && !isPersonalWorkspace"
         variant="primary"
         size="sm"
         @click="handleOpenPlansAndPricing"
@@ -132,7 +127,6 @@
 
     <Divider class="mx-0 my-2" />
 
-    <!-- Plans & Pricing (PERSONAL and OWNER only) -->
     <div
       v-if="showPlansAndPricing"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
@@ -145,7 +139,6 @@
       }}</span>
     </div>
 
-    <!-- Manage Plan (PERSONAL and OWNER, only if subscribed) -->
     <div
       v-if="showManagePlan"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
@@ -306,8 +299,8 @@ const showManagePlan = computed(
 )
 const showSubscribeAction = computed(
   () =>
-    permissions.value.canManageSubscription &&
-    (!isActiveSubscription.value || isCancelled.value)
+    (isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
+    (!isActiveSubscription.value && permissions.value.canManageSubscription)
 )
 
 const handleOpenUserSettings = () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -52,19 +52,8 @@ const mockIsActiveSubscription = ref(true)
 const mockIsInPersonalWorkspace = ref(false)
 const mockIsWorkspaceSubscribed = ref(true)
 const mockCanManageSubscription = ref(true)
-const mockMembers = ref([
-  {
-    id: 'member-1',
-    email: 'creator@example.com',
-    joinDate: new Date('2026-01-01T00:00:00Z')
-  },
-  {
-    id: 'member-2',
-    email: 'me@example.com',
-    joinDate: new Date('2026-02-01T00:00:00Z')
-  }
-])
-const mockUserEmail = ref<string | null>('me@example.com')
+const mockCanManageSubscriptionLifecycle = ref(true)
+const mockCanLeaveWorkspace = ref(true)
 const mockTeamCreditStops = ref<TeamCreditStops | null>(teamCreditStops)
 const mockCurrentTeamCreditStop = ref<CurrentTeamCreditStop | null>({
   id: 'team_700',
@@ -82,7 +71,7 @@ const mockShowDeleteWorkspaceDialog = vi.fn()
 
 type MenuUiConfig = {
   showEditWorkspaceMenuItem: boolean
-  workspaceMenuAction: 'leave' | 'delete' | null
+  workspaceMenuAction: 'delete' | null
   workspaceMenuDisabledTooltip: string | null
 }
 
@@ -94,14 +83,13 @@ const ownerUiConfig: MenuUiConfig = {
 }
 const memberUiConfig: MenuUiConfig = {
   showEditWorkspaceMenuItem: false,
-  workspaceMenuAction: 'leave',
+  workspaceMenuAction: null,
   workspaceMenuDisabledTooltip: null
 }
 const personalUiConfig: MenuUiConfig = {
   showEditWorkspaceMenuItem: true,
-  workspaceMenuAction: 'delete',
-  workspaceMenuDisabledTooltip:
-    'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
+  workspaceMenuAction: null,
+  workspaceMenuDisabledTooltip: null
 }
 const mockUiConfig = ref<MenuUiConfig>(ownerUiConfig)
 
@@ -151,28 +139,15 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
-    members: mockMembers
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
   })
 }))
 
-// Mirrors useWorkspaceUI's original-owner derivation (earliest join date, ties
-// broken by member id) so member/email toggles still drive owner-only menus.
-const mockIsOriginalOwner = computed(() => {
-  if (mockIsInPersonalWorkspace.value) return true
-  const email = mockUserEmail.value?.toLowerCase()
-  if (!email || mockMembers.value.length === 0) return false
-  const original = [...mockMembers.value].sort(
-    (a, b) =>
-      a.joinDate.getTime() - b.joinDate.getTime() || a.id.localeCompare(b.id)
-  )[0]
-  return original.email.toLowerCase() === email
-})
-
 const mockIsTeamPlanCancelled = computed(
-  () =>
-    !mockIsInPersonalWorkspace.value &&
-    (mockSubscription.value?.isCancelled ?? false)
+  () => mockHasTeamPlan.value && (mockSubscription.value?.isCancelled ?? false)
+)
+const mockIsSubscriptionCancelled = computed(
+  () => mockSubscription.value?.isCancelled ?? false
 )
 
 const mockIsDeleteDisabled = computed(
@@ -184,12 +159,14 @@ const mockIsDeleteDisabled = computed(
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: computed(() => ({
-      canManageSubscription: mockCanManageSubscription.value
+      canManageSubscription: mockCanManageSubscription.value,
+      canManageSubscriptionLifecycle: mockCanManageSubscriptionLifecycle.value,
+      canLeaveWorkspace: mockCanLeaveWorkspace.value
     })),
     uiConfig: computed(() => mockUiConfig.value),
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
-    isOriginalOwner: mockIsOriginalOwner,
+    isSubscriptionCancelled: mockIsSubscriptionCancelled,
     isTeamPlanCancelled: mockIsTeamPlanCancelled,
     isDeleteDisabled: mockIsDeleteDisabled,
     deleteDisabledTooltipKey: computed(() =>
@@ -244,7 +221,9 @@ const ButtonStub = {
 }
 
 const SubscriptionFooterLinksStub = {
-  template: '<div data-testid="subscription-footer-links" />'
+  props: ['showInvoiceHistory'],
+  template:
+    '<div data-testid="subscription-footer-links" :data-show-invoice-history="String(showInvoiceHistory)" />'
 }
 
 const DropdownMenuStub = {
@@ -278,19 +257,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsInPersonalWorkspace.value = false
     mockIsWorkspaceSubscribed.value = true
     mockCanManageSubscription.value = true
-    mockMembers.value = [
-      {
-        id: 'member-1',
-        email: 'creator@example.com',
-        joinDate: new Date('2026-01-01T00:00:00Z')
-      },
-      {
-        id: 'member-2',
-        email: 'me@example.com',
-        joinDate: new Date('2026-02-01T00:00:00Z')
-      }
-    ]
-    mockUserEmail.value = 'me@example.com'
+    mockCanManageSubscriptionLifecycle.value = true
+    mockCanLeaveWorkspace.value = true
     mockUiConfig.value = ownerUiConfig
     mockSubscriptionTier.value = 'PRO'
     mockPlanSlug.value = 'team-monthly'
@@ -318,6 +286,10 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
     ).toBeInTheDocument()
     expect(screen.getByTestId('subscription-footer-links')).toBeInTheDocument()
+    expect(screen.getByTestId('subscription-footer-links')).toHaveAttribute(
+      'data-show-invoice-history',
+      'true'
+    )
   })
 
   it('uses the yearly stop price for an annual subscription, still shown per month', () => {
@@ -386,24 +358,63 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
   })
 
-  it('hides plan management actions from members without permission', () => {
+  it('keeps a Personal workspace Team-plan member view read-only', () => {
+    mockIsInPersonalWorkspace.value = true
     mockCanManageSubscription.value = false
+    mockCanManageSubscriptionLifecycle.value = false
+    mockCanLeaveWorkspace.value = true
     mockUiConfig.value = memberUiConfig
     renderComponent()
 
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(screen.getByTestId('credits-tile')).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Manage billing' })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Change plan' })
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Edit workspace details' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Leave Workspace' })
+    ).toBeInTheDocument()
     expect(screen.getByText('Invite members')).toBeInTheDocument()
+    expect(screen.getByTestId('subscription-footer-links')).toHaveAttribute(
+      'data-show-invoice-history',
+      'false'
+    )
   })
 
-  it('reactivates a cancelled plan as the original owner, keeping Manage billing', async () => {
+  it('uses Team-plan change copy in a Personal workspace', () => {
+    mockIsInPersonalWorkspace.value = true
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Change plan' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Upgrade plan' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps an inactive paid Team plan visible in a Personal workspace', () => {
+    mockIsInPersonalWorkspace.value = true
+    mockIsActiveSubscription.value = false
+    renderComponent()
+
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(screen.queryByText('Free')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('reactivates a cancelled plan for an owner, keeping Manage billing', async () => {
     const user = userEvent.setup()
     mockSubscriptionStatus.value = 'canceled'
-    mockUserEmail.value = 'creator@example.com'
+    mockCanLeaveWorkspace.value = false
     renderComponent()
 
     expect(
@@ -423,15 +434,20 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockResubscribe).toHaveBeenCalledOnce()
   })
 
-  it('hides Reactivate plan from a promoted owner on a cancelled plan', () => {
+  it('keeps a cancelled Personal plan in a Team workspace reactivatable', () => {
     mockSubscriptionStatus.value = 'canceled'
+    mockHasTeamPlan.value = false
+    mockIsWorkspaceSubscribed.value = false
     renderComponent()
 
     expect(
-      screen.getByRole('button', { name: 'Manage billing' })
+      screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Reactivate plan' })
+      screen.getByRole('button', { name: 'Reactivate plan' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Subscribe Now' })
     ).not.toBeInTheDocument()
   })
 
@@ -483,6 +499,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockIsWorkspaceSubscribed.value = false
     mockHasSubscription.value = false
     mockCanManageSubscription.value = false
+    mockCanManageSubscriptionLifecycle.value = false
     renderComponent()
 
     expect(
@@ -504,6 +521,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockHasSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
     mockUiConfig.value = personalUiConfig
+    mockCanLeaveWorkspace.value = false
     renderComponent()
 
     expect(screen.getByText('Free')).toBeInTheDocument()
@@ -530,6 +548,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockHasSubscription.value = false
     mockIsWorkspaceSubscribed.value = false
     mockUiConfig.value = personalUiConfig
+    mockCanLeaveWorkspace.value = false
     renderComponent()
 
     expect(
@@ -545,12 +564,13 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowEditWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('offers a subscribed personal workspace Edit, Cancel plan, and a locked Delete', () => {
+  it('offers a subscribed personal workspace Edit and Cancel without Delete', () => {
     mockIsInPersonalWorkspace.value = true
     mockIsActiveSubscription.value = true
     mockHasSubscription.value = true
     mockIsWorkspaceSubscribed.value = false
     mockUiConfig.value = personalUiConfig
+    mockCanLeaveWorkspace.value = false
     renderComponent()
 
     expect(
@@ -560,8 +580,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Cancel plan' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Delete Workspace' })
-    ).toBeDisabled()
+      screen.queryByRole('button', { name: 'Delete Workspace' })
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Leave Workspace' })
     ).not.toBeInTheDocument()
@@ -623,6 +643,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
   it('offers members only Leave Workspace in the menu', () => {
     mockCanManageSubscription.value = false
+    mockCanManageSubscriptionLifecycle.value = false
     mockUiConfig.value = memberUiConfig
     renderComponent()
 
@@ -635,11 +656,15 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(
       screen.queryByRole('button', { name: 'Edit workspace details' })
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Delete Workspace' })
+    ).not.toBeInTheDocument()
   })
 
   it('opens the leave-workspace dialog from a member menu', async () => {
     const user = userEvent.setup()
     mockCanManageSubscription.value = false
+    mockCanManageSubscriptionLifecycle.value = false
     mockUiConfig.value = memberUiConfig
     renderComponent()
 
@@ -647,7 +672,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('offers a promoted owner Edit and Leave (no Cancel or Delete)', () => {
+  it('offers an additional workspace owner Edit, Cancel, Leave, and locked Delete', async () => {
+    const user = userEvent.setup()
     renderComponent()
 
     expect(
@@ -657,34 +683,14 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Leave Workspace' })
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Cancel plan' })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Delete Workspace' })
-    ).not.toBeInTheDocument()
-  })
-
-  it('offers the original owner Edit, Cancel plan, and a subscription-locked Delete', async () => {
-    const user = userEvent.setup()
-    mockUserEmail.value = 'creator@example.com'
-    renderComponent()
-
-    expect(
-      screen.getByRole('button', { name: 'Edit workspace details' })
-    ).toBeInTheDocument()
-    expect(
       screen.getByRole('button', { name: 'Delete Workspace' })
     ).toBeDisabled()
-    expect(
-      screen.queryByRole('button', { name: 'Leave Workspace' })
-    ).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Cancel plan' }))
     expect(mockShowCancelSubscriptionDialog).toHaveBeenCalledOnce()
   })
 
-  it('enables Delete for the original owner once the plan is cancelled', () => {
-    mockUserEmail.value = 'creator@example.com'
+  it('enables Delete for any additional workspace owner once the plan is cancelled', () => {
     mockSubscriptionStatus.value = 'canceled'
     renderComponent()
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -45,7 +45,7 @@
     <template v-else>
       <!-- Cancelled subscription info card -->
       <div
-        v-if="isTeamPlanCancelled"
+        v-if="isSubscriptionCancelled"
         class="mb-6 flex gap-1 rounded-2xl border border-warning-background bg-warning-background/20 p-4"
       >
         <div
@@ -151,7 +151,7 @@
                     {{ planDisplayName }}
                   </h3>
                   <StatusBadge
-                    v-if="isTeamPlanCancelled"
+                    v-if="isSubscriptionCancelled"
                     :label="$t('subscription.canceled')"
                     severity="warn"
                   />
@@ -164,7 +164,7 @@
                   v-if="isActiveSubscription"
                   class="text-sm text-text-secondary"
                 >
-                  <template v-if="isTeamPlanCancelled">
+                  <template v-if="isSubscriptionCancelled">
                     {{
                       $t('subscription.endsOnDate', {
                         date: formattedEndDate
@@ -195,7 +195,10 @@
                   {{ $t('subscription.manageBilling') }}
                 </Button>
                 <Button
-                  v-if="isTeamPlanCancelled && isOriginalOwner"
+                  v-if="
+                    isSubscriptionCancelled &&
+                    permissions.canManageSubscriptionLifecycle
+                  "
                   size="lg"
                   variant="primary"
                   class="rounded-lg px-4 text-sm font-normal"
@@ -206,7 +209,8 @@
                 </Button>
                 <Button
                   v-else-if="
-                    !isTeamPlanCancelled && permissions.canManageSubscription
+                    !isSubscriptionCancelled &&
+                    permissions.canManageSubscription
                   "
                   size="lg"
                   variant="secondary"
@@ -214,7 +218,7 @@
                   @click="handleUpgrade"
                 >
                   {{
-                    isInPersonalWorkspace
+                    isInPersonalWorkspace && !isTeamPlan
                       ? $t('subscription.upgradePlan')
                       : $t('subscription.changePlan')
                   }}
@@ -305,7 +309,10 @@
         </Button>
       </div>
 
-      <SubscriptionFooterLinks class="mt-auto pt-6" />
+      <SubscriptionFooterLinks
+        class="mt-auto pt-6"
+        :show-invoice-history="permissions.canManageSubscription"
+      />
     </template>
   </div>
 </template>
@@ -335,7 +342,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
-const { permissions, isOriginalOwner, isTeamPlanCancelled } = useWorkspaceUI()
+const { permissions, isSubscriptionCancelled } = useWorkspaceUI()
 const { t, n, locale } = useI18n()
 
 const billingOperationStore = useBillingOperationStore()
@@ -363,7 +370,13 @@ const { menuEntries } = useWorkspaceMenuItems()
 // stays active until its end date, so it keeps the subscribed treatment.
 const showSubscribePrompt = computed(() => {
   if (!permissions.value.canManageSubscription) return false
-  if (isTeamPlanCancelled.value) return false
+  if (isSubscriptionCancelled.value) return false
+  if (
+    subscription.value &&
+    !isFreeTierPlan.value &&
+    (subscription.value.planSlug || subscription.value.tier)
+  )
+    return false
   if (isInPersonalWorkspace.value) return !isActiveSubscription.value
   return !isWorkspaceSubscribed.value
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -139,7 +139,18 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
 
     expect(mockUseSubscriptionCheckout).toHaveBeenCalledWith(
       expect.any(Function),
-      'out_of_credits'
+      'out_of_credits',
+      { tierPlanType: 'team' }
+    )
+  })
+
+  it('marks the legacy Personal table as a personal-plan target', () => {
+    renderComponent({ isPersonal: true })
+
+    expect(mockUseSubscriptionCheckout).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      { tierPlanType: 'personal' }
     )
   })
 

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -154,7 +154,9 @@ const {
   handleConfirmTransition,
   handleResubscribe,
   handleSuccessClose
-} = useSubscriptionCheckout(emit, reason)
+} = useSubscriptionCheckout(emit, reason, {
+  tierPlanType: isPersonal ? 'personal' : 'team'
+})
 </script>
 
 <style scoped>

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -13,6 +13,10 @@ const mockTopup = vi.fn<(amountCents: number) => Promise<CreateTopupResponse>>()
 const mockStartOperation = vi.fn()
 const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
+const mockCloseDialog = vi.fn()
+const mockTrackTopUpPurchase = vi.fn()
+const mockCanTopUp = vi.hoisted(() => ({ value: true }))
+const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: true }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -29,17 +33,37 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   })
 }))
 
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return { canTopUp: mockCanTopUp.value }
+      }
+    }
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: {
+      get value() {
+        return mockShouldUseWorkspaceBilling.value
+      }
+    }
+  })
+}))
+
 vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
   useSettingsDialog: () => ({ show: mockShowSettings })
 }))
 
 vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: () => ({ closeDialog: vi.fn() })
+  useDialogStore: () => ({ closeDialog: mockCloseDialog })
 }))
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackApiCreditTopupButtonPurchaseClicked: vi.fn()
+    trackApiCreditTopupButtonPurchaseClicked: mockTrackTopUpPurchase
   })
 }))
 
@@ -127,6 +151,8 @@ async function clickAddCredits() {
 describe('TopUpCreditsDialogContentWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanTopUp.value = true
+    mockShouldUseWorkspaceBilling.value = true
     mockFetchBalance.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
   })
@@ -161,5 +187,30 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
 
     expect(mockFetchBalance).not.toHaveBeenCalled()
     expect(mockFetchStatus).not.toHaveBeenCalled()
+  })
+
+  it('does not top up after the workspace role loses permission', async () => {
+    renderDialog()
+    mockCanTopUp.value = false
+
+    await clickAddCredits()
+
+    expect(mockTopup).not.toHaveBeenCalled()
+    expect(mockTrackTopUpPurchase).not.toHaveBeenCalled()
+    expect(mockToastAdd).not.toHaveBeenCalled()
+    expect(mockCloseDialog).not.toHaveBeenCalled()
+  })
+
+  it('keeps a mounted workspace dialog usable after routing switches to legacy billing', async () => {
+    mockCanTopUp.value = false
+    mockShouldUseWorkspaceBilling.value = false
+    mockTopup.mockResolvedValue(topupResponse('completed'))
+
+    renderDialog()
+    await clickAddCredits()
+
+    expect(mockTopup).toHaveBeenCalledWith(5000)
+    expect(mockFetchBalance).toHaveBeenCalledOnce()
+    expect(mockFetchStatus).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -158,10 +158,12 @@ import { creditsToUsd, usdToCredits } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import FormattedNumberStepper from '@/components/ui/stepper/FormattedNumberStepper.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useTelemetry } from '@/platform/telemetry'
 import { clearTopupTracking } from '@/platform/telemetry/topupTracker'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -177,6 +179,8 @@ const telemetry = useTelemetry()
 const toast = useToast()
 const { buildDocsUrl, docsPaths } = useExternalLink()
 const { fetchBalance, fetchStatus, topup } = useBillingContext()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
+const { permissions } = useWorkspaceUI()
 
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)
@@ -249,7 +253,13 @@ function handleClose(clearTracking = true) {
 }
 
 async function handleBuy() {
-  if (loading.value || !isValidAmount.value) return
+  if (
+    loading.value ||
+    !isValidAmount.value ||
+    (shouldUseWorkspaceBilling.value && !permissions.value.canTopUp)
+  ) {
+    return
+  }
 
   loading.value = true
   try {

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -24,14 +24,27 @@ const mockSubscription = ref<MockSubscription | null>(null)
 const mockCurrentPlanSlug = ref<string | null>(null)
 const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
 const mockTeamFlag = ref(false)
+const mockIsTeamPlan = ref(false)
+const mockCanManageSubscription = ref(true)
+const mockCanDowngradeToPersonal = ref(true)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     plans: ref([]),
     currentPlanSlug: computed(() => mockCurrentPlanSlug.value),
     fetchPlans: vi.fn(),
+    isTeamPlan: computed(() => mockIsTeamPlan.value),
     subscription: computed(() => mockSubscription.value),
     currentTeamCreditStop: computed(() => mockCurrentTeamCreditStop.value)
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: computed(() => ({
+      canManageSubscription: mockCanManageSubscription.value,
+      canDowngradeToPersonal: mockCanDowngradeToPersonal.value
+    }))
   })
 }))
 
@@ -73,6 +86,9 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
     mockTeamFlag.value = false
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = true
+    mockCanDowngradeToPersonal.value = true
   })
 
   it('prompts free-tier users to subscribe, never to "change"', () => {
@@ -105,17 +121,39 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     ).toBeTruthy()
   })
 
-  it('keeps personal tier cards actionable for a team subscriber', () => {
+  it('keeps personal tier cards actionable for the original owner of a team plan', () => {
     mockSubscription.value = { tier: 'TEAM', duration: 'ANNUAL' }
     mockCurrentTeamCreditStop.value = {
       id: 'team_700',
       credits_monthly: 147_700,
       stop_usd: 700
     }
+    mockIsTeamPlan.value = true
 
     renderComponent()
 
-    expect(screen.queryByRole('button', { name: /Not available/ })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeEnabled()
+  })
+
+  it('normalizes a promoted owner on a team plan away from personal plans', () => {
+    mockSubscription.value = { tier: 'TEAM', duration: 'ANNUAL' }
+    mockCurrentTeamCreditStop.value = {
+      id: 'team_700',
+      credits_monthly: 147_700,
+      stop_usd: 700
+    }
+    mockTeamFlag.value = true
+    mockIsTeamPlan.value = true
+    mockCanDowngradeToPersonal.value = false
+
+    renderComponent({ initialPlanMode: 'personal' })
+
+    expect(
+      screen.queryByRole('button', { name: 'Change to Standard Yearly' })
+    ).toBeNull()
+    expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled()
   })
 })
 
@@ -131,6 +169,9 @@ describe('UnifiedPricingTable team plan CTA', () => {
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
     mockTeamFlag.value = true
+    mockIsTeamPlan.value = false
+    mockCanManageSubscription.value = true
+    mockCanDowngradeToPersonal.value = true
   })
 
   it('disables the CTA while sitting on the active current plan', () => {

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -436,6 +436,7 @@ import {
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { Plan } from '@/platform/workspace/api/workspaceApi'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
@@ -468,6 +469,7 @@ const emit = defineEmits<{
 
 const { t, n } = useI18n()
 const { flags } = useFeatureFlags()
+const { permissions } = useWorkspaceUI()
 
 /** Team plans only exist behind the flag (mirrors useBillingContext type). */
 const showTeam = computed(() => flags.teamWorkspacesEnabled)
@@ -552,7 +554,7 @@ const planScopeButtonPt = {
   }
 }
 
-const planScopeOptions: PlanScopeOption[] = [
+const allPlanScopeOptions: PlanScopeOption[] = [
   { label: t('subscription.planScope.personal'), value: 'personal' },
   { label: t('subscription.planScope.team'), value: 'team' }
 ]
@@ -611,9 +613,28 @@ const {
   plans: apiPlans,
   currentPlanSlug,
   fetchPlans,
+  isTeamPlan,
   subscription,
   currentTeamCreditStop
 } = useBillingContext()
+
+const canSelectPersonalPlan = computed(
+  () => !isTeamPlan.value || permissions.value.canDowngradeToPersonal
+)
+
+const planScopeOptions = computed(() =>
+  canSelectPersonalPlan.value
+    ? allPlanScopeOptions
+    : allPlanScopeOptions.filter((option) => option.value === 'team')
+)
+
+watch(
+  canSelectPersonalPlan,
+  (canSelect) => {
+    if (!canSelect) planMode.value = 'team'
+  },
+  { immediate: true }
+)
 
 const { teamCreditStops } = useBillingPlans()
 
@@ -722,6 +743,7 @@ const teamButtonLabel = computed(() => {
 
 const isTeamButtonDisabled = computed(
   () =>
+    !permissions.value.canManageSubscription ||
     isLoading ||
     (isTeamSubscribed.value &&
       isTeamCurrentPlanSelected.value &&
@@ -810,7 +832,12 @@ const getButtonSeverity = (
 }
 
 const isButtonDisabled = (tier: PricingTierConfig): boolean => {
-  if (isLoading) return true
+  if (
+    isLoading ||
+    !permissions.value.canManageSubscription ||
+    !canSelectPersonalPlan.value
+  )
+    return true
   if (isCurrentPlan(tier.key)) {
     return !isCancelled.value
   }
@@ -836,7 +863,12 @@ const getAnnualTotal = (tier: PricingTierConfig): number => {
 }
 
 function handleSubscribe(tierKey: CheckoutTierKey) {
-  if (isLoading) return
+  if (
+    isLoading ||
+    !permissions.value.canManageSubscription ||
+    !canSelectPersonalPlan.value
+  )
+    return
   if (isCurrentPlan(tierKey)) {
     if (isCancelled.value) {
       emit('resubscribe')

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -26,6 +26,7 @@ const {
   mockFilteredMembers,
   mockFilteredPendingInvites,
   mockHasTeamPlan,
+  mockHasLapsedTeamPlan,
   mockIsPlanLoading,
   mockIsOnTeamPlan,
   mockHasMultipleMembers,
@@ -53,6 +54,7 @@ const {
     mockFilteredMembers: ref<WorkspaceMember[]>([]),
     mockFilteredPendingInvites: ref<PendingInvite[]>([]),
     mockHasTeamPlan: ref(true),
+    mockHasLapsedTeamPlan: ref(false),
     mockIsPlanLoading: ref(false),
     mockIsOnTeamPlan: ref(true),
     mockActiveView: ref<'active' | 'pending'>('active'),
@@ -77,7 +79,7 @@ const {
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
       showEditWorkspaceMenuItem: true,
-      workspaceMenuAction: 'delete' as 'leave' | 'delete' | null,
+      workspaceMenuAction: 'delete' as 'delete' | null,
       workspaceMenuDisabledTooltip: null as string | null
     })
   }
@@ -91,7 +93,7 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     hasTeamPlan: mockHasTeamPlan,
     isPlanLoading: mockIsPlanLoading,
     isOnTeamPlan: mockIsOnTeamPlan,
-    hasLapsedTeamPlan: computed(() => false),
+    hasLapsedTeamPlan: mockHasLapsedTeamPlan,
     hasMultipleMembers: mockHasMultipleMembers,
     showSearch: mockShowSearch,
     showViewTabs: mockShowViewTabs,
@@ -210,6 +212,7 @@ describe('MembersPanelContent', () => {
     mockFilteredMembers.value = []
     mockFilteredPendingInvites.value = []
     mockHasTeamPlan.value = true
+    mockHasLapsedTeamPlan.value = false
     mockIsPlanLoading.value = false
     mockIsOnTeamPlan.value = true
     mockHasMultipleMembers.value = true
@@ -435,6 +438,31 @@ describe('MembersPanelContent', () => {
         screen.queryAllByRole('button', { name: 'g.moreOptions' })
       ).toHaveLength(0)
     })
+
+    it('does not show an upgrade action', () => {
+      mockHasTeamPlan.value = false
+      mockIsOnTeamPlan.value = false
+      renderComponent()
+
+      expect(
+        screen.queryByRole('button', {
+          name: /workspacePanel\.members\.upgradeToTeam/
+        })
+      ).toBeNull()
+    })
+
+    it('does not show a reactivate action for a lapsed Team plan', () => {
+      mockHasTeamPlan.value = true
+      mockHasLapsedTeamPlan.value = true
+      mockIsOnTeamPlan.value = false
+      renderComponent()
+
+      expect(
+        screen.queryByRole('button', {
+          name: /workspacePanel\.members\.reactivateTeam/
+        })
+      ).toBeNull()
+    })
   })
 
   describe('not on team plan', () => {
@@ -467,6 +495,19 @@ describe('MembersPanelContent', () => {
         name: /workspacePanel\.members\.upgradeToTeam/
       })
       await userEvent.click(upgradeBtn)
+      expect(mockShowTeamPlans).toHaveBeenCalled()
+    })
+
+    it('lets an owner reactivate a lapsed Team plan', async () => {
+      mockHasTeamPlan.value = true
+      mockHasLapsedTeamPlan.value = true
+      renderComponent()
+
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: /workspacePanel\.members\.reactivateTeam/
+        })
+      )
       expect(mockShowTeamPlans).toHaveBeenCalled()
     })
 

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -186,7 +186,9 @@
     </div>
     <!-- Upsell Banner -->
     <MemberUpsellBanner
-      v-if="!isPlanLoading && !isOnTeamPlan"
+      v-if="
+        !isPlanLoading && !isOnTeamPlan && permissions.canManageSubscription
+      "
       :reactivate="hasLapsedTeamPlan"
       @show-plans="showTeamPlans()"
     />

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
@@ -16,12 +16,18 @@ const ownerConfig = {
 }
 const memberConfig = {
   showEditWorkspaceMenuItem: false,
-  workspaceMenuAction: 'leave' as const,
+  workspaceMenuAction: null,
+  workspaceMenuDisabledTooltip: null
+}
+const personalConfig = {
+  showEditWorkspaceMenuItem: true,
+  workspaceMenuAction: null,
   workspaceMenuDisabledTooltip: null
 }
 
 const mockUiConfig = ref<Record<string, unknown>>(ownerConfig)
-const mockIsCurrentUserOriginalOwner = ref(false)
+const mockCanLeaveWorkspace = ref(false)
+const mockCanManageSubscription = ref(true)
 const mockIsWorkspaceSubscribed = ref(false)
 
 const mockShowLeaveWorkspaceDialog = vi.fn()
@@ -29,13 +35,18 @@ const mockShowDeleteWorkspaceDialog = vi.fn()
 const mockShowEditWorkspaceDialog = vi.fn()
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({ uiConfig: mockUiConfig })
+  useWorkspaceUI: () => ({
+    permissions: computed(() => ({
+      canLeaveWorkspace: mockCanLeaveWorkspace.value,
+      canManageSubscription: mockCanManageSubscription.value
+    })),
+    uiConfig: mockUiConfig
+  })
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
-    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
-    isCurrentUserOriginalOwner: mockIsCurrentUserOriginalOwner
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
   })
 }))
 
@@ -73,12 +84,15 @@ describe('WorkspaceMenuButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUiConfig.value = ownerConfig
-    mockIsCurrentUserOriginalOwner.value = false
+    mockCanLeaveWorkspace.value = false
+    mockCanManageSubscription.value = true
     mockIsWorkspaceSubscribed.value = false
   })
 
   it('lets a member leave and offers no destructive workspace actions', () => {
     mockUiConfig.value = memberConfig
+    mockCanLeaveWorkspace.value = true
+    mockCanManageSubscription.value = false
     renderComponent()
 
     const leave = screen.getByRole('button', { name: 'Leave Workspace' })
@@ -88,7 +102,9 @@ describe('WorkspaceMenuButton', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('lets a non-creator owner leave', () => {
+  it('lets an additional workspace owner leave and delete', async () => {
+    const user = userEvent.setup()
+    mockCanLeaveWorkspace.value = true
     renderComponent()
 
     expect(
@@ -96,32 +112,79 @@ describe('WorkspaceMenuButton', () => {
     ).toBeEnabled()
     expect(
       screen.getByRole('button', { name: 'Delete Workspace' })
-    ).toBeInTheDocument()
+    ).toBeEnabled()
+
+    await user.click(screen.getByRole('button', { name: 'Delete Workspace' }))
+    expect(mockShowDeleteWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('shows the creator a disabled Leave option', () => {
-    mockIsCurrentUserOriginalOwner.value = true
+  it('does not expose Delete in a personal workspace', () => {
+    mockUiConfig.value = personalConfig
     renderComponent()
 
     expect(
-      screen.getByRole('button', { name: 'Leave Workspace' })
+      screen.queryByRole('button', { name: 'Delete Workspace' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('disables Delete while the additional workspace is subscribed', () => {
+    mockIsWorkspaceSubscribed.value = true
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Delete Workspace' })
     ).toBeDisabled()
   })
 
-  it('opens the leave dialog when a non-creator owner clicks Leave', async () => {
+  it('hides Leave when workspace permission is withheld', () => {
+    renderComponent()
+
+    expect(
+      screen.queryByRole('button', { name: 'Leave Workspace' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens the leave dialog when an owner clicks Leave', async () => {
     const user = userEvent.setup()
+    mockCanLeaveWorkspace.value = true
     renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
     expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
   })
 
-  it('does not open the leave dialog for the creator', async () => {
-    const user = userEvent.setup()
-    mockIsCurrentUserOriginalOwner.value = true
+  it('rechecks permission before opening the leave dialog', () => {
+    mockCanLeaveWorkspace.value = true
     renderComponent()
 
-    await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
+    const leave = screen.getByRole('button', { name: 'Leave Workspace' })
+    mockCanLeaveWorkspace.value = false
+    leave.click()
+
     expect(mockShowLeaveWorkspaceDialog).not.toHaveBeenCalled()
+  })
+
+  it('rechecks owner permission before opening the delete dialog', () => {
+    renderComponent()
+
+    const deleteWorkspace = screen.getByRole('button', {
+      name: 'Delete Workspace'
+    })
+    mockCanManageSubscription.value = false
+    deleteWorkspace.click()
+
+    expect(mockShowDeleteWorkspaceDialog).not.toHaveBeenCalled()
+  })
+
+  it('rechecks the subscription lock before opening the delete dialog', () => {
+    renderComponent()
+
+    const deleteWorkspace = screen.getByRole('button', {
+      name: 'Delete Workspace'
+    })
+    mockIsWorkspaceSubscribed.value = true
+    deleteWorkspace.click()
+
+    expect(mockShowDeleteWorkspaceDialog).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
@@ -31,10 +31,8 @@ const {
   showDeleteWorkspaceDialog,
   showEditWorkspaceDialog
 } = useDialogService()
-const { isWorkspaceSubscribed, isCurrentUserOriginalOwner } = storeToRefs(
-  useTeamWorkspaceStore()
-)
-const { uiConfig } = useWorkspaceUI()
+const { isWorkspaceSubscribed } = storeToRefs(useTeamWorkspaceStore())
+const { permissions, uiConfig } = useWorkspaceUI()
 
 // Disable delete when the workspace has an active subscription (prevents
 // accidental deletion); uses the workspace's own status, not the global one.
@@ -50,6 +48,22 @@ const deleteTooltip = computed(() => {
   return tooltipKey ? t(tooltipKey) : undefined
 })
 
+function leaveWorkspace() {
+  if (!permissions.value.canLeaveWorkspace) return
+  void showLeaveWorkspaceDialog()
+}
+
+function deleteWorkspace() {
+  if (
+    !permissions.value.canManageSubscription ||
+    uiConfig.value.workspaceMenuAction !== 'delete' ||
+    isDeleteDisabled.value
+  ) {
+    return
+  }
+  void showDeleteWorkspaceDialog()
+}
+
 const menuItems = computed<MenuItem[]>(() => {
   const items: MenuItem[] = []
 
@@ -61,8 +75,10 @@ const menuItems = computed<MenuItem[]>(() => {
     })
   }
 
-  const action = uiConfig.value.workspaceMenuAction
-  if (action === 'delete') {
+  if (
+    uiConfig.value.workspaceMenuAction === 'delete' &&
+    permissions.value.canManageSubscription
+  ) {
     items.push({
       label: t('workspacePanel.menu.deleteWorkspace'),
       icon: 'pi pi-trash',
@@ -71,29 +87,16 @@ const menuItems = computed<MenuItem[]>(() => {
         : 'text-destructive-background',
       disabled: isDeleteDisabled.value,
       tooltip: deleteTooltip.value,
-      command: isDeleteDisabled.value
-        ? undefined
-        : () => showDeleteWorkspaceDialog()
+      command: isDeleteDisabled.value ? undefined : deleteWorkspace
     })
   }
 
-  // Members and non-creator owners can leave; the creator sees it disabled.
-  if (action === 'leave' || action === 'delete') {
-    items.push(
-      isCurrentUserOriginalOwner.value
-        ? {
-            label: t('workspacePanel.menu.leaveWorkspace'),
-            icon: 'pi pi-sign-out',
-            class: 'opacity-50',
-            disabled: true,
-            tooltip: t('workspacePanel.menu.creatorCannotLeave')
-          }
-        : {
-            label: t('workspacePanel.menu.leaveWorkspace'),
-            icon: 'pi pi-sign-out',
-            command: () => showLeaveWorkspaceDialog()
-          }
-    )
+  if (permissions.value.canLeaveWorkspace) {
+    items.push({
+      label: t('workspacePanel.menu.leaveWorkspace'),
+      icon: 'pi pi-sign-out',
+      command: leaveWorkspace
+    })
   }
 
   return items

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -12,6 +12,12 @@ const mockFetchMembers = vi.hoisted(() => vi.fn())
 const mockSubscribe = vi.hoisted(() => vi.fn())
 const mockPreviewSubscribe = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
+const mockPermissions = vi.hoisted(() => ({
+  value: {
+    canManageSubscription: true,
+    canDowngradeToPersonal: true
+  }
+}))
 
 vi.mock('pinia', async (importOriginal) => {
   const actual = await importOriginal()
@@ -33,6 +39,10 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
     startOperation: mockStartOperation
   })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({ permissions: mockPermissions })
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -95,6 +105,10 @@ describe('useDowngradeToPersonal', () => {
       billing_op_id: 'op-1',
       status: 'subscribed'
     })
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canDowngradeToPersonal: true
+    }
     windowOpen = vi.spyOn(window, 'open').mockReturnValue({} as Window)
   })
 
@@ -156,6 +170,48 @@ describe('useDowngradeToPersonal', () => {
   })
 
   describe('downgradeToPersonal', () => {
+    it('rejects a promoted owner before previewing or removing members', async () => {
+      mockPermissions.value.canDowngradeToPersonal = false
+      mockMembers.value = teamWithOwnerAnd('m1')
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('stops before member removal when downgrade access is revoked during preview', async () => {
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockImplementation(async () => {
+        mockPermissions.value.canDowngradeToPersonal = false
+        return { allowed: true }
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('stops before submit when downgrade access is revoked during member removal', async () => {
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockRemoveMember.mockImplementation(async () => {
+        mockPermissions.value.canDowngradeToPersonal = false
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockRemoveMember).toHaveBeenCalledOnce()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
     it('removes every non-creator member then initiates the tier change', async () => {
       mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       const { downgradeToPersonal } = useDowngradeToPersonal()
@@ -342,6 +398,29 @@ describe('useDowngradeToPersonal', () => {
       await refreshMembers()
 
       expect(hasOtherMembers.value).toBe(true)
+    })
+
+    it('rejects a member without fetching workspace members', async () => {
+      mockPermissions.value = {
+        canManageSubscription: false,
+        canDowngradeToPersonal: false
+      }
+      const { refreshMembers } = useDowngradeToPersonal()
+
+      await expect(refreshMembers()).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockFetchMembers).not.toHaveBeenCalled()
+    })
+
+    it('rejects a promoted owner after refreshing the original-owner signal', async () => {
+      mockPermissions.value.canDowngradeToPersonal = false
+      const { refreshMembers } = useDowngradeToPersonal()
+
+      await expect(refreshMembers()).rejects.toThrow(
+        'subscription.downgrade.notAllowed'
+      )
+      expect(mockFetchMembers).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -5,6 +5,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
@@ -20,6 +21,7 @@ export function useDowngradeToPersonal() {
   const { subscribe, previewSubscribe } = useBillingContext()
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
+  const { permissions } = useWorkspaceUI()
 
   const removableMembers = computed(() => {
     const hasFlag = members.value.some((m) => m.isOriginalOwner)
@@ -32,18 +34,31 @@ export function useDowngradeToPersonal() {
 
   const hasOtherMembers = computed(() => removableMembers.value.length > 0)
 
+  function ensureCanDowngrade(): void {
+    if (!permissions.value.canDowngradeToPersonal) {
+      throw new Error(t('subscription.downgrade.notAllowed'))
+    }
+  }
+
   async function refreshMembers(): Promise<void> {
+    if (!permissions.value.canManageSubscription) {
+      throw new Error(t('subscription.downgrade.notAllowed'))
+    }
     await workspaceStore.fetchMembers()
+    ensureCanDowngrade()
   }
 
   async function downgradeToPersonal(planSlug: string): Promise<void> {
+    ensureCanDowngrade()
     const preview = await previewSubscribe(planSlug)
     if (!preview?.allowed) {
       throw new Error(preview?.reason || t('subscription.downgrade.notAllowed'))
     }
+    ensureCanDowngrade()
 
     const membersToRemove = removableMembers.value
     for (const member of membersToRemove) {
+      ensureCanDowngrade()
       try {
         await workspaceStore.removeMember(member.id)
       } catch (error) {
@@ -56,6 +71,7 @@ export function useDowngradeToPersonal() {
       }
     }
 
+    ensureCanDowngrade()
     const response = await subscribe(planSlug, {
       returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
       cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -256,6 +256,7 @@ const mockShowInviteMemberDialog = vi.fn()
 const mockShowInviteMemberUpsellDialog = vi.fn()
 
 const {
+  mockActiveWorkspace,
   mockMembers,
   mockPendingInvites,
   mockOriginalOwnerId,
@@ -274,6 +275,9 @@ const {
   const { ref } = require('vue') as typeof import('vue')
 
   return {
+    mockActiveWorkspace: ref<{ type: 'personal' | 'team' } | null>({
+      type: 'personal'
+    }),
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
     mockOriginalOwnerId: ref<string | null>(null),
@@ -299,7 +303,7 @@ const {
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
       showEditWorkspaceMenuItem: true,
-      workspaceMenuAction: 'delete' as 'leave' | 'delete' | null,
+      workspaceMenuAction: 'delete' as 'delete' | null,
       workspaceMenuDisabledTooltip: null as string | null
     }),
     mockIsActiveSubscription: ref(true),
@@ -333,6 +337,7 @@ vi.mock('pinia', async (importOriginal) => {
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   MAX_WORKSPACE_MEMBERS: 30,
   useTeamWorkspaceStore: () => ({
+    activeWorkspace: mockActiveWorkspace,
     members: mockMembers,
     pendingInvites: mockPendingInvites,
     originalOwnerId: mockOriginalOwnerId,
@@ -404,6 +409,7 @@ vi.mock('@/services/dialogService', () => ({
 describe('useMembersPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockActiveWorkspace.value = { type: 'personal' }
     mockMembers.value = []
     mockPendingInvites.value = []
     mockOriginalOwnerId.value = null
@@ -707,13 +713,23 @@ describe('useMembersPanel', () => {
   })
 
   describe('isOriginalOwner', () => {
-    it('matches against the store originalOwnerId', async () => {
+    it('protects the matching creator in a personal workspace', async () => {
       mockOriginalOwnerId.value = 'creator-1'
       const panel = await setup()
       expect(panel.isOriginalOwner(createMember({ id: 'creator-1' }))).toBe(
         true
       )
       expect(panel.isOriginalOwner(createMember({ id: 'other' }))).toBe(false)
+    })
+
+    it('treats an additional workspace creator as an ordinary owner', async () => {
+      mockActiveWorkspace.value = { type: 'team' }
+      mockOriginalOwnerId.value = 'creator-1'
+      const panel = await setup()
+
+      expect(panel.isOriginalOwner(createMember({ id: 'creator-1' }))).toBe(
+        false
+      )
     })
   })
 

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -101,6 +101,7 @@ export function useMembersPanel() {
   } = useDialogService()
   const workspaceStore = useTeamWorkspaceStore()
   const {
+    activeWorkspace,
     members,
     pendingInvites,
     originalOwnerId,
@@ -271,7 +272,10 @@ export function useMembersPanel() {
   }
 
   function isOriginalOwner(member: WorkspaceMember): boolean {
-    return member.id === originalOwnerId.value
+    return (
+      activeWorkspace.value?.type === 'personal' &&
+      member.id === originalOwnerId.value
+    )
   }
 
   const filteredMembers = computed(() => {

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useResubscribe } from './useResubscribe'
+
+const state = vi.hoisted(() => ({
+  shouldUseWorkspaceBilling: true,
+  canManageSubscriptionLifecycle: true,
+  resubscribe: vi.fn(),
+  toastAdd: vi.fn(),
+  trackResubscribeClicked: vi.fn()
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({ resubscribe: state.resubscribe })
+}))
+
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: {
+      get value() {
+        return state.shouldUseWorkspaceBilling
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return {
+          canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackResubscribeClicked: state.trackResubscribeClicked
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: state.toastAdd })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+describe('useResubscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.shouldUseWorkspaceBilling = true
+    state.canManageSubscriptionLifecycle = true
+    state.resubscribe.mockResolvedValue(undefined)
+  })
+
+  it('does not resubscribe after the workspace role loses permission', async () => {
+    const { handleResubscribe, isResubscribing } = useResubscribe()
+    state.canManageSubscriptionLifecycle = false
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).not.toHaveBeenCalled()
+    expect(state.trackResubscribeClicked).not.toHaveBeenCalled()
+    expect(state.toastAdd).not.toHaveBeenCalled()
+    expect(isResubscribing.value).toBe(false)
+  })
+
+  it('keeps legacy resubscribe behavior independent of workspace roles', async () => {
+    state.shouldUseWorkspaceBilling = false
+    state.canManageSubscriptionLifecycle = false
+    const { handleResubscribe } = useResubscribe()
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).toHaveBeenCalledOnce()
+    expect(state.trackResubscribeClicked).toHaveBeenCalledOnce()
+    expect(state.toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' })
+    )
+  })
+
+  it('shows an error and resets loading when resubscription fails', async () => {
+    state.resubscribe.mockRejectedValueOnce(new Error('Resubscribe failed'))
+    const { handleResubscribe, isResubscribing } = useResubscribe()
+
+    await handleResubscribe()
+
+    expect(state.resubscribe).toHaveBeenCalledOnce()
+    expect(state.toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Resubscribe failed'
+      })
+    )
+    expect(isResubscribing.value).toBe(false)
+  })
+})

--- a/src/platform/workspace/composables/useResubscribe.ts
+++ b/src/platform/workspace/composables/useResubscribe.ts
@@ -3,7 +3,9 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useTelemetry } from '@/platform/telemetry'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 /**
  * Reactivates a cancelled-but-still-active subscription and surfaces success or
@@ -13,10 +15,19 @@ export function useResubscribe() {
   const { t } = useI18n()
   const toast = useToast()
   const { resubscribe } = useBillingContext()
+  const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { permissions } = useWorkspaceUI()
 
   const isResubscribing = ref(false)
 
   async function handleResubscribe() {
+    if (
+      shouldUseWorkspaceBilling.value &&
+      !permissions.value.canManageSubscriptionLifecycle
+    ) {
+      return
+    }
+
     useTelemetry()?.trackResubscribeClicked({
       source: 'settings_billing_panel'
     })

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -78,7 +78,10 @@ const {
   mockToastAdd,
   mockStartOperation,
   mockTrackBeginCheckout,
-  mockUserId
+  mockShowDowngradeToPersonalDialog,
+  mockUserId,
+  mockIsTeamPlan,
+  mockPermissions
 } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(),
   mockPreviewSubscribe: vi.fn(),
@@ -89,7 +92,16 @@ const {
   mockToastAdd: vi.fn(),
   mockStartOperation: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
-  mockUserId: { value: 'user-1' as string | null }
+  mockShowDowngradeToPersonalDialog: vi.fn(),
+  mockUserId: { value: 'user-1' as string | null },
+  mockIsTeamPlan: { value: false },
+  mockPermissions: {
+    value: {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -99,7 +111,24 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     plans: computed(() => mockPlans.value),
     fetchStatus: mockFetchStatus,
     fetchBalance: mockFetchBalance,
+    isTeamPlan: computed(() => mockIsTeamPlan.value),
     resubscribe: mockResubscribe
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return mockPermissions.value
+      }
+    }
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showDowngradeToPersonalDialog: mockShowDowngradeToPersonalDialog
   })
 }))
 
@@ -150,10 +179,15 @@ vi.mock('vue-i18n', async (importOriginal) => {
 describe('useSubscriptionCheckout', () => {
   let emit: ReturnType<typeof vi.fn>
 
-  async function setup(paymentIntentSource?: PaymentIntentSource) {
+  async function setup(
+    paymentIntentSource?: PaymentIntentSource,
+    tierPlanType: 'personal' | 'team' = 'personal'
+  ) {
     const { useSubscriptionCheckout } =
       await import('./useSubscriptionCheckout')
-    return useSubscriptionCheckout(emit as never, paymentIntentSource)
+    return useSubscriptionCheckout(emit as never, paymentIntentSource, {
+      tierPlanType
+    })
   }
 
   beforeEach(() => {
@@ -162,6 +196,12 @@ describe('useSubscriptionCheckout', () => {
     mockPlans.value = allPlans()
     mockStartOperation.mockResolvedValue({ status: 'succeeded' })
     mockUserId.value = 'user-1'
+    mockIsTeamPlan.value = false
+    mockPermissions.value = {
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: true,
+      canDowngradeToPersonal: true
+    }
     emit = vi.fn()
   })
 
@@ -258,6 +298,72 @@ describe('useSubscriptionCheckout', () => {
       })
 
       expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly')
+    })
+
+    it('does not preview a plan for a member', async () => {
+      mockPermissions.value = {
+        canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canDowngradeToPersonal: false
+      }
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+    })
+
+    it('does not preview a personal plan for a promoted owner on a team plan', async () => {
+      mockIsTeamPlan.value = true
+      mockPermissions.value.canDowngradeToPersonal = false
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+    })
+
+    it('allows a promoted owner to preview a legacy Team-plan change', async () => {
+      mockIsTeamPlan.value = true
+      mockPermissions.value.canDowngradeToPersonal = false
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade'
+      })
+      const checkout = await setup(undefined, 'team')
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('standard-yearly')
+      expect(checkout.checkoutStep.value).toBe('preview')
+    })
+
+    it('routes an original-owner Team-to-personal change through member removal', async () => {
+      mockIsTeamPlan.value = true
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(mockShowDowngradeToPersonalDialog).toHaveBeenCalledWith({
+        planName: 'subscription.tiers.standard.name',
+        planSlug: 'standard-yearly'
+      })
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
     })
   })
 
@@ -367,6 +473,26 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockPreviewSubscribe).not.toHaveBeenCalled()
       expect(checkout.previewData.value).toBeNull()
+    })
+
+    it('does not prepare a team checkout for a member', async () => {
+      mockPermissions.value.canManageSubscription = false
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      expect(checkout.selectedTeamStop.value).toBeNull()
+      expect(checkout.checkoutStep.value).toBe('pricing')
     })
   })
 
@@ -819,6 +945,17 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
     })
+
+    it('does not submit when workspace ownership is revoked', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockPermissions.value.canManageSubscription = false
+
+      await checkout.handleAddCreditCard()
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
   })
 
   describe('handleConfirmTransition', () => {
@@ -852,6 +989,27 @@ describe('useSubscriptionCheckout', () => {
           detail: 'Transition error'
         })
       )
+    })
+
+    it('does not submit a previewed plan after permission is revoked', async () => {
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      expect(checkout.checkoutStep.value).toBe('preview')
+      mockPermissions.value.canManageSubscription = false
+
+      await checkout.handleConfirmTransition()
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
+      expect(emit).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
     })
   })
 
@@ -887,6 +1045,16 @@ describe('useSubscriptionCheckout', () => {
           detail: 'Resubscribe failed'
         })
       )
+    })
+
+    it('does not resubscribe for a member', async () => {
+      mockPermissions.value.canManageSubscriptionLifecycle = false
+      const checkout = await setup()
+
+      await checkout.handleResubscribe()
+
+      expect(mockResubscribe).not.toHaveBeenCalled()
+      expect(mockTrackResubscribeClicked).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -18,6 +18,7 @@ import type {
   PreviewSubscribeResponse,
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
@@ -27,6 +28,10 @@ type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 interface SelectedTeamCheckout {
   stop: TeamPlanSelection
   checkoutType: SubscriptionCheckoutType
+}
+
+interface SubscriptionCheckoutOptions {
+  tierPlanType?: 'personal' | 'team'
 }
 
 /**
@@ -59,7 +64,8 @@ export function useSubscriptionCheckout(
   emit: {
     (e: 'close', subscribed: boolean): void
   },
-  paymentIntentSource?: PaymentIntentSource
+  paymentIntentSource?: PaymentIntentSource,
+  { tierPlanType = 'personal' }: SubscriptionCheckoutOptions = {}
 ) {
   const { t } = useI18n()
   const toast = useToast()
@@ -69,8 +75,10 @@ export function useSubscriptionCheckout(
     plans,
     fetchStatus,
     fetchBalance,
+    isTeamPlan,
     resubscribe
   } = useBillingContext()
+  const { permissions } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
 
@@ -88,6 +96,28 @@ export function useSubscriptionCheckout(
     () => selectedTeamCheckout.value?.stop ?? null
   )
   const isTeamCheckout = computed(() => selectedTeamCheckout.value !== null)
+
+  function canSelectTierPlan(): boolean {
+    return (
+      tierPlanType === 'team' ||
+      !isTeamPlan.value ||
+      permissions.value.canDowngradeToPersonal
+    )
+  }
+
+  async function showTeamToPersonalDowngrade(
+    planSlug: string,
+    tierKey: CheckoutTierKey
+  ): Promise<boolean> {
+    if (tierPlanType === 'team' || !isTeamPlan.value) return false
+
+    const { useDialogService } = await import('@/services/dialogService')
+    await useDialogService().showDowngradeToPersonalDialog({
+      planName: t(`subscription.tiers.${tierKey}.name`),
+      planSlug
+    })
+    return true
+  }
 
   const previewVariant = computed<PreviewVariant>(() => {
     if (selectedTeamCheckout.value) {
@@ -112,6 +142,8 @@ export function useSubscriptionCheckout(
     tierKey: CheckoutTierKey
     billingCycle: BillingCycle
   }) {
+    if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
+
     const { tierKey, billingCycle } = payload
 
     isLoadingPreview.value = true
@@ -129,6 +161,7 @@ export function useSubscriptionCheckout(
         })
         return
       }
+      if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       const response = await previewSubscribe(planSlug)
 
       if (!response || !response.allowed) {
@@ -170,6 +203,8 @@ export function useSubscriptionCheckout(
     billingCycle: BillingCycle
     isChange?: boolean
   }) {
+    if (!permissions.value.canManageSubscription) return
+
     selectedTeamCheckout.value = {
       stop: payload.stop,
       checkoutType: payload.isChange ? 'change' : 'new'
@@ -209,6 +244,8 @@ export function useSubscriptionCheckout(
   }
 
   async function handleSubscription() {
+    if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
+
     const tierKey = selectedTierKey.value
     if (!tierKey) return
 
@@ -223,6 +260,7 @@ export function useSubscriptionCheckout(
     try {
       const planSlug = getApiPlanSlug(tierKey, billingCycle)
       if (!planSlug) return
+      if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
@@ -302,6 +340,8 @@ export function useSubscriptionCheckout(
   }
 
   async function handleTeamSubscription() {
+    if (!permissions.value.canManageSubscription) return
+
     const teamCheckout = selectedTeamCheckout.value
     if (!teamCheckout?.stop.id) {
       toast.add({
@@ -343,6 +383,8 @@ export function useSubscriptionCheckout(
   }
 
   async function handleResubscribe() {
+    if (!permissions.value.canManageSubscriptionLifecycle) return
+
     telemetry?.trackResubscribeClicked({
       source: 'pricing_dialog',
       payment_intent_source: paymentIntentSource

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
@@ -1,0 +1,232 @@
+import { computed } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkspaceMenuItems } from './useWorkspaceMenuItems'
+
+const state = vi.hoisted(() => ({
+  canLeaveWorkspace: false,
+  canManageSubscription: false,
+  canManageSubscriptionLifecycle: false,
+  isActiveSubscription: true,
+  isDeleteDisabled: false,
+  isFreeTier: false,
+  isInPersonalWorkspace: false,
+  isSubscriptionCancelled: false
+}))
+
+const dialogMocks = vi.hoisted(() => ({
+  showCancelSubscriptionDialog: vi.fn(),
+  showEditWorkspaceDialog: vi.fn(),
+  showDeleteWorkspaceDialog: vi.fn(),
+  showLeaveWorkspaceDialog: vi.fn()
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isFreeTier: computed(() => state.isFreeTier),
+    subscription: computed(() => ({ endDate: '2026-08-01T00:00:00Z' }))
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: {
+      get value() {
+        return {
+          canLeaveWorkspace: state.canLeaveWorkspace,
+          canManageSubscription: state.canManageSubscription,
+          canManageSubscriptionLifecycle: state.canManageSubscriptionLifecycle
+        }
+      }
+    },
+    uiConfig: computed(() => ({
+      showEditWorkspaceMenuItem: false,
+      workspaceMenuAction: null,
+      workspaceMenuDisabledTooltip: null
+    })),
+    isInPersonalWorkspace: computed(() => state.isInPersonalWorkspace),
+    isActiveSubscription: computed(() => state.isActiveSubscription),
+    isSubscriptionCancelled: computed(() => state.isSubscriptionCancelled),
+    isDeleteDisabled: {
+      get value() {
+        return state.isDeleteDisabled
+      }
+    },
+    deleteDisabledTooltipKey: computed(() => null)
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => dialogMocks
+}))
+
+describe('useWorkspaceMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.canLeaveWorkspace = false
+    state.canManageSubscription = false
+    state.canManageSubscriptionLifecycle = false
+    state.isActiveSubscription = true
+    state.isDeleteDisabled = false
+    state.isFreeTier = false
+    state.isInPersonalWorkspace = false
+    state.isSubscriptionCancelled = false
+  })
+
+  it('allows a promoted owner to cancel an active plan', () => {
+    state.canManageSubscriptionLifecycle = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
+  it('withholds cancellation from a member', () => {
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
+  it('withholds cancellation for an already-cancelled plan', () => {
+    state.canManageSubscriptionLifecycle = true
+    state.isSubscriptionCancelled = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'subscription.cancelPlan'
+    )
+  })
+
+  it('rechecks eligibility before opening the cancellation dialog', () => {
+    state.canManageSubscriptionLifecycle = true
+    const { menuItems } = useWorkspaceMenuItems()
+    const cancelItem = menuItems.value.find(
+      (item) => item.label === 'subscription.cancelPlan'
+    )
+
+    state.canManageSubscriptionLifecycle = false
+    cancelItem?.command?.({
+      originalEvent: new Event('click'),
+      item: cancelItem
+    })
+
+    expect(dialogMocks.showCancelSubscriptionDialog).not.toHaveBeenCalled()
+  })
+
+  it('shows Leave only when workspace permission grants it', () => {
+    const hiddenItems = useWorkspaceMenuItems().menuItems
+
+    expect(hiddenItems.value.map((item) => item.label)).not.toContain(
+      'workspacePanel.menu.leaveWorkspace'
+    )
+
+    state.canLeaveWorkspace = true
+    const visibleItems = useWorkspaceMenuItems().menuItems
+
+    expect(visibleItems.value.map((item) => item.label)).toContain(
+      'workspacePanel.menu.leaveWorkspace'
+    )
+  })
+
+  it('rechecks permission before opening the Leave dialog', () => {
+    state.canLeaveWorkspace = true
+    const { menuItems } = useWorkspaceMenuItems()
+    const leaveItem = menuItems.value.find(
+      (item) => item.label === 'workspacePanel.menu.leaveWorkspace'
+    )
+
+    state.canLeaveWorkspace = false
+    leaveItem?.command?.({
+      originalEvent: new Event('click'),
+      item: leaveItem
+    })
+
+    expect(dialogMocks.showLeaveWorkspaceDialog).not.toHaveBeenCalled()
+  })
+
+  it('shows Leave and Delete when owner permissions grant both', () => {
+    state.canLeaveWorkspace = true
+    state.canManageSubscription = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).toEqual([
+      'workspacePanel.menu.deleteWorkspace',
+      'workspacePanel.menu.leaveWorkspace'
+    ])
+  })
+
+  it('withholds Delete from members', () => {
+    state.canLeaveWorkspace = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).toEqual([
+      'workspacePanel.menu.leaveWorkspace'
+    ])
+  })
+
+  it('withholds Delete from personal workspace owners', () => {
+    state.canManageSubscription = true
+    state.isInPersonalWorkspace = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+
+    expect(menuItems.value.map((item) => item.label)).not.toContain(
+      'workspacePanel.menu.deleteWorkspace'
+    )
+  })
+
+  it('disables Delete while the additional workspace is subscribed', () => {
+    state.canManageSubscription = true
+    state.isDeleteDisabled = true
+
+    const { menuItems } = useWorkspaceMenuItems()
+    const deleteItem = menuItems.value.find(
+      (item) => item.label === 'workspacePanel.menu.deleteWorkspace'
+    )
+
+    expect(deleteItem).toMatchObject({ disabled: true, command: undefined })
+  })
+
+  it('rechecks owner permission before opening the Delete dialog', () => {
+    state.canManageSubscription = true
+    const { menuItems } = useWorkspaceMenuItems()
+    const deleteItem = menuItems.value.find(
+      (item) => item.label === 'workspacePanel.menu.deleteWorkspace'
+    )
+
+    state.canManageSubscription = false
+    deleteItem?.command?.({
+      originalEvent: new Event('click'),
+      item: deleteItem
+    })
+
+    expect(dialogMocks.showDeleteWorkspaceDialog).not.toHaveBeenCalled()
+  })
+
+  it('rechecks the subscription lock before opening the Delete dialog', () => {
+    state.canManageSubscription = true
+    const { menuItems } = useWorkspaceMenuItems()
+    const deleteItem = menuItems.value.find(
+      (item) => item.label === 'workspacePanel.menu.deleteWorkspace'
+    )
+
+    state.isDeleteDisabled = true
+    deleteItem?.command?.({
+      originalEvent: new Event('click'),
+      item: deleteItem
+    })
+
+    expect(dialogMocks.showDeleteWorkspaceDialog).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.ts
@@ -17,11 +17,11 @@ export function useWorkspaceMenuItems() {
   const { t } = useI18n()
   const { isFreeTier, subscription } = useBillingContext()
   const {
+    permissions,
     uiConfig,
     isInPersonalWorkspace,
     isActiveSubscription,
-    isOriginalOwner,
-    isTeamPlanCancelled,
+    isSubscriptionCancelled,
     isDeleteDisabled,
     deleteDisabledTooltipKey
   } = useWorkspaceUI()
@@ -37,33 +37,42 @@ export function useWorkspaceMenuItems() {
   }
 
   function cancelSubscription() {
+    if (
+      !permissions.value.canManageSubscriptionLifecycle ||
+      !canCancelPlan.value
+    ) {
+      return
+    }
     void showCancelSubscriptionDialog(subscription.value?.endDate ?? undefined)
   }
 
   function deleteWorkspace() {
+    if (
+      !permissions.value.canManageSubscription ||
+      isInPersonalWorkspace.value ||
+      isDeleteDisabled.value
+    ) {
+      return
+    }
     void showDeleteWorkspaceDialog()
   }
 
   function leaveWorkspace() {
+    if (!permissions.value.canLeaveWorkspace) return
     void showLeaveWorkspaceDialog()
   }
 
   const canCancelPlan = computed(
     () =>
-      isOriginalOwner.value &&
+      permissions.value.canManageSubscriptionLifecycle &&
       isActiveSubscription.value &&
-      !isTeamPlanCancelled.value &&
+      !isSubscriptionCancelled.value &&
       !isFreeTier.value
   )
 
   const canDeleteWorkspace = computed(
     () =>
-      isOriginalOwner.value &&
-      (!isInPersonalWorkspace.value || isActiveSubscription.value)
-  )
-
-  const canLeaveWorkspace = computed(
-    () => !isInPersonalWorkspace.value && !isOriginalOwner.value
+      permissions.value.canManageSubscription && !isInPersonalWorkspace.value
   )
 
   const deleteTooltip = computed(() => {
@@ -100,7 +109,7 @@ export function useWorkspaceMenuItems() {
       })
     }
 
-    if (canLeaveWorkspace.value) {
+    if (permissions.value.canLeaveWorkspace) {
       items.push({
         label: t('workspacePanel.menu.leaveWorkspace'),
         command: leaveWorkspace

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -2,17 +2,16 @@ import { ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
-import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const mockStore = vi.hoisted(() => ({
   activeWorkspace: null as WorkspaceWithRole | null,
   isCurrentUserOriginalOwner: false,
+  originalOwnerId: null as string | null,
   ensureMembersLoaded: vi.fn()
 }))
-const mockMembers = vi.hoisted(() => ({ value: [] as WorkspaceMember[] }))
-const mockUserEmail = vi.hoisted(() => ({ value: null as string | null }))
 const mockIsActiveSubscription = vi.hoisted(() => ({ value: false }))
 const mockIsCancelled = vi.hoisted(() => ({ value: false }))
+const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
@@ -25,23 +24,20 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
     get isWorkspaceSubscribed() {
       return false
     },
-    get members() {
-      return mockMembers.value
-    },
     get isCurrentUserOriginalOwner() {
       return mockStore.isCurrentUserOriginalOwner
+    },
+    get originalOwnerId() {
+      return mockStore.originalOwnerId
     },
     ensureMembersLoaded: mockStore.ensureMembersLoaded
   })
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({ userEmail: ref(mockUserEmail.value) })
-}))
-
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: ref(mockIsActiveSubscription.value),
+    isTeamPlan: ref(mockIsTeamPlan.value),
     subscription: ref({ isCancelled: mockIsCancelled.value })
   })
 }))
@@ -53,6 +49,12 @@ const personalWorkspace: WorkspaceWithRole = {
   role: 'owner',
   created_at: '2026-01-01T00:00:00Z',
   joined_at: '2026-01-01T00:00:00Z'
+}
+
+const personalMemberWorkspace: WorkspaceWithRole = {
+  ...personalWorkspace,
+  id: 'ws-personal-member',
+  role: 'member'
 }
 
 const teamOwnerWorkspace: WorkspaceWithRole = {
@@ -81,11 +83,11 @@ async function loadComposable() {
 function resetStore() {
   mockStore.activeWorkspace = null
   mockStore.isCurrentUserOriginalOwner = false
+  mockStore.originalOwnerId = null
   mockStore.ensureMembersLoaded.mockReset()
-  mockMembers.value = []
-  mockUserEmail.value = null
   mockIsActiveSubscription.value = false
   mockIsCancelled.value = false
+  mockIsTeamPlan.value = false
 }
 
 describe('useWorkspaceUI', () => {
@@ -99,14 +101,21 @@ describe('useWorkspaceUI', () => {
   })
 
   describe('when no active workspace', () => {
-    it('defaults to personal workspace behavior', async () => {
+    it('fails billing permissions closed', async () => {
+      mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
       expect(ui.workspaceType.value).toBe('personal')
       expect(ui.workspaceRole.value).toBe('owner')
-      expect(ui.permissions.value.canManageSubscription).toBe(true)
-      expect(ui.permissions.value.canTopUp).toBe(true)
+      expect(ui.permissions.value).toMatchObject({
+        canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canDowngradeToPersonal: false,
+        canTopUp: false
+      })
       expect(ui.permissions.value.canViewOtherMembers).toBe(false)
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(false)
       expect(ui.uiConfig.value.showMembersList).toBe(false)
     })
   })
@@ -122,6 +131,8 @@ describe('useWorkspaceUI', () => {
       expect(ui.workspaceType.value).toBe('personal')
       expect(ui.permissions.value).toMatchObject({
         canManageSubscription: true,
+        canManageSubscriptionLifecycle: true,
+        canDowngradeToPersonal: false,
         canTopUp: true,
         canViewOtherMembers: false,
         canViewPendingInvites: false,
@@ -131,6 +142,65 @@ describe('useWorkspaceUI', () => {
         canLeaveWorkspace: false,
         canAccessWorkspaceMenu: false
       })
+    })
+
+    it('gives a Team-plan member only member actions', async () => {
+      mockStore.activeWorkspace = personalMemberWorkspace
+      mockIsTeamPlan.value = true
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value).toMatchObject({
+        canViewOtherMembers: true,
+        canViewPendingInvites: false,
+        canInviteMembers: false,
+        canManageInvites: false,
+        canManageMembers: false,
+        canLeaveWorkspace: true,
+        canAccessWorkspaceMenu: true,
+        canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canDowngradeToPersonal: false,
+        canTopUp: false
+      })
+      expect(ui.uiConfig.value).toMatchObject({
+        showEditWorkspaceMenuItem: false,
+        workspaceMenuAction: null
+      })
+    })
+
+    it('withholds leave from a Personal-plan member', async () => {
+      mockStore.activeWorkspace = personalMemberWorkspace
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(false)
+    })
+
+    it('withholds leave from a Team-plan owner until creator identity resolves', async () => {
+      mockIsTeamPlan.value = true
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(false)
+    })
+
+    it('lets a promoted owner leave while using a Team plan', async () => {
+      mockIsTeamPlan.value = true
+      mockStore.originalOwnerId = 'original-owner'
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(true)
+    })
+
+    it('keeps the original creator from leaving while using a Team plan', async () => {
+      mockIsTeamPlan.value = true
+      mockStore.originalOwnerId = 'current-user'
+      mockStore.isCurrentUserOriginalOwner = true
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(false)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(false)
     })
 
     it('lets the personal owner rename their workspace', async () => {
@@ -177,6 +247,8 @@ describe('useWorkspaceUI', () => {
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: true,
+        canManageSubscriptionLifecycle: true,
+        canDowngradeToPersonal: false,
         canTopUp: true
       })
     })
@@ -201,6 +273,7 @@ describe('useWorkspaceUI', () => {
   describe('team workspace as member', () => {
     beforeEach(() => {
       mockStore.activeWorkspace = teamMemberWorkspace
+      mockIsTeamPlan.value = true
     })
 
     it('restricts management actions while allowing leave', async () => {
@@ -216,6 +289,8 @@ describe('useWorkspaceUI', () => {
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canDowngradeToPersonal: false,
         canTopUp: false
       })
     })
@@ -226,7 +301,7 @@ describe('useWorkspaceUI', () => {
       expect(ui.uiConfig.value.showMembersList).toBe(true)
       expect(ui.uiConfig.value.showPendingTab).toBe(false)
       expect(ui.uiConfig.value.showEditWorkspaceMenuItem).toBe(false)
-      expect(ui.uiConfig.value.workspaceMenuAction).toBe('leave')
+      expect(ui.uiConfig.value.workspaceMenuAction).toBeNull()
       expect(ui.uiConfig.value.workspaceMenuDisabledTooltip).toBeNull()
       expect(ui.uiConfig.value.membersGridCols).toBe('grid-cols-[1fr_auto]')
       expect(ui.uiConfig.value.headerGridCols).toBe('grid-cols-[1fr_auto]')
@@ -234,113 +309,125 @@ describe('useWorkspaceUI', () => {
         'grid-cols-[50%_20%_20%_10%]'
       )
     })
+
+    it('allows leave independently of the active plan', async () => {
+      mockIsTeamPlan.value = false
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
+      expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(true)
+    })
   })
 
-  describe('isOriginalOwner', () => {
-    const earlier = new Date('2026-01-01T00:00:00Z')
+  describe('original-owner permissions', () => {
+    it('uses the canonical store signal for personal workspaces', async () => {
+      mockStore.activeWorkspace = personalWorkspace
+      const ui = await loadComposable()
 
-    function member(
-      id: string,
-      email: string,
-      joinDate: Date
-    ): WorkspaceMember {
-      return {
-        id,
-        name: id,
-        email,
-        joinDate,
-        role: 'owner',
-        isOriginalOwner: false
-      }
-    }
+      expect(ui.isOriginalOwner.value).toBe(false)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
+    })
 
-    beforeEach(() => {
+    it('allows an original owner to downgrade', async () => {
       mockStore.activeWorkspace = teamOwnerWorkspace
-    })
-
-    it('treats the personal owner as their own original owner', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+      mockStore.isCurrentUserOriginalOwner = true
+      mockStore.originalOwnerId = 'current-user'
+      mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
       expect(ui.isOriginalOwner.value).toBe(true)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(true)
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
     })
 
-    it('names the earliest-joined member as the original owner', async () => {
-      mockMembers.value = [
-        member('m2', 'late@example.com', new Date('2026-02-01T00:00:00Z')),
-        member('m1', 'early@example.com', earlier)
-      ]
-      mockUserEmail.value = 'early@example.com'
+    it('allows an additional workspace owner to leave before creator identity resolves', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsTeamPlan.value = true
       const ui = await loadComposable()
 
-      expect(ui.isOriginalOwner.value).toBe(true)
-    })
-
-    it('breaks join-date ties with the member id so only one is the owner', async () => {
-      mockMembers.value = [
-        member('m-b', 'b@example.com', earlier),
-        member('m-a', 'a@example.com', earlier)
-      ]
-
-      mockUserEmail.value = 'a@example.com'
-      const owner = await loadComposable()
-      expect(owner.isOriginalOwner.value).toBe(true)
-
-      vi.resetModules()
-      mockUserEmail.value = 'b@example.com'
-      const notOwner = await loadComposable()
-      expect(notOwner.isOriginalOwner.value).toBe(false)
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
     })
   })
 
-  // Drives off the members-list self-row original-owner signal, surfaced by the
-  // store getter `isCurrentUserOriginalOwner`.
-  describe('subscription lifecycle (creator-only)', () => {
-    it('grants lifecycle to the personal-workspace sole owner', async () => {
-      mockStore.activeWorkspace = personalWorkspace
+  describe('subscription lifecycle', () => {
+    it('grants lifecycle and downgrade to the original owner', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockStore.isCurrentUserOriginalOwner = true
+      mockIsTeamPlan.value = true
       const ui = await loadComposable()
+      expect(ui.permissions.value.canManageSubscription).toBe(true)
       expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(true)
     })
 
-    it('grants lifecycle to a team owner who is the original owner', async () => {
+    it('withholds downgrade from an original owner on a Personal plan', async () => {
       mockStore.activeWorkspace = teamOwnerWorkspace
       mockStore.isCurrentUserOriginalOwner = true
       const ui = await loadComposable()
+
+      expect(ui.permissions.value.canManageSubscription).toBe(true)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
+    })
+
+    it('grants lifecycle but withholds downgrade from a promoted owner', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockStore.isCurrentUserOriginalOwner = false
+      mockStore.originalOwnerId = 'original-owner'
+      mockIsTeamPlan.value = true
+      const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscription).toBe(true)
       expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(true)
-    })
-
-    it('withholds lifecycle from a promoted (non-creator) team owner', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
-      const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscription).toBe(true)
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
-    })
-
-    it('fails closed while the members list is still loading', async () => {
-      mockStore.activeWorkspace = teamOwnerWorkspace
-      mockStore.isCurrentUserOriginalOwner = false
-      const ui = await loadComposable()
-      expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
+      expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
     })
 
     it('withholds lifecycle from members', async () => {
       mockStore.activeWorkspace = teamMemberWorkspace
       const ui = await loadComposable()
       expect(ui.permissions.value.canManageSubscriptionLifecycle).toBe(false)
+      expect(ui.permissions.value.canDowngradeToPersonal).toBe(false)
     })
+  })
 
-    it('delegates member loading to the store when a team workspace becomes active', async () => {
+  describe('original-owner data loading', () => {
+    it('loads members for a team owner', async () => {
       mockStore.activeWorkspace = teamOwnerWorkspace
       await loadComposable()
       expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
     })
 
-    it('does not load members for a personal workspace', async () => {
+    it('loads members for a personal owner', async () => {
       mockStore.activeWorkspace = personalWorkspace
       await loadComposable()
+      expect(mockStore.ensureMembersLoaded).toHaveBeenCalled()
+    })
+
+    it('does not load members for a member', async () => {
+      mockStore.activeWorkspace = personalMemberWorkspace
+      await loadComposable()
       expect(mockStore.ensureMembersLoaded).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cancelled Team plan', () => {
+    it('uses plan identity instead of workspace type', async () => {
+      mockStore.activeWorkspace = personalWorkspace
+      mockIsTeamPlan.value = true
+      mockIsCancelled.value = true
+      const ui = await loadComposable()
+
+      expect(ui.isTeamPlanCancelled.value).toBe(true)
+      expect(ui.isSubscriptionCancelled.value).toBe(true)
+    })
+
+    it('ignores a cancelled non-Team plan in a team workspace', async () => {
+      mockStore.activeWorkspace = teamOwnerWorkspace
+      mockIsTeamPlan.value = false
+      mockIsCancelled.value = true
+      const ui = await loadComposable()
+
+      expect(ui.isTeamPlanCancelled.value).toBe(false)
+      expect(ui.isSubscriptionCancelled.value).toBe(true)
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -1,11 +1,9 @@
 import { computed, watch } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
-import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 
 import type { WorkspaceRole, WorkspaceType } from '../api/workspaceApi'
-import type { WorkspaceMember } from '../stores/teamWorkspaceStore'
 import { useTeamWorkspaceStore } from '../stores/teamWorkspaceStore'
 
 /** Permission flags for workspace actions */
@@ -18,10 +16,8 @@ interface WorkspacePermissions {
   canLeaveWorkspace: boolean
   canAccessWorkspaceMenu: boolean
   canManageSubscription: boolean
-  // Creator-only subscription lifecycle: cancel / reactivate / downgrade.
-  // Any owner has `canManageSubscription` (manage payment, top-up, change
-  // commit); only the original owner gets `canManageSubscriptionLifecycle`.
   canManageSubscriptionLifecycle: boolean
+  canDowngradeToPersonal: boolean
   canTopUp: boolean
 }
 
@@ -35,15 +31,46 @@ interface WorkspaceUIConfig {
   pendingGridCols: string
   headerGridCols: string
   showEditWorkspaceMenuItem: boolean
-  workspaceMenuAction: 'leave' | 'delete' | null
+  workspaceMenuAction: 'delete' | null
   workspaceMenuDisabledTooltip: string | null
 }
 
 function getPermissions(
   type: WorkspaceType,
   role: WorkspaceRole,
-  isOriginalOwner: boolean
+  isOriginalOwner: boolean,
+  isOriginalOwnerResolved: boolean,
+  hasActiveWorkspace: boolean,
+  isTeamPlan: boolean
 ): WorkspacePermissions {
+  const canManageBilling = hasActiveWorkspace && role === 'owner'
+  const canLeaveWorkspace =
+    hasActiveWorkspace &&
+    (type === 'personal'
+      ? isTeamPlan &&
+        !isOriginalOwner &&
+        (role === 'member' || isOriginalOwnerResolved)
+      : true)
+  const billingPermissions = {
+    canManageSubscription: canManageBilling,
+    canManageSubscriptionLifecycle: canManageBilling,
+    canDowngradeToPersonal: canManageBilling && isTeamPlan && isOriginalOwner,
+    canTopUp: canManageBilling
+  }
+
+  if (role === 'member') {
+    return {
+      canViewOtherMembers: true,
+      canViewPendingInvites: false,
+      canInviteMembers: false,
+      canManageInvites: false,
+      canManageMembers: false,
+      canLeaveWorkspace,
+      canAccessWorkspaceMenu: canLeaveWorkspace,
+      ...billingPermissions
+    }
+  }
+
   if (type === 'personal') {
     return {
       canViewOtherMembers: false,
@@ -51,42 +78,21 @@ function getPermissions(
       canInviteMembers: false,
       canManageInvites: false,
       canManageMembers: false,
-      canLeaveWorkspace: false,
-      canAccessWorkspaceMenu: false,
-      canManageSubscription: true,
-      // Personal workspace is single-member: the user is the sole owner/creator.
-      canManageSubscriptionLifecycle: true,
-      canTopUp: true
+      canLeaveWorkspace,
+      canAccessWorkspaceMenu: canLeaveWorkspace,
+      ...billingPermissions
     }
   }
 
-  if (role === 'owner') {
-    return {
-      canViewOtherMembers: true,
-      canViewPendingInvites: true,
-      canInviteMembers: true,
-      canManageInvites: true,
-      canManageMembers: true,
-      canLeaveWorkspace: true,
-      canAccessWorkspaceMenu: true,
-      canManageSubscription: true,
-      canManageSubscriptionLifecycle: isOriginalOwner,
-      canTopUp: true
-    }
-  }
-
-  // member role
   return {
     canViewOtherMembers: true,
-    canViewPendingInvites: false,
-    canInviteMembers: false,
-    canManageInvites: false,
-    canManageMembers: false,
-    canLeaveWorkspace: true,
+    canViewPendingInvites: true,
+    canInviteMembers: true,
+    canManageInvites: true,
+    canManageMembers: true,
+    canLeaveWorkspace,
     canAccessWorkspaceMenu: true,
-    canManageSubscription: false,
-    canManageSubscriptionLifecycle: false,
-    canTopUp: false
+    ...billingPermissions
   }
 }
 
@@ -94,6 +100,21 @@ function getUIConfig(
   type: WorkspaceType,
   role: WorkspaceRole
 ): WorkspaceUIConfig {
+  if (role === 'member') {
+    return {
+      showMembersList: true,
+      showPendingTab: false,
+      showSearch: true,
+      showRoleColumn: true,
+      membersGridCols: 'grid-cols-[1fr_auto]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[1fr_auto]',
+      showEditWorkspaceMenuItem: false,
+      workspaceMenuAction: null,
+      workspaceMenuDisabledTooltip: null
+    }
+  }
+
   if (type === 'personal') {
     return {
       showMembersList: false,
@@ -109,51 +130,19 @@ function getUIConfig(
     }
   }
 
-  if (role === 'owner') {
-    return {
-      showMembersList: true,
-      showPendingTab: true,
-      showSearch: true,
-      showRoleColumn: true,
-      membersGridCols: 'grid-cols-[50%_40%_10%]',
-      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-      headerGridCols: 'grid-cols-[50%_40%_10%]',
-      showEditWorkspaceMenuItem: true,
-      workspaceMenuAction: 'delete',
-      workspaceMenuDisabledTooltip:
-        'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
-    }
-  }
-
-  // member role
   return {
     showMembersList: true,
-    showPendingTab: false,
+    showPendingTab: true,
     showSearch: true,
     showRoleColumn: true,
-    membersGridCols: 'grid-cols-[1fr_auto]',
+    membersGridCols: 'grid-cols-[50%_40%_10%]',
     pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-    headerGridCols: 'grid-cols-[1fr_auto]',
-    showEditWorkspaceMenuItem: false,
-    workspaceMenuAction: 'leave',
-    workspaceMenuDisabledTooltip: null
+    headerGridCols: 'grid-cols-[50%_40%_10%]',
+    showEditWorkspaceMenuItem: true,
+    workspaceMenuAction: 'delete',
+    workspaceMenuDisabledTooltip:
+      'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
   }
-}
-
-/**
- * The original owner is the earliest-joined member. Ties on join date are
- * broken by the stable member id so exactly one member is the original owner.
- */
-function isOriginalOwnerByEmail(
-  members: WorkspaceMember[],
-  email: string
-): boolean {
-  if (members.length === 0) return false
-  const original = [...members].sort(
-    (a, b) =>
-      a.joinDate.getTime() - b.joinDate.getTime() || a.id.localeCompare(b.id)
-  )[0]
-  return original.email.toLowerCase() === email
 }
 
 /**
@@ -161,12 +150,10 @@ function isOriginalOwnerByEmail(
  */
 function useWorkspaceUIInternal() {
   const store = useTeamWorkspaceStore()
-  const { userEmail } = useCurrentUser()
-  const { isActiveSubscription, subscription } = useBillingContext()
+  const { isActiveSubscription, isTeamPlan, subscription } = useBillingContext()
 
   const isInPersonalWorkspace = computed(() => store.isInPersonalWorkspace)
   const isWorkspaceSubscribed = computed(() => store.isWorkspaceSubscribed)
-  const members = computed(() => store.members)
 
   const workspaceType = computed<WorkspaceType>(
     () => store.activeWorkspace?.type ?? 'personal'
@@ -176,14 +163,10 @@ function useWorkspaceUIInternal() {
     () => store.activeWorkspace?.role ?? 'owner'
   )
 
-  // The original-owner signal lives on the members-list self-row, so a team
-  // workspace's members must be loaded before its lifecycle gate can resolve.
-  // The store dedupes in-flight/already-loaded requests and logs failures;
-  // until members arrive the getter fails closed.
   watch(
-    () => store.activeWorkspace?.id,
+    [() => store.activeWorkspace?.id, () => store.activeWorkspace?.role],
     () => {
-      if (store.activeWorkspace?.type === 'team') {
+      if (store.activeWorkspace?.role === 'owner') {
         void store.ensureMembersLoaded()
       }
     },
@@ -194,7 +177,10 @@ function useWorkspaceUIInternal() {
     getPermissions(
       workspaceType.value,
       workspaceRole.value,
-      store.isCurrentUserOriginalOwner
+      store.isCurrentUserOriginalOwner,
+      store.originalOwnerId !== null,
+      store.activeWorkspace !== null,
+      isTeamPlan.value
     )
   )
 
@@ -202,19 +188,14 @@ function useWorkspaceUIInternal() {
     getUIConfig(workspaceType.value, workspaceRole.value)
   )
 
-  // Cancel / reactivate / delete are original-owner-only; personal workspaces
-  // are single-member, so the user is always their own original owner.
-  const isOriginalOwner = computed(() => {
-    if (isInPersonalWorkspace.value) return true
-    const email = userEmail.value?.toLowerCase()
-    return !!email && isOriginalOwnerByEmail(members.value, email)
-  })
+  const isOriginalOwner = computed(() => store.isCurrentUserOriginalOwner)
 
-  // Cancellation is meaningful only for team (workspace) billing; personal plans
-  // use legacy billing with different semantics.
+  const isSubscriptionCancelled = computed(
+    () => subscription.value?.isCancelled ?? false
+  )
+
   const isTeamPlanCancelled = computed(
-    () =>
-      !isInPersonalWorkspace.value && (subscription.value?.isCancelled ?? false)
+    () => isTeamPlan.value && isSubscriptionCancelled.value
   )
 
   // A workspace can't be deleted while its subscription is active and not yet
@@ -239,6 +220,7 @@ function useWorkspaceUIInternal() {
     isWorkspaceSubscribed,
     isActiveSubscription,
     isOriginalOwner,
+    isSubscriptionCancelled,
     isTeamPlanCancelled,
     isDeleteDisabled,
     deleteDisabledTooltipKey

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -2,6 +2,8 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
+
 import { sortWorkspaces, useTeamWorkspaceStore } from './teamWorkspaceStore'
 
 // Mock workspaceAuthStore
@@ -541,21 +543,43 @@ describe('useTeamWorkspaceStore', () => {
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
+      vi.clearAllMocks()
 
       await store.leaveWorkspace()
 
       expect(mockWorkspaceApi.leave).toHaveBeenCalled()
       expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID,
+        mockPersonalWorkspace.id
+      )
       expect(mockReload).toHaveBeenCalled()
     })
 
-    it('throws when trying to leave personal workspace', async () => {
+    it('forwards personal workspace leave and clears its persisted ID', async () => {
       const store = useTeamWorkspaceStore()
       await store.initialize()
+      vi.clearAllMocks()
+
+      await store.leaveWorkspace()
+
+      expect(mockWorkspaceApi.leave).toHaveBeenCalled()
+      expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+        WORKSPACE_STORAGE_KEYS.LAST_WORKSPACE_ID
+      )
+      expect(mockReload).toHaveBeenCalled()
+    })
+
+    it('throws when there is no active workspace', async () => {
+      const store = useTeamWorkspaceStore()
 
       await expect(store.leaveWorkspace()).rejects.toThrow(
-        'Cannot leave personal workspace'
+        'No active workspace'
       )
+
+      expect(mockWorkspaceApi.leave).not.toHaveBeenCalled()
     })
   })
 
@@ -800,7 +824,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members[0].role).toBe('member')
     })
 
-    it('changeMemberRole refuses to change the flagged creator and never calls the API', async () => {
+    it('changeMemberRole refuses to change a personal workspace creator', async () => {
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [
           {
@@ -822,8 +846,6 @@ describe('useTeamWorkspaceStore', () => {
         ],
         pagination: { offset: 0, limit: 50, total: 2 }
       })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
 
       const store = useTeamWorkspaceStore()
       await store.initialize()
@@ -834,6 +856,52 @@ describe('useTeamWorkspaceStore', () => {
       )
       expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
       expect(store.members.find((m) => m.id === 'creator')?.role).toBe('owner')
+    })
+
+    it('changeMemberRole allows changing an additional workspace creator', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'creator',
+            name: 'Creator',
+            email: 'creator@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'owner',
+            is_original_owner: true
+          },
+          {
+            id: 'user-2',
+            name: 'User Two',
+            email: 'two@test.com',
+            joined_at: '2024-01-02T00:00:00Z',
+            role: 'owner',
+            is_original_owner: false
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'creator',
+        name: 'Creator',
+        email: 'creator@test.com',
+        joined_at: '2024-01-01T00:00:00Z',
+        role: 'member',
+        is_original_owner: true
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      await store.changeMemberRole('creator', 'member')
+
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'creator',
+        'member'
+      )
+      expect(store.members.find((m) => m.id === 'creator')?.role).toBe('member')
     })
 
     it('originalOwnerId is the member flagged is_original_owner, even when not earliest-joined', async () => {
@@ -871,7 +939,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.originalOwnerId).toBe('creator')
     })
 
-    it('originalOwnerId falls back to the earliest-joined member when no flag is present', async () => {
+    it('allows changing the fallback creator in an additional workspace', async () => {
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: [
           {
@@ -891,6 +959,14 @@ describe('useTeamWorkspaceStore', () => {
         ],
         pagination: { offset: 0, limit: 50, total: 2 }
       })
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'founder',
+        name: 'Founder',
+        email: 'founder@test.com',
+        joined_at: '2024-01-01T00:00:00Z',
+        role: 'member',
+        is_original_owner: false
+      })
       mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
       mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
 
@@ -900,10 +976,11 @@ describe('useTeamWorkspaceStore', () => {
 
       expect(store.originalOwnerId).toBe('founder')
 
-      await expect(store.changeMemberRole('founder', 'member')).rejects.toThrow(
-        "Cannot change the workspace creator's role"
+      await store.changeMemberRole('founder', 'member')
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'founder',
+        'member'
       )
-      expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
     })
 
     it('originalOwnerId fallback skips a non-owner earliest joiner, keeping them changeable', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -515,25 +515,23 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     await renameWorkspace(activeWorkspaceId.value, name)
   }
 
-  /**
-   * Leave the current workspace.
-   * Switches to personal workspace after leaving.
-   */
   async function leaveWorkspace(): Promise<void> {
     const current = activeWorkspace.value
-    if (!current || current.type === 'personal') {
-      throw new Error('Cannot leave personal workspace')
-    }
+    if (!current) throw new Error('No active workspace')
 
     const workspaceAuthStore = useWorkspaceAuthStore()
 
     await workspaceApi.leave()
 
-    // Go to personal workspace
-    const personal = personalWorkspace.value
+    const personal = workspaces.value.find(
+      (workspace) =>
+        workspace.type === 'personal' && workspace.id !== current.id
+    )
     workspaceAuthStore.clearWorkspaceContext()
     if (personal) {
       setLastWorkspaceId(personal.id)
+    } else {
+      clearLastWorkspaceId()
     }
     window.location.reload()
     // Code after this won't run (page reloads)
@@ -602,7 +600,10 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     userId: string,
     role: WorkspaceMember['role']
   ): Promise<void> {
-    if (userId === originalOwnerId.value) {
+    if (
+      activeWorkspace.value?.type === 'personal' &&
+      userId === originalOwnerId.value
+    ) {
       throw new Error("Cannot change the workspace creator's role")
     }
     // Only the role changes; merge it onto the existing row rather than trusting


### PR DESCRIPTION
## Summary

Backports #13812 to `cloud/1.45` after the [automatic cherry-pick](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/29704878740) conflicted, preserving release-specific billing routing and dialog behavior.

## Changes

- **What**: Applies role-gated billing mutations, Personal/default creator protection, additional-workspace creator actions, and execution-time permission rechecks.
- **Dependencies**: Uses the Members and independent billing-flag backports already present on `cloud/1.45`.

## Review Focus

- Resolves `useSubscriptionDialog` against the release-only PrimeVue dialog props and Settings layering.
- Keeps the `BillingStatusBanner` story/test and Storybook workspace mock deleted because their runtime surface is absent on this branch.
- Keeps `consolidated_billing_enabled` responsible for Personal billing routing and `billing_control_enabled` responsible for the control gate.

## Validation

- Focused unit suite: 18 files, 398 tests passed.
- `pnpm typecheck`, `pnpm format:check`, `pnpm lint`, and `pnpm knip` passed.
- Cloud `memberRoleChange.spec.ts`: 2 passed, 5 existing release-specific `fixme` cases.

## Screenshots

| Personal/default workspace creator | Additional workspace creator |
| --- | --- |
| <img width="720" alt="Personal workspace creator menu with billing actions but no Leave or Delete action" src="https://github.com/user-attachments/assets/1fa2e62f-9b93-4d8c-b9bb-d02a2a671531" /> | <img width="720" alt="Additional workspace creator menu with Leave and subscription-locked Delete actions" src="https://github.com/user-attachments/assets/3cb7255d-2e41-44d4-a7f8-feddcb90644d" /> |

<img width="720" alt="Another owner can change the additional workspace creator role or remove the creator" src="https://github.com/user-attachments/assets/8fb7b5a5-63b4-4124-a99a-85121f8fa374" />