### PR TITLE
test: centralize cloud app boot timeout

### DIFF
--- a/browser_tests/fixtures/cloudAppFixture.ts
+++ b/browser_tests/fixtures/cloudAppFixture.ts
@@ -1,0 +1,21 @@
+import { expect as baseExpect, test as base } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const CLOUD_APP_BOOT_TIMEOUT = 45_000
+
+export const cloudAppFixture = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    testInfo.setTimeout(CLOUD_APP_BOOT_TIMEOUT)
+    await use(page)
+  }
+})
+
+export const cloudAppExpect = baseExpect.configure({
+  timeout: CLOUD_APP_BOOT_TIMEOUT
+})
+
+export async function waitForCloudApp(page: Page): Promise<void> {
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: CLOUD_APP_BOOT_TIMEOUT
+  })
+}

--- a/browser_tests/tests/cloudSecrets.spec.ts
+++ b/browser_tests/tests/cloudSecrets.spec.ts
@@ -3,7 +3,10 @@ import type { Page, Route } from '@playwright/test'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import {
+  cloudAppFixture as test,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
 import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 
@@ -168,8 +171,6 @@ test.describe('Cloud user secrets (API keys)', { tag: '@cloud' }, () => {
   test('an entitled account can add, list, and delete a provider key', async ({
     page
   }) => {
-    test.slow()
-
     await mockCloudBoot(page, {
       features: BOOT_FEATURES,
       settings: BOOT_SETTINGS
@@ -178,9 +179,7 @@ test.describe('Cloud user secrets (API keys)', { tag: '@cloud' }, () => {
     const backend = await mockSecretsBackend(page, ['runway', 'gemini'])
 
     await page.goto(APP_URL)
-    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-      timeout: 45_000
-    })
+    await waitForCloudApp(page)
 
     const settingsDialog = await openSecretsPanel(page)
 
@@ -240,8 +239,6 @@ test.describe('Cloud user secrets (API keys)', { tag: '@cloud' }, () => {
   test('a non-entitled account never sees the gated providers', async ({
     page
   }) => {
-    test.slow()
-
     await mockCloudBoot(page, {
       features: BOOT_FEATURES,
       settings: BOOT_SETTINGS
@@ -251,9 +248,7 @@ test.describe('Cloud user secrets (API keys)', { tag: '@cloud' }, () => {
     await mockSecretsBackend(page, [])
 
     await page.goto(APP_URL)
-    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-      timeout: 45_000
-    })
+    await waitForCloudApp(page)
 
     const settingsDialog = await openSecretsPanel(page)
     await expect(settingsDialog.getByText(/No secrets stored/)).toBeVisible()

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -3,7 +3,11 @@ import type { Page } from '@playwright/test'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import {
+  cloudAppExpect,
+  cloudAppFixture as test,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
 import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 
 /**
@@ -53,8 +57,6 @@ test.describe('Cloud onboarding survey gate', { tag: '@cloud' }, () => {
   test('a transient 401 on the survey check does not bounce a working user to the survey', async ({
     page
   }) => {
-    test.slow()
-
     await mockCloudBoot(page, { features: BOOT_FEATURES })
     await mockSurveyTransient401(page)
     await bootCloud(page)
@@ -64,23 +66,19 @@ test.describe('Cloud onboarding survey gate', { tag: '@cloud' }, () => {
     // The full app boots — CloudSurveyView is a standalone onboarding view, so
     // reaching the extension manager proves we landed on the working app and
     // the transient 401 was treated as "completed", not a bounce.
-    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-      timeout: 45_000
-    })
+    await waitForCloudApp(page)
     await expect(page).not.toHaveURL(/\/cloud\/survey/)
   })
 
   test('a not-completed (404) user landing on / is routed to the survey', async ({
     page
   }) => {
-    test.slow()
-
     await mockCloudBoot(page, { features: BOOT_FEATURES })
     await mockSurveyNotCompleted(page)
     await bootCloud(page)
 
     await page.goto(APP_URL)
 
-    await expect(page).toHaveURL(/\/cloud\/survey/, { timeout: 45_000 })
+    await cloudAppExpect(page).toHaveURL(/\/cloud\/survey/)
   })
 })

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -7,7 +7,11 @@ import type {
   WorkspaceWithRole
 } from '@/platform/workspace/api/workspaceApi'
 
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import {
+  cloudAppExpect,
+  cloudAppFixture as test,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
 import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
 import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
@@ -79,40 +83,36 @@ const pricingHeading = (page: Page) =>
 
 test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
   test('opens the pricing table for a personal owner', async ({ page }) => {
-    test.slow()
     await setupCloudApp(page, workspace('personal', 'owner'), [])
 
     await page.goto(`${APP_URL}/?pricing=1`)
 
-    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+    await cloudAppExpect(pricingHeading(page)).toBeVisible()
     await expect(page).not.toHaveURL(/[?&]pricing=/)
   })
 
   test('opens on the Team tab for ?pricing=team', async ({ page }) => {
-    test.slow()
     await setupCloudApp(page, workspace('personal', 'owner'), [])
 
     await page.goto(`${APP_URL}/?pricing=team`)
 
-    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+    await cloudAppExpect(pricingHeading(page)).toBeVisible()
     await expect(
       page.getByRole('button', { name: 'For Teams' })
     ).toHaveAttribute('aria-pressed', 'true')
   })
 
   test('opens for a team original owner', async ({ page }) => {
-    test.slow()
     await setupCloudApp(page, workspace('team', 'owner'), [
       member({ email: SELF_EMAIL, role: 'owner', is_original_owner: true })
     ])
 
     await page.goto(`${APP_URL}/?pricing=1`)
 
-    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+    await cloudAppExpect(pricingHeading(page)).toBeVisible()
   })
 
   test('is a silent no-op for a team member', async ({ page }) => {
-    test.slow()
     await setupCloudApp(page, workspace('team', 'member'), [
       member({
         email: 'creator@test.comfy.org',
@@ -124,9 +124,7 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?pricing=1`)
 
-    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-      timeout: 45_000
-    })
+    await waitForCloudApp(page)
     await expect(page).not.toHaveURL(/[?&]pricing=/)
     await expect(pricingHeading(page)).toBeHidden()
   })

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -453,13 +453,12 @@ test.describe('Scheduled Team downgrade', { tag: '@cloud' }, () => {
   test('shows the existing success view when subscribe replays 200', async ({
     page
   }) => {
-    test.slow()
     await page.goto(`${APP_URL}/?pricing=personal`)
 
     const changePlan = page.getByRole('button', {
       name: 'Change to Creator Yearly'
     })
-    await expect(changePlan).toBeVisible({ timeout: 45_000 })
+    await cloudAppExpect(changePlan).toBeVisible()
 
     const subscribeResponse = page.waitForResponse(
       (response) =>
@@ -523,13 +522,12 @@ test.describe(
       test('keeps the success view while status retries, then reopens with the reconciled plan', async ({
         page
       }) => {
-        test.slow()
         await page.goto(`${APP_URL}/?pricing=personal`)
 
         const changePlan = page.getByRole('button', {
           name: 'Change to Creator Yearly'
         })
-        await expect(changePlan).toBeVisible({ timeout: 45_000 })
+        await cloudAppExpect(changePlan).toBeVisible()
         await changePlan.click()
 
         await expect(
@@ -599,7 +597,6 @@ test.describe(
       test('reconciles status and balance without polling', async ({
         page
       }) => {
-        test.slow()
         await page.goto(`${APP_URL}/?pricing=personal`)
 
         const subscribeResponse = page.waitForResponse(


### PR DESCRIPTION
## Summary

Centralize the 45-second boot budget used by fully mocked cloud-app browser tests.

## Changes

- **What**: Add a shared cloud app fixture that owns the test and boot-assertion timeouts, then migrate pricing deep-link, survey-gate, and secrets specs away from repeated `test.slow()` and literal timeout values.

## Review Focus

Confirm the longer timeout remains scoped to cloud app boot assertions while post-boot assertions keep Playwright's default timeout.

Follow-up to the timeout discussion in #13840.