### PR TITLE
feat(website): add Trust & Safety link to footer

### DIFF
--- a/apps/website/src/components/common/FooterLinkColumn.vue
+++ b/apps/website/src/components/common/FooterLinkColumn.vue
@@ -19,6 +19,8 @@ const { title, links } = defineProps<{
         v-for="link in links"
         :key="link.href"
         :href="link.href"
+        :target="link.external ? '_blank' : undefined"
+        :rel="link.external ? 'noopener' : undefined"
         class="hover:text-primary-warm-white block py-1.5 text-sm transition-colors"
       >
         {{ link.label }}

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -88,7 +88,12 @@ const companyColumn: { title: string; links: FooterLink[] } = {
     { label: t('nav.brand', locale), href: routes.brand },
     { label: t('footer.termsOfService', locale), href: routes.termsOfService },
     { label: t('footer.enterpriseMsa', locale), href: routes.enterpriseMsa },
-    { label: t('footer.privacyPolicy', locale), href: routes.privacyPolicy }
+    { label: t('footer.privacyPolicy', locale), href: routes.privacyPolicy },
+    {
+      label: t('footer.trustSafety', locale),
+      href: externalLinks.trustCenter,
+      external: true
+    }
   ]
 }
 

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -94,6 +94,7 @@ export const externalLinks = {
   platformUsage: 'https://platform.comfy.org/profile/usage',
   reddit: 'https://www.reddit.com/r/comfyui/',
   support: 'https://support.comfy.org/hc/en-us',
+  trustCenter: 'https://app.vanta.com/comfy.org/trust/o6nu46b16iu3e7fhc41hnz',
   wikidataComfyOrg: 'https://www.wikidata.org/wiki/Q130598554',
   wikidataComfyUi: 'https://www.wikidata.org/wiki/Q127798647',
   wikipediaComfyUi: 'https://en.wikipedia.org/wiki/ComfyUI',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2372,6 +2372,7 @@ const translations = {
   'footer.about': { en: 'About', 'zh-CN': '关于' },
   'footer.termsOfService': { en: 'Terms of Service', 'zh-CN': '服务条款' },
   'footer.privacyPolicy': { en: 'Privacy Policy', 'zh-CN': '隐私政策' },
+  'footer.trustSafety': { en: 'Trust & Safety', 'zh-CN': '信任与安全' },
   'footer.support': { en: 'Support', 'zh-CN': '支持' },
   'footer.sales': { en: 'Sales', 'zh-CN': '销售' },
   'footer.press': { en: 'Press', 'zh-CN': '媒体' },


### PR DESCRIPTION
Adds a Trust & Safety link to the footer Company column, directly under Privacy Policy, opening the Vanta trust center (https://app.vanta.com/comfy.org/trust/o6nu46b16iu3e7fhc41hnz) in a new tab.

External footer links now render with `target="_blank" rel="noopener"` (previously they opened in the same tab).

zh-CN label: 信任与安全 — please confirm wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)