### PR TITLE
fix(widgets): persist customtext DOM widget value writes to the store

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
@@ -23,8 +23,30 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
   const actual = await importOriginal<typeof Litegraph>()
   return { ...actual, resolveNodeRootGraphId: vi.fn(() => 'root') }
 })
+const { widgetStoreMock } = vi.hoisted(() => {
+  const map = new Map<
+    string,
+    { type: string; value: unknown; options: unknown }
+  >()
+  return {
+    widgetStoreMock: {
+      map,
+      getWidget: (id: string) => map.get(id),
+      registerWidget: (
+        id: string,
+        init: { type: string; value: unknown; options: unknown }
+      ) => {
+        const existing = map.get(id)
+        if (existing) return existing
+        const state = { ...init }
+        map.set(id, state)
+        return state
+      }
+    }
+  }
+})
 vi.mock('@/stores/widgetValueStore', () => ({
-  useWidgetValueStore: () => ({ getWidget: () => undefined })
+  useWidgetValueStore: () => widgetStoreMock
 }))
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({ get: () => false })
@@ -46,6 +68,7 @@ function createStringWidget(node: LGraphNode) {
 describe('useStringWidget (multiline)', () => {
   function setup() {
     vi.clearAllMocks()
+    widgetStoreMock.map.clear()
     const node = createMockDOMWidgetNode()
     const widget = createStringWidget(node)
     const callback = vi.fn<(value: string) => void>()
@@ -53,8 +76,26 @@ describe('useStringWidget (multiline)', () => {
     const inputEl = widget.element
     document.body.append(inputEl)
     onTestFinished(() => inputEl.remove())
-    return { widget, inputEl, callback }
+    return { node, widget, inputEl, callback }
   }
+
+  it('writes the value into the store when no entry exists yet', () => {
+    const { node } = setup()
+
+    // The real DOMWidget value setter delegates to options.setValue
+    // (domWidget.ts). Invoke the actual closure the composable registered.
+    const addDOMWidget = node.addDOMWidget as unknown as {
+      mock: { calls: unknown[][] }
+    }
+    const options = addDOMWidget.mock.calls[0][3] as {
+      setValue: (v: string) => void
+    }
+    options.setValue('from-execution')
+
+    const entries = [...widgetStoreMock.map.values()]
+    expect(entries.some((s) => s.value === 'from-execution')).toBe(true)
+    expect(entries.every((s) => s.type === 'customtext')).toBe(true)
+  })
 
   it('fires the widget callback on input', () => {
     const { inputEl, callback } = setup()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -35,10 +35,17 @@ function addMultilineWidget(
     setValue(v: string) {
       inputEl.value = v
       const graphId = resolveNodeRootGraphId(node, app.rootGraph.id)
-      const widgetState = widgetStore.getWidget(
-        widgetId(graphId, node.id, name)
-      )
-      if (widgetState) widgetState.value = v
+      const id = widgetId(graphId, node.id, name)
+      const widgetState = widgetStore.getWidget(id)
+      if (widgetState) {
+        widgetState.value = v
+        return
+      }
+      widgetStore.registerWidget(id, {
+        type: 'customtext',
+        value: v,
+        options: widget.options ?? {}
+      })
     }
   })
 


### PR DESCRIPTION
## Summary

Fixes BUG-001b (QA: Ali A-2/A-5): custom-node multiline widgets render but show no value — pythongosssss Show Text and ltdrdata ImpactWildcardProcessor `populated_text` stay blank on 1.47, though the serialized prompt is correct. Works on 1.45.21.

## Changes

- **What**: multiline (`customtext`) DOM widgets read their displayed value exclusively from `widgetValueStore` (Vue Nodes; `SafeWidgetData` omits `value`), but `useStringWidget`'s `setValue` only wrote the store `if (widgetState)` — so imperative / execution-time value writes (`widget.value = x` → `domWidget.ts` `set value` → `options.setValue`) never reached the display when no entry existed yet. Serialization stayed correct via the `inputEl.value` fallback in `getValue`, which is why the prompt was right but the node blank. Now `setValue` registers the value when no entry exists.
- **Breaking**: none.

## Review Focus

- @drjkl — this is in the DOM-widget store-binding you're reworking (ECS #13528 series). Litegraph #2902 (sync dom widget store on remove) landed the delete-on-remove half; this is the write-into-store half. **Please confirm this fits your rework / doesn't conflict, or fold it in.** If the fuller fix belongs in your series, happy to close this stopgap.
- Metadata: the fallback registration uses `type: 'customtext'` + the widget's current options; label/serialize/disabled default until the widget's normal registration reconciles. Flagging in case those should be carried through.

Unit test drives the real `setValue` closure and asserts the value lands in the store when no entry exists.