### PR TITLE
[backport core/1.47] fix: stop warning when unsetting keybinding for removed command

### DIFF
--- a/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
+++ b/src/platform/keybindings/keybindingService.registerUserKeybindings.test.ts
@@ -1,0 +1,77 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KeybindingImpl } from '@/platform/keybindings/keybinding'
+import { useKeybindingService } from '@/platform/keybindings/keybindingService'
+import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useCommandStore } from '@/stores/commandStore'
+
+const settings = vi.hoisted(() => ({
+  values: {} as Record<string, unknown>
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn((key: string) => settings.values[key] ?? [])
+  }))
+}))
+
+describe('keybindingService - registerUserKeybindings', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    settings.values = {}
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('does not warn when unset binding targets a command that no longer exists', () => {
+    // A command removed from the app (e.g. ConvertSelectedNodesToGroupNode,
+    // removed in #12931) can still linger in the persisted UnsetBindings.
+    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+      {
+        commandId: 'ConvertSelectedNodesToGroupNode',
+        combo: { key: 'g', ctrl: true, alt: false, shift: false }
+      }
+    ]
+
+    useKeybindingService().registerUserKeybindings()
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Trying to unset non-exist keybinding')
+    )
+  })
+
+  it('still unsets bindings for commands that are registered', () => {
+    const commandStore = useCommandStore()
+    commandStore.registerCommand({
+      id: 'Comfy.Test.Registered',
+      function: vi.fn()
+    })
+
+    const keybindingStore = useKeybindingStore()
+    const combo = { key: 'g', ctrl: true, alt: false, shift: false }
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({ commandId: 'Comfy.Test.Registered', combo })
+    )
+
+    settings.values['Comfy.Keybinding.UnsetBindings'] = [
+      { commandId: 'Comfy.Test.Registered', combo }
+    ]
+
+    useKeybindingService().registerUserKeybindings()
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Trying to unset non-exist keybinding')
+    )
+    expect(
+      keybindingStore.getKeybindingByCommandId('Comfy.Test.Registered')
+    ).toBeUndefined()
+  })
+})

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -121,6 +121,9 @@ export function useKeybindingService() {
   function registerUserKeybindings() {
     const unsetBindings = settingStore.get('Comfy.Keybinding.UnsetBindings')
     for (const keybinding of unsetBindings) {
+      if (!commandStore.isRegistered(keybinding.commandId)) {
+        continue
+      }
       keybindingStore.unsetKeybinding(new KeybindingImpl(keybinding))
     }
     const newBindings = settingStore.get('Comfy.Keybinding.NewBindings')


### PR DESCRIPTION
Backport of the keybinding portion of #13777 to `core/1.47`.

The original PR merged to `main` and backported to `cloud/1.47`, but not `core/1.47` (it was bundled with cloud-only workspace link fixes). This split-backports just the keybinding change: skip unsetting a keybinding whose command was removed (e.g. `ConvertSelectedNodesToGroupNode` after group-node creation was removed), which was logging `Trying to unset non-exist keybinding` on every reload on core builds too.

Cherry-picked cleanly from the original keybinding-only commit; includes its unit test.