### PR TITLE
fix(workspace): show renamed personal workspace in switcher

### DIFF
--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -1,6 +1,8 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import PrimeVue from 'primevue/config'
+import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -134,10 +136,11 @@ function renderComponent(
             }
           }
         }),
+        PrimeVue,
         i18n
       ],
       directives: {
-        tooltip: {}
+        tooltip: Tooltip
       },
       stubs: {
         WorkspaceSwitcherPopover: WorkspaceSwitcherPopoverStub,
@@ -177,6 +180,17 @@ describe('CurrentUserPopoverWorkspace', () => {
     expect(
       screen.queryByTestId('workspace-switcher-panel')
     ).not.toBeInTheDocument()
+  })
+
+  it('exposes the full workspace name on hover', async () => {
+    const user = userEvent.setup()
+    renderComponent('team', 'member')
+
+    await user.hover(screen.getByTestId('workspace-switcher-trigger'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Team Workspace')
+    })
   })
 
   it('closes the switcher panel after selecting a workspace', async () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -1,7 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
-    class="current-user-popover -m-3 w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+    class="current-user-popover -m-3 w-fit max-w-96 min-w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->
     <div class="mb-4 flex flex-col items-center px-0 py-3">
@@ -32,7 +32,7 @@
         data-testid="workspace-switcher-trigger"
         @click="toggleWorkspaceSwitcher"
       >
-        <div class="flex min-w-0 flex-1 items-center gap-2">
+        <div class="flex w-0 flex-1 items-center gap-2">
           <WorkspaceProfilePic
             class="size-6 shrink-0 text-xs"
             :workspace-name="workspaceName"

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -1,7 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
-    class="current-user-popover -m-3 w-fit max-w-96 min-w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+    class="current-user-popover -m-3 w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->
     <div class="mb-4 flex flex-col items-center px-0 py-3">
@@ -27,6 +27,7 @@
     <div class="relative">
       <div
         ref="workspaceSwitcherTrigger"
+        v-tooltip="{ value: workspaceName, showDelay: 300 }"
         class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
         data-testid="workspace-switcher-trigger"
         @click="toggleWorkspaceSwitcher"
@@ -36,9 +37,9 @@
             class="size-6 shrink-0 text-xs"
             :workspace-name="workspaceName"
           />
-          <span class="truncate text-sm text-base-foreground">{{
-            workspaceName
-          }}</span>
+          <span class="truncate text-sm text-base-foreground">
+            {{ workspaceName }}
+          </span>
         </div>
         <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
       </div>

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -103,24 +103,60 @@ describe('WorkspaceSwitcherPopover', () => {
     billingMocks.subscription.value = null
   })
 
-  it('shows a renamed personal workspace name', () => {
-    renderComponent({
-      workspaces: [
-        createWorkspaceState({
-          id: 'ws-personal',
-          name: 'My Creative Workspace',
-          type: 'personal',
-          role: 'owner'
-        })
-      ]
-    })
+  it.for([
+    {
+      type: 'personal',
+      plan: 'free',
+      isSubscribed: true,
+      subscriptionPlan: null,
+      subscriptionTier: 'FREE'
+    },
+    {
+      type: 'personal',
+      plan: 'paid',
+      isSubscribed: true,
+      subscriptionPlan: 'PRO_MONTHLY',
+      subscriptionTier: 'PRO'
+    },
+    {
+      type: 'team',
+      plan: 'free',
+      isSubscribed: false,
+      subscriptionPlan: null,
+      subscriptionTier: null
+    },
+    {
+      type: 'team',
+      plan: 'paid',
+      isSubscribed: true,
+      subscriptionPlan: 'team_per_credit_monthly',
+      subscriptionTier: null
+    }
+  ] as const)(
+    'shows a renamed $type workspace name on a $plan plan',
+    ({ type, isSubscribed, subscriptionPlan, subscriptionTier }) => {
+      renderComponent({
+        workspaces: [
+          createWorkspaceState({
+            id: `ws-${type}`,
+            name: 'My Creative Workspace',
+            type,
+            role: 'owner',
+            isSubscribed,
+            subscriptionPlan,
+            subscriptionTier
+          })
+        ],
+        activeWorkspaceId: `ws-${type}`
+      })
 
-    expect(screen.getByText('My Creative Workspace')).toHaveAttribute(
-      'title',
-      'My Creative Workspace'
-    )
-    expect(screen.queryByText('Personal')).not.toBeInTheDocument()
-  })
+      expect(screen.getByText('My Creative Workspace')).toHaveAttribute(
+        'title',
+        'My Creative Workspace'
+      )
+      expect(screen.queryByText('Personal')).not.toBeInTheDocument()
+    }
+  )
 
   it('exposes the full team workspace name as a tooltip on the row', () => {
     renderComponent()

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -103,6 +103,25 @@ describe('WorkspaceSwitcherPopover', () => {
     billingMocks.subscription.value = null
   })
 
+  it('shows a renamed personal workspace name', () => {
+    renderComponent({
+      workspaces: [
+        createWorkspaceState({
+          id: 'ws-personal',
+          name: 'My Creative Workspace',
+          type: 'personal',
+          role: 'owner'
+        })
+      ]
+    })
+
+    expect(screen.getByText('My Creative Workspace')).toHaveAttribute(
+      'title',
+      'My Creative Workspace'
+    )
+    expect(screen.queryByText('Personal')).not.toBeInTheDocument()
+  })
+
   it('exposes the full team workspace name as a tooltip on the row', () => {
     renderComponent()
 

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -40,10 +40,10 @@
                 <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
                   <div class="flex max-w-full min-w-0 items-center gap-1.5">
                     <span
-                      :title="getDisplayName(workspace)"
+                      :title="workspace.name"
                       class="min-w-0 truncate text-sm text-base-foreground"
                     >
-                      {{ getDisplayName(workspace) }}
+                      {{ workspace.name }}
                     </span>
                     <span
                       v-if="resolveTierLabel(workspace)"
@@ -168,12 +168,6 @@ const availableWorkspaces = computed<AvailableWorkspace[]>(() =>
 
 function isCurrentWorkspace(workspace: AvailableWorkspace): boolean {
   return workspace.id === workspaceId.value
-}
-
-function getDisplayName(workspace: AvailableWorkspace): string {
-  return workspace.type === 'personal'
-    ? t('workspaceSwitcher.personal')
-    : workspace.name
 }
 
 function getRoleLabel(role: AvailableWorkspace['role']): string {


### PR DESCRIPTION
## Summary

Show the saved workspace name in the workspace switcher so renamed personal workspaces are no longer displayed as “Personal.” Keep long workspace names within the account popover and expose the full name on hover.

## Why this happened

The workspace switcher had presentation logic that returned the localized `workspaceSwitcher.personal` label whenever `workspace.type === 'personal'`. Renaming correctly updated the stored workspace name, and the current-workspace header already displayed that value, but the dropdown discarded it for personal workspaces. The override was introduced when tier badges and member roles were added to the switcher; the rename path itself was working correctly.

The account popover used a shrink-to-content width, allowing a long workspace name to expand the card before the existing truncation could take effect.

## Changes

- **Workspace switcher**: Render `workspace.name` for both personal and team workspace rows, while preserving existing role and tier badges.
- **Account popover**: Remove the workspace name’s intrinsic width contribution so it ellipsizes without changing the card’s responsive 20–24rem sizing, and show the full name in a hover tooltip.
- **Regression coverage**: Verify renamed workspaces display their stored name and the account popover exposes the full name on hover.

## Workspace and plan verification

Workspace names are now rendered directly from `workspace.name`; workspace type and billing fields are only used for role/tier presentation and cannot override the name.

| Workspace | Plan state checked | Result |
| --- | --- | --- |
| Personal | Free (`FREE`) | Renamed workspace name displayed |
| Personal | Paid (`PRO_MONTHLY` / `PRO`) | Renamed workspace name displayed; tier badge unaffected |
| Team | Free / unsubscribed | Renamed workspace name displayed |
| Team | Paid (`team_per_credit_monthly`) | Renamed workspace name displayed; team tier behavior unaffected |

Focused component verification passes across the workspace switcher and account popover. Typecheck, lint, format, and `knip` also passed.

## Review Focus

Confirm personal and team rows consistently display their stored workspace names, tier badges remain independent of the name, and long names cannot expand the account popover.

## Screenshots

### Workspace switcher rename

| As is | To be |
| --- | --- |
| ![Workspace switcher displaying Personal instead of the renamed workspace](https://ampcode.com/attachments/9c6a2921cfdbbd29b128b1ebd015ec75e1552fb00d70b2ac654a6bc9a2bbb05e.png) | ![Workspace switcher displaying the renamed personal workspace](https://ampcode.com/attachments/0410666388b936e1170212c6d3f85f732865446d126589a806dc63ebb6ff6aa7.png) |

### Account popover long workspace name

![As-is overflow and to-be ellipsis with full-name hover tooltip](https://ampcode.com/attachments/34fcd3d3f0ec1673d63fd5da8fa7bf1599c776840203be6ef1cd94a639eb3426.png)
