### PR TITLE
fix(widgets): separate widget label from long value in node tooltip

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -193,6 +193,13 @@ export class VueNodeHelpers {
   }
 
   /**
+   * Get the visible widget tooltip text element (PrimeVue tooltip portal).
+   */
+  getVisibleWidgetTooltip(): Locator {
+    return this.page.locator('.p-tooltip-text:visible')
+  }
+
+  /**
    * Select an option from a combo widget on a node.
    */
   async selectComboOption(

--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -8,21 +8,18 @@ import {
 import type {
   ComboInputSpec,
   ComboInputSpecV2,
-  ComfyNodeDef,
-  InputSpec
+  InputSpec,
+  ObjectInfoResponse
 } from '@/schemas/nodeDefSchema'
-
-type ObjectInfoResponse = Record<string, ComfyNodeDef>
 
 type ComboInput = ComboInputSpec | ComboInputSpecV2
 
 const OBJECT_INFO_ROUTE = '**/object_info'
 
-function getRequiredInput(
+function getRequiredInputs(
   objectInfo: ObjectInfoResponse,
-  nodeType: string,
-  inputName: string
-): InputSpec {
+  nodeType: string
+): Record<string, InputSpec> {
   const nodeInfo = objectInfo[nodeType]
   if (!nodeInfo) {
     throw new Error(`Missing object_info entry for ${nodeType}`)
@@ -33,12 +30,35 @@ function getRequiredInput(
     throw new Error(`Missing required inputs for ${nodeType}`)
   }
 
-  const input = requiredInputs[inputName]
+  return requiredInputs
+}
+
+function getRequiredInput(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  inputName: string
+): InputSpec {
+  const input = getRequiredInputs(objectInfo, nodeType)[inputName]
   if (!input) {
     throw new Error(`Missing input ${nodeType}.${inputName}`)
   }
 
   return input
+}
+
+export function setStringInputTooltip(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  inputName: string,
+  tooltip: string
+): void {
+  const requiredInputs = getRequiredInputs(objectInfo, nodeType)
+  if (!requiredInputs[inputName]) {
+    throw new Error(`Missing input ${nodeType}.${inputName}`)
+  }
+
+  const input: InputSpec = ['STRING', { tooltip }]
+  requiredInputs[inputName] = input
 }
 
 function getComboInput(

--- a/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
@@ -66,7 +66,5 @@ test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
     const box = await tooltipText.boundingBox()
     expect(box).not.toBeNull()
     expect(box!.width).toBeLessThanOrEqual(MAX_TOOLTIP_WIDTH)
-    // ...and uses the widened bound (was max-w-75 === 300px before the fix).
-    expect(box!.width).toBeGreaterThan(300)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
@@ -1,0 +1,72 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+// BUG-020: a widget tooltip that joins a short label and a long value with a
+// blank line collapsed onto a single line because the tooltip text had no
+// whitespace-preserving rule. Reproduce that shape (label + blank line + long
+// value) and assert the rendered tooltip keeps them on separate lines and stays
+// within the widened width bound.
+const WIDGET_LABEL = 'Detection prompt for the segmentation model.'
+const LONG_VALUE =
+  'a very long default detection value that keeps going and going and going ' +
+  'so it has to wrap across several lines while remaining readable inside the ' +
+  'bounded tooltip surface'
+const TOOLTIP_TEXT = `${WIDGET_LABEL}\n\n${LONG_VALUE}`
+
+// max-w-96 === 24rem === 384px at the default 16px root font size.
+const MAX_TOOLTIP_WIDTH = 384
+
+test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
+  test('renders a long widget tooltip with label and value on separate lines within bounds', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.route(/\/object_info$/, async (route) => {
+      const response = await route.fetch()
+      const objectInfo = await response.json()
+      const stringInput =
+        objectInfo.DevToolsNodeWithStringInput.input.required.string_input
+      stringInput[1] = { ...(stringInput[1] ?? {}), tooltip: TOOLTIP_TEXT }
+      await route.fulfill({ response, json: objectInfo })
+    })
+    // Reload so the patched object_info (with the multi-line tooltip) is the one
+    // the node definition store boots from.
+    await comfyPage.workflow.reloadAndWaitForApp()
+
+    // Enable tooltips before the widget mounts: the v-tooltip directive reads
+    // its disabled state once at mount, so the setting must be on beforehand.
+    await comfyPage.settings.setSetting('Comfy.EnableTooltips', true)
+    await comfyPage.workflow.loadWorkflow('inputs/string_input')
+
+    const widget = comfyPage.vueNodes
+      .getWidgetByName('Node With String Input', 'string_input')
+      .first()
+    await widget.hover()
+
+    const tooltipText = comfyPage.page.locator('.p-tooltip-text:visible')
+    await expect(tooltipText).toBeVisible()
+
+    // Behavioral check: whitespace-pre-line preserves the blank-line separator,
+    // so innerText keeps the label and value on distinct lines instead of
+    // collapsing them onto one (the BUG-020 regression).
+    const lines = (
+      await tooltipText.evaluate((el) => (el as HTMLElement).innerText)
+    )
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines[0]).toBe(WIDGET_LABEL)
+    expect(lines.at(-1)).toBe(LONG_VALUE)
+
+    // Width stays bounded by max-w-96 so the long value wraps rather than
+    // stretching the tooltip off-screen.
+    const box = await tooltipText.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.width).toBeLessThanOrEqual(MAX_TOOLTIP_WIDTH)
+    // ...and uses the widened bound (was max-w-75 === 300px before the fix).
+    expect(box!.width).toBeGreaterThan(300)
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
@@ -2,39 +2,40 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
-
-// BUG-020: a widget tooltip that joins a short label and a long value with a
-// blank line collapsed onto a single line because the tooltip text had no
-// whitespace-preserving rule. Reproduce that shape (label + blank line + long
-// value) and assert the rendered tooltip keeps them on separate lines and stays
-// within the widened width bound.
-const WIDGET_LABEL = 'Detection prompt for the segmentation model.'
-const LONG_VALUE =
-  'a very long default detection value that keeps going and going and going ' +
-  'so it has to wrap across several lines while remaining readable inside the ' +
-  'bounded tooltip surface'
-const TOOLTIP_TEXT = `${WIDGET_LABEL}\n\n${LONG_VALUE}`
+import {
+  routeObjectInfoFromSetupApi,
+  setStringInputTooltip
+} from '@e2e/fixtures/utils/objectInfo'
 
 // max-w-96 === 24rem === 384px at the default 16px root font size.
 const MAX_TOOLTIP_WIDTH = 384
 
-type ObjectInfoResponse = Record<string, ComfyNodeDef>
-
 test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
+  // BUG-020: a widget tooltip that joins a short label and a long value with a
+  // blank line collapsed onto a single line because the tooltip text had no
+  // whitespace-preserving rule. Reproduce that shape (label + blank line + long
+  // value) and assert the rendered tooltip keeps them on separate lines and
+  // stays within the widened width bound.
   test('renders a long widget tooltip with label and value on separate lines within bounds', async ({
     comfyPage
   }) => {
-    await comfyPage.page.route(/\/object_info$/, async (route) => {
-      const response = await route.fetch()
-      const objectInfo = (await response.json()) as ObjectInfoResponse
-      const required = objectInfo.DevToolsNodeWithStringInput?.input?.required
-      if (required?.string_input) {
-        const patchedInput: InputSpec = ['STRING', { tooltip: TOOLTIP_TEXT }]
-        required.string_input = patchedInput
-      }
-      await route.fulfill({ response, json: objectInfo })
-    })
+    const label = 'Detection prompt for the segmentation model.'
+    const longValue =
+      'a very long default detection value that keeps going and going and going ' +
+      'so it has to wrap across several lines while remaining readable inside the ' +
+      'bounded tooltip surface'
+    const tooltipContent = `${label}\n\n${longValue}`
+
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      comfyPage.page,
+      (objectInfo) =>
+        setStringInputTooltip(
+          objectInfo,
+          'DevToolsNodeWithStringInput',
+          'string_input',
+          tooltipContent
+        )
+    )
     // Reload so the patched object_info (with the multi-line tooltip) is the one
     // the node definition store boots from.
     await comfyPage.workflow.reloadAndWaitForApp()
@@ -49,7 +50,7 @@ test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
       .first()
     await widget.hover()
 
-    const tooltipText = comfyPage.page.locator('.p-tooltip-text:visible')
+    const tooltipText = comfyPage.vueNodes.getVisibleWidgetTooltip()
     await expect(tooltipText).toBeVisible()
 
     // Behavioral check: whitespace-pre-line preserves the blank-line separator,
@@ -60,14 +61,16 @@ test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
       (el) => (el as HTMLElement).innerText
     )
     const [labelLine, separatorLine, ...valueLines] = renderedText.split('\n')
-    expect(labelLine.trim()).toBe(WIDGET_LABEL)
+    expect(labelLine.trim()).toBe(label)
     expect(separatorLine.trim()).toBe('')
-    expect(valueLines.join('\n').trim()).toBe(LONG_VALUE)
+    expect(valueLines.join('\n').trim()).toBe(longValue)
 
     // Width stays bounded by max-w-96 so the long value wraps rather than
     // stretching the tooltip off-screen.
     const box = await tooltipText.boundingBox()
     expect(box).not.toBeNull()
     expect(box!.width).toBeLessThanOrEqual(MAX_TOOLTIP_WIDTH)
+
+    await unrouteObjectInfo()
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetTooltip.spec.ts
@@ -2,6 +2,7 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 
 // BUG-020: a widget tooltip that joins a short label and a long value with a
 // blank line collapsed onto a single line because the tooltip text had no
@@ -18,16 +19,20 @@ const TOOLTIP_TEXT = `${WIDGET_LABEL}\n\n${LONG_VALUE}`
 // max-w-96 === 24rem === 384px at the default 16px root font size.
 const MAX_TOOLTIP_WIDTH = 384
 
+type ObjectInfoResponse = Record<string, ComfyNodeDef>
+
 test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
   test('renders a long widget tooltip with label and value on separate lines within bounds', async ({
     comfyPage
   }) => {
     await comfyPage.page.route(/\/object_info$/, async (route) => {
       const response = await route.fetch()
-      const objectInfo = await response.json()
-      const stringInput =
-        objectInfo.DevToolsNodeWithStringInput.input.required.string_input
-      stringInput[1] = { ...(stringInput[1] ?? {}), tooltip: TOOLTIP_TEXT }
+      const objectInfo = (await response.json()) as ObjectInfoResponse
+      const required = objectInfo.DevToolsNodeWithStringInput?.input?.required
+      if (required?.string_input) {
+        const patchedInput: InputSpec = ['STRING', { tooltip: TOOLTIP_TEXT }]
+        required.string_input = patchedInput
+      }
       await route.fulfill({ response, json: objectInfo })
     })
     // Reload so the patched object_info (with the multi-line tooltip) is the one
@@ -48,18 +53,16 @@ test.describe('Vue Node Widget Tooltip', { tag: '@vue-nodes' }, () => {
     await expect(tooltipText).toBeVisible()
 
     // Behavioral check: whitespace-pre-line preserves the blank-line separator,
-    // so innerText keeps the label and value on distinct lines instead of
-    // collapsing them onto one (the BUG-020 regression).
-    const lines = (
-      await tooltipText.evaluate((el) => (el as HTMLElement).innerText)
+    // so innerText keeps the label and value on distinct lines with an empty
+    // line between them instead of collapsing them onto one (the BUG-020
+    // regression).
+    const renderedText = await tooltipText.evaluate(
+      (el) => (el as HTMLElement).innerText
     )
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-
-    expect(lines.length).toBeGreaterThan(1)
-    expect(lines[0]).toBe(WIDGET_LABEL)
-    expect(lines.at(-1)).toBe(LONG_VALUE)
+    const [labelLine, separatorLine, ...valueLines] = renderedText.split('\n')
+    expect(labelLine.trim()).toBe(WIDGET_LABEL)
+    expect(separatorLine.trim()).toBe('')
+    expect(valueLines.join('\n').trim()).toBe(LONG_VALUE)
 
     // Width stays bounded by max-w-96 so the long value wraps rather than
     // stretching the tooltip off-screen.

--- a/packages/object-info-parser/src/schemas/nodeDefSchema.ts
+++ b/packages/object-info-parser/src/schemas/nodeDefSchema.ts
@@ -357,6 +357,9 @@ export const zMatchTypeOptions = z.object({
 export type ComfyInputsSpec = z.infer<typeof zComfyInputsSpec>
 export type ComfyOutputTypesSpec = z.infer<typeof zComfyOutputTypesSpec>
 export type ComfyNodeDef = z.infer<typeof zComfyNodeDef>
+
+/** Full `/object_info` response: node definitions keyed by node type. */
+export type ObjectInfoResponse = Record<string, ComfyNodeDef>
 export type RemoteWidgetConfig = z.infer<typeof zRemoteWidgetConfig>
 
 export type ComboInputOptions = z.infer<typeof zComboInputOptions>

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
@@ -117,4 +117,17 @@ describe('useNodeTooltips', () => {
     expect(getOutputSlotTooltip(0)).toBe(jsonTooltip)
     expect(consoleError).not.toHaveBeenCalled()
   })
+
+  it('preserves the newline separating a widget label from its long value', () => {
+    const { createTooltipConfig } = useNodeTooltips('SAM3_Detect')
+
+    const config = createTooltipConfig(`${jsonTooltip}\n\na-long-value`)
+
+    // Without a whitespace-preserving rule the \n\n separator collapses to a
+    // space and the label runs into the value (BUG-020).
+    const pt = config.pt as { text?: { class?: string } } | undefined
+    const textClass = pt?.text?.class ?? ''
+    expect(textClass).toContain('whitespace-pre-line')
+    expect(config.value).toContain('\n\n')
+  })
 })

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -169,7 +169,7 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
       pt: {
         text: {
           class:
-            'border-node-component-tooltip-border bg-node-component-tooltip-surface border rounded-md px-4 py-2 text-node-component-tooltip text-sm font-normal leading-tight max-w-75 shadow-none'
+            'border-node-component-tooltip-border bg-node-component-tooltip-surface border rounded-md px-4 py-2 text-node-component-tooltip text-sm font-normal leading-tight max-w-96 whitespace-pre-line shadow-none'
         },
         arrow: ({ context }: TooltipPassThroughMethodOptions) => ({
           class: cn(


### PR DESCRIPTION
## Summary

QA finding F-1 / BUG-020 (1.47 cosmetic): the Vue-node widget tooltip compresses long values — the widget label and the long value run together with no separation, and the tooltip is narrow.

Root cause: the tooltip text is built as `[label, longValue].join('\n\n')` in `useProcessedWidgets`, but the PrimeVue `pt.text` class in `useNodeTooltips.createTooltipConfig` had no `whitespace-*` rule. With the default `white-space: normal`, the `\n\n` separator collapses to a single space, so the label and value render on one line.

## Changes

- Add `whitespace-pre-line` to the tooltip `pt.text` class so the `\n\n` separator renders as a visual break between the widget label and its value (matches the sibling `NodeTooltip.vue`, which already uses `white-space: pre-wrap`).
- Widen the tooltip from `max-w-75` (18.75rem) to `max-w-96` (24rem) so long values wrap comfortably instead of compressing.
- Add a regression test asserting the separator is preserved (fails on the old `max-w-75`, no-`whitespace` class).

## Test

`pnpm vitest run src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts` — 4 passed. Verified the new test fails without the fix.

Gates: vitest, eslint (0 errors), oxfmt, typecheck all green.