### PR TITLE
Fix canvasOnly widgets displaying in prop panel

### DIFF
--- a/browser_tests/tests/propertiesPanel/nodeSelection.spec.ts
+++ b/browser_tests/tests/propertiesPanel/nodeSelection.spec.ts
@@ -36,6 +36,24 @@ test.describe('Properties panel - Node selection', () => {
     })
 
     test(
+      'should not display canvasOnly widgets',
+      { tag: '@vue-nodes' },
+      async ({ comfyPage }) => {
+        await comfyPage.contextMenu
+          .openFor(comfyPage.vueNodes.getNodeByTitle('KSampler'))
+          .then((m) => m.clickMenuItemExact('Convert to Subgraph'))
+
+        await panel.contentArea
+          .getByRole('button', { name: 'ADVANCED INPUTS' })
+          .click()
+        await expect(panel.contentArea.getByText('steps')).toBeVisible()
+        await expect(
+          panel.contentArea.getByText('control after generate')
+        ).toBeHidden()
+      }
+    )
+
+    test(
       'a linked widget is disabled',
       { tag: '@vue-nodes' },
       async ({ comfyPage }) => {

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -75,7 +75,7 @@ const advancedInputsWidgets = computed((): NodeWidgetsList => {
   const allInteriorWidgets = interiorNodes.flatMap((interiorNode) => {
     const { widgets = [] } = interiorNode
     return widgets
-      .filter((w) => !w.computedDisabled)
+      .filter((w) => !w.computedDisabled && !w.options.canvasOnly)
       .map((widget) => ({ node: interiorNode, widget }))
   })
 


### PR DESCRIPTION
`canvasOnly` widgets like `control after generate` were incorrectly displaying in the properties panel list of advanced parameters for a parent subgraph node.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/cbf5f951-908e-4222-8ab4-d73692765066"/> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/64f58bb6-eb46-45ee-9029-b75c2110dce9"  />|