### PR TITLE
Fix unsaved workflow warning on local logout

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -33,6 +33,7 @@ const mockDialogService = vi.hoisted(() => ({
 
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockTrackAuthFailed = vi.hoisted(() => vi.fn())
+const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 
 const knownAuthErrorCodes = new Set([
   'auth/invalid-credential',
@@ -50,7 +51,9 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
-  isCloud: false
+  get isCloud() {
+    return mockDistributionState.isCloud
+  }
 }))
 
 vi.mock('@/platform/telemetry', () => ({
@@ -110,11 +113,28 @@ function makeWorkflow(path: string): ModifiedWorkflow {
   return { path, isModified: true } satisfies ModifiedWorkflow
 }
 
+beforeEach(() => {
+  mockDistributionState.isCloud = false
+})
+
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockDistributionState.isCloud = true
     mockWorkflowStore.modifiedWorkflows = []
+  })
+
+  it('logs out on non-cloud distributions without prompting when workflows are modified', async () => {
+    mockDistributionState.isCloud = false
+    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    const { logout } = useAuthActions()
+
+    await logout()
+
+    expect(mockDialogService.confirm).not.toHaveBeenCalled()
+    expect(mockWorkflowService.saveWorkflow).not.toHaveBeenCalled()
+    expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
   })
 
   it('logs out without prompting when no workflows are modified', async () => {

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -82,28 +82,30 @@ export const useAuthActions = () => {
   }
 
   const logout = wrapWithErrorHandlingAsync(async () => {
-    const workflowStore = useWorkflowStore()
-    const modifiedWorkflows = workflowStore.modifiedWorkflows
-    if (modifiedWorkflows.length > 0) {
-      const dialogService = useDialogService()
-      const confirmed = await dialogService.confirm({
-        title: t('auth.signOut.unsavedChangesTitle'),
-        message: t('auth.signOut.unsavedChangesMessage'),
-        type: 'dirtyClose',
-        denyLabel: t('auth.signOut.signOutAnyway')
-      })
-      if (confirmed === null) return
+    if (isCloud) {
+      const workflowStore = useWorkflowStore()
+      const modifiedWorkflows = workflowStore.modifiedWorkflows
+      if (modifiedWorkflows.length > 0) {
+        const dialogService = useDialogService()
+        const confirmed = await dialogService.confirm({
+          title: t('auth.signOut.unsavedChangesTitle'),
+          message: t('auth.signOut.unsavedChangesMessage'),
+          type: 'dirtyClose',
+          denyLabel: t('auth.signOut.signOutAnyway')
+        })
+        if (confirmed === null) return
 
-      if (confirmed === true) {
-        const workflowService = useWorkflowService()
-        for (const workflow of modifiedWorkflows) {
-          try {
-            const saved = await workflowService.saveWorkflow(workflow)
-            if (!saved) return
-          } catch {
-            throw new Error(
-              t('auth.signOut.saveFailed', { workflow: workflow.path })
-            )
+        if (confirmed === true) {
+          const workflowService = useWorkflowService()
+          for (const workflow of modifiedWorkflows) {
+            try {
+              const saved = await workflowService.saveWorkflow(workflow)
+              if (!saved) return
+            } catch {
+              throw new Error(
+                t('auth.signOut.saveFailed', { workflow: workflow.path })
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Skip the unsaved-workflow confirmation during local logout because local logout does not discard or navigate away from the current workflow.

## Changes

- **What**: Gate the existing unsaved-workflow confirmation and optional cloud save behind the cloud-distribution check while keeping authentication logout common to both distributions.
- **Tests**: Add a non-cloud regression case that verifies modified workflows do not trigger confirmation or saving, and retain coverage for all cloud dialog outcomes.

## Root Cause

The logout flow checked for modified workflows before distinguishing cloud logout from local logout, so the cloud-oriented data-loss warning was also shown locally even though the local flow leaves the workflow in place.

## Review Focus

- Local logout must bypass only the workflow confirmation/save block.
- Cloud logout must preserve the existing cancel, discard, and save behavior.
- Authentication logout and cloud-only post-logout navigation must remain unchanged.

## Validation

- `pnpm test:unit src/composables/auth/useAuthActions.test.ts` (18 tests)
- Focused test runs in isolation and shuffled with seeds 1 and 2
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm knip`
- `pnpm lint`

## Screenshots (if applicable)

Before 

https://github.com/user-attachments/assets/9dd89cec-ad3e-4ce2-a110-0d9fb46db9d3

**After** 

https://github.com/user-attachments/assets/90c92137-8344-49ae-9458-24ef701b8017


