### PR TITLE
fix: route legacy Stripe top-ups to Checkout

### DIFF
--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -8,7 +8,11 @@ const { mockFlags, mockActiveWorkspace } = vi.hoisted(() => ({
     consolidatedBillingEnabled: false
   },
   mockActiveWorkspace: {
-    value: null as { id: string; type: 'personal' | 'team' } | null
+    value: null as {
+      id: string
+      type: 'personal' | 'team'
+      billingRail?: 'legacy_stripe' | 'stripe'
+    } | null
   }
 }))
 
@@ -58,6 +62,31 @@ describe('useBillingRouting', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = personal
+
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+
+    expect(type.value).toBe('workspace')
+    expect(shouldUseWorkspaceBilling.value).toBe(true)
+  })
+
+  it('keeps legacy Stripe personal workspaces on Stripe Checkout', () => {
+    mockFlags.teamWorkspacesEnabled = true
+    mockFlags.consolidatedBillingEnabled = true
+    mockActiveWorkspace.value = {
+      ...personal,
+      billingRail: 'legacy_stripe'
+    }
+
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+
+    expect(type.value).toBe('legacy')
+    expect(shouldUseWorkspaceBilling.value).toBe(false)
+  })
+
+  it('uses workspace billing for migrated Stripe personal workspaces', () => {
+    mockFlags.teamWorkspacesEnabled = true
+    mockFlags.consolidatedBillingEnabled = true
+    mockActiveWorkspace.value = { ...personal, billingRail: 'stripe' }
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -2,19 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const { mockFlags, mockActiveWorkspace } = vi.hoisted(() => ({
-  mockFlags: {
-    teamWorkspacesEnabled: false,
-    consolidatedBillingEnabled: false
-  },
-  mockActiveWorkspace: {
-    value: null as {
-      id: string
-      type: 'personal' | 'team'
-      billingRail?: 'legacy_stripe' | 'stripe'
-    } | null
-  }
-}))
+const { mockFlags, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
+  vi.hoisted(() => ({
+    mockFlags: {
+      teamWorkspacesEnabled: false,
+      consolidatedBillingEnabled: false
+    },
+    mockActiveWorkspace: {
+      value: null as { id: string; type: 'personal' | 'team' } | null
+    },
+    mockActiveWorkspaceBillingRail: {
+      value: null as 'legacy_stripe' | 'stripe' | null
+    }
+  }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({ flags: mockFlags })
@@ -24,6 +24,9 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     get activeWorkspace() {
       return mockActiveWorkspace.value
+    },
+    get activeWorkspaceBillingRail() {
+      return mockActiveWorkspaceBillingRail.value
     }
   })
 }))
@@ -36,6 +39,7 @@ describe('useBillingRouting', () => {
     mockFlags.teamWorkspacesEnabled = false
     mockFlags.consolidatedBillingEnabled = false
     mockActiveWorkspace.value = personal
+    mockActiveWorkspaceBillingRail.value = null
   })
 
   it('uses legacy billing when team workspaces are disabled', () => {
@@ -72,10 +76,8 @@ describe('useBillingRouting', () => {
   it('keeps legacy Stripe personal workspaces on Stripe Checkout', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
-    mockActiveWorkspace.value = {
-      ...personal,
-      billingRail: 'legacy_stripe'
-    }
+    mockActiveWorkspace.value = personal
+    mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
@@ -86,7 +88,8 @@ describe('useBillingRouting', () => {
   it('uses workspace billing for migrated Stripe personal workspaces', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
-    mockActiveWorkspace.value = { ...personal, billingRail: 'stripe' }
+    mockActiveWorkspace.value = personal
+    mockActiveWorkspaceBillingRail.value = 'stripe'
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
@@ -98,6 +101,7 @@ describe('useBillingRouting', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = false
     mockActiveWorkspace.value = team
+    mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
@@ -109,6 +113,7 @@ describe('useBillingRouting', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = team
+    mockActiveWorkspaceBillingRail.value = 'stripe'
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -8,9 +8,10 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * on a declared legacy Stripe rail stay on `/customers/*`; team workspaces are
- * always workspace-scoped. The routing matrix is covered in
- * useBillingRouting.test.ts.
+ * stay legacy until `consolidatedBillingEnabled`, and known legacy Stripe
+ * workspaces remain legacy after it is enabled. An unknown rail keeps the
+ * flag-based route so workspace status can load it. Team workspaces are always
+ * workspace-scoped. The routing matrix is covered in useBillingRouting.test.ts.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
@@ -24,11 +25,11 @@ export function useBillingRouting() {
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return 'legacy'
 
-    if (workspaceStore.activeWorkspace?.billingRail === 'legacy_stripe') {
-      return 'legacy'
-    }
-
-    if (workspaceType === 'personal' && !flags.consolidatedBillingEnabled) {
+    if (
+      workspaceType === 'personal' &&
+      (!flags.consolidatedBillingEnabled ||
+        workspaceStore.activeWorkspaceBillingRail === 'legacy_stripe')
+    ) {
       return 'legacy'
     }
 

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -8,8 +8,9 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * stay legacy until `consolidatedBillingEnabled`; team workspaces are always
- * workspace-scoped. The routing matrix is covered in useBillingRouting.test.ts.
+ * on a declared legacy Stripe rail stay on `/customers/*`; team workspaces are
+ * always workspace-scoped. The routing matrix is covered in
+ * useBillingRouting.test.ts.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
@@ -22,6 +23,10 @@ export function useBillingRouting() {
     // eagerly routes to workspace billing.
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return 'legacy'
+
+    if (workspaceStore.activeWorkspace?.billingRail === 'legacy_stripe') {
+      return 'legacy'
+    }
 
     if (workspaceType === 'personal' && !flags.consolidatedBillingEnabled) {
       return 'legacy'

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -12,6 +12,7 @@ import type { UserId } from '@/types/authTypes'
 
 export type WorkspaceType = 'personal' | 'team'
 export type WorkspaceRole = 'owner' | 'member'
+export type BillingRail = 'legacy_stripe' | 'stripe'
 
 interface Workspace {
   id: WorkspaceId
@@ -263,6 +264,7 @@ export interface CurrentTeamCreditStop {
 
 export interface BillingStatusResponse {
   is_active: boolean
+  billing_rail?: BillingRail
   subscription_status?: BillingSubscriptionStatus
   subscription_tier?: SubscriptionTier
   subscription_duration?: SubscriptionDuration

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -28,6 +28,7 @@ const mockBillingPlans = vi.hoisted(() => ({
 
 const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
+const mockUpdateActiveWorkspace = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: mockWorkspaceApi
@@ -49,6 +50,12 @@ vi.mock(
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
     startOperation: mockStartOperation
+  })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    updateActiveWorkspace: mockUpdateActiveWorkspace
   })
 }))
 
@@ -203,6 +210,7 @@ describe('useWorkspaceBilling', () => {
     it('maps status response into subscription info', async () => {
       mockWorkspaceApi.getBillingStatus.mockResolvedValue({
         ...activeStatus,
+        billing_rail: 'stripe',
         subscription_status: 'canceled',
         cancel_at: '2026-06-01T00:00:00Z'
       })
@@ -222,6 +230,9 @@ describe('useWorkspaceBilling', () => {
       })
       expect(billing.isActiveSubscription.value).toBe(true)
       expect(billing.isFreeTier.value).toBe(false)
+      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
+        billingRail: 'stripe'
+      })
     })
 
     it("keeps a 'scheduled' subscription on the active treatment", async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -28,7 +28,7 @@ const mockBillingPlans = vi.hoisted(() => ({
 
 const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
-const mockUpdateActiveWorkspace = vi.hoisted(() => vi.fn())
+const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: mockWorkspaceApi
@@ -55,7 +55,8 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
-    updateActiveWorkspace: mockUpdateActiveWorkspace
+    activeWorkspace: { id: 'workspace-1' },
+    setWorkspaceBillingRail: mockSetWorkspaceBillingRail
   })
 }))
 
@@ -230,9 +231,10 @@ describe('useWorkspaceBilling', () => {
       })
       expect(billing.isActiveSubscription.value).toBe(true)
       expect(billing.isFreeTier.value).toBe(false)
-      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
-        billingRail: 'stripe'
-      })
+      expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
+        'workspace-1',
+        'stripe'
+      )
     })
 
     it("keeps a 'scheduled' subscription on the active treatment", async () => {
@@ -255,6 +257,7 @@ describe('useWorkspaceBilling', () => {
       await billing.fetchStatus()
 
       expect(billing.isFreeTier.value).toBe(true)
+      expect(mockSetWorkspaceBillingRail).not.toHaveBeenCalled()
     })
 
     it('sets error and rethrows when fetchStatus fails', async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -118,15 +118,19 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
 
   async function fetchStatus(): Promise<void> {
     const requestId = ++latestBillingReadIds.status
+    const workspaceId = workspaceStore.activeWorkspace?.id
     isLoading.value = true
     error.value = null
     try {
       const status = await workspaceApi.getBillingStatus()
       if (requestId === latestBillingReadIds.status) {
         statusData.value = status
-        workspaceStore.updateActiveWorkspace({
-          billingRail: status.billing_rail
-        })
+        if (workspaceId && status.billing_rail) {
+          workspaceStore.setWorkspaceBillingRail(
+            workspaceId,
+            status.billing_rail
+          )
+        }
       }
     } catch (err) {
       if (requestId === latestBillingReadIds.status) {

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import type {
   BalanceInfo,
@@ -30,6 +31,7 @@ import type {
 export function useWorkspaceBilling(): BillingState & BillingActions {
   const billingPlans = useBillingPlans()
   const billingOperationStore = useBillingOperationStore()
+  const workspaceStore = useTeamWorkspaceStore()
 
   const isInitialized = ref(false)
   const isLoading = ref(false)
@@ -120,7 +122,12 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     error.value = null
     try {
       const status = await workspaceApi.getBillingStatus()
-      if (requestId === latestBillingReadIds.status) statusData.value = status
+      if (requestId === latestBillingReadIds.status) {
+        statusData.value = status
+        workspaceStore.updateActiveWorkspace({
+          billingRail: status.billing_rail
+        })
+      }
     } catch (err) {
       if (requestId === latestBillingReadIds.status) {
         error.value =

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -36,7 +36,6 @@ export interface PendingInvite {
 type SubscriptionPlan = string | null
 
 interface WorkspaceState extends WorkspaceWithRole {
-  billingRail?: BillingRail
   isSubscribed: boolean
   subscriptionPlan: SubscriptionPlan
   subscriptionTier: SubscriptionTier | null
@@ -122,6 +121,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const initState = ref<InitState>('uninitialized')
   const workspaces = shallowRef<WorkspaceState[]>([])
   const activeWorkspaceId = ref<string | null>(null)
+  const billingRailByWorkspaceId = shallowRef<Record<string, BillingRail>>({})
   const error = ref<Error | null>(null)
 
   const isCreating = ref(false)
@@ -140,6 +140,13 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   const isInPersonalWorkspace = computed(
     () => activeWorkspace.value?.type === 'personal'
   )
+
+  const activeWorkspaceBillingRail = computed(() => {
+    const workspaceId = activeWorkspaceId.value
+    return workspaceId
+      ? (billingRailByWorkspaceId.value[workspaceId] ?? null)
+      : null
+  })
 
   const sharedWorkspaces = computed(() =>
     workspaces.value.filter((w) => w.type !== 'personal')
@@ -224,6 +231,16 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   function updateActiveWorkspace(updates: Partial<WorkspaceState>) {
     if (!activeWorkspaceId.value) return
     updateWorkspace(activeWorkspaceId.value, updates)
+  }
+
+  function setWorkspaceBillingRail(
+    workspaceId: string,
+    billingRail: BillingRail
+  ) {
+    billingRailByWorkspaceId.value = {
+      ...billingRailByWorkspaceId.value,
+      [workspaceId]: billingRail
+    }
   }
 
   /**
@@ -745,6 +762,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     activeWorkspace,
     personalWorkspace,
     isInPersonalWorkspace,
+    activeWorkspaceBillingRail,
     sharedWorkspaces,
     ownedWorkspacesCount,
     canCreateWorkspace,
@@ -788,6 +806,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
     // Subscription
     subscribeWorkspace,
-    updateActiveWorkspace
+    updateActiveWorkspace,
+    setWorkspaceBillingRail
   }
 })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -8,6 +8,7 @@ import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQuery
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 
 import type {
+  BillingRail,
   ListMembersParams,
   Member,
   PendingInvite as ApiPendingInvite,
@@ -35,6 +36,7 @@ export interface PendingInvite {
 type SubscriptionPlan = string | null
 
 interface WorkspaceState extends WorkspaceWithRole {
+  billingRail?: BillingRail
   isSubscribed: boolean
   subscriptionPlan: SubscriptionPlan
   subscriptionTier: SubscriptionTier | null


### PR DESCRIPTION
## Summary

- treat `/api/billing/status`'s billing rail as authoritative for personal billing routing
- route known `legacy_stripe` personal workspaces to the original `/customers/credit` Stripe Checkout flow
- keep migrated Stripe and team workspaces on workspace-scoped billing
- key cached billing rail state by workspace so switching workspaces cannot reuse a stale rail
- preserve the existing flag-based route while the rail is unknown so status can bootstrap

## Why

`consolidatedBillingEnabled` was being used as the sole personal billing router. When enabled for a `legacy_stripe` user, the frontend posted `/api/billing/topup`, entering the Metronome payment-gated commit path instead of the known-good original Stripe Checkout flow.

Cloud companion guard: https://github.com/Comfy-Org/cloud/pull/5311

## Validation

- `pnpm vitest run src/composables/billing/useBillingRouting.test.ts src/platform/workspace/composables/useWorkspaceBilling.test.ts` (67/67)
- `pnpm typecheck`
- oxfmt / commit hooks
- pre-push knip
