### PR TITLE
fix: redirect workspace top-ups to Checkout

### DIFF
--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -47,6 +47,8 @@ vi.mock('@/stores/authStore', () => ({
   })
 }))
 
+import type { CreateTopupResponse } from './workspaceApi'
+
 import { workspaceApi } from './workspaceApi'
 
 const AUTH_HEADER = { Authorization: 'Bearer test-token' }
@@ -446,6 +448,37 @@ describe('workspaceApi', () => {
     })
   })
 
+  describe('topup', () => {
+    it('createTopup() sends redirect URLs for payment Checkout fallback', async () => {
+      const data: CreateTopupResponse = {
+        billing_op_id: 'op-topup',
+        topup_id: 'op-topup',
+        status: 'needs_payment_method',
+        amount_cents: 5000,
+        payment_method_url: 'https://checkout.stripe.com/session'
+      }
+      mockAxiosInstance.post.mockResolvedValue({ data })
+
+      const result = await workspaceApi.createTopup(5000, {
+        idempotencyKey: 'topup-key',
+        returnUrl: 'https://www.comfy.org/settings',
+        cancelUrl: 'https://www.comfy.org/settings'
+      })
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/billing/topup',
+        {
+          amount_cents: 5000,
+          idempotency_key: 'topup-key',
+          return_url: 'https://www.comfy.org/settings',
+          cancel_url: 'https://www.comfy.org/settings'
+        },
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(data)
+    })
+  })
+
   describe('payment', () => {
     it('getPaymentPortalUrl() sends POST with return_url', async () => {
       const data = { url: 'https://stripe.com/portal' }
@@ -472,11 +505,18 @@ describe('workspaceApi', () => {
       }
       mockAxiosInstance.post.mockResolvedValue({ data })
 
-      const result = await workspaceApi.createTopup(1000, 'key-3')
+      const result = await workspaceApi.createTopup(1000, {
+        idempotencyKey: 'key-3'
+      })
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/billing/topup',
-        { amount_cents: 1000, idempotency_key: 'key-3' },
+        {
+          amount_cents: 1000,
+          idempotency_key: 'key-3',
+          return_url: undefined,
+          cancel_url: undefined
+        },
         { headers: AUTH_HEADER }
       )
       expect(result).toEqual(data)

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -287,15 +287,18 @@ export interface BillingBalanceResponse {
 interface CreateTopupRequest {
   amount_cents: number
   idempotency_key?: string
+  return_url?: string
+  cancel_url?: string
 }
 
-type TopupStatus = 'pending' | 'completed' | 'failed'
+type TopupStatus = 'pending' | 'completed' | 'failed' | 'needs_payment_method'
 
 export interface CreateTopupResponse {
   billing_op_id: string
   topup_id: string
   status: TopupStatus
   amount_cents: number
+  payment_method_url?: string
 }
 
 type BillingOpStatus = 'pending' | 'succeeded' | 'failed'
@@ -756,7 +759,11 @@ export const workspaceApi = {
    */
   async createTopup(
     amountCents: number,
-    idempotencyKey?: string
+    options: {
+      idempotencyKey?: string
+      returnUrl?: string
+      cancelUrl?: string
+    } = {}
   ): Promise<CreateTopupResponse> {
     const headers = await getAuthHeaderOrThrow()
     try {
@@ -764,7 +771,9 @@ export const workspaceApi = {
         api.apiURL('/billing/topup'),
         {
           amount_cents: amountCents,
-          idempotency_key: idempotencyKey
+          idempotency_key: options.idempotencyKey ?? crypto.randomUUID(),
+          return_url: options.returnUrl,
+          cancel_url: options.cancelUrl
         } satisfies CreateTopupRequest,
         { headers }
       )

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -179,6 +179,23 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(mockFetchStatus).not.toHaveBeenCalled()
   })
 
+  it('redirects to Checkout when the top-up needs customer payment', async () => {
+    const assign = vi
+      .spyOn(window.location, 'assign')
+      .mockImplementation(() => undefined)
+    mockTopup.mockResolvedValue({
+      ...topupResponse('needs_payment_method'),
+      payment_method_url: 'https://checkout.stripe.com/session'
+    })
+
+    renderDialog()
+    await clickAddCredits()
+
+    expect(assign).toHaveBeenCalledWith('https://checkout.stripe.com/session')
+    expect(mockStartOperation).not.toHaveBeenCalled()
+    expect(mockFetchBalance).not.toHaveBeenCalled()
+  })
+
   it('does not refresh balance or status for a failed top-up', async () => {
     mockTopup.mockResolvedValue(topupResponse('failed'))
 

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -269,7 +269,12 @@ async function handleBuy() {
     const response = await topup(amountCents)
     if (!response) return
 
-    if (response.status === 'completed') {
+    if (
+      response.status === 'needs_payment_method' &&
+      response.payment_method_url
+    ) {
+      window.location.assign(response.payment_method_url)
+    } else if (response.status === 'completed') {
       toast.add({
         severity: 'success',
         summary: t('credits.topUp.purchaseSuccess'),

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -794,7 +794,10 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       const result = await billing.topup(500)
 
-      expect(mockWorkspaceApi.createTopup).toHaveBeenCalledWith(500)
+      expect(mockWorkspaceApi.createTopup).toHaveBeenCalledWith(500, {
+        returnUrl: window.location.href,
+        cancelUrl: window.location.href
+      })
       expect(result).toBe(topupResponse)
       expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
       expect(mockWorkspaceApi.getBillingBalance).not.toHaveBeenCalled()
@@ -878,7 +881,10 @@ describe('useWorkspaceBilling', () => {
       const billing = setupBilling()
       const result = await billing.topup(500)
 
-      expect(mockWorkspaceApi.createTopup).toHaveBeenCalledWith(500)
+      expect(mockWorkspaceApi.createTopup).toHaveBeenCalledWith(500, {
+        returnUrl: window.location.href,
+        cancelUrl: window.location.href
+      })
       expect(result).toBe(topupResponse)
       expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
       expect(mockWorkspaceApi.getBillingBalance).not.toHaveBeenCalled()

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -303,7 +303,10 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     isLoading.value = true
     error.value = null
     try {
-      return await workspaceApi.createTopup(amountCents)
+      return await workspaceApi.createTopup(amountCents, {
+        returnUrl: window.location.href,
+        cancelUrl: window.location.href
+      })
     } catch (err) {
       error.value =
         err instanceof Error ? err.message : 'Failed to top up credits'


### PR DESCRIPTION
## Summary
- send workspace top-up return/cancel URLs to the backend
- redirect when the backend returns `needs_payment_method` with a Checkout URL
- preserve the existing direct top-up experience for reusable saved payment methods

## Tests
- workspace API, billing composable, and top-up dialog tests
- pre-push `knip --cache` passed (with the repository's Node 25 engine warning under Node 22)

Depends on Comfy-Org/cloud#5321.