### PR TITLE
fix: guard numeric rendering state

### DIFF
--- a/src/extensions/core/load3d/cameraFromMatrices.test.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.test.ts
@@ -132,6 +132,35 @@ describe('computeCameraFromMatrices', () => {
     ).toThrow(/intrinsics/)
   })
 
+  it.for<[label: string, value: number, expectedError: RegExp]>([
+    ['NaN', Number.NaN, /extrinsics\[0\]\[3\].*NaN/],
+    ['Infinity', Number.POSITIVE_INFINITY, /extrinsics\[0\]\[3\].*Infinity/]
+  ])('throws when extrinsics contains %s', ([, value, expectedError]) => {
+    expect(() =>
+      computeCameraFromMatrices(
+        extrinsics(IDENTITY_R, [value, 0, 0]),
+        intrinsics(500, 500, 320, 240)
+      )
+    ).toThrow(expectedError)
+  })
+
+  it.for([
+    {
+      label: 'NaN fx',
+      matrix: intrinsics(Number.NaN, 500, 320, 240),
+      expectedError: /intrinsics\[0\]\[0\].*NaN/
+    },
+    {
+      label: 'infinite cy',
+      matrix: intrinsics(500, 500, 320, Number.POSITIVE_INFINITY),
+      expectedError: /intrinsics\[1\]\[2\].*Infinity/
+    }
+  ])('throws when intrinsics contains $label', ({ matrix, expectedError }) => {
+    expect(() =>
+      computeCameraFromMatrices(extrinsics(IDENTITY_R, [0, 0, 0]), matrix)
+    ).toThrow(expectedError)
+  })
+
   it.for<[label: string, fy: number]>([
     ['zero', 0],
     ['NaN', Number.NaN],

--- a/src/extensions/core/load3d/cameraFromMatrices.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.ts
@@ -33,6 +33,7 @@ export function computeCameraFromMatrices(
 ): CameraFromMatricesResult {
   assertMatrixShape(extrinsics, 4, 4, 'extrinsics')
   assertMatrixShape(intrinsics, 3, 3, 'intrinsics')
+  assertFiniteMatrix(extrinsics, 'extrinsics')
 
   const r00 = extrinsics[0][0]
   const r01 = extrinsics[0][1]
@@ -63,6 +64,7 @@ export function computeCameraFromMatrices(
       `intrinsics[1][1] (fy) must be a non-zero finite number, got ${fy}`
     )
   }
+  assertFiniteMatrix(intrinsics, 'intrinsics')
   const fovYRad = 2 * Math.atan(cy / fy)
   const fovYDegrees = (fovYRad * 180) / Math.PI
 
@@ -70,6 +72,22 @@ export function computeCameraFromMatrices(
     position: [posX, -posY, -posZ],
     target: [targetX, -targetY, -targetZ],
     fovYDegrees
+  }
+}
+
+function assertFiniteMatrix(
+  matrix: readonly (readonly number[])[],
+  name: string
+): void {
+  for (let row = 0; row < matrix.length; row++) {
+    for (let column = 0; column < matrix[row].length; column++) {
+      const value = matrix[row][column]
+      if (!Number.isFinite(value)) {
+        throw new Error(
+          `${name}[${row}][${column}] must be finite, got ${value}`
+        )
+      }
+    }
   }
 }
 

--- a/src/platform/workflow/core/utils/workflowView.test.ts
+++ b/src/platform/workflow/core/utils/workflowView.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseWorkflowView } from './workflowView'
+
+describe('parseWorkflowView', () => {
+  it('returns a valid workflow view', () => {
+    expect(parseWorkflowView({ scale: 0.01, offset: [10, -20] })).toEqual({
+      scale: 0.01,
+      offset: [10, -20]
+    })
+  })
+
+  it.for([0, -1, Number.POSITIVE_INFINITY])(
+    'rejects an invalid scale of %s',
+    (scale) => {
+      expect(parseWorkflowView({ scale, offset: [0, 0] })).toBeUndefined()
+    }
+  )
+
+  it.for([
+    { label: 'infinite x', offset: [Number.POSITIVE_INFINITY, 0] },
+    { label: 'NaN y', offset: [0, Number.NaN] }
+  ])('rejects an offset with $label', ({ offset }) => {
+    expect(parseWorkflowView({ scale: 1, offset })).toBeUndefined()
+  })
+
+  it.for([
+    { label: 'null input', value: null },
+    { label: 'missing scale', value: { offset: [0, 0] } },
+    { label: 'missing offset', value: { scale: 1 } },
+    { label: 'non-array offset', value: { scale: 1, offset: '0,0' } },
+    { label: 'short offset', value: { scale: 1, offset: [0] } },
+    { label: 'non-number coordinate', value: { scale: 1, offset: ['0', 0] } }
+  ])('rejects $label', ({ value }) => {
+    expect(parseWorkflowView(value)).toBeUndefined()
+  })
+})

--- a/src/platform/workflow/core/utils/workflowView.ts
+++ b/src/platform/workflow/core/utils/workflowView.ts
@@ -1,0 +1,23 @@
+interface WorkflowView {
+  scale: number
+  offset: [number, number]
+}
+
+export function parseWorkflowView(value: unknown): WorkflowView | undefined {
+  if (typeof value !== 'object' || value === null) return
+
+  const scale = Reflect.get(value, 'scale')
+  const offset = Reflect.get(value, 'offset')
+  if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) return
+  if (
+    !Array.isArray(offset) ||
+    typeof offset[0] !== 'number' ||
+    typeof offset[1] !== 'number' ||
+    !Number.isFinite(offset[0]) ||
+    !Number.isFinite(offset[1])
+  ) {
+    return
+  }
+
+  return { scale, offset: [offset[0], offset[1]] }
+}

--- a/src/platform/workflow/core/utils/workflowView.ts
+++ b/src/platform/workflow/core/utils/workflowView.ts
@@ -6,10 +6,8 @@ interface WorkflowView {
 export function parseWorkflowView(value: unknown): WorkflowView | undefined {
   if (typeof value !== 'object' || value === null) return
 
-  const { scale, offset } = value as {
-    scale?: unknown
-    offset?: unknown
-  }
+  const scale = 'scale' in value ? value.scale : undefined
+  const offset = 'offset' in value ? value.offset : undefined
   if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) return
   if (
     !Array.isArray(offset) ||

--- a/src/platform/workflow/core/utils/workflowView.ts
+++ b/src/platform/workflow/core/utils/workflowView.ts
@@ -6,8 +6,10 @@ interface WorkflowView {
 export function parseWorkflowView(value: unknown): WorkflowView | undefined {
   if (typeof value !== 'object' || value === null) return
 
-  const scale = Reflect.get(value, 'scale')
-  const offset = Reflect.get(value, 'offset')
+  const { scale, offset } = value as {
+    scale?: unknown
+    offset?: unknown
+  }
   if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) return
   if (
     !Array.isArray(offset) ||

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -33,6 +33,7 @@ import { groupMissingNodesByPack } from '@/platform/telemetry/utils/groupMissing
 import type { WorkflowOpenSource } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
+import { parseWorkflowView } from '@/platform/workflow/core/utils/workflowView'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowValidation } from '@/platform/workflow/validation/composables/useWorkflowValidation'
@@ -1343,6 +1344,7 @@ export class ComfyApp {
 
     const canvasVisible = !!(this.canvasEl.width && this.canvasEl.height)
     const fitView = () => {
+      const workflowView = parseWorkflowView(graphData.extra?.ds)
       if (
         restore_view &&
         useSettingStore().get('Comfy.EnableWorkflowViewRestore')
@@ -1350,9 +1352,9 @@ export class ComfyApp {
         // Always fit view for templates to ensure they're visible on load
         if (openSource === 'template') {
           useLitegraphService().fitView()
-        } else if (graphData.extra?.ds) {
-          this.canvas.ds.offset = graphData.extra.ds.offset
-          this.canvas.ds.scale = graphData.extra.ds.scale
+        } else if (workflowView) {
+          this.canvas.ds.offset = workflowView.offset
+          this.canvas.ds.scale = workflowView.scale
 
           // Fit view if no nodes visible in restored viewport
           this.canvas.ds.computeVisibleArea(this.canvas.viewport)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -45,6 +45,7 @@ import type {
 } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
+import { parseWorkflowView } from '@/platform/workflow/core/utils/workflowView'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowValidation } from '@/platform/workflow/validation/composables/useWorkflowValidation'
@@ -1411,6 +1412,7 @@ export class ComfyApp {
 
     const canvasVisible = !!(this.canvasEl.width && this.canvasEl.height)
     const fitView = () => {
+      const workflowView = parseWorkflowView(graphData.extra?.ds)
       if (
         restore_view &&
         useSettingStore().get('Comfy.EnableWorkflowViewRestore')
@@ -1418,9 +1420,9 @@ export class ComfyApp {
         // Always fit view for templates to ensure they're visible on load
         if (openSource === 'template') {
           useLitegraphService().fitView()
-        } else if (graphData.extra?.ds) {
-          this.canvas.ds.offset = graphData.extra.ds.offset
-          this.canvas.ds.scale = graphData.extra.ds.scale
+        } else if (workflowView) {
+          this.canvas.ds.offset = workflowView.offset
+          this.canvas.ds.scale = workflowView.scale
 
           // Fit view if no nodes visible in restored viewport
           this.canvas.ds.computeVisibleArea(this.canvas.viewport)

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -450,5 +450,17 @@ describe('colorUtil - adjustColor', () => {
         'hsla(0, 0%, 0%, 1)'
       )
     })
+
+    it('applies zero opacity', () => {
+      expect(adjustColor('rgba(255, 0, 0, 0.5)', { opacity: 0 })).toBe(
+        'hsla(0, 100%, 50%, 0)'
+      )
+    })
+
+    it('clamps RGB channels before applying adjustments', () => {
+      expect(adjustColor('rgb(510, 0, 0)', { opacity: 0.5 })).toBe(
+        'hsla(0, 100%, 50%, 0.5)'
+      )
+    })
   })
 })

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -433,5 +433,17 @@ describe('colorUtil - adjustColor', () => {
         'hsla(0, 0%, 0%, 1)'
       )
     })
+
+    it('applies zero opacity', () => {
+      expect(adjustColor('rgba(255, 0, 0, 0.5)', { opacity: 0 })).toBe(
+        'hsla(0, 100%, 50%, 0)'
+      )
+    })
+
+    it('clamps RGB channels before applying adjustments', () => {
+      expect(adjustColor('rgb(510, 0, 0)', { opacity: 0.5 })).toBe(
+        'hsla(0, 100%, 50%, 0.5)'
+      )
+    })
   })
 })

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -360,7 +360,6 @@ describe('colorUtil - adjustColor', () => {
   it('returns the original value for invalid color formats', () => {
     const invalidColors = [
       'cmky(100, 50, 50, 0.5)',
-      'rgb(300, -10, 256)',
       'xyz(255, 255, 255)',
       'hsl(100, 50, 50%)',
       'hsl(100, 50%, 50)',
@@ -460,6 +459,9 @@ describe('colorUtil - adjustColor', () => {
     it('clamps RGB channels before applying adjustments', () => {
       expect(adjustColor('rgb(510, 0, 0)', { opacity: 0.5 })).toBe(
         'hsla(0, 100%, 50%, 0.5)'
+      )
+      expect(adjustColor('rgb(-510, 255, 0)', { opacity: 0.5 })).toBe(
+        'hsla(120, 100%, 50%, 0.5)'
       )
     })
   })

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -456,6 +456,12 @@ describe('colorUtil - adjustColor', () => {
       )
     })
 
+    it('preserves the parsed opacity for non-finite overrides', () => {
+      expect(adjustColor('rgba(255, 0, 0, 0.5)', { opacity: Number.NaN })).toBe(
+        'hsla(0, 100%, 50%, 0.5)'
+      )
+    })
+
     it('clamps RGB channels before applying adjustments', () => {
       expect(adjustColor('rgb(510, 0, 0)', { opacity: 0.5 })).toBe(
         'hsla(0, 100%, 50%, 0.5)'

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -1,4 +1,5 @@
 import { memoize } from 'es-toolkit/compat'
+import { clamp } from 'es-toolkit/math'
 
 type RGB = { r: number; g: number; b: number }
 interface HSB {
@@ -37,9 +38,9 @@ export function isTransparent(color: string) {
 }
 
 export function rgbToHsl({ r, g, b }: RGB): HSL {
-  r /= 255
-  g /= 255
-  b /= 255
+  r = clamp(r, 0, 255) / 255
+  g = clamp(g, 0, 255) / 255
+  b = clamp(b, 0, 255) / 255
   const max = Math.max(r, g, b),
     min = Math.min(r, g, b)
   let h = 0,
@@ -453,7 +454,7 @@ const applyColorAdjustments = (
     hsla.l = Math.max(0, Math.min(100, hsla.l + options.lightness * 100.0))
   }
 
-  if (options.opacity) {
+  if (options.opacity !== undefined) {
     hsla.a = Math.max(0, Math.min(1, options.opacity))
   }
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -1,4 +1,5 @@
 import { memoize } from 'es-toolkit/compat'
+import { clamp } from 'es-toolkit/math'
 
 type RGB = { r: number; g: number; b: number }
 interface HSB {
@@ -37,9 +38,9 @@ export function isTransparent(color: string) {
 }
 
 export function rgbToHsl({ r, g, b }: RGB): HSL {
-  r /= 255
-  g /= 255
-  b /= 255
+  r = clamp(r, 0, 255) / 255
+  g = clamp(g, 0, 255) / 255
+  b = clamp(b, 0, 255) / 255
   const max = Math.max(r, g, b),
     min = Math.min(r, g, b)
   let h = 0,
@@ -448,7 +449,7 @@ const applyColorAdjustments = (
     hsla.l = Math.max(0, Math.min(100, hsla.l + options.lightness * 100.0))
   }
 
-  if (options.opacity) {
+  if (options.opacity !== undefined) {
     hsla.a = Math.max(0, Math.min(1, options.opacity))
   }
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -228,7 +228,7 @@ const identifyColorFormat = (color: string): ColorFormatInternal | null => {
       color.length === 9)
   )
     return 'hex'
-  if (/rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*/.test(color))
+  if (/rgba?\(\s*-?\d+\s*,\s*-?\d+\s*,\s*-?\d+\s*/.test(color))
     return color.includes('rgba') ? 'rgba' : 'rgb'
   if (/hsla?\(\s*\d+(\.\d+)?\s*,\s*\d+(\.\d+)?%\s*,\s*\d+(\.\d+)?%/.test(color))
     return color.includes('hsla') ? 'hsla' : 'hsl'
@@ -339,7 +339,7 @@ function parseToHSLA(color: string, format: ColorFormatInternal): HSLA | null {
 
     case 'rgb':
     case 'rgba': {
-      match = color.match(/\d+(\.\d+)?/g)
+      match = color.match(/-?\d+(\.\d+)?/g)
       if (!match || match.length < 3) return null
       const [r, g, b] = match.map(Number)
       const hsl = rgbToHsl({ r, g, b })

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -454,7 +454,7 @@ const applyColorAdjustments = (
     hsla.l = Math.max(0, Math.min(100, hsla.l + options.lightness * 100.0))
   }
 
-  if (options.opacity !== undefined) {
+  if (options.opacity !== undefined && Number.isFinite(options.opacity)) {
     hsla.a = Math.max(0, Math.min(1, options.opacity))
   }
 


### PR DESCRIPTION
## Summary

Guard three numeric edge cases found by a Freerange audit before they can poison canvas, 3D camera, or color rendering state.

## Changes

- **What**: Reject non-positive or non-finite restored workflow view state and fall back to fitting the graph.
- **What**: Reject non-finite 3D camera matrix entries with the exact invalid cell in the error.
- **What**: Apply zero opacity and clamp RGB channels before HSL conversion.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- Invalid serialized viewport state must use the existing `fitView()` fallback.
- Camera matrix validation must happen before Three.js state is mutated.
- Color adjustment should preserve current unsupported-format behavior while handling numeric upper bounds.

## Validation

- `pnpm exec vitest run src/platform/workflow/core/utils/workflowView.test.ts src/extensions/core/load3d/cameraFromMatrices.test.ts src/utils/colorUtil.test.ts` (104 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with 44 existing warnings)
- `pnpm format:check`
- `pnpm knip`
- CodeRabbit review, no critical or warning findings

Created by Codex
