### PR TITLE
feat: add workspace provider governance

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2919,7 +2919,46 @@
     "tabs": {
       "dashboard": "Dashboard",
       "planCredits": "Plan & Credits",
-      "membersCount": "Members ({count})"
+      "membersCount": "Members ({count})",
+      "partnerProviders": "Partner Nodes"
+    },
+    "providerGovernance": {
+      "title": "Partner provider access",
+      "description": "Choose which partner providers are available to this workspace.",
+      "searchPlaceholder": "Search providers...",
+      "loading": "Loading provider policy...",
+      "loadError": "The provider policy could not be loaded.",
+      "retry": "Try Again",
+      "saveError": "The provider policy could not be saved. Try again.",
+      "saved": "Provider policy saved",
+      "empty": "No partner providers are available.",
+      "noMatches": "No providers match your search.",
+      "allowAll": "Allow all",
+      "blockAll": "Block all",
+      "providerToggle": "Allow {name}",
+      "newProviderDefault": "New providers are blocked until a workspace owner reviews them.",
+      "propagation": "Changes can take up to {minutes} minutes to apply.",
+      "setup": {
+        "title": "Set up partner provider access",
+        "description": "Start with every current provider allowed. You can review provider choices before restricting access.",
+        "action": "Set up governance"
+      },
+      "enforcement": {
+        "title": "Restrict partner provider access",
+        "unrestricted": "All partner providers are currently allowed. Provider choices are saved for review but do not block usage.",
+        "restricted": "Only enabled providers can be used in this workspace.",
+        "toggle": "Restrict partner provider access"
+      },
+      "confirmRestrict": {
+        "title": "Restrict partner provider access?",
+        "description": "Disabled providers will stop working after the policy change reaches the execution services. New providers will also be blocked until reviewed.",
+        "action": "Restrict access"
+      },
+      "confirmUnrestrict": {
+        "title": "Allow unrestricted partner provider access?",
+        "description": "Every partner provider, including newly added providers, will be allowed. Your provider choices will remain saved for future review.",
+        "action": "Allow unrestricted access"
+      }
     },
     "dashboard": {
       "placeholder": "Dashboard workspace settings"

--- a/src/platform/workspace/api/partnerNodePolicyApi.test.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getPartnerNodePolicy,
-  PartnerNodePolicyApiError
+  getPartnerProviders,
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 
 const mockFetchApi = vi.fn()
@@ -22,22 +24,52 @@ describe('partnerNodePolicyApi', () => {
     vi.clearAllMocks()
   })
 
-  it('normalizes the configured policy response', async () => {
+  it('normalizes the provider catalog', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        providers: [
+          {
+            provider_id: 'openai',
+            display_name: 'OpenAI (inc. Sora)',
+            node_categories: ['OpenAI', 'Sora']
+          }
+        ]
+      })
+    )
+
+    await expect(getPartnerProviders()).resolves.toEqual([
+      {
+        id: 'openai',
+        displayName: 'OpenAI (inc. Sora)',
+        nodeCategories: ['OpenAI', 'Sora']
+      }
+    ])
+    expect(mockFetchApi).toHaveBeenCalledWith('/providers', {
+      cache: 'no-store'
+    })
+  })
+
+  it('normalizes the configured provider policy', async () => {
     mockFetchApi.mockResolvedValue(
       jsonResponse({
         enforcement_enabled: true,
-        nodes: { AllowedNode: true, DisabledNode: false }
+        providers: [
+          { provider_id: 'openai', enabled: true },
+          { provider_id: 'kling', enabled: false }
+        ]
       })
     )
 
     await expect(getPartnerNodePolicy()).resolves.toEqual({
       enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
+      providers: [
+        { providerId: 'openai', enabled: true },
+        { providerId: 'kling', enabled: false }
+      ]
     })
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      '/workspace/partner-node-policy',
-      { cache: 'no-store' }
-    )
+    expect(mockFetchApi).toHaveBeenCalledWith('/workspace/provider-policy', {
+      cache: 'no-store'
+    })
   })
 
   it('maps 404 to an unconfigured policy', async () => {
@@ -48,7 +80,30 @@ describe('partnerNodePolicyApi', () => {
     await expect(getPartnerNodePolicy()).resolves.toBeNull()
   })
 
-  it('preserves non-404 status codes for policy decisions', async () => {
+  it('serializes the whole provider policy document', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        enforcement_enabled: false,
+        providers: [{ provider_id: 'openai', enabled: true }]
+      })
+    )
+
+    await updatePartnerNodePolicy({
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: true }]
+    })
+
+    expect(mockFetchApi).toHaveBeenCalledWith('/workspace/provider-policy', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        enforcement_enabled: false,
+        providers: [{ provider_id: 'openai', enabled: true }]
+      })
+    })
+  })
+
+  it('preserves non-404 status codes', async () => {
     mockFetchApi.mockResolvedValue(
       jsonResponse({}, { status: 503, statusText: 'Service Unavailable' })
     )
@@ -58,9 +113,9 @@ describe('partnerNodePolicyApi', () => {
     )
   })
 
-  it('rejects malformed policy responses', async () => {
+  it('rejects malformed provider policy responses', async () => {
     mockFetchApi.mockResolvedValue(
-      jsonResponse({ enforcement_enabled: 'yes', nodes: [] })
+      jsonResponse({ enforcement_enabled: 'yes', providers: [] })
     )
 
     await expect(getPartnerNodePolicy()).rejects.toMatchObject({

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -2,14 +2,43 @@ import { z } from 'zod'
 
 import { api } from '@/scripts/api'
 
-const partnerNodePolicyResponseSchema = z.object({
-  enforcement_enabled: z.boolean(),
-  nodes: z.record(z.string(), z.boolean())
+const PROVIDERS_PATH = '/providers'
+const PROVIDER_POLICY_PATH = '/workspace/provider-policy'
+
+const providerCatalogResponseSchema = z.object({
+  providers: z.array(
+    z.object({
+      provider_id: z.string(),
+      display_name: z.string(),
+      node_categories: z.array(z.string())
+    })
+  )
 })
 
-export interface PartnerNodePolicy {
+const providerPolicyResponseSchema = z.object({
+  enforcement_enabled: z.boolean(),
+  providers: z.array(
+    z.object({
+      provider_id: z.string(),
+      enabled: z.boolean()
+    })
+  )
+})
+
+export interface PartnerProvider {
+  id: string
+  displayName: string
+  nodeCategories: readonly string[]
+}
+
+export interface PartnerProviderPolicyEntry {
+  providerId: string
+  enabled: boolean
+}
+
+export interface PartnerProviderPolicy {
   enforcementEnabled: boolean
-  nodes: Readonly<Record<string, boolean>>
+  providers: readonly PartnerProviderPolicyEntry[]
 }
 
 export class PartnerNodePolicyApiError extends Error {
@@ -22,18 +51,58 @@ export class PartnerNodePolicyApiError extends Error {
   }
 }
 
-export async function getPartnerNodePolicy(): Promise<PartnerNodePolicy | null> {
-  const response = await api.fetchApi('/workspace/partner-node-policy', {
+function parseProviderPolicy(data: unknown): PartnerProviderPolicy {
+  const policy = providerPolicyResponseSchema.parse(data)
+  return {
+    enforcementEnabled: policy.enforcement_enabled,
+    providers: policy.providers.map((provider) => ({
+      providerId: provider.provider_id,
+      enabled: provider.enabled
+    }))
+  }
+}
+
+function throwResponseError(response: Response): never {
+  throw new PartnerNodePolicyApiError(response.status, response.statusText)
+}
+
+export async function getPartnerProviders(): Promise<PartnerProvider[]> {
+  const response = await api.fetchApi(PROVIDERS_PATH, { cache: 'no-store' })
+  if (!response.ok) throwResponseError(response)
+
+  const catalog = providerCatalogResponseSchema.parse(await response.json())
+  return catalog.providers.map((provider) => ({
+    id: provider.provider_id,
+    displayName: provider.display_name,
+    nodeCategories: provider.node_categories
+  }))
+}
+
+export async function getPartnerNodePolicy(): Promise<PartnerProviderPolicy | null> {
+  const response = await api.fetchApi(PROVIDER_POLICY_PATH, {
     cache: 'no-store'
   })
   if (response.status === 404) return null
-  if (!response.ok) {
-    throw new PartnerNodePolicyApiError(response.status, response.statusText)
-  }
+  if (!response.ok) throwResponseError(response)
 
-  const data = partnerNodePolicyResponseSchema.parse(await response.json())
-  return {
-    enforcementEnabled: data.enforcement_enabled,
-    nodes: data.nodes
-  }
+  return parseProviderPolicy(await response.json())
+}
+
+export async function updatePartnerNodePolicy(
+  policy: PartnerProviderPolicy
+): Promise<PartnerProviderPolicy> {
+  const response = await api.fetchApi(PROVIDER_POLICY_PATH, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      enforcement_enabled: policy.enforcementEnabled,
+      providers: policy.providers.map((provider) => ({
+        provider_id: provider.providerId,
+        enabled: provider.enabled
+      }))
+    })
+  })
+  if (!response.ok) throwResponseError(response)
+
+  return parseProviderPolicy(await response.json())
 }

--- a/src/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.test.ts
@@ -1,0 +1,284 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+import type { PartnerProviderPolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { PartnerNodePolicyStatus } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+
+import PartnerProviderGovernancePanel from './PartnerProviderGovernancePanel.vue'
+
+interface MockConfirmOptions {
+  headerProps: { title: string }
+  footerProps: { onConfirm: () => void }
+}
+const mocks = vi.hoisted(() => ({
+  closeDialog: vi.fn(),
+  loadPolicy: vi.fn(),
+  savePolicy: vi.fn(),
+  showConfirmDialog: vi.fn((_options: MockConfirmOptions) => ({
+    key: 'confirm'
+  })),
+  toastAdd: vi.fn()
+}))
+
+const state = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    governedWorkspaceId: ref<string | null>('workspace-one'),
+    policy: ref<PartnerProviderPolicy | null>({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }),
+    providers: ref([
+      {
+        id: 'openai',
+        displayName: 'OpenAI (inc. Sora)',
+        nodeCategories: ['OpenAI', 'Sora']
+      },
+      {
+        id: 'kling',
+        displayName: 'Kling',
+        nodeCategories: ['Kling']
+      },
+      {
+        id: 'route-only',
+        displayName: 'Route only',
+        nodeCategories: []
+      }
+    ]),
+    status: ref<PartnerNodePolicyStatus>('configured')
+  }
+})
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/components/dialog/confirm/confirmDialog', () => ({
+  showConfirmDialog: mocks.showConfirmDialog
+}))
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    ...state,
+    isProviderEnabled: (providerId: string) =>
+      state.policy.value?.providers.find(
+        (provider) => provider.providerId === providerId
+      )?.enabled === true,
+    createInitialPolicy: () => ({
+      enforcementEnabled: false,
+      providers: state.providers.value.map((provider) => ({
+        providerId: provider.id,
+        enabled: true
+      }))
+    }),
+    loadPolicy: mocks.loadPolicy,
+    savePolicy: mocks.savePolicy
+  })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: mocks.toastAdd })
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: { getServerFeature: () => 300 }
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ closeDialog: mocks.closeDialog })
+}))
+
+const ProviderPolicySwitchStub = defineComponent({
+  name: 'ProviderPolicySwitch',
+  props: {
+    modelValue: Boolean,
+    disabled: Boolean,
+    label: String
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <button
+      role="switch"
+      :aria-checked="modelValue"
+      :aria-label="label"
+      :disabled="disabled"
+      @click="$emit('update:modelValue', !modelValue)"
+    />
+  `
+})
+
+const SearchInputStub = defineComponent({
+  name: 'SearchInput',
+  props: {
+    modelValue: { type: String, required: true },
+    placeholder: String,
+    disabled: Boolean
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <input
+      :value="modelValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  `
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function renderPanel() {
+  return render(PartnerProviderGovernancePanel, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ProviderPolicySwitch: ProviderPolicySwitchStub,
+        SearchInput: SearchInputStub
+      }
+    }
+  })
+}
+
+describe('PartnerProviderGovernancePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.governedWorkspaceId.value = 'workspace-one'
+    state.policy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    state.status.value = 'configured'
+    mocks.savePolicy.mockResolvedValue(true)
+  })
+
+  it('renders provider-level policy and defaults a new provider to denied', () => {
+    renderPanel()
+
+    expect(screen.getByText('OpenAI (inc. Sora)')).toBeInTheDocument()
+    expect(screen.getByText('OpenAI, Sora')).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Allow OpenAI (inc. Sora)' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('switch', { name: 'Allow Kling' })
+    ).not.toBeChecked()
+    expect(screen.queryByText('Route only')).toBeNull()
+  })
+
+  it('confirms before leaving restricted mode', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(
+      screen.getByRole('switch', {
+        name: 'Restrict partner provider access'
+      })
+    )
+
+    expect(mocks.showConfirmDialog).toHaveBeenCalledOnce()
+    expect(mocks.showConfirmDialog.mock.calls[0][0].headerProps.title).toBe(
+      'Allow unrestricted partner provider access?'
+    )
+    mocks.showConfirmDialog.mock.calls[0][0].footerProps.onConfirm()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('switch', {
+          name: 'Restrict partner provider access'
+        })
+      ).not.toBeChecked()
+    )
+  })
+
+  it('confirms before entering restricted mode', async () => {
+    const user = userEvent.setup()
+    state.policy.value = {
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    renderPanel()
+
+    await user.click(
+      screen.getByRole('switch', {
+        name: 'Restrict partner provider access'
+      })
+    )
+
+    expect(mocks.showConfirmDialog.mock.calls[0][0].headerProps.title).toBe(
+      'Restrict partner provider access?'
+    )
+  })
+
+  it('creates an unrestricted allow-all document from the setup flow', async () => {
+    const user = userEvent.setup()
+    state.policy.value = null
+    state.status.value = 'unconfigured'
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Set up governance' }))
+
+    expect(mocks.savePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: false,
+      providers: [
+        { providerId: 'openai', enabled: true },
+        { providerId: 'kling', enabled: true },
+        { providerId: 'route-only', enabled: true }
+      ]
+    })
+  })
+
+  it('saves one complete provider policy document', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('switch', { name: 'Allow Kling' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(mocks.savePolicy).toHaveBeenCalledWith({
+      enforcementEnabled: true,
+      providers: [
+        { providerId: 'openai', enabled: true },
+        { providerId: 'kling', enabled: true },
+        { providerId: 'route-only', enabled: false }
+      ]
+    })
+    expect(mocks.toastAdd).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Provider policy saved',
+      life: 2000
+    })
+  })
+
+  it('shows the server-derived propagation window', () => {
+    renderPanel()
+
+    expect(
+      screen.getByText('Changes can take up to 5 minutes to apply.')
+    ).toBeInTheDocument()
+  })
+
+  it('offers retry when policy evaluation is unavailable', async () => {
+    const user = userEvent.setup()
+    state.status.value = 'unavailable'
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Try Again' }))
+
+    expect(mocks.loadPolicy).toHaveBeenCalledOnce()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The provider policy could not be loaded.'
+    )
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.vue
@@ -1,0 +1,381 @@
+<template>
+  <div class="grow overflow-auto pt-6">
+    <div
+      class="flex min-h-full flex-col gap-5 rounded-2xl border border-interface-stroke p-6"
+    >
+      <div class="flex items-start gap-6">
+        <div class="min-w-0 flex-1">
+          <h2 class="m-0 text-base font-semibold text-base-foreground">
+            {{ $t('workspacePanel.providerGovernance.title') }}
+          </h2>
+          <p class="mt-1 mb-0 text-sm text-muted-foreground">
+            {{ $t('workspacePanel.providerGovernance.description') }}
+          </p>
+        </div>
+        <SearchInput
+          v-if="status === 'configured'"
+          v-model="searchQuery"
+          :placeholder="
+            $t('workspacePanel.providerGovernance.searchPlaceholder')
+          "
+          size="lg"
+          class="w-64 shrink-0"
+          :disabled="isSaving"
+        />
+      </div>
+
+      <div
+        v-if="status === 'loading'"
+        role="status"
+        class="flex min-h-48 flex-1 items-center justify-center gap-2 text-sm text-muted-foreground"
+      >
+        <i class="icon-[lucide--loader-circle] size-4 animate-spin" />
+        {{ $t('workspacePanel.providerGovernance.loading') }}
+      </div>
+
+      <div
+        v-else-if="status === 'error' || status === 'unavailable'"
+        role="alert"
+        class="flex min-h-48 flex-1 items-center justify-center gap-2 text-sm text-muted-foreground"
+      >
+        <span>{{ $t('workspacePanel.providerGovernance.loadError') }}</span>
+        <Button variant="muted-textonly" @click="loadPolicy">
+          {{ $t('workspacePanel.providerGovernance.retry') }}
+        </Button>
+      </div>
+
+      <div
+        v-else-if="status === 'unconfigured'"
+        class="flex min-h-56 flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-interface-stroke/60 px-8 text-center"
+      >
+        <div class="max-w-lg">
+          <h3 class="m-0 text-base font-semibold text-base-foreground">
+            {{ $t('workspacePanel.providerGovernance.setup.title') }}
+          </h3>
+          <p class="mt-2 mb-0 text-sm text-muted-foreground">
+            {{ $t('workspacePanel.providerGovernance.setup.description') }}
+          </p>
+        </div>
+        <span v-if="saveError" role="alert" class="text-destructive text-sm">
+          {{ $t('workspacePanel.providerGovernance.saveError') }}
+        </span>
+        <Button
+          variant="primary"
+          size="lg"
+          :loading="isSaving"
+          @click="enableGovernance"
+        >
+          {{ $t('workspacePanel.providerGovernance.setup.action') }}
+        </Button>
+      </div>
+
+      <template v-else-if="status === 'configured'">
+        <div
+          class="flex min-h-16 items-center gap-4 rounded-xl border border-interface-stroke/60 px-4 py-3"
+        >
+          <div class="min-w-0 flex-1">
+            <div class="text-sm font-medium text-base-foreground">
+              {{ $t('workspacePanel.providerGovernance.enforcement.title') }}
+            </div>
+            <div class="mt-0.5 text-xs text-muted-foreground">
+              {{ enforcementDescription }}
+            </div>
+          </div>
+          <ProviderPolicySwitch
+            :model-value="draftEnforcementEnabled"
+            :disabled="isSaving"
+            :label="$t('workspacePanel.providerGovernance.enforcement.toggle')"
+            @update:model-value="confirmEnforcementChange"
+          />
+        </div>
+
+        <div
+          v-if="draftEnforcementEnabled"
+          class="rounded-xl bg-warning-background/20 px-4 py-3 text-xs text-base-foreground"
+        >
+          {{ $t('workspacePanel.providerGovernance.newProviderDefault') }}
+        </div>
+
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <p class="m-0 text-xs text-muted-foreground">
+            {{
+              $t('workspacePanel.providerGovernance.propagation', {
+                minutes: propagationMinutes
+              })
+            }}
+          </p>
+          <div class="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              :disabled="isSaving"
+              @click="setAllProviders(true)"
+            >
+              {{ $t('workspacePanel.providerGovernance.allowAll') }}
+            </Button>
+            <Button
+              variant="secondary"
+              :disabled="isSaving"
+              @click="setAllProviders(false)"
+            >
+              {{ $t('workspacePanel.providerGovernance.blockAll') }}
+            </Button>
+          </div>
+        </div>
+
+        <div class="min-h-0 flex-1 overflow-y-auto">
+          <div
+            v-if="visibleProviders.length === 0"
+            class="flex min-h-32 items-center justify-center text-sm text-muted-foreground"
+          >
+            {{
+              searchQuery
+                ? $t('workspacePanel.providerGovernance.noMatches')
+                : $t('workspacePanel.providerGovernance.empty')
+            }}
+          </div>
+
+          <div
+            v-else
+            class="overflow-hidden rounded-xl border border-interface-stroke/60"
+          >
+            <div
+              v-for="provider in visibleProviders"
+              :key="provider.id"
+              class="flex min-h-16 items-center gap-4 border-b border-interface-stroke/40 px-4 last:border-b-0"
+            >
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-sm text-base-foreground">
+                  {{ provider.displayName }}
+                </div>
+                <div class="truncate text-xs text-muted-foreground">
+                  {{ provider.nodeCategories.join(', ') }}
+                </div>
+              </div>
+              <ProviderPolicySwitch
+                :model-value="draftProviders[provider.id] === true"
+                :disabled="isSaving"
+                :label="
+                  $t('workspacePanel.providerGovernance.providerToggle', {
+                    name: provider.displayName
+                  })
+                "
+                @update:model-value="
+                  (enabled: boolean) => setProviderEnabled(provider.id, enabled)
+                "
+              />
+            </div>
+          </div>
+        </div>
+
+        <div class="flex min-h-10 items-center justify-end gap-3">
+          <span v-if="saveError" role="alert" class="text-destructive text-sm">
+            {{ $t('workspacePanel.providerGovernance.saveError') }}
+          </span>
+          <Button
+            variant="primary"
+            size="lg"
+            :disabled="!hasChanges"
+            :loading="isSaving"
+            @click="save"
+          >
+            {{ $t('g.save') }}
+          </Button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import SearchInput from '@/components/ui/search-input/SearchInput.vue'
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+import type { PartnerProviderPolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import ProviderPolicySwitch from '@/platform/workspace/components/dialogs/settings/ProviderPolicySwitch.vue'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { api } from '@/scripts/api'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const { t } = useI18n()
+const governanceStore = usePartnerNodeGovernanceStore()
+const { governedWorkspaceId, policy, providers, status } =
+  storeToRefs(governanceStore)
+const toastStore = useToastStore()
+const dialogStore = useDialogStore()
+
+const searchQuery = ref('')
+const draftProviders = ref<Record<string, boolean>>({})
+const draftEnforcementEnabled = ref(false)
+const isSaving = ref(false)
+const saveError = ref(false)
+let saveGeneration = 0
+
+const propagationMinutes = computed(() =>
+  Math.max(
+    1,
+    Math.ceil(
+      api.getServerFeature<number>(
+        'partner_node_governance_propagation_seconds',
+        1200
+      ) / 60
+    )
+  )
+)
+
+const enforcementDescription = computed(() =>
+  draftEnforcementEnabled.value
+    ? t('workspacePanel.providerGovernance.enforcement.restricted')
+    : t('workspacePanel.providerGovernance.enforcement.unrestricted')
+)
+
+function originalProviderValue(providerId: string): boolean {
+  return policy.value ? governanceStore.isProviderEnabled(providerId) : true
+}
+
+function resetDraft(): void {
+  draftEnforcementEnabled.value = policy.value?.enforcementEnabled ?? false
+  draftProviders.value = Object.fromEntries(
+    providers.value.map((provider) => [
+      provider.id,
+      originalProviderValue(provider.id)
+    ])
+  )
+  saveError.value = false
+}
+
+watch([governedWorkspaceId, policy, providers], resetDraft, { immediate: true })
+
+watch(
+  governedWorkspaceId,
+  () => {
+    saveGeneration += 1
+    isSaving.value = false
+  },
+  { flush: 'sync' }
+)
+
+const hasChanges = computed(
+  () =>
+    !!policy.value &&
+    (draftEnforcementEnabled.value !== policy.value.enforcementEnabled ||
+      providers.value.some(
+        (provider) =>
+          draftProviders.value[provider.id] !==
+          originalProviderValue(provider.id)
+      ))
+)
+
+const visibleProviders = computed(() => {
+  const query = searchQuery.value.trim().toLocaleLowerCase()
+  return providers.value
+    .filter((provider) => provider.nodeCategories.length > 0)
+    .filter(
+      (provider) =>
+        !query ||
+        [provider.id, provider.displayName, ...provider.nodeCategories].some(
+          (value) => value.toLocaleLowerCase().includes(query)
+        )
+    )
+    .toSorted((left, right) =>
+      left.displayName.localeCompare(right.displayName)
+    )
+})
+
+function setProviderEnabled(providerId: string, enabled: boolean): void {
+  draftProviders.value[providerId] = enabled
+  saveError.value = false
+}
+
+function setAllProviders(enabled: boolean): void {
+  draftProviders.value = Object.fromEntries(
+    providers.value.map((provider) => [provider.id, enabled])
+  )
+  saveError.value = false
+}
+
+function confirmEnforcementChange(enabled: boolean): void {
+  if (enabled === draftEnforcementEnabled.value) return
+
+  const dialog = showConfirmDialog({
+    headerProps: {
+      title: t(
+        enabled
+          ? 'workspacePanel.providerGovernance.confirmRestrict.title'
+          : 'workspacePanel.providerGovernance.confirmUnrestrict.title'
+      )
+    },
+    props: {
+      promptText: t(
+        enabled
+          ? 'workspacePanel.providerGovernance.confirmRestrict.description'
+          : 'workspacePanel.providerGovernance.confirmUnrestrict.description'
+      )
+    },
+    footerProps: {
+      confirmText: t(
+        enabled
+          ? 'workspacePanel.providerGovernance.confirmRestrict.action'
+          : 'workspacePanel.providerGovernance.confirmUnrestrict.action'
+      ),
+      confirmVariant: 'primary',
+      onCancel: () => dialogStore.closeDialog(dialog),
+      onConfirm: () => {
+        draftEnforcementEnabled.value = enabled
+        saveError.value = false
+        dialogStore.closeDialog(dialog)
+      }
+    }
+  })
+}
+
+function buildDraftPolicy(): PartnerProviderPolicy {
+  return {
+    enforcementEnabled: draftEnforcementEnabled.value,
+    providers: providers.value.map((provider) => ({
+      providerId: provider.id,
+      enabled:
+        draftProviders.value[provider.id] ?? originalProviderValue(provider.id)
+    }))
+  }
+}
+
+async function persistPolicy(
+  nextPolicy: PartnerProviderPolicy = buildDraftPolicy()
+): Promise<void> {
+  const generation = saveGeneration
+  isSaving.value = true
+  saveError.value = false
+  try {
+    const applied = await governanceStore.savePolicy(nextPolicy)
+    if (!applied || generation !== saveGeneration) return
+    toastStore.add({
+      severity: 'success',
+      summary: t('workspacePanel.providerGovernance.saved'),
+      life: 2000
+    })
+  } catch {
+    if (generation !== saveGeneration) return
+    saveError.value = true
+  } finally {
+    if (generation === saveGeneration) isSaving.value = false
+  }
+}
+
+async function enableGovernance(): Promise<void> {
+  await persistPolicy(governanceStore.createInitialPolicy())
+}
+
+async function save(): Promise<void> {
+  if (!hasChanges.value || isSaving.value) return
+  await persistPolicy()
+}
+
+function loadPolicy(): void {
+  void governanceStore.loadPolicy()
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/ProviderPolicySwitch.vue
+++ b/src/platform/workspace/components/dialogs/settings/ProviderPolicySwitch.vue
@@ -1,0 +1,49 @@
+<template>
+  <button
+    type="button"
+    role="switch"
+    :aria-checked="modelValue"
+    :disabled
+    :aria-label="label"
+    class="group focus-visible:ring-ring relative flex h-10 w-12 shrink-0 cursor-pointer items-center justify-center rounded-lg border-0 bg-transparent outline-hidden focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+    @click="$emit('update:modelValue', !modelValue)"
+  >
+    <span
+      :class="
+        cn(
+          'relative h-6 w-10 rounded-full transition-colors',
+          modelValue
+            ? 'bg-primary-background group-hover:bg-primary-background-hover'
+            : 'bg-secondary-background group-hover:bg-secondary-background-hover'
+        )
+      "
+    >
+      <span
+        :class="
+          cn(
+            'absolute top-1 left-1 size-4 rounded-full bg-base-foreground transition-transform',
+            modelValue && 'translate-x-4'
+          )
+        "
+      />
+    </span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+const {
+  modelValue,
+  disabled = false,
+  label
+} = defineProps<{
+  modelValue: boolean
+  disabled?: boolean
+  label: string
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue'
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -9,18 +10,28 @@ import WorkspacePanelContent from './WorkspacePanelContent.vue'
 const mockFetchMembers = vi.fn()
 const mockFetchPendingInvites = vi.fn()
 
-const { mockHasTeamPlan, mockIsPlanLoading, mockMembers, mockWorkspaceType } =
-  vi.hoisted(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-    const { ref } = require('vue') as typeof import('vue')
+const {
+  mockGovernedWorkspaceId,
+  mockHasTeamPlan,
+  mockIsPlanLoading,
+  mockMembers,
+  mockProviderGovernanceStatus,
+  mockWorkspaceRole,
+  mockWorkspaceType
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
 
-    return {
-      mockHasTeamPlan: ref(true),
-      mockIsPlanLoading: ref(false),
-      mockMembers: ref<WorkspaceMember[]>([]),
-      mockWorkspaceType: ref<'personal' | 'team'>('team')
-    }
-  })
+  return {
+    mockGovernedWorkspaceId: ref<string | null>('workspace-one'),
+    mockHasTeamPlan: ref(true),
+    mockIsPlanLoading: ref(false),
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockProviderGovernanceStatus: ref('configured'),
+    mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
+    mockWorkspaceType: ref<'personal' | 'team'>('team')
+  }
+})
 
 vi.mock('@/platform/workspace/composables/useTeamPlan', () => ({
   useTeamPlan: () => ({
@@ -51,15 +62,20 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => {
 })
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-  const { ref } = require('vue') as typeof import('vue')
   return {
     useWorkspaceUI: () => ({
       workspaceType: mockWorkspaceType,
-      workspaceRole: ref('owner')
+      workspaceRole: mockWorkspaceRole
     })
   }
 })
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    governedWorkspaceId: mockGovernedWorkspaceId,
+    status: mockProviderGovernanceStatus
+  })
+}))
 
 vi.mock(
   '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue',
@@ -85,6 +101,11 @@ vi.mock(
   })
 )
 
+vi.mock(
+  '@/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.vue',
+  () => ({ default: { template: '<div />' } })
+)
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -104,8 +125,9 @@ function createMember(id: string): WorkspaceMember {
   }
 }
 
-function renderComponent() {
+function renderComponent(defaultTab?: string) {
   return render(WorkspacePanelContent, {
+    props: { defaultTab },
     global: {
       plugins: [i18n],
       stubs: { WorkspaceProfilePic: true }
@@ -117,6 +139,9 @@ describe('WorkspacePanelContent billing banner', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMembers.value = []
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockProviderGovernanceStatus.value = 'configured'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -138,6 +163,9 @@ describe('WorkspacePanelContent members tab label', () => {
     mockHasTeamPlan.value = true
     mockIsPlanLoading.value = false
     mockMembers.value = []
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockProviderGovernanceStatus.value = 'configured'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -183,5 +211,57 @@ describe('WorkspacePanelContent members tab label', () => {
     renderComponent()
     expect(mockFetchMembers).not.toHaveBeenCalled()
     expect(mockFetchPendingInvites).not.toHaveBeenCalled()
+  })
+})
+
+describe('WorkspacePanelContent provider governance tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGovernedWorkspaceId.value = 'workspace-one'
+    mockProviderGovernanceStatus.value = 'configured'
+    mockWorkspaceRole.value = 'owner'
+  })
+
+  it('shows provider governance to an eligible workspace owner', () => {
+    renderComponent()
+
+    expect(
+      screen.getByRole('tab', {
+        name: 'workspacePanel.tabs.partnerProviders'
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('hides provider governance from workspace members', () => {
+    mockWorkspaceRole.value = 'member'
+    renderComponent()
+
+    expect(
+      screen.queryByRole('tab', {
+        name: 'workspacePanel.tabs.partnerProviders'
+      })
+    ).toBeNull()
+  })
+
+  it('hides provider governance when the backend marks it ineligible', () => {
+    mockProviderGovernanceStatus.value = 'ineligible'
+    renderComponent()
+
+    expect(
+      screen.queryByRole('tab', {
+        name: 'workspacePanel.tabs.partnerProviders'
+      })
+    ).toBeNull()
+  })
+
+  it('falls back when access is lost on the active tab', async () => {
+    renderComponent('provider-governance')
+
+    mockWorkspaceRole.value = 'member'
+    await nextTick()
+
+    expect(
+      screen.getByRole('tab', { name: 'workspacePanel.tabs.planCredits' })
+    ).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -39,6 +39,20 @@
               : $t('workspacePanel.members.header')
           }}
         </TabsTrigger>
+        <TabsTrigger
+          v-if="showProviderGovernanceTab"
+          value="provider-governance"
+          :class="
+            cn(
+              tabTriggerBase,
+              activeTab === 'provider-governance'
+                ? tabTriggerActive
+                : tabTriggerInactive
+            )
+          "
+        >
+          {{ $t('workspacePanel.tabs.partnerProviders') }}
+        </TabsTrigger>
       </TabsList>
 
       <BillingStatusBanner class="mt-4" />
@@ -49,13 +63,20 @@
       <TabsContent value="members" class="mt-4">
         <MembersPanelContent :key="workspaceRole" />
       </TabsContent>
+      <TabsContent
+        v-if="showProviderGovernanceTab"
+        value="provider-governance"
+        class="mt-4"
+      >
+        <PartnerProviderGovernancePanel />
+      </TabsContent>
     </TabsRoot>
   </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { whenever } from '@vueuse/core'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
@@ -63,9 +84,11 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import BillingStatusBanner from '@/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
+import PartnerProviderGovernancePanel from '@/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -86,7 +109,27 @@ const { fetchMembers, fetchPendingInvites } = workspaceStore
 
 const { workspaceRole } = useWorkspaceUI()
 const { hasTeamPlan, isPlanLoading } = useTeamPlan()
+const { governedWorkspaceId, status: providerGovernanceStatus } = storeToRefs(
+  usePartnerNodeGovernanceStore()
+)
+const showProviderGovernanceTab = computed(
+  () =>
+    !!governedWorkspaceId.value &&
+    providerGovernanceStatus.value !== 'ineligible' &&
+    workspaceRole.value === 'owner'
+)
 const activeTab = ref(defaultTab)
+
+watch(
+  showProviderGovernanceTab,
+  (isVisible) => {
+    if (!isVisible && activeTab.value === 'provider-governance') {
+      activeTab.value =
+        defaultTab === 'provider-governance' ? 'plan' : defaultTab
+    }
+  },
+  { immediate: true }
+)
 
 const showMembersTabCount = computed(
   () => hasTeamPlan.value && members.value.length > 1

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -4,14 +4,17 @@ import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as PartnerNodePolicyApi from '@/platform/workspace/api/partnerNodePolicyApi'
-import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type {
+  PartnerProvider,
+  PartnerProviderPolicy
+} from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
+const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
+const mockUpdatePartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockFlags = vi.hoisted(() => ({
   teamWorkspacesEnabled: true,
   partnerNodeGovernanceEnabled: true
@@ -27,30 +30,25 @@ vi.mock(
     const actual = await importOriginal<typeof PartnerNodePolicyApi>()
     return {
       ...actual,
-      getPartnerNodePolicy: mockGetPartnerNodePolicy
+      getPartnerNodePolicy: mockGetPartnerNodePolicy,
+      getPartnerProviders: mockGetPartnerProviders,
+      updatePartnerNodePolicy: mockUpdatePartnerNodePolicy
     }
   }
 )
 
-function nodeDef(
-  name: string,
-  overrides: Partial<ComfyNodeDef> = {}
-): ComfyNodeDef {
-  return {
-    name,
-    display_name: `Display ${name}`,
-    category: 'partner/image/Provider',
-    python_module: 'comfy_api_nodes.provider',
-    description: '',
-    input: {},
-    output: [],
-    output_is_list: [],
-    output_name: [],
-    output_node: false,
-    api_node: true,
-    ...overrides
+const catalog: PartnerProvider[] = [
+  {
+    id: 'openai',
+    displayName: 'OpenAI (inc. Sora)',
+    nodeCategories: ['OpenAI', 'Sora']
+  },
+  {
+    id: 'kling',
+    displayName: 'Kling',
+    nodeCategories: ['Kling']
   }
-}
+]
 
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
   const store = useTeamWorkspaceStore()
@@ -86,18 +84,12 @@ describe('partnerNodeGovernanceStore', () => {
     vi.clearAllMocks()
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.partnerNodeGovernanceEnabled = true
+    mockGetPartnerProviders.mockResolvedValue(catalog)
     mockGetPartnerNodePolicy.mockResolvedValue(null)
+    mockUpdatePartnerNodePolicy.mockImplementation(
+      async (policy: PartnerProviderPolicy) => policy
+    )
     activateWorkspace('workspace-one')
-    useNodeDefStore().updateNodeDefs([
-      nodeDef('AllowedNode'),
-      nodeDef('DisabledNode'),
-      nodeDef('UnreviewedNode'),
-      nodeDef('CoreNode', {
-        api_node: false,
-        category: 'sampling',
-        python_module: 'nodes'
-      })
-    ])
   })
 
   afterEach(() => {
@@ -105,57 +97,49 @@ describe('partnerNodeGovernanceStore', () => {
     store = undefined
   })
 
-  it('composes partner-node catalog metadata from object info', async () => {
-    useNodeDefStore().updateNodeDefs([
-      nodeDef('PartnerNode', {
-        display_name: 'Partner Node',
-        category: 'partner/video/Acme'
-      }),
-      nodeDef('CoreNode', { api_node: false })
-    ])
-
+  it('loads the server-owned provider catalog', async () => {
     store = await createLoadedStore()
 
-    expect(store.partnerNodes).toEqual([
-      { id: 'PartnerNode', name: 'Partner Node', provider: 'Acme' }
-    ])
-  })
-
-  it('treats 404 as unconfigured and allows every node', async () => {
-    store = await createLoadedStore()
-
+    expect(store.providers).toEqual(catalog)
     expect(store.status).toBe('unconfigured')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
   })
 
-  it('does not block nodes while enforcement is off', async () => {
-    mockGetPartnerNodePolicy.mockResolvedValue({
-      enforcementEnabled: false,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
-
+  it('initializes every current provider as allowed without enforcement', async () => {
     store = await createLoadedStore()
 
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
+    expect(store.createInitialPolicy()).toEqual({
+      enforcementEnabled: false,
+      providers: [
+        { providerId: 'openai', enabled: true },
+        { providerId: 'kling', enabled: true }
+      ]
+    })
   })
 
-  it('allows only explicit true rules while enforcement is on', async () => {
+  it('treats a provider absent from a configured policy as denied', async () => {
     mockGetPartnerNodePolicy.mockResolvedValue({
       enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
+      providers: [{ providerId: 'openai', enabled: true }]
+    } satisfies PartnerProviderPolicy)
 
     store = await createLoadedStore()
 
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(true)
-    expect(store.isNodeDisabled('UnreviewedNode')).toBe(true)
-    expect(store.isNodeDisabled('CoreNode')).toBe(false)
+    expect(store.isProviderEnabled('openai')).toBe(true)
+    expect(store.isProviderEnabled('kling')).toBe(false)
   })
 
-  it('fails closed for a 503 from an enforcing workspace', async () => {
+  it('hides governance when the backend returns 403', async () => {
+    mockGetPartnerNodePolicy.mockRejectedValue(
+      new PartnerNodePolicyApiError(403, 'Forbidden')
+    )
+
+    store = await createLoadedStore()
+
+    expect(store.status).toBe('ineligible')
+    expect(store.providers).toEqual([])
+  })
+
+  it('surfaces a temporarily unverifiable policy', async () => {
     mockGetPartnerNodePolicy.mockRejectedValue(
       new PartnerNodePolicyApiError(503, 'Service Unavailable')
     )
@@ -163,90 +147,21 @@ describe('partnerNodeGovernanceStore', () => {
     store = await createLoadedStore()
 
     expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-    expect(store.isNodeDisabled('CoreNode')).toBe(false)
   })
 
-  it('fails open during initial loading and a generic failure', async () => {
-    let rejectLoad!: (error: Error) => void
-    mockGetPartnerNodePolicy.mockReturnValue(
-      new Promise((_, reject) => {
-        rejectLoad = reject
-      })
-    )
-
-    store = usePartnerNodeGovernanceStore()
-
-    expect(store.status).toBe('loading')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-
-    rejectLoad(new Error('Network error'))
-    await vi.waitFor(() => expect(store?.status).toBe('error'))
-
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-  })
-
-  it('stays fail-closed while retrying an unavailable policy', async () => {
-    mockGetPartnerNodePolicy.mockRejectedValueOnce(
-      new PartnerNodePolicyApiError(503, 'Service Unavailable')
-    )
-    store = await createLoadedStore()
-    let rejectRetry!: (error: Error) => void
-    mockGetPartnerNodePolicy.mockReturnValueOnce(
-      new Promise((_, reject) => {
-        rejectRetry = reject
-      })
-    )
-
-    const retry = store.loadPolicy()
-
-    expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-    rejectRetry(new Error('Network error'))
-    await retry
-    expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-  })
-
-  it('preserves the last enforcing policy after a generic refresh error', async () => {
-    mockGetPartnerNodePolicy.mockResolvedValue({
-      enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
-    store = await createLoadedStore()
-    mockGetPartnerNodePolicy.mockRejectedValue(new Error('Network error'))
-
-    await store.loadPolicy()
-
-    expect(store.status).toBe('error')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(true)
-  })
-
-  it('stays inactive when partner-node governance is disabled', async () => {
-    mockFlags.partnerNodeGovernanceEnabled = false
+  it('stays inactive outside an eligible team workspace', async () => {
+    activateWorkspace('personal', 'personal')
 
     store = usePartnerNodeGovernanceStore()
     await nextTick()
 
+    expect(mockGetPartnerProviders).not.toHaveBeenCalled()
     expect(mockGetPartnerNodePolicy).not.toHaveBeenCalled()
     expect(store.status).toBe('inactive')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-  })
-
-  it('stays inactive in a personal workspace', async () => {
-    activateWorkspace('personal-workspace', 'personal')
-
-    store = usePartnerNodeGovernanceStore()
-    await nextTick()
-
-    expect(mockGetPartnerNodePolicy).not.toHaveBeenCalled()
-    expect(store.status).toBe('inactive')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
   })
 
   it('ignores a stale response after switching workspaces', async () => {
-    let resolveFirst!: (policy: PartnerNodePolicy) => void
+    let resolveFirst!: (policy: PartnerProviderPolicy) => void
     mockGetPartnerNodePolicy
       .mockReturnValueOnce(
         new Promise((resolve) => {
@@ -254,9 +169,9 @@ describe('partnerNodeGovernanceStore', () => {
         })
       )
       .mockResolvedValueOnce({
-        enforcementEnabled: true,
-        nodes: { DisabledNode: true }
-      } satisfies PartnerNodePolicy)
+        enforcementEnabled: false,
+        providers: [{ providerId: 'kling', enabled: true }]
+      } satisfies PartnerProviderPolicy)
     store = usePartnerNodeGovernanceStore()
     await vi.waitFor(() =>
       expect(mockGetPartnerNodePolicy).toHaveBeenCalledTimes(1)
@@ -266,11 +181,23 @@ describe('partnerNodeGovernanceStore', () => {
     await vi.waitFor(() => expect(store?.status).toBe('configured'))
     resolveFirst({
       enforcementEnabled: true,
-      nodes: { DisabledNode: false }
+      providers: [{ providerId: 'openai', enabled: true }]
     })
     await nextTick()
 
     expect(store.governedWorkspaceId).toBe('workspace-two')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
+    expect(store.policy?.providers).toEqual([
+      { providerId: 'kling', enabled: true }
+    ])
+  })
+
+  it('persists a complete provider policy document', async () => {
+    store = await createLoadedStore()
+    const nextPolicy = store.createInitialPolicy()
+
+    await expect(store.savePolicy(nextPolicy)).resolves.toBe(true)
+
+    expect(mockUpdatePartnerNodePolicy).toHaveBeenCalledWith(nextPolicy)
+    expect(store.status).toBe('configured')
   })
 })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -4,23 +4,22 @@ import { computed, ref, shallowRef, watch } from 'vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   getPartnerNodePolicy,
-  PartnerNodePolicyApiError
+  getPartnerProviders,
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
-import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type {
+  PartnerProvider,
+  PartnerProviderPolicy
+} from '@/platform/workspace/api/partnerNodePolicyApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
-
-export interface PartnerNodeCatalogItem {
-  id: string
-  name: string
-  provider: string
-}
 
 export type PartnerNodePolicyStatus =
   | 'inactive'
   | 'loading'
   | 'unconfigured'
   | 'configured'
+  | 'ineligible'
   | 'unavailable'
   | 'error'
 
@@ -29,13 +28,13 @@ export const usePartnerNodeGovernanceStore = defineStore(
   () => {
     const { flags } = useFeatureFlags()
     const workspaceStore = useTeamWorkspaceStore()
-    const nodeDefStore = useNodeDefStore()
 
-    const policy = shallowRef<PartnerNodePolicy | null>(null)
+    const providers = shallowRef<readonly PartnerProvider[]>([])
+    const policy = shallowRef<PartnerProviderPolicy | null>(null)
     const policyWorkspaceId = ref<string | null>(null)
     const status = ref<PartnerNodePolicyStatus>('inactive')
     const error = shallowRef<Error | null>(null)
-    let loadVersion = 0
+    let workspaceVersion = 0
 
     const governedWorkspaceId = computed(() => {
       const workspace = workspaceStore.activeWorkspace
@@ -46,34 +45,30 @@ export const usePartnerNodeGovernanceStore = defineStore(
         : null
     })
 
-    const partnerNodes = computed<PartnerNodeCatalogItem[]>(() =>
-      Object.values(nodeDefStore.nodeDefsByName)
-        .filter((nodeDef) => nodeDef.api_node)
-        .map((nodeDef) => ({
-          id: nodeDef.name,
-          name: nodeDef.display_name || nodeDef.name,
-          provider:
-            nodeDef.category.split('/')[2] ||
-            nodeDef.category ||
-            nodeDef.python_module
-        }))
-    )
-
-    function isNodeDisabled(nodeType: string): boolean {
-      if (!nodeDefStore.nodeDefsByName[nodeType]?.api_node) return false
-      const workspaceId = governedWorkspaceId.value
-      if (!workspaceId || policyWorkspaceId.value !== workspaceId) return false
-      if (status.value === 'unavailable') return true
+    function isProviderEnabled(providerId: string): boolean {
+      if (!policy.value) return true
       return (
-        policy.value?.enforcementEnabled === true &&
-        policy.value.nodes[nodeType] !== true
+        policy.value.providers.find(
+          (provider) => provider.providerId === providerId
+        )?.enabled === true
       )
+    }
+
+    function createInitialPolicy(): PartnerProviderPolicy {
+      return {
+        enforcementEnabled: false,
+        providers: providers.value.map((provider) => ({
+          providerId: provider.id,
+          enabled: true
+        }))
+      }
     }
 
     async function loadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value
-      const version = ++loadVersion
+      const version = workspaceVersion
       if (!workspaceId) {
+        providers.value = []
         policy.value = null
         policyWorkspaceId.value = null
         status.value = 'inactive'
@@ -81,29 +76,32 @@ export const usePartnerNodeGovernanceStore = defineStore(
         return
       }
 
-      const workspaceChanged = policyWorkspaceId.value !== workspaceId
-      if (workspaceChanged) {
+      if (policyWorkspaceId.value !== workspaceId) {
+        providers.value = []
         policy.value = null
         policyWorkspaceId.value = workspaceId
-        status.value = 'loading'
-      } else if (status.value !== 'unavailable') {
-        status.value = 'loading'
       }
+      status.value = 'loading'
       error.value = null
 
       try {
-        const nextPolicy = await getPartnerNodePolicy()
+        const [nextProviders, nextPolicy] = await Promise.all([
+          getPartnerProviders(),
+          getPartnerNodePolicy()
+        ])
         if (
-          version !== loadVersion ||
+          version !== workspaceVersion ||
           governedWorkspaceId.value !== workspaceId
         ) {
           return
         }
+
+        providers.value = nextProviders
         policy.value = nextPolicy
         status.value = nextPolicy ? 'configured' : 'unconfigured'
       } catch (loadError) {
         if (
-          version !== loadVersion ||
+          version !== workspaceVersion ||
           governedWorkspaceId.value !== workspaceId
         ) {
           return
@@ -111,29 +109,76 @@ export const usePartnerNodeGovernanceStore = defineStore(
         error.value =
           loadError instanceof Error
             ? loadError
-            : new Error('Failed to load partner node policy')
-        if (
-          loadError instanceof PartnerNodePolicyApiError &&
-          loadError.status === 503
-        ) {
-          policy.value = null
-          status.value = 'unavailable'
-          return
+            : new Error('Failed to load partner provider policy')
+        if (loadError instanceof PartnerNodePolicyApiError) {
+          if (loadError.status === 403) {
+            providers.value = []
+            policy.value = null
+            status.value = 'ineligible'
+            return
+          }
+          if (loadError.status === 503) {
+            status.value = 'unavailable'
+            return
+          }
         }
-        if (status.value !== 'unavailable') status.value = 'error'
+        status.value = 'error'
       }
     }
 
-    watch(governedWorkspaceId, () => void loadPolicy(), { immediate: true })
+    async function savePolicy(
+      nextPolicy: PartnerProviderPolicy
+    ): Promise<boolean> {
+      const workspaceId = governedWorkspaceId.value
+      const version = workspaceVersion
+      if (!workspaceId || policyWorkspaceId.value !== workspaceId) {
+        throw new Error('Partner provider governance is not ready')
+      }
+
+      let savedPolicy: PartnerProviderPolicy
+      try {
+        savedPolicy = await updatePartnerNodePolicy(nextPolicy)
+      } catch (saveError) {
+        if (
+          version !== workspaceVersion ||
+          governedWorkspaceId.value !== workspaceId
+        ) {
+          return false
+        }
+        throw saveError
+      }
+      if (
+        version !== workspaceVersion ||
+        governedWorkspaceId.value !== workspaceId
+      ) {
+        return false
+      }
+
+      policy.value = savedPolicy
+      status.value = 'configured'
+      error.value = null
+      return true
+    }
+
+    watch(
+      governedWorkspaceId,
+      () => {
+        workspaceVersion++
+        void loadPolicy()
+      },
+      { immediate: true, flush: 'sync' }
+    )
 
     return {
+      providers,
       policy,
       status,
       error,
       governedWorkspaceId,
-      partnerNodes,
-      isNodeDisabled,
-      loadPolicy
+      isProviderEnabled,
+      createInitialPolicy,
+      loadPolicy,
+      savePolicy
     }
   }
 )


### PR DESCRIPTION
## Summary

- **Superseded:** this combined draft has been replaced by the smaller review stack: [#13894](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13894) for the provider API/store, [#13895](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13895) for the owner read-only UI, [#13896](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13896) for provider mutations, and [#13897](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13897) for restriction-mode transitions. Do not review or merge this branch.
- **Known design mismatch:** the current head does not implement the [Team Plan Workspaces Allowlist screen](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4898-28620). It renders Partner Nodes as a top content tab and an inline card. The specification requires an **Allowlist** workspace-nav item directly below Members and a right-hand provider table. The visual evidence below documents that divergence; it is not acceptance evidence.
- [Cloud #5278](https://github.com/Comfy-Org/cloud/pull/5278) is the provider source of truth. This head already reads `GET /api/providers` and `GET/PUT /api/workspace/provider-policy`; Cloud remains authoritative for discovery, prompt, and proxy enforcement. A member read-only view, design-compliant provider table, last-modified metadata, discovery filtering, and client-side queue guards are outside this branch.

## Verification

| Before | After |
| --- | --- |
| <img width="720" alt="Base: Team workspace has no provider-governance controls" src="https://github.com/user-attachments/assets/dedeff1f-b5ec-44cd-8953-7d506113cf84" /> | <img width="720" alt="Current head: Partner Nodes appears as a top tab instead of the Allowlist left-nav screen" src="https://github.com/user-attachments/assets/0f561062-4b6f-43a5-89c5-3699291218cb" /> |

https://github.com/user-attachments/assets/8932ad7f-0526-431b-a19e-b7eacf092532

| Timestamp | Screenshot | Highlight |
| --- | --- | --- |
| `00:03.00` | <img width="360" alt="Baseline workspace settings" src="https://github.com/user-attachments/assets/866bf05d-73f2-4d7f-9de3-62980d24a99d" /> | Base revision exposes Plan & Credits and Members only. |
| `00:05.30` | <img width="360" alt="Current-head restriction confirmation" src="https://github.com/user-attachments/assets/698d5571-59a4-43e8-9a84-1c571cb6d4f7" /> | Current head puts restriction mode inside the top-tab panel; this is not the Figma information architecture. |
| `00:07.10` | <img width="360" alt="Current-head provider policy" src="https://github.com/user-attachments/assets/eb783956-92b3-4d65-b364-4b77caf4f0a0" /> | Current head renders a flat card, not the specified right-hand provider table with Provider, Nodes, Last modified, and toggles. |

- Current-head [API boundary tests](https://github.com/Comfy-Org/ComfyUI_frontend/blob/c88f988dead2feb8a8608dfa5736e765cb83b86d/src/platform/workspace/api/partnerNodePolicyApi.test.ts) pin [Cloud #5278](https://github.com/Comfy-Org/cloud/pull/5278)'s provider catalog and whole-policy GET/PUT payloads.
- Current-head [store](https://github.com/Comfy-Org/ComfyUI_frontend/blob/c88f988dead2feb8a8608dfa5736e765cb83b86d/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts) and [component](https://github.com/Comfy-Org/ComfyUI_frontend/blob/c88f988dead2feb8a8608dfa5736e765cb83b86d/src/platform/workspace/components/dialogs/settings/PartnerProviderGovernancePanel.test.ts) regressions cover current behavior, but they do not establish Figma conformance.
- **Missing:** no design-compliant screenshots or screencast can be produced from head `c88f988`; the UI must be changed first. This branch also has no deployment or authenticated Cloud preview.

Created by Codex.
