### PR TITLE
fix: remove redundant Learn more link from upload-model upgrade dialog

### DIFF
--- a/src/platform/assets/components/UploadModelUpgradeModalFooter.vue
+++ b/src/platform/assets/components/UploadModelUpgradeModalFooter.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="flex w-full flex-wrap justify-end gap-2">
-    <a
-      href="https://blog.comfy.org/p/comfy-cloud-new-features-and-pricing"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mr-auto flex items-center gap-2 text-muted-foreground underline"
-    >
-      <i class="icon-[lucide--external-link]" />
-      <span>{{ $t('g.learnMore') }}</span>
-    </a>
     <Button variant="textonly" @click="emit('close')">{{
       $t('g.close')
     }}</Button>


### PR DESCRIPTION
## Summary

Removes the redundant "Learn more" link from the "Upgrade to unlock this feature" dialog that unpaid cloud users see when they click Import in the model library modal.

## Changes

- **What**: The "Learn more" link opened an external pricing/announcement blog page, while the adjacent Subscribe button already opens the in-app pricing dialog. Both pointed users toward the same pricing intent, so the link was redundant. Removed it, leaving Close and Subscribe. The footer's `justify-end` already keeps both buttons right-aligned, so no layout change was needed.

## Review Focus

The removed anchor carried `mr-auto` to push the buttons to the right. That is redundant with the wrapper's existing `justify-end`, so alignment is unchanged. The `g.learnMore` i18n key stays since it is used elsewhere.

## Screenshots (if applicable)

Before:
<img width="2126" height="1458" alt="image" src="https://github.com/user-attachments/assets/52616d0b-a872-48d5-9ede-6a810a64a632" />

After
<img width="1470" height="837" alt="image" src="https://github.com/user-attachments/assets/a8c1549a-736b-43ab-9276-13f64690c840" />
