### PR TITLE
feat: 4/x show workspace provider access

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2920,7 +2920,8 @@
     "tabs": {
       "dashboard": "Dashboard",
       "planCredits": "Plan & Credits",
-      "membersCount": "Members ({count})"
+      "membersCount": "Members ({count})",
+      "partnerNodes": "Partner nodes"
     },
     "dashboard": {
       "placeholder": "Dashboard workspace settings"
@@ -2953,6 +2954,27 @@
       "noInvites": "No pending invites",
       "noMembers": "No members",
       "searchPlaceholder": "Search..."
+    },
+    "partnerNodes": {
+      "title": "Partner node access",
+      "unrestricted": "Unrestricted",
+      "restricted": "Restricted",
+      "unrestrictedDescription": "Partner nodes from every provider are available.",
+      "restrictedDescription": "Only partner nodes from enabled providers are available.",
+      "searchPlaceholder": "Search providers and partner nodes...",
+      "tableLabel": "Partner node providers",
+      "columns": {
+        "provider": "Provider / partner node",
+        "nodes": "Nodes",
+        "enabled": "Enabled"
+      },
+      "nodeCount": "{count} node | {count} nodes",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "loading": "Loading partner node access",
+      "loadError": "Partner node access couldn't be loaded.",
+      "retry": "Try again",
+      "noResults": "No providers or partner nodes found"
     },
     "menu": {
       "editWorkspace": "Edit workspace details",

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -1,0 +1,224 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import type {
+  PartnerNodePolicy,
+  PartnerProvider
+} from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+
+import PartnerNodeAccessPanel from './PartnerNodeAccessPanel.vue'
+
+const mockLoadPolicy = vi.fn()
+const mockIsProviderEnabled = vi.fn()
+
+const { mockNodeDefsByName, mockPolicy, mockProviders, mockStatus } =
+  vi.hoisted(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+    const { ref } = require('vue') as typeof import('vue')
+    return {
+      mockNodeDefsByName: ref<Record<string, ComfyNodeDefImpl>>({}),
+      mockPolicy: ref<PartnerNodePolicy | null>(null),
+      mockProviders: ref<PartnerProvider[]>([]),
+      mockStatus: ref('configured')
+    }
+  })
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    policy: mockPolicy,
+    providers: mockProviders,
+    status: mockStatus,
+    isProviderEnabled: mockIsProviderEnabled,
+    loadPolicy: mockLoadPolicy
+  })
+}))
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  useNodeDefStore: () => ({ nodeDefsByName: mockNodeDefsByName })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      workspacePanel: {
+        partnerNodes: {
+          title: 'Partner node access',
+          unrestricted: 'Unrestricted',
+          restricted: 'Restricted',
+          unrestrictedDescription:
+            'Partner nodes from every provider are available.',
+          restrictedDescription:
+            'Only partner nodes from enabled providers are available.',
+          searchPlaceholder: 'Search providers and partner nodes...',
+          tableLabel: 'Partner node providers',
+          columns: {
+            provider: 'Provider / partner node',
+            nodes: 'Nodes',
+            enabled: 'Enabled'
+          },
+          nodeCount: '{count} node | {count} nodes',
+          enabled: 'Enabled',
+          disabled: 'Disabled',
+          loading: 'Loading partner node access',
+          loadError: "Partner node access couldn't be loaded.",
+          retry: 'Try again',
+          noResults: 'No providers or partner nodes found'
+        }
+      },
+      g: { clear: 'Clear' }
+    }
+  }
+})
+
+function nodeDef(
+  name: string,
+  displayName: string,
+  category: string
+): ComfyNodeDefImpl {
+  return {
+    name,
+    display_name: displayName,
+    category,
+    api_node: true
+  } as ComfyNodeDefImpl
+}
+
+function renderComponent() {
+  return render(PartnerNodeAccessPanel, {
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('PartnerNodeAccessPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStatus.value = 'configured'
+    mockPolicy.value = null
+    mockProviders.value = [
+      {
+        id: 'openai',
+        displayName: 'OpenAI (inc. Sora)',
+        nodeCategories: ['OpenAI', 'Sora']
+      },
+      {
+        id: 'route-only',
+        displayName: 'Route only',
+        nodeCategories: []
+      }
+    ]
+    mockNodeDefsByName.value = {
+      ImageNode: nodeDef('ImageNode', 'Create image', 'partner/image/OpenAI'),
+      VideoNode: nodeDef('VideoNode', 'Create video', 'partner/video/Sora')
+    }
+    mockIsProviderEnabled.mockReturnValue(true)
+  })
+
+  it('groups object-info nodes under visible catalog providers', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    expect(screen.getByText('OpenAI (inc. Sora)')).toBeTruthy()
+    expect(screen.getByText('2 nodes')).toBeTruthy()
+    expect(screen.queryByText('Route only')).toBeNull()
+    expect(screen.queryByText('Create image')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'OpenAI (inc. Sora)' }))
+
+    expect(screen.getByText('Create image')).toBeTruthy()
+    expect(screen.getByText('Create video')).toBeTruthy()
+  })
+
+  it('searches both provider and node names', async () => {
+    const user = userEvent.setup()
+    mockProviders.value = [
+      ...mockProviders.value,
+      {
+        id: 'acme',
+        displayName: 'Acme',
+        nodeCategories: ['Acme']
+      }
+    ]
+    mockNodeDefsByName.value.AcmeNode = nodeDef(
+      'AcmeNode',
+      'Enhance image',
+      'partner/image/Acme'
+    )
+    renderComponent()
+
+    await user.type(
+      screen.getByRole('combobox', {
+        name: 'Search providers and partner nodes...'
+      }),
+      'Enhance'
+    )
+
+    expect(screen.getByText('Acme')).toBeTruthy()
+    expect(screen.getByText('Enhance image')).toBeTruthy()
+    expect(screen.queryByText('OpenAI (inc. Sora)')).toBeNull()
+  })
+
+  it('keeps name-matched providers without loaded nodes', async () => {
+    const user = userEvent.setup()
+    mockProviders.value = [
+      ...mockProviders.value,
+      {
+        id: 'acme',
+        displayName: 'Acme',
+        nodeCategories: ['Acme']
+      }
+    ]
+    renderComponent()
+    const search = screen.getByRole('combobox', {
+      name: 'Search providers and partner nodes...'
+    })
+
+    await user.type(search, 'Acme')
+
+    expect(screen.getByText('Acme')).toBeTruthy()
+    expect(screen.getByText('0 nodes')).toBeTruthy()
+
+    await user.clear(search)
+    await user.type(search, 'Missing')
+
+    expect(screen.getByText('No providers or partner nodes found')).toBeTruthy()
+  })
+
+  it('shows effective disabled state only while restricted', () => {
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    }
+    mockIsProviderEnabled.mockReturnValue(false)
+    renderComponent()
+
+    expect(screen.getByText('Restricted')).toBeTruthy()
+    expect(screen.getByText('Disabled')).toBeTruthy()
+  })
+
+  it('retries a failed load', async () => {
+    const user = userEvent.setup()
+    mockStatus.value = 'error'
+    renderComponent()
+
+    expect(screen.queryByText('Unrestricted')).toBeNull()
+    expect(
+      screen.queryByText('Partner nodes from every provider are available.')
+    ).toBeNull()
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(mockLoadPolicy).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
@@ -1,0 +1,278 @@
+<template>
+  <section
+    v-if="status !== 'ineligible' && status !== 'inactive'"
+    class="flex min-h-0 grow flex-col gap-6 overflow-auto pt-6"
+    aria-labelledby="partner-node-access-title"
+  >
+    <div class="flex flex-wrap items-start justify-between gap-4">
+      <div class="max-w-2xl">
+        <h2
+          id="partner-node-access-title"
+          class="text-xl font-semibold text-base-foreground"
+        >
+          {{ $t('workspacePanel.partnerNodes.title') }}
+        </h2>
+        <p v-if="isPolicyLoaded" class="mt-1 text-sm text-muted-foreground">
+          {{
+            $t(
+              isRestricted
+                ? 'workspacePanel.partnerNodes.restrictedDescription'
+                : 'workspacePanel.partnerNodes.unrestrictedDescription'
+            )
+          }}
+        </p>
+      </div>
+      <span
+        v-if="isPolicyLoaded"
+        class="rounded-lg bg-secondary-background px-3 py-2 text-sm font-medium text-base-foreground"
+      >
+        {{
+          $t(
+            isRestricted
+              ? 'workspacePanel.partnerNodes.restricted'
+              : 'workspacePanel.partnerNodes.unrestricted'
+          )
+        }}
+      </span>
+    </div>
+
+    <div
+      v-if="status === 'loading'"
+      :aria-label="$t('workspacePanel.partnerNodes.loading')"
+      class="space-y-3"
+    >
+      <Skeleton class="h-10 w-full" />
+      <Skeleton v-for="index in 5" :key="index" class="h-12 w-full" />
+    </div>
+
+    <div
+      v-else-if="status === 'error'"
+      role="alert"
+      class="flex min-h-48 flex-col items-center justify-center gap-3 rounded-2xl border border-interface-stroke p-6 text-center"
+    >
+      <p class="text-sm text-muted-foreground">
+        {{ $t('workspacePanel.partnerNodes.loadError') }}
+      </p>
+      <Button variant="secondary" @click="loadPolicy">
+        {{ $t('workspacePanel.partnerNodes.retry') }}
+      </Button>
+    </div>
+
+    <template v-else>
+      <label class="w-full max-w-80">
+        <span class="sr-only">
+          {{ $t('workspacePanel.partnerNodes.searchPlaceholder') }}
+        </span>
+        <SearchInput
+          v-model="searchQuery"
+          :placeholder="$t('workspacePanel.partnerNodes.searchPlaceholder')"
+          size="lg"
+          class="w-full"
+        />
+      </label>
+
+      <div
+        role="table"
+        :aria-label="$t('workspacePanel.partnerNodes.tableLabel')"
+        class="min-h-0 overflow-auto rounded-2xl border border-interface-stroke"
+      >
+        <div
+          role="row"
+          class="grid grid-cols-[minmax(0,1fr)_8rem_7rem] items-center border-b border-interface-stroke px-4 py-3 text-xs font-medium text-muted-foreground"
+        >
+          <span role="columnheader">
+            {{ $t('workspacePanel.partnerNodes.columns.provider') }}
+          </span>
+          <span role="columnheader">
+            {{ $t('workspacePanel.partnerNodes.columns.nodes') }}
+          </span>
+          <span role="columnheader">
+            {{ $t('workspacePanel.partnerNodes.columns.enabled') }}
+          </span>
+        </div>
+
+        <template v-for="provider in filteredProviders" :key="provider.id">
+          <div
+            role="row"
+            class="grid grid-cols-[minmax(0,1fr)_8rem_7rem] items-center border-b border-interface-stroke px-4 py-2 last:border-b-0"
+          >
+            <div role="cell" class="min-w-0">
+              <Button
+                variant="textonly"
+                size="unset"
+                class="w-full justify-start p-2 text-left"
+                :aria-expanded="isProviderExpanded(provider.id)"
+                @click="toggleExpanded(provider.id)"
+              >
+                <i
+                  :class="
+                    cn(
+                      'size-4 shrink-0 transition-transform',
+                      isProviderExpanded(provider.id) && 'rotate-90',
+                      'icon-[lucide--chevron-right]'
+                    )
+                  "
+                />
+                <span class="truncate">{{ provider.displayName }}</span>
+              </Button>
+            </div>
+            <span role="cell" class="text-sm text-muted-foreground">
+              {{
+                $t(
+                  'workspacePanel.partnerNodes.nodeCount',
+                  provider.nodes.length
+                )
+              }}
+            </span>
+            <span
+              role="cell"
+              :class="
+                cn(
+                  'flex items-center gap-2 text-sm',
+                  provider.enabled
+                    ? 'text-base-foreground'
+                    : 'text-muted-foreground'
+                )
+              "
+            >
+              <i
+                :class="
+                  cn(
+                    'size-4',
+                    provider.enabled
+                      ? 'icon-[lucide--circle-check]'
+                      : 'icon-[lucide--circle-x]'
+                  )
+                "
+              />
+              {{
+                $t(
+                  provider.enabled
+                    ? 'workspacePanel.partnerNodes.enabled'
+                    : 'workspacePanel.partnerNodes.disabled'
+                )
+              }}
+            </span>
+          </div>
+
+          <div
+            v-for="node in isProviderExpanded(provider.id)
+              ? provider.nodes
+              : []"
+            :key="node.id"
+            role="row"
+            class="grid grid-cols-[minmax(0,1fr)_8rem_7rem] items-center border-b border-interface-stroke bg-secondary-background/40 px-4 py-3 text-sm last:border-b-0"
+          >
+            <span role="cell" class="truncate pl-10 text-muted-foreground">
+              {{ node.name }}
+            </span>
+            <span role="cell" />
+            <span role="cell" class="text-muted-foreground">
+              {{
+                $t(
+                  provider.enabled
+                    ? 'workspacePanel.partnerNodes.enabled'
+                    : 'workspacePanel.partnerNodes.disabled'
+                )
+              }}
+            </span>
+          </div>
+        </template>
+
+        <div
+          v-if="filteredProviders.length === 0"
+          class="flex min-h-40 items-center justify-center p-6 text-sm text-muted-foreground"
+        >
+          {{ $t('workspacePanel.partnerNodes.noResults') }}
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
+
+import Button from '@/components/ui/button/Button.vue'
+import SearchInput from '@/components/ui/search-input/SearchInput.vue'
+import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { getProviderName } from '@/utils/categoryUtil'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const governanceStore = usePartnerNodeGovernanceStore()
+const { policy, providers, status } = storeToRefs(governanceStore)
+const { isProviderEnabled, loadPolicy } = governanceStore
+const nodeDefStore = useNodeDefStore()
+const { nodeDefsByName } = storeToRefs(nodeDefStore)
+
+const searchQuery = ref('')
+const expandedProviderIds = ref(new Set<string>())
+
+const isRestricted = computed(() => policy.value?.enforcementEnabled === true)
+const isPolicyLoaded = computed(
+  () => status.value === 'configured' || status.value === 'unconfigured'
+)
+
+const providerRows = computed(() =>
+  providers.value
+    .filter(({ nodeCategories }) => nodeCategories.length > 0)
+    .map((provider) => {
+      const nodes = Object.values(nodeDefsByName.value)
+        .filter(
+          (nodeDef) =>
+            nodeDef.api_node &&
+            provider.nodeCategories.includes(getProviderName(nodeDef.category))
+        )
+        .map((nodeDef) => ({
+          id: nodeDef.name,
+          name: nodeDef.display_name || nodeDef.name
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      return {
+        ...provider,
+        enabled: !isRestricted.value || isProviderEnabled(provider.id),
+        nodes
+      }
+    })
+)
+
+const filteredProviders = computed(() => {
+  const query = searchQuery.value.trim().toLocaleLowerCase()
+  if (!query) return providerRows.value
+
+  return providerRows.value
+    .map((provider) => {
+      if (provider.displayName.toLocaleLowerCase().includes(query)) {
+        return provider
+      }
+      return {
+        ...provider,
+        nodes: provider.nodes.filter(({ name }) =>
+          name.toLocaleLowerCase().includes(query)
+        )
+      }
+    })
+    .filter(
+      ({ displayName, nodes }) =>
+        displayName.toLocaleLowerCase().includes(query) || nodes.length > 0
+    )
+})
+
+function toggleExpanded(providerId: string) {
+  const nextIds = new Set(expandedProviderIds.value)
+  if (nextIds.has(providerId)) nextIds.delete(providerId)
+  else nextIds.add(providerId)
+  expandedProviderIds.value = nextIds
+}
+
+function isProviderExpanded(providerId: string) {
+  return (
+    searchQuery.value.trim().length > 0 ||
+    expandedProviderIds.value.has(providerId)
+  )
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -9,18 +10,28 @@ import WorkspacePanelContent from './WorkspacePanelContent.vue'
 const mockFetchMembers = vi.fn()
 const mockFetchPendingInvites = vi.fn()
 
-const { mockHasTeamPlan, mockIsPlanLoading, mockMembers, mockWorkspaceType } =
-  vi.hoisted(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-    const { ref } = require('vue') as typeof import('vue')
+const {
+  mockGovernanceStatus,
+  mockGovernedWorkspaceId,
+  mockHasTeamPlan,
+  mockIsPlanLoading,
+  mockMembers,
+  mockWorkspaceRole,
+  mockWorkspaceType
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
 
-    return {
-      mockHasTeamPlan: ref(true),
-      mockIsPlanLoading: ref(false),
-      mockMembers: ref<WorkspaceMember[]>([]),
-      mockWorkspaceType: ref<'personal' | 'team'>('team')
-    }
-  })
+  return {
+    mockHasTeamPlan: ref(true),
+    mockIsPlanLoading: ref(false),
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockGovernanceStatus: ref('configured'),
+    mockGovernedWorkspaceId: ref<string | null>('team-workspace'),
+    mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
+    mockWorkspaceType: ref<'personal' | 'team'>('team')
+  }
+})
 
 vi.mock('@/platform/workspace/composables/useTeamPlan', () => ({
   useTeamPlan: () => ({
@@ -51,15 +62,20 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => {
 })
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
-  const { ref } = require('vue') as typeof import('vue')
   return {
     useWorkspaceUI: () => ({
       workspaceType: mockWorkspaceType,
-      workspaceRole: ref('owner')
+      workspaceRole: mockWorkspaceRole
     })
   }
 })
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore: () => ({
+    governedWorkspaceId: mockGovernedWorkspaceId,
+    status: mockGovernanceStatus
+  })
+}))
 
 vi.mock(
   '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue',
@@ -72,6 +88,13 @@ vi.mock(
   '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue',
   () => ({
     default: { name: 'MembersPanelContent', template: '<div />' }
+  })
+)
+
+vi.mock(
+  '@/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue',
+  () => ({
+    default: { name: 'PartnerNodeAccessPanel', template: '<div />' }
   })
 )
 
@@ -117,6 +140,9 @@ describe('WorkspacePanelContent billing banner', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMembers.value = []
+    mockGovernanceStatus.value = 'configured'
+    mockGovernedWorkspaceId.value = 'team-workspace'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -138,6 +164,9 @@ describe('WorkspacePanelContent members tab label', () => {
     mockHasTeamPlan.value = true
     mockIsPlanLoading.value = false
     mockMembers.value = []
+    mockGovernanceStatus.value = 'configured'
+    mockGovernedWorkspaceId.value = 'team-workspace'
+    mockWorkspaceRole.value = 'owner'
     mockWorkspaceType.value = 'team'
   })
 
@@ -183,5 +212,54 @@ describe('WorkspacePanelContent members tab label', () => {
     renderComponent()
     expect(mockFetchMembers).not.toHaveBeenCalled()
     expect(mockFetchPendingInvites).not.toHaveBeenCalled()
+  })
+})
+
+describe('WorkspacePanelContent partner nodes tab', () => {
+  beforeEach(() => {
+    mockGovernanceStatus.value = 'configured'
+    mockGovernedWorkspaceId.value = 'team-workspace'
+    mockWorkspaceRole.value = 'owner'
+  })
+
+  it('shows partner node access to team workspace owners', () => {
+    renderComponent()
+
+    expect(screen.getByText('workspacePanel.tabs.partnerNodes')).toBeTruthy()
+  })
+
+  it('hides partner node access from members', () => {
+    mockWorkspaceRole.value = 'member'
+    renderComponent()
+
+    expect(screen.queryByText('workspacePanel.tabs.partnerNodes')).toBeNull()
+  })
+
+  it('hides partner node access when the backend reports ineligible', () => {
+    mockGovernanceStatus.value = 'ineligible'
+    renderComponent()
+
+    expect(screen.queryByText('workspacePanel.tabs.partnerNodes')).toBeNull()
+  })
+
+  it('returns to the plan tab when partner node access becomes unavailable', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    const partnerNodesTab = screen.getByRole('tab', {
+      name: 'workspacePanel.tabs.partnerNodes'
+    })
+
+    await user.click(partnerNodesTab)
+    expect(partnerNodesTab.getAttribute('aria-selected')).toBe('true')
+
+    mockGovernanceStatus.value = 'ineligible'
+
+    await vi.waitFor(() =>
+      expect(
+        screen
+          .getByRole('tab', { name: 'workspacePanel.tabs.planCredits' })
+          .getAttribute('aria-selected')
+      ).toBe('true')
+    )
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -39,6 +39,20 @@
               : $t('workspacePanel.members.header')
           }}
         </TabsTrigger>
+        <TabsTrigger
+          v-if="showPartnerNodeAccess"
+          value="partner-nodes"
+          :class="
+            cn(
+              tabTriggerBase,
+              activeTab === 'partner-nodes'
+                ? tabTriggerActive
+                : tabTriggerInactive
+            )
+          "
+        >
+          {{ $t('workspacePanel.tabs.partnerNodes') }}
+        </TabsTrigger>
       </TabsList>
 
       <BillingStatusBanner class="mt-4" />
@@ -49,13 +63,16 @@
       <TabsContent value="members" class="mt-4">
         <MembersPanelContent :key="workspaceRole" />
       </TabsContent>
+      <TabsContent v-if="showPartnerNodeAccess" value="partner-nodes">
+        <PartnerNodeAccessPanel />
+      </TabsContent>
     </TabsRoot>
   </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { whenever } from '@vueuse/core'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
@@ -63,10 +80,12 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import BillingStatusBanner from '@/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
+import PartnerNodeAccessPanel from '@/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const tabTriggerBase =
@@ -85,11 +104,29 @@ const { workspaceName, members } = storeToRefs(workspaceStore)
 const { fetchMembers, fetchPendingInvites } = workspaceStore
 
 const { workspaceRole } = useWorkspaceUI()
+const governanceStore = usePartnerNodeGovernanceStore()
+const { governedWorkspaceId, status: governanceStatus } =
+  storeToRefs(governanceStore)
 const { hasTeamPlan, isPlanLoading } = useTeamPlan()
 const activeTab = ref(defaultTab)
 
 const showMembersTabCount = computed(
   () => hasTeamPlan.value && members.value.length > 1
+)
+const showPartnerNodeAccess = computed(
+  () =>
+    workspaceRole.value === 'owner' &&
+    governedWorkspaceId.value !== null &&
+    governanceStatus.value !== 'ineligible'
+)
+
+watch(
+  showPartnerNodeAccess,
+  (isAvailable) => {
+    if (isAvailable || activeTab.value !== 'partner-nodes') return
+    activeTab.value = 'plan'
+  },
+  { immediate: true }
 )
 
 whenever(


### PR DESCRIPTION
## Summary

Adds an owner-only **Partner nodes** tab for eligible team workspaces. It presents provider access as read-only: restricted or unrestricted policy mode, effective provider state, provider and node search, and expandable partner-node groups derived from `object_info`. Catalog entries without node categories stay hidden.

Stack: PR B of D, based on [#13894](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13894). Editing follows in [#13896](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13896).

## Verification

| Before | After |
|---|---|
| <img width="1440" height="900" alt="Workspace settings before PR 13895, with Plan and Credits and Members tabs only" src="https://github.com/user-attachments/assets/a9ee988e-d5b3-41c1-bf6b-fea4ad61628b" /> | <img width="1440" height="900" alt="Workspace settings after PR 13895, showing restricted partner node access with Google expanded" src="https://github.com/user-attachments/assets/cd4c4213-24ea-4cf6-a301-b59f4e50731c" /> |

https://github.com/user-attachments/assets/1f69452a-ac99-4e3b-be82-b82e390d3c61

| Timestamp | Screenshot | Highlight |
|---|---|---|
|`00:01.00`| <img width="720" height="450" alt="Before PR 13895, Workspace settings has no Partner nodes tab" src="https://github.com/user-attachments/assets/f9babfdf-8a68-4450-ade2-9b897fbccac6" /> | The base branch exposes only Plan & Credits and Members. |
|`00:03.50`| <img width="720" height="450" alt="After PR 13895, restricted partner node provider states are visible" src="https://github.com/user-attachments/assets/404802dd-d25b-4f20-bb12-4822beb78fdf" /> | The new owner-only tab shows restricted policy and effective provider state. |
|`00:05.75`| <img width="720" height="450" alt="After PR 13895, searching Veo shows the grouped Google partner node" src="https://github.com/user-attachments/assets/09faf5f7-e603-4f90-916b-dbd40e749a6d" /> | Search narrows the grouped `object_info` nodes to Veo 3 Video. |

Behavioral coverage also exercises owner and ineligible visibility, provider and node search, route-only omission, effective state, and retry.

**Unknown:** not verified in an authenticated Cloud preview; the media uses controlled policy and `object_info` data against the real base and current-head frontend.

Created by Codex