### PR TITLE
fix: hide duplicate Plan & Credits menu

### DIFF
--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -180,7 +180,7 @@ describe('useSettingUI', () => {
     expect(defaultCategory.value.key).toBe('about')
   })
 
-  describe('legacy billing in the workspace layout', () => {
+  describe('plan and credits navigation', () => {
     const navKeys = (groups: { items: { id: string }[] }[]) =>
       groups.flatMap((group) => group.items.map((item) => item.id))
 
@@ -196,42 +196,23 @@ describe('useSettingUI', () => {
       } as typeof window.__CONFIG__
     })
 
-    it('exposes the legacy plan panel when billing is legacy', () => {
-      env.state.billingType = 'legacy'
-      const { defaultCategory, navGroups } = useSettingUI('subscription')
+    it.for(['legacy', 'workspace'] as const)(
+      'uses only the Workspace panel for %s billing in the workspace layout',
+      (billingType) => {
+        env.state.billingType = billingType
+        const { navGroups } = useSettingUI()
 
-      expect(defaultCategory.value.key).toBe('subscription')
-      expect(navKeys(navGroups.value)).toContain('subscription')
-      expect(navKeys(navGroups.value)).toContain('workspace')
-    })
+        expect(navKeys(navGroups.value)).not.toContain('subscription')
+        expect(navKeys(navGroups.value)).toContain('workspace')
+      }
+    )
 
-    it('hides the legacy plan panel when billing is workspace', () => {
-      env.state.billingType = 'workspace'
+    it('keeps the legacy plan panel in the legacy layout', () => {
+      env.state.teamWorkspacesEnabled = false
       const { navGroups } = useSettingUI()
 
-      expect(navKeys(navGroups.value)).not.toContain('subscription')
-      expect(navKeys(navGroups.value)).toContain('workspace')
-    })
-
-    it('never renders the plan panel in more than one tab', () => {
-      const countSubscription = () => {
-        const { navGroups } = useSettingUI()
-        return navKeys(navGroups.value).filter((id) => id === 'subscription')
-          .length
-      }
-
-      for (const teamWorkspacesEnabled of [true, false]) {
-        for (const billingType of ['legacy', 'workspace'] as const) {
-          for (const isLoggedIn of [true, false]) {
-            Object.assign(env.state, {
-              teamWorkspacesEnabled,
-              billingType,
-              isLoggedIn
-            })
-            expect(countSubscription()).toBeLessThanOrEqual(1)
-          }
-        }
-      }
+      expect(navKeys(navGroups.value)).toContain('subscription')
+      expect(navKeys(navGroups.value)).not.toContain('workspace')
     })
   })
 })

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -308,9 +308,6 @@ export function useSettingUI(
       label: 'General',
       children: [
         translateCategory(userPanel.node),
-        ...(shouldShowLegacyPlanCreditsPanel.value && subscriptionPanel
-          ? [translateCategory(subscriptionPanel.node)]
-          : []),
         ...coreSettingCategories.value.slice(0, 1).map(translateCategory),
         ...(shouldShowSecretsPanel.value
           ? [translateCategory(secretsPanel.node)]


### PR DESCRIPTION
## Summary

Hide the standalone Plan & Credits settings entry when the workspace settings layout is enabled. Workspace already exposes the same plan and credit controls under **Workspace → Plan & Credits**.

## Investigation

The duplicate is a UI composition issue, not a duplicate subscription or billing operation.

The workspace settings layout is selected when `teamWorkspacesEnabled` is true. Before this change, that layout also inserted the standalone `subscription` navigation item whenever the active subscription used the legacy frontend billing route:

- `billingType === 'legacy'`
- the user is logged in
- the subscription is active

For a personal workspace, `billingType` resolves to `legacy` when either `consolidated_billing_enabled` is false or the durable workspace billing rail is `legacy_stripe`. A missing workspace type also defaults to legacy during bootstrap, but should be transient. `activeWorkspaceBillingRail` is an in-memory per-workspace value populated from `/api/billing/status`; it is `null` until loaded.

The reported state is consistent with an active personal Pro subscription on the legacy route. The exact account condition—flag off versus `legacy_stripe`—was not captured, but it does not affect the UI fix: the workspace layout should have one billing entry point regardless of its underlying billing route.

```text
Personal workspace
       │
       ├── consolidated_billing_enabled = false ──┐
       │                                          │
       └── billing_rail = legacy_stripe ──────────┤
                                                  ▼
                                        billingType = legacy
                                                  │
                         ┌────────────────────────┴──────────────────────┐
                         ▼                                               ▼
               Workspace panel shown                         Plan & Credits shown
                         └────────────────────────┬──────────────────────┘
                                                  ▼
                                         Duplicate navigation
                                                  │
                                                  ▼
                         Remove standalone item from workspace layout
                                                  │
                                                  ▼
                            Workspace → Plan & Credits remains available
```

## AS IS / TO BE

| AS IS | TO BE |
|---|---|
| Duplicate billing navigation: both **Workspace** and standalone **Plan & Credits** are visible. | One entry point: billing remains under **Workspace → Plan & Credits**. |
| <img src="https://ampcode.com/attachments/aec69117e5bed112eaa7409b36c9c328b5a6d8095b3db267ae053549431bc328.png" width="560" alt="AS IS: duplicate Workspace and Plan & Credits navigation" /> | <img src="https://ampcode.com/attachments/40d0c172e4ebc7cac73a232836939b1c7c552d667707f7f9300208951e3c0796.png" width="560" alt="TO BE: single Workspace billing entry point" /> |

## Changes

- Remove the standalone legacy-billing Plan & Credits navigation item from the workspace layout.
- Preserve the standalone item in the legacy non-workspace layout.
- Cover both legacy and workspace billing routes in the workspace layout.

## Review focus

Confirm personal workspaces using legacy billing can manage plans and credits through Workspace without the duplicate sidebar entry.

Context: https://comfy-organization.slack.com/archives/C0BHR8PMK1D/p1784662257892359?thread_ts=1784661265.207919&channel=C0BHR8PMK1D&message_ts=1784662257.892359