### PR TITLE
fix: evict lowest-priority dialog when dialog stack is full

### DIFF
--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -263,4 +263,43 @@ describe('dialogStore', () => {
       })
     })
   })
+
+  describe('stack overflow eviction', () => {
+    it('evicts the lowest priority dialog when the stack is full', () => {
+      const store = useDialogStore()
+
+      for (let priority = 0; priority < 10; priority++) {
+        store.showDialog({
+          key: `priority-${priority}`,
+          component: MockComponent,
+          priority
+        })
+      }
+
+      expect(store.dialogStack.map((d) => d.key)).toEqual([
+        'priority-9',
+        'priority-8',
+        'priority-7',
+        'priority-6',
+        'priority-5',
+        'priority-4',
+        'priority-3',
+        'priority-2',
+        'priority-1',
+        'priority-0'
+      ])
+
+      store.showDialog({
+        key: 'overflow',
+        component: MockComponent,
+        priority: 5
+      })
+
+      const keys = store.dialogStack.map((d) => d.key)
+
+      expect(keys).toContain('overflow')
+      expect(keys).toContain('priority-9')
+      expect(keys).not.toContain('priority-0')
+    })
+  })
 })

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -185,7 +185,7 @@ export const useDialogStore = defineStore('dialog', () => {
     F extends Component = Component
   >(options: ShowDialogOptions<H, B, F> & { key: string }) {
     if (dialogStack.value.length >= 10) {
-      dialogStack.value.shift()
+      dialogStack.value.pop()
     }
 
     const dialog = {


### PR DESCRIPTION
## Summary

When the dialog stack hits its cap of 10, the highest-priority dialog was evicted instead of the lowest, so important dialogs (e.g. a progress dialog at priority 10) were silently dropped.

## Changes

- **What**: `insertDialogByPriority` keeps `dialogStack` sorted descending (index 0 = highest priority), but the cap enforcement in `createDialog` (`src/stores/dialogStore.ts:188`) called `shift()`, removing the highest-priority entry. Changed to `pop()` so the lowest-priority dialog is evicted. Adds a regression test.

## Review Focus

Eviction happens before insertion, so a new dialog with the lowest priority of all still gets inserted after evicting the previous tail — unchanged from the existing behavior, only the eviction end is corrected.
