### PR TITLE
fix: do not revoke media cache blob URL on release of un-acquired URL

### DIFF
--- a/src/services/mediaCacheService.test.ts
+++ b/src/services/mediaCacheService.test.ts
@@ -1,15 +1,31 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useMediaCache } from './mediaCacheService'
 
 // Mock fetch
 global.fetch = vi.fn()
+
+let objectUrlCounter = 0
 global.URL = {
-  createObjectURL: vi.fn(() => 'blob:mock-url'),
+  createObjectURL: vi.fn(() => `blob:mock-url-${++objectUrlCounter}`),
   revokeObjectURL: vi.fn()
 } as Partial<typeof URL> as typeof URL
 
+function mockFetchSuccess() {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    status: 200,
+    blob: () => Promise.resolve(new Blob(['data']))
+  } as Response)
+}
+
 describe('mediaCacheService', () => {
+  beforeEach(() => {
+    useMediaCache().clearCache()
+    vi.mocked(global.URL.revokeObjectURL).mockClear()
+    vi.mocked(global.fetch).mockReset()
+  })
+
   describe('URL reference counting', () => {
     it('should handle URL acquisition for non-existent cache entry', () => {
       const { acquireUrl } = useMediaCache()
@@ -30,6 +46,39 @@ describe('mediaCacheService', () => {
 
       expect(typeof cache.acquireUrl).toBe('function')
       expect(typeof cache.releaseUrl).toBe('function')
+    })
+
+    it('keeps the url alive while a second consumer still holds it', async () => {
+      mockFetchSuccess()
+      const { getCachedMedia, acquireUrl, releaseUrl } = useMediaCache()
+
+      const src = 'two-consumers.png'
+      const entry = await getCachedMedia(src)
+      const objectUrl = entry.objectUrl!
+
+      expect(acquireUrl(src)).toBe(objectUrl)
+      expect(acquireUrl(src)).toBe(objectUrl)
+
+      releaseUrl(src)
+
+      expect(global.URL.revokeObjectURL).not.toHaveBeenCalledWith(objectUrl)
+
+      releaseUrl(src)
+
+      expect(global.URL.revokeObjectURL).toHaveBeenCalledWith(objectUrl)
+    })
+
+    it('does not revoke a url that was never acquired', async () => {
+      mockFetchSuccess()
+      const { getCachedMedia, releaseUrl } = useMediaCache()
+
+      const src = 'never-acquired.png'
+      const entry = await getCachedMedia(src)
+      const objectUrl = entry.objectUrl!
+
+      releaseUrl(src)
+
+      expect(global.URL.revokeObjectURL).not.toHaveBeenCalledWith(objectUrl)
     })
   })
 })

--- a/src/services/mediaCacheService.ts
+++ b/src/services/mediaCacheService.ts
@@ -160,16 +160,17 @@ class MediaCacheService {
 
   releaseUrl(src: string): void {
     const entry = this.cache.get(src)
-    if (entry?.objectUrl) {
-      const count = (this.urlRefCount.get(entry.objectUrl) || 1) - 1
-      if (count <= 0) {
-        URL.revokeObjectURL(entry.objectUrl)
-        this.urlRefCount.delete(entry.objectUrl)
-        // Remove from cache as well
-        this.cache.delete(src)
-      } else {
-        this.urlRefCount.set(entry.objectUrl, count)
-      }
+    if (!entry?.objectUrl) return
+
+    const currentCount = this.urlRefCount.get(entry.objectUrl) ?? 0
+    if (currentCount === 0) return
+
+    if (currentCount === 1) {
+      URL.revokeObjectURL(entry.objectUrl)
+      this.urlRefCount.delete(entry.objectUrl)
+      this.cache.delete(src)
+    } else {
+      this.urlRefCount.set(entry.objectUrl, currentCount - 1)
     }
   }
 


### PR DESCRIPTION
## Summary

Releasing a blob URL that was never acquired revoked it, tearing down live media previews for consumers still holding the URL.

## Changes

- **What**: `releaseUrl` in `src/services/mediaCacheService.ts` defaulted a missing refcount to `1`, so a release without a matching acquire decremented it to `0`, revoked the object URL, and deleted the cache entry. This is reachable from `LazyImage.vue`, which calls `releaseUrl` on any `blob:`-prefixed src even when it never acquired it. A missing refcount is now treated as `0`, making release of an un-acquired URL a no-op; balanced acquire/release still revokes when the count reaches zero. Adds a regression test.

## Review Focus

- `releaseUrl` refcount handling: never-acquired release must not revoke, while the last balanced release must still revoke and evict the cache entry.
