### PR TITLE
fix: invalidate job output cache when jobs are deleted or cleared

### DIFF
--- a/src/services/jobOutputCache.test.ts
+++ b/src/services/jobOutputCache.test.ts
@@ -1,3 +1,4 @@
+import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
@@ -13,7 +14,11 @@ import {
   getJobWorkflow,
   getOutputsForTask
 } from '@/services/jobOutputCache'
-import { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
+import {
+  ResultItemImpl,
+  TaskItemImpl,
+  useQueueStore
+} from '@/stores/queueStore'
 
 vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', () => ({
   fetchJobDetail: vi.fn(),
@@ -25,7 +30,11 @@ vi.mock('@/scripts/api', () => ({
     getJobDetail: vi.fn(),
     apiURL: vi.fn((path: string) => `/api${path}`),
     addEventListener: vi.fn(),
-    removeEventListener: vi.fn()
+    removeEventListener: vi.fn(),
+    deleteItem: vi.fn(),
+    clearItems: vi.fn(),
+    getQueue: vi.fn(async () => ({ Running: [], Pending: [] })),
+    getHistory: vi.fn(async () => [])
   }
 }))
 
@@ -392,6 +401,59 @@ describe('jobOutputCache', () => {
       const result = await getJobWorkflow(jobId)
 
       expect(result).toBeUndefined()
+    })
+  })
+
+  describe('invalidation when a job is deleted', () => {
+    beforeEach(() => {
+      setActivePinia(createPinia())
+    })
+
+    it('stops serving deleted job detail from the cache', async () => {
+      const jobId = uniqueId('job-deleted')
+      const job = createMockJob(jobId, 1)
+      const detail: JobDetail = {
+        id: jobId,
+        status: 'completed',
+        create_time: Date.now(),
+        priority: 0,
+        outputs: {}
+      }
+      vi.mocked(api.getJobDetail).mockResolvedValue(detail)
+
+      expect(await getJobDetail(jobId)).toEqual(detail)
+
+      const task = new TaskItemImpl(job, {}, [createResultItem('preview')])
+      await useQueueStore().delete(task)
+
+      vi.mocked(api.getJobDetail).mockResolvedValue(undefined)
+
+      expect(await getJobDetail(jobId)).toBeUndefined()
+    })
+
+    it('stops serving deleted task outputs from the cache', async () => {
+      const jobId = uniqueId('task-deleted')
+      const job = createMockJob(jobId, 3)
+
+      const task = new TaskItemImpl(job, {}, [createResultItem('preview')])
+      task.loadFullOutputs = vi
+        .fn()
+        .mockResolvedValue(
+          new TaskItemImpl(job, {}, [createResultItem('full-1')])
+        )
+
+      expect(await getOutputsForTask(task)).toEqual([
+        createResultItem('full-1')
+      ])
+
+      await useQueueStore().delete(task)
+
+      const reloaded = new TaskItemImpl(job, {}, [createResultItem('preview')])
+      reloaded.loadFullOutputs = vi
+        .fn()
+        .mockResolvedValue(new TaskItemImpl(job, {}, []))
+
+      expect(await getOutputsForTask(reloaded)).toEqual([])
     })
   })
 })

--- a/src/services/jobOutputCache.ts
+++ b/src/services/jobOutputCache.ts
@@ -30,6 +30,16 @@ const jobDetailCache = new QuickLRU<string, JobDetail>({
 // Track latest request to dedupe stale responses
 let latestTaskRequestId: string | null = null
 
+export function invalidateCachedJob(jobId: string): void {
+  taskCache.delete(jobId)
+  jobDetailCache.delete(jobId)
+}
+
+export function clearJobOutputCache(): void {
+  taskCache.clear()
+  jobDetailCache.clear()
+}
+
 // ===== Task Output Caching =====
 
 export function findActiveIndex(

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -18,7 +18,11 @@ import { api } from '@/scripts/api'
 import { parseTaskOutput } from '@/stores/resultItemParsing'
 import type { ComfyApp } from '@/scripts/app'
 import { useExtensionService } from '@/services/extensionService'
-import { getJobDetail } from '@/services/jobOutputCache'
+import {
+  clearJobOutputCache,
+  getJobDetail,
+  invalidateCachedJob
+} from '@/services/jobOutputCache'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
@@ -615,11 +619,13 @@ export const useQueueStore = defineStore('queue', () => {
       return
     }
     await Promise.all(targets.map((type) => api.clearItems(type)))
+    clearJobOutputCache()
     await update()
   }
 
   const deleteTask = async (task: TaskItemImpl) => {
     await api.deleteItem(task.apiTaskType, task.jobId)
+    invalidateCachedJob(task.jobId)
     await update()
   }
 


### PR DESCRIPTION
## Summary

Deleting a job or clearing history left its outputs in the job output cache, so the UI kept rendering stale outputs for jobs that no longer exist.

## Changes

- **What**: `src/services/jobOutputCache.ts` holds two module-scope 50-entry LRUs (task outputs, job details) but exposed no invalidation, and `queueStore`'s `delete`/`clear` never touched them — a deleted job kept being served from cache until 50 newer entries evicted it. Adds `invalidateCachedJob(jobId)` and `clearJobOutputCache()` to the cache module and calls them from `useQueueStore().delete` (per deleted job) and `useQueueStore().clear`. Adds regression tests covering both caches.

## Review Focus

- `clear()` drops both caches regardless of which targets were cleared; over-invalidation is safe since entries repopulate on next fetch.
