### PR TITLE
fix: make remote widget retry backoff actually exponential

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.backoff.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.backoff.test.ts
@@ -1,0 +1,117 @@
+import axios from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { IWidget } from '@/lib/litegraph/src/litegraph'
+import { useRemoteWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof axios>()
+  return {
+    default: {
+      ...actual,
+      get: vi.fn()
+    }
+  }
+})
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}))
+
+const DEFAULT_VALUE = 'Loading...'
+const PROBE_RATIO = 1.05
+const MAX_PROBE_DELAY = 600_000
+
+function createMockWidget(): IWidget {
+  return {
+    name: 'test_widget',
+    type: 'text',
+    value: '',
+    options: {}
+  } as Partial<IWidget> as IWidget
+}
+
+function createHook() {
+  return useRemoteWidget({
+    remoteConfig: {
+      route: `/api/test/${Math.random().toString(36).slice(2)}`,
+      refresh: 0,
+      max_retries: 100
+    },
+    defaultValue: DEFAULT_VALUE,
+    node: createMockLGraphNode({
+      addWidget: vi.fn(() => createMockWidget()),
+      onRemoved: undefined
+    }),
+    widget: createMockWidget()
+  })
+}
+
+async function resolveValue(hook: ReturnType<typeof useRemoteWidget>) {
+  await new Promise<void>((resolve) => {
+    hook.getValue(() => resolve())
+  })
+}
+
+function fetchCount() {
+  return vi.mocked(axios.get).mock.calls.length
+}
+
+/**
+ * Returns the smallest probed delay (ms) at which a widget that has already
+ * failed `failures` times is willing to attempt another fetch.
+ */
+async function measureBackoff(failures: number) {
+  const hook = createHook()
+
+  for (let n = 0; n < failures; n++) {
+    vi.setSystemTime(Date.now() + MAX_PROBE_DELAY * 2)
+    vi.mocked(axios.get).mockRejectedValueOnce(new Error('Network error'))
+    await resolveValue(hook)
+  }
+  expect(hook.getCacheEntry()?.retryCount).toBe(failures)
+
+  const lastErrorTime = Date.now()
+  vi.mocked(axios.get).mockRejectedValueOnce(new Error('Network error'))
+
+  for (
+    let delay = 1;
+    delay <= MAX_PROBE_DELAY;
+    delay = Math.ceil(delay * PROBE_RATIO)
+  ) {
+    const before = fetchCount()
+    vi.setSystemTime(lastErrorTime + delay)
+    await resolveValue(hook)
+    if (fetchCount() > before) return delay
+  }
+
+  throw new Error(`No retry attempted within ${MAX_PROBE_DELAY}ms`)
+}
+
+describe('useRemoteWidget retry backoff', () => {
+  beforeEach(() => {
+    vi.mocked(axios.get).mockReset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits strictly longer after each successive failure', async () => {
+    const afterOne = await measureBackoff(1)
+    const afterTwo = await measureBackoff(2)
+    const afterThree = await measureBackoff(3)
+
+    expect(afterTwo).toBeGreaterThan(afterOne)
+    expect(afterThree).toBeGreaterThan(afterTwo)
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -54,7 +54,7 @@ vi.mock('@/platform/settings/settingStore', async () => {
   }
 })
 
-const FIRST_BACKOFF = 1000 // backoff is 1s on first retry
+const FIRST_BACKOFF = 2000 // getBackoff(1): wait after the first failure
 const DEFAULT_VALUE = 'Loading...'
 
 function createMockConfig(overrides = {}): RemoteWidgetConfig {
@@ -341,27 +341,6 @@ describe('useRemoteWidget', () => {
 
     afterEach(() => {
       vi.useRealTimers()
-    })
-
-    it('should implement exponential backoff on errors', async () => {
-      mockAxiosError('Network error')
-
-      const hook = useRemoteWidget(createMockOptions())
-      await getResolvedValue(hook)
-      const entry1 = hook.getCacheEntry()
-      expect(entry1?.error).toBeTruthy()
-
-      await getResolvedValue(hook)
-      expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1)
-
-      vi.setSystemTime(Date.now() + 500)
-      await getResolvedValue(hook)
-      expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1) // Still backing off
-
-      vi.setSystemTime(Date.now() + 3000)
-      await getResolvedValue(hook)
-      expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(2)
-      expect(entry1?.data).toBeDefined()
     })
 
     it('should reset error state on successful fetch', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.ts
@@ -9,6 +9,7 @@ import { useAuthStore } from '@/stores/authStore'
 
 const MAX_RETRIES = 5
 const TIMEOUT = 4096
+const MAX_BACKOFF = 30_000
 
 interface CacheEntry<T> {
   data: T
@@ -46,7 +47,7 @@ const createCacheKey = (config: RemoteWidgetConfig): string => {
 }
 
 const getBackoff = (retryCount: number) =>
-  Math.min(1000 * Math.pow(2, retryCount), 512)
+  Math.min(1000 * Math.pow(2, retryCount), MAX_BACKOFF)
 
 const isInitialized = (entry: CacheEntry<unknown> | undefined) =>
   entry?.data !== undefined &&


### PR DESCRIPTION
## Summary

Fixes the remote-widget retry backoff, which never grew: a slow or erroring remote-widget endpoint was retried at a constant ~512ms interval instead of backing off exponentially.

## Changes

- **What**: In `useRemoteWidget.ts`, `getBackoff` computed `Math.min(1000 * 2^retryCount, 512)` — the exponential term is always ≥ 1000, so the 512ms cap won unconditionally and every retry waited a flat 512ms. Raised the cap to 30s so the backoff is genuinely exponential (2s, 4s, 8s, ... capped at 30s).
- Adds a regression test (`useRemoteWidget.backoff.test.ts`) that measures the actual wait after successive failures and asserts it strictly increases.
- Removes the previous "should implement exponential backoff on errors" test, whose assertions also held for a constant backoff; the new test subsumes it.

## Review Focus

The first post-failure wait changes from ~512ms to 2s (`getBackoff` is evaluated with `retryCount` already incremented), so `FIRST_BACKOFF` in the existing test file was updated to match.
