### PR TITLE
fix: prune app builder config against its own workflow graph

### DIFF
--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -86,6 +86,10 @@ vi.mock('@/stores/appModeStore', () => ({
   useAppModeStore: vi.fn(() => mockAppModeStore)
 }))
 
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: { id: 'root', extra: {}, nodes: [] } }
+}))
+
 vi.mock('@/composables/useErrorHandling', () => ({}))
 
 vi.mock('@/composables/useFeatureFlags', () => ({

--- a/src/composables/useWorkflowActionsMenu.ts
+++ b/src/composables/useWorkflowActionsMenu.ts
@@ -12,6 +12,7 @@ import {
   useWorkflowBookmarkStore,
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
 import { useCommandStore } from '@/stores/commandStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
@@ -229,7 +230,10 @@ export function useWorkflowActionsMenu(
       : workflow?.changeTracker?.activeState?.extra?.linearData
     let hasLinearData: boolean
     if (rawLd) {
-      const { inputs, outputs } = pruneLinearData(rawLd)
+      const { inputs, outputs } = pruneLinearData(
+        rawLd,
+        isActive ? app.rootGraph : undefined
+      )
       hasLinearData = inputs.length > 0 || outputs.length > 0
     } else {
       hasLinearData = workflow?.path?.endsWith('.app.json') ?? false

--- a/src/platform/workflow/sharing/composables/useShareDialog.ts
+++ b/src/platform/workflow/sharing/composables/useShareDialog.ts
@@ -4,6 +4,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useWorkflowStore } from '../../management/stores/workflowStore'
+import { app } from '@/scripts/app'
 import { useAppModeStore } from '@/stores/appModeStore'
 import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 import { t } from '@/i18n'
@@ -27,7 +28,7 @@ export function useShareDialog() {
 
     const isAppDefault = wf.initialMode === 'app'
     const linearData = wf.changeTracker?.activeState?.extra?.linearData
-    const { outputs } = pruneLinearData(linearData)
+    const { outputs } = pruneLinearData(linearData, app.rootGraph)
 
     if (isAppDefault && outputs.length === 0) {
       const dialog = showConfirmDialog({

--- a/src/stores/appModeStore.crossWorkflowPruning.test.ts
+++ b/src/stores/appModeStore.crossWorkflowPruning.test.ts
@@ -1,0 +1,110 @@
+import { createTestingPinia } from '@pinia/testing'
+import { fromAny } from '@total-typescript/shoehorn'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { app } from '@/scripts/app'
+import { ChangeTracker } from '@/scripts/changeTracker'
+import { toNodeId } from '@/types/nodeId'
+import type { WidgetId } from '@/types/widgetId'
+
+import { useAppModeStore } from './appModeStore'
+
+/**
+ * Regression coverage for pruning a NON-ACTIVE workflow's linear data.
+ *
+ * `pruneLinearData` used to resolve every stored id against `app.rootGraph`
+ * unconditionally, while `useWorkflowActionsMenu` calls it with
+ * `workflow.changeTracker.activeState.extra.linearData` for a workflow that is
+ * explicitly NOT the active one — so workflow B's app config got validated
+ * against workflow A's graph and dropped.
+ */
+
+// Graph A — the graph that is actually loaded in the canvas.
+const graphAId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+// Graph B — a different, non-active workflow's graph.
+const graphBId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const widgetInB = `${graphBId}:7:cfg` as WidgetId
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    rootGraph: {
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      extra: {},
+      nodes: [] as LGraphNode[],
+      subgraphs: new Map(),
+      events: new EventTarget(),
+      getNodeById: vi.fn(() => null)
+    }
+  }
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ getCanvas: () => ({ state: undefined }) })
+}))
+
+vi.mock('@/components/builder/useEmptyWorkflowDialog', () => ({
+  useEmptyWorkflowDialog: () => ({ show: vi.fn() })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: vi.fn(() => false), set: vi.fn() })
+}))
+
+function nodeWithWidgets(graphId: string, id: number, names: string[]) {
+  return fromAny<LGraphNode, unknown>({
+    id: toNodeId(id),
+    widgets: names.map((name) => ({
+      name,
+      widgetId: `${graphId}:${id}:${name}` as WidgetId
+    }))
+  })
+}
+
+describe('appModeStore.pruneLinearData — non-active workflow', () => {
+  let store: ReturnType<typeof useAppModeStore>
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    ChangeTracker.isLoadingGraph = false
+
+    // Graph A is loaded: it only contains node 1 with a `seed` widget.
+    const nodeA = nodeWithWidgets(graphAId, 1, ['seed'])
+    vi.mocked(app.rootGraph!).id = graphAId
+    vi.mocked(app.rootGraph!).nodes = [nodeA]
+    vi.mocked(app.rootGraph!).getNodeById = vi.fn((id) =>
+      String(id) === '1' ? nodeA : null
+    )
+
+    store = useAppModeStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('preserves inputs belonging to another workflow instead of pruning them against the active graph', () => {
+    // Workflow B's saved app config: node 7 / widget `cfg` exists in B only.
+    const linearDataOfB = {
+      inputs: [[widgetInB, 'cfg'] as [WidgetId, string]],
+      outputs: [toNodeId(7)]
+    }
+
+    const { inputs } = store.pruneLinearData(linearDataOfB)
+
+    expect(inputs).toEqual([[widgetInB, 'cfg']])
+  })
+
+  it('preserves outputs belonging to another workflow', () => {
+    const linearDataOfB = {
+      inputs: [],
+      outputs: [toNodeId(7)]
+    }
+
+    const { outputs } = store.pruneLinearData(linearDataOfB)
+
+    expect(outputs).toEqual([toNodeId(7)])
+  })
+})

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -467,22 +467,25 @@ describe('appModeStore', () => {
 
   describe('pruneLinearData', () => {
     it('returns empty selections for undefined data', () => {
-      expect(store.pruneLinearData(undefined)).toEqual({
+      expect(store.pruneLinearData(undefined, app.rootGraph)).toEqual({
         inputs: [],
         outputs: []
       })
     })
 
-    it('does not prune when rootGraph is empty', () => {
+    it('does not prune when no graph is provided', () => {
       const originalRootGraph = app.rootGraph
       Object.defineProperty(app, 'rootGraph', { value: null, writable: true })
 
       try {
         expect(
-          store.pruneLinearData({
-            inputs: [[1, 'seed']],
-            outputs: [toNodeId(1)]
-          })
+          store.pruneLinearData(
+            {
+              inputs: [[1, 'seed']],
+              outputs: [toNodeId(1)]
+            },
+            app.rootGraph
+          )
         ).toEqual({
           inputs: [[1, 'seed']],
           outputs: [toNodeId(1)]
@@ -925,10 +928,13 @@ describe('appModeStore', () => {
 
       expect(rootGraph.getNodeById(interior.id)).toBeUndefined()
 
-      const result = store.pruneLinearData({
-        inputs: [[interior.id, sourceWidgetName, { height: 120 }]],
-        outputs: []
-      })
+      const result = store.pruneLinearData(
+        {
+          inputs: [[interior.id, sourceWidgetName, { height: 120 }]],
+          outputs: []
+        },
+        app.rootGraph
+      )
 
       expect(result.inputs).toEqual([
         [promotedEntityId, subgraphInputName, { height: 120 }]
@@ -965,10 +971,13 @@ describe('appModeStore', () => {
           id == sourceNodeId ? rootNode : id == hostId ? hostNode : null
       )
 
-      const result = store.pruneLinearData({
-        inputs: [[sourceNodeId, sourceWidgetName, { height: 120 }]],
-        outputs: []
-      })
+      const result = store.pruneLinearData(
+        {
+          inputs: [[sourceNodeId, sourceWidgetName, { height: 120 }]],
+          outputs: []
+        },
+        app.rootGraph
+      )
 
       expect(result.inputs).toEqual([
         [rootEntityId, sourceWidgetName, { height: 120 }]
@@ -981,10 +990,13 @@ describe('appModeStore', () => {
       vi.mocked(app.rootGraph).nodes = []
       vi.mocked(app.rootGraph).getNodeById = vi.fn(() => null)
 
-      const result = store.pruneLinearData({
-        inputs: [[42, 'widget-name', { height: 42 }]],
-        outputs: []
-      })
+      const result = store.pruneLinearData(
+        {
+          inputs: [[42, 'widget-name', { height: 42 }]],
+          outputs: []
+        },
+        app.rootGraph
+      )
 
       expect(result.inputs).toEqual([])
       expect(warnSpy).toHaveBeenCalledWith(
@@ -1016,10 +1028,13 @@ describe('appModeStore', () => {
           id == hostId ? hostNode : null
       )
 
-      const result = store.pruneLinearData({
-        inputs: [[hostLocator, 'subgraph_input_name']],
-        outputs: []
-      })
+      const result = store.pruneLinearData(
+        {
+          inputs: [[hostLocator, 'subgraph_input_name']],
+          outputs: []
+        },
+        app.rootGraph
+      )
 
       expect(result.inputs).toEqual([[promotedEntityId, 'subgraph_input_name']])
       expect(warnSpy).not.toHaveBeenCalled()

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -87,14 +87,22 @@ export const useAppModeStore = defineStore('appMode', () => {
     return !!app.rootGraph?.nodes?.length
   })
 
-  function pruneLinearData(data: Partial<LinearData> | undefined): {
+  /**
+   * Validates stored linear data against `graph` — the graph the data belongs
+   * to — upgrading legacy id forms and dropping entries whose nodes or widgets
+   * no longer exist. Omit `graph` when the owning workflow's graph is not
+   * loaded (e.g. a non-active workflow): ids are normalized but never dropped.
+   */
+  function pruneLinearData(
+    data: Partial<LinearData> | undefined,
+    graph?: LGraph | null
+  ): {
     inputs: LinearInput[]
     outputs: NodeId[]
   } {
     const rawInputs = data?.inputs ?? []
     const rawOutputs = data?.outputs ?? []
-    const rootGraph = app.rootGraph
-    if (!rootGraph) {
+    if (!graph) {
       return {
         inputs: rawInputs,
         outputs: rawOutputs.flatMap((nodeId) => {
@@ -105,12 +113,12 @@ export const useAppModeStore = defineStore('appMode', () => {
     }
     return {
       inputs: rawInputs
-        .map((input) => upgradeAndValidateInput(input, rootGraph))
+        .map((input) => upgradeAndValidateInput(input, graph))
         .filter((entry): entry is LinearInput => entry !== null),
       outputs: rawOutputs.flatMap((nodeId) => {
         const parsedNodeId = parseNodeId(nodeId)
         if (!parsedNodeId) return []
-        return ChangeTracker.isLoadingGraph || resolveNode(parsedNodeId)
+        return ChangeTracker.isLoadingGraph || resolveNode(parsedNodeId, graph)
           ? [parsedNodeId]
           : []
       })
@@ -127,7 +135,7 @@ export const useAppModeStore = defineStore('appMode', () => {
 
   function upgradeAndValidateInput(
     input: LinearInput,
-    rootGraph: NonNullable<typeof app.rootGraph>
+    rootGraph: LGraph
   ): LinearInput | null {
     const [storedId, widgetName, config] = input
 
@@ -142,7 +150,7 @@ export const useAppModeStore = defineStore('appMode', () => {
     }
 
     if (typeof storedId === 'string' && storedId.includes(':')) {
-      const [, widget] = resolveNodeWidget(storedId, widgetName)
+      const [, widget] = resolveNodeWidget(storedId, widgetName, rootGraph)
       if (!widget?.widgetId) return null
       return buildEntry(widget.widgetId, widgetName, config)
     }
@@ -188,7 +196,7 @@ export const useAppModeStore = defineStore('appMode', () => {
   }
 
   function loadSelections(data: Partial<LinearData> | undefined) {
-    const { inputs, outputs } = pruneLinearData(data)
+    const { inputs, outputs } = pruneLinearData(data, app.rootGraph)
     selectedInputs.value = inputs
     selectedOutputs.value = outputs
   }


### PR DESCRIPTION
## Summary

Opening the workflow actions menu for a non-active app workflow validated its stored builder config (`linearData`) against the active workflow's graph, dropping inputs/outputs that only exist in the target workflow — the menu then showed "Enter builder mode" instead of "Edit builder mode".

## Changes

- **What**: `pruneLinearData` (`src/stores/appModeStore.ts:96`) read `app.rootGraph` unconditionally, so `useWorkflowActionsMenu` pruning a non-active workflow's data resolved ids against the wrong graph. It now takes the graph the data belongs to and threads it through `upgradeAndValidateInput`, `resolveNodeWidget`, and the outputs branch; when the owning workflow's graph is not loaded (non-active), validation is skipped and ids are only normalized. Call sites operating on the active workflow (`loadSelections`, `useShareDialog`) pass `app.rootGraph` and keep their behavior. Adds a regression test.

## Review Focus

- Menu label semantics for non-active workflows now trust the workflow's saved `linearData` as-is; stale entries are still pruned when the workflow is actually opened.
