### PR TITLE
fix: recover workflow draft persistence after transient quota errors

### DIFF
--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -12,17 +12,6 @@ import type {
 } from './draftTypes'
 import { StorageKeys } from './storageKeys'
 
-/** Flag indicating if storage is available */
-let storageAvailable = true
-
-export function isStorageAvailable(): boolean {
-  return storageAvailable
-}
-
-export function markStorageUnavailable(): void {
-  storageAvailable = false
-}
-
 function isQuotaExceeded(error: unknown): boolean {
   return (
     error instanceof DOMException &&
@@ -49,8 +38,6 @@ function isValidIndex(value: unknown): value is DraftIndexV2 {
  * Reads and parses the draft index from localStorage.
  */
 export function readIndex(workspaceId: string): DraftIndexV2 | null {
-  if (!storageAvailable) return null
-
   try {
     const key = StorageKeys.draftIndex(workspaceId)
     const json = localStorage.getItem(key)
@@ -69,8 +56,6 @@ export function readIndex(workspaceId: string): DraftIndexV2 | null {
  * Writes the draft index to localStorage.
  */
 export function writeIndex(workspaceId: string, index: DraftIndexV2): boolean {
-  if (!storageAvailable) return false
-
   try {
     const key = StorageKeys.draftIndex(workspaceId)
     localStorage.setItem(key, JSON.stringify(index))
@@ -88,8 +73,6 @@ export function readPayload(
   workspaceId: string,
   draftKey: string
 ): DraftPayloadV2 | null {
-  if (!storageAvailable) return null
-
   try {
     const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
     const json = localStorage.getItem(key)
@@ -109,8 +92,6 @@ export function writePayload(
   draftKey: string,
   payload: DraftPayloadV2
 ): boolean {
-  if (!storageAvailable) return false
-
   try {
     const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
     localStorage.setItem(key, JSON.stringify(payload))
@@ -146,8 +127,6 @@ export function deletePayloads(workspaceId: string, draftKeys: string[]): void {
  * Gets all draft payload keys for a workspace from localStorage.
  */
 export function getPayloadKeys(workspaceId: string): string[] {
-  if (!storageAvailable) return []
-
   const prefix = `${StorageKeys.prefixes.draftPayload}${workspaceId}:`
   const keys: string[] = []
 
@@ -377,8 +356,6 @@ function writeStorage(storage: Storage, key: string, value: string): void {
  * Used during signout to prevent data leakage.
  */
 export function clearAllV2Storage(): void {
-  if (!storageAvailable) return
-
   const prefixes = [
     StorageKeys.prefixes.draftIndex,
     StorageKeys.prefixes.draftPayload,

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.quotaRecovery.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.quotaRecovery.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: a transient localStorage quota failure must not permanently
+ * disable draft persistence for the rest of the page's life.
+ *
+ * `storageIO.ts` used to keep a module-level `storageAvailable` flag that
+ * `workflowDraftStoreV2.handleQuotaExceeded()` flipped to `false` and nothing
+ * ever flipped back. Once storage pressure is relieved (or the user simply
+ * switches to a different, small workflow) drafts should be persisted again.
+ */
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    clientId: 'test-client',
+    initialClientId: 'test-client'
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    loadGraphData: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+/**
+ * Minimal Storage stand-in whose writes can be made to fail on demand.
+ * happy-dom's own `localStorage` is a Proxy, so its methods cannot be
+ * monkey-patched; we swap the whole global instead.
+ */
+class FakeStorage implements Storage {
+  readonly map = new Map<string, string>()
+  quotaExhausted = false
+
+  get length(): number {
+    return this.map.size
+  }
+
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.quotaExhausted) {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError')
+    }
+    this.map.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}
+
+let fakeStorage: FakeStorage
+let realLocalStorage: Storage
+
+/**
+ * Fresh module registry per test so no module-level state in storageIO
+ * leaks between cases.
+ */
+async function freshStore() {
+  vi.resetModules()
+  const { useWorkflowDraftStoreV2 } = await import('./workflowDraftStoreV2')
+  return useWorkflowDraftStoreV2()
+}
+
+describe('workflowDraftStoreV2 quota recovery', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    realLocalStorage = globalThis.localStorage
+    fakeStorage = new FakeStorage()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: fakeStorage,
+      configurable: true,
+      writable: true
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: realLocalStorage,
+      configurable: true,
+      writable: true
+    })
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('persists a later draft once storage pressure is relieved', async () => {
+    const store = await freshStore()
+
+    // A draft already exists, so the quota handler has something to evict.
+    expect(
+      store.saveDraft('workflows/big.json', '{"nodes":["big"]}', {
+        name: 'big',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    // Storage is momentarily full: every write throws QuotaExceededError.
+    fakeStorage.quotaExhausted = true
+
+    expect(
+      store.saveDraft('workflows/huge.json', 'x'.repeat(64), {
+        name: 'huge',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    // Pressure relieved — the user closed the huge workflow, the browser
+    // freed space, whatever. Writes work again.
+    fakeStorage.quotaExhausted = false
+    fakeStorage.clear()
+
+    const saved = store.saveDraft('workflows/small.json', '{"nodes":[]}', {
+      name: 'small',
+      isTemporary: true
+    })
+
+    expect(saved).toBe(true)
+
+    // Observable outcome: the draft is actually retrievable and on disk.
+    const draft = store.getDraft('workflows/small.json')
+    expect(draft).not.toBeNull()
+    expect(draft!.data).toBe('{"nodes":[]}')
+
+    const payloadKeys = [...fakeStorage.map.keys()].filter((k) =>
+      k.startsWith('Comfy.Workflow.Draft.v2:')
+    )
+    expect(payloadKeys).toHaveLength(1)
+  })
+})

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
@@ -27,8 +27,6 @@ import {
   deletePayload,
   deletePayloads,
   getPayloadKeys,
-  isStorageAvailable,
-  markStorageUnavailable,
   readIndex,
   readPayload,
   writeIndex,
@@ -104,8 +102,6 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
    * Primes index cache, writes payload, then persists updated index.
    */
   function saveDraft(path: string, data: string, meta: DraftMeta): boolean {
-    if (!isStorageAvailable()) return false
-
     const workspaceId = currentWorkspaceId()
     const draftKey = hashPath(path)
     const now = Date.now()
@@ -197,8 +193,6 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       }
     }
 
-    // All evictions failed - mark storage as unavailable
-    markStorageUnavailable()
     return false
   }
 


### PR DESCRIPTION
## Summary

Fixes workflow draft persistence being permanently disabled after a single localStorage `QuotaExceededError` — drafts now persist again once storage space is freed.

## Changes

- **What**: After one quota error, all draft writes silently no-oped for the rest of the page session, even after space was freed. Root cause: `storageIO.ts` kept a module-level `storageAvailable` flag that `handleQuotaExceeded()` (`workflowDraftStoreV2.ts`) latched to `false` after its eviction loop, and nothing ever reset it; `saveDraft()` then early-returned on every call. This removes the latch entirely: every save attempts the write, the existing LRU eviction loop still runs on quota failure (a cheap no-op once the index is empty), and the next write after pressure is relieved simply succeeds. Adds a regression test covering quota failure followed by recovery.

## Review Focus

- Removing the flag also un-gates reads and `clearAllV2Storage()`. Keeping reads gated while un-gating writes would let a gated `readIndex()` return `null`, causing a fresh empty index to be persisted over the real one and orphaning all payloads — so the flag has to go everywhere.
- Failure-toast behavior is unchanged: callers already toast on each `false` return from `saveDraft()`.
