### PR TITLE
fix: widget values misaligned on reload when a serialize:false widget precedes serialized ones

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -926,11 +926,23 @@ export class LGraphNode
       }
 
       if (info.widgets_values) {
-        let i = 0
-        for (const widget of this.widgets ?? []) {
-          if (widget.serialize === false) continue
-          if (i >= info.widgets_values.length) break
-          widget.value = info.widgets_values[i++]
+        const values = info.widgets_values
+        const serializableWidgets = this.widgets.filter(
+          (w) => w.serialize !== false
+        )
+        // serialize() indexes widgets_values by absolute widget position,
+        // leaving holes (null) at serialize:false widgets. Densely packed
+        // arrays (one value per serializable widget) are also accepted.
+        if (values.length === serializableWidgets.length) {
+          for (const [i, widget] of serializableWidgets.entries()) {
+            widget.value = values[i]
+          }
+        } else {
+          for (const [i, widget] of this.widgets.entries()) {
+            if (i >= values.length) break
+            if (widget.serialize === false) continue
+            widget.value = values[i]
+          }
         }
       }
     }

--- a/src/lib/litegraph/src/LGraphNode.widgetSerialization.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.widgetSerialization.test.ts
@@ -1,0 +1,90 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+function createNode() {
+  const node = new LGraphNode('TestNode')
+  node.serialize_widgets = true
+  return node
+}
+
+function roundTrip(source: LGraphNode, build: (node: LGraphNode) => void) {
+  const serialized = source.serialize()
+  const target = createNode()
+  build(target)
+  target.configure(serialized)
+  return target
+}
+
+describe('LGraphNode widget serialization round-trip', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('round-trips values when a non-serialized widget sits between serialized ones', () => {
+    const build = (node: LGraphNode) => {
+      node.addWidget('number', 'steps', 20, null, {})
+      node.addWidget('button', 'action', 'Click', null, {})
+      node.widgets![1].serialize = false
+      node.addWidget('number', 'seed', 0, null, {})
+    }
+
+    const source = createNode()
+    build(source)
+    source.widgets![0].value = 30
+    source.widgets![2].value = 12345
+
+    const restored = roundTrip(source, build)
+
+    expect(restored.widgets![0].value).toBe(30)
+    expect(restored.widgets![2].value).toBe(12345)
+  })
+
+  it('round-trips values when the first widget is non-serialized', () => {
+    const build = (node: LGraphNode) => {
+      node.addWidget('button', 'action', 'Click', null, {})
+      node.widgets![0].serialize = false
+      node.addWidget('number', 'steps', 20, null, {})
+      node.addWidget('text', 'prompt', '', null, {})
+    }
+
+    const source = createNode()
+    build(source)
+    source.widgets![1].value = 30
+    source.widgets![2].value = 'a prompt'
+
+    const restored = roundTrip(source, build)
+
+    expect(restored.widgets![1].value).toBe(30)
+    expect(restored.widgets![2].value).toBe('a prompt')
+  })
+
+  it('round-trips every primitive widget type', () => {
+    const build = (node: LGraphNode) => {
+      node.addWidget('number', 'steps', 20, null, {})
+      node.addWidget('text', 'prompt', '', null, {})
+      node.addWidget('toggle', 'enabled', false, null, {})
+      node.addWidget('combo', 'sampler', 'euler', null, {
+        values: ['euler', 'ddim', 'dpm']
+      })
+    }
+
+    const source = createNode()
+    build(source)
+    source.widgets![0].value = 42
+    source.widgets![1].value = 'a prompt'
+    source.widgets![2].value = true
+    source.widgets![3].value = 'ddim'
+
+    const restored = roundTrip(source, build)
+
+    expect(restored.widgets!.map((w) => w.value)).toEqual([
+      42,
+      'a prompt',
+      true,
+      'ddim'
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes widget values shifting or swapping onto the wrong widgets on workflow reload when a `serialize: false` widget (e.g. a preview or audio UI widget) precedes a serialized widget.

## Changes

- **What**: `LGraphNode.serialize()` writes `widgets_values` at each widget's absolute index while skipping `serialize: false` widgets (`src/lib/litegraph/src/LGraphNode.ts:995-1006`), producing a sparse array with `null` holes. `configure()` read it back with a compacted cursor, so every serialized widget after a skipped one received the wrong slot: for `[serialized, skipped, serialized]` the last widget loaded `null`; with the skipped widget first, values silently swapped. `configure()` (`src/lib/litegraph/src/LGraphNode.ts:928-947`) now reads by absolute index when the array length doesn't match the serializable-widget count, and keeps the packed interpretation when lengths match (densely packed files, and the no-skipped-widgets case where both readings coincide). Adds regression tests for both orderings.

## Review Focus

- The serialized format is unchanged, so workflows already saved in the sparse format — including ones corrupted by this bug on load today — now load correctly. Other consumers that index `widgets_values` by absolute position (`useNodeReplacement.ts`, `errorNodeWidgets.ts`, `widgetInputs.ts`, maskeditor saver) are unaffected.
- The length heuristic: sparse and packed arrays only differ in length when a skipped widget precedes a serialized one, so equal lengths safely fall back to the packed read that existing tests and hand-authored workflows rely on.
