### PR TITLE
fix: surface model download failures instead of reporting them in progress forever

### DIFF
--- a/src/components/sidebar/tabs/modelLibrary/DownloadItem.vue
+++ b/src/components/sidebar/tabs/modelLibrary/DownloadItem.vue
@@ -9,8 +9,18 @@
         removable
         @remove="handleRemoveDownload"
       >
-        {{ t('electronFileDownload.cancelled') }}
+        {{
+          download.status === 'error'
+            ? t('electronFileDownload.failed')
+            : t('electronFileDownload.cancelled')
+        }}
       </Chip>
+      <div
+        v-if="download.status === 'error' && download.message"
+        class="text-danger mt-1 text-sm"
+      >
+        {{ download.message }}
+      </div>
     </div>
     <div
       v-if="

--- a/src/components/sidebar/tabs/modelLibrary/ElectronDownloadItems.vue
+++ b/src/components/sidebar/tabs/modelLibrary/ElectronDownloadItems.vue
@@ -1,10 +1,10 @@
 <template>
-  <div v-if="inProgressDownloads.length > 0" class="mx-6 mb-4">
+  <div v-if="incompleteDownloads.length > 0" class="mx-6 mb-4">
     <div class="my-4 text-lg">
       {{ $t('electronFileDownload.inProgress') }}
     </div>
 
-    <template v-for="download in inProgressDownloads" :key="download.url">
+    <template v-for="download in incompleteDownloads" :key="download.url">
       <DownloadItem :download="download" />
     </template>
   </div>
@@ -18,5 +18,5 @@ import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
 import DownloadItem from './DownloadItem.vue'
 
 const electronDownloadStore = useElectronDownloadStore()
-const { inProgressDownloads } = storeToRefs(electronDownloadStore)
+const { incompleteDownloads } = storeToRefs(electronDownloadStore)
 </script>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1258,7 +1258,8 @@
     "paused": "Paused",
     "resume": "Resume Download",
     "cancel": "Cancel Download",
-    "cancelled": "Cancelled"
+    "cancelled": "Cancelled",
+    "failed": "Failed"
   },
   "maskEditor": {
     "title": "Mask Editor",

--- a/src/stores/electronDownloadStore.test.ts
+++ b/src/stores/electronDownloadStore.test.ts
@@ -1,0 +1,89 @@
+import { DownloadStatus } from '@comfyorg/comfyui-electron-types'
+import type {
+  DownloadProgressUpdate,
+  ElectronAPI
+} from '@comfyorg/comfyui-electron-types'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
+import type { ElectronDownload } from '@/stores/electronDownloadStore'
+
+vi.mock('@/platform/distribution/types', () => ({
+  isDesktop: true
+}))
+
+const progressCallbacks: ((progress: DownloadProgressUpdate) => void)[] = []
+
+const downloadManager = {
+  onDownloadProgress: vi.fn((callback: (p: DownloadProgressUpdate) => void) => {
+    progressCallbacks.push(callback)
+  }),
+  startDownload: vi.fn(),
+  cancelDownload: vi.fn(),
+  pauseDownload: vi.fn(),
+  resumeDownload: vi.fn(),
+  deleteModel: vi.fn(),
+  getAllDownloads: vi.fn(async () => [])
+}
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: () =>
+    ({ DownloadManager: downloadManager }) as unknown as ElectronAPI
+}))
+
+function emitProgress(update: DownloadProgressUpdate) {
+  progressCallbacks.forEach((callback) => callback(update))
+}
+
+describe('electronDownloadStore', () => {
+  beforeEach(() => {
+    progressCallbacks.length = 0
+    setActivePinia(createPinia())
+  })
+
+  const url = 'https://example.com/model.safetensors'
+  const errorMessage = 'EACCES: permission denied, open /models/checkpoints'
+
+  async function driveDownloadToFailure() {
+    const store = useElectronDownloadStore()
+    await store.initialize()
+
+    emitProgress({
+      url,
+      filename: 'model.safetensors',
+      savePath: '/models/checkpoints',
+      progress: 0.42,
+      status: DownloadStatus.IN_PROGRESS
+    })
+
+    expect(store.inProgressDownloads.map((d) => d.url)).toEqual([url])
+
+    emitProgress({
+      url,
+      filename: 'model.safetensors',
+      savePath: '/models/checkpoints',
+      progress: 0.42,
+      status: DownloadStatus.ERROR,
+      message: errorMessage
+    })
+
+    return store
+  }
+
+  it('surfaces the error of a failed download', async () => {
+    const store = await driveDownloadToFailure()
+
+    const download: (ElectronDownload & { message?: string }) | undefined =
+      store.findByUrl(url)
+
+    expect(download?.status).toBe(DownloadStatus.ERROR)
+    expect(download?.message).toBe(errorMessage)
+  })
+
+  it('stops reporting a failed download as in progress', async () => {
+    const store = await driveDownloadToFailure()
+
+    expect(store.inProgressDownloads.map((d) => d.url)).toEqual([])
+  })
+})

--- a/src/stores/electronDownloadStore.ts
+++ b/src/stores/electronDownloadStore.ts
@@ -13,7 +13,13 @@ export interface ElectronDownload extends Pick<
   progress?: number
   savePath?: string
   status?: DownloadStatus
+  message?: string
 }
+
+const isSettled = ({ status }: ElectronDownload) =>
+  status === DownloadStatus.COMPLETED ||
+  status === DownloadStatus.ERROR ||
+  status === DownloadStatus.CANCELLED
 
 /** Electron downloads store handler */
 export const useElectronDownloadStore = defineStore('downloads', () => {
@@ -44,6 +50,7 @@ export const useElectronDownloadStore = defineStore('downloads', () => {
         download.status = data.status
         download.filename = data.filename
         download.savePath = data.savePath
+        download.message = data.message
       }
     })
   }
@@ -72,6 +79,9 @@ export const useElectronDownloadStore = defineStore('downloads', () => {
     findByUrl,
     initialize,
     inProgressDownloads: computed(() =>
+      downloads.value.filter((download) => !isSettled(download))
+    ),
+    incompleteDownloads: computed(() =>
       downloads.value.filter(
         ({ status }) => status !== DownloadStatus.COMPLETED
       )


### PR DESCRIPTION
## Summary

A failed model download on desktop dropped its error message and was reported as in progress forever, including in the model-library sidebar badge count.

## Changes

- **What**:
  - `src/stores/electronDownloadStore.ts`: `onDownloadProgress` copied only `progress`/`status`/`filename`/`savePath` and dropped `DownloadProgressUpdate.message`; `ElectronDownload` now carries `message` so a failure surfaces its reason.
  - `inProgressDownloads` filtered `status !== COMPLETED`, so `error` and `cancelled` downloads counted as in progress indefinitely. It now excludes settled statuses (`completed`/`error`/`cancelled`); `paused` still counts, since a paused download is an active, resumable session.
  - The sidebar download list (`ElectronDownloadItems.vue`) intentionally shows failed/cancelled downloads so they can be dismissed — it now uses a new `incompleteDownloads` getter (everything not completed) instead of `inProgressDownloads`, so only the badge count changes behavior.
  - `DownloadItem.vue`: errored downloads were labeled "Cancelled"; they now show "Failed" plus the error message.

Adds a regression test covering error propagation and the in-progress count.

## Review Focus

Whether `paused` downloads should count toward the sidebar badge (kept counted here).
