### PR TITLE
fix: show unavailable state for app mode widgets on muted or missing nodes

### DIFF
--- a/src/components/builder/AppModeWidgetList.mutedNodes.test.ts
+++ b/src/components/builder/AppModeWidgetList.mutedNodes.test.ts
@@ -1,0 +1,186 @@
+import { render, screen } from '@testing-library/vue'
+import { fromAny } from '@total-typescript/shoehorn'
+import { computed } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type { WidgetId } from '@/types/widgetId'
+
+/**
+ * Regression coverage for silent widget loss in app mode.
+ *
+ * `AppModeWidgetList.vue:63-66` flat-maps away entries whose status is not
+ * `resolved` AND entries whose node mode is not `ALWAYS` (muted / bypassed).
+ * A published app therefore loses a control with no signal to the end user.
+ */
+
+const graphId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const seedWidgetId = `${graphId}:1:seed` as WidgetId
+const cfgWidgetId = `${graphId}:2:cfg` as WidgetId
+
+const resolvedEntries = vi.hoisted(() => ({ value: [] as unknown[] }))
+
+vi.mock('@/components/builder/useResolvedSelectedInputs', () => ({
+  useResolvedSelectedInputs: () => computed(() => resolvedEntries.value)
+}))
+
+vi.mock('@/components/builder/useAppModeWidgetResizing', () => ({
+  useAppModeWidgetResizing: () => ({ onPointerDown: vi.fn() })
+}))
+
+vi.mock('@/stores/appModeStore', () => ({
+  useAppModeStore: () => ({
+    updateInputConfig: vi.fn(),
+    removeSelectedInput: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => ({ surfacedNodeErrors: {} })
+}))
+
+vi.mock('@/composables/maskeditor/useMaskEditor', () => ({
+  useMaskEditor: () => ({ openMaskEditor: vi.fn() })
+}))
+
+vi.mock('@/composables/graph/useGraphNodeManager', () => ({
+  extractVueNodeData: (node: LGraphNode) => ({
+    id: node.id,
+    title: node.title,
+    widgets: node.widgets?.map((w) => ({
+      name: w.name,
+      widgetId: w.widgetId,
+      slotMetadata: undefined,
+      nodeId: node.id
+    }))
+  })
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: (route: string) => route }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { getPreviewFormatParam: () => '', dragOverNode: undefined }
+}))
+
+const AppModeWidgetList = (
+  await import('@/components/builder/AppModeWidgetList.vue')
+).default
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { rename: 'Rename', remove: 'Remove' },
+      linearMode: {
+        dragAndDropImage: 'Drop image',
+        widgetUnavailable: 'Widget unavailable'
+      }
+    }
+  }
+})
+
+function makeEntry(
+  widgetId: WidgetId,
+  nodeId: number,
+  widgetName: string,
+  mode: LGraphEventMode
+) {
+  const widget = fromAny<IBaseWidget, unknown>({
+    name: widgetName,
+    label: widgetName,
+    widgetId
+  })
+  const node = fromAny<LGraphNode, unknown>({
+    id: nodeId,
+    title: `Node ${nodeId}`,
+    type: 'KSampler',
+    mode,
+    widgets: [widget]
+  })
+  return {
+    status: 'resolved' as const,
+    widgetId,
+    node,
+    widget,
+    displayName: widgetName
+  }
+}
+
+function renderList() {
+  return render(AppModeWidgetList, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        NodeWidgets: true,
+        DropZone: { template: '<div><slot /></div>' },
+        Popover: { template: '<div><slot name="button" /></div>' },
+        Button: { template: '<button><slot /></button>' }
+      }
+    }
+  })
+}
+
+describe('AppModeWidgetList — muted / bypassed nodes', () => {
+  beforeEach(() => {
+    resolvedEntries.value = []
+  })
+
+  it('renders every selected widget when all nodes are active (baseline)', () => {
+    resolvedEntries.value = [
+      makeEntry(seedWidgetId, 1, 'seed', LGraphEventMode.ALWAYS),
+      makeEntry(cfgWidgetId, 2, 'cfg', LGraphEventMode.ALWAYS)
+    ]
+
+    renderList()
+
+    expect(screen.getAllByTestId('app-mode-widget-item')).toHaveLength(2)
+  })
+
+  it('does not silently drop a widget whose node is muted', () => {
+    resolvedEntries.value = [
+      makeEntry(seedWidgetId, 1, 'seed', LGraphEventMode.ALWAYS),
+      makeEntry(cfgWidgetId, 2, 'cfg', LGraphEventMode.NEVER)
+    ]
+
+    renderList()
+
+    // The muted widget must still be accounted for in the app — either
+    // rendered, or rendered in an explicit unavailable state. Vanishing with
+    // no signal is the bug.
+    expect(screen.getAllByTestId('app-mode-widget-item')).toHaveLength(2)
+    expect(screen.getAllByTestId('widget-unavailable')).toHaveLength(1)
+    expect(screen.getByText('Widget unavailable')).toBeTruthy()
+  })
+
+  it('does not silently drop a widget whose node is bypassed', () => {
+    resolvedEntries.value = [
+      makeEntry(seedWidgetId, 1, 'seed', LGraphEventMode.ALWAYS),
+      makeEntry(cfgWidgetId, 2, 'cfg', LGraphEventMode.BYPASS)
+    ]
+
+    renderList()
+
+    expect(screen.getAllByTestId('app-mode-widget-item')).toHaveLength(2)
+  })
+
+  it('does not silently drop an unresolved widget', () => {
+    resolvedEntries.value = [
+      makeEntry(seedWidgetId, 1, 'seed', LGraphEventMode.ALWAYS),
+      {
+        status: 'unknown' as const,
+        widgetId: cfgWidgetId,
+        displayName: 'cfg'
+      }
+    ]
+
+    renderList()
+
+    expect(screen.getAllByTestId('app-mode-widget-item')).toHaveLength(2)
+  })
+})

--- a/src/components/builder/AppModeWidgetList.vue
+++ b/src/components/builder/AppModeWidgetList.vue
@@ -26,14 +26,32 @@ import { HideLayoutFieldKey, WidgetHeightKey } from '@/types/widgetTypes'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import { promptRenameWidget } from '@/utils/widgetUtil'
 
-interface WidgetEntry {
+interface WidgetAction {
+  widget: IBaseWidget
+  node: LGraphNode
+}
+
+interface AvailableWidgetEntry {
+  status: 'available'
   key: string
+  label: string
+  nodeTitle: string
   persistedHeight: number | undefined
   nodeData: ReturnType<typeof nodeToNodeData> & {
     widgets: NonNullable<ReturnType<typeof nodeToNodeData>['widgets']>
   }
-  action: { widget: IBaseWidget; node: LGraphNode }
+  action: WidgetAction
 }
+
+interface UnavailableWidgetEntry {
+  status: 'unavailable'
+  key: string
+  label: string
+  nodeTitle?: string
+  action?: WidgetAction
+}
+
+type WidgetEntry = AvailableWidgetEntry | UnavailableWidgetEntry
 
 const { mobile = false, builderMode = false } = defineProps<{
   mobile?: boolean
@@ -60,10 +78,28 @@ const mappedSelections = computed((): WidgetEntry[] => {
     ReturnType<typeof nodeToNodeData>
   >()
 
-  return resolvedInputs.value.flatMap((entry) => {
-    if (entry.status !== 'resolved') return []
+  return resolvedInputs.value.flatMap((entry): WidgetEntry[] => {
+    if (entry.status !== 'resolved') {
+      return [
+        {
+          status: 'unavailable',
+          key: entry.widgetId,
+          label: entry.displayName
+        }
+      ]
+    }
     const { widgetId, node, widget, config } = entry
-    if (node.mode !== LGraphEventMode.ALWAYS) return []
+    if (node.mode !== LGraphEventMode.ALWAYS) {
+      return [
+        {
+          status: 'unavailable',
+          key: widgetId,
+          label: widget.label || widget.name,
+          nodeTitle: node.title,
+          action: { widget, node }
+        }
+      ]
+    }
 
     if (!nodeDataByNode.has(node)) {
       nodeDataByNode.set(node, nodeToNodeData(node))
@@ -81,7 +117,10 @@ const mappedSelections = computed((): WidgetEntry[] => {
 
     return [
       {
+        status: 'available',
         key: widgetId,
+        label: widget.label || widget.name,
+        nodeTitle: node.title,
         persistedHeight: config?.height,
         nodeData: {
           ...fullNodeData,
@@ -92,6 +131,21 @@ const mappedSelections = computed((): WidgetEntry[] => {
     ]
   })
 })
+
+function widgetMenuEntries({ widget, node }: WidgetAction) {
+  return [
+    {
+      label: t('g.rename'),
+      icon: 'icon-[lucide--pencil]',
+      command: () => promptRenameWidget(widget, node, t)
+    },
+    {
+      label: t('g.remove'),
+      icon: 'icon-[lucide--x]',
+      command: () => appModeStore.removeSelectedInput(widget)
+    }
+  ]
+}
 
 function getDropIndicator(node: LGraphNode) {
   if (node.type !== 'LoadImage') return undefined
@@ -135,8 +189,12 @@ function nodeToNodeData(node: LGraphNode) {
 
 async function handleDragDrop() {
   const onDragDrop = async (e: DragEvent) => {
-    for (const { nodeData } of mappedSelections.value)
-      if (nodeData?.onDragOver?.(e) && (await nodeData.onDragDrop?.(e)))
+    for (const entry of mappedSelections.value)
+      if (
+        entry.status === 'available' &&
+        entry.nodeData.onDragOver?.(e) &&
+        (await entry.nodeData.onDragDrop?.(e))
+      )
         return true
     return false
   }
@@ -148,8 +206,8 @@ defineExpose({ handleDragDrop })
 </script>
 <template>
   <div
-    v-for="{ key, persistedHeight, nodeData, action } in mappedSelections"
-    :key
+    v-for="entry in mappedSelections"
+    :key="entry.key"
     :class="
       cn(
         builderMode &&
@@ -158,11 +216,11 @@ defineExpose({ handleDragDrop })
     "
     :aria-label="
       builderMode
-        ? `${action.widget.label ?? action.widget.name} — ${action.node.title}`
+        ? [entry.label, entry.nodeTitle].filter(Boolean).join(' — ')
         : undefined
     "
     :data-testid="builderMode ? 'builder-widget-item' : 'app-mode-widget-item'"
-    :data-widget-key="key"
+    :data-widget-key="entry.key"
   >
     <div
       :class="
@@ -176,29 +234,19 @@ defineExpose({ handleDragDrop })
         :class="cn('truncate text-sm/8', builderMode && 'pointer-events-none')"
         data-testid="builder-widget-label"
       >
-        {{ action.widget.label || action.widget.name }}
+        {{ entry.label }}
       </span>
       <span
-        v-if="builderMode"
+        v-if="builderMode && entry.nodeTitle"
         class="pointer-events-none mx-1 min-w-10 flex-1 truncate text-right text-xs text-muted-foreground"
       >
-        {{ action.node.title }}
+        {{ entry.nodeTitle }}
       </span>
       <div v-else class="flex-1" />
       <Popover
+        v-if="entry.action"
         :class="cn('shrink-0', builderMode && 'pointer-events-auto')"
-        :entries="[
-          {
-            label: t('g.rename'),
-            icon: 'icon-[lucide--pencil]',
-            command: () => promptRenameWidget(action.widget, action.node, t)
-          },
-          {
-            label: t('g.remove'),
-            icon: 'icon-[lucide--x]',
-            command: () => appModeStore.removeSelectedInput(action.widget)
-          }
-        ]"
+        :entries="widgetMenuEntries(entry.action)"
       >
         <template #button>
           <Button
@@ -212,37 +260,47 @@ defineExpose({ handleDragDrop })
       </Popover>
     </div>
     <div
+      v-if="entry.status === 'available'"
       :style="
-        persistedHeight
-          ? { '--persisted-height': `${persistedHeight}px` }
+        entry.persistedHeight
+          ? { '--persisted-height': `${entry.persistedHeight}px` }
           : undefined
       "
       :class="
         cn(
           builderMode && 'pointer-events-none',
-          persistedHeight &&
+          entry.persistedHeight &&
             '**:data-[slot=drop-zone-indicator]:h-(--persisted-height) [&_textarea]:h-(--persisted-height)'
         )
       "
       :inert="builderMode || undefined"
-      @pointerdown.capture="(e) => onPointerDown(action.widget, e)"
+      @pointerdown.capture="(e) => onPointerDown(entry.action.widget, e)"
     >
       <DropZone
-        :on-drag-over="nodeData.onDragOver"
-        :on-drag-drop="nodeData.onDragDrop"
-        :drop-indicator="nodeData.dropIndicator"
+        :on-drag-over="entry.nodeData.onDragOver"
+        :on-drag-drop="entry.nodeData.onDragDrop"
+        :drop-indicator="entry.nodeData.dropIndicator"
         class="text-muted-foreground"
       >
         <NodeWidgets
-          :node-data
+          :node-data="entry.nodeData"
           :class="
             cn(
               'gap-y-3 rounded-lg py-1 [&_textarea]:resize-y **:[.col-span-2]:grid-cols-1',
-              nodeData.hasErrors && 'ring-2 ring-node-stroke-error ring-inset'
+              entry.nodeData.hasErrors &&
+                'ring-2 ring-node-stroke-error ring-inset'
             )
           "
         />
       </DropZone>
+    </div>
+    <div
+      v-else
+      class="mx-3 mb-1.5 flex items-center gap-2 rounded-lg border border-dashed border-border-subtle px-3 py-2 text-sm text-muted-foreground"
+      data-testid="widget-unavailable"
+    >
+      <i class="icon-[lucide--eye-off] shrink-0" />
+      <span>{{ t('linearMode.widgetUnavailable') }}</span>
     </div>
   </div>
 </template>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3789,6 +3789,7 @@
     "hasCreditCost": "Requires additional credits",
     "viewGraph": "View node graph",
     "mobileNoWorkflow": "This workflow hasn't been built for app mode. Try a different one.",
+    "widgetUnavailable": "Widget unavailable",
     "welcome": {
       "title": "App Mode",
       "message": "A simplified view that hides the node graph so you can focus on creating.",


### PR DESCRIPTION
## Summary

In app mode, a promoted widget on a muted or bypassed node (or one whose node/widget no longer resolves) silently vanished from the widget panel, so a published app quietly lost a control with no signal to the user.

## Changes

- **What**: `AppModeWidgetList.vue` (`src/components/builder/AppModeWidgetList.vue:63-66` before this change) flat-mapped away entries whose status was not `resolved` or whose node mode was not `ALWAYS`. These entries are now kept and rendered as an explicit unavailable row: the widget label (and node title in builder mode) with a muted "Widget unavailable" note in place of the widget body. The rename/remove menu is kept when the underlying widget still exists (muted/bypassed node), so a dead control can still be removed from the panel.
- Rendering one row per selected input also keeps `DraggableList` reordering aligned: it reorders `selectedInputs` by DOM index, so silently dropped rows previously made drag reordering in the builder act on the wrong entries.
- Adds a regression test (`AppModeWidgetList.mutedNodes.test.ts`) covering the muted, bypassed, and unresolved cases.

## Review Focus

The unavailable-row UX is intentionally minimal (muted dashed row with an eye-off icon reusing existing tokens). Design review welcome on the exact treatment and copy.
