### PR TITLE
fix: prevent draft loss on load when client clock runs behind server

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -332,7 +332,8 @@ describe('useWorkflowService', () => {
         JSON.stringify(activeWorkflow.activeState),
         {
           name: activeWorkflow.key,
-          isTemporary: activeWorkflow.isTemporary
+          isTemporary: activeWorkflow.isTemporary,
+          baseLastModified: activeWorkflow.lastModified
         }
       )
     })

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -75,7 +75,8 @@ export const useWorkflowService = () => {
         JSON.stringify(activeState),
         {
           name: activeWorkflow.key,
-          isTemporary: activeWorkflow.isTemporary
+          isTemporary: activeWorkflow.isTemporary,
+          baseLastModified: activeWorkflow.lastModified
         }
       )
 

--- a/src/platform/workflow/management/stores/comfyWorkflow.draftFreshness.test.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.draftFreshness.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression: draft freshness must not be decided by comparing a
+ * client-generated timestamp against a server-generated one.
+ *
+ * `ComfyWorkflow.load()` (comfyWorkflow.ts:120) discards a draft when
+ * `draft.updatedAt < this.lastModified`. `draft.updatedAt` comes from the
+ * browser's `Date.now()` at draft-save time, while `lastModified` comes from
+ * the server. A client clock running behind the server therefore throws away
+ * a draft that is genuinely newer than the saved workflow.
+ */
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pre-load the module graph that ComfyWorkflow.load() imports dynamically,
+// so its one-time transform cost is not billed to the first test's timeout.
+import '@/scripts/changeTracker'
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+
+import { ComfyWorkflow } from './comfyWorkflow'
+
+const SERVER_CONTENT = JSON.stringify({
+  id: 'server',
+  nodes: [],
+  links: [],
+  revision: 0
+})
+const DRAFT_CONTENT = JSON.stringify({
+  id: 'draft',
+  nodes: [{ id: 1 }],
+  links: [],
+  revision: 1
+})
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    clientId: 'test-client',
+    initialClientId: 'test-client',
+    getUserData: vi.fn(async () => ({
+      status: 200,
+      statusText: 'OK',
+      text: async () => SERVER_CONTENT
+    }))
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    loadGraphData: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: (key: string) => (key === 'Comfy.Workflow.Persist' ? true : undefined)
+  })
+}))
+
+/** Wall-clock instant, per the server, at which the workflow was last saved. */
+const SERVER_SAVED_AT = Date.parse('2026-07-20T12:00:00.000Z')
+/** The browser's clock runs five minutes behind the server. */
+const CLIENT_SKEW_MS = 5 * 60 * 1000
+/** The user edited 30 real seconds after the server save. */
+const REAL_ELAPSED_MS = 30 * 1000
+
+describe('ComfyWorkflow draft freshness under clock skew', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('keeps a draft written after the server save when the client clock lags', async () => {
+    const path = 'workflows/skewed.json'
+    const draftStore = useWorkflowDraftStoreV2()
+
+    // The draft is written after the server save in real time, but the
+    // browser stamps it with its own (lagging) clock.
+    vi.setSystemTime(SERVER_SAVED_AT + REAL_ELAPSED_MS - CLIENT_SKEW_MS)
+    expect(
+      draftStore.saveDraft(path, DRAFT_CONTENT, {
+        name: 'skewed',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const workflow = new ComfyWorkflow({
+      path,
+      modified: SERVER_SAVED_AT,
+      size: SERVER_CONTENT.length
+    })
+
+    const loaded = await workflow.load()
+
+    // The draft is the newer edit and must win.
+    expect(loaded.activeState).toEqual(JSON.parse(DRAFT_CONTENT))
+    expect(loaded.isModified).toBe(true)
+    // ...and must still be on disk for the next load.
+    expect(draftStore.getDraft(path)).not.toBeNull()
+  })
+
+  // Control: proves the harness itself restores drafts when clocks agree,
+  // so the failure above is attributable to the skew and nothing else.
+  it('keeps a draft written after the server save when clocks agree', async () => {
+    const path = 'workflows/aligned.json'
+    const draftStore = useWorkflowDraftStoreV2()
+
+    vi.setSystemTime(SERVER_SAVED_AT + REAL_ELAPSED_MS)
+    expect(
+      draftStore.saveDraft(path, DRAFT_CONTENT, {
+        name: 'aligned',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const workflow = new ComfyWorkflow({
+      path,
+      modified: SERVER_SAVED_AT,
+      size: SERVER_CONTENT.length
+    })
+
+    const loaded = await workflow.load()
+
+    expect(loaded.activeState).toEqual(JSON.parse(DRAFT_CONTENT))
+    expect(loaded.isModified).toBe(true)
+  })
+
+  it('keeps a draft based on the current server revision when the client clock lags', async () => {
+    const path = 'workflows/based-on-current.json'
+    const draftStore = useWorkflowDraftStoreV2()
+
+    vi.setSystemTime(SERVER_SAVED_AT + REAL_ELAPSED_MS - CLIENT_SKEW_MS)
+    expect(
+      draftStore.saveDraft(path, DRAFT_CONTENT, {
+        name: 'based-on-current',
+        isTemporary: false,
+        baseLastModified: SERVER_SAVED_AT
+      })
+    ).toBe(true)
+
+    const workflow = new ComfyWorkflow({
+      path,
+      modified: SERVER_SAVED_AT,
+      size: SERVER_CONTENT.length
+    })
+
+    const loaded = await workflow.load()
+
+    expect(loaded.activeState).toEqual(JSON.parse(DRAFT_CONTENT))
+    expect(loaded.isModified).toBe(true)
+    expect(draftStore.getDraft(path)).not.toBeNull()
+  })
+
+  it('discards a draft based on an older server revision even when the client clock runs ahead', async () => {
+    const path = 'workflows/based-on-older.json'
+    const draftStore = useWorkflowDraftStoreV2()
+
+    // The server file was saved again (e.g. from another device) after the
+    // revision this draft was based on. A fast client clock must not mask that.
+    vi.setSystemTime(SERVER_SAVED_AT + CLIENT_SKEW_MS)
+    expect(
+      draftStore.saveDraft(path, DRAFT_CONTENT, {
+        name: 'based-on-older',
+        isTemporary: false,
+        baseLastModified: SERVER_SAVED_AT - REAL_ELAPSED_MS
+      })
+    ).toBe(true)
+
+    const workflow = new ComfyWorkflow({
+      path,
+      modified: SERVER_SAVED_AT,
+      size: SERVER_CONTENT.length
+    })
+
+    const loaded = await workflow.load()
+
+    expect(loaded.activeState).toEqual(JSON.parse(SERVER_CONTENT))
+    expect(loaded.isModified).toBe(false)
+    expect(draftStore.getDraft(path)).toBeNull()
+  })
+})

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -117,7 +117,13 @@ export class ComfyWorkflow extends UserFile {
     let draftContent: string | null = null
 
     if (draft) {
-      if (draft.updatedAt < this.lastModified) {
+      // Both timestamps are server-generated, so this stays correct under
+      // client clock skew. Drafts without a recorded base predate that field;
+      // their freshness is unknowable, so they are kept rather than discarded.
+      const serverChangedSinceDraft =
+        draft.baseLastModified !== undefined &&
+        this.lastModified > draft.baseLastModified
+      if (serverChangedSinceDraft) {
         draftStore.removeDraft(this.path)
         draft = undefined
       }

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -79,12 +79,14 @@ describe('useWorkflowStore', () => {
       data?: string
       name?: string
       isTemporary?: boolean
+      baseLastModified?: number
     } = {}
   ) => {
     const draftStore = useWorkflowDraftStoreV2()
     draftStore.saveDraft(path, options.data ?? '{"dirty":true}', {
       name: options.name ?? path.split('/').at(-1) ?? path,
-      isTemporary: options.isTemporary ?? false
+      isTemporary: options.isTemporary ?? false,
+      baseLastModified: options.baseLastModified
     })
     return draftStore
   }
@@ -351,7 +353,8 @@ describe('useWorkflowStore', () => {
       }
       const draftStore = saveV2Draft(workflow.path, {
         data: JSON.stringify(draftGraph),
-        name: 'a.json'
+        name: 'a.json',
+        baseLastModified: remoteModifiedAt - 60_000
       })
 
       vi.mocked(api.getUserData).mockResolvedValue({

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -506,7 +506,12 @@ export const useWorkflowStore = defineStore('workflow', () => {
         openWorkflowPaths.value.splice(openIndex, 1, workflow.path)
       }
 
-      draftStore.moveDraft(oldPath, newPath, workflow.key)
+      draftStore.moveDraft(
+        oldPath,
+        newPath,
+        workflow.key,
+        workflow.lastModified
+      )
 
       // Move thumbnail from old key to new key (using workflow keys, not full paths)
       const newKey = workflow.key

--- a/src/platform/workflow/persistence/base/draftTypes.ts
+++ b/src/platform/workflow/persistence/base/draftTypes.ts
@@ -51,6 +51,13 @@ export interface DraftPayloadV2 {
   data: string
   /** Last workflow content write timestamp. */
   updatedAt: number
+  /**
+   * Server-reported lastModified of the file revision this draft was based
+   * on. Compared against the file's current lastModified to detect drafts
+   * made stale by a save from elsewhere, without mixing client and server
+   * clocks. Absent on drafts saved before this field existed.
+   */
+  baseLastModified?: number
 }
 
 /**

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -106,7 +106,8 @@ export function useWorkflowPersistenceV2() {
     // Save to V2 draft store
     const saved = draftStore.saveDraft(workflowPath, workflowJson, {
       name: activeWorkflow.key,
-      isTemporary: activeWorkflow.isTemporary
+      isTemporary: activeWorkflow.isTemporary,
+      baseLastModified: activeWorkflow.lastModified
     })
 
     if (!saved) {

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
@@ -40,6 +40,8 @@ import { app as comfyApp } from '@/scripts/app'
 interface DraftMeta {
   name: string
   isTemporary: boolean
+  /** Server lastModified of the file revision the draft is based on. */
+  baseLastModified?: number
 }
 
 interface LoadPersistedWorkflowOptions {
@@ -109,6 +111,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     const workspaceId = currentWorkspaceId()
     const draftKey = hashPath(path)
     const now = Date.now()
+    const { baseLastModified, ...entryMeta } = meta
 
     // Prime the index cache before writing payload.
     // loadIndex() runs orphan cleanup on cache miss, which would
@@ -118,7 +121,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     // Write payload before persisting the updated index
     const payloadWritten = writePayload(workspaceId, draftKey, {
       data,
-      updatedAt: now
+      updatedAt: now,
+      baseLastModified
     })
 
     if (!payloadWritten) {
@@ -128,7 +132,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     const { index: newIndex, evicted } = upsertEntry(
       index,
       path,
-      { ...meta, updatedAt: now },
+      { ...entryMeta, updatedAt: now },
       MAX_DRAFTS
     )
 
@@ -156,6 +160,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     const workspaceId = currentWorkspaceId()
     const index = loadIndex()
     const draftKey = hashPath(path)
+    const { baseLastModified, ...entryMeta } = meta
 
     // Try evicting oldest entries until we can write
     let currentIndex = index
@@ -178,7 +183,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       // Try writing again
       const success = writePayload(workspaceId, draftKey, {
         data,
-        updatedAt: Date.now()
+        updatedAt: Date.now(),
+        baseLastModified
       })
 
       if (success) {
@@ -186,7 +192,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
         const { index: finalIndex } = upsertEntry(
           currentIndex,
           path,
-          { ...meta, updatedAt: Date.now() },
+          { ...entryMeta, updatedAt: Date.now() },
           MAX_DRAFTS
         )
         if (!persistIndex(finalIndex)) {
@@ -218,8 +224,15 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
 
   /**
    * Moves a draft from one path to another (rename).
+   * A rename bumps the file's server lastModified without changing content,
+   * so callers should pass the post-rename value as the draft's new base.
    */
-  function moveDraft(oldPath: string, newPath: string, name: string): void {
+  function moveDraft(
+    oldPath: string,
+    newPath: string,
+    name: string,
+    baseLastModified?: number
+  ): void {
     const workspaceId = currentWorkspaceId()
     const index = loadIndex()
     const result = moveEntry(index, oldPath, newPath, name)
@@ -229,7 +242,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       if (oldPayload) {
         const written = writePayload(workspaceId, result.newKey, {
           data: oldPayload.data,
-          updatedAt: oldPayload.updatedAt
+          updatedAt: oldPayload.updatedAt,
+          baseLastModified: baseLastModified ?? oldPayload.baseLastModified
         })
         if (!written) return
 
@@ -250,6 +264,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     name: string
     isTemporary: boolean
     updatedAt: number
+    baseLastModified: number | undefined
   } | null {
     const workspaceId = currentWorkspaceId()
     const index = loadIndex()
@@ -268,7 +283,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       data: payload.data,
       name: entry.name,
       isTemporary: entry.isTemporary,
-      updatedAt: payload.updatedAt
+      updatedAt: payload.updatedAt,
+      baseLastModified: payload.baseLastModified
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes unsaved work being lost on load: a live local draft was discarded whenever the client clock ran behind the server.

## Changes

- **What**: `ComfyWorkflow.load()` (`src/platform/workflow/management/stores/comfyWorkflow.ts:120`) decided draft freshness by comparing `draft.updatedAt` — a browser `Date.now()` captured at draft-save time — against the server-reported `lastModified`. With the client clock behind the server, a draft newer than the saved file failed the comparison and was deleted. Drafts now record `baseLastModified`, the server `lastModified` of the file revision they were based on, at every draft-save site; load discards a draft only when the file's current `lastModified` is newer than that base, a server-clock vs server-clock comparison unaffected by client skew. `moveDraft` re-stamps the base on rename (a rename bumps the file mtime without changing content, which would otherwise spuriously invalidate the draft). Drafts saved before the field existed have unknowable freshness and are kept rather than discarded. Adds a regression test.

## Review Focus

- The bias for legacy drafts (no recorded base): they are kept instead of discarded, preferring preserving unsaved work over stale-draft cleanup for the one-time migration window.
- Staleness detection is preserved: a draft based on an older revision is still discarded when the file was saved from elsewhere, now regardless of skew direction (covered by test).
