### PR TITLE
fix(cloud): require explicit confirmation before team plan checkout

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2757,7 +2757,14 @@
       "ctaMonthly": "Subscribe to Team Monthly",
       "unavailable": "This team plan is not available right now.",
       "changePlan": "Change plan",
-      "currentPlan": "Current plan"
+      "currentPlan": "Current plan",
+      "confirmHeading": "Confirm your Team subscription",
+      "confirmCreditsPerMonth": "{credits} credits / month",
+      "billedMonthly": "Billed monthly",
+      "billedYearly": "Billed yearly",
+      "confirmChargeNotice": "Continuing subscribes your workspace and charges the payment method on file.",
+      "confirmCta": "Confirm & subscribe",
+      "confirmCancel": "Cancel"
     },
     "enterprise": {
       "name": "Enterprise",

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -82,7 +83,17 @@ const createI18nInstance = () =>
         },
         subscription: {
           subscribeTo: 'Subscribe to {plan}',
-          teamPlan: { name: 'Team Plan' },
+          teamPlan: {
+            name: 'Team Plan',
+            confirmHeading: 'Confirm your Team subscription',
+            confirmCreditsPerMonth: '{credits} credits / month',
+            billedMonthly: 'Billed monthly',
+            billedYearly: 'Billed yearly',
+            confirmChargeNotice:
+              'Continuing subscribes your workspace and charges the payment method on file.',
+            confirmCta: 'Confirm & subscribe',
+            confirmCancel: 'Cancel'
+          },
           tiers: {
             standard: { name: 'Standard' },
             creator: { name: 'Creator' },
@@ -179,11 +190,27 @@ describe('CloudSubscriptionRedirectView', () => {
     )
   })
 
-  test('checks out the team plan via the workspace path with the chosen stop and cycle', async () => {
+  test('stages the team plan and does not charge until the user confirms', async () => {
     await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
 
     expect(mockRouterPush).not.toHaveBeenCalledWith('/')
-    expect(screen.getByText('Subscribe to Team Plan')).toBeInTheDocument()
+    // A confirmation is shown instead of an immediate charge
+    expect(
+      screen.getByText('Confirm your Team subscription')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/147,700 credits \/ month/)).toBeInTheDocument()
+    // Nothing is charged on mount
+    expect(mockPerformTeamSubscriptionCheckout).not.toHaveBeenCalled()
+  })
+
+  test('checks out the team plan via the workspace path once confirmed', async () => {
+    await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm & subscribe/i })
+    )
+    await flushPromises()
+
     expect(mockPerformTeamSubscriptionCheckout).toHaveBeenCalledWith(
       'team_700',
       'yearly',
@@ -191,6 +218,16 @@ describe('CloudSubscriptionRedirectView', () => {
     )
     // Team never goes through the personal checkout path
     expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+  })
+
+  test('cancelling the team confirmation goes home without charging', async () => {
+    await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await flushPromises()
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/')
+    expect(mockPerformTeamSubscriptionCheckout).not.toHaveBeenCalled()
   })
 
   test('redirects to home for a team link with no stop', async () => {

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -8,6 +8,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { TEAM_PLAN_CREDIT_STOPS } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
 import { performTeamSubscriptionCheckout } from '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil'
@@ -45,10 +46,32 @@ const tierDisplayName = computed(() => {
   return names[selectedTierKey.value]
 })
 
-const isTeamCheckout = ref(false)
+// The team plan checks out through the workspace endpoint, which charges the
+// payment method on file directly rather than opening a hosted Stripe page. So
+// unlike personal tiers (whose checkout URL / billing portal is itself the
+// confirmation), a team deep link must present its own confirmation before it
+// can charge — otherwise a subscribed user following the link is billed with no
+// consent step.
+const pendingTeam = ref<{ stopId: string; cycle: BillingCycle } | null>(null)
+const teamCheckoutStarted = ref(false)
+
+const teamCreditsLabel = computed(() => {
+  if (!pendingTeam.value) return null
+  const usd = Number(pendingTeam.value.stopId.replace(/^team_/, ''))
+  const stop = TEAM_PLAN_CREDIT_STOPS.find((s) => s.usd === usd)
+  return stop ? stop.credits.toLocaleString() : null
+})
+
+const teamCycleLabel = computed(() =>
+  pendingTeam.value?.cycle === 'yearly'
+    ? t('subscription.teamPlan.billedYearly')
+    : t('subscription.teamPlan.billedMonthly')
+)
 
 const planLabel = computed(() =>
-  isTeamCheckout.value ? t('subscription.teamPlan.name') : tierDisplayName.value
+  teamCheckoutStarted.value
+    ? t('subscription.teamPlan.name')
+    : tierDisplayName.value
 )
 
 const runRedirect = wrapWithErrorHandlingAsync(async () => {
@@ -79,8 +102,8 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     : 'monthly'
 
   // Team is a per-credit plan picked on a slider, so it carries a `stop` (the
-  // chosen credit commitment) instead of a tier and checks out through the
-  // workspace billing endpoint rather than the personal one.
+  // chosen credit commitment) instead of a tier. Stage the checkout and wait
+  // for explicit confirmation instead of charging on mount.
   if (tierKeyParam === 'team') {
     const rawStop = route.query.stop
     const stopId =
@@ -93,10 +116,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
       await router.push('/')
       return
     }
-    isTeamCheckout.value = true
-    await performTeamSubscriptionCheckout(stopId, billingCycle, {
-      paymentIntentSource: 'deep_link'
-    })
+    pendingTeam.value = { stopId, cycle: billingCycle }
     return
   }
 
@@ -121,6 +141,19 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
   }
 }, reportError)
 
+const confirmTeamCheckout = wrapWithErrorHandlingAsync(async () => {
+  const staged = pendingTeam.value
+  if (!staged || teamCheckoutStarted.value) return
+  teamCheckoutStarted.value = true
+  await performTeamSubscriptionCheckout(staged.stopId, staged.cycle, {
+    paymentIntentSource: 'deep_link'
+  })
+}, reportError)
+
+const cancelTeamCheckout = async () => {
+  await router.push('/')
+}
+
 onMounted(() => {
   void runRedirect()
 })
@@ -130,7 +163,45 @@ onMounted(() => {
   <div
     class="bg-comfy-menu-secondary-bg flex size-full items-center justify-center"
   >
-    <div class="flex flex-col items-center gap-4">
+    <div
+      v-if="pendingTeam && !teamCheckoutStarted"
+      class="flex w-full max-w-sm flex-col items-center gap-4 px-6 text-center"
+    >
+      <img
+        src="/assets/images/comfy-logo-single.svg"
+        :alt="t('g.comfyOrgLogoAlt')"
+        class="size-16"
+      />
+      <h1 class="font-inter text-lg/normal font-medium text-base-foreground">
+        {{ t('subscription.teamPlan.confirmHeading') }}
+      </h1>
+      <p
+        v-if="teamCreditsLabel"
+        class="font-inter text-base/normal font-normal text-base-foreground"
+      >
+        {{
+          t('subscription.teamPlan.confirmCreditsPerMonth', {
+            credits: teamCreditsLabel
+          })
+        }}
+        · {{ teamCycleLabel }}
+      </p>
+      <p class="font-inter text-sm/normal font-normal text-muted">
+        {{ t('subscription.teamPlan.confirmChargeNotice') }}
+      </p>
+      <Button
+        class="w-full"
+        :label="t('subscription.teamPlan.confirmCta')"
+        @click="confirmTeamCheckout"
+      />
+      <Button
+        link
+        :label="t('subscription.teamPlan.confirmCancel')"
+        @click="cancelTeamCheckout"
+      />
+    </div>
+
+    <div v-else class="flex flex-col items-center gap-4">
       <img
         src="/assets/images/comfy-logo-single.svg"
         :alt="t('g.comfyOrgLogoAlt')"


### PR DESCRIPTION
## Summary

The `cloud.comfy.org/cloud/subscribe?tier=team&stop=…` deep link checked out the per-credit Team plan **immediately on mount**, with no confirmation step. Unlike personal tiers — whose hosted Stripe Checkout page (new) or billing portal (existing subscriber) is itself the confirmation — the team path routes through `POST /api/billing/subscribe`, which charges the payment method on file directly. So a user who already has a card on file and follows a Team link was subscribed and charged with no consent step, then dropped back to `/`.

This gates the team deep link behind an explicit confirmation, matching the intent that **no charge happens without the user confirming**.

## Changes

- `CloudSubscriptionRedirectView.vue`: the `team` branch no longer calls `performTeamSubscriptionCheckout` on mount. It stages the chosen `stop` + `cycle` and renders a confirmation (plan name, monthly credits, billing cadence, and a "charges the payment method on file" notice). The workspace checkout fires only when the user clicks **Confirm & subscribe**; a **Cancel** link returns home.
- Personal tiers (standard/creator/pro/founder) are unchanged — they already confirm via hosted checkout / billing portal.
- New `subscription.teamPlan.confirm*` / `billed*` i18n keys.

## Why frontend-only

- The team CTA that produces this deep link is not on `main` yet — it ships in the website Education PR (#13406). This fix makes the deep link safe **before** that CTA reaches users.
- The backend already refuses a team subscribe when the workspace has an active subscription (`billing_write.go`: "team plan changes are not supported yet"). The remaining charge path is a fresh workspace's *initial* team subscribe, which is standard billing behavior — the missing piece was the client-side confirmation, added here.

## Tests

`CloudSubscriptionRedirectView.test.ts`: team now (a) stages without charging on mount, (b) charges only after the confirm click, (c) cancels home without charging. Personal-tier tests unchanged. 9/9 pass.

## Companion
Related exposure: website Team CTA in #13406 (do not merge that CTA to prod until this ships to the cloud build).