### PR TITLE
fix(litegraph): persist renamed widget labels via renameWidget input lookup (minimal alternative to #13865)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.widgetLabelRename.regression.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.widgetLabelRename.regression.test.ts
@@ -1,0 +1,147 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  LGraph,
+  LGraphCanvas,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
+import { renameWidget } from '@/utils/widgetUtil'
+
+/**
+ * Mimics a normal core node (e.g. CLIPTextEncode): a `text` widget backed by a
+ * plain input slot whose `widget.name` matches the widget. A normal-node input
+ * never receives a `widgetId` (only subgraph/promotion inputs do), which is the
+ * precondition that triggered the `renameWidget` lookup bug.
+ */
+class ClipTextEncodeLikeNode extends LGraphNode {
+  static override title = 'CLIPTextEncodeLike'
+  constructor() {
+    super('CLIPTextEncodeLike')
+    this.serialize_widgets = true
+    this.addWidget('text', 'text', 'a cat', null)
+    const input = this.addInput('text', 'STRING')
+    input.widget = { name: 'text' }
+  }
+}
+
+LiteGraph.registerNodeType('test/CLIPTextEncodeLike', ClipTextEncodeLikeNode)
+
+/**
+ * Regression #13861: a renamed widget label reverted to its default on
+ * save/reload, delete/undo, and copy/paste for normal (input-backed) nodes.
+ *
+ * Root cause: `renameWidget` looked up the backing input by `widgetId` whenever
+ * the widget had one (true for every in-graph widget), but normal-node inputs
+ * carry no `widgetId`, so the lookup found nothing and never wrote `input.label`
+ * — the channel the label round-trips through. These tests drive the real
+ * `renameWidget` (never hand-setting `widget.label`) and assert the label
+ * survives a real serialize -> configure round-trip.
+ */
+describe('renameWidget label persistence via input lookup (regression #13861)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    Object.assign(LiteGraph, {
+      NODE_TITLE_HEIGHT: 20,
+      NODE_SLOT_HEIGHT: 15,
+      NODE_TEXT_SIZE: 14,
+      isValidConnection: vi.fn().mockReturnValue(true)
+    })
+  })
+
+  function addClipNode(graph: LGraph): LGraphNode {
+    const node = LiteGraph.createNode('test/CLIPTextEncodeLike')!
+    graph.add(node)
+    return node
+  }
+
+  function createCanvas(graph: LGraph): LGraphCanvas {
+    const el = document.createElement('canvas')
+    el.width = 800
+    el.height = 600
+    el.getContext = vi
+      .fn()
+      .mockReturnValue(createMockCanvasRenderingContext2D())
+    el.getBoundingClientRect = vi
+      .fn()
+      .mockReturnValue({ left: 0, top: 0, width: 800, height: 600 })
+    return new LGraphCanvas(el, graph, { skip_render: true })
+  }
+
+  test('renameWidget writes the label onto the normal-node backing input', () => {
+    const graph = new LGraph()
+    const node = addClipNode(graph)
+    const widget = node.widgets![0]
+    const input = node.inputs![0]
+
+    // Preconditions that reproduced the bug: the in-graph widget has a truthy
+    // widgetId, but the normal-node input carries none.
+    expect(widget.widgetId).toBeTruthy()
+    expect(input.widgetId).toBeUndefined()
+    expect(input.widget?.name).toBe('text')
+
+    renameWidget(widget, node, 'Positive Prompt')
+
+    expect(input.label).toBe('Positive Prompt')
+  })
+
+  test('label survives a full graph serialize -> configure round-trip', () => {
+    const graph = new LGraph()
+    const node = addClipNode(graph)
+    renameWidget(node.widgets![0], node, 'Positive Prompt')
+
+    const restored = new LGraph()
+    restored.configure(graph.serialize())
+
+    const restoredNode = restored.getNodeById(node.id)!
+    expect(restoredNode.widgets![0].label).toBe('Positive Prompt')
+  })
+
+  test('label survives delete -> undo', () => {
+    const graph = new LGraph()
+    const node = addClipNode(graph)
+    renameWidget(node.widgets![0], node, 'Positive Prompt')
+
+    const undoSnapshot = graph.serialize()
+    graph.remove(node)
+    expect(graph.getNodeById(node.id)).toBeFalsy()
+
+    const restored = new LGraph()
+    restored.configure(undoSnapshot)
+
+    expect(restored.getNodeById(node.id)!.widgets![0].label).toBe(
+      'Positive Prompt'
+    )
+  })
+
+  test('clearing a rename reverts the label to its default after round-trip', () => {
+    const graph = new LGraph()
+    const node = addClipNode(graph)
+    renameWidget(node.widgets![0], node, 'Positive Prompt')
+    renameWidget(node.widgets![0], node, '')
+
+    expect(node.inputs![0].label).toBeUndefined()
+
+    const restored = new LGraph()
+    restored.configure(graph.serialize())
+
+    expect(restored.getNodeById(node.id)!.widgets![0].label).toBeUndefined()
+  })
+
+  test('label survives copy -> paste', () => {
+    const graph = new LGraph()
+    const canvas = createCanvas(graph)
+    const node = addClipNode(graph)
+    renameWidget(node.widgets![0], node, 'Positive Prompt')
+
+    const pasted = canvas._deserializeItems(canvas._serializeItems([node]), {
+      position: [50, 50]
+    })!
+
+    const pastedNode = [...pasted.nodes.values()][0]
+    expect(pastedNode.widgets![0].label).toBe('Positive Prompt')
+  })
+})

--- a/src/utils/widgetUtil.ts
+++ b/src/utils/widgetUtil.ts
@@ -50,9 +50,10 @@ export function renameWidget(
 ): boolean {
   void parents
   const label = newLabel || undefined
-  const input = widget.widgetId
-    ? node.inputs?.find((inp) => inp.widgetId === widget.widgetId)
-    : node.inputs?.find((inp) => inp.widget?.name === widget.name)
+  const input =
+    (widget.widgetId &&
+      node.inputs?.find((inp) => inp.widgetId === widget.widgetId)) ||
+    node.inputs?.find((inp) => inp.widget?.name === widget.name)
   const widgetState = widget.widgetId
     ? useWidgetValueStore().getWidget(widget.widgetId)
     : undefined


### PR DESCRIPTION
## Summary

Minimal alternative to #13865 for BUG-011 (#13861): renamed widget labels not surviving save/reload, delete/undo, or copy/paste.

Per Austin Mroz's diagnosis, the real root cause is a lookup bug in `renameWidget` (`src/utils/widgetUtil.ts`), not a missing serialization channel:

```ts
const input = widget.widgetId
  ? node.inputs?.find((inp) => inp.widgetId === widget.widgetId)  // normal-node inputs have NO widgetId
  : node.inputs?.find((inp) => inp.widget?.name === widget.name)
```

`widget.widgetId` is a getter that is **truthy for every in-graph widget**. But `input.widgetId` is assigned in only two places, both subgraph/promotion (`SubgraphNode.ts:652`, `promotionUtils.ts:290`) — **normal-node inputs never carry it**. So on a normal node the ternary takes the `widgetId` branch, finds no matching input, and never falls back to name → `input.label` is never written → the label has no home in the serialized node and is lost on reload/undo/paste.

The fix flips the lookup to try `widgetId` first, then fall back to name:

```ts
const input =
  (widget.widgetId &&
    node.inputs?.find((inp) => inp.widgetId === widget.widgetId)) ||
  node.inputs?.find((inp) => inp.widget?.name === widget.name)
```

From there the label round-trips through the **pre-existing** `input.label` channel (`inputAsSerialisable` on serialize; `configure` restores `w.label = input.label`). No new serialization channel.

## Why this instead of #13865

#13865 adds a `userLabel` field + a name-keyed `widgets_labels` side-map + a null-proto accumulator + a configure precedence reconciliation. That treats the symptom: it papers over the un-fixed ternary with a second label home (non-store instance state that cuts against ADR-0008) rather than fixing the 1-line root cause. This PR is the minimal alternative: **one 2-line ternary flip, no map, no `userLabel`, no new field, no configure change.**

Analysis backing this: `research/architecture/widget-label-persistence-options.md` (ADDENDUM).

**Not intended to replace #13865 in-flight** — that PR is under team discussion. This is a scoped, ready-to-ship minimal option for evaluation.

## Coverage

Fully covers all #13861 repro cases (rgthree / pythongosssss / normal renamed widgets), because none of them are socketless — every core widget has a backing input slot and round-trips via `input.label`.

**Not covered:** genuinely-socketless widgets (`options.socketless === true`), for which name-matching finds no input. No core node sets `socketless` anywhere in `src/` (it is data-driven, read only at `litegraphService.ts:310`), and such widgets are additionally almost always `serialize:false` — so the #13865 map was moot for them too. If product ever needs renames on socketless widgets, that should be a separate, scoped follow-up.

## Tests

New real-path regression test `src/lib/litegraph/src/LGraphNode.widgetLabelRename.regression.test.ts` drives the **actual** `renameWidget` (never hand-setting `widget.label`) through serialize → configure on a CLIPTextEncode-like normal node:

- writes the label onto the normal-node backing input (direct root-cause guard)
- survives a full graph serialize → configure round-trip (save/reload)
- survives delete → undo
- survives copy → paste
- clearing a rename reverts to default after round-trip

Verified RED without the flip (all fail: `input.label` is `undefined`) and GREEN with it.

Fixes #13861
