### PR TITLE
feat(website): swap careers hero image for SiteVideo

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -45,6 +45,7 @@
     "@astrojs/vue": "catalog:",
     "@playwright/test": "catalog:",
     "@tailwindcss/vite": "catalog:",
+    "@vitejs/plugin-vue": "catalog:",
     "astro": "catalog:",
     "tailwindcss": "catalog:",
     "tsx": "catalog:",

--- a/apps/website/src/components/careers/HeroSection.vue
+++ b/apps/website/src/components/careers/HeroSection.vue
@@ -4,6 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import GlassCard from '../common/GlassCard.vue'
 import SectionLabel from '../common/SectionLabel.vue'
+import SiteVideo from '../common/SiteVideo.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 </script>
@@ -15,19 +16,23 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
         {{ t('careers.hero.label', locale) }}
       </SectionLabel>
       <h1
-        class="text-primary-comfy-canvas mt-4 text-4xl font-light whitespace-pre-line md:text-6xl"
+        class="mt-4 text-4xl font-light whitespace-pre-line text-primary-comfy-canvas md:text-6xl"
       >
         {{ t('careers.hero.heading', locale) }}
       </h1>
     </div>
 
     <GlassCard class="mx-auto mt-12 max-w-3xl md:mt-16">
-      <img
-        src="https://media.comfy.org/website/careers/hero.webp"
-        alt="Comfy team"
-        class="w-full rounded-4xl object-cover"
+      <SiteVideo
+        name="hero"
+        base-url="https://media.comfy.org/website/careers"
+        poster="https://media.comfy.org/website/careers/hero-poster.jpg"
+        autoplay
+        loop
+        muted
+        video-class="w-full rounded-4xl object-cover"
       />
-      <div class="text-primary-comfy-canvas space-y-6 p-8 text-base/relaxed">
+      <div class="space-y-6 p-8 text-base/relaxed text-primary-comfy-canvas">
         <p>{{ t('careers.hero.body1', locale) }}</p>
         <p>{{ t('careers.hero.body2', locale) }}</p>
         <p>{{ t('careers.hero.body3', locale) }}</p>

--- a/apps/website/src/components/common/SiteVideo.test.ts
+++ b/apps/website/src/components/common/SiteVideo.test.ts
@@ -1,0 +1,94 @@
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import SiteVideo from './SiteVideo.vue'
+
+async function renderSiteVideo(
+  props: Record<string, unknown> = {}
+): Promise<string> {
+  const app = createSSRApp({
+    render: () =>
+      h(SiteVideo, {
+        name: 'hero',
+        baseUrl: 'https://media.example.com/careers',
+        ...props
+      })
+  })
+  return renderToString(app)
+}
+
+describe('SiteVideo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders <video> with the caller-supplied muted attribute', async () => {
+    const html = await renderSiteVideo({ autoplay: true, muted: true })
+    expect(html).toMatch(/<video[^>]*\smuted\b/)
+    expect(html).toMatch(/<video[^>]*\sautoplay\b/)
+  })
+
+  it('does NOT render muted when the caller omits it', async () => {
+    // Regression guard for Vue's Boolean-cast rule: an absent Boolean prop
+    // resolves to `false`, so the component cannot silently fall back to
+    // `autoplay`. Callers must pass `muted` explicitly.
+    const html = await renderSiteVideo({ autoplay: true })
+    expect(html).not.toMatch(/<video[^>]*\smuted\b/)
+  })
+
+  it('warns in dev when autoplay is set without muted', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await renderSiteVideo({ autoplay: true })
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('autoplay without muted')
+    )
+  })
+
+  it('does not warn when both autoplay and muted are set', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await renderSiteVideo({ autoplay: true, muted: true })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('defaults preload to "auto" when autoplay is true', async () => {
+    const html = await renderSiteVideo({ autoplay: true, muted: true })
+    expect(html).toMatch(/preload="auto"/)
+  })
+
+  it('defaults preload to "metadata" when autoplay is false', async () => {
+    const html = await renderSiteVideo()
+    expect(html).toMatch(/preload="metadata"/)
+  })
+
+  it('honors an explicit preload override', async () => {
+    const html = await renderSiteVideo({
+      autoplay: true,
+      muted: true,
+      preload: 'none'
+    })
+    expect(html).toMatch(/preload="none"/)
+  })
+
+  it('emits webm and mp4 sources by default in that order', async () => {
+    const html = await renderSiteVideo()
+    const sources = [...html.matchAll(/<source[^>]*src="([^"]+)"/g)].map(
+      (m) => m[1]
+    )
+    expect(sources).toEqual([
+      'https://media.example.com/careers/hero-1280.webm',
+      'https://media.example.com/careers/hero-1280.mp4'
+    ])
+  })
+
+  it('is aria-hidden when no alt text is provided', async () => {
+    const html = await renderSiteVideo()
+    expect(html).toMatch(/aria-hidden="true"/)
+  })
+
+  it('exposes alt text as aria-label and drops aria-hidden when alt is set', async () => {
+    const html = await renderSiteVideo({ alt: 'Comfy team walking' })
+    expect(html).toMatch(/aria-label="Comfy team walking"/)
+    expect(html).not.toMatch(/aria-hidden/)
+  })
+})

--- a/apps/website/src/components/common/SiteVideo.test.ts
+++ b/apps/website/src/components/common/SiteVideo.test.ts
@@ -1,11 +1,14 @@
 import { createSSRApp, h } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ComponentProps } from 'vue-component-type-helpers'
 
 import SiteVideo from './SiteVideo.vue'
 
+type SiteVideoProps = ComponentProps<typeof SiteVideo>
+
 async function renderSiteVideo(
-  props: Record<string, unknown> = {}
+  props: Partial<SiteVideoProps> = {}
 ): Promise<string> {
   const app = createSSRApp({
     render: () =>
@@ -21,6 +24,7 @@ async function renderSiteVideo(
 describe('SiteVideo', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
 
   it('renders <video> with the caller-supplied muted attribute', async () => {
@@ -48,6 +52,13 @@ describe('SiteVideo', () => {
   it('does not warn when both autoplay and muted are set', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await renderSiteVideo({ autoplay: true, muted: true })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('stays silent in production even when autoplay is set without muted', async () => {
+    vi.stubEnv('DEV', false)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await renderSiteVideo({ autoplay: true })
     expect(warn).not.toHaveBeenCalled()
   })
 

--- a/apps/website/src/components/common/SiteVideo.vue
+++ b/apps/website/src/components/common/SiteVideo.vue
@@ -5,6 +5,13 @@ import { computed } from 'vue'
 import { buildVideoSources, videoKey } from '../../utils/video'
 import type { VideoFormat } from '../../utils/video'
 
+/**
+ * Autoplay note: browsers require `muted` for autoplay to actually start.
+ * `muted` is a Boolean prop, so Vue coerces an omitted value to `false`
+ * (see https://vuejs.org/guide/components/props#boolean-casting) — that
+ * means we cannot fall back to `autoplay` inside the component. Callers
+ * that pass `autoplay` must also pass `muted` explicitly.
+ */
 const {
   name,
   baseUrl,
@@ -14,7 +21,7 @@ const {
   alt,
   autoplay = false,
   loop = false,
-  muted,
+  muted = false,
   controls = false,
   preload,
   containerClass,
@@ -35,7 +42,13 @@ const {
   videoClass?: string
 }>()
 
-const resolvedMuted = computed(() => muted ?? autoplay)
+if (import.meta.env.DEV && autoplay && !muted) {
+  console.warn(
+    `[SiteVideo] "${name}" uses autoplay without muted. Browsers block ` +
+      'unmuted autoplay by default; pass `muted` explicitly.'
+  )
+}
+
 const resolvedPreload = computed(
   () => preload ?? (autoplay ? 'auto' : 'metadata')
 )
@@ -55,7 +68,7 @@ const decorative = computed(() => !alt && !controls)
       :preload="resolvedPreload"
       :autoplay
       :loop
-      :muted="resolvedMuted"
+      :muted
       :controls
       :aria-label="alt"
       :aria-hidden="decorative ? true : undefined"

--- a/apps/website/src/components/common/SiteVideo.vue
+++ b/apps/website/src/components/common/SiteVideo.vue
@@ -14,9 +14,9 @@ const {
   alt,
   autoplay = false,
   loop = false,
-  muted = autoplay,
+  muted,
   controls = false,
-  preload = autoplay ? 'auto' : 'metadata',
+  preload,
   containerClass,
   videoClass
 } = defineProps<{
@@ -35,6 +35,10 @@ const {
   videoClass?: string
 }>()
 
+const resolvedMuted = computed(() => muted ?? autoplay)
+const resolvedPreload = computed(
+  () => preload ?? (autoplay ? 'auto' : 'metadata')
+)
 const sources = computed(() =>
   buildVideoSources({ name, baseUrl, width, formats })
 )
@@ -48,10 +52,10 @@ const decorative = computed(() => !alt && !controls)
       :key="remountKey"
       :class="cn('size-full', videoClass)"
       :poster
-      :preload
+      :preload="resolvedPreload"
       :autoplay
       :loop
-      :muted
+      :muted="resolvedMuted"
       :controls
       :aria-label="alt"
       :aria-hidden="decorative ? true : undefined"

--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -1,4 +1,3 @@
-/** @knipIgnoreUsedByStackedPR */
 export type VideoFormat = 'webm' | 'mp4'
 
 type VideoSource = {

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -1,6 +1,8 @@
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -53,7 +53,6 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     // Marketing media tooling — adopted by pages in a follow-up PR
-    'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',
     // Pending integration: consumed by the useWorkspaceInvoices seam once
     // #13591 (Plan & Credits tabs) lands — FE-1245

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,6 +1023,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.2(vite@8.1.4(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitejs/plugin-vue':
+        specifier: 'catalog:'
+        version: 6.0.8(vite@8.1.4(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       astro:
         specifier: 'catalog:'
         version: 6.4.8(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Replace the static `hero.webp` on `/careers` and `/zh-CN/careers` with the standard `SiteVideo` component (autoplay/loop/muted) so the careers hero shows the new team clip.

## Changes

- **What**:
  - `apps/website/src/components/careers/HeroSection.vue` — swap the `<img src=".../hero.webp">` for `<SiteVideo name="hero" base-url="https://media.comfy.org/website/careers" poster=".../hero-poster.jpg" autoplay loop muted>`. Keeps the original `w-full rounded-4xl object-cover` layout via `video-class`. No `alt` → the video is decorative (`aria-hidden`), matching the previous image role.
  - `apps/website/src/components/common/SiteVideo.vue` — resolve `muted` and `preload` defaults through `computed()` refs. The previous `muted = autoplay` and `preload = autoplay ? 'auto' : 'metadata'` reactive-props-destructuring defaults threw `ReferenceError: autoplay is not defined` at SSR (Astro islands without `client:only`), which prevented the whole hero section from rendering on `/careers`.
  - `apps/website/src/utils/video.ts` and `knip.config.ts` — drop the `@knipIgnoreUsedByStackedPR` marker and the `SiteVideo.vue` knip ignore entry now that this PR is the consumer they were waiting on.

## :rotating_light: Deploy sequencing — media upload required

The new hero references three CDN assets that must be uploaded to `media.comfy.org/website/careers/` **before or with** this PR merging, otherwise the hero card renders empty until they land:

- `hero-1280.webm` — [download](https://uploads.linear.app/bc8e6840-c560-416d-b32a-72ed381e5dd3/7df2c461-ac8d-4f66-b9e1-4e51f1ba22ea/2280d00a-c76c-4542-9616-9d0580fbc6f2) (14 MB, VP9 1280×720)
- `hero-1280.mp4` — [download](https://uploads.linear.app/bc8e6840-c560-416d-b32a-72ed381e5dd3/5c548d00-3a2a-4efd-9261-b1ce8b2727c1/17412bb2-e4b8-430d-84f2-4c26e3e62058) (17 MB, H.264 1280×720)
- `hero-poster.jpg` — [download](https://uploads.linear.app/bc8e6840-c560-416d-b32a-72ed381e5dd3/f9982c7b-ec59-4e18-b8b0-e2447da42f32/eef626ea-647c-444a-844b-850ae8e4a578) (113 KB, 1280×720)

Generated locally via `apps/website/scripts/process-videos.sh` from the source clip. Naming matches `buildVideoSources()` in `src/utils/video.ts` so the `<source>` URLs resolve one-to-one.

## Review Focus

- **SSR fix in `SiteVideo.vue`** — this component previously had zero callers (was knip-ignored as a stacked-PR dep), so the SSR bug had never surfaced. Verified end-to-end via Playwright with the assets intercepted from a local server: video loads at 1280×720, `readyState=4`, `networkState=1`, autoplaying, 70.6 s duration, 16:9 layout preserved.
- **Accessibility** — `<SiteVideo>` with no `alt` is treated as decorative (`aria-hidden="true"`). Matches the intent of the removed `alt="Comfy team"` image — the surrounding heading + four body paragraphs carry the meaning. If the video ever needs a caption, add `alt`.
- **Not an issue, flagged for awareness** — the source clip is ~70 s with audio (muted in the hero). Original message noted a shorter 10–15 s loop is on the table; happy to regenerate and swap files if preferred before deploy.

## Screenshots

**After — English `/careers`, media served locally so the video actually plays:**

![Careers EN with video playing](.glary/screenshots/careers-en-hero-playing.png)

**After — English `/careers`, media 404 (what users would see if PR merges before upload):**

![Careers EN before media upload](.glary/screenshots/careers-en-hero.png)

**After — Chinese `/zh-CN/careers`, media 404:**

![Careers ZH before media upload](.glary/screenshots/careers-zh-hero.png)

## Verification

- `pnpm format` — clean
- `pnpm typecheck` — 0 errors (root + `apps/website` via `astro check`)
- `pnpm lint` — 0 new warnings (44 pre-existing warnings all in unrelated `es-toolkit` imports)
- `pnpm knip` — clean
- `pnpm exec vitest run apps/website/src/utils/video.test.ts` — 7/7 pass
- Playwright manual QA — both locales SSR-render, `<video>` element has correct sources (`hero-1280.webm` then `hero-1280.mp4`), poster URL, `autoplay=true`, `loop=true`, `muted=true`, `playsInline=true`, `aria-hidden="true"`, 0 browser console errors
- Playwright with assets intercepted from a local media server — webm loads, plays 70.6 s, 1280×720, aspect ratio 16:9 preserved, autoplays on load

## Screenshots

![Careers EN with video playing](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c0b6895363086902ae5436e7a558b59d8adc45c6adce29fe832a31edc81bdd3c/pr-images/1784675220145-0b67bba6-f188-4e60-a29f-93e17c5a7c1e.png)

![Careers EN before media upload](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c0b6895363086902ae5436e7a558b59d8adc45c6adce29fe832a31edc81bdd3c/pr-images/1784675220460-6c6b9749-dc66-4166-aca3-0a9b5b5773f5.png)

![Careers ZH before media upload](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c0b6895363086902ae5436e7a558b59d8adc45c6adce29fe832a31edc81bdd3c/pr-images/1784675220950-8d44f28d-cd26-4b65-9949-5353846002b5.png)