### PR TITLE
feat: 6/x surface workspace policy errors

### DIFF
--- a/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
@@ -10,8 +10,10 @@ test.describe('Partner node governance workbench', { tag: '@cloud' }, () => {
   }) => {
     await page.getByTestId(TestIds.topbar.queueButton).click()
 
-    await expect(page.getByRole('alert')).toContainText(
-      'Workflow blocked by workspace policy'
+    const policyAlert = page.getByRole('alert')
+    await expect(policyAlert).toContainText('1 partner node is unavailable')
+    await expect(policyAlert).toContainText(
+      'Disabled Partner Node is disabled by your workspace policy.'
     )
     expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
   })

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -61,6 +61,18 @@ vi.mock('@/i18n', () => {
       'Validation failed',
     'errorCatalog.validationErrors.unknown_validation_error.toastMessage':
       '{nodeName} returned an unrecognized validation error.',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.title':
+      'Partner node unavailable',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.message':
+      "One or more partner nodes are disabled by this workspace's policy.",
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.details':
+      '{nodeName} is disabled by your workspace policy.',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.itemLabel':
+      '{nodeName}',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.toastTitle':
+      'Partner node unavailable',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.toastMessage':
+      '{nodeName} is disabled by your workspace policy.',
     'errorCatalog.promptErrors.prompt_no_outputs.title':
       'Prompt has no outputs',
     'errorCatalog.promptErrors.prompt_no_outputs.desc':
@@ -495,6 +507,50 @@ describe('useErrorGroups', () => {
       expect(error.toastMessage).toBe(
         'KSampler is missing a required input: model'
       )
+    })
+
+    it('groups workspace-disabled partner nodes with names and count', async () => {
+      const { store, groups } = createErrorGroups()
+      store.recordNodeErrors({
+        '1': {
+          class_type: 'FluxFill',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'workspace_partner_node_disabled',
+              message: 'Disabled by workspace policy',
+              details: ''
+            }
+          ]
+        },
+        '2': {
+          class_type: 'VeoVideo',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'workspace_partner_node_disabled',
+              message: 'Disabled by workspace policy',
+              details: ''
+            }
+          ]
+        }
+      })
+      await nextTick()
+
+      const group = groups.allErrorGroups.value.find(
+        (entry) =>
+          entry.groupKey === 'execution:workspace_partner_node_disabled'
+      )
+      expect(group?.type).toBe('execution')
+      if (group?.type !== 'execution') return
+
+      expect(group.displayTitle).toBe('Partner node unavailable')
+      expect(group.count).toBe(2)
+      expect(
+        group.cards.flatMap((card) =>
+          card.errors.map((error) => error.displayItemLabel)
+        )
+      ).toEqual(['FluxFill', 'VeoVideo'])
     })
 
     it('groups lifted boundary errors under the host node card', async () => {

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import GlobalToast from './GlobalToast.vue'
+
+const { removeToast, viewErrorsInGraph } = vi.hoisted(() => ({
+  removeToast: vi.fn(),
+  viewErrorsInGraph: vi.fn()
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: vi.fn(),
+    remove: removeToast,
+    removeAllGroups: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useViewErrorsInGraph', () => ({
+  useViewErrorsInGraph: () => ({ viewErrorsInGraph })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: vi.fn() })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({
+    messagesToAdd: [],
+    messagesToRemove: [],
+    removeAllRequested: false
+  })
+}))
+
+const policyMessage = {
+  severity: 'error',
+  summary: '1 partner node is unavailable',
+  detail: 'Flux Fill is disabled by your workspace policy.',
+  group: 'partner-node-policy'
+}
+
+const ToastStub = defineComponent({
+  props: { group: String },
+  setup() {
+    return { policyMessage }
+  },
+  template: `
+    <div v-if="group === 'partner-node-policy'">
+      <slot name="message" :message="policyMessage" />
+    </div>
+  `
+})
+
+describe('GlobalToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the Errors tab from a partner policy toast', async () => {
+    const user = userEvent.setup()
+    render(GlobalToast, {
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'en',
+            messages: {
+              en: { rightSidePanel: { viewDetails: 'View details' } }
+            }
+          })
+        ],
+        stubs: { Toast: ToastStub }
+      }
+    })
+
+    await user.click(screen.getByRole('button', { name: 'View details' }))
+
+    expect(removeToast).toHaveBeenCalledWith(policyMessage)
+    expect(viewErrorsInGraph).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -1,5 +1,23 @@
 <template>
   <Toast />
+  <Toast group="partner-node-policy">
+    <template #message="slotProps">
+      <div class="flex min-w-0 flex-1 flex-col gap-2">
+        <div class="flex flex-col gap-1">
+          <span class="font-semibold">{{ slotProps.message.summary }}</span>
+          <span class="text-sm">{{ slotProps.message.detail }}</span>
+        </div>
+        <Button
+          variant="muted-textonly"
+          size="sm"
+          class="w-fit px-0 underline hover:bg-transparent"
+          @click="viewPartnerNodePolicyErrors(slotProps.message)"
+        >
+          {{ $t('rightSidePanel.viewDetails') }}
+        </Button>
+      </div>
+    </template>
+  </Toast>
   <Toast group="billing-operation" position="top-right">
     <template #message="slotProps">
       <div class="flex items-center gap-2">
@@ -12,15 +30,24 @@
 
 <script setup lang="ts">
 import Toast from 'primevue/toast'
+import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { nextTick, watch } from 'vue'
 
+import Button from '@/components/ui/button/Button.vue'
+import { useViewErrorsInGraph } from '@/composables/useViewErrorsInGraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 const toast = useToast()
 const toastStore = useToastStore()
 const settingStore = useSettingStore()
+const { viewErrorsInGraph } = useViewErrorsInGraph()
+
+function viewPartnerNodePolicyErrors(message: ToastMessageOptions) {
+  toast.remove(message)
+  viewErrorsInGraph()
+}
 
 watch(
   () => toastStore.messagesToAdd,

--- a/src/extensions/core/cloudPartnerNodeGovernance.test.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.test.ts
@@ -10,15 +10,18 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import type { ComfyApp } from '@/scripts/app'
+import type { NodeError } from '@/schemas/apiSchema'
 import type { QueuePromptGuard } from '@/services/queuePromptGuardService'
 import type { ComfyExtension } from '@/types/comfy'
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 const {
   addToast,
+  executionErrorStore,
   governanceStore,
   isNodeDisabled,
   loadPolicy,
+  recordNodeErrors,
   registerQueuePromptGuard,
   registerExtension,
   usePartnerNodeGovernanceStore
@@ -30,11 +33,19 @@ const {
     isNodeDisabled,
     loadPolicy
   }
+  const executionErrorStore = {
+    lastNodeErrors: null as Record<string, NodeError> | null,
+    recordNodeErrors: vi.fn((nodeErrors: Record<string, NodeError> | null) => {
+      executionErrorStore.lastNodeErrors = nodeErrors
+    })
+  }
   return {
     addToast: vi.fn(),
+    executionErrorStore,
     governanceStore,
     isNodeDisabled,
     loadPolicy,
+    recordNodeErrors: executionErrorStore.recordNodeErrors,
     registerQueuePromptGuard: vi.fn<
       (id: string, guard: QueuePromptGuard) => () => void
     >(() => () => {}),
@@ -49,6 +60,10 @@ vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: () => ({ add: addToast })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => executionErrorStore
 }))
 
 vi.mock('@/services/queuePromptGuardService', () => ({
@@ -66,6 +81,7 @@ describe('cloudPartnerNodeGovernance', () => {
     vi.clearAllMocks()
     governanceStore.status = 'configured'
     loadPolicy.mockResolvedValue()
+    executionErrorStore.lastNodeErrors = null
   })
 
   async function loadExtension(): Promise<ComfyExtension> {
@@ -84,8 +100,8 @@ describe('cloudPartnerNodeGovernance', () => {
     return guard
   }
 
-  function disabledPartnerNode(): LGraphNode {
-    return new LGraphNode('DisabledPartnerNode', 'DisabledPartnerNode')
+  function disabledPartnerNode(title = 'DisabledPartnerNode'): LGraphNode {
+    return new LGraphNode(title, 'DisabledPartnerNode')
   }
 
   function outputNode(title: string): LGraphNode {
@@ -147,12 +163,26 @@ describe('cloudPartnerNodeGovernance', () => {
 
     expect(result).toBe(false)
     expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+    expect(recordNodeErrors).toHaveBeenCalledWith({
+      [createNodeExecutionId([graph.nodes[0].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This partner node is disabled by your workspace policy.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    })
     expect(addToast).toHaveBeenCalledWith({
       severity: 'error',
-      summary: 'Workflow blocked by workspace policy',
-      detail:
-        'Remove disabled partner nodes from this workflow or ask a workspace owner to update the policy.',
-      life: 6000
+      summary: '1 partner node is unavailable',
+      detail: 'DisabledPartnerNode is disabled by your workspace policy.',
+      group: 'partner-node-policy',
+      life: 8000
     })
   })
 
@@ -173,6 +203,7 @@ describe('cloudPartnerNodeGovernance', () => {
 
       expect(await guard({ rootGraph: graph })).toBe(true)
       expect(addToast).not.toHaveBeenCalled()
+      expect(recordNodeErrors).not.toHaveBeenCalled()
     }
   )
 
@@ -226,6 +257,7 @@ describe('cloudPartnerNodeGovernance', () => {
 
     expect(result).toBe(true)
     expect(addToast).not.toHaveBeenCalled()
+    expect(recordNodeErrors).not.toHaveBeenCalled()
   })
 
   it('blocks partial execution when a disabled node is an upstream dependency', async () => {
@@ -245,5 +277,125 @@ describe('cloudPartnerNodeGovernance', () => {
 
     expect(result).toBe(false)
     expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+  })
+
+  it('clears policy node errors after an allowed retry', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+
+    isNodeDisabled.mockReturnValue(false)
+
+    expect(await guard({ rootGraph: graph })).toBe(true)
+    expect(recordNodeErrors).toHaveBeenLastCalledWith(null)
+  })
+
+  it('preserves unrelated node errors after a blocked attempt', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+    await guard({ rootGraph: graph })
+    const unrelatedNodeErrors = {
+      'other-node': {
+        class_type: 'OtherNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'required_input_missing',
+            message: 'Required input is missing',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    } satisfies Record<string, NodeError>
+    executionErrorStore.lastNodeErrors = unrelatedNodeErrors
+    recordNodeErrors.mockClear()
+    isNodeDisabled.mockReturnValue(false)
+
+    expect(await guard({ rootGraph: graph })).toBe(true)
+    expect(recordNodeErrors).not.toHaveBeenCalled()
+    expect(executionErrorStore.lastNodeErrors).toBe(unrelatedNodeErrors)
+  })
+
+  it('merges policy errors with existing node errors', async () => {
+    const graph = new LGraph()
+    const disabledNode = disabledPartnerNode()
+    graph.add(disabledNode)
+    const executionId = createNodeExecutionId([disabledNode.id])
+    executionErrorStore.lastNodeErrors = {
+      [executionId]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'required_input_missing',
+            message: 'Required input is missing',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    }
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+    expect(executionErrorStore.lastNodeErrors?.[executionId]?.errors).toEqual([
+      expect.objectContaining({ type: 'required_input_missing' }),
+      expect.objectContaining({
+        type: 'workspace_partner_node_disabled'
+      })
+    ])
+  })
+
+  it('lists every disabled node in a plural policy toast', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode('Flux Fill'))
+    graph.add(disabledPartnerNode('Veo Video'))
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+    expect(recordNodeErrors).toHaveBeenCalledWith({
+      [createNodeExecutionId([graph.nodes[0].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This partner node is disabled by your workspace policy.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      },
+      [createNodeExecutionId([graph.nodes[1].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This partner node is disabled by your workspace policy.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    })
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: '2 partner nodes are unavailable',
+      detail:
+        'These nodes are disabled by your workspace policy: Flux Fill, Veo Video.',
+      group: 'partner-node-policy',
+      life: 8000
+    })
   })
 })

--- a/src/extensions/core/cloudPartnerNodeGovernance.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.ts
@@ -2,20 +2,32 @@ import { t } from '@/i18n'
 import type {
   ExecutableLGraphNode,
   LGraph,
-  LGraphNode,
-  Subgraph
+  LGraphNode
 } from '@/lib/litegraph/src/litegraph'
-import { ExecutableNodeDTO } from '@/lib/litegraph/src/litegraph'
-import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import {
+  ExecutableNodeDTO,
+  LGraphEventMode
+} from '@/lib/litegraph/src/litegraph'
+import { WORKSPACE_PARTNER_NODE_DISABLED_TYPE } from '@/platform/errorCatalog/validationErrorResolver'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { NodeError } from '@/schemas/apiSchema'
 import { useExtensionService } from '@/services/extensionService'
 import { registerQueuePromptGuard } from '@/services/queuePromptGuardService'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
 import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
 import { isOutputNode } from '@/utils/nodeFilterUtil'
 
 const QUEUE_GUARD_ID = 'workspace.partner-node-governance'
+const POLICY_TOAST_GROUP = 'partner-node-policy'
+
+interface DisabledPartnerNode {
+  executionId: NodeExecutionId
+  nodeType: string
+  nodeTitle: string
+}
 
 function isExcludedFromPrompt(node: Pick<LGraphNode, 'mode'>): boolean {
   return (
@@ -39,53 +51,114 @@ function createExecutableNodeMap(
   return nodesByExecutionId
 }
 
-function hasDisabledPartnerNodeInPartialExecution(
+function getDisabledPartnerNodes(
   graph: LGraph,
-  queueNodeIds: readonly NodeExecutionId[],
+  queueNodeIds: readonly NodeExecutionId[] | undefined,
   isNodeDisabled: (nodeType: string) => boolean
-): boolean {
+): DisabledPartnerNode[] {
   const nodesByExecutionId = createExecutableNodeMap(graph)
   const visited = new Set<string>()
+  const disabledNodes = new Map<NodeExecutionId, DisabledPartnerNode>()
 
-  function hasDisabledDependency(executionId: string): boolean {
-    if (visited.has(executionId)) return false
+  function visitDependency(executionId: string): void {
+    if (visited.has(executionId)) return
     visited.add(executionId)
 
     const node = nodesByExecutionId.get(executionId)
-    if (!node || node.isVirtualNode || isExcludedFromPrompt(node)) return false
-    if (node.type && isNodeDisabled(node.type)) return true
+    if (!node || node.isVirtualNode || isExcludedFromPrompt(node)) return
+    const normalizedExecutionId = tryNormalizeNodeExecutionId(executionId)
+    if (normalizedExecutionId && node.type && isNodeDisabled(node.type)) {
+      const graphNode = getNodeByExecutionId(graph, normalizedExecutionId)
+      disabledNodes.set(normalizedExecutionId, {
+        executionId: normalizedExecutionId,
+        nodeType: node.type,
+        nodeTitle: graphNode?.title || node.title || node.type
+      })
+    }
 
-    return node.inputs.some((_input, index) => {
+    node.inputs.forEach((_input, index) => {
       const resolvedInput = node.resolveInput(index)
-      return (
-        !!resolvedInput &&
-        !resolvedInput.widgetInfo &&
-        hasDisabledDependency(resolvedInput.origin_id)
-      )
+      if (resolvedInput && !resolvedInput.widgetInfo) {
+        visitDependency(resolvedInput.origin_id)
+      }
     })
   }
 
-  return queueNodeIds.some((executionId) => {
-    const node = getNodeByExecutionId(graph, executionId)
-    return !!node && isOutputNode(node) && hasDisabledDependency(executionId)
-  })
+  if (queueNodeIds?.length) {
+    for (const executionId of queueNodeIds) {
+      const node = getNodeByExecutionId(graph, executionId)
+      if (node && isOutputNode(node)) visitDependency(executionId)
+    }
+  } else {
+    for (const executionId of nodesByExecutionId.keys()) {
+      visitDependency(executionId)
+    }
+  }
+
+  return [...disabledNodes.values()]
 }
 
-function hasDisabledPartnerNode(
-  graph: LGraph | Subgraph,
-  isNodeDisabled: (nodeType: string) => boolean
-): boolean {
-  return graph.nodes.some((node) => {
-    if (isExcludedFromPrompt(node)) return false
-    if (
-      node.isSubgraphNode?.() &&
-      node.subgraph &&
-      hasDisabledPartnerNode(node.subgraph, isNodeDisabled)
-    ) {
-      return true
+function createPolicyNodeErrors(
+  disabledNodes: DisabledPartnerNode[]
+): Record<string, NodeError> {
+  const nodeErrors: Record<string, NodeError> = {}
+  for (const node of disabledNodes) {
+    nodeErrors[node.executionId] = {
+      class_type: node.nodeType,
+      dependent_outputs: [],
+      errors: [
+        {
+          type: WORKSPACE_PARTNER_NODE_DISABLED_TYPE,
+          message: t('workspacePanel.allowlist.runBlocked.nodeError'),
+          details: '',
+          extra_info: {}
+        }
+      ]
     }
-    return !!node.type && isNodeDisabled(node.type)
-  })
+  }
+  return nodeErrors
+}
+
+function removePolicyNodeErrors(
+  nodeErrors: Record<string, NodeError> | null
+): Record<string, NodeError> | null {
+  if (!nodeErrors) return nodeErrors
+
+  let changed = false
+  const remainingNodeErrors: Record<string, NodeError> = {}
+  for (const [executionId, nodeError] of Object.entries(nodeErrors)) {
+    const errors = nodeError.errors.filter(
+      ({ type }) => type !== WORKSPACE_PARTNER_NODE_DISABLED_TYPE
+    )
+    if (errors.length !== nodeError.errors.length) changed = true
+    if (errors.length > 0) {
+      remainingNodeErrors[executionId] = { ...nodeError, errors }
+    }
+  }
+
+  if (!changed) return nodeErrors
+  return Object.keys(remainingNodeErrors).length > 0
+    ? remainingNodeErrors
+    : null
+}
+
+function mergePolicyNodeErrors(
+  nodeErrors: Record<string, NodeError> | null,
+  policyNodeErrors: Record<string, NodeError>
+): Record<string, NodeError> {
+  const mergedNodeErrors = { ...removePolicyNodeErrors(nodeErrors) }
+  for (const [executionId, policyNodeError] of Object.entries(
+    policyNodeErrors
+  )) {
+    const existingNodeError = mergedNodeErrors[executionId]
+    mergedNodeErrors[executionId] = existingNodeError
+      ? {
+          ...existingNodeError,
+          errors: [...existingNodeError.errors, ...policyNodeError.errors]
+        }
+      : policyNodeError
+  }
+  return mergedNodeErrors
 }
 
 useExtensionService().registerExtension({
@@ -94,26 +167,51 @@ useExtensionService().registerExtension({
   setup: () => {
     usePartnerNodeGovernanceStore()
     registerQueuePromptGuard(QUEUE_GUARD_ID, async (context) => {
+      const executionErrorStore = useExecutionErrorStore()
       const governanceStore = usePartnerNodeGovernanceStore()
       if (governanceStore.status === 'loading') {
         await governanceStore.loadPolicy()
       }
       const isNodeDisabled = (nodeType: string) =>
         governanceStore.isNodeDisabled(nodeType)
-      const isBlocked = context.queueNodeIds?.length
-        ? hasDisabledPartnerNodeInPartialExecution(
-            context.rootGraph,
-            context.queueNodeIds,
-            isNodeDisabled
-          )
-        : hasDisabledPartnerNode(context.rootGraph, isNodeDisabled)
-      if (!isBlocked) return true
+      const disabledNodes = getDisabledPartnerNodes(
+        context.rootGraph,
+        context.queueNodeIds,
+        isNodeDisabled
+      )
+      if (disabledNodes.length === 0) {
+        const remainingNodeErrors = removePolicyNodeErrors(
+          executionErrorStore.lastNodeErrors
+        )
+        if (remainingNodeErrors !== executionErrorStore.lastNodeErrors) {
+          executionErrorStore.recordNodeErrors(remainingNodeErrors)
+        }
+        return true
+      }
+
+      executionErrorStore.recordNodeErrors(
+        mergePolicyNodeErrors(
+          executionErrorStore.lastNodeErrors,
+          createPolicyNodeErrors(disabledNodes)
+        )
+      )
+      const nodeNames = [
+        ...new Set(disabledNodes.map((node) => node.nodeTitle))
+      ]
+      const messageParams = {
+        count: disabledNodes.length,
+        nodes: nodeNames.join(', ')
+      }
 
       useToastStore().add({
         severity: 'error',
-        summary: t('workspacePanel.allowlist.runBlocked.summary'),
-        detail: t('workspacePanel.allowlist.runBlocked.detail'),
-        life: 6000
+        summary: t(
+          'workspacePanel.allowlist.runBlocked.summary',
+          messageParams
+        ),
+        detail: t('workspacePanel.allowlist.runBlocked.detail', messageParams),
+        group: POLICY_TOAST_GROUP,
+        life: 8000
       })
       return false
     })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2957,8 +2957,9 @@
         "unrestrictedConfirmMessage": "All partner node providers will become available to workspace members."
       },
       "runBlocked": {
-        "summary": "Workflow blocked by workspace policy",
-        "detail": "Remove disabled partner nodes from this workflow or ask a workspace owner to update the policy."
+        "summary": "{count} partner node is unavailable | {count} partner nodes are unavailable",
+        "detail": "{nodes} is disabled by your workspace policy. | These nodes are disabled by your workspace policy: {nodes}.",
+        "nodeError": "This partner node is disabled by your workspace policy."
       }
     },
     "dashboard": {
@@ -3996,6 +3997,7 @@
     "hideAdvancedInputsButton": "Hide advanced inputs",
     "hideAdvancedShort": "Hide advanced",
     "errors": "Errors",
+    "viewDetails": "View details",
     "noErrors": "No errors",
     "errorsDetected": "Error detected | Errors detected",
     "selectedNodeErrors": "{node} — {count} error | {node} — {count} errors",
@@ -4188,6 +4190,14 @@
         "itemLabel": "{nodeName}",
         "toastTitle": "Validation failed",
         "toastMessage": "{nodeName} returned an unrecognized validation error."
+      },
+      "workspace_partner_node_disabled": {
+        "title": "Partner node unavailable",
+        "message": "One or more partner nodes are disabled by this workspace's policy.",
+        "details": "{nodeName} is disabled by your workspace policy.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Partner node unavailable",
+        "toastMessage": "{nodeName} is disabled by your workspace policy."
       },
       "exception_during_inner_validation": {
         "title": "Validation failed",

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -131,6 +131,25 @@ describe('errorMessageResolver', () => {
     })
   })
 
+  it('resolves workspace-disabled partner nodes to actionable panel copy', () => {
+    const result = resolveRunErrorMessage({
+      kind: 'node_validation',
+      error: nodeValidationError('workspace_partner_node_disabled'),
+      nodeDisplayName: 'Flux Fill'
+    })
+
+    expect(result).toEqual({
+      catalogId: 'workspace_partner_node_disabled',
+      displayTitle: 'Partner node unavailable',
+      displayMessage:
+        "One or more partner nodes are disabled by this workspace's policy.",
+      displayDetails: 'Flux Fill is disabled by your workspace policy.',
+      displayItemLabel: 'Flux Fill',
+      toastTitle: 'Partner node unavailable',
+      toastMessage: 'Flux Fill is disabled by your workspace policy.'
+    })
+  })
+
   it('preserves special characters in catalog copy for node names', () => {
     const nodeDisplayName = 'A & B <C>'
     const result = resolveRunErrorMessage({

--- a/src/platform/errorCatalog/validationErrorResolver.ts
+++ b/src/platform/errorCatalog/validationErrorResolver.ts
@@ -19,6 +19,8 @@ import {
 } from '@/utils/executionErrorUtil'
 
 const REQUIRED_INPUT_MISSING_TYPE = 'required_input_missing'
+export const WORKSPACE_PARTNER_NODE_DISABLED_TYPE =
+  'workspace_partner_node_disabled'
 
 // Resolves node validation errors. Most validation types map 1:1 to their
 // catalog/locale keys; FE-specific recategorization uses a separate catalogId,
@@ -91,6 +93,10 @@ const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
   [REQUIRED_INPUT_MISSING_TYPE]: {
     catalogId: MISSING_CONNECTION_CATALOG_ID,
     itemLabel: 'nodeInput'
+  },
+  [WORKSPACE_PARTNER_NODE_DISABLED_TYPE]: {
+    catalogId: WORKSPACE_PARTNER_NODE_DISABLED_TYPE,
+    itemLabel: 'node'
   },
   ...NODE_LEVEL_VALIDATION_ERROR_RULES
 }


### PR DESCRIPTION
Stacked on #13751.

## Summary

Workspace policy blocks now enter the standard model-error flow: the toast names the disabled partner node, exposes **View details**, and opens the Errors panel with a grouped, locatable node error.

Backend policy enforcement remains authoritative; this PR changes frontend presentation only.

## Verification

| Before | After |
| --- | --- |
| <img width="720" alt="Generic workspace policy toast" src="https://github.com/user-attachments/assets/2e811bee-5b4b-46b6-a428-3d5c3897f973" /> | <img width="720" alt="Named partner-node policy toast with View details" src="https://github.com/user-attachments/assets/70d1ffcd-70b2-4c1e-acfb-9403116bced2" /> |

https://github.com/user-attachments/assets/400ed36f-44c1-4e74-91a8-b51ec6315956

| Timestamp | Screenshot | Highlight |
| --- | --- | --- |
| `00:03.50` | <img width="480" alt="Before: generic workspace policy toast" src="https://github.com/user-attachments/assets/a9b2c7b0-4d64-493a-a7e1-e98648013db4" /> | The queue guard reports only a generic workspace-policy block. |
| `00:08.00` | <img width="480" alt="After: named policy toast with View details" src="https://github.com/user-attachments/assets/800217fe-1c2d-46bf-824c-e8e302877693" /> | The toast identifies the disabled node and offers **View details**. |
| `00:10.00` | <img width="480" alt="After: Errors panel with grouped node error" src="https://github.com/user-attachments/assets/6bc74bae-9a1a-47b8-8d0a-522eb8e2fe35" /> | **View details** opens the Errors tab with the grouped node-level error. |

Created by Codex