### PR TITLE
[backport cloud/1.47] fix: show unified pricing for legacy Stripe billing

### DIFF
--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -73,16 +73,18 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
-  it('keeps legacy Stripe personal workspaces on Stripe Checkout', () => {
+  it('uses unified pricing while keeping legacy Stripe top-ups on Checkout', () => {
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
-    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+    const { type, shouldUseWorkspaceBilling, shouldUseUnifiedPricing } =
+      useBillingRouting()
 
     expect(type.value).toBe('legacy')
     expect(shouldUseWorkspaceBilling.value).toBe(false)
+    expect(shouldUseUnifiedPricing.value).toBe(true)
   })
 
   it('uses workspace billing for migrated Stripe personal workspaces', () => {

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -11,11 +11,21 @@ import type { BillingType } from './types'
  * stay legacy until `consolidatedBillingEnabled`, and known legacy Stripe
  * workspaces remain legacy after it is enabled. An unknown rail keeps the
  * flag-based route so workspace status can load it. Team workspaces are always
- * workspace-scoped. The routing matrix is covered in useBillingRouting.test.ts.
+ * workspace-scoped. Pricing follows feature availability independently of the
+ * billing rail. The routing matrix is covered in useBillingRouting.test.ts.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
   const workspaceStore = useTeamWorkspaceStore()
+
+  const shouldUseUnifiedPricing = computed(() => {
+    if (!flags.teamWorkspacesEnabled) return false
+
+    const workspaceType = workspaceStore.activeWorkspace?.type
+    if (!workspaceType) return false
+
+    return workspaceType === 'team' || flags.consolidatedBillingEnabled
+  })
 
   const type = computed<BillingType>(() => {
     if (!flags.teamWorkspacesEnabled) return 'legacy'
@@ -38,5 +48,5 @@ export function useBillingRouting() {
 
   const shouldUseWorkspaceBilling = computed(() => type.value === 'workspace')
 
-  return { type, shouldUseWorkspaceBilling }
+  return { type, shouldUseWorkspaceBilling, shouldUseUnifiedPricing }
 }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -10,6 +10,9 @@ const mockIsInPersonalWorkspace = vi.hoisted(() => ({ value: true }))
 const mockIsFreeTier = vi.hoisted(() => ({ value: false }))
 const mockTier = vi.hoisted(() => ({ value: 'FREE' as string | null }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
+const mockShouldUseUnifiedPricing = vi.hoisted(() => ({
+  value: null as boolean | null
+}))
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockIsLegacyTeamPlan = vi.hoisted(() => ({ value: false }))
 const mockIsTeamPlan = vi.hoisted(() => ({ value: false }))
@@ -41,6 +44,13 @@ vi.mock('@/composables/billing/useBillingRouting', () => ({
   useBillingRouting: () => ({
     get shouldUseWorkspaceBilling() {
       return mockShouldUseWorkspaceBilling
+    },
+    get shouldUseUnifiedPricing() {
+      return {
+        value:
+          mockShouldUseUnifiedPricing.value ??
+          mockShouldUseWorkspaceBilling.value
+      }
     }
   })
 }))
@@ -102,6 +112,7 @@ describe('useSubscriptionDialog', () => {
     mockIsFreeTier.value = false
     mockTier.value = 'FREE'
     mockShouldUseWorkspaceBilling.value = false
+    mockShouldUseUnifiedPricing.value = null
     mockIsLegacyTeamPlan.value = false
     mockIsTeamPlan.value = false
     mockCurrentPlanSlug.value = null
@@ -215,6 +226,19 @@ describe('useSubscriptionDialog', () => {
       expect(props).toHaveProperty('onChooseTeam')
       const { dialogComponentProps } = mockShowLayoutDialog.mock.calls[0][0]
       expectRekaPricingDialogProps(dialogComponentProps)
+    })
+
+    it('uses the unified table when pricing is unified but billing remains legacy', () => {
+      mockShouldUseWorkspaceBilling.value = false
+      mockShouldUseUnifiedPricing.value = true
+      mockIsInPersonalWorkspace.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props.initialPlanMode).toBe('personal')
+      expect(props).not.toHaveProperty('onChooseTeam')
     })
 
     it('routes an existing per-member (legacy) team subscriber to the old team table', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -36,7 +36,8 @@ function getInitialPlanMode(
 }
 
 export const useSubscriptionDialog = () => {
-  const { shouldUseWorkspaceBilling } = useBillingRouting()
+  const { shouldUseWorkspaceBilling, shouldUseUnifiedPricing } =
+    useBillingRouting()
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const workspaceStore = useTeamWorkspaceStore()
@@ -93,10 +94,9 @@ export const useSubscriptionDialog = () => {
     } as const
 
     // Jun-5 model: a single unified pricing table (personal/team plan toggle on
-    // one workspace) for workspaces on the consolidated billing flow. Replaces
-    // the old personal-vs-team workspace fork. Personal workspaces still on the
-    // legacy flow (consolidated billing disabled) get the legacy table.
-    if (shouldUseWorkspaceBilling.value) {
+    // one workspace). The billing rail still selects the checkout and top-up
+    // backend, but does not select the pricing table.
+    if (shouldUseUnifiedPricing.value) {
       // Existing per-member (legacy) team subscribers keep the old tier-based
       // team table; the unified credit-slider table is for everyone else.
       // Resolved lazily (not at composable setup): these three composables form


### PR DESCRIPTION
Backport of #13914 to `cloud/1.47`.

Resolves the automatic cherry-pick conflict while preserving the release branch dialog implementation.