### PR TITLE
fix: always offer Google SSO in webviews (FE-1357)

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -131,14 +131,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium-2x, chromium-0.5x, mobile-chrome, cloud]
+        browser:
+          [chromium-2x, chromium-0.5x, mobile-chrome, cloud, mobile-safari]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Download built frontend
         uses: actions/download-artifact@v7
         with:
-          name: ${{ matrix.browser == 'cloud' && 'frontend-dist-cloud' || 'frontend-dist' }}
+          name: ${{ (matrix.browser == 'cloud' || matrix.browser == 'mobile-safari') && 'frontend-dist-cloud' || 'frontend-dist' }}
           path: dist/
 
       - name: Start ComfyUI server

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -28,10 +28,10 @@ cp -r tools/devtools/* /path/to/your/ComfyUI/custom_nodes/ComfyUI_devtools/
 ### Node.js & Playwright Prerequisites
 
 Ensure you have the Node.js version specified in `.nvmrc` installed.
-Then, set up the Chromium test driver:
+Then, set up the Chromium and WebKit test drivers:
 
 ```bash
-pnpm exec playwright install chromium --with-deps
+pnpm exec playwright install chromium webkit --with-deps
 ```
 
 ### Environment Configuration

--- a/browser_tests/tests/cloudLoginIosWebview.spec.ts
+++ b/browser_tests/tests/cloudLoginIosWebview.spec.ts
@@ -1,0 +1,76 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const CHROME_IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 27_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/145.0.7000.0 Mobile/15E148 Safari/604.1'
+
+async function injectWkWebViewBridge(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, 'webkit', {
+      configurable: true,
+      value: { messageHandlers: {} }
+    })
+  })
+}
+
+test.describe('Cloud login on iOS (FE-1357)', { tag: '@mobile-ios' }, () => {
+  test('offers Google without an in-app-browser notice in Chrome', async ({
+    browser
+  }) => {
+    const context = await browser.newContext({ userAgent: CHROME_IOS_UA })
+    try {
+      const page = await context.newPage()
+      await injectWkWebViewBridge(page)
+
+      await page.goto(APP_URL)
+      await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+
+      await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
+      await expect(
+        page.getByTestId('google-sso-in-app-browser-notice')
+      ).toBeHidden()
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('offers Google without an in-app-browser notice in Safari', async ({
+    page
+  }) => {
+    await injectWkWebViewBridge(page)
+
+    await page.goto(APP_URL)
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
+    await expect(
+      page.getByTestId('google-sso-in-app-browser-notice')
+    ).toBeHidden()
+  })
+
+  test('offers Google with a notice in an embedded WKWebView', async ({
+    browser
+  }) => {
+    const wkWebViewUa =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+    const context = await browser.newContext({ userAgent: wkWebViewUa })
+    try {
+      const page = await context.newPage()
+      await injectWkWebViewBridge(page)
+
+      await page.goto(APP_URL)
+      await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+
+      await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
+      await expect(
+        page.getByTestId('google-sso-in-app-browser-notice')
+      ).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/docs/guidance/playwright.md
+++ b/docs/guidance/playwright.md
@@ -131,7 +131,14 @@ await node.expectBypassed()
 
 ## Test Tags
 
-- `@mobile` — Mobile viewport tests
+- `@mobile` — Mobile viewport tests (runs on Android Pixel 5 via `mobile-chrome` project)
+- `@mobile-ios` — iOS-specific tests (runs on iPhone 15 via `mobile-safari` project). Use
+  this tag sparingly for regressions that only reproduce under iOS-shaped conditions
+  (WKWebView bridge exposure, WebKit-only quirks, iOS Safari/Chrome/Firefox/Edge UAs).
+  Playwright's WebKit engine does not expose embedded-WKWebView globals such as
+  `window.webkit.messageHandlers`; when a test depends on that surface, inject it via
+  `page.addInitScript()` and set `userAgent` on the context. See
+  `browser_tests/tests/cloudLoginIosWebview.spec.ts` for the reference pattern.
 - `@2x` — High DPI tests
 
 ## Test Data

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -81,13 +81,20 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       timeout: 15000,
       grep: /@cloud/,
-      grepInvert: /@oss/
+      grepInvert: /@oss|@mobile-ios/
     },
 
     {
       name: 'mobile-chrome',
       use: { ...devices['Pixel 5'], hasTouch: true },
-      grep: /@mobile/
+      grep: /@mobile\b/,
+      grepInvert: /@mobile-ios/
+    },
+
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 15'] },
+      grep: /@mobile-ios/
     }
   ]
 })

--- a/src/base/webviewDetection.test.ts
+++ b/src/base/webviewDetection.test.ts
@@ -122,6 +122,10 @@ describe('isEmbeddedWebView', () => {
         'Mozilla/5.0 (iPhone; CPU iPhone OS 27_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/145.0.7000.0 Mobile/15E148 Safari/604.1'
       ],
       [
+        'Chrome in desktop mode',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85 Version/11.1.1 Safari/605.1.15'
+      ],
+      [
         'Safari',
         'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
       ],

--- a/src/base/webviewDetection.test.ts
+++ b/src/base/webviewDetection.test.ts
@@ -115,5 +115,53 @@ describe('isEmbeddedWebView', () => {
       vi.stubGlobal('ReactNativeWebView', { postMessage: vi.fn() })
       expect(isEmbeddedWebView('')).toBe(true)
     })
+
+    it.for([
+      [
+        'Chrome',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 27_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/145.0.7000.0 Mobile/15E148 Safari/604.1'
+      ],
+      [
+        'Safari',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      ],
+      [
+        'Firefox',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/604.1'
+      ],
+      [
+        'Edge',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 EdgiOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+      ],
+      [
+        'Opera',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 OPiOS/16.0.14 Mobile/15E148 Safari/9537.53'
+      ],
+      [
+        'iPadOS Safari in desktop mode',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      ]
+    ] as const)(
+      ([browser]: readonly [string, string]) =>
+        `ignores webkit.messageHandlers in ${browser}`,
+      ([, ua]: readonly [string, string]) => {
+        vi.stubGlobal('webkit', { messageHandlers: {} })
+        expect(isEmbeddedWebView(ua)).toBe(false)
+      }
+    )
+
+    it('detects webkit.messageHandlers in a macOS Safari-shaped host', () => {
+      vi.stubGlobal('webkit', { messageHandlers: {} })
+      const ua =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+      expect(isEmbeddedWebView(ua)).toBe(true)
+    })
+
+    it('detects ReactNativeWebView when the UA looks like Chrome on iOS', () => {
+      vi.stubGlobal('ReactNativeWebView', { postMessage: vi.fn() })
+      const ua =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+      expect(isEmbeddedWebView(ua)).toBe(true)
+    })
   })
 })

--- a/src/base/webviewDetection.test.ts
+++ b/src/base/webviewDetection.test.ts
@@ -140,10 +140,6 @@ describe('isEmbeddedWebView', () => {
       [
         'Opera',
         'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 OPiOS/16.0.14 Mobile/15E148 Safari/9537.53'
-      ],
-      [
-        'iPadOS Safari in desktop mode',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
       ]
     ] as const)(
       ([browser]: readonly [string, string]) =>
@@ -154,7 +150,7 @@ describe('isEmbeddedWebView', () => {
       }
     )
 
-    it('detects webkit.messageHandlers in a macOS Safari-shaped host', () => {
+    it('detects webkit.messageHandlers in a Safari-shaped desktop host', () => {
       vi.stubGlobal('webkit', { messageHandlers: {} })
       const ua =
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'

--- a/src/base/webviewDetection.ts
+++ b/src/base/webviewDetection.ts
@@ -19,8 +19,8 @@ function isSocialAppBrowser(ua: string): boolean {
 }
 
 function isFirstPartyIOSBrowser(ua: string): boolean {
-  if (!/iPhone|iPad|iPod|Macintosh.*Mobile\//i.test(ua)) return false
   if (IOS_FIRST_PARTY_BROWSER_PATTERNS.test(ua)) return true
+  if (!/iPhone|iPad|iPod|Macintosh.*Mobile\//i.test(ua)) return false
   return /Safari\//i.test(ua) && /Version\//i.test(ua)
 }
 

--- a/src/base/webviewDetection.ts
+++ b/src/base/webviewDetection.ts
@@ -1,19 +1,7 @@
-/**
- * Detects whether the app is running inside an embedded webview.
- *
- * Google blocks OAuth via `signInWithPopup` in embedded webviews,
- * returning a 403 `disallowed_useragent` error (policy since 2021).
- * This utility is used to hide the Google SSO button in those contexts.
- *
- * Detection covers:
- *   • Android WebView (`wv` token in UA)
- *   • iOS WKWebView (has `AppleWebKit` but lacks `Safari/`)
- *   • Social app in-app browsers (Facebook, Instagram, TikTok, etc.)
- *   • JS bridge objects (`window.webkit.messageHandlers`, `ReactNativeWebView`)
- */
-
 const SOCIAL_APP_PATTERNS =
   /FBAN|FBAV|Instagram|Line\/|Snapchat|TikTok|musical_ly/i
+
+const IOS_FIRST_PARTY_BROWSER_PATTERNS = /CriOS|FxiOS|OPiOS|EdgiOS/i
 
 function isAndroidWebView(ua: string): boolean {
   return /\bwv\b/.test(ua) && /Android/.test(ua)
@@ -22,7 +10,7 @@ function isAndroidWebView(ua: string): boolean {
 function isIOSWebView(ua: string): boolean {
   if (!/AppleWebKit/i.test(ua)) return false
   if (/Safari\//i.test(ua)) return false
-  if (/CriOS|FxiOS|OPiOS|EdgiOS/i.test(ua)) return false
+  if (IOS_FIRST_PARTY_BROWSER_PATTERNS.test(ua)) return false
   return true
 }
 
@@ -30,43 +18,40 @@ function isSocialAppBrowser(ua: string): boolean {
   return SOCIAL_APP_PATTERNS.test(ua)
 }
 
-function hasWebViewBridge(): boolean {
+function isFirstPartyIOSBrowser(ua: string): boolean {
+  if (!/iPhone|iPad|iPod|Macintosh.*Mobile\//i.test(ua)) return false
+  if (IOS_FIRST_PARTY_BROWSER_PATTERNS.test(ua)) return true
+  return /Safari\//i.test(ua) && /Version\//i.test(ua)
+}
+
+function hasWkWebViewMessageBridge(): boolean {
   try {
     const win = globalThis as Record<string, unknown>
-    if (
+    return (
       typeof win.webkit === 'object' &&
       win.webkit !== null &&
       typeof (win.webkit as Record<string, unknown>).messageHandlers ===
         'object'
-    ) {
-      return true
-    }
-    if (win.ReactNativeWebView != null) return true
+    )
   } catch {
-    // Access to bridge objects may throw in sandboxed contexts
+    return false
   }
-  return false
+}
+
+function hasReactNativeWebViewBridge(): boolean {
+  try {
+    const win = globalThis as Record<string, unknown>
+    return win.ReactNativeWebView != null
+  } catch {
+    return false
+  }
 }
 
 export function isEmbeddedWebView(ua: string = navigator.userAgent): boolean {
   if (isSocialAppBrowser(ua)) return true
   if (isAndroidWebView(ua)) return true
   if (isIOSWebView(ua)) return true
-  if (hasWebViewBridge()) return true
+  if (hasReactNativeWebViewBridge()) return true
+  if (!isFirstPartyIOSBrowser(ua) && hasWkWebViewMessageBridge()) return true
   return false
-}
-
-/**
- * Reason why Google SSO is blocked in the current environment, or `null` if it
- * is available. Modeled as a discriminated string so call sites read as
- * "if blocked, here's why" rather than an opaque boolean. Extend this union
- * (e.g. `'unauthorized-host'`) as new blocking conditions are detected.
- */
-type GoogleSsoBlockedReason = 'embedded-webview' | null
-
-export function getGoogleSsoBlockedReason(
-  ua: string = navigator.userAgent
-): GoogleSsoBlockedReason {
-  if (isEmbeddedWebView(ua)) return 'embedded-webview'
-  return null
 }

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -49,7 +49,6 @@
       <div class="flex flex-col gap-6">
         <template v-if="ssoAllowed">
           <Button
-            v-if="!googleSsoBlockedReason"
             type="button"
             class="h-10"
             variant="secondary"
@@ -76,6 +75,14 @@
                 : t('auth.signup.signUpWithGithub')
             }}
           </Button>
+
+          <p
+            v-if="showGoogleSsoInAppBrowserNotice"
+            class="my-0 text-xs text-muted"
+            data-testid="google-sso-in-app-browser-notice"
+          >
+            {{ t('auth.login.googleSsoInAppBrowserNotice') }}
+          </p>
         </template>
 
         <template v-if="!isCloud">
@@ -147,6 +154,7 @@ import Message from 'primevue/message'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { isEmbeddedWebView } from '@/base/webviewDetection'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
@@ -158,7 +166,6 @@ import type { SignInData, SignUpData } from '@/schemas/signInSchema'
 import { isCloud } from '@/platform/distribution/types'
 import { isHostWhitelisted, normalizeHost } from '@/utils/hostWhitelist'
 import { isInChina } from '@/utils/networkUtil'
-import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
 
 import ApiKeyForm from './signin/ApiKeyForm.vue'
 import SignInForm from './signin/SignInForm.vue'
@@ -174,7 +181,7 @@ const isSecureContext = window.isSecureContext
 const isSignIn = ref(true)
 const showApiKeyForm = ref(false)
 const ssoAllowed = isHostWhitelisted(normalizeHost(window.location.hostname))
-const googleSsoBlockedReason = getGoogleSsoBlockedReason()
+const showGoogleSsoInAppBrowserNotice = isEmbeddedWebView()
 const comfyPlatformBaseUrl = computed(() =>
   configValueOrDefault(
     remoteConfig.value,

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2364,6 +2364,7 @@
       "orContinueWith": "Or continue with",
       "loginWithGoogle": "Log in with Google",
       "loginWithGithub": "Log in with Github",
+      "googleSsoInAppBrowserNotice": "If you opened this from an in-app browser (e.g. Instagram, LinkedIn), Google sign-in may not work. Use GitHub or email, or open this page in your device's default browser.",
       "termsText": "By clicking \"Next\" or \"Sign Up\", you agree to our",
       "termsLink": "Terms of Use",
       "andText": "and",

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -28,7 +28,6 @@
       <div class="flex w-full flex-col gap-4 pt-5 pb-2">
         <template v-if="!showEmailForm">
           <Button
-            v-if="!googleSsoBlockedReason"
             type="button"
             variant="secondary"
             class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
@@ -47,6 +46,14 @@
             <i class="pi pi-github text-base" />
             {{ t('auth.login.loginWithGithub') }}
           </Button>
+
+          <p
+            v-if="showGoogleSsoInAppBrowserNotice"
+            class="my-0 text-xs/5 text-primary-comfy-canvas/60"
+            data-testid="google-sso-in-app-browser-notice"
+          >
+            {{ t('auth.login.googleSsoInAppBrowserNotice') }}
+          </p>
 
           <Button
             variant="link"
@@ -100,12 +107,12 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
+import { isEmbeddedWebView } from '@/base/webviewDetection'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import type { SignInData } from '@/schemas/signInSchema'
-import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -114,7 +121,7 @@ const authActions = useAuthActions()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const showEmailForm = ref(false)
-const googleSsoBlockedReason = getGoogleSsoBlockedReason()
+const showGoogleSsoInAppBrowserNotice = isEmbeddedWebView()
 const { onAuthSuccess } = usePostAuthRedirect({
   authError,
   successSummary: 'Login Completed',

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -30,7 +30,6 @@
       <div class="flex w-full flex-col gap-4 pt-5 pb-2">
         <template v-if="!showEmailForm">
           <Button
-            v-if="!googleSsoBlockedReason"
             type="button"
             variant="secondary"
             class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
@@ -49,6 +48,14 @@
             <i class="pi pi-github text-base" />
             {{ t('auth.signup.signUpWithGithub') }}
           </Button>
+
+          <p
+            v-if="showGoogleSsoInAppBrowserNotice"
+            class="my-0 text-xs/5 text-primary-comfy-canvas/60"
+            data-testid="google-sso-in-app-browser-notice"
+          >
+            {{ t('auth.login.googleSsoInAppBrowserNotice') }}
+          </p>
 
           <Button
             variant="link"
@@ -79,11 +86,7 @@
             class="mt-1 h-10 w-full rounded-md border-none bg-smoke-800/5 text-sm/5 font-normal tracking-[-0.011em] text-primary-comfy-canvas/55 hover:bg-sand-300/10"
             @click="switchToSocialLogin"
           >
-            {{
-              googleSsoBlockedReason
-                ? t('auth.login.backToGithubLogin')
-                : t('auth.login.backToSocialLogin')
-            }}
+            {{ t('auth.login.backToSocialLogin') }}
           </Button>
         </template>
       </div>
@@ -131,6 +134,7 @@ import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
+import { isEmbeddedWebView } from '@/base/webviewDetection'
 import SignUpForm from '@/components/dialog/content/signin/SignUpForm.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -139,7 +143,6 @@ import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/use
 import { useTelemetry } from '@/platform/telemetry'
 import type { SignUpData } from '@/schemas/signInSchema'
 import { isInChina } from '@/utils/networkUtil'
-import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -155,7 +158,7 @@ const {
   switchToEmailForm,
   switchToSocialLogin
 } = useFreeTierOnboarding()
-const googleSsoBlockedReason = getGoogleSsoBlockedReason()
+const showGoogleSsoInAppBrowserNotice = isEmbeddedWebView()
 const { onAuthSuccess } = usePostAuthRedirect({
   authError,
   successSummary: 'Sign up Completed',


### PR DESCRIPTION
## Summary

Always offer Google SSO, using embedded-webview detection only to show fallback guidance. This supersedes #13917 with the conditional-notice behavior agreed in Slack.

## Changes

- **What**: Removes the Google-button gates from cloud login, cloud signup, and the sign-in dialog; hardens iOS bridge detection so first-party browsers do not receive the notice; adds the new copy to English only.
- **Testing**: Adds focused detector coverage and a `mobile-safari` Playwright project for Chrome iOS, Safari iOS, and embedded WKWebView behavior.

## Review Focus

- Google remains visible in every detected environment.
- The helper text appears only when the best-effort detector identifies an embedded browser.
- Fixes [FE-1357](https://linear.app/comfyorg/issue/FE-1357/bug-no-google-sign-in-option-on-cloudcomfyorg-login-page).

## Screenshots

Not included; the conditional mobile-browser states are covered by the focused WebKit regression test.