### PR TITLE
fix: route unified pricing through workspace billing

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -21,7 +21,9 @@ const {
   mockTeamWorkspacesEnabled,
   mockConsolidatedBillingEnabled,
   mockIsPersonal,
+  mockActiveWorkspaceBillingRail,
   mockPlans,
+  mockFetchPlans,
   mockPurchaseCredits,
   mockUpdateActiveWorkspace,
   mockBillingStatus
@@ -29,7 +31,11 @@ const {
   mockTeamWorkspacesEnabled: { value: false },
   mockConsolidatedBillingEnabled: { value: false },
   mockIsPersonal: { value: true },
+  mockActiveWorkspaceBillingRail: {
+    value: null as 'legacy_stripe' | 'stripe' | null
+  },
   mockPlans: { value: [] as Plan[] },
+  mockFetchPlans: vi.fn(),
   mockPurchaseCredits: vi.fn(),
   mockUpdateActiveWorkspace: vi.fn(),
   mockBillingStatus: {
@@ -92,6 +98,9 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
         ? { id: 'personal-123', type: 'personal' }
         : { id: 'team-456', type: 'team' }
     },
+    get activeWorkspaceBillingRail() {
+      return mockActiveWorkspaceBillingRail.value
+    },
     updateActiveWorkspace: mockUpdateActiveWorkspace
   })
 }))
@@ -141,9 +150,10 @@ vi.mock('@/platform/cloud/subscription/composables/useBillingPlans', () => ({
       return mockPlans
     },
     currentPlanSlug: { value: null },
+    teamCreditStops: { value: null },
     isLoading: { value: false },
     error: { value: null },
-    fetchPlans: vi.fn().mockResolvedValue(undefined),
+    fetchPlans: mockFetchPlans,
     getPlanBySlug: vi.fn().mockReturnValue(null)
   })
 }))
@@ -167,6 +177,7 @@ describe('useBillingContext', () => {
     mockTeamWorkspacesEnabled.value = false
     mockConsolidatedBillingEnabled.value = false
     mockIsPersonal.value = true
+    mockActiveWorkspaceBillingRail.value = null
     mockPlans.value = []
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
   })
@@ -193,6 +204,47 @@ describe('useBillingContext', () => {
 
     const { type } = useBillingContext()
     expect(type.value).toBe('workspace')
+  })
+
+  it('uses workspace subscription APIs and legacy topups on legacy Stripe', async () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockConsolidatedBillingEnabled.value = true
+    mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
+    mockPlans.value = [
+      {
+        slug: 'pro-annual',
+        tier: 'PRO',
+        duration: 'ANNUAL',
+        price_cents: 96000,
+        credits_cents: 120000,
+        max_seats: 1,
+        availability: { available: true },
+        seat_summary: {
+          seat_count: 1,
+          total_cost_cents: 96000,
+          total_credits_cents: 120000
+        }
+      }
+    ]
+
+    const { type, plans, fetchPlans, previewSubscribe, subscribe, topup } =
+      useBillingContext()
+
+    expect(type.value).toBe('legacy')
+    expect(plans.value).toEqual(mockPlans.value)
+
+    await fetchPlans()
+    await previewSubscribe('pro-annual')
+    await subscribe('pro-annual')
+    await topup(500)
+
+    expect(mockFetchPlans).toHaveBeenCalledOnce()
+    expect(workspaceApi.previewSubscribe).toHaveBeenCalledWith(
+      'pro-annual',
+      undefined
+    )
+    expect(workspaceApi.subscribe).toHaveBeenCalledWith('pro-annual', undefined)
+    expect(mockPurchaseCredits).toHaveBeenCalledWith(5)
   })
 
   it('selects workspace type for team regardless of consolidated billing', () => {

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -25,6 +25,7 @@ const {
   mockPlans,
   mockFetchPlans,
   mockPurchaseCredits,
+  mockSetWorkspaceBillingRail,
   mockUpdateActiveWorkspace,
   mockBillingStatus
 } = vi.hoisted(() => ({
@@ -37,6 +38,7 @@ const {
   mockPlans: { value: [] as Plan[] },
   mockFetchPlans: vi.fn(),
   mockPurchaseCredits: vi.fn(),
+  mockSetWorkspaceBillingRail: vi.fn(),
   mockUpdateActiveWorkspace: vi.fn(),
   mockBillingStatus: {
     value: {
@@ -88,22 +90,35 @@ vi.mock('@/composables/useFeatureFlags', async () => {
   }
 })
 
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    get isInPersonalWorkspace() {
-      return mockIsPersonal.value
-    },
-    get activeWorkspace() {
-      return mockIsPersonal.value
-        ? { id: 'personal-123', type: 'personal' }
-        : { id: 'team-456', type: 'team' }
-    },
-    get activeWorkspaceBillingRail() {
-      return mockActiveWorkspaceBillingRail.value
-    },
-    updateActiveWorkspace: mockUpdateActiveWorkspace
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { ref } = await import('vue')
+  const activeWorkspaceBillingRailRef = ref(
+    mockActiveWorkspaceBillingRail.value
+  )
+  Object.defineProperty(mockActiveWorkspaceBillingRail, 'value', {
+    get: () => activeWorkspaceBillingRailRef.value,
+    set: (value: 'legacy_stripe' | 'stripe' | null) => {
+      activeWorkspaceBillingRailRef.value = value
+    }
   })
-}))
+  return {
+    useTeamWorkspaceStore: () => ({
+      get isInPersonalWorkspace() {
+        return mockIsPersonal.value
+      },
+      get activeWorkspace() {
+        return mockIsPersonal.value
+          ? { id: 'personal-123', type: 'personal' }
+          : { id: 'team-456', type: 'team' }
+      },
+      get activeWorkspaceBillingRail() {
+        return mockActiveWorkspaceBillingRail.value
+      },
+      setWorkspaceBillingRail: mockSetWorkspaceBillingRail,
+      updateActiveWorkspace: mockUpdateActiveWorkspace
+    })
+  }
+})
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
@@ -227,8 +242,16 @@ describe('useBillingContext', () => {
       }
     ]
 
-    const { type, plans, fetchPlans, previewSubscribe, subscribe, topup } =
-      useBillingContext()
+    const {
+      type,
+      subscription,
+      plans,
+      fetchStatus,
+      fetchPlans,
+      previewSubscribe,
+      subscribe,
+      topup
+    } = useBillingContext()
 
     expect(type.value).toBe('legacy')
     expect(plans.value).toEqual(mockPlans.value)
@@ -245,6 +268,33 @@ describe('useBillingContext', () => {
     )
     expect(workspaceApi.subscribe).toHaveBeenCalledWith('pro-annual', undefined)
     expect(mockPurchaseCredits).toHaveBeenCalledWith(5)
+
+    mockBillingStatus.value = {
+      is_active: true,
+      has_funds: true,
+      billing_rail: 'stripe',
+      subscription_status: 'active',
+      subscription_tier: 'CREATOR',
+      subscription_duration: 'ANNUAL',
+      plan_slug: 'creator-annual'
+    }
+    mockSetWorkspaceBillingRail.mockImplementationOnce((_workspaceId, rail) => {
+      mockActiveWorkspaceBillingRail.value = rail
+    })
+    await fetchStatus()
+    await nextTick()
+
+    expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
+    expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
+      'personal-123',
+      'stripe'
+    )
+    expect(type.value).toBe('workspace')
+    expect(subscription.value).toMatchObject({
+      tier: 'CREATOR',
+      duration: 'ANNUAL',
+      planSlug: 'creator-annual'
+    })
   })
 
   it('selects workspace type for team regardless of consolidated billing', () => {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -79,7 +79,7 @@ function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
  */
 function useBillingContextInternal(): BillingContext {
   const store = useTeamWorkspaceStore()
-  const { type } = useBillingRouting()
+  const { type, shouldUseUnifiedPricing } = useBillingRouting()
 
   const legacyBillingRef = shallowRef<(BillingState & BillingActions) | null>(
     null
@@ -110,6 +110,10 @@ function useBillingContextInternal(): BillingContext {
     type.value === 'legacy' ? getLegacyBilling() : getWorkspaceBilling()
   )
 
+  const subscriptionContext = computed(() =>
+    shouldUseUnifiedPricing.value ? getWorkspaceBilling() : activeContext.value
+  )
+
   // Proxy state from active context
   const subscription = computed<SubscriptionInfo | null>(() =>
     toValue(activeContext.value.subscription)
@@ -119,14 +123,14 @@ function useBillingContextInternal(): BillingContext {
     toValue(activeContext.value.balance)
   )
 
-  const plans = computed(() => toValue(activeContext.value.plans))
+  const plans = computed(() => toValue(subscriptionContext.value.plans))
 
   const currentPlanSlug = computed(() =>
-    toValue(activeContext.value.currentPlanSlug)
+    toValue(subscriptionContext.value.currentPlanSlug)
   )
 
   const teamCreditStops = computed(() =>
-    toValue(activeContext.value.teamCreditStops)
+    toValue(subscriptionContext.value.teamCreditStops)
   )
 
   const currentTeamCreditStop = computed(() =>
@@ -270,14 +274,14 @@ function useBillingContextInternal(): BillingContext {
   }
 
   async function subscribe(planSlug: string, options?: SubscribeOptions) {
-    return activeContext.value.subscribe(planSlug, options)
+    return subscriptionContext.value.subscribe(planSlug, options)
   }
 
   async function previewSubscribe(
     planSlug: string,
     options?: PreviewSubscribeOptions
   ) {
-    return activeContext.value.previewSubscribe(planSlug, options)
+    return subscriptionContext.value.previewSubscribe(planSlug, options)
   }
 
   async function manageSubscription() {
@@ -289,7 +293,7 @@ function useBillingContextInternal(): BillingContext {
   }
 
   async function resubscribe() {
-    return activeContext.value.resubscribe()
+    return subscriptionContext.value.resubscribe()
   }
 
   async function topup(amountCents: number) {
@@ -306,7 +310,7 @@ function useBillingContextInternal(): BillingContext {
   }
 
   async function fetchPlans() {
-    return activeContext.value.fetchPlans()
+    return subscriptionContext.value.fetchPlans()
   }
 
   async function requireActiveSubscription() {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -266,7 +266,7 @@ function useBillingContextInternal(): BillingContext {
   }
 
   async function fetchStatus(): Promise<void> {
-    return activeContext.value.fetchStatus()
+    return subscriptionContext.value.fetchStatus()
   }
 
   async function fetchBalance(): Promise<void> {

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -5,6 +5,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import TopUpCreditsDialogContentLegacy from '@/components/dialog/content/TopUpCreditsDialogContentLegacy.vue'
+
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
 const state = vi.hoisted(() => ({
@@ -105,6 +107,7 @@ describe('showTopUpCreditsDialog', () => {
 
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('top-up-credits')
+    expect(args.component).toBe(TopUpCreditsDialogContentLegacy)
   })
 
   it('routes a member of an inactive team to the subscription-required flow, not the credits notice', async () => {


### PR DESCRIPTION
## Summary

Fix personal legacy Stripe workspaces showing available unified pricing plans as unavailable.

## Root Cause

#13914 made the unified pricing table visible for personal workspaces on `billing_rail: legacy_stripe`, but the billing facade still backed that table with the legacy adapter. The legacy adapter intentionally exposes an empty plans array and a no-op `fetchPlans()`, so the checkout could not resolve the selected tier and cadence to a plan slug. It showed `This plan is not available` in frontend validation before calling `preview-subscribe`, even though `/plans` returned the plan with `availability.available: true`.

## How Fixed

When unified pricing is enabled, the billing facade now routes plan data, `fetchPlans`, subscription preview, subscribe, and resubscribe through workspace billing. Status, balance, management, and top-ups continue using the active legacy adapter, preserving the required Stripe Checkout path for `legacy_stripe` top-ups.

A regression test covers the exact `personal + legacy_stripe + unified pricing` path, verifies annual plans resolve through workspace subscription APIs, and confirms top-ups still use the legacy credit flow.

## Changes

- **What**: Route unified pricing plan data, preview, subscribe, and resubscribe through workspace billing while preserving legacy Stripe top-ups.
- **Tests**: Cover the `personal + legacy_stripe + unified pricing` path, including annual plan resolution and legacy top-up routing.

## AS IS / TO BE

Personal workspace with a personal plan and `billing_rail: legacy_stripe`.

**AS IS — selecting an API-available plan fails frontend validation**

![AS IS — unified pricing reports that the selected plan is unavailable](https://ampcode.com/attachments/df855e5bac9ac684cbaa0d48f78cde4b63133dbf599310e1c4eadb06da6ad6e8.png)

**TO BE — unified pricing receives workspace plans and can continue to subscription preview**

![TO BE — unified personal pricing with available subscription actions](https://ampcode.com/attachments/6d1a8507eea4a758b05460be66ed58533d4338967cadd1b5983ba78082cf2520.png)

## Review Focus

Verify the subscription/top-up boundary: unified pricing must use workspace subscription APIs, while `legacy_stripe` top-ups must continue using Checkout.