### PR TITLE
fix(website): hold /mcp hero demo static under prefers-reduced-motion

### DIFF
--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -22,8 +22,7 @@ const BETWEEN_PROMPTS_MS = 650
 
 const promptTextClass =
   'font-formula col-start-1 row-start-1 text-[17px] leading-[1.3] font-light'
-// Caret blink and card-slide are pure CSS; the global prefers-reduced-motion
-// reset in global.css freezes them for free. Only the JS loop below needs a gate.
+// Caret and card-slide are CSS; the global reduced-motion reset freezes them.
 const caretClass =
   'bg-primary-comfy-yellow animate-cursor-blink ml-0.5 inline-block h-5 w-2.25 translate-y-0.5'
 
@@ -101,11 +100,11 @@ function restBeforeNextPrompt() {
   schedule(typeNextPrompt, BETWEEN_PROMPTS_MS)
 }
 
-// The only motion CSS can't stop is this JS typing/advance loop, so gate it here
-// (one place). Under reduced motion, settle on a static fully-typed frame.
+// Gate the JS typing loop — the one bit of motion CSS can't freeze.
 watch([visible, () => prefersReducedMotion()], ([onScreen, reduce]) => {
   clearTimeout(timer)
   if (reduce) {
+    // Hold a clean, fully-typed frame even if the pref flips mid-run.
     typed.value = t(nextPrompt.value.promptKey, locale)
     submitting.value = false
     status.value = idleStatus

--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -2,7 +2,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 import { Check } from '@lucide/vue'
 import { useElementVisibility } from '@vueuse/core'
-import { computed, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onUnmounted, ref, useTemplateRef, watchEffect } from 'vue'
 
 import { prefersReducedMotion } from '../../composables/useReducedMotion'
 import type { Locale } from '../../i18n/translations'
@@ -22,7 +22,6 @@ const BETWEEN_PROMPTS_MS = 650
 
 const promptTextClass =
   'font-formula col-start-1 row-start-1 text-[17px] leading-[1.3] font-light'
-// Caret and card-slide are CSS; the global reduced-motion reset freezes them.
 const caretClass =
   'bg-primary-comfy-yellow animate-cursor-blink ml-0.5 inline-block h-5 w-2.25 translate-y-0.5'
 
@@ -100,17 +99,15 @@ function restBeforeNextPrompt() {
   schedule(typeNextPrompt, BETWEEN_PROMPTS_MS)
 }
 
-// Gate the JS typing loop — the one bit of motion CSS can't freeze.
-watch([visible, () => prefersReducedMotion()], ([onScreen, reduce]) => {
+watchEffect(() => {
   clearTimeout(timer)
-  if (reduce) {
-    // Hold a clean, fully-typed frame even if the pref flips mid-run.
+  if (prefersReducedMotion()) {
     typed.value = t(nextPrompt.value.promptKey, locale)
     submitting.value = false
     status.value = idleStatus
     return
   }
-  if (onScreen) schedule(typeNextPrompt, START_DELAY_MS)
+  if (visible.value) schedule(typeNextPrompt, START_DELAY_MS)
 })
 
 onUnmounted(() => clearTimeout(timer))

--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -24,7 +24,6 @@ const reducedMotion = computed(prefersReducedMotion)
 
 const promptTextClass =
   'font-formula col-start-1 row-start-1 text-[17px] leading-[1.3] font-light'
-// Drop the blinking caret when the user prefers reduced motion.
 const caretClass = computed(() =>
   cn(
     'bg-primary-comfy-yellow ml-0.5 inline-block h-5 w-2.25 translate-y-0.5',
@@ -106,12 +105,16 @@ function restBeforeNextPrompt() {
   schedule(typeNextPrompt, BETWEEN_PROMPTS_MS)
 }
 
-// Run the demo only while on-screen and when motion is allowed. Under reduced
-// motion it holds its initial fully-typed frame — no looping, no abrupt card
-// swaps (which read as flashing once transitions are disabled).
+// Under reduced motion, settle on a static fully-typed frame and never loop.
 watch([visible, reducedMotion], ([onScreen, reduce]) => {
   clearTimeout(timer)
-  if (onScreen && !reduce) schedule(typeNextPrompt, START_DELAY_MS)
+  if (reduce) {
+    typed.value = t(nextPrompt.value.promptKey, locale)
+    submitting.value = false
+    status.value = idleStatus
+    return
+  }
+  if (onScreen) schedule(typeNextPrompt, START_DELAY_MS)
 })
 
 onUnmounted(() => clearTimeout(timer))

--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -19,12 +19,18 @@ const AFTER_TYPING_MS = 520
 const RUN_TOOL_MS = 360
 const AFTER_CARD_MS = 900
 const BETWEEN_PROMPTS_MS = 650
-const REDUCED_MOTION_DWELL_MS = 2600
+
+const reducedMotion = computed(prefersReducedMotion)
 
 const promptTextClass =
   'font-formula col-start-1 row-start-1 text-[17px] leading-[1.3] font-light'
-const caretClass =
-  'bg-primary-comfy-yellow animate-cursor-blink ml-0.5 inline-block h-5 w-2.25 translate-y-0.5'
+// Drop the blinking caret when the user prefers reduced motion.
+const caretClass = computed(() =>
+  cn(
+    'bg-primary-comfy-yellow ml-0.5 inline-block h-5 w-2.25 translate-y-0.5',
+    !reducedMotion.value && 'animate-cursor-blink'
+  )
+)
 
 const generateLabel = t('mcp.hero.demoGenerate', locale)
 const idleStatus = t('mcp.hero.demoStatusIdle', locale)
@@ -40,7 +46,6 @@ const nextPrompt = computed(
 const typed = ref(t(nextPrompt.value.promptKey, locale))
 const submitting = ref(false)
 const status = ref(idleStatus)
-const reducedMotion = computed(prefersReducedMotion)
 
 const root = useTemplateRef<HTMLElement>('root')
 const visible = useElementVisibility(root)
@@ -54,13 +59,6 @@ function schedule(step: () => void, ms: number) {
 
 function typeNextPrompt() {
   const text = t(nextPrompt.value.promptKey, locale)
-
-  if (reducedMotion.value) {
-    typed.value = text
-    schedule(runTool, AFTER_TYPING_MS)
-    return
-  }
-
   typed.value = ''
 
   let typedLength = 0
@@ -104,21 +102,16 @@ function commitCard() {
 }
 
 function restBeforeNextPrompt() {
-  if (!reducedMotion.value) typed.value = ''
-
-  schedule(
-    typeNextPrompt,
-    reducedMotion.value ? REDUCED_MOTION_DWELL_MS : BETWEEN_PROMPTS_MS
-  )
+  typed.value = ''
+  schedule(typeNextPrompt, BETWEEN_PROMPTS_MS)
 }
 
-watch(visible, (onScreen) => {
-  if (onScreen) {
-    schedule(typeNextPrompt, START_DELAY_MS)
-    return
-  }
-
+// Run the demo only while on-screen and when motion is allowed. Under reduced
+// motion it holds its initial fully-typed frame — no looping, no abrupt card
+// swaps (which read as flashing once transitions are disabled).
+watch([visible, reducedMotion], ([onScreen, reduce]) => {
   clearTimeout(timer)
+  if (onScreen && !reduce) schedule(typeNextPrompt, START_DELAY_MS)
 })
 
 onUnmounted(() => clearTimeout(timer))

--- a/apps/website/src/templates/mcp/ComfyMcpDemo.vue
+++ b/apps/website/src/templates/mcp/ComfyMcpDemo.vue
@@ -20,16 +20,12 @@ const RUN_TOOL_MS = 360
 const AFTER_CARD_MS = 900
 const BETWEEN_PROMPTS_MS = 650
 
-const reducedMotion = computed(prefersReducedMotion)
-
 const promptTextClass =
   'font-formula col-start-1 row-start-1 text-[17px] leading-[1.3] font-light'
-const caretClass = computed(() =>
-  cn(
-    'bg-primary-comfy-yellow ml-0.5 inline-block h-5 w-2.25 translate-y-0.5',
-    !reducedMotion.value && 'animate-cursor-blink'
-  )
-)
+// Caret blink and card-slide are pure CSS; the global prefers-reduced-motion
+// reset in global.css freezes them for free. Only the JS loop below needs a gate.
+const caretClass =
+  'bg-primary-comfy-yellow animate-cursor-blink ml-0.5 inline-block h-5 w-2.25 translate-y-0.5'
 
 const generateLabel = t('mcp.hero.demoGenerate', locale)
 const idleStatus = t('mcp.hero.demoStatusIdle', locale)
@@ -105,8 +101,9 @@ function restBeforeNextPrompt() {
   schedule(typeNextPrompt, BETWEEN_PROMPTS_MS)
 }
 
-// Under reduced motion, settle on a static fully-typed frame and never loop.
-watch([visible, reducedMotion], ([onScreen, reduce]) => {
+// The only motion CSS can't stop is this JS typing/advance loop, so gate it here
+// (one place). Under reduced motion, settle on a static fully-typed frame.
+watch([visible, () => prefersReducedMotion()], ([onScreen, reduce]) => {
   clearTimeout(timer)
   if (reduce) {
     typed.value = t(nextPrompt.value.promptKey, locale)
@@ -179,7 +176,6 @@ onUnmounted(() => clearTimeout(timer))
       <TransitionGroup
         name="card-slide"
         tag="div"
-        :css="!reducedMotion"
         class="flex flex-col gap-2.5"
       >
         <div


### PR DESCRIPTION
## Summary

Fixes the `/mcp` hero demo looking broken when the OS "reduce motion" / "show animations off" accessibility setting is on (reported on Windows + Chrome).

## The problem

`ComfyMcpDemo.vue` had *partial* reduced-motion handling (it skipped the per-character typing and slide), but it **kept looping** — cycling the prompt text and the whole 5-card stack every ~2.6s. With the global `@media (prefers-reduced-motion: reduce)` reset zeroing transition/animation durations, those swaps happen instantly, so the content flashes/pops. That's what read as "extremely terrible."

## The fix

The demo now runs only while it's **on-screen AND** the user hasn't requested reduced motion. Under reduced motion it holds its **initial fully-typed frame** (complete prompt + the result cards) with a **static, non-blinking caret** — a calm, intentional still. No behavior change for anyone without reduced motion; the full animation is untouched.

Also drops the now-dead in-loop reduced-motion branches (`REDUCED_MOTION_DWELL_MS`, the typing skip) since the loop simply doesn't start under reduced motion.

## Verification

- Emulated `reducedMotion: 'reduce'`: demo stays static across a 4s window (no prompt/card swap); frame reads cleanly (screenshot below).
- Emulated `no-preference`: full animation still loops as before.
- Setup + tool videos already pause under reduced motion (via `VideoPlayer`) — unchanged.
- 7/7 `e2e/mcp.spec.ts` pass.

## Known residual (out of scope)

The `ToolsSection` "generate anything" `.gif` keeps animating — browsers can't pause GIFs for reduced motion. Converting it to a reduced-motion-aware `<video>` is a separate change; flagging rather than bundling.

## Screenshots

_(reduced-motion static hero — add here)_