### PR TITLE
[backport cloud/1.47] Fix unsaved workflow warning on local logout

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -33,6 +33,7 @@ const mockDialogService = vi.hoisted(() => ({
 
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockTrackAuthFailed = vi.hoisted(() => vi.fn())
+const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 
 const knownAuthErrorCodes = new Set([
   'auth/invalid-credential',
@@ -50,7 +51,9 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
-  isCloud: false
+  get isCloud() {
+    return mockDistributionState.isCloud
+  }
 }))
 
 vi.mock('@/platform/telemetry', () => ({
@@ -110,11 +113,28 @@ function makeWorkflow(path: string): ModifiedWorkflow {
   return { path, isModified: true } satisfies ModifiedWorkflow
 }
 
+beforeEach(() => {
+  mockDistributionState.isCloud = false
+})
+
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockDistributionState.isCloud = true
     mockWorkflowStore.modifiedWorkflows = []
+  })
+
+  it('logs out on non-cloud distributions without prompting when workflows are modified', async () => {
+    mockDistributionState.isCloud = false
+    mockWorkflowStore.modifiedWorkflows = [makeWorkflow('a.json')]
+    const { logout } = useAuthActions()
+
+    await logout()
+
+    expect(mockDialogService.confirm).not.toHaveBeenCalled()
+    expect(mockWorkflowService.saveWorkflow).not.toHaveBeenCalled()
+    expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
   })
 
   it('logs out without prompting when no workflows are modified', async () => {

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -82,28 +82,30 @@ export const useAuthActions = () => {
   }
 
   const logout = wrapWithErrorHandlingAsync(async () => {
-    const workflowStore = useWorkflowStore()
-    const modifiedWorkflows = workflowStore.modifiedWorkflows
-    if (modifiedWorkflows.length > 0) {
-      const dialogService = useDialogService()
-      const confirmed = await dialogService.confirm({
-        title: t('auth.signOut.unsavedChangesTitle'),
-        message: t('auth.signOut.unsavedChangesMessage'),
-        type: 'dirtyClose',
-        denyLabel: t('auth.signOut.signOutAnyway')
-      })
-      if (confirmed === null) return
+    if (isCloud) {
+      const workflowStore = useWorkflowStore()
+      const modifiedWorkflows = workflowStore.modifiedWorkflows
+      if (modifiedWorkflows.length > 0) {
+        const dialogService = useDialogService()
+        const confirmed = await dialogService.confirm({
+          title: t('auth.signOut.unsavedChangesTitle'),
+          message: t('auth.signOut.unsavedChangesMessage'),
+          type: 'dirtyClose',
+          denyLabel: t('auth.signOut.signOutAnyway')
+        })
+        if (confirmed === null) return
 
-      if (confirmed === true) {
-        const workflowService = useWorkflowService()
-        for (const workflow of modifiedWorkflows) {
-          try {
-            const saved = await workflowService.saveWorkflow(workflow)
-            if (!saved) return
-          } catch {
-            throw new Error(
-              t('auth.signOut.saveFailed', { workflow: workflow.path })
-            )
+        if (confirmed === true) {
+          const workflowService = useWorkflowService()
+          for (const workflow of modifiedWorkflows) {
+            try {
+              const saved = await workflowService.saveWorkflow(workflow)
+              if (!saved) return
+            } catch {
+              throw new Error(
+                t('auth.signOut.saveFailed', { workflow: workflow.path })
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
Backport of #13869 to `cloud/1.47`.

The change applies cleanly to this release branch. The automatic workflow removed its generated cloud branch after the companion `core/1.47` backport conflicted, so this PR recreates the clean backport manually.

## Validation

- `pnpm test:unit src/composables/auth/useAuthActions.test.ts` (18 tests)
- `pnpm typecheck`
- Changed-file formatting, oxlint, and ESLint checks
- `pnpm knip` (push hook)