### PR TITLE
[backport cloud/1.47] feat(cloud): add safe unified pricing checkout deep links

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -8,7 +8,8 @@ import type {
   ErrorResponse,
   Plan,
   PreviewSubscribeResponse,
-  SubscribeResponse
+  SubscribeResponse,
+  TeamCreditStops
 } from '@comfyorg/ingest-types'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
@@ -29,13 +30,11 @@ import {
 
 /**
  * The `?pricing=` deep link opens the pricing table on app load, gated to the
- * original owner (canManageSubscriptionLifecycle). Drives a raw `page` so the
+ * billing-management capability. Drives a raw `page` so the
  * cloud app boots against fully mocked endpoints, like the survey-gate spec.
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
-// CloudAuthHelper.mockAuth() signs in as this email; the original-owner gate
-// matches it against the members self-row.
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
 // consolidated_billing_enabled routes personal workspaces to the unified
@@ -117,6 +116,11 @@ const ACTIVE_CREATOR_STATUS = {
   plan_slug: 'creator-annual'
 } satisfies BillingStatusResponse
 
+const LEGACY_ACTIVE_STANDARD_STATUS = {
+  ...ACTIVE_STANDARD_STATUS,
+  billing_rail: 'legacy_stripe'
+} satisfies BillingStatusResponse & { billing_rail: 'legacy_stripe' }
+
 const BILLING_BALANCE = {
   amount_micros: 0,
   currency: 'USD'
@@ -136,6 +140,65 @@ const CREATOR_WITH_CREATOR_PLANS = {
   ...STANDARD_WITH_CREATOR_PLANS,
   current_plan_slug: 'creator-annual'
 } satisfies BillingPlansResponse
+
+const TEAM_CREDIT_STOPS = {
+  default_stop_index: 2,
+  stops: [
+    {
+      id: 'team_200',
+      credits: 42_200,
+      monthly: { list_price_cents: 20_000, price_cents: 20_000 },
+      yearly: { list_price_cents: 20_000, price_cents: 20_000 }
+    },
+    {
+      id: 'team_400',
+      credits: 84_400,
+      monthly: { list_price_cents: 40_000, price_cents: 39_000 },
+      yearly: { list_price_cents: 40_000, price_cents: 38_000 }
+    },
+    {
+      id: 'team_700',
+      credits: 147_700,
+      monthly: { list_price_cents: 70_000, price_cents: 66_500 },
+      yearly: { list_price_cents: 70_000, price_cents: 63_000 }
+    },
+    {
+      id: 'team_1400',
+      credits: 295_400,
+      monthly: { list_price_cents: 140_000, price_cents: 129_500 },
+      yearly: { list_price_cents: 140_000, price_cents: 119_000 }
+    },
+    {
+      id: 'team_2500',
+      credits: 527_500,
+      monthly: { list_price_cents: 250_000, price_cents: 225_000 },
+      yearly: { list_price_cents: 250_000, price_cents: 200_000 }
+    }
+  ]
+} satisfies TeamCreditStops
+
+const TEAM_CATALOG_PLANS = {
+  plans: [],
+  team_credit_stops: TEAM_CREDIT_STOPS
+} satisfies BillingPlansResponse
+
+const TEAM_SUBSCRIBED_RESPONSE = {
+  billing_op_id: 'team-deep-link',
+  status: 'subscribed',
+  effective_at: '2026-07-21T00:00:00Z'
+} satisfies SubscribeResponse
+
+const NEW_CREATOR_SUBSCRIPTION = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: '2026-07-21T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 33_600,
+  cost_next_period_cents: 33_600,
+  credits_today_cents: 7_400,
+  credits_next_period_cents: 7_400,
+  new_plan: CREATOR_ANNUAL_PLAN
+} satisfies PreviewSubscribeResponse
 
 const SCHEDULED_CREATOR_DOWNGRADE = {
   allowed: true,
@@ -432,6 +495,161 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     })
     await expect(page).not.toHaveURL(/[?&]pricing=/)
     await expect(pricingHeading(page)).toBeHidden()
+  })
+
+  test('opens a selected personal plan for an owner without subscribing', async ({
+    page
+  }) => {
+    const subscribeRequests: Request[] = []
+    await setupCloudApp(page, workspace('personal', 'owner'), [])
+    await page.route('**/api/billing/status', (route) =>
+      route.fulfill(jsonRoute(LEGACY_ACTIVE_STANDARD_STATUS))
+    )
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill(
+        jsonRoute({
+          plans: [CREATOR_ANNUAL_PLAN]
+        } satisfies BillingPlansResponse)
+      )
+    )
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(NEW_CREATOR_SUBSCRIPTION))
+    )
+    await page.route('**/api/billing/subscribe', (route) => {
+      subscribeRequests.push(route.request())
+      return route.fulfill(jsonRoute(IMMEDIATE_SUBSCRIBED_RESPONSE))
+    })
+
+    await page.goto(`${APP_URL}/?pricing=creator&cycle=yearly`)
+
+    await cloudAppExpect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeVisible()
+    expect(subscribeRequests).toHaveLength(0)
+    await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
+  })
+
+  test('cleans orphaned pricing params without opening the table', async ({
+    page
+  }) => {
+    await setupCloudApp(page, workspace('personal', 'owner'), [])
+
+    await page.goto(`${APP_URL}/?keep=1&stop=team_700&cycle=yearly`)
+
+    await waitForCloudApp(page)
+    await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
+    await expect(page).not.toHaveURL(/[?&](pricing|stop|cycle)=/)
+    await expect(pricingHeading(page)).toBeHidden()
+  })
+
+  test('denies a selected personal plan for a member', async ({ page }) => {
+    await setupCloudApp(page, workspace('team', 'member'), [
+      member({
+        email: 'creator@test.comfy.org',
+        role: 'owner',
+        is_original_owner: true
+      }),
+      member({ email: SELF_EMAIL, role: 'member' })
+    ])
+
+    await page.goto(`${APP_URL}/?keep=1&pricing=creator&cycle=yearly`)
+
+    await waitForCloudApp(page)
+    await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
+    await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
+    await expect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeHidden()
+  })
+
+  test('opens a catalog-resolved Team stop and only subscribes after confirm', async ({
+    page
+  }) => {
+    const subscribeRequests: Request[] = []
+    await setupCloudApp(page, workspace('team', 'owner'), [
+      member({ email: SELF_EMAIL, role: 'owner', is_original_owner: true })
+    ])
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
+    )
+    await page.route('**/api/billing/subscribe', (route) => {
+      subscribeRequests.push(route.request())
+      return route.fulfill(jsonRoute(TEAM_SUBSCRIBED_RESPONSE))
+    })
+
+    await page.goto(
+      `${APP_URL}/?keep=1&pricing=team&stop=team_700&cycle=yearly`
+    )
+
+    await cloudAppExpect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeVisible()
+    const confirmationDialog = page.getByRole('dialog')
+    await expect(
+      confirmationDialog.getByText('$630', { exact: true }).last()
+    ).toBeVisible()
+    await expect(
+      confirmationDialog.getByText('1,772,400', { exact: true })
+    ).toBeVisible()
+    expect(subscribeRequests).toHaveLength(0)
+    await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
+    await expect(page).not.toHaveURL(/[?&](pricing|stop|cycle)=/)
+
+    await page.getByRole('button', { name: 'Subscribe to Team Plan' }).click()
+
+    await expect.poll(() => subscribeRequests.length).toBe(1)
+    expect(subscribeRequests[0].postDataJSON()).toMatchObject({
+      plan_slug: 'team_per_credit_annual',
+      team_credit_stop_id: 'team_700',
+      billing_cycle: 'yearly'
+    })
+  })
+
+  test('allows a promoted owner to open selected Team confirmation', async ({
+    page
+  }) => {
+    await setupCloudApp(page, workspace('team', 'owner'), [
+      member({
+        email: 'creator@test.comfy.org',
+        role: 'owner',
+        is_original_owner: true
+      }),
+      member({ email: SELF_EMAIL, role: 'owner', is_original_owner: false })
+    ])
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
+    )
+
+    await page.goto(`${APP_URL}/?pricing=team&stop=team_400&cycle=monthly`)
+
+    await cloudAppExpect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeVisible()
+    await expect(page.getByText('$390', { exact: true })).toBeVisible()
+  })
+
+  test('denies selected Team confirmation for a member and cleans the URL', async ({
+    page
+  }) => {
+    await setupCloudApp(page, workspace('team', 'member'), [
+      member({
+        email: 'creator@test.comfy.org',
+        role: 'owner',
+        is_original_owner: true
+      }),
+      member({ email: SELF_EMAIL, role: 'member' })
+    ])
+
+    await page.goto(
+      `${APP_URL}/?keep=1&pricing=team&stop=team_700&cycle=yearly`
+    )
+
+    await waitForCloudApp(page)
+    await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
+    await expect(page).not.toHaveURL(/[?&](pricing|stop|cycle)=/)
+    await expect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeHidden()
   })
 })
 

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -522,9 +522,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?pricing=creator&cycle=yearly`)
 
-    await cloudAppExpect(
+    await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 45_000 })
     expect(subscribeRequests).toHaveLength(0)
     await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
   })
@@ -536,7 +536,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?keep=1&stop=team_700&cycle=yearly`)
 
-    await waitForCloudApp(page)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
     await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
     await expect(page).not.toHaveURL(/[?&](pricing|stop|cycle)=/)
     await expect(pricingHeading(page)).toBeHidden()
@@ -554,7 +556,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?keep=1&pricing=creator&cycle=yearly`)
 
-    await waitForCloudApp(page)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
     await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
     await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
     await expect(
@@ -581,9 +585,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
       `${APP_URL}/?keep=1&pricing=team&stop=team_700&cycle=yearly`
     )
 
-    await cloudAppExpect(
+    await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 45_000 })
     const confirmationDialog = page.getByRole('dialog')
     await expect(
       confirmationDialog.getByText('$630', { exact: true }).last()
@@ -622,9 +626,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?pricing=team&stop=team_400&cycle=monthly`)
 
-    await cloudAppExpect(
+    await expect(
       page.getByRole('heading', { name: 'Confirm your payment' })
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 45_000 })
     await expect(page.getByText('$390', { exact: true })).toBeVisible()
   })
 
@@ -644,7 +648,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
       `${APP_URL}/?keep=1&pricing=team&stop=team_700&cycle=yearly`
     )
 
-    await waitForCloudApp(page)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
     await expect(page).toHaveURL(/[?&]keep=1(?:&|$)/)
     await expect(page).not.toHaveURL(/[?&](pricing|stop|cycle)=/)
     await expect(

--- a/src/composables/billing/types.ts
+++ b/src/composables/billing/types.ts
@@ -107,6 +107,7 @@ export interface BillingState {
 
 export interface BillingContext extends BillingState, BillingActions {
   type: ComputedRef<BillingType>
+  reconcileSubscriptionSuccess: () => Promise<void>
   /**
    * True when the active team workspace is still on a pre-credit-slider
    * (legacy) per-member tier plan, which keeps the old team pricing table.

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -4,6 +4,7 @@ import { nextTick } from 'vue'
 
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type {
+  BillingRail,
   BillingStatusResponse,
   Plan
 } from '@/platform/workspace/api/workspaceApi'
@@ -21,17 +22,29 @@ const {
   mockTeamWorkspacesEnabled,
   mockConsolidatedBillingEnabled,
   mockIsPersonal,
+  mockBillingRail,
   mockPlans,
+  mockFetchPlans,
+  mockLegacyFetchStatus,
+  mockLegacyFetchBalance,
+  mockLegacySubscribe,
   mockPurchaseCredits,
   mockUpdateActiveWorkspace,
+  mockSetWorkspaceBillingRail,
   mockBillingStatus
 } = vi.hoisted(() => ({
   mockTeamWorkspacesEnabled: { value: false },
   mockConsolidatedBillingEnabled: { value: false },
   mockIsPersonal: { value: true },
+  mockBillingRail: { value: undefined as BillingRail | undefined },
   mockPlans: { value: [] as Plan[] },
+  mockFetchPlans: vi.fn().mockResolvedValue(undefined),
+  mockLegacyFetchStatus: vi.fn().mockResolvedValue(undefined),
+  mockLegacyFetchBalance: vi.fn().mockResolvedValue(undefined),
+  mockLegacySubscribe: vi.fn().mockResolvedValue(undefined),
   mockPurchaseCredits: vi.fn(),
   mockUpdateActiveWorkspace: vi.fn(),
+  mockSetWorkspaceBillingRail: vi.fn(),
   mockBillingStatus: {
     value: {
       is_active: true,
@@ -82,19 +95,33 @@ vi.mock('@/composables/useFeatureFlags', async () => {
   }
 })
 
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    get isInPersonalWorkspace() {
-      return mockIsPersonal.value
-    },
-    get activeWorkspace() {
-      return mockIsPersonal.value
-        ? { id: 'personal-123', type: 'personal' }
-        : { id: 'team-456', type: 'team' }
-    },
-    updateActiveWorkspace: mockUpdateActiveWorkspace
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { ref } = await import('vue')
+  const billingRailRef = ref(mockBillingRail.value)
+  Object.defineProperty(mockBillingRail, 'value', {
+    get: () => billingRailRef.value,
+    set: (value: BillingRail | undefined) => {
+      billingRailRef.value = value
+    }
   })
-}))
+  return {
+    useTeamWorkspaceStore: () => ({
+      get isInPersonalWorkspace() {
+        return mockIsPersonal.value
+      },
+      get activeWorkspace() {
+        return mockIsPersonal.value
+          ? { id: 'personal-123', type: 'personal' }
+          : { id: 'team-456', type: 'team' }
+      },
+      get activeWorkspaceBillingRail() {
+        return mockBillingRail.value
+      },
+      updateActiveWorkspace: mockUpdateActiveWorkspace,
+      setWorkspaceBillingRail: mockSetWorkspaceBillingRail
+    })
+  }
+})
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
@@ -105,9 +132,9 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
       value: { renewal_date: '2025-01-01T00:00:00Z', end_date: null }
     },
     isCancelled: { value: false },
-    fetchStatus: vi.fn().mockResolvedValue(undefined),
+    fetchStatus: mockLegacyFetchStatus,
     manageSubscription: vi.fn().mockResolvedValue(undefined),
-    subscribe: vi.fn().mockResolvedValue(undefined),
+    subscribe: mockLegacySubscribe,
     showSubscriptionDialog: vi.fn()
   })
 }))
@@ -131,7 +158,7 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
     balance: { amount_micros: 5000000 },
-    fetchBalance: vi.fn().mockResolvedValue({ amount_micros: 5000000 })
+    fetchBalance: mockLegacyFetchBalance
   })
 }))
 
@@ -143,7 +170,7 @@ vi.mock('@/platform/cloud/subscription/composables/useBillingPlans', () => ({
     currentPlanSlug: { value: null },
     isLoading: { value: false },
     error: { value: null },
-    fetchPlans: vi.fn().mockResolvedValue(undefined),
+    fetchPlans: mockFetchPlans,
     getPlanBySlug: vi.fn().mockReturnValue(null)
   })
 }))
@@ -167,6 +194,12 @@ describe('useBillingContext', () => {
     mockTeamWorkspacesEnabled.value = false
     mockConsolidatedBillingEnabled.value = false
     mockIsPersonal.value = true
+    mockBillingRail.value = undefined
+    mockSetWorkspaceBillingRail.mockImplementation(
+      (_workspaceId: string, billingRail: BillingRail) => {
+        mockBillingRail.value = billingRail
+      }
+    )
     mockPlans.value = []
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
   })
@@ -261,6 +294,100 @@ describe('useBillingContext', () => {
     await topup(500)
 
     expect(mockPurchaseCredits).toHaveBeenCalledWith(5)
+  })
+
+  it('uses workspace checkout while keeping legacy topups on legacy Stripe', async () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockConsolidatedBillingEnabled.value = true
+    mockBillingRail.value = 'legacy_stripe'
+    mockPlans.value = [
+      {
+        slug: 'creator-annual',
+        tier: 'CREATOR',
+        duration: 'ANNUAL',
+        price_cents: 33600,
+        credits_cents: 42086,
+        max_seats: 1,
+        availability: { available: true },
+        seat_summary: {
+          seat_count: 1,
+          total_cost_cents: 33600,
+          total_credits_cents: 42086
+        }
+      }
+    ]
+
+    const context = useBillingContext()
+    vi.clearAllMocks()
+
+    expect(context.type.value).toBe('legacy')
+    expect(context.plans.value).toEqual(mockPlans.value)
+
+    await context.fetchPlans()
+    await context.fetchStatus()
+
+    expect(mockFetchPlans).toHaveBeenCalledOnce()
+    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
+
+    await context.previewSubscribe('creator-annual')
+    await context.subscribe('creator-annual')
+    await context.topup(500)
+
+    expect(workspaceApi.previewSubscribe).toHaveBeenCalledWith(
+      'creator-annual',
+      undefined
+    )
+    expect(workspaceApi.subscribe).toHaveBeenCalledWith(
+      'creator-annual',
+      undefined
+    )
+    expect(mockLegacySubscribe).not.toHaveBeenCalled()
+    expect(mockPurchaseCredits).toHaveBeenCalledWith(5)
+  })
+
+  it('switches billing adapters before refreshing a migrated balance', async () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockConsolidatedBillingEnabled.value = true
+    mockBillingRail.value = 'legacy_stripe'
+    mockBillingStatus.value = {
+      ...DEFAULT_BILLING_STATUS,
+      billing_rail: 'stripe'
+    }
+
+    const context = useBillingContext()
+    vi.clearAllMocks()
+
+    await context.reconcileSubscriptionSuccess()
+
+    expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
+      'personal-123',
+      'stripe'
+    )
+    expect(context.type.value).toBe('workspace')
+    expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
+    expect(workspaceApi.getBillingBalance).toHaveBeenCalled()
+    expect(mockLegacyFetchStatus).not.toHaveBeenCalled()
+    expect(mockLegacyFetchBalance).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh a balance through a stale rail after discovery fails', async () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockConsolidatedBillingEnabled.value = true
+    mockBillingRail.value = 'legacy_stripe'
+
+    const context = useBillingContext()
+    vi.clearAllMocks()
+    vi.mocked(workspaceApi.getBillingStatus).mockRejectedValueOnce(
+      new Error('status unavailable')
+    )
+
+    await expect(context.reconcileSubscriptionSuccess()).rejects.toThrow(
+      'status unavailable'
+    )
+
+    expect(workspaceApi.getBillingBalance).not.toHaveBeenCalled()
+    expect(mockLegacyFetchBalance).not.toHaveBeenCalled()
   })
 
   it('rejects topup amounts that are not positive whole-dollar cents', async () => {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -41,12 +41,14 @@ function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
 }
 
 /**
- * Unified billing context that selects the billing implementation by build/flag.
+ * Unified billing context that selects billing state and account actions by
+ * billing rail. When unified pricing is enabled, its catalog and checkout
+ * actions use workspace billing independently so legacy Stripe workspaces can
+ * migrate plans while balance, top-up, and subscription management stay legacy.
  *
  * - Team workspaces disabled (OSS/Desktop): legacy billing via /customers/*
- * - Team workspaces enabled: workspace billing via /api/billing/* for team
- *   workspaces, and for personal workspaces once consolidated billing is
- *   enabled; personal workspaces otherwise stay on legacy billing
+ * - Unified pricing: plan catalog and checkout via /api/billing/*
+ * - Other state and actions: legacy or workspace billing selected by rail
  *
  * The context automatically initializes when the workspace changes and provides
  * a unified interface for subscription status, balance, and billing actions.
@@ -79,7 +81,7 @@ function isTeamPlanSlug(planSlug: string | null | undefined): boolean {
  */
 function useBillingContextInternal(): BillingContext {
   const store = useTeamWorkspaceStore()
-  const { type } = useBillingRouting()
+  const { type, shouldUseUnifiedPricing } = useBillingRouting()
 
   const legacyBillingRef = shallowRef<(BillingState & BillingActions) | null>(
     null
@@ -109,6 +111,9 @@ function useBillingContextInternal(): BillingContext {
   const activeContext = computed(() =>
     type.value === 'legacy' ? getLegacyBilling() : getWorkspaceBilling()
   )
+  const checkoutContext = computed(() =>
+    shouldUseUnifiedPricing.value ? getWorkspaceBilling() : activeContext.value
+  )
 
   // Proxy state from active context
   const subscription = computed<SubscriptionInfo | null>(() =>
@@ -119,14 +124,14 @@ function useBillingContextInternal(): BillingContext {
     toValue(activeContext.value.balance)
   )
 
-  const plans = computed(() => toValue(activeContext.value.plans))
+  const plans = computed(() => toValue(checkoutContext.value.plans))
 
   const currentPlanSlug = computed(() =>
-    toValue(activeContext.value.currentPlanSlug)
+    toValue(checkoutContext.value.currentPlanSlug)
   )
 
   const teamCreditStops = computed(() =>
-    toValue(activeContext.value.teamCreditStops)
+    toValue(checkoutContext.value.teamCreditStops)
   )
 
   const currentTeamCreditStop = computed(() =>
@@ -264,15 +269,24 @@ function useBillingContextInternal(): BillingContext {
     return activeContext.value.fetchBalance()
   }
 
+  async function reconcileSubscriptionSuccess(): Promise<void> {
+    const checkout = checkoutContext.value
+    await checkout.fetchStatus()
+
+    const account = activeContext.value
+    if (account !== checkout) await account.fetchStatus()
+    await account.fetchBalance()
+  }
+
   async function subscribe(planSlug: string, options?: SubscribeOptions) {
-    return activeContext.value.subscribe(planSlug, options)
+    return checkoutContext.value.subscribe(planSlug, options)
   }
 
   async function previewSubscribe(
     planSlug: string,
     options?: PreviewSubscribeOptions
   ) {
-    return activeContext.value.previewSubscribe(planSlug, options)
+    return checkoutContext.value.previewSubscribe(planSlug, options)
   }
 
   async function manageSubscription() {
@@ -301,7 +315,7 @@ function useBillingContextInternal(): BillingContext {
   }
 
   async function fetchPlans() {
-    return activeContext.value.fetchPlans()
+    return checkoutContext.value.fetchPlans()
   }
 
   async function requireActiveSubscription() {
@@ -337,6 +351,7 @@ function useBillingContextInternal(): BillingContext {
     initialize,
     fetchStatus,
     fetchBalance,
+    reconcileSubscriptionSuccess,
     subscribe,
     previewSubscribe,
     manageSubscription,

--- a/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
@@ -127,16 +127,23 @@ describe('useBillingPlans', () => {
       )
 
       const useBillingPlans = await importUseBillingPlans()
-      const { fetchPlans, isLoading } = useBillingPlans()
+      const { fetchPlans, isLoading, plans } = useBillingPlans()
 
       const first = fetchPlans()
       expect(isLoading.value).toBe(true)
-      const second = fetchPlans()
+      let secondResolved = false
+      const second = fetchPlans().then(() => {
+        secondResolved = true
+      })
+
+      await Promise.resolve()
+      expect(secondResolved).toBe(false)
 
       resolveFetch({ plans: [buildPlan()] })
       await Promise.all([first, second])
 
       expect(mockGetBillingPlans).toHaveBeenCalledTimes(1)
+      expect(plans.value).toEqual([buildPlan()])
       expect(isLoading.value).toBe(false)
     })
 

--- a/src/platform/cloud/subscription/composables/useBillingPlans.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPlans.ts
@@ -11,25 +11,33 @@ const currentPlanSlug = ref<string | null>(null)
 const teamCreditStops = ref<TeamCreditStops | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
+let fetchPromise: Promise<void> | null = null
 
 export function useBillingPlans() {
-  async function fetchPlans() {
-    if (isLoading.value) return
+  function fetchPlans(): Promise<void> {
+    if (fetchPromise) return fetchPromise
 
     isLoading.value = true
     error.value = null
 
-    try {
-      const response = await workspaceApi.getBillingPlans()
-      plans.value = response.plans
-      currentPlanSlug.value = response.current_plan_slug ?? null
-      teamCreditStops.value = response.team_credit_stops ?? null
-    } catch (err) {
-      error.value = err instanceof Error ? err.message : 'Failed to fetch plans'
-      console.error('[useBillingPlans] Failed to fetch plans:', err)
-    } finally {
-      isLoading.value = false
-    }
+    fetchPromise = workspaceApi
+      .getBillingPlans()
+      .then((response) => {
+        plans.value = response.plans
+        currentPlanSlug.value = response.current_plan_slug ?? null
+        teamCreditStops.value = response.team_credit_stops ?? null
+      })
+      .catch((err: unknown) => {
+        error.value =
+          err instanceof Error ? err.message : 'Failed to fetch plans'
+        console.error('[useBillingPlans] Failed to fetch plans:', err)
+      })
+      .finally(() => {
+        isLoading.value = false
+        fetchPromise = null
+      })
+
+    return fetchPromise
   }
 
   const monthlyPlans = computed(() =>

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -1,6 +1,8 @@
 import { fromAny } from '@total-typescript/shoehorn'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { TeamCreditStops } from '@/platform/workspace/api/workspaceApi'
+
 import { usePricingTableUrlLoader } from './usePricingTableUrlLoader'
 
 const preservedQueryMocks = vi.hoisted(() => ({
@@ -42,16 +44,45 @@ vi.mock(
 const mockPermissions = vi.hoisted(() => ({
   value: { canManageSubscription: true }
 }))
+const mockTeamCreditStops = vi.hoisted(() => ({
+  value: null as TeamCreditStops | null
+}))
+const mockFetchPlans = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    teamCreditStops: mockTeamCreditStops,
+    fetchPlans: mockFetchPlans
+  })
+}))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({ permissions: mockPermissions })
 }))
+
+const TEAM_CREDIT_STOPS = {
+  default_stop_index: 2,
+  stops: [200, 400, 700, 1400, 2500].map((usd, index) => ({
+    id: `team_${usd}`,
+    credits: usd * 211,
+    monthly: {
+      list_price_cents: usd * 100,
+      price_cents: usd * 100 - index * 500
+    },
+    yearly: {
+      list_price_cents: usd * 100,
+      price_cents: usd * 100 - index * 1000
+    }
+  }))
+} satisfies TeamCreditStops
 
 describe('usePricingTableUrlLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRouteQuery.value = {}
     mockPermissions.value = { canManageSubscription: true }
+    mockTeamCreditStops.value = TEAM_CREDIT_STOPS
+    mockFetchPlans.mockResolvedValue(undefined)
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -69,16 +100,15 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).not.toHaveBeenCalled()
   })
 
-  it('opens the pricing table for an owner', async () => {
+  it('opens the pricing table for any owner capability', async () => {
     mockRouteQuery.value = { pricing: '1' }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
-    expect(mockShowPricingTable).toHaveBeenCalledWith({
-      reason: 'deep_link',
-      planMode: undefined
-    })
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'deep_link' })
+    )
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
@@ -88,10 +118,9 @@ describe('usePricingTableUrlLoader', () => {
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
-    expect(mockShowPricingTable).toHaveBeenCalledWith({
-      reason: 'deep_link',
-      planMode: 'team'
-    })
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'deep_link', planMode: 'team' })
+    )
   })
 
   it('opens on the personal tab for ?pricing=personal', async () => {
@@ -100,10 +129,27 @@ describe('usePricingTableUrlLoader', () => {
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'deep_link', planMode: 'personal' })
+    )
+  })
+
+  it('opens the selected plan confirmation from a marketing deep link', async () => {
+    mockRouteQuery.value = { pricing: 'creator', cycle: 'monthly' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
     expect(mockShowPricingTable).toHaveBeenCalledWith({
       reason: 'deep_link',
-      planMode: 'personal'
+      planMode: 'personal',
+      initialCheckout: {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      }
     })
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
   it('is a silent no-op for a member', async () => {
@@ -116,8 +162,12 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockShowPricingTable).not.toHaveBeenCalled()
   })
 
-  it('denies, strips, and clears together when the user is not eligible', async () => {
-    mockRouteQuery.value = { pricing: '1', other: 'param' }
+  it('denies selected-plan entry and strips its params for a member', async () => {
+    mockRouteQuery.value = {
+      pricing: 'creator',
+      cycle: 'monthly',
+      other: 'param'
+    }
     mockPermissions.value = { canManageSubscription: false }
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
@@ -132,10 +182,12 @@ describe('usePricingTableUrlLoader', () => {
     )
   })
 
-  it('restores preserved query and opens the table', async () => {
+  it('restores a preserved Team selection with its catalog values', async () => {
     mockRouteQuery.value = {}
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
-      pricing: '1'
+      pricing: 'team',
+      stop: 'team_700',
+      cycle: 'yearly'
     })
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
@@ -144,7 +196,21 @@ describe('usePricingTableUrlLoader', () => {
     expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
       'pricing'
     )
-    expect(mockShowPricingTable).toHaveBeenCalledOnce()
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team',
+      initialCheckout: {
+        planMode: 'team',
+        stop: {
+          id: 'team_700',
+          credits: 147700,
+          usd: 700,
+          discountedUsd: 680
+        },
+        billingCycle: 'yearly'
+      }
+    })
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
   it('strips but does not open for an empty param', async () => {
@@ -170,15 +236,209 @@ describe('usePricingTableUrlLoader', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 
-  it('opens the default tab for an unrecognized pricing value', async () => {
+  it('strips but does not open for an unrecognized pricing value', async () => {
     mockRouteQuery.value = { pricing: 'garbage' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it.for<Record<string, string>>([
+    { stop: 'team_700' },
+    { cycle: 'monthly' },
+    { stop: 'team_700', cycle: 'yearly', other: 'param' }
+  ])('cleans orphaned pricing state: %o', async (query) => {
+    mockRouteQuery.value = query
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      query: 'other' in query ? { other: 'param' } : {}
+    })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+  })
+
+  it('cleans orphaned pricing state restored from preservation', async () => {
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+      cycle: 'monthly',
+      other: 'param'
+    })
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      query: { other: 'param' }
+    })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+  })
+
+  it.for<Record<string, string>>([
+    { pricing: 'creator' },
+    { pricing: 'creator', cycle: 'weekly' },
+    { pricing: 'founder', cycle: 'yearly' }
+  ])('strips but does not open an unsupported checkout: %o', async (query) => {
+    mockRouteQuery.value = query
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it.for(
+    TEAM_CREDIT_STOPS.stops.flatMap((stop) =>
+      (['monthly', 'yearly'] as const).map((billingCycle) => ({
+        catalogStop: stop,
+        billingCycle
+      }))
+    )
+  )(
+    'opens $catalogStop.id $billingCycle from the API catalog',
+    async ({ catalogStop, billingCycle }) => {
+      mockRouteQuery.value = {
+        pricing: 'team',
+        stop: catalogStop.id,
+        cycle: billingCycle
+      }
+
+      const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+      await loadPricingTableFromUrl()
+
+      expect(mockShowPricingTable).toHaveBeenCalledWith({
+        reason: 'deep_link',
+        planMode: 'team',
+        initialCheckout: {
+          planMode: 'team',
+          stop: {
+            id: catalogStop.id,
+            credits: catalogStop.credits,
+            usd: catalogStop[billingCycle].list_price_cents / 100,
+            discountedUsd: catalogStop[billingCycle].price_cents / 100
+          },
+          billingCycle
+        }
+      })
+      expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    }
+  )
+
+  it('fetches the Team catalog before resolving a selected stop', async () => {
+    mockRouteQuery.value = {
+      pricing: 'team',
+      stop: 'team_700',
+      cycle: 'yearly'
+    }
+    mockTeamCreditStops.value = null
+    mockFetchPlans.mockImplementationOnce(async () => {
+      mockTeamCreditStops.value = TEAM_CREDIT_STOPS
+    })
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockFetchPlans).toHaveBeenCalledOnce()
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialCheckout: expect.objectContaining({
+          planMode: 'team',
+          stop: expect.objectContaining({ id: 'team_700' })
+        })
+      })
+    )
+  })
+
+  it('falls back to the Team table when the catalog fetch fails', async () => {
+    mockRouteQuery.value = {
+      pricing: 'team',
+      stop: 'team_700',
+      cycle: 'yearly'
+    }
+    mockTeamCreditStops.value = null
+    mockFetchPlans.mockRejectedValueOnce(new Error('catalog unavailable'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
     await loadPricingTableFromUrl()
 
     expect(mockShowPricingTable).toHaveBeenCalledWith({
       reason: 'deep_link',
-      planMode: undefined
+      planMode: 'team'
     })
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('falls back when the catalog remains unavailable after fetching', async () => {
+    mockRouteQuery.value = {
+      pricing: 'team',
+      stop: 'team_700',
+      cycle: 'yearly'
+    }
+    mockTeamCreditStops.value = null
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team'
+    })
+  })
+
+  it('falls back to the Team table for a stop absent from the catalog', async () => {
+    mockRouteQuery.value = {
+      pricing: 'team',
+      stop: 'unknown',
+      cycle: 'monthly'
+    }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team'
+    })
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it.for([
+    { pricing: 'team', stop: 'team_700' },
+    { pricing: 'team', cycle: 'yearly' },
+    { pricing: 'team', stop: '', cycle: 'monthly' },
+    { pricing: 'team', stop: 'team_700', cycle: 'weekly' },
+    { pricing: 'personal', stop: 'team_700', cycle: 'yearly' }
+  ])('fails closed for an invalid Team selection: %o', async (query) => {
+    mockRouteQuery.value = fromAny<Record<string, string>, unknown>(query)
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it.for([
+    { pricing: 'team', stop: ['team_700'], cycle: 'yearly' },
+    { pricing: 'team', stop: 'team_700', cycle: ['yearly'] }
+  ])('fails closed for array Team params: %o', async (query) => {
+    mockRouteQuery.value = fromAny<Record<string, string>, unknown>(query)
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
   })
 })

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -1,5 +1,6 @@
 import { useRoute, useRouter } from 'vue-router'
 
+import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import {
   clearPreservedQuery,
@@ -7,13 +8,91 @@ import {
   mergePreservedQueryIntoQuery
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import type { TeamCreditStops } from '@/platform/workspace/api/workspaceApi'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
 
+function isCheckoutTier(
+  value: string
+): value is Extract<
+  SubscriptionCheckoutSelection,
+  { planMode: 'personal' }
+>['tierKey'] {
+  return value === 'standard' || value === 'creator' || value === 'pro'
+}
+
+function isBillingCycle(
+  value: unknown
+): value is SubscriptionCheckoutSelection['billingCycle'] {
+  return value === 'monthly' || value === 'yearly'
+}
+
+function getTeamCheckoutRequest(
+  pricing: string,
+  stop: unknown,
+  cycle: unknown
+):
+  | {
+      stop: string
+      billingCycle: SubscriptionCheckoutSelection['billingCycle']
+    }
+  | undefined {
+  if (
+    pricing !== 'team' ||
+    typeof stop !== 'string' ||
+    !stop ||
+    !isBillingCycle(cycle)
+  ) {
+    return
+  }
+
+  return { stop, billingCycle: cycle }
+}
+
+function getCheckoutSelection(
+  pricing: string,
+  stop: unknown,
+  cycle: unknown,
+  teamCreditStops: TeamCreditStops | null
+): SubscriptionCheckoutSelection | undefined {
+  if (isCheckoutTier(pricing)) {
+    if (stop !== undefined || !isBillingCycle(cycle)) return
+
+    return {
+      planMode: 'personal',
+      tierKey: pricing,
+      billingCycle: cycle
+    }
+  }
+
+  const teamCheckoutRequest = getTeamCheckoutRequest(pricing, stop, cycle)
+  if (!teamCheckoutRequest) return
+
+  const catalogStop = teamCreditStops?.stops.find(
+    (candidate) => candidate.id === teamCheckoutRequest.stop
+  )
+  if (!catalogStop) return
+
+  return {
+    planMode: 'team',
+    stop: {
+      id: catalogStop.id,
+      credits: catalogStop.credits,
+      usd: catalogStop[teamCheckoutRequest.billingCycle].list_price_cents / 100,
+      discountedUsd:
+        catalogStop[teamCheckoutRequest.billingCycle].price_cents / 100
+    },
+    billingCycle: teamCheckoutRequest.billingCycle
+  }
+}
+
 /**
  * Opens the pricing table from a `?pricing=` deep link, to send pilot users
- * straight to subscribe. Values: `1` (default tab), `team`, `personal`.
+ * straight to subscribe. Values: `1` (default tab), `team`, `personal`, or a
+ * selected personal tier or Team credit stop with a billing cycle to open its
+ * confirmation.
  *
  * Gated to workspace owners (`canManageSubscription`); a member is a silent
  * no-op with the param stripped. Survives the login redirect via the
@@ -23,6 +102,7 @@ export function usePricingTableUrlLoader() {
   const route = useRoute()
   const router = useRouter()
   const subscriptionDialog = useSubscriptionDialog()
+  const { teamCreditStops, fetchPlans } = useBillingContext()
   const { permissions } = useWorkspaceUI()
 
   /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
@@ -31,13 +111,21 @@ export function usePricingTableUrlLoader() {
     const query =
       mergePreservedQueryIntoQuery(NAMESPACE, route.query) ?? route.query
     const param = query.pricing
-    if (param === undefined) return
+    if (
+      param === undefined &&
+      query.stop === undefined &&
+      query.cycle === undefined
+    ) {
+      return
+    }
 
     // Strip any present pricing param (even ineligible or malformed values) and
     // write the clean URL in a single replace before any await, so a clean URL
     // is guaranteed even if the replace rejects or the gate later denies.
     const cleanQuery = { ...query }
     delete cleanQuery.pricing
+    delete cleanQuery.stop
+    delete cleanQuery.cycle
     router.replace({ query: cleanQuery }).catch((error) => {
       console.warn(
         '[usePricingTableUrlLoader] Failed to clean URL params:',
@@ -52,10 +140,65 @@ export function usePricingTableUrlLoader() {
 
     if (!permissions.value.canManageSubscription) return
 
-    const planMode =
-      param === 'team' || param === 'personal' ? param : undefined
+    const teamCheckoutRequest = getTeamCheckoutRequest(
+      param,
+      query.stop,
+      query.cycle
+    )
+    if (teamCheckoutRequest && !teamCreditStops.value) {
+      try {
+        await fetchPlans()
+      } catch (error) {
+        console.error(
+          '[usePricingTableUrlLoader] Failed to load Team pricing plans:',
+          error
+        )
+      }
+      if (!permissions.value.canManageSubscription) return
+      if (!teamCreditStops.value) {
+        subscriptionDialog.showPricingTable({
+          reason: 'deep_link',
+          planMode: 'team'
+        })
+        return
+      }
+    }
 
-    subscriptionDialog.showPricingTable({ reason: 'deep_link', planMode })
+    const initialCheckout = getCheckoutSelection(
+      param,
+      query.stop,
+      query.cycle,
+      teamCreditStops.value
+    )
+    if (isCheckoutTier(param) && !initialCheckout) return
+    if (teamCheckoutRequest && !initialCheckout) {
+      subscriptionDialog.showPricingTable({
+        reason: 'deep_link',
+        planMode: 'team'
+      })
+      return
+    }
+    if (
+      !initialCheckout &&
+      (query.stop !== undefined || query.cycle !== undefined)
+    ) {
+      return
+    }
+
+    const planMode = initialCheckout
+      ? initialCheckout.planMode
+      : param === 'team' || param === 'personal'
+        ? param
+        : undefined
+
+    if (!initialCheckout && !['1', 'team', 'personal'].includes(param)) return
+    if (!permissions.value.canManageSubscription) return
+
+    subscriptionDialog.showPricingTable({
+      reason: 'deep_link',
+      planMode,
+      initialCheckout
+    })
   }
 
   return {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -190,6 +190,62 @@ describe('useSubscriptionDialog', () => {
       expect(props.initialPlanMode).toBe('team')
     })
 
+    it('passes a deep-linked checkout selection to the unified dialog', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+      const initialCheckout = {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      } as const
+
+      showPricingTable({ planMode: 'personal', initialCheckout })
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props.initialCheckout).toEqual(initialCheckout)
+    })
+
+    it('routes a personal deep link through the legacy Team downgrade flow', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsInPersonalWorkspace.value = false
+      mockIsLegacyTeamPlan.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+      const initialCheckout = {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      } as const
+
+      showPricingTable({ initialCheckout })
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props).toMatchObject({ isPersonal: true, initialCheckout })
+    })
+
+    it('keeps a Team stop deep link table-only for a legacy Team plan', () => {
+      mockShouldUseWorkspaceBilling.value = true
+      mockIsInPersonalWorkspace.value = false
+      mockIsLegacyTeamPlan.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable({
+        initialCheckout: {
+          planMode: 'team',
+          stop: {
+            id: 'team_700',
+            credits: 147_700,
+            usd: 700,
+            discountedUsd: 630
+          },
+          billingCycle: 'yearly'
+        }
+      })
+
+      const props = mockShowLayoutDialog.mock.calls[0][0].props
+      expect(props).not.toHaveProperty('initialCheckout')
+      expect(props).not.toHaveProperty('isPersonal')
+    })
+
     it('defaults to the team tab for a Team plan in a personal workspace', () => {
       mockShouldUseWorkspaceBilling.value = true
       mockIsInPersonalWorkspace.value = true
@@ -215,17 +271,29 @@ describe('useSubscriptionDialog', () => {
       expect(props.initialPlanMode).toBe('personal')
     })
 
-    it('uses the legacy table (with onChooseTeam) on the legacy billing flow', () => {
+    it('keeps personal checkout deep links table-only on the legacy billing flow', () => {
       mockShouldUseWorkspaceBilling.value = false
       mockIsInPersonalWorkspace.value = true
       const { showPricingTable } = useSubscriptionDialog()
 
-      showPricingTable()
+      showPricingTable({
+        reason: 'deep_link',
+        initialCheckout: {
+          planMode: 'personal',
+          tierKey: 'creator',
+          billingCycle: 'monthly'
+        }
+      })
 
       const props = mockShowLayoutDialog.mock.calls[0][0].props
       expect(props).toHaveProperty('onChooseTeam')
+      expect(props).not.toHaveProperty('initialCheckout')
       const { dialogComponentProps } = mockShowLayoutDialog.mock.calls[0][0]
       expectRekaPricingDialogProps(dialogComponentProps)
+      expect(mockTrackSubscription).toHaveBeenCalledWith(
+        'modal_opened',
+        expect.objectContaining({ reason: 'deep_link' })
+      )
     })
 
     it('uses the unified table when pricing is unified but billing remains legacy', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -6,6 +6,7 @@ import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
@@ -21,6 +22,8 @@ export interface SubscriptionDialogOptions {
    * always lands on the team tab even from a personal workspace).
    */
   planMode?: 'personal' | 'team'
+  /** Starts checkout in workspace billing dialogs; legacy billing stays table-only. */
+  initialCheckout?: SubscriptionCheckoutSelection
 }
 
 function getInitialPlanMode(
@@ -106,6 +109,10 @@ export const useSubscriptionDialog = () => {
       const { currentPlanSlug, isLegacyTeamPlan, isTeamPlan } =
         useBillingContext()
       if (isLegacyTeamPlan.value) {
+        const personalInitialCheckout =
+          options?.initialCheckout?.planMode === 'personal'
+            ? options.initialCheckout
+            : undefined
         dialogService.showLayoutDialog({
           key: DIALOG_KEY,
           component: defineAsyncComponent(
@@ -114,7 +121,13 @@ export const useSubscriptionDialog = () => {
           ),
           props: {
             onClose: hide,
-            reason: options?.reason
+            reason: options?.reason,
+            ...(personalInitialCheckout
+              ? {
+                  initialCheckout: personalInitialCheckout,
+                  isPersonal: true
+                }
+              : {})
           },
           // The legacy table hosts a PrimeVue Popover teleported to body; Reka
           // modal mode traps focus and disables body pointer-events, making it
@@ -136,6 +149,7 @@ export const useSubscriptionDialog = () => {
         props: {
           onClose: hide,
           reason: options?.reason,
+          initialCheckout: options?.initialCheckout,
           initialPlanMode: getInitialPlanMode(
             options?.planMode,
             isTeamPlan.value,

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -23,6 +23,12 @@ const plainDefinition = {
   keys: ['plain_code', 'plain_source']
 }
 
+const dependentDefinition = {
+  namespace: PLAIN_NAMESPACE,
+  keys: ['primary', 'dependent'],
+  requiredKey: 'primary'
+}
+
 function createTestRouter(
   history: RouterHistory = createMemoryHistory()
 ): Router {
@@ -76,6 +82,27 @@ describe('installPreservedQueryTracker', () => {
     expect(
       getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_source')
     ).toBeUndefined()
+  })
+
+  it('captures dependent keys only when their required key is present', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [dependentDefinition])
+
+    await router.push('/?primary=one&dependent=two')
+
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'primary')).toBe('one')
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'dependent')).toBe('two')
+  })
+
+  it('clears preserved state for an orphaned dependent key', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [dependentDefinition])
+    await router.push('/?primary=one&dependent=two')
+
+    await router.push('/?dependent=orphan')
+
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'primary')).toBeUndefined()
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'dependent')).toBeUndefined()
   })
 
   it('navigates exactly once when no strip-marked keys are present', async () => {

--- a/src/platform/navigation/preservedQueryTracker.ts
+++ b/src/platform/navigation/preservedQueryTracker.ts
@@ -2,12 +2,14 @@ import type { Router } from 'vue-router'
 
 import {
   capturePreservedQuery,
+  clearPreservedQuery,
   hydratePreservedQuery
 } from '@/platform/navigation/preservedQueryManager'
 
 interface PreservedQueryDefinition {
   namespace: string
   keys: string[]
+  requiredKey?: string
   /**
    * When set, keys present in the query are removed from the client-side URL
    * before navigation completes. Later guards, afterEach hooks, and views must
@@ -28,17 +30,23 @@ export const installPreservedQueryTracker = (
     const queryKeys = new Set(Object.keys(to.query))
     const keysToStrip = new Set<string>()
 
-    definitions.forEach(({ namespace, keys, stripAfterCapture }) => {
-      hydratePreservedQuery(namespace)
-      const presentKeys = keys.filter((key) => queryKeys.has(key))
-      if (presentKeys.length === 0) return
-      capturePreservedQuery(namespace, to.query, keys, {
-        merge: stripAfterCapture
-      })
-      if (stripAfterCapture) {
-        presentKeys.forEach((key) => keysToStrip.add(key))
+    definitions.forEach(
+      ({ namespace, keys, requiredKey, stripAfterCapture }) => {
+        hydratePreservedQuery(namespace)
+        const presentKeys = keys.filter((key) => queryKeys.has(key))
+        if (presentKeys.length === 0) return
+        if (requiredKey && !queryKeys.has(requiredKey)) {
+          clearPreservedQuery(namespace)
+          return
+        }
+        capturePreservedQuery(namespace, to.query, keys, {
+          merge: stripAfterCapture
+        })
+        if (stripAfterCapture) {
+          presentKeys.forEach((key) => keysToStrip.add(key))
+        }
       }
-    })
+    )
 
     if (keysToStrip.size === 0) {
       next()

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -7,6 +7,7 @@ import { createI18n } from 'vue-i18n'
 import SubscriptionRequiredDialogContentUnified from './SubscriptionRequiredDialogContentUnified.vue'
 
 const mockHandleSubscribeTeamClick = vi.fn()
+const mockHandleSubscribeClick = vi.fn()
 const mockIsInPersonalWorkspace = ref(false)
 
 vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
@@ -23,7 +24,7 @@ vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
     isPolling: ref(false),
     isTeamCheckout: computed(() => false),
     previewVariant: computed(() => null),
-    handleSubscribeClick: vi.fn(),
+    handleSubscribeClick: mockHandleSubscribeClick,
     handleSubscribeTeamClick: mockHandleSubscribeTeamClick,
     handleBackToPricing: vi.fn(),
     handleSuccessClose: vi.fn(),
@@ -112,5 +113,42 @@ describe('SubscriptionRequiredDialogContentUnified team-plan subscribe', () => {
     await vi.waitFor(() => {
       expect(mockHandleSubscribeTeamClick).toHaveBeenCalledWith(TEAM_PAYLOAD)
     })
+  })
+
+  it('opens the selected personal plan confirmation on mount', async () => {
+    renderComponent({
+      initialCheckout: {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      }
+    })
+
+    await vi.waitFor(() => {
+      expect(mockHandleSubscribeClick).toHaveBeenCalledWith({
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+    })
+  })
+
+  it('opens a resolved Team stop confirmation on mount', async () => {
+    renderComponent({
+      initialCheckout: {
+        planMode: 'team',
+        stop: TEAM_PAYLOAD.stop,
+        billingCycle: TEAM_PAYLOAD.billingCycle
+      }
+    })
+
+    await vi.waitFor(() => {
+      expect(mockHandleSubscribeTeamClick).toHaveBeenCalledWith({
+        planMode: 'team',
+        stop: TEAM_PAYLOAD.stop,
+        billingCycle: TEAM_PAYLOAD.billingCycle
+      })
+    })
+    expect(mockHandleSubscribeClick).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -111,9 +111,11 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { useEventListener } from '@vueuse/core'
+import { onMounted } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
@@ -121,10 +123,11 @@ import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
 
-const { onClose, reason, initialPlanMode } = defineProps<{
+const { onClose, reason, initialPlanMode, initialCheckout } = defineProps<{
   onClose: () => void
   reason?: PaymentIntentSource
   initialPlanMode?: 'personal' | 'team'
+  initialCheckout?: SubscriptionCheckoutSelection
 }>()
 
 const emit = defineEmits<{
@@ -153,6 +156,15 @@ const {
   handleTeamSubscribe,
   handleResubscribe
 } = useSubscriptionCheckout(emit, reason)
+
+onMounted(() => {
+  if (!initialCheckout) return
+  if (initialCheckout.planMode === 'team') {
+    void handleSubscribeTeamClick(initialCheckout)
+    return
+  }
+  void handleSubscribeClick(initialCheckout)
+})
 
 // Backspace mirrors the back arrow on the confirm step, but never while an
 // editable element is focused (let it delete text there).

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -6,6 +6,7 @@ import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import SubscriptionRequiredDialogContentWorkspace from './SubscriptionRequiredDialogContentWorkspace.vue'
 
@@ -78,6 +79,7 @@ function renderComponent(
     onClose?: () => void
     reason?: PaymentIntentSource
     isPersonal?: boolean
+    initialCheckout?: SubscriptionCheckoutSelection
   } = {}
 ) {
   return render(SubscriptionRequiredDialogContentWorkspace, {
@@ -86,6 +88,9 @@ function renderComponent(
       ...(props.reason ? { reason: props.reason } : {}),
       ...(props.isPersonal !== undefined
         ? { isPersonal: props.isPersonal }
+        : {}),
+      ...(props.initialCheckout
+        ? { initialCheckout: props.initialCheckout }
         : {})
     },
     global: {
@@ -152,6 +157,18 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
       undefined,
       { tierPlanType: 'personal' }
     )
+  })
+
+  it('opens a personal deep-linked checkout on mount', () => {
+    const initialCheckout = {
+      planMode: 'personal',
+      tierKey: 'creator',
+      billingCycle: 'monthly'
+    } as const
+
+    renderComponent({ isPersonal: true, initialCheckout })
+
+    expect(mockHandleSubscribeClick).toHaveBeenCalledWith(initialCheckout)
   })
 
   it('shows the team workspace header by default', () => {

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -114,9 +114,11 @@
 
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import { onMounted } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
+import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composables/useSubscriptionCheckout'
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import PricingTableWorkspace from './PricingTableWorkspace.vue'
@@ -127,11 +129,13 @@ import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPrev
 const {
   onClose,
   reason,
-  isPersonal = false
+  isPersonal = false,
+  initialCheckout
 } = defineProps<{
   onClose: () => void
   reason?: PaymentIntentSource
   isPersonal?: boolean
+  initialCheckout?: SubscriptionCheckoutSelection
 }>()
 
 const emit = defineEmits<{
@@ -156,6 +160,12 @@ const {
   handleSuccessClose
 } = useSubscriptionCheckout(emit, reason, {
   tierPlanType: isPersonal ? 'personal' : 'team'
+})
+
+onMounted(() => {
+  if (initialCheckout?.planMode === 'personal') {
+    void handleSubscribeClick(initialCheckout)
+  }
 })
 </script>
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -71,6 +71,7 @@ describe('findPlanSlug', () => {
 const {
   mockSubscribe,
   mockPreviewSubscribe,
+  mockFetchPlans,
   mockFetchStatus,
   mockFetchBalance,
   mockPlans,
@@ -86,6 +87,7 @@ const {
 } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(),
   mockPreviewSubscribe: vi.fn(),
+  mockFetchPlans: vi.fn(),
   mockFetchStatus: vi.fn(),
   mockFetchBalance: vi.fn(),
   mockPlans: { value: [] as Plan[] },
@@ -110,7 +112,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     subscribe: mockSubscribe,
     previewSubscribe: mockPreviewSubscribe,
-    plans: computed(() => mockPlans.value),
+    plans: mockPlans,
+    fetchPlans: mockFetchPlans,
     fetchStatus: mockFetchStatus,
     fetchBalance: mockFetchBalance,
     isTeamPlan: computed(() => mockIsTeamPlan.value),
@@ -196,6 +199,7 @@ describe('useSubscriptionCheckout', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     mockPlans.value = allPlans()
+    mockFetchPlans.mockResolvedValue(undefined)
     mockStartOperation.mockResolvedValue({ status: 'succeeded' })
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
     mockUserId.value = 'user-1'
@@ -231,6 +235,7 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.checkoutStep.value).toBe('preview')
       expect(checkout.previewData.value).toStrictEqual(preview)
+      expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
     it('shows error toast when preview is disallowed', async () => {
@@ -269,6 +274,48 @@ describe('useSubscriptionCheckout', () => {
           detail: 'This plan is not available'
         })
       )
+      expect(mockFetchPlans).toHaveBeenCalledOnce()
+    })
+
+    it('waits for plans before opening a deep-linked confirmation', async () => {
+      const checkout = await setup()
+      mockPlans.value = []
+      let resolvePlans = () => {}
+      mockFetchPlans.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvePlans = () => {
+              mockPlans.value = [makeCreatorMonthly()]
+              resolve()
+            }
+          })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'new_subscription',
+        effective_at: '2025-01-01',
+        is_immediate: true,
+        cost_today_cents: 3500,
+        cost_next_period_cents: 3500,
+        credits_today_cents: 7400,
+        credits_next_period_cents: 7400,
+        new_plan: makeCreatorMonthly().seat_summary
+      })
+
+      const checkoutPromise = checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      expect(checkout.checkoutStep.value).toBe('pricing')
+      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
+      resolvePlans()
+      await checkoutPromise
+
+      expect(mockFetchPlans).toHaveBeenCalledOnce()
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith('creator-monthly')
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
     it('shows error toast on network failure', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -23,7 +23,19 @@ import { useBillingOperationStore } from '@/platform/workspace/stores/billingOpe
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
 type CheckoutStep = 'pricing' | 'preview' | 'success'
-type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
+export type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
+
+export type SubscriptionCheckoutSelection =
+  | {
+      planMode: 'personal'
+      tierKey: CheckoutTierKey
+      billingCycle: BillingCycle
+    }
+  | {
+      planMode: 'team'
+      stop: TeamPlanSelection
+      billingCycle: BillingCycle
+    }
 
 interface SelectedTeamCheckout {
   stop: TeamPlanSelection
@@ -69,8 +81,14 @@ export function useSubscriptionCheckout(
 ) {
   const { t } = useI18n()
   const toast = useToast()
-  const { subscribe, previewSubscribe, plans, isTeamPlan, resubscribe } =
-    useBillingContext()
+  const {
+    subscribe,
+    previewSubscribe,
+    plans,
+    fetchPlans,
+    isTeamPlan,
+    resubscribe
+  } = useBillingContext()
   const { permissions } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
@@ -156,7 +174,11 @@ export function useSubscriptionCheckout(
     selectedBillingCycle.value = billingCycle
 
     try {
-      const planSlug = getApiPlanSlug(tierKey, billingCycle)
+      let planSlug = getApiPlanSlug(tierKey, billingCycle)
+      if (!planSlug) {
+        await fetchPlans()
+        planSlug = getApiPlanSlug(tierKey, billingCycle)
+      }
       if (!planSlug) {
         toast.add({
           severity: 'error',

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -5,11 +5,13 @@ import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspace
 
 const mockFetchStatus = vi.fn()
 const mockFetchBalance = vi.fn()
+const mockReconcileSubscriptionSuccess = vi.fn()
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     fetchStatus: mockFetchStatus,
-    fetchBalance: mockFetchBalance
+    fetchBalance: mockFetchBalance,
+    reconcileSubscriptionSuccess: mockReconcileSubscriptionSuccess
   })
 }))
 
@@ -190,8 +192,9 @@ describe('billingOperationStore', () => {
       expect(operation?.status).toBe('succeeded')
       expect(store.hasPendingOperations).toBe(false)
 
-      expect(mockFetchStatus).toHaveBeenCalled()
-      expect(mockFetchBalance).toHaveBeenCalled()
+      expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+      expect(mockFetchBalance).not.toHaveBeenCalled()
 
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'success',

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -158,10 +158,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
 
     const billingContext = useBillingContext()
-    await Promise.allSettled([
-      billingContext.fetchStatus(),
-      billingContext.fetchBalance()
-    ])
+    if (operation.type === 'subscription') {
+      await Promise.allSettled([billingContext.reconcileSubscriptionSuccess()])
+    } else {
+      await Promise.allSettled([
+        billingContext.fetchStatus(),
+        billingContext.fetchBalance()
+      ])
+    }
 
     if (operation.type === 'cancel') {
       useTeamWorkspaceStore().updateActiveWorkspace({ isSubscribed: false })

--- a/src/router.ts
+++ b/src/router.ts
@@ -118,7 +118,8 @@ installPreservedQueryTracker(router, [
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.PRICING,
-    keys: ['pricing']
+    keys: ['pricing', 'stop', 'cycle'],
+    requiredKey: 'pricing'
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN,

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -39,6 +39,7 @@ export function useBillingContext(): BillingContext {
     initialize: async () => {},
     fetchStatus: async () => {},
     fetchBalance: async () => {},
+    reconcileSubscriptionSuccess: async () => {},
     subscribe: async () => {},
     previewSubscribe: async () => null,
     manageSubscription: async () => {},


### PR DESCRIPTION
Backport of #13915 to `cloud/1.47`.

The change applies cleanly to this release branch. The automatic workflow pushed and then cleaned up its generated branch after the companion `cloud/1.45` backport conflicted, so this PR recreates the clean backport manually.

## Validation

- 212 focused unit tests across billing plans/context, URL loading, dialogs, checkout, and billing operations
- `vue-tsc --noEmit -p tsconfig.json`
- Changed-file `oxfmt --check`
- `git diff --check`
- `pnpm knip` (push hook)