### PR TITLE
feat: 7/x support workspace admin governance

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2987,7 +2987,12 @@
       "loading": "Loading partner node access",
       "loadError": "Partner node access couldn't be loaded.",
       "retry": "Try again",
-      "noResults": "No providers or partner nodes found"
+      "noResults": "No providers or partner nodes found",
+      "runBlocked": {
+        "summary": "Partner nodes",
+        "detail": "This node has been disabled by your team admin.",
+        "nodeError": "This node has been disabled by your team admin."
+      }
     },
     "menu": {
       "editWorkspace": "Edit workspace details",
@@ -3102,6 +3107,7 @@
     "subscribe": "Subscribe",
     "personal": "Personal",
     "roleOwner": "Owner",
+    "roleAdmin": "Admin",
     "roleMember": "Member",
     "createWorkspace": "Create a workspace",
     "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",
@@ -3992,6 +3998,7 @@
     "hideAdvancedInputsButton": "Hide advanced inputs",
     "hideAdvancedShort": "Hide advanced",
     "errors": "Errors",
+    "viewDetails": "View details",
     "noErrors": "No errors",
     "errorsDetected": "Error detected | Errors detected",
     "selectedNodeErrors": "{node} — {count} error | {node} — {count} errors",
@@ -4184,6 +4191,15 @@
         "itemLabel": "{nodeName}",
         "toastTitle": "Validation failed",
         "toastMessage": "{nodeName} returned an unrecognized validation error."
+      },
+      "workspace_partner_node_disabled": {
+        "title": "Disabled node",
+        "titlePlural": "Disabled nodes",
+        "message": "This node has been disabled by your team admin. Use a different node.",
+        "messagePlural": "These nodes have been disabled by your team admin. Use different nodes.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Partner nodes",
+        "toastMessage": "This node has been disabled by your team admin."
       },
       "exception_during_inner_validation": {
         "title": "Validation failed",
@@ -4499,7 +4515,8 @@
     "hideDevOnly": "Hide Dev-Only Nodes",
     "hideDevOnlyDescription": "Hides nodes marked as dev-only unless dev mode is enabled",
     "hideSubgraph": "Hide Subgraph Nodes",
-    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search"
+    "hideSubgraphDescription": "Temporarily hides subgraph nodes from node library and search",
+    "workspacePartnerNodeGovernance": "Hide partner nodes disabled by workspace policy"
   },
   "secrets": {
     "title": "API Keys & Secrets",

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -4,14 +4,15 @@ import { attachUnifiedRemintInterceptor } from '@/platform/auth/unified/remintRe
 import type { SubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
   WorkspaceId,
-  WorkspaceInviteId
+  WorkspaceInviteId,
+  WorkspaceRole
 } from '@/platform/workspace/workspaceTypes'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserId } from '@/types/authTypes'
 
 export type WorkspaceType = 'personal' | 'team'
-export type WorkspaceRole = 'owner' | 'member'
+export type { WorkspaceRole }
 export type BillingRail = 'legacy_stripe' | 'stripe'
 
 interface Workspace {

--- a/src/platform/workspace/components/RoleBadge.test.ts
+++ b/src/platform/workspace/components/RoleBadge.test.ts
@@ -11,13 +11,14 @@ const i18n = createI18n({
     en: {
       workspaceSwitcher: {
         roleOwner: 'Owner',
+        roleAdmin: 'Admin',
         roleMember: 'Member'
       }
     }
   }
 })
 
-function renderRoleBadge(role: 'owner' | 'member') {
+function renderRoleBadge(role: 'owner' | 'admin' | 'member') {
   return render(RoleBadge, {
     props: { role },
     global: { plugins: [i18n] }
@@ -33,5 +34,10 @@ describe('RoleBadge', () => {
   it('renders the member label', () => {
     renderRoleBadge('member')
     expect(screen.getByText('Member')).toBeInTheDocument()
+  })
+
+  it('renders the admin label', () => {
+    renderRoleBadge('admin')
+    expect(screen.getByText('Admin')).toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/RoleBadge.vue
+++ b/src/platform/workspace/components/RoleBadge.vue
@@ -10,15 +10,17 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
+
 const { role } = defineProps<{
-  role: 'owner' | 'member'
+  role: WorkspaceRole
 }>()
 
 const { t } = useI18n()
 
-const roleBadgeLabel = computed(() =>
-  role === 'owner'
-    ? t('workspaceSwitcher.roleOwner')
-    : t('workspaceSwitcher.roleMember')
-)
+const roleBadgeLabel = computed(() => {
+  if (role === 'owner') return t('workspaceSwitcher.roleOwner')
+  if (role === 'admin') return t('workspaceSwitcher.roleAdmin')
+  return t('workspaceSwitcher.roleMember')
+})
 </script>

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -172,6 +172,7 @@ function isCurrentWorkspace(workspace: AvailableWorkspace): boolean {
 
 function getRoleLabel(role: AvailableWorkspace['role']): string {
   if (role === 'owner') return t('workspaceSwitcher.roleOwner')
+  if (role === 'admin') return t('workspaceSwitcher.roleAdmin')
   if (role === 'member') return t('workspaceSwitcher.roleMember')
   return ''
 }

--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -34,7 +34,9 @@
       {{
         member.role === 'owner'
           ? $t('workspaceSwitcher.roleOwner')
-          : $t('workspaceSwitcher.roleMember')
+          : member.role === 'admin'
+            ? $t('workspaceSwitcher.roleAdmin')
+            : $t('workspaceSwitcher.roleMember')
       }}
     </span>
     <div

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -28,7 +28,7 @@ const {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockGovernanceStatus: ref('configured'),
     mockGovernedWorkspaceId: ref<string | null>('team-workspace'),
-    mockWorkspaceRole: ref<'owner' | 'member'>('owner'),
+    mockWorkspaceRole: ref<'owner' | 'admin' | 'member'>('owner'),
     mockWorkspaceType: ref<'personal' | 'team'>('team')
   }
 })
@@ -223,6 +223,13 @@ describe('WorkspacePanelContent partner nodes tab', () => {
   })
 
   it('shows partner node access to team workspace owners', () => {
+    renderComponent()
+
+    expect(screen.getByText('workspacePanel.tabs.partnerNodes')).toBeTruthy()
+  })
+
+  it('shows partner node access to team workspace admins', () => {
+    mockWorkspaceRole.value = 'admin'
     renderComponent()
 
     expect(screen.getByText('workspacePanel.tabs.partnerNodes')).toBeTruthy()

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -94,6 +94,7 @@ const tabTriggerActive =
   'bg-interface-menu-component-surface-hovered text-text-primary font-bold'
 const tabTriggerInactive =
   'bg-transparent text-text-secondary hover:bg-button-hover-surface focus:bg-button-hover-surface'
+const partnerNodeManagerRoles: readonly string[] = ['owner', 'admin']
 
 const { defaultTab = 'plan' } = defineProps<{
   defaultTab?: string
@@ -115,7 +116,7 @@ const showMembersTabCount = computed(
 )
 const showPartnerNodeAccess = computed(
   () =>
-    workspaceRole.value === 'owner' &&
+    partnerNodeManagerRoles.includes(workspaceRole.value) &&
     governedWorkspaceId.value !== null &&
     governanceStatus.value !== 'ineligible'
 )

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -75,6 +75,12 @@ const teamMemberWorkspace: WorkspaceWithRole = {
   joined_at: '2026-03-01T00:00:00Z'
 }
 
+const teamAdminWorkspace: WorkspaceWithRole = {
+  ...teamMemberWorkspace,
+  id: 'ws-team-admin',
+  role: 'admin'
+}
+
 async function loadComposable() {
   const module = await import('@/platform/workspace/composables/useWorkspaceUI')
   return module.useWorkspaceUI()
@@ -316,6 +322,29 @@ describe('useWorkspaceUI', () => {
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
       expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(true)
+    })
+  })
+
+  describe('team workspace as admin', () => {
+    beforeEach(() => {
+      mockStore.activeWorkspace = teamAdminWorkspace
+    })
+
+    it('can manage members without receiving owner billing permissions', async () => {
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value).toMatchObject({
+        canViewPendingInvites: true,
+        canInviteMembers: true,
+        canManageInvites: true,
+        canManageMembers: true,
+        canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canTopUp: false
+      })
+      expect(ui.uiConfig.value.showPendingTab).toBe(true)
+      expect(ui.uiConfig.value.showEditWorkspaceMenuItem).toBe(false)
+      expect(ui.uiConfig.value.workspaceMenuAction).toBeNull()
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -58,6 +58,19 @@ function getPermissions(
     canTopUp: canManageBilling
   }
 
+  if (role === 'admin' && type === 'team') {
+    return {
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canManageMembers: true,
+      canLeaveWorkspace,
+      canAccessWorkspaceMenu: true,
+      ...billingPermissions
+    }
+  }
+
   if (role === 'member') {
     return {
       canViewOtherMembers: true,
@@ -100,6 +113,21 @@ function getUIConfig(
   type: WorkspaceType,
   role: WorkspaceRole
 ): WorkspaceUIConfig {
+  if (role === 'admin' && type === 'team') {
+    return {
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showRoleColumn: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: false,
+      workspaceMenuAction: null,
+      workspaceMenuDisabledTooltip: null
+    }
+  }
+
   if (role === 'member') {
     return {
       showMembersList: true,

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -13,6 +13,7 @@ import type {
   Member,
   PendingInvite as ApiPendingInvite,
   SubscriptionTier,
+  WorkspaceRole,
   WorkspaceWithRole
 } from '../api/workspaceApi'
 import { workspaceApi } from '../api/workspaceApi'
@@ -22,7 +23,7 @@ export interface WorkspaceMember {
   name: string
   email: string
   joinDate: Date
-  role: 'owner' | 'member'
+  role: WorkspaceRole
   isOriginalOwner: boolean
 }
 

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -144,6 +144,27 @@ describe('useWorkspaceAuthStore', () => {
       expect(workspaceToken.value).toBe('valid-token')
     })
 
+    it('restores an admin workspace role from session storage', () => {
+      const adminWorkspace = {
+        ...mockWorkspaceWithRole,
+        role: 'admin' as const
+      }
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+        JSON.stringify(adminWorkspace)
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'valid-token')
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
+        String(Date.now() + 3600 * 1000)
+      )
+
+      const store = useWorkspaceAuthStore()
+
+      expect(store.initializeFromSession()).toBe(true)
+      expect(store.currentWorkspace).toEqual(adminWorkspace)
+    })
+
     it('returns false when sessionStorage is empty', () => {
       const store = useWorkspaceAuthStore()
 

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -20,7 +20,7 @@ const WorkspaceWithRoleSchema = z.object({
   id: z.string(),
   name: z.string(),
   type: z.enum(['personal', 'team']),
-  role: z.enum(['owner', 'member'])
+  role: z.enum(['owner', 'admin', 'member'])
 })
 
 const WorkspaceTokenResponseSchema = z.object({
@@ -31,7 +31,7 @@ const WorkspaceTokenResponseSchema = z.object({
     name: z.string(),
     type: z.enum(['personal', 'team'])
   }),
-  role: z.enum(['owner', 'member']),
+  role: z.enum(['owner', 'admin', 'member']),
   permissions: z.array(z.string())
 })
 

--- a/src/platform/workspace/workspaceTypes.ts
+++ b/src/platform/workspace/workspaceTypes.ts
@@ -14,10 +14,11 @@ export type WorkspaceId = string
  * primitive at use sites without changing structural typing.
  */
 export type WorkspaceInviteId = string
+export type WorkspaceRole = 'owner' | 'admin' | 'member'
 
 export interface WorkspaceWithRole {
   id: WorkspaceId
   name: string
   type: 'personal' | 'team'
-  role: 'owner' | 'member'
+  role: WorkspaceRole
 }


### PR DESCRIPTION
Stacked on #13897.

## Summary

Adds Team workspace Admin as a governance operator without widening owner-only account controls.

- Admin can open Partner Node Access and manage members/invites.
- Billing, top-up, downgrade, workspace edit, and delete remain owner-only.
- `main.json` also forward-declares copy consumed by #13939 and #13940; this PR does not activate run blocking.

## Verification

| Before — parent `7ecc99b` | After — #13937 `a22cf4e` |
| --- | --- |
| <img width="720" alt="Workspace member row shows Member before PR 13937" src="https://github.com/user-attachments/assets/1bc2a1e4-8501-4df0-b70d-a8131a5882e0" /> | <img width="720" alt="Workspace member row shows Admin after PR 13937" src="https://github.com/user-attachments/assets/d2d9d150-c1b4-4987-8a91-72aac9185e65" /> |

https://github.com/user-attachments/assets/77add931-fea7-448a-a8c5-1fd1b80cc1a7

| Timestamp | Screenshot | Highlight |
| --- | --- | --- |
| `00:03.5` | <img width="360" alt="Before PR 13937 member role" src="https://github.com/user-attachments/assets/8badcabd-07d8-4244-9022-8a5a0a87ea88" /> | The same Avery row is presented as `Member` on the parent commit. |
| `00:08.5` | <img width="360" alt="After PR 13937 admin role" src="https://github.com/user-attachments/assets/2d5fd472-6d3a-4c53-9e0a-0dd10112c956" /> | The PR head presents Avery as `Admin`. |

| Boundary | Current-head proof |
| --- | --- |
| Role presentation | [`RoleBadge.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/a22cf4e754e813dab2f9adbfc175906706b4e713/src/platform/workspace/components/RoleBadge.test.ts) exercises the `Admin` label. |
| Governance access | [`WorkspacePanelContent.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/a22cf4e754e813dab2f9adbfc175906706b4e713/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts) covers Partner Node Access for Admin. |
| Permission boundary | [`useWorkspaceUI.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/a22cf4e754e813dab2f9adbfc175906706b4e713/src/platform/workspace/composables/useWorkspaceUI.test.ts) proves Admin member management while owner billing permissions remain false. |
| Session restoration | [`useWorkspaceAuth.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/a22cf4e754e813dab2f9adbfc175906706b4e713/src/platform/workspace/stores/useWorkspaceAuth.test.ts) restores an Admin workspace role from persisted auth state. |

A live Admin session and mutation still depend on the coordinated [Cloud governance contract](https://github.com/Comfy-Org/cloud/pull/5278). This head proves the frontend permission boundary, not end-to-end Cloud Admin authorization.

Created by Codex
