### PR TITLE
feat: 8/x filter disabled partner providers

### DIFF
--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -11,6 +11,9 @@ const partnerProviderSchema = z.object({
 const partnerProviderCatalogResponseSchema = z.object({
   providers: z.array(partnerProviderSchema)
 })
+export type PartnerProviderCatalogResponse = z.infer<
+  typeof partnerProviderCatalogResponseSchema
+>
 
 const partnerProviderPolicyEntrySchema = z.object({
   provider_id: z.string(),
@@ -21,6 +24,9 @@ const partnerNodePolicyResponseSchema = z.object({
   enforcement_enabled: z.boolean(),
   providers: z.array(partnerProviderPolicyEntrySchema)
 })
+export type PartnerNodePolicyResponse = z.infer<
+  typeof partnerNodePolicyResponseSchema
+>
 
 export interface PartnerProvider {
   id: string

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type * as PartnerNodePolicyApi from '@/platform/workspace/api/partnerNodePolicyApi'
 import type {
   PartnerNodePolicy,
@@ -11,6 +12,8 @@ import type {
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
@@ -50,6 +53,26 @@ const providers: PartnerProvider[] = [
   }
 ]
 
+function nodeDef(
+  name: string,
+  overrides: Partial<ComfyNodeDef> = {}
+): ComfyNodeDef {
+  return {
+    name,
+    display_name: `Display ${name}`,
+    category: 'api/image/OpenAI',
+    python_module: 'comfy_api_nodes.openai',
+    description: '',
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: false,
+    api_node: true,
+    ...overrides
+  }
+}
+
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
   const store = useTeamWorkspaceStore()
   store.workspaces = [
@@ -88,9 +111,19 @@ describe('partnerNodeGovernanceStore', () => {
     mockGetPartnerProviders.mockResolvedValue(providers)
     mockGetPartnerNodePolicy.mockResolvedValue(null)
     activateWorkspace('workspace-one')
+    useNodeDefStore().updateNodeDefs([
+      nodeDef('OpenAINode'),
+      nodeDef('UnknownPartnerNode', { category: 'api/image/Unknown' }),
+      nodeDef('CoreNode', {
+        api_node: false,
+        category: 'sampling',
+        python_module: 'nodes'
+      })
+    ])
   })
 
   afterEach(() => {
+    delete LiteGraph.registered_node_types.OpenAINode
     store?.$dispose()
     store = undefined
   })
@@ -121,6 +154,70 @@ describe('partnerNodeGovernanceStore', () => {
         { providerId: 'route-only', enabled: true }
       ]
     })
+  })
+
+  it('resolves object-info node categories to permanent provider IDs', async () => {
+    store = await createLoadedStore()
+
+    expect(store.getNodeProviderId('OpenAINode')).toBe('openai')
+    expect(store.getNodeProviderId('UnknownPartnerNode')).toBeNull()
+    expect(store.getNodeProviderId('CoreNode')).toBeNull()
+  })
+
+  it('denies nodes from disabled providers only while enforcement is active', async () => {
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
+    store = await createLoadedStore()
+
+    expect(store.isNodeDisabled('OpenAINode')).toBe(true)
+    expect(store.isNodeDisabled('UnknownPartnerNode')).toBe(false)
+    expect(store.isNodeDisabled('CoreNode')).toBe(false)
+
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
+    await store.loadPolicy()
+
+    expect(store.isNodeDisabled('OpenAINode')).toBe(false)
+  })
+
+  it('filters disabled providers out of node discovery', async () => {
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
+    store = await createLoadedStore()
+    const nodeDefStore = useNodeDefStore()
+
+    expect(nodeDefStore.visibleNodeDefs.map(({ name }) => name)).toEqual([
+      'UnknownPartnerNode',
+      'CoreNode'
+    ])
+    expect(nodeDefStore.nodeSearchService.searchNode('OpenAINode')).toEqual([])
+  })
+
+  it('keeps the legacy node menu synchronized with provider policy', async () => {
+    class OpenAINode extends LGraphNode {}
+    LiteGraph.registered_node_types.OpenAINode = OpenAINode
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
+    store = await createLoadedStore()
+
+    expect(OpenAINode.skip_list).toBe(true)
+
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
+    await store.loadPolicy()
+    await nextTick()
+
+    expect(OpenAINode.skip_list).toBe(false)
   })
 
   it('hides governance when the backend reports an ineligible workspace', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -1,7 +1,16 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef, watch } from 'vue'
+import {
+  computed,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  watch,
+  watchEffect
+} from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { t } from '@/i18n'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
   getPartnerNodePolicy,
   getPartnerProviders,
@@ -13,6 +22,8 @@ import type {
   PartnerProvider
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { getProviderName } from '@/utils/categoryUtil'
 
 export type PartnerNodePolicyStatus =
   | 'inactive'
@@ -22,11 +33,14 @@ export type PartnerNodePolicyStatus =
   | 'ineligible'
   | 'error'
 
+const DISCOVERY_FILTER_ID = 'workspace.partner-node-governance'
+
 export const usePartnerNodeGovernanceStore = defineStore(
   'partnerNodeGovernance',
   () => {
     const { flags } = useFeatureFlags()
     const workspaceStore = useTeamWorkspaceStore()
+    const nodeDefStore = useNodeDefStore()
 
     const providers = shallowRef<PartnerProvider[]>([])
     const policy = shallowRef<PartnerNodePolicy | null>(null)
@@ -64,6 +78,65 @@ export const usePartnerNodeGovernanceStore = defineStore(
         )?.enabled === true
       )
     }
+
+    function getNodeProviderId(nodeType: string): string | null {
+      const nodeDef = nodeDefStore.nodeDefsByName[nodeType]
+      if (!nodeDef?.api_node) return null
+
+      const nodeCategory = getProviderName(nodeDef.category)
+      return (
+        providers.value.find(({ nodeCategories }) =>
+          nodeCategories.includes(nodeCategory)
+        )?.id ?? null
+      )
+    }
+
+    function isNodeDisabled(nodeType: string): boolean {
+      if (policy.value?.enforcementEnabled !== true) return false
+
+      const providerId = getNodeProviderId(nodeType)
+      return providerId !== null && !isProviderEnabled(providerId)
+    }
+
+    nodeDefStore.registerNodeDefFilter({
+      id: DISCOVERY_FILTER_ID,
+      name: t('nodeFilters.workspacePartnerNodeGovernance'),
+      predicate: (nodeDef) => !isNodeDisabled(nodeDef.name)
+    })
+
+    const legacyHiddenNodeTypes = new Set<string>()
+    watchEffect(() => {
+      const showDevOnly = nodeDefStore.showDevOnly
+      for (const nodeDef of Object.values(nodeDefStore.nodeDefsByName)) {
+        if (!nodeDef.api_node) continue
+
+        const nodeType = LiteGraph.registered_node_types[nodeDef.name]
+        if (!nodeType) continue
+
+        if (isNodeDisabled(nodeDef.name)) {
+          if (!nodeType.skip_list) {
+            nodeType.skip_list = true
+            legacyHiddenNodeTypes.add(nodeDef.name)
+          }
+          continue
+        }
+
+        if (legacyHiddenNodeTypes.delete(nodeDef.name)) {
+          nodeType.skip_list = nodeDef.dev_only && !showDevOnly
+        }
+      }
+    })
+
+    onScopeDispose(() => {
+      nodeDefStore.unregisterNodeDefFilter(DISCOVERY_FILTER_ID)
+      for (const nodeName of legacyHiddenNodeTypes) {
+        const nodeDef = nodeDefStore.nodeDefsByName[nodeName]
+        const nodeType = LiteGraph.registered_node_types[nodeName]
+        if (nodeDef && nodeType) {
+          nodeType.skip_list = nodeDef.dev_only && !nodeDefStore.showDevOnly
+        }
+      }
+    })
 
     async function loadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value
@@ -219,6 +292,8 @@ export const usePartnerNodeGovernanceStore = defineStore(
       governedWorkspaceId,
       createInitialPolicy,
       isProviderEnabled,
+      getNodeProviderId,
+      isNodeDisabled,
       loadPolicy,
       savePolicy,
       setProviderEnabled,

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -1,6 +1,7 @@
+import axios from 'axios'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { promoteValueWidgetViaSubgraphInput } from '@/core/graph/subgraph/promotionUtils'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -10,7 +11,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import type { NodeDefFilter } from '@/stores/nodeDefStore'
 
 describe('useNodeDefStore', () => {
@@ -19,6 +20,10 @@ describe('useNodeDefStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useNodeDefStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   const createMockNodeDef = (
@@ -282,6 +287,30 @@ describe('useNodeDefStore', () => {
       expect(store.visibleNodeDefs.map((n) => n.name)).toEqual([
         'normal',
         'FakeSubgraph'
+      ])
+    })
+  })
+
+  describe('node frequency visibility', () => {
+    it('excludes node definitions hidden by registered filters', async () => {
+      vi.spyOn(axios, 'get').mockResolvedValue({
+        data: { HiddenNode: 2, VisibleNode: 1 }
+      })
+      store.updateNodeDefs([
+        createMockNodeDef({ name: 'HiddenNode' }),
+        createMockNodeDef({ name: 'VisibleNode' })
+      ])
+      store.registerNodeDefFilter({
+        id: 'test.hide-node',
+        name: 'Hide node',
+        predicate: (nodeDef) => nodeDef.name !== 'HiddenNode'
+      })
+
+      const frequencyStore = useNodeFrequencyStore()
+      await frequencyStore.loadNodeFrequencies()
+
+      expect(frequencyStore.topNodeDefs.map(({ name }) => name)).toEqual([
+        'VisibleNode'
       ])
     })
   })

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -562,9 +562,15 @@ export const useNodeFrequencyStore = defineStore('nodeFrequency', () => {
 
   const nodeDefStore = useNodeDefStore()
   const topNodeDefs = computed<ComfyNodeDefImpl[]>(() => {
+    const visibleNodeNames = new Set(
+      nodeDefStore.visibleNodeDefs.map((nodeDef) => nodeDef.name)
+    )
     return nodeNamesByFrequency.value
       .map((nodeName: string) => nodeDefStore.nodeDefsByName[nodeName])
-      .filter((nodeDef: ComfyNodeDefImpl) => nodeDef !== undefined)
+      .filter(
+        (nodeDef): nodeDef is ComfyNodeDefImpl =>
+          nodeDef !== undefined && visibleNodeNames.has(nodeDef.name)
+      )
       .slice(0, topNodeDefLimit.value)
   })
 


### PR DESCRIPTION
Stacked on #13937.

## Summary

Applies workspace provider policy to every frontend node-discovery surface.

- Maps the `object_info` category suffix to stable provider IDs from the server catalog.
- Registers one policy predicate for search and frequent-node suggestions, and synchronizes the legacy LiteGraph `skip_list`.
- Hides nodes only when enforcement is configured and their mapped provider is disabled; unknown and core categories remain visible.

## Verification

| Before — #13937 `a22cf4e` | After — #13938 `5d6d3e4` |
| --- | --- |
| <img width="720" alt="Disabled provider node appears in search before PR 13938" src="https://github.com/user-attachments/assets/a7d8f6e5-3fa0-4d79-adff-61e9c5c87f7e" /> | <img width="720" alt="Search shows No Results after PR 13938" src="https://github.com/user-attachments/assets/6584d2b2-3843-4150-a3c1-555df5a8219c" /> |

https://github.com/user-attachments/assets/b6817dcb-cbfb-400e-a272-c32000e3130a

| Timestamp | Screenshot | Highlight |
| --- | --- | --- |
| `00:03.5` | <img width="360" alt="Before PR 13938 disabled provider search result" src="https://github.com/user-attachments/assets/ae795aaf-b379-47b6-a403-9ffc8a7d5463" /> | `Disabled Partner Node` is discoverable before the filtering slice. |
| `00:07.5` | <img width="360" alt="After PR 13938 disabled provider search result filtered" src="https://github.com/user-attachments/assets/5a19a271-ebf4-4ff4-be8f-d979638d59d9" /> | The same query returns **No Results** after policy filtering. |

| Boundary | Current-head proof |
| --- | --- |
| Catalog mapping | [`partnerNodeGovernanceStore.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/5d6d3e4f4a3261abce405816b824ee14308579c1/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts) resolves object-info categories to permanent provider IDs. |
| Policy semantics | The same store coverage proves disabled nodes are denied only while enforcement is active. |
| Search and suggestions | [`nodeDefStore.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/5d6d3e4f4a3261abce405816b824ee14308579c1/src/stores/nodeDefStore.test.ts) excludes definitions hidden by registered filters. |
| Legacy menu | Store coverage verifies LiteGraph `skip_list` stays synchronized with provider policy. |

Created by Codex
