### PR TITLE
feat: 9/x surface partner node run denials

### DIFF
--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -61,6 +61,20 @@ vi.mock('@/i18n', () => {
       'Validation failed',
     'errorCatalog.validationErrors.unknown_validation_error.toastMessage':
       '{nodeName} returned an unrecognized validation error.',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.title':
+      'Disabled node',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.titlePlural':
+      'Disabled nodes',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.message':
+      'This node has been disabled by your team admin. Use a different node.',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.messagePlural':
+      'These nodes have been disabled by your team admin. Use different nodes.',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.itemLabel':
+      '{nodeName}',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.toastTitle':
+      'Partner nodes',
+    'errorCatalog.validationErrors.workspace_partner_node_disabled.toastMessage':
+      'This node has been disabled by your team admin.',
     'errorCatalog.promptErrors.prompt_no_outputs.title':
       'Prompt has no outputs',
     'errorCatalog.promptErrors.prompt_no_outputs.desc':
@@ -495,6 +509,58 @@ describe('useErrorGroups', () => {
       expect(error.toastMessage).toBe(
         'KSampler is missing a required input: model'
       )
+    })
+
+    it('groups workspace-disabled partner nodes with names and count', async () => {
+      const { store, groups } = createErrorGroups()
+      store.recordNodeErrors({
+        '1': {
+          class_type: 'FluxFill',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'workspace_partner_node_disabled',
+              message: 'Disabled by workspace policy',
+              details: ''
+            }
+          ]
+        },
+        '2': {
+          class_type: 'VeoVideo',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'workspace_partner_node_disabled',
+              message: 'Disabled by workspace policy',
+              details: ''
+            }
+          ]
+        }
+      })
+      await nextTick()
+
+      const group = groups.allErrorGroups.value.find(
+        (entry) =>
+          entry.groupKey === 'execution:workspace_partner_node_disabled'
+      )
+      expect(group?.type).toBe('execution')
+      if (group?.type !== 'execution') return
+
+      expect(group.displayTitle).toBe('Disabled nodes')
+      expect(group.displayMessage).toBe(
+        'These nodes have been disabled by your team admin. Use different nodes.'
+      )
+      expect(group.count).toBe(2)
+      expect(
+        group.cards.flatMap((card) =>
+          card.errors.map((error) => error.displayItemLabel)
+        )
+      ).toEqual(['FluxFill', 'VeoVideo'])
+      expect(
+        group.cards.flatMap((card) =>
+          card.errors.map((error) => error.displayDetails)
+        )
+      ).toEqual([undefined, undefined])
     })
 
     it('groups lifted boundary errors under the host node card', async () => {

--- a/src/components/rightSidePanel/errors/useErrorGroups.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.ts
@@ -39,6 +39,7 @@ import {
   resolveMissingErrorMessage,
   resolveRunErrorMessage
 } from '@/platform/errorCatalog/errorMessageResolver'
+import { WORKSPACE_PARTNER_NODE_DISABLED_TYPE } from '@/platform/errorCatalog/validationErrorResolver'
 import {
   compareExecutionId,
   tryNormalizeNodeExecutionId
@@ -151,12 +152,25 @@ function toSortedGroups(groupsMap: Map<string, GroupEntry>): ErrorGroup[] {
   return Array.from(groupsMap.entries())
     .map(([rawGroupKey, groupData]) => {
       const cards = Array.from(groupData.cards.values()).sort(compareNodeId)
+      const count = countExecutionCards(cards)
+      const isPluralPartnerNodePolicyError =
+        rawGroupKey === WORKSPACE_PARTNER_NODE_DISABLED_TYPE && count > 1
       return {
         type: 'execution' as const,
         groupKey: `execution:${rawGroupKey}`,
-        displayTitle: groupData.displayTitle,
-        displayMessage: groupData.displayMessage,
-        count: countExecutionCards(cards),
+        displayTitle: isPluralPartnerNodePolicyError
+          ? st(
+              'errorCatalog.validationErrors.workspace_partner_node_disabled.titlePlural',
+              'Disabled nodes'
+            )
+          : groupData.displayTitle,
+        displayMessage: isPluralPartnerNodePolicyError
+          ? st(
+              'errorCatalog.validationErrors.workspace_partner_node_disabled.messagePlural',
+              'These nodes have been disabled by your team admin. Use different nodes.'
+            )
+          : groupData.displayMessage,
+        count,
         cards,
         priority: groupData.priority
       }

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import GlobalToast from './GlobalToast.vue'
+
+const { removeToast, viewErrorsInGraph } = vi.hoisted(() => ({
+  removeToast: vi.fn(),
+  viewErrorsInGraph: vi.fn()
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: vi.fn(),
+    remove: removeToast,
+    removeAllGroups: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useViewErrorsInGraph', () => ({
+  useViewErrorsInGraph: () => ({ viewErrorsInGraph })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: vi.fn() })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({
+    messagesToAdd: [],
+    messagesToRemove: [],
+    removeAllRequested: false
+  })
+}))
+
+const policyMessage = {
+  severity: 'error',
+  summary: 'Partner nodes',
+  detail: 'This node has been disabled by your team admin.',
+  group: 'partner-node-policy'
+}
+
+const ToastStub = defineComponent({
+  props: { group: String },
+  setup() {
+    return { policyMessage }
+  },
+  template: `
+    <div v-if="group === 'partner-node-policy'">
+      <slot name="message" :message="policyMessage" />
+    </div>
+  `
+})
+
+describe('GlobalToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the Errors tab from a partner policy toast', async () => {
+    const user = userEvent.setup()
+    render(GlobalToast, {
+      global: {
+        plugins: [
+          createI18n({
+            legacy: false,
+            locale: 'en',
+            messages: {
+              en: { rightSidePanel: { viewDetails: 'View details' } }
+            }
+          })
+        ],
+        stubs: { Toast: ToastStub }
+      }
+    })
+
+    await user.click(screen.getByRole('button', { name: 'View details' }))
+
+    expect(removeToast).toHaveBeenCalledWith(policyMessage)
+    expect(viewErrorsInGraph).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -1,5 +1,23 @@
 <template>
   <Toast />
+  <Toast group="partner-node-policy">
+    <template #message="slotProps">
+      <div class="flex min-w-0 flex-1 flex-col gap-2">
+        <div class="flex flex-col gap-1">
+          <span class="font-semibold">{{ slotProps.message.summary }}</span>
+          <span class="text-sm">{{ slotProps.message.detail }}</span>
+        </div>
+        <Button
+          variant="muted-textonly"
+          size="sm"
+          class="w-fit px-0 underline hover:bg-transparent"
+          @click="viewPartnerNodePolicyErrors(slotProps.message)"
+        >
+          {{ $t('rightSidePanel.viewDetails') }}
+        </Button>
+      </div>
+    </template>
+  </Toast>
   <Toast group="billing-operation" position="top-right">
     <template #message="slotProps">
       <div class="flex items-center gap-2">
@@ -12,15 +30,24 @@
 
 <script setup lang="ts">
 import Toast from 'primevue/toast'
+import type { ToastMessageOptions } from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { nextTick, watch } from 'vue'
 
+import Button from '@/components/ui/button/Button.vue'
+import { useViewErrorsInGraph } from '@/composables/useViewErrorsInGraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 const toast = useToast()
 const toastStore = useToastStore()
 const settingStore = useSettingStore()
+const { viewErrorsInGraph } = useViewErrorsInGraph()
+
+function viewPartnerNodePolicyErrors(message: ToastMessageOptions) {
+  toast.remove(message)
+  viewErrorsInGraph()
+}
 
 watch(
   () => toastStore.messagesToAdd,

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -131,6 +131,25 @@ describe('errorMessageResolver', () => {
     })
   })
 
+  it('resolves workspace-disabled partner nodes to actionable panel copy', () => {
+    const result = resolveRunErrorMessage({
+      kind: 'node_validation',
+      error: nodeValidationError('workspace_partner_node_disabled'),
+      nodeDisplayName: 'Flux Fill'
+    })
+
+    expect(result).toEqual({
+      catalogId: 'workspace_partner_node_disabled',
+      displayTitle: 'Disabled node',
+      displayMessage:
+        'This node has been disabled by your team admin. Use a different node.',
+      displayDetails: undefined,
+      displayItemLabel: 'Flux Fill',
+      toastTitle: 'Partner nodes',
+      toastMessage: 'This node has been disabled by your team admin.'
+    })
+  })
+
   it('preserves special characters in catalog copy for node names', () => {
     const nodeDisplayName = 'A & B <C>'
     const result = resolveRunErrorMessage({

--- a/src/platform/errorCatalog/validationErrorResolver.ts
+++ b/src/platform/errorCatalog/validationErrorResolver.ts
@@ -19,6 +19,8 @@ import {
 } from '@/utils/executionErrorUtil'
 
 const REQUIRED_INPUT_MISSING_TYPE = 'required_input_missing'
+export const WORKSPACE_PARTNER_NODE_DISABLED_TYPE =
+  'workspace_partner_node_disabled'
 
 // Resolves node validation errors. Most validation types map 1:1 to their
 // catalog/locale keys; FE-specific recategorization uses a separate catalogId,
@@ -91,6 +93,10 @@ const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
   [REQUIRED_INPUT_MISSING_TYPE]: {
     catalogId: MISSING_CONNECTION_CATALOG_ID,
     itemLabel: 'nodeInput'
+  },
+  [WORKSPACE_PARTNER_NODE_DISABLED_TYPE]: {
+    catalogId: WORKSPACE_PARTNER_NODE_DISABLED_TYPE,
+    itemLabel: 'node'
   },
   ...NODE_LEVEL_VALIDATION_ERROR_RULES
 }

--- a/src/platform/workspace/utils/partnerNodePolicyPromptError.test.ts
+++ b/src/platform/workspace/utils/partnerNodePolicyPromptError.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+import {
+  isPartnerNodePolicyPromptResponse,
+  normalizePartnerNodePolicyPromptError
+} from './partnerNodePolicyPromptError'
+
+const prompt: ComfyApiWorkflow = {
+  '1': {
+    class_type: 'KlingImage2VideoNode',
+    inputs: {},
+    _meta: { title: 'Kling Image to Video' }
+  },
+  '2': {
+    class_type: 'KSampler',
+    inputs: {},
+    _meta: { title: 'KSampler' }
+  }
+}
+
+describe('partnerNodePolicyPromptError', () => {
+  it('maps authoritative Cloud offenders back to frontend node errors', () => {
+    const result = normalizePartnerNodePolicyPromptError(
+      {
+        error: {
+          type: 'PARTNER_NODE_DISABLED',
+          message: 'Workspace policy denied KlingImage2VideoNode',
+          class_types: ['KlingImage2VideoNode'],
+          providers: ['kling']
+        }
+      },
+      prompt
+    )
+
+    expect(result?.node_errors).toEqual({
+      '1': {
+        class_type: 'KlingImage2VideoNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This node has been disabled by your team admin.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    })
+    expect(result && isPartnerNodePolicyPromptResponse(result)).toBe(true)
+  })
+
+  it('ignores malformed or unrelated prompt errors', () => {
+    expect(
+      normalizePartnerNodePolicyPromptError(
+        { error: { type: 'PARTNER_NODE_DISABLED' } },
+        prompt
+      )
+    ).toBeNull()
+    expect(
+      normalizePartnerNodePolicyPromptError(
+        {
+          error: {
+            type: 'OTHER_ERROR',
+            class_types: ['KlingImage2VideoNode']
+          }
+        },
+        prompt
+      )
+    ).toBeNull()
+  })
+})

--- a/src/platform/workspace/utils/partnerNodePolicyPromptError.ts
+++ b/src/platform/workspace/utils/partnerNodePolicyPromptError.ts
@@ -1,0 +1,71 @@
+import { WORKSPACE_PARTNER_NODE_DISABLED_TYPE } from '@/platform/errorCatalog/validationErrorResolver'
+import type { PromptResponse } from '@/schemas/apiSchema'
+import type { ComfyApiWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+const PARTNER_NODE_DISABLED_PROMPT_TYPE = 'PARTNER_NODE_DISABLED'
+
+function stringArray(value: unknown): string[] | null {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : null
+}
+
+export function normalizePartnerNodePolicyPromptError(
+  response: unknown,
+  prompt: ComfyApiWorkflow
+): PromptResponse | null {
+  if (!response || typeof response !== 'object') return null
+
+  const rawError = Reflect.get(response, 'error')
+  if (!rawError || typeof rawError !== 'object') return null
+  if (Reflect.get(rawError, 'type') !== PARTNER_NODE_DISABLED_PROMPT_TYPE) {
+    return null
+  }
+
+  const classTypes = stringArray(Reflect.get(rawError, 'class_types'))
+  if (!classTypes?.length) return null
+
+  const deniedClassTypes = new Set(classTypes)
+  const nodeErrors: NonNullable<PromptResponse['node_errors']> = {}
+  for (const [executionId, node] of Object.entries(prompt)) {
+    if (!deniedClassTypes.has(node.class_type)) continue
+
+    nodeErrors[executionId] = {
+      class_type: node.class_type,
+      dependent_outputs: [],
+      errors: [
+        {
+          type: WORKSPACE_PARTNER_NODE_DISABLED_TYPE,
+          message: 'This node has been disabled by your team admin.',
+          details: '',
+          extra_info: {}
+        }
+      ]
+    }
+  }
+  if (Object.keys(nodeErrors).length === 0) return null
+
+  const message = Reflect.get(rawError, 'message')
+  const providers = stringArray(Reflect.get(rawError, 'providers'))
+  return {
+    error: {
+      type: PARTNER_NODE_DISABLED_PROMPT_TYPE,
+      message:
+        typeof message === 'string'
+          ? message
+          : 'Partner nodes are disabled by workspace policy.',
+      details: '',
+      extra_info: { class_types: classTypes, providers: providers ?? [] }
+    },
+    node_errors: nodeErrors
+  }
+}
+
+export function isPartnerNodePolicyPromptResponse(
+  response: PromptResponse
+): boolean {
+  return (
+    typeof response.error === 'object' &&
+    response.error.type === PARTNER_NODE_DISABLED_PROMPT_TYPE
+  )
+}

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/platform/assets/schemas/assetSchema'
 import { isCloud } from '@/platform/distribution/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { normalizePartnerNodePolicyPromptError } from '@/platform/workspace/utils/partnerNodePolicyPromptError'
 import type { ShareableAssetsResponse } from '@/schemas/apiSchema'
 import { zShareableAssetsResponse } from '@/schemas/apiSchema'
 import type {
@@ -1000,7 +1001,11 @@ export class ComfyApi extends EventTarget {
           }
         }
       }
-      throw new PromptExecutionError(errorResponse, res.status)
+      throw new PromptExecutionError(
+        normalizePartnerNodePolicyPromptError(errorResponse, prompt) ??
+          errorResponse,
+        res.status
+      )
     }
 
     return await res.json()

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -34,6 +34,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { registerQueuePromptGuard } from '@/services/queuePromptGuardService'
 
 const {
   mockApiKeyAuthStore,
@@ -212,6 +213,58 @@ describe('ComfyApp', () => {
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
 
+    it('blocks before adding a disallowed prompt to the client queue', async () => {
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.before-queue',
+        () => false
+      )
+      const dispatchEvent = vi
+        .spyOn(api, 'dispatchCustomEvent')
+        .mockImplementation(() => true)
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+
+      try {
+        await expect(app.queuePrompt(0)).resolves.toBe(false)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(mockAuthStore.getAuthToken).not.toHaveBeenCalled()
+      expect(dispatchEvent).not.toHaveBeenCalled()
+      expect(queuePrompt).not.toHaveBeenCalled()
+    })
+
+    it('checks policy again after deferred authentication resolves', async () => {
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      let resolveAuth: (token: string | undefined) => void = () => {}
+      mockAuthStore.getAuthToken.mockReturnValue(
+        new Promise((resolve) => {
+          resolveAuth = resolve
+        })
+      )
+      let guardCalls = 0
+      const unregisterGuard = registerQueuePromptGuard(
+        'app.test.after-auth',
+        () => ++guardCalls === 1
+      )
+      const queuePrompt = vi.spyOn(api, 'queuePrompt')
+
+      try {
+        const result = app.queuePrompt(0)
+        await vi.waitFor(() => {
+          expect(mockAuthStore.getAuthToken).toHaveBeenCalledOnce()
+        })
+        resolveAuth(undefined)
+
+        await expect(result).resolves.toBe(false)
+      } finally {
+        unregisterGuard()
+      }
+
+      expect(guardCalls).toBe(2)
+      expect(queuePrompt).not.toHaveBeenCalled()
+    })
+
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
       const workflow = new ComfyWorkflow({
@@ -285,6 +338,48 @@ describe('ComfyApp', () => {
       expect(errorStore.lastNodeErrors).toBeNull()
       expect(errorStore.lastPromptError).toMatchObject({
         type: 'prompt_no_outputs'
+      })
+    })
+
+    it('surfaces authoritative partner policy denials in the Errors panel and toast', async () => {
+      prepareEmptyPromptQueue()
+      const nodeErrors: Record<string, NodeError> = {
+        '1': {
+          class_type: 'KlingImage2VideoNode',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'workspace_partner_node_disabled',
+              message: 'This node has been disabled by your team admin.',
+              details: '',
+              extra_info: {}
+            }
+          ]
+        }
+      }
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(
+        new PromptExecutionError(
+          {
+            node_errors: nodeErrors,
+            error: {
+              type: 'PARTNER_NODE_DISABLED',
+              message: 'Workspace policy denied KlingImage2VideoNode',
+              details: ''
+            }
+          },
+          403
+        )
+      )
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      expect(useExecutionErrorStore().lastNodeErrors).toEqual(nodeErrors)
+      expect(mockToastStore.add).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Partner nodes',
+        detail: 'This node has been disabled by your team admin.',
+        group: 'partner-node-policy',
+        life: 8000
       })
     })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -68,6 +68,7 @@ import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreco
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
+import { runQueuePromptGuards } from '@/services/queuePromptGuardService'
 import { useSubgraphService } from '@/services/subgraphService'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useCommandStore } from '@/stores/commandStore'
@@ -109,6 +110,7 @@ import type { MissingModelPipelineResult } from '@/platform/missingModel/missing
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import { isPartnerNodePolicyPromptResponse } from '@/platform/workspace/utils/partnerNodePolicyPromptError'
 import {
   scanAllMediaCandidates,
   verifyMediaCandidates
@@ -1624,11 +1626,22 @@ export class ComfyApp {
     })
   }
 
+  private async isQueuePromptAllowed(
+    queueNodeIds?: readonly NodeExecutionId[]
+  ): Promise<boolean> {
+    return await runQueuePromptGuards({
+      rootGraph: this.rootGraph,
+      queueNodeIds
+    })
+  }
+
   async queuePrompt(
     number: number,
     batchCount: number = 1,
     queueNodeIds?: NodeExecutionId[]
   ): Promise<boolean> {
+    if (!(await this.isQueuePromptAllowed(queueNodeIds))) return false
+
     const requestId = this.nextQueueRequestId++
     this.queueItems.push({ number, batchCount, queueNodeIds, requestId })
     api.dispatchCustomEvent('promptQueueing', {
@@ -1662,6 +1675,11 @@ export class ComfyApp {
 
         const isPartialExecution = !!queueNodeIds?.length
         for (let i = 0; i < batchCount; i++) {
+          if (!(await this.isQueuePromptAllowed(queueNodeIds))) {
+            queueResultOverride = false
+            break
+          }
+
           // Allow widgets to run callbacks before a prompt has been queued
           // e.g. random seed before every gen
           forEachNode(this.rootGraph, (node) => {
@@ -1730,7 +1748,18 @@ export class ComfyApp {
               console.error(error)
               break
             }
-            if (
+            const isPartnerNodePolicyDenial =
+              error instanceof PromptExecutionError &&
+              isPartnerNodePolicyPromptResponse(error.response)
+            if (isPartnerNodePolicyDenial) {
+              useToastStore().add({
+                severity: 'error',
+                summary: t('workspacePanel.partnerNodes.runBlocked.summary'),
+                detail: t('workspacePanel.partnerNodes.runBlocked.detail'),
+                group: 'partner-node-policy',
+                life: 8000
+              })
+            } else if (
               error instanceof PromptExecutionError &&
               typeof error.response.error === 'object' &&
               error.response.error?.type === 'missing_node_type'

--- a/src/services/queuePromptGuardService.test.ts
+++ b/src/services/queuePromptGuardService.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+
+import {
+  registerQueuePromptGuard,
+  runQueuePromptGuards
+} from './queuePromptGuardService'
+
+const addToast = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: addToast })
+}))
+
+describe('queuePromptGuardService', () => {
+  const unregisterGuards: Array<() => void> = []
+
+  afterEach(() => {
+    unregisterGuards.splice(0).forEach((unregister) => unregister())
+    vi.restoreAllMocks()
+  })
+
+  it('blocks when any guard rejects the prompt', async () => {
+    unregisterGuards.push(
+      registerQueuePromptGuard('test.allow', () => true),
+      registerQueuePromptGuard('test.block', () => false)
+    )
+
+    await expect(
+      runQueuePromptGuards({ rootGraph: {} as LGraph })
+    ).resolves.toBe(false)
+    expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('fails closed while continuing after guards throw or reject', async () => {
+    const error = new Error('Invalid graph')
+    const successfulGuard = vi.fn(() => true)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    unregisterGuards.push(
+      registerQueuePromptGuard('test.throw', () => {
+        throw error
+      }),
+      registerQueuePromptGuard('test.reject', async () => {
+        await Promise.resolve()
+        throw error
+      }),
+      registerQueuePromptGuard('test.success', successfulGuard)
+    )
+
+    await expect(
+      runQueuePromptGuards({ rootGraph: {} as LGraph })
+    ).resolves.toBe(false)
+
+    expect(successfulGuard).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledTimes(2)
+    expect(addToast).toHaveBeenCalledOnce()
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Failed to queue'
+    })
+  })
+})

--- a/src/services/queuePromptGuardService.ts
+++ b/src/services/queuePromptGuardService.ts
@@ -1,0 +1,52 @@
+import { t } from '@/i18n'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+
+export interface QueuePromptGuardContext {
+  readonly rootGraph: LGraph
+  readonly queueNodeIds?: readonly NodeExecutionId[]
+}
+
+export type QueuePromptGuard = (
+  context: QueuePromptGuardContext
+) => boolean | Promise<boolean>
+
+const guards = new Map<string, QueuePromptGuard>()
+
+async function runGuard(
+  guard: QueuePromptGuard,
+  context: QueuePromptGuardContext
+): Promise<'allowed' | 'blocked' | 'failed'> {
+  try {
+    return (await guard(context)) === false ? 'blocked' : 'allowed'
+  } catch (error) {
+    console.error('Queue prompt guard failed; blocking prompt', error)
+    return 'failed'
+  }
+}
+
+export function registerQueuePromptGuard(
+  id: string,
+  guard: QueuePromptGuard
+): () => void {
+  guards.set(id, guard)
+  return () => {
+    if (guards.get(id) === guard) guards.delete(id)
+  }
+}
+
+export async function runQueuePromptGuards(
+  context: QueuePromptGuardContext
+): Promise<boolean> {
+  const results = await Promise.all(
+    [...guards.values()].map((guard) => runGuard(guard, context))
+  )
+  if (results.includes('failed')) {
+    useToastStore().add({
+      severity: 'error',
+      summary: t('toastMessages.failedToQueue')
+    })
+  }
+  return results.every((result) => result === 'allowed')
+}


### PR DESCRIPTION
Stacked on #13938.

## Summary

Routes partner-node policy denials through the standard model-error experience.

- Runs queue guards before the client queue is mutated and again after deferred authentication resolves.
- Normalizes authoritative Cloud `PARTNER_NODE_DISABLED` responses into node-scoped `workspace_partner_node_disabled` errors.
- Shows the Partner nodes Alert Toast and lets **View details** open the grouped Errors panel.

## Verification

| Before — #13938 `5d6d3e4` | After — #13939 `804b295` |
| --- | --- |
| <img width="720" alt="Generic Access Restricted dialog before PR 13939" src="https://github.com/user-attachments/assets/8b3d011e-0144-4113-9635-eb587bb220f8" /> | <img width="720" alt="Node-scoped disabled node error panel after PR 13939" src="https://github.com/user-attachments/assets/231476ed-94b3-4229-860e-dc0aa2164f2b" /> |

https://github.com/user-attachments/assets/1695c988-fb6f-4d04-b653-3b8c2d0202ec

| Timestamp | Screenshot | Highlight |
| --- | --- | --- |
| `00:04.5` | <img width="360" alt="Before PR 13939 generic access restricted dialog" src="https://github.com/user-attachments/assets/2802d57f-9862-4500-af7a-ca23034da7a7" /> | The backend rejection falls through to the generic **Access Restricted** dialog. |
| `00:07.5` | <img width="360" alt="After PR 13939 partner node alert toast" src="https://github.com/user-attachments/assets/5cd86379-d7aa-4670-9ac6-8cfe17edf78a" /> | The PR head shows the `Partner nodes` Alert Toast with **View details**. |
| `00:09.5` | <img width="360" alt="After PR 13939 grouped disabled node error" src="https://github.com/user-attachments/assets/5fc2d7c3-808f-480f-ac60-df037e7c6a20" /> | **View details** opens the grouped, node-scoped Errors panel. |

| Observable boundary | Current-head proof |
| --- | --- |
| Pre-queue rejection | [`app.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/804b295b53875be2216a1ddc85159e34e45322e4/src/scripts/app.test.ts) proves a denied prompt is blocked before client-queue insertion and rechecked after auth. |
| Cloud payload normalization | [`partnerNodePolicyPromptError.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/804b295b53875be2216a1ddc85159e34e45322e4/src/platform/workspace/utils/partnerNodePolicyPromptError.test.ts) maps Cloud offender class types/providers back to frontend node errors and ignores malformed or unrelated errors. |
| Alert Toast action | [`GlobalToast.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/804b295b53875be2216a1ddc85159e34e45322e4/src/components/toast/GlobalToast.test.ts) proves **View details** opens the Errors tab. |
| Grouped error copy | [`useErrorGroups.test.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/804b295b53875be2216a1ddc85159e34e45322e4/src/components/rightSidePanel/errors/useErrorGroups.test.ts) groups disabled partner nodes with names and count. |

The Cloud graph-policy guard is not registered until #13940. This head covers queue/error plumbing plus authoritative backend rejections; proactive local graph enforcement remains the next slice, with Cloud still authoritative via [Comfy-Org/cloud#5278](https://github.com/Comfy-Org/cloud/pull/5278).

Created by Codex
