### PR TITLE
feat: 10/x enforce partner node workspace policy

### DIFF
--- a/browser_tests/fixtures/partnerNodeGovernanceFixture.ts
+++ b/browser_tests/fixtures/partnerNodeGovernanceFixture.ts
@@ -1,0 +1,121 @@
+import type { Page } from '@playwright/test'
+
+import type { ListAssetsResponse } from '@comfyorg/ingest-types'
+
+import type {
+  PartnerNodePolicyResponse,
+  PartnerProviderCatalogResponse
+} from '@/platform/workspace/api/partnerNodePolicyApi'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { PromptResponse } from '@/schemas/apiSchema'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+
+import { comfyPageFixture as base } from '@e2e/fixtures/ComfyPage'
+import { WORKSPACE_FEATURE_FLAG } from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const DISABLED_NODE = 'DisabledPartnerNode'
+
+interface PartnerNodeGovernanceFixture {
+  promptRequestCount: () => number
+}
+
+function disabledPartnerNode(): ComfyNodeDef {
+  return {
+    name: DISABLED_NODE,
+    display_name: 'Disabled Partner Node',
+    category: 'api/image/Acme',
+    python_module: 'comfy_api_nodes.acme',
+    description: '',
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: true,
+    api_node: true
+  }
+}
+
+async function setupGovernedWorkspace(page: Page) {
+  await new CloudWorkspaceMockHelper(page).setup()
+  await page.route('**/api/features', (route) =>
+    route.fulfill(
+      jsonRoute({
+        ...WORKSPACE_FEATURE_FLAG,
+        partner_node_governance_enabled: true
+      } satisfies RemoteConfig)
+    )
+  )
+  await page.route('**/api/object_info', (route) =>
+    route.fulfill(jsonRoute({ [DISABLED_NODE]: disabledPartnerNode() }))
+  )
+  await page.route(/\/api\/assets(?:\?.*)?$/, (route) =>
+    route.fulfill(
+      jsonRoute({
+        assets: [],
+        total: 0,
+        has_more: false
+      } satisfies ListAssetsResponse)
+    )
+  )
+  await page.route('**/api/providers', (route) =>
+    route.fulfill(
+      jsonRoute({
+        providers: [
+          {
+            provider_id: 'acme',
+            display_name: 'Acme',
+            node_categories: ['Acme']
+          }
+        ]
+      } satisfies PartnerProviderCatalogResponse)
+    )
+  )
+  await page.route('**/api/workspace/provider-policy', (route) =>
+    route.fulfill(
+      jsonRoute({
+        enforcement_enabled: true,
+        providers: [{ provider_id: 'acme', enabled: false }]
+      } satisfies PartnerNodePolicyResponse)
+    )
+  )
+  await page.route('**/api/experiment/models', (route) =>
+    route.fulfill(jsonRoute([]))
+  )
+}
+
+export const partnerNodeGovernanceTest = base.extend<{
+  partnerNodeGovernance: PartnerNodeGovernanceFixture
+}>({
+  partnerNodeGovernance: async ({ page }, use) => {
+    await setupGovernedWorkspace(page)
+    let promptRequests = 0
+    await page.route('**/api/prompt', (route) => {
+      if (route.request().method() === 'POST') {
+        promptRequests++
+        return route.fulfill(
+          jsonRoute({
+            prompt_id: 'unexpected-prompt',
+            node_errors: {},
+            error: ''
+          } satisfies PromptResponse)
+        )
+      }
+      return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+    })
+
+    await page.goto(APP_URL)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+    await page.evaluate((nodeType) => {
+      const node = window.LiteGraph!.createNode(nodeType)
+      if (!node) throw new Error(`Failed to create ${nodeType}`)
+      window.app!.rootGraph.add(node)
+    }, DISABLED_NODE)
+
+    await use({ promptRequestCount: () => promptRequests })
+  }
+})

--- a/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
@@ -34,15 +34,6 @@ test.describe('Partner node governance workbench', { tag: '@cloud' }, () => {
     await expect(policyAlert).toContainText(
       'This node has been disabled by your team admin.'
     )
-    await policyAlert.getByRole('button', { name: 'View details' }).click()
-    await expect(
-      page.getByRole('button', { name: '1 Disabled node' })
-    ).toBeVisible()
-    await expect(
-      page.getByText(
-        'This node has been disabled by your team admin. Use a different node.'
-      )
-    ).toBeVisible()
     expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
   })
 })

--- a/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
@@ -34,6 +34,15 @@ test.describe('Partner node governance workbench', { tag: '@cloud' }, () => {
     await expect(policyAlert).toContainText(
       'This node has been disabled by your team admin.'
     )
+    await policyAlert.getByRole('button', { name: 'View details' }).click()
+    await expect(
+      page.getByRole('button', { name: '1 Disabled node' })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'This node has been disabled by your team admin. Use a different node.'
+      )
+    ).toBeVisible()
     expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
   })
 })

--- a/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
+++ b/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test'
+
+import { partnerNodeGovernanceTest as test } from '@e2e/fixtures/partnerNodeGovernanceFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+test.describe('Partner node governance workbench', { tag: '@cloud' }, () => {
+  test('hides nodes from disabled providers in search', async ({
+    page,
+    partnerNodeGovernance
+  }) => {
+    await page.evaluate(() =>
+      window.app!.extensionManager.command.execute('Workspace.SearchBox.Toggle')
+    )
+    const search = page.getByRole('search')
+    await search.getByRole('combobox').fill('Disabled Partner Node')
+
+    await expect(
+      search.getByTestId(TestIds.searchBoxV2.resultItem)
+    ).toHaveCount(0)
+    await expect(
+      search.getByTestId(TestIds.searchBoxV2.noResults)
+    ).toBeVisible()
+    expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
+  })
+
+  test('blocks queueing a disabled provider before the prompt request', async ({
+    page,
+    partnerNodeGovernance
+  }) => {
+    await page.getByTestId(TestIds.topbar.queueButton).click()
+
+    const policyAlert = page.getByRole('alert')
+    await expect(policyAlert).toContainText('Partner nodes')
+    await expect(policyAlert).toContainText(
+      'This node has been disabled by your team admin.'
+    )
+    expect(partnerNodeGovernance.promptRequestCount()).toBe(0)
+  })
+})

--- a/src/extensions/core/cloudPartnerNodeGovernance.test.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.test.ts
@@ -1,0 +1,400 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
+import type { ComfyApp } from '@/scripts/app'
+import type { NodeError } from '@/schemas/apiSchema'
+import type { QueuePromptGuard } from '@/services/queuePromptGuardService'
+import type { ComfyExtension } from '@/types/comfy'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+
+const {
+  addToast,
+  executionErrorStore,
+  governanceStore,
+  isNodeDisabled,
+  loadPolicy,
+  recordNodeErrors,
+  registerQueuePromptGuard,
+  registerExtension,
+  usePartnerNodeGovernanceStore
+} = vi.hoisted(() => {
+  const isNodeDisabled = vi.fn()
+  const loadPolicy = vi.fn<() => Promise<void>>().mockResolvedValue()
+  const governanceStore = {
+    status: 'configured',
+    isNodeDisabled,
+    loadPolicy
+  }
+  const executionErrorStore = {
+    lastNodeErrors: null as Record<string, NodeError> | null,
+    recordNodeErrors: vi.fn((nodeErrors: Record<string, NodeError> | null) => {
+      executionErrorStore.lastNodeErrors = nodeErrors
+    })
+  }
+  return {
+    addToast: vi.fn(),
+    executionErrorStore,
+    governanceStore,
+    isNodeDisabled,
+    loadPolicy,
+    recordNodeErrors: executionErrorStore.recordNodeErrors,
+    registerQueuePromptGuard: vi.fn<
+      (id: string, guard: QueuePromptGuard) => () => void
+    >(() => () => {}),
+    registerExtension: vi.fn<(extension: ComfyExtension) => void>(),
+    usePartnerNodeGovernanceStore: vi.fn(() => governanceStore)
+  }
+})
+
+vi.mock('@/platform/workspace/stores/partnerNodeGovernanceStore', () => ({
+  usePartnerNodeGovernanceStore
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: addToast })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => executionErrorStore
+}))
+
+vi.mock('@/services/queuePromptGuardService', () => ({
+  registerQueuePromptGuard
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({ registerExtension })
+}))
+
+describe('cloudPartnerNodeGovernance', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.resetModules()
+    vi.clearAllMocks()
+    governanceStore.status = 'configured'
+    loadPolicy.mockResolvedValue()
+    executionErrorStore.lastNodeErrors = null
+  })
+
+  async function loadExtension(): Promise<ComfyExtension> {
+    await import('./cloudPartnerNodeGovernance')
+    const extension = registerExtension.mock.calls[0]?.[0]
+    if (!extension)
+      throw new Error('Expected governance extension registration')
+    return extension
+  }
+
+  async function loadGuard(): Promise<QueuePromptGuard> {
+    const extension = await loadExtension()
+    extension.setup?.(fromPartial<ComfyApp>({}))
+    const guard = registerQueuePromptGuard.mock.calls[0]?.[1]
+    if (!guard) throw new Error('Expected queue guard registration')
+    return guard
+  }
+
+  function disabledPartnerNode(title = 'DisabledPartnerNode'): LGraphNode {
+    return new LGraphNode(title, 'DisabledPartnerNode')
+  }
+
+  function outputNode(title: string): LGraphNode {
+    class OutputNode extends LGraphNode {
+      static override nodeData = { output_node: true }
+    }
+
+    return new OutputNode(title, title)
+  }
+
+  function connectNodes(graph: LGraph, source: LGraphNode, target: LGraphNode) {
+    source.addOutput('output', '*')
+    target.addInput('input', '*')
+    graph.add(source)
+    graph.add(target)
+    source.connect(0, target, 0)
+  }
+
+  it('initializes governance during Cloud setup', async () => {
+    const extension = await loadExtension()
+    expect(extension.name).toBe('Comfy.Cloud.PartnerNodeGovernance')
+
+    extension.setup?.(fromPartial<ComfyApp>({}))
+
+    expect(usePartnerNodeGovernanceStore).toHaveBeenCalledOnce()
+    expect(registerQueuePromptGuard).toHaveBeenCalledOnce()
+  })
+
+  it('waits for the initial policy load before checking the graph', async () => {
+    let resolvePolicy!: () => void
+    loadPolicy.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePolicy = resolve
+      })
+    )
+    governanceStore.status = 'loading'
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    const result = guard({ rootGraph: graph })
+
+    expect(loadPolicy).toHaveBeenCalledOnce()
+    expect(isNodeDisabled).not.toHaveBeenCalled()
+    resolvePolicy()
+    await expect(result).resolves.toBe(false)
+  })
+
+  it('blocks queueing when the graph contains a disabled partner node', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({ rootGraph: graph })
+
+    expect(result).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+    expect(recordNodeErrors).toHaveBeenCalledWith({
+      [createNodeExecutionId([graph.nodes[0].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This node has been disabled by your team admin.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    })
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Partner nodes',
+      detail: 'This node has been disabled by your team admin.',
+      group: 'partner-node-policy',
+      life: 8000
+    })
+  })
+
+  it.each([
+    ['muted', LGraphEventMode.NEVER],
+    ['bypassed', LGraphEventMode.BYPASS]
+  ])(
+    'allows queueing when the disabled partner node is %s',
+    async (_label, mode) => {
+      const graph = new LGraph()
+      const node = disabledPartnerNode()
+      node.mode = mode
+      graph.add(node)
+      isNodeDisabled.mockImplementation(
+        (nodeType) => nodeType === 'DisabledPartnerNode'
+      )
+      const guard = await loadGuard()
+
+      expect(await guard({ rootGraph: graph })).toBe(true)
+      expect(addToast).not.toHaveBeenCalled()
+      expect(recordNodeErrors).not.toHaveBeenCalled()
+    }
+  )
+
+  it('allows queueing when the disabled partner node is inside a muted subgraph', async () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    subgraph.add(disabledPartnerNode())
+    const host = createTestSubgraphNode(subgraph)
+    host.mode = LGraphEventMode.NEVER
+    rootGraph.add(host)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph })).toBe(true)
+    expect(addToast).not.toHaveBeenCalled()
+  })
+
+  it('blocks queueing when the disabled partner node is inside an active subgraph', async () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    subgraph.add(disabledPartnerNode())
+    rootGraph.add(createTestSubgraphNode(subgraph))
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph })).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+  })
+
+  it('allows partial execution when a disabled node is on another output branch', async () => {
+    const graph = new LGraph()
+    const allowedSource = new LGraphNode('AllowedNode', 'AllowedNode')
+    const allowedOutput = outputNode('AllowedOutput')
+    const disabledSource = disabledPartnerNode()
+    const unrelatedOutput = outputNode('UnrelatedOutput')
+    connectNodes(graph, allowedSource, allowedOutput)
+    connectNodes(graph, disabledSource, unrelatedOutput)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({
+      rootGraph: graph,
+      queueNodeIds: [createNodeExecutionId([allowedOutput.id])]
+    })
+
+    expect(result).toBe(true)
+    expect(addToast).not.toHaveBeenCalled()
+    expect(recordNodeErrors).not.toHaveBeenCalled()
+  })
+
+  it('blocks partial execution when a disabled node is an upstream dependency', async () => {
+    const graph = new LGraph()
+    const disabledSource = disabledPartnerNode()
+    const selectedOutput = outputNode('SelectedOutput')
+    connectNodes(graph, disabledSource, selectedOutput)
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    const result = await guard({
+      rootGraph: graph,
+      queueNodeIds: [createNodeExecutionId([selectedOutput.id])]
+    })
+
+    expect(result).toBe(false)
+    expect(isNodeDisabled).toHaveBeenCalledWith('DisabledPartnerNode')
+  })
+
+  it('clears policy node errors after an allowed retry', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+
+    isNodeDisabled.mockReturnValue(false)
+
+    expect(await guard({ rootGraph: graph })).toBe(true)
+    expect(recordNodeErrors).toHaveBeenLastCalledWith(null)
+  })
+
+  it('preserves unrelated node errors after a blocked attempt', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode())
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+    await guard({ rootGraph: graph })
+    const unrelatedNodeErrors = {
+      'other-node': {
+        class_type: 'OtherNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'required_input_missing',
+            message: 'Required input is missing',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    } satisfies Record<string, NodeError>
+    executionErrorStore.lastNodeErrors = unrelatedNodeErrors
+    recordNodeErrors.mockClear()
+    isNodeDisabled.mockReturnValue(false)
+
+    expect(await guard({ rootGraph: graph })).toBe(true)
+    expect(recordNodeErrors).not.toHaveBeenCalled()
+    expect(executionErrorStore.lastNodeErrors).toBe(unrelatedNodeErrors)
+  })
+
+  it('merges policy errors with existing node errors', async () => {
+    const graph = new LGraph()
+    const disabledNode = disabledPartnerNode()
+    graph.add(disabledNode)
+    const executionId = createNodeExecutionId([disabledNode.id])
+    executionErrorStore.lastNodeErrors = {
+      [executionId]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'required_input_missing',
+            message: 'Required input is missing',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    }
+    isNodeDisabled.mockReturnValue(true)
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+    expect(executionErrorStore.lastNodeErrors?.[executionId]?.errors).toEqual([
+      expect.objectContaining({ type: 'required_input_missing' }),
+      expect.objectContaining({
+        type: 'workspace_partner_node_disabled'
+      })
+    ])
+  })
+
+  it('uses the policy alert copy when multiple nodes are disabled', async () => {
+    const graph = new LGraph()
+    graph.add(disabledPartnerNode('Flux Fill'))
+    graph.add(disabledPartnerNode('Veo Video'))
+    isNodeDisabled.mockImplementation(
+      (nodeType) => nodeType === 'DisabledPartnerNode'
+    )
+    const guard = await loadGuard()
+
+    expect(await guard({ rootGraph: graph })).toBe(false)
+    expect(recordNodeErrors).toHaveBeenCalledWith({
+      [createNodeExecutionId([graph.nodes[0].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This node has been disabled by your team admin.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      },
+      [createNodeExecutionId([graph.nodes[1].id])]: {
+        class_type: 'DisabledPartnerNode',
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'workspace_partner_node_disabled',
+            message: 'This node has been disabled by your team admin.',
+            details: '',
+            extra_info: {}
+          }
+        ]
+      }
+    })
+    expect(addToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Partner nodes',
+      detail: 'This node has been disabled by your team admin.',
+      group: 'partner-node-policy',
+      life: 8000
+    })
+  })
+})

--- a/src/extensions/core/cloudPartnerNodeGovernance.ts
+++ b/src/extensions/core/cloudPartnerNodeGovernance.ts
@@ -1,0 +1,205 @@
+import { t } from '@/i18n'
+import type {
+  ExecutableLGraphNode,
+  LGraph,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
+import {
+  ExecutableNodeDTO,
+  LGraphEventMode
+} from '@/lib/litegraph/src/litegraph'
+import { WORKSPACE_PARTNER_NODE_DISABLED_TYPE } from '@/platform/errorCatalog/validationErrorResolver'
+import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { NodeError } from '@/schemas/apiSchema'
+import { useExtensionService } from '@/services/extensionService'
+import { registerQueuePromptGuard } from '@/services/queuePromptGuardService'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+import { isOutputNode } from '@/utils/nodeFilterUtil'
+
+const QUEUE_GUARD_ID = 'workspace.partner-node-governance'
+const POLICY_TOAST_GROUP = 'partner-node-policy'
+
+interface DisabledPartnerNode {
+  executionId: NodeExecutionId
+  nodeType: string
+}
+
+function isExcludedFromPrompt(node: Pick<LGraphNode, 'mode'>): boolean {
+  return (
+    node.mode === LGraphEventMode.NEVER || node.mode === LGraphEventMode.BYPASS
+  )
+}
+
+function createExecutableNodeMap(
+  graph: LGraph
+): Map<string, ExecutableLGraphNode> {
+  const nodesByExecutionId = new Map<string, ExecutableLGraphNode>()
+  for (const node of graph.computeExecutionOrder(false)) {
+    const nodeDto = new ExecutableNodeDTO(node, [], nodesByExecutionId)
+    nodesByExecutionId.set(nodeDto.id, nodeDto)
+    if (isExcludedFromPrompt(node)) continue
+
+    for (const innerNode of nodeDto.getInnerNodes()) {
+      nodesByExecutionId.set(innerNode.id, innerNode)
+    }
+  }
+  return nodesByExecutionId
+}
+
+function getDisabledPartnerNodes(
+  graph: LGraph,
+  queueNodeIds: readonly NodeExecutionId[] | undefined,
+  isNodeDisabled: (nodeType: string) => boolean
+): DisabledPartnerNode[] {
+  const nodesByExecutionId = createExecutableNodeMap(graph)
+  const visited = new Set<string>()
+  const disabledNodes = new Map<NodeExecutionId, DisabledPartnerNode>()
+
+  function visitDependency(executionId: string): void {
+    if (visited.has(executionId)) return
+    visited.add(executionId)
+
+    const node = nodesByExecutionId.get(executionId)
+    if (!node || node.isVirtualNode || isExcludedFromPrompt(node)) return
+    const normalizedExecutionId = tryNormalizeNodeExecutionId(executionId)
+    if (normalizedExecutionId && node.type && isNodeDisabled(node.type)) {
+      disabledNodes.set(normalizedExecutionId, {
+        executionId: normalizedExecutionId,
+        nodeType: node.type
+      })
+    }
+
+    node.inputs.forEach((_input, index) => {
+      const resolvedInput = node.resolveInput(index)
+      if (resolvedInput && !resolvedInput.widgetInfo) {
+        visitDependency(resolvedInput.origin_id)
+      }
+    })
+  }
+
+  if (queueNodeIds?.length) {
+    for (const executionId of queueNodeIds) {
+      const node = getNodeByExecutionId(graph, executionId)
+      if (node && isOutputNode(node)) visitDependency(executionId)
+    }
+  } else {
+    for (const executionId of nodesByExecutionId.keys()) {
+      visitDependency(executionId)
+    }
+  }
+
+  return [...disabledNodes.values()]
+}
+
+function createPolicyNodeErrors(
+  disabledNodes: DisabledPartnerNode[]
+): Record<string, NodeError> {
+  const nodeErrors: Record<string, NodeError> = {}
+  for (const node of disabledNodes) {
+    nodeErrors[node.executionId] = {
+      class_type: node.nodeType,
+      dependent_outputs: [],
+      errors: [
+        {
+          type: WORKSPACE_PARTNER_NODE_DISABLED_TYPE,
+          message: t('workspacePanel.partnerNodes.runBlocked.nodeError'),
+          details: '',
+          extra_info: {}
+        }
+      ]
+    }
+  }
+  return nodeErrors
+}
+
+function removePolicyNodeErrors(
+  nodeErrors: Record<string, NodeError> | null
+): Record<string, NodeError> | null {
+  if (!nodeErrors) return nodeErrors
+
+  let changed = false
+  const remainingNodeErrors: Record<string, NodeError> = {}
+  for (const [executionId, nodeError] of Object.entries(nodeErrors)) {
+    const errors = nodeError.errors.filter(
+      ({ type }) => type !== WORKSPACE_PARTNER_NODE_DISABLED_TYPE
+    )
+    if (errors.length !== nodeError.errors.length) changed = true
+    if (errors.length > 0) {
+      remainingNodeErrors[executionId] = { ...nodeError, errors }
+    }
+  }
+
+  if (!changed) return nodeErrors
+  return Object.keys(remainingNodeErrors).length > 0
+    ? remainingNodeErrors
+    : null
+}
+
+function mergePolicyNodeErrors(
+  nodeErrors: Record<string, NodeError> | null,
+  policyNodeErrors: Record<string, NodeError>
+): Record<string, NodeError> {
+  const mergedNodeErrors = { ...removePolicyNodeErrors(nodeErrors) }
+  for (const [executionId, policyNodeError] of Object.entries(
+    policyNodeErrors
+  )) {
+    const existingNodeError = mergedNodeErrors[executionId]
+    mergedNodeErrors[executionId] = existingNodeError
+      ? {
+          ...existingNodeError,
+          errors: [...existingNodeError.errors, ...policyNodeError.errors]
+        }
+      : policyNodeError
+  }
+  return mergedNodeErrors
+}
+
+useExtensionService().registerExtension({
+  name: 'Comfy.Cloud.PartnerNodeGovernance',
+
+  setup: () => {
+    usePartnerNodeGovernanceStore()
+    registerQueuePromptGuard(QUEUE_GUARD_ID, async (context) => {
+      const executionErrorStore = useExecutionErrorStore()
+      const governanceStore = usePartnerNodeGovernanceStore()
+      if (governanceStore.status === 'loading') {
+        await governanceStore.loadPolicy()
+      }
+      const isNodeDisabled = (nodeType: string) =>
+        governanceStore.isNodeDisabled(nodeType)
+      const disabledNodes = getDisabledPartnerNodes(
+        context.rootGraph,
+        context.queueNodeIds,
+        isNodeDisabled
+      )
+      if (disabledNodes.length === 0) {
+        const remainingNodeErrors = removePolicyNodeErrors(
+          executionErrorStore.lastNodeErrors
+        )
+        if (remainingNodeErrors !== executionErrorStore.lastNodeErrors) {
+          executionErrorStore.recordNodeErrors(remainingNodeErrors)
+        }
+        return true
+      }
+
+      executionErrorStore.recordNodeErrors(
+        mergePolicyNodeErrors(
+          executionErrorStore.lastNodeErrors,
+          createPolicyNodeErrors(disabledNodes)
+        )
+      )
+      useToastStore().add({
+        severity: 'error',
+        summary: t('workspacePanel.partnerNodes.runBlocked.summary'),
+        detail: t('workspacePanel.partnerNodes.runBlocked.detail'),
+        group: POLICY_TOAST_GROUP,
+        life: 8000
+      })
+      return false
+    })
+  }
+})

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -37,6 +37,7 @@ import './widgetInputs'
 if (isCloud) {
   await import('./cloudRemoteConfig')
   await import('./cloudBadges')
+  await import('./cloudPartnerNodeGovernance')
   await import('./cloudSessionCookie')
 }
 


### PR DESCRIPTION
Stacked on #13939.

## Summary

Registers the Cloud workspace-policy guard and closes the frontend runtime loop.

- Waits for the initial policy load before inspecting the executable graph.
- Blocks active disabled-provider nodes across root graphs and subgraphs while respecting muted, bypassed, and partial-execution paths.
- Records node-scoped policy errors, shows the Alert Toast, and stops before `/api/prompt`.

## Verification

| Before | After |
|---|---|
| <img width="720" alt="Before PR 13940: queue waits on the backend" src="https://github.com/user-attachments/assets/783d39d7-d36c-473d-92a6-631549e07d92" /> | <img width="720" alt="After PR 13940: local partner-node policy toast appears" src="https://github.com/user-attachments/assets/e317f507-38de-4f14-8622-c5548ad2ee62" /> |

https://github.com/user-attachments/assets/276a56c5-309e-4e8b-944e-c3e456b64871

- The [Cloud browser scenario](https://github.com/Comfy-Org/ComfyUI_frontend/blob/a3173647b2994798965535e46cdbef62a823f992/browser_tests/tests/partnerNodeGovernanceWorkbench.spec.ts) proves disabled providers are removed from discovery and a blocked run makes zero `POST /api/prompt` requests.
- `cloudPartnerNodeGovernance.test.ts` covers active, muted, and bypassed subgraphs; partial-execution branches; loading-state safety; error merge and cleanup; and single/multiple-node copy.
- Commit hooks passed oxfmt, oxlint, ESLint, app typecheck, browser typecheck, and knip.

The Model Errors details UI is covered by the follow-up #13948.

Cloud remains authoritative for catalog, policy, prompt, and proxy enforcement through [Comfy-Org/cloud#5278](https://github.com/Comfy-Org/cloud/pull/5278).

Created by Codex