### PR TITLE
fix: align partner policy errors with workspace design

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -172,8 +172,9 @@ const tabs = computed<RightSidePanelTabList>(() => {
   const list: RightSidePanelTabList = []
 
   if (
-    settingStore.get('Comfy.RightSidePanel.ShowErrorsTab') &&
-    hasRelevantErrors.value
+    hasRelevantErrors.value &&
+    (rightSidePanelStore.activeTab === 'errors' ||
+      settingStore.get('Comfy.RightSidePanel.ShowErrorsTab'))
   ) {
     list.push({
       label: () => t('rightSidePanel.errors'),

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -8,9 +8,9 @@
           <span class="text-sm">{{ slotProps.message.detail }}</span>
         </div>
         <Button
-          variant="muted-textonly"
+          variant="secondary"
           size="sm"
-          class="w-fit px-0 underline hover:bg-transparent"
+          class="w-fit"
           @click="viewPartnerNodePolicyErrors(slotProps.message)"
         >
           {{ $t('rightSidePanel.viewDetails') }}


### PR DESCRIPTION
Stacked on #13939.

## Summary

Aligns the disabled partner-node error flow with the Model Errors design while keeping error-tab lifecycle correct.

## Changes

- **What**: Uses the design's secondary **View details** action and allows that action to open the Errors tab even when the global Errors-tab setting is off.
- **Behavior**: Keeps the Errors tab available only while relevant errors exist, preventing the stale empty tab regression after errors clear.

## Review Focus

- **View details** opens the disabled-node group from the partner-policy toast.
- Clearing the relevant errors removes the Errors tab even when it was active.

## Screenshots

| Before | After |
|---|---|
| <img width="1280" height="800" alt="Model errors before: View details leaves the Errors tab unavailable" src="https://github.com/user-attachments/assets/85855352-fad7-43c0-8b45-313a949c18e6" /> | <img width="1280" height="800" alt="Model errors after: View details opens the Errors tab and disabled-node group" src="https://github.com/user-attachments/assets/5f7a8e6a-41da-4ad0-81a4-0b25e66204e5" /> |

## Verification

- 48 focused unit tests passed.
- Commit hooks passed stylelint, oxfmt, oxlint, ESLint, app typecheck, and knip.

Created by Codex