### PR TITLE
ci: sync stale pinact pin comment and cover .yml files in pinact config

### DIFF
--- a/.github/workflows/pr-cursor-review.yaml
+++ b/.github/workflows/pr-cursor-review.yaml
@@ -29,7 +29,7 @@ jobs:
     # SHA-pinned per zizmor `unpinned-uses: hash-pin`. Bump this SHA to pick up
     # upstream changes; keep `workflows_ref` matching so prompts/scripts load
     # from the same commit as the workflow definition.
-    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@964d5aad37cbfb57c5b23961d42c2fd85868bf1d # github-workflows main (df507e6)
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@964d5aad37cbfb57c5b23961d42c2fd85868bf1d # github-workflows main (964d5aa)
     with:
       # Overriding diff_excludes replaces the reusable default wholesale, so
       # this restates the generated/vendored defaults and adds this repo's heavy

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -4,7 +4,9 @@ version: 3
 
 files:
   - pattern: .github/workflows/*.yaml
+  - pattern: .github/workflows/*.yml
   - pattern: .github/actions/**/*.yaml
+  - pattern: .github/actions/**/*.yml
 
 # Actions that don't need SHA pinning (official GitHub actions are trusted)
 ignore_actions:


### PR DESCRIPTION
## ELI-5

Our workflow files pin outside actions to exact commit IDs, with a little note next to each pin saying which version that commit is. One note got left behind when its pin was updated, so it named the wrong commit. This fixes the note and widens the checker's file list so it watches all the workflow files, not just the ones with a `.yaml` ending.

## Summary

Sync the stale pin comment on the cursor-review reusable-workflow reference (left behind by #13890) and extend `.pinact.yaml` file patterns to cover `.yml` files.

## Changes

- **What**:
  - `.github/workflows/pr-cursor-review.yaml`: the pin comment still read `(df507e6)` after #13890 bumped the SHA to `964d5aad...` — updated to `(964d5aa)`. Verified `964d5aad` is an ancestor of `github-workflows` `main` and carries no tag (the repo's only tag is `v1` → `4d9cb6b8`), so the short-hash comment form is the correct one — there is no version tag to use.
  - `.pinact.yaml`: `files` patterns only matched `*.yaml`, leaving `cla.yml`, `detect-unreviewed-merge.yml`, and `.github/actions/lint-format-verify/action.yml` outside pinact's coverage. Added `*.yml` patterns. Verified with CI's exact pinact version (v3.7.3, pinned via `pinact-action` v1.3.1's aqua config) that the extended config produces no churn: `pinact run` and `pinact run --check` both exit 0 with no file modifications.

## Review Focus

- **Does CI catch comment drift like this? Empirically: no.** Ran CI's exact pinact v3.7.3 against the pre-fix state: `pinact run --check` exits 0 and fix-mode `pinact run` modifies nothing — the free-form `# github-workflows main (…)` comment is invisible to it. pinact's `--verify` (not enabled in our CI) only validates semver-style comments, so it skips this line too. Keeping such comments in sync stays a manual step for anyone bumping this SHA; the adjacent code comment already instructs bumpers to keep things matching.
- **Why not enable `verify: true` on `pinact-action`?** Tested: v3.7.3 `--verify` hard-fails (exit 1) on `actions-cool/maintain-one-comment@4b2dbf0 # v3.2.0` because that repository has been disabled by GitHub staff (TOS block since 2026-05-19) — API and git access both return 403, so the tag can no longer be resolved. Runtime action resolution still works (recent `pr-report` runs pass), but that dependency is now unverifiable and worth replacing separately.
- **pinact v4 note:** pinact ≥ v4 rejects SHA pins whose comment isn't a resolvable tag ("SHA-pinned action requires a version comment"), which would fail the cursor-review line. CI is pinned to v3.7.3 so this is not live; whoever upgrades pinact will need an ignore rule for untagged `Comfy-Org/github-workflows` pins.
