### PR TITLE
feat: 3/x add partner node policy foundation

### DIFF
--- a/src/platform/workspace/api/partnerNodePolicyApi.test.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getPartnerNodePolicy,
   getPartnerProviders,
-  PartnerNodePolicyApiError
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 
 const mockFetchApi = vi.fn()
@@ -71,6 +72,33 @@ describe('partnerNodePolicyApi', () => {
     )
 
     await expect(getPartnerNodePolicy()).resolves.toBeNull()
+  })
+
+  it('serializes and normalizes a replacement policy', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        enforcement_enabled: false,
+        providers: [{ provider_id: 'openai', enabled: true }]
+      })
+    )
+
+    await expect(
+      updatePartnerNodePolicy({
+        enforcementEnabled: false,
+        providers: [{ providerId: 'openai', enabled: true }]
+      })
+    ).resolves.toEqual({
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: true }]
+    })
+    expect(mockFetchApi).toHaveBeenCalledWith('/workspace/provider-policy', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        enforcement_enabled: false,
+        providers: [{ provider_id: 'openai', enabled: true }]
+      })
+    })
   })
 
   it('preserves response status codes for policy decisions', async () => {

--- a/src/platform/workspace/api/partnerNodePolicyApi.test.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getPartnerNodePolicy,
+  getPartnerProviders,
   PartnerNodePolicyApiError
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 
@@ -20,6 +21,31 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 describe('partnerNodePolicyApi', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('normalizes the provider catalog', async () => {
+    mockFetchApi.mockResolvedValue(
+      jsonResponse({
+        providers: [
+          {
+            provider_id: 'openai',
+            display_name: 'OpenAI (inc. Sora)',
+            node_categories: ['OpenAI', 'Sora']
+          }
+        ]
+      })
+    )
+
+    await expect(getPartnerProviders()).resolves.toEqual([
+      {
+        id: 'openai',
+        displayName: 'OpenAI (inc. Sora)',
+        nodeCategories: ['OpenAI', 'Sora']
+      }
+    ])
+    expect(mockFetchApi).toHaveBeenCalledWith('/providers', {
+      cache: 'no-store'
+    })
   })
 
   it('normalizes the configured policy response', async () => {

--- a/src/platform/workspace/api/partnerNodePolicyApi.test.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.test.ts
@@ -52,18 +52,17 @@ describe('partnerNodePolicyApi', () => {
     mockFetchApi.mockResolvedValue(
       jsonResponse({
         enforcement_enabled: true,
-        nodes: { AllowedNode: true, DisabledNode: false }
+        providers: [{ provider_id: 'openai', enabled: false }]
       })
     )
 
     await expect(getPartnerNodePolicy()).resolves.toEqual({
       enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
+      providers: [{ providerId: 'openai', enabled: false }]
     })
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      '/workspace/partner-node-policy',
-      { cache: 'no-store' }
-    )
+    expect(mockFetchApi).toHaveBeenCalledWith('/workspace/provider-policy', {
+      cache: 'no-store'
+    })
   })
 
   it('maps 404 to an unconfigured policy', async () => {
@@ -74,19 +73,19 @@ describe('partnerNodePolicyApi', () => {
     await expect(getPartnerNodePolicy()).resolves.toBeNull()
   })
 
-  it('preserves non-404 status codes for policy decisions', async () => {
+  it('preserves response status codes for policy decisions', async () => {
     mockFetchApi.mockResolvedValue(
-      jsonResponse({}, { status: 503, statusText: 'Service Unavailable' })
+      jsonResponse({}, { status: 403, statusText: 'Forbidden' })
     )
 
-    await expect(getPartnerNodePolicy()).rejects.toEqual(
-      new PartnerNodePolicyApiError(503, 'Service Unavailable')
+    await expect(getPartnerProviders()).rejects.toEqual(
+      new PartnerNodePolicyApiError(403, 'Forbidden')
     )
   })
 
   it('rejects malformed policy responses', async () => {
     mockFetchApi.mockResolvedValue(
-      jsonResponse({ enforcement_enabled: 'yes', nodes: [] })
+      jsonResponse({ enforcement_enabled: 'yes', providers: [] })
     )
 
     await expect(getPartnerNodePolicy()).rejects.toMatchObject({

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -12,9 +12,14 @@ const partnerProviderCatalogResponseSchema = z.object({
   providers: z.array(partnerProviderSchema)
 })
 
+const partnerProviderPolicyEntrySchema = z.object({
+  provider_id: z.string(),
+  enabled: z.boolean()
+})
+
 const partnerNodePolicyResponseSchema = z.object({
   enforcement_enabled: z.boolean(),
-  nodes: z.record(z.string(), z.boolean())
+  providers: z.array(partnerProviderPolicyEntrySchema)
 })
 
 export interface PartnerProvider {
@@ -23,9 +28,14 @@ export interface PartnerProvider {
   nodeCategories: readonly string[]
 }
 
+export interface PartnerProviderPolicyEntry {
+  providerId: string
+  enabled: boolean
+}
+
 export interface PartnerNodePolicy {
   enforcementEnabled: boolean
-  nodes: Readonly<Record<string, boolean>>
+  providers: readonly PartnerProviderPolicyEntry[]
 }
 
 export class PartnerNodePolicyApiError extends Error {
@@ -38,11 +48,25 @@ export class PartnerNodePolicyApiError extends Error {
   }
 }
 
+function normalizePolicy(
+  data: z.infer<typeof partnerNodePolicyResponseSchema>
+): PartnerNodePolicy {
+  return {
+    enforcementEnabled: data.enforcement_enabled,
+    providers: data.providers.map(({ provider_id, enabled }) => ({
+      providerId: provider_id,
+      enabled
+    }))
+  }
+}
+
+function throwResponseError(response: Response): never {
+  throw new PartnerNodePolicyApiError(response.status, response.statusText)
+}
+
 export async function getPartnerProviders(): Promise<PartnerProvider[]> {
   const response = await api.fetchApi('/providers', { cache: 'no-store' })
-  if (!response.ok) {
-    throw new PartnerNodePolicyApiError(response.status, response.statusText)
-  }
+  if (!response.ok) throwResponseError(response)
 
   const data = partnerProviderCatalogResponseSchema.parse(await response.json())
   return data.providers.map(
@@ -55,17 +79,13 @@ export async function getPartnerProviders(): Promise<PartnerProvider[]> {
 }
 
 export async function getPartnerNodePolicy(): Promise<PartnerNodePolicy | null> {
-  const response = await api.fetchApi('/workspace/partner-node-policy', {
+  const response = await api.fetchApi('/workspace/provider-policy', {
     cache: 'no-store'
   })
   if (response.status === 404) return null
-  if (!response.ok) {
-    throw new PartnerNodePolicyApiError(response.status, response.statusText)
-  }
+  if (!response.ok) throwResponseError(response)
 
-  const data = partnerNodePolicyResponseSchema.parse(await response.json())
-  return {
-    enforcementEnabled: data.enforcement_enabled,
-    nodes: data.nodes
-  }
+  return normalizePolicy(
+    partnerNodePolicyResponseSchema.parse(await response.json())
+  )
 }

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -2,10 +2,26 @@ import { z } from 'zod'
 
 import { api } from '@/scripts/api'
 
+const partnerProviderSchema = z.object({
+  provider_id: z.string(),
+  display_name: z.string(),
+  node_categories: z.array(z.string())
+})
+
+const partnerProviderCatalogResponseSchema = z.object({
+  providers: z.array(partnerProviderSchema)
+})
+
 const partnerNodePolicyResponseSchema = z.object({
   enforcement_enabled: z.boolean(),
   nodes: z.record(z.string(), z.boolean())
 })
+
+export interface PartnerProvider {
+  id: string
+  displayName: string
+  nodeCategories: readonly string[]
+}
 
 export interface PartnerNodePolicy {
   enforcementEnabled: boolean
@@ -20,6 +36,22 @@ export class PartnerNodePolicyApiError extends Error {
     super(message)
     this.name = 'PartnerNodePolicyApiError'
   }
+}
+
+export async function getPartnerProviders(): Promise<PartnerProvider[]> {
+  const response = await api.fetchApi('/providers', { cache: 'no-store' })
+  if (!response.ok) {
+    throw new PartnerNodePolicyApiError(response.status, response.statusText)
+  }
+
+  const data = partnerProviderCatalogResponseSchema.parse(await response.json())
+  return data.providers.map(
+    ({ provider_id, display_name, node_categories }) => ({
+      id: provider_id,
+      displayName: display_name,
+      nodeCategories: node_categories
+    })
+  )
 }
 
 export async function getPartnerNodePolicy(): Promise<PartnerNodePolicy | null> {

--- a/src/platform/workspace/api/partnerNodePolicyApi.ts
+++ b/src/platform/workspace/api/partnerNodePolicyApi.ts
@@ -89,3 +89,24 @@ export async function getPartnerNodePolicy(): Promise<PartnerNodePolicy | null> 
     partnerNodePolicyResponseSchema.parse(await response.json())
   )
 }
+
+export async function updatePartnerNodePolicy(
+  policy: PartnerNodePolicy
+): Promise<PartnerNodePolicy> {
+  const response = await api.fetchApi('/workspace/provider-policy', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      enforcement_enabled: policy.enforcementEnabled,
+      providers: policy.providers.map(({ providerId, enabled }) => ({
+        provider_id: providerId,
+        enabled
+      }))
+    })
+  })
+  if (!response.ok) throwResponseError(response)
+
+  return normalizePolicy(
+    partnerNodePolicyResponseSchema.parse(await response.json())
+  )
+}

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -4,14 +4,16 @@ import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as PartnerNodePolicyApi from '@/platform/workspace/api/partnerNodePolicyApi'
-import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type {
+  PartnerNodePolicy,
+  PartnerProvider
+} from '@/platform/workspace/api/partnerNodePolicyApi'
 import { PartnerNodePolicyApiError } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
+const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
 const mockFlags = vi.hoisted(() => ({
   teamWorkspacesEnabled: true,
   partnerNodeGovernanceEnabled: true
@@ -27,30 +29,24 @@ vi.mock(
     const actual = await importOriginal<typeof PartnerNodePolicyApi>()
     return {
       ...actual,
-      getPartnerNodePolicy: mockGetPartnerNodePolicy
+      getPartnerNodePolicy: mockGetPartnerNodePolicy,
+      getPartnerProviders: mockGetPartnerProviders
     }
   }
 )
 
-function nodeDef(
-  name: string,
-  overrides: Partial<ComfyNodeDef> = {}
-): ComfyNodeDef {
-  return {
-    name,
-    display_name: `Display ${name}`,
-    category: 'partner/image/Provider',
-    python_module: 'comfy_api_nodes.provider',
-    description: '',
-    input: {},
-    output: [],
-    output_is_list: [],
-    output_name: [],
-    output_node: false,
-    api_node: true,
-    ...overrides
+const providers: PartnerProvider[] = [
+  {
+    id: 'openai',
+    displayName: 'OpenAI (inc. Sora)',
+    nodeCategories: ['OpenAI', 'Sora']
+  },
+  {
+    id: 'route-only',
+    displayName: 'Route only',
+    nodeCategories: []
   }
-}
+]
 
 function activateWorkspace(id: string, type: 'personal' | 'team' = 'team') {
   const store = useTeamWorkspaceStore()
@@ -86,18 +82,9 @@ describe('partnerNodeGovernanceStore', () => {
     vi.clearAllMocks()
     mockFlags.teamWorkspacesEnabled = true
     mockFlags.partnerNodeGovernanceEnabled = true
+    mockGetPartnerProviders.mockResolvedValue(providers)
     mockGetPartnerNodePolicy.mockResolvedValue(null)
     activateWorkspace('workspace-one')
-    useNodeDefStore().updateNodeDefs([
-      nodeDef('AllowedNode'),
-      nodeDef('DisabledNode'),
-      nodeDef('UnreviewedNode'),
-      nodeDef('CoreNode', {
-        api_node: false,
-        category: 'sampling',
-        python_module: 'nodes'
-      })
-    ])
   })
 
   afterEach(() => {
@@ -105,133 +92,54 @@ describe('partnerNodeGovernanceStore', () => {
     store = undefined
   })
 
-  it('composes partner-node catalog metadata from object info', async () => {
-    useNodeDefStore().updateNodeDefs([
-      nodeDef('PartnerNode', {
-        display_name: 'Partner Node',
-        category: 'partner/video/Acme'
-      }),
-      nodeDef('CoreNode', { api_node: false })
-    ])
+  it('loads the provider catalog and configured policy together', async () => {
+    mockGetPartnerNodePolicy.mockResolvedValue({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    } satisfies PartnerNodePolicy)
 
     store = await createLoadedStore()
 
-    expect(store.partnerNodes).toEqual([
-      { id: 'PartnerNode', name: 'Partner Node', provider: 'Acme' }
-    ])
+    expect(store.status).toBe('configured')
+    expect(store.providers).toEqual(providers)
+    expect(store.isProviderEnabled('openai')).toBe(false)
+    expect(store.isProviderEnabled('route-only')).toBe(false)
   })
 
-  it('treats 404 as unconfigured and allows every node', async () => {
+  it('builds an unrestricted initial policy from every catalog provider', async () => {
     store = await createLoadedStore()
 
     expect(store.status).toBe('unconfigured')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-  })
-
-  it('does not block nodes while enforcement is off', async () => {
-    mockGetPartnerNodePolicy.mockResolvedValue({
+    expect(store.isProviderEnabled('openai')).toBe(true)
+    expect(store.createInitialPolicy()).toEqual({
       enforcementEnabled: false,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
-
-    store = await createLoadedStore()
-
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
+      providers: [
+        { providerId: 'openai', enabled: true },
+        { providerId: 'route-only', enabled: true }
+      ]
+    })
   })
 
-  it('allows only explicit true rules while enforcement is on', async () => {
-    mockGetPartnerNodePolicy.mockResolvedValue({
-      enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
-
-    store = await createLoadedStore()
-
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(true)
-    expect(store.isNodeDisabled('UnreviewedNode')).toBe(true)
-    expect(store.isNodeDisabled('CoreNode')).toBe(false)
-  })
-
-  it('fails closed for a 503 from an enforcing workspace', async () => {
-    mockGetPartnerNodePolicy.mockRejectedValue(
-      new PartnerNodePolicyApiError(503, 'Service Unavailable')
+  it('hides governance when the backend reports an ineligible workspace', async () => {
+    mockGetPartnerProviders.mockRejectedValue(
+      new PartnerNodePolicyApiError(403, 'Forbidden')
     )
 
     store = await createLoadedStore()
 
-    expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-    expect(store.isNodeDisabled('CoreNode')).toBe(false)
+    expect(store.status).toBe('ineligible')
+    expect(store.providers).toEqual([])
   })
 
-  it('fails open during initial loading and a generic failure', async () => {
-    let rejectLoad!: (error: Error) => void
-    mockGetPartnerNodePolicy.mockReturnValue(
-      new Promise((_, reject) => {
-        rejectLoad = reject
-      })
-    )
-
-    store = usePartnerNodeGovernanceStore()
-
-    expect(store.status).toBe('loading')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-
-    rejectLoad(new Error('Network error'))
-    await vi.waitFor(() => expect(store?.status).toBe('error'))
-
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
-  })
-
-  it('stays fail-closed while retrying an unavailable policy', async () => {
-    mockGetPartnerNodePolicy.mockRejectedValueOnce(
-      new PartnerNodePolicyApiError(503, 'Service Unavailable')
-    )
-    store = await createLoadedStore()
-    let rejectRetry!: (error: Error) => void
-    mockGetPartnerNodePolicy.mockReturnValueOnce(
-      new Promise((_, reject) => {
-        rejectRetry = reject
-      })
-    )
-
-    const retry = store.loadPolicy()
-
-    expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-    rejectRetry(new Error('Network error'))
-    await retry
-    expect(store.status).toBe('unavailable')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(true)
-  })
-
-  it('preserves the last enforcing policy after a generic refresh error', async () => {
-    mockGetPartnerNodePolicy.mockResolvedValue({
-      enforcementEnabled: true,
-      nodes: { AllowedNode: true, DisabledNode: false }
-    } satisfies PartnerNodePolicy)
-    store = await createLoadedStore()
-    mockGetPartnerNodePolicy.mockRejectedValue(new Error('Network error'))
-
-    await store.loadPolicy()
-
-    expect(store.status).toBe('error')
-    expect(store.isNodeDisabled('AllowedNode')).toBe(false)
-    expect(store.isNodeDisabled('DisabledNode')).toBe(true)
-  })
-
-  it('stays inactive when partner-node governance is disabled', async () => {
+  it('stays inactive when partner-provider governance is disabled', async () => {
     mockFlags.partnerNodeGovernanceEnabled = false
 
     store = usePartnerNodeGovernanceStore()
     await nextTick()
 
+    expect(mockGetPartnerProviders).not.toHaveBeenCalled()
     expect(mockGetPartnerNodePolicy).not.toHaveBeenCalled()
     expect(store.status).toBe('inactive')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
   })
 
   it('stays inactive in a personal workspace', async () => {
@@ -240,13 +148,13 @@ describe('partnerNodeGovernanceStore', () => {
     store = usePartnerNodeGovernanceStore()
     await nextTick()
 
+    expect(mockGetPartnerProviders).not.toHaveBeenCalled()
     expect(mockGetPartnerNodePolicy).not.toHaveBeenCalled()
     expect(store.status).toBe('inactive')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
   })
 
   it('ignores a stale response after switching workspaces', async () => {
-    let resolveFirst!: (policy: PartnerNodePolicy) => void
+    let resolveFirst!: (policy: PartnerNodePolicy | null) => void
     mockGetPartnerNodePolicy
       .mockReturnValueOnce(
         new Promise((resolve) => {
@@ -255,7 +163,7 @@ describe('partnerNodeGovernanceStore', () => {
       )
       .mockResolvedValueOnce({
         enforcementEnabled: true,
-        nodes: { DisabledNode: true }
+        providers: [{ providerId: 'openai', enabled: true }]
       } satisfies PartnerNodePolicy)
     store = usePartnerNodeGovernanceStore()
     await vi.waitFor(() =>
@@ -266,11 +174,11 @@ describe('partnerNodeGovernanceStore', () => {
     await vi.waitFor(() => expect(store?.status).toBe('configured'))
     resolveFirst({
       enforcementEnabled: true,
-      nodes: { DisabledNode: false }
+      providers: [{ providerId: 'openai', enabled: false }]
     })
     await nextTick()
 
     expect(store.governedWorkspaceId).toBe('workspace-two')
-    expect(store.isNodeDisabled('DisabledNode')).toBe(false)
+    expect(store.isProviderEnabled('openai')).toBe(true)
   })
 })

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -162,8 +162,8 @@ describe('partnerNodeGovernanceStore', () => {
     {
       id: 'personal-workspace',
       type: 'personal',
-      expectedStatus: 'inactive',
-      expectedWorkspaceId: null
+      expectedStatus: 'unconfigured',
+      expectedWorkspaceId: 'personal-workspace'
     }
   ] as const)(
     'clears saving state after switching to a $type workspace',
@@ -312,15 +312,15 @@ describe('partnerNodeGovernanceStore', () => {
     expect(store.status).toBe('inactive')
   })
 
-  it('stays inactive in a personal workspace', async () => {
+  it('loads governance in a personal workspace when enabled', async () => {
     activateWorkspace('personal-workspace', 'personal')
 
-    store = usePartnerNodeGovernanceStore()
-    await nextTick()
+    store = await createLoadedStore()
 
-    expect(mockGetPartnerProviders).not.toHaveBeenCalled()
-    expect(mockGetPartnerNodePolicy).not.toHaveBeenCalled()
-    expect(store.status).toBe('inactive')
+    expect(mockGetPartnerProviders).toHaveBeenCalledOnce()
+    expect(mockGetPartnerNodePolicy).toHaveBeenCalledOnce()
+    expect(store.governedWorkspaceId).toBe('personal-workspace')
+    expect(store.status).toBe('unconfigured')
   })
 
   it('ignores a stale response after switching workspaces', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -14,8 +14,8 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 
 const mockGetPartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockGetPartnerProviders = vi.hoisted(() => vi.fn())
+const mockUpdatePartnerNodePolicy = vi.hoisted(() => vi.fn())
 const mockFlags = vi.hoisted(() => ({
-  teamWorkspacesEnabled: true,
   partnerNodeGovernanceEnabled: true
 }))
 
@@ -30,7 +30,8 @@ vi.mock(
     return {
       ...actual,
       getPartnerNodePolicy: mockGetPartnerNodePolicy,
-      getPartnerProviders: mockGetPartnerProviders
+      getPartnerProviders: mockGetPartnerProviders,
+      updatePartnerNodePolicy: mockUpdatePartnerNodePolicy
     }
   }
 )
@@ -80,7 +81,7 @@ describe('partnerNodeGovernanceStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
-    mockFlags.teamWorkspacesEnabled = true
+    mockUpdatePartnerNodePolicy.mockReset()
     mockFlags.partnerNodeGovernanceEnabled = true
     mockGetPartnerProviders.mockResolvedValue(providers)
     mockGetPartnerNodePolicy.mockResolvedValue(null)
@@ -129,6 +130,175 @@ describe('partnerNodeGovernanceStore', () => {
 
     expect(store.status).toBe('ineligible')
     expect(store.providers).toEqual([])
+  })
+
+  it('saves the server-normalized policy', async () => {
+    const requestedPolicy: PartnerNodePolicy = {
+      enforcementEnabled: false,
+      providers: [{ providerId: 'openai', enabled: false }]
+    }
+    const savedPolicy: PartnerNodePolicy = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    mockUpdatePartnerNodePolicy.mockResolvedValue(savedPolicy)
+    store = await createLoadedStore()
+
+    await store.savePolicy(requestedPolicy)
+
+    expect(mockUpdatePartnerNodePolicy).toHaveBeenCalledWith(requestedPolicy)
+    expect(store.policy).toEqual(savedPolicy)
+    expect(store.status).toBe('configured')
+    expect(store.isSaving).toBe(false)
+  })
+
+  it.for([
+    {
+      id: 'workspace-two',
+      type: 'team',
+      expectedStatus: 'unconfigured',
+      expectedWorkspaceId: 'workspace-two'
+    },
+    {
+      id: 'personal-workspace',
+      type: 'personal',
+      expectedStatus: 'inactive',
+      expectedWorkspaceId: null
+    }
+  ] as const)(
+    'clears saving state after switching to a $type workspace',
+    async ({ id, type, expectedStatus, expectedWorkspaceId }) => {
+      let resolveSave!: (policy: PartnerNodePolicy) => void
+      const savedPolicy: PartnerNodePolicy = {
+        enforcementEnabled: true,
+        providers: [{ providerId: 'openai', enabled: true }]
+      }
+      mockUpdatePartnerNodePolicy.mockReturnValue(
+        new Promise((resolve) => {
+          resolveSave = resolve
+        })
+      )
+      store = await createLoadedStore()
+
+      const savePromise = store.savePolicy(store.createInitialPolicy())
+      expect(store.isSaving).toBe(true)
+
+      activateWorkspace(id, type)
+      await vi.waitFor(() => expect(store?.status).toBe(expectedStatus))
+
+      expect(store.isSaving).toBe(false)
+
+      resolveSave(savedPolicy)
+      await savePromise
+
+      expect(store.governedWorkspaceId).toBe(expectedWorkspaceId)
+      expect(store.policy).toBeNull()
+    }
+  )
+
+  it('ignores a save response after switching away and back', async () => {
+    let resolveSave!: (policy: PartnerNodePolicy) => void
+    const savedPolicy: PartnerNodePolicy = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    }
+    mockUpdatePartnerNodePolicy.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    store = await createLoadedStore()
+
+    const savePromise = store.savePolicy(store.createInitialPolicy())
+    activateWorkspace('workspace-two')
+    await vi.waitFor(() => expect(store?.status).toBe('unconfigured'))
+    activateWorkspace('workspace-one')
+    await vi.waitFor(() => expect(store?.status).toBe('unconfigured'))
+
+    resolveSave(savedPolicy)
+    await savePromise
+
+    expect(store.policy).toBeNull()
+  })
+
+  it('rejects an overlapping save after a same-workspace reload', async () => {
+    let resolveSave!: (policy: PartnerNodePolicy) => void
+    mockUpdatePartnerNodePolicy
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSave = resolve
+        })
+      )
+      .mockResolvedValueOnce({
+        enforcementEnabled: true,
+        providers: [{ providerId: 'openai', enabled: false }]
+      } satisfies PartnerNodePolicy)
+    store = await createLoadedStore()
+    const acceptedPolicy = store.createInitialPolicy()
+
+    const savePromise = store.savePolicy(acceptedPolicy)
+    mockGetPartnerNodePolicy.mockResolvedValueOnce(acceptedPolicy)
+    await store.loadPolicy()
+
+    expect(store.isSaving).toBe(true)
+    await expect(
+      store.savePolicy({
+        enforcementEnabled: true,
+        providers: [{ providerId: 'openai', enabled: false }]
+      })
+    ).rejects.toThrow('Provider policy save already in progress')
+    const saveCallCount = mockUpdatePartnerNodePolicy.mock.calls.length
+
+    resolveSave(acceptedPolicy)
+    await savePromise
+
+    expect(saveCallCount).toBe(1)
+    expect(store.policy).toEqual(acceptedPolicy)
+    expect(store.isSaving).toBe(false)
+  })
+
+  it('ignores a load response after a save completes', async () => {
+    let resolveLoad!: (policy: PartnerNodePolicy | null) => void
+    const savedPolicy: PartnerNodePolicy = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    store = await createLoadedStore()
+    mockGetPartnerNodePolicy.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLoad = resolve
+      })
+    )
+    mockUpdatePartnerNodePolicy.mockResolvedValue(savedPolicy)
+
+    const loadPromise = store.loadPolicy()
+    await vi.waitFor(() => expect(store?.status).toBe('loading'))
+    await store.savePolicy(store.createInitialPolicy())
+    expect(store.policy).toEqual(savedPolicy)
+    resolveLoad({
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    })
+    await loadPromise
+
+    expect(store.policy).toEqual(savedPolicy)
+  })
+
+  it('reloads the catalog after an unknown-provider response', async () => {
+    mockUpdatePartnerNodePolicy.mockRejectedValue(
+      new PartnerNodePolicyApiError(422, 'Unprocessable Entity')
+    )
+    store = await createLoadedStore()
+    mockGetPartnerProviders.mockClear()
+    mockGetPartnerNodePolicy.mockClear()
+
+    await expect(store.savePolicy(store.createInitialPolicy())).rejects.toEqual(
+      new PartnerNodePolicyApiError(422, 'Unprocessable Entity')
+    )
+
+    expect(mockGetPartnerProviders).toHaveBeenCalledOnce()
+    expect(mockGetPartnerNodePolicy).toHaveBeenCalledOnce()
+    expect(store.isSaving).toBe(false)
   })
 
   it('stays inactive when partner-provider governance is disabled', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -4,24 +4,21 @@ import { computed, ref, shallowRef, watch } from 'vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   getPartnerNodePolicy,
+  getPartnerProviders,
   PartnerNodePolicyApiError
 } from '@/platform/workspace/api/partnerNodePolicyApi'
-import type { PartnerNodePolicy } from '@/platform/workspace/api/partnerNodePolicyApi'
+import type {
+  PartnerNodePolicy,
+  PartnerProvider
+} from '@/platform/workspace/api/partnerNodePolicyApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
-
-export interface PartnerNodeCatalogItem {
-  id: string
-  name: string
-  provider: string
-}
 
 export type PartnerNodePolicyStatus =
   | 'inactive'
   | 'loading'
   | 'unconfigured'
   | 'configured'
-  | 'unavailable'
+  | 'ineligible'
   | 'error'
 
 export const usePartnerNodeGovernanceStore = defineStore(
@@ -29,13 +26,12 @@ export const usePartnerNodeGovernanceStore = defineStore(
   () => {
     const { flags } = useFeatureFlags()
     const workspaceStore = useTeamWorkspaceStore()
-    const nodeDefStore = useNodeDefStore()
 
+    const providers = shallowRef<PartnerProvider[]>([])
     const policy = shallowRef<PartnerNodePolicy | null>(null)
-    const policyWorkspaceId = ref<string | null>(null)
     const status = ref<PartnerNodePolicyStatus>('inactive')
     const error = shallowRef<Error | null>(null)
-    let loadVersion = 0
+    let requestVersion = 0
 
     const governedWorkspaceId = computed(() => {
       const workspace = workspaceStore.activeWorkspace
@@ -46,93 +42,86 @@ export const usePartnerNodeGovernanceStore = defineStore(
         : null
     })
 
-    const partnerNodes = computed<PartnerNodeCatalogItem[]>(() =>
-      Object.values(nodeDefStore.nodeDefsByName)
-        .filter((nodeDef) => nodeDef.api_node)
-        .map((nodeDef) => ({
-          id: nodeDef.name,
-          name: nodeDef.display_name || nodeDef.name,
-          provider:
-            nodeDef.category.split('/')[2] ||
-            nodeDef.category ||
-            nodeDef.python_module
+    function createInitialPolicy(): PartnerNodePolicy {
+      return {
+        enforcementEnabled: false,
+        providers: providers.value.map(({ id }) => ({
+          providerId: id,
+          enabled: true
         }))
-    )
+      }
+    }
 
-    function isNodeDisabled(nodeType: string): boolean {
-      if (!nodeDefStore.nodeDefsByName[nodeType]?.api_node) return false
-      const workspaceId = governedWorkspaceId.value
-      if (!workspaceId || policyWorkspaceId.value !== workspaceId) return false
-      if (status.value === 'unavailable') return true
+    function isProviderEnabled(providerId: string): boolean {
+      if (!policy.value) return true
       return (
-        policy.value?.enforcementEnabled === true &&
-        policy.value.nodes[nodeType] !== true
+        policy.value.providers.find(
+          (provider) => provider.providerId === providerId
+        )?.enabled === true
       )
     }
 
     async function loadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value
-      const version = ++loadVersion
+      const version = ++requestVersion
       if (!workspaceId) {
+        providers.value = []
         policy.value = null
-        policyWorkspaceId.value = null
         status.value = 'inactive'
         error.value = null
         return
       }
 
-      const workspaceChanged = policyWorkspaceId.value !== workspaceId
-      if (workspaceChanged) {
-        policy.value = null
-        policyWorkspaceId.value = workspaceId
-        status.value = 'loading'
-      } else if (status.value !== 'unavailable') {
-        status.value = 'loading'
-      }
+      providers.value = []
+      policy.value = null
+      status.value = 'loading'
       error.value = null
 
       try {
-        const nextPolicy = await getPartnerNodePolicy()
+        const [nextProviders, nextPolicy] = await Promise.all([
+          getPartnerProviders(),
+          getPartnerNodePolicy()
+        ])
         if (
-          version !== loadVersion ||
+          version !== requestVersion ||
           governedWorkspaceId.value !== workspaceId
         ) {
           return
         }
+        providers.value = nextProviders
         policy.value = nextPolicy
         status.value = nextPolicy ? 'configured' : 'unconfigured'
       } catch (loadError) {
         if (
-          version !== loadVersion ||
+          version !== requestVersion ||
           governedWorkspaceId.value !== workspaceId
         ) {
           return
         }
+        providers.value = []
+        policy.value = null
         error.value =
           loadError instanceof Error
             ? loadError
-            : new Error('Failed to load partner node policy')
-        if (
+            : new Error('Failed to load partner provider policy')
+        status.value =
           loadError instanceof PartnerNodePolicyApiError &&
-          loadError.status === 503
-        ) {
-          policy.value = null
-          status.value = 'unavailable'
-          return
-        }
-        if (status.value !== 'unavailable') status.value = 'error'
+          loadError.status === 403
+            ? 'ineligible'
+            : 'error'
       }
     }
 
     watch(governedWorkspaceId, () => void loadPolicy(), { immediate: true })
 
     return {
+      providers,
       policy,
       status,
       error,
       governedWorkspaceId,
-      partnerNodes,
-      isNodeDisabled,
+      createInitialPolicy,
+      isProviderEnabled,
       loadPolicy
     }
   }

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -37,12 +37,11 @@ export const usePartnerNodeGovernanceStore = defineStore(
     let nextSaveId = 0
     let activeSave: { id: number; workspaceId: string } | null = null
 
-    const governedWorkspaceId = computed(() => {
-      const workspace = workspaceStore.activeWorkspace
-      return flags.partnerNodeGovernanceEnabled && workspace?.type === 'team'
-        ? workspace.id
+    const governedWorkspaceId = computed(() =>
+      flags.partnerNodeGovernanceEnabled
+        ? (workspaceStore.activeWorkspace?.id ?? null)
         : null
-    })
+    )
 
     function createInitialPolicy(): PartnerNodePolicy {
       return {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.ts
@@ -5,7 +5,8 @@ import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   getPartnerNodePolicy,
   getPartnerProviders,
-  PartnerNodePolicyApiError
+  PartnerNodePolicyApiError,
+  updatePartnerNodePolicy
 } from '@/platform/workspace/api/partnerNodePolicyApi'
 import type {
   PartnerNodePolicy,
@@ -31,13 +32,14 @@ export const usePartnerNodeGovernanceStore = defineStore(
     const policy = shallowRef<PartnerNodePolicy | null>(null)
     const status = ref<PartnerNodePolicyStatus>('inactive')
     const error = shallowRef<Error | null>(null)
+    const isSaving = ref(false)
     let requestVersion = 0
+    let nextSaveId = 0
+    let activeSave: { id: number; workspaceId: string } | null = null
 
     const governedWorkspaceId = computed(() => {
       const workspace = workspaceStore.activeWorkspace
-      return flags.teamWorkspacesEnabled &&
-        flags.partnerNodeGovernanceEnabled &&
-        workspace?.type === 'team'
+      return flags.partnerNodeGovernanceEnabled && workspace?.type === 'team'
         ? workspace.id
         : null
     })
@@ -64,6 +66,10 @@ export const usePartnerNodeGovernanceStore = defineStore(
     async function loadPolicy(): Promise<void> {
       const workspaceId = governedWorkspaceId.value
       const version = ++requestVersion
+      if (activeSave?.workspaceId !== workspaceId) {
+        activeSave = null
+        isSaving.value = false
+      }
       if (!workspaceId) {
         providers.value = []
         policy.value = null
@@ -112,6 +118,51 @@ export const usePartnerNodeGovernanceStore = defineStore(
       }
     }
 
+    async function savePolicy(nextPolicy: PartnerNodePolicy): Promise<void> {
+      const workspaceId = governedWorkspaceId.value
+      if (!workspaceId) return
+      if (isSaving.value) {
+        throw new Error('Provider policy save already in progress')
+      }
+
+      const version = ++requestVersion
+      const saveId = ++nextSaveId
+      activeSave = { id: saveId, workspaceId }
+      isSaving.value = true
+      try {
+        const savedPolicy = await updatePartnerNodePolicy(nextPolicy)
+        if (
+          version !== requestVersion ||
+          governedWorkspaceId.value !== workspaceId
+        ) {
+          return
+        }
+
+        policy.value = savedPolicy
+        status.value = 'configured'
+        error.value = null
+      } catch (saveError) {
+        if (
+          version !== requestVersion ||
+          governedWorkspaceId.value !== workspaceId
+        ) {
+          return
+        }
+        if (
+          saveError instanceof PartnerNodePolicyApiError &&
+          saveError.status === 422
+        ) {
+          await loadPolicy()
+        }
+        throw saveError
+      } finally {
+        if (activeSave?.id === saveId) {
+          activeSave = null
+          isSaving.value = false
+        }
+      }
+    }
+
     watch(governedWorkspaceId, () => void loadPolicy(), { immediate: true })
 
     return {
@@ -119,10 +170,12 @@ export const usePartnerNodeGovernanceStore = defineStore(
       policy,
       status,
       error,
+      isSaving,
       governedWorkspaceId,
       createInitialPolicy,
       isProviderEnabled,
-      loadPolicy
+      loadPolicy,
+      savePolicy
     }
   }
 )


### PR DESCRIPTION
## Stack

1. [#13950 — feat: 3/x add partner node policy foundation](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13950)
2. [#13952 — feat: 4/x surface workspace partner node policy denials](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13952)
3. [#13951 — feat: 5/x add workspace partner node allowlist UI](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13951)

## Summary

Adds typed provider-policy API and store support, gated by `partner_node_governance_enabled`. Depends on [cloud#5402](https://github.com/Comfy-Org/cloud/pull/5402).

## Verification

- API/store tests cover provider and policy load/save, response validation, 403/404/422 handling, personal workspaces, and stale or overlapping requests.
- Nonvisual change; authenticated Cloud integration remains unverified while cloud#5402 is open.

Created by Codex