### PR TITLE
fix(workspace): show personal subscription cancel state

### DIFF
--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -106,7 +106,8 @@ const mockSubscription = computed<SubscriptionInfo | null>(() =>
         duration: mockSubscriptionDuration.value,
         planSlug: mockPlanSlug.value,
         renewalDate: RENEWAL_DATE_ISO,
-        endDate: END_DATE_ISO,
+        endDate:
+          mockSubscriptionStatus.value === 'canceled' ? END_DATE_ISO : null,
         isCancelled: mockSubscriptionStatus.value === 'canceled',
         hasFunds: true
       }
@@ -460,6 +461,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
         : `creator-${duration.toLowerCase()}`
       mockSubscriptionDuration.value = duration
       mockCanLeaveWorkspace.value = false
+      mockResubscribe.mockImplementationOnce(async () => {
+        mockSubscriptionStatus.value = 'active'
+      })
       renderComponent()
 
       expect(
@@ -480,6 +484,14 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
       await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
       expect(mockResubscribe).toHaveBeenCalledOnce()
+      expect(
+        await screen.findByText(
+          `Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
+      ).not.toBeInTheDocument()
     }
   )
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -416,45 +416,72 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('reactivates a cancelled plan for an owner, keeping Manage billing', async () => {
-    const user = userEvent.setup()
-    mockSubscriptionStatus.value = 'canceled'
-    mockCanLeaveWorkspace.value = false
-    renderComponent()
+  it.for([
+    ...(['MONTHLY', 'ANNUAL'] as const).flatMap((duration) => [
+      {
+        workspaceType: 'Personal',
+        planType: 'Personal',
+        isPersonalWorkspace: true,
+        isTeamPlan: false,
+        duration
+      },
+      {
+        workspaceType: 'Personal',
+        planType: 'Team',
+        isPersonalWorkspace: true,
+        isTeamPlan: true,
+        duration
+      },
+      {
+        workspaceType: 'Team',
+        planType: 'Personal',
+        isPersonalWorkspace: false,
+        isTeamPlan: false,
+        duration
+      },
+      {
+        workspaceType: 'Team',
+        planType: 'Team',
+        isPersonalWorkspace: false,
+        isTeamPlan: true,
+        duration
+      }
+    ])
+  ])(
+    'shows canceled state and reactivation for a $planType $duration plan in a $workspaceType workspace',
+    async ({ isPersonalWorkspace, isTeamPlan, duration }) => {
+      const user = userEvent.setup()
+      mockSubscriptionStatus.value = 'canceled'
+      mockIsInPersonalWorkspace.value = isPersonalWorkspace
+      mockHasTeamPlan.value = isTeamPlan
+      mockSubscriptionTier.value = isTeamPlan ? 'PRO' : 'CREATOR'
+      mockPlanSlug.value = isTeamPlan
+        ? `team_per_credit_${duration.toLowerCase()}`
+        : `creator-${duration.toLowerCase()}`
+      mockSubscriptionDuration.value = duration
+      mockCanLeaveWorkspace.value = false
+      renderComponent()
 
-    expect(
-      screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Manage billing' })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Change plan' })
-    ).not.toBeInTheDocument()
+      expect(
+        screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Manage billing' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Change plan' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Cancel plan' })
+      ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
-    expect(mockResubscribe).toHaveBeenCalledOnce()
-  })
-
-  it('keeps a cancelled Personal plan in a Team workspace reactivatable', () => {
-    mockSubscriptionStatus.value = 'canceled'
-    mockHasTeamPlan.value = false
-    mockIsWorkspaceSubscribed.value = false
-    renderComponent()
-
-    expect(
-      screen.getByText(`Ends on ${formatPanelDate(END_DATE_ISO)}`)
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Reactivate plan' })
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Subscribe Now' })
-    ).not.toBeInTheDocument()
-  })
+      await user.click(screen.getByRole('button', { name: 'Reactivate plan' }))
+      expect(mockResubscribe).toHaveBeenCalledOnce()
+    }
+  )
 
   it('shows the zero-state subscribe prompt to unsubscribed team owners', () => {
     mockIsActiveSubscription.value = false

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -237,6 +237,21 @@ describe('useWorkspaceBilling', () => {
       )
     })
 
+    it('maps a personal subscription with cancel_at as cancelled', async () => {
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        cancel_at: '2026-06-01T00:00:00Z'
+      })
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(billing.subscription.value).toMatchObject({
+        endDate: '2026-06-01T00:00:00Z',
+        isCancelled: true
+      })
+    })
+
     it("keeps a 'scheduled' subscription on the active treatment", async () => {
       mockWorkspaceApi.getBillingStatus.mockResolvedValue({
         ...activeStatus,

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -252,6 +252,21 @@ describe('useWorkspaceBilling', () => {
       })
     })
 
+    it('maps a reactivated subscription as active', async () => {
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        cancel_at: null
+      })
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(billing.subscription.value).toMatchObject({
+        endDate: null,
+        isCancelled: false
+      })
+    })
+
     it("keeps a 'scheduled' subscription on the active treatment", async () => {
       mockWorkspaceApi.getBillingStatus.mockResolvedValue({
         ...activeStatus,

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -60,7 +60,8 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       planSlug: status.plan_slug ?? null,
       renewalDate: status.renewal_date ?? null,
       endDate: status.cancel_at ?? null,
-      isCancelled: status.subscription_status === 'canceled',
+      isCancelled:
+        status.subscription_status === 'canceled' || status.cancel_at != null,
       hasFunds: status.has_funds
     }
   })

--- a/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceMenuItems.test.ts
@@ -77,15 +77,30 @@ describe('useWorkspaceMenuItems', () => {
     state.isSubscriptionCancelled = false
   })
 
-  it('allows a promoted owner to cancel an active plan', () => {
-    state.canManageSubscriptionLifecycle = true
+  it.for([
+    { workspaceType: 'Personal', isInPersonalWorkspace: true },
+    { workspaceType: 'Team', isInPersonalWorkspace: false }
+  ])(
+    'uses the shared cancellation dialog for an active $workspaceType workspace plan',
+    ({ isInPersonalWorkspace }) => {
+      state.canManageSubscriptionLifecycle = true
+      state.isInPersonalWorkspace = isInPersonalWorkspace
 
-    const { menuItems } = useWorkspaceMenuItems()
+      const { menuItems } = useWorkspaceMenuItems()
+      const cancelItem = menuItems.value.find(
+        (item) => item.label === 'subscription.cancelPlan'
+      )
+      cancelItem?.command?.({
+        originalEvent: new Event('click'),
+        item: cancelItem
+      })
 
-    expect(menuItems.value.map((item) => item.label)).toContain(
-      'subscription.cancelPlan'
-    )
-  })
+      expect(cancelItem).toBeDefined()
+      expect(dialogMocks.showCancelSubscriptionDialog).toHaveBeenCalledWith(
+        '2026-08-01T00:00:00Z'
+      )
+    }
+  )
 
   it('withholds cancellation from a member', () => {
     const { menuItems } = useWorkspaceMenuItems()


### PR DESCRIPTION
## Summary

Fix canceled subscriptions displaying as renewing in **Personal Workspace** settings. The canceled state now follows the billing contract consistently across Personal and Team workspaces, plan types, and billing cycles.

## What was wrong

A Personal subscription scheduled to end on Aug 22 displayed:

- `Renews on Aug 22, 2026`
- `Upgrade plan`
- no canceled banner or badge
- no `Reactivate plan` action

### AS IS — previous adapter

![Personal Workspace incorrectly showing a scheduled cancellation as renewing](https://ampcode.com/attachments/217836b6cfd837b3dc138b5c17427cc3327ddbc199b58f99708b044c90bcecc8.png)

With `subscription_status: active` and a future `cancel_at`, the old adapter showed `Renews on` and `Upgrade plan`.

### TO BE — fixed adapter

![Personal Workspace correctly showing canceled state and Reactivate plan](https://ampcode.com/attachments/97d1bc9bf5911ce8af6d5edbee641a3a008c53c5fd9078447794d08278a1d981.png)

The same Personal Workspace and billing payload now show the canceled warning, canceled badge, `Ends on <date>`, and `Reactivate plan`.

## Root cause

`useWorkspaceBilling` only set `isCancelled` when `subscription_status === 'canceled'`. A scheduled cancellation has two valid backend representations:

- `subscription_status === 'canceled'`: the lifecycle status has transitioned, or
- `cancel_at != null`: cancellation is scheduled while access remains active through the paid period

The cloud/1.47 RC exposed the scheduled cancellation through the workspace billing adapter. That adapter preserved `cancel_at` as `endDate` but ignored it when deriving cancellation state, so the shared panel rendered the active/renewing branch.

## Why cloud/1.45 appeared correct

The cloud/1.45 and cloud/1.47 branches contain the same old workspace predicate, so this was not introduced by a source-code change between those release branches. Personal billing can appear correct on cloud/1.45 when it remains on the legacy `/customers/*` adapter: that adapter derives cancellation directly from `end_date`.

The 1.47 RC routed/exposed the affected subscription through workspace-scoped `/api/billing/*`, where the response can remain `subscription_status: active` while carrying a future `cancel_at`. QA subsequently reproduced the same 1.47 behavior on a Team workspace, which is always workspace-scoped. The fix therefore belongs in the shared workspace adapter and should be included in cloud/1.47; it is not a Personal-only UI implementation.

## Fix

Treat either billing signal as canceled:

```ts
status.subscription_status === 'canceled' || status.cancel_at != null
```

This is the correct contract because `cancel_at` is specifically the scheduled-cancellation timestamp. Reactivation clears `cancel_at` and returns the subscription status to active, so the predicate becomes false and the panel returns to `Renews on`. A fully canceled record remains canceled through `subscription_status` even if `cancel_at` is absent.

No separate Personal cancellation path was introduced. Personal and Team workspaces continue to use the same menu action, cancellation dialog, billing facade, cancellation action, and resubscribe action.

## Verification

Automated coverage exercises every combination below:

| Workspace | Plan | Billing cycle | Expected canceled UI |
|---|---|---|---|
| Personal | Personal | Monthly | Canceled banner/badge, Ends on, Reactivate |
| Personal | Personal | Annual | Canceled banner/badge, Ends on, Reactivate |
| Personal | Team | Monthly | Canceled banner/badge, Ends on, Reactivate |
| Personal | Team | Annual | Canceled banner/badge, Ends on, Reactivate |
| Team | Personal | Monthly | Canceled banner/badge, Ends on, Reactivate |
| Team | Personal | Annual | Canceled banner/badge, Ends on, Reactivate |
| Team | Team | Monthly | Canceled banner/badge, Ends on, Reactivate |
| Team | Team | Annual | Canceled banner/badge, Ends on, Reactivate |

Each case verifies:

- `Ends on <date>` is shown and `Renews on <date>` is hidden after cancellation
- `Manage billing` remains available
- `Reactivate plan` is shown and invokes resubscribe
- the refreshed active response (`subscription_status: active`, `cancel_at: null`) removes `Ends on` and restores `Renews on`
- `Change plan` and `Cancel plan` are hidden after cancellation

Cancellation parity is covered separately: active Personal and Team workspace plans both open the same shared cancellation dialog with the subscription end date.

Checks:

- `useWorkspaceBilling.test.ts`: 61 passed
- `SubscriptionPanelContentWorkspace.test.ts`: 31 passed
- `useWorkspaceMenuItems.test.ts`: 13 passed
- 105 focused tests passed
- Typecheck passed
- ESLint, Oxlint, formatting, pre-push Knip, and the full code-change PR CI suite passed
- screenshot-only commit CI rerun is in progress
- CodeRabbit completed successfully; both findings are marked addressed in `0e7da5c`

