### PR TITLE
feat(website): redirect /trust to Vanta trust center

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -57,7 +57,7 @@
     },
     {
       "source": "/trust",
-      "destination": "https://app.vanta.com/comfy.org/trust/o6nu46b16iu3e7fhc41hnz",
+      "destination": "https://trust.comfy.org",
       "permanent": false
     },
     {

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -56,6 +56,11 @@
       "permanent": true
     },
     {
+      "source": "/trust",
+      "destination": "https://app.vanta.com/comfy.org/trust/o6nu46b16iu3e7fhc41hnz",
+      "permanent": false
+    },
+    {
       "source": "/login",
       "destination": "https://cloud.comfy.org/login",
       "permanent": false


### PR DESCRIPTION
Adds a Vercel redirect so comfy.org/trust points to the Comfy trust center at https://trust.comfy.org (Vanta Trust Center on a custom domain, now live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)