### PR TITLE
feat: 5/6 support workspace admin roles

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3075,6 +3075,7 @@
     "subscribe": "Subscribe",
     "personal": "Personal",
     "roleOwner": "Owner",
+    "roleAdmin": "Admin",
     "roleMember": "Member",
     "createWorkspace": "Create a workspace",
     "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -4,14 +4,15 @@ import { attachUnifiedRemintInterceptor } from '@/platform/auth/unified/remintRe
 import type { SubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
   WorkspaceId,
-  WorkspaceInviteId
+  WorkspaceInviteId,
+  WorkspaceRole
 } from '@/platform/workspace/workspaceTypes'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserId } from '@/types/authTypes'
 
 export type WorkspaceType = 'personal' | 'team'
-export type WorkspaceRole = 'owner' | 'member'
+export type { WorkspaceRole }
 export type BillingRail = 'legacy_stripe' | 'stripe'
 
 interface Workspace {

--- a/src/platform/workspace/components/RoleBadge.test.ts
+++ b/src/platform/workspace/components/RoleBadge.test.ts
@@ -11,13 +11,14 @@ const i18n = createI18n({
     en: {
       workspaceSwitcher: {
         roleOwner: 'Owner',
+        roleAdmin: 'Admin',
         roleMember: 'Member'
       }
     }
   }
 })
 
-function renderRoleBadge(role: 'owner' | 'member') {
+function renderRoleBadge(role: 'owner' | 'admin' | 'member') {
   return render(RoleBadge, {
     props: { role },
     global: { plugins: [i18n] }
@@ -33,5 +34,10 @@ describe('RoleBadge', () => {
   it('renders the member label', () => {
     renderRoleBadge('member')
     expect(screen.getByText('Member')).toBeInTheDocument()
+  })
+
+  it('renders the admin label', () => {
+    renderRoleBadge('admin')
+    expect(screen.getByText('Admin')).toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/RoleBadge.vue
+++ b/src/platform/workspace/components/RoleBadge.vue
@@ -10,15 +10,17 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
+
 const { role } = defineProps<{
-  role: 'owner' | 'member'
+  role: WorkspaceRole
 }>()
 
 const { t } = useI18n()
 
-const roleBadgeLabel = computed(() =>
-  role === 'owner'
-    ? t('workspaceSwitcher.roleOwner')
-    : t('workspaceSwitcher.roleMember')
-)
+const roleBadgeLabel = computed(() => {
+  if (role === 'owner') return t('workspaceSwitcher.roleOwner')
+  if (role === 'admin') return t('workspaceSwitcher.roleAdmin')
+  return t('workspaceSwitcher.roleMember')
+})
 </script>

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -172,6 +172,7 @@ function isCurrentWorkspace(workspace: AvailableWorkspace): boolean {
 
 function getRoleLabel(role: AvailableWorkspace['role']): string {
   if (role === 'owner') return t('workspaceSwitcher.roleOwner')
+  if (role === 'admin') return t('workspaceSwitcher.roleAdmin')
   if (role === 'member') return t('workspaceSwitcher.roleMember')
   return ''
 }

--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -34,7 +34,9 @@
       {{
         member.role === 'owner'
           ? $t('workspaceSwitcher.roleOwner')
-          : $t('workspaceSwitcher.roleMember')
+          : member.role === 'admin'
+            ? $t('workspaceSwitcher.roleAdmin')
+            : $t('workspaceSwitcher.roleMember')
       }}
     </span>
     <div

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -75,6 +75,12 @@ const teamMemberWorkspace: WorkspaceWithRole = {
   joined_at: '2026-03-01T00:00:00Z'
 }
 
+const teamAdminWorkspace: WorkspaceWithRole = {
+  ...teamMemberWorkspace,
+  id: 'ws-team-admin',
+  role: 'admin'
+}
+
 async function loadComposable() {
   const module = await import('@/platform/workspace/composables/useWorkspaceUI')
   return module.useWorkspaceUI()
@@ -316,6 +322,29 @@ describe('useWorkspaceUI', () => {
 
       expect(ui.permissions.value.canLeaveWorkspace).toBe(true)
       expect(ui.permissions.value.canAccessWorkspaceMenu).toBe(true)
+    })
+  })
+
+  describe('team workspace as admin', () => {
+    beforeEach(() => {
+      mockStore.activeWorkspace = teamAdminWorkspace
+    })
+
+    it('can manage members without receiving owner billing permissions', async () => {
+      const ui = await loadComposable()
+
+      expect(ui.permissions.value).toMatchObject({
+        canViewPendingInvites: true,
+        canInviteMembers: true,
+        canManageInvites: true,
+        canManageMembers: true,
+        canManageSubscription: false,
+        canManageSubscriptionLifecycle: false,
+        canTopUp: false
+      })
+      expect(ui.uiConfig.value.showPendingTab).toBe(true)
+      expect(ui.uiConfig.value.showEditWorkspaceMenuItem).toBe(false)
+      expect(ui.uiConfig.value.workspaceMenuAction).toBeNull()
     })
   })
 

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -130,6 +130,7 @@ function getUIConfig(
     }
   }
 
+  const isOwner = role === 'owner'
   return {
     showMembersList: true,
     showPendingTab: true,
@@ -138,10 +139,11 @@ function getUIConfig(
     membersGridCols: 'grid-cols-[50%_40%_10%]',
     pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
     headerGridCols: 'grid-cols-[50%_40%_10%]',
-    showEditWorkspaceMenuItem: true,
-    workspaceMenuAction: 'delete',
-    workspaceMenuDisabledTooltip:
-      'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
+    showEditWorkspaceMenuItem: isOwner,
+    workspaceMenuAction: isOwner ? 'delete' : null,
+    workspaceMenuDisabledTooltip: isOwner
+      ? 'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
+      : null
   }
 }
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -13,6 +13,7 @@ import type {
   Member,
   PendingInvite as ApiPendingInvite,
   SubscriptionTier,
+  WorkspaceRole,
   WorkspaceWithRole
 } from '../api/workspaceApi'
 import { workspaceApi } from '../api/workspaceApi'
@@ -22,7 +23,7 @@ export interface WorkspaceMember {
   name: string
   email: string
   joinDate: Date
-  role: 'owner' | 'member'
+  role: WorkspaceRole
   isOriginalOwner: boolean
 }
 

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -176,6 +176,28 @@ describe('useWorkspaceAuthStore', () => {
       ).toBeNull()
     })
 
+    it('restores an admin workspace role from session storage', () => {
+      const adminWorkspace = {
+        ...mockWorkspaceWithRole,
+        role: 'admin' as const
+      }
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+        JSON.stringify(adminWorkspace)
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'valid-token')
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
+        String(Date.now() + 3600 * 1000)
+      )
+      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, 'user-a')
+
+      const store = useWorkspaceAuthStore()
+
+      expect(store.initializeFromSession()).toBe(true)
+      expect(store.currentWorkspace).toEqual(adminWorkspace)
+    })
+
     it('returns false when sessionStorage is empty', () => {
       const store = useWorkspaceAuthStore()
 

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -20,7 +20,7 @@ const WorkspaceWithRoleSchema = z.object({
   id: z.string(),
   name: z.string(),
   type: z.enum(['personal', 'team']),
-  role: z.enum(['owner', 'member'])
+  role: z.enum(['owner', 'admin', 'member'])
 })
 
 const WorkspaceTokenResponseSchema = z.object({
@@ -31,7 +31,7 @@ const WorkspaceTokenResponseSchema = z.object({
     name: z.string(),
     type: z.enum(['personal', 'team'])
   }),
-  role: z.enum(['owner', 'member']),
+  role: z.enum(['owner', 'admin', 'member']),
   permissions: z.array(z.string())
 })
 

--- a/src/platform/workspace/workspaceTypes.ts
+++ b/src/platform/workspace/workspaceTypes.ts
@@ -14,10 +14,11 @@ export type WorkspaceId = string
  * primitive at use sites without changing structural typing.
  */
 export type WorkspaceInviteId = string
+export type WorkspaceRole = 'owner' | 'admin' | 'member'
 
 export interface WorkspaceWithRole {
   id: WorkspaceId
   name: string
   type: 'personal' | 'team'
-  role: 'owner' | 'member'
+  role: WorkspaceRole
 }


### PR DESCRIPTION
## Stack

1. [#13950 — feat: 3/6 add partner node policy foundation](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13950)
2. [#13952 — feat: 4/6 surface workspace partner node policy denials](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13952)
3. [#13961 — feat: 5/6 support workspace admin roles](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13961)
4. [#13951 — feat: 6/6 add workspace partner node allowlist UI](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13951)

## Summary

Extends the workspace role contract to `owner | admin | member` across API types, workspace-token/session parsing, stores, permissions, and localized labels. Team admins can manage members and invites without receiving owner-only billing, subscription-lifecycle, workspace-edit, or delete capabilities. This PR remains independently based on `main`; #13951 combines it with #13950 through a temporary integration base.

## Verification

| Before — base `e1b25e7` | After — head `371fd8f` |
|---|---|
| ![Before: admin workspace member labeled Member](https://github.com/user-attachments/assets/7612b46d-4beb-4f14-b154-03835c8ff913) | ![After: admin workspace member labeled Admin](https://github.com/user-attachments/assets/9ba6e597-9123-419f-8c50-4bc34add46ad) |

https://github.com/user-attachments/assets/a3699478-0539-4ae6-a96d-90ca763d272b

| Timestamp | Screenshot | Highlight |
|---|---|---|
| `00:05.50` | ![Baseline frame showing the admin member with a Member badge](https://github.com/user-attachments/assets/62d66621-2dc4-4ab8-8073-a5521c2604c9) | Pinned base: the workspace admin role is presented as Member. |
| `00:13.00` | ![Current-head frame showing the admin member with an Admin badge](https://github.com/user-attachments/assets/712a0ee2-3fa2-4acf-bff1-fdb7e80aca5a) | Current head: the same role is presented as Admin. |

- Auth-boundary coverage proves that an admin workspace survives session restoration, while both workspace and token-response schemas accept the role.
- Permission coverage proves that team admins receive member/invite management while billing and destructive workspace controls remain owner-only.
- The Admin label is mapped across the shared badge, workspace switcher, and member list.
- Visual proof uses route-mocked local app state at the pinned base and current head. An authenticated Cloud admin session is not verified.

Created by Codex