### PR TITLE
ci: run website e2e on merge queue commits

### DIFF
--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Description
`website-e2e` is a required status check on `main`, but `ci-website-e2e.yaml` has no `merge_group` trigger. On merge-queue commits the workflow never runs, the required check never reports, and every queue entry hangs in `AWAITING_CHECKS` until the queue times out — the queue is currently deadlocked for all PRs (observed: #13860, #13926, #13931 all stuck).

The `changes-filter` action already defaults its outputs to `true` for non-`pull_request` events specifically to support this, and the other required workflows (`ci-lint-format`, `ci-tests-e2e`) already carry the trigger — this workflow was missed when `website-e2e` became required.

Merge-group runs execute workflow files from the merged tree, so this PR's own queue entry triggers correctly once enqueued.

## How has this been tested?
Verified via the merge-queue API that all 32 reported checks on the stuck head entry are green and `website-e2e` is the only required context absent; verified the trigger matrix across sibling required workflows.

## Documentation
- [ ] Documentation has been added/updated if needed

## Screenshots or screen capture
N/A