### PR TITLE
docs: align test review guidance

### DIFF
--- a/.agents/checks/test-quality.md
+++ b/.agents/checks/test-quality.md
@@ -31,7 +31,8 @@ Rules:
 
 - Tests use **Vitest** (not Jest) — run with `pnpm test:unit`
 - Test files are **colocated**: `MyComponent.test.ts` next to `MyComponent.vue`
-- Use `@vue/test-utils` for component testing, `@pinia/testing` (`createTestingPinia`) for store tests
+- Use `@testing-library/vue` with `@testing-library/user-event` for new
+  component tests, and `@pinia/testing` (`createTestingPinia`) for store tests
 - Browser/E2E tests use **Playwright** in `browser_tests/` — run with `pnpm test:browser:local`
 - Mock composables using the singleton factory pattern inside `vi.mock()` — see `docs/testing/unit-testing.md` for the pattern
 - Never use `any` in test code either — proper typing applies to tests too

--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -1,7 +1,6 @@
 ---
 globs:
   - '**/*.test.ts'
-  - '**/*.spec.ts'
 ---
 
 # Vitest Patterns


### PR DESCRIPTION
## Summary

Align test review guidance with the repository's enforced component-test and file-naming conventions.

## Changes

- **What**: Require Testing Library for new component tests in the test-quality review lens.
- **What**: Scope Vitest patterns to `*.test.ts`, keeping Playwright `*.spec.ts` files out of Vitest guidance.

## Review Focus

Confirm the review lens matches the current ESLint restriction and that Vitest guidance no longer targets Playwright files.

## Verification

- `pnpm exec oxfmt --check .agents/checks/test-quality.md docs/testing/vitest-patterns.md`
- YAML frontmatter parse for both files
- `pnpm typecheck`
- Commit hooks: oxfmt, oxlint, ESLint
- Push hook: `pnpm knip`

Created by Codex