### PR TITLE
fix(billing): point Contact us to support instead of Discord

### DIFF
--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -316,6 +316,7 @@ import type {
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { Plan } from '@/platform/workspace/api/workspaceApi'
+import { useCommandStore } from '@/stores/commandStore'
 
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 
@@ -348,6 +349,7 @@ interface PricingTierConfig {
 }
 
 const { t, n } = useI18n()
+const commandStore = useCommandStore()
 
 const billingCycleOptions: BillingCycleOption[] = [
   { label: t('subscription.yearly'), value: 'yearly' },
@@ -533,8 +535,8 @@ function handleSubscribe(tierKey: CheckoutTierKey) {
   })
 }
 
-function handleContactUs() {
-  window.open('https://discord.com/invite/comfyorg', '_blank')
+async function handleContactUs() {
+  await commandStore.execute('Comfy.ContactSupport')
 }
 
 function handleViewEnterprise() {


### PR DESCRIPTION
## Summary

QA re-test of the 1.47 RC found the pricing "Contact us" button now opens a Discord invite (`https://discord.com/invite/comfyorg`), introduced by #13777 while fixing the earlier `www.comfy.org/discord` 404. A Discord invite is the wrong destination for a billing/team request (e.g. asking for a higher team-member limit).

This routes the button through the existing `Comfy.ContactSupport` command, mirroring the subscription dialog's "Contact us". That opens the Zendesk support form (`support.comfy.org`) pre-filled with the current user's email/ID.

## Changes

- `PricingTableWorkspace.vue`: `handleContactUs` now `await commandStore.execute('Comfy.ContactSupport')` instead of `window.open('https://discord.com/invite/comfyorg')`.

## Notes

- `Comfy.ContactSupport` builds its URL via `buildSupportUrl()` in `src/platform/support/config.ts` (`https://support.comfy.org/hc/en-us/requests/new`).
- No existing unit/component test covers this component, so none added; the change reuses the already-tested command path.

Follow-up to #13777.
