### PR TITLE
Update free tier dialog

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2775,7 +2775,7 @@
       "title": "You're on the Free plan",
       "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
       "descriptionGeneric": "Your free plan includes a monthly credit allowance to try Comfy Cloud.",
-      "descriptionQuota": "Your free plan includes {runs} executions each month to try Comfy Cloud.",
+      "descriptionQuota": "Your free plan includes {runs} runs to get started with Comfy Cloud — no card needed.",
       "nextRefresh": "Your next refresh will occur on {date}.",
       "subscribeCta": "Subscribe for more",
       "outOfCredits": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2676,7 +2676,7 @@
     "refreshCredits": "Refresh credits",
     "benefits": {
       "benefit1": "Monthly credits for Partner Nodes — top up when needed",
-      "benefit1FreeTier": "More monthly credits, top up anytime",
+      "benefit1FreeTier": "Monthly credits, top up anytime",
       "benefit2": "Up to 1 hour runtime per job on Pro",
       "benefit3": "Bring your own models (Creator & Pro)"
     },
@@ -2775,7 +2775,8 @@
       "title": "You're on the Free plan",
       "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
       "descriptionGeneric": "Your free plan includes a monthly credit allowance to try Comfy Cloud.",
-      "nextRefresh": "Your credits refresh on {date}.",
+      "descriptionQuota": "Your free plan includes {runs} executions each month to try Comfy Cloud.",
+      "nextRefresh": "Your next refresh will occur on {date}.",
       "subscribeCta": "Subscribe for more",
       "outOfCredits": {
         "title": "You're out of free credits",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2776,14 +2776,14 @@
       "description": "Your free plan includes {credits} credits each month to try Comfy Cloud.",
       "descriptionGeneric": "Your free plan includes a monthly credit allowance to try Comfy Cloud.",
       "descriptionQuota": "Your free plan includes {runs} runs to get started with Comfy Cloud — no card needed.",
-      "nextRefresh": "Your next refresh will occur on {date}.",
+      "nextRefresh": "Your credits refresh on {date}.",
       "subscribeCta": "Subscribe for more",
       "outOfCredits": {
         "title": "You're out of free credits",
-        "subtitle": "Subscribe to unlock top-ups and more"
+        "subtitle": "Subscribe to add top-ups and more"
       },
       "topUpBlocked": {
-        "title": "Unlock top-ups and more"
+        "title": "Add top-ups and more"
       },
       "upgradeCta": "View plans"
     },

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.test.ts
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.test.ts
@@ -57,28 +57,28 @@ describe('FreeTierDialogContent', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent()
     expect(
-      screen.getByText('Your next refresh will occur on Jul 15, 2026.')
+      screen.getByText('Your credits refresh on Jul 15, 2026.')
     ).toBeInTheDocument()
   })
 
   it('hides the next refresh line when renewalDate is null', () => {
     mockRenewalDate.value = null
     renderComponent()
-    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/credits refresh on/)).not.toBeInTheDocument()
   })
 
   it('keeps the generic copy for intent reasons outside the credits variants', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent({ reason: 'subscribe_to_run' })
     expect(
-      screen.getByText('Your next refresh will occur on Jul 15, 2026.')
+      screen.getByText('Your credits refresh on Jul 15, 2026.')
     ).toBeInTheDocument()
   })
 
   it('swaps to the out-of-credits copy without the refresh line', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent({ reason: 'out_of_credits' })
-    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/credits refresh on/)).not.toBeInTheDocument()
   })
 
   it('shows the quota copy and no refresh line when the job quota is enabled', () => {
@@ -91,6 +91,6 @@ describe('FreeTierDialogContent', () => {
         'Your free plan includes 5 runs to get started with Comfy Cloud — no card needed.'
       )
     ).toBeInTheDocument()
-    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/credits refresh on/)).not.toBeInTheDocument()
   })
 })

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.test.ts
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import { render, screen } from '@testing-library/vue'
@@ -10,12 +10,26 @@ import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import FreeTierDialogContent from './FreeTierDialogContent.vue'
 
 const mockRenewalDate = vi.hoisted(() => ({ value: null as string | null }))
+const mockQuota = vi.hoisted(() => ({ quotaEnabled: false, maxAvailable: 0 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
     renewalDate: mockRenewalDate
   }))
 }))
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useFreeTierQuota',
+  async () => {
+    const { computed } = await import('vue')
+    return {
+      useFreeTierQuota: () => ({
+        quotaEnabled: computed(() => mockQuota.quotaEnabled),
+        maxAvailable: computed(() => mockQuota.maxAvailable)
+      })
+    }
+  }
+)
 
 function renderComponent(props?: { reason?: PaymentIntentSource }) {
   const i18n = createI18n({
@@ -33,31 +47,50 @@ function renderComponent(props?: { reason?: PaymentIntentSource }) {
 }
 
 describe('FreeTierDialogContent', () => {
+  beforeEach(() => {
+    mockRenewalDate.value = null
+    mockQuota.quotaEnabled = false
+    mockQuota.maxAvailable = 0
+  })
+
   it('renders the next refresh line formatted from the facade renewalDate', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent()
     expect(
-      screen.getByText('Your credits refresh on Jul 15, 2026.')
+      screen.getByText('Your next refresh will occur on Jul 15, 2026.')
     ).toBeInTheDocument()
   })
 
   it('hides the next refresh line when renewalDate is null', () => {
     mockRenewalDate.value = null
     renderComponent()
-    expect(screen.queryByText(/credits refresh on/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
   })
 
   it('keeps the generic copy for intent reasons outside the credits variants', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent({ reason: 'subscribe_to_run' })
     expect(
-      screen.getByText('Your credits refresh on Jul 15, 2026.')
+      screen.getByText('Your next refresh will occur on Jul 15, 2026.')
     ).toBeInTheDocument()
   })
 
   it('swaps to the out-of-credits copy without the refresh line', () => {
     mockRenewalDate.value = '2026-07-15T10:00:00Z'
     renderComponent({ reason: 'out_of_credits' })
-    expect(screen.queryByText(/credits refresh on/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
+  })
+
+  it('shows the quota copy and no refresh line when the job quota is enabled', () => {
+    mockQuota.quotaEnabled = true
+    mockQuota.maxAvailable = 5
+    mockRenewalDate.value = '2026-07-15T10:00:00Z'
+    renderComponent()
+    expect(
+      screen.getByText(
+        'Your free plan includes 5 runs to get started with Comfy Cloud — no card needed.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/next refresh/)).not.toBeInTheDocument()
   })
 })

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -69,7 +69,9 @@
           </p>
 
           <p
-            v-if="!isCreditsBlockedVariant && formattedRenewalDate"
+            v-if="
+              !isCreditsBlockedVariant && !quotaEnabled && formattedRenewalDate
+            "
             class="m-0 text-sm text-text-secondary"
           >
             {{

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -56,11 +56,15 @@
             class="m-0 text-sm text-text-secondary"
           >
             {{
-              freeTierCredits
-                ? $t('subscription.freeTier.description', {
-                    credits: freeTierCredits.toLocaleString()
+              quotaEnabled
+                ? $t('subscription.freeTier.descriptionQuota', {
+                    runs: maxAvailable
                   })
-                : $t('subscription.freeTier.descriptionGeneric')
+                : freeTierCredits
+                  ? $t('subscription.freeTier.description', {
+                      credits: freeTierCredits.toLocaleString()
+                    })
+                  : $t('subscription.freeTier.descriptionGeneric')
             }}
           </p>
 
@@ -102,6 +106,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
+import { useFreeTierQuota } from '@/platform/cloud/subscription/composables/useFreeTierQuota'
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
 
 const { reason } = defineProps<{
@@ -114,6 +119,7 @@ defineEmits<{
 }>()
 
 const { renewalDate } = useBillingContext()
+const { quotaEnabled, maxAvailable } = useFreeTierQuota()
 
 const formattedRenewalDate = computed(() => {
   if (!renewalDate.value) return ''


### PR DESCRIPTION
When the FreeTierQuota system added in #13657 is enabled, the subscription dialog would still incorrectly mention a credit allowance.
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/d34f8f35-a516-4998-ba36-0d1cf9d95043"/> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/52071ef8-8895-426c-9c87-00a3c516db8a"  />|