### PR TITLE
[backport cloud/1.45] feat(billing): integrate dedicated resend-invite endpoint

### DIFF
--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -276,6 +276,25 @@ describe('workspaceApi', () => {
       )
     })
 
+    it('resendInvite() sends POST /workspace/invites/:id/resend', async () => {
+      const invite = {
+        id: 'inv-1',
+        email: 'a@b.com',
+        invited_at: '2024-02-01T00:00:00Z',
+        expires_at: '2024-02-08T00:00:00Z'
+      }
+      mockAxiosInstance.post.mockResolvedValue({ data: invite })
+
+      const result = await workspaceApi.resendInvite('inv-1')
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/workspace/invites/inv-1/resend',
+        null,
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(invite)
+    })
+
     it('acceptInvite() uses firebase auth and POST /invites/:token/accept', async () => {
       const data = { workspace_id: 'ws-1', workspace_name: 'Team' }
       mockAxiosInstance.post.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -59,7 +59,6 @@ export interface ListMembersParams {
 export interface PendingInvite {
   id: WorkspaceInviteId
   email: string
-  token: string
   invited_at: string
   expires_at: string
 }
@@ -546,6 +545,20 @@ export const workspaceApi = {
         api.apiURL(`/workspace/invites/${inviteId}`),
         { headers }
       )
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async resendInvite(inviteId: WorkspaceInviteId): Promise<PendingInvite> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.post<PendingInvite>(
+        api.apiURL(`/workspace/invites/${encodeURIComponent(inviteId)}/resend`),
+        null,
+        { headers }
+      )
+      return response.data
     } catch (err) {
       handleAxiosError(err)
     }

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -53,6 +53,7 @@ const mockWorkspaceApi = vi.hoisted(() => ({
   listInvites: vi.fn(),
   createInvite: vi.fn(),
   revokeInvite: vi.fn(),
+  resendInvite: vi.fn(),
   acceptInvite: vi.fn(),
   accessBillingPortal: vi.fn()
 }))
@@ -1334,7 +1335,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.pendingInvites[0].id).toBe('inv-2')
     })
 
-    it('resendInvite creates a fresh invite before revoking the old one', async () => {
+    it('resendInvite replaces the stored invite with the refreshed response', async () => {
       mockWorkspaceApi.listInvites.mockResolvedValue({
         invites: [
           {
@@ -1346,10 +1347,9 @@ describe('useTeamWorkspaceStore', () => {
           }
         ]
       })
-      mockWorkspaceApi.createInvite.mockResolvedValue({
-        id: 'inv-2',
+      mockWorkspaceApi.resendInvite.mockResolvedValue({
+        id: 'inv-1',
         email: 'one@test.com',
-        token: 'token-2',
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
@@ -1362,19 +1362,18 @@ describe('useTeamWorkspaceStore', () => {
 
       const result = await store.resendInvite('inv-1')
 
-      expect(mockWorkspaceApi.revokeInvite).toHaveBeenCalledWith('inv-1')
-      expect(mockWorkspaceApi.createInvite).toHaveBeenCalledWith({
-        email: 'one@test.com'
-      })
-      expect(
-        mockWorkspaceApi.createInvite.mock.invocationCallOrder[0]
-      ).toBeLessThan(mockWorkspaceApi.revokeInvite.mock.invocationCallOrder[0])
-      expect(result.id).toBe('inv-2')
+      expect(mockWorkspaceApi.resendInvite).toHaveBeenCalledWith('inv-1')
+      expect(mockWorkspaceApi.createInvite).not.toHaveBeenCalled()
+      expect(mockWorkspaceApi.revokeInvite).not.toHaveBeenCalled()
+      expect(result.id).toBe('inv-1')
       expect(store.pendingInvites).toHaveLength(1)
-      expect(store.pendingInvites[0].id).toBe('inv-2')
+      expect(store.pendingInvites[0].expiryDate).toEqual(
+        new Date('2024-02-08T00:00:00Z')
+      )
     })
 
-    it('resendInvite keeps the original invite and rethrows when creation fails', async () => {
+    it('resendInvite propagates a 404 and leaves the original invite unchanged', async () => {
+      const error = new mockWorkspaceApiError('Not Found', 404)
       mockWorkspaceApi.listInvites.mockResolvedValue({
         invites: [
           {
@@ -1386,9 +1385,7 @@ describe('useTeamWorkspaceStore', () => {
           }
         ]
       })
-      mockWorkspaceApi.createInvite.mockRejectedValue(
-        new Error('create failed')
-      )
+      mockWorkspaceApi.resendInvite.mockRejectedValue(error)
       mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
       mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
 
@@ -1396,34 +1393,37 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
       await store.fetchPendingInvites()
 
-      await expect(store.resendInvite('inv-1')).rejects.toThrow('create failed')
+      await expect(store.resendInvite('inv-1')).rejects.toBe(error)
 
-      expect(mockWorkspaceApi.revokeInvite).not.toHaveBeenCalled()
       expect(store.pendingInvites).toHaveLength(1)
-      expect(store.pendingInvites[0].id).toBe('inv-1')
+      expect(store.pendingInvites[0].expiryDate).toEqual(
+        new Date('2024-01-08T00:00:00Z')
+      )
     })
 
-    it('resendInvite resyncs invites and rethrows when revoking the old fails', async () => {
-      const inviteOne = {
+    it('resendInvite updates the originating workspace after a workspace switch', async () => {
+      const originalInvite = {
         id: 'inv-1',
         email: 'one@test.com',
         token: 'token-1',
         invited_at: '2024-01-01T00:00:00Z',
         expires_at: '2024-01-08T00:00:00Z'
       }
-      const inviteTwo = {
-        id: 'inv-2',
+      const refreshedInvite = {
+        id: 'inv-1',
         email: 'one@test.com',
-        token: 'token-2',
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       }
-      mockWorkspaceApi.listInvites
-        .mockResolvedValueOnce({ invites: [inviteOne] })
-        .mockResolvedValue({ invites: [inviteOne, inviteTwo] })
-      mockWorkspaceApi.createInvite.mockResolvedValue(inviteTwo)
-      mockWorkspaceApi.revokeInvite.mockRejectedValue(
-        new Error('revoke failed')
+      let resolveResend!: (invite: typeof refreshedInvite) => void
+
+      mockWorkspaceApi.listInvites.mockResolvedValue({
+        invites: [originalInvite]
+      })
+      mockWorkspaceApi.resendInvite.mockReturnValue(
+        new Promise((resolve) => {
+          resolveResend = resolve
+        })
       )
       mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
       mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
@@ -1432,10 +1432,19 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
       await store.fetchPendingInvites()
 
-      await expect(store.resendInvite('inv-1')).rejects.toThrow('revoke failed')
+      const resend = store.resendInvite('inv-1')
+      store.activeWorkspaceId = mockPersonalWorkspace.id
+      resolveResend(refreshedInvite)
+      await resend
 
-      expect(mockWorkspaceApi.listInvites).toHaveBeenCalledTimes(2)
-      expect(store.pendingInvites.map((i) => i.id)).toEqual(['inv-1', 'inv-2'])
+      const teamWorkspace = store.workspaces.find(
+        (workspace) => workspace.id === mockTeamWorkspace.id
+      )
+      expect(teamWorkspace?.pendingInvites[0].expiryDate).toEqual(
+        new Date('2024-02-08T00:00:00Z')
+      )
+      expect(store.activeWorkspace?.id).toBe(mockPersonalWorkspace.id)
+      expect(store.pendingInvites).toEqual([])
     })
 
     it('resendInvite rejects a concurrent resend for the same invite', async () => {
@@ -1447,14 +1456,11 @@ describe('useTeamWorkspaceStore', () => {
         expires_at: '2024-01-08T00:00:00Z'
       }
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: [inviteOne] })
-      mockWorkspaceApi.createInvite.mockResolvedValue({
-        id: 'inv-2',
-        email: 'one@test.com',
-        token: 'token-2',
+      mockWorkspaceApi.resendInvite.mockResolvedValue({
+        ...inviteOne,
         invited_at: '2024-02-01T00:00:00Z',
         expires_at: '2024-02-08T00:00:00Z'
       })
-      mockWorkspaceApi.revokeInvite.mockResolvedValue(undefined)
       mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
       mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
 
@@ -1468,7 +1474,7 @@ describe('useTeamWorkspaceStore', () => {
       )
       await first
 
-      expect(mockWorkspaceApi.createInvite).toHaveBeenCalledTimes(1)
+      expect(mockWorkspaceApi.resendInvite).toHaveBeenCalledTimes(1)
     })
 
     it('resendInvite throws for an unknown invite id', async () => {
@@ -1481,8 +1487,7 @@ describe('useTeamWorkspaceStore', () => {
       await expect(store.resendInvite('missing')).rejects.toThrow(
         'Invite not found'
       )
-      expect(mockWorkspaceApi.revokeInvite).not.toHaveBeenCalled()
-      expect(mockWorkspaceApi.createInvite).not.toHaveBeenCalled()
+      expect(mockWorkspaceApi.resendInvite).not.toHaveBeenCalled()
     })
 
     it('acceptInvite refreshes workspace list', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -683,33 +683,30 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
 
   const resendingInviteIds = new Set<string>()
 
-  /**
-   * Resend a pending invite by issuing a fresh one before revoking the old.
-   * Create-first so a failed resend never destroys the original invite. If the
-   * revoke fails, the store is resynced (so the leftover original surfaces) and
-   * the error is rethrown so the caller can report the partial failure rather
-   * than show success over two live invites for the same email.
-   */
   async function resendInvite(inviteId: string): Promise<PendingInvite> {
     if (resendingInviteIds.has(inviteId)) {
       throw new Error('Invite resend already in progress')
     }
-    const invite = activeWorkspace.value?.pendingInvites.find(
-      (i) => i.id === inviteId
-    )
-    if (!invite) {
+    const workspace = activeWorkspace.value
+    if (!workspace?.pendingInvites.some((invite) => invite.id === inviteId)) {
       throw new Error('Invite not found')
     }
     resendingInviteIds.add(inviteId)
     try {
-      const newInvite = await createInvite(invite.email)
-      try {
-        await revokeInvite(inviteId)
-      } catch (error) {
-        await fetchPendingInvites()
-        throw error
+      const refreshed = mapApiInviteToPendingInvite(
+        await workspaceApi.resendInvite(inviteId)
+      )
+      const currentWorkspace = workspaces.value.find(
+        (candidate) => candidate.id === workspace.id
+      )
+      if (currentWorkspace) {
+        updateWorkspace(workspace.id, {
+          pendingInvites: currentWorkspace.pendingInvites.map((invite) =>
+            invite.id === inviteId ? refreshed : invite
+          )
+        })
       }
-      return newInvite
+      return refreshed
     } finally {
       resendingInviteIds.delete(inviteId)
     }


### PR DESCRIPTION
Backport of #13137 to `cloud/1.45`.

The automatic cherry-pick conflicted in `teamWorkspaceStore.ts` because this release predates main's identity-generation guard. The resolution preserves the release's invite-ID in-flight tracking while updating the captured originating workspace after the resend completes.

## Validation

- 6 resend-specific workspace API/store tests
- Typecheck, changed-file formatting/linting (commit hook)
- `pnpm knip` (push hook)
- `git diff --check`