### PR TITLE
fix(canvas): move group without inner nodes on Mac in Drag Navigation mode

### DIFF
--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -201,6 +201,32 @@ test.describe('Vue Node Groups', { tag: ['@screenshot', '@vue-nodes'] }, () => {
     expect(await ksampler.boundingBox()).toEqual(initialNodeBounds)
   })
 
+  test('does not drag contents when meta (Cmd) is held', async ({
+    comfyPage
+  }) => {
+    await comfyPage.keyboard.selectAll()
+    await comfyPage.page.keyboard.press(CREATE_GROUP_HOTKEY)
+    const groupCount = () => comfyPage.page.evaluate(() => graph!.groups.length)
+    await expect.poll(groupCount, 'create group').toBe(1)
+    await comfyPage.page.mouse.click(100, 100)
+
+    const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+    const initialNodeBounds = await ksampler.boundingBox()
+    expect(initialNodeBounds).toBeTruthy()
+
+    const groupPos = await getGroupTitlePosition(comfyPage, 'Group')
+    await comfyPage.page.mouse.move(groupPos.x, groupPos.y)
+    await comfyPage.page.mouse.down()
+    await comfyPage.page.keyboard.down('Meta')
+    await comfyPage.page.mouse.move(groupPos.x + 100, groupPos.y)
+    await comfyPage.page.mouse.up()
+    await comfyPage.page.keyboard.up('Meta')
+    await expect
+      .poll(() => getGroupTitlePosition(comfyPage, 'Group'))
+      .not.toEqual(groupPos)
+    expect(await ksampler.boundingBox()).toEqual(initialNodeBounds)
+  })
+
   test('should keep groups aligned after loading legacy Vue workflows', async ({
     comfyPage
   }) => {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -116,7 +116,11 @@ import type {
 import type { NeverNever, PickNevers } from './types/utility'
 import type { IBaseWidget, TWidgetValue } from './types/widgets'
 import { alignNodes, distributeNodes, getBoundaryNodes } from './utils/arrange'
-import { findFirstNode, getAllNestedItems } from './utils/collections'
+import {
+  findFirstNode,
+  getAllNestedItems,
+  getDraggedItems
+} from './utils/collections'
 import { resolveConnectingLinkColor } from './utils/linkColors'
 import { createUuidv4 } from '@/utils/uuid'
 import { BaseWidget } from './widgets/BaseWidget'
@@ -3554,7 +3558,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         this._autoPan?.updatePointer(e.clientX, e.clientY)
 
         const selected = this.selectedItems
-        const allItems = e.ctrlKey ? selected : getAllNestedItems(selected)
+        const allItems = getDraggedItems(selected, e)
 
         const deltaX = delta[0] / this.ds.scale
         const deltaY = delta[1] / this.ds.scale

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -116,11 +116,7 @@ import type {
 import type { NeverNever, PickNevers } from './types/utility'
 import type { IBaseWidget, TWidgetValue } from './types/widgets'
 import { alignNodes, distributeNodes, getBoundaryNodes } from './utils/arrange'
-import {
-  findFirstNode,
-  getAllNestedItems,
-  getDraggedItems
-} from './utils/collections'
+import { findFirstNode, getDraggedItems } from './utils/collections'
 import { resolveConnectingLinkColor } from './utils/linkColors'
 import { createUuidv4 } from '@/utils/uuid'
 import { BaseWidget } from './widgets/BaseWidget'
@@ -693,6 +689,16 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
   private _visibleReroutes: Set<Reroute> = new Set()
   private _autoPan: AutoPanController | null = null
+  /**
+   * Modifier state of the most recent drag pointer event, so the auto-pan
+   * callback resolves the same dragged-item set as normal pointer movement
+   * (e.g. Cmd/Ctrl-drag moves a group without its contents). Updated on every
+   * drag move and seeded from the pointer-down event when a drag starts.
+   */
+  private _lastDragModifiers: Pick<MouseEvent, 'ctrlKey' | 'metaKey'> = {
+    ctrlKey: false,
+    metaKey: false
+  }
   private _ghostPointerHandler: ((e: PointerEvent) => void) | null = null
   private _ghostKeyHandler: ((e: KeyboardEvent) => void) | null = null
 
@@ -3558,6 +3564,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         this._autoPan?.updatePointer(e.clientX, e.clientY)
 
         const selected = this.selectedItems
+        this._lastDragModifiers = { ctrlKey: e.ctrlKey, metaKey: e.metaKey }
         const allItems = getDraggedItems(selected, e)
 
         const deltaX = delta[0] / this.ds.scale
@@ -3644,6 +3651,16 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     this.processSelect(item, pointer.eDown, sticky)
     this.isDragging = true
 
+    // Seed the auto-pan modifier state from the pointer-down event so a drag
+    // that reaches the canvas edge before the first move still honours the
+    // "move group without contents" modifier.
+    if (pointer.eDown) {
+      this._lastDragModifiers = {
+        ctrlKey: pointer.eDown.ctrlKey,
+        metaKey: pointer.eDown.metaKey
+      }
+    }
+
     this._startNodeAutoPan()
   }
 
@@ -3654,7 +3671,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       maxPanSpeed: this.auto_pan_speed,
       onPan: (panX, panY) => {
         const selected = this.selectedItems
-        const allItems = getAllNestedItems(selected)
+        const allItems = getDraggedItems(selected, this._lastDragModifiers)
 
         if (LiteGraph.vueNodesMode) {
           this.moveChildNodesInGroupVueMode(allItems, panX, panY)

--- a/src/lib/litegraph/src/utils/collections.test.ts
+++ b/src/lib/litegraph/src/utils/collections.test.ts
@@ -24,15 +24,26 @@ describe('getDraggedItems', () => {
     group._bounding.set([0, 0, 500, 500])
     graph.add(group)
 
+    // Give the nodes an explicit size so their bounding-box centres are
+    // deterministically inside the group's bounds — recomputeInsideNodes()
+    // selects by centre point, not by pos alone.
     nodeA = new TestNode()
     nodeA.pos = [50, 50]
+    nodeA.size = [100, 100]
     graph.add(nodeA)
 
     nodeB = new TestNode()
     nodeB.pos = [100, 100]
+    nodeB.size = [100, 100]
     graph.add(nodeB)
 
     group.recomputeInsideNodes()
+
+    // Guard: fail loudly if the fixture did not actually nest the nodes.
+    // Without this, the modifier tests below (which assert the nodes are
+    // *absent*) would pass vacuously if the group's child set were empty.
+    expect(group.children.has(nodeA)).toBe(true)
+    expect(group.children.has(nodeB)).toBe(true)
 
     selected = new Set<Positionable>([group])
   })

--- a/src/lib/litegraph/src/utils/collections.test.ts
+++ b/src/lib/litegraph/src/utils/collections.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { Positionable } from '@/lib/litegraph/src/interfaces'
+import { getDraggedItems } from '@/lib/litegraph/src/utils/collections'
+
+class TestNode extends LGraphNode {
+  constructor() {
+    super('test')
+  }
+}
+
+describe('getDraggedItems', () => {
+  let graph: LGraph
+  let group: LGraphGroup
+  let nodeA: TestNode
+  let nodeB: TestNode
+  let selected: Set<Positionable>
+
+  beforeEach(() => {
+    graph = new LGraph()
+
+    group = new LGraphGroup('TestGroup')
+    group._bounding.set([0, 0, 500, 500])
+    graph.add(group)
+
+    nodeA = new TestNode()
+    nodeA.pos = [50, 50]
+    graph.add(nodeA)
+
+    nodeB = new TestNode()
+    nodeB.pos = [100, 100]
+    graph.add(nodeB)
+
+    group.recomputeInsideNodes()
+
+    selected = new Set<Positionable>([group])
+  })
+
+  it('drags the group with its contents when no modifier is held', () => {
+    const items = getDraggedItems(selected, { ctrlKey: false, metaKey: false })
+
+    expect(items.has(group)).toBe(true)
+    expect(items.has(nodeA)).toBe(true)
+    expect(items.has(nodeB)).toBe(true)
+  })
+
+  it('drags only the group when Ctrl is held (Windows/Linux)', () => {
+    const items = getDraggedItems(selected, { ctrlKey: true, metaKey: false })
+
+    expect(items.has(group)).toBe(true)
+    expect(items.has(nodeA)).toBe(false)
+    expect(items.has(nodeB)).toBe(false)
+  })
+
+  it('drags only the group when Meta/Cmd is held (macOS)', () => {
+    const items = getDraggedItems(selected, { ctrlKey: false, metaKey: true })
+
+    expect(items.has(group)).toBe(true)
+    expect(items.has(nodeA)).toBe(false)
+    expect(items.has(nodeB)).toBe(false)
+  })
+})

--- a/src/lib/litegraph/src/utils/collections.ts
+++ b/src/lib/litegraph/src/utils/collections.ts
@@ -32,6 +32,25 @@ export function getAllNestedItems(
 }
 
 /**
+ * Resolves which items a drag gesture should move, honouring the
+ * "move group without its contents" modifier.
+ *
+ * Holding Ctrl (Windows/Linux) or Meta/Cmd (macOS) moves the selected items
+ * on their own, leaving nodes nested inside a dragged group in place.
+ * Without the modifier, a dragged group carries its contents with it.
+ * @param selected The currently selected items being dragged
+ * @param event The pointer event driving the drag
+ * @returns The items to move for this drag frame
+ */
+export function getDraggedItems(
+  selected: Set<Positionable>,
+  event: Pick<MouseEvent, 'ctrlKey' | 'metaKey'>
+): Set<Positionable> {
+  const moveGroupOnly = event.ctrlKey || event.metaKey
+  return moveGroupOnly ? selected : getAllNestedItems(selected)
+}
+
+/**
  * Iterates through a collection of {@link Positionable} items, returning the first {@link LGraphNode}.
  * @param items The items to search through
  * @returns The first node found in {@link items}, otherwise `undefined`


### PR DESCRIPTION
## Summary

On macOS with **Navigation Mode = "Drag Navigation"**, holding the Cmd modifier while dragging a group's title bar failed to detach the group from its contents — the inner nodes always moved with the group. On Windows the same gesture (Ctrl+drag) correctly moves the group alone.

Root cause: the drag-move path in `processMouseMove` decided which items to move using `e.ctrlKey` only, ignoring `e.metaKey`. macOS uses Cmd (`metaKey`) where Windows uses Ctrl, so the modifier was never recognised on Mac and inner nodes were always included.

## Fix

Extracted the decision into `getDraggedItems()` (in `utils/collections.ts`), which treats **Ctrl and Meta/Cmd equivalently** — the same `ctrlOrMeta` convention already used in `processMouseDown`. Mac now matches Windows: modifier held → group moves without its contents; no modifier → group carries its contents.

## Tests

- Unit (`collections.test.ts`): `getDraggedItems` returns the group only when Ctrl **or** Meta is held, and the group + nested nodes otherwise. Verified red→green (the Meta case fails against the old `ctrlKey`-only logic).
- E2E (`vueNodes/groups/groups.spec.ts`): added a "does not drag contents when meta (Cmd) is held" sibling to the existing Control test, asserting the inner node's bounding box is unchanged after a Cmd+drag of the group.

## Notes

- Cross-platform by design: the check is on `metaKey`/`ctrlKey`, not `navigator.platform`, so the E2E exercises the fixed path on CI regardless of host OS.