### PR TITLE
fix(3d): classify Gaussian splat uploads as 3D in the Assets browser

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -116,6 +116,12 @@ describe('formatUtil', () => {
         expect(getMediaTypeFromFilename('apple.usdz')).toBe('3D')
         expect(getMediaTypeFromFilename('scan.ply')).toBe('3D')
       })
+
+      it('should identify Gaussian splat extensions that Load3D accepts', () => {
+        expect(getMediaTypeFromFilename('scene.spz')).toBe('3D')
+        expect(getMediaTypeFromFilename('scene.splat')).toBe('3D')
+        expect(getMediaTypeFromFilename('scene.ksplat')).toBe('3D')
+      })
     })
 
     describe('text files', () => {

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -598,7 +598,10 @@ const THREE_D_EXTENSIONS = [
   'glb',
   'stl',
   'usdz',
-  'ply'
+  'ply',
+  'spz',
+  'splat',
+  'ksplat'
 ] as const
 const TEXT_EXTENSIONS = [
   'txt',

--- a/src/extensions/core/load3d/constants.test.ts
+++ b/src/extensions/core/load3d/constants.test.ts
@@ -1,6 +1,7 @@
+import { getMediaTypeFromFilename } from '@comfyorg/shared-frontend-utils/formatUtil'
 import { describe, expect, it } from 'vitest'
 
-import { getExportFormatOptions } from './constants'
+import { SUPPORTED_EXTENSIONS, getExportFormatOptions } from './constants'
 
 describe('getExportFormatOptions', () => {
   it('returns the convertible mesh formats for mesh sources', () => {
@@ -35,4 +36,17 @@ describe('getExportFormatOptions', () => {
       { label: 'PLY', value: 'ply' }
     ])
   })
+})
+
+describe('Assets browser recognizes every Load3D-uploadable format', () => {
+  // Guards against the classifier (shared-frontend-utils) drifting out of sync
+  // with the formats Load3D accepts. A format Load3D can load but the Assets
+  // browser tags as 'other' gets no 3D preview and can't be opened in the
+  // 3D viewer.
+  it.each([...SUPPORTED_EXTENSIONS])(
+    'classifies %s uploads as 3D media',
+    (ext) => {
+      expect(getMediaTypeFromFilename(`model${ext}`)).toBe('3D')
+    }
+  )
 })


### PR DESCRIPTION
## Summary

QA (1.47 RC re-test) reported that a 3D model uploaded via the **Load 3D (Advanced)** node had no preview and could not be viewed through the Assets browser.

Root cause (FE, verifiable): Load3D and Load3D Advanced accept Gaussian-splat models — `.spz`, `.splat`, `.ksplat` (`SUPPORTED_EXTENSIONS` in `src/extensions/core/load3d/constants.ts`) — but the Assets browser's media classifier `getMediaTypeFromFilename` (`packages/shared-frontend-utils/src/formatUtil.ts`) did not list them. So such an asset was classified as `'other'`:

- the card rendered the generic file component instead of `Media3DTop`, i.e. no 3D preview; and
- `isPreviewableMediaType('other')` is `false`, so `AssetsSidebarTab.handleZoomClick` early-returned — the 3D viewer (`Load3dViewerContent`) was never opened. That is the "can't be viewed through Assets" symptom.

## Fix

Add `spz`, `splat`, `ksplat` to `THREE_D_EXTENSIONS` so the classifier returns `'3D'` for them, restoring the 3D card preview and the 3D viewer path.

## Tests

- `formatUtil.test.ts`: the three splat extensions classify as `'3D'`.
- `constants.test.ts`: a regression guard asserting **every** Load3D `SUPPORTED_EXTENSIONS` format is classified as `'3D'`, so the two lists cannot drift apart again. (Verified red→green: without the fix the three splat cases fail.)

## Scope notes (not fixed here — backend/env)

- For plain-mesh uploads (`.glb` etc.) the classifier already returns `'3D'`. Where such a freshly-uploaded input model still shows only the box **placeholder** with no thumbnail, that is because there is no server-generated 3D preview for inputs (the client `persistThumbnail` path only runs when the assets API is enabled). That thumbnail-generation gap is backend/product, tracked separately.
- The OSS `/internal/files/input` endpoint lists only top-level files (`os.scandir`, non-recursive), so models uploaded into `input/3d/` are not enumerated there at all — an OSS backend limitation, not addressed by the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)