### PR TITLE
fix(cloud/oauth): back-compat redirect /cloud/oauth/consent → /oauth/consent (FE-1133)

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -135,5 +135,14 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         component: () => import('@/platform/cloud/oauth/OAuthConsentView.vue')
       }
     ]
+  },
+  {
+    // Back-compat (FE-1133 / BE-4146): the cloud OAuth backend still 302s to
+    // the old consent path with `?oauth_request_id=...`; the route moved to
+    // `/oauth/consent`. Redirect the old path (query preserved) so the browser
+    // authorize flow works before the backend `frontendConsentPath` is updated.
+    // Remove once BE-4146 lands the backend path change.
+    path: '/cloud/oauth/consent',
+    redirect: (to) => ({ path: '/oauth/consent', query: to.query })
   }
 ]


### PR DESCRIPTION
## What
Adds a back-compat redirect `/cloud/oauth/consent` → `/oauth/consent` (query preserved), restoring the old consent path that #13081 (FE-1133) removed.

## Why
#13081 moved the OAuth consent route to `/oauth/consent` and deleted `/cloud/oauth/consent`. But the cloud backend (`services/ingest/server/implementation/oauth_authorize.go`, `frontendConsentPath`) still 302s browser OAuth navigations to `/cloud/oauth/consent?oauth_request_id=…`. So once 1.47 ships, the consent screen 404s until the backend is updated — and a lone backend cutover isn't safe either (it 404s against the currently-live frontend). This makes the frontend serve **both** paths so deploy order stops mattering:

- old backend → `/cloud/oauth/consent?oauth_request_id=X` → redirect → `/oauth/consent?oauth_request_id=X` ✅
- future backend → `/oauth/consent` ✅ (skips the hop)

The `oauth_request_id` query param survives via the function redirect `(to) => ({ path, query: to.query })`. Backend path cleanup is tracked in **BE-4146**; once it lands, this redirect can be removed.

## Notes
- Auth guard is unaffected: `isPublicRoute` matches route **name** `cloud-oauth-consent` (unchanged), and the record-level `redirect` resolves before `beforeEach` — so no `router.ts` allowlist change is needed.
- Should backport to `cloud/1.47` alongside #13081/#13996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)