### PR TITLE
refactor: extract SubscriptionPanel date/tier helpers into logic module

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2594,6 +2594,7 @@
     "reactivatePlan": "Reactivate plan",
     "resubscribeTo": "Resubscribe to {plan}",
     "resubscribeSuccess": "Subscription reactivated successfully",
+    "resubscribeFailed": "Failed to reactivate subscription",
     "subscribeFailed": "Failed to subscribe",
     "canceledCard": {
       "title": "Your subscription has been canceled",

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -328,7 +328,6 @@ import DropdownMenu from '@/components/common/DropdownMenu.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
@@ -338,6 +337,10 @@ import { useWorkspacePlanPricing } from '@/platform/workspace/composables/useWor
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import {
+  formatSubscriptionDate,
+  resolveSubscriptionTierKey
+} from './subscriptionPanelWorkspace.logic'
 
 const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
@@ -426,27 +429,18 @@ const isYearlySubscription = computed(
   () => subscription.value?.duration === 'ANNUAL'
 )
 
-function formatSubtitleDate(isoDate: string | null | undefined) {
-  if (!isoDate) return ''
-  return new Date(isoDate).toLocaleDateString(locale.value, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric'
-  })
-}
-
 const formattedRenewalDate = computed(() =>
-  formatSubtitleDate(subscription.value?.renewalDate)
+  formatSubscriptionDate(subscription.value?.renewalDate, locale.value)
 )
 
 const formattedEndDate = computed(() =>
-  formatSubtitleDate(subscription.value?.endDate)
+  formatSubscriptionDate(subscription.value?.endDate, locale.value)
 )
 
 const subscriptionTierName = computed(() => {
   const tier = subscription.value?.tier
   if (!tier) return ''
-  const key = TIER_TO_KEY[tier] ?? 'standard'
+  const key = resolveSubscriptionTierKey(tier)
   const baseName = t(`subscription.tiers.${key}.name`)
   return isYearlySubscription.value
     ? t('subscription.tierNameYearly', { name: baseName })
@@ -457,11 +451,9 @@ const planDisplayName = computed(() =>
   isTeamPlan.value ? t('subscription.teamPlanName') : subscriptionTierName.value
 )
 
-const tierKey = computed(() => {
-  const tier = subscription.value?.tier
-  if (!tier) return 'free'
-  return TIER_TO_KEY[tier] ?? 'standard'
-})
+const tierKey = computed(() =>
+  resolveSubscriptionTierKey(subscription.value?.tier)
+)
 
 const TEAM_PERK_KEYS = [
   'inviteMembers',

--- a/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
+++ b/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
@@ -1,6 +1,8 @@
-import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import type {
+  SubscriptionTier,
+  TierKey
+} from '@/platform/cloud/subscription/constants/tierPricing'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
-import type { SubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
 
 export function resolveSubscriptionTierKey(
   tier: SubscriptionTier | null | undefined

--- a/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
+++ b/src/platform/workspace/components/subscriptionPanelWorkspace.logic.ts
@@ -1,0 +1,22 @@
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { SubscriptionTier } from '@/platform/cloud/subscription/constants/tierPricing'
+
+export function resolveSubscriptionTierKey(
+  tier: SubscriptionTier | null | undefined
+): TierKey {
+  if (!tier) return 'free'
+  return TIER_TO_KEY[tier] ?? 'standard'
+}
+
+export function formatSubscriptionDate(
+  isoDate: string | null | undefined,
+  locale: string
+): string {
+  if (!isoDate) return ''
+  return new Date(isoDate).toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+}

--- a/src/platform/workspace/composables/useResubscribe.ts
+++ b/src/platform/workspace/composables/useResubscribe.ts
@@ -40,10 +40,14 @@ export function useResubscribe() {
         life: 5000
       })
     } catch (error) {
+      const detail =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : t('subscription.resubscribeFailed')
       toast.add({
         severity: 'error',
         summary: t('g.error'),
-        detail: error instanceof Error ? error.message : t('g.error')
+        detail
       })
     } finally {
       isResubscribing.value = false


### PR DESCRIPTION
## Summary

- Extracts the inline `formatSubtitleDate` helper and two copies of the `TIER_TO_KEY` tier-key resolution from `SubscriptionPanelContentWorkspace.vue` into a co-located `subscriptionPanelWorkspace.logic.ts` module as pure, locale-aware functions
- Fixes the resubscribe error toast fallback: was silently showing the generic `g.error` string when the API returned an empty error body; now uses a dedicated `subscription.resubscribeFailed` key

## What changed

- `subscriptionPanelWorkspace.logic.ts` (new) — `resolveSubscriptionTierKey` and `formatSubscriptionDate` pure functions
- `SubscriptionPanelContentWorkspace.vue` — drops `TIER_TO_KEY` direct import, removes inline date helper, uses logic module
- `useResubscribe.ts` — improved error toast fallback message
- `locales/en/main.json` — adds `resubscribeFailed` key

Semantic re-application of improvements from #11398 onto current main after the billing rearchitecture that landed in #12761/#12734.