### PR TITLE
[backport cloud/1.47] fix(glsl): reflect promoted subgraph widget edits in live preview and histogram

### DIFF
--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -7,6 +7,7 @@ import {
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import { getPromotedWidgetNames } from '@e2e/fixtures/utils/promotedWidgets'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)
@@ -585,6 +586,67 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
       await expect(subgraph.previewImage).toBeVisible()
       await subgraph.waitForBlobSrc()
       await subgraph.expectEveryPixelToBe([255, 0, 0, 255])
+    })
+  })
+
+  test.describe('GLSL inside a subgraph with a promoted uniform widget', () => {
+    const SUBGRAPH_NODE_ID = '1'
+    const SUBGRAPH_TITLE = 'GLSL Subgraph With Float'
+
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'nodes/glsl_shader_subgraph_with_float'
+      )
+      await comfyPage.vueNodes.waitForNodes(1)
+    })
+
+    // Regression guard for #13875: editing a promoted host widget must reach the
+    // GLSL preview renderer.
+    test('reflects promoted host widget edits in the preview', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const subgraph = new GLSLShaderNode(
+        comfyPage,
+        SUBGRAPH_NODE_ID,
+        SUBGRAPH_TITLE
+      )
+
+      await test.step('promote the interior float value onto the host node', async () => {
+        await comfyPage.vueNodes.enterSubgraph(SUBGRAPH_NODE_ID)
+        await comfyPage.vueNodes.waitForNodes(2)
+        const interiorFloat = comfyPage.vueNodes.getNodeByTitle(
+          PRIMITIVE_FLOAT_NODE_TITLE
+        )
+        await comfyPage.subgraph.promoteWidget(interiorFloat, 'value')
+        await comfyPage.subgraph.exitViaBreadcrumb()
+        await comfyPage.vueNodes.waitForNodes(1)
+        await expect
+          .poll(() => getPromotedWidgetNames(comfyPage, SUBGRAPH_NODE_ID))
+          .toContain('value')
+      })
+
+      // Interior float defaults to 1.0; shader writes vec4(u_float0, 0, 0, 1).
+      await subgraph.simulateExecutionOutput(ws)
+      const initialSrc = await subgraph.waitForBlobSrc()
+      await subgraph.expectEveryPixelToBe([255, 0, 0, 255], 2)
+
+      await test.step('editing the promoted host widget re-renders the preview', async () => {
+        const promotedValue = comfyPage.vueNodes.getWidgetByName(
+          SUBGRAPH_TITLE,
+          'value'
+        )
+        const { input } =
+          comfyPage.vueNodes.getInputNumberControls(promotedValue)
+        await expect(input).toBeVisible()
+        await input.fill('0')
+        await input.blur()
+
+        await expect.poll(() => subgraph.getPreviewSrc()).not.toBe(initialSrc)
+        await expect.poll(() => subgraph.getPreviewSrc()).toMatch(/^blob:/)
+        await subgraph.expectEveryPixelToBe([0, 0, 0, 255], 2)
+      })
     })
   })
 })

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -54,6 +54,7 @@ vi.mock('@/services/litegraphService', () => ({
 import {
   CANVAS_IMAGE_PREVIEW_WIDGET,
   autoExposeKnownPreviewNodes,
+  createPromotedHostWidgetIdLookup,
   demoteWidget,
   getPromotableWidgets,
   hasUnpromotedWidgets,
@@ -585,6 +586,68 @@ describe('isLinkedPromotion', () => {
     expect(isLinkedPromotion(host, String(nodeB.id), 'value')).toBe(true)
     expect(isLinkedPromotion(host, String(nodeA.id), 'value')).toBe(false)
     expect(isLinkedPromotion(host, '5', 'string_a')).toBe(false)
+  })
+})
+
+describe('createPromotedHostWidgetIdLookup', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  function promoteFreshSource(
+    host: SubgraphNode,
+    nodeTitle: string,
+    widgetName: string
+  ): LGraphNode {
+    const node = new LGraphNode(nodeTitle)
+    host.subgraph.add(node)
+    const input = node.addInput(widgetName, 'STRING')
+    const sourceWidget = node.addWidget('text', widgetName, 'v', () => {})
+    input.widget = { name: sourceWidget.name }
+    expect(
+      promoteValueWidgetViaSubgraphInput(host, node, sourceWidget).ok
+    ).toBe(true)
+    return node
+  }
+
+  it('returns undefined (does not throw) when the interior source node is gone', () => {
+    const host = createTestSubgraphNode(createTestSubgraph())
+    const interiorNode = promoteFreshSource(host, 'Source', 'text')
+    const resolveBefore = createPromotedHostWidgetIdLookup(host)
+    expect(resolveBefore(String(interiorNode.id), 'text')).toBe(
+      host.inputs[0]?.widgetId
+    )
+
+    host.subgraph.remove(interiorNode)
+
+    let resolveAfter: ReturnType<typeof createPromotedHostWidgetIdLookup>
+    expect(() => {
+      resolveAfter = createPromotedHostWidgetIdLookup(host)
+    }).not.toThrow()
+    expect(resolveAfter!(String(interiorNode.id), 'text')).toBeUndefined()
+  })
+
+  it('resolves each host widgetId independently for two sources promoting different widgets', () => {
+    const host = createTestSubgraphNode(createTestSubgraph())
+    const nodeA = promoteFreshSource(host, 'GlslA', 'alpha')
+    const nodeB = promoteFreshSource(host, 'GlslB', 'beta')
+
+    const hostIdAlpha = host.inputs.find(
+      (input) => input.name === 'alpha'
+    )?.widgetId
+    const hostIdBeta = host.inputs.find(
+      (input) => input.name === 'beta'
+    )?.widgetId
+    expect(hostIdAlpha).toBeDefined()
+    expect(hostIdBeta).toBeDefined()
+    expect(hostIdAlpha).not.toBe(hostIdBeta)
+
+    const resolve = createPromotedHostWidgetIdLookup(host)
+
+    expect(resolve(String(nodeA.id), 'alpha')).toBe(hostIdAlpha)
+    expect(resolve(String(nodeB.id), 'beta')).toBe(hostIdBeta)
+    expect(resolve(String(nodeA.id), 'beta')).toBeUndefined()
+    expect(resolve(String(nodeB.id), 'alpha')).toBeUndefined()
   })
 })
 

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -62,6 +62,42 @@ export function findHostInputForPromotion(
   })
 }
 
+/**
+ * Host-first resolver for promoted widget value keys.
+ *
+ * Anchors on the host `SubgraphNode.inputs` (which own the promoted `widgetId`
+ * per ADR 0009) and walks host -> interior only to key each host widget by the
+ * interior source it projects. Consumers that discover an interior source can
+ * then look up the host value key without a per-source reverse walk.
+ */
+export function createPromotedHostWidgetIdLookup(
+  subgraphNode: SubgraphNode
+): (
+  sourceNodeId: SerializedNodeId,
+  sourceWidgetName: string
+) => WidgetId | undefined {
+  const key = (nodeId: SerializedNodeId, name: string): string =>
+    `${toNodeId(nodeId)}\u0000${name}`
+
+  const hostWidgetIdBySource = new Map<string, WidgetId>()
+  for (const input of subgraphNode.inputs) {
+    const hostWidgetId = input.widgetId
+    const subgraphSlot = input._subgraphSlot
+    if (!hostWidgetId || !subgraphSlot) continue
+
+    const source = resolvePromotionSource(subgraphNode, subgraphSlot)
+    if (!source) continue
+
+    hostWidgetIdBySource.set(
+      key(source.sourceNodeId, source.sourceWidgetName),
+      hostWidgetId
+    )
+  }
+
+  return (sourceNodeId, sourceWidgetName) =>
+    hostWidgetIdBySource.get(key(sourceNodeId, sourceWidgetName))
+}
+
 function resolvePromotionSource(
   subgraphNode: SubgraphNode,
   subgraphInput: { linkIds: readonly LinkId[] }

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -1,9 +1,12 @@
 import type { TooltipOptions } from 'primevue'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
+import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { toNodeId } from '@/types/nodeId'
+import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
 
 import type { SafeWidgetData } from '@/composables/graph/useGraphNodeManager'
 import {
@@ -22,6 +25,18 @@ import {
 import { widgetId } from '@/types/widgetId'
 
 const GRAPH_ID = 'graph-test'
+
+const { executionIdToNodeLocatorId } = vi.hoisted(() => ({
+  executionIdToNodeLocatorId: vi.fn()
+}))
+
+vi.mock('@/utils/graphTraversalUtil', async (importActual) => {
+  const actual = await importActual<typeof GraphTraversalUtil>()
+  return {
+    ...actual,
+    executionIdToNodeLocatorId
+  }
+})
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({
@@ -480,6 +495,49 @@ describe('computeProcessedWidgets borderStyle', () => {
       createNodeLocatorId(subgraphId, toNodeId('inner-node'))
     )
   })
+
+  it('resolves a promoted widget locator from its source execution id', () => {
+    const sourceExecutionId = createNodeExecutionId([
+      toNodeId('host-node'),
+      toNodeId('inner-node')
+    ])
+    executionIdToNodeLocatorId.mockImplementationOnce((_graph, executionId) =>
+      executionId === sourceExecutionId ? 'source:inner-node' : undefined
+    )
+    const widget = createMockWidget({
+      name: 'curve',
+      type: 'curve',
+      nodeId: toNodeId('host-node'),
+      sourceExecutionId
+    })
+
+    const result = computeProcessedWidgets({
+      nodeData: {
+        id: toNodeId('host-node'),
+        type: 'SubgraphNode',
+        widgets: [widget],
+        title: 'Test',
+        mode: 0,
+        selected: false,
+        executing: false,
+        inputs: [],
+        outputs: [],
+        subgraphId: null
+      },
+      graphId: GRAPH_ID,
+      showAdvanced: false,
+      isGraphReady: false,
+      rootGraph: fromAny<LGraph, unknown>({}),
+      ui: noopUi
+    })
+
+    expect(result[0].simplified.nodeLocatorId).toBe('source:inner-node')
+    expect(executionIdToNodeLocatorId).toHaveBeenCalledWith(
+      expect.anything(),
+      sourceExecutionId
+    )
+  })
+
   it('deduplication keeps visible widget over hidden duplicate', () => {
     const sharedWidgetId = widgetId(GRAPH_ID, toNodeId('1'), 'text')
     const hiddenWidget = createMockWidget({

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -39,13 +39,16 @@ import type { NodeId } from '@/types/nodeId'
 import type { WidgetId } from '@/types/widgetId'
 import { widgetId } from '@/types/widgetId'
 import type { WidgetState } from '@/types/widgetState'
+import {
+  executionIdToNodeLocatorId,
+  getExecutionIdFromNodeData
+} from '@/utils/graphTraversalUtil'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   LinkedUpstreamInfo,
   SimplifiedWidget,
   WidgetValue
 } from '@/types/simplifiedWidget'
-import { getExecutionIdFromNodeData } from '@/utils/graphTraversalUtil'
 
 const TOOLTIP_VALUE_TYPES = ['asset', 'combo', 'number', 'text'] as const
 type TooltipValueType = (typeof TOOLTIP_VALUE_TYPES)[number]
@@ -185,8 +188,18 @@ function getProcessedNodeExecutionId(
 
 function getWidgetNodeLocatorId(
   nodeData: VueNodeData,
-  bareWidgetId: NodeId | null
+  bareWidgetId: NodeId | null,
+  sourceExecutionId: NodeExecutionId | undefined,
+  rootGraph: LGraph | null
 ): NodeLocatorId | undefined {
+  if (sourceExecutionId && rootGraph) {
+    const sourceLocator = executionIdToNodeLocatorId(
+      rootGraph,
+      sourceExecutionId
+    )
+    if (sourceLocator) return sourceLocator
+  }
+
   if (!bareWidgetId) return undefined
 
   return (
@@ -330,7 +343,12 @@ export function computeProcessedWidgets({
           }
         : undefined
 
-    const nodeLocatorId = getWidgetNodeLocatorId(nodeData, bareWidgetId)
+    const nodeLocatorId = getWidgetNodeLocatorId(
+      nodeData,
+      bareWidgetId,
+      widget.sourceExecutionId,
+      rootGraph
+    )
 
     const simplified: SimplifiedWidget = {
       name: widgetState?.name ?? widget.name,

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -232,7 +232,7 @@ function createInnerPreview(
     const node = nodeRef.value
     const inner = innerGLSLNode
     if (!node?.isSubgraphNode() || !inner) return null
-    return extractUniformSources(inner, node.subgraph as Subgraph)
+    return extractUniformSources(inner, node.subgraph as Subgraph, node)
   })
 
   const { floatValues, intValues, boolValues, curveValues } = useGLSLUniforms(

--- a/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
@@ -1,0 +1,139 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { computed } from 'vue'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { CurveData } from '@/components/curve/types'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+import type { extractUniformSources } from '@/renderer/glsl/useGLSLUniforms'
+import { useGLSLUniforms } from '@/renderer/glsl/useGLSLUniforms'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { NodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
+import { widgetId } from '@/types/widgetId'
+import type { UUID } from '@/utils/uuid'
+
+/**
+ * Regression guard for the GLSL live preview breaking on *promoted* subgraph
+ * widget edits (QA 2026-07-20, Terry Jia; fixed by #13875).
+ *
+ * Under ADR 0009 link-only promotion, a promoted proxy widget's live value is
+ * stored at the host widget key (`hostWidgetId`), while the uniform source is
+ * still discovered from the interior source node. `useGLSLUniforms` must read
+ * the host key so edits to the promoted curve/range proxy reach the renderer.
+ *
+ * #13875's own tests only prove `extractUniformSources` populates
+ * `hostWidgetId`; nothing pins the *read* side (`collectValues` / `curveValues`
+ * preferring `hostWidgetId`). This test closes that seam: without the read-side
+ * fix the composable returns the stale interior value.
+ */
+
+const GRAPH_ID: UUID = '3f8e2a1c-0b47-4d96-8a5e-1c2d3e4f5a6b'
+const INTERIOR_NODE_ID = toNodeId('10')
+const HOST_NODE_ID = toNodeId('99')
+
+type UniformSources = ReturnType<typeof extractUniformSources>
+
+const emptySources: UniformSources = {
+  floats: [],
+  ints: [],
+  bools: [],
+  curves: []
+}
+
+const rendererConfig: GLSLRendererConfig = {
+  maxInputs: 5,
+  maxFloatUniforms: 20,
+  maxIntUniforms: 20,
+  maxBoolUniforms: 10,
+  maxCurves: 4
+}
+
+function runUniforms(sources: UniformSources) {
+  return useGLSLUniforms(
+    computed<UUID | undefined>(() => GRAPH_ID),
+    computed<NodeId | undefined>(() => HOST_NODE_ID),
+    computed<LGraphNode | null>(() => null),
+    computed<UniformSources | null>(() => sources),
+    computed(() => rendererConfig)
+  )
+}
+
+describe('useGLSLUniforms reads promoted widget values from the host key', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('curveValues reflects the edited host curve, not the stale interior curve', () => {
+    const staleCurve: CurveData = {
+      points: [
+        [0, 0],
+        [1, 0]
+      ],
+      interpolation: 'linear'
+    }
+    const editedCurve: CurveData = {
+      points: [
+        [0, 0],
+        [1, 1]
+      ],
+      interpolation: 'linear'
+    }
+
+    const hostCurveId = widgetId(GRAPH_ID, HOST_NODE_ID, 'curve0')
+    const store = useWidgetValueStore()
+    store.registerWidget(widgetId(GRAPH_ID, INTERIOR_NODE_ID, 'curve'), {
+      type: 'curve',
+      value: staleCurve,
+      options: {}
+    })
+    store.registerWidget(hostCurveId, {
+      type: 'curve',
+      value: editedCurve,
+      options: {}
+    })
+
+    const { curveValues } = runUniforms({
+      ...emptySources,
+      curves: [
+        {
+          nodeId: INTERIOR_NODE_ID,
+          widgetName: 'curve',
+          hostWidgetId: hostCurveId,
+          directValue: () => staleCurve
+        }
+      ]
+    })
+
+    expect(curveValues.value).toEqual([editedCurve])
+  })
+
+  it('floatValues reflects the edited host range, not the stale interior range', () => {
+    const hostRangeId = widgetId(GRAPH_ID, HOST_NODE_ID, 'float0')
+    const store = useWidgetValueStore()
+    store.registerWidget(widgetId(GRAPH_ID, INTERIOR_NODE_ID, 'range'), {
+      type: 'number',
+      value: 7,
+      options: {}
+    })
+    store.registerWidget(hostRangeId, {
+      type: 'number',
+      value: 42,
+      options: {}
+    })
+
+    const { floatValues } = runUniforms({
+      ...emptySources,
+      floats: [
+        {
+          nodeId: INTERIOR_NODE_ID,
+          widgetName: 'range',
+          hostWidgetId: hostRangeId,
+          directValue: () => 7
+        }
+      ]
+    })
+
+    expect(floatValues.value).toEqual([42])
+  })
+})

--- a/src/renderer/glsl/useGLSLUniforms.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.test.ts
@@ -1,13 +1,22 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 
 import {
   extractUniformSources,
   toNumber
 } from '@/renderer/glsl/useGLSLUniforms'
+
+const { createPromotedHostWidgetIdLookup } = vi.hoisted(() => ({
+  createPromotedHostWidgetIdLookup: vi.fn()
+}))
+
+vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
+  createPromotedHostWidgetIdLookup
+}))
 
 function createMockSubgraph(
   links: Record<number, { origin_id: number; origin_slot: number }>,
@@ -96,6 +105,42 @@ describe('extractUniformSources', () => {
 
     choiceWidget.value = 'Reds'
     expect(result.ints[0].directValue()).toBe(1)
+  })
+
+  it('leaves hostWidgetId undefined when no subgraphNode is given', () => {
+    const glslNode = fromAny<LGraphNode, unknown>({
+      inputs: [{ name: 'curves.u_curve0', link: 1 }]
+    })
+    const subgraph = createMockSubgraph(
+      { 1: { origin_id: 10, origin_slot: 0 } },
+      { 10: { id: 10, widgets: [{ name: 'curve', value: {} }] } }
+    )
+
+    const result = extractUniformSources(glslNode, subgraph)
+
+    expect(result.curves[0].hostWidgetId).toBeUndefined()
+  })
+
+  it('resolves hostWidgetId from the promoted host input when subgraphNode is given', () => {
+    createPromotedHostWidgetIdLookup.mockReturnValueOnce(
+      (sourceNodeId: number, widgetName: string) =>
+        sourceNodeId === 10 && widgetName === 'curve'
+          ? 'graph:99:curve0'
+          : undefined
+    )
+
+    const glslNode = fromAny<LGraphNode, unknown>({
+      inputs: [{ name: 'curves.u_curve0', link: 1 }]
+    })
+    const subgraph = createMockSubgraph(
+      { 1: { origin_id: 10, origin_slot: 0 } },
+      { 10: { id: 10, widgets: [{ name: 'curve', value: {} }] } }
+    )
+    const subgraphNode = fromAny<SubgraphNode, unknown>({ id: 99 })
+
+    const result = extractUniformSources(glslNode, subgraph, subgraphNode)
+
+    expect(result.curves[0].hostWidgetId).toBe('graph:99:curve0')
   })
 })
 

--- a/src/renderer/glsl/useGLSLUniforms.ts
+++ b/src/renderer/glsl/useGLSLUniforms.ts
@@ -9,9 +9,12 @@ import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 import { isCurveData } from '@/components/curve/curveUtils'
 import type { CurveData } from '@/components/curve/types'
+import { createPromotedHostWidgetIdLookup } from '@/core/graph/subgraph/promotionUtils'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
 import { hexToInt } from '@/utils/colorUtil'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetId } from '@/types/widgetId'
 import { widgetId } from '@/types/widgetId'
 
 interface AutogrowGroup {
@@ -23,6 +26,7 @@ interface AutogrowGroup {
 interface UniformSource {
   nodeId: NodeId
   widgetName: string
+  hostWidgetId?: WidgetId
   /** Fallback getter for widgets not registered in widgetValueStore (e.g. hidden computed widgets). */
   directValue: () => unknown
 }
@@ -67,7 +71,8 @@ export function getAutogrowLimits(node: LGraphNode): GLSLRendererConfig {
 
 export function extractUniformSources(
   glslNode: LGraphNode,
-  subgraph: Subgraph
+  subgraph: Subgraph,
+  subgraphNode?: SubgraphNode
 ): UniformSources {
   const floats: UniformSource[] = []
   const ints: UniformSource[] = []
@@ -75,6 +80,10 @@ export function extractUniformSources(
   const curves: UniformSource[] = []
 
   if (!glslNode.inputs) return { floats, ints, bools, curves }
+
+  const hostWidgetIdForSource = subgraphNode
+    ? createPromotedHostWidgetIdLookup(subgraphNode)
+    : undefined
 
   for (const input of glslNode.inputs) {
     if (input.link == null) continue
@@ -95,6 +104,7 @@ export function extractUniformSources(
     const source: UniformSource = {
       nodeId: sourceNode.id,
       widgetName: widget.name,
+      hostWidgetId: hostWidgetIdForSource?.(sourceNode.id, widget.name),
       directValue: () => widget.value
     }
 
@@ -133,12 +143,14 @@ export function useGLSLUniforms(
     if (!gId) return []
 
     if (subgraphSources) {
-      return subgraphSources.map(({ nodeId: nId, widgetName, directValue }) => {
-        const widget = widgetValueStore.getWidget(
-          widgetId(gId, nId, widgetName)
-        )
-        return coerce(widget?.value ?? directValue() ?? defaultValue)
-      })
+      return subgraphSources.map(
+        ({ nodeId: nId, widgetName, hostWidgetId, directValue }) => {
+          const widget = widgetValueStore.getWidget(
+            hostWidgetId ?? widgetId(gId, nId, widgetName)
+          )
+          return coerce(widget?.value ?? directValue() ?? defaultValue)
+        }
+      )
     }
 
     const nId = nodeId.value
@@ -217,9 +229,9 @@ export function useGLSLUniforms(
     const sources = uniformSources.value?.curves
     if (sources && sources.length > 0) {
       return sources
-        .map(({ nodeId: nId, widgetName, directValue }) => {
+        .map(({ nodeId: nId, widgetName, hostWidgetId, directValue }) => {
           const widget = widgetValueStore.getWidget(
-            widgetId(gId, nId, widgetName)
+            hostWidgetId ?? widgetId(gId, nId, widgetName)
           )
           const value = widget?.value ?? directValue()
           return isCurveData(value) ? (value as CurveData) : null


### PR DESCRIPTION
Manual backport of #13875 to `cloud/1.47` (auto-backport bot failed on conflict in `useProcessedWidgets.ts` imports).

Under ADR 0009 link-only promotion, a promoted proxy widget's live value lives at the host widget key while its node output (histogram) is keyed by the interior source node's locator. GLSL live preview and curve/range histogram read the wrong key, so editing a promoted curve/range proxy never re-rendered. Fix resolves promoted sources to their host widget key / source node locator.

Cherry-pick of merge commit d6bc36c. Conflict resolved: kept the new `graphTraversalUtil` import block (`executionIdToNodeLocatorId`, `getExecutionIdFromNodeData`); dropped the `hasErrorForSlot` import that is unused on this branch.

Gates: typecheck OK, unit 88/88, eslint/oxlint/oxfmt OK.

Backport of #13875. Do not merge without release owner review.