### PR TITLE
[backport cloud/1.45] fix(auth): reconnect realtime WebSocket on account switch

### DIFF
--- a/browser_tests/tests/wsReconnectAccountSwitch.spec.ts
+++ b/browser_tests/tests/wsReconnectAccountSwitch.spec.ts
@@ -1,0 +1,32 @@
+import { mergeTests } from '@playwright/test'
+
+import {
+  comfyExpect as expect,
+  comfyPageFixture
+} from '@e2e/fixtures/ComfyPage'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const test = mergeTests(comfyPageFixture, webSocketFixture)
+
+test.describe('WebSocket reconnect on account switch', { tag: '@ui' }, () => {
+  test('tears down the old socket and re-handshakes on an identity switch', async ({
+    comfyPage,
+    getWebSocket
+  }) => {
+    const initialSocket = await getWebSocket()
+    let initialClosed = false
+    initialSocket.onClose(() => {
+      initialClosed = true
+    })
+
+    // The account-switch path (authStore.onAuthStateChanged) reconnects the
+    // realtime socket through api.resetSocket(); drive it directly to assert
+    // the connection-plane contract without a full cloud-auth harness.
+    await comfyPage.page.evaluate(() => window.app!.api.resetSocket())
+
+    await expect.poll(() => initialClosed).toBe(true)
+    await expect
+      .poll(async () => (await getWebSocket()) !== initialSocket)
+      .toBe(true)
+  })
+})

--- a/src/scripts/api.socketReset.test.ts
+++ b/src/scripts/api.socketReset.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+
+let currentToken: string | undefined = 'token-a'
+// When set, each getAuthToken() call parks until released, capturing the token
+// value that was active at call time — models a deferred/async token fetch.
+let deferTokenFetch = false
+let pendingTokenReleases: (() => void)[] = []
+
+const releaseNextToken = async () => {
+  const release = pendingTokenReleases.shift()
+  release?.()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+vi.mock('@/platform/distribution/types', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/platform/distribution/types')>()),
+  isCloud: true
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    getAuthToken: () => {
+      if (!deferTokenFetch) return Promise.resolve(currentToken)
+      const captured = currentToken
+      return new Promise<string | undefined>((resolve) => {
+        pendingTokenReleases.push(() => resolve(captured))
+      })
+    }
+  })
+}))
+
+class FakeWebSocket {
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.OPEN
+  binaryType = ''
+  send = vi.fn()
+  removeEventListener = vi.fn()
+  handlers: Record<string, (event: unknown) => void> = {}
+  addEventListener = vi.fn(
+    (event: string, handler: (event: unknown) => void) => {
+      this.handlers[event] = handler
+    }
+  )
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED
+    this.handlers['close']?.(new Event('close'))
+  })
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = FakeWebSocket.OPEN
+    this.handlers['open']?.(new Event('open'))
+  }
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('ComfyApi realtime socket reset', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    currentToken = 'token-a'
+    deferTokenFetch = false
+    pendingTokenReleases = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    api.socket = null
+  })
+
+  afterEach(() => {
+    api.socket = null
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('closes the previous socket and opens a fresh one on reset', async () => {
+    await api.resetSocket()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    const first = FakeWebSocket.instances[0]
+    first.simulateOpen()
+
+    await api.resetSocket()
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(first.close).toHaveBeenCalled()
+    expect(api.socket).toBe(FakeWebSocket.instances[1])
+  })
+
+  it('re-authenticates the new socket with the active account token', async () => {
+    await api.resetSocket()
+    expect(FakeWebSocket.instances[0].url).toContain('token=token-a')
+
+    currentToken = 'token-b'
+    await api.resetSocket()
+
+    expect(FakeWebSocket.instances[1].url).toContain('token=token-b')
+    expect(FakeWebSocket.instances[1].url).not.toContain('token=token-a')
+  })
+
+  it('does not let the replaced socket spawn a competing reconnect', async () => {
+    await api.resetSocket()
+    const stale = FakeWebSocket.instances[0]
+    stale.simulateOpen()
+
+    await api.resetSocket()
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    // A late close event on the socket that was already replaced must be a
+    // no-op; only the active socket owns the reconnect lifecycle.
+    stale.handlers['close']?.(new Event('close'))
+    await flush()
+
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+
+  it('supersedes an in-flight reset so the socket cannot settle on a stale identity', async () => {
+    await api.resetSocket()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    deferTokenFetch = true
+
+    // A -> B begins and parks on its token fetch (captured as token-b).
+    currentToken = 'token-b'
+    const firstSwitch = api.resetSocket()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // B -> C arrives before B's token resolves, bumping the connect generation.
+    currentToken = 'token-c'
+    const secondSwitch = api.resetSocket()
+
+    // B's fetch resolves, but its generation was superseded, so it bails
+    // without opening a socket.
+    await releaseNextToken()
+    // C's fetch resolves and, as the latest generation, opens the socket.
+    await releaseNextToken()
+    await Promise.all([firstSwitch, secondSwitch])
+
+    const last = FakeWebSocket.instances.at(-1)!
+    expect(api.socket).toBe(last)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(last.url).toContain('token=token-c')
+    expect(last.url).not.toContain('token=token-b')
+  })
+
+  it('clears the stale client id and handshake identity when resetting', async () => {
+    window.name = 'client-from-account-a'
+    sessionStorage.setItem('clientId', 'client-from-account-a')
+    await api.resetSocket()
+    api.clientId = 'client-from-account-a'
+
+    await api.resetSocket()
+
+    expect(api.clientId).toBeUndefined()
+    expect(window.name).toBe('')
+    expect(sessionStorage.getItem('clientId')).toBeNull()
+  })
+})

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -334,6 +334,16 @@ export class ComfyApi extends EventTarget {
   socket: WebSocket | null = null
 
   /**
+   * Monotonic id bumped by every createSocket() attempt. Because createSocket()
+   * holds `this.socket === null` across its async token fetch, two attempts can
+   * overlap (an identity reset racing the close-handler's reconnect, or two
+   * resets in quick succession). Each attempt captures its generation and, once
+   * its awaits settle, only proceeds if it is still the latest — so the newest
+   * identity always wins and superseded attempts never open a leaked socket.
+   */
+  private socketGeneration = 0
+
+  /**
    * Cache Firebase auth store composable function.
    */
   private authStoreComposable?: typeof useAuthStore
@@ -555,6 +565,7 @@ export class ComfyApi extends EventTarget {
     if (this.socket) {
       return
     }
+    const generation = ++this.socketGeneration
 
     let opened = false
     let existingSession = window.name
@@ -589,14 +600,20 @@ export class ComfyApi extends EventTarget {
     const query = params.toString()
     const wsUrl = query ? `${baseUrl}?${query}` : baseUrl
 
-    this.socket = new WebSocket(wsUrl)
-    this.socket.binaryType = 'arraybuffer'
+    // A newer connect attempt (an identity reset, or a later reconnect) began
+    // while this one awaited its token. Abandon this attempt so only the latest
+    // generation owns this.socket and no superseded socket is opened.
+    if (generation !== this.socketGeneration) return
 
-    this.socket.addEventListener('open', () => {
+    const socket = new WebSocket(wsUrl)
+    this.socket = socket
+    socket.binaryType = 'arraybuffer'
+
+    socket.addEventListener('open', () => {
       opened = true
 
       // Send feature flags as the first message
-      this.socket!.send(
+      socket.send(
         JSON.stringify({
           type: 'feature_flags',
           data: this.getClientFeatureFlags()
@@ -608,15 +625,23 @@ export class ComfyApi extends EventTarget {
       }
     })
 
-    this.socket.addEventListener('error', () => {
-      if (this.socket) this.socket.close()
+    socket.addEventListener('error', () => {
+      // A replaced socket (e.g. after resetSocket on an account switch) is
+      // already being torn down; ignore its late errors so it cannot start an
+      // unnecessary permanent polling loop for the previous identity.
+      if (this.socket !== socket) return
+      socket.close()
       if (!isReconnect && !opened) {
         this._pollQueue()
       }
     })
 
-    this.socket.addEventListener('close', () => {
+    socket.addEventListener('close', () => {
+      // A replaced socket (e.g. after resetSocket on an account switch) must
+      // not reconnect; only the active socket owns the reconnect lifecycle.
+      if (this.socket !== socket) return
       setTimeout(async () => {
+        if (this.socket !== socket) return
         this.socket = null
         await this.createSocket(true)
       }, 300)
@@ -626,7 +651,10 @@ export class ComfyApi extends EventTarget {
       }
     })
 
-    this.socket.addEventListener('message', (event) => {
+    socket.addEventListener('message', (event) => {
+      // Ignore late messages from a replaced socket so previous-account
+      // realtime data is not dispatched after an identity switch.
+      if (this.socket !== socket) return
       try {
         if (event.data instanceof ArrayBuffer) {
           const view = new DataView(event.data)
@@ -786,6 +814,36 @@ export class ComfyApi extends EventTarget {
    */
   init() {
     this.createSocket()
+  }
+
+  /**
+   * Tears down the active realtime socket and reconnects, re-authenticating
+   * with the currently active account's token. Invoked on a direct identity
+   * change so a tab cannot keep receiving the previous account's realtime
+   * events over a handshake that was authenticated as that account.
+   */
+  async resetSocket(): Promise<void> {
+    const previous = this.socket
+    // Detach before closing so the previous socket's close handler sees it is
+    // no longer the active socket and does not start a competing reconnect.
+    this.socket = null
+    // Clear every handshake identity source: createSocket() reads the client id
+    // from window.name (mirrored in session storage), not this.clientId, so the
+    // next connect must not inherit the prior account's id.
+    this.clientId = undefined
+    window.name = ''
+    sessionStorage.removeItem('clientId')
+    if (previous && previous.readyState !== WebSocket.CLOSED) {
+      try {
+        previous.close()
+      } catch {
+        // Already-terminating socket; nothing to clean up.
+      }
+    }
+    // createSocket() bumps the generation; any overlapping reset or reconnect
+    // that is still awaiting its token will see it lost the race and bail,
+    // leaving this the sole owner of the reconnected socket.
+    await this.createSocket()
   }
 
   /**

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -5,8 +5,13 @@ import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
+import type * as ApiModule from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import { createTestingPinia } from '@pinia/testing'
+
+const { mockResetSocket } = vi.hoisted(() => ({
+  mockResetSocket: vi.fn()
+}))
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
@@ -88,6 +93,16 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
 
 vi.mock('@/services/dialogService')
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+
+// authStore.onAuthStateChanged (cloud) calls api.resetSocket() on an identity
+// change (the sign-out / account-switch cases below). Keep the real API
+// singleton but stub resetSocket so those transitions don't open a real
+// WebSocket (unavailable in this test environment).
+vi.mock('@/scripts/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof ApiModule>()
+  Object.assign(actual.api, { resetSocket: mockResetSocket })
+  return actual
+})
 
 const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
 vi.mock('@/stores/apiKeyAuthStore', () => ({

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -11,6 +11,7 @@ import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQuery
 import { useDialogService } from '@/services/dialogService'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
+import type * as ApiModule from '@/scripts/api'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import { createTestingPinia } from '@pinia/testing'
 
@@ -27,6 +28,10 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
     teamWorkspacesEnabled: false,
     unifiedCloudAuthEnabled: false
   }
+}))
+
+const { mockResetSocket } = vi.hoisted(() => ({
+  mockResetSocket: vi.fn()
 }))
 
 type MockUser = Omit<User, 'getIdToken' | 'delete'> & {
@@ -116,6 +121,15 @@ vi.mock('@/stores/toastStore', () => ({
     add: vi.fn()
   })
 }))
+
+// Keep the real API singleton (other modules rely on its full surface) but
+// override resetSocket so we can assert socket lifecycle calls without opening
+// a real WebSocket.
+vi.mock('@/scripts/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof ApiModule>()
+  Object.assign(actual.api, { resetSocket: mockResetSocket })
+  return actual
+})
 
 // Mock useDialogService
 vi.mock('@/services/dialogService')
@@ -1093,6 +1107,58 @@ describe('useAuthStore', () => {
       const error = await store.createCustomer().catch((e: unknown) => e)
       expect(error).toBeInstanceOf(AuthStoreError)
       expect((error as AuthStoreError).status).toBe(422)
+    })
+  })
+
+  describe('realtime socket identity lifecycle', () => {
+    const accountB: MockUser = {
+      ...mockUser,
+      uid: 'account-b-id',
+      email: 'b@example.com'
+    } as MockUser
+
+    it('does not reset the socket on the initial sign-in', () => {
+      // The store is created in beforeEach, which drives the initial
+      // authStateCallback(mockUser); the first identity must not reconnect
+      // because api.init() already owns the initial connect.
+      expect(mockResetSocket).not.toHaveBeenCalled()
+    })
+
+    it('reconnects the socket on a direct A -> B account switch', () => {
+      mockResetSocket.mockClear()
+
+      authStateCallback(accountB)
+
+      expect(mockResetSocket).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reconnect on a same-account token refresh', () => {
+      mockResetSocket.mockClear()
+
+      // Same UID observed again (e.g. onAuthStateChanged re-emitting the same
+      // user) must not tear down the connection.
+      authStateCallback(mockUser)
+
+      expect(mockResetSocket).not.toHaveBeenCalled()
+    })
+
+    it('reconnects the socket on sign-out', () => {
+      mockResetSocket.mockClear()
+
+      authStateCallback(null)
+
+      expect(mockResetSocket).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reconnect when transitioning from signed-out to signed-in', () => {
+      authStateCallback(null)
+      mockResetSocket.mockClear()
+
+      // Re-signing in from a signed-out state records the identity again; the
+      // socket was already torn down on sign-out, so there is no extra reset.
+      authStateCallback(accountB)
+
+      expect(mockResetSocket).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -30,6 +30,7 @@ import {
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useTelemetry } from '@/platform/telemetry'
+import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
@@ -139,6 +140,18 @@ export const useAuthStore = defineStore('auth', () => {
   void setPersistence(auth, browserLocalPersistence)
 
   onAuthStateChanged(auth, (user) => {
+    const previousUserId = currentUser.value?.uid ?? null
+    const identityChanged =
+      previousUserId !== null && previousUserId !== (user?.uid ?? null)
+
+    // A direct account switch (A -> B, or sign-out) must re-handshake the
+    // realtime socket so a tab stops receiving the previous account's live
+    // events. The initial connect is owned by api.init(), so only react once an
+    // identity has been recorded (`identityChanged` is false on first sign-in).
+    if (isCloud && identityChanged) {
+      void api.resetSocket()
+    }
+
     currentUser.value = user
     isInitialized.value = true
     if (user === null) {


### PR DESCRIPTION
Manual backport of #13971 to `cloud/1.45` (auto-backport bot failed on conflict in `authStore.ts`).

Reconnect and re-authenticate the realtime WebSocket on a direct account switch (A -> B, no reload). `ComfyApi.resetSocket()` tears down the active socket, detaches it first, clears the stale `clientId`, and reconnects with the active account's token; socket close/error/message handlers bail when `this.socket !== socket` so a replaced socket cannot spawn a competing reconnect. `authStore.onAuthStateChanged` (cloud only) resets the socket when the active Firebase UID changes.

**Conflict resolution (auth-sensitive):** cloud/1.45 lacks the `identityChanged`/workspace-reset block from #13832, so the cherry-pick conflicted in `onAuthStateChanged`. Resolved to the *minimal faithful* #13971 net diff: added the `previousUserId`/`identityChanged` computation (dependency of the reset gate) and the `if (isCloud && identityChanged) void api.resetSocket()` call only. The #13832-owned `clearWorkspaceContext()`/`resetForIdentityChange()` lines were intentionally excluded (out of scope for this branch; sign-out workspace clearing already handled by existing 1.45 code). `api.ts` resetSocket + replaced-socket guards applied cleanly.

Gates: typecheck OK, unit 72/72, eslint/oxlint/oxfmt OK.

Backport of #13971. Do not merge without release owner review.