### PR TITLE
ci: disable CLA action's auto-lock on merged PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -68,7 +68,7 @@ jobs:
           # Signatures are stored in a separate repo; locking the PR is not needed
           # to protect them. Disabled because it prevents contributors from commenting
           # on their own merged PRs.
-          lock-pullrequest-aftermerge: "false"
+          lock-pullrequest-aftermerge: 'false'
 
           # Where the CLA document lives (shown to contributors)
           path-to-document: https://github.com/Comfy-Org/comfy-cla/blob/main/comfyui_icla.md

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -65,6 +65,11 @@ jobs:
           # PAT required to write to the centralized signatures repo.
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
+          # Signatures are stored in a separate repo; locking the PR is not needed
+          # to protect them. Disabled because it prevents contributors from commenting
+          # on their own merged PRs.
+          lock-pullrequest-aftermerge: "false"
+
           # Where the CLA document lives (shown to contributors)
           path-to-document: https://github.com/Comfy-Org/comfy-cla/blob/main/comfyui_icla.md
 


### PR DESCRIPTION
## What

Adds `lock-pullrequest-aftermerge: "false"` to the CLA Assistant step in `.github/workflows/cla.yml`.

## Why

Since PR #13058 (June 24, 2026), every merged PR has been automatically locked by `github-actions[bot]` within ~9 seconds of merge. This was traced to the `contributor-assistant/github-action` action, which has `lock-pullrequest-aftermerge` **defaulting to `true`**.

The action's intent is to prevent contributors from deleting their CLA signature comments after merge — effectively revoking their signature. However, **our CLA signatures are stored in a separate repo** (`comfy-org/comfy-cla`), not as PR comments. The signature record is already protected independently of the PR thread, so locking the PR provides no additional protection.

The side effect is that contributors cannot comment on their own merged PRs, which is surprising and unhelpful.

## Root cause trail

- Trigger: `pull_request_target: [closed]` fires on merge
- Action: `contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08`
- Source: [`src/pullrequest/pullRequestLock.ts`](https://github.com/contributor-assistant/github-action/blob/main/src/pullrequest/pullRequestLock.ts) calls `octokit.issues.lock()` when `lock-pullrequest-aftermerge` input is `"true"` (the default in [`action.yml`](https://github.com/contributor-assistant/github-action/blob/main/action.yml))
- Actor shown in GitHub timeline: `github-actions[bot]` (workflow GITHUB_TOKEN, `performed_via_github_app: null`)

## Test plan

- [ ] Merge a PR after this lands and confirm `github-actions[bot]` no longer locks it