### PR TITLE
refactor(vue-nodes): address DrJKL review on the size-Proxy (trim comments, cut spec-mechanics tests, hoist mutations)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -117,6 +117,9 @@ const MUTATING_SIZE_METHODS = new Set([
   'sort'
 ])
 
+/** Captures only the {@link layoutStore} singleton, so shared across nodes. */
+const layoutMutations = useLayoutMutations()
+
 interface INodePropertyInfo {
   name?: string
   type?: string
@@ -515,9 +518,8 @@ export class LGraphNode
     this._pos[1] = value[1]
     if (this.id === UNASSIGNED_NODE_ID || !this.graph) return
 
-    const mutations = useLayoutMutations()
-    mutations.setSource(LayoutSource.Canvas)
-    mutations.moveNode(this.id, { x: value[0], y: value[1] })
+    layoutMutations.setSource(LayoutSource.Canvas)
+    layoutMutations.moveNode(this.id, { x: value[0], y: value[1] })
   }
 
   /**
@@ -542,15 +544,8 @@ export class LGraphNode
    * mutating methods ({@link MUTATING_SIZE_METHODS}) also commit, so growing the
    * node via `node.size.set(...)` reflows just like a bare element write.
    *
-   * TODO(litegraph-stable-resize-api): this Proxy is the deprecation on-ramp for
-   * a stable resize API that does not exist yet. Its set trap already commits the
-   * legacy `node.size[1] =` idiom through `resizeNode` — the SAME layout-store
-   * primitive the sanctioned future API will call. Direction / migration: target
-   * end-state is a `Comfy.Node.Resize` command + `NodeHandle.setSize()`/
-   * `autosize()`/`on('resize')` (v2 extension handles). Once that API lands, emit
-   * a one-time `warnDeprecated` from this trap naming the sanctioned call, turning
-   * direct element writes into a migrate-me signal instead of a silent shim (the
-   * deliberate fast-follow — no runtime warn today).
+   * TODO(litegraph-stable-resize-api): interim shim — remove once a stable resize
+   * API replaces direct typed-array size access.
    */
   public get size(): Size {
     return (this._sizeProxy ??= new Proxy(this._size, {
@@ -594,9 +589,8 @@ export class LGraphNode
     const layout = layoutStore.getNodeLayoutRef(this.id).value
     if (layout && isSizeEqual(layout.size, size)) return
 
-    const mutations = useLayoutMutations()
-    mutations.setSource(LayoutSource.Canvas)
-    mutations.resizeNode(this.id, size)
+    layoutMutations.setSource(LayoutSource.Canvas)
+    layoutMutations.resizeNode(this.id, size)
   }
 
   /**

--- a/src/renderer/core/layout/sync/useLayoutSync.ts
+++ b/src/renderer/core/layout/sync/useLayoutSync.ts
@@ -51,9 +51,7 @@ export function useLayoutSync() {
         liteNode.size[0] !== layout.size.width ||
         liteNode.size[1] !== layout.size.height
       ) {
-        // Assign through the setter so both axes update together. The setter's
-        // isSizeEqual guard makes this write-back a no-op commit (the value now
-        // equals the layout), so no feedback loop through handleLayoutChange.
+        // The setter's isSizeEqual guard no-ops this equal write-back.
         liteNode.size = [layout.size.width, layout.size.height]
         liteNode.onResize?.(liteNode.size)
       }

--- a/src/renderer/extensions/vueNodes/layout/nodeSizeReflow.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/nodeSizeReflow.test.ts
@@ -114,21 +114,6 @@ describe('LGraphNode size reflow', () => {
     ).toHaveLength(1)
   })
 
-  it('commits a chained index write after a fluent TypedArray mutator', () => {
-    const { node, resizeCommits } = setup()
-
-    const size = node.size
-    if (!(size instanceof Float64Array)) throw new Error('not a Float64Array')
-    size.fill(160)[1] = 180
-
-    const layout = layoutStore.getNodeLayoutRef(node.id)
-    expect(layout.value?.size).toEqual({ width: 160, height: 180 })
-    expect(
-      resizeCommits(),
-      'fill(...) returns the Proxy, so the chained [1] = write still commits'
-    ).toHaveLength(2)
-  })
-
   it('does not commit for size mutations before the node joins a graph', () => {
     const detached = new LGraphNode('detached')
 
@@ -136,63 +121,6 @@ describe('LGraphNode size reflow', () => {
       detached.size[1] = 500
     }).not.toThrow()
     expect(detached.size[1]).toBe(500)
-  })
-
-  it('keeps typed-array semantics through the size Proxy', () => {
-    const { node } = setup()
-    node.size[1] = 175
-
-    expect(node.size[0]).toBe(210)
-    expect(node.size[1]).toBe(175)
-    expect(node.size.length).toBe(2)
-    expect([...node.size]).toEqual([210, 175])
-    expect(Array.from(node.size)).toEqual([210, 175])
-  })
-
-  it('preserves the Float64Array identity and buffer contract', () => {
-    const { node } = setup()
-    const size = node.size
-
-    expect(size instanceof Float64Array).toBe(true)
-    if (!(size instanceof Float64Array)) throw new Error('not a Float64Array')
-
-    expect(size.BYTES_PER_ELEMENT).toBe(8)
-    expect(size.buffer).toBeInstanceOf(ArrayBuffer)
-    // size is the subarray(2, 4) view of the node's [x, y, w, h] Rectangle.
-    expect(size.byteOffset).toBe(2 * Float64Array.BYTES_PER_ELEMENT)
-
-    const view = size.subarray(1, 2)
-    expect(ArrayBuffer.isView(view)).toBe(true)
-    node.size[1] = 321
-    expect(view[0]).toBe(321)
-  })
-
-  it('returns a cached Proxy that stays bound to the live backing store', () => {
-    const { node } = setup()
-    const cached = node.size
-
-    expect(node.size).toBe(cached)
-
-    node.size = [260, 140]
-    expect(cached[0]).toBe(260)
-    expect(cached[1]).toBe(140)
-
-    node.size[1] = 999
-    expect(cached[1]).toBe(999)
-  })
-
-  it('does not disturb the sibling pos subarray when size is mutated', () => {
-    const { node } = setup()
-    node.pos[0] = 33
-    node.pos[1] = 44
-
-    node.size[0] = 500
-    node.size[1] = 600
-
-    expect(node.pos[0]).toBe(33)
-    expect(node.pos[1]).toBe(44)
-    expect(node.size[0]).toBe(500)
-    expect(node.size[1]).toBe(600)
   })
 
   it('serializes size as a plain array, never leaking the Proxy', () => {

--- a/tools/devtools/web/runtimeReflow.js
+++ b/tools/devtools/web/runtimeReflow.js
@@ -37,7 +37,7 @@ app.registerExtension({
         const img = new Image()
         img.onload = () => {
           this.imgs = [img]
-          resizeViaDirectSizeMutation(this, Math.max(this.size[1] + 120, 200))
+          resizeViaDirectSizeMutation(this, this.size[1] + 120)
         }
         img.src = ONE_PIXEL_PNG
       }


### PR DESCRIPTION
## Summary

Follow-up to the merged #13867 (runtime size-Proxy reflow) addressing DrJKL's post-merge review: trim speculative comments, cut change-detector tests, and hoist a per-call allocation.

## Changes

- **What**:
  - `LGraphNode.ts` — trim the `TODO(litegraph-stable-resize-api)` block (~9 lines enumerating a not-yet-existing `Comfy.Node.Resize` / `NodeHandle` API, drafted in #13929) to a one-line intent pointer; hoist `useLayoutMutations()` to module scope (it captures only the `layoutStore` singleton) and reuse it in `set pos` and `_sizeUpdated`.
  - `nodeSizeReflow.test.ts` — cut five change-detector tests that assert ECMAScript TypedArray/Proxy spec mechanics (typed-array semantics, buffer contract, cached-Proxy identity, sibling `pos` subarray, fluent-mutator chain). Keep the behavioral cases: single commit per grow, per-axis sequential writes, whole-array assign, no-feedback-loop guard, in-place `.set()`, detached no-commit, and serialize-no-leak.
  - `useLayoutSync.ts` — collapse a 3-line justification comment to one line.
  - `tools/devtools/web/runtimeReflow.js` — drop the dead `Math.max(..., 200)` (start height + 120 already exceeds 200).
- **Breaking**: None. No production behavior change; the size-Proxy runtime semantics are unchanged.

## Review Focus

- The hoisted module-scope `layoutMutations` is safe because `useLayoutMutations()` closes over only the `layoutStore` module singleton (verified in `layoutMutations.ts`).
- The `double as unknown as` at the `page.evaluate` boundary in `runtimeReflow.ts` is left as-is per DrJKL's note (acceptable last-resort interop assertion).

Follow-up to #13867.
