### PR TITLE
feat: support hosted invoice payment actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
+import { useEventListener } from '@vueuse/core'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
 
@@ -13,12 +14,17 @@ import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { isDesktop } from '@/platform/distribution/types'
 import { app } from '@/scripts/app'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
 import { parsePreloadError } from '@/utils/preloadErrorUtil'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 
 const workspaceStore = useWorkspaceStore()
+const billingOperationStore = useBillingOperationStore()
+useEventListener(globalThis, 'pageshow', () => {
+  billingOperationStore.resumePendingOperations()
+})
 app.extensionManager = useWorkspaceStore()
 
 const conflictDetection = useConflictDetection()

--- a/src/components/toast/GlobalToast.test.ts
+++ b/src/components/toast/GlobalToast.test.ts
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import GlobalToast from './GlobalToast.vue'
+
+const hostedInvoiceUrl = ref<string | null>(null)
+
+vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
+  useBillingOperationStore: () => ({
+    get hostedInvoiceUrl() {
+      return hostedInvoiceUrl.value
+    }
+  })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: vi.fn() })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({
+    messagesToAdd: [],
+    messagesToRemove: [],
+    removeAllRequested: false
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: vi.fn(),
+    remove: vi.fn(),
+    removeAllGroups: vi.fn()
+  })
+}))
+
+const ToastStub = {
+  props: ['group'],
+  template: `
+    <div v-if="group === 'billing-operation'">
+      <slot name="message" :message="{ summary: 'Processing payment' }" />
+    </div>
+  `
+}
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      billingOperation: {
+        continueToPayment: 'Continue to payment'
+      }
+    }
+  }
+})
+
+describe('GlobalToast hosted invoice action', () => {
+  beforeEach(() => {
+    hostedInvoiceUrl.value = null
+  })
+
+  it('renders an explicit new-tab payment link when the operation exposes one', async () => {
+    const { rerender } = render(GlobalToast, {
+      global: {
+        plugins: [i18n],
+        stubs: { Toast: ToastStub }
+      }
+    })
+
+    expect(
+      screen.queryByRole('link', { name: 'Continue to payment' })
+    ).not.toBeInTheDocument()
+
+    hostedInvoiceUrl.value = 'https://invoice.test/bearer-token'
+    await rerender({})
+
+    expect(
+      screen.getByRole('link', { name: 'Continue to payment' })
+    ).toHaveAttribute('href', 'https://invoice.test/bearer-token')
+    expect(
+      screen.getByRole('link', { name: 'Continue to payment' })
+    ).toHaveAttribute('target', '_blank')
+    expect(
+      screen.getByRole('link', { name: 'Continue to payment' })
+    ).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -2,25 +2,46 @@
   <Toast />
   <Toast group="billing-operation" position="top-right">
     <template #message="slotProps">
-      <div class="flex items-center gap-2">
-        <i class="pi pi-spin pi-spinner text-primary" />
-        <span>{{ slotProps.message.summary }}</span>
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-2">
+          <i class="pi pi-spin pi-spinner text-primary" />
+          <span>{{ slotProps.message.summary }}</span>
+        </div>
+        <a
+          v-if="billingOperationStore.hostedInvoiceUrl"
+          :href="billingOperationStore.hostedInvoiceUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          :class="
+            cn(
+              buttonVariants({ variant: 'primary', size: 'lg' }),
+              'w-full no-underline'
+            )
+          "
+        >
+          {{ $t('billingOperation.continueToPayment') }}
+          <i class="pi pi-external-link" />
+        </a>
       </div>
     </template>
   </Toast>
 </template>
 
 <script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
 import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
 import { nextTick, watch } from 'vue'
 
+import { buttonVariants } from '@/components/ui/button/button.variants'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 
 const toast = useToast()
 const toastStore = useToastStore()
 const settingStore = useSettingStore()
+const billingOperationStore = useBillingOperationStore()
 
 watch(
   () => toastStore.messagesToAdd,
@@ -34,7 +55,7 @@ watch(
     })
     toastStore.messagesToAdd = []
   },
-  { deep: true }
+  { deep: true, immediate: true }
 )
 
 watch(

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2554,6 +2554,7 @@
   },
   "billingOperation": {
     "subscriptionProcessing": "Processing payment — setting up your workspace...",
+    "continueToPayment": "Continue to payment",
     "subscriptionSuccess": "Subscription updated successfully",
     "subscriptionFailed": "Subscription update failed",
     "subscriptionTimeout": "Subscription verification timed out",

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -302,15 +302,30 @@ export interface CreateTopupResponse {
   amount_cents: number
 }
 
-type BillingOpStatus = 'pending' | 'succeeded' | 'failed'
-
-export interface BillingOpStatusResponse {
-  id: string
-  status: BillingOpStatus
-  error_message?: string
-  started_at: string
-  completed_at?: string
+interface BillingOpCustomerAction {
+  type: 'pay_hosted_invoice'
+  url: string
 }
+
+interface BillingOpStatusBase {
+  id: string
+  started_at: string
+}
+
+export type BillingOpStatusResponse = BillingOpStatusBase &
+  (
+    | {
+        status: 'pending'
+        customer_action?: BillingOpCustomerAction
+      }
+    | {
+        status: 'succeeded' | 'failed'
+        error_message?: string
+        customer_action?: never
+      }
+  ) & {
+    completed_at?: string
+  }
 
 interface BillingEvent {
   event_type: string

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -759,7 +759,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    it('opens the payment URL when the team subscribe needs a payment method', async () => {
+    it('redirects in the same tab when the team subscribe needs a payment method', async () => {
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -775,15 +775,15 @@ describe('useSubscriptionCheckout', () => {
         billing_op_id: 'op-team-3',
         payment_method_url: 'https://stripe.com/team-pay'
       })
+      const assignSpy = vi
+        .spyOn(globalThis.location, 'assign')
+        .mockImplementation(() => {})
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleTeamSubscribe()
 
-      expect(openSpy).toHaveBeenCalledWith(
-        'https://stripe.com/team-pay',
-        '_blank'
-      )
-      openSpy.mockRestore()
+      expect(assignSpy).toHaveBeenCalledWith('https://stripe.com/team-pay')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      assignSpy.mockRestore()
     })
 
     it('does not subscribe and shows an error when the stop has no id', async () => {
@@ -908,6 +908,64 @@ describe('useSubscriptionCheckout', () => {
       expect(mockFetchBalance).not.toHaveBeenCalled()
     })
 
+    it('completes a zero-due personal upgrade without polling for a URL', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'creator'
+      checkout.selectedBillingCycle.value = 'monthly'
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'upgrade',
+        effective_at: '2026-07-23',
+        is_immediate: true,
+        cost_today_cents: 0,
+        cost_next_period_cents: 3500,
+        credits_today_cents: 0,
+        credits_next_period_cents: 7400,
+        new_plan: makeCreatorMonthly()
+      }
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-zero-due'
+      })
+      const openSpy = vi.spyOn(window, 'open')
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.checkoutStep.value).toBe('success')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('completes a saved-card personal payment without polling for a URL', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'creator'
+      checkout.selectedBillingCycle.value = 'monthly'
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'upgrade',
+        effective_at: '2026-07-23',
+        is_immediate: true,
+        cost_today_cents: 900,
+        cost_next_period_cents: 3500,
+        credits_today_cents: 2000,
+        credits_next_period_cents: 7400,
+        new_plan: makeCreatorMonthly()
+      }
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-saved-card'
+      })
+      const openSpy = vi.spyOn(window, 'open')
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.checkoutStep.value).toBe('success')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
     it('skips begin_checkout when no user id is available', async () => {
       mockUserId.value = null
       const checkout = await setup('subscribe_to_run')
@@ -949,7 +1007,7 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
-    it('opens payment URL when needs_payment_method', async () => {
+    it('waits for the polled payment action when a payment method is needed', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -959,14 +1017,14 @@ describe('useSubscriptionCheckout', () => {
         payment_method_url: 'https://stripe.com/pay'
       })
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleAddCreditCard()
 
-      expect(openSpy).toHaveBeenCalledWith('https://stripe.com/pay', '_blank')
-      openSpy.mockRestore()
+      expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
+        hostedInvoiceReturnUrl: 'http://localhost:3000/'
+      })
     })
 
-    it('warns when the payment popup is blocked', async () => {
+    it('does not open the payment URL from the subscribe response', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -979,11 +1037,11 @@ describe('useSubscriptionCheckout', () => {
 
       await checkout.handleAddCreditCard()
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({
-          severity: 'warn',
-          detail: 'subscription.preview.paymentPopupBlocked'
-        })
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-blocked',
+        'subscription',
+        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
       )
       openSpy.mockRestore()
     })
@@ -1004,7 +1062,8 @@ describe('useSubscriptionCheckout', () => {
       expect(openSpy).not.toHaveBeenCalled()
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-no-url',
-        'subscription'
+        'subscription',
+        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1026,7 +1085,8 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-1',
-        'subscription'
+        'subscription',
+        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1047,7 +1107,8 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-2',
-        'subscription'
+        'subscription',
+        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
       )
       expect(checkout.checkoutStep.value).toBe('preview')
     })

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -322,7 +322,8 @@ export function useSubscriptionCheckout(
 
   async function handleSubscribeResponse(
     response: SubscribeResponse | void,
-    shouldTrackSubscriptionSuccess = true
+    shouldTrackSubscriptionSuccess = true,
+    redirectImmediatePaymentUrl = false
   ): Promise<void> {
     if (!response) return
 
@@ -334,25 +335,15 @@ export function useSubscriptionCheckout(
       return
     }
 
-    // needs_payment_method / pending_payment both finish asynchronously, so poll
-    // the billing op either way. needs_payment_method additionally points at a
-    // Stripe page to collect a card when the backend supplies the URL; without
-    // it we still poll rather than silently stranding the user on confirm.
     if (
+      redirectImmediatePaymentUrl &&
       response.status === 'needs_payment_method' &&
       response.payment_method_url
     ) {
-      // The open runs after `await subscribe(...)`, so it's not a direct user
-      // gesture and can be popup-blocked; warn instead of failing silently.
-      const paymentWindow = window.open(response.payment_method_url, '_blank')
-      if (!paymentWindow) {
-        toast.add({
-          severity: 'warn',
-          summary: t('g.warning'),
-          detail: t('subscription.preview.paymentPopupBlocked')
-        })
-      }
+      globalThis.location.assign(response.payment_method_url)
+      return
     }
+
     await advanceToSuccessOnOperation(response.billing_op_id)
   }
 
@@ -362,7 +353,8 @@ export function useSubscriptionCheckout(
   async function advanceToSuccessOnOperation(opId: string) {
     const operation = await billingOperationStore.startOperation(
       opId,
-      'subscription'
+      'subscription',
+      { hostedInvoiceReturnUrl: globalThis.location.href }
     )
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
   }
@@ -402,7 +394,7 @@ export function useSubscriptionCheckout(
           paymentIntentSource
         })
       }
-      await handleSubscribeResponse(response)
+      await handleSubscribeResponse(response, true, true)
     } catch (error) {
       showSubscribeError(error)
     } finally {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -78,10 +78,12 @@ describe('billingOperationStore', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.useFakeTimers()
+    localStorage.clear()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   describe('startOperation', () => {
@@ -171,6 +173,198 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.topupProcessing',
         group: 'billing-operation'
       })
+    })
+
+    it('persists recovery context before navigating to a hosted invoice', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-hosted',
+        status: 'pending',
+        customer_action: {
+          type: 'pay_hosted_invoice',
+          url: 'https://invoice.test/bearer-token'
+        },
+        started_at: new Date().toISOString()
+      })
+      const assignSpy = vi
+        .spyOn(globalThis.location, 'assign')
+        .mockImplementation(() => {})
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-hosted', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).toHaveBeenCalledWith(
+        'https://invoice.test/bearer-token'
+      )
+      expect(store.getOperation('op-hosted')).toMatchObject({
+        status: 'pending',
+        paymentNavigationStarted: true
+      })
+      const persisted = localStorage.getItem('comfy.billing.pending_operation')
+      expect(persisted).toContain('op-hosted')
+      expect(persisted).toContain(globalThis.location.href)
+      expect(persisted).not.toContain('bearer-token')
+    })
+
+    it('resumes a hosted invoice operation after browser return', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'pending',
+          customer_action: {
+            type: 'pay_hosted_invoice',
+            url: 'https://invoice.test/bearer-token'
+          },
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'succeeded',
+          started_at: new Date().toISOString(),
+          completed_at: new Date().toISOString()
+        })
+      vi.spyOn(globalThis.location, 'assign').mockImplementation(() => {})
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-return', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      store.resumePendingOperations()
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(terminal).resolves.toMatchObject({ status: 'succeeded' })
+      expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+    })
+
+    it('does not navigate when recovery context cannot be persisted', async () => {
+      const setItemSpy = vi
+        .spyOn(globalThis.localStorage, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('storage unavailable')
+        })
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-storage-failure',
+        status: 'pending',
+        customer_action: {
+          type: 'pay_hosted_invoice',
+          url: 'https://invoice.test/bearer-token'
+        },
+        started_at: new Date().toISOString()
+      })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-storage-failure', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).not.toHaveBeenCalled()
+      expect(store.getOperation('op-storage-failure')).toMatchObject({
+        status: 'failed'
+      })
+      setItemSpy.mockRestore()
+    })
+
+    it('does not navigate a topup operation carrying a customer action', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-topup-action',
+          status: 'pending',
+          customer_action: {
+            type: 'pay_hosted_invoice',
+            url: 'https://invoice.test/bearer-token'
+          },
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-topup-action',
+          status: 'succeeded',
+          started_at: new Date().toISOString()
+        })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-topup-action', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      await expect(terminal).resolves.toMatchObject({ status: 'succeeded' })
+      expect(assignSpy).not.toHaveBeenCalled()
+    })
+
+    it('recovers a persisted operation after reload without reusing its URL', async () => {
+      localStorage.setItem(
+        'comfy.billing.pending_operation',
+        JSON.stringify({
+          opId: 'op-reload',
+          type: 'subscription',
+          startedAt: Date.now() - 300_000,
+          returnUrl: globalThis.location.href,
+          paymentNavigationStarted: true
+        })
+      )
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-reload',
+        status: 'succeeded',
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString()
+      })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-reload')).toMatchObject({
+        status: 'succeeded'
+      })
+      expect(assignSpy).not.toHaveBeenCalled()
+      expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+    })
+
+    it('coalesces reload and pageshow recovery polling', async () => {
+      localStorage.setItem(
+        'comfy.billing.pending_operation',
+        JSON.stringify({
+          opId: 'op-single-flight',
+          type: 'subscription',
+          startedAt: Date.now(),
+          returnUrl: globalThis.location.href,
+          paymentNavigationStarted: true
+        })
+      )
+      let resolveStatus!: (value: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      store.resumePendingOperations()
+
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledOnce()
+      resolveStatus({
+        id: 'op-single-flight',
+        status: 'succeeded',
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -175,7 +175,7 @@ describe('billingOperationStore', () => {
       })
     })
 
-    it('persists recovery context before navigating to a hosted invoice', async () => {
+    it('exposes a hosted invoice without navigating or persisting its URL', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-hosted',
         status: 'pending',
@@ -195,9 +195,8 @@ describe('billingOperationStore', () => {
       })
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(assignSpy).toHaveBeenCalledWith(
-        'https://invoice.test/bearer-token'
-      )
+      expect(assignSpy).not.toHaveBeenCalled()
+      expect(store.hostedInvoiceUrl).toBe('https://invoice.test/bearer-token')
       expect(store.getOperation('op-hosted')).toMatchObject({
         status: 'pending',
         paymentNavigationStarted: true
@@ -208,7 +207,7 @@ describe('billingOperationStore', () => {
       expect(persisted).not.toContain('bearer-token')
     })
 
-    it('resumes a hosted invoice operation after browser return', async () => {
+    it('keeps polling the exact hosted invoice operation to completion', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus)
         .mockResolvedValueOnce({
           id: 'op-return',
@@ -238,11 +237,24 @@ describe('billingOperationStore', () => {
       })
       await vi.advanceTimersByTimeAsync(0)
       await vi.advanceTimersByTimeAsync(1500)
-
-      store.resumePendingOperations()
-      await vi.advanceTimersByTimeAsync(0)
+      expect(store.hostedInvoiceUrl).toBe('https://invoice.test/bearer-token')
+      await vi.advanceTimersByTimeAsync(2250)
 
       await expect(terminal).resolves.toMatchObject({ status: 'succeeded' })
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenNthCalledWith(
+        1,
+        'op-return'
+      )
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenNthCalledWith(
+        2,
+        'op-return'
+      )
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenNthCalledWith(
+        3,
+        'op-return'
+      )
+      expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
+      expect(store.hostedInvoiceUrl).toBeNull()
       expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
     })
 
@@ -273,6 +285,7 @@ describe('billingOperationStore', () => {
       expect(store.getOperation('op-storage-failure')).toMatchObject({
         status: 'failed'
       })
+      expect(store.hostedInvoiceUrl).toBeNull()
       setItemSpy.mockRestore()
     })
 
@@ -330,6 +343,54 @@ describe('billingOperationStore', () => {
       })
       expect(assignSpy).not.toHaveBeenCalled()
       expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+    })
+
+    it('re-exposes a hosted invoice URL after reload and keeps it ephemeral', async () => {
+      localStorage.setItem(
+        'comfy.billing.pending_operation',
+        JSON.stringify({
+          opId: 'op-reload-action',
+          type: 'subscription',
+          startedAt: Date.now(),
+          returnUrl: globalThis.location.href,
+          paymentNavigationStarted: true
+        })
+      )
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-reload-action',
+          status: 'pending',
+          customer_action: {
+            type: 'pay_hosted_invoice',
+            url: 'https://invoice.test/reloaded-bearer-token'
+          },
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-reload-action',
+          status: 'succeeded',
+          started_at: new Date().toISOString(),
+          completed_at: new Date().toISOString()
+        })
+
+      const store = useBillingOperationStore()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.hostedInvoiceUrl).toBe(
+        'https://invoice.test/reloaded-bearer-token'
+      )
+      expect(
+        localStorage.getItem('comfy.billing.pending_operation')
+      ).not.toContain('reloaded-bearer-token')
+
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(store.getOperation('op-reload-action')).toMatchObject({
+        status: 'succeeded'
+      })
+      expect(store.hostedInvoiceUrl).toBeNull()
+      expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+      expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
     })
 
     it('coalesces reload and pageshow recovery polling', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -15,6 +15,7 @@ const INITIAL_INTERVAL_MS = 1000
 const MAX_INTERVAL_MS = 8000
 const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000 // 2 minutes
+const PENDING_OPERATION_STORAGE_KEY = 'comfy.billing.pending_operation'
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -25,6 +26,20 @@ interface BillingOperation {
   status: OperationStatus
   errorMessage: string | null
   startedAt: number
+  returnUrl: string | null
+  paymentNavigationStarted: boolean
+}
+
+interface PendingBillingOperation {
+  opId: string
+  type: 'subscription'
+  startedAt: number
+  returnUrl: string
+  paymentNavigationStarted: boolean
+}
+
+interface StartOperationOptions {
+  hostedInvoiceReturnUrl?: string
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -36,6 +51,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   const receivedToasts = new Map<string, ToastMessageOptions>()
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
+  const pollsInFlight = new Set<string>()
 
   const hasPendingOperations = computed(() =>
     [...operations.value.values()].some((op) => op.status === 'pending')
@@ -59,7 +75,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   function startOperation(
     opId: string,
-    type: OperationType
+    type: OperationType,
+    options: StartOperationOptions = {}
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
     if (existing) {
@@ -71,11 +88,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       type,
       status: 'pending',
       errorMessage: null,
-      startedAt: Date.now()
+      startedAt: Date.now(),
+      returnUrl: getSameOriginUrl(options.hostedInvoiceReturnUrl),
+      paymentNavigationStarted: false
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
     intervals.set(opId, INITIAL_INTERVAL_MS)
+    persistPendingOperation(operation)
 
     if (type !== 'cancel') {
       const messageKey =
@@ -92,10 +112,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       useToastStore().add(toastMessage)
     }
 
-    const terminal = new Promise<BillingOperation>((resolve) => {
-      terminalResolvers.set(opId, resolve)
-    })
-    terminalPromises.set(opId, terminal)
+    const terminal = createTerminalPromise(opId)
 
     void poll(opId)
 
@@ -104,15 +121,24 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   async function poll(opId: string) {
     const operation = operations.value.get(opId)
-    if (!operation || operation.status !== 'pending') return
+    if (
+      !operation ||
+      operation.status !== 'pending' ||
+      pollsInFlight.has(opId)
+    ) {
+      return
+    }
 
     if (Date.now() - operation.startedAt > TIMEOUT_MS) {
       handleTimeout(opId)
       return
     }
 
+    pollsInFlight.add(opId)
     try {
       const response = await workspaceApi.getBillingOpStatus(opId)
+      const currentOperation = operations.value.get(opId)
+      if (!currentOperation || currentOperation.status !== 'pending') return
 
       if (response.status === 'succeeded') {
         await handleSuccess(opId)
@@ -124,13 +150,26 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         return
       }
 
+      if (
+        response.customer_action?.type === 'pay_hosted_invoice' &&
+        !currentOperation.paymentNavigationStarted &&
+        currentOperation.returnUrl
+      ) {
+        beginPaymentNavigation(opId, response.customer_action.url)
+        return
+      }
+
       scheduleNextPoll(opId)
     } catch {
-      if (Date.now() - operation.startedAt > TIMEOUT_MS) {
+      const currentOperation = operations.value.get(opId)
+      if (!currentOperation || currentOperation.status !== 'pending') return
+      if (Date.now() - currentOperation.startedAt > TIMEOUT_MS) {
         handleTimeout(opId)
         return
       }
       scheduleNextPoll(opId)
+    } finally {
+      pollsInFlight.delete(opId)
     }
   }
 
@@ -142,7 +181,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     )
     intervals.set(opId, nextInterval)
 
-    const timeoutId = setTimeout(() => void poll(opId), nextInterval)
+    const timeoutId = setTimeout(() => {
+      if (timeouts.get(opId) === timeoutId) timeouts.delete(opId)
+      void poll(opId)
+    }, nextInterval)
     timeouts.set(opId, timeoutId)
   }
 
@@ -152,6 +194,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'succeeded', null)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     if (operation.type === 'subscription') {
       useTelemetry()?.trackMonthlySubscriptionSucceeded()
@@ -203,6 +246,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'failed', errorMessage ?? defaultMessage)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     if (operation.type !== 'cancel') {
       useToastStore().add({
@@ -223,6 +267,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'timeout', message)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     if (operation.type !== 'cancel') {
       useToastStore().add({
@@ -257,6 +302,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     terminalPromises.delete(opId)
   }
 
+  function createTerminalPromise(opId: string) {
+    const terminal = new Promise<BillingOperation>((resolve) => {
+      terminalResolvers.set(opId, resolve)
+    })
+    terminalPromises.set(opId, terminal)
+    return terminal
+  }
+
   function updateOperationStatus(
     opId: string,
     status: OperationStatus,
@@ -269,6 +322,121 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     operations.value = new Map(operations.value).set(opId, updated)
   }
 
+  function beginPaymentNavigation(opId: string, paymentUrl: string) {
+    const operation = operations.value.get(opId)
+    if (!operation?.returnUrl) return
+
+    const updated = { ...operation, paymentNavigationStarted: true }
+    if (!persistPendingOperation(updated)) {
+      handleFailure(opId, null)
+      return
+    }
+    operations.value = new Map(operations.value).set(opId, updated)
+    globalThis.location.assign(paymentUrl)
+  }
+
+  function persistPendingOperation(operation: BillingOperation): boolean {
+    if (operation.type !== 'subscription' || !operation.returnUrl) return false
+
+    const pendingOperation: PendingBillingOperation = {
+      opId: operation.opId,
+      type: operation.type,
+      startedAt: operation.startedAt,
+      returnUrl: operation.returnUrl,
+      paymentNavigationStarted: operation.paymentNavigationStarted
+    }
+
+    try {
+      localStorage.setItem(
+        PENDING_OPERATION_STORAGE_KEY,
+        JSON.stringify(pendingOperation)
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  function getSameOriginUrl(value: string | undefined): string | null {
+    if (!value) return null
+
+    try {
+      const url = new URL(value)
+      return url.origin === globalThis.location.origin ? url.href : null
+    } catch {
+      return null
+    }
+  }
+
+  function clearPendingOperation(opId: string) {
+    try {
+      const pendingOperation = readPendingOperation()
+      if (pendingOperation?.opId === opId) {
+        localStorage.removeItem(PENDING_OPERATION_STORAGE_KEY)
+      }
+    } catch {
+      return
+    }
+  }
+
+  function readPendingOperation(): PendingBillingOperation | null {
+    let value: string | null
+    try {
+      value = localStorage.getItem(PENDING_OPERATION_STORAGE_KEY)
+    } catch {
+      return null
+    }
+    if (!value) return null
+
+    try {
+      const candidate: unknown = JSON.parse(value)
+      if (!candidate || typeof candidate !== 'object') return null
+      if (
+        !('opId' in candidate) ||
+        typeof candidate.opId !== 'string' ||
+        !('type' in candidate) ||
+        candidate.type !== 'subscription' ||
+        !('startedAt' in candidate) ||
+        typeof candidate.startedAt !== 'number' ||
+        !('returnUrl' in candidate) ||
+        typeof candidate.returnUrl !== 'string' ||
+        !('paymentNavigationStarted' in candidate) ||
+        typeof candidate.paymentNavigationStarted !== 'boolean'
+      ) {
+        return null
+      }
+
+      const returnUrl = new URL(candidate.returnUrl)
+      if (returnUrl.origin !== globalThis.location.origin) return null
+
+      return {
+        opId: candidate.opId,
+        type: candidate.type,
+        startedAt: candidate.startedAt,
+        returnUrl: returnUrl.href,
+        paymentNavigationStarted: candidate.paymentNavigationStarted
+      }
+    } catch {
+      return null
+    }
+  }
+
+  function recoverPendingOperation() {
+    const pendingOperation = readPendingOperation()
+    if (!pendingOperation || operations.value.has(pendingOperation.opId)) return
+
+    const operation: BillingOperation = {
+      ...pendingOperation,
+      status: 'pending',
+      errorMessage: null,
+      startedAt: Date.now()
+    }
+    operations.value = new Map(operations.value).set(operation.opId, operation)
+    intervals.set(operation.opId, INITIAL_INTERVAL_MS)
+    void createTerminalPromise(operation.opId)
+    void poll(operation.opId)
+  }
+
   function cleanup(opId: string) {
     const timeoutId = timeouts.get(opId)
     if (timeoutId) {
@@ -276,6 +444,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       timeouts.delete(opId)
     }
     intervals.delete(opId)
+    pollsInFlight.delete(opId)
 
     // Remove the "received" toast
     const receivedToast = receivedToasts.get(opId)
@@ -287,11 +456,34 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   function clearOperation(opId: string) {
     cleanup(opId)
+    clearPendingOperation(opId)
     const newMap = new Map(operations.value)
     newMap.delete(opId)
     operations.value = newMap
     terminalResolvers.delete(opId)
     terminalPromises.delete(opId)
+  }
+
+  recoverPendingOperation()
+
+  function resumePendingOperations() {
+    for (const operation of operations.value.values()) {
+      if (
+        operation.status === 'pending' &&
+        operation.paymentNavigationStarted &&
+        !timeouts.has(operation.opId)
+      ) {
+        updateOperationStatus(operation.opId, 'pending', null)
+        const resumed = operations.value.get(operation.opId)
+        if (resumed) {
+          operations.value = new Map(operations.value).set(operation.opId, {
+            ...resumed,
+            startedAt: Date.now()
+          })
+        }
+        void poll(operation.opId)
+      }
+    }
   }
 
   return {
@@ -301,6 +493,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     isAddingCredits,
     getOperation,
     startOperation,
+    recoverPendingOperation,
+    resumePendingOperations,
     clearOperation
   }
 })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -28,6 +28,7 @@ interface BillingOperation {
   startedAt: number
   returnUrl: string | null
   paymentNavigationStarted: boolean
+  hostedInvoiceUrl: string | null
 }
 
 interface PendingBillingOperation {
@@ -69,6 +70,16 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     )
   )
 
+  const hostedInvoiceUrl = computed(
+    () =>
+      [...operations.value.values()].find(
+        (op) =>
+          op.status === 'pending' &&
+          op.type === 'subscription' &&
+          op.hostedInvoiceUrl
+      )?.hostedInvoiceUrl ?? null
+  )
+
   function getOperation(opId: string) {
     return operations.value.get(opId)
   }
@@ -90,27 +101,15 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       errorMessage: null,
       startedAt: Date.now(),
       returnUrl: getSameOriginUrl(options.hostedInvoiceReturnUrl),
-      paymentNavigationStarted: false
+      paymentNavigationStarted: false,
+      hostedInvoiceUrl: null
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
     intervals.set(opId, INITIAL_INTERVAL_MS)
     persistPendingOperation(operation)
 
-    if (type !== 'cancel') {
-      const messageKey =
-        type === 'subscription'
-          ? 'billingOperation.subscriptionProcessing'
-          : 'billingOperation.topupProcessing'
-
-      const toastMessage: ToastMessageOptions = {
-        severity: 'info',
-        summary: t(messageKey),
-        group: 'billing-operation'
-      }
-      receivedToasts.set(opId, toastMessage)
-      useToastStore().add(toastMessage)
-    }
+    showProcessingToast(operation)
 
     const terminal = createTerminalPromise(opId)
 
@@ -152,10 +151,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
       if (
         response.customer_action?.type === 'pay_hosted_invoice' &&
-        !currentOperation.paymentNavigationStarted &&
+        !currentOperation.hostedInvoiceUrl &&
         currentOperation.returnUrl
       ) {
-        beginPaymentNavigation(opId, response.customer_action.url)
+        exposeHostedInvoice(opId, response.customer_action.url)
         return
       }
 
@@ -318,21 +317,46 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const operation = operations.value.get(opId)
     if (!operation) return
 
-    const updated = { ...operation, status, errorMessage }
+    const updated = {
+      ...operation,
+      status,
+      errorMessage,
+      hostedInvoiceUrl: status === 'pending' ? operation.hostedInvoiceUrl : null
+    }
     operations.value = new Map(operations.value).set(opId, updated)
   }
 
-  function beginPaymentNavigation(opId: string, paymentUrl: string) {
+  function exposeHostedInvoice(opId: string, paymentUrl: string) {
     const operation = operations.value.get(opId)
     if (!operation?.returnUrl) return
 
-    const updated = { ...operation, paymentNavigationStarted: true }
+    const updated = {
+      ...operation,
+      paymentNavigationStarted: true,
+      hostedInvoiceUrl: paymentUrl
+    }
     if (!persistPendingOperation(updated)) {
       handleFailure(opId, null)
       return
     }
     operations.value = new Map(operations.value).set(opId, updated)
-    globalThis.location.assign(paymentUrl)
+    scheduleNextPoll(opId)
+  }
+
+  function showProcessingToast(operation: BillingOperation) {
+    if (operation.type === 'cancel') return
+
+    const messageKey =
+      operation.type === 'subscription'
+        ? 'billingOperation.subscriptionProcessing'
+        : 'billingOperation.topupProcessing'
+    const toastMessage: ToastMessageOptions = {
+      severity: 'info',
+      summary: t(messageKey),
+      group: 'billing-operation'
+    }
+    receivedToasts.set(operation.opId, toastMessage)
+    useToastStore().add(toastMessage)
   }
 
   function persistPendingOperation(operation: BillingOperation): boolean {
@@ -429,11 +453,13 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       ...pendingOperation,
       status: 'pending',
       errorMessage: null,
-      startedAt: Date.now()
+      startedAt: Date.now(),
+      hostedInvoiceUrl: null
     }
     operations.value = new Map(operations.value).set(operation.opId, operation)
     intervals.set(operation.opId, INITIAL_INTERVAL_MS)
     void createTerminalPromise(operation.opId)
+    showProcessingToast(operation)
     void poll(operation.opId)
   }
 
@@ -491,6 +517,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     hasPendingOperations,
     isSettingUp,
     isAddingCredits,
+    hostedInvoiceUrl,
     getOperation,
     startOperation,
     recoverPendingOperation,


### PR DESCRIPTION
## Summary

Support pending hosted-invoice customer actions for personal subscription checkout with durable same-tab payment recovery.

## Changes

- **What**: Extend the BillingOp polling contract with pending-only `customer_action: { type: 'pay_hosted_invoice', url }`; persist operation and same-origin return context before navigation; resume safely after reload/browser-back; preserve immediate subscribed, Team checkout, and top-up behavior.

## Review Focus

Review the polling single-flight/resume lifecycle and the bearer-URL boundary: the action URL is used only for `location.assign` and is never stored or logged.

Validation: 92 focused Vitest tests, `pnpm typecheck`, touched-file ESLint/Oxlint/oxfmt, and pre-push `pnpm knip`.