### PR TITLE
fix: 7/x keep partner node bulk actions available in restricted mode

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -333,6 +333,10 @@ describe('PartnerNodeAccessPanel', () => {
         .getByRole('switch', { name: 'Set access for OpenAI (inc. Sora)' })
         .getAttribute('aria-checked')
     ).toBe('false')
+    expect(
+      screen.queryByRole('button', { name: 'Enable all' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Disable all' })).toBeDisabled()
   })
 
   it('disables provider controls while access is unrestricted', () => {
@@ -348,12 +352,28 @@ describe('PartnerNodeAccessPanel', () => {
 
   it('saves enable-all changes immediately', async () => {
     const user = userEvent.setup()
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    }
     mockIsProviderEnabled.mockReturnValue(false)
     renderComponent()
 
+    expect(screen.getByRole('button', { name: 'Disable all' })).toBeEnabled()
     await user.click(screen.getByRole('button', { name: 'Enable all' }))
 
     expect(mockSetAllProvidersEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('keeps both bulk actions visible while access is restricted', () => {
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    renderComponent()
+
+    expect(screen.getByRole('button', { name: 'Enable all' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Disable all' })).toBeEnabled()
   })
 
   it('surfaces save failures', async () => {

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
@@ -106,7 +106,7 @@
         </label>
         <div class="flex items-center gap-2">
           <Button
-            v-if="!allProvidersEnabled"
+            v-if="isRestricted"
             variant="textonly"
             size="lg"
             :loading="pendingBulkAction === 'enable'"
@@ -116,7 +116,6 @@
             {{ $t('workspacePanel.partnerNodes.enableAll') }}
           </Button>
           <Button
-            v-else
             variant="textonly"
             size="lg"
             :disabled="!isRestricted || isSaving || !canEditPolicy"
@@ -378,9 +377,6 @@ const isPolicyLoaded = computed(
 )
 const isReadOnly = computed(() => workspaceRole.value !== 'owner')
 const canEditPolicy = computed(() => !isReadOnly.value && isPolicyLoaded.value)
-const allProvidersEnabled = computed(() =>
-  providers.value.every(({ id }) => isProviderEnabled(id))
-)
 
 const providerRows = computed(() =>
   providers.value


### PR DESCRIPTION
## Summary

Keeps Enable all and Disable all simultaneously available while partner node access is Restricted.

## Changes

- **What**: Shows Enable all for every Restricted policy state, keeps Disable all visible, and hides Enable all while Unrestricted.
- **Dependencies**: Stacked on #13951.

## Review Focus

- Restricted mode exposes both bulk actions even when every provider is already enabled.
- Unrestricted mode hides Enable all and leaves Disable all visible but disabled.
- Enable all saves immediately; Disable all retains its confirmation dialog.

## Screenshots (if applicable)

| Restricted (both bulk actions) | Unrestricted (Enable all hidden) |
|---|---|
| <img width="900" alt="Restricted mode shows Enable all and Disable all" src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/evidence/pr-13953-bulk-actions-assets/restricted-both-bulk-actions.png" /> | <img width="900" alt="Unrestricted mode hides Enable all and disables Disable all" src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/evidence/pr-13953-bulk-actions-assets/unrestricted-disable-all-disabled.png" /> |

https://github.com/Comfy-Org/ComfyUI_frontend/releases/download/evidence/pr-13953-bulk-actions/enable-disable-all.mp4

Captured from the identical two-file patch on integration head `77a89d72b9` with a route-mocked Team workspace policy fixture. Cloud workspace state was not mutated.

Created by Codex