### PR TITLE
fix(ui): keep the overflow tooltip above stacked dialogs

### DIFF
--- a/src/components/ui/tooltip/AccessibleTooltip.test.ts
+++ b/src/components/ui/tooltip/AccessibleTooltip.test.ts
@@ -1,24 +1,24 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import AccessibleTooltip from './AccessibleTooltip.vue'
 
-function openDialogAbove(baseZIndex: number): {
-  zIndex: number
-  close: () => void
-} {
+const openDialogs: HTMLElement[] = []
+afterEach(() => {
+  for (const dialog of openDialogs.splice(0)) {
+    ZIndex.clear(dialog)
+    dialog.remove()
+  }
+})
+
+function openDialogAbove(baseZIndex: number): number {
   const dialog = document.body.appendChild(document.createElement('div'))
   ZIndex.set('modal', dialog, baseZIndex)
-  return {
-    zIndex: Number(dialog.style.zIndex),
-    close: () => {
-      ZIndex.clear(dialog)
-      dialog.remove()
-    }
-  }
+  openDialogs.push(dialog)
+  return Number(dialog.style.zIndex)
 }
 
 function renderInCard(
@@ -84,7 +84,7 @@ describe('AccessibleTooltip', () => {
   })
 
   it('lifts above a dialog that raised the shared modal z-index', async () => {
-    const dialog = openDialogAbove(2400)
+    const dialogZIndex = openDialogAbove(2400)
     const { user, unmount } = renderInCard()
 
     await user.hover(screen.getByRole('button'))
@@ -93,9 +93,8 @@ describe('AccessibleTooltip', () => {
     expect(
       Number(tooltip.style.zIndex),
       'disclosure must out-stack the open dialog, or it renders invisibly behind the modal'
-    ).toBeGreaterThan(dialog.zIndex)
+    ).toBeGreaterThan(dialogZIndex)
 
-    dialog.close()
     unmount()
   })
 

--- a/src/components/ui/tooltip/AccessibleTooltip.test.ts
+++ b/src/components/ui/tooltip/AccessibleTooltip.test.ts
@@ -1,9 +1,25 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import AccessibleTooltip from './AccessibleTooltip.vue'
+
+function openDialogAbove(baseZIndex: number): {
+  zIndex: number
+  close: () => void
+} {
+  const dialog = document.body.appendChild(document.createElement('div'))
+  ZIndex.set('modal', dialog, baseZIndex)
+  return {
+    zIndex: Number(dialog.style.zIndex),
+    close: () => {
+      ZIndex.clear(dialog)
+      dialog.remove()
+    }
+  }
+}
 
 function renderInCard(
   label: string | string[] = ['Kling', 'Luma'],
@@ -64,6 +80,22 @@ describe('AccessibleTooltip', () => {
     const tooltip = await screen.findByTestId('disclosure-tooltip')
     expect(tooltip).toHaveTextContent('Kling, Luma')
 
+    unmount()
+  })
+
+  it('lifts above a dialog that raised the shared modal z-index', async () => {
+    const dialog = openDialogAbove(2400)
+    const { user, unmount } = renderInCard()
+
+    await user.hover(screen.getByRole('button'))
+    const tooltip = await screen.findByTestId('disclosure-tooltip')
+
+    expect(
+      Number(tooltip.style.zIndex),
+      'disclosure must out-stack the open dialog, or it renders invisibly behind the modal'
+    ).toBeGreaterThan(dialog.zIndex)
+
+    dialog.close()
     unmount()
   })
 

--- a/src/components/ui/tooltip/AccessibleTooltip.test.ts
+++ b/src/components/ui/tooltip/AccessibleTooltip.test.ts
@@ -8,14 +8,11 @@ import AccessibleTooltip from './AccessibleTooltip.vue'
 
 const openDialogs: HTMLElement[] = []
 afterEach(() => {
-  for (const dialog of openDialogs.splice(0)) {
-    ZIndex.clear(dialog)
-    dialog.remove()
-  }
+  for (const dialog of openDialogs.splice(0)) ZIndex.clear(dialog)
 })
 
 function openDialogAbove(baseZIndex: number): number {
-  const dialog = document.body.appendChild(document.createElement('div'))
+  const dialog = document.createElement('div')
   ZIndex.set('modal', dialog, baseZIndex)
   openDialogs.push(dialog)
   return Number(dialog.style.zIndex)

--- a/src/components/ui/tooltip/AccessibleTooltip.vue
+++ b/src/components/ui/tooltip/AccessibleTooltip.vue
@@ -9,6 +9,7 @@ import {
 } from 'reka-ui'
 import { computed, ref } from 'vue'
 
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {
@@ -28,13 +29,14 @@ const {
 }>()
 
 const open = ref(false)
+const contentStyle = useModalLiftedZIndex(open)
 
 const labelText = computed(() =>
   Array.isArray(label) ? label.join(', ') : label
 )
 
 const contentClass = cn(
-  'z-2000 max-w-48 rounded-md bg-charcoal-300 px-3 py-2',
+  'z-1700 max-w-48 rounded-md bg-charcoal-300 px-3 py-2',
   'text-xs text-white shadow-interface will-change-[transform,opacity]',
   'data-[state=closed]:animate-out data-[state=open]:animate-in',
   'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
@@ -70,6 +72,7 @@ const contentClass = cn(
           aria-hidden
           aria-label=" "
           data-testid="disclosure-tooltip"
+          :style="contentStyle"
           :class="contentClass"
         >
           {{ labelText }}


### PR DESCRIPTION
## Summary

The tooltip on the `+N` tag chips and provider badges in the templates modal wasn't showing up. Hovering or tabbing to one did nothing visible.

## Changes

- **What**: Replaced the fixed z-index with `useModalLiftedZIndex`, which reads the current counter and puts the tooltip one above whichever dialog is on top. Same approach `Popover.vue`, `DropdownMenu.vue`, and `ColorPicker.vue` already use for content portaled to the body, so the tooltip stops being the odd one out.

- Added a test that opens a dialog on the real counter and checks the tooltip still lands above it.

## Review Focus

The base class went from `z-2000` down to `z-1700` — that's deliberate. `1700` is the shared starting point everything else uses, and the actual lift now happens inline through `:style`.

The test asserts the tooltip is above the dialog rather than equal to a specific number, so it won't break if the base ever moves.

Worth knowing: the existing e2e occlusion check didn't catch this, because it only opens the templates dialog on its own and the counter never climbs. The new unit test is what covers that case.