### PR TITLE
feat: add Alipay subscription checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@primevue/themes": "catalog:",
     "@sentry/vue": "catalog:",
     "@sparkjsdev/spark": "catalog:",
+    "@stripe/stripe-js": "catalog:",
     "@tanstack/vue-virtual": "catalog:",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-link": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     '@storybook/vue3-vite':
       specifier: ^10.5.0
       version: 10.5.0
+    '@stripe/stripe-js':
+      specifier: ^9.12.0
+      version: 9.12.0
     '@tailwindcss/vite':
       specifier: ^4.3.2
       version: 4.3.2
@@ -510,6 +513,9 @@ importers:
       '@sparkjsdev/spark':
         specifier: 'catalog:'
         version: 2.1.0(three@0.184.0)
+      '@stripe/stripe-js':
+        specifier: 'catalog:'
+        version: 9.12.0
       '@tanstack/vue-virtual':
         specifier: 'catalog:'
         version: 3.13.32(vue@3.5.39(typescript@6.0.3))
@@ -3877,6 +3883,10 @@ packages:
     peerDependencies:
       storybook: ^10.5.0
       vue: ^3.0.0
+
+  '@stripe/stripe-js@9.12.0':
+    resolution: {integrity: sha512-wCUYZNYo7E/6B3Rv2i/g/Rmj2mTiOX6HEwWYUWUuNUKwEhzTo/SXuQ1IoNo3mknWIHUQyqdakv1Nl2SiYPrCrw==}
+    engines: {node: '>=12.16'}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -12253,6 +12263,8 @@ snapshots:
       type-fest: 5.8.0
       vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.3.7
+
+  '@stripe/stripe-js@9.12.0': {}
 
   '@swc/helpers@0.5.23':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalog:
   '@storybook/addon-mcp': 0.1.6
   '@storybook/vue3': ^10.5.0
   '@storybook/vue3-vite': ^10.5.0
+  '@stripe/stripe-js': ^9.12.0
   '@tailwindcss/vite': ^4.3.2
   '@tanstack/vue-virtual': ^3.13.12
   '@testing-library/jest-dom': ^6.9.1

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2830,6 +2830,11 @@
       "message": "Team billing is coming soon. You'll be able to subscribe to a plan for your workspace with per-seat pricing. Stay tuned for updates."
     },
     "preview": {
+      "paymentMethod": "Payment method",
+      "stripeMethodChoice": "Choose Card or Alipay securely with Stripe.",
+      "alipayRenewalNote": "Card can be saved for top-ups and auto top-ups. Approved Alipay can be used for subscription renewals; auto top-ups require a card.",
+      "payAndSubscribe": "Pay and subscribe",
+      "stripeUnavailable": "Stripe payment methods are unavailable right now. Please try again later.",
       "confirmPayment": "Confirm your payment",
       "confirmPlanChange": "Confirm your plan change",
       "startingToday": "Starts today",

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
 import { isDesktop, isNightly } from '@/platform/distribution/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useBootstrapStore } from '@/stores/bootstrapStore'
 
 import App from './App.vue'
@@ -157,5 +158,6 @@ LGraph.autoExposePreviewNodes = (hostNode) =>
 
 const bootstrapStore = useBootstrapStore(pinia)
 void bootstrapStore.startStoreBootstrap()
+if (isCloud) useBillingOperationStore(pinia).restoreRedirectOperation()
 
 app.mount('#vue-app')

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -384,6 +384,7 @@ describe('workspaceApi', () => {
         '/api/billing/subscribe',
         {
           plan_slug: 'pro-monthly',
+          confirmation_token: undefined,
           return_url: 'https://return.url',
           cancel_url: 'https://cancel.url',
           team_credit_stop_id: undefined,
@@ -407,6 +408,7 @@ describe('workspaceApi', () => {
         '/api/billing/subscribe',
         {
           plan_slug: 'team_per_credit_annual',
+          confirmation_token: undefined,
           return_url: undefined,
           cancel_url: undefined,
           team_credit_stop_id: 'team_700',

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -159,6 +159,7 @@ type SubscribeBillingCycle = 'monthly' | 'yearly'
 interface SubscribeRequest {
   plan_slug: string
   idempotency_key?: string
+  confirmation_token?: string
   return_url?: string
   cancel_url?: string
   /** Required for the per-credit Team plan; selects the slider stop. */
@@ -167,6 +168,7 @@ interface SubscribeRequest {
 }
 
 export interface SubscribeOptions {
+  confirmationToken?: string
   returnUrl?: string
   cancelUrl?: string
   teamCreditStopId?: string
@@ -185,6 +187,7 @@ export interface SubscribeResponse {
   status: SubscribeStatus
   effective_at?: string
   payment_method_url?: string
+  next_action_redirect_url?: string
 }
 
 interface CancelSubscriptionRequest {
@@ -676,6 +679,7 @@ export const workspaceApi = {
         api.apiURL('/billing/subscribe'),
         {
           plan_slug: planSlug,
+          confirmation_token: options.confirmationToken,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -307,6 +307,7 @@ export interface BillingOpStatusResponse {
   id: string
   status: BillingOpStatus
   error_message?: string
+  next_action_redirect_url?: string
   started_at: string
   completed_at?: string
 }

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -138,6 +138,7 @@
 
       <!-- Add Credit Card Button -->
       <Button
+        v-if="showSubmit"
         variant="tertiary"
         size="lg"
         class="w-full rounded-lg"
@@ -186,6 +187,7 @@ interface Props {
   previewData?: PreviewSubscribeResponse | null
   /** Team-plan checkout (selected slider stop); overrides tier-derived display. */
   teamPlan?: TeamPlanSelection | null
+  showSubmit?: boolean
 }
 
 const {
@@ -193,7 +195,8 @@ const {
   billingCycle = 'monthly',
   isLoading = false,
   previewData = null,
-  teamPlan = null
+  teamPlan = null,
+  showSubmit = true
 } = defineProps<Props>()
 
 defineEmits<{

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -73,8 +73,16 @@
         :team-plan="selectedTeamStop!"
         :billing-cycle="selectedBillingCycle"
         :is-loading="isSubscribing || isPolling"
+        :show-submit="false"
         @add-credit-card="handleTeamSubscribe"
         @back="handleBackToPricing"
+      />
+
+      <UnifiedStripePaymentSelector
+        v-if="previewVariant === 'team-new'"
+        :amount-cents="selectedTeamStop!.discountedUsd * 100"
+        :is-loading="isSubscribing || isPolling"
+        @confirm="handleTeamSubscribe"
       />
 
       <SubscriptionAddPaymentPreviewWorkspace
@@ -83,16 +91,40 @@
         :tier-key="selectedTierKey!"
         :billing-cycle="selectedBillingCycle"
         :is-loading="isSubscribing || isPolling"
+        :show-submit="previewData!.cost_today_cents === 0"
         @add-credit-card="handleAddCreditCard"
         @back="handleBackToPricing"
+      />
+
+      <UnifiedStripePaymentSelector
+        v-if="
+          previewVariant === 'personal-new' && previewData!.cost_today_cents > 0
+        "
+        :amount-cents="previewData!.cost_today_cents"
+        :is-loading="isSubscribing || isPolling"
+        @confirm="handleAddCreditCard"
       />
 
       <SubscriptionTransitionPreviewWorkspace
         v-else-if="previewVariant === 'personal-change'"
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
+        :show-submit="
+          !previewData!.is_immediate || previewData!.cost_today_cents === 0
+        "
         @confirm="handleConfirmTransition"
         @back="handleBackToPricing"
+      />
+
+      <UnifiedStripePaymentSelector
+        v-if="
+          previewVariant === 'personal-change' &&
+          previewData!.is_immediate &&
+          previewData!.cost_today_cents > 0
+        "
+        :amount-cents="previewData!.cost_today_cents"
+        :is-loading="isSubscribing || isPolling"
+        @confirm="handleConfirmTransition"
       />
     </template>
 
@@ -122,6 +154,7 @@ import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPrev
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
+import UnifiedStripePaymentSelector from './UnifiedStripePaymentSelector.vue'
 
 const { onClose, reason, initialPlanMode, initialCheckout } = defineProps<{
   onClose: () => void

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -123,6 +123,7 @@
       <SubscriptionTermsNote />
 
       <Button
+        v-if="showSubmit"
         variant="tertiary"
         size="lg"
         class="w-full rounded-lg"
@@ -160,13 +161,15 @@ type PersonalTierKey = 'standard' | 'creator' | 'pro'
 const {
   previewData,
   isLoading = false,
-  teamPlan = null
+  teamPlan = null,
+  showSubmit = true
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
   /** Set for a team credit-commit change: plan name + refill credits come from
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
+  showSubmit?: boolean
 }>()
 
 defineEmits<{

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="flex flex-col gap-4 rounded-lg border border-border-subtle p-4">
+    <div>
+      <h3 class="m-0 text-base font-semibold text-base-foreground">
+        {{ $t('subscription.preview.paymentMethod') }}
+      </h3>
+      <p class="m-0 mt-1 text-sm text-muted-foreground">
+        {{ $t('subscription.preview.stripeMethodChoice') }}
+      </p>
+    </div>
+    <div v-if="configurationError" class="text-sm text-error">
+      {{ configurationError }}
+    </div>
+    <div ref="paymentElementTarget" />
+    <p class="m-0 text-xs text-muted-foreground">
+      {{ $t('subscription.preview.alipayRenewalNote') }}
+    </p>
+    <Button
+      size="lg"
+      class="w-full rounded-lg"
+      :disabled="!stripeElements"
+      :loading="isLoading || isSubmitting"
+      @click="submit"
+    >
+      {{ $t('subscription.preview.payAndSubscribe') }}
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { loadStripe } from '@stripe/stripe-js'
+import type {
+  Stripe,
+  StripeElements,
+  StripePaymentElement
+} from '@stripe/stripe-js'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+
+const { amountCents, isLoading = false } = defineProps<{
+  amountCents: number
+  isLoading?: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: [confirmationToken: string]
+}>()
+
+const { t } = useI18n()
+const paymentElementTarget = ref<HTMLDivElement>()
+const stripeElements = ref<StripeElements>()
+const configurationError = ref('')
+const isSubmitting = ref(false)
+let stripe: Stripe | null = null
+let paymentElement: StripePaymentElement | undefined
+
+onMounted(async () => {
+  const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+  if (!publishableKey) {
+    configurationError.value = t('subscription.preview.stripeUnavailable')
+    return
+  }
+
+  stripe = await loadStripe(publishableKey)
+  if (!stripe || !paymentElementTarget.value) {
+    configurationError.value = t('subscription.preview.stripeUnavailable')
+    return
+  }
+
+  stripeElements.value = stripe.elements({
+    mode: 'subscription',
+    amount: amountCents,
+    currency: 'usd',
+    setupFutureUsage: 'off_session'
+  })
+  paymentElement = stripeElements.value.create('payment', {
+    layout: 'accordion'
+  })
+  paymentElement.mount(paymentElementTarget.value)
+})
+
+onBeforeUnmount(() => paymentElement?.destroy())
+
+async function submit() {
+  if (!stripeElements.value || !stripe) return
+  isSubmitting.value = true
+  configurationError.value = ''
+  try {
+    const submitResult = await stripeElements.value.submit()
+    if (submitResult.error) {
+      configurationError.value = submitResult.error.message ?? t('g.error')
+      return
+    }
+    const result = await stripe.createConfirmationToken({
+      elements: stripeElements.value
+    })
+    if (result.error) {
+      configurationError.value = result.error.message ?? t('g.error')
+      return
+    }
+    emit('confirm', result.confirmationToken.id)
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -78,6 +78,7 @@ const {
   mockResubscribe,
   mockToastAdd,
   mockStartOperation,
+  mockBeginRedirectOperation,
   mockTrackBeginCheckout,
   mockTrackMonthlySubscriptionSucceeded,
   mockShowDowngradeToPersonalDialog,
@@ -94,6 +95,7 @@ const {
   mockResubscribe: vi.fn(),
   mockToastAdd: vi.fn(),
   mockStartOperation: vi.fn(),
+  mockBeginRedirectOperation: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
   mockTrackMonthlySubscriptionSucceeded: vi.fn(),
   mockShowDowngradeToPersonalDialog: vi.fn(),
@@ -145,6 +147,7 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
     startOperation: mockStartOperation,
+    beginRedirectOperation: mockBeginRedirectOperation,
     hasPendingOperations: false
   })
 }))
@@ -759,7 +762,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    it('opens the payment URL when the team subscribe needs a payment method', async () => {
+    it('persists the team operation before redirecting for a payment method', async () => {
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -776,14 +779,13 @@ describe('useSubscriptionCheckout', () => {
         payment_method_url: 'https://stripe.com/team-pay'
       })
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleTeamSubscribe()
 
-      expect(openSpy).toHaveBeenCalledWith(
-        'https://stripe.com/team-pay',
-        '_blank'
+      expect(mockBeginRedirectOperation).toHaveBeenCalledWith(
+        'op-team-3',
+        'subscription'
       )
-      openSpy.mockRestore()
+      expect(mockStartOperation).not.toHaveBeenCalled()
     })
 
     it('does not subscribe and shows an error when the stop has no id', async () => {
@@ -949,7 +951,26 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
-    it('opens payment URL when needs_payment_method', async () => {
+    it('submits the Stripe confirmation token for an immediate plan change', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-upgrade'
+      })
+      mockStartOperation.mockResolvedValueOnce({ status: 'failed' })
+
+      await checkout.handleConfirmTransition('ctoken_upgrade')
+
+      expect(mockSubscribe).toHaveBeenCalledWith('standard-yearly', {
+        confirmationToken: 'ctoken_upgrade',
+        returnUrl: 'https://platform.comfy.org/payment/success',
+        cancelUrl: 'https://platform.comfy.org/payment/failed'
+      })
+    })
+
+    it('persists the operation before redirecting for a payment method', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -959,33 +980,32 @@ describe('useSubscriptionCheckout', () => {
         payment_method_url: 'https://stripe.com/pay'
       })
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleAddCreditCard()
 
-      expect(openSpy).toHaveBeenCalledWith('https://stripe.com/pay', '_blank')
-      openSpy.mockRestore()
+      expect(mockBeginRedirectOperation).toHaveBeenCalledWith(
+        'op-2',
+        'subscription'
+      )
+      expect(mockStartOperation).not.toHaveBeenCalled()
     })
 
-    it('warns when the payment popup is blocked', async () => {
+    it('persists the operation before redirecting for payment authorization', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
       mockSubscribe.mockResolvedValueOnce({
-        status: 'needs_payment_method',
-        billing_op_id: 'op-blocked',
-        payment_method_url: 'https://stripe.com/pay'
+        status: 'pending_payment',
+        billing_op_id: 'op-action',
+        next_action_redirect_url: 'https://stripe.com/alipay'
       })
-      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
 
       await checkout.handleAddCreditCard()
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({
-          severity: 'warn',
-          detail: 'subscription.preview.paymentPopupBlocked'
-        })
+      expect(mockBeginRedirectOperation).toHaveBeenCalledWith(
+        'op-action',
+        'subscription'
       )
-      openSpy.mockRestore()
+      expect(mockStartOperation).not.toHaveBeenCalled()
     })
 
     it('polls the operation without opening a window when needs_payment_method has no URL', async () => {
@@ -1016,11 +1036,9 @@ describe('useSubscriptionCheckout', () => {
       checkout.selectedBillingCycle.value = 'yearly'
       mockSubscribe.mockResolvedValueOnce({
         status: 'needs_payment_method',
-        billing_op_id: 'op-async-1',
-        payment_method_url: 'https://stripe.com/pay'
+        billing_op_id: 'op-async-1'
       })
       mockStartOperation.mockResolvedValueOnce({ status: 'succeeded' })
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
       await checkout.handleAddCreditCard()
 
@@ -1029,7 +1047,6 @@ describe('useSubscriptionCheckout', () => {
         'subscription'
       )
       expect(checkout.checkoutStep.value).toBe('success')
-      openSpy.mockRestore()
     })
 
     it('stays on the confirm step when the async operation does not succeed', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -269,7 +269,7 @@ export function useSubscriptionCheckout(
     emit('close', true)
   }
 
-  async function handleSubscription() {
+  async function handleSubscription(confirmationToken?: string) {
     if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
 
     const tierKey = selectedTierKey.value
@@ -288,6 +288,7 @@ export function useSubscriptionCheckout(
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       const response = await subscribe(planSlug, {
+        confirmationToken,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
       })
@@ -334,24 +335,25 @@ export function useSubscriptionCheckout(
       return
     }
 
-    // needs_payment_method / pending_payment both finish asynchronously, so poll
-    // the billing op either way. needs_payment_method additionally points at a
-    // Stripe page to collect a card when the backend supplies the URL; without
-    // it we still poll rather than silently stranding the user on confirm.
+    if (response.next_action_redirect_url) {
+      billingOperationStore.beginRedirectOperation(
+        response.billing_op_id,
+        'subscription'
+      )
+      globalThis.location.assign(response.next_action_redirect_url)
+      return
+    }
+
     if (
       response.status === 'needs_payment_method' &&
       response.payment_method_url
     ) {
-      // The open runs after `await subscribe(...)`, so it's not a direct user
-      // gesture and can be popup-blocked; warn instead of failing silently.
-      const paymentWindow = window.open(response.payment_method_url, '_blank')
-      if (!paymentWindow) {
-        toast.add({
-          severity: 'warn',
-          summary: t('g.warning'),
-          detail: t('subscription.preview.paymentPopupBlocked')
-        })
-      }
+      billingOperationStore.beginRedirectOperation(
+        response.billing_op_id,
+        'subscription'
+      )
+      globalThis.location.assign(response.payment_method_url)
+      return
     }
     await advanceToSuccessOnOperation(response.billing_op_id)
   }
@@ -367,7 +369,7 @@ export function useSubscriptionCheckout(
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
   }
 
-  async function handleTeamSubscription() {
+  async function handleTeamSubscription(confirmationToken?: string) {
     if (!permissions.value.canManageSubscription) return
 
     const teamCheckout = selectedTeamCheckout.value
@@ -387,6 +389,7 @@ export function useSubscriptionCheckout(
     try {
       const planSlug = getTeamPlanSlug(billingCycle)
       const response = await subscribe(planSlug, {
+        confirmationToken,
         teamCreditStopId: stop.id,
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -172,6 +172,25 @@ describe('billingOperationStore', () => {
         group: 'billing-operation'
       })
     })
+
+    it('persists a pending operation when polling returns a payment action', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-redirect',
+        status: 'pending',
+        next_action_redirect_url: 'https://stripe.com/authorize',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-redirect', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(localStorage.getItem('Comfy.BillingRedirectOperation')).toBe(
+        JSON.stringify({ opId: 'op-redirect', type: 'subscription' })
+      )
+      localStorage.removeItem('Comfy.BillingRedirectOperation')
+    })
   })
 
   describe('polling success', () => {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -15,6 +15,7 @@ const INITIAL_INTERVAL_MS = 1000
 const MAX_INTERVAL_MS = 8000
 const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000 // 2 minutes
+const REDIRECT_OPERATION_STORAGE_KEY = 'Comfy.BillingRedirectOperation'
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -25,6 +26,11 @@ interface BillingOperation {
   status: OperationStatus
   errorMessage: string | null
   startedAt: number
+}
+
+interface PersistedRedirectOperation {
+  opId: string
+  type: OperationType
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -63,6 +69,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
     if (existing) {
+      if (existing.status !== 'pending') {
+        clearOperation(opId)
+        return startOperation(opId, type)
+      }
       return terminalPromises.get(opId) ?? Promise.resolve(existing)
     }
 
@@ -100,6 +110,47 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     void poll(opId)
 
     return terminal
+  }
+
+  function beginRedirectOperation(opId: string, type: OperationType) {
+    try {
+      localStorage.setItem(
+        REDIRECT_OPERATION_STORAGE_KEY,
+        JSON.stringify({ opId, type } satisfies PersistedRedirectOperation)
+      )
+    } catch {
+      return
+    }
+  }
+
+  function restoreRedirectOperation() {
+    let persisted: string | null
+    try {
+      persisted = localStorage.getItem(REDIRECT_OPERATION_STORAGE_KEY)
+    } catch {
+      return
+    }
+    if (!persisted) return
+
+    try {
+      const operation: unknown = JSON.parse(persisted)
+      if (!isPersistedRedirectOperation(operation)) {
+        localStorage.removeItem(REDIRECT_OPERATION_STORAGE_KEY)
+        return
+      }
+      void startOperation(operation.opId, operation.type)
+    } catch {
+      localStorage.removeItem(REDIRECT_OPERATION_STORAGE_KEY)
+    }
+  }
+
+  function isPersistedRedirectOperation(
+    value: unknown
+  ): value is PersistedRedirectOperation {
+    if (!value || typeof value !== 'object') return false
+    if (!('opId' in value) || typeof value.opId !== 'string') return false
+    if (!('type' in value)) return false
+    return value.type === 'subscription' || value.type === 'topup'
   }
 
   async function poll(opId: string) {
@@ -255,6 +306,20 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
     terminalResolvers.delete(opId)
     terminalPromises.delete(opId)
+    clearPersistedRedirectOperation(opId)
+  }
+
+  function clearPersistedRedirectOperation(opId: string) {
+    try {
+      const persisted = localStorage.getItem(REDIRECT_OPERATION_STORAGE_KEY)
+      if (!persisted) return
+      const operation: unknown = JSON.parse(persisted)
+      if (isPersistedRedirectOperation(operation) && operation.opId === opId) {
+        localStorage.removeItem(REDIRECT_OPERATION_STORAGE_KEY)
+      }
+    } catch {
+      localStorage.removeItem(REDIRECT_OPERATION_STORAGE_KEY)
+    }
   }
 
   function updateOperationStatus(
@@ -301,6 +366,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     isAddingCredits,
     getOperation,
     startOperation,
+    beginRedirectOperation,
+    restoreRedirectOperation,
     clearOperation
   }
 })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -165,6 +165,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     try {
       const response = await workspaceApi.getBillingOpStatus(opId)
 
+      if (response.next_action_redirect_url) {
+        beginRedirectOperation(opId, operation.type)
+        globalThis.location.assign(response.next_action_redirect_url)
+        return
+      }
+
       if (response.status === 'succeeded') {
         await handleSuccess(opId)
         return


### PR DESCRIPTION
## Summary
- add Stripe Payment Element collection for card and Alipay ConfirmationTokens
- use it for new paid personal subscriptions and immediate paid personal upgrades
- persist BillingOps across Stripe redirects and resume polling on return
- recover redirect actions that become available after the initial subscribe request
- leave zero-due and scheduled transitions on their existing confirmation path

## Validation
- pnpm test:unit src/platform/workspace/api/workspaceApi.test.ts src/platform/workspace/composables/useSubscriptionCheckout.test.ts src/platform/workspace/stores/billingOperationStore.test.ts
- pnpm typecheck
- pnpm lint:unstaged
- pnpm build:cloud
- pre-push pnpm knip

## Test scenarios
1. New personal subscription: choose Card and complete without leaving the app.
2. New personal subscription: choose Alipay, authorize on Stripe, return, and observe success.
3. Immediate personal upgrade: choose Alipay and verify return-route recovery.
4. Delayed action: verify BillingOp polling redirects when authorization becomes available after the initial response.
5. Scheduled or zero-due change: verify the existing confirmation button remains.