### PR TITLE
feat: support hosted invoice payment recovery

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
+import { useEventListener } from '@vueuse/core'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
 
@@ -17,12 +18,18 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
 import { parsePreloadError } from '@/utils/preloadErrorUtil'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 
 const workspaceStore = useWorkspaceStore()
 app.extensionManager = useWorkspaceStore()
 
 const conflictDetection = useConflictDetection()
+const billingOperationStore = useBillingOperationStore()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
+
+useEventListener(window, 'pageshow', () => {
+  billingOperationStore.resumePendingOperations()
+})
 
 watch(
   isLoading,

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -306,6 +306,10 @@ export interface BillingOpStatusResponse {
   error_message?: string
   started_at: string
   completed_at?: string
+  customer_action?: {
+    type: 'pay_hosted_invoice'
+    url: string
+  }
 }
 
 interface BillingEvent {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1004,7 +1004,8 @@ describe('useSubscriptionCheckout', () => {
       expect(openSpy).not.toHaveBeenCalled()
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-no-url',
-        'subscription'
+        'subscription',
+        'https://platform.comfy.org/payment/success'
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1026,7 +1027,8 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-1',
-        'subscription'
+        'subscription',
+        'https://platform.comfy.org/payment/success'
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1047,7 +1049,8 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-2',
-        'subscription'
+        'subscription',
+        'https://platform.comfy.org/payment/success'
       )
       expect(checkout.checkoutStep.value).toBe('preview')
     })

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -287,8 +287,9 @@ export function useSubscriptionCheckout(
       const planSlug = getApiPlanSlug(tierKey, billingCycle)
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
+      const returnUrl = `${getComfyPlatformBaseUrl()}/payment/success`
       const response = await subscribe(planSlug, {
-        returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
+        returnUrl,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
       })
 
@@ -301,7 +302,7 @@ export function useSubscriptionCheckout(
           paymentIntentSource
         })
       }
-      await handleSubscribeResponse(response)
+      await handleSubscribeResponse(response, true, returnUrl)
     } catch (error) {
       showSubscribeError(error)
     } finally {
@@ -322,7 +323,8 @@ export function useSubscriptionCheckout(
 
   async function handleSubscribeResponse(
     response: SubscribeResponse | void,
-    shouldTrackSubscriptionSuccess = true
+    shouldTrackSubscriptionSuccess = true,
+    returnUrl: string | null = null
   ): Promise<void> {
     if (!response) return
 
@@ -353,16 +355,20 @@ export function useSubscriptionCheckout(
         })
       }
     }
-    await advanceToSuccessOnOperation(response.billing_op_id)
+    await advanceToSuccessOnOperation(response.billing_op_id, returnUrl)
   }
 
   // A Stripe-backed subscribe finishes asynchronously: await the billing op and
   // advance to the success step ourselves. The store refreshes status/balance
   // before resolving and surfaces any failure via toast.
-  async function advanceToSuccessOnOperation(opId: string) {
+  async function advanceToSuccessOnOperation(
+    opId: string,
+    returnUrl: string | null = null
+  ) {
     const operation = await billingOperationStore.startOperation(
       opId,
-      'subscription'
+      'subscription',
+      returnUrl
     )
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
   }

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -75,6 +75,7 @@ import { useBillingOperationStore } from './billingOperationStore'
 
 describe('billingOperationStore', () => {
   beforeEach(() => {
+    localStorage.clear()
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.useFakeTimers()
@@ -171,6 +172,100 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.topupProcessing',
         group: 'billing-operation'
       })
+    })
+
+    it('persists only pending operation recovery data', () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-hosted',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation(
+        'op-hosted',
+        'subscription',
+        'https://platform.comfy.org/payment/success'
+      )
+
+      const stored = JSON.parse(
+        localStorage.getItem('comfy.billing.pendingOperations') ?? '[]'
+      )
+      expect(stored).toEqual([
+        {
+          opId: 'op-hosted',
+          type: 'subscription',
+          startedAt: expect.any(Number),
+          returnUrl: 'https://platform.comfy.org/payment/success',
+          paymentNavigationStarted: false
+        }
+      ])
+    })
+  })
+
+  describe('hosted invoice recovery', () => {
+    it('recovers and polls a persisted pending operation', async () => {
+      localStorage.setItem(
+        'comfy.billing.pendingOperations',
+        JSON.stringify([
+          {
+            opId: 'op-recovered',
+            type: 'subscription',
+            startedAt: Date.now(),
+            returnUrl: 'https://platform.comfy.org/payment/success',
+            paymentNavigationStarted: true
+          }
+        ])
+      )
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-recovered',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledWith(
+        'op-recovered'
+      )
+      expect(store.getOperation('op-recovered')?.status).toBe('succeeded')
+      expect(localStorage.getItem('comfy.billing.pendingOperations')).toBeNull()
+    })
+
+    it('marks navigation before opening a hosted invoice in the same tab', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-hosted',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        customer_action: {
+          type: 'pay_hosted_invoice',
+          url: 'https://invoice.stripe.com/i/example'
+        }
+      })
+      const assignSpy = vi
+        .spyOn(window.location, 'assign')
+        .mockImplementation(() => undefined)
+
+      const store = useBillingOperationStore()
+      void store.startOperation(
+        'op-hosted',
+        'subscription',
+        'https://platform.comfy.org/payment/success'
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).toHaveBeenCalledWith(
+        'https://invoice.stripe.com/i/example'
+      )
+      expect(store.getOperation('op-hosted')?.paymentNavigationStarted).toBe(
+        true
+      )
+      expect(
+        JSON.parse(
+          localStorage.getItem('comfy.billing.pendingOperations') ?? '[]'
+        )[0]
+      ).not.toHaveProperty('url')
     })
   })
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -15,6 +15,7 @@ const INITIAL_INTERVAL_MS = 1000
 const MAX_INTERVAL_MS = 8000
 const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000 // 2 minutes
+const PENDING_OPERATIONS_STORAGE_KEY = 'comfy.billing.pendingOperations'
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -25,14 +26,34 @@ interface BillingOperation {
   status: OperationStatus
   errorMessage: string | null
   startedAt: number
+  returnUrl: string | null
+  paymentNavigationStarted: boolean
 }
+
+type PersistedBillingOperation = Pick<
+  BillingOperation,
+  'opId' | 'type' | 'startedAt' | 'returnUrl' | 'paymentNavigationStarted'
+>
 
 type TerminalResolver = (operation: BillingOperation) => void
 
 export const useBillingOperationStore = defineStore('billingOperation', () => {
-  const operations = ref<Map<string, BillingOperation>>(new Map())
+  const operations = ref<Map<string, BillingOperation>>(
+    new Map(
+      readPendingOperations().map((operation) => [
+        operation.opId,
+        {
+          ...operation,
+          status: 'pending',
+          errorMessage: null,
+          startedAt: Date.now()
+        }
+      ])
+    )
+  )
   const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
   const intervals = new Map<string, number>()
+  const polling = new Set<string>()
   const receivedToasts = new Map<string, ToastMessageOptions>()
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
@@ -59,7 +80,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   function startOperation(
     opId: string,
-    type: OperationType
+    type: OperationType,
+    returnUrl: string | null = null
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
     if (existing) {
@@ -71,10 +93,13 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       type,
       status: 'pending',
       errorMessage: null,
-      startedAt: Date.now()
+      startedAt: Date.now(),
+      returnUrl,
+      paymentNavigationStarted: false
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
+    persistPendingOperations()
     intervals.set(opId, INITIAL_INTERVAL_MS)
 
     if (type !== 'cancel') {
@@ -104,10 +129,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   async function poll(opId: string) {
     const operation = operations.value.get(opId)
-    if (!operation || operation.status !== 'pending') return
+    if (!operation || operation.status !== 'pending' || polling.has(opId))
+      return
+
+    polling.add(opId)
 
     if (Date.now() - operation.startedAt > TIMEOUT_MS) {
       handleTimeout(opId)
+      polling.delete(opId)
       return
     }
 
@@ -124,6 +153,16 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         return
       }
 
+      if (
+        response.customer_action?.type === 'pay_hosted_invoice' &&
+        !operation.paymentNavigationStarted &&
+        isSafePaymentUrl(response.customer_action.url)
+      ) {
+        updatePaymentNavigationStarted(opId)
+        window.location.assign(response.customer_action.url)
+        return
+      }
+
       scheduleNextPoll(opId)
     } catch {
       if (Date.now() - operation.startedAt > TIMEOUT_MS) {
@@ -131,6 +170,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         return
       }
       scheduleNextPoll(opId)
+    } finally {
+      polling.delete(opId)
     }
   }
 
@@ -267,6 +308,18 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     const updated = { ...operation, status, errorMessage }
     operations.value = new Map(operations.value).set(opId, updated)
+    persistPendingOperations()
+  }
+
+  function updatePaymentNavigationStarted(opId: string) {
+    const operation = operations.value.get(opId)
+    if (!operation) return
+
+    operations.value = new Map(operations.value).set(opId, {
+      ...operation,
+      paymentNavigationStarted: true
+    })
+    persistPendingOperations()
   }
 
   function cleanup(opId: string) {
@@ -290,9 +343,49 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const newMap = new Map(operations.value)
     newMap.delete(opId)
     operations.value = newMap
+    persistPendingOperations()
     terminalResolvers.delete(opId)
     terminalPromises.delete(opId)
   }
+
+  function resumePendingOperations() {
+    for (const [opId, operation] of operations.value) {
+      if (operation.status !== 'pending') continue
+      intervals.set(opId, INITIAL_INTERVAL_MS)
+      void poll(opId)
+    }
+  }
+
+  function persistPendingOperations() {
+    const pendingOperations: PersistedBillingOperation[] = [
+      ...operations.value.values()
+    ]
+      .filter((operation) => operation.status === 'pending')
+      .map(
+        ({ opId, type, startedAt, returnUrl, paymentNavigationStarted }) => ({
+          opId,
+          type,
+          startedAt,
+          returnUrl,
+          paymentNavigationStarted
+        })
+      )
+
+    try {
+      if (pendingOperations.length === 0) {
+        localStorage.removeItem(PENDING_OPERATIONS_STORAGE_KEY)
+      } else {
+        localStorage.setItem(
+          PENDING_OPERATIONS_STORAGE_KEY,
+          JSON.stringify(pendingOperations)
+        )
+      }
+    } catch {
+      return
+    }
+  }
+
+  resumePendingOperations()
 
   return {
     operations,
@@ -301,6 +394,44 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     isAddingCredits,
     getOperation,
     startOperation,
+    resumePendingOperations,
     clearOperation
   }
 })
+
+function readPendingOperations(): PersistedBillingOperation[] {
+  try {
+    const stored = localStorage.getItem(PENDING_OPERATIONS_STORAGE_KEY)
+    if (!stored) return []
+
+    const value: unknown = JSON.parse(stored)
+    if (!Array.isArray(value)) return []
+
+    return value.filter(isPersistedBillingOperation)
+  } catch {
+    return []
+  }
+}
+
+function isPersistedBillingOperation(
+  value: unknown
+): value is PersistedBillingOperation {
+  if (!value || typeof value !== 'object') return false
+
+  const operation = value as Record<string, unknown>
+  return (
+    typeof operation.opId === 'string' &&
+    ['subscription', 'topup', 'cancel'].includes(String(operation.type)) &&
+    typeof operation.startedAt === 'number' &&
+    (operation.returnUrl === null || typeof operation.returnUrl === 'string') &&
+    typeof operation.paymentNavigationStarted === 'boolean'
+  )
+}
+
+function isSafePaymentUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Follow async billing operations into Stripe-hosted invoice payment with same-tab navigation and recovery after return.

## Changes

- **What**: Persist safe pending-operation metadata, resume polling on initialization/pageshow, and navigate HTTPS hosted-invoice customer actions only after recording navigation state.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Pending-operation recovery and terminal cleanup; personal subscription paths only. Team Metronome checkout behavior is unchanged.

## Screenshots (if applicable)

Not applicable; behavior-only change.