### PR TITLE
fix(select): lift Reka dropdowns above modal stack

### DIFF
--- a/src/components/custom/widget/TemplateFilterControls.vue
+++ b/src/components/custom/widget/TemplateFilterControls.vue
@@ -6,7 +6,6 @@
     :class="triggerClass"
     :label="modelFilterLabel"
     :options="modelOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -19,7 +18,6 @@
     :class="triggerClass"
     :label="useCaseFilterLabel"
     :options="useCaseOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -32,7 +30,6 @@
     :class="triggerClass"
     :label="runsOnFilterLabel"
     :options="runsOnOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -45,7 +42,6 @@
     :class="triggerClass"
     :label="$t('templateWorkflows.sorting')"
     :options="sortOptions"
-    :content-style="contentStyle"
   >
     <template #icon>
       <i class="icon-[lucide--arrow-up-down] text-muted-foreground" />
@@ -54,8 +50,6 @@
 </template>
 
 <script setup lang="ts">
-import type { StyleValue } from 'vue'
-
 import MultiSelect from '@/components/ui/multi-select/MultiSelect.vue'
 import type { SelectOption } from '@/components/ui/select/types'
 import SingleSelect from '@/components/ui/single-select/SingleSelect.vue'
@@ -69,7 +63,6 @@ const {
   modelFilterLabel,
   useCaseFilterLabel,
   runsOnFilterLabel,
-  contentStyle,
   triggerClass = ''
 } = defineProps<{
   modelOptions: SelectOption[]
@@ -79,7 +72,6 @@ const {
   modelFilterLabel: string
   useCaseFilterLabel: string
   runsOnFilterLabel: string
-  contentStyle?: StyleValue
   triggerClass?: string
 }>()
 

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -34,7 +34,6 @@
 
     <template #contentFilter>
       <div
-        :ref="primeVueOverlay.overlayScopeRef"
         :class="
           cn(
             '@container/filters relative px-6',
@@ -444,7 +443,6 @@ import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
 import { useIntersectionObserver } from '@/composables/useIntersectionObserver'
 import { useLazyPagination } from '@/composables/useLazyPagination'
-import { usePrimeVueOverlayChildStyle } from '@/composables/usePopoverSizing'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
 import type { TemplateSortMode } from '@/composables/useTemplateFiltering'
 import { useTelemetry } from '@/platform/telemetry'
@@ -708,8 +706,6 @@ const mobileFiltersOpen = ref(false)
 const loadingTemplate = ref<string | null>(null)
 const hoveredTemplate = ref<string | null>(null)
 const cardRefs = ref<HTMLElement[]>([])
-const primeVueOverlay = usePrimeVueOverlayChildStyle()
-const selectContentStyle = primeVueOverlay.contentStyle
 
 // Force re-render key for templates when sorting changes
 const templateListKey = ref(0)
@@ -838,8 +834,7 @@ const filterControlBindings = computed(() => ({
   sortOptions: sortOptions.value,
   modelFilterLabel: modelFilterLabel.value,
   useCaseFilterLabel: useCaseFilterLabel.value,
-  runsOnFilterLabel: runsOnFilterLabel.value,
-  contentStyle: selectContentStyle.value
+  runsOnFilterLabel: runsOnFilterLabel.value
 }))
 
 // Lazy pagination setup

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,6 +1,7 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -72,7 +73,33 @@ function findContentElement(): HTMLElement | null {
   return document.querySelector('[data-dismissable-layer]')
 }
 
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
 describe('MultiSelect', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const user = userEvent.setup()
+    const { unmount } = renderInParent()
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
   it('keeps open-state border styling available while the dropdown is open', async () => {
     const user = userEvent.setup()
     const { unmount } = renderInParent()

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -85,7 +85,7 @@ afterEach(() => {
 describe('MultiSelect', () => {
   it('opens above a dialog registered with the modal z-index counter', async () => {
     openModal = document.createElement('div')
-    ZIndex.set('modal', openModal, 1700)
+    ZIndex.set('modal', openModal, 3702)
     const dialogZIndex = Number(openModal.style.zIndex)
     const user = userEvent.setup()
     const { unmount } = renderInParent()

--- a/src/components/ui/multi-select/MultiSelect.vue
+++ b/src/components/ui/multi-select/MultiSelect.vue
@@ -51,7 +51,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[popoverStyle, contentStyle]"
+        :style="[popoverStyle, contentStyle, liftedContentStyle]"
         :class="cn(selectContentClass, 'flex flex-col')"
         @keydown="onContentKeydown"
         @focus-outside="preventFocusDismiss"
@@ -167,6 +167,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -224,6 +225,7 @@ const searchQuery = defineModel<string>('searchQuery', { default: '' })
 
 const { t } = useI18n()
 const isOpen = ref(false)
+const liftedContentStyle = useModalLiftedZIndex(isOpen)
 const selectedCount = computed(() => selectedItems.value.length)
 const hasActions = computed(() => showSelectedCount || showClearButton)
 

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -91,7 +91,7 @@ afterEach(() => {
 describe('SingleSelect', () => {
   it('opens above a dialog registered with the modal z-index counter', async () => {
     openModal = document.createElement('div')
-    ZIndex.set('modal', openModal, 1700)
+    ZIndex.set('modal', openModal, 3702)
     const dialogZIndex = Number(openModal.style.zIndex)
     const { unmount } = renderInParent()
 

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -1,5 +1,6 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -78,7 +79,31 @@ async function openSelect(triggerEl: HTMLElement) {
   await nextTick()
 }
 
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
 describe('SingleSelect', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderInParent()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
   it('lets a consumer class override the trigger variant it conflicts with', () => {
     const { unmount } = render(SingleSelect, {
       props: { modelValue: undefined, options, label: 'Pick' },

--- a/src/components/ui/single-select/SingleSelect.vue
+++ b/src/components/ui/single-select/SingleSelect.vue
@@ -40,7 +40,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[optionStyle, contentStyle]"
+        :style="[optionStyle, contentStyle, liftedContentStyle]"
         :class="cn(selectContentClass, 'min-w-(--reka-select-trigger-width)')"
         @keydown="onContentKeydown"
       >
@@ -97,6 +97,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -140,6 +141,7 @@ const selectedItem = defineModel<string | undefined>({ required: true })
 
 const { t } = useI18n()
 const isOpen = ref(false)
+const liftedContentStyle = useModalLiftedZIndex(isOpen)
 
 function onContentKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary

Lift shared Reka single- and multi-select dropdowns above the active modal stack, fixing template filters that could render behind the templates dialog after repeated dialog opens.

## Changes

- **What**: Apply the existing renderer-agnostic `useModalLiftedZIndex` behavior to shared Reka select content and remove the templates-only PrimeVue mask workaround.
- **Tests**: Cover both shared select variants against a dynamically registered modal z-index.

## Review Focus

The regression is limited to releases where the templates modal uses the Reka renderer: Core v1.47.3+ and Cloud 1.47. Core 1.45, 1.46, and 1.47.0–1.47.2 still used the PrimeVue templates dialog and are unaffected.

Rapid repeated opens advance the shared PrimeUI modal z-index counter. Fresh local sessions usually leave the dialog below the selects' static `z-3000`, while longer production sessions can place the dialog above it (observed at 3703). Reading the shared counter when a select opens removes that session- and timing-dependent mismatch without coupling Reka controls to PrimeVue DOM masks.

## Screenshots

### AS IS

The Model Filter is open, but its dropdown renders behind the templates modal when the modal reaches z-index `3703` and the dropdown remains at `3000`.

![AS IS — filter dropdown hidden behind the templates modal](https://ampcode.com/attachments/0194ab4089436d5c604bef52435f16e16ed9924007ad6f0adeddb7d3fd35f959.png)

### TO BE — preview environment

Captured from the deployed PR preview after six complete Templates modal open/close cycles followed by eight rapid clicks. The Model Filter remains visible above the modal (`1703 > 1702`).

![TO BE — preview filter remains above the modal after repeated open and close interactions](https://ampcode.com/attachments/dd9f7abed76ea90571a393012f1647179b04b1aeafd16e975692b605e68bc9c5.png)




https://github.com/user-attachments/assets/3fa36ce4-5efc-43cf-9760-5fea934057f8


