### PR TITLE
fix(ui): keep filter dropdowns above Reka dialogs

### DIFF
--- a/src/composables/usePopoverSizing.test.ts
+++ b/src/composables/usePopoverSizing.test.ts
@@ -1,11 +1,25 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { effectScope } from 'vue'
 import type { EffectScope } from 'vue'
 
 import { usePrimeVueOverlayChildStyle } from '@/composables/usePopoverSizing'
 
+// Base that vRekaZIndex registers Reka dialogs at.
+const MODAL_BASE_Z_INDEX = 1700
+// The popover's static z-3000 class, which a stacked dialog can climb past.
+const POPOVER_Z_INDEX_FLOOR = 3000
+
 describe('usePrimeVueOverlayChildStyle', () => {
   let scope: EffectScope | undefined
+  const openDialogs: HTMLElement[] = []
+
+  function openRekaDialog(): number {
+    const dialog = document.createElement('div')
+    ZIndex.set('modal', dialog, MODAL_BASE_Z_INDEX)
+    openDialogs.push(dialog)
+    return Number(dialog.style.zIndex)
+  }
 
   function mountComposable() {
     scope = effectScope()
@@ -30,10 +44,33 @@ describe('usePrimeVueOverlayChildStyle', () => {
     scope?.stop()
     scope = undefined
     document.body.innerHTML = ''
+    for (const dialog of openDialogs.splice(0)) ZIndex.clear(dialog)
   })
 
-  it('preserves existing stacking when there is no PrimeVue parent overlay', () => {
+  it('preserves existing stacking when no dialog is open above it', () => {
     const { overlayScopeRef, contentStyle } = mountComposable()
+
+    overlayScopeRef.value = document.createElement('div')
+
+    expect(contentStyle.value).toEqual({})
+  })
+
+  it('renders above a Reka dialog, which has no PrimeVue mask to find', () => {
+    const { overlayScopeRef, contentStyle } = mountComposable()
+
+    let dialogZIndex = openRekaDialog()
+    while (dialogZIndex <= POPOVER_Z_INDEX_FLOOR) {
+      dialogZIndex = openRekaDialog()
+    }
+
+    overlayScopeRef.value = document.createElement('div')
+
+    expect(contentStyle.value).toEqual({ zIndex: dialogZIndex + 1 })
+  })
+
+  it('keeps the static floor while stacked dialogs stay below it', () => {
+    const { overlayScopeRef, contentStyle } = mountComposable()
+    openRekaDialog()
 
     overlayScopeRef.value = document.createElement('div')
 

--- a/src/composables/usePopoverSizing.ts
+++ b/src/composables/usePopoverSizing.ts
@@ -39,7 +39,7 @@ export function usePopoverSizing(
  *
  * PrimeVue dialogs are found by mask lookup. Reka dialogs render no mask, so
  * they are read from the shared @primeuix 'modal' counter they join via
- * `v-reka-z-index` — that counter can climb past the popover's static z-3000
+ * `v-reka-z-index`, a counter that can climb past the popover's static z-3000
  * when overlays open in quick succession.
  *
  * This is a temporary bridge while PrimeVue dialogs and controls are

--- a/src/composables/usePopoverSizing.ts
+++ b/src/composables/usePopoverSizing.ts
@@ -1,3 +1,4 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { computed, ref } from 'vue'
 import type { CSSProperties, ComputedRef, Ref } from 'vue'
 
@@ -34,11 +35,16 @@ export function usePopoverSizing(
 }
 
 /**
- * Keeps portaled Reka popovers above their containing PrimeVue dialog.
+ * Keeps portaled Reka popovers above their containing dialog.
+ *
+ * PrimeVue dialogs are found by mask lookup. Reka dialogs render no mask, so
+ * they are read from the shared @primeuix 'modal' counter they join via
+ * `v-reka-z-index` — that counter can climb past the popover's static z-3000
+ * when overlays open in quick succession.
  *
  * This is a temporary bridge while PrimeVue dialogs and controls are
  * incrementally migrated to Reka UI. Once the affected PrimeVue parents are
- * migrated, this helper should be removed with the compatibility patch.
+ * migrated, the mask lookup should be removed with the compatibility patch.
  */
 export function usePrimeVueOverlayChildStyle(): {
   overlayScopeRef: Ref<HTMLElement | null>
@@ -49,7 +55,12 @@ export function usePrimeVueOverlayChildStyle(): {
     const overlay = overlayScopeRef.value?.closest(
       '.p-dialog-mask, .p-overlay-mask'
     )
-    if (!overlay) return {}
+    if (!overlay) {
+      const topZIndex = ZIndex.getCurrent('modal')
+      return topZIndex >= PRIMEVUE_DIALOG_CHILD_Z_INDEX_FLOOR
+        ? { zIndex: topZIndex + 1 }
+        : {}
+    }
 
     const zIndex = Number.parseInt(getComputedStyle(overlay).zIndex, 10)
     if (!Number.isFinite(zIndex)) return {}


### PR DESCRIPTION
## Summary

Filter dropdowns in the templates modal rendered behind the modal instead of on top of it. They now stay above whichever dialog is open.

## Changes

**What**

- Portaled popovers used to lift themselves above a containing dialog by looking for a PrimeVue mask. Dialogs that moved to Reka don't render one, so the lift quietly did nothing and the dropdown kept its static z-index while the dialog climbed above it. When no mask is found we now read the same shared modal counter the dialogs register with, so the dropdown lands one above the top dialog.
- **Breaking**: None. PrimeVue dialogs keep the existing mask path, and popovers with nothing stacked above them keep their static z-index.

## Testing

The bug only appears once the shared counter climbs past the popover's floor, which needs overlays opening in quick succession. Slow clicking never reproduces it, which is why this went unnoticed locally, so the coverage drives the real counter rather than a mock.

- `src/composables/usePopoverSizing.test.ts`: registers dialogs on the real counter until it clears the floor and asserts the popover lands above the top one. A second case pins that a single dialog below the floor leaves the static z-index alone. Verified both fail without the fix, and that dropping the floor constant to 1000 breaks them, so they guard the constant rather than restating it.

Manual: open the templates modal, alternate a tooltip and a menu a few times so the counter climbs, then open a filter dropdown and confirm it paints above the modal.
