### PR TITLE
fix(ui): keep select popovers above stacked dialogs

### DIFF
--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,6 +1,7 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -151,5 +152,48 @@ describe('MultiSelect', () => {
 
       unmount()
     })
+  })
+})
+
+describe('MultiSelect z-index', () => {
+  const openDialogs: HTMLElement[] = []
+
+  afterEach(() => {
+    for (const dialog of openDialogs.splice(0)) ZIndex.clear(dialog)
+  })
+
+  function openDialog(): number {
+    const dialog = document.createElement('div')
+    ZIndex.set('modal', dialog, 1700)
+    openDialogs.push(dialog)
+    return Number(dialog.style.zIndex)
+  }
+
+  it('opens above a dialog that raised the counter after mount', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderInParent()
+
+    let dialogZIndex = openDialog()
+    while (dialogZIndex <= 3000) dialogZIndex = openDialog()
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    const content = findContentElement()
+    expect(Number(content?.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('keeps the static z-index when no dialog is stacked above it', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderInParent()
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    expect(findContentElement()?.style.zIndex).toBe('')
+
+    unmount()
   })
 })

--- a/src/components/ui/multi-select/MultiSelect.vue
+++ b/src/components/ui/multi-select/MultiSelect.vue
@@ -51,7 +51,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[popoverStyle, contentStyle]"
+        :style="[popoverStyle, contentStyle, liftedZIndex]"
         :class="cn(selectContentClass, 'flex flex-col')"
         @keydown="onContentKeydown"
         @focus-outside="preventFocusDismiss"
@@ -167,6 +167,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -242,6 +243,7 @@ const popoverStyle = usePopoverSizing({
   minWidth: popoverMinWidth,
   maxWidth: popoverMaxWidth
 })
+const liftedZIndex = useModalLiftedZIndex(isOpen)
 
 const fuseOptions: UseFuseOptions<SelectOption> = {
   fuseOptions: {

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -1,5 +1,6 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -126,5 +127,44 @@ describe('SingleSelect', () => {
 
       unmount()
     })
+  })
+})
+
+describe('SingleSelect z-index', () => {
+  const openDialogs: HTMLElement[] = []
+
+  afterEach(() => {
+    for (const dialog of openDialogs.splice(0)) ZIndex.clear(dialog)
+  })
+
+  function openDialog(): number {
+    const dialog = document.createElement('div')
+    ZIndex.set('modal', dialog, 1700)
+    openDialogs.push(dialog)
+    return Number(dialog.style.zIndex)
+  }
+
+  it('opens above a dialog that raised the counter after mount', async () => {
+    const { unmount } = renderInParent()
+
+    let dialogZIndex = openDialog()
+    while (dialogZIndex <= 3000) dialogZIndex = openDialog()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(Number(content?.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('keeps the static z-index when no dialog is stacked above it', async () => {
+    const { unmount } = renderInParent()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    expect(findContentElement()?.style.zIndex).toBe('')
+
+    unmount()
   })
 })

--- a/src/components/ui/single-select/SingleSelect.vue
+++ b/src/components/ui/single-select/SingleSelect.vue
@@ -40,7 +40,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[optionStyle, contentStyle]"
+        :style="[optionStyle, contentStyle, liftedZIndex]"
         :class="cn(selectContentClass, 'min-w-(--reka-select-trigger-width)')"
         @keydown="onContentKeydown"
       >
@@ -97,6 +97,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -152,4 +153,5 @@ const optionStyle = usePopoverSizing({
   minWidth: popoverMinWidth,
   maxWidth: popoverMaxWidth
 })
+const liftedZIndex = useModalLiftedZIndex(isOpen)
 </script>


### PR DESCRIPTION
## Summary

Filter dropdowns in the templates modal rendered behind the modal instead of above it. They now stay on top of whichever dialog is open.

## Changes

**What**

- The dropdown kept a static z-index while the containing dialog climbed the shared modal counter above it, so it painted behind the modal. SingleSelect and MultiSelect now lift their popover past the top dialog whenever they open.
- **Breaking**: None. Popovers with nothing stacked above them keep their static z-index.

## Review Focus

The lift is keyed off the popover's own open state via `useModalLiftedZIndex(isOpen)`, the same composable AccessibleTooltip uses, so the counter is re-read on each open rather than once at mount. An earlier attempt read it from a container ref in the shared composable, which went stale when a dialog raised the counter after mount. That path is dropped.

## Testing

The bug only shows once the counter climbs past the popover's floor after the component has mounted, which a mock read once at setup would miss. Both suites raise the counter after render, then open the dropdown and assert it lands above the top dialog. Verified each fails without the lift.

- `MultiSelect.test.ts`, `SingleSelect.test.ts`: lift above a dialog registered after mount, and leave the static z-index alone when nothing is stacked above.

Gates: typecheck clean, lint 0 errors, unit suites pass.

Manual: open the templates modal, alternate a tooltip and a menu a few times so the counter climbs, then open a filter dropdown and confirm it paints above the modal.
