### PR TITLE
Gate quota display on user being free tier

### DIFF
--- a/browser_tests/tests/freeTierQuota.spec.ts
+++ b/browser_tests/tests/freeTierQuota.spec.ts
@@ -15,6 +15,9 @@ test.describe('Free Tier Quota', { tag: ['@cloud', '@vue-nodes'] }, () => {
       free_tier_balance: { allowance: 5, remaining: 3, used: 0 }
     }
     await page.route('**/api/features', (r) => r.fulfill(jsonRoute(features)))
+    await page.route('**/customers/cloud-subscription-status', (r) =>
+      r.fulfill(jsonRoute({ is_active: true, subscription_tier: 'FREE' }))
+    )
   })
 
   wstest('Free Tier Quota', async ({ comfyPage, comfyMouse, getWebSocket }) => {

--- a/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
+++ b/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import FreeTierQuota from './FreeTierQuota.vue'
+
+const mockIsFreeTier = ref(true)
+const mockShowSubscriptionDialog = vi.fn()
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isFreeTier: mockIsFreeTier,
+    showSubscriptionDialog: mockShowSubscriptionDialog
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/composables/useFreeTierQuota', () => ({
+  useFreeTierQuota: () => ({
+    available: computed(() => 3),
+    hasInvalidNodes: computed(() => false),
+    maxAvailable: computed(() => 5),
+    quotaEnabled: computed(() => true)
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      actionbar: {
+        freeTierRuns: '{available} / {MAX_AVAILABLE} runs left',
+        freeTierRunsExhausted: 'No runs left'
+      }
+    }
+  }
+})
+
+describe('FreeTierQuota', () => {
+  it('hides the displayed quota when the user leaves the free tier', async () => {
+    render(FreeTierQuota, { global: { plugins: [i18n] } })
+
+    expect(screen.getByTestId('free-tier-quota')).toBeInTheDocument()
+
+    mockIsFreeTier.value = false
+    await nextTick()
+
+    expect(screen.queryByTestId('free-tier-quota')).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/cloud/subscription/components/FreeTierQuota.vue
+++ b/src/platform/cloud/subscription/components/FreeTierQuota.vue
@@ -12,7 +12,7 @@ const DOT_COLORS = [
   'bg-success-background'
 ]
 
-const { showSubscriptionDialog } = useBillingContext()
+const { isFreeTier, showSubscriptionDialog } = useBillingContext()
 const { t } = useI18n()
 const { available, hasInvalidNodes, maxAvailable, quotaEnabled } =
   useFreeTierQuota()
@@ -34,7 +34,7 @@ const label = computed(() =>
 </script>
 <template>
   <div
-    v-if="quotaEnabled"
+    v-if="quotaEnabled && isFreeTier"
     class="mt-2 w-full cursor-pointer border-t border-border-subtle bg-comfy-menu-bg px-4 pt-2 select-none"
     data-testid="free-tier-quota"
     @click="showSubscriptionDialog({ reason: 'free_tier_quota' })"


### PR DESCRIPTION
Under some circumstances, a user could subscribe without the remote config being refreshed. This would cause the Free Tier Quota to inadvertently persist. This is fixed by hard gating display on the user being free tier.