### PR TITLE
fix(website): remove "new" badge from Comfy API, Launches, Affiliates nav items

### DIFF
--- a/apps/website/src/data/mainNavigation.ts
+++ b/apps/website/src/data/mainNavigation.ts
@@ -65,8 +65,7 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             { label: t('nav.comfyCloud', locale), href: routes.cloud },
             {
               label: t('nav.comfyApi', locale),
-              href: routes.api,
-              badge: 'new'
+              href: routes.api
             },
             {
               label: t('nav.comfyEnterprise', locale),
@@ -87,8 +86,7 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             // { label: t('nav.agentSkills', locale), href: '#' },
             {
               label: t('nav.launches', locale),
-              href: routes.launches,
-              badge: 'new'
+              href: routes.launches
             },
             { label: t('nav.supportedModels', locale), href: routes.models },
             {
@@ -122,8 +120,7 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             { label: t('nav.gallery', locale), href: routes.gallery },
             {
               label: t('nav.affiliates', locale),
-              href: routes.affiliates,
-              badge: 'new'
+              href: routes.affiliates
             },
             {
               label: t('nav.learning', locale),


### PR DESCRIPTION
## Summary
Removes the "new" badge from three navbar items that are no longer new:
- **Comfy API** (Products column)
- **Launches** (Features column)
- **Affiliates** (Programs column)

Other "new" badges (Products, Community, MCP Server, Learning) are left untouched.

## Changes
- `apps/website/src/data/mainNavigation.ts` — dropped `badge: 'new'` from the three nav items above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)