### PR TITLE
feat: tag RUM traffic with bucket and version

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,6 @@
 if (__DISTRIBUTION__ === 'cloud') {
   const { initDatadogRum } = await import('@/platform/telemetry/initDatadogRum')
-  initDatadogRum()
+  void initDatadogRum().catch(() => {})
 }
 
 await import('./main')

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -1,9 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const hoisted = vi.hoisted(() => ({
-  getInitConfiguration: vi.fn(),
-  init: vi.fn()
-}))
+const hoisted = vi.hoisted(() => {
+  const context: Record<string, unknown> = {}
+
+  return {
+    context,
+    fetch: vi.fn<typeof fetch>(),
+    getInitConfiguration: vi.fn(),
+    init: vi.fn(),
+    setGlobalContextProperty: vi.fn((key: string, value: unknown) => {
+      context[key] = value
+    })
+  }
+})
 
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: hoisted
@@ -14,8 +23,21 @@ import { initDatadogRum } from './initDatadogRum'
 
 describe('initDatadogRum', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+    for (const key of Object.keys(hoisted.context)) {
+      delete hoisted.context[key]
+    }
+    hoisted.setGlobalContextProperty.mockImplementation((key, value) => {
+      hoisted.context[key] = value
+    })
+    hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
     hoisted.getInitConfiguration.mockReturnValue(undefined)
+    vi.stubGlobal('fetch', hoisted.fetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it.for([
@@ -23,21 +45,167 @@ describe('initDatadogRum', () => {
     { hostname: 'stagingcloud.comfy.org', env: 'stg-v2' },
     { hostname: 'testcloud.comfy.org', env: 'test-v2' },
     { hostname: 'fe-pr-13691.testenvs.comfy.org', env: 'test-v2' }
-  ])('initializes $hostname with the $env environment', ({ hostname, env }) => {
-    initDatadogRum(hostname)
+  ])(
+    'initializes $hostname with the $env environment',
+    async ({ hostname, env }) => {
+      await initDatadogRum(hostname)
 
-    expect(hoisted.init).toHaveBeenCalledWith({
-      clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
-      applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
-      site: 'us5.datadoghq.com',
-      service: 'comfy-cloud-frontend',
-      env,
-      version: __COMFYUI_FRONTEND_VERSION__,
-      beforeSend: rumBeforeSend,
-      sessionSampleRate: 100,
-      sessionReplaySampleRate: 0,
-      allowedTracingUrls: [expect.any(RegExp)]
+      expect(hoisted.init).toHaveBeenCalledWith({
+        clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
+        applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
+        site: 'us5.datadoghq.com',
+        service: 'comfy-cloud-frontend',
+        env,
+        version: __COMFYUI_FRONTEND_VERSION__,
+        beforeSend: rumBeforeSend,
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 0,
+        allowedTracingUrls: [expect.any(RegExp)]
+      })
+    }
+  )
+
+  it('tags canary traffic with its bucket and frontend version', async () => {
+    let resolveProbe: (response: Response) => void
+    hoisted.fetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve
+      })
+    )
+    hoisted.init.mockImplementation(() => {
+      expect(hoisted.context).toEqual({
+        bucket: 'canary',
+        version: __COMFYUI_FRONTEND_COMMIT__
+      })
     })
+
+    const initialization = initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.init).not.toHaveBeenCalled()
+    resolveProbe!(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'canary',
+          'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__
+        }
+      })
+    )
+    await initialization
+
+    expect(hoisted.context).toEqual({
+      bucket: 'canary',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('serializes concurrent initialization', async () => {
+    let resolveProbe: (response: Response) => void
+    hoisted.fetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve
+      })
+    )
+
+    const firstInitialization = initDatadogRum('cloud.comfy.org')
+    const secondInitialization = initDatadogRum('cloud.comfy.org')
+
+    resolveProbe!(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'canary',
+          'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__
+        }
+      })
+    )
+    await Promise.all([firstInitialization, secondInitialization])
+
+    expect(hoisted.fetch).toHaveBeenCalledOnce()
+    expect(hoisted.init).toHaveBeenCalledOnce()
+    expect(hoisted.context).toEqual({
+      bucket: 'canary',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+  })
+
+  it('defaults the bucket to stable and tracks its frontend version', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: { 'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__ }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({
+      bucket: 'stable',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+  })
+
+  it('leaves traffic unclassified when the frontend version is absent', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: { 'X-Frontend-Bucket': 'canary' }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+  })
+
+  it('leaves traffic unclassified when the probe reaches another version', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'stable',
+          'X-Frontend-Version': 'another-frontend-commit'
+        }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+  })
+
+  it('leaves traffic unclassified when the header probe fails', async () => {
+    hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('initializes RUM when the header probe rejects', async () => {
+    hoisted.fetch.mockRejectedValue(new Error('network error'))
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('initializes RUM when the header probe times out', async () => {
+    const abortController = new AbortController()
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(abortController.signal)
+    hoisted.fetch.mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Timed out', 'AbortError'))
+          })
+        })
+    )
+
+    const initialization = initDatadogRum('cloud.comfy.org')
+    abortController.abort()
+    await initialization
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
   })
 
   it.for([
@@ -45,16 +213,16 @@ describe('initDatadogRum', () => {
     'testenvs.comfy.org',
     'eviltestenvs.comfy.org',
     'preview.testenvs.comfy.org.example.com'
-  ])('does not initialize on unknown hostname %s', (hostname) => {
-    initDatadogRum(hostname)
+  ])('does not initialize on unknown hostname %s', async (hostname) => {
+    await initDatadogRum(hostname)
 
     expect(hoisted.init).not.toHaveBeenCalled()
   })
 
-  it('does not initialize twice', () => {
+  it('does not initialize twice', async () => {
     hoisted.getInitConfiguration.mockReturnValue({})
 
-    initDatadogRum('cloud.comfy.org')
+    await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.init).not.toHaveBeenCalled()
   })

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -7,12 +7,30 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['stagingcloud.comfy.org', 'stg-v2'],
   ['testcloud.comfy.org', 'test-v2']
 ])
+const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
+let initializationPromise: Promise<void> | undefined
 
-export function initDatadogRum(hostname = window.location.hostname): void {
-  const env =
-    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
-    (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
-  if (!env || datadogRum.getInitConfiguration()) return
+async function setFrontendContext(): Promise<void> {
+  const response = await fetch(window.location.origin, {
+    method: 'HEAD',
+    cache: 'no-store',
+    signal: AbortSignal.timeout(FRONTEND_CONTEXT_FETCH_TIMEOUT_MS)
+  })
+  if (!response.ok) return
+
+  const frontendVersion = response.headers.get('X-Frontend-Version')
+  if (frontendVersion !== __COMFYUI_FRONTEND_COMMIT__) return
+
+  datadogRum.setGlobalContextProperty(
+    'bucket',
+    response.headers.get('X-Frontend-Bucket') ?? 'stable'
+  )
+  datadogRum.setGlobalContextProperty('version', frontendVersion)
+}
+
+async function initializeDatadogRum(env: string): Promise<void> {
+  await setFrontendContext().catch(() => {})
+  if (datadogRum.getInitConfiguration()) return
 
   datadogRum.init({
     clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
@@ -26,4 +44,18 @@ export function initDatadogRum(hostname = window.location.hostname): void {
     sessionReplaySampleRate: 0,
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
+}
+
+export function initDatadogRum(
+  hostname = window.location.hostname
+): Promise<void> {
+  const env =
+    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
+    (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
+  if (!env || datadogRum.getInitConfiguration()) return Promise.resolve()
+
+  initializationPromise ??= initializeDatadogRum(env).finally(() => {
+    initializationPromise = undefined
+  })
+  return initializationPromise
 }


### PR DESCRIPTION
## Summary

> [!NOTE]
> In Datadog Global Context
> bucket: &lt;value of `X-Frontend-Bucket`&gt;
> version: &lt;value of `X-Frontend-Version`&gt;