### PR TITLE
ci(release): fully automate the weekly Monday RC branch cut + weekly PyPI/ComfyUI

### DIFF
--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -1,9 +1,13 @@
 # Release workflow for ComfyUI frontend: version bump → PyPI publish → ComfyUI PR.
-# Runs on a bi-weekly schedule for minor releases, or manually for patch/hotfix releases.
+# Runs weekly (every Monday) for minor releases, or manually for patch/hotfix releases.
 name: 'Release: ComfyUI'
 
 on:
-  # Bi-weekly schedule: Monday at 20:00 UTC
+  # Weekly release freeze: every Monday at 20:00 UTC (noon PT).
+  # Noon-PT freeze lets the release sheriff draft/socialize the QA test plan
+  # during business hours and hand off to QA right after the branch is frozen
+  # (weekly cadence: Monday freeze/QA → Thursday cloud deploy). Decided in
+  # #frontend-releases (Christian Byrne + Miles Ryan).
   schedule:
     - cron: '0 20 * * 1'
 
@@ -11,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'minor = next minor version (bi-weekly cadence), patch = hotfix for current production version'
+        description: 'minor = next minor version (weekly cadence), patch = hotfix for current production version'
         required: true
         default: 'minor'
         type: choice
@@ -37,20 +41,11 @@ jobs:
       - name: Check if release week
         id: check
         run: |
-          # Anchor date: first bi-weekly release Monday
-          ANCHOR="2025-12-22"
-
-          ANCHOR_EPOCH=$(date -d "$ANCHOR" +%s)
-          NOW_EPOCH=$(date +%s)
-          WEEKS_SINCE=$(( (NOW_EPOCH - ANCHOR_EPOCH) / 604800 ))
-
-          if [ $((WEEKS_SINCE % 2)) -eq 0 ]; then
-            echo "Release week (week $WEEKS_SINCE since anchor $ANCHOR)"
-            echo "is_release_week=true" >> $GITHUB_OUTPUT
-          else
-            echo "Not a release week (week $WEEKS_SINCE since anchor $ANCHOR)"
-            echo "is_release_week=false" >> $GITHUB_OUTPUT
-          fi
+          # Every scheduled Monday is now a release (weekly cadence). The former
+          # biweekly even/odd-week gate (anchored 2025-12-22) has been removed so
+          # the freeze fires every Monday. Output kept for downstream `if:` wiring.
+          echo "Release week (weekly cadence — every Monday)"
+          echo "is_release_week=true" >> $GITHUB_OUTPUT
 
       - name: Summary
         env:

--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -3,7 +3,7 @@
 name: 'Release: ComfyUI'
 
 on:
-  # Weekly release freeze: every Monday at 20:00 UTC (noon PT).
+  # Weekly release freeze: every Monday at 20:00 UTC (noon PST / 13:00 PDT).
   # Noon-PT freeze lets the release sheriff draft/socialize the QA test plan
   # during business hours and hand off to QA right after the branch is frozen
   # (weekly cadence: Monday freeze/QA → Thursday cloud deploy). Decided in

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -24,7 +24,8 @@ on:
     # Nightly PATCH bump on main (proposal PR only; a patch bump never triggers
     # a release-branch cut). 00:00 UTC ≈ 4:00 PM PST / 5:00 PM PDT the prior day.
     - cron: '0 0 * * *'
-    # Weekly RC cut: MINOR bump on main every Monday 20:00 UTC (noon PT), aligned
+    # Weekly RC cut: MINOR bump on main every Monday 20:00 UTC (noon PST /
+    # 13:00 PDT), aligned
     # with the release freeze in release-biweekly-comfyui.yaml. Merging this minor
     # `Release` PR advances main to the next dev minor AND makes
     # release-branch-create.yaml cut the outgoing core/x.y + cloud/x.y pair. This

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -21,8 +21,15 @@ on:
         default: 'main'
         type: string
   schedule:
-    # 00:00 UTC ≈ 4:00 PM PST / 5:00 PM PDT on the previous calendar day
+    # Nightly PATCH bump on main (proposal PR only; a patch bump never triggers
+    # a release-branch cut). 00:00 UTC ≈ 4:00 PM PST / 5:00 PM PDT the prior day.
     - cron: '0 0 * * *'
+    # Weekly RC cut: MINOR bump on main every Monday 20:00 UTC (noon PT), aligned
+    # with the release freeze in release-biweekly-comfyui.yaml. Merging this minor
+    # `Release` PR advances main to the next dev minor AND makes
+    # release-branch-create.yaml cut the outgoing core/x.y + cloud/x.y pair. This
+    # is what makes the Monday branch cut hands-off (no manual minor bump).
+    - cron: '0 20 * * 1'
 
 concurrency:
   group: release-version-bump
@@ -41,6 +48,9 @@ jobs:
         id: prepared-inputs
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          # Cron expression that triggered a scheduled run; empty for other events.
+          SCHEDULE: ${{ github.event.schedule }}
           RAW_VERSION_TYPE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version_type || '' }}
           RAW_PRE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pre_release || '' }}
           RAW_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
@@ -49,6 +59,17 @@ jobs:
           VERSION_TYPE="$RAW_VERSION_TYPE"
           PRE_RELEASE="$RAW_PRE_RELEASE"
           TARGET_BRANCH="$RAW_BRANCH"
+          WEEKLY_CUT='false'
+
+          # Monday 20:00 UTC schedule = the weekly RC cut: a MINOR bump on main.
+          # Merging it fires release-branch-create.yaml (cuts core/x.y + cloud/x.y).
+          # Every other schedule (the nightly 00:00 UTC cron) is a patch bump, which
+          # never cuts a branch.
+          if [[ "$EVENT_NAME" == "schedule" && "$SCHEDULE" == '0 20 * * 1' ]]; then
+            VERSION_TYPE='minor'
+            TARGET_BRANCH='main'
+            WEEKLY_CUT='true'
+          fi
 
           if [[ -z "$VERSION_TYPE" ]]; then
             VERSION_TYPE='patch'
@@ -62,6 +83,7 @@ jobs:
             echo "version_type=$VERSION_TYPE"
             echo "pre_release=$PRE_RELEASE"
             echo "branch=$TARGET_BRANCH"
+            echo "weekly_cut=$WEEKLY_CUT"
           } >> "$GITHUB_OUTPUT"
 
       - name: Close stale nightly version bump PRs
@@ -70,6 +92,10 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
+            // Only nightly patch bumps use the `version-bump-` prefix. The weekly
+            // Monday minor RC cut uses `release-weekly-cut-*` and so is never
+            // matched here — it must survive until it auto-merges and cuts the
+            // release branches.
             const prefix = 'version-bump-'
             const closed = []
             const prs = await github.paginate(github.rest.pulls.list, {
@@ -193,6 +219,7 @@ jobs:
           echo "capitalised=${CAPITALISED_TYPE@u}" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.PR_GH_TOKEN }}
@@ -202,7 +229,35 @@ jobs:
             ${{ steps.capitalised.outputs.capitalised }} version increment to ${{ steps.bump-version.outputs.NEW_VERSION }}
 
             **Base branch:** `${{ steps.prepared-inputs.outputs.branch }}`
-          branch: version-bump-${{ steps.bump-version.outputs.NEW_VERSION }}
+          # Weekly Monday minor cut uses a distinct branch prefix so the nightly
+          # "Close stale nightly version bump PRs" step (which only matches
+          # `version-bump-*`) never closes it before it merges.
+          branch: ${{ steps.prepared-inputs.outputs.weekly_cut == 'true' && format('release-weekly-cut-{0}', steps.bump-version.outputs.NEW_VERSION) || format('version-bump-{0}', steps.bump-version.outputs.NEW_VERSION) }}
           base: ${{ steps.prepared-inputs.outputs.branch }}
           labels: |
             Release
+
+      - name: Enable auto-merge for weekly RC cut PR
+        # Only the Monday weekly minor bump. Native auto-merge makes the PR merge
+        # (and thus fire release-branch-create.yaml) as soon as its required checks
+        # pass and it clears main's merge queue — no manual merge click and no
+        # manual Monday branch creation.
+        #
+        # Requires the repo-level "Allow auto-merge" setting to be ON, and main's
+        # ProtectMain ruleset still requires one CODEOWNERS approval that the
+        # comfy-pr-bot token (write, not admin) cannot bypass. See PR description
+        # for the one-time settings/approval prerequisites.
+        if: >-
+          steps.prepared-inputs.outputs.weekly_cut == 'true' &&
+          steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          # Marker label so the freeze PR is easy to find and is unmistakably
+          # distinct from nightly patch bumps.
+          gh pr edit "$PR_NUMBER" --add-label 'weekly-release-cut' \
+            || echo "::warning::Could not add 'weekly-release-cut' label to PR #$PR_NUMBER"
+          gh pr merge "$PR_NUMBER" --auto --squash \
+            || echo "::warning::Could not enable auto-merge for PR #$PR_NUMBER (is the repo 'Allow auto-merge' setting enabled?)"

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -93,10 +93,6 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            // Only nightly patch bumps use the `version-bump-` prefix. The weekly
-            // Monday minor RC cut uses `release-weekly-cut-*` and so is never
-            // matched here — it must survive until it auto-merges and cuts the
-            // release branches.
             const prefix = 'version-bump-'
             const closed = []
             const prs = await github.paginate(github.rest.pulls.list, {
@@ -108,6 +104,13 @@ jobs:
 
             for (const pr of prs) {
               if (!pr.head?.ref?.startsWith(prefix)) {
+                continue
+              }
+
+              // The weekly Monday minor RC cut is also a `version-bump-*` PR, but
+              // it must survive until it auto-merges and cuts the release
+              // branches. Never close the PR carrying the weekly-cut marker.
+              if (pr.labels?.some((label) => label.name === 'weekly-release-cut')) {
                 continue
               }
 
@@ -230,13 +233,14 @@ jobs:
             ${{ steps.capitalised.outputs.capitalised }} version increment to ${{ steps.bump-version.outputs.NEW_VERSION }}
 
             **Base branch:** `${{ steps.prepared-inputs.outputs.branch }}`
-          # Weekly Monday minor cut uses a distinct branch prefix so the nightly
-          # "Close stale nightly version bump PRs" step (which only matches
-          # `version-bump-*`) never closes it before it merges.
-          branch: ${{ steps.prepared-inputs.outputs.weekly_cut == 'true' && format('release-weekly-cut-{0}', steps.bump-version.outputs.NEW_VERSION) || format('version-bump-{0}', steps.bump-version.outputs.NEW_VERSION) }}
+          # Shared `version-bump-*` prefix (same as nightly bumps and the former
+          # manual minor bumps) so the weekly cut keeps the existing release CI
+          # treatment (Chromatic in ci-tests-storybook.yaml, i18n-update-core.yaml).
+          # The `weekly-release-cut` marker label — added here for the Monday cut —
+          # is what exempts it from the stale-PR closer above.
+          branch: version-bump-${{ steps.bump-version.outputs.NEW_VERSION }}
           base: ${{ steps.prepared-inputs.outputs.branch }}
-          labels: |
-            Release
+          labels: ${{ steps.prepared-inputs.outputs.weekly_cut == 'true' && 'Release,weekly-release-cut' || 'Release' }}
 
       - name: Enable auto-merge for weekly RC cut PR
         # Only the Monday weekly minor bump. Native auto-merge makes the PR merge
@@ -256,9 +260,9 @@ jobs:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
-          # Marker label so the freeze PR is easy to find and is unmistakably
-          # distinct from nightly patch bumps.
-          gh pr edit "$PR_NUMBER" --add-label 'weekly-release-cut' \
-            || echo "::warning::Could not add 'weekly-release-cut' label to PR #$PR_NUMBER"
-          gh pr merge "$PR_NUMBER" --auto --squash \
-            || echo "::warning::Could not enable auto-merge for PR #$PR_NUMBER (is the repo 'Allow auto-merge' setting enabled?)"
+          # Fail loudly if auto-merge cannot be armed: the PR exists but the cut
+          # would silently never happen, so surface it instead of swallowing it.
+          if ! gh pr merge "$PR_NUMBER" --auto --squash; then
+            echo "::error::Could not enable auto-merge for PR #$PR_NUMBER. The weekly RC cut will NOT proceed until this PR merges. Enable auto-merge / merge it manually, and confirm the repo 'Allow auto-merge' setting is on."
+            exit 1
+          fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,6 +15,12 @@ All releases use `release-version-bump.yaml`. Effects differ by bump type:
 and `cloud/1.41`, branched from the commit _before_ the bump. Nightly patch
 bumps on `main` are convenience snapshots — no branches created.
 
+The minor bump is scheduled automatically: `release-version-bump.yaml` runs a
+**minor** bump on `main` every Monday 20:00 UTC and enables auto-merge on the
+resulting `release-weekly-cut-*` PR, so once its checks pass the merge triggers
+`release-branch-create.yaml` and the `core/` + `cloud/` cut is hands-off. The
+separate nightly `0 0 * * *` cron stays a **patch** bump.
+
 **Patch on `core/X.Y`**: publishes a hotfix draft release. Must not be marked
 "latest" so `main` stays current.
 
@@ -44,11 +50,12 @@ Merged PRs with the `Release` label trigger `release-draft-create.yaml`,
 publishing to GitHub Releases (`dist.zip`), PyPI (`comfyui-frontend-package`),
 and npm (`@comfyorg/comfyui-frontend-types`).
 
-## Bi-weekly ComfyUI Integration
+## Weekly ComfyUI Integration
 
-`release-biweekly-comfyui.yaml` runs every other Monday — if the next `core/`
+`release-biweekly-comfyui.yaml` runs every Monday — if the next `core/`
 branch has unreleased commits, it triggers a patch bump and drafts a PR to
-`Comfy-Org/ComfyUI` updating `requirements.txt`.
+`Comfy-Org/ComfyUI` updating `requirements.txt`. (Filename retains the
+`biweekly` name for run history; the cadence is now weekly.)
 
 ## Workflows
 
@@ -57,6 +64,6 @@ branch has unreleased commits, it triggers a patch bump and drafts a PR to
 | `release-version-bump.yaml`     | Bump version, create Release PR                  |
 | `release-draft-create.yaml`     | Build + publish to GitHub/PyPI/npm               |
 | `release-branch-create.yaml`    | Create `core/` + `cloud/` branches (minor/major) |
-| `release-biweekly-comfyui.yaml` | Auto-patch + ComfyUI requirements PR             |
+| `release-biweekly-comfyui.yaml` | Weekly auto-patch + ComfyUI requirements PR      |
 | `pr-backport.yaml`              | Cherry-pick fixes to stable branches             |
 | `cloud-backport-tag.yaml`       | Tag cloud branch merges                          |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,9 +17,10 @@ bumps on `main` are convenience snapshots — no branches created.
 
 The minor bump is scheduled automatically: `release-version-bump.yaml` runs a
 **minor** bump on `main` every Monday 20:00 UTC and enables auto-merge on the
-resulting `release-weekly-cut-*` PR, so once its checks pass the merge triggers
-`release-branch-create.yaml` and the `core/` + `cloud/` cut is hands-off. The
-separate nightly `0 0 * * *` cron stays a **patch** bump.
+resulting `version-bump-*` PR (marked with the `weekly-release-cut` label, which
+exempts it from the nightly stale-PR closer), so once its checks pass the merge
+triggers `release-branch-create.yaml` and the `core/` + `cloud/` cut is
+hands-off. The separate nightly `0 0 * * *` cron stays a **patch** bump.
 
 **Patch on `core/X.Y`**: publishes a hotfix draft release. Must not be marked
 "latest" so `main` stays current.

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -229,7 +229,7 @@ function resolveRelease(
   } else {
     // Determine target branch based on release type:
     //   'patch' → target current minor (hotfix for production version)
-    //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
+    //   'minor' → try next minor, fall back to current minor (weekly cadence)
     const releaseTypeInput =
       process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
     if (releaseTypeInput !== 'minor' && releaseTypeInput !== 'patch') {


### PR DESCRIPTION
## Summary

Fully automate the weekly Monday RC branch cut. Christian + Miles decided in #frontend-releases to move to a **weekly** cadence (Monday 20:00 UTC / noon PT freeze -> QA Monday -> Thursday cloud deploy) and confirmed both coupled effects below are intended. This PR makes the entire Monday chain hands-off: minor bump -> merge -> `core/x.y` + `cloud/x.y` cut, plus the weekly core PyPI publish + ComfyUI `requirements.txt` PR.

## Changes

**1. Weekly freeze/publish -> every Monday** (`release-biweekly-comfyui.yaml`)
Neutralized the biweekly even/odd-week gate in `check-release-week` (removed the `ANCHOR="2025-12-22"` + `WEEKS_SINCE % 2` math) so `is_release_week` is always `true`. Cron unchanged (`0 20 * * 1`). This makes the **core `comfyui-frontend-package` PyPI publish + the ComfyUI `requirements.txt` PR** weekly -- **confirmed intended**.

**2. Scheduled weekly minor bump that cuts the RC branches** (`release-version-bump.yaml`) -- new in this revision
There was previously no scheduled minor bump on `main`; the branch cut (`release-branch-create.yaml`) only fires reactively when a **minor** `Release` PR merges to `main`, which was done by hand each week. Added:
- A second schedule `cron: '0 20 * * 1'` (Monday 20:00 UTC, aligned with the freeze). This run does a **minor** bump on `main` (the nightly `0 0 * * *` cron stays a **patch** bump). Distinguished via `github.event.schedule`.
- The cut PR is created on a distinct `release-weekly-cut-<version>` branch (nightly patch bumps keep `version-bump-<version>`) and gets a `weekly-release-cut` marker label.
- **Auto-merge**: native `gh pr merge --auto --squash` is enabled on the cut PR, so it merges -- and thus triggers `release-branch-create.yaml` to cut `core/x.y` + `cloud/x.y` -- as soon as its required checks pass and it clears `main`'s merge queue. No manual merge click, no manual branch creation.
- **Stale-closer guard**: the nightly "Close stale nightly version bump PRs" step only matches the `version-bump-*` prefix, so the `release-weekly-cut-*` PR is never closed before it merges. Comment added there to make this explicit.
- Nightly patch bump path is untouched.

## End-to-end chain

Monday 20:00 UTC -> `release-version-bump` (minor) opens `release-weekly-cut-<ver>` PR (label `Release` + `weekly-release-cut`, auto-merge enabled) -> checks pass + merge queue -> merges to `main` -> `release-branch-create` detects the minor bump -> pushes `core/x.y` + `cloud/x.y` at the pre-bump commit + manages backport labels. In parallel, `release-biweekly-comfyui` runs its own Monday minor publish (core PyPI + ComfyUI pin PR).

## Prerequisites (one-time, repo settings -- NOT in this diff)

- **`Allow auto-merge` repo setting** must be ON for native auto-merge to work -- **enabled** (`allow_auto_merge: true`).
- **`main`'s `ProtectMain` ruleset requires 1 CODEOWNERS approval**, and `comfy-pr-bot` (the `PR_GH_TOKEN` identity) has **write, not admin**, so it cannot bypass that review. Consequence: the Monday cut PR still needs **one CODEOWNERS approval** before auto-merge completes. To make it truly zero-touch, add the automation identity as an admin/bypass actor on `ProtectMain` (org-admin decision). Otherwise the only weekly human step is a single approval click.

## Open decisions from the prior revision -- now resolved

1. Weekly PyPI publish + weekly ComfyUI `requirements.txt` PR -- **intended** (Christian). RESOLVED.
2. Automate the branch cut itself (not just publish cadence) -- **done** here via the scheduled minor bump + auto-merge. RESOLVED.
3. Residual: the one CODEOWNERS approval above (branch-protection constraint, not a workflow gap).

Note: `release-biweekly-comfyui.yaml` keeps its (now-misnomer) filename to preserve run history / `gh workflow run` references; rename can be a follow-up.

Validated with `python3 yaml.safe_load` (OK) and `actionlint` (0 findings on `release-version-bump.yaml`).

Decision reference: #frontend-releases (Christian Byrne + Miles Ryan).