### PR TITLE
[backport cloud/1.47] fix(select): lift Reka dropdowns above modal stack

### DIFF
--- a/src/components/custom/widget/TemplateFilterControls.vue
+++ b/src/components/custom/widget/TemplateFilterControls.vue
@@ -6,7 +6,6 @@
     :class="triggerClass"
     :label="modelFilterLabel"
     :options="modelOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -19,7 +18,6 @@
     :class="triggerClass"
     :label="useCaseFilterLabel"
     :options="useCaseOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -32,7 +30,6 @@
     :class="triggerClass"
     :label="runsOnFilterLabel"
     :options="runsOnOptions"
-    :content-style="contentStyle"
     :show-search-box="true"
     :show-selected-count="true"
     :show-clear-button="true"
@@ -45,7 +42,6 @@
     :class="triggerClass"
     :label="$t('templateWorkflows.sorting')"
     :options="sortOptions"
-    :content-style="contentStyle"
   >
     <template #icon>
       <i class="icon-[lucide--arrow-up-down] text-muted-foreground" />
@@ -54,8 +50,6 @@
 </template>
 
 <script setup lang="ts">
-import type { StyleValue } from 'vue'
-
 import MultiSelect from '@/components/ui/multi-select/MultiSelect.vue'
 import type { SelectOption } from '@/components/ui/select/types'
 import SingleSelect from '@/components/ui/single-select/SingleSelect.vue'
@@ -69,7 +63,6 @@ const {
   modelFilterLabel,
   useCaseFilterLabel,
   runsOnFilterLabel,
-  contentStyle,
   triggerClass = ''
 } = defineProps<{
   modelOptions: SelectOption[]
@@ -79,7 +72,6 @@ const {
   modelFilterLabel: string
   useCaseFilterLabel: string
   runsOnFilterLabel: string
-  contentStyle?: StyleValue
   triggerClass?: string
 }>()
 

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -34,7 +34,6 @@
 
     <template #contentFilter>
       <div
-        :ref="primeVueOverlay.overlayScopeRef"
         :class="
           cn(
             '@container/filters relative px-6',
@@ -444,7 +443,6 @@ import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
 import { useIntersectionObserver } from '@/composables/useIntersectionObserver'
 import { useLazyPagination } from '@/composables/useLazyPagination'
-import { usePrimeVueOverlayChildStyle } from '@/composables/usePopoverSizing'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
 import type { TemplateSortMode } from '@/composables/useTemplateFiltering'
 import { useTelemetry } from '@/platform/telemetry'
@@ -708,8 +706,6 @@ const mobileFiltersOpen = ref(false)
 const loadingTemplate = ref<string | null>(null)
 const hoveredTemplate = ref<string | null>(null)
 const cardRefs = ref<HTMLElement[]>([])
-const primeVueOverlay = usePrimeVueOverlayChildStyle()
-const selectContentStyle = primeVueOverlay.contentStyle
 
 // Force re-render key for templates when sorting changes
 const templateListKey = ref(0)
@@ -838,8 +834,7 @@ const filterControlBindings = computed(() => ({
   sortOptions: sortOptions.value,
   modelFilterLabel: modelFilterLabel.value,
   useCaseFilterLabel: useCaseFilterLabel.value,
-  runsOnFilterLabel: runsOnFilterLabel.value,
-  contentStyle: selectContentStyle.value
+  runsOnFilterLabel: runsOnFilterLabel.value
 }))
 
 // Lazy pagination setup

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,6 +1,7 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -72,7 +73,33 @@ function findContentElement(): HTMLElement | null {
   return document.querySelector('[data-dismissable-layer]')
 }
 
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
 describe('MultiSelect', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const user = userEvent.setup()
+    const { unmount } = renderInParent()
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
   it('keeps open-state border styling available while the dropdown is open', async () => {
     const user = userEvent.setup()
     const { unmount } = renderInParent()

--- a/src/components/ui/multi-select/MultiSelect.vue
+++ b/src/components/ui/multi-select/MultiSelect.vue
@@ -51,7 +51,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[popoverStyle, contentStyle]"
+        :style="[popoverStyle, contentStyle, liftedContentStyle]"
         :class="cn(selectContentClass, 'flex flex-col')"
         @keydown="onContentKeydown"
         @focus-outside="preventFocusDismiss"
@@ -167,6 +167,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -224,6 +225,7 @@ const searchQuery = defineModel<string>('searchQuery', { default: '' })
 
 const { t } = useI18n()
 const isOpen = ref(false)
+const liftedContentStyle = useModalLiftedZIndex(isOpen)
 const selectedCount = computed(() => selectedItems.value.length)
 const hasActions = computed(() => showSelectedCount || showClearButton)
 

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -1,5 +1,6 @@
+import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -78,7 +79,31 @@ async function openSelect(triggerEl: HTMLElement) {
   await nextTick()
 }
 
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
 describe('SingleSelect', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderInParent()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
   it('lets a consumer class override the trigger variant it conflicts with', () => {
     const { unmount } = render(SingleSelect, {
       props: { modelValue: undefined, options, label: 'Pick' },

--- a/src/components/ui/single-select/SingleSelect.vue
+++ b/src/components/ui/single-select/SingleSelect.vue
@@ -40,7 +40,7 @@
         position="popper"
         :side-offset="8"
         align="start"
-        :style="[optionStyle, contentStyle]"
+        :style="[optionStyle, contentStyle, liftedContentStyle]"
         :class="cn(selectContentClass, 'min-w-(--reka-select-trigger-width)')"
         @keydown="onContentKeydown"
       >
@@ -97,6 +97,7 @@ import {
 } from '@/components/ui/select/select.variants'
 import type { SelectOption } from '@/components/ui/select/types'
 import { useAttrsClass } from '@/composables/useAttrsClass'
+import { useModalLiftedZIndex } from '@/composables/useModalLiftedZIndex'
 import { usePopoverSizing } from '@/composables/usePopoverSizing'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -140,6 +141,7 @@ const selectedItem = defineModel<string | undefined>({ required: true })
 
 const { t } = useI18n()
 const isOpen = ref(false)
+const liftedContentStyle = useModalLiftedZIndex(isOpen)
 
 function onContentKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {


### PR DESCRIPTION
Backport of #14054 to `cloud/1.47`

Manually created after the combined backport workflow failed because the separate Core target conflicted.