### PR TITLE
chore: add per-language CODEOWNERS entries for translation reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,6 +56,29 @@
 # Model-to-node mappings (cloud team)
 /src/platform/assets/mappings/                    @deepme987 @Comfy-Org/comfy_frontend_devs
 
+# Translations - native-language reviewers
+# NOTE: GitHub only honors a code owner that has WRITE access to this repo.
+# Owners without write access are silently ignored: they are never auto-requested
+# and never satisfy a required-review rule. The entries below therefore list only
+# reviewers who currently have write access.
+#
+# Scoped to the per-language directories on purpose - /src/locales/en/ is left
+# unowned so ordinary feature PRs that add English keys do not trigger a review
+# request. Only changes to an actual translation route here.
+#
+# Pending (needs a write grant before adding, otherwise the line is inert):
+#   /src/locales/it/     @PorkItaly              (#13880)
+#   /src/locales/uk/     @necyryl                (#13028)
+#   /src/locales/he/     @yosef-chai
+#   /src/locales/fa/     @danialshirali16
+#   /src/locales/tr/     @snomiao
+#   /src/locales/ar/     @arab-future-academy
+#   /src/locales/pt-BR/  @JonatanAtila
+# See the PR description for the proposed `translation-reviewers` team.
+/src/locales/zh/                                  @comfyui-wiki @Comfy-Org/comfy_frontend_devs
+/src/locales/zh-TW/                               @comfyui-wiki @Comfy-Org/comfy_frontend_devs
+/src/locales/ko/                                  @ltdrdata @Comfy-Org/comfy_frontend_devs
+
 # LLM Instructions (blank on purpose)
 .claude/
 .cursor/


### PR DESCRIPTION
## Why

`src/locales/CONTRIBUTING.md` tells translation contributors:

> Request review from language maintainers: @Yorha4D @KarryCharon @DorotaLuna @shinshin86 — **get added to CODEOWNERS as a reviewer for your language**

That has never been implemented. `CODEOWNERS` has **zero** `/src/locales/**` entries, so translation PRs get no native-reviewer routing at all. That's a large part of why locale contributions stall — e.g. #13028 (Ukrainian, +28k lines of hand translation) sat untouched in draft for three weeks, and #13880 (Italian) went unreviewed since Jul 21.

This adds the entries for the reviewers who can actually hold them today.

## The constraint that shapes this PR

**GitHub only honors a code owner who has `write` access to the repo.** Owners without write are silently ignored — never auto-requested, never able to satisfy a required-review rule. So adding read-only contributors would produce lines that *look* like they work and don't.

I audited every active translation contributor via `repos/.../collaborators/{user}/permission`:

**Have write today (live in this PR):**
| login | languages |
|---|---|
| `@comfyui-wiki` | zh, zh-TW |
| `@ltdrdata` | ko |

**Read-only — would be inert, so listed as comments only:**
`@PorkItaly` (it, #13880), `@necyryl` (uk, #13028), `@yosef-chai` (he), `@danialshirali16` (fa), `@snomiao` (tr), `@arab-future-academy` (ar), `@JonatanAtila` (pt-BR), `@DorotaL` (zh), `@LifetimeVip` (zh/zh-TW).

Worth flagging: **`@DorotaLuna` and `@shinshin86` — the two maintainers CONTRIBUTING.md tells everyone to tag — are also read-only.** The doc is writing a check the permissions can't cash.

## Scoping choice

Entries are on the per-language directories, **not** `/src/locales/` as a whole. `/src/locales/en/` is deliberately left unowned so ordinary feature PRs that add English keys (89 of the 300 currently-open PRs touch `src/locales/**`) don't start requesting translation review. Only changes to an actual translation route here.

Side effect worth knowing: the release-time "Update locales" bot PRs touch every locale, so they will now request review from `@comfyui-wiki` and `@ltdrdata`. That seems correct, but say the word if it's too noisy and I'll narrow it further.

## Follow-up needed (not in this PR)

To route the other seven languages, those contributors need repo **write**. My recommendation is a `@Comfy-Org/translation-reviewers` **team** granted write, referenced by one CODEOWNERS line, rather than ~9 individual grants:

- one auditable access decision instead of nine
- matches the existing `@Comfy-Org/comfy_frontend_devs` pattern already used throughout this file
- membership churns without CODEOWNERS edits

**Honest tradeoff:** write access is repo-wide and *cannot* be scoped to `/src/locales/**` — CODEOWNERS and branch protection can't confine a translator's push to a subtree. Granting write technically lets them push anywhere. Mitigations: required-PR-review branch protection on `main` (so they still can't merge unreviewed), keeping the team small and audited, and adding people only after CLA + a vetted contribution history. That's an org-admin call, not mine — flagging it rather than assuming it.

Two other follow-ups: `CONTRIBUTING.md` should be corrected to state the write prerequisite and drop the stale maintainer tag-list, and a few contributor display names still need login mapping ("Makki Shizu", Zhiqi Yao, 729_GM, DMSteins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
