### PR TITLE
feat: enable 3D Viewer (Beta) by default

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -232,7 +232,7 @@ useExtensionService().registerExtension({
       tooltip:
         'Enables the 3D Viewer (Beta) for selected nodes. This feature allows you to visualize and interact with 3D models directly within the full size 3d viewer.',
       type: 'boolean',
-      defaultValue: false,
+      defaultValue: true,
       experimental: true
     },
     {


### PR DESCRIPTION
## Summary
- Change the default for `Comfy.Load3D.3DViewerEnable` from `false` to `true`, so the full-size 3D Viewer (Beta) is available out of the box for new installs / users without a saved override.

## Test plan
- [x] Fresh settings (no `Comfy.Load3D.3DViewerEnable` in `comfy.settings.json`): confirm Settings → 3D → Enable 3D Viewer (Beta) is on
- [x] Select a Load 3D node and confirm the 3D Viewer control appears in the selection toolbox / node menu

I have read and agree to the Contributor License Agreement.