### PR TITLE
ci(i18n): regenerate translations on cloud release branches

### DIFF
--- a/.github/workflows/cloud-release-version-bump.yaml
+++ b/.github/workflows/cloud-release-version-bump.yaml
@@ -1,0 +1,140 @@
+# Description: Cadenced patch bump for active cloud release branch(es).
+#
+# Why this exists:
+#   New localization keys land on `main` and get backported to `cloud/x.y`, but
+#   `i18n-update-core.yaml` only runs for version-bump PRs, and nothing was
+#   driving version bumps on the cloud line on a cadence. A manual bump on the
+#   cloud branch (e.g. #14066) was inert because it did not open a version-bump
+#   PR that i18n would pick up. This workflow closes that gap: on a cadence it
+#   dispatches the existing `release-version-bump.yaml` against the active cloud
+#   branch, which opens a `version-bump-*` PR. `i18n-update-core.yaml` (now
+#   allowed to run for `cloud/**` PRs) then regenerates translations for any new
+#   backported keys and commits them INTO that same PR, so the patch bump and
+#   the regenerated locale JSON merge to the cloud branch together as one
+#   trackable "this was deployed" commit. lobe-i18n only translates missing
+#   keys, so already-translated keys are never re-translated on later runs.
+#
+# Decision reference: #frontend-releases (Christian Byrne + Austin Mroz).
+# Companion change: `i18n-update-core.yaml` triggers on `cloud/**` PRs.
+
+name: 'Cloud Release: Patch Bump + i18n Regen'
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Cloud branch to bump (blank = auto-detect latest cloud/x.y)'
+        required: false
+        default: ''
+        type: string
+      force:
+        description: 'Bump even if no new commits since the last version bump'
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Daily at 07:00 UTC. Offset from the main nightly bump (00:00 UTC) so the
+    # two do not contend. Aligns roughly with the daily cloud backport deploys.
+    - cron: '0 7 * * *'
+
+concurrency:
+  group: cloud-release-version-bump
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bump-cloud:
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    runs-on: ubuntu-latest
+    env:
+      # PAT so the dispatched release-version-bump run (and the PR it opens)
+      # actually triggers downstream workflows; GITHUB_TOKEN-triggered events do
+      # not start new workflow runs.
+      GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch cloud branches
+        run: git fetch --no-tags origin '+refs/heads/cloud/*:refs/remotes/origin/cloud/*'
+
+      - name: Resolve target branch(es)
+        id: resolve
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_BRANCH:-}" ]]; then
+            # Explicit override from workflow_dispatch.
+            if ! git show-ref --verify --quiet "refs/remotes/origin/${INPUT_BRANCH}"; then
+              echo "::error::Branch '${INPUT_BRANCH}' not found on origin"
+              exit 1
+            fi
+            BRANCHES="$INPUT_BRANCH"
+          else
+            # Auto-detect the newest cloud/x.y line. Older cloud branches are
+            # EOL once a newer minor is cut, so only the latest is bumped.
+            BRANCHES=$(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/cloud/*' \
+              | sed -n 's#^origin/\(cloud/[0-9]\+\.[0-9]\+\)$#\1#p' \
+              | sort -t/ -k2 -V \
+              | tail -n1)
+          fi
+          if [[ -z "$BRANCHES" ]]; then
+            echo "::error::No active cloud/x.y branch found"
+            exit 1
+          fi
+          echo "Resolved cloud branch(es): $BRANCHES"
+          {
+            echo 'branches<<EOF'
+            echo "$BRANCHES"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch patch bump for each active cloud branch
+        env:
+          BRANCHES: ${{ steps.resolve.outputs.branches }}
+          FORCE: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r BRANCH; do
+            [[ -z "$BRANCH" ]] && continue
+
+            # Idempotency gate A: never stack a second bump PR on a branch that
+            # already has one open and awaiting merge.
+            OPEN=$(gh pr list --repo "$GITHUB_REPOSITORY" --base "$BRANCH" \
+              --state open --json headRefName \
+              --jq '[.[] | select(.headRefName | startswith("version-bump-"))] | length')
+            if [[ "$OPEN" -gt 0 ]]; then
+              echo "⏭️  $BRANCH: a version-bump PR is already open; skipping."
+              continue
+            fi
+
+            # Idempotency gate B: skip when nothing merged since the last bump,
+            # so quiet days do not churn empty patch bumps. `force` overrides.
+            # If the last bump commit can't be found, proceed (fail open so we
+            # never silently stop regenerating translations).
+            LAST_BUMP=$(git log -1 --format='%H' -G'"version":' "origin/$BRANCH" -- package.json || true)
+            if [[ "${FORCE:-false}" != "true" && -n "$LAST_BUMP" ]]; then
+              NEW=$(git rev-list --count "$LAST_BUMP..origin/$BRANCH")
+              if [[ "$NEW" -eq 0 ]]; then
+                echo "⏭️  $BRANCH: no new commits since last bump; skipping."
+                continue
+              fi
+              echo "ℹ️  $BRANCH: $NEW commit(s) since last bump."
+            fi
+
+            # Dispatch the main definition of release-version-bump (it checks out
+            # and bumps the `branch` input); do NOT run the cloud branch's older
+            # copy, which predates the `branch` input.
+            echo "🚀 $BRANCH: dispatching patch bump."
+            gh workflow run release-version-bump.yaml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              -f version_type=patch \
+              -f branch="$BRANCH"
+          done <<< "$BRANCHES"

--- a/.github/workflows/cloud-release-version-bump.yaml
+++ b/.github/workflows/cloud-release-version-bump.yaml
@@ -107,7 +107,7 @@ jobs:
             # Idempotency gate A: never stack a second bump PR on a branch that
             # already has one open and awaiting merge.
             OPEN=$(gh pr list --repo "$GITHUB_REPOSITORY" --base "$BRANCH" \
-              --state open --json headRefName \
+              --state open --limit 1000 --json headRefName \
               --jq '[.[] | select(.headRefName | startswith("version-bump-"))] | length')
             if [[ "$OPEN" -gt 0 ]]; then
               echo "⏭️  $BRANCH: a version-bump PR is already open; skipping."

--- a/.github/workflows/cloud-release-version-bump.yaml
+++ b/.github/workflows/cloud-release-version-bump.yaml
@@ -55,7 +55,7 @@ jobs:
       GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -71,6 +71,10 @@ jobs:
           set -euo pipefail
           if [[ -n "${INPUT_BRANCH:-}" ]]; then
             # Explicit override from workflow_dispatch.
+            if ! [[ "$INPUT_BRANCH" =~ ^cloud/[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Branch must match cloud/<major>.<minor>"
+              exit 1
+            fi
             if ! git show-ref --verify --quiet "refs/remotes/origin/${INPUT_BRANCH}"; then
               echo "::error::Branch '${INPUT_BRANCH}' not found on origin"
               exit 1

--- a/.github/workflows/i18n-update-core.yaml
+++ b/.github/workflows/i18n-update-core.yaml
@@ -4,9 +4,12 @@ name: 'i18n: Update Core'
 on:
   # Manual dispatch for urgent translation updates
   workflow_dispatch:
-  # Only trigger on PRs to main/master - additional branch filtering in job condition
+  # Trigger on PRs to main and to release branches (core/x.y, cloud/x.y).
+  # Release branches need this so translations for backported locale keys are
+  # regenerated and baked into the version-bump PR, mirroring main. Additional
+  # branch filtering (version-bump-* head) is in the job condition below.
   pull_request:
-    branches: [main]
+    branches: [main, 'core/**', 'cloud/**']
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -32,8 +32,12 @@ on:
     # is what makes the Monday branch cut hands-off (no manual minor bump).
     - cron: '0 20 * * 1'
 
+# Key concurrency by target branch so per-branch bumps (e.g. the cloud
+# release fan-out that dispatches this workflow once per active branch) do
+# not cancel one another before their PRs are opened. Scheduled/main runs
+# fall back to 'main'.
 concurrency:
-  group: release-version-bump
+  group: release-version-bump-${{ github.event.inputs.branch || 'main' }}
   cancel-in-progress: true
 
 jobs:
@@ -80,10 +84,18 @@ jobs:
             TARGET_BRANCH='main'
           fi
 
+          # create-pull-request treats `branch` as a repo-wide ref, so a bare
+          # version-bump-<version> head can collide across base branches (the
+          # cloud fan-out bumps cloud/x.y while nightly/weekly bump main) and
+          # update the wrong PR. Fold a normalized base slug into the head name.
+          BRANCH_SLUG="${TARGET_BRANCH//[^a-zA-Z0-9]/-}"
+          BRANCH_SLUG="${BRANCH_SLUG,,}"
+
           {
             echo "version_type=$VERSION_TYPE"
             echo "pre_release=$PRE_RELEASE"
             echo "branch=$TARGET_BRANCH"
+            echo "branch_slug=$BRANCH_SLUG"
             echo "weekly_cut=$WEEKLY_CUT"
           } >> "$GITHUB_OUTPUT"
 
@@ -236,9 +248,11 @@ jobs:
           # Shared `version-bump-*` prefix (same as nightly bumps and the former
           # manual minor bumps) so the weekly cut keeps the existing release CI
           # treatment (Chromatic in ci-tests-storybook.yaml, i18n-update-core.yaml).
+          # The base slug after the prefix keeps heads unique per base branch
+          # while every `startsWith('version-bump-')` filter still matches.
           # The `weekly-release-cut` marker label — added here for the Monday cut —
           # is what exempts it from the stale-PR closer above.
-          branch: version-bump-${{ steps.bump-version.outputs.NEW_VERSION }}
+          branch: version-bump-${{ steps.prepared-inputs.outputs.branch_slug }}-${{ steps.bump-version.outputs.NEW_VERSION }}
           base: ${{ steps.prepared-inputs.outputs.branch }}
           labels: ${{ steps.prepared-inputs.outputs.weekly_cut == 'true' && 'Release,weekly-release-cut' || 'Release' }}
 


### PR DESCRIPTION
## Summary

Regenerate translations for backported locale keys on the cloud release line, and bake them into a per-deploy patch bump commit on the cloud branch. Decision: #frontend-releases (Christian Byrne + Austin Mroz).

## Root cause

New localization keys land on `main` (e.g. #13984) and are backported to `cloud/x.y`, but `i18n-update-core.yaml` only triggers on `pull_request` to `main` and its job only runs for `version-bump-*` heads. Two gaps followed:

1. i18n never listened to PRs whose base is `cloud/x.y`, so even a `version-bump-*` PR on the cloud branch did not regenerate translations.
2. Nothing drove version bumps on the cloud line on a cadence.

That is why Austin's manual patch bump on `cloud/1.47` (#14066, still open) was **inert**: it was just a `package.json` bump on `cloud/1.47` with no i18n run behind it, so no `Update locales` commit was ever added. `cloud/1.47`'s history confirms it -- its bumps (`1.47.7`, `1.47.6`, ...) carry no accompanying locale commits.

## Changes

- **What**:
  - `i18n-update-core.yaml`: extend `on.pull_request.branches` to `[main, core/**, cloud/**]`. The job condition is unchanged (same-repo `version-bump-*` head). This reuses the exact mechanism `main` already relies on: the i18n job runs `collect-i18n` + `locale` + `format` and commits `Update locales` **into the version-bump PR branch**, so the patch bump and regenerated locale JSON merge to the cloud branch together as one trackable commit.
  - `cloud-release-version-bump.yaml` (new): daily cron (`0 7 * * *`) + `workflow_dispatch`. Auto-detects the newest `cloud/x.y` branch (or takes an explicit `branch` input) and dispatches the existing `release-version-bump.yaml` with `version_type=patch` against it -- which opens the `version-bump-*` PR that i18n then completes.
- **Breaking**: none. `main`'s path is unchanged; `core/**` gains the same (previously missing) behavior symmetrically.

## How stability / determinism is guaranteed (Austin's requirement)

`lobe-i18n` only translates **missing** target-locale keys. Once a backported key is translated and committed to `cloud/x.y` (via the merged version-bump PR), later runs produce no locale diff, so `git diff --staged --quiet || git commit` adds no further commit. Translations are baked once into a committed bump and never re-translated on subsequent deploys.

## Idempotency + multi-branch

- **No stacking** (gate A): skip if a `version-bump-*` PR is already open against the branch.
- **No empty churn** (gate B): skip when nothing merged since the last version bump (detected via the last commit that changed the `version` field); `force` dispatch input overrides. Fails open if the last bump can't be located, so translations are never silently skipped.
- **Multi-branch**: auto-follows to `cloud/1.48` etc. -- no branch is hardcoded. Defaults to the single latest cloud line (older cloud branches are EOL); dispatch `branch` targets any specific branch.

## Review focus

- **Design tension for Christian to resolve**: gate B makes an empty deploy (no new backports) a **no-op** -- no bump, no tracking commit. That optimizes for "don't churn" over "one bump per deploy for tracking." If you want a bump on *every* deploy regardless of content, drop gate B (or have the cron always pass `force`). Left conservative (content-gated) by default. Austin's "bake once, don't re-translate" holds either way.
- **Token**: the cadence workflow uses `PR_GH_TOKEN` so the dispatched `release-version-bump` run (and the PR it opens) actually trigger downstream workflows -- `GITHUB_TOKEN`-triggered events do not start new runs.
- **Not merging bump PRs automatically**: the cloud bump PR is left open for the existing human/deploy merge step (unlike #14061's main auto-merge). Enabling auto-merge on the cloud line can be a follow-up if desired.
- **Relationship to #14061**: separate concern and separate files -- #14061 automates the weekly `main` minor bump + `core/x.y`/`cloud/x.y` branch *cut*; this PR keeps already-cut cloud branches' translations fresh via patch bumps. No file overlap (it does not touch `i18n-update-core.yaml`); this reuses its `release-version-bump.yaml` at runtime only.

Once merged, #14066 is superseded and can be closed (re-running the cadence, or dispatching this workflow for `cloud/1.47`, produces the correct bump + translation PR).

Refs #14066, #13984, #14061.
