### PR TITLE
test: remove redundant AssetBrowserModal mock comment

### DIFF
--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -39,12 +39,6 @@ vi.mock('@/stores/modelToNodeStore', () => ({
   })
 }))
 
-// Stub model-type fetching so mounting the modal does not fire a real
-// `api.getModelFolders()` network request. The unmocked call hit
-// http://localhost:3000/api/experiment/models, failed with ECONNREFUSED, and
-// logged via console.error asynchronously after the test had finished —
-// racing with vitest worker teardown and surfacing as a flaky
-// "EnvironmentTeardownError: Closing rpc while onUserConsoleLog was pending".
 vi.mock('@/platform/assets/composables/useModelTypes', () => ({
   useModelTypes: () => ({
     fetchModelTypes: vi.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
## Summary

Remove a redundant comment from the `useModelTypes` test mock added in #13037; the mock is self-explanatory.

## Changes

- **What**: Delete the six-line explanatory comment without changing test behavior

## Review Focus

Confirm the diff is comment-only.