### PR TITLE
fix(ci): apply the backport label from the branch convention

### DIFF
--- a/.github/workflows/pr-label-backport.yaml
+++ b/.github/workflows/pr-label-backport.yaml
@@ -1,0 +1,109 @@
+---
+# Description: Guarantees that every backport PR carries the `backport` label,
+# whoever opened it.
+#
+# Why: pr-backport.yaml applies the label in exactly one place — its own
+# `gh pr create --label "backport"` call. That call is only reached when the
+# cherry-pick applies cleanly. When it conflicts, the workflow fails and its
+# failure comment asks a human or an agent to finish the backport by hand,
+# including "create PR ... with label backport". That handoff gets missed.
+#
+# The cost of missing it is silent: backport-auto-merge.yaml sweeps
+# `gh pr list --label backport`, and pr-assign-release-sheriff.yaml keys off the
+# same label, so an unlabelled backport PR is invisible to both and sits open
+# until somebody notices. PRs #14018-#14021 are the worked example — all four
+# were opened by hand after #13875 and #13971 hit cherry-pick conflicts, and all
+# four ended up with only a `size:M` label.
+#
+# The label is derived from the branch naming convention instead
+# (`backport-<pr>-to-<target>`), which the workflow generates and which manual
+# backports follow because the failure comment tells them to. The rule itself
+# lives in scripts/cicd/backport-label.ts so it can be unit tested.
+name: 'PR: Label Backport'
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+  # Backstop for PRs opened while this workflow was failing, and for backports
+  # retargeted onto their release branch after being opened. Offset from
+  # backport-auto-merge.yaml's `*/15` sweep so a backfilled label is in place
+  # before the next merge sweep looks for it.
+  schedule:
+    - cron: '5,20,35,50 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize every run so two runs cannot race on the same PR.
+concurrency:
+  group: label-backport
+  cancel-in-progress: false
+
+jobs:
+  label:
+    name: Apply the backport label
+    # Cheap gate so an unrelated PR does not spin up a runner. The real rule is
+    # in scripts/cicd/backport-label.ts and is re-applied to live PR state below.
+    if: >-
+      github.repository == 'Comfy-Org/ComfyUI_frontend' &&
+      (github.event_name != 'pull_request_target' ||
+       startsWith(github.event.pull_request.head.ref, 'backport-'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # labels are applied through the issues API
+
+    steps:
+      # pull_request_target checks out the base branch, never PR head code.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Collect candidate PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          FIELDS=number,headRefName,baseRefName,labels
+
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Read the PR directly: a just-opened PR is not reliably in the
+            # search index yet.
+            gh pr view "$PR_NUMBER" --json "$FIELDS" | jq -s '.' > prs.json
+          else
+            gh pr list --state open --search 'head:backport-' --limit 100 \
+              --json "$FIELDS" > prs.json
+          fi
+
+          echo "Candidate PRs: $(jq 'length' prs.json)"
+
+      - name: Plan missing labels
+        id: plan
+        run: pnpm exec tsx scripts/cicd/plan-backport-labels.ts --prs prs.json
+
+      - name: Apply the backport label
+        if: steps.plan.outputs.numbers != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBERS: ${{ steps.plan.outputs.numbers }}
+        run: |
+          set -euo pipefail
+
+          # `gh pr edit --add-label` currently fails repo-wide on a deprecated
+          # projectCards GraphQL field, so add the label through REST.
+          for pr in $NUMBERS; do
+            if gh api --method POST "repos/${GH_REPO}/issues/${pr}/labels" \
+              -f "labels[]=backport" --silent; then
+              echo "- Labelled #${pr}" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::warning::Could not add the backport label to #${pr}"
+            fi
+          done

--- a/scripts/cicd/backport-label.test.ts
+++ b/scripts/cicd/backport-label.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PullRequestSummary } from './backport-label'
+import {
+  isBackportBranchForBase,
+  planBackportLabels,
+  toSafeBranchName
+} from './backport-label'
+
+function pr(
+  number: number,
+  headRefName: string,
+  baseRefName: string,
+  labels: string[] = []
+): PullRequestSummary {
+  return {
+    number,
+    headRefName,
+    baseRefName,
+    labels: labels.map((name) => ({ name }))
+  }
+}
+
+describe('toSafeBranchName', () => {
+  it('replaces every slash, matching the workflow tr', () => {
+    expect(toSafeBranchName('cloud/1.47')).toBe('cloud-1.47')
+    expect(toSafeBranchName('core/1.45')).toBe('core-1.45')
+    expect(toSafeBranchName('release/hotfix/urgent')).toBe(
+      'release-hotfix-urgent'
+    )
+  })
+
+  it('leaves slashless branches alone', () => {
+    expect(toSafeBranchName('main')).toBe('main')
+  })
+})
+
+describe('isBackportBranchForBase', () => {
+  it('recognises the branches pr-backport.yaml generates', () => {
+    expect(
+      isBackportBranchForBase('backport-13875-to-cloud-1.47', 'cloud/1.47')
+    ).toBe(true)
+    expect(
+      isBackportBranchForBase('backport-13875-to-core-1.47', 'core/1.47')
+    ).toBe(true)
+    expect(
+      isBackportBranchForBase('backport-13971-to-cloud-1.45', 'cloud/1.45')
+    ).toBe(true)
+  })
+
+  it('recognises non-release targets that use the branch: label form', () => {
+    expect(
+      isBackportBranchForBase('backport-42-to-release-hotfix', 'release/hotfix')
+    ).toBe(true)
+  })
+
+  it('rejects a branch whose encoded target is not the PR base', () => {
+    expect(
+      isBackportBranchForBase('backport-13875-to-cloud-1.47', 'cloud/1.45')
+    ).toBe(false)
+    expect(
+      isBackportBranchForBase('backport-13875-to-cloud-1.47', 'main')
+    ).toBe(false)
+  })
+
+  it('rejects ordinary branches that merely mention backport', () => {
+    expect(isBackportBranchForBase('fix/backport-tooling', 'cloud/1.47')).toBe(
+      false
+    )
+    expect(isBackportBranchForBase('backport-cloud-1.47', 'cloud/1.47')).toBe(
+      false
+    )
+    expect(
+      isBackportBranchForBase('glary/backport-label-invariant', 'main')
+    ).toBe(false)
+  })
+
+  it('requires a numeric source PR number', () => {
+    expect(
+      isBackportBranchForBase('backport-abc-to-cloud-1.47', 'cloud/1.47')
+    ).toBe(false)
+  })
+})
+
+describe('planBackportLabels', () => {
+  // The four PRs from the incident: #13875 and #13971 both hit cherry-pick
+  // conflicts, so pr-backport.yaml never reached its `gh pr create --label
+  // "backport"` call and the backports were opened by hand with only the
+  // auto-applied size label.
+  it('flags hand-created backport PRs that are missing the label', () => {
+    expect(
+      planBackportLabels([
+        pr(14018, 'backport-13875-to-cloud-1.47', 'cloud/1.47', ['size:M']),
+        pr(14019, 'backport-13875-to-core-1.47', 'core/1.47', ['size:M']),
+        pr(14020, 'backport-13971-to-cloud-1.47', 'cloud/1.47', ['size:M']),
+        pr(14021, 'backport-13971-to-cloud-1.45', 'cloud/1.45', ['size:M'])
+      ])
+    ).toEqual([14018, 14019, 14020, 14021])
+  })
+
+  it('leaves workflow-created backports alone', () => {
+    expect(
+      planBackportLabels([
+        pr(13830, 'backport-13825-to-cloud-1.47', 'cloud/1.47', [
+          'backport',
+          'size:L'
+        ])
+      ])
+    ).toEqual([])
+  })
+
+  it('ignores PRs that are not backports', () => {
+    expect(
+      planBackportLabels([
+        pr(14022, 'glary/release-sheriff-auto-assign', 'main', ['size:L']),
+        pr(14023, 'fix/backport-docs', 'main')
+      ])
+    ).toEqual([])
+  })
+
+  it('returns each PR once, in ascending order', () => {
+    expect(
+      planBackportLabels([
+        pr(20, 'backport-2-to-core-1.47', 'core/1.47'),
+        pr(10, 'backport-1-to-cloud-1.47', 'cloud/1.47'),
+        pr(20, 'backport-2-to-core-1.47', 'core/1.47')
+      ])
+    ).toEqual([10, 20])
+  })
+
+  it('handles an empty candidate list', () => {
+    expect(planBackportLabels([])).toEqual([])
+  })
+})

--- a/scripts/cicd/backport-label.test.ts
+++ b/scripts/cicd/backport-label.test.ts
@@ -54,6 +54,19 @@ describe('isBackportBranchForBase', () => {
     ).toBe(true)
   })
 
+  // The slash-to-dash encoding mirrors the workflow's `tr '/' '-'` and is
+  // therefore non-injective by design: one backport head branch matches both a
+  // slashed base and its dashed twin. Pinned so a future "make it injective"
+  // change cannot silently stop matching the branches the workflow generates.
+  it('matches both a slashed base and its dashed twin (mirrors the producer)', () => {
+    expect(
+      isBackportBranchForBase('backport-42-to-release-hotfix', 'release/hotfix')
+    ).toBe(true)
+    expect(
+      isBackportBranchForBase('backport-42-to-release-hotfix', 'release-hotfix')
+    ).toBe(true)
+  })
+
   it('rejects a branch whose encoded target is not the PR base', () => {
     expect(
       isBackportBranchForBase('backport-13875-to-cloud-1.47', 'cloud/1.45')

--- a/scripts/cicd/backport-label.ts
+++ b/scripts/cicd/backport-label.ts
@@ -1,0 +1,65 @@
+/**
+ * Decides which open pull requests are backports that are missing the
+ * `backport` label.
+ *
+ * Why this exists: `pr-backport.yaml` applies the label at exactly one point —
+ * the `gh pr create --label "backport"` call it makes itself. Whenever the
+ * cherry-pick conflicts, that call never happens and the backport is finished
+ * by hand (the workflow's own failure comment instructs a human or agent to
+ * "create PR titled ... with label backport"). That handoff is easy to miss,
+ * and a backport PR without the label is invisible to
+ * `backport-auto-merge.yaml`, which sweeps `gh pr list --label backport`, so
+ * the PR sits open until somebody notices.
+ *
+ * The label is therefore derived from the branch naming convention instead of
+ * being trusted to whoever opened the PR.
+ */
+
+/**
+ * Mirrors the branch name `pr-backport.yaml` builds for a backport:
+ * `BACKPORT_BRANCH="backport-${PR_NUMBER}-to-$(echo "$TARGET" | tr '/' '-')"`.
+ */
+export function toSafeBranchName(branch: string): string {
+  return branch.replaceAll('/', '-')
+}
+
+const BACKPORT_BRANCH_PATTERN = /^backport-\d+-to-(.+)$/
+
+/**
+ * True when `headRef` is the backport branch that `pr-backport.yaml` would
+ * have generated for a backport targeting `baseRef`.
+ *
+ * The target encoded in the branch name must match the PR's actual base, so a
+ * `backport-123-to-cloud-1.47` branch retargeted at `main` is not treated as a
+ * backport.
+ */
+export function isBackportBranchForBase(
+  headRef: string,
+  baseRef: string
+): boolean {
+  const match = BACKPORT_BRANCH_PATTERN.exec(headRef)
+  if (!match) return false
+  return match[1] === toSafeBranchName(baseRef)
+}
+
+export interface PullRequestSummary {
+  number: number
+  headRefName: string
+  baseRefName: string
+  labels: { name: string }[]
+}
+
+export const BACKPORT_LABEL = 'backport'
+
+/**
+ * Returns the numbers of the PRs that are backports by branch convention but
+ * do not carry the `backport` label yet.
+ */
+export function planBackportLabels(prs: PullRequestSummary[]): number[] {
+  const needsLabel = prs.filter(
+    (pr) =>
+      isBackportBranchForBase(pr.headRefName, pr.baseRefName) &&
+      !pr.labels.some((label) => label.name === BACKPORT_LABEL)
+  )
+  return [...new Set(needsLabel.map((pr) => pr.number))].sort((a, b) => a - b)
+}

--- a/scripts/cicd/backport-label.ts
+++ b/scripts/cicd/backport-label.ts
@@ -18,6 +18,14 @@
 /**
  * Mirrors the branch name `pr-backport.yaml` builds for a backport:
  * `BACKPORT_BRANCH="backport-${PR_NUMBER}-to-$(echo "$TARGET" | tr '/' '-')"`.
+ *
+ * The slash-to-dash mapping is deliberately identical to that `tr`, including
+ * its non-injectivity (`release/hotfix` and `release-hotfix` both encode to
+ * `release-hotfix`). Matching the producer exactly is the point: an "injective"
+ * encoding here would stop recognising the branches the workflow actually
+ * creates. Divergence, not the shared collision, would be the bug — and it is
+ * harmless in practice because the label grants nothing on its own and real
+ * targets are `core/x.y` / `cloud/x.y`, which have no dashed twin.
  */
 export function toSafeBranchName(branch: string): string {
   return branch.replaceAll('/', '-')

--- a/scripts/cicd/plan-backport-labels.ts
+++ b/scripts/cicd/plan-backport-labels.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+import { appendFileSync, readFileSync } from 'node:fs'
+import { parseArgs } from 'node:util'
+
+import type { PullRequestSummary } from './backport-label'
+import { planBackportLabels } from './backport-label'
+
+function setOutput(name: string, value: string) {
+  const file = process.env.GITHUB_OUTPUT
+  if (!file) {
+    process.stdout.write(`${name}=${value}\n`)
+    return
+  }
+  appendFileSync(file, `${name}=${value}\n`)
+}
+
+function main() {
+  const { values } = parseArgs({
+    options: {
+      prs: { type: 'string', default: 'prs.json' }
+    }
+  })
+
+  const prs = JSON.parse(
+    readFileSync(values.prs, 'utf8')
+  ) as PullRequestSummary[]
+
+  const numbers = planBackportLabels(prs)
+  process.stderr.write(
+    `${prs.length} candidate PR(s); ${numbers.length} missing the backport label.\n`
+  )
+  for (const number of numbers) {
+    process.stderr.write(`  #${number}\n`)
+  }
+
+  setOutput('numbers', numbers.join(' '))
+}
+
+main()


### PR DESCRIPTION
## Summary

Backport PRs that are finished by hand after a cherry-pick conflict never get the `backport` label, which makes them invisible to `backport-auto-merge.yaml` and leaves them sitting open — this derives the label from the branch naming convention instead.

## Changes

- **What**: New `pr-label-backport.yaml` adds the `backport` label to any PR whose head branch is the `backport-<pr>-to-<target>` branch that `pr-backport.yaml` generates for that PR's base. Runs on PR open/reopen/edit, plus a sweep offset from the `backport-auto-merge.yaml` schedule. The rule lives in `scripts/cicd/backport-label.ts` so it is unit tested.

### Why

`pr-backport.yaml` applies the label in exactly one place — its own `gh pr create --label "backport"` call. That call is only reached when every cherry-pick applies cleanly. When one conflicts, the job fails and its failure comment asks a human or agent to finish the backport by hand, "with label backport". That handoff gets missed, and nothing detects it.

Worked example, from the workflow runs on 2026-07-23:

- #13875 merged; run `29972930308` conflicted on `useProcessedWidgets.ts` for both `core/1.47` and `cloud/1.47`.
- #13971 merged; run `29975951441` conflicted on `authStore.ts` for `cloud/1.45`.
- Both runs failed before `Create PR for each successful backport`, so no PR was ever created by the workflow.
- #14018, #14019, #14020 and #14021 were then opened by hand 35 minutes later with the correct `backport-*-to-*` branches and titles, but only a `size:M` label.
- `backport-auto-merge.yaml` sweeps `gh pr list --label backport`, so all four were invisible to it.

Timeline events confirm the label was never added rather than added and removed: the only `labeled` event on each is `dosubot[bot]` applying `size:M`, and there is no `unlabeled` event. No workflow in the repo removes the `backport` label.

## Review Focus

- The rule requires the target encoded in the branch name to equal the PR's base (`backport-13875-to-cloud-1.47` counts only against `cloud/1.47`), so a retargeted or coincidentally-named branch is not mislabelled.
- The label is added via REST (`POST /issues/{n}/labels`) because `gh pr edit --add-label` currently fails repo-wide on a deprecated projectCards GraphQL field.
- `pull_request_target` is used to get write permission on fork PRs; only the base branch is checked out, never PR head code.
- Replaying the four incident PRs plus the correctly-labelled #13830 through the planner flags exactly #14018-#14021 and leaves #13830 alone.

### Not fixed here

Run `29975951441` also exposes a separate bug in `pr-backport.yaml`: `backport-13971-to-cloud-1.47` cherry-picked cleanly and was pushed, but because its sibling `cloud/1.45` target conflicted, the whole `Backport commits` step exited 1 — which skipped `Create PR for each successful backport` and let `Cleanup stranded backport branches` delete the good branch. Both runs also failed to post their failure comment at all (`Unable to create comment because issue is locked`), so nobody was notified. Those are worth a follow-up but are a different defect.
