### PR TITLE
fix(dialog): reject PrimeVue-only props on Reka dialogs at compile time

### DIFF
--- a/src/components/dialog/rekaRendererProps.test.ts
+++ b/src/components/dialog/rekaRendererProps.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Reka is the default dialog renderer (#12593), and `GlobalDialog`'s Reka
+ * branch binds only the Reka props — a PrimeVue `style`/`pt`/`class` on a Reka
+ * dialog is silently dropped and the dialog renders at the default size. The
+ * defect shipped twice (#12666) and needed two follow-up fixes (#13092,
+ * #13633), so `DialogComponentProps` is discriminated on `renderer` to reject
+ * those props at compile time.
+ *
+ * The `@ts-expect-error` assertions below are the regression net: each one
+ * reconstructs a shipped pre-fix prop object, and `pnpm typecheck` fails if the
+ * discriminated union stops rejecting it.
+ */
+import { createTestingPinia } from '@pinia/testing'
+import { cleanup, render, screen } from '@testing-library/vue'
+import { setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
+import type { DialogComponentProps } from '@/stores/dialogStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { g: { close: 'Close', maximizeDialog: 'Maximize' } } },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const Body = defineComponent({
+  name: 'Body',
+  setup: () => () => h('p', 'body content')
+})
+
+describe('PrimeVue-only props on the Reka renderer', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('are dropped rather than applied', async () => {
+    render(GlobalDialog, { global: { plugins: [PrimeVue, i18n] } })
+
+    // Only reachable by defeating the type below; this is the state the type
+    // now prevents.
+    const deadProps = {
+      style: 'width: min(1328px, 95vw)',
+      pt: { root: { class: 'legacy-pt-root' } }
+    } as unknown as DialogComponentProps
+
+    useDialogStore().showDialog({
+      key: 'reka-ignores-primevue-props',
+      title: 'Pricing',
+      component: Body,
+      dialogComponentProps: deadProps
+    })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.getAttribute('style') ?? '').not.toContain('1328px')
+    expect(dialog).not.toHaveClass('legacy-pt-root')
+  })
+
+  it('are rejected on an implicit Reka dialog (the #12666 / #13633 shape)', () => {
+    // @ts-expect-error `style`/`pt` are PrimeVue-only; with `renderer` omitted
+    // the dialog renders with Reka and both are ignored. Use `size` +
+    // `contentClass`.
+    const prefix13633: DialogComponentProps = {
+      style: 'width: min(1328px, 95vw); max-height: 958px;',
+      pt: {
+        root: { class: 'rounded-2xl bg-transparent h-full' },
+        content: { class: '!p-0 rounded-2xl h-full' }
+      }
+    }
+
+    expect(prefix13633).toBeDefined()
+  })
+
+  it('are rejected on an explicit Reka dialog (the #13092 shape)', () => {
+    // @ts-expect-error `style`/`pt` are ignored by the Reka renderer.
+    const prefix13092: DialogComponentProps = {
+      renderer: 'reka',
+      style: 'max-width: 95vw; max-height: 90vh;',
+      pt: { root: { class: 'rounded-2xl bg-transparent' } }
+    }
+
+    expect(prefix13092).toBeDefined()
+  })
+
+  it('are rejected when spread in from a shared props object', () => {
+    const sharedShellProps = {
+      style: 'width: min(1328px, 95vw); max-height: 958px;',
+      pt: { root: { class: 'rounded-2xl bg-transparent h-full' } }
+    }
+
+    // @ts-expect-error the props are dead however they reach the dialog.
+    const spreadPreFix: DialogComponentProps = {
+      ...sharedShellProps,
+      modal: false
+    }
+
+    expect(spreadPreFix).toBeDefined()
+  })
+
+  it('accepts the Reka equivalents these fixes landed', () => {
+    const fixed: DialogComponentProps = {
+      renderer: 'reka',
+      size: 'full',
+      modal: false,
+      contentClass: 'sm:max-w-7xl max-h-[90vh] rounded-2xl',
+      overlayClass: 'bg-black/60',
+      headerClass: 'p-0',
+      bodyClass: 'p-0',
+      footerClass: 'p-0'
+    }
+
+    expect(fixed.size).toBe('full')
+  })
+
+  it('keeps the PrimeVue props available on the legacy renderer', () => {
+    const legacy: DialogComponentProps = {
+      renderer: 'primevue',
+      style: 'width: min(1328px, 95vw)',
+      pt: { root: { class: 'rounded-2xl' } },
+      position: 'top',
+      unstyled: true
+    }
+
+    expect(legacy.renderer).toBe('primevue')
+  })
+})

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -28,14 +28,17 @@ type DialogPosition =
  */
 type DialogRenderer = 'primevue' | 'reka'
 
+/**
+ * Props read by both renderers, plus the Reka-only props. `GlobalDialog`'s
+ * Reka branch binds each of these explicitly (or forwards them to
+ * `rekaPrimeVueBridge`); the PrimeVue branch `v-bind`s the whole object.
+ */
 interface CustomDialogComponentProps {
   maximizable?: boolean
   maximized?: boolean
   onClose?: () => void
   closable?: boolean
   modal?: boolean
-  position?: DialogPosition
-  pt?: DialogPassThroughOptions
   closeOnEscape?: boolean
   dismissableMask?: boolean
   /**
@@ -46,7 +49,6 @@ interface CustomDialogComponentProps {
    * outside-pointer dismissal are unaffected. Defaults to `true`.
    */
   dismissOnFocusOutside?: boolean
-  unstyled?: boolean
   headless?: boolean
   renderer?: DialogRenderer
   size?: DialogContentSize
@@ -78,8 +80,54 @@ interface CustomDialogComponentProps {
   footerClass?: HTMLAttributes['class']
 }
 
-export type DialogComponentProps = Record<string, unknown> &
-  CustomDialogComponentProps
+/**
+ * Props only the PrimeVue `Dialog` reads. `GlobalDialog`'s Reka branch never
+ * binds them, so passing one to a Reka dialog is a silent no-op: the dialog
+ * renders at the default `size` with none of the requested chrome. That defect
+ * shipped twice (#12666) and needed two follow-up fixes (#13092, #13633), so
+ * `DialogComponentProps` makes it a compile error instead.
+ *
+ * Reka equivalents: `style`/`class`/`pt.root`/`pt.content` -> `size` +
+ * `contentClass` / `bodyClass`; `pt.mask` -> `overlayClass`; `pt.header` ->
+ * `headerClass`; `pt.footer` -> `footerClass`.
+ */
+interface PrimeVueOnlyDialogProps {
+  position?: DialogPosition
+  pt?: DialogPassThroughOptions
+  unstyled?: boolean
+  style?: HTMLAttributes['style']
+  class?: HTMLAttributes['class']
+}
+
+/**
+ * Props for a dialog on the default Reka renderer. The index signature is the
+ * escape hatch for props neither renderer declares (extension dialogs); the
+ * `never` mapping still rejects the PrimeVue-only props above, whether
+ * `renderer: 'reka'` is explicit or left to the store default.
+ */
+type RekaDialogComponentProps = Record<string, unknown> &
+  CustomDialogComponentProps & { renderer?: 'reka' } & {
+    [K in keyof PrimeVueOnlyDialogProps]?: never
+  }
+
+/** Props for a dialog opted in to the legacy PrimeVue renderer. */
+type PrimeVueDialogComponentProps = Record<string, unknown> &
+  CustomDialogComponentProps &
+  PrimeVueOnlyDialogProps & { renderer: 'primevue' }
+
+/** Author-facing dialog props, discriminated on `renderer`. */
+export type DialogComponentProps =
+  | RekaDialogComponentProps
+  | PrimeVueDialogComponentProps
+
+/**
+ * Props on a live dialog stack item, after the store has merged its defaults.
+ * `GlobalDialog` renders both branches, so it reads both renderers' props
+ * regardless of which branch is active.
+ */
+type ResolvedDialogComponentProps = Record<string, unknown> &
+  CustomDialogComponentProps &
+  PrimeVueOnlyDialogProps & { renderer?: DialogRenderer }
 
 export interface DialogInstance {
   key: string
@@ -91,7 +139,7 @@ export interface DialogInstance {
   contentProps: Record<string, unknown>
   footerComponent?: Component
   footerProps?: Record<string, unknown>
-  dialogComponentProps: DialogComponentProps
+  dialogComponentProps: ResolvedDialogComponentProps
   priority: number
 }
 
@@ -120,7 +168,7 @@ export interface ShowDialogOptions<
 interface UpdateDialogOptions {
   key: string
   contentProps?: Partial<DialogInstance['contentProps']>
-  dialogComponentProps?: Partial<DialogComponentProps>
+  dialogComponentProps?: Partial<ResolvedDialogComponentProps>
 }
 
 export const useDialogStore = defineStore('dialog', () => {


### PR DESCRIPTION
## Summary

Make PrimeVue-only dialog props a compile error on Reka-rendered dialogs, so the "silently ignored prop" defect that shipped twice can't ship a third time.

## The bug class

Reka is the default dialog renderer (#12593), and `GlobalDialog`'s Reka branch binds only the Reka props (`size`, `contentClass`, `overlayClass`, `headerClass`, `bodyClass`, `footerClass`, `modal`, `maximized`, ...). A PrimeVue `style` / `pt` / `class` / `position` / `unstyled` on a Reka dialog is dropped on the floor — no error, no warning, the dialog just renders at the default `md` (576px) frame.

It recurred because the failure is invisible at the call site:

- #12666 landed dialogs carrying PrimeVue-only `style`/`pt` sizing props
- #13092 — "restore unified pricing dialog width (Reka renderer ...)" — fixed the fallout
- #13633 — "size pricing dialogs with Reka props" — fixed more of the same fallout

Same defect, two follow-up fixes. Related: #13558 (dialog architecture track).

## Changes

- **What**: `DialogComponentProps` is now a union discriminated on `renderer`. PrimeVue-only props move out of `CustomDialogComponentProps` into `PrimeVueOnlyDialogProps`, which is only reachable under `renderer: 'primevue'`. The Reka branch keeps its `Record<string, unknown>` index signature (the extension escape hatch) but maps those keys to `never`.
  `DialogInstance` / `updateDialog` use a separate `ResolvedDialogComponentProps` — `GlobalDialog` renders both branches, so it still reads both renderers' props.
- **Breaking**: type-level only. Callers passing `style`/`pt`/`class`/`position`/`unstyled` must either switch to the Reka equivalent or opt in with `renderer: 'primevue'`. No runtime change.

## Why a type, not a lint rule

Strictly stronger and cheaper: it can't be `eslint-disable`d, needs no new plugin infrastructure (the repo has no local ESLint rules today), and the `?: never` mapping catches the props even when they arrive through a variable or a spread — which is exactly the shape #13633 had (`const dialogComponentProps = { style, pt }` reused by two call sites). A selector-based `no-restricted-syntax` rule would only have seen the inline literal.

The escape hatch stays honest: the index signature still allows undeclared props, so this constrains the five props the fallout PRs actually removed plus the two PrimeVue-only ones already declared on the type — not a guessed list.

## Proof it fails on the pre-fix code

`src/components/dialog/rekaRendererProps.test.ts` reconstructs the shipped pre-fix prop objects behind `@ts-expect-error`, so `pnpm typecheck` is the gate. Reverting `DialogComponentProps` to its pre-PR shape:

```
src/components/dialog/rekaRendererProps.test.ts(70,5): error TS2578: Unused '@ts-expect-error' directive.
src/components/dialog/rekaRendererProps.test.ts(85,5): error TS2578: Unused '@ts-expect-error' directive.
src/components/dialog/rekaRendererProps.test.ts(101,5): error TS2578: Unused '@ts-expect-error' directive.
```

Covered: the #13633 shape (no `renderer`, defaults to Reka), the #13092 shape (explicit `renderer: 'reka'`), and the same props arriving via spread from a shared object. Positive controls assert the Reka equivalents still compile and that `renderer: 'primevue'` still accepts the full PrimeVue surface. One behavioral test renders `GlobalDialog` and shows a `style`/`pt` never reaches the DOM on the Reka path — i.e. the type is describing reality, not a guess.

## Violation count

**Zero** repo-wide — `pnpm typecheck` is clean with the union in place. #13092 and #13633 already fixed the two known sites, so this is purely a net under them. No drive-by refactor needed.

## Review Focus

- The `Record<string, unknown> & { [K in keyof PrimeVueOnlyDialogProps]?: never }` intersection is what makes this work despite the index signature: the explicit `never` declaration wins over the index signature, so the props are rejected even without excess-property checking.
- `updateDialog` intentionally keeps the permissive `Partial<ResolvedDialogComponentProps>`. `Partial<Union>` erases the discriminant, so narrowing it there would buy nothing; its one production caller only patches `contentProps`.
- No production call site uses `renderer: 'primevue'` any more (only tests). The branch is kept for the FE-578 cleanup rather than removed here.

## Gates

`pnpm typecheck`, `pnpm lint` (0 errors; 44 pre-existing `import-x/no-named-as-default-member` warnings elsewhere), `pnpm knip`, `pnpm format`, `pnpm test:unit` (1020 files / 13466 tests) — all pass.
