### PR TITLE
fix(glsl): stop live preview from rendering black frames when input is unavailable

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -717,7 +717,7 @@ const lgraphNode = computed(() => {
 // reaching through lgraphNode for promoted preview resolution.
 const { promotedPreviews } = usePromotedPreviews(lgraphNode)
 
-useGLSLPreview(lgraphNode)
+const { hideExecutedOutput } = useGLSLPreview(lgraphNode)
 
 const showAdvancedInputsButton = computed(() => {
   const node = lgraphNode.value
@@ -780,7 +780,12 @@ const nodeMedia = computed(() => {
   const newOutputs = nodeOutputs.nodeOutputs[nodeOutputLocatorId.value]
   const node = lgraphNode.value
 
-  if (!node || !newOutputs?.images?.length || node.hideOutputImages)
+  if (
+    !node ||
+    !newOutputs?.images?.length ||
+    node.hideOutputImages ||
+    hideExecutedOutput.value
+  )
     return undefined
 
   if (node instanceof SubgraphNode) return undefined

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -23,6 +23,7 @@ const mockRendererFactory = vi.hoisted(() => {
   const setBoolUniform = vi.fn()
   const bindCurveTexture = vi.fn()
   const bindInputImage = vi.fn()
+  const clearInputImage = vi.fn()
   const render = vi.fn()
   const toBlob = vi.fn(() => Promise.resolve(new Blob(['test'])))
   const dispose = vi.fn()
@@ -40,6 +41,7 @@ const mockRendererFactory = vi.hoisted(() => {
         setBoolUniform,
         bindCurveTexture,
         bindInputImage,
+        clearInputImage,
         render,
         toBlob,
         dispose
@@ -54,6 +56,7 @@ const mockRendererFactory = vi.hoisted(() => {
     setBoolUniform,
     bindCurveTexture,
     bindInputImage,
+    clearInputImage,
     render,
     toBlob,
     dispose
@@ -66,13 +69,15 @@ vi.mock('@/renderer/glsl/useGLSLRenderer', () => ({
 }))
 
 const mockSetNodePreviewsByNodeId = vi.fn()
+const mockRevokePreviewsByLocatorId = vi.fn()
 const mockNodeOutputs = reactive<Record<string, unknown>>({})
 
 vi.mock('@/stores/nodeOutputStore', () => ({
   useNodeOutputStore: () => ({
     setNodePreviewsByNodeId: mockSetNodePreviewsByNodeId,
     setNodePreviewsByLocatorId: vi.fn(),
-    revokePreviewsByLocatorId: vi.fn(),
+    revokePreviewsByLocatorId: mockRevokePreviewsByLocatorId,
+    getNodeImageUrls: vi.fn(() => undefined),
     nodeOutputs: mockNodeOutputs
   })
 }))
@@ -126,6 +131,8 @@ describe('useGLSLPreview', () => {
     mockRendererFactory.lastConfig.value = undefined
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:test')
     globalThis.URL.revokeObjectURL = vi.fn()
+    globalThis.ImageBitmap ??=
+      class ImageBitmap {} as unknown as typeof globalThis.ImageBitmap
   })
 
   it('does not activate for non-GLSLShader nodes', () => {
@@ -286,6 +293,106 @@ describe('useGLSLPreview', () => {
       const toBlobOrder = mockRendererFactory.toBlob.mock.invocationCallOrder[0]
       expect(compileOrder).toBeLessThan(renderOrder)
       expect(renderOrder).toBeLessThan(toBlobOrder)
+    })
+
+    it('binds a resolved image to its original slot when an earlier slot is unresolved', async () => {
+      const image1 = fromAny<HTMLImageElement, unknown>({
+        naturalWidth: 64,
+        naturalHeight: 64
+      })
+      const node = createMockNode({
+        inputs: [
+          { name: 'images.image0', link: 10 },
+          { name: 'images.image1', link: 11 }
+        ],
+        getInputNode: vi.fn((slot: number) =>
+          slot === 1 ? fromAny({ imgs: [image1] }) : null
+        )
+      })
+      await setupAndRender(node)
+      for (let i = 0; i < 5; i++) await nextTick()
+
+      expect(mockRendererFactory.bindInputImage).toHaveBeenCalledTimes(1)
+      expect(mockRendererFactory.bindInputImage).toHaveBeenCalledWith(1, image1)
+    })
+
+    it('clears a previously bound texture when its slot becomes unavailable while another still resolves', async () => {
+      const img0 = fromAny<HTMLImageElement, unknown>({
+        naturalWidth: 32,
+        naturalHeight: 32
+      })
+      const img1 = fromAny<HTMLImageElement, unknown>({
+        naturalWidth: 32,
+        naturalHeight: 32
+      })
+      const up0 = { imgs: [img0] as unknown[] }
+      const up1 = { imgs: [img1] as unknown[] }
+      const node = createMockNode({
+        inputs: [
+          { name: 'images.image0', link: 10 },
+          { name: 'images.image1', link: 11 }
+        ],
+        getInputNode: vi.fn((slot: number) => fromAny(slot === 0 ? up0 : up1))
+      })
+      const store = fromAny<WidgetValueStoreStub, unknown>(
+        useWidgetValueStore()
+      )
+      store._widgetMap.set(
+        widgetId('test-graph-id', node.id, 'fragment_shader'),
+        { value: 'void main() {}' }
+      )
+      mockNodeOutputs['1'] = {
+        images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
+      }
+
+      const nodeRef = shallowRef<LGraphNode | null>(null)
+      useGLSLPreview(nodeRef)
+      nodeRef.value = node
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      for (let i = 0; i < 6; i++) await nextTick()
+
+      expect(mockRendererFactory.bindInputImage).toHaveBeenCalledWith(0, img0)
+      expect(mockRendererFactory.bindInputImage).toHaveBeenCalledWith(1, img1)
+
+      up0.imgs = []
+      vi.clearAllMocks()
+      delete mockNodeOutputs['1']
+      await nextTick()
+      mockNodeOutputs['1'] = {
+        images: [{ filename: 'a.png', subfolder: '', type: 'temp' }]
+      }
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      for (let i = 0; i < 6; i++) await nextTick()
+
+      expect(mockRendererFactory.clearInputImage).toHaveBeenCalledWith(0)
+      expect(mockRendererFactory.bindInputImage).toHaveBeenCalledWith(1, img1)
+      expect(mockRendererFactory.bindInputImage).not.toHaveBeenCalledWith(
+        0,
+        expect.anything()
+      )
+    })
+
+    it('hides the executed output after publishing a live preview', async () => {
+      const node = createMockNode()
+      const { hideExecutedOutput } = await setupAndRender(node)
+      for (let i = 0; i < 5; i++) await nextTick()
+
+      expect(hideExecutedOutput.value).toBe(true)
+    })
+
+    it('revokes the live preview and reveals the executed output when the input is unavailable', async () => {
+      const node = createMockNode({
+        inputs: [{ name: 'images.image0', link: 10 }],
+        getInputNode: vi.fn(() => null)
+      })
+      const { hideExecutedOutput } = await setupAndRender(node)
+      for (let i = 0; i < 5; i++) await nextTick()
+
+      expect(hideExecutedOutput.value).toBe(false)
+      expect(mockRevokePreviewsByLocatorId).toHaveBeenCalledWith('1')
+      expect(mockRendererFactory.compileFragment).not.toHaveBeenCalled()
     })
 
     it('sets lastError on compilation failure', async () => {

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -47,6 +47,7 @@ export function useGLSLPreview(
   nodeMaybe: MaybeRefOrGetter<LGraphNode | null | undefined>
 ) {
   const lastError = ref<string | null>(null)
+  const hideExecutedOutput = ref(false)
 
   const nodeRef = computed(() => toValue(nodeMaybe) ?? null)
 
@@ -78,7 +79,8 @@ export function useGLSLPreview(
             isGLSLNode,
             isGLSLSubgraphNode,
             lastError,
-            isActive
+            isActive,
+            hideExecutedOutput
           )
         )!
       } else if (!related && innerScope) {
@@ -99,6 +101,7 @@ export function useGLSLPreview(
 
   return {
     isActive: computed(() => isActive.value),
+    hideExecutedOutput: computed(() => hideExecutedOutput.value),
     lastError,
     dispose() {
       innerDispose?.()
@@ -115,12 +118,24 @@ export function useGLSLPreview(
  * independently of the component lifecycle.
  * Returns a dispose function.
  */
+type InputImage = HTMLImageElement | ImageBitmap
+
+function loadImageFromUrl(url: string): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => resolve(null)
+    img.src = url
+  })
+}
+
 function createInnerPreview(
   nodeRef: ComputedRef<LGraphNode | null>,
   isGLSLNode: ComputedRef<boolean>,
   isGLSLSubgraphNode: ComputedRef<boolean>,
   lastError: Ref<string | null>,
-  isActiveOut: Ref<boolean>
+  isActiveOut: Ref<boolean>,
+  hideExecutedOutput: Ref<boolean>
 ): () => void {
   const widgetValueStore = useWidgetValueStore()
   const nodeOutputStore = useNodeOutputStore()
@@ -134,7 +149,9 @@ function createInnerPreview(
     const node = nodeRef.value
     if (!node?.isSubgraphNode()) return null
     const subgraph = node.subgraph as Subgraph | undefined
-    return subgraph?.nodes.find((n) => n.type === GLSL_NODE_TYPE) ?? null
+    const shaders =
+      subgraph?.nodes.filter((n) => n.type === GLSL_NODE_TYPE) ?? []
+    return shaders.length === 1 ? shaders[0] : null
   })()
 
   const ownerSubgraphNode = (() => {
@@ -243,44 +260,44 @@ function createInnerPreview(
     rendererConfig
   )
 
-  function loadInputImages(): void {
-    const node = nodeRef.value
-    if (!node?.inputs || !renderer) return
+  async function resolveSlotImage(
+    node: LGraphNode,
+    slot: number
+  ): Promise<InputImage | null> {
+    const upstreamNode = node.getInputNode(slot)
+    if (upstreamNode?.imgs?.length) return upstreamNode.imgs[0]
 
-    if (isGLSLSubgraphNode.value) {
-      let imageSlotIndex = 0
-      for (let slot = 0; slot < node.inputs.length; slot++) {
-        if (node.inputs[slot].type !== 'IMAGE') continue
-        const upstreamNode = node.getInputNode(slot)
-        if (upstreamNode?.imgs?.length) {
-          renderer.bindInputImage(imageSlotIndex, upstreamNode.imgs[0])
-        }
-        imageSlotIndex++
-      }
-      return
+    if (upstreamNode) {
+      const url = nodeOutputStore.getNodeImageUrls(upstreamNode)?.[0]
+      if (url) return await loadImageFromUrl(url)
     }
 
-    let imageSlotIndex = 0
+    const owner = ownerSubgraphNode
+    if (owner) return getImageThroughSubgraphBoundary(node, slot, owner) ?? null
+
+    return null
+  }
+
+  async function resolveInputImages(): Promise<{
+    images: (InputImage | null)[]
+    expected: number
+  }> {
+    const node = nodeRef.value
+    if (!node?.inputs) return { images: [], expected: 0 }
+
+    const images: (InputImage | null)[] = []
+    let expected = 0
     for (let slot = 0; slot < node.inputs.length; slot++) {
       const input = node.inputs[slot]
-      if (!input.name.startsWith('images.image')) continue
+      const isImageInput = isGLSLSubgraphNode.value
+        ? input.type === 'IMAGE'
+        : input.name.startsWith('images.image')
+      if (!isImageInput) continue
+      if (input.link != null) expected++
 
-      const upstreamNode = node.getInputNode(slot)
-      if (upstreamNode?.imgs?.length) {
-        renderer.bindInputImage(imageSlotIndex, upstreamNode.imgs[0])
-        imageSlotIndex++
-        continue
-      }
-
-      const owner = ownerSubgraphNode
-      if (owner) {
-        const img = getImageThroughSubgraphBoundary(node, slot, owner)
-        if (img) {
-          renderer.bindInputImage(imageSlotIndex, img)
-        }
-      }
-      imageSlotIndex++
+      images.push(await resolveSlotImage(node, slot))
     }
+    return { images, expected }
   }
 
   const customResolution = computed((): [number, number] | null => {
@@ -309,50 +326,15 @@ function createInnerPreview(
     )
   })
 
-  function getResolution(): [number, number] {
+  function getResolution(images: InputImage[]): [number, number] {
     const custom = customResolution.value
     if (custom) return custom
 
-    const node = nodeRef.value
-    if (!node?.inputs) return [DEFAULT_SIZE, DEFAULT_SIZE]
-
-    if (isGLSLSubgraphNode.value) {
-      for (let slot = 0; slot < node.inputs.length; slot++) {
-        if (node.inputs[slot].type !== 'IMAGE') continue
-        const upstreamNode = node.getInputNode(slot)
-        if (!upstreamNode?.imgs?.length) continue
-        const img = upstreamNode.imgs[0]
-        return clampResolution(
-          img.naturalWidth || DEFAULT_SIZE,
-          img.naturalHeight || DEFAULT_SIZE
-        )
-      }
-      return [DEFAULT_SIZE, DEFAULT_SIZE]
-    }
-
-    for (let slot = 0; slot < node.inputs.length; slot++) {
-      const input = node.inputs[slot]
-      if (!input.name.startsWith('images.image')) continue
-
-      const upstreamNode = node.getInputNode(slot)
-      if (upstreamNode?.imgs?.length) {
-        const img = upstreamNode.imgs[0]
-        return clampResolution(
-          img.naturalWidth || DEFAULT_SIZE,
-          img.naturalHeight || DEFAULT_SIZE
-        )
-      }
-
-      const owner = ownerSubgraphNode
-      if (owner) {
-        const img = getImageThroughSubgraphBoundary(node, slot, owner)
-        if (img) {
-          return clampResolution(
-            img.naturalWidth || DEFAULT_SIZE,
-            img.naturalHeight || DEFAULT_SIZE
-          )
-        }
-      }
+    const img = images[0]
+    if (img) {
+      const w = img instanceof ImageBitmap ? img.width : img.naturalWidth
+      const h = img instanceof ImageBitmap ? img.height : img.naturalHeight
+      return clampResolution(w || DEFAULT_SIZE, h || DEFAULT_SIZE)
     }
 
     return [DEFAULT_SIZE, DEFAULT_SIZE]
@@ -360,6 +342,17 @@ function createInnerPreview(
 
   let disposed = false
   let lastRendererConfig: GLSLRendererConfig | null = null
+
+  function revokePreview(): void {
+    const inner = innerGLSLNode
+    if (inner) {
+      nodeOutputStore.revokePreviewsByLocatorId(nodeToNodeLocatorId(inner))
+      return
+    }
+    const node = nodeRef.value
+    if (node)
+      nodeOutputStore.revokePreviewsByLocatorId(nodeToNodeLocatorId(node))
+  }
 
   function ensureRenderer(): ReturnType<typeof useGLSLRenderer> {
     const config = rendererConfig.value
@@ -388,11 +381,22 @@ function createInnerPreview(
     const source = shaderSource.value
     if (!source || !shouldRender.value) return
 
+    const { images, expected } = await resolveInputImages()
+    if (requestId !== renderRequestId || disposed) return
+
+    const resolved = images.filter((img): img is InputImage => img != null)
+    if (expected > 0 && resolved.length === 0) {
+      revokePreview()
+      if (isGLSLNode.value) hideExecutedOutput.value = false
+      return
+    }
+
     const r = ensureRenderer()
 
     try {
+      const [w, h] = getResolution(resolved)
+
       if (!rendererReady) {
-        const [w, h] = getResolution()
         if (!r.init(w, h)) {
           lastError.value = 'WebGL2 not available'
           return
@@ -408,10 +412,13 @@ function createInnerPreview(
       }
       lastError.value = null
 
-      const [w, h] = getResolution()
       r.setResolution(w, h)
 
-      loadInputImages()
+      for (let i = 0; i < images.length; i++) {
+        const img = images[i]
+        if (img) r.bindInputImage(i, img)
+        else r.clearInputImage(i)
+      }
 
       for (let i = 0; i < floatValues.value.length; i++) {
         r.setFloatUniform(i, floatValues.value[i])
@@ -446,6 +453,7 @@ function createInnerPreview(
       } finally {
         releaseSharedObjectUrl(blobUrl)
       }
+      if (isGLSLNode.value) hideExecutedOutput.value = true
     } catch (error) {
       if (requestId !== renderRequestId) return
       lastError.value =
@@ -460,10 +468,7 @@ function createInnerPreview(
   watch(
     shouldRender,
     (active) => {
-      if (isGLSLNode.value) {
-        const node = nodeRef.value
-        if (node) node.hideOutputImages = active
-      }
+      if (isGLSLNode.value) hideExecutedOutput.value = active
       if (active) debouncedRender()
     },
     { immediate: true }
@@ -491,21 +496,11 @@ function createInnerPreview(
   // Return dispose function for the inner tier
   return () => {
     disposed = true
+    hideExecutedOutput.value = false
     debouncedRender.cancel()
     renderer?.dispose()
     renderer = null
 
-    // Revoke preview blob URLs to avoid memory leaks
-    const inner = innerGLSLNode
-    if (inner) {
-      const locatorId = nodeToNodeLocatorId(inner)
-      nodeOutputStore.revokePreviewsByLocatorId(locatorId)
-    } else {
-      const nId = nodeId.value
-      if (nId != null) {
-        const locatorId = nodeToNodeLocatorId(nodeRef.value!)
-        nodeOutputStore.revokePreviewsByLocatorId(locatorId)
-      }
-    }
+    revokePreview()
   }
 }

--- a/src/renderer/glsl/useGLSLRenderer.test.ts
+++ b/src/renderer/glsl/useGLSLRenderer.test.ts
@@ -513,6 +513,25 @@ describe('useGLSLRenderer', () => {
     })
   })
 
+  describe('clearInputImage', () => {
+    beforeEach(() => {
+      renderer = useGLSLRenderer()
+      renderer.init(128, 128)
+    })
+
+    it('deletes the texture bound at the given index', () => {
+      renderer.bindInputImage(0, new Image())
+      mockGL.deleteTexture.mockClear()
+      renderer.clearInputImage(0)
+      expect(mockGL.deleteTexture).toHaveBeenCalledTimes(1)
+    })
+
+    it('does nothing when the slot is empty', () => {
+      renderer.clearInputImage(0)
+      expect(mockGL.deleteTexture).not.toHaveBeenCalled()
+    })
+  })
+
   describe('render', () => {
     const source = 'void main() { fragColor0 = vec4(1.0); }'
 

--- a/src/renderer/glsl/useGLSLRenderer.ts
+++ b/src/renderer/glsl/useGLSLRenderer.ts
@@ -366,6 +366,16 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     inputTextures[index] = texture
   }
 
+  function clearInputImage(index: number): void {
+    if (disposed || !gl) return
+    if (index < 0 || index >= maxInputs) return
+    const texture = inputTextures[index]
+    if (texture) {
+      gl.deleteTexture(texture)
+      inputTextures[index] = null
+    }
+  }
+
   function render(): void {
     if (disposed || !program || !pingPongFBOs || !gl || !canvas) return
 
@@ -494,6 +504,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     setBoolUniform,
     bindCurveTexture,
     bindInputImage,
+    clearInputImage,
     render,
     readPixels,
     toBlob,


### PR DESCRIPTION
## Summary
The GLSL live preview rendered a black frame at the default resolution whenever the shader's input image was not available on the frontend, and never recovered. This happened in several situations:

- Switching workflow tabs recreates nodes with empty `imgs`, so the re-mounted preview ran before the upstream image finished decoding. resolveInputImages now uses the upstream node's decoded `imgs` when present, otherwise loads the output image url (already in the store) and awaits it, deriving resolution from the resolved image.

- The upstream is an intermediate node whose output tensor is never surfaced to the UI. A connected-but-unresolved input is now detected (via `input.link`) and the node falls back to showing its own executed output instead of rendering black. The hide-output state moved to a reactive ref (`hideExecutedOutput`) so toggling it actually re-reveals the executed output.

- A subgraph interior node whose input crosses the subgraph boundary: `getInputNode` does not traverse the boundary, so connected inputs are now counted via `input.link` to avoid rendering black.

- A subgraph wrapping a multi-shader chain previously rendered one arbitrary inner shader, clobbering the promoted preview with a wrong (often black) frame. Only subgraphs that wrap a single shader are previewed live now.

## Screenshots
before
<img width="1592" height="1624" alt="image" src="https://github.com/user-attachments/assets/46d3afa4-8347-45f5-b31e-5061e146a933" />

https://github.com/user-attachments/assets/74c603dc-f8b2-436e-a401-a632f82ce43b


after

https://github.com/user-attachments/assets/0e562b01-5044-44ff-80ea-1611056b312e

