### PR TITLE
feat: track user manual refresh actions

### DIFF
--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -4,6 +4,7 @@ const hoisted = vi.hoisted(() => {
   const context: Record<string, unknown> = {}
 
   return {
+    addAction: vi.fn(),
     context,
     fetch: vi.fn<typeof fetch>(),
     getInitConfiguration: vi.fn(),
@@ -21,6 +22,19 @@ vi.mock('@datadog/browser-rum', () => ({
 import { rumBeforeSend } from './datadogRumBeforeSend'
 import { initDatadogRum } from './initDatadogRum'
 
+function createNavigationEntry(type: string): PerformanceEntry & {
+  type: string
+} {
+  return {
+    duration: 0,
+    entryType: 'navigation',
+    name: window.location.href,
+    startTime: 0,
+    toJSON: () => ({}),
+    type
+  }
+}
+
 describe('initDatadogRum', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -33,6 +47,7 @@ describe('initDatadogRum', () => {
     hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
     hoisted.getInitConfiguration.mockReturnValue(undefined)
     vi.stubGlobal('fetch', hoisted.fetch)
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([])
   })
 
   afterEach(() => {
@@ -225,5 +240,26 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.init).not.toHaveBeenCalled()
+  })
+
+  it('tracks a page reload', async () => {
+    vi.mocked(performance.getEntriesByType).mockReturnValue([
+      createNavigationEntry('reload')
+    ])
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.addAction).toHaveBeenCalledWith('user_manual_refresh')
+  })
+
+  it('does not track a non-reload navigation', async () => {
+    vi.mocked(performance.getEntriesByType).mockReturnValue([
+      createNavigationEntry('navigate')
+    ])
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.init).toHaveBeenCalledOnce()
+    expect(hoisted.addAction).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -4,7 +4,6 @@ const hoisted = vi.hoisted(() => {
   const context: Record<string, unknown> = {}
 
   return {
-    addAction: vi.fn(),
     context,
     fetch: vi.fn<typeof fetch>(),
     getInitConfiguration: vi.fn(),
@@ -18,22 +17,13 @@ const hoisted = vi.hoisted(() => {
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: hoisted
 }))
+vi.mock('./manualRefreshTracker', () => ({
+  trackUserManualRefresh: vi.fn()
+}))
 
 import { rumBeforeSend } from './datadogRumBeforeSend'
 import { initDatadogRum } from './initDatadogRum'
-
-function createNavigationEntry(type: string): PerformanceEntry & {
-  type: string
-} {
-  return {
-    duration: 0,
-    entryType: 'navigation',
-    name: window.location.href,
-    startTime: 0,
-    toJSON: () => ({}),
-    type
-  }
-}
+import { trackUserManualRefresh } from './manualRefreshTracker'
 
 describe('initDatadogRum', () => {
   beforeEach(() => {
@@ -47,7 +37,6 @@ describe('initDatadogRum', () => {
     hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
     hoisted.getInitConfiguration.mockReturnValue(undefined)
     vi.stubGlobal('fetch', hoisted.fetch)
-    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([])
   })
 
   afterEach(() => {
@@ -242,24 +231,13 @@ describe('initDatadogRum', () => {
     expect(hoisted.init).not.toHaveBeenCalled()
   })
 
-  it('tracks a page reload', async () => {
-    vi.mocked(performance.getEntriesByType).mockReturnValue([
-      createNavigationEntry('reload')
-    ])
+  it('tracks manual refreshes only once RUM is initialized', async () => {
+    await initDatadogRum('localhost')
+
+    expect(vi.mocked(trackUserManualRefresh)).not.toHaveBeenCalled()
 
     await initDatadogRum('cloud.comfy.org')
 
-    expect(hoisted.addAction).toHaveBeenCalledWith('user_manual_refresh')
-  })
-
-  it('does not track a non-reload navigation', async () => {
-    vi.mocked(performance.getEntriesByType).mockReturnValue([
-      createNavigationEntry('navigate')
-    ])
-
-    await initDatadogRum('cloud.comfy.org')
-
-    expect(hoisted.init).toHaveBeenCalledOnce()
-    expect(hoisted.addAction).not.toHaveBeenCalled()
+    expect(vi.mocked(trackUserManualRefresh)).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -10,6 +10,19 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
 const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
 let initializationPromise: Promise<void> | undefined
 
+function trackUserManualRefresh(): void {
+  const navigationEntry = performance.getEntriesByType('navigation')[0]
+  if (
+    !navigationEntry ||
+    !('type' in navigationEntry) ||
+    navigationEntry.type !== 'reload'
+  ) {
+    return
+  }
+
+  datadogRum.addAction('user_manual_refresh')
+}
+
 async function setFrontendContext(): Promise<void> {
   const response = await fetch(window.location.origin, {
     method: 'HEAD',
@@ -44,6 +57,7 @@ async function initializeDatadogRum(env: string): Promise<void> {
     sessionReplaySampleRate: 0,
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
+  trackUserManualRefresh()
 }
 
 export function initDatadogRum(

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -1,6 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum'
 
 import { rumBeforeSend } from './datadogRumBeforeSend'
+import { trackUserManualRefresh } from './manualRefreshTracker'
 
 const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['cloud.comfy.org', 'prod-v2'],
@@ -9,19 +10,6 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
 ])
 const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
 let initializationPromise: Promise<void> | undefined
-
-function trackUserManualRefresh(): void {
-  const navigationEntry = performance.getEntriesByType('navigation')[0]
-  if (
-    !navigationEntry ||
-    !('type' in navigationEntry) ||
-    navigationEntry.type !== 'reload'
-  ) {
-    return
-  }
-
-  datadogRum.addAction('user_manual_refresh')
-}
 
 async function setFrontendContext(): Promise<void> {
   const response = await fetch(window.location.origin, {

--- a/src/platform/telemetry/manualRefreshTracker.test.ts
+++ b/src/platform/telemetry/manualRefreshTracker.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  addAction: vi.fn(),
+  getInternalContext: vi.fn()
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: hoisted
+}))
+
+import { trackUserManualRefresh } from './manualRefreshTracker'
+
+function mockNavigationType(type: string): void {
+  vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+    { type } as PerformanceNavigationTiming
+  ])
+}
+
+describe('trackUserManualRefresh', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    hoisted.getInternalContext.mockReturnValue({ session_id: 'session-1' })
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('counts reloads within the same session', () => {
+    mockNavigationType('reload')
+
+    trackUserManualRefresh()
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction.mock.calls).toEqual([
+      ['user_manual_refresh', { refresh_count: 1 }],
+      ['user_manual_refresh', { refresh_count: 2 }]
+    ])
+  })
+
+  it('restarts the count for a new session', () => {
+    mockNavigationType('reload')
+
+    trackUserManualRefresh()
+    hoisted.getInternalContext.mockReturnValue({ session_id: 'session-2' })
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction).toHaveBeenLastCalledWith('user_manual_refresh', {
+      refresh_count: 1
+    })
+  })
+
+  it('ignores a non-reload navigation', () => {
+    mockNavigationType('navigate')
+
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/telemetry/manualRefreshTracker.ts
+++ b/src/platform/telemetry/manualRefreshTracker.ts
@@ -1,0 +1,33 @@
+import { datadogRum } from '@datadog/browser-rum'
+
+const REFRESH_COUNT_KEY = 'Comfy.ManualRefreshCount'
+
+function nextRefreshCount(sessionId: string): number {
+  const [storedSessionId, storedCount] = (
+    localStorage.getItem(REFRESH_COUNT_KEY) ?? ''
+  ).split(':')
+  const count = storedSessionId === sessionId ? Number(storedCount) + 1 : 1
+  localStorage.setItem(REFRESH_COUNT_KEY, `${sessionId}:${count}`)
+  return count
+}
+
+/**
+ * Report a page reload as a RUM action carrying its running count within the
+ * current RUM session, so refresh bursts are queryable by threshold.
+ *
+ * Must be called after `datadogRum.init()`, which is what makes the session id
+ * available.
+ */
+export function trackUserManualRefresh(): void {
+  const [navigationEntry] = performance.getEntriesByType(
+    'navigation'
+  ) as PerformanceNavigationTiming[]
+  if (navigationEntry?.type !== 'reload') return
+
+  const sessionId = datadogRum.getInternalContext()?.session_id
+  if (!sessionId) return
+
+  datadogRum.addAction('user_manual_refresh', {
+    refresh_count: nextRefreshCount(sessionId)
+  })
+}


### PR DESCRIPTION
## Summary

- Reload → `addAction('user_manual_refresh', { refresh_count })`
- `refresh_count` = position within the current RUM session. `localStorage` keyed by `session_id`, resets when the session rolls.
- Counted client-side so the threshold is a **query filter**, not a group-by: RUM has no `HAVING` on a timeseries, and `session_id` is too high-cardinality for a custom metric.

## Verification

`manualRefreshTracker.test.ts` asserts the exact `addAction` payloads:

| `navigation.type` | `session_id` | Emitted |
| --- | --- | --- |
| `navigate` | `session-1` | none |
| `reload` | `session-1` | `refresh_count: 1` |
| `reload` | `session-1` | `refresh_count: 2` |
| `reload` | `session-2` | `refresh_count: 1` |

Reload survival is structural, not asserted: the tracker has no module-level state, so a reload and a repeat call are the same path.

Timeline — `count_distinct(@session.id)` over:

```
@type:action @action.name:user_manual_refresh @context.refresh_count:>=3
```

- **Unverified**: production RUM ingestion in an authenticated session.
- **Limitation**: `type === 'reload'` also matches 12 in-app `location.reload()` calls (workspace switch/create/delete/leave, logout, extension settings, auth recovery) → ≥3 series is an upper bound until those are marked first-party.
