### PR TITLE
fix: align Cloud login/signup with dark onboarding theme

### DIFF
--- a/src/components/dialog/content/signin/PasswordFields.vue
+++ b/src/components/dialog/content/signin/PasswordFields.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Password Field -->
   <FormField v-slot="$field" name="password" class="flex flex-col gap-2">
-    <div class="mb-2 flex items-center justify-between">
+    <div class="flex items-center justify-between">
       <label
         class="text-base font-medium opacity-80"
         for="comfy-org-sign-up-password"
@@ -68,7 +68,7 @@
   <!-- Confirm Password Field -->
   <FormField v-slot="$field" name="confirmPassword" class="flex flex-col gap-2">
     <label
-      class="mb-2 text-base font-medium opacity-80"
+      class="text-base font-medium opacity-80"
       for="comfy-org-sign-up-confirm-password"
     >
       {{ t('auth.login.confirmPasswordLabel') }}

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -1,14 +1,14 @@
 <template>
   <Form
     v-slot="$form"
-    class="flex flex-col gap-6"
+    class="flex flex-col gap-4"
     :resolver="zodResolver(signUpSchema)"
     @submit="onSubmit"
   >
     <!-- Email Field -->
     <FormField v-slot="$field" name="email" class="flex flex-col gap-2">
       <label
-        class="mb-2 text-base font-medium opacity-80"
+        class="text-base font-medium opacity-80"
         for="comfy-org-sign-up-email"
       >
         {{ t('auth.signup.emailLabel') }}
@@ -51,7 +51,8 @@
     <Button
       v-else
       type="submit"
-      class="mt-4 h-10 font-medium"
+      variant="secondary"
+      class="relative mt-4 h-10 gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 text-sm font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
       :disabled="!$form.valid || waitingForTurnstile"
       :aria-describedby="
         waitingForTurnstile ? 'comfy-org-sign-up-turnstile-hint' : undefined

--- a/src/platform/cloud/onboarding/CloudForgotPasswordView.vue
+++ b/src/platform/cloud/onboarding/CloudForgotPasswordView.vue
@@ -6,7 +6,7 @@
         <h1 class="my-0 text-xl/normal font-medium">
           {{ t('cloudForgotPassword_title') }}
         </h1>
-        <p class="my-0 text-base text-muted">
+        <p class="my-0 text-base text-primary-comfy-canvas/70">
           {{ t('cloudForgotPassword_instructions') }}
         </p>
       </div>
@@ -42,9 +42,10 @@
         <div class="flex flex-col gap-4">
           <Button
             type="submit"
+            variant="secondary"
             :loading="loading"
             :disabled="!email || loading"
-            class="h-10 font-medium text-white"
+            class="h-10 border-none bg-primary-comfy-canvas/10 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/15"
           >
             {{ t('cloudForgotPassword_sendResetLink') }}
           </Button>
@@ -52,7 +53,7 @@
           <Button
             type="button"
             variant="secondary"
-            class="h-10 bg-charcoal-500"
+            class="h-10 border border-solid border-primary-comfy-canvas/20 bg-transparent text-primary-comfy-canvas hover:bg-primary-comfy-canvas/5"
             @click="navigateToLogin"
           >
             {{ t('cloudForgotPassword_backToLogin') }}
@@ -61,7 +62,7 @@
       </form>
 
       <!-- Help text -->
-      <p class="mt-5 text-sm text-gray-600">
+      <p class="mt-5 text-sm text-primary-comfy-canvas/60">
         {{ t('cloudForgotPassword_didntReceiveEmail') }}
       </p>
     </div>
@@ -121,14 +122,20 @@ const handleSubmit = async () => {
 </script>
 <style scoped>
 :deep(.p-inputtext) {
-  border: none !important;
+  border: 1px solid rgb(from var(--color-primary-comfy-canvas) r g b / 0.2) !important;
   box-shadow: none !important;
-  background: #2d2e32 !important;
+  background: transparent !important;
   color: var(--color-primary-comfy-canvas) !important;
   caret-color: var(--color-primary-comfy-canvas);
 }
 
 :deep(.p-inputtext::placeholder) {
   color: rgb(from var(--color-primary-comfy-canvas) r g b / 0.5);
+}
+
+:deep(.p-message-success) {
+  background: rgb(from var(--color-jade-400) r g b / 0.12) !important;
+  border-color: rgb(from var(--color-jade-400) r g b / 0.2) !important;
+  color: var(--color-jade-400) !important;
 }
 </style>

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -5,16 +5,16 @@
     <div class="flex w-full max-w-md flex-col items-start">
       <div class="flex w-full flex-col gap-4">
         <h1
-          class="my-0 font-inter text-xl/8 font-extrabold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
+          class="my-0 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
         >
           {{ t('auth.login.title') }}
         </h1>
         <p
-          class="my-0 text-base/6 tracking-[-0.02em] text-primary-comfy-canvas"
+          class="my-0 text-base/6 tracking-[-0.02em] text-primary-comfy-canvas/70"
         >
           {{ t('auth.login.newUser') }}
           <span
-            class="cursor-pointer text-azure-600"
+            class="cursor-pointer text-primary-comfy-canvas underline"
             @click="navigateToSignup"
             >{{ t('auth.login.signUp') }}</span
           >
@@ -30,7 +30,7 @@
           <Button
             type="button"
             variant="secondary"
-            class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
+            class="relative h-10 w-full gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 text-sm/4 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
             @click="signInWithGoogle"
           >
             <i class="pi pi-google text-base" />
@@ -40,7 +40,7 @@
           <Button
             type="button"
             variant="secondary"
-            class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 font-inter text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
+            class="relative h-10 w-full gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 font-inter text-sm/4 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
             @click="signInWithGithub"
           >
             <i class="pi pi-github text-base" />
@@ -78,13 +78,13 @@
       </div>
 
       <p
-        class="mx-auto my-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 py-4 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas"
+        class="mx-auto my-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 py-4 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas/70"
       >
         {{ t('auth.login.termsText') }}
         <a
           href="https://www.comfy.org/terms-of-service"
           target="_blank"
-          class="cursor-pointer text-azure-600 no-underline"
+          class="cursor-pointer text-primary-comfy-canvas underline"
         >
           {{ t('auth.login.termsLink') }}
         </a>
@@ -92,7 +92,7 @@
         <a
           href="https://www.comfy.org/privacy-policy"
           target="_blank"
-          class="cursor-pointer text-azure-600 no-underline"
+          class="cursor-pointer text-primary-comfy-canvas underline"
         >
           {{ t('auth.login.privacyLink') }} </a
         >.
@@ -161,3 +161,10 @@ const signInWithEmail = async (values: SignInData) => {
   }
 }
 </script>
+<style scoped>
+:deep(.p-message-warn) {
+  background: rgb(from var(--color-gold-500) r g b / 0.12) !important;
+  border-color: rgb(from var(--color-gold-500) r g b / 0.3) !important;
+  color: var(--color-gold-500) !important;
+}
+</style>

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -5,7 +5,7 @@
     <div class="flex w-full max-w-md flex-col items-start">
       <div class="flex w-full flex-col gap-4">
         <h1
-          class="my-0 font-inter text-xl/8 font-extrabold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
+          class="my-0 font-inter text-xl/8 font-semibold tracking-wide text-primary-comfy-canvas sm:text-2xl/8"
         >
           {{ t('auth.signup.title') }}
         </h1>
@@ -16,7 +16,7 @@
             t('auth.signup.alreadyHaveAccount')
           }}</span>
           <span
-            class="ml-1 cursor-pointer text-azure-600"
+            class="ml-1 cursor-pointer text-primary-comfy-canvas underline"
             @click="navigateToLogin"
             >{{ t('auth.signup.signIn') }}</span
           >
@@ -32,7 +32,7 @@
           <Button
             type="button"
             variant="secondary"
-            class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
+            class="relative h-10 w-full gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 text-sm/4 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
             @click="signInWithGoogle"
           >
             <i class="pi pi-google text-base" />
@@ -42,7 +42,7 @@
           <Button
             type="button"
             variant="secondary"
-            class="relative h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 font-inter text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
+            class="relative h-10 w-full gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 font-inter text-sm/4 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
             @click="signInWithGithub"
           >
             <i class="pi pi-github text-base" />
@@ -92,13 +92,13 @@
       </div>
 
       <p
-        class="mx-auto my-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 py-4 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas"
+        class="mx-auto my-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 py-4 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas/70"
       >
         {{ t('auth.login.termsText') }}
         <a
           href="https://www.comfy.org/terms-of-service"
           target="_blank"
-          class="cursor-pointer text-azure-600 no-underline"
+          class="cursor-pointer text-primary-comfy-canvas underline"
         >
           {{ t('auth.login.termsLink') }}
         </a>
@@ -106,18 +106,18 @@
         <a
           href="https://www.comfy.org/privacy-policy"
           target="_blank"
-          class="cursor-pointer text-azure-600 no-underline"
+          class="cursor-pointer text-primary-comfy-canvas underline"
         >
           {{ t('auth.login.privacyLink') }} </a
         >.
       </p>
       <p
-        class="mx-auto mt-2 mb-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas"
+        class="mx-auto mt-2 mb-0 flex w-full max-w-10/12 flex-wrap items-center justify-center gap-x-1 text-center text-sm/5 tracking-[-0.011em] text-primary-comfy-canvas/70"
       >
         {{ t('cloudWaitlist_questionsText') }}
         <a
           href="https://support.comfy.org"
-          class="cursor-pointer text-azure-600 no-underline"
+          class="cursor-pointer text-primary-comfy-canvas underline"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -210,9 +210,9 @@ onMounted(async () => {
 </script>
 <style scoped>
 :deep(.p-inputtext) {
-  border: none !important;
+  border: 1px solid rgb(from var(--color-primary-comfy-canvas) r g b / 0.2) !important;
   box-shadow: none !important;
-  background: #2d2e32 !important;
+  background: transparent !important;
   color: var(--color-primary-comfy-canvas) !important;
   caret-color: var(--color-primary-comfy-canvas);
 }
@@ -222,15 +222,23 @@ onMounted(async () => {
 }
 
 :deep(.p-password input) {
-  border: none !important;
+  border: 1px solid rgb(from var(--color-primary-comfy-canvas) r g b / 0.2) !important;
   box-shadow: none !important;
+  background: transparent !important;
 }
 
 :deep(.p-password-toggle-mask-icon) {
   cursor: pointer;
+  color: rgb(from var(--color-primary-comfy-canvas) r g b / 0.5) !important;
 }
 :deep(.p-checkbox-checked .p-checkbox-box) {
   background-color: #f0ff41 !important;
   border-color: #f0ff41 !important;
+}
+
+:deep(.p-message-warn) {
+  background: rgb(from var(--color-gold-500) r g b / 0.12) !important;
+  border-color: rgb(from var(--color-gold-500) r g b / 0.3) !important;
+  color: var(--color-gold-500) !important;
 }
 </style>

--- a/src/platform/cloud/onboarding/components/CloudHeroCarousel.vue
+++ b/src/platform/cloud/onboarding/components/CloudHeroCarousel.vue
@@ -84,7 +84,7 @@
         href="https://www.comfy.org/download"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex h-8 items-center gap-2 rounded-lg border border-primary-comfy-canvas/20 bg-charcoal-500 p-2 text-xs font-medium text-primary-comfy-canvas no-underline hover:bg-charcoal-500/80"
+        class="inline-flex h-8 items-center gap-2 rounded-lg border border-primary-comfy-canvas/20 bg-transparent p-2 text-xs font-medium text-primary-comfy-canvas no-underline hover:bg-primary-comfy-canvas/5"
       >
         <i class="pi pi-download text-xs text-primary-comfy-canvas/90" />
         {{ t('cloudStart_download') }}

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.vue
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.vue
@@ -1,13 +1,13 @@
 <template>
   <Form
     v-slot="$form"
-    class="flex flex-col gap-6"
+    class="flex flex-col gap-4"
     :resolver="zodResolver(signInSchema)"
     @submit="onSubmit"
   >
     <!-- Email Field -->
     <div class="flex flex-col gap-2">
-      <label class="mb-2 text-base font-medium opacity-80" :for="emailInputId">
+      <label class="text-base font-medium opacity-80" :for="emailInputId">
         {{ t('auth.login.emailLabel') }}
       </label>
       <InputText
@@ -26,7 +26,7 @@
 
     <!-- Password Field -->
     <div class="flex flex-col gap-2">
-      <div class="mb-2 flex items-center justify-between">
+      <div class="flex items-center justify-between">
         <label
           class="text-base font-medium opacity-80"
           for="cloud-sign-in-password"
@@ -51,7 +51,7 @@
 
       <router-link
         :to="{ name: 'cloud-forgot-password' }"
-        class="text-sm font-medium text-muted no-underline"
+        class="text-sm font-medium text-primary-comfy-canvas underline"
       >
         {{ t('auth.login.forgotPassword') }}
       </router-link>
@@ -68,7 +68,7 @@
       v-else
       type="submit"
       variant="secondary"
-      class="relative mt-4 h-10 w-full gap-4 rounded-md border border-solid border-smoke-800/10 bg-smoke-800/10 text-sm/4 font-medium text-primary-comfy-canvas shadow-inset-highlight hover:bg-sand-300/20"
+      class="relative mt-4 h-10 w-full gap-4 rounded-md border border-solid border-primary-comfy-canvas/20 bg-primary-comfy-canvas/5 text-sm/4 font-medium text-primary-comfy-canvas hover:bg-primary-comfy-canvas/10"
       :disabled="!$form.valid"
     >
       {{ t('auth.login.loginButton') }}
@@ -115,9 +115,9 @@ const onSubmit = (event: FormSubmitEvent) => {
 </script>
 <style scoped>
 :deep(.p-inputtext) {
-  border: none !important;
+  border: 1px solid rgb(from var(--color-primary-comfy-canvas) r g b / 0.2) !important;
   box-shadow: none !important;
-  background: #2d2e32 !important;
+  background: transparent !important;
   color: var(--color-primary-comfy-canvas) !important;
   caret-color: var(--color-primary-comfy-canvas);
 }
@@ -127,15 +127,23 @@ const onSubmit = (event: FormSubmitEvent) => {
 }
 
 :deep(.p-password input) {
-  border: none !important;
+  border: 1px solid rgb(from var(--color-primary-comfy-canvas) r g b / 0.2) !important;
   box-shadow: none !important;
+  background: transparent !important;
 }
 
 :deep(.p-password-toggle-mask-icon) {
   cursor: pointer;
+  color: rgb(from var(--color-primary-comfy-canvas) r g b / 0.5) !important;
 }
 :deep(.p-checkbox-checked .p-checkbox-box) {
   background-color: #f0ff41 !important;
   border-color: #f0ff41 !important;
+}
+
+:deep(.p-message-error) {
+  background: rgb(from var(--color-coral-500) r g b / 0.12) !important;
+  border-color: rgb(from var(--color-coral-500) r g b / 0.2) !important;
+  color: var(--color-coral-500) !important;
 }
 </style>

--- a/src/platform/cloud/onboarding/components/CloudTemplate.vue
+++ b/src/platform/cloud/onboarding/components/CloudTemplate.vue
@@ -5,7 +5,7 @@
     <div class="relative flex flex-1 flex-col">
       <div class="flex h-16 shrink-0 items-center px-6">
         <i
-          class="icon-[comfy--comfy-logo] h-5 w-22 text-brand-yellow md:h-6 md:w-26"
+          class="icon-[comfy--comfy-logo] aspect-100/23 h-5 text-brand-yellow md:h-6"
         />
       </div>
       <div class="flex flex-1 items-center justify-center overflow-auto">

--- a/src/platform/cloud/onboarding/components/OAuthLayoutView.vue
+++ b/src/platform/cloud/onboarding/components/OAuthLayoutView.vue
@@ -3,7 +3,7 @@
     class="dark-theme relative h-svh w-screen overflow-y-auto bg-primary-comfy-ink font-sans text-primary-comfy-canvas"
   >
     <i
-      class="absolute top-6 left-6 icon-[comfy--comfy-logo] h-5 w-22 text-brand-yellow md:h-6 md:w-26"
+      class="absolute top-6 left-6 icon-[comfy--comfy-logo] aspect-100/23 h-5 text-brand-yellow md:h-6"
       aria-hidden="true"
     />
     <RouterView />


### PR DESCRIPTION
## ELI5
The Cloud login, signup, and forgot-password screens are supposed to look like a sleek dark app, but several pieces (buttons, borders, links, warning banners) were secretly still wearing their light-mode/desktop-app clothes underneath, so they showed up as mismatched grey or pastel blobs instead of blending into the dark background. This PR strips off those leftover light-mode styles and makes every screen in the flow consistently dark, flat, and legible.

## Summary
- Fixed the Comfy wordmark logo being slightly stretched (mismatched width/height vs. its real aspect ratio) in both the Cloud onboarding layout and the OAuth layout
- Replaced blue (`azure-600`) and brand-yellow link colors with the plain canvas text color + underline, so links read as "clickable" without clashing with the dark background; surrounding plain text is dimmed slightly for contrast
- Flattened the Google/GitHub/Sign in/Sign up/Send reset link buttons: removed the embossed shadow + light-mode fallback fills, replaced with a subtle translucent white background and a normal border
- Removed the solid dark fill on Email/Password/Confirm Password inputs in favor of a plain border; fixed a cascade bug where the Password field's border was being stripped by a more specific CSS rule than the Email field's
- Recolored the "eye" password-visibility icon to white at 50% opacity instead of the theme's default muted-blue tone
- Restyled the warning/error/success `Message` banners (previously near-opaque pastel light-mode backgrounds) to translucent, on-brand tinted banners (gold/coral/jade) with a subtle border
- Tightened label-to-input spacing and spacing between the Email/Password/Confirm Password fields; bumped the page title to `font-semibold`; fixed the "Sign up" submit button rendering at a smaller font size than its siblings
- Made the "Download ComfyUI" hero CTA and the Forgot Password buttons consistent with the same flat styling

## Test plan
- [ ] Deploy to staging/ephemeral
- [ ] Verify `/cloud/login` (social buttons, email form, links, insecure-context warning) looks correct in both collapsed and email-form states
- [ ] Verify `/cloud/signup` (social buttons, email form with free-tier/China warnings, links) looks correct
- [ ] Verify `/cloud/forgot-password` (email input, Send reset link, Back to login, success message)
- [ ] Verify the OAuth consent layout logo is no longer stretched
- [ ] Purely visual/CSS change — no new user-visible behavior, nothing to gate behind a flag