### PR TITLE
fix: expose Sentry to cloud extensions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,11 @@ Sentry.init({
         defaultIntegrations: false
       })
 })
+
+if (isCloud && __SENTRY_ENABLED__) {
+  window.Sentry = Sentry
+}
+
 // Assertion reporter receives pre-formatted messages (with "[Assertion failed]: " prefix).
 // Strings here are intentionally not i18n'd: they're developer/nightly diagnostics,
 // not user-facing in stable releases.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { ComfyDesktop2Bridge } from '@comfyorg/comfyui-desktop-bridge-types'
+import type * as Sentry from '@sentry/vue'
 import type {
   DeviceStats,
   EmbeddingsResponse,
@@ -92,6 +93,9 @@ declare global {
 
     /** For use by extensions and in the browser console. Where possible, import `app` and access via `app.graph` instead. */
     graph?: unknown
+
+    /** Compatibility bridge for unbundled Comfy Cloud extensions. */
+    Sentry?: typeof Sentry
 
     /** For use in tests to capture WebSocket messages */
     __capturedMessages?: CapturedMessages


### PR DESCRIPTION
## Summary

Expose the initialized Sentry SDK as `window.Sentry` for unbundled Comfy Cloud extensions, only when the cloud build has Sentry enabled. Add the matching `Window` type.

## Verification

The [CPU preview](https://fe-pr-14092.testenvs.comfy.org) deployed [head `71b46be`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/71b46be47ef19323c811c2ba8114ed7008d4606f) successfully through the [Cloud workflow](https://github.com/Comfy-Org/cloud/actions/runs/30118882161). Its served [main bundle](https://fe-pr-14092.testenvs.comfy.org/assets/main-hDxPx8gh.js) initializes Sentry with `enabled: true` and assigns `window.Sentry`; the live [Cloud extension](https://fe-pr-14092.testenvs.comfy.org/extensions/cloud/sentry.js) reads that global.

Verified in http://fe-pr-14092.testenvs.comfy.org/
<img width="719" height="500" alt="image" src="https://github.com/user-attachments/assets/1c6ac33e-4a2e-4736-b32c-7ff3e683bcb3" />
