### PR TITLE
feat: track workflow phase timing and run funnel in RUM

### DIFF
--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -41,6 +41,7 @@ import type {
   TemplateMetadata,
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
+  WorkflowExecutionStartedMetadata,
   WorkflowImportMetadata,
   WorkflowQueuedMetadata,
   WorkflowSavedMetadata,
@@ -286,6 +287,14 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackWorkflowSubmission(metadata: WorkflowSubmissionMetadata): void {
     this.dispatch((provider) => provider.trackWorkflowSubmission?.(metadata))
+  }
+
+  trackWorkflowExecutionStarted(
+    metadata: WorkflowExecutionStartedMetadata
+  ): void {
+    this.dispatch((provider) =>
+      provider.trackWorkflowExecutionStarted?.(metadata)
+    )
   }
 
   trackExecutionOutcome(metadata: ExecutionOutcomeMetadata): void {

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -44,6 +44,7 @@ import type {
   WorkflowImportMetadata,
   WorkflowQueuedMetadata,
   WorkflowSavedMetadata,
+  WorkflowSubmissionMetadata,
   WorkspaceInviteMetadata
 } from './types'
 
@@ -281,6 +282,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackWorkflowQueued(metadata: WorkflowQueuedMetadata): void {
     this.dispatch((provider) => provider.trackWorkflowQueued?.(metadata))
+  }
+
+  trackWorkflowSubmission(metadata: WorkflowSubmissionMetadata): void {
+    this.dispatch((provider) => provider.trackWorkflowSubmission?.(metadata))
   }
 
   trackExecutionOutcome(metadata: ExecutionOutcomeMetadata): void {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -74,6 +74,7 @@ describe('DatadogRumTelemetryProvider', () => {
       startTime: 42,
       submittedAt: 92,
       outcome: 'accepted',
+      jobId: 'job-1',
       workflowContext
     })
 
@@ -95,6 +96,41 @@ describe('DatadogRumTelemetryProvider', () => {
         workflow_type: 'custom'
       }
     })
+    expect(addAction).toHaveBeenCalledWith('workflow_submission', {
+      ...workflowContext,
+      job_id: 'job-1',
+      outcome: 'accepted',
+      product: 'cloud_generation'
+    })
+  })
+
+  it('emits a submission funnel step when the backend rejects the prompt', () => {
+    new DatadogRumTelemetryProvider().trackWorkflowSubmission({
+      startTime: 42,
+      submittedAt: 92,
+      outcome: 'prompt_rejected',
+      workflowContext
+    })
+
+    expect(addAction).toHaveBeenCalledWith('workflow_submission', {
+      ...workflowContext,
+      outcome: 'prompt_rejected',
+      product: 'cloud_generation'
+    })
+  })
+
+  it('emits an execution start funnel step without a duration vital', () => {
+    new DatadogRumTelemetryProvider().trackWorkflowExecutionStarted({
+      jobId: 'job-1',
+      workflowContext
+    })
+
+    expect(addAction).toHaveBeenCalledWith('workflow_execution_start', {
+      ...workflowContext,
+      job_id: 'job-1',
+      product: 'cloud_generation'
+    })
+    expect(addDurationVital).not.toHaveBeenCalled()
   })
 
   it.for(['success', 'failure', 'interrupted'] as const)(
@@ -108,9 +144,16 @@ describe('DatadogRumTelemetryProvider', () => {
         executionStartedAt: 142,
         terminalAt: 242,
         outcome,
+        jobId: 'job-1',
         workflowContext
       })
 
+      expect(addAction).toHaveBeenCalledWith('workflow_run_finished', {
+        ...workflowContext,
+        job_id: 'job-1',
+        outcome,
+        product: 'cloud_generation'
+      })
       expect(getInternalContext).toHaveBeenCalledWith(42)
       const context = {
         ...workflowContext,
@@ -162,7 +205,8 @@ describe('DatadogRumTelemetryProvider', () => {
       executionStartedAt: 92,
       submittedAt: 142,
       terminalAt: 242,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
 
     expect(addDurationVital).toHaveBeenCalledWith('workflow_queue_wait', {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { WorkflowQueuedMetadata } from '@/platform/telemetry/types'
+import type {
+  WorkflowExecutionContext,
+  WorkflowQueuedMetadata
+} from '@/platform/telemetry/types'
 
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
@@ -14,9 +17,21 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: { addAction, addDurationVital, getInternalContext }
 }))
 
+const workflowContext = {
+  workflow_type: 'custom',
+  view_mode: 'graph',
+  execution_scope: 'full',
+  total_node_count: 42,
+  executable_node_count: 12,
+  custom_node_count: 3,
+  api_node_count: 1,
+  subgraph_count: 2
+} satisfies WorkflowExecutionContext
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
+  getInternalContext.mockReset()
 })
 
 describe('DatadogRumTelemetryProvider', () => {
@@ -59,16 +74,7 @@ describe('DatadogRumTelemetryProvider', () => {
       startTime: 42,
       submittedAt: 92,
       outcome: 'accepted',
-      workflowContext: {
-        workflow_type: 'custom',
-        view_mode: 'graph',
-        execution_scope: 'full',
-        total_node_count: 42,
-        executable_node_count: 12,
-        custom_node_count: 3,
-        api_node_count: 1,
-        subgraph_count: 2
-      }
+      workflowContext
     })
 
     expect(addDurationVital).toHaveBeenCalledWith('workflow_submission', {
@@ -92,44 +98,81 @@ describe('DatadogRumTelemetryProvider', () => {
   })
 
   it.for(['success', 'failure'] as const)(
-    'records a workflow vital with a %s outcome',
+    'records workflow phase timing with a %s outcome',
     (outcome) => {
       getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
-      vi.spyOn(performance, 'now').mockReturnValue(142)
 
       new DatadogRumTelemetryProvider().trackExecutionOutcome({
         startTime: 42,
+        submittedAt: 92,
+        executionStartedAt: 142,
+        terminalAt: 242,
         outcome,
-        workflowContext: {
-          workflow_type: 'custom',
-          view_mode: 'graph',
-          execution_scope: 'full',
-          total_node_count: 42,
-          executable_node_count: 12,
-          custom_node_count: 3,
-          api_node_count: 1,
-          subgraph_count: 2
-        }
+        workflowContext
       })
 
       expect(getInternalContext).toHaveBeenCalledWith(42)
-      expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
-        startTime: performance.timeOrigin + 42,
-        duration: 100,
-        context: {
-          api_node_count: 1,
-          custom_node_count: 3,
-          executable_node_count: 12,
-          execution_scope: 'full',
-          origin_view_id: 'view-a',
-          outcome,
-          product: 'cloud_generation',
-          subgraph_count: 2,
-          total_node_count: 42,
-          view_mode: 'graph',
-          workflow_type: 'custom'
-        }
-      })
+      const context = {
+        ...workflowContext,
+        origin_view_id: 'view-a',
+        outcome,
+        product: 'cloud_generation'
+      }
+      const timingContext = { ...context, timing_schema_version: 2 }
+      expect(addDurationVital.mock.calls).toEqual([
+        [
+          'workflow_execution',
+          {
+            startTime: performance.timeOrigin + 42,
+            duration: 200,
+            context
+          }
+        ],
+        [
+          'workflow_total_time',
+          {
+            startTime: performance.timeOrigin + 42,
+            duration: 200,
+            context: timingContext
+          }
+        ],
+        [
+          'workflow_queue_wait',
+          {
+            startTime: performance.timeOrigin + 92,
+            duration: 50,
+            context: timingContext
+          }
+        ],
+        [
+          'workflow_execution_time',
+          {
+            startTime: performance.timeOrigin + 142,
+            duration: 100,
+            context: timingContext
+          }
+        ]
+      ])
     }
   )
+
+  it('clamps queue wait when execution starts before the response arrives', () => {
+    new DatadogRumTelemetryProvider().trackExecutionOutcome({
+      startTime: 42,
+      executionStartedAt: 92,
+      submittedAt: 142,
+      terminalAt: 242,
+      outcome: 'success'
+    })
+
+    expect(addDurationVital).toHaveBeenCalledWith('workflow_queue_wait', {
+      startTime: performance.timeOrigin + 142,
+      duration: 0,
+      context: {
+        outcome: 'success',
+        product: 'cloud_generation',
+        timing_schema_version: 2
+      }
+    })
+  })
 })

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -97,7 +97,7 @@ describe('DatadogRumTelemetryProvider', () => {
     })
   })
 
-  it.for(['success', 'failure'] as const)(
+  it.for(['success', 'failure', 'interrupted'] as const)(
     'records workflow phase timing with a %s outcome',
     (outcome) => {
       getInternalContext.mockReturnValue({ view: { id: 'view-a' } })

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -63,8 +63,35 @@ describe('DatadogRumTelemetryProvider', () => {
       api_node_count: 1,
       subgraph_count: 2,
       trigger_source: 'keybinding',
+      subscribe_to_run: false,
+      product: 'cloud_generation'
+    })
+  })
+
+  it('tags every funnel step with the same product', () => {
+    const provider = new DatadogRumTelemetryProvider()
+
+    provider.trackWorkflowQueued({
+      workflowContext,
+      trigger_source: 'unknown',
       subscribe_to_run: false
     })
+    provider.trackWorkflowSubmission({
+      startTime: 0,
+      submittedAt: 1,
+      outcome: 'accepted',
+      jobId: 'job-1'
+    })
+    provider.trackWorkflowExecutionStarted({ jobId: 'job-1' })
+    provider.trackExecutionOutcome({
+      startTime: 0,
+      terminalAt: 2,
+      outcome: 'success',
+      jobId: 'job-1'
+    })
+
+    const products = addAction.mock.calls.map(([, context]) => context.product)
+    expect(products).toEqual(Array(4).fill('cloud_generation'))
   })
 
   it('records workflow submission timing and outcome', () => {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -52,6 +52,45 @@ describe('DatadogRumTelemetryProvider', () => {
     })
   })
 
+  it('records workflow submission timing and outcome', () => {
+    getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
+
+    new DatadogRumTelemetryProvider().trackWorkflowSubmission({
+      startTime: 42,
+      submittedAt: 92,
+      outcome: 'accepted',
+      workflowContext: {
+        workflow_type: 'custom',
+        view_mode: 'graph',
+        execution_scope: 'full',
+        total_node_count: 42,
+        executable_node_count: 12,
+        custom_node_count: 3,
+        api_node_count: 1,
+        subgraph_count: 2
+      }
+    })
+
+    expect(addDurationVital).toHaveBeenCalledWith('workflow_submission', {
+      startTime: performance.timeOrigin + 42,
+      duration: 50,
+      context: {
+        api_node_count: 1,
+        custom_node_count: 3,
+        executable_node_count: 12,
+        execution_scope: 'full',
+        origin_view_id: 'view-a',
+        outcome: 'accepted',
+        product: 'cloud_generation',
+        subgraph_count: 2,
+        timing_schema_version: 2,
+        total_node_count: 42,
+        view_mode: 'graph',
+        workflow_type: 'custom'
+      }
+    })
+  })
+
   it.for(['success', 'failure'] as const)(
     'records a workflow vital with a %s outcome',
     (outcome) => {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -3,9 +3,22 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   ExecutionOutcomeMetadata,
   TelemetryProvider,
+  WorkflowExecutionContext,
+  WorkflowExecutionStartedMetadata,
   WorkflowQueuedMetadata,
   WorkflowSubmissionMetadata
 } from '../../types'
+
+function funnelStep(
+  jobId: string | undefined,
+  workflowContext: WorkflowExecutionContext | undefined
+) {
+  return {
+    product: 'cloud_generation',
+    ...(jobId && { job_id: jobId }),
+    ...(workflowContext ?? {})
+  }
+}
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
   trackWorkflowQueued({
@@ -22,8 +35,13 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     startTime,
     submittedAt,
     outcome,
+    jobId,
     workflowContext
   }: WorkflowSubmissionMetadata): void {
+    datadogRum.addAction('workflow_submission', {
+      outcome,
+      ...funnelStep(jobId, workflowContext)
+    })
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     datadogRum.addDurationVital('workflow_submission', {
       startTime: performance.timeOrigin + startTime,
@@ -38,14 +56,29 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     })
   }
 
+  trackWorkflowExecutionStarted({
+    jobId,
+    workflowContext
+  }: WorkflowExecutionStartedMetadata): void {
+    datadogRum.addAction(
+      'workflow_execution_start',
+      funnelStep(jobId, workflowContext)
+    )
+  }
+
   trackExecutionOutcome({
     startTime,
     submittedAt,
     executionStartedAt,
     terminalAt,
     outcome,
+    jobId,
     workflowContext
   }: ExecutionOutcomeMetadata): void {
+    datadogRum.addAction('workflow_run_finished', {
+      outcome,
+      ...funnelStep(jobId, workflowContext)
+    })
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     const context = {
       outcome,

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -3,7 +3,8 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   ExecutionOutcomeMetadata,
   TelemetryProvider,
-  WorkflowQueuedMetadata
+  WorkflowQueuedMetadata,
+  WorkflowSubmissionMetadata
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
@@ -14,6 +15,26 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     datadogRum.addAction('workflow_queue', {
       ...workflowContext,
       ...metadata
+    })
+  }
+
+  trackWorkflowSubmission({
+    startTime,
+    submittedAt,
+    outcome,
+    workflowContext
+  }: WorkflowSubmissionMetadata): void {
+    const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
+    datadogRum.addDurationVital('workflow_submission', {
+      startTime: performance.timeOrigin + startTime,
+      duration: submittedAt - startTime,
+      context: {
+        outcome,
+        product: 'cloud_generation',
+        timing_schema_version: 2,
+        ...(workflowContext ?? {}),
+        ...(originViewId && { origin_view_id: originViewId })
+      }
     })
   }
 

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -26,8 +26,8 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     ...metadata
   }: WorkflowQueuedMetadata): void {
     datadogRum.addAction('workflow_queue', {
-      ...workflowContext,
-      ...metadata
+      ...metadata,
+      ...funnelStep(undefined, workflowContext)
     })
   }
 

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -40,18 +40,46 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
 
   trackExecutionOutcome({
     startTime,
+    submittedAt,
+    executionStartedAt,
+    terminalAt,
     outcome,
     workflowContext
   }: ExecutionOutcomeMetadata): void {
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
+    const context = {
+      outcome,
+      product: 'cloud_generation',
+      ...(workflowContext ?? {}),
+      ...(originViewId && { origin_view_id: originViewId })
+    }
     datadogRum.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
-      duration: performance.now() - startTime,
+      duration: terminalAt - startTime,
+      context
+    })
+    const timingContext = {
+      ...context,
+      timing_schema_version: 2
+    }
+    datadogRum.addDurationVital('workflow_total_time', {
+      startTime: performance.timeOrigin + startTime,
+      duration: terminalAt - startTime,
+      context: timingContext
+    })
+    if (submittedAt !== undefined && executionStartedAt !== undefined) {
+      datadogRum.addDurationVital('workflow_queue_wait', {
+        startTime: performance.timeOrigin + submittedAt,
+        duration: Math.max(0, executionStartedAt - submittedAt),
+        context: timingContext
+      })
+    }
+    if (executionStartedAt === undefined) return
+    datadogRum.addDurationVital('workflow_execution_time', {
+      startTime: performance.timeOrigin + executionStartedAt,
+      duration: terminalAt - executionStartedAt,
       context: {
-        outcome,
-        product: 'cloud_generation',
-        ...(workflowContext ?? {}),
-        ...(originViewId && { origin_view_id: originViewId })
+        ...timingContext
       }
     })
   }

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -222,7 +222,7 @@ export interface ExecutionOutcomeMetadata {
   submittedAt?: number
   executionStartedAt?: number
   terminalAt: number
-  outcome: 'success' | 'failure'
+  outcome: 'success' | 'failure' | 'interrupted'
   workflowContext?: WorkflowExecutionContext
 }
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -214,6 +214,12 @@ export interface WorkflowSubmissionMetadata {
   startTime: number
   submittedAt: number
   outcome: WorkflowSubmissionOutcome
+  jobId?: string
+  workflowContext?: WorkflowExecutionContext
+}
+
+export interface WorkflowExecutionStartedMetadata {
+  jobId: string
   workflowContext?: WorkflowExecutionContext
 }
 
@@ -223,6 +229,7 @@ export interface ExecutionOutcomeMetadata {
   executionStartedAt?: number
   terminalAt: number
   outcome: 'success' | 'failure' | 'interrupted'
+  jobId: string
   workflowContext?: WorkflowExecutionContext
 }
 
@@ -710,6 +717,9 @@ export interface TelemetryProvider {
   trackWorkflowExecution?(): void
   trackWorkflowQueued?(metadata: WorkflowQueuedMetadata): void
   trackWorkflowSubmission?(metadata: WorkflowSubmissionMetadata): void
+  trackWorkflowExecutionStarted?(
+    metadata: WorkflowExecutionStartedMetadata
+  ): void
   trackExecutionOutcome?(metadata: ExecutionOutcomeMetadata): void
   trackExecutionError?(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess?(metadata: ExecutionSuccessMetadata): void

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -204,6 +204,19 @@ export interface WorkflowQueuedMetadata {
   subscribe_to_run: boolean
 }
 
+type WorkflowSubmissionOutcome =
+  | 'accepted'
+  | 'account_blocked'
+  | 'prompt_rejected'
+  | 'unexpected_failure'
+
+export interface WorkflowSubmissionMetadata {
+  startTime: number
+  submittedAt: number
+  outcome: WorkflowSubmissionOutcome
+  workflowContext?: WorkflowExecutionContext
+}
+
 export interface ExecutionOutcomeMetadata {
   startTime: number
   outcome: 'success' | 'failure'
@@ -693,6 +706,7 @@ export interface TelemetryProvider {
   // Workflow execution events
   trackWorkflowExecution?(): void
   trackWorkflowQueued?(metadata: WorkflowQueuedMetadata): void
+  trackWorkflowSubmission?(metadata: WorkflowSubmissionMetadata): void
   trackExecutionOutcome?(metadata: ExecutionOutcomeMetadata): void
   trackExecutionError?(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess?(metadata: ExecutionSuccessMetadata): void

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -219,6 +219,9 @@ export interface WorkflowSubmissionMetadata {
 
 export interface ExecutionOutcomeMetadata {
   startTime: number
+  submittedAt?: number
+  executionStartedAt?: number
+  terminalAt: number
   outcome: 'success' | 'failure'
   workflowContext?: WorkflowExecutionContext
 }

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -477,6 +477,7 @@ describe('ComfyApp', () => {
             execution_scope: 'full'
           })
         })
+        expect(useExecutionStore().queuedJobs['job-1']?.submittedAt).toBe(92)
       } finally {
         now.mockRestore()
         setTelemetryRegistry(null)

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -472,6 +472,7 @@ describe('ComfyApp', () => {
           startTime: 42,
           submittedAt: 92,
           outcome: 'accepted',
+          jobId: 'job-1',
           workflowContext: expect.objectContaining({
             workflow_type: 'custom',
             execution_scope: 'full'

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -450,6 +450,138 @@ describe('ComfyApp', () => {
       }
     })
 
+    it('tracks accepted workflow submission timing', async () => {
+      prepareEmptyPromptQueue()
+      const trackWorkflowSubmission = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackWorkflowSubmission })
+      setTelemetryRegistry(registry)
+      const now = vi
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(42)
+        .mockReturnValueOnce(92)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      try {
+        await app.queuePrompt(0)
+
+        expect(trackWorkflowSubmission).toHaveBeenCalledExactlyOnceWith({
+          startTime: 42,
+          submittedAt: 92,
+          outcome: 'accepted',
+          workflowContext: expect.objectContaining({
+            workflow_type: 'custom',
+            execution_scope: 'full'
+          })
+        })
+      } finally {
+        now.mockRestore()
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('tracks a resolved response without a prompt ID as rejected', async () => {
+      prepareEmptyPromptQueue()
+      const trackWorkflowSubmission = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackWorkflowSubmission })
+      setTelemetryRegistry(registry)
+      const now = vi
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(42)
+        .mockReturnValueOnce(92)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        error: 'Prompt rejected'
+      })
+
+      try {
+        await app.queuePrompt(0)
+
+        expect(trackWorkflowSubmission).toHaveBeenCalledExactlyOnceWith({
+          startTime: 42,
+          submittedAt: 92,
+          outcome: 'prompt_rejected',
+          workflowContext: expect.objectContaining({
+            workflow_type: 'custom',
+            execution_scope: 'full'
+          })
+        })
+      } finally {
+        now.mockRestore()
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it.each([
+      {
+        name: 'account precondition',
+        error: new PromptExecutionError({
+          node_errors: {},
+          error: {
+            type: 'RuntimeError',
+            message: 'Unauthorized: Please login first to use this node.',
+            details: ''
+          }
+        }),
+        outcome: 'account_blocked'
+      },
+      {
+        name: 'prompt rejection',
+        error: new PromptExecutionError({
+          node_errors: {},
+          error: {
+            type: 'prompt_no_outputs',
+            message: 'Prompt has no outputs',
+            details: ''
+          }
+        }),
+        outcome: 'prompt_rejected'
+      },
+      {
+        name: 'unexpected failure',
+        error: new Error('Network client failed'),
+        outcome: 'unexpected_failure'
+      }
+    ] as const)(
+      'tracks $name submission timing',
+      async ({ error, outcome }) => {
+        prepareEmptyPromptQueue()
+        const trackWorkflowSubmission = vi.fn()
+        const registry = new TelemetryRegistry()
+        registry.registerProvider({ trackWorkflowSubmission })
+        setTelemetryRegistry(registry)
+        const now = vi
+          .spyOn(performance, 'now')
+          .mockReturnValueOnce(42)
+          .mockReturnValueOnce(92)
+        const consoleError = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
+        vi.spyOn(api, 'queuePrompt').mockRejectedValue(error)
+
+        try {
+          await app.queuePrompt(0)
+
+          expect(trackWorkflowSubmission).toHaveBeenCalledExactlyOnceWith({
+            startTime: 42,
+            submittedAt: 92,
+            outcome,
+            workflowContext: expect.objectContaining({
+              workflow_type: 'custom',
+              execution_scope: 'full'
+            })
+          })
+        } finally {
+          consoleError.mockRestore()
+          now.mockRestore()
+          setTelemetryRegistry(null)
+        }
+      }
+    )
+
     it('attributes telemetry to the graph selected when submission starts', async () => {
       const initialGraph = new LGraph()
       initialGraph.add(new LGraphNode('Initial node'))

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1762,6 +1762,7 @@ export class ComfyApp {
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
                   startTime,
+                  submittedAt,
                   workflow: submissionWorkflow,
                   workflowContext
                 })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1739,6 +1739,7 @@ export class ComfyApp {
               startTime,
               submittedAt,
               outcome: res.prompt_id ? 'accepted' : 'prompt_rejected',
+              ...(res.prompt_id && { jobId: res.prompt_id }),
               ...(workflowContext && { workflowContext })
             })
             delete api.authToken

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1734,6 +1734,13 @@ export class ComfyApp {
               partialExecutionTargets: queueNodeIds,
               previewMethod
             })
+            const submittedAt = performance.now()
+            telemetry?.trackWorkflowSubmission({
+              startTime,
+              submittedAt,
+              outcome: res.prompt_id ? 'accepted' : 'prompt_rejected',
+              ...(workflowContext && { workflowContext })
+            })
             delete api.authToken
             delete api.apiKey
             if (res.prompt_id && telemetry && !workflowQueuedMetadata) {
@@ -1783,6 +1790,16 @@ export class ComfyApp {
                   exceptionMessage: preconditionResponseError.message
                 })
               : undefined
+            telemetry?.trackWorkflowSubmission({
+              startTime,
+              submittedAt: performance.now(),
+              outcome: promptPrecondition
+                ? 'account_blocked'
+                : error instanceof PromptExecutionError
+                  ? 'prompt_rejected'
+                  : 'unexpected_failure',
+              ...(workflowContext && { workflowContext })
+            })
             // Account preconditions (sign-in, subscription, credits) open their
             // own modal and must stay out of the error panel and error count.
             if (promptPrecondition) {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,5 +1,5 @@
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { app } from '@/scripts/app'
@@ -56,6 +56,10 @@ vi.mock('@/composables/useAppMode', async (importOriginal) => {
 beforeEach(() => {
   mockAppModeState.mode.value = 'graph'
   mockAppModeState.isAppMode.value = false
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { createTestingPinia } from '@pinia/testing'
@@ -618,6 +622,7 @@ describe('useExecutionStore - workflowStatus', () => {
       id: jobId,
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
       startTime: 42,
+      submittedAt: 142,
       workflow
     })
   }
@@ -648,14 +653,18 @@ describe('useExecutionStore - workflowStatus', () => {
   })
 
   it('flushes terminal completed when WS finishes before storeJob', () => {
-    // Instant-finish race: WS fires start+success before HTTP response.
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(92)
     fireExecutionStart('job-1')
+    performanceNow.mockReturnValue(192)
     fireExecutionSuccess('job-1')
 
     callStoreJob('job-1', workflowA)
     expect(mockTrackExecutionOutcome).toHaveBeenCalledOnce()
     expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
       startTime: 42,
+      submittedAt: 142,
+      executionStartedAt: 92,
+      terminalAt: 192,
       outcome: 'success'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
@@ -663,12 +672,14 @@ describe('useExecutionStore - workflowStatus', () => {
   })
 
   it('flushes terminal failed when WS errors before storeJob', () => {
-    // Invalid-workflow path: execution_error fires before HTTP response.
+    vi.spyOn(performance, 'now').mockReturnValue(192)
     fireExecutionError('job-1')
 
     callStoreJob('job-1', workflowA)
     expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
       startTime: 42,
+      submittedAt: 142,
+      terminalAt: 192,
       outcome: 'failure'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
@@ -684,11 +695,16 @@ describe('useExecutionStore - workflowStatus', () => {
 
   it('sets completed on execution_success', () => {
     callStoreJob('job-1', workflowA)
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(142)
     fireExecutionStart('job-1')
+    performanceNow.mockReturnValue(242)
     fireExecutionSuccess('job-1')
 
     expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
       startTime: 42,
+      submittedAt: 142,
+      executionStartedAt: 142,
+      terminalAt: 242,
       outcome: 'success'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
@@ -711,13 +727,20 @@ describe('useExecutionStore - workflowStatus', () => {
       id: 'job-1',
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
       startTime: 42,
+      submittedAt: 142,
       workflow: workflowA,
       workflowContext
     })
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(142)
+    fireExecutionStart('job-1')
+    performanceNow.mockReturnValue(242)
     fireExecutionSuccess('job-1')
 
     expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
       startTime: 42,
+      submittedAt: 142,
+      executionStartedAt: 142,
+      terminalAt: 242,
       outcome: 'success',
       workflowContext
     })
@@ -1368,7 +1391,10 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
 
       expect(store.activeJobId).toBe('job-1')
-      expect(store.queuedJobs['job-1']).toEqual({ nodes: {} })
+      expect(store.queuedJobs['job-1']).toEqual({
+        nodes: {},
+        executionStartedAt: expect.any(Number)
+      })
     })
 
     it('clears transient errors while preserving validation errors', () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1424,9 +1424,42 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       })
     })
 
+    function submitJob(id: string) {
+      store.storeJob({
+        nodes: ['1'],
+        id,
+        promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+        startTime: 42,
+        submittedAt: 142,
+        workflow: createQueuedWorkflow()
+      })
+    }
+
     it('emits the execution start funnel step once per job', () => {
+      submitJob('job-1')
+
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(mockTrackWorkflowExecutionStarted).toHaveBeenCalledExactlyOnceWith(
+        { jobId: 'job-1' }
+      )
+    })
+
+    it('does not count the step in a tab that did not submit the job', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(store.queuedJobs['job-1'].executionStartedAt).toEqual(
+        expect.any(Number)
+      )
+      expect(mockTrackWorkflowExecutionStarted).not.toHaveBeenCalled()
+    })
+
+    it('emits the step when execution_start beats the queuePrompt response', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+      expect(mockTrackWorkflowExecutionStarted).not.toHaveBeenCalled()
+
+      submitJob('job-1')
 
       expect(mockTrackWorkflowExecutionStarted).toHaveBeenCalledExactlyOnceWith(
         { jobId: 'job-1' }

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -23,7 +23,8 @@ const {
   mockTrackExecutionError,
   mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
-  mockTrackSharedWorkflowRun
+  mockTrackSharedWorkflowRun,
+  mockTrackWorkflowExecutionStarted
 } = await vi.hoisted(async () => {
   const { shallowRef } = await import('vue')
   return {
@@ -36,7 +37,8 @@ const {
     mockTrackExecutionError: vi.fn(),
     mockTrackExecutionOutcome: vi.fn(),
     mockTrackExecutionSuccess: vi.fn(),
-    mockTrackSharedWorkflowRun: vi.fn()
+    mockTrackSharedWorkflowRun: vi.fn(),
+    mockTrackWorkflowExecutionStarted: vi.fn()
   }
 })
 
@@ -99,6 +101,7 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackExecutionError: mockTrackExecutionError,
     trackExecutionOutcome: mockTrackExecutionOutcome,
+    trackWorkflowExecutionStarted: mockTrackWorkflowExecutionStarted,
     trackExecutionSuccess: mockTrackExecutionSuccess,
     trackSharedWorkflowRun: mockTrackSharedWorkflowRun
   })
@@ -665,7 +668,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 92,
       terminalAt: 192,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
     expect(store.queuedJobs['job-1']).toBeUndefined()
@@ -680,7 +684,8 @@ describe('useExecutionStore - workflowStatus', () => {
       startTime: 42,
       submittedAt: 142,
       terminalAt: 192,
-      outcome: 'failure'
+      outcome: 'failure',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
   })
@@ -697,7 +702,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 92,
       terminalAt: 192,
-      outcome: 'interrupted'
+      outcome: 'interrupted',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
@@ -714,7 +720,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 142,
       terminalAt: 242,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
   })
@@ -751,6 +758,7 @@ describe('useExecutionStore - workflowStatus', () => {
       executionStartedAt: 142,
       terminalAt: 242,
       outcome: 'success',
+      jobId: 'job-1',
       workflowContext
     })
   })
@@ -775,7 +783,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 142,
       terminalAt: 242,
-      outcome: 'interrupted'
+      outcome: 'interrupted',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
@@ -1413,6 +1422,15 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         nodes: {},
         executionStartedAt: expect.any(Number)
       })
+    })
+
+    it('emits the execution start funnel step once per job', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(mockTrackWorkflowExecutionStarted).toHaveBeenCalledExactlyOnceWith(
+        { jobId: 'job-1' }
+      )
     })
 
     it('clears transient errors while preserving validation errors', () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -685,11 +685,20 @@ describe('useExecutionStore - workflowStatus', () => {
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
   })
 
-  it('drops pending status on interrupt before storeJob', () => {
+  it('flushes interrupted timing when storeJob arrives after WS', () => {
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(92)
     fireExecutionStart('job-1')
+    performanceNow.mockReturnValue(192)
     fireExecutionInterrupted('job-1')
 
     callStoreJob('job-1', workflowA)
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      submittedAt: 142,
+      executionStartedAt: 92,
+      terminalAt: 192,
+      outcome: 'interrupted'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
 
@@ -756,9 +765,18 @@ describe('useExecutionStore - workflowStatus', () => {
 
   it('skips status badge on user-initiated interrupt', () => {
     callStoreJob('job-1', workflowA)
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(142)
     fireExecutionStart('job-1')
+    performanceNow.mockReturnValue(242)
     fireExecutionInterrupted('job-1')
 
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      submittedAt: 142,
+      executionStartedAt: 142,
+      terminalAt: 242,
+      outcome: 'interrupted'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -213,6 +213,7 @@ export const useExecutionStore = defineStore('execution', () => {
       }),
       terminalAt,
       outcome,
+      jobId,
       ...(queuedJob.workflowContext && {
         workflowContext: queuedJob.workflowContext
       })
@@ -436,7 +437,16 @@ export const useExecutionStore = defineStore('execution', () => {
     executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
-    queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
+    const startedJob = queuedJobs.value[activeJobId.value]
+    if (startedJob.executionStartedAt === undefined) {
+      startedJob.executionStartedAt = performance.now()
+      useTelemetry()?.trackWorkflowExecutionStarted({
+        jobId: activeJobId.value,
+        ...(startedJob.workflowContext && {
+          workflowContext: startedJob.workflowContext
+        })
+      })
+    }
     clearInitializationByJobId(activeJobId.value)
 
     // Ensure path mapping exists — execution_start can arrive via WebSocket

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -6,7 +6,10 @@ import { useAppMode } from '@/composables/useAppMode'
 import { isCloud } from '@/platform/distribution/types'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTelemetry } from '@/platform/telemetry'
-import type { WorkflowExecutionContext } from '@/platform/telemetry/types'
+import type {
+  ExecutionOutcomeMetadata,
+  WorkflowExecutionContext
+} from '@/platform/telemetry/types'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type {
@@ -46,6 +49,12 @@ interface ExecutionNodeInfo {
   type?: string | null
 }
 
+interface PendingWorkflowStatus {
+  status: WorkflowExecutionStatus
+  terminalAt?: number
+  executionStartedAt?: number
+}
+
 interface QueuedJob {
   /**
    * The nodes that are queued to be executed. The key is the node id and the
@@ -53,6 +62,8 @@ interface QueuedJob {
    */
   nodes: Record<string, boolean>
   startTime?: number
+  submittedAt?: number
+  executionStartedAt?: number
   workflowContext?: WorkflowExecutionContext
   /**
    * The workflow that is queued to be executed
@@ -144,17 +155,14 @@ export const useExecutionStore = defineStore('execution', () => {
 
   // Buffers statuses arriving before storeJob attaches the workflow.
   // FIFO-capped to bound growth if a matching storeJob never fires.
-  const pendingWorkflowStatusByJobId = new Map<
-    string,
-    WorkflowExecutionStatus
-  >()
+  const pendingWorkflowStatusByJobId = new Map<string, PendingWorkflowStatus>()
 
   function bufferPendingWorkflowStatus(
     jobId: string,
-    status: WorkflowExecutionStatus
+    pending: PendingWorkflowStatus
   ) {
     pendingWorkflowStatusByJobId.delete(jobId)
-    pendingWorkflowStatusByJobId.set(jobId, status)
+    pendingWorkflowStatusByJobId.set(jobId, pending)
     while (pendingWorkflowStatusByJobId.size > MAX_PROGRESS_JOBS) {
       const oldest = pendingWorkflowStatusByJobId.keys().next().value
       if (oldest === undefined) break
@@ -182,29 +190,54 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function trackExecutionOutcome(
     jobId: string,
-    status: WorkflowExecutionStatus
-  ) {
-    if (status === 'running') return
+    outcome: ExecutionOutcomeMetadata['outcome'],
+    terminalAt?: number
+  ): boolean {
+    if (terminalAt === undefined) return false
     const queuedJob = queuedJobs.value[jobId]
     const startTime = queuedJob?.startTime
-    if (startTime === undefined) return
+    if (startTime === undefined) return false
     useTelemetry()?.trackExecutionOutcome({
       startTime,
-      outcome: status === 'completed' ? 'success' : 'failure',
+      ...(queuedJob.submittedAt !== undefined && {
+        submittedAt: queuedJob.submittedAt
+      }),
+      ...(queuedJob.executionStartedAt !== undefined && {
+        executionStartedAt: queuedJob.executionStartedAt
+      }),
+      terminalAt,
+      outcome,
       ...(queuedJob.workflowContext && {
         workflowContext: queuedJob.workflowContext
       })
     })
+    return true
   }
 
-  function setWorkflowStatus(jobId: string, status: WorkflowExecutionStatus) {
+  function setWorkflowStatus(
+    jobId: string,
+    status: WorkflowExecutionStatus,
+    terminalAt?: number
+  ) {
     const workflow = jobIdToWorkflow.get(jobId)
     if (!workflow) {
-      bufferPendingWorkflowStatus(jobId, status)
+      bufferPendingWorkflowStatus(jobId, {
+        status,
+        terminalAt,
+        ...(queuedJobs.value[jobId]?.executionStartedAt !== undefined && {
+          executionStartedAt: queuedJobs.value[jobId].executionStartedAt
+        })
+      })
       return
     }
     applyWorkflowStatus(workflow, status)
-    trackExecutionOutcome(jobId, status)
+    if (status !== 'running') {
+      trackExecutionOutcome(
+        jobId,
+        status === 'completed' ? 'success' : 'failure',
+        terminalAt
+      )
+    }
   }
 
   function clearWorkflowStatus(workflow: ComfyWorkflow) {
@@ -397,6 +430,7 @@ export const useExecutionStore = defineStore('execution', () => {
     executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
+    queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
     clearInitializationByJobId(activeJobId.value)
 
     // Ensure path mapping exists — execution_start can arrive via WebSocket
@@ -434,7 +468,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
     const jobId = e.detail.prompt_id
-    setWorkflowStatus(jobId, 'completed')
+    setWorkflowStatus(jobId, 'completed', performance.now())
     const queuedJob = queuedJobs.value[jobId]
     const telemetry = useTelemetry()
     if (queuedJob) {
@@ -574,7 +608,7 @@ export const useExecutionStore = defineStore('execution', () => {
       return
     }
 
-    setWorkflowStatus(e.detail.prompt_id, 'failed')
+    setWorkflowStatus(e.detail.prompt_id, 'failed', performance.now())
     executionErrorStore.recordExecutionError(e.detail)
     clearInitializationByJobId(e.detail.prompt_id)
     resetExecutionState(e.detail.prompt_id)
@@ -740,6 +774,7 @@ export const useExecutionStore = defineStore('execution', () => {
     id,
     promptOutput,
     startTime,
+    submittedAt,
     workflow,
     workflowContext
   }: {
@@ -747,6 +782,7 @@ export const useExecutionStore = defineStore('execution', () => {
     id: JobId
     promptOutput: ComfyApiWorkflow
     startTime?: number
+    submittedAt?: number
     workflow: ComfyWorkflow
     workflowContext?: WorkflowExecutionContext
   }) {
@@ -761,6 +797,7 @@ export const useExecutionStore = defineStore('execution', () => {
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
     queuedJob.startTime = startTime
+    queuedJob.submittedAt = submittedAt
     queuedJob.workflowContext = workflowContext
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
@@ -786,10 +823,20 @@ export const useExecutionStore = defineStore('execution', () => {
     if (pending === undefined || !workflow) return
     pendingWorkflowStatusByJobId.delete(jobId)
     // Don't let a stale 'running' overwrite a terminal status already set.
-    if (pending === 'running' && workflowStatus.value.has(workflow)) return
-    applyWorkflowStatus(workflow, pending)
-    trackExecutionOutcome(jobId, pending)
-    if (pending === 'running' || activeJobId.value === jobId) return
+    if (pending.status === 'running' && workflowStatus.value.has(workflow))
+      return
+    if (pending.executionStartedAt !== undefined) {
+      queuedJobs.value[jobId].executionStartedAt = pending.executionStartedAt
+    }
+    applyWorkflowStatus(workflow, pending.status)
+    if (pending.status !== 'running') {
+      trackExecutionOutcome(
+        jobId,
+        pending.status === 'completed' ? 'success' : 'failure',
+        pending.terminalAt
+      )
+    }
+    if (pending.status === 'running' || activeJobId.value === jobId) return
     delete queuedJobs.value[jobId]
     jobIdToWorkflow.delete(jobId)
   }

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -194,6 +194,16 @@ export const useExecutionStore = defineStore('execution', () => {
     mutateStatus((m) => m.set(workflow, status))
   }
 
+  function trackWorkflowExecutionStarted(
+    jobId: string,
+    workflowContext: WorkflowExecutionContext | undefined
+  ) {
+    useTelemetry()?.trackWorkflowExecutionStarted({
+      jobId,
+      ...(workflowContext && { workflowContext })
+    })
+  }
+
   function trackExecutionOutcome(
     jobId: string,
     outcome: ExecutionOutcomeMetadata['outcome'],
@@ -440,12 +450,15 @@ export const useExecutionStore = defineStore('execution', () => {
     const startedJob = queuedJobs.value[activeJobId.value]
     if (startedJob.executionStartedAt === undefined) {
       startedJob.executionStartedAt = performance.now()
-      useTelemetry()?.trackWorkflowExecutionStarted({
-        jobId: activeJobId.value,
-        ...(startedJob.workflowContext && {
-          workflowContext: startedJob.workflowContext
-        })
-      })
+      // execution_start is broadcast to every connected tab, but only the tab
+      // that submitted has startTime. Spectator tabs must not count the step;
+      // a submitting tab that has not yet stored the job emits from storeJob.
+      if (startedJob.startTime !== undefined) {
+        trackWorkflowExecutionStarted(
+          activeJobId.value,
+          startedJob.workflowContext
+        )
+      }
     }
     clearInitializationByJobId(activeJobId.value)
 
@@ -821,9 +834,19 @@ export const useExecutionStore = defineStore('execution', () => {
       ...queuedJob.nodes
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
+    const wasStored = queuedJob.startTime !== undefined
     queuedJob.startTime = startTime
     queuedJob.submittedAt = submittedAt
     queuedJob.workflowContext = workflowContext
+    // execution_start can beat the queuePrompt response, leaving the step
+    // unattributed until the job is stored.
+    if (
+      !wasStored &&
+      startTime !== undefined &&
+      queuedJob.executionStartedAt !== undefined
+    ) {
+      trackWorkflowExecutionStarted(String(id), workflowContext)
+    }
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
     queuedJob.shareId = workflow?.shareId

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -49,11 +49,17 @@ interface ExecutionNodeInfo {
   type?: string | null
 }
 
-interface PendingWorkflowStatus {
-  status: WorkflowExecutionStatus
-  terminalAt?: number
-  executionStartedAt?: number
-}
+type PendingWorkflowStatus =
+  | {
+      status: WorkflowExecutionStatus
+      terminalAt?: number
+      executionStartedAt?: number
+    }
+  | {
+      outcome: 'interrupted'
+      terminalAt: number
+      executionStartedAt?: number
+    }
 
 interface QueuedJob {
   /**
@@ -453,8 +459,17 @@ export const useExecutionStore = defineStore('execution', () => {
     e: CustomEvent<ExecutionInterruptedWsMessage>
   ) {
     const jobId = e.detail.prompt_id
+    const terminalAt = performance.now()
+    if (!trackExecutionOutcome(jobId, 'interrupted', terminalAt)) {
+      bufferPendingWorkflowStatus(jobId, {
+        outcome: 'interrupted',
+        terminalAt,
+        ...(queuedJobs.value[jobId]?.executionStartedAt !== undefined && {
+          executionStartedAt: queuedJobs.value[jobId].executionStartedAt
+        })
+      })
+    }
     // User-initiated stop is not a failure — drop the badge entirely.
-    pendingWorkflowStatusByJobId.delete(jobId)
     const workflow = jobIdToWorkflow.get(jobId)
     if (workflow) clearWorkflowStatus(workflow)
     if (activeJobId.value) clearInitializationByJobId(activeJobId.value)
@@ -822,6 +837,15 @@ export const useExecutionStore = defineStore('execution', () => {
     const pending = pendingWorkflowStatusByJobId.get(jobId)
     if (pending === undefined || !workflow) return
     pendingWorkflowStatusByJobId.delete(jobId)
+    if ('outcome' in pending) {
+      if (pending.executionStartedAt !== undefined) {
+        queuedJobs.value[jobId].executionStartedAt = pending.executionStartedAt
+      }
+      trackExecutionOutcome(jobId, pending.outcome, pending.terminalAt)
+      delete queuedJobs.value[jobId]
+      jobIdToWorkflow.delete(jobId)
+      return
+    }
     // Don't let a stale 'running' overwrite a terminal status already set.
     if (pending.status === 'running' && workflowStatus.value.has(workflow))
       return


### PR DESCRIPTION
## Stack

1. [#14084 — feat: add workflow context to RUM events](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14084)
2. [#14098 — refactor: make workflow context graph selection explicit](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14098)
3. [#14093 — feat: track workflow phase timing and run funnel in RUM](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14093)

Formerly-#14135 was folded into this PR as its final commit rather than stacked on top of it.

## Summary

Make a cloud workflow run measurable in Datadog RUM along two independent axes:

- **How long** — schema-v2 duration vitals split the run into frontend submission, backend queue wait, active execution, and total user wait. The legacy `workflow_execution` vital is dual-written unversioned so existing consumers keep working.
- **How many** — a RUM action fires at each run boundary as it is crossed, so drop-off is countable as a funnel. `workflow_submission`, `workflow_execution_start`, and `workflow_run_finished` join the pre-existing `workflow_queue` action, and each stage after the first is countable per run by `job_id`.

Terminal timestamps are captured at the WebSocket event rather than at emit time, queue wait is clamped to zero when execution starts before the HTTP response arrives, and user stops report `interrupted` rather than `failure`.

## Review Focus

### Why actions in addition to vitals

Vitals cannot serve as RUM funnel steps, and three of the four phase vitals are emitted from the terminal path — so a run abandoned mid-queue produces no vital at all, making that drop-off indistinguishable from a run that never submitted. Each action fires as its boundary is crossed instead, so an absent step localizes the failure:

| Step | Absence means |
| --- | --- |
| `workflow_queue` | — |
| `workflow_submission` | client never posted |
| `workflow_execution_start` | died in queue |
| `workflow_run_finished` | died mid-execution |

Two decisions worth attention:

- `workflow_execution_start` reuses the existing `executionStartedAt` guard in `handleExecutionStart`, so a replayed WebSocket message cannot double-count the step, and the funnel step can never disagree with the timing field.
- `jobId` is required on `ExecutionOutcomeMetadata` but optional on `WorkflowSubmissionMetadata` — a rejected submission has no `prompt_id`, and a placeholder would pollute a `cardinality(@context.job_id)` query. That query is the session-independent fallback for queue waits that outlive the 15-minute RUM session, since RUM funnels are session-scoped.

Actions and vitals deliberately share the name `workflow_submission`; Datadog namespaces them as `@action.name` and `@vital.name`.

## Verification

### The phases partition the run

One live two-node `Empty Latent Image → Save Latent` run against a real backend. Localhost RUM support came from the now-closed [#14105](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14105), applied to the local test checkout only and never to this branch.

```
service:comfy-cloud-frontend env:test-v2 @type:vital @vital.name:workflow_* @view.url_host:localhost
```

[Open the fixed Datadog Explorer window](https://us5.datadoghq.com/rum/sessions?query=service%3Acomfy-cloud-frontend%20env%3Atest-v2%20%40type%3Avital%20%40vital.name%3Aworkflow_*%20%40view.url_host%3Alocalhost&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&refresh_mode=paused&from_ts=1785038226454&to_ts=1785038406454&live=false)

`workflow_submission` 868.7 ms + `workflow_queue_wait` 1765.7 ms + `workflow_execution_time` 1204.5 ms = 3838.9 ms, matching `workflow_total_time` 3.84 s — the phases cover the run with no gap or overlap. Legacy `workflow_execution` reports the same 3.84 s, so the dual-write agrees; only the four new vitals carry `timing_schema_version: 2`.

<img width="1512" height="772" alt="Datadog Explorer showing five workflow phase vitals summing to the total run duration" src="https://github.com/user-attachments/assets/313b64aa-43b5-49a5-b90f-2ceb979302a8" />

This capture predates the funnel commit, which adds no `addDurationVital` call and changes none of the existing ones, so it still describes the vitals emitted at this head.

### The funnel truncates where the run dies

Recorded at the boundary the frontend actually owns — the arguments handed to `datadogRum.addAction` — by driving the real `executionStore` and the real `DatadogRumTelemetryProvider` through a run lifecycle with only `@datadog/browser-rum` stubbed as a recorder.

A run that completes emits all four steps in boundary order:

```
action  workflow_queue            job_id=—            outcome=—
action  workflow_submission       job_id=job-evidence outcome=accepted
action  workflow_execution_start  job_id=job-evidence outcome=—
action  workflow_run_finished     job_id=job-evidence outcome=success
```

The same run abandoned while still queued stops after submission, which is the behavior the vitals cannot express:

```
action  workflow_queue            job_id=—             outcome=—
action  workflow_submission       job_id=job-abandoned outcome=accepted
(no workflow_execution_start, no workflow_run_finished)
```

A rejected submission carries the outcome and no `job_id`, so nothing synthetic enters a `cardinality(@context.job_id)` count:

```
action  workflow_submission       job_id=—            outcome=prompt_rejected
```

A user stop reaches `workflow_run_finished` with `outcome=interrupted`, and leaves `getWorkflowStatus` undefined so no failure badge is written.

### One run counts once, in any number of tabs

`execution_start` is broadcast over the WebSocket to every connected tab, so the per-tab `executionStartedAt` guard cannot deduplicate it. Emitted events in `env:test-v2` showed the inflation directly — 7 `workflow_execution_start` actions across 4 `job_id`s, the duplicates sharing a session and a millisecond but differing by `tab.id`, one foregrounded with full workflow context and one background carrying only `job_id`. The other steps were never affected because they require `queuedJob.startTime`, which only the submitting tab sets.

Suppressing spectator tabs on `startTime` alone would undercount instead, since `execution_start` can beat the `queuePrompt` response. The step is emitted from `storeJob` when the WebSocket wins that race, mirroring how terminal outcomes already replay through the pending buffer. Three tests cover it: the submitting tab counts once across repeated messages, a tab that never stored the job counts zero, and a tab whose response arrives late still counts once.

### Queue wait clamps instead of going negative

Dropping `Math.max(0, …)` and keeping the raw subtraction fails at this head:

```
FAIL  DatadogRumTelemetryProvider >
      clamps queue wait when execution starts before the response arrives

-     "duration": 0,
+     "duration": -50,
```

### Known gaps

**`workflow_queue` cannot be deduplicated by run.** It now routes through `funnelStep()` and carries `product`, so a funnel filtered on `@context.product` keeps its first step — but no `prompt_id` exists before submission, so it carries no `job_id`. The session-independent `job_id` fallback can therefore only reconstruct steps 2–4; step 1 counts Run clicks. Session-scoped funnels are unaffected.

**WebSocket-before-HTTP ordering is not pinned by a test.** `terminalAt` and `executionStartedAt` are captured at the WebSocket event and carried through the pending buffer, so a late `storeJob` cannot inflate them — but replacing the captured `terminalAt` with `performance.now()` at emit time still passes every test in `executionStore.test.ts` and `app.test.ts`, because the ordering tests never advance the mocked clock between the terminal WebSocket event and the late `storeJob`.

**The funnel actions have not been observed in Datadog.** Evidence above stops at the frontend boundary. Datadog currently holds workflow telemetry only in `env:test-v2`, all of it HeadlessChrome on `127.0.0.1` from local validation runs — `prod-v2` and `stg-v2` have never received a workflow event, so there is no traffic to render a populated funnel against yet.

