### PR TITLE
refactor: inline Cloud Sentry telemetry

### DIFF
--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -29,7 +29,8 @@ export async function initTelemetry(): Promise<void> {
       { ClickHouseTelemetryProvider },
       { SyftTelemetryProvider },
       { CustomerIoTelemetryProvider },
-      { DatadogRumTelemetryProvider }
+      { DatadogRumTelemetryProvider },
+      { SentryTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
       import('./providers/cloud/MixpanelTelemetryProvider'),
@@ -39,7 +40,8 @@ export async function initTelemetry(): Promise<void> {
       import('./providers/cloud/ClickHouseTelemetryProvider'),
       import('./providers/cloud/SyftTelemetryProvider'),
       import('./providers/cloud/CustomerIoTelemetryProvider'),
-      import('./providers/cloud/DatadogRumTelemetryProvider')
+      import('./providers/cloud/DatadogRumTelemetryProvider'),
+      import('./providers/cloud/SentryTelemetryProvider')
     ])
 
     const registry = new TelemetryRegistry()
@@ -51,6 +53,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new SyftTelemetryProvider())
     registry.registerProvider(new CustomerIoTelemetryProvider())
     registry.registerProvider(new DatadogRumTelemetryProvider())
+    registry.registerProvider(new SentryTelemetryProvider())
 
     setTelemetryRegistry(registry)
   })()

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ExecutionContext, ShellLayoutMetadata } from '../../types'
+import { SentryTelemetryProvider } from './SentryTelemetryProvider'
+
+const mocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
+  setContext: vi.fn(),
+  setUser: vi.fn(),
+  onUserLogout: vi.fn(),
+  resolvedUserId: 'existing-user' as string | undefined,
+  workflowIsModified: true,
+  executionContext: {
+    is_template: false,
+    workflow_name: 'private-workflow-name',
+    custom_node_count: 2,
+    api_node_count: 1,
+    toolkit_node_count: 1,
+    subgraph_count: 3,
+    total_node_count: 12,
+    has_api_nodes: true,
+    api_node_names: ['PrivateApiNode'],
+    has_toolkit_nodes: true,
+    toolkit_node_names: ['PrivateToolkitNode']
+  } satisfies ExecutionContext
+}))
+
+vi.mock('@sentry/vue', () => ({
+  addBreadcrumb: mocks.addBreadcrumb,
+  setContext: mocks.setContext,
+  setUser: mocks.setUser
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    onUserLogout: mocks.onUserLogout,
+    resolvedUserInfo: {
+      value: mocks.resolvedUserId
+        ? {
+            id: mocks.resolvedUserId
+          }
+        : null
+    }
+  })
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    activeWorkflow: {
+      isModified: mocks.workflowIsModified
+    }
+  })
+}))
+
+vi.mock('../../utils/getExecutionContext', () => ({
+  getExecutionContext: () => mocks.executionContext
+}))
+
+const shellLayout: ShellLayoutMetadata = {
+  view_mode: 'graph',
+  is_app_mode: false,
+  dock_state: 'docked',
+  actionbar_position: 'top',
+  active_sidebar_tab: 'node-library',
+  right_side_panel_open: false,
+  bottom_panel_open: true,
+  open_workflow_tabs: 2
+}
+
+describe('SentryTelemetryProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolvedUserId = 'existing-user'
+    mocks.workflowIsModified = true
+  })
+
+  it('identifies resolved and newly authenticated users and clears logout', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackUserLoggedIn()
+    provider.trackAuth({ user_id: 'new-user' })
+
+    expect(mocks.setUser).toHaveBeenNthCalledWith(1, { id: 'existing-user' })
+    expect(mocks.setUser).toHaveBeenNthCalledWith(2, { id: 'new-user' })
+    expect(mocks.onUserLogout).toHaveBeenCalledOnce()
+
+    const onLogout = mocks.onUserLogout.mock.calls[0][0]
+    onLogout()
+
+    expect(mocks.setUser).toHaveBeenLastCalledWith(null)
+  })
+
+  it('sets bounded app context without workflow names or node-name arrays', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackShellLayout(shellLayout)
+
+    expect(mocks.setContext).toHaveBeenCalledExactlyOnceWith(
+      'ComfyUI App State',
+      {
+        ...shellLayout,
+        workflow_is_modified: true,
+        is_template: false,
+        custom_node_count: 2,
+        api_node_count: 1,
+        toolkit_node_count: 1,
+        subgraph_count: 3,
+        total_node_count: 12,
+        has_api_nodes: true,
+        has_toolkit_nodes: true
+      }
+    )
+  })
+
+  it('records privacy-safe node and execution breadcrumbs', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackNodeAdded({
+      node_type: 'KSampler',
+      source: 'search_modal'
+    })
+    provider.trackWorkflowExecution()
+    provider.trackExecutionError({
+      jobId: 'private-job-id',
+      nodeId: 'private-node-id',
+      nodeType: 'KSampler',
+      error: 'private exception details'
+    })
+    provider.trackExecutionSuccess({ jobId: 'private-job-id' })
+
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(1, {
+      category: 'workflow',
+      message: 'node_added',
+      level: 'info',
+      data: {
+        node_type: 'KSampler',
+        source: 'search_modal'
+      }
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(2, {
+      category: 'workflow.execution',
+      message: 'started',
+      level: 'info'
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(3, {
+      category: 'workflow.execution',
+      message: 'failed',
+      level: 'error',
+      data: { node_type: 'KSampler' }
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(4, {
+      category: 'workflow.execution',
+      message: 'succeeded',
+      level: 'info'
+    })
+    expect(mocks.setContext).toHaveBeenCalledWith('Workflow Execution', {
+      status: 'failure',
+      node_type: 'KSampler'
+    })
+  })
+})

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
@@ -1,0 +1,119 @@
+import * as Sentry from '@sentry/vue'
+
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+import type {
+  AuthMetadata,
+  ExecutionErrorMetadata,
+  ExecutionSuccessMetadata,
+  NodeAddedMetadata,
+  ShellLayoutMetadata,
+  TelemetryProvider
+} from '../../types'
+import { getExecutionContext } from '../../utils/getExecutionContext'
+
+export class SentryTelemetryProvider implements TelemetryProvider {
+  private shellLayout: ShellLayoutMetadata | null = null
+  private isWatchingLogout = false
+
+  trackAuth({ user_id }: AuthMetadata): void {
+    this.setUser(user_id)
+  }
+
+  trackUserLoggedIn(): void {
+    this.setUser(useCurrentUser().resolvedUserInfo.value?.id)
+  }
+
+  trackShellLayout(metadata: ShellLayoutMetadata): void {
+    this.shellLayout = metadata
+    this.updateAppContext()
+  }
+
+  trackNodeAdded({ node_type, source }: NodeAddedMetadata): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow',
+      message: 'node_added',
+      level: 'info',
+      data: { node_type, source }
+    })
+  }
+
+  trackWorkflowExecution(): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'started',
+      level: 'info'
+    })
+    Sentry.setContext('Workflow Execution', { status: 'running' })
+    this.updateAppContext()
+  }
+
+  trackExecutionError({ nodeType }: ExecutionErrorMetadata): void {
+    const data = nodeType ? { node_type: nodeType } : undefined
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'failed',
+      level: 'error',
+      data
+    })
+    Sentry.setContext('Workflow Execution', {
+      status: 'failure',
+      ...data
+    })
+    this.updateAppContext()
+  }
+
+  trackExecutionSuccess(_metadata: ExecutionSuccessMetadata): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'succeeded',
+      level: 'info'
+    })
+    Sentry.setContext('Workflow Execution', { status: 'success' })
+    this.updateAppContext()
+  }
+
+  private setUser(userId: string | undefined): void {
+    if (!userId) return
+
+    Sentry.setUser({ id: userId })
+    this.watchForLogout()
+  }
+
+  private watchForLogout(): void {
+    if (this.isWatchingLogout) return
+
+    this.isWatchingLogout = true
+    useCurrentUser().onUserLogout(() => {
+      Sentry.setUser(null)
+    })
+  }
+
+  private updateAppContext(): void {
+    const {
+      is_template,
+      custom_node_count,
+      api_node_count,
+      toolkit_node_count,
+      subgraph_count,
+      total_node_count,
+      has_api_nodes,
+      has_toolkit_nodes
+    } = getExecutionContext()
+    const activeWorkflow = useWorkflowStore().activeWorkflow
+
+    Sentry.setContext('ComfyUI App State', {
+      ...(this.shellLayout ?? {}),
+      workflow_is_modified: activeWorkflow?.isModified ?? false,
+      is_template,
+      custom_node_count,
+      api_node_count,
+      toolkit_node_count,
+      subgraph_count,
+      total_node_count,
+      has_api_nodes,
+      has_toolkit_nodes
+    })
+  }
+}

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -3,13 +3,19 @@ import { describe, expect, it } from 'vitest'
 import { shouldLoadExtension } from './extensionService'
 
 describe('shouldLoadExtension', () => {
-  it('skips the legacy Cloud RUM extension in cloud builds', () => {
-    expect(shouldLoadExtension('/extensions/cloud/rum.js', true)).toBe(false)
-  })
+  it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
+    'skips the inlined Cloud extension %s in cloud builds',
+    (extension) => {
+      expect(shouldLoadExtension(extension, true)).toBe(false)
+    }
+  )
 
-  it('keeps the legacy path available outside cloud builds', () => {
-    expect(shouldLoadExtension('/extensions/cloud/rum.js', false)).toBe(true)
-  })
+  it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
+    'keeps the legacy path %s available outside cloud builds',
+    (extension) => {
+      expect(shouldLoadExtension(extension, false)).toBe(true)
+    }
+  )
 
   it('skips core extensions that load through the core entry point', () => {
     expect(shouldLoadExtension('/extensions/core/foo.js', false)).toBe(false)

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -15,14 +15,17 @@ import type { AuthUserInfo } from '@/types/authTypes'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
 
-const LEGACY_CLOUD_RUM_EXTENSION = '/extensions/cloud/rum.js'
+const INLINED_CLOUD_EXTENSIONS = new Set([
+  '/extensions/cloud/rum.js',
+  '/extensions/cloud/sentry.js'
+])
 
 export function shouldLoadExtension(
   extension: string,
   isCloudBuild: boolean
 ): boolean {
   if (extension.includes('extensions/core')) return false
-  return !isCloudBuild || extension !== LEGACY_CLOUD_RUM_EXTENSION
+  return !isCloudBuild || !INLINED_CLOUD_EXTENSIONS.has(extension)
 }
 
 export const useExtensionService = () => {


### PR DESCRIPTION
## Summary

Move Cloud's Sentry integration from `/extensions/cloud/sentry.js` into the frontend telemetry provider system, so Cloud builds use the bundled SDK without exposing `window.Sentry`. The provider attaches user identity, bounded app and workflow context, and privacy-safe node and execution breadcrumbs while excluding workflow names, file paths, raw job and node IDs, node-name arrays, and exception text. Supersedes #14092.

## Verification

Sentry log: https://comfy-org.sentry.io/issues/7631852530/?query=is%3Aunresolved&referrer=issue-stream
Prove that Sentry works capturing exceptions

<img width="855" height="188" alt="image" src="https://github.com/user-attachments/assets/a8043575-ccb6-4e76-ac1c-e0e374e81035" />
