### PR TITLE
docs: point staff to internal Cloud preview runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ This project uses **pnpm**. Always prefer scripts defined in `package.json` (e.g
   - Keep it extremely concise and information-dense
   - Don't use emojis or add excessive headers/sections
   - Follow the PR description template in the `.github/` folder.
+  - Comfy staff working on the Cloud-hosted frontend can follow the
+    [internal Cloud preview runbook](https://github.com/Comfy-Org/cloud/blob/main/docs/runbooks/pr-preview-environments.md).
+    It does not apply to local development or other deployment targets in this repository.
 - Quality gates:
   - `pnpm lint`
   - `pnpm typecheck`


### PR DESCRIPTION
## Summary

Point Comfy staff working on the Cloud-hosted frontend to the private Cloud preview runbook without publishing runtime details in this open source repository.

## Changes

- **What**: Adds one scoped `AGENTS.md` pointer to the internal runbook in [Comfy-Org/cloud#5561](https://github.com/Comfy-Org/cloud/pull/5561).

## Review Focus

Confirm the wording is sufficiently narrow: this is internal-only, applies only to the Cloud-hosted frontend, and excludes local development and other deployment targets.

## Screenshots (if applicable)

Not applicable; documentation only.
