### PR TITLE
Prototype exact-invoice Checkout navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
+import { useEventListener } from '@vueuse/core'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
 
@@ -13,12 +14,17 @@ import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
 import { isDesktop } from '@/platform/distribution/types'
 import { app } from '@/scripts/app'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { electronAPI } from '@/utils/envUtil'
 import { parsePreloadError } from '@/utils/preloadErrorUtil'
 import { useConflictDetection } from '@/workbench/extensions/manager/composables/useConflictDetection'
 
 const workspaceStore = useWorkspaceStore()
+const billingOperationStore = useBillingOperationStore()
+useEventListener(globalThis, 'pageshow', () => {
+  billingOperationStore.resumePendingOperations()
+})
 app.extensionManager = useWorkspaceStore()
 
 const conflictDetection = useConflictDetection()

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -19,9 +19,7 @@ vi.mock('vue-router', () => ({
   })
 }))
 
-// Firebase / subscription mocks
 const authActionMocks = vi.hoisted(() => ({
-  reportError: vi.fn(),
   accessBillingPortal: vi.fn()
 }))
 
@@ -31,6 +29,7 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 
 vi.mock('@/composables/useErrorHandling', () => ({
   useErrorHandling: () => ({
+    toastErrorHandler: vi.fn(),
     wrapWithErrorHandlingAsync:
       <T extends (...args: never[]) => unknown>(fn: T) =>
       (...args: Parameters<T>) =>
@@ -41,7 +40,8 @@ vi.mock('@/composables/useErrorHandling', () => ({
 const subscriptionMocks = vi.hoisted(() => ({
   isActiveSubscription: { value: false },
   isInitialized: { value: true },
-  subscriptionStatus: { value: null }
+  subscriptionStatus: { value: null },
+  initialize: vi.fn()
 }))
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
@@ -52,11 +52,25 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => subscriptionMocks
 }))
 
-// Avoid real network / isCloud behavior
-const mockPerformSubscriptionCheckout = vi.fn()
-vi.mock('@/platform/cloud/subscription/utils/subscriptionCheckoutUtil', () => ({
-  performSubscriptionCheckout: (...args: unknown[]) =>
-    mockPerformSubscriptionCheckout(...args)
+const mockShowPricingTable = vi.fn()
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({ showPricingTable: mockShowPricingTable })
+  })
+)
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    activeWorkspace: { id: 'w-personal', type: 'personal' },
+    isInPersonalWorkspace: true
+  })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: { teamWorkspacesEnabled: true, consolidatedBillingEnabled: true }
+  })
 }))
 
 const mockPerformTeamSubscriptionCheckout = vi.fn()
@@ -136,15 +150,15 @@ describe('CloudSubscriptionRedirectView', () => {
     // Shows copy under logo
     expect(screen.getByText('Subscribe to Creator')).toBeInTheDocument()
 
-    // Triggers checkout flow
-    expect(mockPerformSubscriptionCheckout).toHaveBeenCalledWith(
-      'creator',
-      'monthly',
-      {
-        openInNewTab: false,
-        paymentIntentSource: 'deep_link'
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'personal',
+      initialCheckout: {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
       }
-    )
+    })
 
     // Shows loading affordances
     expect(
@@ -152,14 +166,17 @@ describe('CloudSubscriptionRedirectView', () => {
     ).toBeInTheDocument()
   })
 
-  test('opens billing portal when subscription is already active', async () => {
+  test('uses workspace checkout for an existing personal subscription', async () => {
     subscriptionMocks.isActiveSubscription.value = true
 
     await mountView({ tier: 'creator' })
 
-    expect(mockRouterPush).not.toHaveBeenCalledWith('/')
-    expect(authActionMocks.accessBillingPortal).toHaveBeenCalledTimes(1)
-    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialCheckout: expect.objectContaining({ tierKey: 'creator' })
+      })
+    )
+    expect(authActionMocks.accessBillingPortal).not.toHaveBeenCalled()
   })
 
   test('uses first value when subscriptionType is an array', async () => {
@@ -169,13 +186,10 @@ describe('CloudSubscriptionRedirectView', () => {
 
     expect(mockRouterPush).not.toHaveBeenCalledWith('/')
     expect(screen.getByText('Subscribe to Creator')).toBeInTheDocument()
-    expect(mockPerformSubscriptionCheckout).toHaveBeenCalledWith(
-      'creator',
-      'monthly',
-      {
-        openInNewTab: false,
-        paymentIntentSource: 'deep_link'
-      }
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialCheckout: expect.objectContaining({ tierKey: 'creator' })
+      })
     )
   })
 
@@ -190,7 +204,7 @@ describe('CloudSubscriptionRedirectView', () => {
       { paymentIntentSource: 'deep_link' }
     )
     // Team never goes through the personal checkout path
-    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
   })
 
   test('redirects to home for a team link with no stop', async () => {

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -6,11 +6,11 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
-import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { performTeamSubscriptionCheckout } from '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil'
+import type { CheckoutTierKey } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import type { BillingCycle } from '../subscription/utils/subscriptionTierRank'
 
@@ -19,17 +19,17 @@ function isBillingCycle(value: string): value is BillingCycle {
 }
 
 // Only paid personal tiers can be checked out via this redirect.
-function isCheckoutTierKey(value: string): value is TierKey {
-  return ['standard', 'creator', 'pro', 'founder'].includes(value)
+function isCheckoutTierKey(value: string): value is CheckoutTierKey {
+  return ['standard', 'creator', 'pro'].includes(value)
 }
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { reportError, accessBillingPortal } = useAuthActions()
-const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const { toastErrorHandler, wrapWithErrorHandlingAsync } = useErrorHandling()
+const { showPricingTable } = useSubscriptionDialog()
 
-const { isActiveSubscription, isInitialized, initialize } = useBillingContext()
+const { isInitialized, initialize } = useBillingContext()
 
 const selectedTierKey = ref<TierKey | null>(null)
 
@@ -111,15 +111,16 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     await initialize()
   }
 
-  if (isActiveSubscription.value) {
-    await accessBillingPortal(undefined, false)
-  } else {
-    await performSubscriptionCheckout(tierKeyParam, billingCycle, {
-      openInNewTab: false,
-      paymentIntentSource: 'deep_link'
-    })
-  }
-}, reportError)
+  showPricingTable({
+    reason: 'deep_link',
+    planMode: 'personal',
+    initialCheckout: {
+      planMode: 'personal',
+      tierKey: tierKeyParam,
+      billingCycle
+    }
+  })
+}, toastErrorHandler)
 
 onMounted(() => {
   void runRedirect()

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, reactive } from 'vue'
 
-const { mockIsCloud, mockSubscribe, mockTrackBeginCheckout, mockUserId } =
-  vi.hoisted(() => ({
-    mockIsCloud: { value: true },
-    mockSubscribe: vi.fn(),
-    mockTrackBeginCheckout: vi.fn(),
-    mockUserId: { value: 'user-1' as string | null }
-  }))
+const {
+  mockIsCloud,
+  mockStartOperation,
+  mockSubscribe,
+  mockTrackBeginCheckout,
+  mockUserId
+} = vi.hoisted(() => ({
+  mockIsCloud: { value: true },
+  mockStartOperation: vi.fn(),
+  mockSubscribe: vi.fn(),
+  mockTrackBeginCheckout: vi.fn(),
+  mockUserId: { value: 'user-1' as string | null }
+}))
 
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -19,6 +25,9 @@ vi.mock('@/config/comfyApi', () => ({
 }))
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: { subscribe: mockSubscribe }
+}))
+vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
+  useBillingOperationStore: () => ({ startOperation: mockStartOperation })
 }))
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({ trackBeginCheckout: mockTrackBeginCheckout })
@@ -60,7 +69,8 @@ describe('performTeamSubscriptionCheckout', () => {
     expect(mockSubscribe).toHaveBeenCalledWith('team_per_credit_annual', {
       returnUrl: 'https://app.test/payment/success',
       cancelUrl: 'https://app.test/payment/failed',
-      teamCreditStopId: 'team_700'
+      teamCreditStopId: 'team_700',
+      useCheckout: true
     })
     expect(assignedHref).toBe('https://stripe.test/pay')
     expect(mockTrackBeginCheckout).toHaveBeenCalledWith({
@@ -84,8 +94,34 @@ describe('performTeamSubscriptionCheckout', () => {
     expect(mockSubscribe).toHaveBeenCalledWith('team_per_credit_monthly', {
       returnUrl: expect.any(String),
       cancelUrl: expect.any(String),
-      teamCreditStopId: 'team_1400'
+      teamCreditStopId: 'team_1400',
+      useCheckout: true
     })
+    expect(assignedHref).toBe('/')
+  })
+
+  it('polls a pending native Checkout operation until it redirects', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'pending_payment',
+      billing_op_id: 'op_checkout'
+    })
+    mockStartOperation.mockResolvedValue({ status: 'succeeded' })
+
+    await performTeamSubscriptionCheckout('team_700', 'monthly', {
+      paymentIntentSource: 'deep_link'
+    })
+
+    expect(mockStartOperation).toHaveBeenCalledWith(
+      'op_checkout',
+      'subscription',
+      {
+        tier: 'team',
+        cycle: 'monthly',
+        checkoutType: 'new',
+        paymentIntentSource: 'deep_link',
+        checkoutReturnUrl: undefined
+      }
+    )
     expect(assignedHref).toBe('/')
   })
 

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
@@ -3,6 +3,7 @@ import { getTeamPlanSlug } from '@/platform/cloud/subscription/constants/teamPla
 import { isCloud } from '@/platform/distribution/types'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
 import type { BillingCycle } from './subscriptionTierRank'
@@ -14,7 +15,7 @@ interface PerformTeamSubscriptionCheckoutOptions {
 /**
  * Direct team-plan checkout for the marketing `/cloud/subscribe?tier=team` deep
  * link: subscribes to the per-credit Team plan at the chosen slider stop and
- * sends the user straight to the Stripe payment page.
+ * follows the billing operation to Stripe Checkout.
  *
  * Mirrors `performSubscriptionCheckout` (personal) but routes through the
  * workspace billing endpoint (`POST /api/billing/subscribe`), because the
@@ -22,9 +23,7 @@ interface PerformTeamSubscriptionCheckoutOptions {
  * included — subscribe to it. The slug encodes the cadence; the stop id is
  * validated and priced server-side.
  *
- * Caller guards on `isCloud`, owns loading state, and wraps error handling. A
- * `needs_payment_method` response is a full-page redirect to Stripe; the other
- * statuses land back in the app, which polls the billing op to completion.
+ * Caller guards on `isCloud`, owns loading state, and wraps error handling.
  */
 export async function performTeamSubscriptionCheckout(
   teamCreditStopId: string,
@@ -37,7 +36,8 @@ export async function performTeamSubscriptionCheckout(
   const response = await workspaceApi.subscribe(planSlug, {
     returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
     cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-    teamCreditStopId
+    teamCreditStopId,
+    useCheckout: true
   })
 
   trackWorkspaceCheckoutStarted({
@@ -59,6 +59,20 @@ export async function performTeamSubscriptionCheckout(
     }
     globalThis.location.href = response.payment_method_url
     return
+  }
+
+  if (response.status !== 'subscribed') {
+    await useBillingOperationStore().startOperation(
+      response.billing_op_id,
+      'subscription',
+      {
+        tier: 'team',
+        cycle: billingCycle,
+        checkoutType: 'new',
+        paymentIntentSource: options.paymentIntentSource,
+        checkoutReturnUrl: globalThis.location.href
+      }
+    )
   }
 
   globalThis.location.href = '/'

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -402,13 +402,14 @@ describe('workspaceApi', () => {
       expect(result).toEqual(data)
     })
 
-    it('subscribe() sends POST with plan_slug and optional URLs', async () => {
+    it('subscribe() sends POST with plan_slug and Checkout options', async () => {
       const data = { billing_op_id: 'op-1', status: 'subscribed' }
       mockAxiosInstance.post.mockResolvedValue({ data })
 
       const result = await workspaceApi.subscribe('pro-monthly', {
         returnUrl: 'https://return.url',
-        cancelUrl: 'https://cancel.url'
+        cancelUrl: 'https://cancel.url',
+        useCheckout: true
       })
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
@@ -417,6 +418,7 @@ describe('workspaceApi', () => {
           plan_slug: 'pro-monthly',
           return_url: 'https://return.url',
           cancel_url: 'https://cancel.url',
+          use_checkout: true,
           team_credit_stop_id: undefined,
           billing_cycle: undefined
         },
@@ -440,6 +442,7 @@ describe('workspaceApi', () => {
           plan_slug: 'team_per_credit_annual',
           return_url: undefined,
           cancel_url: undefined,
+          use_checkout: undefined,
           team_credit_stop_id: 'team_700',
           billing_cycle: 'yearly'
         },

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -165,7 +165,7 @@ interface SubscribeRequest {
   idempotency_key?: string
   return_url?: string
   cancel_url?: string
-  checkout_invoice_payment?: boolean
+  use_checkout?: boolean
   /** Required for the per-credit Team plan; selects the slider stop. */
   team_credit_stop_id?: string
   billing_cycle?: SubscribeBillingCycle
@@ -176,7 +176,7 @@ interface SubscribeRequest {
 export interface SubscribeOptions {
   returnUrl?: string
   cancelUrl?: string
-  checkoutInvoicePayment?: boolean
+  useCheckout?: boolean
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
   confirmReactivation?: boolean
@@ -308,7 +308,7 @@ export interface CreateTopupResponse {
 }
 
 interface BillingOpCustomerAction {
-  type: 'pay_hosted_invoice' | 'pay_checkout_invoice'
+  type: 'pay_hosted_invoice' | 'open_checkout'
   url: string
 }
 
@@ -706,7 +706,7 @@ export const workspaceApi = {
           plan_slug: planSlug,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
-          checkout_invoice_payment: options.checkoutInvoicePayment,
+          use_checkout: options.useCheckout,
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
           confirm_reactivation: options.confirmReactivation

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -165,6 +165,7 @@ interface SubscribeRequest {
   idempotency_key?: string
   return_url?: string
   cancel_url?: string
+  checkout_invoice_payment?: boolean
   /** Required for the per-credit Team plan; selects the slider stop. */
   team_credit_stop_id?: string
   billing_cycle?: SubscribeBillingCycle
@@ -175,6 +176,7 @@ interface SubscribeRequest {
 export interface SubscribeOptions {
   returnUrl?: string
   cancelUrl?: string
+  checkoutInvoicePayment?: boolean
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
   confirmReactivation?: boolean
@@ -305,15 +307,30 @@ export interface CreateTopupResponse {
   amount_cents: number
 }
 
-type BillingOpStatus = 'pending' | 'succeeded' | 'failed'
-
-export interface BillingOpStatusResponse {
-  id: string
-  status: BillingOpStatus
-  error_message?: string
-  started_at: string
-  completed_at?: string
+interface BillingOpCustomerAction {
+  type: 'pay_hosted_invoice' | 'pay_checkout_invoice'
+  url: string
 }
+
+interface BillingOpStatusBase {
+  id: string
+  started_at: string
+}
+
+export type BillingOpStatusResponse = BillingOpStatusBase &
+  (
+    | {
+        status: 'pending'
+        customer_action?: BillingOpCustomerAction
+      }
+    | {
+        status: 'succeeded' | 'failed'
+        error_message?: string
+        customer_action?: never
+      }
+  ) & {
+    completed_at?: string
+  }
 
 interface BillingEvent {
   event_type: string
@@ -689,6 +706,7 @@ export const workspaceApi = {
           plan_slug: planSlug,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
+          checkout_invoice_payment: options.checkoutInvoicePayment,
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
           confirm_reactivation: options.confirmReactivation

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1072,7 +1072,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    it('opens the payment URL when the team subscribe needs a payment method', async () => {
+    it('redirects in the same tab when the team subscribe needs a payment method', async () => {
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -1088,15 +1088,15 @@ describe('useSubscriptionCheckout', () => {
         billing_op_id: 'op-team-3',
         payment_method_url: 'https://stripe.com/team-pay'
       })
+      const assignSpy = vi
+        .spyOn(globalThis.location, 'assign')
+        .mockImplementation(() => {})
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleTeamSubscribe()
 
-      expect(openSpy).toHaveBeenCalledWith(
-        'https://stripe.com/team-pay',
-        '_blank'
-      )
-      openSpy.mockRestore()
+      expect(assignSpy).toHaveBeenCalledWith('https://stripe.com/team-pay')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      assignSpy.mockRestore()
     })
 
     it('does not subscribe and shows an error when the stop has no id', async () => {
@@ -1284,7 +1284,8 @@ describe('useSubscriptionCheckout', () => {
       expect(mockSubscribe).toHaveBeenCalledWith('standard-yearly', {
         returnUrl: 'https://platform.comfy.org/payment/success',
         cancelUrl: 'https://platform.comfy.org/payment/failed',
-        confirmReactivation: false
+        confirmReactivation: false,
+        checkoutInvoicePayment: true
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
@@ -1302,6 +1303,64 @@ describe('useSubscriptionCheckout', () => {
       // this composable's job.
       expect(mockFetchStatus).toHaveBeenCalledTimes(1)
       expect(mockFetchBalance).not.toHaveBeenCalled()
+    })
+
+    it('completes a zero-due personal upgrade without polling for a URL', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'creator'
+      checkout.selectedBillingCycle.value = 'monthly'
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'upgrade',
+        effective_at: '2026-07-23',
+        is_immediate: true,
+        cost_today_cents: 0,
+        cost_next_period_cents: 3500,
+        credits_today_cents: 0,
+        credits_next_period_cents: 7400,
+        new_plan: makeCreatorMonthly()
+      }
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-zero-due'
+      })
+      const openSpy = vi.spyOn(window, 'open')
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.checkoutStep.value).toBe('success')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('completes a saved-card personal payment without polling for a URL', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'creator'
+      checkout.selectedBillingCycle.value = 'monthly'
+      checkout.previewData.value = {
+        allowed: true,
+        transition_type: 'upgrade',
+        effective_at: '2026-07-23',
+        is_immediate: true,
+        cost_today_cents: 900,
+        cost_next_period_cents: 3500,
+        credits_today_cents: 2000,
+        credits_next_period_cents: 7400,
+        new_plan: makeCreatorMonthly()
+      }
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-saved-card'
+      })
+      const openSpy = vi.spyOn(window, 'open')
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.checkoutStep.value).toBe('success')
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
     })
 
     it('skips begin_checkout when no user id is available', async () => {
@@ -1345,7 +1404,7 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
-    it('opens payment URL when needs_payment_method', async () => {
+    it('waits for the polled payment action when a payment method is needed', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -1355,14 +1414,14 @@ describe('useSubscriptionCheckout', () => {
         payment_method_url: 'https://stripe.com/pay'
       })
 
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       await checkout.handleAddCreditCard()
 
-      expect(openSpy).toHaveBeenCalledWith('https://stripe.com/pay', '_blank')
-      openSpy.mockRestore()
+      expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
+        hostedInvoiceReturnUrl: 'http://localhost:3000/'
+      })
     })
 
-    it('warns when the payment popup is blocked', async () => {
+    it('does not open the payment URL from the subscribe response', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -1375,11 +1434,11 @@ describe('useSubscriptionCheckout', () => {
 
       await checkout.handleAddCreditCard()
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({
-          severity: 'warn',
-          detail: 'subscription.preview.paymentPopupBlocked'
-        })
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-blocked',
+        'subscription',
+        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
       )
       openSpy.mockRestore()
     })
@@ -1405,7 +1464,8 @@ describe('useSubscriptionCheckout', () => {
           tier: 'standard',
           cycle: 'yearly',
           checkoutType: 'new',
-          paymentIntentSource: undefined
+          paymentIntentSource: undefined,
+          hostedInvoiceReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('success')
@@ -1433,7 +1493,8 @@ describe('useSubscriptionCheckout', () => {
           tier: 'standard',
           cycle: 'yearly',
           checkoutType: 'new',
-          paymentIntentSource: undefined
+          paymentIntentSource: undefined,
+          hostedInvoiceReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('success')
@@ -1460,7 +1521,8 @@ describe('useSubscriptionCheckout', () => {
           tier: 'standard',
           cycle: 'yearly',
           checkoutType: 'new',
-          paymentIntentSource: undefined
+          paymentIntentSource: undefined,
+          hostedInvoiceReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('preview')

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -1285,7 +1285,7 @@ describe('useSubscriptionCheckout', () => {
         returnUrl: 'https://platform.comfy.org/payment/success',
         cancelUrl: 'https://platform.comfy.org/payment/failed',
         confirmReactivation: false,
-        checkoutInvoicePayment: true
+        useCheckout: true
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
@@ -1417,7 +1417,11 @@ describe('useSubscriptionCheckout', () => {
       await checkout.handleAddCreditCard()
 
       expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
-        hostedInvoiceReturnUrl: 'http://localhost:3000/'
+        tier: 'standard',
+        cycle: 'yearly',
+        checkoutType: 'new',
+        paymentIntentSource: undefined,
+        checkoutReturnUrl: 'http://localhost:3000/'
       })
     })
 
@@ -1438,7 +1442,13 @@ describe('useSubscriptionCheckout', () => {
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-blocked',
         'subscription',
-        { hostedInvoiceReturnUrl: 'http://localhost:3000/' }
+        {
+          tier: 'standard',
+          cycle: 'yearly',
+          checkoutType: 'new',
+          paymentIntentSource: undefined,
+          checkoutReturnUrl: 'http://localhost:3000/'
+        }
       )
       openSpy.mockRestore()
     })
@@ -1465,7 +1475,7 @@ describe('useSubscriptionCheckout', () => {
           cycle: 'yearly',
           checkoutType: 'new',
           paymentIntentSource: undefined,
-          hostedInvoiceReturnUrl: 'http://localhost:3000/'
+          checkoutReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('success')
@@ -1494,7 +1504,7 @@ describe('useSubscriptionCheckout', () => {
           cycle: 'yearly',
           checkoutType: 'new',
           paymentIntentSource: undefined,
-          hostedInvoiceReturnUrl: 'http://localhost:3000/'
+          checkoutReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('success')
@@ -1522,7 +1532,7 @@ describe('useSubscriptionCheckout', () => {
           cycle: 'yearly',
           checkoutType: 'new',
           paymentIntentSource: undefined,
-          hostedInvoiceReturnUrl: 'http://localhost:3000/'
+          checkoutReturnUrl: 'http://localhost:3000/'
         }
       )
       expect(checkout.checkoutStep.value).toBe('preview')

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -831,7 +831,8 @@ describe('useSubscriptionCheckout', () => {
         billingCycle: 'monthly',
         returnUrl: 'https://platform.comfy.org/payment/success',
         cancelUrl: 'https://platform.comfy.org/payment/failed',
-        confirmReactivation: false
+        confirmReactivation: false,
+        useCheckout: true
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
@@ -1170,6 +1171,10 @@ describe('useSubscriptionCheckout', () => {
 
       await checkout.handleTeamSubscribe()
 
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({ useCheckout: false })
+      )
       expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
         expect.objectContaining({
           tier: 'team',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -595,7 +595,8 @@ export function useSubscriptionCheckout(
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        useCheckout: checkoutType === 'new'
       })
 
       if (response) {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -431,7 +431,8 @@ export function useSubscriptionCheckout(
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        checkoutInvoicePayment: true
       })
 
       if (response) {
@@ -499,7 +500,8 @@ export function useSubscriptionCheckout(
   async function handleSubscribeResponse(
     response: SubscribeResponse | void,
     context: SubscriptionOutcomeContext,
-    shouldTrackSubscriptionSuccess = true
+    shouldTrackSubscriptionSuccess = true,
+    redirectImmediatePaymentUrl = false
   ): Promise<void> {
     if (!response) {
       trackSubscriptionFailure(context, 'missing_checkout_response')
@@ -523,24 +525,13 @@ export function useSubscriptionCheckout(
       return
     }
 
-    // needs_payment_method / pending_payment both finish asynchronously, so poll
-    // the billing op either way. needs_payment_method additionally points at a
-    // Stripe page to collect a card when the backend supplies the URL; without
-    // it we still poll rather than silently stranding the user on confirm.
     if (
+      redirectImmediatePaymentUrl &&
       response.status === 'needs_payment_method' &&
       response.payment_method_url
     ) {
-      // The open runs after `await subscribe(...)`, so it's not a direct user
-      // gesture and can be popup-blocked; warn instead of failing silently.
-      const paymentWindow = window.open(response.payment_method_url, '_blank')
-      if (!paymentWindow) {
-        toast.add({
-          severity: 'warn',
-          summary: t('g.warning'),
-          detail: t('subscription.preview.paymentPopupBlocked')
-        })
-      }
+      globalThis.location.assign(response.payment_method_url)
+      return
     }
     await advanceToSuccessOnOperation(response.billing_op_id, context)
   }
@@ -559,7 +550,8 @@ export function useSubscriptionCheckout(
         tier: context.tier,
         cycle: context.cycle,
         checkoutType: context.checkoutType,
-        paymentIntentSource
+        paymentIntentSource,
+        hostedInvoiceReturnUrl: globalThis.location.href
       }
     )
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
@@ -619,7 +611,7 @@ export function useSubscriptionCheckout(
         tier: 'team',
         cycle: billingCycle,
         checkoutType
-      })
+      }, true, true)
     } catch (error) {
       trackSubscriptionFailure({
         tier: 'team',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -607,11 +607,16 @@ export function useSubscriptionCheckout(
           paymentIntentSource
         })
       }
-      await handleSubscribeResponse(response, {
-        tier: 'team',
-        cycle: billingCycle,
-        checkoutType
-      }, true, true)
+      await handleSubscribeResponse(
+        response,
+        {
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType
+        },
+        true,
+        true
+      )
     } catch (error) {
       trackSubscriptionFailure({
         tier: 'team',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -432,7 +432,7 @@ export function useSubscriptionCheckout(
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
         confirmReactivation,
-        checkoutInvoicePayment: true
+        useCheckout: true
       })
 
       if (response) {
@@ -551,7 +551,7 @@ export function useSubscriptionCheckout(
         cycle: context.cycle,
         checkoutType: context.checkoutType,
         paymentIntentSource,
-        hostedInvoiceReturnUrl: globalThis.location.href
+        checkoutReturnUrl: globalThis.location.href
       }
     )
     if (operation.status === 'succeeded') checkoutStep.value = 'success'

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -78,10 +78,12 @@ describe('billingOperationStore', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.useFakeTimers()
+    localStorage.clear()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   describe('startOperation', () => {
@@ -171,6 +173,226 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.topupProcessing',
         group: 'billing-operation'
       })
+    })
+
+    it('persists recovery context before navigating to a hosted invoice', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-hosted',
+        status: 'pending',
+        customer_action: {
+          type: 'pay_hosted_invoice',
+          url: 'https://invoice.test/bearer-token'
+        },
+        started_at: new Date().toISOString()
+      })
+      const assignSpy = vi
+        .spyOn(globalThis.location, 'assign')
+        .mockImplementation(() => {})
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-hosted', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).toHaveBeenCalledWith(
+        'https://invoice.test/bearer-token'
+      )
+      expect(store.getOperation('op-hosted')).toMatchObject({
+        status: 'pending',
+        paymentNavigationStarted: true
+      })
+      const persisted = localStorage.getItem('comfy.billing.pending_operation')
+      expect(persisted).toContain('op-hosted')
+      expect(persisted).toContain(globalThis.location.href)
+      expect(persisted).not.toContain('bearer-token')
+    })
+
+    it('persists recovery context before navigating to exact-invoice Checkout', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-checkout',
+        status: 'pending',
+        customer_action: {
+          type: 'pay_checkout_invoice',
+          url: 'https://checkout.stripe.com/c/pay/cs_test_exact'
+        },
+        started_at: new Date().toISOString()
+      })
+      const assignSpy = vi
+        .spyOn(globalThis.location, 'assign')
+        .mockImplementation(() => {})
+      const store = useBillingOperationStore()
+
+      void store.startOperation('op-checkout', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/c/pay/cs_test_exact'
+      )
+      expect(
+        localStorage.getItem('comfy.billing.pending_operation')
+      ).not.toContain('cs_test_exact')
+    })
+
+    it('resumes a hosted invoice operation after browser return', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'pending',
+          customer_action: {
+            type: 'pay_hosted_invoice',
+            url: 'https://invoice.test/bearer-token'
+          },
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-return',
+          status: 'succeeded',
+          started_at: new Date().toISOString(),
+          completed_at: new Date().toISOString()
+        })
+      vi.spyOn(globalThis.location, 'assign').mockImplementation(() => {})
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-return', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      store.resumePendingOperations()
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(terminal).resolves.toMatchObject({ status: 'succeeded' })
+      expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+    })
+
+    it('does not navigate when recovery context cannot be persisted', async () => {
+      const setItemSpy = vi
+        .spyOn(globalThis.localStorage, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('storage unavailable')
+        })
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-storage-failure',
+        status: 'pending',
+        customer_action: {
+          type: 'pay_hosted_invoice',
+          url: 'https://invoice.test/bearer-token'
+        },
+        started_at: new Date().toISOString()
+      })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-storage-failure', 'subscription', {
+        hostedInvoiceReturnUrl: globalThis.location.href
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(assignSpy).not.toHaveBeenCalled()
+      expect(store.getOperation('op-storage-failure')).toMatchObject({
+        status: 'failed'
+      })
+      setItemSpy.mockRestore()
+    })
+
+    it('does not navigate a topup operation carrying a customer action', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-topup-action',
+          status: 'pending',
+          customer_action: {
+            type: 'pay_hosted_invoice',
+            url: 'https://invoice.test/bearer-token'
+          },
+          started_at: new Date().toISOString()
+        })
+        .mockResolvedValueOnce({
+          id: 'op-topup-action',
+          status: 'succeeded',
+          started_at: new Date().toISOString()
+        })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-topup-action', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      await expect(terminal).resolves.toMatchObject({ status: 'succeeded' })
+      expect(assignSpy).not.toHaveBeenCalled()
+    })
+
+    it('recovers a persisted operation after reload without reusing its URL', async () => {
+      localStorage.setItem(
+        'comfy.billing.pending_operation',
+        JSON.stringify({
+          opId: 'op-reload',
+          type: 'subscription',
+          startedAt: Date.now() - 300_000,
+          returnUrl: globalThis.location.href,
+          paymentNavigationStarted: true
+        })
+      )
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-reload',
+        status: 'succeeded',
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString()
+      })
+      const assignSpy = vi.spyOn(globalThis.location, 'assign')
+
+      const store = useBillingOperationStore()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-reload')).toMatchObject({
+        status: 'succeeded'
+      })
+      expect(assignSpy).not.toHaveBeenCalled()
+      expect(localStorage.getItem('comfy.billing.pending_operation')).toBeNull()
+    })
+
+    it('coalesces reload and pageshow recovery polling', async () => {
+      localStorage.setItem(
+        'comfy.billing.pending_operation',
+        JSON.stringify({
+          opId: 'op-single-flight',
+          type: 'subscription',
+          startedAt: Date.now(),
+          returnUrl: globalThis.location.href,
+          paymentNavigationStarted: true
+        })
+      )
+      let resolveStatus!: (value: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      store.resumePendingOperations()
+
+      expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledOnce()
+      resolveStatus({
+        id: 'op-single-flight',
+        status: 'succeeded',
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -191,7 +191,7 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-hosted', 'subscription', {
-        hostedInvoiceReturnUrl: globalThis.location.href
+        checkoutReturnUrl: globalThis.location.href
       })
       await vi.advanceTimersByTimeAsync(0)
 
@@ -208,12 +208,12 @@ describe('billingOperationStore', () => {
       expect(persisted).not.toContain('bearer-token')
     })
 
-    it('persists recovery context before navigating to exact-invoice Checkout', async () => {
+    it('persists recovery context before opening Checkout', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-checkout',
         status: 'pending',
         customer_action: {
-          type: 'pay_checkout_invoice',
+          type: 'open_checkout',
           url: 'https://checkout.stripe.com/c/pay/cs_test_exact'
         },
         started_at: new Date().toISOString()
@@ -224,7 +224,7 @@ describe('billingOperationStore', () => {
       const store = useBillingOperationStore()
 
       void store.startOperation('op-checkout', 'subscription', {
-        hostedInvoiceReturnUrl: globalThis.location.href
+        checkoutReturnUrl: globalThis.location.href
       })
       await vi.advanceTimersByTimeAsync(0)
 
@@ -262,7 +262,7 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       const terminal = store.startOperation('op-return', 'subscription', {
-        hostedInvoiceReturnUrl: globalThis.location.href
+        checkoutReturnUrl: globalThis.location.href
       })
       await vi.advanceTimersByTimeAsync(0)
       await vi.advanceTimersByTimeAsync(1500)
@@ -293,7 +293,7 @@ describe('billingOperationStore', () => {
 
       const store = useBillingOperationStore()
       void store.startOperation('op-storage-failure', 'subscription', {
-        hostedInvoiceReturnUrl: globalThis.location.href
+        checkoutReturnUrl: globalThis.location.href
       })
       await vi.advanceTimersByTimeAsync(0)
 
@@ -391,7 +391,14 @@ describe('billingOperationStore', () => {
       })
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'succeeded',
+          outcome: 'success',
+          billing_op_id: 'op-single-flight'
+        })
+      )
       expect(mockReconcileSubscriptionSuccess).toHaveBeenCalledOnce()
     })
   })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -22,6 +22,7 @@ const INITIAL_INTERVAL_MS = 1000
 const MAX_INTERVAL_MS = 8000
 const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000 // 2 minutes
+const PENDING_OPERATION_STORAGE_KEY = 'comfy.billing.pending_operation'
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -31,6 +32,7 @@ export interface StartOperationMetadata {
   cycle?: BillingCycle
   checkoutType?: SubscriptionCheckoutType
   paymentIntentSource?: PaymentIntentSource
+  hostedInvoiceReturnUrl?: string
   downgradeToPersonal?: {
     memberRemovalCount: number
     memberRemovalFailures: number
@@ -49,6 +51,16 @@ interface BillingOperation {
   checkoutType?: SubscriptionCheckoutType
   paymentIntentSource?: PaymentIntentSource
   downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
+  returnUrl: string | null
+  paymentNavigationStarted: boolean
+}
+
+interface PendingBillingOperation {
+  opId: string
+  type: 'subscription'
+  startedAt: number
+  returnUrl: string
+  paymentNavigationStarted: boolean
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -60,6 +72,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   const receivedToasts = new Map<string, ToastMessageOptions>()
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
+  const pollsInFlight = new Set<string>()
 
   const hasPendingOperations = computed(() =>
     [...operations.value.values()].some((op) => op.status === 'pending')
@@ -84,7 +97,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   function startOperation(
     opId: string,
     type: OperationType,
-    metadata?: StartOperationMetadata
+    metadata: StartOperationMetadata = {}
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
     if (existing) {
@@ -97,15 +110,18 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       status: 'pending',
       errorMessage: null,
       startedAt: Date.now(),
-      tier: metadata?.tier,
-      cycle: metadata?.cycle,
-      checkoutType: metadata?.checkoutType,
-      paymentIntentSource: metadata?.paymentIntentSource,
-      downgradeToPersonal: metadata?.downgradeToPersonal
+      tier: metadata.tier,
+      cycle: metadata.cycle,
+      checkoutType: metadata.checkoutType,
+      paymentIntentSource: metadata.paymentIntentSource,
+      downgradeToPersonal: metadata.downgradeToPersonal,
+      returnUrl: getSameOriginUrl(metadata.hostedInvoiceReturnUrl),
+      paymentNavigationStarted: false
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
     intervals.set(opId, INITIAL_INTERVAL_MS)
+    persistPendingOperation(operation)
 
     if (type !== 'cancel') {
       const messageKey =
@@ -122,10 +138,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       useToastStore().add(toastMessage)
     }
 
-    const terminal = new Promise<BillingOperation>((resolve) => {
-      terminalResolvers.set(opId, resolve)
-    })
-    terminalPromises.set(opId, terminal)
+    const terminal = createTerminalPromise(opId)
 
     void poll(opId)
 
@@ -134,15 +147,24 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   async function poll(opId: string) {
     const operation = operations.value.get(opId)
-    if (!operation || operation.status !== 'pending') return
+    if (
+      !operation ||
+      operation.status !== 'pending' ||
+      pollsInFlight.has(opId)
+    ) {
+      return
+    }
 
     if (Date.now() - operation.startedAt > TIMEOUT_MS) {
       handleTimeout(opId)
       return
     }
 
+    pollsInFlight.add(opId)
     try {
       const response = await workspaceApi.getBillingOpStatus(opId)
+      const currentOperation = operations.value.get(opId)
+      if (!currentOperation || currentOperation.status !== 'pending') return
 
       if (response.status === 'succeeded') {
         await handleSuccess(opId)
@@ -154,13 +176,27 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         return
       }
 
+      if (
+        (response.customer_action?.type === 'pay_hosted_invoice' ||
+          response.customer_action?.type === 'pay_checkout_invoice') &&
+        !currentOperation.paymentNavigationStarted &&
+        currentOperation.returnUrl
+      ) {
+        beginPaymentNavigation(opId, response.customer_action.url)
+        return
+      }
+
       scheduleNextPoll(opId)
     } catch {
-      if (Date.now() - operation.startedAt > TIMEOUT_MS) {
+      const currentOperation = operations.value.get(opId)
+      if (!currentOperation || currentOperation.status !== 'pending') return
+      if (Date.now() - currentOperation.startedAt > TIMEOUT_MS) {
         handleTimeout(opId)
         return
       }
       scheduleNextPoll(opId)
+    } finally {
+      pollsInFlight.delete(opId)
     }
   }
 
@@ -172,7 +208,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     )
     intervals.set(opId, nextInterval)
 
-    const timeoutId = setTimeout(() => void poll(opId), nextInterval)
+    const timeoutId = setTimeout(() => {
+      if (timeouts.get(opId) === timeoutId) timeouts.delete(opId)
+      void poll(opId)
+    }, nextInterval)
     timeouts.set(opId, timeoutId)
   }
 
@@ -182,6 +221,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'succeeded', null)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     const telemetry = useTelemetry()
     if (operation.type === 'subscription') {
@@ -274,6 +314,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'failed', detail ?? defaultMessage)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     const telemetry = useTelemetry()
     telemetry?.trackBillingEvent({
@@ -320,6 +361,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'timeout', message)
     cleanup(opId)
+    clearPendingOperation(opId)
 
     const telemetry = useTelemetry()
     telemetry?.trackBillingEvent({
@@ -380,6 +422,14 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     terminalPromises.delete(opId)
   }
 
+  function createTerminalPromise(opId: string) {
+    const terminal = new Promise<BillingOperation>((resolve) => {
+      terminalResolvers.set(opId, resolve)
+    })
+    terminalPromises.set(opId, terminal)
+    return terminal
+  }
+
   function updateOperationStatus(
     opId: string,
     status: OperationStatus,
@@ -392,6 +442,121 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     operations.value = new Map(operations.value).set(opId, updated)
   }
 
+  function beginPaymentNavigation(opId: string, paymentUrl: string) {
+    const operation = operations.value.get(opId)
+    if (!operation?.returnUrl) return
+
+    const updated = { ...operation, paymentNavigationStarted: true }
+    if (!persistPendingOperation(updated)) {
+      handleFailure(opId, null)
+      return
+    }
+    operations.value = new Map(operations.value).set(opId, updated)
+    globalThis.location.assign(paymentUrl)
+  }
+
+  function persistPendingOperation(operation: BillingOperation): boolean {
+    if (operation.type !== 'subscription' || !operation.returnUrl) return false
+
+    const pendingOperation: PendingBillingOperation = {
+      opId: operation.opId,
+      type: operation.type,
+      startedAt: operation.startedAt,
+      returnUrl: operation.returnUrl,
+      paymentNavigationStarted: operation.paymentNavigationStarted
+    }
+
+    try {
+      localStorage.setItem(
+        PENDING_OPERATION_STORAGE_KEY,
+        JSON.stringify(pendingOperation)
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  function getSameOriginUrl(value: string | undefined): string | null {
+    if (!value) return null
+
+    try {
+      const url = new URL(value)
+      return url.origin === globalThis.location.origin ? url.href : null
+    } catch {
+      return null
+    }
+  }
+
+  function clearPendingOperation(opId: string) {
+    try {
+      const pendingOperation = readPendingOperation()
+      if (pendingOperation?.opId === opId) {
+        localStorage.removeItem(PENDING_OPERATION_STORAGE_KEY)
+      }
+    } catch {
+      return
+    }
+  }
+
+  function readPendingOperation(): PendingBillingOperation | null {
+    let value: string | null
+    try {
+      value = localStorage.getItem(PENDING_OPERATION_STORAGE_KEY)
+    } catch {
+      return null
+    }
+    if (!value) return null
+
+    try {
+      const candidate: unknown = JSON.parse(value)
+      if (!candidate || typeof candidate !== 'object') return null
+      if (
+        !('opId' in candidate) ||
+        typeof candidate.opId !== 'string' ||
+        !('type' in candidate) ||
+        candidate.type !== 'subscription' ||
+        !('startedAt' in candidate) ||
+        typeof candidate.startedAt !== 'number' ||
+        !('returnUrl' in candidate) ||
+        typeof candidate.returnUrl !== 'string' ||
+        !('paymentNavigationStarted' in candidate) ||
+        typeof candidate.paymentNavigationStarted !== 'boolean'
+      ) {
+        return null
+      }
+
+      const returnUrl = new URL(candidate.returnUrl)
+      if (returnUrl.origin !== globalThis.location.origin) return null
+
+      return {
+        opId: candidate.opId,
+        type: candidate.type,
+        startedAt: candidate.startedAt,
+        returnUrl: returnUrl.href,
+        paymentNavigationStarted: candidate.paymentNavigationStarted
+      }
+    } catch {
+      return null
+    }
+  }
+
+  function recoverPendingOperation() {
+    const pendingOperation = readPendingOperation()
+    if (!pendingOperation || operations.value.has(pendingOperation.opId)) return
+
+    const operation: BillingOperation = {
+      ...pendingOperation,
+      status: 'pending',
+      errorMessage: null,
+      startedAt: Date.now()
+    }
+    operations.value = new Map(operations.value).set(operation.opId, operation)
+    intervals.set(operation.opId, INITIAL_INTERVAL_MS)
+    void createTerminalPromise(operation.opId)
+    void poll(operation.opId)
+  }
+
   function cleanup(opId: string) {
     const timeoutId = timeouts.get(opId)
     if (timeoutId) {
@@ -399,6 +564,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       timeouts.delete(opId)
     }
     intervals.delete(opId)
+    pollsInFlight.delete(opId)
 
     // Remove the "received" toast
     const receivedToast = receivedToasts.get(opId)
@@ -410,11 +576,34 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   function clearOperation(opId: string) {
     cleanup(opId)
+    clearPendingOperation(opId)
     const newMap = new Map(operations.value)
     newMap.delete(opId)
     operations.value = newMap
     terminalResolvers.delete(opId)
     terminalPromises.delete(opId)
+  }
+
+  recoverPendingOperation()
+
+  function resumePendingOperations() {
+    for (const operation of operations.value.values()) {
+      if (
+        operation.status === 'pending' &&
+        operation.paymentNavigationStarted &&
+        !timeouts.has(operation.opId)
+      ) {
+        updateOperationStatus(operation.opId, 'pending', null)
+        const resumed = operations.value.get(operation.opId)
+        if (resumed) {
+          operations.value = new Map(operations.value).set(operation.opId, {
+            ...resumed,
+            startedAt: Date.now()
+          })
+        }
+        void poll(operation.opId)
+      }
+    }
   }
 
   return {
@@ -424,6 +613,8 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     isAddingCredits,
     getOperation,
     startOperation,
+    recoverPendingOperation,
+    resumePendingOperations,
     clearOperation
   }
 })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -32,7 +32,7 @@ export interface StartOperationMetadata {
   cycle?: BillingCycle
   checkoutType?: SubscriptionCheckoutType
   paymentIntentSource?: PaymentIntentSource
-  hostedInvoiceReturnUrl?: string
+  checkoutReturnUrl?: string
   downgradeToPersonal?: {
     memberRemovalCount: number
     memberRemovalFailures: number
@@ -115,7 +115,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       checkoutType: metadata.checkoutType,
       paymentIntentSource: metadata.paymentIntentSource,
       downgradeToPersonal: metadata.downgradeToPersonal,
-      returnUrl: getSameOriginUrl(metadata.hostedInvoiceReturnUrl),
+      returnUrl: getSameOriginUrl(metadata.checkoutReturnUrl),
       paymentNavigationStarted: false
     }
 
@@ -178,7 +178,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
       if (
         (response.customer_action?.type === 'pay_hosted_invoice' ||
-          response.customer_action?.type === 'pay_checkout_invoice') &&
+          response.customer_action?.type === 'open_checkout') &&
         !currentOperation.paymentNavigationStarted &&
         currentOperation.returnUrl
       ) {


### PR DESCRIPTION
## Summary
- request isolated exact-invoice Checkout for personal subscriptions and upgrades
- recognize pay_checkout_invoice actions from BillingOp polling
- preserve return/reload recovery and never infer success from the Checkout redirect

Stacked on #14030.

## Validation
- pnpm test:unit src/platform/workspace/composables/useSubscriptionCheckout.test.ts src/platform/workspace/stores/billingOperationStore.test.ts
- pnpm typecheck
- pnpm lint:unstaged
- commit hooks: lint-staged, typecheck, knip