### PR TITLE
fix(templates): restore filter search input

### DIFF
--- a/browser_tests/fixtures/components/TemplatesDialog.ts
+++ b/browser_tests/fixtures/components/TemplatesDialog.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from '@playwright/test'
 export class TemplatesDialog {
   public readonly root: Locator
   public readonly modelFilter: Locator
+  public readonly modelFilterSearch: Locator
   public readonly resultsCount: Locator
   public readonly mobileFiltersToggle: Locator
   public readonly filterBar: Locator
@@ -12,6 +13,9 @@ export class TemplatesDialog {
     this.root = page.getByRole('dialog')
     this.modelFilter = this.root
       .getByRole('button', { name: /Model Filter/ })
+      .filter({ visible: true })
+    this.modelFilterSearch = this.page
+      .getByRole('combobox', { name: 'Search' })
       .filter({ visible: true })
     this.resultsCount = this.root.getByText(/Showing.*of.*templates/i)
     this.mobileFiltersToggle = this.root.getByRole('button', {

--- a/browser_tests/tests/templates/templateFilterSearch.spec.ts
+++ b/browser_tests/tests/templates/templateFilterSearch.spec.ts
@@ -1,0 +1,43 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { makeTemplate } from '@e2e/fixtures/data/templateFixtures'
+import { withTemplates } from '@e2e/fixtures/helpers/TemplateHelper'
+import { templateApiFixture } from '@e2e/fixtures/templateApiFixture'
+
+const test = mergeTests(comfyPageFixture, templateApiFixture)
+
+test.describe('Template filter search', () => {
+  test.beforeEach(async ({ templateApi }) => {
+    templateApi.configure(
+      withTemplates([
+        makeTemplate({ name: 'flux', title: 'Flux', models: ['Flux'] }),
+        makeTemplate({ name: 'sdxl', title: 'SDXL', models: ['SDXL'] })
+      ])
+    )
+    await templateApi.mock()
+  })
+
+  test('accepts input in a filter dropdown search', async ({ comfyPage }) => {
+    await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
+    await expect(comfyPage.templates.content).toBeVisible()
+
+    await comfyPage.templatesDialog.openFilters()
+    await comfyPage.templatesDialog.modelFilter.click()
+    await expect(comfyPage.templatesDialog.modelFilterSearch).toBeVisible()
+
+    await comfyPage.templatesDialog.modelFilterSearch.click()
+    await expect(comfyPage.templatesDialog.modelFilterSearch).toBeFocused()
+    await comfyPage.templatesDialog.modelFilterSearch.pressSequentially('flux')
+
+    await expect(comfyPage.templatesDialog.modelFilterSearch).toHaveValue(
+      'flux'
+    )
+    await expect(
+      comfyPage.page.getByRole('option', { name: 'Flux' })
+    ).toBeVisible()
+    await expect(
+      comfyPage.page.getByRole('option', { name: 'SDXL' })
+    ).toBeHidden()
+  })
+})

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -143,6 +143,21 @@ describe('useWorkflowTemplateSelectorDialog', () => {
         source: 'sidebar'
       })
     })
+
+    it('allows focus in portalled template filters', () => {
+      mockNewUserService.isNewUser.mockReturnValue(false)
+
+      const dialog = useWorkflowTemplateSelectorDialog()
+      dialog.show()
+
+      expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dialogComponentProps: expect.objectContaining({
+            modal: false
+          })
+        })
+      )
+    })
   })
 
   describe('hide', () => {

--- a/src/composables/useWorkflowTemplateSelectorDialog.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.ts
@@ -43,6 +43,7 @@ export const useWorkflowTemplateSelectorDialog = () => {
       // Size it like the other large dialogs (Settings/Manager).
       dialogComponentProps: {
         size: 'full',
+        modal: false,
         contentClass:
           'w-[90vw] max-w-[1400px] sm:max-w-[1400px] h-[80vh] rounded-2xl overflow-hidden'
       }


### PR DESCRIPTION
## Summary

Restore keyboard input in the Templates filter dropdowns by opening the Templates dialog non-modally, allowing its portalled Reka combobox inputs to retain focus.

## Changes

- **What**: Disable the Templates dialog focus trap and add unit plus browser regression coverage for focusing, typing, and filtering model options.

## Review Focus

The dropdown content is portalled outside `DialogContent`; Reka's modal `FocusScope` therefore restores focus to the trigger on every input focus attempt. This is separate from the z-index issue fixed by #14054.

Related: [FE-1380](https://linear.app/comfyorg/issue/FE-1380/bug-template-filter-dropdown-search-inputs-are-non-functional-on-cloud) · [Slack report](https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1784912991197739)

## Screenshots

### AS IS

An attempted `flux` entry leaves focus on **Model Filter**, the search value empty, and every option visible.

![AS IS — search input cannot retain focus](https://ampcode.com/user-content/attachments/f1f974b2f94f3cf3ec1d6a8c2ba2ed0df521532eb3b44a68a72f7d7ddfb581e2-file.png)

### TO BE

The search input retains focus, accepts `flux`, and filters the options to **Flux**.

![TO BE — search input accepts text](https://ampcode.com/user-content/attachments/915de94b964b4857606360948122f1e23d70f82a8794881fe882a317fb425a87-file.png)

### Interaction

![TO BE — template model filter search interaction](https://ampcode.com/user-content/attachments/9ab9a92fe81c38158dd06269a690f4f3ee751e3a8e24dd9c863ac30b5c653fe5-file.gif)