### PR TITLE
feat(nodes): add opt-in viewport virtualization

### DIFF
--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -277,6 +277,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
   test.describe('vue renderer large graph', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+      await comfyPage.settings.setSetting(
+        'Comfy.VueNodes.ViewportVirtualization',
+        true
+      )
       await comfyPage.workflow.loadWorkflow('large-graph-workflow')
       await comfyPage.vueNodes.waitForNodes()
     })
@@ -289,9 +293,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       }
 
       const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
+      const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
       recordMeasurement(m)
       console.log(
-        `Vue large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.domNodes} DOM nodes`
+        `Vue large graph idle: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.taskDurationMs.toFixed(1)}ms task`
       )
     })
 
@@ -313,9 +318,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       await comfyPage.page.mouse.up({ button: 'middle' })
 
       const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
+      const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
       recordMeasurement(m)
       console.log(
-        `Vue large graph pan: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
+        `Vue large graph pan: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
       )
     })
 

--- a/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
+++ b/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { assertNodeSlotsWithinBounds } from '@e2e/fixtures/utils/slotBoundsUtil'
+
+test.describe('Viewport node virtualization', { tag: ['@canvas'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      true
+    )
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
+  test('mounts nearby nodes, swaps them while panning, and toggles immediately', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.canvasOps.setScale(1)
+    await (await comfyPage.nodeOps.getNodeRefById(1)).centerOnNode()
+
+    const graphNodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeLessThan(graphNodeCount)
+
+    const initialNodeIds = await comfyPage.vueNodes.getNodeIds()
+    const canvasBox = await comfyPage.canvas.boundingBox()
+    if (!canvasBox) throw new Error('Canvas bounding box not available')
+
+    const centerX = canvasBox.x + canvasBox.width / 2
+    const centerY = canvasBox.y + canvasBox.height / 2
+    await comfyPage.page.mouse.move(centerX, centerY)
+    await comfyPage.page.mouse.down({ button: 'middle' })
+    await comfyPage.page.mouse.move(centerX, centerY - 700, { steps: 20 })
+    await comfyPage.page.mouse.up({ button: 'middle' })
+
+    await expect
+      .poll(async () => {
+        const currentNodeIds = await comfyPage.vueNodes.getNodeIds()
+        return currentNodeIds.some((id) => !initialNodeIds.includes(id))
+      })
+      .toBe(true)
+
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      false
+    )
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount(), { timeout: 15_000 })
+      .toBe(graphNodeCount)
+
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      true
+    )
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeLessThan(graphNodeCount)
+  })
+
+  test('keeps a focused widget mounted while its node is offscreen', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.canvasOps.setScale(1)
+
+    const editedNode = await comfyPage.nodeOps.getNodeRefById(2)
+    await editedNode.centerOnNode()
+    const textarea = comfyPage.vueNodes.getNodeLocator('2').getByRole('textbox')
+    await textarea.fill('virtualized edit')
+    await expect(textarea).toBeFocused()
+
+    await (await comfyPage.nodeOps.getNodeRefById(241)).centerOnNode()
+
+    await expect(comfyPage.vueNodes.getNodeLocator('2')).toBeAttached()
+    await expect(textarea).toBeFocused()
+    await expect(textarea).toHaveValue('virtualized edit')
+
+    await comfyPage.canvas.focus()
+    await expect(comfyPage.vueNodes.getNodeLocator('2')).toHaveCount(0)
+  })
+
+  test('preserves links and output updates while a node is offscreen', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('execution/partial_execution')
+    await comfyPage.canvasOps.setScale(1)
+
+    const outputNode = await comfyPage.nodeOps.getNodeRefById(1)
+    await outputNode.centerOnNode()
+    await outputNode.dragBy({ x: 3_000, y: 0 })
+    await comfyPage.canvas.focus()
+    await (await comfyPage.nodeOps.getNodeRefById(3)).centerOnNode()
+    await expect(comfyPage.vueNodes.getNodeLocator('1')).toHaveCount(0)
+
+    await comfyPage.command.executeCommand('Comfy.QueuePrompt')
+    await expect
+      .poll(async () => (await outputNode.getWidget(0)).getValue(), {
+        timeout: 10_000
+      })
+      .toBe('foo')
+
+    await outputNode.centerOnNode()
+    await expect(
+      comfyPage.vueNodes
+        .getNodeLocator('1')
+        .getByRole('textbox', { name: 'preview_text' })
+    ).toHaveValue('foo')
+    await assertNodeSlotsWithinBounds(comfyPage.page, '1')
+  })
+
+  test('renders collapsed nodes after entering a subgraph', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-collapsed-node'
+    )
+    await comfyPage.vueNodes.enterSubgraph('2')
+    await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+    await comfyPage.canvasOps.setScale(1)
+    await (await comfyPage.nodeOps.getNodeRefById(1)).centerOnNode()
+
+    await expect(comfyPage.vueNodes.getNodeLocator('1')).toHaveAttribute(
+      'data-collapsed',
+      'true'
+    )
+    await assertNodeSlotsWithinBounds(comfyPage.page, '1')
+  })
+})

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -73,7 +73,7 @@
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <LGraphNode
-      v-for="nodeData in allNodes"
+      v-for="nodeData in renderNodes"
       :key="nodeData.id"
       :node-data="nodeData"
       :error="
@@ -158,6 +158,7 @@ import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { useViewportNodeVirtualization } from '@/composables/graph/useViewportNodeVirtualization'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
@@ -293,6 +294,14 @@ watch(
 const allNodes = computed((): VueNodeData[] =>
   Array.from(vueNodeLifecycle.nodeManager.value?.vueNodeData?.values() ?? [])
 )
+const viewportVirtualizationEnabled = computed(() =>
+  settingStore.get('Comfy.VueNodes.ViewportVirtualization')
+)
+const { renderNodes } = useViewportNodeVirtualization({
+  allNodes,
+  canvas: () => canvasStore.canvas,
+  enabled: viewportVirtualizationEnabled
+})
 watch(
   () => linearMode.value,
   (isLinearMode) => {

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -4,7 +4,7 @@
  */
 import { reactiveComputed } from '@vueuse/core'
 import cloneDeep from 'es-toolkit/compat/cloneDeep'
-import { reactive, shallowReactive } from 'vue'
+import { reactive, shallowReactive, watch } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { promotedInputWidgets } from '@/core/graph/subgraph/promotedInputWidget'
@@ -17,6 +17,10 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import {
+  deleteTrackedNodeSlots,
+  reconcileTrackedNodeSlots
+} from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -484,6 +488,19 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
   // Non-reactive storage for original LiteGraph nodes
   const nodeRefs = new Map<NodeId, LGraphNode>()
+  const nodeSlotModelStops = new Map<NodeId, () => void>()
+
+  const watchNodeSlotModel = (node: LGraphNode) => {
+    nodeSlotModelStops.get(node.id)?.()
+    const stop = watch(
+      [() => node.inputs?.length ?? 0, () => node.outputs?.length ?? 0],
+      ([inputCount, outputCount]) => {
+        reconcileTrackedNodeSlots(node.id, inputCount, outputCount)
+      },
+      { immediate: true }
+    )
+    nodeSlotModelStops.set(node.id, stop)
+  }
 
   const refreshNodeSlots = (nodeId: NodeId) => {
     const nodeRef = nodeRefs.get(nodeId)
@@ -544,6 +561,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
     // Extract initial data for Vue (may be incomplete during graph configure)
     vueNodeData.set(id, extractVueNodeData(node))
+    watchNodeSlotModel(node)
 
     const initializeVueNodeLayout = () => {
       // Check if the node was removed mid-sequence
@@ -593,6 +611,8 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
   }
 
   const dropNodeReferences = (id: NodeId) => {
+    nodeSlotModelStops.get(id)?.()
+    nodeSlotModelStops.delete(id)
     nodeRefs.delete(id)
     vueNodeData.delete(id)
   }
@@ -606,6 +626,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
     // Remove node from layout store
     setSource(LayoutSource.Canvas)
     void deleteNode(id)
+    deleteTrackedNodeSlots(id)
     dropNodeReferences(id)
     originalCallback?.(node)
   }
@@ -631,6 +652,8 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       )
 
       // Clear all state maps
+      nodeSlotModelStops.forEach((stop) => stop())
+      nodeSlotModelStops.clear()
       nodeRefs.clear()
       vueNodeData.clear()
     }

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import {
+  createPinnedNodeIds,
+  createRenderNodeList,
+  getViewportBounds
+} from '@/composables/graph/useViewportNodeVirtualization'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+
+function createCanvas(options?: {
+  width?: number
+  height?: number
+  scale?: number
+  offset?: [number, number]
+  viewport?: [number, number, number, number]
+}): LGraphCanvas {
+  const element = document.createElement('canvas')
+  element.width = options?.width ?? 1000
+  element.height = options?.height ?? 500
+
+  return {
+    ds: {
+      element,
+      scale: options?.scale ?? 2,
+      offset: options?.offset ?? [10, 20]
+    },
+    viewport: options?.viewport
+  } as LGraphCanvas
+}
+
+function createNode(id: string): VueNodeData {
+  return {
+    id: toNodeId(id),
+    title: id,
+    type: 'TestNode',
+    mode: 0,
+    selected: false,
+    executing: false
+  }
+}
+
+describe('getViewportBounds', () => {
+  it('matches the canvas transform with 25 percent overscan', () => {
+    expect(getViewportBounds(createCanvas())).toEqual({
+      x: -135,
+      y: -82.5,
+      width: 750,
+      height: 375
+    })
+  })
+
+  it('uses the configured LiteGraph viewport', () => {
+    expect(
+      getViewportBounds(createCanvas({ viewport: [100, 50, 400, 200] }))
+    ).toEqual({
+      x: -10,
+      y: -20,
+      width: 300,
+      height: 150
+    })
+  })
+
+  it('updates for pan, zoom, and canvas resize', () => {
+    const initial = getViewportBounds(createCanvas())
+    const panned = getViewportBounds(createCanvas({ offset: [20, 30] }))
+    const zoomed = getViewportBounds(createCanvas({ scale: 1 }))
+    const resized = getViewportBounds(createCanvas({ width: 1200 }))
+
+    expect(panned?.x).toBe(initial!.x - 10)
+    expect(panned?.y).toBe(initial!.y - 10)
+    expect(zoomed?.width).toBe(initial!.width * 2)
+    expect(resized?.width).toBe(initial!.width * 1.2)
+  })
+})
+
+describe('createRenderNodeList', () => {
+  const nodes = ['a', 'b', 'c', 'd'].map(createNode)
+
+  it('preserves graph order while combining visible and pinned nodes', () => {
+    const result = createRenderNodeList({
+      allNodes: nodes,
+      enabled: true,
+      layoutReady: true,
+      visibleNodeIds: new Set([nodes[2].id, nodes[0].id]),
+      pinnedNodeIds: new Set([nodes[3].id]),
+      previous: []
+    })
+
+    expect(result.map((node) => node.id)).toEqual([
+      nodes[0].id,
+      nodes[2].id,
+      nodes[3].id
+    ])
+  })
+
+  it('retains the render array when its node IDs are unchanged', () => {
+    const previous = [nodes[0], nodes[2]]
+    const refreshedNodes = nodes.map((node) => ({ ...node }))
+    const result = createRenderNodeList({
+      allNodes: refreshedNodes,
+      enabled: true,
+      layoutReady: true,
+      visibleNodeIds: new Set([nodes[0].id, nodes[2].id]),
+      pinnedNodeIds: new Set(),
+      previous
+    })
+
+    expect(result).toBe(previous)
+    expect(result[0]).toBe(refreshedNodes[0])
+    expect(result[1]).toBe(refreshedNodes[2])
+  })
+
+  it.for([
+    { enabled: false, layoutReady: true },
+    { enabled: true, layoutReady: false }
+  ])('renders every node for fallback state %o', (state) => {
+    const result = createRenderNodeList({
+      allNodes: nodes,
+      ...state,
+      visibleNodeIds: new Set(),
+      pinnedNodeIds: new Set(),
+      previous: []
+    })
+
+    expect(result).toEqual(nodes)
+  })
+})
+
+describe('createPinnedNodeIds', () => {
+  const ids = Array.from({ length: 9 }, (_, index) =>
+    toNodeId(String(index + 1))
+  )
+
+  it('includes every active-node pinning source', () => {
+    const result = createPinnedNodeIds({
+      activePointerNodeIds: [ids[0]],
+      selectedNodeIds: [ids[1], ids[2]],
+      focusedNodeId: ids[3],
+      titleEditedNodeId: ids[4],
+      contextMenuTargetNodeIds: [ids[5]],
+      capturingInputNodeId: ids[6],
+      linkEndpointNodeIds: [ids[7], ids[8]]
+    })
+
+    expect(result).toEqual(new Set(ids))
+  })
+})

--- a/src/composables/graph/useViewportNodeVirtualization.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.ts
@@ -1,0 +1,274 @@
+import { useEventListener, useRafFn } from '@vueuse/core'
+import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+
+import { isNodeOptionsOpen } from '@/composables/graph/useMoreOptionsMenu'
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import {
+  useCanvasStore,
+  useTitleEditorStore
+} from '@/renderer/core/canvas/canvasStore'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { Bounds } from '@/renderer/core/layout/types'
+import type { NodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
+import { isLGraphNode } from '@/utils/litegraphUtil'
+
+const VIEWPORT_OVERSCAN_RATIO = 0.25
+
+export function getViewportBounds(
+  canvas: LGraphCanvas,
+  overscanRatio = VIEWPORT_OVERSCAN_RATIO
+): Bounds | null {
+  const { ds, viewport } = canvas
+  const scale = ds.scale
+  if (!(scale > 0) || !ds.element) return null
+
+  let width = ds.element.width
+  let height = ds.element.height
+  let x = -ds.offset[0]
+  let y = -ds.offset[1]
+
+  if (viewport) {
+    x += viewport[0] / scale
+    y += viewport[1] / scale
+    width = viewport[2]
+    height = viewport[3]
+  }
+
+  const graphWidth = width / scale
+  const graphHeight = height / scale
+  const overscanX = graphWidth * overscanRatio
+  const overscanY = graphHeight * overscanRatio
+
+  return {
+    x: x - overscanX,
+    y: y - overscanY,
+    width: graphWidth + overscanX * 2,
+    height: graphHeight + overscanY * 2
+  }
+}
+
+function haveSameNodeIds(
+  left: readonly VueNodeData[],
+  right: readonly VueNodeData[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((node, index) => node.id === right[index]?.id)
+  )
+}
+
+export function createRenderNodeList(options: {
+  allNodes: readonly VueNodeData[]
+  enabled: boolean
+  layoutReady: boolean
+  visibleNodeIds: ReadonlySet<NodeId>
+  pinnedNodeIds: ReadonlySet<NodeId>
+  previous: VueNodeData[]
+}): VueNodeData[] {
+  const {
+    allNodes,
+    enabled,
+    layoutReady,
+    visibleNodeIds,
+    pinnedNodeIds,
+    previous
+  } = options
+  const next =
+    enabled && layoutReady
+      ? allNodes.filter(
+          (node) => visibleNodeIds.has(node.id) || pinnedNodeIds.has(node.id)
+        )
+      : [...allNodes]
+
+  if (!haveSameNodeIds(previous, next)) return next
+
+  // Preserve the array identity while refreshing the per-node data objects.
+  // GraphNodeManager replaces these objects when reactive node state changes.
+  for (let index = 0; index < next.length; index++) {
+    previous[index] = next[index]
+  }
+  return previous
+}
+
+export function createPinnedNodeIds(options: {
+  activePointerNodeIds?: Iterable<NodeId>
+  selectedNodeIds?: Iterable<NodeId>
+  focusedNodeId?: NodeId
+  titleEditedNodeId?: NodeId
+  contextMenuTargetNodeIds?: Iterable<NodeId>
+  capturingInputNodeId?: NodeId
+  linkEndpointNodeIds?: Iterable<NodeId>
+}): Set<NodeId> {
+  const result = new Set(options.activePointerNodeIds)
+  for (const nodeId of options.selectedNodeIds ?? []) result.add(nodeId)
+  for (const nodeId of options.contextMenuTargetNodeIds ?? []) {
+    result.add(nodeId)
+  }
+  for (const nodeId of options.linkEndpointNodeIds ?? []) result.add(nodeId)
+  if (options.focusedNodeId) result.add(options.focusedNodeId)
+  if (options.titleEditedNodeId) result.add(options.titleEditedNodeId)
+  if (options.capturingInputNodeId) result.add(options.capturingInputNodeId)
+  return result
+}
+
+function getNodeIdFromElement(target: EventTarget | null): NodeId | undefined {
+  if (!(target instanceof Element)) return
+  const value = target.closest<HTMLElement>('[data-node-id]')?.dataset.nodeId
+  return value ? toNodeId(value) : undefined
+}
+
+function boundsKey(bounds: Bounds | null): string {
+  if (!bounds) return 'none'
+  return `${bounds.x},${bounds.y},${bounds.width},${bounds.height}`
+}
+
+export function useViewportNodeVirtualization(options: {
+  allNodes: MaybeRefOrGetter<readonly VueNodeData[]>
+  canvas: MaybeRefOrGetter<LGraphCanvas | null | undefined>
+  enabled: MaybeRefOrGetter<boolean>
+}) {
+  const canvasStore = useCanvasStore()
+  const titleEditorStore = useTitleEditorStore()
+  const { state: slotDragState } = useSlotLinkDragUIState()
+  const renderNodes = shallowRef<VueNodeData[]>([])
+  const activePointerNodes = new Map<number, NodeId>()
+  const focusedNodeId = shallowRef<NodeId>()
+
+  let lastNodes: readonly VueNodeData[] | undefined
+  let lastViewportKey = ''
+  let lastLayoutRevision = -1
+  let lastPinnedKey = ''
+  let lastEnabled: boolean | undefined
+
+  function collectPinnedNodeIds(canvas: LGraphCanvas): Set<NodeId> {
+    const titleTarget = titleEditorStore.titleEditorTarget
+    const titleEditedNodeId =
+      titleTarget && isLGraphNode(titleTarget) ? titleTarget.id : undefined
+
+    const selectedNodeIds: NodeId[] = []
+    const contextMenuTargetNodeIds: NodeId[] = []
+    if (
+      layoutStore.isDraggingVueNodes.value ||
+      layoutStore.isResizingVueNodes.value
+    ) {
+      for (const item of canvasStore.selectedItems) {
+        if (isLGraphNode(item)) selectedNodeIds.push(item.id)
+      }
+    }
+
+    if (isNodeOptionsOpen()) {
+      for (const item of canvasStore.selectedItems) {
+        if (isLGraphNode(item)) contextMenuTargetNodeIds.push(item.id)
+      }
+    }
+
+    const linkEndpointNodeIds: NodeId[] = []
+    if (slotDragState.active) {
+      if (slotDragState.source) {
+        linkEndpointNodeIds.push(slotDragState.source.nodeId)
+      }
+      if (slotDragState.candidate) {
+        linkEndpointNodeIds.push(slotDragState.candidate.layout.nodeId)
+      }
+    }
+
+    for (const link of canvas.linkConnector.renderLinks) {
+      if (isLGraphNode(link.node)) linkEndpointNodeIds.push(link.node.id)
+    }
+
+    return createPinnedNodeIds({
+      activePointerNodeIds: activePointerNodes.values(),
+      selectedNodeIds,
+      focusedNodeId: focusedNodeId.value,
+      titleEditedNodeId,
+      contextMenuTargetNodeIds,
+      capturingInputNodeId: canvas.node_capturing_input?.id ?? undefined,
+      linkEndpointNodeIds
+    })
+  }
+
+  function refresh(force = false) {
+    const allNodes = toValue(options.allNodes)
+    const canvas = toValue(options.canvas)
+    const enabled = toValue(options.enabled)
+    const viewportBounds = canvas ? getViewportBounds(canvas) : null
+    const viewportKey = boundsKey(viewportBounds)
+    const layoutRevision = layoutStore.getRevision()
+    const pinnedNodeIds = canvas
+      ? collectPinnedNodeIds(canvas)
+      : new Set<NodeId>()
+    const pinnedKey = [...pinnedNodeIds].sort().join(',')
+
+    if (
+      !force &&
+      lastNodes === allNodes &&
+      lastViewportKey === viewportKey &&
+      lastLayoutRevision === layoutRevision &&
+      lastPinnedKey === pinnedKey &&
+      lastEnabled === enabled
+    ) {
+      return
+    }
+
+    lastNodes = allNodes
+    lastViewportKey = viewportKey
+    lastLayoutRevision = layoutRevision
+    lastPinnedKey = pinnedKey
+    lastEnabled = enabled
+
+    const layoutReady =
+      Boolean(viewportBounds) &&
+      allNodes.every((node) => layoutStore.hasNodeLayout(node.id))
+    const visibleNodeIds =
+      enabled && layoutReady && viewportBounds
+        ? new Set(layoutStore.queryNodesInBounds(viewportBounds))
+        : new Set<NodeId>()
+
+    const previous = renderNodes.value
+    const next = createRenderNodeList({
+      allNodes,
+      enabled,
+      layoutReady,
+      visibleNodeIds,
+      pinnedNodeIds,
+      previous
+    })
+    if (next === previous) triggerRef(renderNodes)
+    else renderNodes.value = next
+  }
+
+  useEventListener(
+    document,
+    'pointerdown',
+    (event) => {
+      const nodeId = getNodeIdFromElement(event.target)
+      if (nodeId) activePointerNodes.set(event.pointerId, nodeId)
+    },
+    { capture: true }
+  )
+  useEventListener(document, ['pointerup', 'pointercancel'], (event) => {
+    activePointerNodes.delete(event.pointerId)
+  })
+  useEventListener(document, ['focusin', 'focusout'], () => {
+    queueMicrotask(() => {
+      focusedNodeId.value = getNodeIdFromElement(document.activeElement)
+    })
+  })
+
+  watch(
+    () => toValue(options.enabled),
+    () => refresh(true),
+    { flush: 'sync' }
+  )
+
+  useRafFn(() => refresh(), { immediate: true })
+
+  return {
+    renderNodes: computed(() => renderNodes.value),
+    refresh
+  }
+}

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -8,6 +8,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { clearTrackedSlotLayouts } from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
 import { useLayoutSync } from '@/renderer/core/layout/sync/useLayoutSync'
 import { app as comfyApp } from '@/scripts/app'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
@@ -67,6 +68,7 @@ function useVueNodeLifecycleIndividual() {
 
   const disposeNodeManagerAndSyncs = () => {
     stopSync()
+    clearTrackedSlotLayouts()
     if (!nodeManager.value) return
 
     try {
@@ -151,6 +153,7 @@ function useVueNodeLifecycleIndividual() {
 
   // Cleanup function for component unmounting
   const cleanup = () => {
+    clearTrackedSlotLayouts()
     if (nodeManager.value) {
       nodeManager.value.cleanup()
       nodeManager.value = null

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -430,6 +430,10 @@
     "name": "Modern Node Design (Nodes 2.0)",
     "tooltip": "Modern: DOM-based rendering with enhanced interactivity, native browser features, and updated visual design. Classic: Traditional canvas rendering."
   },
+  "Comfy_VueNodes_ViewportVirtualization": {
+    "name": "Viewport node virtualization",
+    "tooltip": "Mount only nodes near the visible canvas. Disable this if a custom node requires its widgets to remain mounted while offscreen."
+  },
   "Comfy_WidgetControlMode": {
     "name": "Widget control mode",
     "tooltip": "Controls when widget values are updated (randomize/increment/decrement), either before the prompt is queued or after.",

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1202,6 +1202,18 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.27.1'
   },
   {
+    id: 'Comfy.VueNodes.ViewportVirtualization',
+    category: ['Comfy', 'Nodes 2.0', 'ViewportVirtualization'],
+    name: 'Viewport node virtualization',
+    type: 'boolean',
+    tooltip:
+      'Mount only nodes near the visible canvas. Disable this if a custom node requires its widgets to remain mounted while offscreen.',
+    defaultValue: false,
+    sortOrder: 110,
+    experimental: true,
+    versionAdded: '1.48.5'
+  },
+  {
     id: 'Comfy.AppBuilder.VueNodeSwitchDismissed',
     name: 'App Builder Vue Node switch dismissed',
     type: 'hidden',

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -476,6 +476,32 @@ describe('layoutStore CRDT operations', () => {
     expect(nodesInBounds).toContain('node-c')
   })
 
+  it.for([
+    { x: -25000, y: -30000 },
+    { x: 25000, y: 30000 }
+  ])('indexes nodes beyond the default canvas bounds', ({ x, y }) => {
+    const nodeId = toNodeId(`far-node-${x}-${y}`)
+    const layout: NodeLayout = {
+      ...createTestNode(nodeId),
+      position: { x, y },
+      bounds: { x, y, width: 200, height: 100 }
+    }
+
+    layoutStore.applyOperation({
+      type: 'createNode',
+      entity: 'node',
+      nodeId,
+      layout,
+      timestamp: Date.now(),
+      source: LayoutSource.External,
+      actor: 'test'
+    })
+
+    expect(
+      layoutStore.queryNodesInBounds({ x, y, width: 200, height: 100 })
+    ).toContain(nodeId)
+  })
+
   it('should maintain operation history', () => {
     const nodeId = toNodeId('test-node-history')
     const layout = createTestNode(nodeId)

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -381,6 +381,14 @@ class LayoutStoreImpl implements LayoutStore {
     return computed(() => this.version)
   }
 
+  getRevision(): number {
+    return this.version
+  }
+
+  hasNodeLayout(nodeId: NodeId): boolean {
+    return this.ynodes.has(String(nodeId))
+  }
+
   /**
    * Query node at point (non-reactive for performance)
    */

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -274,6 +274,8 @@ export interface LayoutStore {
   getNodesInBounds(bounds: Bounds): ComputedRef<NodeId[]>
   getAllNodes(): ComputedRef<ReadonlyMap<NodeId, NodeLayout>>
   getVersion(): ComputedRef<number>
+  getRevision(): number
+  hasNodeLayout(nodeId: NodeId): boolean
 
   // Spatial queries (non-reactive)
   queryNodeAtPoint(point: Point): NodeId | null

--- a/src/renderer/core/spatial/QuadTree.test.ts
+++ b/src/renderer/core/spatial/QuadTree.test.ts
@@ -25,14 +25,17 @@ describe('QuadTree', () => {
       expect(quadTree.size).toBe(1)
     })
 
-    it('should reject items outside bounds', () => {
+    it('should expand to include items outside bounds', () => {
       const success = quadTree.insert(
         'node1',
         { x: -100, y: -100, width: 50, height: 50 },
         'node1'
       )
-      expect(success).toBe(false)
-      expect(quadTree.size).toBe(0)
+      expect(success).toBe(true)
+      expect(quadTree.size).toBe(1)
+      expect(
+        quadTree.query({ x: -110, y: -110, width: 70, height: 70 })
+      ).toEqual(['node1'])
     })
 
     it('should handle duplicate IDs by replacing', () => {
@@ -162,6 +165,22 @@ describe('QuadTree', () => {
         height: 100
       })
       expect(newResults).toContain('node1')
+    })
+
+    it.for([
+      { x: -25000, y: -30000 },
+      { x: 25000, y: 30000 }
+    ])('expands when an item moves to $x, $y', ({ x, y }) => {
+      quadTree.insert(
+        'node1',
+        { x: 100, y: 100, width: 50, height: 50 },
+        'node1'
+      )
+
+      expect(quadTree.update('node1', { x, y, width: 50, height: 50 })).toBe(
+        true
+      )
+      expect(quadTree.query({ x, y, width: 50, height: 50 })).toEqual(['node1'])
     })
   })
 

--- a/src/renderer/core/spatial/QuadTree.ts
+++ b/src/renderer/core/spatial/QuadTree.ts
@@ -220,6 +220,7 @@ class QuadNode<T> {
 
 export class QuadTree<T> {
   private root: QuadNode<T>
+  private rootBounds: Bounds
   private itemMap: Map<string, QuadTreeItem<T>> = new Map()
   private options: Required<QuadTreeOptions>
 
@@ -230,8 +231,9 @@ export class QuadTree<T> {
       minNodeSize: options.minNodeSize ?? 50
     }
 
+    this.rootBounds = { ...bounds }
     this.root = new QuadNode<T>(
-      bounds,
+      this.rootBounds,
       0,
       this.options.maxDepth,
       this.options.maxItemsPerNode
@@ -244,6 +246,12 @@ export class QuadTree<T> {
     // Remove old item if it exists
     if (this.itemMap.has(id)) {
       this.remove(id)
+    }
+
+    if (!containsBounds(this.rootBounds, bounds)) {
+      this.itemMap.set(id, item)
+      this.expandToFit(bounds)
+      return true
     }
 
     const success = this.root.insert(item)
@@ -281,7 +289,7 @@ export class QuadTree<T> {
 
   clear() {
     this.root = new QuadNode<T>(
-      this.root['bounds'],
+      this.rootBounds,
       0,
       this.options.maxDepth,
       this.options.maxItemsPerNode
@@ -299,4 +307,44 @@ export class QuadTree<T> {
       tree: this.root.getDebugInfo()
     }
   }
+
+  private expandToFit(bounds: Bounds): void {
+    const expanded = { ...this.rootBounds }
+
+    while (bounds.x < expanded.x) {
+      expanded.x -= expanded.width
+      expanded.width *= 2
+    }
+    while (bounds.x + bounds.width > expanded.x + expanded.width) {
+      expanded.width *= 2
+    }
+    while (bounds.y < expanded.y) {
+      expanded.y -= expanded.height
+      expanded.height *= 2
+    }
+    while (bounds.y + bounds.height > expanded.y + expanded.height) {
+      expanded.height *= 2
+    }
+
+    this.rootBounds = expanded
+    this.root = new QuadNode<T>(
+      this.rootBounds,
+      0,
+      this.options.maxDepth,
+      this.options.maxItemsPerNode
+    )
+
+    for (const item of this.itemMap.values()) {
+      this.root.insert(item)
+    }
+  }
+}
+
+function containsBounds(container: Bounds, item: Bounds): boolean {
+  return (
+    item.x >= container.x &&
+    item.y >= container.y &&
+    item.x + item.width <= container.x + container.width &&
+    item.y + item.height <= container.y + container.height
+  )
 }

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -14,6 +14,11 @@ import type { SlotLayout } from '@/renderer/core/layout/types'
 import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
 
 import {
+  deleteTrackedNodeSlots,
+  reconcileTrackedNodeSlots
+} from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
+
+import {
   syncNodeSlotLayoutsFromDOM,
   flushScheduledSlotLayoutSync,
   requestSlotLayoutSyncForAllNodes,
@@ -139,19 +144,24 @@ describe('useSlotElementTracking', () => {
   it.for([
     { type: 'input' as const, isInput: true },
     { type: 'output' as const, isInput: false }
-  ])('cleans up $type slot layout on unmount', async ({ type, isInput }) => {
-    const { unmount } = await mountAndRegisterSlot(type)
+  ])(
+    'retains $type slot layout on virtualized unmount',
+    async ({ type, isInput }) => {
+      const { unmount } = await mountAndRegisterSlot(type)
 
-    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, isInput)
-    const registryStore = useNodeSlotRegistryStore()
-    expect(registryStore.getNode(NODE_ID)?.slots.has(slotKey)).toBe(true)
-    expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, isInput)
+      const registryStore = useNodeSlotRegistryStore()
+      expect(registryStore.getNode(NODE_ID)?.slots.has(slotKey)).toBe(true)
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
 
-    unmount()
+      unmount()
 
-    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
-    expect(registryStore.getNode(NODE_ID)).toBeUndefined()
-  })
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      expect(
+        registryStore.getNode(NODE_ID)?.slots.get(slotKey)?.el
+      ).toBeUndefined()
+    }
+  )
 
   it('clears pendingSlotSync when slot layouts already exist', () => {
     // Seed a slot layout (simulates slot layouts persisting through undo/redo)
@@ -176,17 +186,16 @@ describe('useSlotElementTracking', () => {
     expect(layoutStore.pendingSlotSync).toBe(false)
   })
 
-  it('keeps pendingSlotSync when graph has nodes but no slot layouts', () => {
+  it('clears pendingSlotSync when graph nodes have no measured slots', () => {
     // No slot layouts exist (simulates initial mount before Vue registers slots)
     layoutStore.setPendingSlotSync(true)
 
     flushScheduledSlotLayoutSync()
 
-    // Should remain pending — waiting for Vue components to mount
-    expect(layoutStore.pendingSlotSync).toBe(true)
+    expect(layoutStore.pendingSlotSync).toBe(false)
   })
 
-  it('keeps pendingSlotSync when all registered slots are hidden', () => {
+  it('clears pendingSlotSync when all registered slots are detached', () => {
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     const hiddenSlot = document.createElement('div')
 
@@ -201,11 +210,11 @@ describe('useSlotElementTracking', () => {
     layoutStore.setPendingSlotSync(true)
     requestSlotLayoutSyncForAllNodes()
 
-    expect(layoutStore.pendingSlotSync).toBe(true)
+    expect(layoutStore.pendingSlotSync).toBe(false)
     expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
   })
 
-  it('removes stale slot layouts when slot element is hidden', () => {
+  it('retains slot layouts when slot elements detach', () => {
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     const hiddenSlot = document.createElement('div')
 
@@ -228,7 +237,7 @@ describe('useSlotElementTracking', () => {
 
     syncNodeSlotLayoutsFromDOM(NODE_ID)
 
-    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(layoutStore.getSlotLayout(slotKey)).toEqual(staleLayout)
   })
 
   it('skips slot layout writeback when measured slot geometry is unchanged', () => {
@@ -273,6 +282,68 @@ describe('useSlotElementTracking', () => {
     expect(batchUpdateSpy).not.toHaveBeenCalled()
   })
 
+  it('updates retained slot layouts while an offscreen node moves', async () => {
+    const { unmount } = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+
+    unmount()
+    layoutStore.applyOperation({
+      type: 'moveNode',
+      entity: 'node',
+      nodeId: NODE_ID,
+      position: { x: 100, y: 200 },
+      previousPosition: { x: 0, y: 0 },
+      timestamp: Date.now(),
+      source: LayoutSource.External,
+      actor: 'test'
+    })
+    await nextTick()
+
+    expect(layoutStore.getSlotLayout(slotKey)?.position).toEqual({
+      x: 115,
+      y: 205
+    })
+  })
+
+  it('reattaches and remeasures a retained slot', async () => {
+    const first = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    first.unmount()
+
+    const second = await mountAndRegisterSlot('input')
+    const entry = useNodeSlotRegistryStore()
+      .getNode(NODE_ID)
+      ?.slots.get(slotKey)
+
+    expect(entry?.el?.isConnected).toBe(true)
+    expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+    second.unmount()
+  })
+
+  it('removes retained layouts when the slot model deletes a slot', async () => {
+    const { unmount } = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    unmount()
+
+    reconcileTrackedNodeSlots(NODE_ID, 0, 0)
+
+    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(
+      useNodeSlotRegistryStore().getNode(NODE_ID)?.slots.has(slotKey)
+    ).toBe(false)
+  })
+
+  it('clears retained layouts when the graph deletes a node', async () => {
+    const { unmount } = await mountAndRegisterSlot('output')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, false)
+    unmount()
+
+    deleteTrackedNodeSlots(NODE_ID)
+
+    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(useNodeSlotRegistryStore().getNode(NODE_ID)).toBeUndefined()
+  })
+
   describe('collapsed node slot sync', () => {
     function registerCollapsedSlot() {
       const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
@@ -306,14 +377,14 @@ describe('useSlotElementTracking', () => {
       expect(layout!.position.y).toBe(screenCenter[1] * 0.5)
     })
 
-    it('clears cachedOffset for collapsed nodes', () => {
+    it('caches collapsed slot offsets for offscreen movement', () => {
       const { slotKey, node } = registerCollapsedSlot()
       const entry = node.slots.get(slotKey)!
       expect(entry.cachedOffset).toBeDefined()
 
       syncNodeSlotLayoutsFromDOM(NODE_ID)
 
-      expect(entry.cachedOffset).toBeUndefined()
+      expect(entry.cachedOffset).toEqual({ x: 7.5, y: 17.5 })
     })
 
     it('defers sync when canvas is not initialized', () => {

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -39,19 +39,13 @@ export function scheduleSlotLayoutSync(nodeId: NodeId) {
   raf.schedule()
 }
 
-function shouldWaitForSlotLayouts(): boolean {
-  const graph = app.canvas?.graph
-  const hasNodes = Boolean(graph && graph._nodes && graph._nodes.length > 0)
-  return hasNodes && !layoutStore.hasSlotLayouts
-}
-
 function completePendingSlotSync(): void {
   layoutStore.setPendingSlotSync(false)
   app.canvas?.setDirty(true, true)
 }
 
-function getSlotElementRect(el: HTMLElement): DOMRect | null {
-  if (!el.isConnected) return null
+function getSlotElementRect(el?: HTMLElement): DOMRect | null {
+  if (!el?.isConnected) return null
 
   const rect = el.getBoundingClientRect()
   if (rect.width <= 0 || rect.height <= 0) return null
@@ -61,11 +55,17 @@ function getSlotElementRect(el: HTMLElement): DOMRect | null {
 export function requestSlotLayoutSyncForAllNodes(): void {
   const nodeSlotRegistryStore = useNodeSlotRegistryStore()
   for (const nodeId of nodeSlotRegistryStore.getNodeIds()) {
-    scheduleSlotLayoutSync(nodeId)
+    const node = nodeSlotRegistryStore.getNode(nodeId)
+    if (
+      node &&
+      Array.from(node.slots.values()).some(({ el }) => el?.isConnected)
+    ) {
+      scheduleSlotLayoutSync(nodeId)
+    }
   }
 
-  // If no slots are currently registered, run the completion check immediately
-  // so pendingSlotSync can be cleared when the graph has no nodes.
+  // Detached virtualized nodes already have cached or model-based geometry and
+  // must not hold link rendering open while waiting for a future remount.
   if (pendingNodes.size === 0) {
     flushScheduledSlotLayoutSync()
   }
@@ -97,14 +97,6 @@ function createSlotLayout(options: {
 
 export function flushScheduledSlotLayoutSync() {
   if (pendingNodes.size === 0) {
-    // No pending nodes - check if we should wait for Vue components to mount
-    if (shouldWaitForSlotLayouts()) {
-      // Graph has nodes but no slot layouts yet - Vue hasn't mounted.
-      // Keep flag set so late mounts can re-assert via scheduleSlotLayoutSync()
-      return
-    }
-    // Either no nodes (nothing to wait for) or slot layouts already exist
-    // (undo/redo preserved them). Clear the flag so links can render.
     completePendingSlotSync()
     return
   }
@@ -112,10 +104,6 @@ export function flushScheduledSlotLayoutSync() {
     pendingNodes.delete(nodeId)
     syncNodeSlotLayoutsFromDOM(nodeId)
   }
-
-  // Keep pending sync active until at least one measurable slot layout has
-  // been captured for the current graph.
-  if (shouldWaitForSlotLayouts()) return
 
   completePendingSlotSync()
 }
@@ -135,10 +123,10 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
   // share the same DOM transform, so their pixel difference divided by the
   // effective scale yields a correct canvas-space offset regardless of
   // whether the TransformPane has flushed its latest transform to the DOM.
-  const closestNode = node.slots
-    .values()
-    .next()
-    .value?.el.closest('[data-node-id]')
+  const connectedEntry = Array.from(node.slots.values()).find(
+    (entry) => entry.el?.isConnected
+  )
+  const closestNode = connectedEntry?.el?.closest('[data-node-id]')
   const nodeEl = closestNode instanceof HTMLElement ? closestNode : null
   const nodeRect = nodeEl?.getBoundingClientRect()
 
@@ -165,12 +153,7 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
 
   for (const [slotKey, entry] of node.slots) {
     const rect = getSlotElementRect(entry.el)
-    if (!rect) {
-      // Drop stale layout values while the slot is hidden so we don't render
-      // links with off-screen coordinates from a previous graph/tab state.
-      layoutStore.deleteSlotLayout(slotKey)
-      continue
-    }
+    if (!rect) continue
 
     const screenCenter: [number, number] = [
       rect.left + rect.width / 2,
@@ -182,7 +165,10 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
     if (conv) {
       const [cx, cy] = conv.clientPosToCanvasPos(screenCenter)
       centerCanvas = { x: cx, y: cy }
-      entry.cachedOffset = undefined
+      entry.cachedOffset = {
+        x: centerCanvas.x - nodeLayout.position.x,
+        y: centerCanvas.y - nodeLayout.position.y
+      }
     } else {
       if (!nodeRect || effectiveScale <= 0) continue
 
@@ -269,6 +255,7 @@ export function useSlotElementTracking(options: {
 }) {
   const { nodeId, index, type, element } = options
   const nodeSlotRegistryStore = useNodeSlotRegistryStore()
+  let registeredElement: HTMLElement | undefined
 
   onMounted(() => {
     if (!nodeId) return
@@ -314,13 +301,18 @@ export function useSlotElementTracking(options: {
         // Defensive cleanup: remove stale entry if it exists with different element
         // This handles edge cases where Vue component reuse prevents proper unmount
         const existingEntry = node.slots.get(slotKey)
-        if (existingEntry && existingEntry.el !== el) {
+        if (existingEntry?.el && existingEntry.el !== el) {
           delete existingEntry.el.dataset.slotKey
-          layoutStore.deleteSlotLayout(slotKey)
         }
 
         el.dataset.slotKey = String(slotKey)
-        node.slots.set(slotKey, { el, index, type })
+        registeredElement = el
+        node.slots.set(slotKey, {
+          ...existingEntry,
+          el,
+          index,
+          type
+        })
 
         // Seed initial sync from DOM
         scheduleSlotLayoutSync(nodeId)
@@ -337,19 +329,13 @@ export function useSlotElementTracking(options: {
     const node = nodeSlotRegistryStore.getNode(nodeId)
     if (!node) return
 
-    // Remove this slot from registry and layout
+    // Detach the DOM element while retaining cached geometry. Virtualized
+    // nodes continue to participate in link layout and movement updates.
     const slotKey = getSlotKey(nodeId, index, type === 'input')
     const entry = node.slots.get(slotKey)
-    if (entry) {
+    if (entry?.el && entry.el === registeredElement) {
       delete entry.el.dataset.slotKey
-      node.slots.delete(slotKey)
-    }
-    layoutStore.deleteSlotLayout(slotKey)
-
-    // If node has no more slots, clean up
-    if (node.slots.size === 0) {
-      if (node.stopWatch) node.stopWatch()
-      nodeSlotRegistryStore.deleteNode(nodeId)
+      entry.el = undefined
     }
   })
 

--- a/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
+++ b/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
@@ -5,7 +5,7 @@ import type { NodeId } from '@/types/nodeId'
 import type { SlotId } from '@/types/slotId'
 
 type SlotEntry = {
-  el: HTMLElement
+  el?: HTMLElement
   index: number
   type: 'input' | 'output'
   cachedOffset?: { x: number; y: number }

--- a/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
+++ b/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
@@ -1,0 +1,46 @@
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
+import type { NodeId } from '@/types/nodeId'
+
+/** Remove geometry only for slots that no longer exist in the node model. */
+export function reconcileTrackedNodeSlots(
+  nodeId: NodeId,
+  inputCount: number,
+  outputCount: number
+) {
+  const registryStore = useNodeSlotRegistryStore()
+  const node = registryStore.getNode(nodeId)
+  if (!node) return
+
+  for (const [slotKey, entry] of node.slots) {
+    const count = entry.type === 'input' ? inputCount : outputCount
+    if (entry.index < count) continue
+
+    if (entry.el) delete entry.el.dataset.slotKey
+    node.slots.delete(slotKey)
+    layoutStore.deleteSlotLayout(slotKey)
+  }
+}
+
+/** Clear retained slot geometry when its owning node is actually deleted. */
+export function deleteTrackedNodeSlots(nodeId: NodeId) {
+  const registryStore = useNodeSlotRegistryStore()
+  const node = registryStore.getNode(nodeId)
+  if (!node) return
+
+  node.stopWatch?.()
+  for (const [slotKey, entry] of node.slots) {
+    if (entry.el) delete entry.el.dataset.slotKey
+    layoutStore.deleteSlotLayout(slotKey)
+  }
+  registryStore.deleteNode(nodeId)
+}
+
+/** Clear all retained geometry when the active graph or renderer changes. */
+export function clearTrackedSlotLayouts() {
+  const registryStore = useNodeSlotRegistryStore()
+  for (const nodeId of registryStore.getNodeIds()) {
+    deleteTrackedNodeSlots(nodeId)
+  }
+  layoutStore.clearAllSlotLayouts()
+}

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -426,6 +426,7 @@ const zSettings = z.object({
   'Comfy.Canvas.LeftMouseClickBehavior': z.string(),
   'Comfy.Canvas.MouseWheelScroll': z.string(),
   'Comfy.VueNodes.Enabled': z.boolean(),
+  'Comfy.VueNodes.ViewportVirtualization': z.boolean(),
   'Comfy.AppBuilder.VueNodeSwitchDismissed': z.boolean(),
   'Comfy.Assets.UseAssetAPI': z.boolean(),
   'Comfy.Queue.QPOV2': z.boolean(),


### PR DESCRIPTION
# Opt-in Nodes 2.0 Viewport Virtualization

## Summary

Adds opt-in component virtualization for Nodes 2.0 so large workflows only
mount nodes intersecting the viewport plus a 25% overscan region. LiteGraph
graph state, prompt serialization, execution, outputs, links, and selection
remain independent of Vue component mounting.

The feature is disabled by default because some custom Vue or legacy widgets
may depend on continuous mount lifecycles. Disabling the setting restores the
existing all-mounted behavior immediately.

## Changes

- **What**:
  - Adds the experimental `Comfy.VueNodes.ViewportVirtualization` setting under
    **Comfy → Nodes 2.0 → ViewportVirtualization**, named **Viewport node
    virtualization**, defaulting to `false`.
  - Replaces the all-node render loop with a viewport-derived list that matches
    LiteGraph canvas transforms, preserves graph order, and avoids replacing
    the render array when its IDs are unchanged.
  - Queries the layout spatial index once per changed animation frame and
    renders all nodes while virtualization is disabled or layout initialization
    is incomplete.
  - Keeps nodes mounted while they are actively pointed at, selected during
    drag/resize, focused, title-edited, targeted by an open context menu,
    capturing input, or participating in a link drag.
  - Retains cached slot offsets and absolute layouts across virtualized
    unmounts, updates retained slots when offscreen nodes move, and remeasures
    slots when nodes remount.
  - Reconciles retained slots on real slot-model or node deletion and clears
    them on graph disposal, renderer changes, and subgraph navigation.
  - Allows pending slot synchronization to finish without waiting for every
    graph node to mount; unmeasured slots continue using the existing
    model-derived fallback.
  - Expands the layout QuadTree when workflows contain nodes outside its
    current bounds.
  - Adds unit, Playwright, and large-graph performance coverage.
- **Breaking**: None. The feature is opt-in and defaults to disabled.
- **Dependencies**: None.
- **Version bump**: None.

## Review Focus

- Viewport math and 25% overscan behavior across pan, zoom, resize, and
  LiteGraph sub-viewports.
- Active-node pinning during pointer, focus, context-menu, resize, and link-drag
  interactions.
- Slot-cache lifetime: virtualized unmount versus actual slot/node deletion and
  graph disposal.
- Immediate fallback to the current all-mounted behavior when the setting is
  disabled.
- Compatibility with collapsed nodes, subgraphs, offscreen execution/output
  updates, classic rendering, App Mode, previews, and minimap data.

## Validation

- [x] Targeted Vitest suite: 93 tests passed.
- [x] Nodes 2.0 Playwright suite: 4 Chromium tests passed.
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:browser`
- [x] `pnpm format:check`
- [x] `pnpm knip`
- [x] `git diff --check`
- [x] Stylelint passed.
- [x] Type-aware Oxlint passed; three unrelated pre-existing warnings remain in
      `turnstileScript.test.ts`.
- [x] ESLint passed for every modified source file.

Local note: the full cached `eslint src` process encountered a Node 25
`SIGSEGV` twice after scanning the repository. Running ESLint directly over all
modified source files completed successfully.

## Performance Coverage

The existing Nodes 2.0 large-graph performance tests now enable virtualization
and record:

- mounted Vue node count;
- total DOM node count;
- idle task cost;
- pan frame duration;
- total blocking time.

## Screenshots (if applicable)

Not applicable. This change affects mounting behavior and performance without
changing node visuals.