### PR TITLE
feat: support localhost RUM validation

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -16,6 +16,9 @@ DEV_SERVER_COMFYUI_URL=http://127.0.0.1:8188
 # and public addresses.
 # VITE_REMOTE_DEV=true
 
+# Optional client token for sending localhost RUM to test-v2.
+# VITE_LOCAL_DATADOG_RUM_CLIENT_TOKEN=
+
 # The directory containing the ComfyUI installation used to run Playwright tests.
 # If you aren't using a separate install for testing, point this to your regular install.
 TEST_COMFYUI_DIR=/home/ComfyUI

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -37,6 +37,7 @@ describe('initDatadogRum', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
     vi.unstubAllGlobals()
   })
 
@@ -64,6 +65,20 @@ describe('initDatadogRum', () => {
       })
     }
   )
+
+  it('initializes opted-in localhost RUM in test-v2', async () => {
+    vi.stubEnv('VITE_LOCAL_DATADOG_RUM_CLIENT_TOKEN', 'local-client-token')
+
+    await initDatadogRum('localhost')
+
+    expect(hoisted.context).toEqual({ local_rum: true })
+    expect(hoisted.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientToken: 'local-client-token',
+        env: 'test-v2'
+      })
+    )
+  })
 
   it('tags canary traffic with its bucket and frontend version', async () => {
     let resolveProbe: (response: Response) => void

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -28,12 +28,18 @@ async function setFrontendContext(): Promise<void> {
   datadogRum.setGlobalContextProperty('version', frontendVersion)
 }
 
-async function initializeDatadogRum(env: string): Promise<void> {
+async function initializeDatadogRum(
+  env: string,
+  clientToken?: string
+): Promise<void> {
   await setFrontendContext().catch(() => {})
   if (datadogRum.getInitConfiguration()) return
+  if (clientToken) {
+    datadogRum.setGlobalContextProperty('local_rum', true)
+  }
 
   datadogRum.init({
-    clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
+    clientToken: clientToken ?? 'pub7704486e5b64eb4ff6f62891cda45559',
     applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
     site: 'us5.datadoghq.com',
     service: 'comfy-cloud-frontend',
@@ -49,13 +55,19 @@ async function initializeDatadogRum(env: string): Promise<void> {
 export function initDatadogRum(
   hostname = window.location.hostname
 ): Promise<void> {
+  const clientToken =
+    hostname === 'localhost'
+      ? import.meta.env.VITE_LOCAL_DATADOG_RUM_CLIENT_TOKEN
+      : undefined
   const env =
-    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
+    (clientToken ? 'test-v2' : DATADOG_ENV_BY_HOSTNAME.get(hostname)) ??
     (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
   if (!env || datadogRum.getInitConfiguration()) return Promise.resolve()
 
-  initializationPromise ??= initializeDatadogRum(env).finally(() => {
-    initializationPromise = undefined
-  })
+  initializationPromise ??= initializeDatadogRum(env, clientToken).finally(
+    () => {
+      initializationPromise = undefined
+    }
+  )
   return initializationPromise
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,7 @@ declare global {
 
   interface ImportMetaEnv {
     VITE_APP_VERSION?: string
+    VITE_LOCAL_DATADOG_RUM_CLIENT_TOKEN?: string
     VITE_STAGING_API_BASE_URL?: string
     VITE_STAGING_PLATFORM_BASE_URL?: string
   }


### PR DESCRIPTION
## Summary

Allow opted-in localhost Datadog RUM validation with the minimum client-side configuration:

- Read `VITE_LOCAL_DATADOG_RUM_CLIENT_TOKEN` only on `localhost`.
- Send those events to the existing RUM application with `env:test-v2` and `local_rum:true`.
- Keep localhost RUM disabled when the token is absent.

The client token is intentionally browser-visible. Distribution and rotation of a dedicated token are the access boundary; this does not authenticate an `@comfy.org` email address.

## Verification

The focused test verifies that an opted-in localhost initializes Datadog with the supplied client token, `env:test-v2`, and `local_rum:true`. The existing unknown-host test verifies that localhost remains disabled without the token.

RUM query:

```text
service:comfy-cloud-frontend env:test-v2 @type:view @view.url_host:localhost @context.local_rum:true
```

[Open the fixed Datadog Explorer window](https://us5.datadoghq.com/rum/sessions?query=service%3Acomfy-cloud-frontend%20env%3Atest-v2%20%40type%3Aview%20%40view.url_host%3Alocalhost%20%40context.local_rum%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&refresh_mode=paused&from_ts=1785100073600&to_ts=1785101093600&live=false)

| Explorer result | Event attributes |
|---|---|
| <img width="720" alt="Datadog Explorer showing two localhost RUM views" src="https://github.com/user-attachments/assets/5df0b4a7-6c6d-4047-b6a6-4f19c2575f8d" /> | <img width="720" alt="Datadog attributes showing local_rum true and a localhost URL" src="https://github.com/user-attachments/assets/31c2f448-8b9d-44ae-a187-a38ceb92f7a5" /> |

The Explorer screenshots prove the unchanged observable RUM contract. They were captured before the client-only simplification. The current head was not re-ingested because this workspace does not contain the distributed client token.

- Focused RUM test: 18 passed.
- Full unit suite: 13,501 passed, 8 skipped, with one unrelated onboarding lazy-route timeout. The timed-out test passed 7/7 in isolation.
- `pnpm typecheck`
- `pnpm lint`: 0 errors, 44 existing warnings.
- `pnpm format:check`
- `pnpm knip`

Created by Codex
