### PR TITLE
Feat/viewport node virtualization

### DIFF
--- a/browser_tests/fixtures/helpers/PerformanceHelper.ts
+++ b/browser_tests/fixtures/helpers/PerformanceHelper.ts
@@ -25,6 +25,7 @@ export interface PerfMeasurement {
   heapDeltaBytes: number
   heapUsedBytes: number
   domNodes: number
+  mountedNodeCount?: number
   jsHeapTotalBytes: number
   scriptDurationMs: number
   eventListeners: number

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -292,9 +292,11 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
         await comfyPage.nextFrame()
       }
 
-      const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
+      const m = await comfyPage.perf.stopMeasuring(
+        'vue-large-graph-virtualized-idle'
+      )
       const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
-      recordMeasurement(m)
+      recordMeasurement({ ...m, mountedNodeCount })
       console.log(
         `Vue large graph idle: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.taskDurationMs.toFixed(1)}ms task`
       )
@@ -317,9 +319,11 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       }
       await comfyPage.page.mouse.up({ button: 'middle' })
 
-      const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
+      const m = await comfyPage.perf.stopMeasuring(
+        'vue-large-graph-virtualized-pan'
+      )
       const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
-      recordMeasurement(m)
+      recordMeasurement({ ...m, mountedNodeCount })
       console.log(
         `Vue large graph pan: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
       )

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -277,6 +277,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
   test.describe('vue renderer large graph', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+      await comfyPage.settings.setSetting(
+        'Comfy.VueNodes.ViewportVirtualization',
+        true
+      )
       await comfyPage.workflow.loadWorkflow('large-graph-workflow')
       await comfyPage.vueNodes.waitForNodes()
     })
@@ -289,9 +293,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       }
 
       const m = await comfyPage.perf.stopMeasuring('vue-large-graph-idle')
+      const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
       recordMeasurement(m)
       console.log(
-        `Vue large graph idle: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.domNodes} DOM nodes`
+        `Vue large graph idle: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.taskDurationMs.toFixed(1)}ms task`
       )
     })
 
@@ -313,9 +318,10 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       await comfyPage.page.mouse.up({ button: 'middle' })
 
       const m = await comfyPage.perf.stopMeasuring('vue-large-graph-pan')
+      const mountedNodeCount = await comfyPage.vueNodes.getNodeCount()
       recordMeasurement(m)
       console.log(
-        `Vue large graph pan: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
+        `Vue large graph pan: ${mountedNodeCount} mounted nodes, ${m.domNodes} DOM nodes, ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame, TBT=${m.totalBlockingTimeMs.toFixed(0)}ms`
       )
     })
 

--- a/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
+++ b/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { assertNodeSlotsWithinBounds } from '@e2e/fixtures/utils/slotBoundsUtil'
+
+test.describe('Viewport node virtualization', { tag: ['@canvas'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      true
+    )
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
+  test('mounts nearby nodes, swaps them while panning, and toggles immediately', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.canvasOps.setScale(1)
+    await (await comfyPage.nodeOps.getNodeRefById(1)).centerOnNode()
+
+    const graphNodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeLessThan(graphNodeCount)
+
+    const initialNodeIds = await comfyPage.vueNodes.getNodeIds()
+    const canvasBox = await comfyPage.canvas.boundingBox()
+    if (!canvasBox) throw new Error('Canvas bounding box not available')
+
+    const centerX = canvasBox.x + canvasBox.width / 2
+    const centerY = canvasBox.y + canvasBox.height / 2
+    await comfyPage.page.mouse.move(centerX, centerY)
+    await comfyPage.page.mouse.down({ button: 'middle' })
+    await comfyPage.page.mouse.move(centerX, centerY - 700, { steps: 20 })
+    await comfyPage.page.mouse.up({ button: 'middle' })
+
+    await expect
+      .poll(async () => {
+        const currentNodeIds = await comfyPage.vueNodes.getNodeIds()
+        return currentNodeIds.some((id) => !initialNodeIds.includes(id))
+      })
+      .toBe(true)
+
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      false
+    )
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount(), { timeout: 15_000 })
+      .toBe(graphNodeCount)
+
+    await comfyPage.settings.setSetting(
+      'Comfy.VueNodes.ViewportVirtualization',
+      true
+    )
+    await expect
+      .poll(() => comfyPage.vueNodes.getNodeCount())
+      .toBeLessThan(graphNodeCount)
+  })
+
+  test('keeps a focused widget mounted while its node is offscreen', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.canvasOps.setScale(1)
+
+    const editedNode = await comfyPage.nodeOps.getNodeRefById(2)
+    await editedNode.centerOnNode()
+    const textarea = comfyPage.vueNodes.getNodeLocator('2').getByRole('textbox')
+    await textarea.fill('virtualized edit')
+    await expect(textarea).toBeFocused()
+
+    await (await comfyPage.nodeOps.getNodeRefById(241)).centerOnNode()
+
+    await expect(comfyPage.vueNodes.getNodeLocator('2')).toBeAttached()
+    await expect(textarea).toBeFocused()
+    await expect(textarea).toHaveValue('virtualized edit')
+
+    await comfyPage.canvas.focus()
+    await expect(comfyPage.vueNodes.getNodeLocator('2')).toHaveCount(0)
+  })
+
+  test('preserves links and output updates while a node is offscreen', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('execution/partial_execution')
+    await comfyPage.canvasOps.setScale(1)
+
+    const outputNode = await comfyPage.nodeOps.getNodeRefById(1)
+    await outputNode.centerOnNode()
+    await outputNode.dragBy({ x: 3_000, y: 0 })
+    await comfyPage.canvas.focus()
+    await (await comfyPage.nodeOps.getNodeRefById(3)).centerOnNode()
+    await expect(comfyPage.vueNodes.getNodeLocator('1')).toHaveCount(0)
+
+    await comfyPage.command.executeCommand('Comfy.QueuePrompt')
+    await expect
+      .poll(async () => (await outputNode.getWidget(0)).getValue(), {
+        timeout: 10_000
+      })
+      .toBe('foo')
+
+    await outputNode.centerOnNode()
+    await expect(
+      comfyPage.vueNodes
+        .getNodeLocator('1')
+        .getByRole('textbox', { name: 'preview_text' })
+    ).toHaveValue('foo')
+    await assertNodeSlotsWithinBounds(comfyPage.page, '1')
+  })
+
+  test('renders collapsed nodes after entering a subgraph', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-collapsed-node'
+    )
+    await comfyPage.vueNodes.enterSubgraph('2')
+    await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+    await comfyPage.canvasOps.setScale(1)
+    await (await comfyPage.nodeOps.getNodeRefById(1)).centerOnNode()
+
+    await expect(comfyPage.vueNodes.getNodeLocator('1')).toHaveAttribute(
+      'data-collapsed',
+      'true'
+    )
+    await assertNodeSlotsWithinBounds(comfyPage.page, '1')
+  })
+})

--- a/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
+++ b/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
@@ -37,15 +37,24 @@ test.describe('Viewport node virtualization', { tag: ['@canvas'] }, () => {
 
     const centerX = canvasBox.x + canvasBox.width / 2
     const centerY = canvasBox.y + canvasBox.height / 2
-    await comfyPage.page.mouse.move(centerX, centerY)
-    await comfyPage.page.mouse.down({ button: 'middle' })
-    await comfyPage.page.mouse.move(centerX, centerY - 700, { steps: 20 })
-    await comfyPage.page.mouse.up({ button: 'middle' })
+    const panStep = canvasBox.height / 3
+    for (let step = 0; step < 3; step++) {
+      await comfyPage.page.mouse.move(centerX, centerY)
+      await comfyPage.page.mouse.down({ button: 'middle' })
+      await comfyPage.page.mouse.move(centerX, centerY - panStep, { steps: 20 })
+      await comfyPage.page.mouse.up({ button: 'middle' })
+    }
 
     await expect
       .poll(async () => {
         const currentNodeIds = await comfyPage.vueNodes.getNodeIds()
-        return currentNodeIds.some((id) => !initialNodeIds.includes(id))
+        const hasMountedNode = currentNodeIds.some(
+          (id) => !initialNodeIds.includes(id)
+        )
+        const hasUnmountedNode = initialNodeIds.some(
+          (id) => !currentNodeIds.includes(id)
+        )
+        return hasMountedNode && hasUnmountedNode
       })
       .toBe(true)
 

--- a/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
+++ b/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
@@ -88,6 +88,22 @@ test.describe('Viewport node virtualization', { tag: ['@canvas'] }, () => {
     await expect(comfyPage.vueNodes.getNodeLocator('2')).toHaveCount(0)
   })
 
+  test('updates a mounted node immediately when it collapses', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+    await comfyPage.canvasOps.setScale(1)
+
+    const node = await comfyPage.nodeOps.getNodeRefById(2)
+    await node.centerOnNode()
+    const vueNode = comfyPage.vueNodes.getNodeLocator('2')
+    await expect(vueNode).not.toHaveAttribute('data-collapsed', 'true')
+
+    await vueNode.getByTestId('node-collapse-button').click()
+
+    await expect(vueNode).toHaveAttribute('data-collapsed', 'true')
+  })
+
   test('preserves links and output updates while a node is offscreen', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
+++ b/browser_tests/tests/vueNodes/viewportVirtualization.spec.ts
@@ -111,6 +111,10 @@ test.describe('Viewport node virtualization', { tag: ['@canvas'] }, () => {
     await vueNode.getByTestId('node-collapse-button').click()
 
     await expect(vueNode).toHaveAttribute('data-collapsed', 'true')
+
+    await vueNode.getByTestId('node-collapse-button').click()
+
+    await expect(vueNode).not.toHaveAttribute('data-collapsed', 'true')
   })
 
   test('preserves links and output updates while a node is offscreen', async ({

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -62,6 +62,13 @@
     class="absolute inset-0 size-full touch-none"
   />
 
+  <LinkOverlayCanvas
+    v-if="shouldRenderVueNodes && comfyApp.canvas && comfyAppReady"
+    :canvas="comfyApp.canvas"
+    @ready="onLinkOverlayReady"
+    @dispose="onLinkOverlayDispose"
+  />
+
   <!-- TransformPane for Vue node rendering -->
   <TransformPane
     v-if="shouldRenderVueNodes && comfyApp.canvas && comfyAppReady"
@@ -84,13 +91,6 @@
       :data-node-id="nodeData.id"
     />
   </TransformPane>
-
-  <LinkOverlayCanvas
-    v-if="shouldRenderVueNodes && comfyApp.canvas && comfyAppReady"
-    :canvas="comfyApp.canvas"
-    @ready="onLinkOverlayReady"
-    @dispose="onLinkOverlayDispose"
-  />
 
   <!-- Selection rectangle overlay - rendered in DOM layer to appear above DOM widgets -->
   <SelectionRectangle

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -124,6 +124,7 @@ import {
   onUnmounted,
   ref,
   shallowRef,
+  triggerRef,
   useTemplateRef,
   watch,
   watchEffect
@@ -322,7 +323,9 @@ watch(
         enabled: true
       })
       watchEffect(() => {
-        renderNodes.value = virtualization.renderNodes.value
+        const next = virtualization.renderNodes.value
+        if (renderNodes.value === next) triggerRef(renderNodes)
+        else renderNodes.value = next
       })
     })
   },

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -118,6 +118,7 @@
 import { until, useEventListener } from '@vueuse/core'
 import {
   computed,
+  effectScope,
   nextTick,
   onMounted,
   onUnmounted,
@@ -297,11 +298,29 @@ const allNodes = computed((): VueNodeData[] =>
 const viewportVirtualizationEnabled = computed(() =>
   settingStore.get('Comfy.VueNodes.ViewportVirtualization')
 )
-const { renderNodes } = useViewportNodeVirtualization({
-  allNodes,
-  canvas: () => canvasStore.canvas,
-  enabled: viewportVirtualizationEnabled
-})
+const renderNodes = shallowRef<readonly VueNodeData[]>([])
+let viewportVirtualizationScope = effectScope()
+watch(
+  shouldRenderVueNodes,
+  (enabled) => {
+    viewportVirtualizationScope.stop()
+    viewportVirtualizationScope = effectScope()
+    renderNodes.value = []
+    if (!enabled) return
+
+    viewportVirtualizationScope.run(() => {
+      const virtualization = useViewportNodeVirtualization({
+        allNodes,
+        canvas: () => canvasStore.canvas,
+        enabled: viewportVirtualizationEnabled
+      })
+      watchEffect(() => {
+        renderNodes.value = virtualization.renderNodes.value
+      })
+    })
+  },
+  { immediate: true }
+)
 watch(
   () => linearMode.value,
   (isLinearMode) => {
@@ -594,6 +613,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  viewportVirtualizationScope.stop()
   cleanupErrorHooks?.()
   cleanupErrorHooks = null
   vueNodeLifecycle.cleanup()

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -301,18 +301,25 @@ const viewportVirtualizationEnabled = computed(() =>
 const renderNodes = shallowRef<readonly VueNodeData[]>([])
 let viewportVirtualizationScope = effectScope()
 watch(
-  shouldRenderVueNodes,
-  (enabled) => {
+  [shouldRenderVueNodes, viewportVirtualizationEnabled],
+  ([renderVueNodes, virtualize]) => {
     viewportVirtualizationScope.stop()
     viewportVirtualizationScope = effectScope()
     renderNodes.value = []
-    if (!enabled) return
+    if (!renderVueNodes) return
 
     viewportVirtualizationScope.run(() => {
+      if (!virtualize) {
+        watchEffect(() => {
+          renderNodes.value = allNodes.value
+        })
+        return
+      }
+
       const virtualization = useViewportNodeVirtualization({
         allNodes,
         canvas: () => canvasStore.canvas,
-        enabled: viewportVirtualizationEnabled
+        enabled: true
       })
       watchEffect(() => {
         renderNodes.value = virtualization.renderNodes.value

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -73,7 +73,7 @@
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <LGraphNode
-      v-for="nodeData in allNodes"
+      v-for="nodeData in renderNodes"
       :key="nodeData.id"
       :node-data="nodeData"
       :error="
@@ -158,6 +158,7 @@ import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { useViewportNodeVirtualization } from '@/composables/graph/useViewportNodeVirtualization'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
@@ -293,6 +294,14 @@ watch(
 const allNodes = computed((): VueNodeData[] =>
   Array.from(vueNodeLifecycle.nodeManager.value?.vueNodeData?.values() ?? [])
 )
+const viewportVirtualizationEnabled = computed(() =>
+  settingStore.get('Comfy.VueNodes.ViewportVirtualization')
+)
+const { renderNodes } = useViewportNodeVirtualization({
+  allNodes,
+  canvas: () => canvasStore.canvas,
+  enabled: viewportVirtualizationEnabled
+})
 watch(
   () => linearMode.value,
   (isLinearMode) => {

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -839,6 +839,23 @@ describe('Tracked slot model reconciliation', () => {
     expect(layoutStore.getSlotLayout(outputKey)).toBeNull()
   })
 
+  it('tracks slot counts without traversing nested slot payloads', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    node.addInput('input', 'INT')
+    graph.add(node)
+    const input = node.inputs?.[0]
+    expect(input).toBeDefined()
+    Object.defineProperty(input!, 'deepTraversalTrap', {
+      enumerable: true,
+      get: () => {
+        throw new Error('slot payload was traversed')
+      }
+    })
+
+    expect(() => useGraphNodeManager(graph)).not.toThrow()
+  })
+
   it('retains same-ID slot geometry until graph configuration completes', () => {
     const graph = new LGraph()
     const node = new LGraphNode('test')

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -13,7 +13,10 @@ import {
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { SlotLayout } from '@/renderer/core/layout/types'
+import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
 import { app } from '@/scripts/app'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -774,6 +777,78 @@ describe('reconcileNodeErrorFlags (via lastNodeErrors watcher)', () => {
 
     expect(interiorNode.has_errors).toBe(true)
     expect(subgraphNode.has_errors).toBe(true)
+  })
+})
+
+describe('Tracked slot model reconciliation', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    layoutStore.initializeFromLiteGraph([])
+  })
+
+  function trackSlot(nodeId: LGraphNode['id'], type: 'input' | 'output') {
+    const slotKey = getSlotKey(nodeId, 0, type === 'input')
+    useNodeSlotRegistryStore()
+      .ensureNode(nodeId)
+      .slots.set(slotKey, { index: 0, type })
+    const layout: SlotLayout = {
+      nodeId,
+      index: 0,
+      type,
+      position: { x: 10, y: 20 },
+      bounds: { x: 10, y: 20, width: 10, height: 10 }
+    }
+    layoutStore.batchUpdateSlotLayouts([{ key: slotKey, layout }])
+    return slotKey
+  }
+
+  it('reacts to slot additions and removes retained geometry after deletion', async () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    graph.add(node)
+    const { vueNodeData } = useGraphNodeManager(graph)
+
+    node.addInput('input', 'INT')
+    node.addOutput('output', 'INT')
+    await nextTick()
+
+    expect(vueNodeData.get(node.id)?.inputs).toHaveLength(1)
+    expect(vueNodeData.get(node.id)?.outputs).toHaveLength(1)
+
+    const inputKey = trackSlot(node.id, 'input')
+    const outputKey = trackSlot(node.id, 'output')
+    node.removeInput(0)
+    node.removeOutput(0)
+    await nextTick()
+
+    expect(layoutStore.getSlotLayout(inputKey)).toBeNull()
+    expect(layoutStore.getSlotLayout(outputKey)).toBeNull()
+  })
+
+  it('retains same-ID slot geometry until graph configuration completes', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    graph.add(node)
+    const slotKey = trackSlot(node.id, 'input')
+    const previousApp = window.app
+    const configuringGraph = vi
+      .spyOn(app, 'configuringGraph', 'get')
+      .mockReturnValue(true)
+
+    try {
+      window.app = app
+      useGraphNodeManager(graph)
+
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+
+      node.addInput('input', 'INT')
+      node.onAfterGraphConfigured?.()
+
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+    } finally {
+      configuringGraph.mockRestore()
+      window.app = previousApp
+    }
   })
 })
 

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -786,14 +786,18 @@ describe('Tracked slot model reconciliation', () => {
     layoutStore.initializeFromLiteGraph([])
   })
 
-  function trackSlot(nodeId: LGraphNode['id'], type: 'input' | 'output') {
-    const slotKey = getSlotKey(nodeId, 0, type === 'input')
+  function trackSlot(
+    nodeId: LGraphNode['id'],
+    type: 'input' | 'output',
+    index = 0
+  ) {
+    const slotKey = getSlotKey(nodeId, index, type === 'input')
     useNodeSlotRegistryStore()
       .ensureNode(nodeId)
-      .slots.set(slotKey, { index: 0, type })
+      .slots.set(slotKey, { index, type })
     const layout: SlotLayout = {
       nodeId,
-      index: 0,
+      index,
       type,
       position: { x: 10, y: 20 },
       bounds: { x: 10, y: 20, width: 10, height: 10 }
@@ -830,6 +834,7 @@ describe('Tracked slot model reconciliation', () => {
     const node = new LGraphNode('test')
     graph.add(node)
     const slotKey = trackSlot(node.id, 'input')
+    const outOfRangeSlotKey = trackSlot(node.id, 'input', 1)
     const previousApp = window.app
     const configuringGraph = vi
       .spyOn(app, 'configuringGraph', 'get')
@@ -845,6 +850,7 @@ describe('Tracked slot model reconciliation', () => {
       node.onAfterGraphConfigured?.()
 
       expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      expect(layoutStore.getSlotLayout(outOfRangeSlotKey)).toBeNull()
     } finally {
       configuringGraph.mockRestore()
       window.app = previousApp

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -872,6 +872,7 @@ describe('Tracked slot model reconciliation', () => {
       useGraphNodeManager(graph)
 
       expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      expect(layoutStore.getSlotLayout(outOfRangeSlotKey)).not.toBeNull()
 
       node.addInput('input', 'INT')
       node.onAfterGraphConfigured?.()

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -13,6 +13,7 @@ import {
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { app } from '@/scripts/app'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
@@ -84,6 +85,28 @@ describe('Node Reactivity', () => {
 
     expect(onValueChange).toHaveBeenCalledTimes(1)
     expect(widgetValue.value).toBe(99)
+  })
+})
+
+describe('Node layout stacking', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    layoutStore.initializeFromLiteGraph([])
+  })
+
+  it('uses graph render order instead of execution order for initial z-index', () => {
+    const graph = new LGraph()
+    const backNode = new LGraphNode('back')
+    const frontNode = new LGraphNode('front')
+    graph.add(backNode)
+    graph.add(frontNode)
+    backNode.order = 99
+    frontNode.order = 1
+
+    useGraphNodeManager(graph)
+
+    expect(layoutStore.getNodeLayoutRef(backNode.id).value?.zIndex).toBe(0)
+    expect(layoutStore.getNodeLayoutRef(frontNode.id).value?.zIndex).toBe(1)
   })
 })
 

--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -794,7 +794,11 @@ describe('Tracked slot model reconciliation', () => {
     const slotKey = getSlotKey(nodeId, index, type === 'input')
     useNodeSlotRegistryStore()
       .ensureNode(nodeId)
-      .slots.set(slotKey, { index, type })
+      .slots.set(slotKey, {
+        index,
+        type,
+        cachedOffset: { x: 10, y: 20 }
+      })
     const layout: SlotLayout = {
       nodeId,
       index,
@@ -812,20 +816,26 @@ describe('Tracked slot model reconciliation', () => {
     graph.add(node)
     const { vueNodeData } = useGraphNodeManager(graph)
 
-    node.addInput('input', 'INT')
+    node.addInput('first input', 'INT')
+    node.addInput('second input', 'INT')
     node.addOutput('output', 'INT')
     await nextTick()
 
-    expect(vueNodeData.get(node.id)?.inputs).toHaveLength(1)
+    expect(vueNodeData.get(node.id)?.inputs).toHaveLength(2)
     expect(vueNodeData.get(node.id)?.outputs).toHaveLength(1)
 
-    const inputKey = trackSlot(node.id, 'input')
+    const inputKey0 = trackSlot(node.id, 'input', 0)
+    const inputKey1 = trackSlot(node.id, 'input', 1)
     const outputKey = trackSlot(node.id, 'output')
+    const trackedNode = useNodeSlotRegistryStore().getNode(node.id)
+
     node.removeInput(0)
     node.removeOutput(0)
     await nextTick()
 
-    expect(layoutStore.getSlotLayout(inputKey)).toBeNull()
+    expect(trackedNode?.slots.get(inputKey0)?.cachedOffset).toBeUndefined()
+    expect(layoutStore.getSlotLayout(inputKey0)).not.toBeNull()
+    expect(layoutStore.getSlotLayout(inputKey1)).toBeNull()
     expect(layoutStore.getSlotLayout(outputKey)).toBeNull()
   })
 

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -4,7 +4,7 @@
  */
 import { reactiveComputed } from '@vueuse/core'
 import cloneDeep from 'es-toolkit/compat/cloneDeep'
-import { reactive, shallowReactive } from 'vue'
+import { reactive, shallowReactive, watch } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { promotedInputWidgets } from '@/core/graph/subgraph/promotedInputWidget'
@@ -17,6 +17,10 @@ import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import {
+  deleteTrackedNodeSlots,
+  reconcileTrackedNodeSlots
+} from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -484,6 +488,19 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
   // Non-reactive storage for original LiteGraph nodes
   const nodeRefs = new Map<NodeId, LGraphNode>()
+  const nodeSlotModelStops = new Map<NodeId, () => void>()
+
+  const watchNodeSlotModel = (node: LGraphNode) => {
+    nodeSlotModelStops.get(node.id)?.()
+    const stop = watch(
+      [() => node.inputs?.length ?? 0, () => node.outputs?.length ?? 0],
+      ([inputCount, outputCount]) => {
+        reconcileTrackedNodeSlots(node.id, inputCount, outputCount)
+      },
+      { immediate: true }
+    )
+    nodeSlotModelStops.set(node.id, stop)
+  }
 
   const refreshNodeSlots = (nodeId: NodeId) => {
     const nodeRef = nodeRefs.get(nodeId)
@@ -544,6 +561,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
     // Extract initial data for Vue (may be incomplete during graph configure)
     vueNodeData.set(id, extractVueNodeData(node))
+    watchNodeSlotModel(node)
 
     const initializeVueNodeLayout = () => {
       // Check if the node was removed mid-sequence
@@ -593,6 +611,8 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
   }
 
   const dropNodeReferences = (id: NodeId) => {
+    nodeSlotModelStops.get(id)?.()
+    nodeSlotModelStops.delete(id)
     nodeRefs.delete(id)
     vueNodeData.delete(id)
   }
@@ -606,6 +626,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
     // Remove node from layout store
     setSource(LayoutSource.Canvas)
     void deleteNode(id)
+    deleteTrackedNodeSlots(id)
     dropNodeReferences(id)
     originalCallback?.(node)
   }
@@ -631,6 +652,8 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       )
 
       // Clear all state maps
+      nodeSlotModelStops.forEach((stop) => stop())
+      nodeSlotModelStops.clear()
       nodeRefs.clear()
       vueNodeData.clear()
     }

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -497,10 +497,14 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
     const reconcileNodeSlots = () => {
       reconcileTrackedNodeSlots(node.id, inputs.length, outputs.length)
     }
-    const stop = watch([inputs, outputs], reconcileNodeSlots, {
-      deep: true,
-      immediate
-    })
+    // extractVueNodeData wraps both arrays with shallowReactive. Reconciliation
+    // only depends on their counts; a deep watch would traverse link and graph
+    // objects stored in slot payloads while large workflows are configuring.
+    const stop = watch(
+      [() => inputs.length, () => outputs.length],
+      reconcileNodeSlots,
+      { immediate }
+    )
     nodeSlotModelStops.set(node.id, stop)
     return reconcileNodeSlots
   }

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -492,16 +492,18 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
   const watchNodeSlotModel = (node: LGraphNode, immediate: boolean) => {
     nodeSlotModelStops.get(node.id)?.()
-    const inputs = node.inputs ?? []
-    const outputs = node.outputs ?? []
     const reconcileNodeSlots = () => {
-      reconcileTrackedNodeSlots(node.id, inputs.length, outputs.length)
+      reconcileTrackedNodeSlots(
+        node.id,
+        node.inputs?.length ?? 0,
+        node.outputs?.length ?? 0
+      )
     }
     // extractVueNodeData wraps both arrays with shallowReactive. Reconciliation
     // only depends on their counts; a deep watch would traverse link and graph
     // objects stored in slot payloads while large workflows are configuring.
     const stop = watch(
-      [() => inputs.length, () => outputs.length],
+      [() => node.inputs?.length ?? 0, () => node.outputs?.length ?? 0],
       reconcileNodeSlots,
       { immediate }
     )

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -570,6 +570,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       // Extract actual positions after configure() has potentially updated them
       const nodePosition = { x: node.pos[0], y: node.pos[1] }
       const nodeSize = { width: node.size[0], height: node.size[1] }
+      const graphIndex = graph._nodes.indexOf(node)
 
       // Skip layout creation if it already exists
       // (e.g. in-place node replacement where the old node's layout is reused for the new node with the same ID).
@@ -581,7 +582,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
       void createNode(id, {
         position: nodePosition,
         size: nodeSize,
-        zIndex: node.order || 0,
+        zIndex: graphIndex >= 0 ? graphIndex : graph._nodes.length,
         visible: true
       })
     }

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -490,16 +490,19 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
   const nodeRefs = new Map<NodeId, LGraphNode>()
   const nodeSlotModelStops = new Map<NodeId, () => void>()
 
-  const watchNodeSlotModel = (node: LGraphNode) => {
+  const watchNodeSlotModel = (node: LGraphNode, immediate: boolean) => {
     nodeSlotModelStops.get(node.id)?.()
-    const stop = watch(
-      [() => node.inputs?.length ?? 0, () => node.outputs?.length ?? 0],
-      ([inputCount, outputCount]) => {
-        reconcileTrackedNodeSlots(node.id, inputCount, outputCount)
-      },
-      { immediate: true }
-    )
+    const inputs = node.inputs ?? []
+    const outputs = node.outputs ?? []
+    const reconcileNodeSlots = () => {
+      reconcileTrackedNodeSlots(node.id, inputs.length, outputs.length)
+    }
+    const stop = watch([inputs, outputs], reconcileNodeSlots, {
+      deep: true,
+      immediate
+    })
     nodeSlotModelStops.set(node.id, stop)
+    return reconcileNodeSlots
   }
 
   const refreshNodeSlots = (nodeId: NodeId) => {
@@ -561,7 +564,8 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
 
     // Extract initial data for Vue (may be incomplete during graph configure)
     vueNodeData.set(id, extractVueNodeData(node))
-    watchNodeSlotModel(node)
+    const isConfiguringGraph = Boolean(window.app?.configuringGraph)
+    const reconcileNodeSlots = watchNodeSlotModel(node, !isConfiguringGraph)
 
     const initializeVueNodeLayout = () => {
       // Check if the node was removed mid-sequence
@@ -588,7 +592,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
     }
 
     // Check if we're in the middle of configuring the graph (workflow loading)
-    if (window.app?.configuringGraph) {
+    if (isConfiguringGraph) {
       // During workflow loading - defer layout initialization until configure completes
       // Chain our callback with any existing onAfterGraphConfigured callback
       node.onAfterGraphConfigured = useChainCallback(
@@ -596,6 +600,7 @@ export function useGraphNodeManager(graph: LGraph): GraphNodeManager {
         () => {
           // Re-extract data now that configure() has populated title/slots/widgets/etc.
           vueNodeData.set(id, extractVueNodeData(node))
+          reconcileNodeSlots()
           initializeVueNodeLayout()
         }
       )

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -202,27 +202,32 @@ describe('useViewportNodeVirtualization', () => {
     const secondNode = createNode('b')
     const allNodes = shallowRef([firstNode])
     vi.spyOn(layoutStore, 'getRevision').mockReturnValue(1)
-    const hasNodeLayout = vi
-      .spyOn(layoutStore, 'hasNodeLayout')
-      .mockImplementation((nodeId) => nodeId === firstNode.id)
+    vi.spyOn(layoutStore, 'hasNodeLayout').mockImplementation(
+      (nodeId) => nodeId === firstNode.id
+    )
     vi.spyOn(layoutStore, 'queryNodesInBounds').mockReturnValue([firstNode.id])
     const scope = effectScope()
-
-    scope.run(() => {
-      const { refresh } = useViewportNodeVirtualization({
+    const virtualization = scope.run(() =>
+      useViewportNodeVirtualization({
         allNodes,
         canvas: createCanvas(),
         enabled: true
       })
+    )
+    if (!virtualization) {
+      scope.stop()
+      throw new Error('Expected virtualization scope to initialize')
+    }
 
-      refresh(true)
-      hasNodeLayout.mockClear()
+    try {
+      virtualization.refresh(true)
       allNodes.value = [secondNode]
-      refresh(true)
-    })
+      virtualization.refresh(true)
+    } finally {
+      scope.stop()
+    }
 
-    expect(hasNodeLayout).toHaveBeenCalledWith(secondNode.id)
-    scope.stop()
+    expect(virtualization.renderNodes.value).toEqual(allNodes.value)
   })
 })
 

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -10,7 +10,7 @@ import {
   getViewportBounds,
   useViewportNodeVirtualization
 } from '@/composables/graph/useViewportNodeVirtualization'
-import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toNodeId } from '@/types/nodeId'
 
@@ -228,6 +228,39 @@ describe('useViewportNodeVirtualization', () => {
     }
 
     expect(virtualization.renderNodes.value).toEqual(allNodes.value)
+  })
+
+  it('keeps an offscreen input-capturing node pinned', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const offscreenNode = createNode('offscreen')
+    const canvas = createCanvas()
+    canvas.node_capturing_input = { id: offscreenNode.id } as LGraphNode
+    vi.spyOn(layoutStore, 'getRevision').mockReturnValue(1)
+    vi.spyOn(layoutStore, 'hasNodeLayout').mockReturnValue(true)
+    vi.spyOn(layoutStore, 'queryNodesInBounds').mockReturnValue([])
+    const scope = effectScope()
+    const virtualization = scope.run(() =>
+      useViewportNodeVirtualization({
+        allNodes: [offscreenNode],
+        canvas,
+        enabled: true
+      })
+    )
+    if (!virtualization) {
+      scope.stop()
+      throw new Error('Expected virtualization scope to initialize')
+    }
+
+    try {
+      virtualization.refresh(true)
+      expect(virtualization.renderNodes.value).toEqual([offscreenNode])
+
+      canvas.node_capturing_input = null
+      virtualization.refresh(true)
+      expect(virtualization.renderNodes.value).toEqual([])
+    } finally {
+      scope.stop()
+    }
   })
 })
 

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -29,7 +29,7 @@ function createCanvas(options?: {
   element.width = options?.width ?? 1000
   element.height = options?.height ?? 500
 
-  return {
+  const canvas = {
     ds: {
       element,
       scale: options?.scale ?? 2,
@@ -37,6 +37,10 @@ function createCanvas(options?: {
     },
     viewport: options?.viewport
   } as LGraphCanvas
+  Object.defineProperty(canvas, 'linkConnector', {
+    value: { renderLinks: [] }
+  })
+  return canvas
 }
 
 function createNode(id: string): VueNodeData {
@@ -189,6 +193,35 @@ describe('useViewportNodeVirtualization', () => {
     await nextTick()
 
     expect(observedTitles.at(-1)).toBe('updated')
+    scope.stop()
+  })
+
+  it('rechecks layout readiness when the node IDs change', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const firstNode = createNode('a')
+    const secondNode = createNode('b')
+    const allNodes = shallowRef([firstNode])
+    vi.spyOn(layoutStore, 'getRevision').mockReturnValue(1)
+    const hasNodeLayout = vi
+      .spyOn(layoutStore, 'hasNodeLayout')
+      .mockImplementation((nodeId) => nodeId === firstNode.id)
+    vi.spyOn(layoutStore, 'queryNodesInBounds').mockReturnValue([firstNode.id])
+    const scope = effectScope()
+
+    scope.run(() => {
+      const { refresh } = useViewportNodeVirtualization({
+        allNodes,
+        canvas: createCanvas(),
+        enabled: true
+      })
+
+      refresh(true)
+      hasNodeLayout.mockClear()
+      allNodes.value = [secondNode]
+      refresh(true)
+    })
+
+    expect(hasNodeLayout).toHaveBeenCalledWith(secondNode.id)
     scope.stop()
   })
 })

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import {
+  createPinnedNodeIds,
+  createRenderNodeList,
+  getViewportBounds
+} from '@/composables/graph/useViewportNodeVirtualization'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+
+function createCanvas(options?: {
+  width?: number
+  height?: number
+  scale?: number
+  offset?: [number, number]
+  viewport?: [number, number, number, number]
+}): LGraphCanvas {
+  const element = document.createElement('canvas')
+  element.width = options?.width ?? 1000
+  element.height = options?.height ?? 500
+
+  return {
+    ds: {
+      element,
+      scale: options?.scale ?? 2,
+      offset: options?.offset ?? [10, 20]
+    },
+    viewport: options?.viewport
+  } as LGraphCanvas
+}
+
+function createNode(id: string): VueNodeData {
+  return {
+    id: toNodeId(id),
+    title: id,
+    type: 'TestNode',
+    mode: 0,
+    selected: false,
+    executing: false
+  }
+}
+
+describe('getViewportBounds', () => {
+  it('matches the canvas transform with 25 percent overscan', () => {
+    expect(getViewportBounds(createCanvas())).toEqual({
+      x: -135,
+      y: -82.5,
+      width: 750,
+      height: 375
+    })
+  })
+
+  it('uses the configured LiteGraph viewport', () => {
+    expect(
+      getViewportBounds(createCanvas({ viewport: [100, 50, 400, 200] }))
+    ).toEqual({
+      x: -10,
+      y: -20,
+      width: 300,
+      height: 150
+    })
+  })
+
+  it('updates for pan, zoom, and canvas resize', () => {
+    const initial = getViewportBounds(createCanvas())
+    const panned = getViewportBounds(createCanvas({ offset: [20, 30] }))
+    const zoomed = getViewportBounds(createCanvas({ scale: 1 }))
+    const resized = getViewportBounds(createCanvas({ width: 1200 }))
+
+    expect(panned?.x).toBe(initial!.x - 10)
+    expect(panned?.y).toBe(initial!.y - 10)
+    expect(zoomed?.width).toBe(initial!.width * 2)
+    expect(resized?.width).toBe(initial!.width * 1.2)
+  })
+})
+
+describe('createRenderNodeList', () => {
+  const nodes = ['a', 'b', 'c', 'd'].map(createNode)
+
+  it('preserves graph order while combining visible and pinned nodes', () => {
+    const result = createRenderNodeList({
+      allNodes: nodes,
+      enabled: true,
+      layoutReady: true,
+      visibleNodeIds: new Set([nodes[2].id, nodes[0].id]),
+      pinnedNodeIds: new Set([nodes[3].id]),
+      previous: []
+    })
+
+    expect(result.map((node) => node.id)).toEqual([
+      nodes[0].id,
+      nodes[2].id,
+      nodes[3].id
+    ])
+  })
+
+  it('retains the render array when its node IDs are unchanged', () => {
+    const previous = [nodes[0], nodes[2]]
+    const refreshedNodes = nodes.map((node) => ({ ...node }))
+    const result = createRenderNodeList({
+      allNodes: refreshedNodes,
+      enabled: true,
+      layoutReady: true,
+      visibleNodeIds: new Set([nodes[0].id, nodes[2].id]),
+      pinnedNodeIds: new Set(),
+      previous
+    })
+
+    expect(result).toBe(previous)
+    expect(result[0]).toBe(refreshedNodes[0])
+    expect(result[1]).toBe(refreshedNodes[2])
+  })
+
+  it.for([
+    { enabled: false, layoutReady: true },
+    { enabled: true, layoutReady: false }
+  ])('renders every node for fallback state %o', (state) => {
+    const result = createRenderNodeList({
+      allNodes: nodes,
+      ...state,
+      visibleNodeIds: new Set(),
+      pinnedNodeIds: new Set(),
+      previous: []
+    })
+
+    expect(result).toEqual(nodes)
+  })
+})
+
+describe('createPinnedNodeIds', () => {
+  const ids = Array.from({ length: 9 }, (_, index) =>
+    toNodeId(String(index + 1))
+  )
+
+  it('includes every active-node pinning source', () => {
+    const result = createPinnedNodeIds({
+      activePointerNodeIds: [ids[0]],
+      selectedNodeIds: [ids[1], ids[2]],
+      focusedNodeId: ids[3],
+      titleEditedNodeId: ids[4],
+      contextMenuTargetNodeIds: [ids[5]],
+      capturingInputNodeId: ids[6],
+      linkEndpointNodeIds: [ids[7], ids[8]]
+    })
+
+    expect(result).toEqual(new Set(ids))
+  })
+})

--- a/src/composables/graph/useViewportNodeVirtualization.test.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.test.ts
@@ -1,13 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, shallowRef, watchEffect } from 'vue'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import {
   createPinnedNodeIds,
   createRenderNodeList,
-  getViewportBounds
+  getViewportBounds,
+  useViewportNodeVirtualization
 } from '@/composables/graph/useViewportNodeVirtualization'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toNodeId } from '@/types/nodeId'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function createCanvas(options?: {
   width?: number
@@ -125,6 +134,62 @@ describe('createRenderNodeList', () => {
     })
 
     expect(result).toEqual(nodes)
+  })
+})
+
+describe('useViewportNodeVirtualization', () => {
+  it('avoids canvas and layout bookkeeping while disabled', () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const canvas = vi.fn(() => createCanvas())
+    const getLayoutRevision = vi.spyOn(layoutStore, 'getRevision')
+    const scope = effectScope()
+
+    scope.run(() => {
+      const { renderNodes, refresh } = useViewportNodeVirtualization({
+        allNodes: [createNode('a')],
+        canvas,
+        enabled: false
+      })
+
+      refresh(true)
+
+      expect(renderNodes.value.map((node) => node.id)).toEqual([toNodeId('a')])
+    })
+
+    expect(canvas).not.toHaveBeenCalled()
+    expect(getLayoutRevision).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
+  it('publishes refreshed node data without replacing a stable render list', async () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    const allNodes = shallowRef([createNode('a')])
+    const observedTitles: string[] = []
+    const scope = effectScope()
+
+    scope.run(() => {
+      const { renderNodes, refresh } = useViewportNodeVirtualization({
+        allNodes,
+        canvas: null,
+        enabled: false
+      })
+      watchEffect(() => {
+        observedTitles.push(renderNodes.value[0]?.title ?? '')
+      })
+
+      refresh(true)
+      const initialRenderNodes = renderNodes.value
+      allNodes.value = [{ ...allNodes.value[0], title: 'updated' }]
+      refresh(true)
+
+      expect(renderNodes.value).toBe(initialRenderNodes)
+      expect(renderNodes.value[0]?.title).toBe('updated')
+    })
+
+    await nextTick()
+
+    expect(observedTitles.at(-1)).toBe('updated')
+    scope.stop()
   })
 })
 

--- a/src/composables/graph/useViewportNodeVirtualization.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.ts
@@ -345,13 +345,16 @@ export function useViewportNodeVirtualization(options: {
     { flush: 'sync' }
   )
 
+  const { pause, resume } = useRafFn(() => refresh(), { immediate: true })
   watch(
     () => toValue(options.enabled),
-    () => refresh(true),
-    { flush: 'sync' }
+    (enabled) => {
+      if (enabled) resume()
+      else pause()
+      refresh(true)
+    },
+    { flush: 'sync', immediate: true }
   )
-
-  useRafFn(() => refresh(), { immediate: true })
 
   return {
     renderNodes: shallowReadonly(renderNodes),

--- a/src/composables/graph/useViewportNodeVirtualization.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.ts
@@ -149,7 +149,7 @@ export function useViewportNodeVirtualization(options: {
   let cachedPinnedStateKey = ''
   let cachedPinnedNodeIds = new Set<NodeId>()
   let cachedLayoutRevision = -1
-  let cachedLayoutNodeCount = -1
+  let cachedLayoutNodeIds: NodeId[] = []
   let cachedLayoutReady = false
 
   function collectPinnedNodeIds(canvas: LGraphCanvas): Set<NodeId> {
@@ -220,12 +220,12 @@ export function useViewportNodeVirtualization(options: {
     allNodes: readonly VueNodeData[],
     layoutRevision: number
   ): boolean {
-    if (
-      cachedLayoutRevision !== layoutRevision ||
-      cachedLayoutNodeCount !== allNodes.length
-    ) {
+    const nodeIdsChanged =
+      cachedLayoutNodeIds.length !== allNodes.length ||
+      allNodes.some((node, index) => node.id !== cachedLayoutNodeIds[index])
+    if (cachedLayoutRevision !== layoutRevision || nodeIdsChanged) {
       cachedLayoutRevision = layoutRevision
-      cachedLayoutNodeCount = allNodes.length
+      cachedLayoutNodeIds = allNodes.map((node) => node.id)
       cachedLayoutReady = allNodes.every((node) =>
         layoutStore.hasNodeLayout(node.id)
       )

--- a/src/composables/graph/useViewportNodeVirtualization.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.ts
@@ -1,0 +1,274 @@
+import { useEventListener, useRafFn } from '@vueuse/core'
+import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+
+import { isNodeOptionsOpen } from '@/composables/graph/useMoreOptionsMenu'
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import {
+  useCanvasStore,
+  useTitleEditorStore
+} from '@/renderer/core/canvas/canvasStore'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { Bounds } from '@/renderer/core/layout/types'
+import type { NodeId } from '@/types/nodeId'
+import { toNodeId } from '@/types/nodeId'
+import { isLGraphNode } from '@/utils/litegraphUtil'
+
+const VIEWPORT_OVERSCAN_RATIO = 0.25
+
+export function getViewportBounds(
+  canvas: LGraphCanvas,
+  overscanRatio = VIEWPORT_OVERSCAN_RATIO
+): Bounds | null {
+  const { ds, viewport } = canvas
+  const scale = ds.scale
+  if (!(scale > 0) || !ds.element) return null
+
+  let width = ds.element.width
+  let height = ds.element.height
+  let x = -ds.offset[0]
+  let y = -ds.offset[1]
+
+  if (viewport) {
+    x += viewport[0] / scale
+    y += viewport[1] / scale
+    width = viewport[2]
+    height = viewport[3]
+  }
+
+  const graphWidth = width / scale
+  const graphHeight = height / scale
+  const overscanX = graphWidth * overscanRatio
+  const overscanY = graphHeight * overscanRatio
+
+  return {
+    x: x - overscanX,
+    y: y - overscanY,
+    width: graphWidth + overscanX * 2,
+    height: graphHeight + overscanY * 2
+  }
+}
+
+function haveSameNodeIds(
+  left: readonly VueNodeData[],
+  right: readonly VueNodeData[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((node, index) => node.id === right[index]?.id)
+  )
+}
+
+export function createRenderNodeList(options: {
+  allNodes: readonly VueNodeData[]
+  enabled: boolean
+  layoutReady: boolean
+  visibleNodeIds: ReadonlySet<NodeId>
+  pinnedNodeIds: ReadonlySet<NodeId>
+  previous: VueNodeData[]
+}): VueNodeData[] {
+  const {
+    allNodes,
+    enabled,
+    layoutReady,
+    visibleNodeIds,
+    pinnedNodeIds,
+    previous
+  } = options
+  const next =
+    enabled && layoutReady
+      ? allNodes.filter(
+          (node) => visibleNodeIds.has(node.id) || pinnedNodeIds.has(node.id)
+        )
+      : [...allNodes]
+
+  if (!haveSameNodeIds(previous, next)) return next
+
+  // Preserve the array identity while refreshing the per-node data objects.
+  // GraphNodeManager replaces these objects when reactive node state changes.
+  for (let index = 0; index < next.length; index++) {
+    previous[index] = next[index]
+  }
+  return previous
+}
+
+export function createPinnedNodeIds(options: {
+  activePointerNodeIds?: Iterable<NodeId>
+  selectedNodeIds?: Iterable<NodeId>
+  focusedNodeId?: NodeId
+  titleEditedNodeId?: NodeId
+  contextMenuTargetNodeIds?: Iterable<NodeId>
+  capturingInputNodeId?: NodeId
+  linkEndpointNodeIds?: Iterable<NodeId>
+}): Set<NodeId> {
+  const result = new Set(options.activePointerNodeIds)
+  for (const nodeId of options.selectedNodeIds ?? []) result.add(nodeId)
+  for (const nodeId of options.contextMenuTargetNodeIds ?? []) {
+    result.add(nodeId)
+  }
+  for (const nodeId of options.linkEndpointNodeIds ?? []) result.add(nodeId)
+  if (options.focusedNodeId) result.add(options.focusedNodeId)
+  if (options.titleEditedNodeId) result.add(options.titleEditedNodeId)
+  if (options.capturingInputNodeId) result.add(options.capturingInputNodeId)
+  return result
+}
+
+function getNodeIdFromElement(target: EventTarget | null): NodeId | undefined {
+  if (!(target instanceof Element)) return
+  const value = target.closest<HTMLElement>('[data-node-id]')?.dataset.nodeId
+  return value ? toNodeId(value) : undefined
+}
+
+function boundsKey(bounds: Bounds | null): string {
+  if (!bounds) return 'none'
+  return `${bounds.x},${bounds.y},${bounds.width},${bounds.height}`
+}
+
+export function useViewportNodeVirtualization(options: {
+  allNodes: MaybeRefOrGetter<readonly VueNodeData[]>
+  canvas: MaybeRefOrGetter<LGraphCanvas | null | undefined>
+  enabled: MaybeRefOrGetter<boolean>
+}) {
+  const canvasStore = useCanvasStore()
+  const titleEditorStore = useTitleEditorStore()
+  const { state: slotDragState } = useSlotLinkDragUIState()
+  const renderNodes = shallowRef<VueNodeData[]>([])
+  const activePointerNodes = new Map<number, NodeId>()
+  const focusedNodeId = shallowRef<NodeId>()
+
+  let lastNodes: readonly VueNodeData[] | undefined
+  let lastViewportKey = ''
+  let lastLayoutRevision = -1
+  let lastPinnedKey = ''
+  let lastEnabled: boolean | undefined
+
+  function collectPinnedNodeIds(canvas: LGraphCanvas): Set<NodeId> {
+    const titleTarget = titleEditorStore.titleEditorTarget
+    const titleEditedNodeId =
+      titleTarget && isLGraphNode(titleTarget) ? titleTarget.id : undefined
+
+    const selectedNodeIds: NodeId[] = []
+    const contextMenuTargetNodeIds: NodeId[] = []
+    if (
+      layoutStore.isDraggingVueNodes.value ||
+      layoutStore.isResizingVueNodes.value
+    ) {
+      for (const item of canvasStore.selectedItems) {
+        if (isLGraphNode(item)) selectedNodeIds.push(item.id)
+      }
+    }
+
+    if (isNodeOptionsOpen()) {
+      for (const item of canvasStore.selectedItems) {
+        if (isLGraphNode(item)) contextMenuTargetNodeIds.push(item.id)
+      }
+    }
+
+    const linkEndpointNodeIds: NodeId[] = []
+    if (slotDragState.active) {
+      if (slotDragState.source) {
+        linkEndpointNodeIds.push(slotDragState.source.nodeId)
+      }
+      if (slotDragState.candidate) {
+        linkEndpointNodeIds.push(slotDragState.candidate.layout.nodeId)
+      }
+    }
+
+    for (const link of canvas.linkConnector.renderLinks) {
+      if (isLGraphNode(link.node)) linkEndpointNodeIds.push(link.node.id)
+    }
+
+    return createPinnedNodeIds({
+      activePointerNodeIds: activePointerNodes.values(),
+      selectedNodeIds,
+      focusedNodeId: focusedNodeId.value,
+      titleEditedNodeId,
+      contextMenuTargetNodeIds,
+      capturingInputNodeId: canvas.node_capturing_input?.id ?? undefined,
+      linkEndpointNodeIds
+    })
+  }
+
+  function refresh(force = false) {
+    const allNodes = toValue(options.allNodes)
+    const canvas = toValue(options.canvas)
+    const enabled = toValue(options.enabled)
+    const viewportBounds = canvas ? getViewportBounds(canvas) : null
+    const viewportKey = boundsKey(viewportBounds)
+    const layoutRevision = layoutStore.getRevision()
+    const pinnedNodeIds = canvas
+      ? collectPinnedNodeIds(canvas)
+      : new Set<NodeId>()
+    const pinnedKey = [...pinnedNodeIds].sort().join(',')
+
+    if (
+      !force &&
+      lastNodes === allNodes &&
+      lastViewportKey === viewportKey &&
+      lastLayoutRevision === layoutRevision &&
+      lastPinnedKey === pinnedKey &&
+      lastEnabled === enabled
+    ) {
+      return
+    }
+
+    lastNodes = allNodes
+    lastViewportKey = viewportKey
+    lastLayoutRevision = layoutRevision
+    lastPinnedKey = pinnedKey
+    lastEnabled = enabled
+
+    const layoutReady =
+      Boolean(viewportBounds) &&
+      allNodes.every((node) => layoutStore.hasNodeLayout(node.id))
+    const visibleNodeIds =
+      enabled && layoutReady && viewportBounds
+        ? new Set(layoutStore.queryNodesInBounds(viewportBounds))
+        : new Set<NodeId>()
+
+    const previous = renderNodes.value
+    const next = createRenderNodeList({
+      allNodes,
+      enabled,
+      layoutReady,
+      visibleNodeIds,
+      pinnedNodeIds,
+      previous
+    })
+    if (next === previous) triggerRef(renderNodes)
+    else renderNodes.value = next
+  }
+
+  useEventListener(
+    document,
+    'pointerdown',
+    (event) => {
+      const nodeId = getNodeIdFromElement(event.target)
+      if (nodeId) activePointerNodes.set(event.pointerId, nodeId)
+    },
+    { capture: true }
+  )
+  useEventListener(document, ['pointerup', 'pointercancel'], (event) => {
+    activePointerNodes.delete(event.pointerId)
+  })
+  useEventListener(document, ['focusin', 'focusout'], () => {
+    queueMicrotask(() => {
+      focusedNodeId.value = getNodeIdFromElement(document.activeElement)
+    })
+  })
+
+  watch(
+    () => toValue(options.enabled),
+    () => refresh(true),
+    { flush: 'sync' }
+  )
+
+  useRafFn(() => refresh(), { immediate: true })
+
+  return {
+    renderNodes: computed(() => renderNodes.value),
+    refresh
+  }
+}

--- a/src/composables/graph/useViewportNodeVirtualization.ts
+++ b/src/composables/graph/useViewportNodeVirtualization.ts
@@ -1,5 +1,5 @@
 import { useEventListener, useRafFn } from '@vueuse/core'
-import { computed, shallowRef, toValue, triggerRef, watch } from 'vue'
+import { shallowReadonly, shallowRef, toValue, triggerRef, watch } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
 import { isNodeOptionsOpen } from '@/composables/graph/useMoreOptionsMenu'
@@ -139,10 +139,18 @@ export function useViewportNodeVirtualization(options: {
   const focusedNodeId = shallowRef<NodeId>()
 
   let lastNodes: readonly VueNodeData[] | undefined
+  let lastCanvas: LGraphCanvas | null | undefined
   let lastViewportKey = ''
   let lastLayoutRevision = -1
-  let lastPinnedKey = ''
+  let lastPinnedStateKey = ''
   let lastEnabled: boolean | undefined
+  let pinnedStateRevision = 0
+  let cachedPinnedCanvas: LGraphCanvas | undefined
+  let cachedPinnedStateKey = ''
+  let cachedPinnedNodeIds = new Set<NodeId>()
+  let cachedLayoutRevision = -1
+  let cachedLayoutNodeCount = -1
+  let cachedLayoutReady = false
 
   function collectPinnedNodeIds(canvas: LGraphCanvas): Set<NodeId> {
     const titleTarget = titleEditorStore.titleEditorTarget
@@ -191,38 +199,93 @@ export function useViewportNodeVirtualization(options: {
     })
   }
 
+  function getPinnedStateKey(canvas: LGraphCanvas): string {
+    const renderLinkNodeIds = canvas.linkConnector.renderLinks
+      .map((link) => (isLGraphNode(link.node) ? link.node.id : ''))
+      .join(',')
+    return `${pinnedStateRevision}|${isNodeOptionsOpen()}|${canvas.node_capturing_input?.id ?? ''}|${renderLinkNodeIds}`
+  }
+
+  function getPinnedNodeIds(canvas: LGraphCanvas) {
+    const stateKey = getPinnedStateKey(canvas)
+    if (cachedPinnedCanvas !== canvas || cachedPinnedStateKey !== stateKey) {
+      cachedPinnedCanvas = canvas
+      cachedPinnedStateKey = stateKey
+      cachedPinnedNodeIds = collectPinnedNodeIds(canvas)
+    }
+    return { nodeIds: cachedPinnedNodeIds, stateKey }
+  }
+
+  function getLayoutReady(
+    allNodes: readonly VueNodeData[],
+    layoutRevision: number
+  ): boolean {
+    if (
+      cachedLayoutRevision !== layoutRevision ||
+      cachedLayoutNodeCount !== allNodes.length
+    ) {
+      cachedLayoutRevision = layoutRevision
+      cachedLayoutNodeCount = allNodes.length
+      cachedLayoutReady = allNodes.every((node) =>
+        layoutStore.hasNodeLayout(node.id)
+      )
+    }
+    return cachedLayoutReady
+  }
+
   function refresh(force = false) {
     const allNodes = toValue(options.allNodes)
-    const canvas = toValue(options.canvas)
     const enabled = toValue(options.enabled)
+
+    if (!enabled) {
+      if (!force && lastNodes === allNodes && lastEnabled === enabled) return
+
+      lastNodes = allNodes
+      lastEnabled = enabled
+
+      const previous = renderNodes.value
+      const next = createRenderNodeList({
+        allNodes,
+        enabled,
+        layoutReady: false,
+        visibleNodeIds: new Set<NodeId>(),
+        pinnedNodeIds: new Set<NodeId>(),
+        previous
+      })
+      if (next === previous) triggerRef(renderNodes)
+      else renderNodes.value = next
+      return
+    }
+
+    const canvas = toValue(options.canvas)
     const viewportBounds = canvas ? getViewportBounds(canvas) : null
     const viewportKey = boundsKey(viewportBounds)
     const layoutRevision = layoutStore.getRevision()
-    const pinnedNodeIds = canvas
-      ? collectPinnedNodeIds(canvas)
-      : new Set<NodeId>()
-    const pinnedKey = [...pinnedNodeIds].sort().join(',')
+    const pinnedState = canvas ? getPinnedNodeIds(canvas) : undefined
+    const pinnedNodeIds = pinnedState?.nodeIds ?? new Set<NodeId>()
+    const pinnedStateKey = pinnedState?.stateKey ?? 'none'
 
     if (
       !force &&
       lastNodes === allNodes &&
+      lastCanvas === canvas &&
       lastViewportKey === viewportKey &&
       lastLayoutRevision === layoutRevision &&
-      lastPinnedKey === pinnedKey &&
+      lastPinnedStateKey === pinnedStateKey &&
       lastEnabled === enabled
     ) {
       return
     }
 
     lastNodes = allNodes
+    lastCanvas = canvas
     lastViewportKey = viewportKey
     lastLayoutRevision = layoutRevision
-    lastPinnedKey = pinnedKey
+    lastPinnedStateKey = pinnedStateKey
     lastEnabled = enabled
 
     const layoutReady =
-      Boolean(viewportBounds) &&
-      allNodes.every((node) => layoutStore.hasNodeLayout(node.id))
+      Boolean(viewportBounds) && getLayoutReady(allNodes, layoutRevision)
     const visibleNodeIds =
       enabled && layoutReady && viewportBounds
         ? new Set(layoutStore.queryNodesInBounds(viewportBounds))
@@ -246,18 +309,41 @@ export function useViewportNodeVirtualization(options: {
     'pointerdown',
     (event) => {
       const nodeId = getNodeIdFromElement(event.target)
-      if (nodeId) activePointerNodes.set(event.pointerId, nodeId)
+      if (nodeId && activePointerNodes.get(event.pointerId) !== nodeId) {
+        activePointerNodes.set(event.pointerId, nodeId)
+        pinnedStateRevision++
+      }
     },
     { capture: true }
   )
   useEventListener(document, ['pointerup', 'pointercancel'], (event) => {
-    activePointerNodes.delete(event.pointerId)
+    if (activePointerNodes.delete(event.pointerId)) pinnedStateRevision++
   })
   useEventListener(document, ['focusin', 'focusout'], () => {
     queueMicrotask(() => {
       focusedNodeId.value = getNodeIdFromElement(document.activeElement)
     })
   })
+
+  watch(
+    [
+      () => [...canvasStore.selectedNodeIds].join(','),
+      () => layoutStore.isDraggingVueNodes.value,
+      () => layoutStore.isResizingVueNodes.value,
+      () => focusedNodeId.value,
+      () => {
+        const target = titleEditorStore.titleEditorTarget
+        return target && isLGraphNode(target) ? target.id : undefined
+      },
+      () => slotDragState.active,
+      () => slotDragState.source?.nodeId,
+      () => slotDragState.candidate?.layout.nodeId
+    ],
+    () => {
+      pinnedStateRevision++
+    },
+    { flush: 'sync' }
+  )
 
   watch(
     () => toValue(options.enabled),
@@ -268,7 +354,7 @@ export function useViewportNodeVirtualization(options: {
   useRafFn(() => refresh(), { immediate: true })
 
   return {
-    renderNodes: computed(() => renderNodes.value),
+    renderNodes: shallowReadonly(renderNodes),
     refresh
   }
 }

--- a/src/composables/graph/useVueNodeLifecycle.ts
+++ b/src/composables/graph/useVueNodeLifecycle.ts
@@ -8,6 +8,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { clearTrackedSlotLayouts } from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
 import { useLayoutSync } from '@/renderer/core/layout/sync/useLayoutSync'
 import { app as comfyApp } from '@/scripts/app'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
@@ -67,6 +68,7 @@ function useVueNodeLifecycleIndividual() {
 
   const disposeNodeManagerAndSyncs = () => {
     stopSync()
+    clearTrackedSlotLayouts()
     if (!nodeManager.value) return
 
     try {
@@ -151,6 +153,7 @@ function useVueNodeLifecycleIndividual() {
 
   // Cleanup function for component unmounting
   const cleanup = () => {
+    clearTrackedSlotLayouts()
     if (nodeManager.value) {
       nodeManager.value.cleanup()
       nodeManager.value = null

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -430,6 +430,10 @@
     "name": "Modern Node Design (Nodes 2.0)",
     "tooltip": "Modern: DOM-based rendering with enhanced interactivity, native browser features, and updated visual design. Classic: Traditional canvas rendering."
   },
+  "Comfy_VueNodes_ViewportVirtualization": {
+    "name": "Viewport node virtualization",
+    "tooltip": "Mount only nodes near the visible canvas. Disable this if a custom node requires its widgets to remain mounted while offscreen."
+  },
   "Comfy_WidgetControlMode": {
     "name": "Widget control mode",
     "tooltip": "Controls when widget values are updated (randomize/increment/decrement), either before the prompt is queued or after.",

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1202,6 +1202,18 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.27.1'
   },
   {
+    id: 'Comfy.VueNodes.ViewportVirtualization',
+    category: ['Comfy', 'Nodes 2.0', 'ViewportVirtualization'],
+    name: 'Viewport node virtualization',
+    type: 'boolean',
+    tooltip:
+      'Mount only nodes near the visible canvas. Disable this if a custom node requires its widgets to remain mounted while offscreen.',
+    defaultValue: false,
+    sortOrder: 110,
+    experimental: true,
+    versionAdded: '1.48.5'
+  },
+  {
     id: 'Comfy.AppBuilder.VueNodeSwitchDismissed',
     name: 'App Builder Vue Node switch dismissed',
     type: 'hidden',

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1209,7 +1209,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'Mount only nodes near the visible canvas. Disable this if a custom node requires its widgets to remain mounted while offscreen.',
     defaultValue: false,
-    sortOrder: 110,
+    sortOrder: 90,
     experimental: true,
     versionAdded: '1.48.5'
   },

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -476,6 +476,32 @@ describe('layoutStore CRDT operations', () => {
     expect(nodesInBounds).toContain('node-c')
   })
 
+  it.for([
+    { x: -25000, y: -30000 },
+    { x: 25000, y: 30000 }
+  ])('indexes nodes beyond the default canvas bounds', ({ x, y }) => {
+    const nodeId = toNodeId(`far-node-${x}-${y}`)
+    const layout: NodeLayout = {
+      ...createTestNode(nodeId),
+      position: { x, y },
+      bounds: { x, y, width: 200, height: 100 }
+    }
+
+    layoutStore.applyOperation({
+      type: 'createNode',
+      entity: 'node',
+      nodeId,
+      layout,
+      timestamp: Date.now(),
+      source: LayoutSource.External,
+      actor: 'test'
+    })
+
+    expect(
+      layoutStore.queryNodesInBounds({ x, y, width: 200, height: 100 })
+    ).toContain(nodeId)
+  })
+
   it('should maintain operation history', () => {
     const nodeId = toNodeId('test-node-history')
     const layout = createTestNode(nodeId)

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -381,6 +381,14 @@ class LayoutStoreImpl implements LayoutStore {
     return computed(() => this.version)
   }
 
+  getRevision(): number {
+    return this.version
+  }
+
+  hasNodeLayout(nodeId: NodeId): boolean {
+    return this.ynodes.has(String(nodeId))
+  }
+
   /**
    * Query node at point (non-reactive for performance)
    */

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -274,6 +274,8 @@ export interface LayoutStore {
   getNodesInBounds(bounds: Bounds): ComputedRef<NodeId[]>
   getAllNodes(): ComputedRef<ReadonlyMap<NodeId, NodeLayout>>
   getVersion(): ComputedRef<number>
+  getRevision(): number
+  hasNodeLayout(nodeId: NodeId): boolean
 
   // Spatial queries (non-reactive)
   queryNodeAtPoint(point: Point): NodeId | null

--- a/src/renderer/core/spatial/QuadTree.test.ts
+++ b/src/renderer/core/spatial/QuadTree.test.ts
@@ -25,14 +25,17 @@ describe('QuadTree', () => {
       expect(quadTree.size).toBe(1)
     })
 
-    it('should reject items outside bounds', () => {
+    it('should expand to include items outside bounds', () => {
       const success = quadTree.insert(
         'node1',
         { x: -100, y: -100, width: 50, height: 50 },
         'node1'
       )
-      expect(success).toBe(false)
-      expect(quadTree.size).toBe(0)
+      expect(success).toBe(true)
+      expect(quadTree.size).toBe(1)
+      expect(
+        quadTree.query({ x: -110, y: -110, width: 70, height: 70 })
+      ).toEqual(['node1'])
     })
 
     it('should handle duplicate IDs by replacing', () => {
@@ -162,6 +165,22 @@ describe('QuadTree', () => {
         height: 100
       })
       expect(newResults).toContain('node1')
+    })
+
+    it.for([
+      { x: -25000, y: -30000 },
+      { x: 25000, y: 30000 }
+    ])('expands when an item moves to $x, $y', ({ x, y }) => {
+      quadTree.insert(
+        'node1',
+        { x: 100, y: 100, width: 50, height: 50 },
+        'node1'
+      )
+
+      expect(quadTree.update('node1', { x, y, width: 50, height: 50 })).toBe(
+        true
+      )
+      expect(quadTree.query({ x, y, width: 50, height: 50 })).toEqual(['node1'])
     })
   })
 

--- a/src/renderer/core/spatial/QuadTree.test.ts
+++ b/src/renderer/core/spatial/QuadTree.test.ts
@@ -38,6 +38,25 @@ describe('QuadTree', () => {
       ).toEqual(['node1'])
     })
 
+    it.for([
+      { width: 0, height: 0 },
+      { width: -100, height: -100 }
+    ])(
+      'should expand from $width x $height root bounds',
+      ({ width, height }) => {
+        const tree = new QuadTree<string>({ x: 0, y: 0, width, height })
+        const inBounds = { x: 0, y: 0, width: 25, height: 25 }
+        const outOfBounds = { x: 100, y: 100, width: 25, height: 25 }
+
+        expect(tree.insert('in-bounds', inBounds, 'in-bounds')).toBe(true)
+        expect(tree.insert('out-of-bounds', outOfBounds, 'out-of-bounds')).toBe(
+          true
+        )
+        expect(tree.query(inBounds)).toEqual(['in-bounds'])
+        expect(tree.query(outOfBounds)).toEqual(['out-of-bounds'])
+      }
+    )
+
     it('should handle duplicate IDs by replacing', () => {
       quadTree.insert(
         'node1',

--- a/src/renderer/core/spatial/QuadTree.ts
+++ b/src/renderer/core/spatial/QuadTree.ts
@@ -220,6 +220,7 @@ class QuadNode<T> {
 
 export class QuadTree<T> {
   private root: QuadNode<T>
+  private rootBounds: Bounds
   private itemMap: Map<string, QuadTreeItem<T>> = new Map()
   private options: Required<QuadTreeOptions>
 
@@ -230,8 +231,9 @@ export class QuadTree<T> {
       minNodeSize: options.minNodeSize ?? 50
     }
 
+    this.rootBounds = { ...bounds }
     this.root = new QuadNode<T>(
-      bounds,
+      this.rootBounds,
       0,
       this.options.maxDepth,
       this.options.maxItemsPerNode
@@ -244,6 +246,12 @@ export class QuadTree<T> {
     // Remove old item if it exists
     if (this.itemMap.has(id)) {
       this.remove(id)
+    }
+
+    if (!containsBounds(this.rootBounds, bounds)) {
+      this.itemMap.set(id, item)
+      this.expandToFit(bounds)
+      return true
     }
 
     const success = this.root.insert(item)
@@ -281,7 +289,7 @@ export class QuadTree<T> {
 
   clear() {
     this.root = new QuadNode<T>(
-      this.root['bounds'],
+      this.rootBounds,
       0,
       this.options.maxDepth,
       this.options.maxItemsPerNode
@@ -299,4 +307,44 @@ export class QuadTree<T> {
       tree: this.root.getDebugInfo()
     }
   }
+
+  private expandToFit(bounds: Bounds): void {
+    const expanded = { ...this.rootBounds }
+
+    while (bounds.x < expanded.x) {
+      expanded.x -= expanded.width
+      expanded.width *= 2
+    }
+    while (bounds.x + bounds.width > expanded.x + expanded.width) {
+      expanded.width *= 2
+    }
+    while (bounds.y < expanded.y) {
+      expanded.y -= expanded.height
+      expanded.height *= 2
+    }
+    while (bounds.y + bounds.height > expanded.y + expanded.height) {
+      expanded.height *= 2
+    }
+
+    this.rootBounds = expanded
+    this.root = new QuadNode<T>(
+      this.rootBounds,
+      0,
+      this.options.maxDepth,
+      this.options.maxItemsPerNode
+    )
+
+    for (const item of this.itemMap.values()) {
+      this.root.insert(item)
+    }
+  }
+}
+
+function containsBounds(container: Bounds, item: Bounds): boolean {
+  return (
+    item.x >= container.x &&
+    item.y >= container.y &&
+    item.x + item.width <= container.x + container.width &&
+    item.y + item.height <= container.y + container.height
+  )
 }

--- a/src/renderer/core/spatial/QuadTree.ts
+++ b/src/renderer/core/spatial/QuadTree.ts
@@ -309,7 +309,13 @@ export class QuadTree<T> {
   }
 
   private expandToFit(bounds: Bounds): void {
-    const expanded = { ...this.rootBounds }
+    const fallbackSize =
+      this.options.minNodeSize > 0 ? this.options.minNodeSize : 1
+    const expanded = {
+      ...this.rootBounds,
+      width: this.rootBounds.width > 0 ? this.rootBounds.width : fallbackSize,
+      height: this.rootBounds.height > 0 ? this.rootBounds.height : fallbackSize
+    }
 
     while (bounds.x < expanded.x) {
       expanded.x -= expanded.width

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/vue'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { toNodeId } from '@/types/nodeId'
 import { defineComponent, nextTick, ref } from 'vue'
@@ -26,25 +26,9 @@ import {
 } from './useSlotElementTracking'
 
 const mockGraph = vi.hoisted(() => ({ _nodes: [] as unknown[] }))
-const mockCanvasState = vi.hoisted(() => ({
-  canvas: {} as object | null
-}))
-const mockClientPosToCanvasPos = vi.hoisted(() =>
-  vi.fn(([x, y]: [number, number]) => [x * 0.5, y * 0.5] as [number, number])
-)
 
 vi.mock('@/scripts/app', () => ({
   app: { canvas: { graph: mockGraph, setDirty: vi.fn() } }
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => mockCanvasState
-}))
-
-vi.mock('@/composables/element/useCanvasPositionConversion', () => ({
-  useSharedCanvasPositionConversion: () => ({
-    clientPosToCanvasPos: mockClientPosToCanvasPos
-  })
 }))
 
 const NODE_ID = toNodeId('test-node')
@@ -67,11 +51,15 @@ function createTestSetup(type: 'input' | 'output') {
   return { el, TestComponent }
 }
 
-function createSlotElement(collapsed = false): HTMLElement {
+function createSlotElement(
+  collapsed = false,
+  rects?: { node?: DOMRect; slot?: DOMRect }
+): HTMLElement {
   const container = document.createElement('div')
   container.dataset.nodeId = NODE_ID
   if (collapsed) container.dataset.collapsed = ''
   container.getBoundingClientRect = () =>
+    rects?.node ??
     ({
       left: 0,
       top: 0,
@@ -82,11 +70,12 @@ function createSlotElement(collapsed = false): HTMLElement {
       x: 0,
       y: 0,
       toJSON: () => ({})
-    }) as DOMRect
+    } as DOMRect)
   document.body.appendChild(container)
 
   const el = document.createElement('div')
   el.getBoundingClientRect = () =>
+    rects?.slot ??
     ({
       left: 10,
       top: 30,
@@ -97,7 +86,7 @@ function createSlotElement(collapsed = false): HTMLElement {
       x: 10,
       y: 30,
       toJSON: () => ({})
-    }) as DOMRect
+    } as DOMRect)
   container.appendChild(el)
 
   return el
@@ -106,10 +95,13 @@ function createSlotElement(collapsed = false): HTMLElement {
 /**
  * Mount the wrapper, set the element ref, and wait for slot registration.
  */
-async function mountAndRegisterSlot(type: 'input' | 'output') {
+async function mountAndRegisterSlot(
+  type: 'input' | 'output',
+  rects?: { node?: DOMRect; slot?: DOMRect }
+) {
   const { el, TestComponent } = createTestSetup(type)
   const { unmount } = render(TestComponent)
-  el.value = createSlotElement()
+  el.value = createSlotElement(false, rects)
   await nextTick()
   flushScheduledSlotLayoutSync()
   return { unmount }
@@ -137,8 +129,10 @@ describe('useSlotElementTracking', () => {
       actor: 'test'
     })
     mockGraph._nodes = [{ id: 1 }]
-    mockCanvasState.canvas = {}
-    mockClientPosToCanvasPos.mockClear()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
   })
 
   it.for([
@@ -310,13 +304,18 @@ describe('useSlotElementTracking', () => {
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     first.unmount()
 
-    const second = await mountAndRegisterSlot('input')
+    const second = await mountAndRegisterSlot('input', {
+      slot: new DOMRect(30, 50, 10, 10)
+    })
     const entry = useNodeSlotRegistryStore()
       .getNode(NODE_ID)
       ?.slots.get(slotKey)
 
     expect(entry?.el?.isConnected).toBe(true)
-    expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+    expect(layoutStore.getSlotLayout(slotKey)?.position).toEqual({
+      x: 35,
+      y: 25
+    })
     second.unmount()
   })
 
@@ -333,6 +332,34 @@ describe('useSlotElementTracking', () => {
     ).toBe(false)
   })
 
+  it('invalidates retained offsets when a slot direction shrinks', () => {
+    const inputKey0 = getSlotKey(NODE_ID, 0, true)
+    const inputKey1 = getSlotKey(NODE_ID, 1, true)
+    const outputKey = getSlotKey(NODE_ID, 0, false)
+    const node = useNodeSlotRegistryStore().ensureNode(NODE_ID)
+    node.slots.set(inputKey0, {
+      index: 0,
+      type: 'input',
+      cachedOffset: { x: 10, y: 20 }
+    })
+    node.slots.set(inputKey1, {
+      index: 1,
+      type: 'input',
+      cachedOffset: { x: 30, y: 40 }
+    })
+    node.slots.set(outputKey, {
+      index: 0,
+      type: 'output',
+      cachedOffset: { x: 50, y: 60 }
+    })
+
+    reconcileTrackedNodeSlots(NODE_ID, 1, 1)
+
+    expect(node.slots.has(inputKey1)).toBe(false)
+    expect(node.slots.get(inputKey0)?.cachedOffset).toBeUndefined()
+    expect(node.slots.get(outputKey)?.cachedOffset).toEqual({ x: 50, y: 60 })
+  })
+
   it('clears retained layouts when the graph deletes a node', async () => {
     const { unmount } = await mountAndRegisterSlot('output')
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, false)
@@ -347,7 +374,47 @@ describe('useSlotElementTracking', () => {
   describe('collapsed node slot sync', () => {
     function registerCollapsedSlot() {
       const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
-      const slotEl = createSlotElement(true)
+      const slotEl = createSlotElement(true, {
+        node: {
+          left: 200,
+          top: 340,
+          right: 360,
+          bottom: 400,
+          width: 160,
+          height: 60,
+          x: 200,
+          y: 340,
+          toJSON: () => ({})
+        } as DOMRect,
+        slot: {
+          left: 197,
+          top: 367,
+          right: 203,
+          bottom: 373,
+          width: 6,
+          height: 6,
+          x: 197,
+          y: 367,
+          toJSON: () => ({})
+        } as DOMRect
+      })
+
+      layoutStore.applyOperation({
+        type: 'moveNode',
+        entity: 'node',
+        nodeId: NODE_ID,
+        position: { x: 100, y: 200 },
+        previousPosition: { x: 0, y: 0 },
+        timestamp: Date.now(),
+        source: LayoutSource.External,
+        actor: 'test'
+      })
+      layoutStore.batchUpdateNodeBounds([
+        {
+          nodeId: NODE_ID,
+          bounds: { x: 100, y: 200, width: 80, height: 0 }
+        }
+      ])
 
       const registryStore = useNodeSlotRegistryStore()
       const node = registryStore.ensureNode(NODE_ID)
@@ -361,39 +428,17 @@ describe('useSlotElementTracking', () => {
       return { slotKey, node }
     }
 
-    it('uses clientPosToCanvasPos for collapsed nodes', () => {
-      const { slotKey } = registerCollapsedSlot()
-
-      syncNodeSlotLayoutsFromDOM(NODE_ID)
-
-      // Slot element center: (10 + 10/2, 30 + 10/2) = (15, 35)
-      const screenCenter: [number, number] = [15, 35]
-      expect(mockClientPosToCanvasPos).toHaveBeenCalledWith(screenCenter)
-
-      // Mock returns x*0.5, y*0.5
-      const layout = layoutStore.getSlotLayout(slotKey)
-      expect(layout).not.toBeNull()
-      expect(layout!.position.x).toBe(screenCenter[0] * 0.5)
-      expect(layout!.position.y).toBe(screenCenter[1] * 0.5)
-    })
-
-    it('caches collapsed slot offsets for offscreen movement', () => {
+    it('measures collapsed slots relative to rendered bounds', () => {
       const { slotKey, node } = registerCollapsedSlot()
-      const entry = node.slots.get(slotKey)!
-      expect(entry.cachedOffset).toBeDefined()
 
       syncNodeSlotLayoutsFromDOM(NODE_ID)
 
-      expect(entry.cachedOffset).toEqual({ x: 7.5, y: 17.5 })
-    })
-
-    it('defers sync when canvas is not initialized', () => {
-      mockCanvasState.canvas = null
-      registerCollapsedSlot()
-
-      syncNodeSlotLayoutsFromDOM(NODE_ID)
-
-      expect(mockClientPosToCanvasPos).not.toHaveBeenCalled()
+      // The collapsed DOM is 160px wide for an 80-canvas-unit bound, so the
+      // effective scale is 2. The slot center is on the left edge and 15
+      // canvas units above node.position.y after accounting for title height.
+      const layout = layoutStore.getSlotLayout(slotKey)
+      expect(layout?.position).toEqual({ x: 100, y: 185 })
+      expect(node.slots.get(slotKey)?.cachedOffset).toEqual({ x: 0, y: -15 })
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -53,10 +53,11 @@ function createTestSetup(type: 'input' | 'output') {
 
 function createSlotElement(
   collapsed = false,
-  rects?: { node?: DOMRect; slot?: DOMRect }
+  rects?: { node?: DOMRect; slot?: DOMRect },
+  containerNodeId: string = NODE_ID
 ): HTMLElement {
   const container = document.createElement('div')
-  container.dataset.nodeId = NODE_ID
+  container.dataset.nodeId = containerNodeId
   if (collapsed) container.dataset.collapsed = ''
   container.getBoundingClientRect = () =>
     rects?.node ??
@@ -231,6 +232,32 @@ describe('useSlotElementTracking', () => {
 
     syncNodeSlotLayoutsFromDOM(NODE_ID)
 
+    expect(layoutStore.getSlotLayout(slotKey)).toEqual(staleLayout)
+  })
+
+  it('ignores slot elements owned by another node', () => {
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    const slotEl = createSlotElement(false, undefined, 'other-node')
+    const staleLayout: SlotLayout = {
+      nodeId: NODE_ID,
+      index: SLOT_INDEX,
+      type: 'input',
+      position: { x: 10, y: 20 },
+      bounds: { x: 6, y: 16, width: 8, height: 8 }
+    }
+    layoutStore.batchUpdateSlotLayouts([{ key: slotKey, layout: staleLayout }])
+
+    const node = useNodeSlotRegistryStore().ensureNode(NODE_ID)
+    node.slots.set(slotKey, {
+      el: slotEl,
+      index: SLOT_INDEX,
+      type: 'input',
+      cachedOffset: { x: 10, y: 20 }
+    })
+
+    syncNodeSlotLayoutsFromDOM(NODE_ID)
+
+    expect(node.slots.get(slotKey)?.cachedOffset).toEqual({ x: 10, y: 20 })
     expect(layoutStore.getSlotLayout(slotKey)).toEqual(staleLayout)
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -14,6 +14,11 @@ import type { SlotLayout } from '@/renderer/core/layout/types'
 import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
 
 import {
+  deleteTrackedNodeSlots,
+  reconcileTrackedNodeSlots
+} from '@/renderer/extensions/vueNodes/utils/slotLayoutCache'
+
+import {
   syncNodeSlotLayoutsFromDOM,
   flushScheduledSlotLayoutSync,
   requestSlotLayoutSyncForAllNodes,
@@ -139,19 +144,24 @@ describe('useSlotElementTracking', () => {
   it.for([
     { type: 'input' as const, isInput: true },
     { type: 'output' as const, isInput: false }
-  ])('cleans up $type slot layout on unmount', async ({ type, isInput }) => {
-    const { unmount } = await mountAndRegisterSlot(type)
+  ])(
+    'retains $type slot layout on virtualized unmount',
+    async ({ type, isInput }) => {
+      const { unmount } = await mountAndRegisterSlot(type)
 
-    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, isInput)
-    const registryStore = useNodeSlotRegistryStore()
-    expect(registryStore.getNode(NODE_ID)?.slots.has(slotKey)).toBe(true)
-    expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, isInput)
+      const registryStore = useNodeSlotRegistryStore()
+      expect(registryStore.getNode(NODE_ID)?.slots.has(slotKey)).toBe(true)
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
 
-    unmount()
+      unmount()
 
-    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
-    expect(registryStore.getNode(NODE_ID)).toBeUndefined()
-  })
+      expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+      expect(
+        registryStore.getNode(NODE_ID)?.slots.get(slotKey)?.el
+      ).toBeUndefined()
+    }
+  )
 
   it('clears pendingSlotSync when slot layouts already exist', () => {
     // Seed a slot layout (simulates slot layouts persisting through undo/redo)
@@ -176,17 +186,16 @@ describe('useSlotElementTracking', () => {
     expect(layoutStore.pendingSlotSync).toBe(false)
   })
 
-  it('keeps pendingSlotSync when graph has nodes but no slot layouts', () => {
+  it('clears pendingSlotSync when graph nodes have no measured slots', () => {
     // No slot layouts exist (simulates initial mount before Vue registers slots)
     layoutStore.setPendingSlotSync(true)
 
     flushScheduledSlotLayoutSync()
 
-    // Should remain pending — waiting for Vue components to mount
-    expect(layoutStore.pendingSlotSync).toBe(true)
+    expect(layoutStore.pendingSlotSync).toBe(false)
   })
 
-  it('keeps pendingSlotSync when all registered slots are hidden', () => {
+  it('clears pendingSlotSync when all registered slots are detached', () => {
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     const hiddenSlot = document.createElement('div')
 
@@ -201,11 +210,11 @@ describe('useSlotElementTracking', () => {
     layoutStore.setPendingSlotSync(true)
     requestSlotLayoutSyncForAllNodes()
 
-    expect(layoutStore.pendingSlotSync).toBe(true)
+    expect(layoutStore.pendingSlotSync).toBe(false)
     expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
   })
 
-  it('removes stale slot layouts when slot element is hidden', () => {
+  it('retains slot layouts when slot elements detach', () => {
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     const hiddenSlot = document.createElement('div')
 
@@ -228,7 +237,7 @@ describe('useSlotElementTracking', () => {
 
     syncNodeSlotLayoutsFromDOM(NODE_ID)
 
-    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(layoutStore.getSlotLayout(slotKey)).toEqual(staleLayout)
   })
 
   it('skips slot layout writeback when measured slot geometry is unchanged', () => {
@@ -273,6 +282,68 @@ describe('useSlotElementTracking', () => {
     expect(batchUpdateSpy).not.toHaveBeenCalled()
   })
 
+  it('updates retained slot layouts while an offscreen node moves', async () => {
+    const { unmount } = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+
+    unmount()
+    layoutStore.applyOperation({
+      type: 'moveNode',
+      entity: 'node',
+      nodeId: NODE_ID,
+      position: { x: 100, y: 200 },
+      previousPosition: { x: 0, y: 0 },
+      timestamp: Date.now(),
+      source: LayoutSource.External,
+      actor: 'test'
+    })
+    await nextTick()
+
+    expect(layoutStore.getSlotLayout(slotKey)?.position).toEqual({
+      x: 115,
+      y: 205
+    })
+  })
+
+  it('reattaches and remeasures a retained slot', async () => {
+    const first = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    first.unmount()
+
+    const second = await mountAndRegisterSlot('input')
+    const entry = useNodeSlotRegistryStore()
+      .getNode(NODE_ID)
+      ?.slots.get(slotKey)
+
+    expect(entry?.el?.isConnected).toBe(true)
+    expect(layoutStore.getSlotLayout(slotKey)).not.toBeNull()
+    second.unmount()
+  })
+
+  it('removes retained layouts when the slot model deletes a slot', async () => {
+    const { unmount } = await mountAndRegisterSlot('input')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    unmount()
+
+    reconcileTrackedNodeSlots(NODE_ID, 0, 0)
+
+    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(
+      useNodeSlotRegistryStore().getNode(NODE_ID)?.slots.has(slotKey)
+    ).toBe(false)
+  })
+
+  it('clears retained layouts when the graph deletes a node', async () => {
+    const { unmount } = await mountAndRegisterSlot('output')
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, false)
+    unmount()
+
+    deleteTrackedNodeSlots(NODE_ID)
+
+    expect(layoutStore.getSlotLayout(slotKey)).toBeNull()
+    expect(useNodeSlotRegistryStore().getNode(NODE_ID)).toBeUndefined()
+  })
+
   describe('collapsed node slot sync', () => {
     function registerCollapsedSlot() {
       const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
@@ -306,14 +377,14 @@ describe('useSlotElementTracking', () => {
       expect(layout!.position.y).toBe(screenCenter[1] * 0.5)
     })
 
-    it('clears cachedOffset for collapsed nodes', () => {
+    it('caches collapsed slot offsets for offscreen movement', () => {
       const { slotKey, node } = registerCollapsedSlot()
       const entry = node.slots.get(slotKey)!
       expect(entry.cachedOffset).toBeDefined()
 
       syncNodeSlotLayoutsFromDOM(NODE_ID)
 
-      expect(entry.cachedOffset).toBeUndefined()
+      expect(entry.cachedOffset).toEqual({ x: 7.5, y: 17.5 })
     })
 
     it('defers sync when canvas is not initialized', () => {

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -26,9 +26,10 @@ import {
 } from './useSlotElementTracking'
 
 const mockGraph = vi.hoisted(() => ({ _nodes: [] as unknown[] }))
+const mockSetDirty = vi.hoisted(() => vi.fn())
 
 vi.mock('@/scripts/app', () => ({
-  app: { canvas: { graph: mockGraph, setDirty: vi.fn() } }
+  app: { canvas: { graph: mockGraph, setDirty: mockSetDirty } }
 }))
 
 const NODE_ID = toNodeId('test-node')
@@ -130,6 +131,7 @@ describe('useSlotElementTracking', () => {
       actor: 'test'
     })
     mockGraph._nodes = [{ id: 1 }]
+    mockSetDirty.mockClear()
   })
 
   afterEach(() => {
@@ -330,6 +332,7 @@ describe('useSlotElementTracking', () => {
     const first = await mountAndRegisterSlot('input')
     const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
     first.unmount()
+    const deleteSlotLayout = vi.spyOn(layoutStore, 'deleteSlotLayout')
 
     const second = await mountAndRegisterSlot('input', {
       slot: new DOMRect(30, 50, 10, 10)
@@ -339,11 +342,34 @@ describe('useSlotElementTracking', () => {
       ?.slots.get(slotKey)
 
     expect(entry?.el?.isConnected).toBe(true)
+    expect(deleteSlotLayout).toHaveBeenCalledWith(slotKey)
     expect(layoutStore.getSlotLayout(slotKey)?.position).toEqual({
       x: 35,
       y: 25
     })
     second.unmount()
+  })
+
+  it('redraws links after cached slot positions follow a node move', async () => {
+    const { unmount } = await mountAndRegisterSlot('input')
+    mockSetDirty.mockClear()
+
+    layoutStore.batchUpdateNodeBounds([
+      {
+        nodeId: NODE_ID,
+        bounds: { x: 100, y: 50, width: 200, height: 100 },
+        preserveSize: true
+      }
+    ])
+    await nextTick()
+
+    const slotKey = getSlotKey(NODE_ID, SLOT_INDEX, true)
+    expect(layoutStore.getSlotLayout(slotKey)?.position).toEqual({
+      x: 115,
+      y: 55
+    })
+    expect(mockSetDirty).toHaveBeenCalledWith(false, true)
+    unmount()
   })
 
   it('removes retained layouts when the slot model deletes a slot', async () => {

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -125,7 +125,11 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
     (entry) => entry.el?.isConnected
   )
   const closestNode = connectedEntry?.el?.closest('[data-node-id]')
-  const nodeEl = closestNode instanceof HTMLElement ? closestNode : null
+  const nodeEl =
+    closestNode instanceof HTMLElement &&
+    closestNode.dataset.nodeId === String(nodeId)
+      ? closestNode
+      : null
   const nodeRect = nodeEl?.getBoundingClientRect()
 
   const effectiveScale =

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -39,19 +39,13 @@ export function scheduleSlotLayoutSync(nodeId: NodeId) {
   raf.schedule()
 }
 
-function shouldWaitForSlotLayouts(): boolean {
-  const graph = app.canvas?.graph
-  const hasNodes = Boolean(graph && graph._nodes && graph._nodes.length > 0)
-  return hasNodes && !layoutStore.hasSlotLayouts
-}
-
 function completePendingSlotSync(): void {
   layoutStore.setPendingSlotSync(false)
   app.canvas?.setDirty(true, true)
 }
 
-function getSlotElementRect(el: HTMLElement): DOMRect | null {
-  if (!el.isConnected) return null
+function getSlotElementRect(el?: HTMLElement): DOMRect | null {
+  if (!el?.isConnected) return null
 
   const rect = el.getBoundingClientRect()
   if (rect.width <= 0 || rect.height <= 0) return null
@@ -61,11 +55,17 @@ function getSlotElementRect(el: HTMLElement): DOMRect | null {
 export function requestSlotLayoutSyncForAllNodes(): void {
   const nodeSlotRegistryStore = useNodeSlotRegistryStore()
   for (const nodeId of nodeSlotRegistryStore.getNodeIds()) {
-    scheduleSlotLayoutSync(nodeId)
+    const node = nodeSlotRegistryStore.getNode(nodeId)
+    if (
+      node &&
+      Array.from(node.slots.values()).some(({ el }) => el?.isConnected)
+    ) {
+      scheduleSlotLayoutSync(nodeId)
+    }
   }
 
-  // If no slots are currently registered, run the completion check immediately
-  // so pendingSlotSync can be cleared when the graph has no nodes.
+  // Detached virtualized nodes already have cached or model-based geometry and
+  // must not hold link rendering open while waiting for a future remount.
   if (pendingNodes.size === 0) {
     flushScheduledSlotLayoutSync()
   }
@@ -97,14 +97,6 @@ function createSlotLayout(options: {
 
 export function flushScheduledSlotLayoutSync() {
   if (pendingNodes.size === 0) {
-    // No pending nodes - check if we should wait for Vue components to mount
-    if (shouldWaitForSlotLayouts()) {
-      // Graph has nodes but no slot layouts yet - Vue hasn't mounted.
-      // Keep flag set so late mounts can re-assert via scheduleSlotLayoutSync()
-      return
-    }
-    // Either no nodes (nothing to wait for) or slot layouts already exist
-    // (undo/redo preserved them). Clear the flag so links can render.
     completePendingSlotSync()
     return
   }
@@ -112,10 +104,6 @@ export function flushScheduledSlotLayoutSync() {
     pendingNodes.delete(nodeId)
     syncNodeSlotLayoutsFromDOM(nodeId)
   }
-
-  // Keep pending sync active until at least one measurable slot layout has
-  // been captured for the current graph.
-  if (shouldWaitForSlotLayouts()) return
 
   completePendingSlotSync()
 }
@@ -135,10 +123,10 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
   // share the same DOM transform, so their pixel difference divided by the
   // effective scale yields a correct canvas-space offset regardless of
   // whether the TransformPane has flushed its latest transform to the DOM.
-  const closestNode = node.slots
-    .values()
-    .next()
-    .value?.el.closest('[data-node-id]')
+  const connectedEntry = Array.from(node.slots.values()).find(
+    (entry) => entry.el?.isConnected
+  )
+  const closestNode = connectedEntry?.el?.closest('[data-node-id]')
   const nodeEl = closestNode instanceof HTMLElement ? closestNode : null
   const nodeRect = nodeEl?.getBoundingClientRect()
 
@@ -165,12 +153,7 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
 
   for (const [slotKey, entry] of node.slots) {
     const rect = getSlotElementRect(entry.el)
-    if (!rect) {
-      // Drop stale layout values while the slot is hidden so we don't render
-      // links with off-screen coordinates from a previous graph/tab state.
-      layoutStore.deleteSlotLayout(slotKey)
-      continue
-    }
+    if (!rect) continue
 
     const screenCenter: [number, number] = [
       rect.left + rect.width / 2,
@@ -182,7 +165,10 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
     if (conv) {
       const [cx, cy] = conv.clientPosToCanvasPos(screenCenter)
       centerCanvas = { x: cx, y: cy }
-      entry.cachedOffset = undefined
+      entry.cachedOffset = {
+        x: centerCanvas.x - nodeLayout.position.x,
+        y: centerCanvas.y - nodeLayout.position.y
+      }
     } else {
       if (!nodeRect || effectiveScale <= 0) continue
 
@@ -269,6 +255,7 @@ export function useSlotElementTracking(options: {
 }) {
   const { nodeId, index, type, element } = options
   const nodeSlotRegistryStore = useNodeSlotRegistryStore()
+  let registeredElement: HTMLElement | undefined
 
   onMounted(() => {
     if (!nodeId) return
@@ -314,13 +301,18 @@ export function useSlotElementTracking(options: {
         // Defensive cleanup: remove stale entry if it exists with different element
         // This handles edge cases where Vue component reuse prevents proper unmount
         const existingEntry = node.slots.get(slotKey)
-        if (existingEntry && existingEntry.el !== el) {
+        if (existingEntry?.el && existingEntry.el !== el) {
           delete existingEntry.el.dataset.slotKey
-          layoutStore.deleteSlotLayout(slotKey)
         }
 
         el.dataset.slotKey = String(slotKey)
-        node.slots.set(slotKey, { el, index, type })
+        registeredElement = el
+        node.slots.set(slotKey, {
+          ...existingEntry,
+          el,
+          index,
+          type
+        })
 
         // Seed initial sync from DOM
         scheduleSlotLayoutSync(nodeId)
@@ -337,19 +329,13 @@ export function useSlotElementTracking(options: {
     const node = nodeSlotRegistryStore.getNode(nodeId)
     if (!node) return
 
-    // Remove this slot from registry and layout
+    // Detach the DOM element while retaining cached geometry. Virtualized
+    // nodes continue to participate in link layout and movement updates.
     const slotKey = getSlotKey(nodeId, index, type === 'input')
     const entry = node.slots.get(slotKey)
-    if (entry) {
+    if (entry?.el && entry.el === registeredElement) {
       delete entry.el.dataset.slotKey
-      node.slots.delete(slotKey)
-    }
-    layoutStore.deleteSlotLayout(slotKey)
-
-    // If node has no more slots, clean up
-    if (node.slots.size === 0) {
-      if (node.stopWatch) node.stopWatch()
-      nodeSlotRegistryStore.deleteNode(nodeId)
+      entry.el = undefined
     }
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -8,9 +8,7 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import type { Ref } from 'vue'
 
-import { useSharedCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { app } from '@/scripts/app'
@@ -130,24 +128,12 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
   const nodeEl = closestNode instanceof HTMLElement ? closestNode : null
   const nodeRect = nodeEl?.getBoundingClientRect()
 
-  // Collapsed nodes preserve expanded size in layoutStore, so DOM-relative
-  // scale derivation breaks. Fall back to clientPosToCanvasPos instead.
-  const isCollapsed = nodeEl?.dataset.collapsed != null
   const effectiveScale =
-    !isCollapsed && nodeRect && nodeLayout.size.width > 0
-      ? nodeRect.width / nodeLayout.size.width
+    nodeRect && nodeLayout.bounds.width > 0
+      ? nodeRect.width / nodeLayout.bounds.width
       : 0
 
-  const canvasStore = useCanvasStore()
-  const conv =
-    isCollapsed && canvasStore.canvas
-      ? useSharedCanvasPositionConversion()
-      : null
-
-  if (isCollapsed && !conv) {
-    scheduleSlotLayoutSync(nodeId)
-    return
-  }
+  if (!nodeRect || effectiveScale <= 0) return
 
   const batch: Array<{ key: SlotId; layout: SlotLayout }> = []
 
@@ -160,33 +146,20 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
       rect.top + rect.height / 2
     ]
 
-    let centerCanvas: { x: number; y: number }
+    // DOM-relative measurement: compute offset from the node element's
+    // top-left corner in canvas units. The node element is rendered at
+    // (position.x, position.y - NODE_TITLE_HEIGHT), so the Y offset
+    // must subtract NODE_TITLE_HEIGHT to be relative to position.y.
+    entry.cachedOffset = {
+      x: (screenCenter[0] - nodeRect.left) / effectiveScale,
+      y:
+        (screenCenter[1] - nodeRect.top) / effectiveScale -
+        LiteGraph.NODE_TITLE_HEIGHT
+    }
 
-    if (conv) {
-      const [cx, cy] = conv.clientPosToCanvasPos(screenCenter)
-      centerCanvas = { x: cx, y: cy }
-      entry.cachedOffset = {
-        x: centerCanvas.x - nodeLayout.position.x,
-        y: centerCanvas.y - nodeLayout.position.y
-      }
-    } else {
-      if (!nodeRect || effectiveScale <= 0) continue
-
-      // DOM-relative measurement: compute offset from the node element's
-      // top-left corner in canvas units. The node element is rendered at
-      // (position.x, position.y - NODE_TITLE_HEIGHT), so the Y offset
-      // must subtract NODE_TITLE_HEIGHT to be relative to position.y.
-      entry.cachedOffset = {
-        x: (screenCenter[0] - nodeRect.left) / effectiveScale,
-        y:
-          (screenCenter[1] - nodeRect.top) / effectiveScale -
-          LiteGraph.NODE_TITLE_HEIGHT
-      }
-
-      centerCanvas = {
-        x: nodeLayout.position.x + entry.cachedOffset.x,
-        y: nodeLayout.position.y + entry.cachedOffset.y
-      }
+    const centerCanvas = {
+      x: nodeLayout.position.x + entry.cachedOffset.x,
+      y: nodeLayout.position.y + entry.cachedOffset.y
     }
 
     const nextLayout = createSlotLayout({

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -221,7 +221,10 @@ function updateNodeSlotsFromCache(nodeId: NodeId) {
     })
   }
 
-  if (batch.length) layoutStore.batchUpdateSlotLayouts(batch)
+  if (batch.length) {
+    layoutStore.batchUpdateSlotLayouts(batch)
+    app.canvas?.setDirty(false, true)
+  }
 }
 
 export function useSlotElementTracking(options: {
@@ -280,6 +283,10 @@ export function useSlotElementTracking(options: {
         const existingEntry = node.slots.get(slotKey)
         if (existingEntry?.el && existingEntry.el !== el) {
           delete existingEntry.el.dataset.slotKey
+        }
+        if (existingEntry) {
+          existingEntry.cachedOffset = undefined
+          layoutStore.deleteSlotLayout(slotKey)
         }
 
         el.dataset.slotKey = String(slotKey)

--- a/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
+++ b/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
@@ -5,7 +5,7 @@ import type { NodeId } from '@/types/nodeId'
 import type { SlotId } from '@/types/slotId'
 
 type SlotEntry = {
-  el: HTMLElement
+  el?: HTMLElement
   index: number
   type: 'input' | 'output'
   cachedOffset?: { x: number; y: number }

--- a/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
+++ b/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
@@ -1,0 +1,46 @@
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { useNodeSlotRegistryStore } from '@/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore'
+import type { NodeId } from '@/types/nodeId'
+
+/** Remove geometry only for slots that no longer exist in the node model. */
+export function reconcileTrackedNodeSlots(
+  nodeId: NodeId,
+  inputCount: number,
+  outputCount: number
+) {
+  const registryStore = useNodeSlotRegistryStore()
+  const node = registryStore.getNode(nodeId)
+  if (!node) return
+
+  for (const [slotKey, entry] of node.slots) {
+    const count = entry.type === 'input' ? inputCount : outputCount
+    if (entry.index < count) continue
+
+    if (entry.el) delete entry.el.dataset.slotKey
+    node.slots.delete(slotKey)
+    layoutStore.deleteSlotLayout(slotKey)
+  }
+}
+
+/** Clear retained slot geometry when its owning node is actually deleted. */
+export function deleteTrackedNodeSlots(nodeId: NodeId) {
+  const registryStore = useNodeSlotRegistryStore()
+  const node = registryStore.getNode(nodeId)
+  if (!node) return
+
+  node.stopWatch?.()
+  for (const [slotKey, entry] of node.slots) {
+    if (entry.el) delete entry.el.dataset.slotKey
+    layoutStore.deleteSlotLayout(slotKey)
+  }
+  registryStore.deleteNode(nodeId)
+}
+
+/** Clear all retained geometry when the active graph or renderer changes. */
+export function clearTrackedSlotLayouts() {
+  const registryStore = useNodeSlotRegistryStore()
+  for (const nodeId of registryStore.getNodeIds()) {
+    deleteTrackedNodeSlots(nodeId)
+  }
+  layoutStore.clearAllSlotLayouts()
+}

--- a/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
+++ b/src/renderer/extensions/vueNodes/utils/slotLayoutCache.ts
@@ -12,6 +12,7 @@ export function reconcileTrackedNodeSlots(
   const node = registryStore.getNode(nodeId)
   if (!node) return
 
+  const removedTypes = new Set<'input' | 'output'>()
   for (const [slotKey, entry] of node.slots) {
     const count = entry.type === 'input' ? inputCount : outputCount
     if (entry.index < count) continue
@@ -19,6 +20,11 @@ export function reconcileTrackedNodeSlots(
     if (entry.el) delete entry.el.dataset.slotKey
     node.slots.delete(slotKey)
     layoutStore.deleteSlotLayout(slotKey)
+    removedTypes.add(entry.type)
+  }
+
+  for (const entry of node.slots.values()) {
+    if (removedTypes.has(entry.type)) entry.cachedOffset = undefined
   }
 }
 

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -426,6 +426,7 @@ const zSettings = z.object({
   'Comfy.Canvas.LeftMouseClickBehavior': z.string(),
   'Comfy.Canvas.MouseWheelScroll': z.string(),
   'Comfy.VueNodes.Enabled': z.boolean(),
+  'Comfy.VueNodes.ViewportVirtualization': z.boolean(),
   'Comfy.AppBuilder.VueNodeSwitchDismissed': z.boolean(),
   'Comfy.Assets.UseAssetAPI': z.boolean(),
   'Comfy.Queue.QPOV2': z.boolean(),


### PR DESCRIPTION
# Opt-in Nodes 2.0 Viewport Virtualization

## Summary

Adds opt-in component virtualization for Nodes 2.0 so large workflows only
mount nodes intersecting the viewport plus a 25% overscan region. LiteGraph
graph state, prompt serialization, execution, outputs, links, and selection
remain independent of Vue component mounting.

The feature is disabled by default because some custom Vue or legacy widgets
may depend on continuous mount lifecycles. Disabling the setting restores the
existing all-mounted behavior immediately.

## Changes

- **What**:
  - Adds the experimental `Comfy.VueNodes.ViewportVirtualization` setting under
    **Comfy → Nodes 2.0 → ViewportVirtualization**, named **Viewport node
    virtualization**, defaulting to `false`. Its `sortOrder` is `90`, placing it
    directly below Modern Node Design at `100`.
  - Replaces the all-node render loop with a viewport-derived list that matches
    LiteGraph canvas transforms, preserves graph order, and avoids replacing
    the render array when its IDs are unchanged.
  - Queries the layout spatial index once per changed animation frame and
    renders all nodes while virtualization is disabled or layout initialization
    is incomplete.
  - Uses an early disabled-mode path that publishes refreshed node data without
    reading canvas, viewport, pinned-node, or layout bookkeeping state.
  - Keeps nodes mounted while they are actively pointed at, selected during
    drag/resize, focused, title-edited, targeted by an open context menu,
    capturing input, or participating in a link drag.
  - Retains cached slot offsets and absolute layouts across virtualized
    unmounts, updates retained slots when offscreen nodes move, and remeasures
    slots when nodes remount.
  - Reconciles retained slots on real slot-model or node deletion and clears
    them on graph disposal, renderer changes, and subgraph navigation.
  - Allows pending slot synchronization to finish without waiting for every
    graph node to mount; unmeasured slots continue using the existing
    model-derived fallback.
  - Expands the layout QuadTree when workflows contain nodes outside its
    current bounds and normalizes zero or negative root dimensions before
    expansion.
  - Publishes in-place render-list refreshes directly so collapsed state,
    titles, flags, and other node changes update immediately even when the
    visible node IDs remain unchanged.
  - Measures collapsed slot positions relative to the node's rendered bounds,
    avoiding stale canvas-transform conversions during load, pan, and zoom.
  - Initializes Vue node stacking from LiteGraph's graph render order rather
    than prompt execution order, and renders the link overlay beneath Vue node
    bodies.
  - Adds unit, Playwright, and large-graph performance coverage.
- **Breaking**: None. The feature is opt-in and defaults to disabled.
- **Dependencies**: None.
- **Version bump**: None.

## Review Focus

- Viewport math and 25% overscan behavior across pan, zoom, resize, and
  LiteGraph sub-viewports.
- Active-node pinning during pointer, focus, context-menu, resize, and link-drag
  interactions.
- Slot-cache lifetime: virtualized unmount versus actual slot/node deletion and
  graph disposal.
- Immediate fallback to the current all-mounted behavior when the setting is
  disabled, without virtualization bookkeeping, while preserving node-data
  updates.
- Compatibility with collapsed nodes, subgraphs, offscreen execution/output
  updates, classic rendering, App Mode, previews, and minimap data.
- Immediate node-data reactivity when the virtualized render list retains the
  same IDs.
- Collapsed slot geometry and node/link stacking in large custom-node
  workflows.

## Validation

- [x] Targeted viewport and QuadTree Vitest suite: 28 tests passed.
- [x] Broader viewport, layout, slot, and graph-manager Vitest suite: 93 tests
      passed.
- [x] Nodes 2.0 viewport Playwright suite: 5 Chromium tests passed.
- [x] Immediate-collapse Playwright regression passed on Chromium.
- [x] Combined Vue node-size Playwright regression passed twice on Chromium.
- [x] Reproduced and verified against the 603-node `iGEN_ONE_RB92_W22`
      workflow.
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:browser`
- [x] `pnpm format:check`
- [x] `pnpm knip`
- [x] `git diff --check`
- [x] Stylelint passed.
- [x] Type-aware Oxlint passed; three unrelated pre-existing warnings remain in
      `turnstileScript.test.ts`.
- [x] Full cached ESLint passed with unrelated pre-existing warnings only.
- [x] Combined viewport-virtualization and Vue-size package production build.

## Contributor License Agreement

  > I have read and agree to the Contributor License Agreement

  Signing terms: https://github.com/Comfy-Org/comfy-cla/blob/main/comfyui_icla.md

## Performance Coverage

The existing Nodes 2.0 large-graph performance tests now enable virtualization
and record:

- mounted Vue node count;
- total DOM node count;
- idle task cost;
- pan frame duration;
- total blocking time.

## Local Build and Installation

The combined viewport-virtualization and Vue-size test build can be shared as
either artifact below:

- `comfyui_frontend_package/dist/comfyui-frontend-1.48.5+vuefix.zip`
- `comfyui_frontend_package/dist/comfyui_frontend_package-1.48.5+vuefix-py3-none-any.whl`

Rebuild the frontend and wheel without changing `package.json`:

```bash
pnpm build
pnpm zipdist -- dist comfyui_frontend_package/dist/comfyui-frontend-1.48.5+vuefix.zip
cp -a dist/. comfyui_frontend_package/comfyui_frontend_package/static/
COMFYUI_FRONTEND_VERSION=1.48.5+vuefix \
  /mnt/data/AI/comfy_env/bin/python -m pip wheel \
  --no-deps --no-build-isolation ./comfyui_frontend_package \
  --wheel-dir ./comfyui_frontend_package/dist
```

Install or update the local wheel:

```bash
/mnt/data/AI/comfy_env/bin/python -m pip install \
  --force-reinstall --no-deps \
  ./comfyui_frontend_package/dist/comfyui_frontend_package-1.48.5+vuefix-py3-none-any.whl
```

Current artifact SHA-256 checksums:

```text
bb3be02a5f7ce3cf44bced24a280d74b35dab4c0c288d797da5a8164801967ac  comfyui-frontend-1.48.5+vuefix.zip
97140ff1697b9f9a37cdfae322fc3799b025b23581f8f854522a1bde8a2f7d3a  comfyui_frontend_package-1.48.5+vuefix-py3-none-any.whl
```

## Screenshots (if applicable)

Not applicable. This change affects mounting behavior and performance without
changing node visuals.
