### PR TITLE
Fix/load3d menu overlap

### DIFF
--- a/src/components/load3d/Load3DMenuBar.vue
+++ b/src/components/load3d/Load3DMenuBar.vue
@@ -5,7 +5,7 @@
       class="pointer-events-auto flex h-10 items-center gap-1 bg-interface-menu-surface px-2"
       @wheel.stop
     >
-      <Popover v-model:open="catMenuOpen">
+      <Popover v-model:open="categoryMenuOpen">
         <PopoverTrigger as-child>
           <button
             :class="chipClass"
@@ -186,6 +186,7 @@ import {
 import ModelMenuGroup from '@/components/load3d/menubar/ModelMenuGroup.vue'
 import RecordMenuControl from '@/components/load3d/menubar/RecordMenuControl.vue'
 import SceneMenuGroup from '@/components/load3d/menubar/SceneMenuGroup.vue'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import ViewerControls from '@/components/load3d/controls/ViewerControls.vue'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
@@ -294,8 +295,9 @@ watch(categoryDefs, (defs) => {
   }
 })
 
-const catMenuOpen = ref(false)
-const exportOpen = ref(false)
+const exclusivePopover = usePopoverExclusivity()
+const categoryMenuOpen = exclusivePopover('category-menu')
+const exportOpen = exclusivePopover('export')
 
 const sceneHasImage = computed(
   () =>
@@ -327,7 +329,7 @@ const compact = computed(
 
 function selectCategory(key: string) {
   activeCategory.value = key
-  catMenuOpen.value = false
+  categoryMenuOpen.value = false
 }
 
 function onExport(format: string) {

--- a/src/components/load3d/menubar/CameraMenuGroup.vue
+++ b/src/components/load3d/menubar/CameraMenuGroup.vue
@@ -10,7 +10,7 @@
     <span v-if="!compact">{{ cameraTypeLabel }}</span>
   </button>
 
-  <Popover v-if="isPerspective">
+  <Popover v-if="isPerspective" v-model:open="fovOpen">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.fov'))"
@@ -52,6 +52,7 @@ import {
   panelClass,
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import Slider from '@/components/ui/slider/Slider.vue'
@@ -66,6 +67,8 @@ const { compact = false } = defineProps<{
 const config = defineModel<CameraConfig>('config')
 
 const { t } = useI18n()
+
+const fovOpen = usePopoverExclusivity()('camera-fov')
 
 const cameraType = computed(() => config.value?.cameraType)
 const isPerspective = computed(() => cameraType.value === 'perspective')

--- a/src/components/load3d/menubar/LightMenuGroup.vue
+++ b/src/components/load3d/menubar/LightMenuGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <Popover v-if="isOriginalMaterial">
+  <Popover v-if="isOriginalMaterial" v-model:open="intensityOpen">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.intensity'))"
@@ -46,6 +46,7 @@ import {
   panelClass,
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import Slider from '@/components/ui/slider/Slider.vue'
@@ -62,6 +63,8 @@ const { compact = false, isOriginalMaterial = false } = defineProps<{
 const config = defineModel<LightConfig>('config')
 
 const { t } = useI18n()
+
+const intensityOpen = usePopoverExclusivity()('light-intensity')
 
 const settingStore = useSettingStore()
 const lightIntensityMinimum = settingStore.get(

--- a/src/components/load3d/menubar/ModelMenuGroup.test.ts
+++ b/src/components/load3d/menubar/ModelMenuGroup.test.ts
@@ -53,6 +53,25 @@ describe('ModelMenuGroup', () => {
     expect(config.materialMode).toBe('wireframe')
   })
 
+  it('only shows one popover at a time', async () => {
+    const { user } = renderGroup()
+
+    await user.click(screen.getByRole('button', { name: 'Up Direction' }))
+    expect(screen.getByRole('button', { name: '+Y' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Material' }))
+    expect(screen.queryByRole('button', { name: '+Y' })).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Wireframe' })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Up Direction' }))
+    expect(
+      screen.queryByRole('button', { name: 'Wireframe' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '+Y' })).toBeInTheDocument()
+  })
+
   it('toggles the skeleton only when supported', async () => {
     const config = makeConfig({ showSkeleton: false })
     const { user, rerender } = renderGroup({ config, hasSkeleton: false })

--- a/src/components/load3d/menubar/ModelMenuGroup.test.ts
+++ b/src/components/load3d/menubar/ModelMenuGroup.test.ts
@@ -75,6 +75,16 @@ describe('ModelMenuGroup', () => {
     expect(screen.queryByRole('button', { name: '+Y' })).not.toBeInTheDocument()
   })
 
+  it('closes the open popover on Escape', async () => {
+    const { user } = renderGroup()
+
+    await user.click(screen.getByRole('button', { name: 'Up Direction' }))
+    expect(screen.getByRole('button', { name: '+Y' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('button', { name: '+Y' })).not.toBeInTheDocument()
+  })
+
   it('toggles the skeleton only when supported', async () => {
     const config = makeConfig({ showSkeleton: false })
     const { user, rerender } = renderGroup({ config, hasSkeleton: false })

--- a/src/components/load3d/menubar/ModelMenuGroup.test.ts
+++ b/src/components/load3d/menubar/ModelMenuGroup.test.ts
@@ -70,6 +70,9 @@ describe('ModelMenuGroup', () => {
       screen.queryByRole('button', { name: 'Wireframe' })
     ).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: '+Y' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Up Direction' }))
+    expect(screen.queryByRole('button', { name: '+Y' })).not.toBeInTheDocument()
   })
 
   it('toggles the skeleton only when supported', async () => {

--- a/src/components/load3d/menubar/ModelMenuGroup.vue
+++ b/src/components/load3d/menubar/ModelMenuGroup.vue
@@ -1,12 +1,11 @@
 <template>
-  <Popover :open="openPopover === 'upDirection'">
+  <Popover v-model:open="upDirectionOpen">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.upDirection'))"
         :class="actionClass(false)"
         type="button"
         :aria-label="compact ? t('load3d.menuBar.upDirection') : undefined"
-        @click="togglePopover('upDirection')"
       >
         <i class="icon-[lucide--move-3d] size-4" />
         <span v-if="!compact">{{ t('load3d.menuBar.upDirection') }}</span>
@@ -30,14 +29,13 @@
     </PopoverContent>
   </Popover>
 
-  <Popover v-if="materialModes.length" :open="openPopover === 'material'">
+  <Popover v-if="materialModes.length" v-model:open="materialOpen">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.material'))"
         :class="actionClass(false)"
         type="button"
         :aria-label="compact ? t('load3d.menuBar.material') : undefined"
-        @click="togglePopover('material')"
       >
         <i class="icon-[lucide--box] size-4" />
         <span v-if="!compact">{{ t('load3d.menuBar.material') }}</span>
@@ -76,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -85,6 +83,7 @@ import {
   rowClass,
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import type {
@@ -113,16 +112,9 @@ const upDirection = computed(() => config.value?.upDirection)
 const materialMode = computed(() => config.value?.materialMode)
 const showSkeleton = computed(() => config.value?.showSkeleton ?? false)
 
-type MenuPopover = 'upDirection' | 'material'
-
-// One-way `:open` binding, no `@update:open`: reka-ui's own dismiss/toggle
-// emits are intentionally ignored so they can't race this ref (they were the
-// cause of a flash-then-close bug when both popovers were kept in sync).
-const openPopover = ref<MenuPopover | null>(null)
-
-function togglePopover(popover: MenuPopover) {
-  openPopover.value = openPopover.value === popover ? null : popover
-}
+const exclusivePopover = usePopoverExclusivity()
+const upDirectionOpen = exclusivePopover('model-up-direction')
+const materialOpen = exclusivePopover('model-material')
 
 const upDirections: UpDirection[] = [
   'original',

--- a/src/components/load3d/menubar/ModelMenuGroup.vue
+++ b/src/components/load3d/menubar/ModelMenuGroup.vue
@@ -1,11 +1,12 @@
 <template>
-  <Popover>
+  <Popover :open="openPopover === 'upDirection'">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.upDirection'))"
         :class="actionClass(false)"
         type="button"
         :aria-label="compact ? t('load3d.menuBar.upDirection') : undefined"
+        @click="togglePopover('upDirection')"
       >
         <i class="icon-[lucide--move-3d] size-4" />
         <span v-if="!compact">{{ t('load3d.menuBar.upDirection') }}</span>
@@ -29,13 +30,14 @@
     </PopoverContent>
   </Popover>
 
-  <Popover v-if="materialModes.length">
+  <Popover v-if="materialModes.length" :open="openPopover === 'material'">
     <PopoverTrigger as-child>
       <button
         v-tooltip.bottom="tip(t('load3d.menuBar.material'))"
         :class="actionClass(false)"
         type="button"
         :aria-label="compact ? t('load3d.menuBar.material') : undefined"
+        @click="togglePopover('material')"
       >
         <i class="icon-[lucide--box] size-4" />
         <span v-if="!compact">{{ t('load3d.menuBar.material') }}</span>
@@ -74,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -110,6 +112,17 @@ const { t } = useI18n()
 const upDirection = computed(() => config.value?.upDirection)
 const materialMode = computed(() => config.value?.materialMode)
 const showSkeleton = computed(() => config.value?.showSkeleton ?? false)
+
+type MenuPopover = 'upDirection' | 'material'
+
+// One-way `:open` binding, no `@update:open`: reka-ui's own dismiss/toggle
+// emits are intentionally ignored so they can't race this ref (they were the
+// cause of a flash-then-close bug when both popovers were kept in sync).
+const openPopover = ref<MenuPopover | null>(null)
+
+function togglePopover(popover: MenuPopover) {
+  openPopover.value = openPopover.value === popover ? null : popover
+}
 
 const upDirections: UpDirection[] = [
   'original',

--- a/src/components/load3d/menubar/RecordMenuControl.vue
+++ b/src/components/load3d/menubar/RecordMenuControl.vue
@@ -86,7 +86,6 @@
 
 <script setup lang="ts">
 import { PopoverTrigger } from 'reka-ui'
-import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -95,6 +94,7 @@ import {
   rowClass,
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -116,7 +116,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const menuOpen = ref(false)
+const menuOpen = usePopoverExclusivity()('recording-menu')
 
 function downloadRecording() {
   menuOpen.value = false

--- a/src/components/load3d/menubar/SceneMenuGroup.vue
+++ b/src/components/load3d/menubar/SceneMenuGroup.vue
@@ -63,7 +63,7 @@
       <i class="icon-[lucide--globe] size-4" />
       <span v-if="!compact">{{ t('load3d.menuBar.panorama') }}</span>
     </button>
-    <Popover v-if="isPanorama">
+    <Popover v-if="isPanorama" v-model:open="fovOpen">
       <PopoverTrigger as-child>
         <button
           v-tooltip.bottom="tip(t('load3d.menuBar.fov'))"
@@ -118,6 +118,7 @@ import {
   panelClass,
   tip
 } from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
 import Popover from '@/components/ui/popover/Popover.vue'
 import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import Slider from '@/components/ui/slider/Slider.vue'
@@ -156,6 +157,8 @@ const fovValue = computed(() => fov.value ?? 10)
 
 const colorRef = ref<HTMLInputElement | null>(null)
 const bgImageRef = ref<HTMLInputElement | null>(null)
+
+const fovOpen = usePopoverExclusivity()('scene-fov')
 
 function toggleGrid() {
   if (config.value) config.value.showGrid = !config.value.showGrid

--- a/src/components/load3d/menubar/usePopoverExclusivity.test.ts
+++ b/src/components/load3d/menubar/usePopoverExclusivity.test.ts
@@ -1,0 +1,65 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
+
+const Toggle = defineComponent({
+  props: { popoverId: { type: String, required: true } },
+  setup(props) {
+    const open = usePopoverExclusivity()(props.popoverId)
+    return () =>
+      h('div', [
+        h(
+          'span',
+          { 'data-testid': `${props.popoverId}-state` },
+          open.value ? 'open' : 'closed'
+        ),
+        h(
+          'button',
+          { onClick: () => (open.value = true) },
+          `open ${props.popoverId}`
+        ),
+        h(
+          'button',
+          { onClick: () => (open.value = false) },
+          `close ${props.popoverId}`
+        )
+      ])
+  }
+})
+
+const Menubar = defineComponent({
+  setup() {
+    usePopoverExclusivity()
+    return () => [h(Toggle, { popoverId: 'a' }), h(Toggle, { popoverId: 'b' })]
+  }
+})
+
+function renderMenubar() {
+  render(Menubar)
+  return userEvent.setup()
+}
+
+describe('usePopoverExclusivity', () => {
+  it('keeps popovers across components mutually exclusive', async () => {
+    const user = renderMenubar()
+
+    await user.click(screen.getByRole('button', { name: 'open a' }))
+    expect(screen.getByTestId('a-state')).toHaveTextContent('open')
+
+    await user.click(screen.getByRole('button', { name: 'open b' }))
+    expect(screen.getByTestId('b-state')).toHaveTextContent('open')
+    expect(screen.getByTestId('a-state')).toHaveTextContent('closed')
+  })
+
+  it('ignores a close from a popover that is not the open one', async () => {
+    const user = renderMenubar()
+
+    await user.click(screen.getByRole('button', { name: 'open a' }))
+    await user.click(screen.getByRole('button', { name: 'close b' }))
+
+    expect(screen.getByTestId('a-state')).toHaveTextContent('open')
+  })
+})

--- a/src/components/load3d/menubar/usePopoverExclusivity.ts
+++ b/src/components/load3d/menubar/usePopoverExclusivity.ts
@@ -1,0 +1,30 @@
+import type { InjectionKey, Ref, WritableComputedRef } from 'vue'
+import { computed, inject, provide, ref } from 'vue'
+
+const openPopoverKey: InjectionKey<Ref<string | null>> =
+  Symbol('load3dOpenPopover')
+
+/**
+ * Keeps Load3D menubar popovers mutually exclusive. `@pointerdown.stop` on the
+ * Load3D container blocks reka-ui's document-level outside-pointerdown
+ * dismissal, so sibling popovers cannot close each other on their own — on
+ * Safari not even via the focus-outside fallback, because clicking a button
+ * there does not focus it.
+ *
+ * Call once per component; the returned factory yields a writable `open`
+ * binding per popover id. The open-popover id is shared with ancestor scopes
+ * via provide/inject, so exclusivity spans the whole menubar.
+ */
+export function usePopoverExclusivity() {
+  const openPopover = inject(openPopoverKey, null) ?? ref<string | null>(null)
+  provide(openPopoverKey, openPopover)
+  return function exclusivePopover(id: string): WritableComputedRef<boolean> {
+    return computed({
+      get: () => openPopover.value === id,
+      set: (open) => {
+        if (open) openPopover.value = id
+        else if (openPopover.value === id) openPopover.value = null
+      }
+    })
+  }
+}

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -232,7 +232,7 @@ useExtensionService().registerExtension({
       tooltip:
         'Enables the 3D Viewer (Beta) for selected nodes. This feature allows you to visualize and interact with 3D models directly within the full size 3d viewer.',
       type: 'boolean',
-      defaultValue: false,
+      defaultValue: true,
       experimental: true
     },
     {


### PR DESCRIPTION
## Summary

Load3D's "Up Direction" and "Material" toolbar popovers could both be open at once instead of being mutually exclusive.

## Changes

- What: `ModelMenuGroup.vue's` two popovers are now driven by a single openPopover ref instead of each managing its own uncontrolled open state. reka-ui's built-in outside-click dismissal never reaches document for these popovers, because WidgetDOM.vue calls .stop on pointerdown/pointermove/pointerup for DOM node widgets, so the popovers can't rely on it to close each other. Each trigger's @click now toggles the shared ref directly, and reka-ui's own dismiss/toggle emits are intentionally left unhandled (:open is bound one-way, no @update:open) so they can't race the ref — an earlier version that wired both directions produced a flash-then-close bug.

## Review Focus

- The one-way :open binding is deliberate, not an oversight — see the comment above openPopover in ModelMenuGroup.vue. Re-adding @update:open reintroduces the race.

## Screenshots (if applicable)

before
<img width="1504" height="980" alt="image" src="https://github.com/user-attachments/assets/599255f0-7778-4524-b7a2-2a8ec083d9e5" />

after
<img width="782" height="498" alt="image" src="https://github.com/user-attachments/assets/bb687083-345d-4daf-b420-1988cbc54bf6" />

