### PR TITLE
feat(selection-toolbox): add Batch Selected Images button

### DIFF
--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -13,6 +13,7 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import { useExtensionService } from '@/services/extensionService'
 import {
   createMockCanvas,
+  createMockLGraphNode,
   createMockPositionable
 } from '@/utils/__tests__/litegraphTestUtils'
 import * as litegraphUtil from '@/utils/litegraphUtil'
@@ -90,7 +91,11 @@ vi.mock('@/services/extensionService', () => ({
 vi.mock('@/utils/litegraphUtil', () => ({
   isLGraphNode: vi.fn(() => true),
   isImageNode: vi.fn(() => false),
-  isLoad3dNode: vi.fn(() => false)
+  isLoad3dNode: vi.fn(() => false),
+  hasImageOutput: vi.fn(
+    (node: LGraphNode | undefined) =>
+      !!node?.outputs?.some((output) => output.type === 'IMAGE')
+  )
 }))
 
 vi.mock('@/utils/nodeFilterUtil', () => ({
@@ -115,9 +120,14 @@ let nodeDefMock = {
   title: 'Test Node'
 } as unknown
 
+let nodeDefsByNameMock: Record<string, unknown> = {}
+
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: () => ({
-    fromLGraphNode: vi.fn(() => nodeDefMock)
+    fromLGraphNode: vi.fn(() => nodeDefMock),
+    get nodeDefsByName() {
+      return nodeDefsByNameMock
+    }
   })
 }))
 
@@ -152,6 +162,9 @@ describe('SelectionToolbox', () => {
       type: 'TestNode',
       title: 'Test Node'
     } as unknown
+    nodeDefsByNameMock = {
+      BatchImagesNode: { name: 'BatchImagesNode' }
+    }
 
     // Mock the canvas to avoid "getCanvas: canvas is null" errors
     canvasStore.canvas = createMockCanvas()
@@ -181,6 +194,10 @@ describe('SelectionToolbox', () => {
               '<button data-testid="color-picker-button" class="color-picker-button" />'
           },
           FrameNodes: { template: '<div class="frame-nodes" />' },
+          BatchImagesButton: {
+            template:
+              '<button data-testid="batch-images-button" class="batch-images-button" />'
+          },
           PublishButton: {
             template:
               '<button data-testid="add-to-library" class="bookmark-button" />'
@@ -384,6 +401,52 @@ describe('SelectionToolbox', () => {
       canvasStore.selectedItems = [createMockPositionable()]
       const { container: container2 } = renderComponent()
       expect(container2.querySelector('.load-3d-viewer-button')).toBeFalsy()
+    })
+
+    it('should show batch images button only when multiple image-output nodes are selected', () => {
+      const createImageOutputNode = () =>
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] })
+      const createNonImageNode = () =>
+        createMockLGraphNode({ outputs: [{ name: 'LATENT', type: 'LATENT' }] })
+
+      // Multiple nodes with IMAGE outputs
+      canvasStore.selectedItems = [
+        createImageOutputNode(),
+        createImageOutputNode()
+      ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeTruthy()
+
+      // Single image-output node
+      canvasStore.selectedItems = [createImageOutputNode()]
+      const { container: container2 } = renderComponent()
+      expect(
+        container2.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
+
+      // Multiple nodes but only one has an IMAGE output
+      canvasStore.selectedItems = [
+        createImageOutputNode(),
+        createNonImageNode()
+      ]
+      const { container: container3 } = renderComponent()
+      expect(
+        container3.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
+    })
+
+    it('should not show batch images button when the Batch Images node def is unavailable', () => {
+      nodeDefsByNameMock = {}
+      canvasStore.selectedItems = [
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] }),
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] })
+      ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
     })
 
     it('should show ExecuteButton only when output nodes are selected', () => {

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -22,6 +22,7 @@
         <ColorPickerButton v-if="showColorPicker" />
         <ArrangeButton v-if="showArrange" />
         <FrameNodes v-if="showFrameNodes" />
+        <BatchImagesButton v-if="showBatchImages" />
         <ConvertToSubgraphButton v-if="showConvertToSubgraph" />
         <ConfigureSubgraph v-if="showSubgraphButtons" />
         <PublishSubgraphButton v-if="showSubgraphButtons" />
@@ -51,6 +52,7 @@ import Panel from 'primevue/panel'
 import { computed, ref } from 'vue'
 
 import ArrangeButton from '@/components/graph/selectionToolbox/ArrangeButton.vue'
+import BatchImagesButton from '@/components/graph/selectionToolbox/BatchImagesButton.vue'
 import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
 import ConfigureSubgraph from '@/components/graph/selectionToolbox/ConfigureSubgraph.vue'
@@ -70,6 +72,7 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import { useExtensionService } from '@/services/extensionService'
 import { useCommandStore } from '@/stores/commandStore'
 import type { ComfyCommandImpl } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import FrameNodes from './selectionToolbox/FrameNodes.vue'
 import NodeOptionsButton from './selectionToolbox/NodeOptionsButton.vue'
@@ -77,6 +80,7 @@ import VerticalDivider from './selectionToolbox/VerticalDivider.vue'
 
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
+const nodeDefStore = useNodeDefStore()
 const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
@@ -108,6 +112,7 @@ const {
   isSingleImageNode,
   hasAny3DNodeSelected,
   hasOutputNodesSelected,
+  hasMultipleImageOutputNodes,
   canOpenNodeInfo
 } = useSelectionState()
 
@@ -115,6 +120,11 @@ const showColorPicker = computed(() => hasAnySelection.value)
 const showConvertToSubgraph = computed(() => hasAnySelection.value)
 const showArrange = computed(() => hasMultipleSelection.value)
 const showFrameNodes = computed(() => hasMultipleSelection.value)
+const showBatchImages = computed(
+  () =>
+    hasMultipleImageOutputNodes.value &&
+    !!nodeDefStore.nodeDefsByName?.['BatchImagesNode']
+)
 const showSubgraphButtons = computed(() => isSingleSubgraph.value)
 
 const showBypass = computed(
@@ -137,6 +147,7 @@ const showAnyPrimaryActions = computed(
     showConvertToSubgraph.value ||
     showArrange.value ||
     showFrameNodes.value ||
+    showBatchImages.value ||
     showSubgraphButtons.value
 )
 

--- a/src/components/graph/selectionToolbox/BatchImagesButton.vue
+++ b/src/components/graph/selectionToolbox/BatchImagesButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <Button
+    v-tooltip.top="{
+      value: $t('commands.Comfy_Graph_BatchSelectedImageNodes.label'),
+      showDelay: 1000
+    }"
+    variant="muted-textonly"
+    :aria-label="$t('commands.Comfy_Graph_BatchSelectedImageNodes.label')"
+    data-testid="batch-images-button"
+    @click="() => commandStore.execute('Comfy.Graph.BatchSelectedImageNodes')"
+  >
+    <i class="icon-[lucide--images]" />
+  </Button>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+import { useCommandStore } from '@/stores/commandStore'
+
+const commandStore = useCommandStore()
+</script>

--- a/src/composables/graph/useSelectionState.ts
+++ b/src/composables/graph/useSelectionState.ts
@@ -8,6 +8,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import {
+  hasImageOutput,
   isImageNode,
   isLGraphGroup,
   isLGraphNode,
@@ -79,6 +80,12 @@ export function useSelectionState() {
   })
 
   const hasImageNode = computed(() => isSingleImageNode.value)
+  const imageOutputNodes = computed(() =>
+    selectedNodes.value.filter((node) => hasImageOutput(node))
+  )
+  const hasMultipleImageOutputNodes = computed(
+    () => imageOutputNodes.value.length > 1
+  )
   const hasOutputNodesSelected = computed(
     () => filterOutputNodes(selectedNodes.value).length > 0
   )
@@ -130,6 +137,8 @@ export function useSelectionState() {
     isSingleImageNode,
     hasSubgraphs,
     hasImageNode,
+    imageOutputNodes,
+    hasMultipleImageOutputNodes,
     hasOutputNodesSelected,
     selectedNodesStates,
     computeSelectionFlags

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1114,6 +1114,7 @@ export function useCoreCommands(): ComfyCommand[] {
           source.connect(outputIndex, batchNode, inputIndex)
         }
 
+        canvas.deselectAll()
         canvas.select(batchNode)
         canvasStore.updateSelectedItems()
       }

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -42,6 +42,7 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { ComfyCommand } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useHelpCenterStore } from '@/stores/helpCenterStore'
@@ -58,6 +59,7 @@ import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { ensureWorkflowSuffix, getWorkflowSuffix } from '@/utils/formatUtil'
+import { hasImageOutput, isLGraphNode } from '@/utils/litegraphUtil'
 import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
@@ -1060,6 +1062,59 @@ export function useCoreCommands(): ComfyCommand[] {
 
         const { node } = res
         canvas.select(node)
+        canvasStore.updateSelectedItems()
+      }
+    },
+    {
+      id: 'Comfy.Graph.BatchSelectedImageNodes',
+      icon: 'icon-[lucide--images]',
+      label: 'Batch Selected Images',
+      versionAdded: '1.49.0',
+      function: () => {
+        const canvas = canvasStore.getCanvas()
+        const imageNodes = [...canvas.selectedItems]
+          .filter(isLGraphNode)
+          .filter((node) => hasImageOutput(node))
+          .sort((a, b) => a.pos[1] - b.pos[1] || a.pos[0] - b.pos[0])
+        if (imageNodes.length < 2) return
+
+        const nodeDef = useNodeDefStore().nodeDefsByName['BatchImagesNode']
+        if (!nodeDef) {
+          toastStore.add({
+            severity: 'error',
+            summary: t('toastMessages.batchImagesNodeUnavailable')
+          })
+          return
+        }
+
+        const right = Math.max(
+          ...imageNodes.map((node) => node.pos[0] + node.size[0])
+        )
+        const centerY =
+          imageNodes.reduce(
+            (sum, node) => sum + node.pos[1] + node.size[1] / 2,
+            0
+          ) / imageNodes.length
+
+        const batchNode = useLitegraphService().addNodeOnGraph(nodeDef, {
+          pos: [right + 100, centerY]
+        })
+        if (!batchNode) return
+        batchNode.pos = [right + 100, centerY - batchNode.size[1] / 2]
+
+        for (const source of imageNodes) {
+          const outputIndex = source.outputs.findIndex(
+            (output) => output.type === 'IMAGE'
+          )
+          // Connecting the last free slot makes autogrow add the next one
+          const inputIndex = batchNode.inputs.findIndex(
+            (input) => input.link == null && input.type === 'IMAGE'
+          )
+          if (inputIndex === -1) break
+          source.connect(outputIndex, batchNode, inputIndex)
+        }
+
+        canvas.select(batchNode)
         canvasStore.updateSelectedItems()
       }
     },

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -137,6 +137,9 @@
   "Comfy_ExportWorkflowAPI": {
     "label": "Export Workflow (API Format)"
   },
+  "Comfy_Graph_BatchSelectedImageNodes": {
+    "label": "Batch Selected Images"
+  },
   "Comfy_Graph_ConvertToSubgraph": {
     "label": "Convert Selection to Subgraph"
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2259,6 +2259,7 @@
     "nothingSelected": "Nothing selected",
     "cannotCreateSubgraph": "Cannot create subgraph",
     "failedToConvertToSubgraph": "Failed to convert items to subgraph",
+    "batchImagesNodeUnavailable": "The Batch Images node is not available on this server",
     "failedToInitializeLoad3dViewer": "Failed to initialize 3D Viewer",
     "failedToLoadBackgroundImage": "Failed to load background image",
     "failedToLoadModel": "Failed to load 3D model",

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -80,6 +80,11 @@ export function isImageNode(node: LGraphNode | undefined): node is ImageNode {
   )
 }
 
+export function hasImageOutput(node: LGraphNode | undefined): boolean {
+  if (!node) return false
+  return !!node.outputs?.some((output) => output.type === 'IMAGE')
+}
+
 export function isVideoNode(node: LGraphNode | undefined): node is VideoNode {
   if (!node) return false
   return node.previewMediaType === 'video' || !!node.videoContainer


### PR DESCRIPTION
## Summary

Adds a selection toolbox button that batches all selected image-output nodes into a single Batch Images node with one click, instead of linking each image manually.

## Changes

- **What**: New `Comfy.Graph.BatchSelectedImageNodes` command and `BatchImagesButton` in the selection toolbox. When 2+ selected nodes have an IMAGE output, the button creates a `BatchImagesNode` to the right of the selection and connects each node''s IMAGE output to it in top-to-bottom order, relying on the node''s autogrow inputs to add a slot per connection. Only the new node is left selected afterwards, matching Convert to Subgraph behavior.

## Review Focus

- The button is hidden when the backend does not provide `BatchImagesNode` (older servers), and the command shows an error toast in that case.
- Connections stop gracefully if the autogrow max (50 inputs) is reached.
- Selected nodes are sorted by position (top-to-bottom, then left-to-right) so `image0..N` match the visual order.

## Screenshots 
<img width="550" height="763" alt="image" src="https://github.com/user-attachments/assets/2e7fc1e5-081e-4225-8fe1-26fcfa85fb3d" />

Result:
<img width="551" height="714" alt="image" src="https://github.com/user-attachments/assets/c317f5d6-5eae-4967-9317-ad875320344d" />

