### PR TITLE
feat(video): VIDEO_EDIT rich widget with trim and crop editors

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -249,6 +249,9 @@
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-400);
 
+  --video-trim-selection-background: var(--color-datatype-CLIP, #ffd500);
+  --video-trim-playhead-background: #f0513b;
+
   /* Default UI element color palette variables */
   --palette-contrast-mix-color: #fff;
   --palette-interface-panel-surface: var(--comfy-menu-bg);
@@ -532,6 +535,10 @@
   );
   --color-component-node-widget-promoted: var(--component-node-widget-promoted);
   --color-component-node-widget-advanced: var(--component-node-widget-advanced);
+  --color-video-trim-selection-background: var(
+    --video-trim-selection-background
+  );
+  --color-video-trim-playhead-background: var(--video-trim-playhead-background);
 
   /* Semantic tokens */
   --color-base-foreground: var(--base-foreground);

--- a/src/components/videoEdit/VideoEditPanel.test.ts
+++ b/src/components/videoEdit/VideoEditPanel.test.ts
@@ -1,0 +1,175 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+import VideoEditPanel from './VideoEditPanel.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      videoEdit: {
+        trimVideo: 'Trim Video',
+        cropVideo: 'Crop Video',
+        startFrame: 'Start Frame',
+        endFrame: 'End Frame',
+        duration: 'Duration',
+        frames: 'Number of Frames',
+        fileSize: 'File Size',
+        resolution: '{width} × {height}',
+        loadingVideo: 'Loading video preview',
+        setStartFrame: 'Reset start frame',
+        setEndFrame: 'Reset end frame',
+        durationZero: '0s',
+        durationSeconds: '{count}s',
+        selectedOfTotal: '{selected} / {total}',
+        fileSizeUnknown: '—',
+        fileSizeBytes: '{count} B',
+        fileSizeKilobytes: '{count} KB',
+        fileSizeMegabytes: '{count} MB',
+        noVideoSource: 'Select or connect a video to preview and edit'
+      },
+      imageCrop: {
+        ratio: 'Ratio',
+        custom: 'Custom',
+        lockRatio: 'Lock ratio',
+        unlockRatio: 'Unlock ratio'
+      }
+    }
+  }
+})
+
+function stub(testId: string) {
+  return defineComponent({
+    setup: () => () => h('div', { 'data-testid': testId })
+  })
+}
+
+const ToggleStub = defineComponent({
+  props: {
+    widget: { type: Object, required: true },
+    modelValue: { type: Boolean, default: false }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('button', {
+        'data-testid': `toggle-${props.widget.name}`,
+        onClick: () => emit('update:modelValue', !props.modelValue)
+      })
+  }
+})
+
+type PanelProps = ComponentProps<typeof VideoEditPanel>
+
+function renderPanel(props: Partial<PanelProps> = {}) {
+  return render(VideoEditPanel, {
+    props: {
+      features: ['trim', 'crop'],
+      videoUrl: '/api/view?filename=clip.mp4',
+      thumbnails: ['data:image/jpeg;base64,one'],
+      totalFrames: 100,
+      duration: 10,
+      fps: 10,
+      fileSize: 2048,
+      width: 1920,
+      height: 1080,
+      loading: false,
+      ...props
+    } as PanelProps,
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: {} },
+      stubs: {
+        VideoFilmstripTrim: stub('stub-filmstrip'),
+        VideoCropOverlay: stub('stub-crop-overlay'),
+        WidgetInputNumberInput: stub('stub-number-input'),
+        WidgetBoundingBox: stub('stub-bounding-box'),
+        WidgetToggleSwitch: ToggleStub,
+        Loader: stub('stub-loader'),
+        Select: stub('stub-select'),
+        SelectTrigger: stub('stub-select-trigger'),
+        SelectValue: stub('stub-select-value'),
+        SelectContent: stub('stub-select-content'),
+        SelectItem: stub('stub-select-item'),
+        Button: stub('stub-lock-button')
+      }
+    }
+  })
+}
+
+describe('VideoEditPanel', () => {
+  it('shows an empty state without a video source', () => {
+    renderPanel({ videoUrl: undefined })
+
+    expect(screen.getByTestId('video-edit-empty')).toBeTruthy()
+    expect(screen.queryByTestId('video-preview')).toBeNull()
+    expect(screen.queryByTestId('toggle-trim_enabled')).toBeNull()
+  })
+
+  it('renders only the toggles of the enabled features', () => {
+    renderPanel({ features: ['trim'] })
+
+    expect(screen.getByTestId('toggle-trim_enabled')).toBeTruthy()
+    expect(screen.queryByTestId('toggle-crop_enabled')).toBeNull()
+  })
+
+  it('keeps the filmstrip visible but collapses trim controls until enabled', async () => {
+    renderPanel({ features: ['trim'] })
+
+    expect(screen.getByTestId('stub-filmstrip')).toBeTruthy()
+    expect(screen.queryByTestId('stub-number-input')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('toggle-trim_enabled'))
+
+    expect(screen.getAllByTestId('stub-number-input')).toHaveLength(2)
+  })
+
+  it('expands the crop editor when the crop toggle is enabled', async () => {
+    renderPanel({ features: ['crop'] })
+
+    expect(screen.queryByTestId('stub-crop-overlay')).toBeNull()
+    expect(screen.queryByTestId('stub-bounding-box')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('toggle-crop_enabled'))
+
+    expect(screen.getByTestId('stub-crop-overlay')).toBeTruthy()
+    expect(screen.getByTestId('stub-bounding-box')).toBeTruthy()
+  })
+
+  it('shows a loading overlay while the filmstrip loads', () => {
+    renderPanel({ loading: true })
+
+    expect(screen.getByTestId('video-preview-loading')).toBeTruthy()
+  })
+
+  it('shows selected/total metadata when trim is a feature', () => {
+    renderPanel({
+      features: ['trim'],
+      startFrame: 0,
+      endFrame: 99
+    })
+
+    expect(screen.getByText('10s / 10s')).toBeTruthy()
+    expect(screen.getByText('100 / 100')).toBeTruthy()
+    expect(screen.getByText('2 KB')).toBeTruthy()
+  })
+
+  it('shows plain totals when trim is not a feature', () => {
+    renderPanel({ features: ['crop'] })
+
+    expect(screen.getByText('10s')).toBeTruthy()
+    expect(screen.getByText('100')).toBeTruthy()
+  })
+
+  it('renders the source resolution', () => {
+    renderPanel()
+
+    expect(screen.getByText('1920 × 1080')).toBeTruthy()
+  })
+})

--- a/src/components/videoEdit/VideoEditPanel.vue
+++ b/src/components/videoEdit/VideoEditPanel.vue
@@ -1,0 +1,431 @@
+<template>
+  <div class="flex flex-col gap-2" @pointerdown.stop>
+    <div
+      v-if="!videoUrl"
+      data-testid="video-edit-empty"
+      class="flex min-h-24 flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-node-stroke bg-node-component-surface p-4 text-center"
+    >
+      <i class="icon-[lucide--film] size-6 text-muted-foreground" />
+      <p class="m-0 text-sm text-muted-foreground">
+        {{ t('videoEdit.noVideoSource') }}
+      </p>
+    </div>
+    <div
+      v-else
+      data-testid="video-preview-container"
+      class="relative w-full"
+      :style="videoAspectRatioStyle"
+    >
+      <div
+        class="relative size-full overflow-hidden rounded-lg bg-node-component-surface"
+      >
+        <video
+          ref="videoRef"
+          data-testid="video-preview"
+          :src="videoUrl"
+          class="size-full object-contain"
+          preload="metadata"
+          crossorigin="anonymous"
+          playsinline
+          @loadedmetadata="handleVideoMetadata"
+          @timeupdate="handleTimeUpdate"
+        />
+        <VideoCropOverlay
+          v-if="hasCrop && cropEnabled && !loading && width > 0 && height > 0"
+          v-model="cropBounds"
+          :source-width="width"
+          :source-height="height"
+          :locked-ratio="lockedRatio"
+        />
+        <div
+          v-if="loading"
+          class="absolute inset-0 flex flex-col items-center justify-center gap-0 bg-node-component-surface"
+          data-testid="video-preview-loading"
+          :aria-busy="true"
+          :aria-label="t('videoEdit.loadingVideo')"
+        >
+          <Loader size="md" variant="loader-circle" />
+          <p class="text-sm text-muted-foreground">
+            {{ t('videoEdit.loadingVideo') }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="videoUrl"
+      class="grid grid-cols-[minmax(80px,min-content)_minmax(125px,1fr)] gap-1"
+    >
+      <WidgetToggleSwitch
+        v-if="hasTrim"
+        v-model="trimEnabled"
+        class="col-span-full grid grid-cols-subgrid"
+        :widget="trimToggleWidget"
+      />
+
+      <VideoFilmstripTrim
+        v-if="hasTrim"
+        v-model:start-frame="startFrame"
+        v-model:end-frame="endFrame"
+        v-model:playhead-frame="playheadFrame"
+        v-model:is-playing="isPlaying"
+        class="col-span-full"
+        :trim-enabled="trimEnabled"
+        :total-frames="effectiveTotalFrames"
+        :thumbnails="thumbnails"
+        @scrub="handleScrub"
+      />
+
+      <WidgetInputNumberInput
+        v-if="hasTrim && trimEnabled"
+        v-model="startFrame"
+        root-class="col-span-full grid grid-cols-subgrid items-center"
+        :widget="startFrameWidget"
+      />
+
+      <WidgetInputNumberInput
+        v-if="hasTrim && trimEnabled"
+        v-model="endFrame"
+        root-class="col-span-full grid grid-cols-subgrid items-center"
+        :widget="endFrameWidget"
+      />
+
+      <div
+        v-if="hasTrim && trimEnabled"
+        class="col-span-full grid grid-cols-2 gap-1"
+      >
+        <button
+          v-tooltip="t('videoEdit.setStartFrame')"
+          type="button"
+          :class="WidgetInputActionButtonClass"
+          :disabled="setStartFrameDisabled"
+          :aria-label="t('videoEdit.setStartFrame')"
+          @click="setStartFrame"
+        >
+          <i class="icon-[lucide--skip-back] size-4" />
+        </button>
+        <button
+          v-tooltip="t('videoEdit.setEndFrame')"
+          type="button"
+          :class="WidgetInputActionButtonClass"
+          :disabled="setEndFrameDisabled"
+          :aria-label="t('videoEdit.setEndFrame')"
+          @click="setEndFrame"
+        >
+          <i class="icon-[lucide--skip-forward] size-4" />
+        </button>
+      </div>
+
+      <WidgetToggleSwitch
+        v-if="hasCrop"
+        v-model="cropEnabled"
+        class="col-span-full grid grid-cols-subgrid"
+        :widget="cropToggleWidget"
+      />
+
+      <div
+        v-if="hasCrop && cropEnabled"
+        class="col-span-full flex items-center gap-2"
+      >
+        <label class="text-xs text-muted-foreground">
+          {{ t('imageCrop.ratio') }}
+        </label>
+        <Select v-model="selectedRatio" :disabled="!canLockRatio">
+          <SelectTrigger class="h-7 w-24 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="key in ratioKeys" :key="key" :value="key">
+              {{ key === 'custom' ? t('imageCrop.custom') : key }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          size="icon"
+          :variant="isLockEnabled ? 'primary' : 'secondary'"
+          class="size-7"
+          :disabled="!canLockRatio"
+          :aria-label="
+            isLockEnabled
+              ? t('imageCrop.unlockRatio')
+              : t('imageCrop.lockRatio')
+          "
+          @click="isLockEnabled = !isLockEnabled"
+        >
+          <i
+            :class="
+              isLockEnabled
+                ? 'icon-[lucide--lock] size-3.5'
+                : 'icon-[lucide--lock-open] size-3.5'
+            "
+          />
+        </Button>
+      </div>
+
+      <WidgetBoundingBox
+        v-if="hasCrop && cropEnabled"
+        v-model="cropBounds"
+        class="col-span-full"
+        :disabled="loading || width <= 0"
+      />
+
+      <div
+        class="col-span-full mt-2 grid grid-cols-subgrid gap-y-0.5 border-t border-node-stroke py-2"
+      >
+        <div
+          v-for="row in metadataRows"
+          :key="row.label"
+          class="col-span-full grid grid-cols-subgrid py-0.5 text-sm"
+        >
+          <span class="truncate text-muted-foreground">{{ row.label }}</span>
+          <span class="text-right text-base-foreground">{{ row.value }}</span>
+        </div>
+      </div>
+      <p
+        v-if="resolutionLabel"
+        class="col-span-full m-0 border-t border-node-stroke py-3 text-center text-sm text-base-foreground"
+      >
+        {{ resolutionLabel }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, toRef, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import WidgetBoundingBox from '@/components/boundingbox/WidgetBoundingBox.vue'
+import Loader from '@/components/loader/Loader.vue'
+import Button from '@/components/ui/button/Button.vue'
+import Select from '@/components/ui/select/Select.vue'
+import SelectContent from '@/components/ui/select/SelectContent.vue'
+import SelectItem from '@/components/ui/select/SelectItem.vue'
+import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
+import SelectValue from '@/components/ui/select/SelectValue.vue'
+import VideoCropOverlay from '@/components/videoEdit/VideoCropOverlay.vue'
+import VideoFilmstripTrim from '@/components/videoEdit/VideoFilmstripTrim.vue'
+import { useCropRatioLock } from '@/composables/video/useCropRatioLock'
+import { useTrimPlayback } from '@/composables/video/useTrimPlayback'
+import { useVideoEditFormats } from '@/composables/video/useVideoEditFormats'
+import { DEFAULT_VIDEO_FPS } from '@/composables/video/useVideoFilmstrip'
+import type { VideoEditFeature } from '@/lib/litegraph/src/types/widgets'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { WidgetInputActionButtonClass } from '@/renderer/extensions/vueNodes/widgets/components/layout'
+import WidgetInputNumberInput from '@/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue'
+import WidgetToggleSwitch from '@/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.vue'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { frameToTime, timeToFrame } from '@/utils/videoFrameUtil'
+
+const {
+  features,
+  videoUrl,
+  thumbnails,
+  totalFrames,
+  duration,
+  fps,
+  fileSize,
+  width,
+  height,
+  loading = false
+} = defineProps<{
+  features: VideoEditFeature[]
+  videoUrl?: string
+  thumbnails: string[]
+  totalFrames: number
+  duration: number
+  fps: number
+  fileSize?: number
+  width: number
+  height: number
+  loading?: boolean
+}>()
+
+const startFrame = defineModel<number>('startFrame', { default: 0 })
+const endFrame = defineModel<number>('endFrame', { default: 0 })
+const playheadFrame = defineModel<number>('playheadFrame', { default: 0 })
+const cropBounds = defineModel<Bounds>('cropBounds', {
+  default: () => ({ x: 0, y: 0, width: 0, height: 0 })
+})
+const trimEnabled = defineModel<boolean>('trimEnabled', { default: false })
+const cropEnabled = defineModel<boolean>('cropEnabled', { default: false })
+
+const { t } = useI18n()
+const { formatDuration, formatFileSize } = useVideoEditFormats()
+
+const videoRef = useTemplateRef<HTMLVideoElement>('videoRef')
+const videoIntrinsicSize = ref<{ width: number; height: number } | null>(null)
+
+const hasTrim = computed(() => features.includes('trim'))
+const hasCrop = computed(() => features.includes('crop'))
+
+const effectiveTotalFrames = computed(() => Math.max(totalFrames, 1))
+const frameMax = computed(() => Math.max(totalFrames - 1, 0))
+
+const toTime = (frame: number) =>
+  frameToTime(frame, duration, frameMax.value, fps || DEFAULT_VIDEO_FPS)
+const toFrame = (time: number) =>
+  timeToFrame(time, duration, frameMax.value, fps || DEFAULT_VIDEO_FPS)
+
+const { isPlaying, seekPreviewToFrame, handleScrub, handleTimeUpdate } =
+  useTrimPlayback({
+    videoRef,
+    frameMax,
+    startFrame,
+    endFrame,
+    playheadFrame,
+    hasTrimTimeline: hasTrim,
+    frameToTime: toTime,
+    timeToFrame: toFrame
+  })
+
+const { lockedRatio, ratioKeys, selectedRatio, isLockEnabled, canLockRatio } =
+  useCropRatioLock(cropBounds, {
+    sourceWidth: toRef(() => width),
+    sourceHeight: toRef(() => height)
+  })
+
+const setStartFrameDisabled = computed(() => !videoUrl || startFrame.value <= 0)
+
+const setEndFrameDisabled = computed(
+  () => !videoUrl || endFrame.value >= frameMax.value
+)
+
+function setStartFrame() {
+  isPlaying.value = false
+  startFrame.value = 0
+  void seekPreviewToFrame(0)
+}
+
+function setEndFrame() {
+  isPlaying.value = false
+  endFrame.value = frameMax.value
+  void seekPreviewToFrame(frameMax.value)
+}
+
+const trimToggleWidget = computed(
+  (): SimplifiedWidget<boolean> => ({
+    name: 'trim_enabled',
+    label: t('videoEdit.trimVideo'),
+    type: 'toggle',
+    value: trimEnabled.value
+  })
+)
+
+const cropToggleWidget = computed(
+  (): SimplifiedWidget<boolean> => ({
+    name: 'crop_enabled',
+    label: t('videoEdit.cropVideo'),
+    type: 'toggle',
+    value: cropEnabled.value
+  })
+)
+
+const startFrameWidget = computed(
+  (): SimplifiedWidget<number> => ({
+    name: 'start_frame',
+    label: t('videoEdit.startFrame'),
+    type: 'number',
+    value: startFrame.value,
+    options: {
+      min: 0,
+      max: Math.max(endFrame.value - 1, 0),
+      step: 1,
+      step2: 1,
+      precision: 0,
+      disabled: !videoUrl
+    }
+  })
+)
+
+const endFrameWidget = computed(
+  (): SimplifiedWidget<number> => ({
+    name: 'end_frame',
+    label: t('videoEdit.endFrame'),
+    type: 'number',
+    value: endFrame.value,
+    options: {
+      min: Math.min(startFrame.value + 1, effectiveTotalFrames.value - 1),
+      max: Math.max(effectiveTotalFrames.value - 1, 0),
+      step: 1,
+      step2: 1,
+      precision: 0,
+      disabled: !videoUrl
+    }
+  })
+)
+
+const videoAspectRatioStyle = computed(() => {
+  const intrinsic = videoIntrinsicSize.value
+  const aspectWidth = width || intrinsic?.width
+  const aspectHeight = height || intrinsic?.height
+  if (aspectWidth && aspectHeight) {
+    return { aspectRatio: `${aspectWidth} / ${aspectHeight}` }
+  }
+  return { aspectRatio: '16 / 9' }
+})
+
+const selectedDurationSeconds = computed(() =>
+  Math.max(toTime(endFrame.value) - toTime(startFrame.value), 0)
+)
+
+const selectedFrameCount = computed(() =>
+  Math.max(endFrame.value - startFrame.value + 1, 0)
+)
+
+const metadataRows = computed(() => [
+  {
+    label: t('videoEdit.duration'),
+    value: hasTrim.value
+      ? t('videoEdit.selectedOfTotal', {
+          selected: formatDuration(selectedDurationSeconds.value),
+          total: formatDuration(duration)
+        })
+      : formatDuration(duration)
+  },
+  {
+    label: t('videoEdit.frames'),
+    value: hasTrim.value
+      ? t('videoEdit.selectedOfTotal', {
+          selected: selectedFrameCount.value,
+          total: effectiveTotalFrames.value
+        })
+      : String(effectiveTotalFrames.value)
+  },
+  {
+    label: t('videoEdit.fileSize'),
+    value: formatFileSize(fileSize)
+  }
+])
+
+const resolutionLabel = computed(() => {
+  const intrinsic = videoIntrinsicSize.value
+  const displayWidth = width || intrinsic?.width
+  const displayHeight = height || intrinsic?.height
+  if (!displayWidth || !displayHeight) return ''
+  return t('videoEdit.resolution', {
+    width: displayWidth,
+    height: displayHeight
+  })
+})
+
+watch(
+  toRef(() => videoUrl),
+  () => {
+    playheadFrame.value = 0
+    isPlaying.value = false
+    videoIntrinsicSize.value = null
+  }
+)
+
+function handleVideoMetadata() {
+  const video = videoRef.value
+  if (video?.videoWidth && video.videoHeight) {
+    videoIntrinsicSize.value = {
+      width: video.videoWidth,
+      height: video.videoHeight
+    }
+  }
+  if (hasTrim.value) void seekPreviewToFrame(playheadFrame.value)
+}
+</script>

--- a/src/components/videoEdit/VideoFilmstripTrim.test.ts
+++ b/src/components/videoEdit/VideoFilmstripTrim.test.ts
@@ -1,0 +1,506 @@
+/* eslint-disable testing-library/prefer-user-event -- pointer capture scrubbing needs low-level pointer events */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import type { Ref } from 'vue'
+
+const { activeHandle } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: createRef } = require('vue')
+  return {
+    activeHandle: createRef(null) as Ref<'min' | 'max' | 'midpoint' | null>
+  }
+})
+
+vi.mock('@/composables/useRangeEditor', () => ({
+  useRangeEditor: () => ({
+    startDrag: vi.fn(),
+    activeHandle
+  })
+}))
+
+import type { ComponentProps } from 'vue-component-type-helpers'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { createI18n } from 'vue-i18n'
+
+import VideoFilmstripTrim from './VideoFilmstripTrim.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      videoEdit: {
+        play: 'Play',
+        pause: 'Pause',
+        loadingFilmstrip: 'Loading filmstrip…',
+        seekVideo: 'Seek video',
+        adjustStartFrame: 'Adjust start frame',
+        adjustEndFrame: 'Adjust end frame'
+      }
+    }
+  }
+})
+
+type FilmstripProps = ComponentProps<typeof VideoFilmstripTrim>
+
+function expectedFrameAt(clientX: number, width = 200, frameMax = 100) {
+  const contentWidth = Math.max(width - 16, 1)
+  const norm = Math.min(Math.max((clientX - 8) / contentWidth, 0), 1)
+  return Math.round(norm * frameMax)
+}
+
+function renderFilmstrip(props: FilmstripProps) {
+  return render(VideoFilmstripTrim, {
+    props,
+    global: {
+      plugins: [i18n]
+    }
+  })
+}
+
+function mockTrackRect() {
+  const track = screen.getByTestId('trim-track')
+  vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 200,
+    height: 64,
+    right: 200,
+    bottom: 64,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
+  return track
+}
+
+describe('VideoFilmstripTrim', () => {
+  beforeEach(() => {
+    activeHandle.value = null
+  })
+
+  it('insets the filmstrip track by half a handle width on each side', () => {
+    renderFilmstrip({
+      totalFrames: 100,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 0,
+      endFrame: 99,
+      playheadFrame: 0,
+      disabled: false
+    })
+
+    const filmstrip = screen.getByTestId('filmstrip-track')
+    expect(filmstrip.style.left).toBe('8px')
+    expect(filmstrip.style.right).toBe('8px')
+  })
+
+  it('prevents filmstrip thumbnails from being dragged', () => {
+    renderFilmstrip({
+      totalFrames: 100,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 0,
+      endFrame: 99,
+      playheadFrame: 0,
+      disabled: false
+    })
+
+    expect(
+      screen.getByTestId('filmstrip-thumbnail').getAttribute('draggable')
+    ).toBe('false')
+  })
+
+  it('shows whole frame number in tooltip while dragging end handle', () => {
+    activeHandle.value = 'max'
+    renderFilmstrip({
+      totalFrames: 401,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 0,
+      endFrame: 400,
+      playheadFrame: 0,
+      disabled: false
+    })
+
+    expect(screen.getByTestId('trim-handle-tooltip')).toHaveTextContent('400')
+  })
+
+  it('shows whole frame number in tooltip while dragging start handle', () => {
+    activeHandle.value = 'min'
+    renderFilmstrip({
+      totalFrames: 401,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 120,
+      endFrame: 400,
+      playheadFrame: 120,
+      disabled: false
+    })
+
+    expect(screen.getByTestId('trim-handle-tooltip')).toHaveTextContent('120')
+  })
+
+  it('maps the content-inset edges and midpoint to fixed frames', async () => {
+    const playheadFrame = ref(0)
+    render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 0,
+        endFrame: 100,
+        playheadFrame: 0,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+
+    await fireEvent.pointerDown(track, { clientX: 8, button: 0, pointerId: 1 })
+    await fireEvent.pointerUp(track, { pointerId: 1 })
+    expect(playheadFrame.value).toBe(0)
+
+    await fireEvent.pointerDown(track, {
+      clientX: 100,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerUp(track, { pointerId: 1 })
+    expect(playheadFrame.value).toBe(50)
+
+    await fireEvent.pointerDown(track, {
+      clientX: 192,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerUp(track, { pointerId: 1 })
+    expect(playheadFrame.value).toBe(100)
+
+    await fireEvent.pointerDown(track, {
+      clientX: 300,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerUp(track, { pointerId: 1 })
+    expect(playheadFrame.value).toBe(100)
+  })
+
+  it('scrubs to the clicked frame on the filmstrip', async () => {
+    const playheadFrame = ref(0)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 0,
+        endFrame: 100,
+        playheadFrame: 0,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+
+    await fireEvent.pointerDown(track, { clientX: 100, button: 0 })
+
+    expect(playheadFrame.value).toBe(expectedFrameAt(100))
+    expect(emitted().scrub).toEqual([[expectedFrameAt(100)]])
+  })
+
+  it('clamps scrubbing to the trim selection when trim is enabled', async () => {
+    const playheadFrame = ref(50)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 10,
+        endFrame: 80,
+        playheadFrame: 50,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+
+    await fireEvent.pointerDown(track, { clientX: 20, button: 0 })
+
+    expect(playheadFrame.value).toBe(10)
+    expect(emitted().scrub).toEqual([[10]])
+
+    await fireEvent.pointerDown(track, { clientX: 180, button: 0 })
+
+    expect(playheadFrame.value).toBe(80)
+    expect(emitted().scrub).toEqual([[10], [80]])
+  })
+
+  it('emits a single scrub while dragging past the trim bound', async () => {
+    const playheadFrame = ref(50)
+    const scrubs: number[] = []
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(VideoFilmstripTrim, {
+            totalFrames: 101,
+            thumbnails: ['data:image/jpeg;base64,one'],
+            startFrame: 10,
+            endFrame: 80,
+            playheadFrame: playheadFrame.value,
+            disabled: false,
+            'onUpdate:playheadFrame': (value: number) => {
+              playheadFrame.value = value
+            },
+            onScrub: (frame: number) => {
+              scrubs.push(frame)
+            }
+          })
+      }
+    })
+    render(Host, {
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+    track.setPointerCapture = vi.fn()
+
+    await fireEvent.pointerDown(track, {
+      clientX: 180,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerMove(track, { clientX: 190, pointerId: 1 })
+    await fireEvent.pointerMove(track, { clientX: 195, pointerId: 1 })
+
+    expect(playheadFrame.value).toBe(80)
+    expect(scrubs).toEqual([80])
+  })
+
+  it('emits the initial scrub even when the pointer lands on the current frame', async () => {
+    const playheadFrame = ref(50)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 0,
+        endFrame: 100,
+        playheadFrame: 50,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+
+    await fireEvent.pointerDown(track, { clientX: 100, button: 0 })
+
+    expect(emitted().scrub).toEqual([[50]])
+  })
+
+  it('seeks with arrow keys, Home and End from the slider track', async () => {
+    const playheadFrame = ref(50)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 10,
+        endFrame: 80,
+        playheadFrame: 50,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = screen.getByRole('slider', { name: 'Seek video' })
+    expect(track.getAttribute('aria-valuemin')).toBe('10')
+    expect(track.getAttribute('aria-valuemax')).toBe('80')
+    expect(track.getAttribute('aria-valuenow')).toBe('50')
+    expect(track.getAttribute('tabindex')).toBe('0')
+
+    await fireEvent.keyDown(track, { key: 'ArrowRight' })
+    expect(playheadFrame.value).toBe(51)
+
+    await fireEvent.keyDown(track, { key: 'Home' })
+    expect(playheadFrame.value).toBe(10)
+
+    await fireEvent.keyDown(track, { key: 'End' })
+    expect(playheadFrame.value).toBe(80)
+
+    expect(emitted().scrub).toEqual([[51], [10], [80]])
+  })
+
+  it('updates playhead while dragging across the filmstrip', async () => {
+    const playheadFrame = ref(0)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 0,
+        endFrame: 100,
+        playheadFrame: 0,
+        disabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+    track.setPointerCapture = vi.fn()
+
+    await fireEvent.pointerDown(track, { clientX: 40, button: 0, pointerId: 1 })
+    await fireEvent.pointerMove(track, {
+      clientX: 120,
+      button: 0,
+      pointerId: 1
+    })
+
+    expect(playheadFrame.value).toBe(expectedFrameAt(120))
+    expect(emitted().scrub).toEqual([
+      [expectedFrameAt(40)],
+      [expectedFrameAt(120)]
+    ])
+  })
+
+  it('shows the frame number in a tooltip while scrubbing', async () => {
+    const playheadFrame = ref(0)
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(VideoFilmstripTrim, {
+            totalFrames: 101,
+            thumbnails: ['data:image/jpeg;base64,one'],
+            startFrame: 0,
+            endFrame: 100,
+            playheadFrame: playheadFrame.value,
+            disabled: false,
+            'onUpdate:playheadFrame': (value: number) => {
+              playheadFrame.value = value
+            }
+          })
+      }
+    })
+    render(Host, {
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+    track.setPointerCapture = vi.fn()
+
+    expect(screen.queryByTestId('scrub-tooltip')).toBeNull()
+
+    await fireEvent.pointerDown(track, {
+      clientX: 120,
+      button: 0,
+      pointerId: 1
+    })
+
+    expect(screen.getByTestId('scrub-tooltip')).toHaveTextContent(
+      String(expectedFrameAt(120))
+    )
+
+    await fireEvent.pointerUp(track, { pointerId: 1 })
+
+    expect(screen.queryByTestId('scrub-tooltip')).toBeNull()
+  })
+
+  it('renders trim handles when enabled', () => {
+    renderFilmstrip({
+      totalFrames: 100,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 10,
+      endFrame: 80,
+      playheadFrame: 10,
+      disabled: false
+    })
+
+    expect(screen.getByTestId('handle-start')).toBeTruthy()
+    expect(screen.getByTestId('handle-end')).toBeTruthy()
+  })
+
+  it('hides trim handles when disabled', () => {
+    renderFilmstrip({
+      totalFrames: 100,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 10,
+      endFrame: 80,
+      playheadFrame: 10,
+      disabled: true
+    })
+
+    expect(screen.queryByTestId('handle-start')).toBeNull()
+    expect(screen.queryByTestId('handle-end')).toBeNull()
+  })
+
+  it('hides trim selection UI when trim is toggled off', () => {
+    renderFilmstrip({
+      totalFrames: 100,
+      thumbnails: ['data:image/jpeg;base64,one'],
+      startFrame: 10,
+      endFrame: 80,
+      playheadFrame: 10,
+      trimEnabled: false
+    })
+
+    expect(screen.getByTestId('playhead')).toBeTruthy()
+    expect(screen.getByTestId('filmstrip-track').style.left).toBe('8px')
+    expect(screen.getByTestId('filmstrip-track').style.right).toBe('8px')
+    expect(screen.queryByTestId('handle-start')).toBeNull()
+    expect(screen.queryByTestId('handle-end')).toBeNull()
+  })
+
+  it('scrubs across the full timeline when trim is toggled off', async () => {
+    const playheadFrame = ref(0)
+    const { emitted } = render(VideoFilmstripTrim, {
+      props: {
+        totalFrames: 101,
+        thumbnails: ['data:image/jpeg;base64,one'],
+        startFrame: 10,
+        endFrame: 80,
+        playheadFrame: 0,
+        trimEnabled: false,
+        'onUpdate:playheadFrame': (value: number) => {
+          playheadFrame.value = value
+        }
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    const track = mockTrackRect()
+
+    await fireEvent.pointerDown(track, { clientX: 100, button: 0 })
+
+    expect(playheadFrame.value).toBe(expectedFrameAt(100))
+    expect(emitted().scrub).toEqual([[expectedFrameAt(100)]])
+  })
+})

--- a/src/components/videoEdit/VideoFilmstripTrim.vue
+++ b/src/components/videoEdit/VideoFilmstripTrim.vue
@@ -1,0 +1,349 @@
+<template>
+  <div class="flex h-16 w-full items-stretch gap-px" @pointerdown.stop>
+    <button
+      type="button"
+      :class="
+        cn(
+          'flex w-14 shrink-0 items-center justify-center rounded-l-lg border-none bg-component-node-widget-background px-4 text-muted-foreground',
+          !disabled &&
+            'cursor-pointer hover:bg-component-node-widget-background-hovered',
+          disabled && 'cursor-default opacity-50'
+        )
+      "
+      :disabled="disabled"
+      :aria-label="isPlaying ? t('videoEdit.pause') : t('videoEdit.play')"
+      @click="togglePlay"
+    >
+      <i
+        :class="
+          cn(
+            isPlaying ? 'icon-[lucide--pause]' : 'icon-[lucide--play]',
+            !isPlaying && 'ml-0.5',
+            'size-5'
+          )
+        "
+      />
+    </button>
+
+    <div
+      ref="trackRef"
+      data-testid="trim-track"
+      :class="
+        cn(
+          'relative min-w-0 flex-1 rounded-r-lg bg-component-node-widget-background',
+          disabled || totalFrames <= 1
+            ? 'cursor-default'
+            : isScrubDragging
+              ? 'cursor-grabbing'
+              : 'cursor-grab'
+        )
+      "
+      role="slider"
+      :tabindex="disabled || totalFrames <= 1 ? -1 : 0"
+      :aria-valuemin="scrubMinFrame"
+      :aria-valuemax="scrubMaxFrame"
+      :aria-valuenow="playheadFrame"
+      :aria-label="t('videoEdit.seekVideo')"
+      @pointerdown.stop="startScrubDrag"
+      @keydown="handleTrackKeydown"
+      @contextmenu.prevent.stop
+    >
+      <span v-if="isFilmstripLoading" role="status" class="sr-only">
+        {{ t('videoEdit.loadingFilmstrip') }}
+      </span>
+      <div
+        v-if="isScrubDragging"
+        data-testid="scrub-tooltip"
+        class="pointer-events-none absolute bottom-full z-30 mb-1 flex -translate-x-1/2 flex-col items-center"
+        :style="playheadStyle"
+      >
+        <span
+          class="rounded-lg bg-interface-menu-surface px-2.5 py-1 text-sm font-semibold text-base-foreground tabular-nums"
+        >
+          {{ playheadFrame }}
+        </span>
+        <span
+          class="size-0 border-x-[5px] border-t-[5px] border-x-transparent border-t-interface-menu-surface"
+        />
+      </div>
+
+      <div
+        v-if="activeHandle === 'min' || activeHandle === 'max'"
+        data-testid="trim-handle-tooltip"
+        class="pointer-events-none absolute bottom-full z-10 mb-1 flex -translate-x-1/2 flex-col items-center"
+        :style="activeHandleTooltipStyle"
+      >
+        <span
+          class="rounded-lg bg-interface-menu-surface px-2.5 py-1 text-sm font-semibold text-base-foreground tabular-nums"
+        >
+          {{ activeHandleFrame }}
+        </span>
+        <span
+          class="size-0 border-x-[5px] border-t-[5px] border-x-transparent border-t-interface-menu-surface"
+        />
+      </div>
+
+      <div
+        data-testid="filmstrip-track"
+        class="pointer-events-none absolute top-2 flex h-12 items-stretch overflow-hidden"
+        :style="{
+          left: `${CONTENT_INSET_PX}px`,
+          right: `${CONTENT_INSET_PX}px`
+        }"
+        aria-hidden="true"
+      >
+        <img
+          v-for="(thumbnail, index) in thumbnails"
+          :key="index"
+          data-testid="filmstrip-thumbnail"
+          :src="thumbnail"
+          alt=""
+          draggable="false"
+          class="h-full min-w-0 flex-1 object-cover select-none"
+        />
+        <div
+          v-if="isFilmstripLoading"
+          class="flex size-full items-stretch gap-px overflow-hidden"
+          data-testid="filmstrip-skeleton"
+        >
+          <Skeleton
+            v-for="index in FILMSTRIP_SAMPLE_COUNT"
+            :key="index"
+            class="h-full min-w-10 flex-1 rounded-none"
+          />
+        </div>
+      </div>
+
+      <div
+        v-if="trimEnabled && startNorm > 0"
+        class="pointer-events-none absolute inset-y-0 left-0 bg-black/50"
+        :style="leftDimStyle"
+      />
+      <div
+        v-if="trimEnabled && endNorm < 1"
+        class="pointer-events-none absolute inset-y-0 right-0 bg-black/50"
+        :style="rightDimStyle"
+      />
+
+      <div
+        v-if="trimEnabled"
+        class="pointer-events-none absolute inset-y-0 flex"
+        :style="selectionStyle"
+      >
+        <button
+          v-if="!disabled && totalFrames > 1"
+          type="button"
+          data-testid="handle-start"
+          :class="
+            cn(
+              'pointer-events-auto flex shrink-0 cursor-ew-resize',
+              'items-center justify-center bg-video-trim-selection-background',
+              'rounded-l-lg border-none p-0'
+            )
+          "
+          :style="{ width: `${HANDLE_WIDTH_PX}px` }"
+          :aria-label="t('videoEdit.adjustStartFrame')"
+          @pointerdown.stop="startDrag('min', $event)"
+        >
+          <span class="h-4 w-px rounded-full bg-secondary-background" />
+        </button>
+
+        <div class="flex min-w-0 flex-1 flex-col">
+          <div :class="cn('h-2 shrink-0', trimSelectionBarClass)" />
+          <div class="h-12 shrink-0" />
+          <div :class="cn('h-2 shrink-0', trimSelectionBarClass)" />
+        </div>
+
+        <button
+          v-if="!disabled && totalFrames > 1"
+          type="button"
+          data-testid="handle-end"
+          :class="
+            cn(
+              'pointer-events-auto flex shrink-0 cursor-ew-resize',
+              'items-center justify-center bg-video-trim-selection-background',
+              'rounded-r-lg border-none p-0'
+            )
+          "
+          :style="{ width: `${HANDLE_WIDTH_PX}px` }"
+          :aria-label="t('videoEdit.adjustEndFrame')"
+          @pointerdown.stop="startDrag('max', $event)"
+        >
+          <span class="h-4 w-px rounded-full bg-secondary-background" />
+        </button>
+      </div>
+
+      <div
+        data-testid="playhead"
+        :class="
+          cn(
+            'absolute top-2 z-20 flex h-12 w-3 -translate-x-1/2 touch-none items-stretch justify-center',
+            isScrubDragging ? 'cursor-grabbing' : 'cursor-grab'
+          )
+        "
+        :style="playheadStyle"
+        @pointerdown.stop="startScrubDrag"
+      >
+        <div
+          class="pointer-events-none flex w-1.5 items-center justify-center rounded-full bg-video-trim-playhead-background"
+        >
+          <span class="h-4 w-px rounded-full bg-secondary-background" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
+import { useRangeEditor } from '@/composables/useRangeEditor'
+import { useTimelineScrub } from '@/composables/video/useTimelineScrub'
+import { FILMSTRIP_SAMPLE_COUNT } from '@/composables/video/useVideoFilmstrip'
+import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const HANDLE_WIDTH_PX = 16
+const CONTENT_INSET_PX = HANDLE_WIDTH_PX / 2
+const TRACK_CONTENT_SPAN = `(100% - ${CONTENT_INSET_PX * 2}px)`
+
+function timelineInsetLeftStyle(normalized: number) {
+  return {
+    left: `calc(${normalized} * ${TRACK_CONTENT_SPAN} + ${CONTENT_INSET_PX}px)`
+  }
+}
+
+const {
+  totalFrames,
+  thumbnails,
+  disabled = false,
+  trimEnabled = true
+} = defineProps<{
+  totalFrames: number
+  thumbnails: string[]
+  disabled?: boolean
+  trimEnabled?: boolean
+}>()
+
+const startFrame = defineModel<number>('startFrame', { required: true })
+const endFrame = defineModel<number>('endFrame', { required: true })
+const playheadFrame = defineModel<number>('playheadFrame', { required: true })
+const isPlaying = defineModel<boolean>('isPlaying', { default: false })
+
+const emit = defineEmits<{
+  scrub: [frame: number]
+}>()
+
+const { t } = useI18n()
+
+const trackRef = useTemplateRef<HTMLDivElement>('trackRef')
+const frameMax = computed(() => Math.max(totalFrames - 1, 0))
+
+const rangeValue = computed<RangeValue>({
+  get: () => ({
+    min: startFrame.value,
+    max: endFrame.value
+  }),
+  set: (value) => {
+    startFrame.value = Math.round(value.min)
+    endFrame.value = Math.round(value.max)
+  }
+})
+
+const contentInsetX = computed(() => CONTENT_INSET_PX)
+
+const { startDrag, activeHandle } = useRangeEditor({
+  trackRef,
+  modelValue: rangeValue,
+  valueMin: toRef(() => 0),
+  valueMax: frameMax,
+  showMidpoint: toRef(() => false),
+  contentInsetX
+})
+
+const scrubMinFrame = computed(() => (trimEnabled ? startFrame.value : 0))
+const scrubMaxFrame = computed(() =>
+  trimEnabled ? endFrame.value : frameMax.value
+)
+
+const { isScrubDragging, startScrubDrag, scrubToFrame } = useTimelineScrub(
+  playheadFrame,
+  {
+    trackRef,
+    frameMax,
+    scrubMin: scrubMinFrame,
+    scrubMax: scrubMaxFrame,
+    contentInsetX: CONTENT_INSET_PX,
+    isDisabled: () => disabled || totalFrames <= 1,
+    onScrub: (frame) => emit('scrub', frame)
+  }
+)
+
+function handleTrackKeydown(event: KeyboardEvent) {
+  if (disabled || totalFrames <= 1) return
+  const seekTargets: Record<string, number> = {
+    ArrowLeft: playheadFrame.value - 1,
+    ArrowDown: playheadFrame.value - 1,
+    ArrowRight: playheadFrame.value + 1,
+    ArrowUp: playheadFrame.value + 1,
+    Home: scrubMinFrame.value,
+    End: scrubMaxFrame.value
+  }
+  const target = seekTargets[event.key]
+  if (target === undefined) return
+  event.preventDefault()
+  scrubToFrame(target)
+}
+
+const isFilmstripLoading = computed(() => thumbnails.length === 0)
+
+const trimSelectionBarClass = computed(() =>
+  isFilmstripLoading.value
+    ? 'bg-component-node-widget-background'
+    : 'bg-video-trim-selection-background'
+)
+
+const startNorm = computed(() =>
+  frameMax.value <= 0 ? 0 : startFrame.value / frameMax.value
+)
+const endNorm = computed(() =>
+  frameMax.value <= 0 ? 1 : endFrame.value / frameMax.value
+)
+
+const playheadNorm = computed(() =>
+  frameMax.value <= 0 ? 0 : playheadFrame.value / frameMax.value
+)
+
+const playheadStyle = computed(() => timelineInsetLeftStyle(playheadNorm.value))
+
+const leftDimStyle = computed(() => ({
+  width: `calc(${startNorm.value} * ${TRACK_CONTENT_SPAN})`
+}))
+
+const rightDimStyle = computed(() => ({
+  width: `calc(${1 - endNorm.value} * ${TRACK_CONTENT_SPAN})`
+}))
+
+const selectionStyle = computed(() => ({
+  left: `calc(${startNorm.value} * ${TRACK_CONTENT_SPAN})`,
+  width: `calc((${endNorm.value} - ${startNorm.value}) * ${TRACK_CONTENT_SPAN} + ${HANDLE_WIDTH_PX}px)`
+}))
+
+const activeHandleFrame = computed(() => {
+  if (activeHandle.value === 'min') return startFrame.value
+  if (activeHandle.value === 'max') return endFrame.value
+  return 0
+})
+
+const activeHandleTooltipStyle = computed(() => {
+  const norm = activeHandle.value === 'min' ? startNorm.value : endNorm.value
+  return timelineInsetLeftStyle(norm)
+})
+
+function togglePlay() {
+  if (disabled) return
+  isPlaying.value = !isPlaying.value
+}
+</script>

--- a/src/components/videoEdit/WidgetVideoEdit.test.ts
+++ b/src/components/videoEdit/WidgetVideoEdit.test.ts
@@ -1,0 +1,147 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import type { VideoEditValue } from '@/lib/litegraph/src/types/widgets'
+import { toNodeId } from '@/types/nodeId'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetVideoEdit from './WidgetVideoEdit.vue'
+
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: { graph: { getNodeById: () => ({}) } } }
+}))
+
+vi.mock('@/composables/video/useVideoSourceUrl', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: createRef } = require('vue')
+  return {
+    useVideoSourceUrl: () => ({
+      videoUrl: createRef('/api/view?filename=clip.mp4')
+    })
+  }
+})
+
+vi.mock('@/composables/video/useVideoFilmstrip', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: createRef } = require('vue')
+  return {
+    DEFAULT_VIDEO_FPS: 20,
+    useVideoFilmstrip: () => ({
+      thumbnails: createRef([]),
+      duration: createRef(10),
+      totalFrames: createRef(101),
+      width: createRef(1920),
+      height: createRef(1080),
+      fps: createRef(10),
+      fileSize: createRef(1024),
+      loading: createRef(false)
+    })
+  }
+})
+
+const recorded: { props?: Record<string, unknown> } = {}
+
+const PanelStub = defineComponent({
+  props: [
+    'features',
+    'videoUrl',
+    'thumbnails',
+    'totalFrames',
+    'duration',
+    'fps',
+    'fileSize',
+    'width',
+    'height',
+    'loading',
+    'startFrame',
+    'endFrame',
+    'cropBounds',
+    'trimEnabled',
+    'cropEnabled'
+  ],
+  emits: [
+    'update:startFrame',
+    'update:endFrame',
+    'update:cropBounds',
+    'update:trimEnabled',
+    'update:cropEnabled'
+  ],
+  setup(props, { emit }) {
+    recorded.props = props
+    return () =>
+      h('button', {
+        'data-testid': 'emit-start-frame',
+        onClick: () => emit('update:startFrame', 10)
+      })
+  }
+})
+
+function createWidget(
+  options: Record<string, unknown> = {}
+): SimplifiedWidget<VideoEditValue> {
+  return {
+    name: 'edit',
+    type: 'videoedit',
+    value: {},
+    options
+  } as SimplifiedWidget<VideoEditValue>
+}
+
+function renderWidget(widget = createWidget()) {
+  const modelValue = ref<VideoEditValue>({})
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(WidgetVideoEdit, {
+          widget,
+          nodeId: toNodeId('node-1'),
+          modelValue: modelValue.value,
+          'onUpdate:modelValue': (value: VideoEditValue) => {
+            modelValue.value = value
+          }
+        })
+    }
+  })
+  render(Host, {
+    global: {
+      stubs: { VideoEditPanel: PanelStub }
+    }
+  })
+  return { modelValue }
+}
+
+describe('WidgetVideoEdit', () => {
+  beforeEach(() => {
+    recorded.props = undefined
+  })
+
+  it('defaults to both features when the widget options omit them', () => {
+    renderWidget()
+
+    expect(recorded.props?.features).toEqual(['trim', 'crop'])
+  })
+
+  it('passes the features from the widget options to the panel', () => {
+    renderWidget(createWidget({ features: ['trim'] }))
+
+    expect(recorded.props?.features).toEqual(['trim'])
+  })
+
+  it('feeds the resolved source url and probed metadata to the panel', () => {
+    renderWidget()
+
+    expect(recorded.props?.videoUrl).toBe('/api/view?filename=clip.mp4')
+    expect(recorded.props?.duration).toBe(10)
+    expect(recorded.props?.totalFrames).toBe(101)
+  })
+
+  it('writes trim seconds into the model when the panel moves a frame handle', async () => {
+    const { modelValue } = renderWidget()
+
+    await userEvent.click(screen.getByTestId('emit-start-frame'))
+
+    expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+  })
+})

--- a/src/components/videoEdit/WidgetVideoEdit.vue
+++ b/src/components/videoEdit/WidgetVideoEdit.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="w-full" :data-widget-name="widget.name">
+    <VideoEditPanel
+      v-model:start-frame="startFrame"
+      v-model:end-frame="endFrame"
+      v-model:crop-bounds="cropBounds"
+      v-model:trim-enabled="trimEnabled"
+      v-model:crop-enabled="cropEnabled"
+      :features="features"
+      :video-url="videoUrl"
+      :thumbnails="thumbnails"
+      :total-frames="totalFrames"
+      :duration="duration"
+      :fps="fps"
+      :file-size="fileSize"
+      :width="width"
+      :height="height"
+      :loading="loading"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import VideoEditPanel from '@/components/videoEdit/VideoEditPanel.vue'
+import { useVideoEditModel } from '@/composables/video/useVideoEditModel'
+import { useVideoFilmstrip } from '@/composables/video/useVideoFilmstrip'
+import { useVideoSourceUrl } from '@/composables/video/useVideoSourceUrl'
+import type {
+  IWidgetVideoEditOptions,
+  VideoEditFeature,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import { app } from '@/scripts/app'
+import type { NodeId } from '@/types/nodeId'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+const { widget, nodeId } = defineProps<{
+  widget: SimplifiedWidget<VideoEditValue, IWidgetVideoEditOptions>
+  nodeId: NodeId
+}>()
+
+const modelValue = defineModel<VideoEditValue>({
+  default: () => ({})
+})
+
+const features = computed(
+  (): VideoEditFeature[] => widget.options?.features ?? ['trim', 'crop']
+)
+
+const node = computed(() => app.canvas.graph?.getNodeById(nodeId))
+
+const { videoUrl } = useVideoSourceUrl(node)
+
+const {
+  thumbnails,
+  duration,
+  totalFrames,
+  width,
+  height,
+  fps,
+  fileSize,
+  loading
+} = useVideoFilmstrip(videoUrl)
+
+const frameMax = computed(() => Math.max(totalFrames.value - 1, 0))
+
+const { startFrame, endFrame, cropBounds, trimEnabled, cropEnabled } =
+  useVideoEditModel(modelValue, {
+    duration,
+    frameMax,
+    width,
+    height
+  })
+</script>

--- a/src/composables/video/useTimelineScrub.ts
+++ b/src/composables/video/useTimelineScrub.ts
@@ -1,0 +1,100 @@
+import { onScopeDispose, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import { denormalize } from '@/utils/mathUtil'
+
+interface UseTimelineScrubOptions {
+  trackRef: Ref<HTMLElement | null>
+  frameMax: Ref<number>
+  scrubMin: Ref<number>
+  scrubMax: Ref<number>
+  contentInsetX: number
+  isDisabled: () => boolean
+  onScrub: (frame: number) => void
+}
+
+export function useTimelineScrub(
+  playheadFrame: Ref<number>,
+  options: UseTimelineScrubOptions
+) {
+  const {
+    trackRef,
+    frameMax,
+    scrubMin,
+    scrubMax,
+    contentInsetX,
+    isDisabled,
+    onScrub
+  } = options
+
+  const isScrubDragging = ref(false)
+  let cleanupScrubDrag: (() => void) | null = null
+
+  function pointerToFrame(event: PointerEvent) {
+    const el = trackRef.value
+    if (!el) return playheadFrame.value
+    const rect = el.getBoundingClientRect()
+    const contentWidth = Math.max(rect.width - 2 * contentInsetX, 1)
+    const normalized = clamp(
+      (event.clientX - rect.left - contentInsetX) / contentWidth,
+      0,
+      1
+    )
+    return Math.round(denormalize(normalized, 0, frameMax.value))
+  }
+
+  function scrubToFrame(frame: number, force = false) {
+    const clamped = clamp(frame, scrubMin.value, scrubMax.value)
+    if (!force && clamped === playheadFrame.value) return
+    playheadFrame.value = clamped
+    onScrub(clamped)
+  }
+
+  function updateScrubFromPointer(event: PointerEvent) {
+    scrubToFrame(pointerToFrame(event))
+  }
+
+  function startScrubDrag(event: PointerEvent) {
+    if (isDisabled() || event.button !== 0) return
+
+    const el = trackRef.value
+    if (!el) return
+
+    cleanupScrubDrag?.()
+
+    isScrubDragging.value = true
+    scrubToFrame(pointerToFrame(event), true)
+    try {
+      el.setPointerCapture(event.pointerId)
+    } catch {
+      // non-active pointer id; scrubbing continues with bubbling events
+    }
+
+    const onMove = (moveEvent: PointerEvent) => {
+      updateScrubFromPointer(moveEvent)
+    }
+
+    const endDrag = () => {
+      isScrubDragging.value = false
+      el.removeEventListener('pointermove', onMove)
+      el.removeEventListener('pointerup', endDrag)
+      el.removeEventListener('lostpointercapture', endDrag)
+      cleanupScrubDrag = null
+    }
+
+    cleanupScrubDrag = endDrag
+
+    el.addEventListener('pointermove', onMove)
+    el.addEventListener('pointerup', endDrag)
+    el.addEventListener('lostpointercapture', endDrag)
+  }
+
+  onScopeDispose(() => {
+    isScrubDragging.value = false
+    cleanupScrubDrag?.()
+  })
+
+  return { isScrubDragging, startScrubDrag, scrubToFrame }
+}

--- a/src/composables/video/useTrimPlayback.test.ts
+++ b/src/composables/video/useTrimPlayback.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope, Ref } from 'vue'
+
+import { useTrimPlayback } from './useTrimPlayback'
+
+type Listener = (event: Event) => void
+
+class MockVideoElement {
+  duration = 10
+  paused = true
+  emitSeeked = true
+  private _currentTime = 0
+  play = vi.fn(async () => {
+    this.paused = false
+  })
+  pause = vi.fn(() => {
+    this.paused = true
+  })
+  private listeners = new Map<string, Set<Listener>>()
+
+  get currentTime() {
+    return this._currentTime
+  }
+
+  set currentTime(value: number) {
+    this._currentTime = value
+    if (this.emitSeeked) {
+      queueMicrotask(() => this.emit('seeked'))
+    }
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
+    this.listeners.get(type)!.add(listener)
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  emit(type: string) {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener(new Event(type))
+    }
+  }
+}
+
+async function flushSeek() {
+  await new Promise((resolve) => setTimeout(resolve))
+}
+
+describe('useTrimPlayback', () => {
+  let scope: EffectScope | undefined
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  function createPlayback({ hasTrimTimeline = true } = {}) {
+    const video = new MockVideoElement()
+    const startFrame = ref(0)
+    const endFrame = ref(100)
+    const playheadFrame = ref(0)
+
+    scope = effectScope()
+    const playback = scope.run(() =>
+      useTrimPlayback({
+        videoRef: ref(video) as unknown as Ref<HTMLVideoElement | null>,
+        frameMax: ref(100),
+        startFrame,
+        endFrame,
+        playheadFrame,
+        hasTrimTimeline: ref(hasTrimTimeline),
+        frameToTime: (frame) => frame / 10,
+        timeToFrame: (time) => Math.round(time * 10)
+      })
+    )!
+
+    return { video, startFrame, endFrame, playheadFrame, ...playback }
+  }
+
+  it('seeks the video and stops playback on scrub', async () => {
+    const { video, playheadFrame, isPlaying, handleScrub } = createPlayback()
+    isPlaying.value = true
+
+    handleScrub(50)
+    await flushSeek()
+
+    expect(isPlaying.value).toBe(false)
+    expect(playheadFrame.value).toBe(50)
+    expect(video.currentTime).toBe(5)
+  })
+
+  it('plays from the current playhead within the trim window', async () => {
+    const { video, playheadFrame, isPlaying } = createPlayback()
+    playheadFrame.value = 30
+
+    isPlaying.value = true
+    await flushSeek()
+
+    expect(video.currentTime).toBe(3)
+    expect(video.play).toHaveBeenCalled()
+  })
+
+  it('restarts from the start frame when the playhead reached the end', async () => {
+    const { video, startFrame, endFrame, playheadFrame, isPlaying } =
+      createPlayback()
+    startFrame.value = 20
+    endFrame.value = 80
+    await nextTick()
+    playheadFrame.value = 80
+
+    isPlaying.value = true
+    await flushSeek()
+
+    expect(playheadFrame.value).toBe(20)
+    expect(video.currentTime).toBe(2)
+  })
+
+  it('stops playing when the video refuses to play', async () => {
+    const { video, isPlaying } = createPlayback()
+    video.play.mockRejectedValueOnce(new Error('autoplay blocked'))
+
+    isPlaying.value = true
+    await flushSeek()
+
+    expect(isPlaying.value).toBe(false)
+  })
+
+  it('re-seeks the video when a trim handle passes the playhead during playback', async () => {
+    const { video, startFrame, playheadFrame, isPlaying } = createPlayback()
+    playheadFrame.value = 10
+
+    isPlaying.value = true
+    await flushSeek()
+    expect(video.currentTime).toBe(1)
+
+    startFrame.value = 30
+    await nextTick()
+    await flushSeek()
+
+    expect(isPlaying.value).toBe(true)
+    expect(playheadFrame.value).toBe(30)
+    expect(video.currentTime).toBe(3)
+  })
+
+  it('pauses the video when playback stops', async () => {
+    const { video, isPlaying } = createPlayback()
+    isPlaying.value = true
+    await flushSeek()
+
+    isPlaying.value = false
+    await nextTick()
+
+    expect(video.pause).toHaveBeenCalled()
+  })
+
+  it('syncs the playhead on timeupdate and stops at the trim end', async () => {
+    const { video, endFrame, playheadFrame, isPlaying, handleTimeUpdate } =
+      createPlayback()
+    endFrame.value = 60
+    await nextTick()
+    isPlaying.value = true
+    await flushSeek()
+
+    video.currentTime = 4
+    handleTimeUpdate()
+    expect(playheadFrame.value).toBe(40)
+    expect(isPlaying.value).toBe(true)
+
+    video.currentTime = 6.2
+    handleTimeUpdate()
+    expect(playheadFrame.value).toBe(60)
+    expect(isPlaying.value).toBe(false)
+  })
+
+  it('ignores timeupdate when trim is not the active feature', async () => {
+    const { video, playheadFrame, isPlaying, handleTimeUpdate } =
+      createPlayback({ hasTrimTimeline: false })
+    isPlaying.value = true
+    await flushSeek()
+
+    video.currentTime = 4
+    handleTimeUpdate()
+
+    expect(playheadFrame.value).toBe(0)
+  })
+
+  it('releases the seek lock when no seeked event ever arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const { video, playheadFrame, isPlaying, handleTimeUpdate } =
+        createPlayback()
+      video.emitSeeked = false
+      playheadFrame.value = 30
+
+      isPlaying.value = true
+      await nextTick()
+
+      video.currentTime = 4
+      handleTimeUpdate()
+      expect(playheadFrame.value).toBe(30)
+
+      await vi.advanceTimersByTimeAsync(5000)
+
+      video.currentTime = 4.5
+      handleTimeUpdate()
+      expect(playheadFrame.value).toBe(45)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clamps the playhead when the trim handles move past it', async () => {
+    const { startFrame, playheadFrame } = createPlayback()
+    playheadFrame.value = 10
+
+    startFrame.value = 30
+    await nextTick()
+    await flushSeek()
+
+    expect(playheadFrame.value).toBe(30)
+  })
+})

--- a/src/composables/video/useTrimPlayback.ts
+++ b/src/composables/video/useTrimPlayback.ts
@@ -1,0 +1,136 @@
+import { ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+const SEEK_EVENT_TIMEOUT_MS = 5000
+
+interface UseTrimPlaybackOptions {
+  videoRef: Ref<HTMLVideoElement | null>
+  frameMax: Ref<number>
+  startFrame: Ref<number>
+  endFrame: Ref<number>
+  playheadFrame: Ref<number>
+  hasTrimTimeline: Ref<boolean>
+  frameToTime: (frame: number) => number
+  timeToFrame: (time: number) => number
+}
+
+export function useTrimPlayback(options: UseTrimPlaybackOptions) {
+  const {
+    videoRef,
+    frameMax,
+    startFrame,
+    endFrame,
+    playheadFrame,
+    hasTrimTimeline,
+    frameToTime,
+    timeToFrame
+  } = options
+
+  const isPlaying = ref(false)
+  const isSeeking = ref(false)
+  let activeSeekId = 0
+
+  function clampSeekTime(video: HTMLVideoElement, time: number) {
+    if (!Number.isFinite(video.duration) || video.duration <= 0) {
+      return Math.max(time, 0)
+    }
+    return clamp(time, 0, Math.max(video.duration - 0.001, 0))
+  }
+
+  function waitForVideoSeek(video: HTMLVideoElement): Promise<void> {
+    return new Promise((resolve) => {
+      const finish = () => {
+        clearTimeout(timer)
+        video.removeEventListener('seeked', finish)
+        video.removeEventListener('error', finish)
+        resolve()
+      }
+      const timer = setTimeout(finish, SEEK_EVENT_TIMEOUT_MS)
+      video.addEventListener('seeked', finish, { once: true })
+      video.addEventListener('error', finish, { once: true })
+    })
+  }
+
+  async function seekPreviewToFrame(frame: number) {
+    const video = videoRef.value
+    if (!video) return
+
+    const clamped = clamp(frame, 0, frameMax.value)
+    playheadFrame.value = clamped
+
+    const targetTime = clampSeekTime(video, frameToTime(clamped))
+    if (Math.abs(video.currentTime - targetTime) <= 0.0001) return
+
+    const seekId = ++activeSeekId
+    isSeeking.value = true
+    video.currentTime = targetTime
+    await waitForVideoSeek(video)
+
+    if (seekId === activeSeekId) {
+      isSeeking.value = false
+    }
+  }
+
+  async function handlePlaybackChange(playing: boolean) {
+    const video = videoRef.value
+    if (!video) return
+    if (playing) {
+      const startAt =
+        playheadFrame.value >= endFrame.value
+          ? startFrame.value
+          : clamp(playheadFrame.value, startFrame.value, endFrame.value)
+      await seekPreviewToFrame(startAt)
+      if (!isPlaying.value) return
+      try {
+        await video.play()
+      } catch {
+        isPlaying.value = false
+      }
+    } else {
+      video.pause()
+    }
+  }
+
+  function resolvePlayheadTrimCollision() {
+    const start = startFrame.value
+    const end = endFrame.value
+    const previous = playheadFrame.value
+    if (previous < start) {
+      playheadFrame.value = start
+    } else if (previous > end) {
+      playheadFrame.value = end
+    }
+    if (playheadFrame.value !== previous) {
+      void seekPreviewToFrame(playheadFrame.value)
+    }
+  }
+
+  function handleScrub(frame: number) {
+    isPlaying.value = false
+    void seekPreviewToFrame(frame)
+  }
+
+  function handleTimeUpdate() {
+    const video = videoRef.value
+    if (!video || !hasTrimTimeline.value || !isPlaying.value || isSeeking.value)
+      return
+
+    const frame = timeToFrame(video.currentTime)
+    playheadFrame.value = clamp(frame, startFrame.value, endFrame.value)
+
+    if (frame >= endFrame.value) {
+      isPlaying.value = false
+      void seekPreviewToFrame(endFrame.value)
+    }
+  }
+
+  watch(isPlaying, (playing) => {
+    void handlePlaybackChange(playing)
+  })
+
+  watch([startFrame, endFrame], resolvePlayheadTrimCollision)
+
+  return { isPlaying, seekPreviewToFrame, handleScrub, handleTimeUpdate }
+}

--- a/src/composables/video/useVideoEditFormats.test.ts
+++ b/src/composables/video/useVideoEditFormats.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useVideoEditFormats } from './useVideoEditFormats'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}|${Object.values(params).join(',')}` : key
+  })
+}))
+
+describe('useVideoEditFormats', () => {
+  describe('formatDuration', () => {
+    it('uses the zero label for empty durations', () => {
+      const { formatDuration } = useVideoEditFormats()
+
+      expect(formatDuration(0)).toBe('videoEdit.durationZero')
+    })
+
+    it('rounds to a tenth of a second', () => {
+      const { formatDuration } = useVideoEditFormats()
+
+      expect(formatDuration(2.44)).toBe('videoEdit.durationSeconds|2.4')
+      expect(formatDuration(10)).toBe('videoEdit.durationSeconds|10')
+    })
+  })
+
+  describe('formatFileSize', () => {
+    it('shows a placeholder for unknown sizes', () => {
+      const { formatFileSize } = useVideoEditFormats()
+
+      expect(formatFileSize(undefined)).toBe('videoEdit.fileSizeUnknown')
+    })
+
+    it('picks the unit by magnitude', () => {
+      const { formatFileSize } = useVideoEditFormats()
+
+      expect(formatFileSize(500)).toBe('videoEdit.fileSizeBytes|500')
+      expect(formatFileSize(1024)).toBe('videoEdit.fileSizeKilobytes|1')
+      expect(formatFileSize(2048)).toBe('videoEdit.fileSizeKilobytes|2')
+      expect(formatFileSize(1024 * 1024)).toBe('videoEdit.fileSizeMegabytes|1')
+      expect(formatFileSize(1.3 * 1024 * 1024)).toBe(
+        'videoEdit.fileSizeMegabytes|1.3'
+      )
+    })
+  })
+})

--- a/src/composables/video/useVideoEditFormats.ts
+++ b/src/composables/video/useVideoEditFormats.ts
@@ -1,0 +1,29 @@
+import { useI18n } from 'vue-i18n'
+
+export function useVideoEditFormats() {
+  const { t } = useI18n()
+
+  function formatDuration(seconds: number) {
+    if (!seconds) return t('videoEdit.durationZero')
+    return t('videoEdit.durationSeconds', {
+      count: Math.round(seconds * 10) / 10
+    })
+  }
+
+  function formatFileSize(bytes?: number) {
+    if (bytes == null) return t('videoEdit.fileSizeUnknown')
+    if (bytes < 1024) {
+      return t('videoEdit.fileSizeBytes', { count: bytes })
+    }
+    if (bytes < 1024 * 1024) {
+      return t('videoEdit.fileSizeKilobytes', {
+        count: Math.round(bytes / 1024)
+      })
+    }
+    return t('videoEdit.fileSizeMegabytes', {
+      count: Number((bytes / (1024 * 1024)).toFixed(1))
+    })
+  }
+
+  return { formatDuration, formatFileSize }
+}

--- a/src/composables/video/useVideoEditModel.test.ts
+++ b/src/composables/video/useVideoEditModel.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope } from 'vue'
+
+import type { VideoEditValue } from '@/lib/litegraph/src/types/widgets'
+
+import { useVideoEditModel } from './useVideoEditModel'
+
+describe('useVideoEditModel', () => {
+  let scope: EffectScope | undefined
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  function createModel(initial: VideoEditValue = {}) {
+    const modelValue = ref<VideoEditValue>(initial)
+    scope = effectScope()
+    const model = scope.run(() =>
+      useVideoEditModel(modelValue, {
+        duration: ref(10),
+        frameMax: ref(100),
+        width: ref(1920),
+        height: ref(1080)
+      })
+    )!
+    return { modelValue, ...model }
+  }
+
+  describe('trim frames', () => {
+    it('spans the full range for the default no-op value', () => {
+      const { startFrame, endFrame } = createModel()
+
+      expect(startFrame.value).toBe(0)
+      expect(endFrame.value).toBe(100)
+    })
+
+    it('writes start_time in seconds and keeps trimming to the end', () => {
+      const { modelValue, startFrame } = createModel()
+
+      startFrame.value = 10
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+    })
+
+    it('writes an explicit duration when the end handle moves off the last frame', () => {
+      const { modelValue, endFrame } = createModel()
+
+      endFrame.value = 80
+
+      expect(modelValue.value.trim).toEqual({ start_time: 0, duration: 8 })
+    })
+
+    it('normalizes duration back to 0 when the end returns to the last frame', () => {
+      const { modelValue, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      endFrame.value = 100
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+    })
+
+    it('derives frames from an explicit trim window', () => {
+      const { startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      expect(startFrame.value).toBe(10)
+      expect(endFrame.value).toBe(80)
+    })
+
+    it('keeps the end time fixed when the start moves inside an explicit window', () => {
+      const { modelValue, startFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      startFrame.value = 20
+
+      expect(modelValue.value.trim).toEqual({ start_time: 2, duration: 6 })
+    })
+
+    it('clamps the start handle below the end handle instead of collapsing', () => {
+      const { modelValue, startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      startFrame.value = 90
+
+      expect(modelValue.value.trim).toEqual({ start_time: 7.9, duration: 0.1 })
+      expect(endFrame.value).toBe(80)
+    })
+
+    it('clamps the end handle above the start handle instead of snapping to the video end', () => {
+      const { modelValue, startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      endFrame.value = 5
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0.1 })
+      expect(startFrame.value).toBe(10)
+      expect(endFrame.value).toBe(11)
+    })
+  })
+
+  describe('crop bounds', () => {
+    it('shows the full frame for zero crop values', () => {
+      const { cropBounds } = createModel()
+
+      expect(cropBounds.value).toEqual({
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080
+      })
+    })
+
+    it('rounds and stores a partial crop', () => {
+      const { modelValue, cropBounds } = createModel()
+
+      cropBounds.value = { x: 10.4, y: 20.6, width: 640.2, height: 360.5 }
+
+      expect(modelValue.value.crop).toEqual({
+        x: 10,
+        y: 21,
+        width: 640,
+        height: 361
+      })
+    })
+
+    it('normalizes a full-frame crop back to zeros', () => {
+      const { modelValue, cropBounds } = createModel({
+        crop: { x: 10, y: 10, width: 100, height: 100 }
+      })
+
+      cropBounds.value = { x: 0, y: 0, width: 1920, height: 1080 }
+
+      expect(modelValue.value.crop).toEqual({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      })
+    })
+  })
+
+  describe('section toggles', () => {
+    it('starts disabled for no-op values', () => {
+      const { trimEnabled, cropEnabled } = createModel()
+
+      expect(trimEnabled.value).toBe(false)
+      expect(cropEnabled.value).toBe(false)
+    })
+
+    it('starts enabled for active values', () => {
+      const { trimEnabled, cropEnabled } = createModel({
+        trim: { start_time: 1, duration: 0 },
+        crop: { x: 0, y: 0, width: 640, height: 360 }
+      })
+
+      expect(trimEnabled.value).toBe(true)
+      expect(cropEnabled.value).toBe(true)
+    })
+
+    it('resets the trim section when toggled off', () => {
+      const { modelValue, trimEnabled } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      trimEnabled.value = false
+
+      expect(modelValue.value.trim).toEqual({ start_time: 0, duration: 0 })
+    })
+
+    it('resets the crop section when toggled off', () => {
+      const { modelValue, cropEnabled } = createModel({
+        crop: { x: 10, y: 10, width: 640, height: 360 }
+      })
+
+      cropEnabled.value = false
+
+      expect(modelValue.value.crop).toEqual({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      })
+    })
+
+    it('expands the editor without touching the value when toggled on', () => {
+      const { modelValue, trimEnabled } = createModel()
+
+      trimEnabled.value = true
+
+      expect(trimEnabled.value).toBe(true)
+      expect(modelValue.value.trim).toBeUndefined()
+    })
+
+    it('auto-enables a section when an active value arrives later', async () => {
+      const { modelValue, cropEnabled } = createModel()
+      expect(cropEnabled.value).toBe(false)
+
+      modelValue.value = {
+        ...modelValue.value,
+        crop: { x: 5, y: 5, width: 100, height: 100 }
+      }
+      await nextTick()
+
+      expect(cropEnabled.value).toBe(true)
+    })
+  })
+})

--- a/src/composables/video/useVideoEditModel.ts
+++ b/src/composables/video/useVideoEditModel.ts
@@ -1,0 +1,157 @@
+import { computed, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import type {
+  VideoEditTrim,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { frameToTime, roundSeconds, timeToFrame } from '@/utils/videoFrameUtil'
+
+interface UseVideoEditModelOptions {
+  duration: Ref<number>
+  frameMax: Ref<number>
+  width: Ref<number>
+  height: Ref<number>
+}
+
+export function useVideoEditModel(
+  modelValue: Ref<VideoEditValue>,
+  options: UseVideoEditModelOptions
+) {
+  const { duration, frameMax, width, height } = options
+
+  const toTime = (frame: number) =>
+    frameToTime(frame, duration.value, frameMax.value)
+  const toFrame = (time: number) =>
+    timeToFrame(time, duration.value, frameMax.value)
+
+  const trimSection = computed(
+    () => modelValue.value.trim ?? { start_time: 0, duration: 0 }
+  )
+
+  const trimsToVideoEnd = computed(() => trimSection.value.duration === 0)
+
+  const endTimeSeconds = computed(() =>
+    trimsToVideoEnd.value
+      ? duration.value
+      : trimSection.value.start_time + trimSection.value.duration
+  )
+
+  function setTrim(trim: VideoEditTrim) {
+    modelValue.value = { ...modelValue.value, trim }
+  }
+
+  const currentEndFrame = () =>
+    trimsToVideoEnd.value
+      ? frameMax.value
+      : clamp(toFrame(endTimeSeconds.value), 0, frameMax.value)
+
+  const startFrame = computed({
+    get: () => clamp(toFrame(trimSection.value.start_time), 0, frameMax.value),
+    set: (frame) => {
+      const maxStart = Math.max(currentEndFrame() - 1, 0)
+      const startTime = roundSeconds(toTime(clamp(frame, 0, maxStart)))
+      setTrim({
+        start_time: startTime,
+        duration: trimsToVideoEnd.value
+          ? 0
+          : roundSeconds(Math.max(endTimeSeconds.value - startTime, 0))
+      })
+    }
+  })
+
+  const endFrame = computed({
+    get: () => currentEndFrame(),
+    set: (frame) => {
+      const minEnd = clamp(
+        toFrame(trimSection.value.start_time) + 1,
+        0,
+        frameMax.value
+      )
+      const clamped = clamp(frame, minEnd, frameMax.value)
+      setTrim({
+        start_time: trimSection.value.start_time,
+        duration:
+          clamped >= frameMax.value
+            ? 0
+            : roundSeconds(
+                Math.max(toTime(clamped) - trimSection.value.start_time, 0)
+              )
+      })
+    }
+  })
+
+  const cropBounds = computed<Bounds>({
+    get: () => {
+      const crop = modelValue.value.crop
+      if (!crop || crop.width <= 0 || crop.height <= 0) {
+        return { x: 0, y: 0, width: width.value, height: height.value }
+      }
+      return { ...crop }
+    },
+    set: (next) => {
+      const coversFullFrame =
+        next.x <= 0 &&
+        next.y <= 0 &&
+        next.width >= width.value &&
+        next.height >= height.value
+      modelValue.value = {
+        ...modelValue.value,
+        crop: coversFullFrame
+          ? { x: 0, y: 0, width: 0, height: 0 }
+          : {
+              x: Math.round(next.x),
+              y: Math.round(next.y),
+              width: Math.round(next.width),
+              height: Math.round(next.height)
+            }
+      }
+    }
+  })
+
+  const hasActiveTrim = () => {
+    const trim = modelValue.value.trim
+    return !!trim && (trim.start_time > 0 || trim.duration > 0)
+  }
+
+  const hasActiveCrop = () => {
+    const crop = modelValue.value.crop
+    return !!crop && crop.width > 0 && crop.height > 0
+  }
+
+  const trimEnabledState = ref(hasActiveTrim())
+  const cropEnabledState = ref(hasActiveCrop())
+
+  const trimEnabled = computed({
+    get: () => trimEnabledState.value,
+    set: (enabled) => {
+      trimEnabledState.value = enabled
+      if (!enabled) setTrim({ start_time: 0, duration: 0 })
+    }
+  })
+
+  const cropEnabled = computed({
+    get: () => cropEnabledState.value,
+    set: (enabled) => {
+      cropEnabledState.value = enabled
+      if (!enabled) {
+        modelValue.value = {
+          ...modelValue.value,
+          crop: { x: 0, y: 0, width: 0, height: 0 }
+        }
+      }
+    }
+  })
+
+  watch(hasActiveTrim, (active) => {
+    if (active) trimEnabledState.value = true
+  })
+  watch(hasActiveCrop, (active) => {
+    if (active) cropEnabledState.value = true
+  })
+
+  return { startFrame, endFrame, cropBounds, trimEnabled, cropEnabled }
+}

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -146,6 +146,7 @@ export type IWidget =
   | ICurveWidget
   | IPainterWidget
   | IRangeWidget
+  | IVideoEditWidget
   | IBoundingBoxesWidget
   | IColorsWidget
 
@@ -385,6 +386,31 @@ export interface IRangeWidget extends IBaseWidget<
 > {
   type: 'range'
   value: RangeValue
+}
+
+export interface VideoEditTrim {
+  start_time: number
+  duration: number
+}
+
+export interface VideoEditValue {
+  trim?: VideoEditTrim
+  crop?: Bounds
+}
+
+export type VideoEditFeature = 'trim' | 'crop'
+
+export interface IWidgetVideoEditOptions extends IWidgetOptions {
+  features?: VideoEditFeature[]
+}
+
+export interface IVideoEditWidget extends IBaseWidget<
+  VideoEditValue,
+  'videoedit',
+  IWidgetVideoEditOptions
+> {
+  type: 'videoedit'
+  value: VideoEditValue
 }
 
 /**

--- a/src/lib/litegraph/src/widgets/VideoEditWidget.ts
+++ b/src/lib/litegraph/src/widgets/VideoEditWidget.ts
@@ -1,0 +1,14 @@
+import type { IVideoEditWidget } from '../types/widgets'
+import { BaseWidget } from './BaseWidget'
+import type { WidgetEventOptions } from './BaseWidget'
+
+export class VideoEditWidget
+  extends BaseWidget<IVideoEditWidget>
+  implements IVideoEditWidget
+{
+  override type = 'videoedit' as const
+
+  drawWidget(): void {}
+
+  onClick(_options: WidgetEventOptions): void {}
+}

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -25,6 +25,7 @@ import { BoundingBoxesWidget } from './BoundingBoxesWidget'
 import { ColorsWidget } from './ColorsWidget'
 import { PainterWidget } from './PainterWidget'
 import { RangeWidget } from './RangeWidget'
+import { VideoEditWidget } from './VideoEditWidget'
 import { ImageCropWidget } from './ImageCropWidget'
 import { KnobWidget } from './KnobWidget'
 import { LegacyWidget } from './LegacyWidget'
@@ -64,6 +65,7 @@ export type WidgetTypeMap = {
   curve: CurveWidget
   painter: PainterWidget
   range: RangeWidget
+  videoedit: VideoEditWidget
   boundingboxes: BoundingBoxesWidget
   colors: ColorsWidget
   [key: string]: BaseWidget
@@ -148,6 +150,8 @@ export function toConcreteWidget<TWidget extends IWidget | IBaseWidget>(
       return toClass(PainterWidget, narrowedWidget, node)
     case 'range':
       return toClass(RangeWidget, narrowedWidget, node)
+    case 'videoedit':
+      return toClass(VideoEditWidget, narrowedWidget, node)
     case 'boundingboxes':
       return toClass(BoundingBoxesWidget, narrowedWidget, node)
     case 'colors':

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1955,6 +1955,7 @@
     "UPSCALE_MODEL": "UPSCALE_MODEL",
     "VAE": "VAE",
     "VIDEO": "VIDEO",
+    "VIDEO_EDIT": "VIDEO_EDIT",
     "VOXEL": "VOXEL",
     "WAN_CAMERA_EMBEDDING": "WAN_CAMERA_EMBEDDING",
     "WEBCAM": "WEBCAM"
@@ -2212,7 +2213,32 @@
     "swatchTitle": "Click edit · drag reorder · right-click remove"
   },
   "videoEdit": {
-    "adjustCrop": "Adjust crop region"
+    "trimVideo": "Trim Video",
+    "cropVideo": "Crop Video",
+    "startFrame": "Start Frame",
+    "endFrame": "End Frame",
+    "duration": "Duration",
+    "frames": "Number of Frames",
+    "fileSize": "File Size",
+    "resolution": "{width} × {height}",
+    "play": "Play",
+    "pause": "Pause",
+    "loadingVideo": "Loading video preview",
+    "loadingFilmstrip": "Loading filmstrip…",
+    "seekVideo": "Seek video",
+    "adjustStartFrame": "Adjust start frame",
+    "adjustEndFrame": "Adjust end frame",
+    "adjustCrop": "Adjust crop region",
+    "setStartFrame": "Reset start frame",
+    "setEndFrame": "Reset end frame",
+    "durationZero": "0s",
+    "durationSeconds": "{count}s",
+    "selectedOfTotal": "{selected} / {total}",
+    "fileSizeUnknown": "—",
+    "fileSizeBytes": "{count} B",
+    "fileSizeKilobytes": "{count} KB",
+    "fileSizeMegabytes": "{count} MB",
+    "noVideoSource": "Select or connect a video to preview and edit"
   },
   "toastMessages": {
     "nothingToQueue": "Nothing to queue",

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -776,6 +776,10 @@ const hasVideoInput = computed(() => {
   )
 })
 
+const hasVideoEditWidget = computed(
+  () => nodeData.widgets?.some((widget) => widget.type === 'videoedit') ?? false
+)
+
 const nodeMedia = computed(() => {
   const newOutputs = nodeOutputs.nodeOutputs[nodeOutputLocatorId.value]
   const node = lgraphNode.value
@@ -799,6 +803,8 @@ const nodeMedia = computed(() => {
     (!node.previewMediaType && hasVideoInput.value)
       ? 'video'
       : 'image'
+
+  if (type === 'video' && hasVideoEditWidget.value) return undefined
 
   return { type, urls } as const
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -10,3 +10,12 @@ export const WidgetInputBaseClass = cn([
   // Rounded
   'rounded-md'
 ])
+
+export const WidgetInputActionButtonClass = cn(
+  WidgetInputBaseClass,
+  'flex h-8 cursor-pointer items-center justify-center',
+  'not-disabled:hover:bg-component-node-widget-background-hovered',
+  'disabled:cursor-not-allowed disabled:bg-component-node-widget-background-disabled',
+  'disabled:text-muted-foreground disabled:opacity-50',
+  'disabled:hover:bg-component-node-widget-background-disabled'
+)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { useVideoEditWidget } from './useVideoEditWidget'
+
+function createNode(widgetType = 'videoedit') {
+  const addWidget = vi.fn(
+    (
+      type: string,
+      name: string,
+      value: unknown,
+      _cb: unknown,
+      options: unknown
+    ) => ({
+      type: widgetType === 'videoedit' ? type : widgetType,
+      name,
+      value,
+      options
+    })
+  )
+  return { node: { addWidget } as unknown as LGraphNode, addWidget }
+}
+
+describe('useVideoEditWidget', () => {
+  it('creates default sections for all features', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, { type: 'VIDEO_EDIT', name: 'edit' })
+
+    const [type, name, value, , options] = addWidget.mock.calls[0]
+    expect(type).toBe('videoedit')
+    expect(name).toBe('edit')
+    expect(value).toEqual({
+      trim: { start_time: 0, duration: 0 },
+      crop: { x: 0, y: 0, width: 0, height: 0 }
+    })
+    expect(options).toMatchObject({
+      features: ['trim', 'crop'],
+      serialize: true,
+      canvasOnly: false,
+      hideInPanel: true
+    })
+  })
+
+  it('only creates the sections listed in features', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, {
+      type: 'VIDEO_EDIT',
+      name: 'trim',
+      features: ['trim']
+    })
+
+    const [, , value, , options] = addWidget.mock.calls[0]
+    expect(value).toEqual({ trim: { start_time: 0, duration: 0 } })
+    expect(options).toMatchObject({ features: ['trim'] })
+  })
+
+  it('prefers an explicit default value from the spec', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, {
+      type: 'VIDEO_EDIT',
+      name: 'edit',
+      default: { trim: { start_time: 1.5, duration: 2 } }
+    })
+
+    const [, , value] = addWidget.mock.calls[0]
+    expect(value).toEqual({ trim: { start_time: 1.5, duration: 2 } })
+  })
+
+  it('throws when the node produces an unexpected widget type', () => {
+    const { node } = createNode('number')
+
+    expect(() =>
+      useVideoEditWidget()(node, { type: 'VIDEO_EDIT', name: 'edit' })
+    ).toThrow('Unexpected widget type')
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.ts
@@ -1,0 +1,48 @@
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  IVideoEditWidget,
+  IWidgetVideoEditOptions,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import type {
+  InputSpec as InputSpecV2,
+  VideoEditInputSpec
+} from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+export const useVideoEditWidget = (): ComfyWidgetConstructorV2 => {
+  return (node: LGraphNode, inputSpec: InputSpecV2): IVideoEditWidget => {
+    const spec = inputSpec as VideoEditInputSpec
+    const features = spec.features ?? ['trim', 'crop']
+
+    const defaultValue: VideoEditValue = spec.default ?? {
+      ...(features.includes('trim') && {
+        trim: { start_time: 0, duration: 0 }
+      }),
+      ...(features.includes('crop') && {
+        crop: { x: 0, y: 0, width: 0, height: 0 }
+      })
+    }
+
+    const options: IWidgetVideoEditOptions = {
+      features,
+      serialize: true,
+      canvasOnly: false,
+      hideInPanel: true
+    }
+
+    const rawWidget = node.addWidget(
+      'videoedit',
+      spec.name,
+      structuredClone(defaultValue),
+      () => {},
+      options
+    )
+
+    if (rawWidget.type !== 'videoedit') {
+      throw new Error(`Unexpected widget type: ${rawWidget.type}`)
+    }
+
+    return rawWidget as IVideoEditWidget
+  }
+}

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -75,6 +75,9 @@ const WidgetRange = defineAsyncComponent(
 const WidgetBoundingBoxes = defineAsyncComponent(
   () => import('@/components/boundingBoxes/WidgetBoundingBoxes.vue')
 )
+const WidgetVideoEdit = defineAsyncComponent(
+  () => import('@/components/videoEdit/WidgetVideoEdit.vue')
+)
 const WidgetColors = defineAsyncComponent(
   () => import('@/components/palette/WidgetColors.vue')
 )
@@ -246,6 +249,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     }
   ],
   [
+    'videoedit',
+    {
+      component: WidgetVideoEdit,
+      aliases: ['VIDEO_EDIT'],
+      essential: false
+    }
+  ],
+  [
     'colors',
     {
       component: WidgetColors,
@@ -293,7 +304,8 @@ const EXPANDING_TYPES = [
   'painter',
   'imagecompare',
   'range',
-  'boundingboxes'
+  'boundingboxes',
+  'videoedit'
 ] as const
 
 export function shouldExpand(type: string): boolean {

--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -189,6 +189,31 @@ const zRangeInputSpec = zBaseInputOptions.extend({
   value_max: z.number().optional()
 })
 
+const zVideoEditValue = z.object({
+  trim: z
+    .object({
+      start_time: z.number(),
+      duration: z.number()
+    })
+    .optional(),
+  crop: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number(),
+      height: z.number()
+    })
+    .optional()
+})
+
+const zVideoEditInputSpec = zBaseInputOptions.extend({
+  type: z.literal('VIDEO_EDIT'),
+  name: z.string(),
+  isOptional: z.boolean().optional(),
+  features: z.array(z.enum(['trim', 'crop'])).optional(),
+  default: zVideoEditValue.optional()
+})
+
 const zCustomInputSpec = zBaseInputOptions.extend({
   type: z.string(),
   name: z.string(),
@@ -213,6 +238,7 @@ const zInputSpec = z.union([
   zTextareaInputSpec,
   zCurveInputSpec,
   zRangeInputSpec,
+  zVideoEditInputSpec,
   zCustomInputSpec
 ])
 
@@ -261,6 +287,7 @@ export type BoundingBoxesInputSpec = z.infer<typeof zBoundingBoxesInputSpec>
 export type TextareaInputSpec = z.infer<typeof zTextareaInputSpec>
 export type CurveInputSpec = z.infer<typeof zCurveInputSpec>
 export type RangeInputSpec = z.infer<typeof zRangeInputSpec>
+export type VideoEditInputSpec = z.infer<typeof zVideoEditInputSpec>
 export type CustomInputSpec = z.infer<typeof zCustomInputSpec>
 
 export type InputSpec = z.infer<typeof zInputSpec>

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -26,6 +26,7 @@ import { usePainterWidget } from '@/renderer/extensions/vueNodes/widgets/composa
 import { useRangeWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useRangeWidget'
 import { useStringWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget'
 import { useTextareaWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useTextareaWidget'
+import { useVideoEditWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
@@ -236,6 +237,7 @@ export const ComfyWidgets = {
   TEXTAREA: transformWidgetConstructorV2ToV1(useTextareaWidget()),
   CURVE: transformWidgetConstructorV2ToV1(useCurveWidget()),
   RANGE: transformWidgetConstructorV2ToV1(useRangeWidget()),
+  VIDEO_EDIT: transformWidgetConstructorV2ToV1(useVideoEditWidget()),
   BOUNDING_BOXES: transformWidgetConstructorV2ToV1(useBoundingBoxesWidget()),
   COLORS: transformWidgetConstructorV2ToV1(useColorsWidget()),
   ...dynamicWidgets


### PR DESCRIPTION
For testing and feedback. open sepearte PRs to break it into small parts:
Separate PRs of wave1:
1. https://github.com/Comfy-Org/ComfyUI_frontend/pull/14120
2. https://github.com/Comfy-Org/ComfyUI_frontend/pull/14121
3. https://github.com/Comfy-Org/ComfyUI_frontend/pull/14122
Separate PRs of wave2:
TODO

## Summary
- videoedit widget type wired through nodeDef schema (VIDEO_EDIT + features), widget constructor, litegraph widget map, and widget registry
- WidgetVideoEdit/VideoEditPanel render feature-gated sections: filmstrip trim timeline with playhead scrubbing, crop overlay with drag/resize handles and aspect-ratio presets/lock, WidgetBoundingBox numeric row, reset-frame shortcuts, and trim/crop enable toggles (UI-only; zero values mean no-op)
- Logic lives in composables: useVideoEditModel (seconds/pixels to display domain), useTrimPlayback, useTimelineScrub, useCropBoxEditor,  useCropRatioLock, useVideoEditFormats, useVideoSourceUrl (upstream link or own file widget, reactive to execution outputs, rand param stripped to avoid redundant reloads)
- Exact video metadata (fps/frame count/duration/size) from the new backend /video_metadata endpoint with client-side estimation fallback, replacing client-side MP4 box probing
- Node-level video preview suppressed when a videoedit widget exists (Vue mode); the litegraph renderer keeps its regular preview and the widget draws nothing there
- Unit tests for the composables, utils, and widget components

BE is https://github.com/Comfy-Org/ComfyUI/pull/15090

## Screenshots (if applicable)
<img width="2468" height="1627" alt="image" src="https://github.com/user-attachments/assets/23831840-3c3f-49df-9abe-1e7e7589d0af" />