### PR TITLE
feat(range): content inset support and active handle in useRangeEditor

### DIFF
--- a/src/composables/useRangeEditor.test.ts
+++ b/src/composables/useRangeEditor.test.ts
@@ -50,6 +50,7 @@ interface HarnessOptions {
   valueMax?: number
   showMidpoint?: boolean
   track?: HTMLElement | null
+  contentInsetX?: number
 }
 
 interface Harness {
@@ -72,6 +73,7 @@ const mountRangeEditor = (opts: HarnessOptions = {}): Harness => {
   const valueMin = ref(opts.valueMin ?? 0)
   const valueMax = ref(opts.valueMax ?? 100)
   const showMidpoint = ref(opts.showMidpoint ?? true)
+  const contentInsetX = ref(opts.contentInsetX ?? 0)
 
   let api: ReturnType<typeof useRangeEditor> | undefined
   const TestComponent = defineComponent({
@@ -81,7 +83,8 @@ const mountRangeEditor = (opts: HarnessOptions = {}): Harness => {
         modelValue,
         valueMin,
         valueMax,
-        showMidpoint
+        showMidpoint,
+        contentInsetX
       })
       return () => null
     }
@@ -322,5 +325,154 @@ describe('useRangeEditor', () => {
     expect(removedTypes).toEqual(
       expect.arrayContaining(['pointermove', 'pointerup', 'lostpointercapture'])
     )
+  })
+
+  it('maps pointer at content inset to valueMin when contentInsetX is set', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100,
+      showMidpoint: false,
+      contentInsetX: 16
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 16 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 16 })
+    )
+
+    expect(harness.modelValue.value.min).toBe(0)
+  })
+
+  it('maps pointer at right content inset to valueMax when contentInsetX is set', () => {
+    harness = mountRangeEditor({
+      initial: { min: 0, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100,
+      showMidpoint: false,
+      contentInsetX: 16
+    })
+
+    harness.api.startDrag(
+      'max',
+      createPointerEvent('pointerdown', { clientX: 184 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 184 })
+    )
+
+    expect(harness.modelValue.value.max).toBe(100)
+  })
+
+  it('clamps pointers outside the content insets to the value range', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100,
+      showMidpoint: false,
+      contentInsetX: 16
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 2 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 2 })
+    )
+    expect(harness.modelValue.value.min).toBe(0)
+
+    harness.trackRef.value!.dispatchEvent(createPointerEvent('pointerup'))
+
+    harness.api.startDrag(
+      'max',
+      createPointerEvent('pointerdown', { clientX: 198 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 198 })
+    )
+    expect(harness.modelValue.value.max).toBe(100)
+  })
+
+  it('treats invalid content insets as zero', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      showMidpoint: false,
+      contentInsetX: NaN
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 100 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 100 })
+    )
+
+    expect(harness.modelValue.value.min).toBe(50)
+  })
+
+  it('bounds oversized content insets to half the track width', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      showMidpoint: false,
+      contentInsetX: 1000
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 50 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 50 })
+    )
+
+    expect(Number.isFinite(harness.modelValue.value.min)).toBe(true)
+    expect(harness.modelValue.value.min).toBeGreaterThanOrEqual(0)
+    expect(harness.modelValue.value.min).toBeLessThanOrEqual(80)
+  })
+
+  it('tracks the active handle through the drag lifecycle', () => {
+    harness = mountRangeEditor({ showMidpoint: false })
+
+    expect(harness.api.activeHandle.value).toBeNull()
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 40 })
+    )
+    expect(harness.api.activeHandle.value).toBe('min')
+
+    harness.trackRef.value!.dispatchEvent(createPointerEvent('pointerup'))
+    expect(harness.api.activeHandle.value).toBeNull()
+  })
+
+  it('clears the active handle on lost pointer capture', () => {
+    harness = mountRangeEditor({ showMidpoint: false })
+
+    harness.api.startDrag(
+      'max',
+      createPointerEvent('pointerdown', { clientX: 160 })
+    )
+    expect(harness.api.activeHandle.value).toBe('max')
+
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('lostpointercapture')
+    )
+    expect(harness.api.activeHandle.value).toBeNull()
+  })
+
+  it('does not set the active handle when the track is missing', () => {
+    harness = mountRangeEditor({ track: null })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 40 })
+    )
+
+    expect(harness.api.activeHandle.value).toBeNull()
   })
 })

--- a/src/composables/useRangeEditor.ts
+++ b/src/composables/useRangeEditor.ts
@@ -14,6 +14,7 @@ interface UseRangeEditorOptions {
   valueMin: Ref<number>
   valueMax: Ref<number>
   showMidpoint: Ref<boolean>
+  contentInsetX?: Ref<number>
 }
 
 export function useRangeEditor({
@@ -21,7 +22,8 @@ export function useRangeEditor({
   modelValue,
   valueMin,
   valueMax,
-  showMidpoint
+  showMidpoint,
+  contentInsetX
 }: UseRangeEditorOptions) {
   const activeHandle = ref<HandleType | null>(null)
   let cleanupDrag: (() => void) | null = null
@@ -30,7 +32,16 @@ export function useRangeEditor({
     const el = trackRef.value
     if (!el) return valueMin.value
     const rect = el.getBoundingClientRect()
-    const normalized = clamp((e.clientX - rect.left) / rect.width, 0, 1)
+    const rawInset = contentInsetX?.value ?? 0
+    const inset = Number.isFinite(rawInset)
+      ? clamp(rawInset, 0, rect.width / 2)
+      : 0
+    const contentWidth = Math.max(rect.width - 2 * inset, 1)
+    const normalized = clamp(
+      (e.clientX - rect.left - inset) / contentWidth,
+      0,
+      1
+    )
     return denormalize(normalized, valueMin.value, valueMax.value)
   }
 
@@ -75,9 +86,9 @@ export function useRangeEditor({
     if (e.button !== 0) return
     cleanupDrag?.()
 
-    activeHandle.value = handle
     const el = trackRef.value
     if (!el) return
+    activeHandle.value = handle
 
     el.setPointerCapture(e.pointerId)
 
@@ -108,6 +119,7 @@ export function useRangeEditor({
 
   return {
     handleTrackPointerDown,
-    startDrag
+    startDrag,
+    activeHandle
   }
 }


### PR DESCRIPTION
This is seperate part for the big PR of video edit, crop, trim PR https://github.com/Comfy-Org/ComfyUI_frontend/pull/14118

## Summary
- Optional contentInsetX maps pointer positions onto a track whose value range is horizontally inset (e.g. tracks with handle gutters)
- Expose activeHandle so consumers can render per-handle UI while dragging