### PR TITLE
feat(video): video preview composables and metadata utils

### DIFF
--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -1,0 +1,320 @@
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchVideoMetadata } from '@/utils/videoMetadataUtil'
+
+import {
+  DEFAULT_VIDEO_FPS,
+  FILMSTRIP_SAMPLE_COUNT,
+  useVideoFilmstrip
+} from './useVideoFilmstrip'
+
+vi.mock('@/utils/videoMetadataUtil', () => ({
+  fetchVideoMetadata: vi.fn(async () => undefined)
+}))
+
+type VideoListener = (event: Event) => void
+
+class MockVideoElement {
+  preload = ''
+  muted = false
+  playsInline = false
+  crossOrigin = ''
+  duration = 10
+  videoWidth = 512
+  videoHeight = 512
+  src = ''
+  readyState = 0
+  emitSeekedOnSameValue = true
+  autoEmitMetadata = true
+  private _currentTime = 0
+  private listeners = new Map<string, Set<VideoListener>>()
+
+  get currentTime() {
+    return this._currentTime
+  }
+
+  set currentTime(value: number) {
+    const changed = value !== this._currentTime
+    this._currentTime = value
+    if (changed || this.emitSeekedOnSameValue) {
+      queueMicrotask(() => this.emit('seeked'))
+    }
+  }
+
+  addEventListener(type: string, listener: VideoListener, options?: boolean) {
+    if (options === true) {
+      const wrapped = (event: Event) => {
+        this.removeEventListener(type, wrapped)
+        listener(event)
+      }
+      this.getListeners(type).add(wrapped)
+      return
+    }
+    this.getListeners(type).add(listener)
+  }
+
+  removeEventListener(type: string, listener: VideoListener) {
+    this.getListeners(type).delete(listener)
+  }
+
+  load() {
+    this.src = ''
+  }
+
+  removeAttribute(name: string) {
+    if (name === 'src') this.src = ''
+  }
+
+  private getListeners(type: string) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set())
+    }
+    return this.listeners.get(type)!
+  }
+
+  emit(type: string) {
+    for (const listener of [...this.getListeners(type)]) {
+      listener(new Event(type))
+    }
+  }
+}
+
+function createMockCanvas(context: unknown = { drawImage: vi.fn() }) {
+  return {
+    width: 0,
+    height: 0,
+    getContext: () => context,
+    toDataURL: () => 'data:image/jpeg;base64,thumb'
+  } as unknown as HTMLCanvasElement
+}
+
+function installVideoMocks({
+  onVideoCreated,
+  canvasContext = { drawImage: vi.fn() } as unknown
+}: {
+  onVideoCreated?: (video: MockVideoElement) => void
+  canvasContext?: unknown
+} = {}) {
+  const originalCreateElement = document.createElement.bind(document)
+
+  vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+    if (tagName === 'video') {
+      const video = new MockVideoElement()
+      onVideoCreated?.(video)
+      if (video.autoEmitMetadata) {
+        queueMicrotask(() => video.emit('loadedmetadata'))
+      }
+      return video as unknown as HTMLVideoElement
+    }
+    if (tagName === 'canvas') {
+      return createMockCanvas(canvasContext)
+    }
+    return originalCreateElement(tagName)
+  })
+}
+
+describe('useVideoFilmstrip', () => {
+  let scope: EffectScope | undefined
+
+  function runWithScope<T>(fn: () => T): T {
+    scope = effectScope()
+    return scope.run(fn)!
+  }
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+    vi.restoreAllMocks()
+  })
+
+  it('estimates total frames from duration and default fps', async () => {
+    installVideoMocks()
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { totalFrames, duration, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(duration.value).toBe(10)
+    expect(totalFrames.value).toBe(Math.round(10 * DEFAULT_VIDEO_FPS))
+  })
+
+  it('clears state when url is removed', async () => {
+    installVideoMocks()
+
+    const videoUrl = ref<string | undefined>('https://example.com/video.mp4')
+    const { thumbnails, totalFrames, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    videoUrl.value = undefined
+    await nextTick()
+
+    expect(thumbnails.value).toEqual([])
+    expect(totalFrames.value).toBe(0)
+    expect(loading.value).toBe(false)
+  })
+
+  it('uses backend metadata when available', async () => {
+    installVideoMocks()
+    vi.mocked(fetchVideoMetadata).mockResolvedValueOnce({
+      fps: 24,
+      duration: 10,
+      frame_count: 240,
+      width: 512,
+      height: 512,
+      size: 5 * 1024 * 1024
+    })
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { totalFrames, fps, fileSize, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(fps.value).toBe(24)
+    expect(totalFrames.value).toBe(240)
+    expect(fileSize.value).toBe(5 * 1024 * 1024)
+  })
+
+  it('derives duration and dimensions from backend metadata when the element reports a non-finite duration', async () => {
+    let maxSeekTarget = 0
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.duration = Infinity
+        video.addEventListener('seeked', () => {
+          maxSeekTarget = Math.max(maxSeekTarget, video.currentTime)
+        })
+      }
+    })
+    vi.mocked(fetchVideoMetadata).mockResolvedValueOnce({
+      fps: 24,
+      duration: 8,
+      frame_count: null,
+      width: 640,
+      height: 360,
+      size: 1024
+    })
+
+    const videoUrl = ref('https://example.com/fragmented.mp4')
+    const { duration, width, height, totalFrames, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(duration.value).toBe(8)
+    expect(width.value).toBe(640)
+    expect(height.value).toBe(360)
+    expect(totalFrames.value).toBe(Math.round(8 * 24))
+    expect(maxSeekTarget).toBeGreaterThan(7)
+  })
+
+  it('samples the configured number of frames', async () => {
+    let seekCount = 0
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.addEventListener('seeked', () => {
+          seekCount += 1
+        })
+      }
+    })
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { thumbnails, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl, {
+        sampleCount: FILMSTRIP_SAMPLE_COUNT
+      })
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(seekCount).toBe(FILMSTRIP_SAMPLE_COUNT)
+    expect(thumbnails.value).toHaveLength(FILMSTRIP_SAMPLE_COUNT)
+  })
+
+  it('captures the first sample without a seeked event for same-position seeks', async () => {
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.readyState = 2
+        video.emitSeekedOnSameValue = false
+      }
+    })
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { thumbnails, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl, { sampleCount: 5 })
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(thumbnails.value).toHaveLength(5)
+  })
+
+  it('reports load-failed and resets state when the video errors', async () => {
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.autoEmitMetadata = false
+        queueMicrotask(() => video.emit('error'))
+      }
+    })
+
+    const videoUrl = ref('https://example.com/broken.mp4')
+    const { error, duration, totalFrames, thumbnails, loading } = runWithScope(
+      () => useVideoFilmstrip(videoUrl)
+    )
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(error.value).toBe('load-failed')
+    expect(duration.value).toBe(0)
+    expect(totalFrames.value).toBe(0)
+    expect(thumbnails.value).toEqual([])
+  })
+
+  it('reports canvas-unavailable when a 2d context cannot be created', async () => {
+    installVideoMocks({ canvasContext: null })
+
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { error, loading } = runWithScope(() => useVideoFilmstrip(videoUrl))
+
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+
+    expect(error.value).toBe('canvas-unavailable')
+  })
+
+  it('ignores results from a stale load after the url changes', async () => {
+    const videos: MockVideoElement[] = []
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.duration = videos.length === 0 ? 5 : 10
+        video.autoEmitMetadata = videos.length > 0
+        videos.push(video)
+      }
+    })
+
+    const videoUrl = ref('https://example.com/first.mp4')
+    const { duration, loading } = runWithScope(() =>
+      useVideoFilmstrip(videoUrl)
+    )
+    await nextTick()
+
+    videoUrl.value = 'https://example.com/second.mp4'
+    await vi.waitFor(() => expect(loading.value).toBe(false))
+    expect(duration.value).toBe(10)
+
+    videos[0].emit('loadedmetadata')
+    await nextTick()
+    await nextTick()
+
+    expect(duration.value).toBe(10)
+    expect(loading.value).toBe(false)
+  })
+})

--- a/src/composables/video/useVideoFilmstrip.ts
+++ b/src/composables/video/useVideoFilmstrip.ts
@@ -1,0 +1,229 @@
+import { onScopeDispose, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+import { fetchVideoMetadata } from '@/utils/videoMetadataUtil'
+
+export const DEFAULT_VIDEO_FPS = 20
+export const FILMSTRIP_SAMPLE_COUNT = 20
+
+const METADATA_EVENT_TIMEOUT_MS = 15000
+const SEEK_EVENT_TIMEOUT_MS = 5000
+
+export type FilmstripError = 'canvas-unavailable' | 'load-failed'
+
+interface UseVideoFilmstripOptions {
+  fps?: number
+  sampleCount?: number
+}
+
+class EventTimeoutError extends Error {}
+
+function waitForEvent(
+  target: EventTarget,
+  eventName: string,
+  timeoutMs: number
+): Promise<Event> {
+  return new Promise((resolve, reject) => {
+    const onSuccess = (event: Event) => {
+      cleanup()
+      resolve(event)
+    }
+    const onError = () => {
+      cleanup()
+      reject(new Error(`Failed to load ${eventName}`))
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new EventTimeoutError(`Timed out waiting for ${eventName}`))
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timer)
+      target.removeEventListener(eventName, onSuccess)
+      target.removeEventListener('error', onError)
+    }
+    target.addEventListener(eventName, onSuccess, { once: true })
+    target.addEventListener('error', onError, { once: true })
+  })
+}
+
+async function captureFrame(
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D
+): Promise<string> {
+  const width = video.videoWidth
+  const height = video.videoHeight
+  if (width <= 0 || height <= 0) return ''
+
+  canvas.width = width
+  canvas.height = height
+  context.drawImage(video, 0, 0, width, height)
+  return canvas.toDataURL('image/jpeg', 0.7)
+}
+
+async function sampleFilmstripFrames(
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  duration: number,
+  sampleCount: number,
+  isStale: () => boolean
+): Promise<string[]> {
+  const thumbnails: string[] = []
+  const lastIndex = Math.max(sampleCount - 1, 1)
+
+  for (let index = 0; index < sampleCount; index++) {
+    if (isStale()) break
+    const time = sampleCount <= 1 ? 0 : (duration * index) / lastIndex
+    const target = Math.min(time, Math.max(duration - 0.001, 0))
+    const alreadyAtTarget =
+      Math.abs(video.currentTime - target) < 0.001 && video.readyState >= 2
+    video.currentTime = target
+    if (!alreadyAtTarget) {
+      try {
+        await waitForEvent(video, 'seeked', SEEK_EVENT_TIMEOUT_MS)
+      } catch (waitError) {
+        if (waitError instanceof EventTimeoutError) continue
+        throw waitError
+      }
+    }
+    const thumbnail = await captureFrame(video, canvas, context)
+    if (thumbnail) thumbnails.push(thumbnail)
+  }
+
+  return thumbnails
+}
+
+export function useVideoFilmstrip(
+  videoUrl: Ref<string | undefined>,
+  options: UseVideoFilmstripOptions = {}
+) {
+  const sampleCount = options.sampleCount ?? FILMSTRIP_SAMPLE_COUNT
+
+  const thumbnails = ref<string[]>([])
+  const duration = ref(0)
+  const totalFrames = ref(0)
+  const width = ref(0)
+  const height = ref(0)
+  const fps = ref(options.fps ?? DEFAULT_VIDEO_FPS)
+  const fileSize = ref<number | undefined>()
+  const loading = ref(false)
+  const error = ref<FilmstripError | null>(null)
+
+  let activeLoadId = 0
+
+  function isLoadStale(loadId: number, url: string) {
+    return loadId !== activeLoadId || videoUrl.value !== url
+  }
+
+  function resetVideoState() {
+    thumbnails.value = []
+    duration.value = 0
+    totalFrames.value = 0
+    width.value = 0
+    height.value = 0
+    fps.value = options.fps ?? DEFAULT_VIDEO_FPS
+    fileSize.value = undefined
+  }
+
+  async function loadVideo(url: string) {
+    const loadId = ++activeLoadId
+    loading.value = true
+    error.value = null
+    thumbnails.value = []
+
+    const video = document.createElement('video')
+    video.preload = 'metadata'
+    video.muted = true
+    video.playsInline = true
+    video.crossOrigin = 'anonymous'
+
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d')
+    if (!context) {
+      loading.value = false
+      error.value = 'canvas-unavailable'
+      return
+    }
+
+    try {
+      video.src = url
+      await waitForEvent(video, 'loadedmetadata', METADATA_EVENT_TIMEOUT_MS)
+
+      if (isLoadStale(loadId, url)) return
+
+      const videoDuration = Number.isFinite(video.duration) ? video.duration : 0
+      duration.value = videoDuration
+      width.value = video.videoWidth
+      height.value = video.videoHeight
+
+      const metadata = await fetchVideoMetadata(url)
+
+      if (isLoadStale(loadId, url)) return
+
+      const effectiveDuration = metadata?.duration ?? videoDuration
+      duration.value = effectiveDuration
+      width.value = metadata?.width ?? video.videoWidth
+      height.value = metadata?.height ?? video.videoHeight
+      fps.value = metadata?.fps ?? options.fps ?? DEFAULT_VIDEO_FPS
+      fileSize.value = metadata?.size
+      totalFrames.value =
+        metadata?.frame_count ??
+        Math.max(Math.round(effectiveDuration * fps.value), 1)
+
+      const sampledThumbnails = await sampleFilmstripFrames(
+        video,
+        canvas,
+        context,
+        effectiveDuration,
+        sampleCount,
+        () => isLoadStale(loadId, url)
+      )
+
+      if (isLoadStale(loadId, url)) return
+
+      thumbnails.value = sampledThumbnails
+    } catch {
+      if (isLoadStale(loadId, url)) return
+      error.value = 'load-failed'
+      resetVideoState()
+    } finally {
+      if (loadId === activeLoadId) {
+        loading.value = false
+      }
+      video.removeAttribute('src')
+      video.load()
+    }
+  }
+
+  watch(
+    videoUrl,
+    (url) => {
+      if (!url) {
+        activeLoadId++
+        loading.value = false
+        error.value = null
+        resetVideoState()
+        return
+      }
+      void loadVideo(url)
+    },
+    { immediate: true }
+  )
+
+  onScopeDispose(() => {
+    activeLoadId++
+  })
+
+  return {
+    thumbnails,
+    duration,
+    totalFrames,
+    width,
+    height,
+    fps,
+    fileSize,
+    loading,
+    error
+  }
+}

--- a/src/composables/video/useVideoSourceUrl.test.ts
+++ b/src/composables/video/useVideoSourceUrl.test.ts
@@ -1,0 +1,266 @@
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, h, nextTick } from 'vue'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { useVideoSourceUrl } from './useVideoSourceUrl'
+
+const mocks = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { reactive } = require('vue')
+  return {
+    nodeOutputs: reactive({}) as Record<string, unknown>,
+    nodePreviewImages: reactive({}) as Record<string, unknown>,
+    getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>(),
+    getWidget: vi.fn()
+  }
+})
+
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: (path: string) => `/api${path}` }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { getPreviewFormatParam: () => '' }
+}))
+
+vi.mock('@/platform/distribution/cloudPreviewUtil', () => ({
+  appendCloudResParam: vi.fn()
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    nodeToNodeLocatorId: (node: { id: string }) => String(node.id)
+  })
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({
+    nodeOutputs: mocks.nodeOutputs,
+    nodePreviewImages: mocks.nodePreviewImages,
+    getNodeImageUrls: mocks.getNodeImageUrls
+  })
+}))
+
+vi.mock('@/stores/widgetValueStore', () => ({
+  useWidgetValueStore: () => ({
+    getWidget: mocks.getWidget
+  })
+}))
+
+function fakeNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  return {
+    id: 'node',
+    graph: { rootGraph: { id: 'graph' } },
+    inputs: [],
+    widgets: [],
+    isSubgraphNode: () => false,
+    getInputLink: () => null,
+    ...overrides
+  } as unknown as LGraphNode
+}
+
+function mountSource(node: LGraphNode) {
+  let videoUrl!: ReturnType<typeof useVideoSourceUrl>['videoUrl']
+  render(
+    defineComponent({
+      setup() {
+        videoUrl = useVideoSourceUrl(computed(() => node)).videoUrl
+        return () => h('div')
+      }
+    })
+  )
+  return { videoUrl }
+}
+
+describe('useVideoSourceUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const key of Object.keys(mocks.nodeOutputs)) {
+      delete mocks.nodeOutputs[key]
+    }
+    for (const key of Object.keys(mocks.nodePreviewImages)) {
+      delete mocks.nodePreviewImages[key]
+    }
+  })
+
+  it('switches from the file widget to the executed preview when outputs arrive', async () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+
+    const upstream = fakeNode({ id: 'up' })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => upstream
+    })
+
+    const { videoUrl } = mountSource(node)
+    expect(videoUrl.value).toContain('filename=clip.mp4')
+
+    mocks.getNodeImageUrls.mockReturnValue([
+      '/api/view?filename=out.mp4&type=temp'
+    ])
+    mocks.nodeOutputs['up'] = { images: [{ filename: 'out.mp4' }] }
+    await nextTick()
+
+    expect(videoUrl.value).toBe('/api/view?filename=out.mp4&type=temp')
+  })
+
+  it('prefers upstream outputs and strips the rand cache-buster', () => {
+    mocks.getNodeImageUrls.mockReturnValue([
+      '/api/view?filename=out.mp4&type=temp&rand=0.123'
+    ])
+    mocks.getWidget.mockReturnValue(undefined)
+
+    const upstream = fakeNode({ id: 'up' })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => upstream
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toBe('/api/view?filename=out.mp4&type=temp')
+  })
+
+  it('falls back to the upstream file widget before any execution', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'clip.mp4' })
+
+    const upstream = fakeNode({ id: 'up' })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => upstream
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toContain('/api/view?')
+    expect(videoUrl.value).toContain('filename=clip.mp4')
+  })
+
+  it('uses the node itself as source when there is no video input', () => {
+    mocks.getNodeImageUrls.mockReturnValue([
+      '/api/view?filename=already-trimmed.mp4&type=temp'
+    ])
+    mocks.getWidget.mockReturnValue({ value: 'raw.mp4' })
+
+    const node = fakeNode()
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toContain('filename=raw.mp4')
+  })
+
+  it('resolves nothing when the video input is not linked', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue(undefined)
+
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => null
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toBeUndefined()
+  })
+
+  it('resolves through a subgraph output to the inner source node', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+
+    const innerNode = fakeNode({ id: 'inner' })
+    const subgraphNode = fakeNode({
+      id: 'sub',
+      isSubgraphNode: () => true,
+      resolveSubgraphOutputLink: () => ({ outputNode: innerNode })
+    })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => subgraphNode,
+      getInputLink: () => ({ origin_slot: 0 })
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toContain('filename=inner.mp4')
+  })
+
+  it('resolves through nested subgraph outputs to the innermost source node', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'deep.mp4' })
+
+    const innerNode = fakeNode({ id: 'inner' })
+    const innerSubgraphNode = fakeNode({
+      id: 'inner-sub',
+      isSubgraphNode: () => true,
+      resolveSubgraphOutputLink: () => ({
+        outputNode: innerNode,
+        link: { origin_slot: 0 }
+      })
+    })
+    const outerSubgraphNode = fakeNode({
+      id: 'outer-sub',
+      isSubgraphNode: () => true,
+      resolveSubgraphOutputLink: () => ({
+        outputNode: innerSubgraphNode,
+        link: { origin_slot: 1 }
+      })
+    })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => outerSubgraphNode,
+      getInputLink: () => ({ origin_slot: 0 })
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toContain('filename=deep.mp4')
+  })
+
+  it('resolves nothing when subgraph resolution loops back on itself', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'loop.mp4' })
+
+    const loopingSubgraphNode = fakeNode({
+      id: 'loop-sub',
+      isSubgraphNode: () => true
+    })
+    Object.assign(loopingSubgraphNode, {
+      resolveSubgraphOutputLink: () => ({
+        outputNode: loopingSubgraphNode,
+        link: { origin_slot: 0 }
+      })
+    })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => loopingSubgraphNode,
+      getInputLink: () => ({ origin_slot: 0 })
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toBeUndefined()
+  })
+
+  it('resolves nothing when the subgraph link is missing', () => {
+    mocks.getNodeImageUrls.mockReturnValue(undefined)
+    mocks.getWidget.mockReturnValue({ value: 'inner.mp4' })
+
+    const subgraphNode = fakeNode({
+      id: 'sub',
+      isSubgraphNode: () => true
+    })
+    const node = fakeNode({
+      inputs: [{ name: 'video' }],
+      getInputNode: () => subgraphNode,
+      getInputLink: () => null
+    })
+
+    const { videoUrl } = mountSource(node)
+
+    expect(videoUrl.value).toBeUndefined()
+  })
+})

--- a/src/composables/video/useVideoSourceUrl.ts
+++ b/src/composables/video/useVideoSourceUrl.ts
@@ -1,0 +1,115 @@
+import { onMounted, ref, watch } from 'vue'
+import type { ComputedRef } from 'vue'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { api } from '@/scripts/api'
+import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { widgetId } from '@/types/widgetId'
+import { parseImageWidgetValue } from '@/utils/imageUtil'
+
+const REMOTE_WIDGET_PLACEHOLDER = 'Loading...'
+
+function resolveFileWidgetVideoUrl(rawValue: unknown): string | undefined {
+  if (
+    typeof rawValue !== 'string' ||
+    !rawValue ||
+    rawValue === REMOTE_WIDGET_PLACEHOLDER
+  ) {
+    return undefined
+  }
+
+  const { filename, subfolder, type } = parseImageWidgetValue(rawValue)
+  if (!filename) return undefined
+
+  const params = new URLSearchParams({ filename, subfolder, type })
+  appendCloudResParam(params, filename)
+  return api.apiURL(`/view?${params}${app.getPreviewFormatParam()}`)
+}
+
+export function useVideoSourceUrl(
+  node: ComputedRef<LGraphNode | null | undefined>,
+  inputName = 'video'
+) {
+  const nodeOutputStore = useNodeOutputStore()
+  const widgetValueStore = useWidgetValueStore()
+  const { nodeToNodeLocatorId } = useWorkflowStore()
+
+  const videoUrl = ref<string | undefined>()
+
+  function resolveSourceNode(): LGraphNode | undefined {
+    const current = node.value
+    if (!current) return undefined
+
+    const slot =
+      current.inputs?.findIndex((input) => input.name === inputName) ?? -1
+    if (slot < 0) return current
+
+    let upstream = current.getInputNode(slot)
+    let link = current.getInputLink(slot)
+    const visited = new Set<LGraphNode>()
+    while (upstream?.isSubgraphNode()) {
+      if (!link || visited.has(upstream)) return undefined
+      visited.add(upstream)
+      const resolved = upstream.resolveSubgraphOutputLink(link.origin_slot)
+      if (!resolved) return undefined
+      upstream = resolved.outputNode ?? null
+      link = resolved.link
+    }
+    return upstream ?? undefined
+  }
+
+  function sourceFileWidgetValue(source: LGraphNode): unknown {
+    const graphId = source.graph?.rootGraph?.id
+    return (
+      (graphId
+        ? widgetValueStore.getWidget(widgetId(graphId, source.id, 'file'))
+            ?.value
+        : undefined) ??
+      source.widgets?.find((widget) => widget.name === 'file')?.value
+    )
+  }
+
+  function stripRandParam(url: string): string {
+    const [base, query] = url.split('?')
+    if (!query) return url
+    const params = new URLSearchParams(query)
+    params.delete('rand')
+    return `${base}?${params}`
+  }
+
+  function resolveVideoUrl(): string | undefined {
+    const source = resolveSourceNode()
+    if (!source) return undefined
+
+    const rawOutputUrl = nodeOutputStore.getNodeImageUrls(source)?.[0]
+    const outputUrl = rawOutputUrl && stripRandParam(rawOutputUrl)
+    const fileUrl = resolveFileWidgetVideoUrl(sourceFileWidgetValue(source))
+
+    return source === node.value
+      ? (fileUrl ?? outputUrl)
+      : (outputUrl ?? fileUrl)
+  }
+
+  function updateVideoUrl() {
+    videoUrl.value = resolveVideoUrl()
+  }
+
+  watch(() => {
+    const source = resolveSourceNode()
+    if (!source) return undefined
+    const locatorId = nodeToNodeLocatorId(source)
+    return [
+      nodeOutputStore.nodeOutputs[locatorId],
+      nodeOutputStore.nodePreviewImages[locatorId],
+      sourceFileWidgetValue(source)
+    ]
+  }, updateVideoUrl)
+
+  onMounted(updateVideoUrl)
+
+  return { videoUrl }
+}

--- a/src/utils/videoFrameUtil.test.ts
+++ b/src/utils/videoFrameUtil.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { frameToTime, roundSeconds, timeToFrame } from '@/utils/videoFrameUtil'
+
+describe('frameToTime', () => {
+  it('maps frames proportionally across the duration', () => {
+    expect(frameToTime(50, 10, 100)).toBe(5)
+    expect(frameToTime(0, 10, 100)).toBe(0)
+    expect(frameToTime(100, 10, 100)).toBe(10)
+  })
+
+  it('falls back to fps when duration is unknown', () => {
+    expect(frameToTime(30, 0, 0, 30)).toBe(1)
+  })
+
+  it('returns 0 without duration or fallback fps', () => {
+    expect(frameToTime(30, 0, 0)).toBe(0)
+  })
+
+  it('rejects non-positive or non-finite fallback fps', () => {
+    expect(frameToTime(30, 0, 0, -30)).toBe(0)
+    expect(frameToTime(30, 0, 0, 0)).toBe(0)
+    expect(frameToTime(30, 0, 0, Infinity)).toBe(0)
+  })
+})
+
+describe('timeToFrame', () => {
+  it('maps time proportionally and rounds to whole frames', () => {
+    expect(timeToFrame(5, 10, 100)).toBe(50)
+    expect(timeToFrame(3.34, 10, 100)).toBe(33)
+  })
+
+  it('falls back to fps when duration is unknown', () => {
+    expect(timeToFrame(1, 0, 0, 30)).toBe(30)
+  })
+
+  it('returns 0 without duration or fallback fps', () => {
+    expect(timeToFrame(1, 0, 0)).toBe(0)
+  })
+
+  it('rejects non-positive or non-finite fallback fps', () => {
+    expect(timeToFrame(1, 0, 0, -30)).toBe(0)
+    expect(timeToFrame(1, 0, 0, Infinity)).toBe(0)
+  })
+})
+
+describe('roundSeconds', () => {
+  it('rounds to millisecond precision', () => {
+    expect(roundSeconds(1.23456)).toBe(1.235)
+    expect(roundSeconds(2)).toBe(2)
+  })
+})

--- a/src/utils/videoFrameUtil.ts
+++ b/src/utils/videoFrameUtil.ts
@@ -1,0 +1,29 @@
+function isUsableFps(fps: number | undefined): fps is number {
+  return fps !== undefined && Number.isFinite(fps) && fps > 0
+}
+
+export function frameToTime(
+  frame: number,
+  duration: number,
+  frameMax: number,
+  fallbackFps?: number
+): number {
+  if (duration > 0 && frameMax > 0) return (frame / frameMax) * duration
+  return isUsableFps(fallbackFps) ? frame / fallbackFps : 0
+}
+
+export function timeToFrame(
+  time: number,
+  duration: number,
+  frameMax: number,
+  fallbackFps?: number
+): number {
+  if (duration > 0 && frameMax > 0) {
+    return Math.round((time / duration) * frameMax)
+  }
+  return isUsableFps(fallbackFps) ? Math.round(time * fallbackFps) : 0
+}
+
+export function roundSeconds(seconds: number): number {
+  return Math.round(seconds * 1000) / 1000
+}

--- a/src/utils/videoMetadataUtil.test.ts
+++ b/src/utils/videoMetadataUtil.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+import { fetchVideoMetadata } from '@/utils/videoMetadataUtil'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn(),
+    apiURL: (path: string) => `http://localhost:8188/api${path}`
+  }
+}))
+
+const metadata = {
+  fps: 30,
+  duration: 4.2,
+  frame_count: 126,
+  width: 1920,
+  height: 1080,
+  size: 1024
+}
+
+function mockResponse(ok: boolean, body?: unknown) {
+  vi.mocked(api.fetchApi).mockResolvedValueOnce({
+    ok,
+    json: async () => body
+  } as Response)
+}
+
+describe('fetchVideoMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries the backend with the view resource params', async () => {
+    mockResponse(true, metadata)
+
+    const result = await fetchVideoMetadata(
+      'http://localhost:8188/api/view?filename=a.mp4&subfolder=clips&type=input&rand=0.1'
+    )
+
+    expect(api.fetchApi).toHaveBeenCalledWith(
+      '/video_metadata?filename=a.mp4&subfolder=clips&type=input'
+    )
+    expect(result).toEqual(metadata)
+  })
+
+  it('returns undefined for non-view urls without fetching', async () => {
+    const result = await fetchVideoMetadata('blob:abc')
+
+    expect(api.fetchApi).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('rejects view urls from untrusted origins without fetching', async () => {
+    const result = await fetchVideoMetadata(
+      'https://attacker.invalid/view?filename=a.mp4'
+    )
+
+    expect(api.fetchApi).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when the backend lacks the endpoint', async () => {
+    mockResponse(false)
+
+    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined for malformed responses', async () => {
+    mockResponse(true, { unexpected: true })
+
+    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/utils/videoMetadataUtil.ts
+++ b/src/utils/videoMetadataUtil.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+import { api } from '@/scripts/api'
+
+const zVideoMetadata = z.object({
+  fps: z.number().positive().finite().nullable(),
+  duration: z.number().nonnegative().finite().nullable(),
+  frame_count: z.number().int().nonnegative().nullable(),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+  size: z.number().nonnegative().finite()
+})
+
+export type VideoMetadata = z.infer<typeof zVideoMetadata>
+
+function isTrustedOrigin(url: URL): boolean {
+  if (url.origin === window.location.origin) return true
+  try {
+    const apiBase = new URL(api.apiURL(''), window.location.origin)
+    return url.origin === apiBase.origin
+  } catch {
+    return false
+  }
+}
+
+function viewQueryFromUrl(videoUrl: string): string | undefined {
+  let url: URL
+  try {
+    url = new URL(videoUrl, window.location.origin)
+  } catch {
+    return undefined
+  }
+  if (!isTrustedOrigin(url)) return undefined
+  if (!url.pathname.endsWith('/view')) return undefined
+
+  const filename = url.searchParams.get('filename')
+  if (!filename) return undefined
+
+  const params = new URLSearchParams({ filename })
+  for (const key of ['subfolder', 'type'] as const) {
+    const value = url.searchParams.get(key)
+    if (value !== null) params.set(key, value)
+  }
+  return params.toString()
+}
+
+export async function fetchVideoMetadata(
+  videoUrl: string
+): Promise<VideoMetadata | undefined> {
+  const query = viewQueryFromUrl(videoUrl)
+  if (!query) return undefined
+
+  try {
+    const response = await api.fetchApi(`/video_metadata?${query}`)
+    if (!response.ok) return undefined
+    return zVideoMetadata.parse(await response.json())
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
This is seperate part for the big PR of video edit, crop, trim PR https://github.com/Comfy-Org/ComfyUI_frontend/pull/14118

## Summary
- useVideoSourceUrl resolves a playable url for the video a node operates on: the linked upstream node (with subgraph passthrough) or the node itself, preferring executed output previews over the file widget; keyed store subscription, rand cache-buster stripped
- useVideoFilmstrip samples thumbnail strips off a hidden video element with seek timeouts and stale-load bail-out
- videoMetadataUtil fetches exact fps/frame count/duration/size from the backend /video_metadata endpoint (falls back gracefully when absent); videoFrameUtil holds frame/time conversion helpers