### PR TITLE
feat(video): crop box editor composables and overlay component

### DIFF
--- a/src/components/videoEdit/VideoCropOverlay.test.ts
+++ b/src/components/videoEdit/VideoCropOverlay.test.ts
@@ -1,0 +1,140 @@
+﻿/* eslint-disable testing-library/prefer-user-event -- crop dragging needs low-level pointer events */
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { Bounds } from '@/renderer/core/layout/types'
+
+import VideoCropOverlay from './VideoCropOverlay.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      videoEdit: {
+        adjustCrop: 'Adjust crop region'
+      }
+    }
+  }
+})
+
+function renderOverlay({
+  bounds = { x: 100, y: 100, width: 200, height: 200 },
+  disabled = false,
+  lockedRatio = null as number | null
+} = {}) {
+  const model = ref<Bounds>(bounds)
+  render(VideoCropOverlay, {
+    props: {
+      modelValue: model.value,
+      sourceWidth: 1000,
+      sourceHeight: 1000,
+      disabled,
+      lockedRatio,
+      'onUpdate:modelValue': (value: Bounds) => {
+        model.value = value
+      }
+    },
+    global: {
+      plugins: [i18n]
+    }
+  })
+
+  const root = screen.getByTestId('video-crop-overlay')
+  vi.spyOn(root, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  })
+
+  return { model }
+}
+
+describe('VideoCropOverlay', () => {
+  it('positions the crop box by source-relative percentages', () => {
+    renderOverlay({ bounds: { x: 100, y: 200, width: 500, height: 250 } })
+
+    const box = screen.getByLabelText('Adjust crop region')
+    expect(box.style.left).toBe('10%')
+    expect(box.style.top).toBe('20%')
+    expect(box.style.width).toBe('50%')
+    expect(box.style.height).toBe('25%')
+  })
+
+  it('renders eight resize handles', () => {
+    renderOverlay()
+
+    for (const dir of ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw']) {
+      expect(screen.getByTestId(`crop-handle-${dir}`)).toBeTruthy()
+    }
+  })
+
+  it('moves the crop box by dragging it', async () => {
+    const { model } = renderOverlay()
+
+    const box = screen.getByLabelText('Adjust crop region')
+    box.setPointerCapture = vi.fn()
+
+    await fireEvent.pointerDown(box, {
+      clientX: 0,
+      clientY: 0,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerMove(box, {
+      clientX: 5,
+      clientY: 7,
+      pointerId: 1
+    })
+    await fireEvent.pointerUp(box, { pointerId: 1 })
+
+    expect(model.value).toEqual({ x: 150, y: 170, width: 200, height: 200 })
+  })
+
+  it('resizes the crop box from a corner handle', async () => {
+    const { model } = renderOverlay()
+
+    const handle = screen.getByTestId('crop-handle-se')
+    handle.setPointerCapture = vi.fn()
+
+    await fireEvent.pointerDown(handle, {
+      clientX: 0,
+      clientY: 0,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerMove(handle, {
+      clientX: 10,
+      clientY: 5,
+      pointerId: 1
+    })
+    await fireEvent.pointerUp(handle, { pointerId: 1 })
+
+    expect(model.value).toEqual({ x: 100, y: 100, width: 300, height: 250 })
+  })
+
+  it('does not react to drags while disabled', async () => {
+    const { model } = renderOverlay({ disabled: true })
+
+    const box = screen.getByLabelText('Adjust crop region')
+    box.setPointerCapture = vi.fn()
+
+    await fireEvent.pointerDown(box, {
+      clientX: 0,
+      clientY: 0,
+      button: 0,
+      pointerId: 1
+    })
+    await fireEvent.pointerMove(box, { clientX: 5, clientY: 5, pointerId: 1 })
+
+    expect(model.value).toEqual({ x: 100, y: 100, width: 200, height: 200 })
+  })
+})

--- a/src/components/videoEdit/VideoCropOverlay.vue
+++ b/src/components/videoEdit/VideoCropOverlay.vue
@@ -1,0 +1,104 @@
+<template>
+  <div
+    ref="rootEl"
+    class="pointer-events-none absolute inset-0 overflow-hidden"
+    data-testid="video-crop-overlay"
+  >
+    <div
+      :class="
+        cn(
+          'pointer-events-auto absolute cursor-move border-2 border-white shadow-[0_0_0_9999px_rgba(0,0,0,0.5)]',
+          disabled && 'pointer-events-none opacity-60'
+        )
+      "
+      :style="cropBoxStyle"
+      data-testid="crop-box"
+      :aria-label="$t('videoEdit.adjustCrop')"
+      @pointerdown.stop="startDrag('move', $event)"
+    />
+    <div
+      v-for="handle in HANDLES"
+      :key="handle.dir"
+      :class="
+        cn(
+          'pointer-events-auto absolute size-2.5 -translate-1/2 border border-black/40 bg-white',
+          handle.cursor,
+          disabled && 'pointer-events-none opacity-60'
+        )
+      "
+      :style="handleStyle(handle.dir)"
+      :data-testid="`crop-handle-${handle.dir}`"
+      @pointerdown.stop="startDrag(handle.dir, $event)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef, useTemplateRef } from 'vue'
+
+import { useCropBoxEditor } from '@/composables/video/useCropBoxEditor'
+import type { CropResizeDir } from '@/composables/video/useCropBoxEditor'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const HANDLES: Array<{ dir: CropResizeDir; cursor: string }> = [
+  { dir: 'nw', cursor: 'cursor-nwse-resize' },
+  { dir: 'n', cursor: 'cursor-ns-resize' },
+  { dir: 'ne', cursor: 'cursor-nesw-resize' },
+  { dir: 'e', cursor: 'cursor-ew-resize' },
+  { dir: 'se', cursor: 'cursor-nwse-resize' },
+  { dir: 's', cursor: 'cursor-ns-resize' },
+  { dir: 'sw', cursor: 'cursor-nesw-resize' },
+  { dir: 'w', cursor: 'cursor-ew-resize' }
+]
+
+const {
+  sourceWidth,
+  sourceHeight,
+  lockedRatio = null,
+  disabled = false
+} = defineProps<{
+  sourceWidth: number
+  sourceHeight: number
+  lockedRatio?: number | null
+  disabled?: boolean
+}>()
+
+const bounds = defineModel<Bounds>({ required: true })
+
+const rootEl = useTemplateRef<HTMLDivElement>('rootEl')
+
+const { startDrag } = useCropBoxEditor(bounds, {
+  rootEl,
+  sourceWidth: toRef(() => sourceWidth),
+  sourceHeight: toRef(() => sourceHeight),
+  isDisabled: () => disabled,
+  lockedRatio: toRef(() => lockedRatio)
+})
+
+function pct(value: number, total: number) {
+  return total > 0 ? `${(value / total) * 100}%` : '0%'
+}
+
+const cropBoxStyle = computed(() => ({
+  left: pct(bounds.value.x, sourceWidth),
+  top: pct(bounds.value.y, sourceHeight),
+  width: pct(bounds.value.width, sourceWidth),
+  height: pct(bounds.value.height, sourceHeight)
+}))
+
+function handleStyle(dir: CropResizeDir) {
+  const { x, y, width, height } = bounds.value
+  const cx = dir.includes('w')
+    ? x
+    : dir.includes('e')
+      ? x + width
+      : x + width / 2
+  const cy = dir.includes('n')
+    ? y
+    : dir.includes('s')
+      ? y + height
+      : y + height / 2
+  return { left: pct(cx, sourceWidth), top: pct(cy, sourceHeight) }
+}
+</script>

--- a/src/composables/video/useCropBoxEditor.test.ts
+++ b/src/composables/video/useCropBoxEditor.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, ref } from 'vue'
+import type { EffectScope, Ref } from 'vue'
+
+import type { Bounds } from '@/renderer/core/layout/types'
+
+import { useCropBoxEditor } from './useCropBoxEditor'
+import type { CropDragMode } from './useCropBoxEditor'
+
+describe('useCropBoxEditor', () => {
+  let scope: EffectScope | undefined
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  function createEditor(
+    initial: Bounds,
+    {
+      disabled = false,
+      lockedRatio = null as number | null
+    }: { disabled?: boolean; lockedRatio?: number | null } = {}
+  ) {
+    const bounds = ref<Bounds>(initial)
+    const rootEl = document.createElement('div')
+    vi.spyOn(rootEl, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    })
+
+    scope = effectScope()
+    const editor = scope.run(() =>
+      useCropBoxEditor(bounds, {
+        rootEl: ref(rootEl) as Ref<HTMLElement | null>,
+        sourceWidth: ref(1000),
+        sourceHeight: ref(1000),
+        isDisabled: () => disabled,
+        lockedRatio: ref(lockedRatio)
+      })
+    )!
+
+    const target = document.createElement('div')
+    target.setPointerCapture = vi.fn()
+
+    function drag(
+      mode: CropDragMode,
+      from: { x: number; y: number },
+      to: { x: number; y: number }
+    ) {
+      target.addEventListener(
+        'pointerdown',
+        (event) => editor.startDrag(mode, event as PointerEvent),
+        { once: true }
+      )
+      target.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          clientX: from.x,
+          clientY: from.y,
+          button: 0,
+          pointerId: 1
+        })
+      )
+      target.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: to.x,
+          clientY: to.y,
+          pointerId: 1
+        })
+      )
+      target.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1 }))
+    }
+
+    return { bounds, drag }
+  }
+
+  it('moves the box in source pixels and clamps to the frame', () => {
+    const { bounds, drag } = createEditor({
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 200
+    })
+
+    drag('move', { x: 0, y: 0 }, { x: 5, y: 7 })
+    expect(bounds.value).toEqual({ x: 150, y: 170, width: 200, height: 200 })
+
+    drag('move', { x: 0, y: 0 }, { x: 100, y: 100 })
+    expect(bounds.value).toEqual({ x: 800, y: 800, width: 200, height: 200 })
+  })
+
+  it('resizes from the south-east handle', () => {
+    const { bounds, drag } = createEditor({
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 200
+    })
+
+    drag('se', { x: 0, y: 0 }, { x: 10, y: 5 })
+
+    expect(bounds.value).toEqual({ x: 100, y: 100, width: 300, height: 250 })
+  })
+
+  it('resizes from the north-west handle keeping the opposite corner fixed', () => {
+    const { bounds, drag } = createEditor({
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 200
+    })
+
+    drag('nw', { x: 0, y: 0 }, { x: 5, y: 5 })
+
+    expect(bounds.value).toEqual({ x: 150, y: 150, width: 150, height: 150 })
+  })
+
+  it('enforces the minimum crop size when collapsing', () => {
+    const { bounds, drag } = createEditor({
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 200
+    })
+
+    drag('e', { x: 0, y: 0 }, { x: -100, y: 0 })
+
+    expect(bounds.value.width).toBe(16)
+  })
+
+  it('keeps the ratio when locked, centering the free axis of edge handles', () => {
+    const { bounds, drag } = createEditor(
+      { x: 400, y: 400, width: 200, height: 200 },
+      { lockedRatio: 1 }
+    )
+
+    drag('e', { x: 0, y: 0 }, { x: 10, y: 0 })
+
+    expect(bounds.value.width).toBe(300)
+    expect(bounds.value.height).toBe(300)
+    expect(bounds.value.y).toBe(350)
+  })
+
+  it('resizes a locked corner from vertical-only movement', () => {
+    const { bounds, drag } = createEditor(
+      { x: 100, y: 100, width: 200, height: 200 },
+      { lockedRatio: 1 }
+    )
+
+    drag('se', { x: 0, y: 0 }, { x: 0, y: 10 })
+
+    expect(bounds.value).toEqual({ x: 100, y: 100, width: 300, height: 300 })
+  })
+
+  it('follows the dominant axis when a locked corner drag is diagonal', () => {
+    const { bounds, drag } = createEditor(
+      { x: 100, y: 100, width: 200, height: 200 },
+      { lockedRatio: 1 }
+    )
+
+    drag('nw', { x: 0, y: 0 }, { x: 2, y: 8 })
+
+    expect(bounds.value).toEqual({ x: 180, y: 180, width: 120, height: 120 })
+  })
+
+  it('keeps the ratio when a locked resize hits the frame edge', () => {
+    const { bounds, drag } = createEditor(
+      { x: 700, y: 700, width: 200, height: 200 },
+      { lockedRatio: 1 }
+    )
+
+    drag('se', { x: 0, y: 0 }, { x: 50, y: 50 })
+
+    expect(bounds.value.width).toBe(bounds.value.height)
+    expect(bounds.value.x + bounds.value.width).toBeLessThanOrEqual(1000)
+    expect(bounds.value.y + bounds.value.height).toBeLessThanOrEqual(1000)
+  })
+
+  it('ignores drags while disabled', () => {
+    const { bounds, drag } = createEditor(
+      { x: 100, y: 100, width: 200, height: 200 },
+      { disabled: true }
+    )
+
+    drag('move', { x: 0, y: 0 }, { x: 10, y: 10 })
+
+    expect(bounds.value).toEqual({ x: 100, y: 100, width: 200, height: 200 })
+  })
+})

--- a/src/composables/video/useCropBoxEditor.ts
+++ b/src/composables/video/useCropBoxEditor.ts
@@ -1,0 +1,197 @@
+import { onScopeDispose } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import type { Bounds } from '@/renderer/core/layout/types'
+
+export const MIN_CROP_SIZE = 16
+
+export type CropResizeDir = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw'
+export type CropDragMode = 'move' | CropResizeDir
+
+interface UseCropBoxEditorOptions {
+  rootEl: Ref<HTMLElement | null>
+  sourceWidth: Ref<number>
+  sourceHeight: Ref<number>
+  isDisabled: () => boolean
+  lockedRatio?: Ref<number | null>
+}
+
+export function useCropBoxEditor(
+  bounds: Ref<Bounds>,
+  options: UseCropBoxEditorOptions
+) {
+  const { rootEl, sourceWidth, sourceHeight, isDisabled, lockedRatio } = options
+
+  let cleanupDrag: (() => void) | null = null
+
+  function freeResize(
+    mode: CropResizeDir,
+    start: Bounds,
+    dx: number,
+    dy: number
+  ): Bounds {
+    const maxW = sourceWidth.value
+    const maxH = sourceHeight.value
+    let x1 = start.x
+    let y1 = start.y
+    let x2 = start.x + start.width
+    let y2 = start.y + start.height
+    if (mode.includes('w'))
+      x1 = clamp(Math.round(x1 + dx), 0, x2 - MIN_CROP_SIZE)
+    if (mode.includes('e'))
+      x2 = clamp(Math.round(x2 + dx), x1 + MIN_CROP_SIZE, maxW)
+    if (mode.includes('n'))
+      y1 = clamp(Math.round(y1 + dy), 0, y2 - MIN_CROP_SIZE)
+    if (mode.includes('s'))
+      y2 = clamp(Math.round(y2 + dy), y1 + MIN_CROP_SIZE, maxH)
+    return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+  }
+
+  function lockedWidthFor(
+    mode: CropResizeDir,
+    start: Bounds,
+    free: Bounds,
+    ratio: number
+  ): number {
+    const widthFromHeight = free.height * ratio
+    if (mode === 'n' || mode === 's') return widthFromHeight
+    if (mode === 'e' || mode === 'w') return free.width
+    return Math.abs(free.width - start.width) >=
+      Math.abs(widthFromHeight - start.width)
+      ? free.width
+      : widthFromHeight
+  }
+
+  function ratioResize(
+    mode: CropResizeDir,
+    start: Bounds,
+    dx: number,
+    dy: number,
+    ratio: number
+  ): Bounds {
+    const maxW = sourceWidth.value
+    const maxH = sourceHeight.value
+    const free = freeResize(mode, start, dx, dy)
+
+    let width = lockedWidthFor(mode, start, free, ratio)
+    let height = width / ratio
+
+    const anchorRight = start.x + start.width
+    const anchorBottom = start.y + start.height
+    const centerX = start.x + start.width / 2
+    const centerY = start.y + start.height / 2
+    const hasW = mode.includes('w')
+    const hasE = mode.includes('e')
+    const hasN = mode.includes('n')
+    const hasS = mode.includes('s')
+
+    const availWidth = hasW
+      ? anchorRight
+      : hasE
+        ? maxW - start.x
+        : 2 * Math.min(centerX, maxW - centerX)
+    const availHeight = hasN
+      ? anchorBottom
+      : hasS
+        ? maxH - start.y
+        : 2 * Math.min(centerY, maxH - centerY)
+
+    const minWidth = Math.max(MIN_CROP_SIZE, MIN_CROP_SIZE * ratio)
+    const scale = Math.min(1, availWidth / width, availHeight / height)
+    width = Math.max(width * scale, minWidth)
+    height = width / ratio
+
+    width = Math.round(width)
+    height = Math.round(height)
+
+    const x = hasW
+      ? anchorRight - width
+      : hasE
+        ? start.x
+        : Math.round(centerX - width / 2)
+    const y = hasN
+      ? anchorBottom - height
+      : hasS
+        ? start.y
+        : Math.round(centerY - height / 2)
+
+    return {
+      x: clamp(x, 0, Math.max(maxW - width, 0)),
+      y: clamp(y, 0, Math.max(maxH - height, 0)),
+      width,
+      height
+    }
+  }
+
+  function applyDrag(
+    mode: CropDragMode,
+    start: Bounds,
+    dx: number,
+    dy: number
+  ): Bounds {
+    const maxW = sourceWidth.value
+    const maxH = sourceHeight.value
+
+    if (mode === 'move') {
+      return {
+        x: clamp(Math.round(start.x + dx), 0, Math.max(maxW - start.width, 0)),
+        y: clamp(Math.round(start.y + dy), 0, Math.max(maxH - start.height, 0)),
+        width: start.width,
+        height: start.height
+      }
+    }
+
+    const ratio = lockedRatio?.value
+    return ratio != null
+      ? ratioResize(mode, start, dx, dy, ratio)
+      : freeResize(mode, start, dx, dy)
+  }
+
+  function startDrag(mode: CropDragMode, event: PointerEvent) {
+    if (isDisabled() || event.button !== 0) return
+    const root = rootEl.value
+    const target = event.currentTarget
+    if (!root || !(target instanceof HTMLElement)) return
+    if (sourceWidth.value <= 0 || sourceHeight.value <= 0) return
+
+    cleanupDrag?.()
+
+    const rect = root.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) return
+
+    const scaleX = sourceWidth.value / rect.width
+    const scaleY = sourceHeight.value / rect.height
+    const start = { ...bounds.value }
+    const startX = event.clientX
+    const startY = event.clientY
+
+    target.setPointerCapture(event.pointerId)
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const dx = (moveEvent.clientX - startX) * scaleX
+      const dy = (moveEvent.clientY - startY) * scaleY
+      bounds.value = applyDrag(mode, start, dx, dy)
+    }
+
+    const endDrag = () => {
+      target.removeEventListener('pointermove', onMove)
+      target.removeEventListener('pointerup', endDrag)
+      target.removeEventListener('lostpointercapture', endDrag)
+      cleanupDrag = null
+    }
+
+    cleanupDrag = endDrag
+
+    target.addEventListener('pointermove', onMove)
+    target.addEventListener('pointerup', endDrag)
+    target.addEventListener('lostpointercapture', endDrag)
+  }
+
+  onScopeDispose(() => {
+    cleanupDrag?.()
+  })
+
+  return { startDrag }
+}

--- a/src/composables/video/useCropRatioLock.test.ts
+++ b/src/composables/video/useCropRatioLock.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import type { Bounds } from '@/renderer/core/layout/types'
+
+import { useCropRatioLock } from './useCropRatioLock'
+
+function createLock(
+  initial: Bounds,
+  source: { width: number; height: number } = { width: 1920, height: 1080 }
+) {
+  const bounds = ref<Bounds>(initial)
+  const lock = useCropRatioLock(bounds, {
+    sourceWidth: ref(source.width),
+    sourceHeight: ref(source.height)
+  })
+  return { bounds, ...lock }
+}
+
+describe('useCropRatioLock', () => {
+  it('exposes the preset keys including custom', () => {
+    const { ratioKeys } = createLock({ x: 0, y: 0, width: 640, height: 360 })
+
+    expect(ratioKeys).toContain('16:9')
+    expect(ratioKeys).toContain('1:1')
+    expect(ratioKeys).toContain('custom')
+  })
+
+  it('reshapes the bounds when a preset is selected', () => {
+    const { bounds, selectedRatio, lockedRatio } = createLock({
+      x: 100,
+      y: 100,
+      width: 600,
+      height: 500
+    })
+
+    selectedRatio.value = '1:1'
+
+    expect(lockedRatio.value).toBe(1)
+    expect(bounds.value).toEqual({ x: 100, y: 100, width: 600, height: 600 })
+  })
+
+  it('clamps the reshaped bounds to the source frame', () => {
+    const { bounds, selectedRatio } = createLock({
+      x: 0,
+      y: 900,
+      width: 1000,
+      height: 100
+    })
+
+    selectedRatio.value = '1:1'
+
+    expect(bounds.value.y + bounds.value.height).toBeLessThanOrEqual(1080)
+    expect(bounds.value.width).toBe(bounds.value.height)
+  })
+
+  it('keeps the minimum size inside the frame at the bottom edge', () => {
+    const { bounds, selectedRatio } = createLock({
+      x: 0,
+      y: 1070,
+      width: 100,
+      height: 10
+    })
+
+    selectedRatio.value = '1:1'
+
+    expect(bounds.value.width).toBe(bounds.value.height)
+    expect(bounds.value.width).toBeGreaterThanOrEqual(16)
+    expect(bounds.value.y + bounds.value.height).toBeLessThanOrEqual(1080)
+    expect(bounds.value.x).toBeGreaterThanOrEqual(0)
+    expect(bounds.value.y).toBeGreaterThanOrEqual(0)
+  })
+
+  it('rejects preset selection before source metadata is available', () => {
+    const { bounds, selectedRatio, lockedRatio, canLockRatio } = createLock(
+      { x: 0, y: 0, width: 0, height: 0 },
+      { width: 0, height: 0 }
+    )
+
+    expect(canLockRatio.value).toBe(false)
+
+    selectedRatio.value = '1:1'
+
+    expect(lockedRatio.value).toBeNull()
+    expect(selectedRatio.value).toBe('custom')
+    expect(bounds.value).toEqual({ x: 0, y: 0, width: 0, height: 0 })
+  })
+
+  it('rejects enabling the lock while the bounds are empty', () => {
+    const { isLockEnabled, lockedRatio } = createLock({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0
+    })
+
+    isLockEnabled.value = true
+
+    expect(isLockEnabled.value).toBe(false)
+    expect(lockedRatio.value).toBeNull()
+  })
+
+  it('captures the current ratio when the lock is enabled', () => {
+    const { selectedRatio, isLockEnabled, lockedRatio } = createLock({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 400
+    })
+
+    isLockEnabled.value = true
+
+    expect(lockedRatio.value).toBe(2)
+    expect(selectedRatio.value).toBe('custom')
+  })
+
+  it('maps a captured ratio back to its preset key', () => {
+    const { selectedRatio, isLockEnabled } = createLock({
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360
+    })
+
+    isLockEnabled.value = true
+
+    expect(selectedRatio.value).toBe('16:9')
+  })
+
+  it('starts unlocked and clears the ratio when the lock is disabled', () => {
+    const { selectedRatio, isLockEnabled, lockedRatio } = createLock({
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360
+    })
+
+    expect(selectedRatio.value).toBe('custom')
+    expect(isLockEnabled.value).toBe(false)
+
+    selectedRatio.value = '16:9'
+    isLockEnabled.value = false
+
+    expect(lockedRatio.value).toBeNull()
+    expect(selectedRatio.value).toBe('custom')
+  })
+})

--- a/src/composables/video/useCropRatioLock.ts
+++ b/src/composables/video/useCropRatioLock.ts
@@ -1,0 +1,99 @@
+import { computed, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import { ASPECT_RATIOS } from '@/composables/useImageCrop'
+import { MIN_CROP_SIZE } from '@/composables/video/useCropBoxEditor'
+import type { Bounds } from '@/renderer/core/layout/types'
+
+interface UseCropRatioLockOptions {
+  sourceWidth: Ref<number>
+  sourceHeight: Ref<number>
+}
+
+export function useCropRatioLock(
+  bounds: Ref<Bounds>,
+  options: UseCropRatioLockOptions
+) {
+  const { sourceWidth, sourceHeight } = options
+
+  const lockedRatio = ref<number | null>(null)
+  const ratioKeys = Object.keys(ASPECT_RATIOS)
+
+  const canLockRatio = computed(
+    () =>
+      isPositiveFinite(sourceWidth.value) &&
+      isPositiveFinite(sourceHeight.value) &&
+      isPositiveFinite(bounds.value.width) &&
+      isPositiveFinite(bounds.value.height)
+  )
+
+  function applyLockedRatio() {
+    const ratio = lockedRatio.value
+    if (ratio == null) return
+
+    const sourceW = sourceWidth.value
+    const sourceH = sourceHeight.value
+    let { x, y } = bounds.value
+    let width = bounds.value.width
+    let height = width / ratio
+
+    const scale = Math.min(
+      1,
+      Math.max(sourceW - x, 0) / width,
+      Math.max(sourceH - y, 0) / height
+    )
+    width = Math.max(width * scale, MIN_CROP_SIZE, MIN_CROP_SIZE * ratio)
+    height = width / ratio
+
+    x = clamp(x, 0, Math.max(sourceW - width, 0))
+    y = clamp(y, 0, Math.max(sourceH - height, 0))
+
+    bounds.value = {
+      x: Math.round(x),
+      y: Math.round(y),
+      width: Math.round(Math.min(width, sourceW)),
+      height: Math.round(Math.min(height, sourceH))
+    }
+  }
+
+  const selectedRatio = computed({
+    get: () => {
+      if (lockedRatio.value == null) return 'custom'
+      const entry = Object.entries(ASPECT_RATIOS).find(
+        ([, value]) => value === lockedRatio.value
+      )
+      return entry ? entry[0] : 'custom'
+    },
+    set: (key: string) => {
+      if (key === 'custom') {
+        lockedRatio.value = null
+        return
+      }
+      if (!canLockRatio.value) return
+      lockedRatio.value =
+        ASPECT_RATIOS[key as keyof typeof ASPECT_RATIOS] ?? null
+      applyLockedRatio()
+    }
+  })
+
+  const isLockEnabled = computed({
+    get: () => lockedRatio.value != null,
+    set: (locked: boolean) => {
+      if (locked && lockedRatio.value == null) {
+        if (!canLockRatio.value) return
+        lockedRatio.value = bounds.value.width / bounds.value.height
+      }
+      if (!locked) {
+        lockedRatio.value = null
+      }
+    }
+  })
+
+  return { lockedRatio, ratioKeys, selectedRatio, isLockEnabled, canLockRatio }
+}
+
+function isPositiveFinite(value: number) {
+  return Number.isFinite(value) && value > 0
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2210,6 +2210,9 @@
     "addColor": "Add a color",
     "swatchTitle": "Click edit · drag reorder · right-click remove"
   },
+  "videoEdit": {
+    "adjustCrop": "Adjust crop region"
+  },
   "toastMessages": {
     "nothingToQueue": "Nothing to queue",
     "pleaseSelectOutputNodes": "Please select output nodes",


### PR DESCRIPTION
This is seperate part for the big PR of video edit, crop, trim PR https://github.com/Comfy-Org/ComfyUI_frontend/pull/14118

## Summary
- useCropBoxEditor: drag/move and eight-direction resize of a crop rect in source-pixel space, clamped to the frame with a minimum size; optional locked aspect ratio anchored on the opposite edge/corner
- useCropRatioLock: aspect-ratio presets and lock state (same presets as the image crop widget), reshaping the bounds on selection
- VideoCropOverlay: percent-positioned crop rectangle with handles rendered over a media preview, following the imagecrop visual language