### PR TITLE
feat(assets): introduce small and large grid views to Media Assets

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -297,7 +297,9 @@ export class AssetsSidebarTab extends SidebarTab {
 
   // --- View mode ---
   public readonly listViewOption: Locator
-  public readonly gridViewOption: Locator
+  public readonly gridSmallOption: Locator
+  public readonly gridLargeOption: Locator
+  public readonly gridItems: Locator
 
   // --- Sort options (cloud-only, shown inside settings popover) ---
   public readonly sortNewestFirst: Locator
@@ -343,7 +345,9 @@ export class AssetsSidebarTab extends SidebarTab {
     this.filterAudioCheckbox = page.getByRole('checkbox', { name: 'Audio' })
     this.filter3DCheckbox = page.getByRole('checkbox', { name: '3D' })
     this.listViewOption = page.getByText('List view')
-    this.gridViewOption = page.getByText('Grid view')
+    this.gridSmallOption = page.getByText('Grid (small)')
+    this.gridLargeOption = page.getByText('Grid (large)')
+    this.gridItems = page.locator('[data-virtual-grid-item]')
     this.sortNewestFirst = page.getByText('Newest first')
     this.sortOldestFirst = page.getByText('Oldest first')
     this.sortLongestFirst = page.getByText('Generation time (longest first)')
@@ -379,6 +383,12 @@ export class AssetsSidebarTab extends SidebarTab {
 
   getAssetCardByName(name: string) {
     return this.assetCards.filter({ hasText: name })
+  }
+
+  async getFirstGridItemWidth() {
+    return await this.gridItems.first().evaluate((element) => {
+      return element.getBoundingClientRect().width
+    })
   }
 
   contextMenuItem(label: string) {
@@ -424,7 +434,8 @@ export class AssetsSidebarTab extends SidebarTab {
     await this.settingsButton.click()
     // Wait for popover content to render
     await this.listViewOption
-      .or(this.gridViewOption)
+      .or(this.gridSmallOption)
+      .or(this.gridLargeOption)
       .first()
       .waitFor({ state: 'visible', timeout: 3000 })
   }

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -258,13 +258,13 @@ test.describe('Assets sidebar - grid view display', () => {
 })
 
 // ==========================================================================
-// 4. View mode toggle (grid <-> list)
+// 4. View mode
 // ==========================================================================
 
-test.describe('Assets sidebar - view mode toggle', () => {
+test.describe('Assets sidebar - view mode', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(SAMPLE_JOBS)
-    await comfyPage.assets.mockInputFiles([])
+    await comfyPage.assets.mockInputFiles(SAMPLE_IMPORTED_FILES)
     await comfyPage.setup()
   })
 
@@ -282,7 +282,7 @@ test.describe('Assets sidebar - view mode toggle', () => {
     await expect(tab.listViewItems.first()).toBeVisible()
   })
 
-  test('Can switch back to grid view', async ({ comfyPage }) => {
+  test('Can switch from list to large grid', async ({ comfyPage }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
 
@@ -290,10 +290,54 @@ test.describe('Assets sidebar - view mode toggle', () => {
     await tab.listViewOption.click()
     await expect(tab.listViewItems.first()).toBeVisible()
 
-    await tab.gridViewOption.click()
+    await tab.gridLargeOption.click()
     await tab.waitForAssets()
 
     await expect(tab.assetCards.first()).toBeVisible()
+  })
+
+  test('Small grid remains active across asset views', async ({
+    comfyPage
+  }) => {
+    await comfyPage.assets.mockJobDetail('job-gamma', JOB_GAMMA_DETAIL)
+
+    const tab = comfyPage.menu.assetsTab
+    await tab.open()
+
+    const largeCardWidth = await tab.getFirstGridItemWidth()
+
+    await tab.openSettingsMenu()
+    await tab.gridSmallOption.click()
+
+    await expect
+      .poll(() => tab.getFirstGridItemWidth())
+      .toBeLessThan(largeCardWidth)
+    await expect
+      .poll(() =>
+        comfyPage.page.evaluate(() =>
+          localStorage.getItem('Comfy.Assets.Sidebar.ViewMode')
+        )
+      )
+      .toBe('grid-small')
+
+    await tab.switchToImported()
+
+    await expect(tab.assetCards.first()).toBeVisible()
+    await expect
+      .poll(() => tab.getFirstGridItemWidth())
+      .toBeLessThan(largeCardWidth)
+
+    await tab.switchToGenerated()
+    await tab.assetCards
+      .first()
+      .getByRole('button', { name: 'See more outputs' })
+      .click()
+
+    await expect(tab.backToAssetsButton).toBeVisible()
+    await expect.poll(() => tab.assetCards.count()).toBe(2)
+    await expect
+      .poll(() => tab.getFirstGridItemWidth())
+      .toBeLessThan(largeCardWidth)
   })
 })
 
@@ -872,7 +916,8 @@ test.describe('Assets sidebar - settings menu', () => {
     await tab.openSettingsMenu()
 
     await expect(tab.listViewOption).toBeVisible()
-    await expect(tab.gridViewOption).toBeVisible()
+    await expect(tab.gridSmallOption).toBeVisible()
+    await expect(tab.gridLargeOption).toBeVisible()
   })
 })
 

--- a/src/components/common/VirtualGrid.test.ts
+++ b/src/components/common/VirtualGrid.test.ts
@@ -268,4 +268,53 @@ describe('VirtualGrid', () => {
     expect(renderedItems.length).toBeGreaterThan(0)
     expect(renderedItems.length % 4).toBe(0)
   })
+
+  it('remeasures items when the grid style changes', async () => {
+    const items = createItems(20)
+    let itemWidth = 200
+    const widthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.hasAttribute('data-virtual-grid-item') ? itemWidth : 0
+      })
+    const heightSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.hasAttribute('data-virtual-grid-item') ? 100 : 0
+      })
+
+    try {
+      const { rerender } = render(VirtualGrid, {
+        props: {
+          items,
+          gridStyle: defaultGridStyle,
+          defaultItemHeight: 100,
+          defaultItemWidth: 200,
+          bufferRows: 0
+        },
+        slots: {
+          item: `<template #item="{ item }">
+            <div>{{ item.name }}</div>
+          </template>`
+        }
+      })
+
+      await nextTick()
+      expect(screen.getAllByText(/^Item \d+$/)).toHaveLength(4)
+
+      itemWidth = 100
+      await rerender({
+        gridStyle: {
+          ...defaultGridStyle,
+          gridTemplateColumns: 'repeat(4, 1fr)'
+        }
+      })
+      await nextTick()
+
+      expect(screen.getAllByText(/^Item \d+$/)).toHaveLength(8)
+    } finally {
+      widthSpy.mockRestore()
+      heightSpy.mockRestore()
+    }
+  })
 })

--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -132,6 +132,7 @@ function updateItemSize(): void {
 }
 const onResize = debounce(updateItemSize, resizeDebounce)
 watch([width, height], onResize, { flush: 'post' })
+watch(() => gridStyle, updateItemSize, { flush: 'post' })
 whenever(() => items, updateItemSize, { flush: 'post' })
 onBeforeUnmount(() => {
   onResize.cancel()

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -28,14 +28,18 @@ import { computed } from 'vue'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
+import { getMediaAssetGridColumns } from '@/platform/assets/components/mediaAssetViewOptions'
+import type { MediaAssetGridMode } from '@/platform/assets/components/mediaAssetViewOptions'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
-const { assets, isSelected, showOutputCount, getOutputCount } = defineProps<{
-  assets: AssetItem[]
-  isSelected: (assetId: string) => boolean
-  showOutputCount: (asset: AssetItem) => boolean
-  getOutputCount: (asset: AssetItem) => number
-}>()
+const { assets, isSelected, showOutputCount, getOutputCount, gridMode } =
+  defineProps<{
+    assets: AssetItem[]
+    isSelected: (assetId: string) => boolean
+    showOutputCount: (asset: AssetItem) => boolean
+    getOutputCount: (asset: AssetItem) => number
+    gridMode: MediaAssetGridMode
+  }>()
 
 const emit = defineEmits<{
   (e: 'select-asset', asset: AssetItem): void
@@ -54,10 +58,10 @@ const assetItems = computed<AssetGridItem[]>(() =>
   }))
 )
 
-const gridStyle = {
+const gridStyle = computed(() => ({
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(min(200px, 30vw), 1fr))',
+  gridTemplateColumns: getMediaAssetGridColumns(gridMode),
   padding: '0 0.5rem',
   gap: '0.5rem'
-}
+}))
 </script>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -57,7 +57,8 @@
     <template #body>
       <div
         v-if="showLoadingState"
-        class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 p-2"
+        class="grid gap-2 p-2"
+        :style="skeletonGridStyle"
       >
         <div
           v-for="n in skeletonCount"
@@ -107,6 +108,7 @@
             :is-selected
             :show-output-count
             :get-output-count
+            :grid-mode
             @select-asset="handleAssetSelect"
             @context-menu="handleAssetContextMenu"
             @approach-end="handleApproachEnd"
@@ -191,6 +193,11 @@ import Button from '@/components/ui/button/Button.vue'
 import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
 import MediaAssetFilterBar from '@/platform/assets/components/MediaAssetFilterBar.vue'
 import MediaAssetSelectionBar from '@/platform/assets/components/MediaAssetSelectionBar.vue'
+import { getMediaAssetGridColumns } from '@/platform/assets/components/mediaAssetViewOptions'
+import type {
+  MediaAssetGridMode,
+  MediaAssetViewMode
+} from '@/platform/assets/components/mediaAssetViewOptions'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'
 import { useAssetsApi } from '@/platform/assets/composables/media/useAssetsApi'
 import { useAssetGridSelection } from '@/platform/assets/composables/useAssetGridSelection'
@@ -227,11 +234,17 @@ const folderJobId = ref<string | null>(null)
 const folderExecutionTime = ref<number | undefined>(undefined)
 const expectedFolderCount = ref(0)
 const isInFolderView = computed(() => folderJobId.value !== null)
-const viewMode = useStorage<'list' | 'grid'>(
+const viewMode = useStorage<MediaAssetViewMode>(
   'Comfy.Assets.Sidebar.ViewMode',
   'grid'
 )
 const isListView = computed(() => viewMode.value === 'list')
+const gridMode = computed<MediaAssetGridMode>(() =>
+  viewMode.value === 'grid-small' ? 'grid-small' : 'grid'
+)
+const skeletonGridStyle = computed(() => ({
+  gridTemplateColumns: getMediaAssetGridColumns(gridMode.value)
+}))
 
 const contextMenuRef = ref<InstanceType<typeof MediaAssetContextMenu>>()
 const contextMenuAsset = ref<AssetItem | null>(null)

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -900,6 +900,8 @@
       "filterAudio": "Audio",
       "filter3D": "3D",
       "filterText": "Text",
+      "viewGridSmall": "Grid (small)",
+      "viewGridLarge": "Grid (large)",
       "viewSettings": "View settings"
     },
     "backToAssets": "Back to all assets",

--- a/src/platform/assets/components/MediaAssetFilterBar.vue
+++ b/src/platform/assets/components/MediaAssetFilterBar.vue
@@ -46,6 +46,7 @@ import MediaAssetFilterMenu from './MediaAssetFilterMenu.vue'
 import MediaAssetSettingsButton from './MediaAssetSettingsButton.vue'
 import MediaAssetSettingsMenu from './MediaAssetSettingsMenu.vue'
 import type { SortBy } from './MediaAssetSettingsMenu.vue'
+import type { MediaAssetViewMode } from './mediaAssetViewOptions'
 
 const { showGenerationTimeSort = false, bottomDivider = false } = defineProps<{
   searchQuery: string
@@ -60,7 +61,7 @@ const emit = defineEmits<{
 }>()
 
 const sortBy = defineModel<SortBy>('sortBy', { required: true })
-const viewMode = defineModel<'list' | 'grid'>('viewMode', { required: true })
+const viewMode = defineModel<MediaAssetViewMode>('viewMode', { required: true })
 
 const handleSearchChange = (value: string | undefined) => {
   emit('update:searchQuery', value ?? '')

--- a/src/platform/assets/components/MediaAssetSettingsMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetSettingsMenu.test.ts
@@ -5,10 +5,12 @@ import { defineComponent, ref } from 'vue'
 
 import MediaAssetSettingsMenu from '@/platform/assets/components/MediaAssetSettingsMenu.vue'
 import type { SortBy } from '@/platform/assets/components/MediaAssetSettingsMenu.vue'
+import type { MediaAssetViewMode } from '@/platform/assets/components/mediaAssetViewOptions'
 
 const KEYS = {
   list: 'sideToolbar.queueProgressOverlay.viewList',
-  grid: 'sideToolbar.queueProgressOverlay.viewGrid',
+  gridSmall: 'sideToolbar.mediaAssets.viewGridSmall',
+  grid: 'sideToolbar.mediaAssets.viewGridLarge',
   newest: 'sideToolbar.mediaAssets.sortNewestFirst',
   oldest: 'sideToolbar.mediaAssets.sortOldestFirst',
   longest: 'sideToolbar.mediaAssets.sortLongestFirst',
@@ -16,14 +18,14 @@ const KEYS = {
 } as const
 
 interface MountOptions {
-  viewMode?: 'list' | 'grid'
+  viewMode?: MediaAssetViewMode
   sortBy?: SortBy
   showSortOptions?: boolean
   showGenerationTimeSort?: boolean
 }
 
 function mountWithModels(options: MountOptions = {}) {
-  const viewMode = ref<'list' | 'grid'>(options.viewMode ?? 'list')
+  const viewMode = ref<MediaAssetViewMode>(options.viewMode ?? 'list')
   const sortBy = ref<SortBy>(options.sortBy ?? 'newest')
 
   const Host = defineComponent({
@@ -62,17 +64,24 @@ function getButton(label: string): HTMLElement {
 
 describe('MediaAssetSettingsMenu', () => {
   describe('view-mode options (always visible)', () => {
-    it('renders both list and grid view options', () => {
+    it('renders list and both grid view options', () => {
       mountWithModels()
       expect(getButton(KEYS.list)).toBeTruthy()
+      expect(getButton(KEYS.gridSmall)).toBeTruthy()
       expect(getButton(KEYS.grid)).toBeTruthy()
     })
 
-    it('updates the v-model:viewMode when an option is clicked', async () => {
-      const { viewMode, user } = mountWithModels({ viewMode: 'list' })
-      await user.click(getButton(KEYS.grid))
-      expect(viewMode.value).toBe('grid')
-    })
+    it.for([
+      { label: KEYS.gridSmall, expected: 'grid-small' },
+      { label: KEYS.grid, expected: 'grid' }
+    ] as const)(
+      'updates the v-model:viewMode to $expected when clicked',
+      async ({ label, expected }) => {
+        const { viewMode, user } = mountWithModels({ viewMode: 'list' })
+        await user.click(getButton(label))
+        expect(viewMode.value).toBe(expected)
+      }
+    )
   })
 
   describe('sort options (gated by showSortOptions)', () => {

--- a/src/platform/assets/components/MediaAssetSettingsMenu.vue
+++ b/src/platform/assets/components/MediaAssetSettingsMenu.vue
@@ -18,11 +18,26 @@
     <Button
       variant="textonly"
       class="w-full"
+      @click="handleViewModeChange('grid-small')"
+    >
+      <span class="flex items-center gap-2">
+        <i class="icon-[lucide--grid-3x3] size-4" />
+        <span>{{ $t('sideToolbar.mediaAssets.viewGridSmall') }}</span>
+      </span>
+      <i
+        class="ml-auto icon-[lucide--check] size-4"
+        :class="viewMode !== 'grid-small' && 'opacity-0'"
+      />
+    </Button>
+
+    <Button
+      variant="textonly"
+      class="w-full"
       @click="handleViewModeChange('grid')"
     >
       <span class="flex items-center gap-2">
         <i class="icon-[lucide--layout-grid] size-4" />
-        <span>{{ $t('sideToolbar.queueProgressOverlay.viewGrid') }}</span>
+        <span>{{ $t('sideToolbar.mediaAssets.viewGridLarge') }}</span>
       </span>
       <i
         class="ml-auto icon-[lucide--check] size-4"
@@ -89,6 +104,8 @@
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
 
+import type { MediaAssetViewMode } from './mediaAssetViewOptions'
+
 export type SortBy = 'newest' | 'oldest' | 'longest' | 'fastest'
 
 const { showSortOptions = false, showGenerationTimeSort = false } =
@@ -97,10 +114,10 @@ const { showSortOptions = false, showGenerationTimeSort = false } =
     showGenerationTimeSort?: boolean
   }>()
 
-const viewMode = defineModel<'list' | 'grid'>('viewMode', { required: true })
+const viewMode = defineModel<MediaAssetViewMode>('viewMode', { required: true })
 const sortBy = defineModel<SortBy>('sortBy', { required: true })
 
-function handleViewModeChange(value: 'list' | 'grid') {
+function handleViewModeChange(value: MediaAssetViewMode) {
   viewMode.value = value
 }
 

--- a/src/platform/assets/components/mediaAssetViewOptions.test.ts
+++ b/src/platform/assets/components/mediaAssetViewOptions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMediaAssetGridColumns } from '@/platform/assets/components/mediaAssetViewOptions'
+import type { MediaAssetGridMode } from '@/platform/assets/components/mediaAssetViewOptions'
+
+describe('getMediaAssetGridColumns', () => {
+  it.for([
+    { mode: 'grid-small', minWidth: 128 },
+    { mode: 'grid', minWidth: 240 }
+  ] satisfies Array<{ mode: MediaAssetGridMode; minWidth: number }>)(
+    'uses a $minWidth px minimum width for $mode',
+    ({ mode, minWidth }) => {
+      expect(getMediaAssetGridColumns(mode)).toBe(
+        `repeat(auto-fill, minmax(min(${minWidth}px, 30vw), 1fr))`
+      )
+    }
+  )
+})

--- a/src/platform/assets/components/mediaAssetViewOptions.ts
+++ b/src/platform/assets/components/mediaAssetViewOptions.ts
@@ -1,0 +1,8 @@
+export type MediaAssetViewMode = 'list' | MediaAssetGridMode
+
+export type MediaAssetGridMode = 'grid' | 'grid-small'
+
+export function getMediaAssetGridColumns(mode: MediaAssetGridMode): string {
+  const minWidth = mode === 'grid-small' ? 128 : 240
+  return `repeat(auto-fill, minmax(min(${minWidth}px, 30vw), 1fr))`
+}


### PR DESCRIPTION
## Summary

Adds small and large grid views to the Media Assets sidebar.

Part of [FE-1367](https://linear.app/comfyorg/issue/FE-1367/assets-view-options-media-assets-sidebar-filtering-search-view-modes).

## Changes

- Add `List view`, `Grid (small)`, and `Grid (large)`.
- Preserve the existing `grid` preference as Grid (large).
- Update unit, component, and browser coverage.

## Screenshots
https://github.com/user-attachments/assets/df4c4ffb-fc7f-4fec-a352-dafa7505f708
