### PR TITLE
fix(assets): polish the output folder header

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -360,7 +360,9 @@ export class AssetsSidebarTab extends SidebarTab {
     this.deselectAllButton = page.getByTestId('assets-deselect-selected')
     this.deleteSelectedButton = page.getByTestId('assets-delete-selected')
     this.downloadSelectedButton = page.getByTestId('assets-download-selected')
-    this.backToAssetsButton = page.getByText('Back to all assets')
+    this.backToAssetsButton = page.getByRole('button', {
+      name: 'Back to all assets'
+    })
     this.panelHeader = page.locator('.comfy-vue-side-bar-header')
     this.skeletonLoaders = page.locator(
       '.sidebar-content-container .animate-pulse'

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -249,7 +249,9 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       exact: true
     })
     await expect(folderJobId).toBeVisible()
-    await expect(folderJobId).toHaveCSS('text-overflow', 'ellipsis')
+    await expect(
+      comfyPage.page.getByRole('button', { name: 'Copy Job ID' })
+    ).toBeVisible()
     await expect(tab.getAssetCardByName('multi-output-b')).toBeVisible()
     await expect(
       comfyPage.page.getByRole('img', { name: 'multi-output-b.png' })

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -245,6 +245,11 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       .click()
 
     await expect(tab.backToAssetsButton).toBeVisible()
+    const folderJobId = comfyPage.page.getByText('multi-output', {
+      exact: true
+    })
+    await expect(folderJobId).toBeVisible()
+    await expect(folderJobId).toHaveCSS('text-overflow', 'ellipsis')
     await expect(tab.getAssetCardByName('multi-output-b')).toBeVisible()
     await expect(
       comfyPage.page.getByRole('img', { name: 'multi-output-b.png' })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -179,6 +179,6 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(
       screen.queryByRole('button', { name: 'Back to all assets' })
     ).not.toBeInTheDocument()
-    expect(screen.queryByText('Job ID')).not.toBeInTheDocument()
+    expect(screen.queryByText('multi-output-job')).not.toBeInTheDocument()
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -172,9 +172,11 @@ describe('AssetsSidebarTab folder navigation', () => {
     const copyButton = within(folderTitle).getByRole('button', {
       name: 'Copy Job ID'
     })
+    const jobId = within(folderTitle).getByText('multi-output-job')
 
     expect(backButton).toHaveTextContent('')
     expect(backButton).toHaveAttribute('data-tooltip', 'Back to all assets')
+    expect(jobId).toHaveClass('min-w-0', 'truncate')
     expect(copyButton).toHaveAttribute('data-tooltip', 'Copy Job ID')
     expect(copyButton).toHaveAttribute('data-size', 'icon')
     expect(copyButton).toHaveAttribute('data-variant', 'textonly')

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -102,8 +102,10 @@ const i18n = createI18n({
 })
 
 const sidebarTabTemplateStub = {
+  props: ['title'],
   template: `
     <section>
+      <h2 v-if="title">{{ title }}</h2>
       <div data-testid="folder-title"><slot name="alt-title" /></div>
       <div data-testid="folder-controls"><slot name="header" /></div>
       <slot name="body" />
@@ -172,6 +174,10 @@ describe('AssetsSidebarTab folder navigation', () => {
     )
 
     await userEvent.click(backButton)
+    expect(screen.getByText('Media Assets')).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: 'Back to all assets' })
+    ).not.toBeInTheDocument()
     expect(screen.queryByText('Job ID')).not.toBeInTheDocument()
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -92,6 +92,7 @@ const i18n = createI18n({
   messages: {
     en: {
       assetBrowser: { jobId: 'Job ID' },
+      g: { copyJobId: 'Copy Job ID' },
       sideToolbar: {
         backToAssets: 'Back to all assets',
         mediaAssets: { title: 'Media Assets' },
@@ -125,7 +126,9 @@ const assetsGridStub = {
 }
 
 const buttonStub = {
-  template: '<button><slot /></button>'
+  props: ['size', 'variant'],
+  template:
+    '<button :data-size="size" :data-variant="variant"><slot /></button>'
 }
 
 function renderTab() {
@@ -156,7 +159,7 @@ function renderTab() {
 }
 
 describe('AssetsSidebarTab folder navigation', () => {
-  it('places an icon-only back action beside the job ID', async () => {
+  it('places accessible folder actions beside the job ID', async () => {
     renderTab()
     await userEvent.click(
       screen.getByRole('button', { name: 'Enter output folder' })
@@ -166,9 +169,15 @@ describe('AssetsSidebarTab folder navigation', () => {
     const backButton = within(folderTitle).getByRole('button', {
       name: 'Back to all assets'
     })
+    const copyButton = within(folderTitle).getByRole('button', {
+      name: 'Copy Job ID'
+    })
 
     expect(backButton).toHaveTextContent('')
     expect(backButton).toHaveAttribute('data-tooltip', 'Back to all assets')
+    expect(copyButton).toHaveAttribute('data-tooltip', 'Copy Job ID')
+    expect(copyButton).toHaveAttribute('data-size', 'icon')
+    expect(copyButton).toHaveAttribute('data-variant', 'muted-textonly')
     expect(screen.getByTestId('folder-controls')).not.toHaveTextContent(
       'Back to all assets'
     )

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,0 +1,177 @@
+import { render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import AssetsSidebarTab from './AssetsSidebarTab.vue'
+
+const folderAsset = vi.hoisted(
+  () =>
+    ({
+      id: 'multi-output',
+      name: 'multi-output.png',
+      tags: ['output'],
+      user_metadata: {
+        jobId: 'multi-output-job',
+        nodeId: '1',
+        subfolder: '',
+        outputCount: 2
+      }
+    }) satisfies AssetItem
+)
+
+vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
+  const { ref } = await import('vue')
+
+  return {
+    useAssetsApi: () => ({
+      media: ref([folderAsset]),
+      loading: ref(false),
+      error: ref(null),
+      fetchMediaList: vi.fn().mockResolvedValue([folderAsset]),
+      loadMore: vi.fn(),
+      hasMore: ref(false),
+      isLoadingMore: ref(false)
+    })
+  }
+})
+
+vi.mock('@/platform/assets/composables/useAssetGridSelection', async () => {
+  const { ref } = await import('vue')
+  return {
+    useAssetGridSelection: () => ({ marqueeStyle: ref(null) })
+  }
+})
+
+vi.mock('@/platform/assets/composables/useAssetSelection', async () => {
+  const { ref } = await import('vue')
+
+  return {
+    useAssetSelection: () => ({
+      isSelected: vi.fn().mockReturnValue(false),
+      selectedIds: ref(new Set<string>()),
+      handleAssetClick: vi.fn(),
+      selectAll: vi.fn(),
+      setSelectedIds: vi.fn(),
+      hasSelection: ref(false),
+      clearSelection: vi.fn(),
+      getSelectedAssets: vi.fn().mockReturnValue([]),
+      reconcileSelection: vi.fn(),
+      getOutputCount: vi.fn().mockReturnValue(2),
+      getTotalOutputCount: vi.fn().mockReturnValue(0),
+      activate: vi.fn(),
+      deactivate: vi.fn()
+    })
+  }
+})
+
+vi.mock('@/platform/assets/composables/useMediaAssetActions', () => ({
+  useMediaAssetActions: () => ({
+    downloadAssets: vi.fn(),
+    deleteAssets: vi.fn(),
+    addMultipleToWorkflow: vi.fn(),
+    openMultipleWorkflows: vi.fn(),
+    exportMultipleWorkflows: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/assets/utils/outputAssetUtil', async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveOutputAssetItems: vi.fn().mockResolvedValue([folderAsset])
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      assetBrowser: { jobId: 'Job ID' },
+      sideToolbar: {
+        backToAssets: 'Back to all assets',
+        mediaAssets: { title: 'Media Assets' },
+        labels: { generated: 'Generated', imported: 'Imported' }
+      }
+    }
+  }
+})
+
+const sidebarTabTemplateStub = {
+  template: `
+    <section>
+      <div data-testid="folder-title"><slot name="alt-title" /></div>
+      <div data-testid="folder-controls"><slot name="header" /></div>
+      <slot name="body" />
+    </section>
+  `
+}
+
+const assetsGridStub = {
+  props: ['assets'],
+  emits: ['output-count-click'],
+  template: `
+    <button
+      aria-label="Enter output folder"
+      @click="$emit('output-count-click', assets[0])"
+    />
+  `
+}
+
+const buttonStub = {
+  template: '<button><slot /></button>'
+}
+
+function renderTab() {
+  return render(AssetsSidebarTab, {
+    global: {
+      plugins: [i18n],
+      directives: {
+        tooltip: {
+          mounted(element, { value }) {
+            element.dataset.tooltip = value.value
+          }
+        }
+      },
+      stubs: {
+        SidebarTabTemplate: sidebarTabTemplateStub,
+        AssetsSidebarGridView: assetsGridStub,
+        AssetsSidebarListView: true,
+        Button: buttonStub,
+        MediaAssetFilterBar: true,
+        MediaAssetSelectionBar: true,
+        MediaLightbox: true,
+        MediaAssetContextMenu: true,
+        NoResultsPlaceholder: true,
+        Skeleton: true
+      }
+    }
+  })
+}
+
+describe('AssetsSidebarTab folder navigation', () => {
+  it('places an icon-only back action beside the job ID', async () => {
+    renderTab()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    )
+
+    const folderTitle = screen.getByTestId('folder-title')
+    const backButton = within(folderTitle).getByRole('button', {
+      name: 'Back to all assets'
+    })
+
+    expect(backButton).toHaveTextContent('')
+    expect(backButton).toHaveAttribute('data-tooltip', 'Back to all assets')
+    expect(screen.getByTestId('folder-controls')).not.toHaveTextContent(
+      'Back to all assets'
+    )
+
+    await userEvent.click(backButton)
+    expect(screen.queryByText('Job ID')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -177,7 +177,7 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(backButton).toHaveAttribute('data-tooltip', 'Back to all assets')
     expect(copyButton).toHaveAttribute('data-tooltip', 'Copy Job ID')
     expect(copyButton).toHaveAttribute('data-size', 'icon')
-    expect(copyButton).toHaveAttribute('data-variant', 'muted-textonly')
+    expect(copyButton).toHaveAttribute('data-variant', 'textonly')
     expect(screen.getByTestId('folder-controls')).not.toHaveTextContent(
       'Back to all assets'
     )

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -126,9 +126,7 @@ const assetsGridStub = {
 }
 
 const buttonStub = {
-  props: ['size', 'variant'],
-  template:
-    '<button :data-size="size" :data-variant="variant"><slot /></button>'
+  template: '<button><slot /></button>'
 }
 
 function renderTab() {
@@ -136,11 +134,7 @@ function renderTab() {
     global: {
       plugins: [i18n],
       directives: {
-        tooltip: {
-          mounted(element, { value }) {
-            element.dataset.tooltip = value.value
-          }
-        }
+        tooltip: {}
       },
       stubs: {
         SidebarTabTemplate: sidebarTabTemplateStub,
@@ -169,17 +163,13 @@ describe('AssetsSidebarTab folder navigation', () => {
     const backButton = within(folderTitle).getByRole('button', {
       name: 'Back to all assets'
     })
-    const copyButton = within(folderTitle).getByRole('button', {
+    within(folderTitle).getByRole('button', {
       name: 'Copy Job ID'
     })
     const jobId = within(folderTitle).getByText('multi-output-job')
 
     expect(backButton).toHaveTextContent('')
-    expect(backButton).toHaveAttribute('data-tooltip', 'Back to all assets')
-    expect(jobId).toHaveClass('min-w-0', 'truncate')
-    expect(copyButton).toHaveAttribute('data-tooltip', 'Copy Job ID')
-    expect(copyButton).toHaveAttribute('data-size', 'icon')
-    expect(copyButton).toHaveAttribute('data-variant', 'textonly')
+    expect(jobId).toBeVisible()
     expect(screen.getByTestId('folder-controls')).not.toHaveTextContent(
       'Back to all assets'
     )

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -168,7 +168,7 @@ describe('AssetsSidebarTab folder navigation', () => {
     })
     const jobId = within(folderTitle).getByText('multi-output-job')
 
-    expect(backButton).toHaveTextContent('')
+    expect(backButton).not.toHaveTextContent(/\S/)
     expect(jobId).toBeVisible()
     expect(screen.getByTestId('folder-controls')).not.toHaveTextContent(
       'Back to all assets'

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -10,6 +10,19 @@
         class="flex w-full items-center justify-between gap-2"
       >
         <div class="flex items-center gap-2">
+          <Button
+            v-tooltip.bottom="{
+              value: $t('sideToolbar.backToAssets'),
+              showDelay: 300
+            }"
+            variant="textonly"
+            size="icon"
+            type="button"
+            :aria-label="$t('sideToolbar.backToAssets')"
+            @click="exitFolderView"
+          >
+            <i class="icon-[lucide--arrow-left] size-4" />
+          </Button>
           <span class="font-bold">{{ $t('assetBrowser.jobId') }}:</span>
           <span class="text-sm">{{ folderJobId?.substring(0, 8) }}</span>
           <button
@@ -26,14 +39,6 @@
       </div>
     </template>
     <template #header>
-      <!-- Job Detail View Header -->
-      <div v-if="isInFolderView" class="px-2 2xl:px-4">
-        <Button variant="secondary" size="lg" @click="exitFolderView">
-          <i class="icon-[lucide--arrow-left] size-4" />
-          <span>{{ $t('sideToolbar.backToAssets') }}</span>
-        </Button>
-      </div>
-
       <!-- Filter Bar -->
       <MediaAssetFilterBar
         v-model:search-query="searchQuery"

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -9,7 +9,7 @@
         v-if="isInFolderView"
         class="flex w-full items-center justify-between gap-2"
       >
-        <div class="flex items-center gap-2">
+        <div class="flex min-w-0 flex-1 items-center gap-2">
           <Button
             v-tooltip.bottom="{
               value: $t('sideToolbar.backToAssets'),
@@ -18,13 +18,16 @@
             variant="textonly"
             size="icon"
             type="button"
+            class="shrink-0"
             :aria-label="$t('sideToolbar.backToAssets')"
             @click="exitFolderView"
           >
             <i class="icon-[lucide--arrow-left] size-4" />
           </Button>
-          <span class="font-bold">{{ $t('assetBrowser.jobId') }}:</span>
-          <span class="text-sm">{{ folderJobId?.substring(0, 8) }}</span>
+          <span class="shrink-0 font-bold">
+            {{ $t('assetBrowser.jobId') }}:
+          </span>
+          <span class="min-w-0 truncate text-sm">{{ folderJobId }}</span>
           <Button
             v-tooltip.bottom="{
               value: $t('g.copyJobId'),
@@ -33,13 +36,14 @@
             variant="textonly"
             size="icon"
             type="button"
+            class="shrink-0"
             :aria-label="$t('g.copyJobId')"
             @click="copyJobId"
           >
             <i class="icon-[lucide--copy] size-4" />
           </Button>
         </div>
-        <div>
+        <div class="shrink-0">
           <span>{{ formattedExecutionTime }}</span>
         </div>
       </div>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -30,7 +30,7 @@
               value: $t('g.copyJobId'),
               showDelay: 300
             }"
-            variant="muted-textonly"
+            variant="textonly"
             size="icon"
             type="button"
             :aria-label="$t('g.copyJobId')"

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -25,13 +25,19 @@
           </Button>
           <span class="font-bold">{{ $t('assetBrowser.jobId') }}:</span>
           <span class="text-sm">{{ folderJobId?.substring(0, 8) }}</span>
-          <button
-            class="m-0 cursor-pointer border-0 bg-transparent p-0 outline-0"
-            role="button"
+          <Button
+            v-tooltip.bottom="{
+              value: $t('g.copyJobId'),
+              showDelay: 300
+            }"
+            variant="muted-textonly"
+            size="icon"
+            type="button"
+            :aria-label="$t('g.copyJobId')"
             @click="copyJobId"
           >
-            <i class="icon-[lucide--copy] text-sm"></i>
-          </button>
+            <i class="icon-[lucide--copy] size-4" />
+          </Button>
         </div>
         <div>
           <span>{{ formattedExecutionTime }}</span>


### PR DESCRIPTION
## Summary

- Move the Back action next to the Job ID to prevent layout shift
- Align the Copy action with the Job ID and add standard hover styling and a “Copy Job ID” tooltip
- Show the full Job ID when space allows and truncate it with an ellipsis when constrained
- Update component and browser test coverage

Part of [FE-1367](https://linear.app/comfyorg/issue/FE-1367/assets-view-options-media-assets-sidebar-filtering-search-view-modes).

## Screenshots

Before:
<img width="616" height="312" alt="image" src="https://github.com/user-attachments/assets/e8d41533-4b7c-4fc1-947a-e8fa8cab1c5a" />

After: 
<img width="616" height="238" alt="image" src="https://github.com/user-attachments/assets/631983de-b145-4f9e-8de1-a86630942a10" />

