### PR TITLE
Gate missing-model remote metadata fetch behind explicit user action

### DIFF
--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -19,6 +19,7 @@ const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockShowUploadDialog = vi.hoisted(() => vi.fn())
 const mockCopyToClipboard = vi.hoisted(() => vi.fn())
 const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockFetchModelMetadata = vi.hoisted(() => vi.fn())
 const mockRootGraph = vi.hoisted<{
   value: Record<string, never> | null
 }>(() => ({ value: null }))
@@ -104,10 +105,7 @@ vi.mock('@/platform/missingModel/missingModelDownload', async () => {
   return {
     ...actual,
     downloadModel: mockDownloadModel,
-    fetchModelMetadata: vi.fn().mockResolvedValue({
-      fileSize: null,
-      gatedRepoUrl: null
-    })
+    fetchModelMetadata: mockFetchModelMetadata
   }
 })
 
@@ -183,6 +181,10 @@ describe('MissingModelRow', () => {
     mockGetNodeByExecutionId.mockReset()
     mockUploadContext.resolver = undefined
     mockUploadCallbacks.onUploadSuccess = undefined
+    mockFetchModelMetadata.mockResolvedValue({
+      fileSize: null,
+      gatedRepoUrl: null
+    })
   })
 
   it('opens the model import dialog from the cloud row', async () => {
@@ -441,13 +443,20 @@ describe('MissingModelRow', () => {
     mockIsCloud.value = false
     const user = userEvent.setup()
     const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
-    model.representative.url =
+    const url =
       'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    model.representative.url = url
 
     renderRow(model, vi.fn(), false)
 
+    expect(mockFetchModelMetadata).not.toHaveBeenCalled()
+
     await user.click(screen.getByTestId('missing-model-download'))
 
+    expect(mockFetchModelMetadata).toHaveBeenCalledOnce()
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(
+      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    )
     expect(mockDownloadModel).toHaveBeenCalledWith(
       {
         name: 'model.safetensors',
@@ -456,5 +465,71 @@ describe('MissingModelRow', () => {
       },
       {}
     )
+  })
+
+  it('does not start concurrent metadata requests from repeated download clicks', async () => {
+    mockIsCloud.value = false
+    const user = userEvent.setup()
+    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
+    const url =
+      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    model.representative.url = url
+    let resolveMetadata!: (
+      metadata: Awaited<
+        ReturnType<typeof MissingModelDownload.fetchModelMetadata>
+      >
+    ) => void
+    mockFetchModelMetadata.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveMetadata = resolve
+      })
+    )
+
+    renderRow(model, vi.fn(), false)
+
+    const downloadButton = screen.getByTestId('missing-model-download')
+    await user.click(downloadButton)
+    await user.click(downloadButton)
+
+    expect(mockFetchModelMetadata).toHaveBeenCalledOnce()
+    expect(mockDownloadModel).toHaveBeenCalledTimes(2)
+
+    resolveMetadata({ fileSize: 1024, gatedRepoUrl: null })
+
+    await waitFor(() => {
+      expect(useMissingModelStore().fileSizes[url]).toBe(1024)
+    })
+  })
+
+  it('keeps download available and retries metadata after a fetch error', async () => {
+    mockIsCloud.value = false
+    const user = userEvent.setup()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
+    const url =
+      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    model.representative.url = url
+    mockFetchModelMetadata
+      .mockRejectedValueOnce(new Error('metadata failed'))
+      .mockResolvedValueOnce({ fileSize: 2048, gatedRepoUrl: null })
+
+    renderRow(model, vi.fn(), false)
+
+    const downloadButton = screen.getByTestId('missing-model-download')
+    await user.click(downloadButton)
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledOnce()
+    })
+    await Promise.resolve()
+    await user.click(downloadButton)
+
+    await waitFor(() => {
+      expect(mockFetchModelMetadata).toHaveBeenCalledTimes(2)
+      expect(useMissingModelStore().fileSizes[url]).toBe(2048)
+    })
+    expect(mockDownloadModel).toHaveBeenCalledTimes(2)
+
+    warn.mockRestore()
   })
 })

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -195,7 +195,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, useTemplateRef, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -358,29 +358,29 @@ const { showUploadDialog } = useModelUpload(
   () => missingModelUploadContext.value
 )
 
-onMounted(() => {
-  if (isCloud) return
-
-  const url = model.representative.url
-  if (url && !store.fileSizes[url]) {
-    fetchModelMetadata(url)
-      .then((metadata) => {
-        if (metadata.fileSize !== null) {
-          store.setFileSize(url, metadata.fileSize)
-        }
-      })
-      .catch((error: unknown) => {
-        console.warn(
-          `[MissingModelRow] Failed to fetch metadata for ${url}:`,
-          error
-        )
-      })
-  }
-})
+let metadataFetchPromise: Promise<void> | undefined
 
 function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
+    const url = rep.url
+    if (!store.fileSizes[url] && !metadataFetchPromise) {
+      metadataFetchPromise = fetchModelMetadata(url)
+        .then((metadata) => {
+          if (metadata.fileSize !== null) {
+            store.setFileSize(url, metadata.fileSize)
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            `[MissingModelRow] Failed to fetch metadata for ${url}:`,
+            error
+          )
+        })
+        .finally(() => {
+          metadataFetchPromise = undefined
+        })
+    }
     downloadModel(
       { name: rep.name, url: rep.url, directory: rep.directory },
       store.folderPaths

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -436,7 +436,7 @@ describe('missingModelPipeline', () => {
       })
     })
 
-    it('fetches file sizes only for candidates with complete download metadata', async () => {
+    it('does not fetch remote metadata while initializing downloadable candidates', async () => {
       const downloadableCandidate = {
         nodeType: 'CheckpointLoaderSimple',
         widgetName: 'ckpt_name',
@@ -458,23 +458,28 @@ describe('missingModelPipeline', () => {
         downloadableCandidate,
         urlOnlyCandidate
       ]
-      mockHandles.fetchModelMetadata.mockResolvedValue({ fileSize: 1024 })
 
-      await runMissingModelPipeline({
+      const result = await runMissingModelPipeline({
         graph: createGraph(),
         graphData: createWorkflowGraphData(),
         missingModelStore: mockHandles.missingModelStore
       })
       await vi.dynamicImportSettled()
 
-      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledOnce()
-      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
-        'https://example.com/downloadable.safetensors'
-      )
-      expect(mockHandles.missingModelStore.setFileSize).toHaveBeenCalledWith(
-        'https://example.com/downloadable.safetensors',
-        1024
-      )
+      expect(result).toEqual({
+        missingModels: [
+          {
+            name: 'downloadable.safetensors',
+            url: 'https://example.com/downloadable.safetensors',
+            directory: 'checkpoints',
+            hash: undefined,
+            hash_type: undefined
+          }
+        ],
+        confirmedCandidates: [downloadableCandidate, urlOnlyCandidate]
+      })
+      expect(mockHandles.fetchModelMetadata).not.toHaveBeenCalled()
+      expect(mockHandles.missingModelStore.setFileSize).not.toHaveBeenCalled()
     })
 
     it('clears surfaced and cached missing models when no candidates are confirmed missing', async () => {

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -202,18 +202,6 @@ export async function runMissingModelPipeline({
           })
           cacheModelCandidates(activeWf, confirmedCandidates)
         })
-
-      const missingModelDownload =
-        import('@/platform/missingModel/missingModelDownload')
-      void Promise.allSettled(
-        downloadableCandidates.map(async (c) => {
-          const { fetchModelMetadata } = await missingModelDownload
-          const metadata = await fetchModelMetadata(c.url)
-          if (!controller.signal.aborted && metadata.fileSize !== null) {
-            missingModelStore.setFileSize(c.url, metadata.fileSize)
-          }
-        })
-      )
     }
   } else {
     clearMissingModels(activeWf, silent)


### PR DESCRIPTION
## Problem

The missing-model pipeline previously requested remote model metadata during
pipeline initialization and component mount. Opening a local workflow could
therefore cause network access without an explicit user action.

## Change

- Remove initialization-time remote metadata fetching while preserving local
  missing-model detection.
- Request metadata only after the user explicitly triggers the download action.
- Reuse the same in-flight metadata request across concurrent clicks.
- Clear a failed request so a later explicit user action can retry.

## Scope

This pull request changes exactly four files:

- `src/platform/missingModel/missingModelPipeline.ts`
- `src/platform/missingModel/missingModelPipeline.test.ts`
- `src/platform/missingModel/components/MissingModelRow.vue`
- `src/platform/missingModel/components/MissingModelRow.test.ts`

It contains no package or lockfile changes, configuration changes, dependency
changes, or generated artifacts.

## Original-base coverage adjudication

Original adjudication base:
`4916efd7fe2a80e0b08a32e6c08c41617c8a4dd7`

- Base full coverage: 3/3 passed
- Patch full coverage: 3/3 passed
- Patch final consecutive coverage runs: 2/2 passed
- Both base and patch completed 1,022 test files and 3,958 coverage files
- Base: 13,495 passed / 8 skipped per run
- Patch: 13,497 passed / 8 skipped per run

The earlier timeout was not reproducible. No changed-file stack frame,
patch-path execution, or open-handle candidate was found.

## Latest upstream integration

Latest upstream main reviewed:
`9bd1d37003c2d147d5b9020261da70d4c35d5fa0`

- Upstream commits reviewed: 4
- Drift classification: `UPSTREAM_DRIFT_CLASS_A_UNRELATED`
- Integration candidate: cleanly applied with the same stable patch-id
  (`e81cecdb9ebfff9678e1936a74719cc02c5c209a`)
- Targeted tests: 28 passed
- Missing-model regression: 190 passed
- Full unit: 13,515 passed / 8 skipped
- Typecheck: passed
- Lint: passed (0 errors / 44 warnings)
- Format: passed
- `knip --cache`: passed
- Build: passed

The original commit was preserved. A clean latest-main integration candidate
was validated locally. Official CI on the pull request remains the final
integration adjudicator.
