### PR TITLE
feat: emit workflow run funnel steps as RUM actions

### DIFF
--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -39,6 +39,7 @@ import type {
   TemplateMetadata,
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
+  WorkflowExecutionStartedMetadata,
   WorkflowImportMetadata,
   WorkflowQueuedMetadata,
   WorkflowSavedMetadata,
@@ -277,6 +278,14 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackWorkflowSubmission(metadata: WorkflowSubmissionMetadata): void {
     this.dispatch((provider) => provider.trackWorkflowSubmission?.(metadata))
+  }
+
+  trackWorkflowExecutionStarted(
+    metadata: WorkflowExecutionStartedMetadata
+  ): void {
+    this.dispatch((provider) =>
+      provider.trackWorkflowExecutionStarted?.(metadata)
+    )
   }
 
   trackExecutionOutcome(metadata: ExecutionOutcomeMetadata): void {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -72,6 +72,7 @@ describe('DatadogRumTelemetryProvider', () => {
       startTime: 42,
       submittedAt: 92,
       outcome: 'accepted',
+      jobId: 'job-1',
       workflowContext
     })
 
@@ -93,6 +94,41 @@ describe('DatadogRumTelemetryProvider', () => {
         workflow_type: 'custom'
       }
     })
+    expect(addAction).toHaveBeenCalledWith('workflow_submission', {
+      ...workflowContext,
+      job_id: 'job-1',
+      outcome: 'accepted',
+      product: 'cloud_generation'
+    })
+  })
+
+  it('emits a submission funnel step when the backend rejects the prompt', () => {
+    new DatadogRumTelemetryProvider().trackWorkflowSubmission({
+      startTime: 42,
+      submittedAt: 92,
+      outcome: 'prompt_rejected',
+      workflowContext
+    })
+
+    expect(addAction).toHaveBeenCalledWith('workflow_submission', {
+      ...workflowContext,
+      outcome: 'prompt_rejected',
+      product: 'cloud_generation'
+    })
+  })
+
+  it('emits an execution start funnel step without a duration vital', () => {
+    new DatadogRumTelemetryProvider().trackWorkflowExecutionStarted({
+      jobId: 'job-1',
+      workflowContext
+    })
+
+    expect(addAction).toHaveBeenCalledWith('workflow_execution_start', {
+      ...workflowContext,
+      job_id: 'job-1',
+      product: 'cloud_generation'
+    })
+    expect(addDurationVital).not.toHaveBeenCalled()
   })
 
   it.for(['success', 'failure', 'interrupted'] as const)(
@@ -106,9 +142,16 @@ describe('DatadogRumTelemetryProvider', () => {
         executionStartedAt: 142,
         terminalAt: 242,
         outcome,
+        jobId: 'job-1',
         workflowContext
       })
 
+      expect(addAction).toHaveBeenCalledWith('workflow_run_finished', {
+        ...workflowContext,
+        job_id: 'job-1',
+        outcome,
+        product: 'cloud_generation'
+      })
       expect(getInternalContext).toHaveBeenCalledWith(42)
       const context = {
         ...workflowContext,
@@ -160,7 +203,8 @@ describe('DatadogRumTelemetryProvider', () => {
       executionStartedAt: 92,
       submittedAt: 142,
       terminalAt: 242,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
 
     expect(addDurationVital).toHaveBeenCalledWith('workflow_queue_wait', {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -3,9 +3,22 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   ExecutionOutcomeMetadata,
   TelemetryProvider,
+  WorkflowExecutionContext,
+  WorkflowExecutionStartedMetadata,
   WorkflowQueuedMetadata,
   WorkflowSubmissionMetadata
 } from '../../types'
+
+function funnelStep(
+  jobId: string | undefined,
+  workflowContext: WorkflowExecutionContext | undefined
+) {
+  return {
+    product: 'cloud_generation',
+    ...(jobId && { job_id: jobId }),
+    ...(workflowContext ?? {})
+  }
+}
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
   trackWorkflowQueued(metadata: WorkflowQueuedMetadata): void {
@@ -16,8 +29,13 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     startTime,
     submittedAt,
     outcome,
+    jobId,
     workflowContext
   }: WorkflowSubmissionMetadata): void {
+    datadogRum.addAction('workflow_submission', {
+      outcome,
+      ...funnelStep(jobId, workflowContext)
+    })
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     datadogRum.addDurationVital('workflow_submission', {
       startTime: performance.timeOrigin + startTime,
@@ -32,14 +50,29 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     })
   }
 
+  trackWorkflowExecutionStarted({
+    jobId,
+    workflowContext
+  }: WorkflowExecutionStartedMetadata): void {
+    datadogRum.addAction(
+      'workflow_execution_start',
+      funnelStep(jobId, workflowContext)
+    )
+  }
+
   trackExecutionOutcome({
     startTime,
     submittedAt,
     executionStartedAt,
     terminalAt,
     outcome,
+    jobId,
     workflowContext
   }: ExecutionOutcomeMetadata): void {
+    datadogRum.addAction('workflow_run_finished', {
+      outcome,
+      ...funnelStep(jobId, workflowContext)
+    })
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     const context = {
       outcome,

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -188,6 +188,12 @@ export interface WorkflowSubmissionMetadata {
   startTime: number
   submittedAt: number
   outcome: WorkflowSubmissionOutcome
+  jobId?: string
+  workflowContext?: WorkflowExecutionContext
+}
+
+export interface WorkflowExecutionStartedMetadata {
+  jobId: string
   workflowContext?: WorkflowExecutionContext
 }
 
@@ -197,6 +203,7 @@ export interface ExecutionOutcomeMetadata {
   executionStartedAt?: number
   terminalAt: number
   outcome: 'success' | 'failure' | 'interrupted'
+  jobId: string
   workflowContext?: WorkflowExecutionContext
 }
 
@@ -678,6 +685,9 @@ export interface TelemetryProvider {
   trackWorkflowExecution?(): void
   trackWorkflowQueued?(metadata: WorkflowQueuedMetadata): void
   trackWorkflowSubmission?(metadata: WorkflowSubmissionMetadata): void
+  trackWorkflowExecutionStarted?(
+    metadata: WorkflowExecutionStartedMetadata
+  ): void
   trackExecutionOutcome?(metadata: ExecutionOutcomeMetadata): void
   trackExecutionError?(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess?(metadata: ExecutionSuccessMetadata): void

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -335,6 +335,7 @@ describe('ComfyApp', () => {
           startTime: 42,
           submittedAt: 92,
           outcome: 'accepted',
+          jobId: 'job-1',
           workflowContext: expect.objectContaining({
             workflow_type: 'custom',
             execution_scope: 'full'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1736,6 +1736,7 @@ export class ComfyApp {
               startTime,
               submittedAt,
               outcome: 'accepted',
+              ...(res.prompt_id && { jobId: res.prompt_id }),
               ...(workflowContext && { workflowContext })
             })
             delete api.authToken

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -23,7 +23,8 @@ const {
   mockTrackExecutionError,
   mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
-  mockTrackSharedWorkflowRun
+  mockTrackSharedWorkflowRun,
+  mockTrackWorkflowExecutionStarted
 } = await vi.hoisted(async () => {
   const { shallowRef } = await import('vue')
   return {
@@ -36,7 +37,8 @@ const {
     mockTrackExecutionError: vi.fn(),
     mockTrackExecutionOutcome: vi.fn(),
     mockTrackExecutionSuccess: vi.fn(),
-    mockTrackSharedWorkflowRun: vi.fn()
+    mockTrackSharedWorkflowRun: vi.fn(),
+    mockTrackWorkflowExecutionStarted: vi.fn()
   }
 })
 
@@ -99,6 +101,7 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackExecutionError: mockTrackExecutionError,
     trackExecutionOutcome: mockTrackExecutionOutcome,
+    trackWorkflowExecutionStarted: mockTrackWorkflowExecutionStarted,
     trackExecutionSuccess: mockTrackExecutionSuccess,
     trackSharedWorkflowRun: mockTrackSharedWorkflowRun
   })
@@ -665,7 +668,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 92,
       terminalAt: 192,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
     expect(store.queuedJobs['job-1']).toBeUndefined()
@@ -680,7 +684,8 @@ describe('useExecutionStore - workflowStatus', () => {
       startTime: 42,
       submittedAt: 142,
       terminalAt: 192,
-      outcome: 'failure'
+      outcome: 'failure',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
   })
@@ -697,7 +702,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 92,
       terminalAt: 192,
-      outcome: 'interrupted'
+      outcome: 'interrupted',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
@@ -714,7 +720,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 142,
       terminalAt: 242,
-      outcome: 'success'
+      outcome: 'success',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
   })
@@ -751,6 +758,7 @@ describe('useExecutionStore - workflowStatus', () => {
       executionStartedAt: 142,
       terminalAt: 242,
       outcome: 'success',
+      jobId: 'job-1',
       workflowContext
     })
   })
@@ -775,7 +783,8 @@ describe('useExecutionStore - workflowStatus', () => {
       submittedAt: 142,
       executionStartedAt: 142,
       terminalAt: 242,
-      outcome: 'interrupted'
+      outcome: 'interrupted',
+      jobId: 'job-1'
     })
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
@@ -1413,6 +1422,15 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         nodes: {},
         executionStartedAt: expect.any(Number)
       })
+    })
+
+    it('emits the execution start funnel step once per job', () => {
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(mockTrackWorkflowExecutionStarted).toHaveBeenCalledExactlyOnceWith(
+        { jobId: 'job-1' }
+      )
     })
 
     it('clears transient errors while preserving validation errors', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -213,6 +213,7 @@ export const useExecutionStore = defineStore('execution', () => {
       }),
       terminalAt,
       outcome,
+      jobId,
       ...(queuedJob.workflowContext && {
         workflowContext: queuedJob.workflowContext
       })
@@ -436,7 +437,16 @@ export const useExecutionStore = defineStore('execution', () => {
     executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
-    queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
+    const startedJob = queuedJobs.value[activeJobId.value]
+    if (startedJob.executionStartedAt === undefined) {
+      startedJob.executionStartedAt = performance.now()
+      useTelemetry()?.trackWorkflowExecutionStarted({
+        jobId: activeJobId.value,
+        ...(startedJob.workflowContext && {
+          workflowContext: startedJob.workflowContext
+        })
+      })
+    }
     clearInitializationByJobId(activeJobId.value)
 
     // Ensure path mapping exists — execution_start can arrive via WebSocket


### PR DESCRIPTION
## Stack

1. [#14084 — feat: add workflow context to RUM events](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14084)
2. [#14098 — refactor: make workflow context graph selection explicit](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14098)
3. [#14093 — feat: track workflow phase timing in RUM](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14093)
4. [#14135 — feat: emit workflow run funnel steps as RUM actions](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14135)

## Summary

Emit a Datadog RUM action at each workflow run boundary so run drop-off can be measured as a funnel, which duration vitals cannot express.

## Changes

- **What**: Adds `workflow_submission`, `workflow_execution_start`, and `workflow_run_finished` RUM actions alongside the existing `workflow_queue` action, each carrying `job_id`. `WorkflowExecutionStartedMetadata` and a `trackWorkflowExecutionStarted` dispatcher are added to the telemetry registry. Duration vitals are unchanged.

## Review Focus

Vitals measure latency but cannot serve as RUM funnel steps, and #14093 emits three of its four phase vitals from the terminal path. A run abandoned mid-queue therefore produces nothing at all, making the drop-off indistinguishable from a run that never submitted. Each action here fires as its boundary is crossed instead, so an absent step localizes the failure:

| Step | Absence means |
| --- | --- |
| `workflow_queue` | — |
| `workflow_submission` | client never posted |
| `workflow_execution_start` | died in queue |
| `workflow_run_finished` | died mid-execution |

Two decisions worth attention:

- `workflow_execution_start` reuses the existing `executionStartedAt` guard in `handleExecutionStart`, so a replayed WebSocket message cannot double-count the step and the funnel step can never disagree with the timing field.
- `jobId` is required on `ExecutionOutcomeMetadata` but optional on `WorkflowSubmissionMetadata` — a rejected submission has no `prompt_id`, and a placeholder would pollute a `cardinality(@context.job_id)` query. That query is the session-independent fallback for queue waits that outlive the 15-minute RUM session, since RUM funnels are session-scoped.

Actions and vitals deliberately share the name `workflow_submission`; Datadog namespaces them as `@action.name` and `@vital.name`.

## Verification

`pnpm test:unit` on the affected suites (142 passing), `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm knip`.

Not exercised against a live backend. Datadog currently holds workflow telemetry only in `env:test-v2`, all of it HeadlessChrome on `127.0.0.1` from local validation runs — `prod-v2` and `stg-v2` have never received a workflow event, so there is no traffic to show a populated funnel against yet.

