### PR TITLE
fix(website): show the 2005 svedka fembot ad at archival scale

### DIFF
--- a/apps/website/src/components/customers/content/Figure.astro
+++ b/apps/website/src/components/customers/content/Figure.astro
@@ -1,15 +1,18 @@
 ---
+import { cn } from '@comfyorg/tailwind-utils'
+
 interface Props {
   src: string
   alt: string
   caption?: string
+  width?: 'full' | 'compact'
 }
 
-const { src, alt, caption } = Astro.props
+const { src, alt, caption, width = 'full' } = Astro.props
 const hasCaptionSlot = Astro.slots.has('default')
 ---
 
-<figure class="my-8">
+<figure class={cn('my-8', width === 'compact' && 'max-w-md')}>
   <img
     src={src}
     alt={alt}

--- a/apps/website/src/content/customers/en/svedka-silverside.mdx
+++ b/apps/website/src/content/customers/en/svedka-silverside.mdx
@@ -55,7 +55,7 @@ With workflows built in ComfyUI, Svedka and Silverside AI delivered:
 
 <Section id="topic-4" title="The Problem: an icon with no source files">
 
-<Figure src="https://media.comfy.org/website/customers/svedka-silverside/original-fembot.webp" alt="The original 2000s Svedka Fembot advertisement" caption="The original Svedka fembot. Source: Business Insider" />
+<Figure src="https://media.comfy.org/website/customers/svedka-silverside/original-fembot.webp" alt="The original 2005 Svedka Fembot advertisement" caption="The original Svedka fembot, 2005. Source: Business Insider" width="compact" />
 
 A revived Fembot was the brand's best shot at a sticky asset in a category where the liquid offers little differentiation. "Most households in America have vodka," Remley notes, "and it is colorless, odorless, and ultimately it's pretty flavorless." But the files that created the character were nowhere to be found.
 

--- a/apps/website/src/content/customers/zh-CN/svedka-silverside.mdx
+++ b/apps/website/src/content/customers/zh-CN/svedka-silverside.mdx
@@ -55,7 +55,7 @@ sections:
 
 <Section id="topic-4" title="面临的问题：一个没有源文件的标志性角色">
 
-<Figure src="https://media.comfy.org/website/customers/svedka-silverside/original-fembot.webp" alt="Svedka 早年的 Fembot 广告" caption="Svedka 早年的 Fembot。来源：Business Insider" />
+<Figure src="https://media.comfy.org/website/customers/svedka-silverside/original-fembot.webp" alt="Svedka 2005 年的 Fembot 广告" caption="Svedka 2005 年的 Fembot。来源：Business Insider" width="compact" />
 
 在一个产品本身几乎没有差异化的品类里，重生的 Fembot 是这个品牌打造标志性资产的最佳机会。"美国大多数家庭都有伏特加，"Remley 指出，"而它无色、无味，最终口感也相当寡淡。"但创造这个角色的文件却遍寻不着。
 


### PR DESCRIPTION
## Summary

The 2005 Svedka Fembot ad in the Svedka x Silverside story is a period artifact, so it now renders at archival scale with the year in the caption instead of filling the column like the modern shots around it.

## Changes

- **What**: `Figure` gains an optional `width` prop (`'full' | 'compact'`, defaults to `'full'`, so every other figure on the site is untouched). The Svedka Problem-section figure opts into `compact` and its caption/alt now name the year: "The original Svedka fembot, 2005. Source: Business Insider" / "Svedka 2005 年的 Fembot。来源：Business Insider".

## Review Focus

`compact` maps to `max-w-md` (448px), which is essentially the source image's native 440px width, so the archival asset is shown at 1:1 rather than upscaled. On mobile the column is already narrower, so nothing changes there.

Requested by Tiger: the upscaled version of this image read as too clean next to the AI-generated shots and lost the "we lost the source files" context the story is built on. The hero and listing thumbnail keep their upscaled artwork. The blurry 2005 file itself is restored separately in the media bucket, no code involved.

The `width` value is a style variant with no behaviour attached, so per the repo testing guidelines (no tests for utility classes or styles) this adds no test. Existing suite: 262 unit tests pass, astro check 0 errors.

## Screenshots

Desktop and mobile, EN and zh-CN, in the comment below.
