### PR TITLE
fix(ci): stop backport partial failures from discarding clean backports

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -234,11 +234,6 @@ jobs:
           FAILED=""
           SUCCESS=""
 
-          CREATED_BRANCHES_FILE="$(
-            mktemp "$RUNNER_TEMP/backport-branches-XXXXXX"
-          )"
-          echo "CREATED_BRANCHES_FILE=$CREATED_BRANCHES_FILE" >> "$GITHUB_ENV"
-
           # Get PR data for manual triggers
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_DATA=$(gh pr view ${{ inputs.pr_number }} --json title,mergeCommit)
@@ -300,7 +295,6 @@ jobs:
               # A push failure for one target must not abort the loop and
               # prevent remaining targets from being attempted.
               if "${PUSH_CMD[@]}"; then
-                echo "${BACKPORT_BRANCH}" >> "$CREATED_BRANCHES_FILE"
                 SUCCESS="${SUCCESS}${TARGET_BRANCH}:${BACKPORT_BRANCH} "
                 echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
               else
@@ -329,16 +323,10 @@ jobs:
           echo "success=${SUCCESS}" >> $GITHUB_OUTPUT
           echo "failed=${FAILED}" >> $GITHUB_OUTPUT
 
-          if [ -s "$CREATED_BRANCHES_FILE" ]; then
-            CREATED_LIST=$(paste -sd' ' "$CREATED_BRANCHES_FILE")
-            echo "created-branches=${CREATED_LIST}" >> $GITHUB_OUTPUT
-          else
-            echo "created-branches=" >> $GITHUB_OUTPUT
-          fi
-
-          if [ -n "${FAILED}" ]; then
-            exit 1
-          fi
+          # Do not exit non-zero when only some targets failed: the clean
+          # backports must still get their PRs (next step) and the conflicts
+          # must still be reported. A dedicated final step re-reds the run so
+          # the failure stays visible and retryable.
 
       - name: Create PR for each successful backport
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.success
@@ -381,8 +369,14 @@ jobs:
             fi
           done
 
+      # Runs whenever a target failed, independent of whether the PR-creation
+      # step for the clean targets succeeded — a hiccup there must not suppress
+      # the conflict reports.
       - name: Comment on failures
-        if: steps.filter-targets.outputs.skip != 'true' && failure() && steps.backport.outputs.failed
+        if: >-
+          !cancelled() &&
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BACKPORT_AGENT_PROMPT_TEMPLATE: |
@@ -437,15 +431,22 @@ jobs:
             MERGE_COMMIT=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
           fi
 
-          # Post a comment without letting a single failed `gh pr comment` (e.g.
-          # a locked issue, as happened for PR #13359, or a transient API error)
-          # abort the step under `set -e` and swallow the remaining failures.
-          post_comment() {
+          # A merged PR can be locked (the CLA check locks merged PRs), which
+          # makes `gh pr comment` fail and would otherwise swallow the failure
+          # notice entirely. Fall back to a tracking issue that mentions the
+          # author so a failed backport is never reported to nobody — the exact
+          # gap that left PRs #14018-#14021 to be backported by hand.
+          notify() {
             local body="$1"
             local context="$2"
-            if ! gh pr comment "${PR_NUMBER}" --body "${body}"; then
-              echo "::warning::Could not comment on PR #${PR_NUMBER} about ${context}. Manual backport required."
+            if gh pr comment "${PR_NUMBER}" --body "${body}"; then
+              return
             fi
+            echo "::warning::Could not comment on PR #${PR_NUMBER} (${context}); opening a tracking issue instead."
+            local title="Backport of #${PR_NUMBER} to ${target} failed"
+            gh issue create --title "${title}" --body "${body}" --label backport \
+              || gh issue create --title "${title}" --body "${body}" \
+              || echo "::warning::Also failed to open a tracking issue for #${PR_NUMBER} (${context})."
           }
 
           for failure in ${{ steps.backport.outputs.failed }}; do
@@ -455,16 +456,16 @@ jobs:
             BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${SAFE_TARGET}"
 
             if [ "${reason}" = "branch-missing" ]; then
-              post_comment "@${PR_AUTHOR} Backport failed: Branch \`${target}\` does not exist" "missing branch ${target}"
+              notify "@${PR_AUTHOR} Backport failed: Branch \`${target}\` does not exist" "missing branch ${target}"
 
             elif [ "${reason}" = "already-exists" ]; then
-              post_comment "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed." "already-backported ${target}"
+              notify "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed." "already-backported ${target}"
 
             elif [ "${reason}" = "branch-create-failed" ]; then
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` failed: could not create the backport branch. Please retry or backport manually."
+              notify "@${PR_AUTHOR} Backport to \`${target}\` failed: could not create the backport branch. Please retry or backport manually." "branch-create-failed ${target}"
 
             elif [ "${reason}" = "push-failed" ]; then
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` cherry-picked cleanly but the push failed. Please retry or push the backport branch manually."
+              notify "@${PR_AUTHOR} Backport to \`${target}\` cherry-picked cleanly but the push failed. Please retry or push the backport branch manually." "push-failed ${target}"
 
             elif [ "${reason}" = "conflicts" ]; then
               CONFLICTS_INLINE=$(echo "${conflicts}" | tr ',' ' ')
@@ -486,30 +487,28 @@ jobs:
               export target MERGE_COMMIT_SHORT BACKPORT_BRANCH CONFLICTS_BLOCK AGENT_PROMPT PR_AUTHOR
               COMMENT_BODY=$(envsubst '${target} ${MERGE_COMMIT_SHORT} ${BACKPORT_BRANCH} ${CONFLICTS_BLOCK} ${AGENT_PROMPT} ${PR_AUTHOR}' <<<"$COMMENT_BODY_TEMPLATE")
 
-              post_comment "${COMMENT_BODY}" "cherry-pick conflict on ${target} (backport manually onto ${BACKPORT_BRANCH})"
+              notify "${COMMENT_BODY}" "cherry-pick conflict on ${target} (backport manually onto ${BACKPORT_BRANCH})"
             fi
           done
 
-      - name: Cleanup stranded backport branches
-        if: steps.filter-targets.outputs.skip != 'true' && failure()
-        run: |
-          FILE="${CREATED_BRANCHES_FILE:-}"
-
-          if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
-            echo "No backport branches recorded for cleanup"
-            exit 0
-          fi
-
-          while IFS= read -r branch; do
-            [ -z "$branch" ] && continue
-            printf 'Deleting branch %s\n' "${branch}"
-            if ! git push origin --delete "$branch"; then
-              echo "::warning::Failed to delete ${branch}"
-            fi
-          done < "$FILE"
-
+      # Only clear needs-backport once every target succeeded. If any target
+      # failed, the label stays so a re-run retries the remainder (targets that
+      # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
-        if: steps.filter-targets.outputs.skip != 'true' && success()
+        if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
         run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-red the run for partial failures, after the clean backports have
+      # been turned into PRs and the conflicts reported above.
+      - name: Fail if any backport target failed
+        if: >-
+          !cancelled() &&
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed != ''
+        env:
+          FAILED_TARGETS: ${{ steps.backport.outputs.failed }}
+        run: |
+          echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          exit 1

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -527,7 +527,7 @@ jobs:
       # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
-        run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
+        run: gh api --method DELETE "repos/${{ github.repository }}/issues/${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}/labels/needs-backport" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -329,6 +329,7 @@ jobs:
           # the failure stays visible and retryable.
 
       - name: Create PR for each successful backport
+        id: create-prs
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.success
         env:
           GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
@@ -364,10 +365,16 @@ jobs:
               fi
             else
               echo "::error::Failed to create PR for ${target}: ${PR_URL}"
+              # Record it: a pushed branch with no PR must keep needs-backport
+              # and re-red the run, otherwise the branch is stranded silently
+              # and nothing retries it.
+              PR_CREATE_FAILED="${PR_CREATE_FAILED} ${target}"
               # Still try to comment on the original PR about the failure
               gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`"
             fi
           done
+
+          echo "pr-create-failed=${PR_CREATE_FAILED# }" >> $GITHUB_OUTPUT
 
       # Runs whenever a target failed, independent of whether the PR-creation
       # step for the clean targets succeeded — a hiccup there must not suppress
@@ -495,7 +502,10 @@ jobs:
       # failed, the label stays so a re-run retries the remainder (targets that
       # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
-        if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
+        if: >-
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed == '' &&
+          steps.create-prs.outputs.pr-create-failed == ''
         run: gh api --method DELETE "repos/${{ github.repository }}/issues/${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}/labels/needs-backport" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -506,9 +516,16 @@ jobs:
         if: >-
           !cancelled() &&
           steps.filter-targets.outputs.skip != 'true' &&
-          steps.backport.outputs.failed != ''
+          (steps.backport.outputs.failed != '' ||
+           steps.create-prs.outputs.pr-create-failed != '')
         env:
           FAILED_TARGETS: ${{ steps.backport.outputs.failed }}
+          PR_CREATE_FAILED: ${{ steps.create-prs.outputs.pr-create-failed }}
         run: |
-          echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          if [ -n "${FAILED_TARGETS}" ]; then
+            echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          fi
+          if [ -n "${PR_CREATE_FAILED}" ]; then
+            echo "::error::Backport branches were pushed but PR creation failed: ${PR_CREATE_FAILED}"
+          fi
           exit 1

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -339,6 +339,7 @@ jobs:
           # the failure stays visible and retryable.
 
       - name: Create PR for each successful backport
+        id: create-prs
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.success
         env:
           GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
@@ -380,10 +381,16 @@ jobs:
               fi
             else
               echo "::error::Failed to create PR for ${target}: ${PR_URL}"
+              # Record it: a pushed branch with no PR must keep needs-backport
+              # and re-red the run, otherwise the branch is stranded silently
+              # and nothing retries it.
+              PR_CREATE_FAILED="${PR_CREATE_FAILED} ${target}"
               # Still try to comment on the original PR about the failure
               gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`"
             fi
           done
+
+          echo "pr-create-failed=${PR_CREATE_FAILED# }" >> $GITHUB_OUTPUT
 
       # Runs whenever a target failed, independent of whether the PR-creation
       # step for the clean targets succeeded — a hiccup there must not suppress
@@ -526,7 +533,10 @@ jobs:
       # failed, the label stays so a re-run retries the remainder (targets that
       # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
-        if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
+        if: >-
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed == '' &&
+          steps.create-prs.outputs.pr-create-failed == ''
         run: gh api --method DELETE "repos/${{ github.repository }}/issues/${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}/labels/needs-backport" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -537,9 +547,16 @@ jobs:
         if: >-
           !cancelled() &&
           steps.filter-targets.outputs.skip != 'true' &&
-          steps.backport.outputs.failed != ''
+          (steps.backport.outputs.failed != '' ||
+           steps.create-prs.outputs.pr-create-failed != '')
         env:
           FAILED_TARGETS: ${{ steps.backport.outputs.failed }}
+          PR_CREATE_FAILED: ${{ steps.create-prs.outputs.pr-create-failed }}
         run: |
-          echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          if [ -n "${FAILED_TARGETS}" ]; then
+            echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          fi
+          if [ -n "${PR_CREATE_FAILED}" ]; then
+            echo "::error::Backport branches were pushed but PR creation failed: ${PR_CREATE_FAILED}"
+          fi
           exit 1

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -377,7 +377,11 @@ jobs:
                 fi
                 gh pr merge "${PR_NUM}" --auto --squash --repo "${{ github.repository }}" \
                   || echo "::warning::Failed to enable auto-merge for PR #${PR_NUM}"
-                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
+                # Non-fatal: a merged source PR can be locked, and under `set -e`
+                # a failed comment would abort the loop before the remaining
+                # targets ran and before pr-create-failed was written below.
+                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}" \
+                  || echo "::warning::Could not comment on PR #${PR_NUMBER} (backported to #${PR_NUM})."
               fi
             else
               echo "::error::Failed to create PR for ${target}: ${PR_URL}"
@@ -385,8 +389,10 @@ jobs:
               # and re-red the run, otherwise the branch is stranded silently
               # and nothing retries it.
               PR_CREATE_FAILED="${PR_CREATE_FAILED} ${target}"
-              # Still try to comment on the original PR about the failure
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`"
+              # Also non-fatal, for the same reason: losing this notice must not
+              # also lose the record that the branch was stranded.
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`" \
+                || echo "::warning::Could not comment on PR #${PR_NUMBER} about the failed PR creation for ${target}."
             fi
           done
 

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -361,7 +361,11 @@ jobs:
               if [ -n "${PR_NUM}" ]; then
                 gh pr merge "${PR_NUM}" --auto --squash --repo "${{ github.repository }}" \
                   || echo "::warning::Failed to enable auto-merge for PR #${PR_NUM}"
-                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
+                # Non-fatal: a merged source PR can be locked, and under `set -e`
+                # a failed comment would abort the loop before the remaining
+                # targets ran and before pr-create-failed was written below.
+                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}" \
+                  || echo "::warning::Could not comment on PR #${PR_NUMBER} (backported to #${PR_NUM})."
               fi
             else
               echo "::error::Failed to create PR for ${target}: ${PR_URL}"
@@ -369,8 +373,10 @@ jobs:
               # and re-red the run, otherwise the branch is stranded silently
               # and nothing retries it.
               PR_CREATE_FAILED="${PR_CREATE_FAILED} ${target}"
-              # Still try to comment on the original PR about the failure
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`"
+              # Also non-fatal, for the same reason: losing this notice must not
+              # also lose the record that the branch was stranded.
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`" \
+                || echo "::warning::Could not comment on PR #${PR_NUMBER} about the failed PR creation for ${target}."
             fi
           done
 

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -496,7 +496,7 @@ jobs:
       # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
-        run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
+        run: gh api --method DELETE "repos/${{ github.repository }}/issues/${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}/labels/needs-backport" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -244,11 +244,6 @@ jobs:
           FAILED=""
           SUCCESS=""
 
-          CREATED_BRANCHES_FILE="$(
-            mktemp "$RUNNER_TEMP/backport-branches-XXXXXX"
-          )"
-          echo "CREATED_BRANCHES_FILE=$CREATED_BRANCHES_FILE" >> "$GITHUB_ENV"
-
           # Get PR data for manual triggers
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_DATA=$(gh pr view ${{ inputs.pr_number }} --json title,mergeCommit)
@@ -310,7 +305,6 @@ jobs:
               # A push failure for one target must not abort the loop and
               # prevent remaining targets from being attempted.
               if "${PUSH_CMD[@]}"; then
-                echo "${BACKPORT_BRANCH}" >> "$CREATED_BRANCHES_FILE"
                 SUCCESS="${SUCCESS}${TARGET_BRANCH}:${BACKPORT_BRANCH} "
                 echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
               else
@@ -339,16 +333,10 @@ jobs:
           echo "success=${SUCCESS}" >> $GITHUB_OUTPUT
           echo "failed=${FAILED}" >> $GITHUB_OUTPUT
 
-          if [ -s "$CREATED_BRANCHES_FILE" ]; then
-            CREATED_LIST=$(paste -sd' ' "$CREATED_BRANCHES_FILE")
-            echo "created-branches=${CREATED_LIST}" >> $GITHUB_OUTPUT
-          else
-            echo "created-branches=" >> $GITHUB_OUTPUT
-          fi
-
-          if [ -n "${FAILED}" ]; then
-            exit 1
-          fi
+          # Do not exit non-zero when only some targets failed: the clean
+          # backports must still get their PRs (next step) and the conflicts
+          # must still be reported. A dedicated final step re-reds the run so
+          # the failure stays visible and retryable.
 
       - name: Create PR for each successful backport
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.success
@@ -397,8 +385,14 @@ jobs:
             fi
           done
 
+      # Runs whenever a target failed, independent of whether the PR-creation
+      # step for the clean targets succeeded — a hiccup there must not suppress
+      # the conflict reports.
       - name: Comment on failures
-        if: steps.filter-targets.outputs.skip != 'true' && failure() && steps.backport.outputs.failed
+        if: >-
+          !cancelled() &&
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed != ''
         env:
           BACKPORT_AGENT_PROMPT_TEMPLATE: |
             Backport PR #${PR_NUMBER} (${PR_URL}) to ${target}.
@@ -457,15 +451,22 @@ jobs:
             MERGE_COMMIT=$(jq -r '.pull_request.merge_commit_sha' "$GITHUB_EVENT_PATH")
           fi
 
-          # Post a comment without letting a single failed `gh pr comment` (e.g.
-          # a locked issue, as happened for PR #13359, or a transient API error)
-          # abort the step under `set -e` and swallow the remaining failures.
-          post_comment() {
+          # A merged PR can be locked (the CLA check locks merged PRs), which
+          # makes `gh pr comment` fail and would otherwise swallow the failure
+          # notice entirely. Fall back to a tracking issue that mentions the
+          # author so a failed backport is never reported to nobody — the exact
+          # gap that left PRs #14018-#14021 to be backported by hand.
+          notify() {
             local body="$1"
             local context="$2"
-            if ! gh pr comment "${PR_NUMBER}" --body "${body}"; then
-              echo "::warning::Could not comment on PR #${PR_NUMBER} about ${context}. Manual backport required."
+            if gh pr comment "${PR_NUMBER}" --body "${body}"; then
+              return
             fi
+            echo "::warning::Could not comment on PR #${PR_NUMBER} (${context}); opening a tracking issue instead."
+            local title="Backport of #${PR_NUMBER} to ${target} failed"
+            gh issue create --title "${title}" --body "${body}" --label backport \
+              || gh issue create --title "${title}" --body "${body}" \
+              || echo "::warning::Also failed to open a tracking issue for #${PR_NUMBER} (${context})."
           }
 
           for failure in ${{ steps.backport.outputs.failed }}; do
@@ -475,16 +476,16 @@ jobs:
             BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${SAFE_TARGET}"
 
             if [ "${reason}" = "branch-missing" ]; then
-              post_comment "@${PR_AUTHOR} Backport failed: Branch \`${target}\` does not exist" "missing branch ${target}"
+              notify "@${PR_AUTHOR} Backport failed: Branch \`${target}\` does not exist" "missing branch ${target}"
 
             elif [ "${reason}" = "already-exists" ]; then
-              post_comment "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed." "already-backported ${target}"
+              notify "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed." "already-backported ${target}"
 
             elif [ "${reason}" = "branch-create-failed" ]; then
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` failed: could not create the backport branch. Please retry or backport manually."
+              notify "@${PR_AUTHOR} Backport to \`${target}\` failed: could not create the backport branch. Please retry or backport manually." "branch-create-failed ${target}"
 
             elif [ "${reason}" = "push-failed" ]; then
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` cherry-picked cleanly but the push failed. Please retry or push the backport branch manually."
+              notify "@${PR_AUTHOR} Backport to \`${target}\` cherry-picked cleanly but the push failed. Please retry or push the backport branch manually." "push-failed ${target}"
 
             elif [ "${reason}" = "conflicts" ]; then
               CONFLICTS_INLINE=$(echo "${conflicts}" | tr ',' ' ')
@@ -517,28 +518,28 @@ jobs:
               export target MERGE_COMMIT_SHORT BACKPORT_BRANCH CONFLICTS_BLOCK AGENT_PROMPT PR_AUTHOR STACK_HINT
               COMMENT_BODY=$(envsubst '${target} ${MERGE_COMMIT_SHORT} ${BACKPORT_BRANCH} ${CONFLICTS_BLOCK} ${AGENT_PROMPT} ${PR_AUTHOR} ${STACK_HINT}' <<<"$COMMENT_BODY_TEMPLATE")
 
-              post_comment "${COMMENT_BODY}" "cherry-pick conflict on ${target} (backport manually onto ${BACKPORT_BRANCH})"
+              notify "${COMMENT_BODY}" "cherry-pick conflict on ${target} (backport manually onto ${BACKPORT_BRANCH})"
             fi
           done
 
-      - name: Cleanup stranded backport branches
-        if: steps.filter-targets.outputs.skip != 'true' && failure()
-        run: |
-          FILE="${CREATED_BRANCHES_FILE:-}"
-
-          if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
-            echo "No backport branches recorded for cleanup"
-            exit 0
-          fi
-
-          while IFS= read -r branch; do
-            [ -z "$branch" ] && continue
-            printf 'Deleting branch %s\n' "${branch}"
-            if ! git push origin --delete "$branch"; then
-              echo "::warning::Failed to delete ${branch}"
-            fi
-          done < "$FILE"
-
+      # Only clear needs-backport once every target succeeded. If any target
+      # failed, the label stays so a re-run retries the remainder (targets that
+      # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
-        if: steps.filter-targets.outputs.skip != 'true' && success()
+        if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
         run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-red the run for partial failures, after the clean backports have
+      # been turned into PRs and the conflicts reported above.
+      - name: Fail if any backport target failed
+        if: >-
+          !cancelled() &&
+          steps.filter-targets.outputs.skip != 'true' &&
+          steps.backport.outputs.failed != ''
+        env:
+          FAILED_TARGETS: ${{ steps.backport.outputs.failed }}
+        run: |
+          echo "::error::One or more backport targets failed: ${FAILED_TARGETS}"
+          exit 1


### PR DESCRIPTION
## Summary

A backport with multiple targets loses the clean backports whenever any one target conflicts, and the failure is never reported to the author. Both were the direct cause of PRs #14018–#14021 being recreated by hand.

## Changes

- **What**:
  - **Partial failure no longer discards clean work.** `Backport commits` ran all targets in one step that `exit 1`'d the instant any target failed. That exit (a) skipped `Create PR for each successful backport` — it has an implicit `success()` gate — and (b) fired `Cleanup stranded backport branches` (a `failure()` gate) which deleted the already-pushed branches of the targets that cherry-picked *cleanly*. So one conflict threw away the good backports. Fix: the step records `success`/`failed` outputs and returns cleanly; a dedicated final step re-reds the run after PRs are created and conflicts reported.
  - **Removed the cleanup step.** With the mid-flow `exit 1` gone there are no stranded branches to reap — every pushed branch either gets a PR or is deliberately kept (its comment tells a human to open the PR manually). The step could only ever delete clean backports, so it is pure liability.
  - **`needs-backport` is kept on partial failure** so a re-run retries the remaining targets (already-landed targets are skipped by `Filter already backported targets`).
  - **Failure notifications survive a locked PR.** A merged PR is locked by the CLA check, so `gh pr comment` fails and the notice was swallowed to a workflow `::warning::` nobody reads. `notify()` now falls back to a tracking issue that @-mentions the author, and the `branch-create-failed` / `push-failed` reasons route through it instead of a raw `gh pr comment`.
- **Breaking**: none. Behaviour is unchanged when all targets succeed (PRs created, label cleared, green) or all fail (comments posted, label kept, red).

## Review Focus

The fix hinges on GitHub Actions gating semantics, worth verifying:

- A step whose `if:` uses no status function gets an implicit `success() &&`. `Create PR` (unchanged `if`) and `Remove needs-backport label` rely on this — they run only because `Backport commits` no longer fails.
- `Comment on failures` and the final `Fail if any backport target failed` use `!cancelled() && … failed != ''` so they run on partial failure and are not suppressed by an unrelated hiccup in the PR-creation step.

Traced against the real incident (run `29975951441`, PR #13971 → `cloud/1.45` conflict + `cloud/1.47` clean): under this diff, `cloud/1.47`'s PR is created and kept, `cloud/1.45`'s conflict is reported (or filed as an issue if the source PR is locked), `needs-backport` stays, and the run ends red.

**Testing:** this is GitHub Actions control-flow and `gh`/`git` orchestration inside `run:` blocks — there is no pure logic to unit-extract without refactoring the whole 500-line workflow into a script, which would be a far riskier change than the bug. Validated with `actionlint` (shellcheck over the run blocks — no new findings; two pre-existing `SC2086` removed) and `yamllint`.

**Related, not fixed here:** the `Create PR` step's own `gh pr comment` calls (success notice, and the "PR creation failed, open it manually" notice) have the same locked-PR fragility and could be routed through a shared helper in a follow-up. Left out to keep this focused on the two reported defects.
