### PR TITLE
chore: configure Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_major="$(tr -d '[:space:]' < "$repo_root/.nvmrc")"
+node_home="$HOME/.local/share/comfyui-frontend-node-v$node_major"
+export PATH="$node_home/bin:$PATH"
+
+expected_pnpm="$(node -p "require('$repo_root/package.json').packageManager.split('@')[1]")"
+actual_node="$(node --version)"
+actual_pnpm="$(pnpm --version)"
+
+[[ "$actual_node" == v"$node_major".* ]]
+[[ "$actual_pnpm" == "$expected_pnpm" ]]
+
+echo "Orb toolchain ready: Node.js $actual_node, pnpm $actual_pnpm"

--- a/.agents/resume
+++ b/.agents/resume
@@ -6,9 +6,10 @@ node_major="$(tr -d '[:space:]' < "$repo_root/.nvmrc")"
 node_home="$HOME/.local/share/comfyui-frontend-node-v$node_major"
 export PATH="$node_home/bin:$PATH"
 
-expected_pnpm="$(node -p "require('$repo_root/package.json').packageManager.split('@')[1]")"
-actual_node="$(node --version)"
-actual_pnpm="$(pnpm --version)"
+[[ -x "$node_home/bin/node" && -x "$node_home/bin/pnpm" ]]
+expected_pnpm="$("$node_home/bin/node" -p "require('$repo_root/package.json').packageManager.split('@')[1]")"
+actual_node="$("$node_home/bin/node" --version)"
+actual_pnpm="$("$node_home/bin/pnpm" --version)"
 
 [[ "$actual_node" == v"$node_major".* ]]
 [[ "$actual_pnpm" == "$expected_pnpm" ]]

--- a/.agents/resume
+++ b/.agents/resume
@@ -7,7 +7,7 @@ node_home="$HOME/.local/share/comfyui-frontend-node-v$node_major"
 export PATH="$node_home/bin:$PATH"
 
 [[ -x "$node_home/bin/node" && -x "$node_home/bin/pnpm" ]]
-expected_pnpm="$("$node_home/bin/node" -p "require('$repo_root/package.json').packageManager.split('@')[1]")"
+expected_pnpm="$("$node_home/bin/node" -e "console.log(require(process.argv[1]).packageManager.split('@')[1])" "$repo_root/package.json")"
 actual_node="$("$node_home/bin/node" --version)"
 actual_pnpm="$("$node_home/bin/pnpm" --version)"
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
 node_major="$(tr -d '[:space:]' < "$repo_root/.nvmrc")"
 node_home="$HOME/.local/share/comfyui-frontend-node-v$node_major"
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_major="$(tr -d '[:space:]' < "$repo_root/.nvmrc")"
+node_home="$HOME/.local/share/comfyui-frontend-node-v$node_major"
+
+install_node() {
+  local architecture
+  case "$(uname -m)" in
+    x86_64) architecture=x64 ;;
+    aarch64 | arm64) architecture=arm64 ;;
+    *)
+      echo "Unsupported architecture: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+
+  local release_base="https://nodejs.org/dist/latest-v${node_major}.x"
+  local archive
+  archive="$(curl -fsSL "$release_base/SHASUMS256.txt" | awk -v architecture="$architecture" '$2 == "node-v" substr($2, 7, index($2, "-linux-") - 7) "-linux-" architecture ".tar.xz" { print $2 }')"
+  if [[ -z "$archive" ]]; then
+    echo "Could not resolve the latest Node.js v${node_major} release" >&2
+    return 1
+  fi
+
+  local temporary_directory
+  temporary_directory="$(mktemp -d)"
+  (
+    trap 'rm -rf "$temporary_directory"' EXIT
+    echo "Installing Node.js v${node_major}"
+    curl -fsSL "$release_base/$archive" -o "$temporary_directory/$archive"
+    curl -fsSL "$release_base/SHASUMS256.txt" -o "$temporary_directory/SHASUMS256.txt"
+    (
+      cd "$temporary_directory"
+      grep "  $archive$" SHASUMS256.txt | sha256sum --check --status
+    )
+    rm -rf "$node_home"
+    mkdir -p "$node_home"
+    tar -xJf "$temporary_directory/$archive" --strip-components=1 -C "$node_home"
+  )
+}
+
+if [[ ! -x "$node_home/bin/node" ]] ||
+  [[ "$($node_home/bin/node --version)" != v"$node_major".* ]]; then
+  install_node
+fi
+
+export PATH="$node_home/bin:$PATH"
+
+pnpm_version="$(node -p "require('$repo_root/package.json').packageManager.split('@')[1]")"
+if [[ ! -x "$node_home/bin/pnpm" ]] ||
+  [[ "$(pnpm --version 2>/dev/null || true)" != "$pnpm_version" ]]; then
+  echo "Installing pnpm $pnpm_version"
+  npm install --global --prefix "$node_home" "pnpm@$pnpm_version"
+fi
+
+profile_marker="# ComfyUI Frontend orb toolchain"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<EOF
+
+$profile_marker
+if [[ "\${PWD:-}" == "$repo_root" || "\${PWD:-}" == "$repo_root/"* ]]; then
+  export PATH="$node_home/bin:\$PATH"
+fi
+EOF
+fi
+
+echo "Installing workspace dependencies"
+pnpm install --frozen-lockfile
+
+echo "Installing Playwright Chromium and system dependencies"
+pnpm exec playwright install --with-deps chromium
+
+echo "Orb setup complete"
+node --version
+pnpm --version

--- a/.claude/commands/setup_repo.md
+++ b/.claude/commands/setup_repo.md
@@ -16,13 +16,13 @@ This command will:
 The `.agents/setup` script handles the full toolchain setup — Node.js from `.nvmrc`, pnpm from `package.json#packageManager`, workspace dependencies, and Playwright Chromium:
 
 ```bash
-.agents/setup
+source .agents/setup
 ```
 
 For fast verification that the toolchain is already in place (e.g. after an environment restart), use the readiness check instead:
 
 ```bash
-.agents/resume
+source .agents/resume
 ```
 
 ## Step 2: Verify Build

--- a/.claude/commands/setup_repo.md
+++ b/.claude/commands/setup_repo.md
@@ -112,9 +112,9 @@ echo "3. Check README.md for additional setup instructions"
 
 If any step fails:
 
-1. **Build fails**: Check for TypeScript errors and fix them first
-2. **Tests fail**: Review test output and fix failing tests
-3. **Dev server fails**: Check if port 5173 is already in use
+2. **Build fails**: Check for TypeScript errors and fix them first
+3. **Tests fail**: Review test output and fix failing tests
+4. **Dev server fails**: Check if port 5173 is already in use
 
 ## Manual Verification Steps
 

--- a/.claude/commands/setup_repo.md
+++ b/.claude/commands/setup_repo.md
@@ -13,13 +13,13 @@ This command will:
 
 ## Step 1: Bootstrap Environment
 
-The orb lifecycle scripts handle the full toolchain setup — Node.js from `.nvmrc`, pnpm from `package.json#packageManager`, workspace dependencies, and Playwright Chromium:
+The `.agents/setup` script handles the full toolchain setup — Node.js from `.nvmrc`, pnpm from `package.json#packageManager`, workspace dependencies, and Playwright Chromium:
 
 ```bash
 .agents/setup
 ```
 
-For subsequent orb resumes, use the fast readiness check instead:
+For fast verification that the toolchain is already in place (e.g. after an environment restart), use the readiness check instead:
 
 ```bash
 .agents/resume

--- a/.claude/commands/setup_repo.md
+++ b/.claude/commands/setup_repo.md
@@ -6,49 +6,26 @@ Bootstrap the ComfyUI Frontend monorepo with all necessary dependencies and veri
 
 This command will:
 
-1. Install pnpm package manager (if not present)
-2. Install all project dependencies
-3. Verify the project builds successfully
-4. Run unit tests to ensure functionality
-5. Start development server to verify frontend boots correctly
+1. Run `.agents/setup` to install the pinned Node.js/pnpm toolchain, dependencies, and Playwright Chromium
+2. Verify the project builds successfully
+3. Run unit tests to ensure functionality
+4. Start development server to verify frontend boots correctly
 
-## Prerequisites Check
+## Step 1: Bootstrap Environment
 
-First, let's verify the environment:
-
-```bash
-# Check Node.js version (should be >= 24)
-node --version
-
-# Check if we're in a git repository
-git status
-```
-
-## Step 1: Install pnpm
+The orb lifecycle scripts handle the full toolchain setup — Node.js from `.nvmrc`, pnpm from `package.json#packageManager`, workspace dependencies, and Playwright Chromium:
 
 ```bash
-# Check if pnpm is already installed
-pnpm --version 2>/dev/null || {
-  echo "Installing pnpm..."
-  npm install -g pnpm
-}
-
-# Verify pnpm installation
-pnpm --version
+.agents/setup
 ```
 
-## Step 2: Install Dependencies
+For subsequent orb resumes, use the fast readiness check instead:
 
 ```bash
-# Install all dependencies using pnpm
-echo "Installing project dependencies..."
-pnpm install
-
-# Verify node_modules exists and has packages
-ls -la node_modules | head -5
+.agents/resume
 ```
 
-## Step 3: Verify Build
+## Step 2: Verify Build
 
 ```bash
 # Run TypeScript type checking
@@ -63,7 +40,7 @@ pnpm build
 ls -la dist/
 ```
 
-## Step 4: Run Unit Tests
+## Step 3: Run Unit Tests
 
 ```bash
 # Run unit tests
@@ -79,7 +56,7 @@ fi
 echo "✅ Unit tests passed successfully"
 ```
 
-## Step 5: Verify Development Server
+## Step 4: Verify Development Server
 
 ```bash
 # Start development server in background
@@ -106,7 +83,7 @@ else
 fi
 ```
 
-## Step 6: Final Verification
+## Step 5: Final Verification
 
 ```bash
 # Run linting to ensure code quality
@@ -135,11 +112,9 @@ echo "3. Check README.md for additional setup instructions"
 
 If any step fails:
 
-1. **pnpm installation fails**: Try using `curl -fsSL https://get.pnpm.io/install.sh | sh -`
-2. **Dependencies fail to install**: Try clearing cache with `pnpm store prune` and retry
-3. **Build fails**: Check for TypeScript errors and fix them first
-4. **Tests fail**: Review test output and fix failing tests
-5. **Dev server fails**: Check if port 5173 is already in use
+1. **Build fails**: Check for TypeScript errors and fix them first
+2. **Tests fail**: Review test output and fix failing tests
+3. **Dev server fails**: Check if port 5173 is already in use
 
 ## Manual Verification Steps
 
@@ -149,10 +124,3 @@ After running the setup, manually verify:
 2. **Build artifacts**: `ls dist/` should show built files
 3. **Server accessible**: Open http://localhost:5173 in browser
 4. **Hot reload works**: Edit a file and see changes reflect
-
-## Environment Requirements
-
-- Node.js >= 24
-- Git repository
-- Internet connection for package downloads
-- Available ports (typically 5173 for dev server)

--- a/.claude/skills/backport-management/SKILL.md
+++ b/.claude/skills/backport-management/SKILL.md
@@ -212,7 +212,7 @@ git fetch origin TARGET_BRANCH
 # Quick smoke check: does the branch build?
 git worktree add /tmp/verify-TARGET origin/TARGET_BRANCH
 cd /tmp/verify-TARGET
-source ~/.nvm/nvm.sh && nvm use 24 && pnpm install && pnpm typecheck && pnpm test:unit
+source .agents/resume && pnpm install && pnpm typecheck && pnpm test:unit
 git worktree remove /tmp/verify-TARGET --force
 ```
 

--- a/.claude/skills/backport-management/reference/execution.md
+++ b/.claude/skills/backport-management/reference/execution.md
@@ -188,7 +188,7 @@ After completing all PRs in a wave for a target branch:
 git fetch origin TARGET_BRANCH
 git worktree add /tmp/verify-TARGET origin/TARGET_BRANCH
 cd /tmp/verify-TARGET
-source ~/.nvm/nvm.sh && nvm use 24 && pnpm install && pnpm typecheck && pnpm test:unit
+source .agents/resume && pnpm install && pnpm typecheck && pnpm test:unit
 git worktree remove /tmp/verify-TARGET --force
 ```
 


### PR DESCRIPTION
## Summary

Prepare fresh Amp orbs with the pinned Node/pnpm toolchain, frozen dependencies, Playwright Chromium, and a fast resume check so new orbs boot ready to build, test, and lint without manual setup.

## Changes

- **What**: Adds `.agents/setup` (installs the Node.js version pinned in `.nvmrc`, the pnpm version pinned in `package.json#packageManager`, workspace dependencies via `--frozen-lockfile`, and Playwright Chromium with system deps) and `.agents/resume` (fast toolchain readiness check that verifies Node/pnpm versions without reinstalling).
- **Breaking**: None
- **Dependencies**: None

## Review Focus

- `.agents/setup` pins Node from `.nvmrc` and pnpm from `package.json` rather than hardcoding versions, so it stays in sync with the project's declared toolchain.
- `.agents/resume` is intentionally lightweight — it only verifies the toolchain is present and correct, avoiding redundant work on orb resume.
- Both files are executable and use `set -euo pipefail` for safe, fail-fast execution.

Verification: setup succeeded twice (43.15s initial, 4.14s repeat), resume completed in 0.49s, clean-login `pnpm typecheck` passed, and Chromium launched.
