### PR TITLE
fix: block global keybindings while a reka dialog is open

### DIFF
--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -167,9 +167,13 @@ describe('keybindingService - dialog gate', () => {
   })
 
   it('leaves Escape un-prevented so reka can dismiss its own dialog', async () => {
-    appendRekaDialog()
+    const dialog = appendRekaDialog()
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
 
-    const event = createKeyboardEvent('Escape')
+    // Targeted inside the dialog: from outside, the containment check below
+    // the Escape branch would satisfy this assertion on its own.
+    const event = createKeyboardEvent('Escape', inner)
     await keybindingService.keybindHandler(event)
 
     expect(event.preventDefault).not.toHaveBeenCalled()
@@ -225,6 +229,18 @@ describe('keybindingService - dialog gate', () => {
 
     expect(mockCommandExecute).not.toHaveBeenCalled()
     expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does NOT execute a global keybinding targeted inside a popover layered over an open dialog', async () => {
+    appendRekaDialog()
+    const popover = appendRekaPopover()
+    const inner = document.createElement('button')
+    popover.appendChild(inner)
+
+    const event = createKeyboardEvent('w', inner)
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
   })
 
   it('blocks a global keybinding when a popover precedes the open dialog', async () => {

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -209,4 +209,31 @@ describe('keybindingService - dialog gate', () => {
       'Workspace.ToggleSidebarTab.workflows'
     )
   })
+
+  it('does NOT execute the Escape keybinding while a store dialog is open', async () => {
+    const dialogStore = useDialogStore()
+    dialogStore.dialogStack.push(createTestDialogInstance('templates-dialog'))
+
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+
+    const event = createKeyboardEvent('Escape', inner)
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('blocks a global keybinding when a popover precedes the open dialog', async () => {
+    appendRekaPopover()
+    appendRekaDialog()
+
+    const event = createKeyboardEvent('w')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
 })

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -1,6 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { markRaw, reactive } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
@@ -41,9 +41,40 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+/**
+ * Mirrors what reka renders for open `DialogContent`: `role="dialog"` plus
+ * `data-state`, portaled to the body and never registered with `dialogStore`.
+ */
+function appendRekaDialog(state: 'open' | 'closed' = 'open'): HTMLElement {
+  const content = document.createElement('div')
+  content.setAttribute('role', 'dialog')
+  content.setAttribute('data-state', state)
+  document.body.appendChild(content)
+  return content
+}
+
+/**
+ * Reka gives `PopoverContent` the same `role`/`data-state` pair as a dialog,
+ * distinguished only by the popper wrapper it is positioned inside.
+ */
+function appendRekaPopover(): HTMLElement {
+  const wrapper = document.createElement('div')
+  wrapper.setAttribute('data-reka-popper-content-wrapper', '')
+  const content = document.createElement('div')
+  content.setAttribute('role', 'dialog')
+  content.setAttribute('data-state', 'open')
+  wrapper.appendChild(content)
+  document.body.appendChild(wrapper)
+  return content
+}
+
 describe('keybindingService - dialog gate', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
+
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -113,5 +144,69 @@ describe('keybindingService - dialog gate', () => {
     } finally {
       document.body.removeChild(dialog)
     }
+  })
+
+  it('does NOT execute a global keybinding while a reka dialog is open', async () => {
+    appendRekaDialog()
+
+    const event = createKeyboardEvent('w')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('does NOT execute the Escape keybinding while a reka dialog is open', async () => {
+    const dialog = appendRekaDialog()
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+
+    const event = createKeyboardEvent('Escape', inner)
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('leaves Escape un-prevented so reka can dismiss its own dialog', async () => {
+    appendRekaDialog()
+
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('still executes a keybinding whose target lives inside the open reka dialog', async () => {
+    const dialog = appendRekaDialog()
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+
+    const event = createKeyboardEvent('w', inner)
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).toHaveBeenCalledWith(
+      'Workspace.ToggleSidebarTab.workflows'
+    )
+  })
+
+  it('executes a global keybinding while a reka popover is open', async () => {
+    appendRekaPopover()
+
+    const event = createKeyboardEvent('w')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).toHaveBeenCalledWith(
+      'Workspace.ToggleSidebarTab.workflows'
+    )
+  })
+
+  it('executes a global keybinding once a reka dialog has closed', async () => {
+    appendRekaDialog('closed')
+
+    const event = createKeyboardEvent('w')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).toHaveBeenCalledWith(
+      'Workspace.ToggleSidebarTab.workflows'
+    )
   })
 })

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -71,6 +71,7 @@ describe('keybindingService - Escape key handling', () => {
       altKey?: boolean
       metaKey?: boolean
       shiftKey?: boolean
+      target?: HTMLElement
     } = {}
   ): KeyboardEvent {
     const event = new KeyboardEvent('keydown', {
@@ -83,8 +84,9 @@ describe('keybindingService - Escape key handling', () => {
       cancelable: true
     })
 
+    const target = options.target ?? document.body
     event.preventDefault = vi.fn()
-    event.composedPath = vi.fn(() => [document.body])
+    event.composedPath = vi.fn(() => [target])
 
     return event
   }
@@ -126,6 +128,39 @@ describe('keybindingService - Escape key handling', () => {
     await keybindingService.keybindHandler(event)
 
     expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('should execute a Shift+Escape keybinding targeted inside an open dialog', async () => {
+    const dialogStore = useDialogStore()
+    dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))
+
+    const keybindingStore = useKeybindingStore()
+    keybindingStore.addDefaultKeybinding(
+      new KeybindingImpl({
+        commandId: 'Test.ShiftEscape',
+        combo: { key: 'Escape', shift: true }
+      })
+    )
+
+    keybindingService = useKeybindingService()
+
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    const inner = document.createElement('button')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+
+    try {
+      const event = createKeyboardEvent('Escape', {
+        shiftKey: true,
+        target: inner
+      })
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith('Test.ShiftEscape')
+    } finally {
+      document.body.removeChild(dialog)
+    }
   })
 
   it('should verify Escape keybinding exists in CORE_KEYBINDINGS', () => {

--- a/src/platform/keybindings/keybindingService.reka.test.ts
+++ b/src/platform/keybindings/keybindingService.reka.test.ts
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import Dialog from '@/components/ui/dialog/Dialog.vue'
+import DialogContent from '@/components/ui/dialog/DialogContent.vue'
+import DialogDescription from '@/components/ui/dialog/DialogDescription.vue'
+import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
+import { useKeybindingService } from '@/platform/keybindings/keybindingService'
+import { useCommandStore } from '@/stores/commandStore'
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => ({
+    get: vi.fn(() => [])
+  }))
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: null
+  }
+}))
+
+const open = ref(false)
+
+const RekaDialogHost = defineComponent({
+  name: 'RekaDialogHost',
+  setup: () => () =>
+    h(
+      Dialog,
+      { open: open.value, 'onUpdate:open': (v: boolean) => (open.value = v) },
+      () =>
+        h(DialogPortal, null, () =>
+          h(DialogContent, null, () => [
+            h(DialogTitle, null, () => 'Reka dialog'),
+            h(DialogDescription, null, () => 'Opened outside dialogStore')
+          ])
+        )
+    )
+})
+
+/**
+ * Exercises the real reka primitives rather than a hand-built DOM fixture, so
+ * the `role="dialog"` / `data-state` signal the guard relies on is verified
+ * against what reka actually renders.
+ */
+describe('keybindingService - reka dialog integration', () => {
+  let keybindHandler: (event: KeyboardEvent) => Promise<void>
+  let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    open.value = false
+
+    const commandStore = useCommandStore()
+    mockCommandExecute = vi.fn()
+    commandStore.execute = mockCommandExecute
+
+    const keybindingService = useKeybindingService()
+    keybindingService.registerCoreKeybindings()
+    keybindHandler = keybindingService.keybindHandler
+    // GraphView binds the handler on mount, so it always precedes the
+    // DismissableLayer listener a later-opened dialog installs.
+    window.addEventListener('keydown', keybindHandler)
+  })
+
+  afterEach(() => {
+    window.removeEventListener('keydown', keybindHandler)
+  })
+
+  function pressEscape(): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true
+    })
+    window.dispatchEvent(event)
+    return event
+  }
+
+  it('runs the Escape command when no reka dialog is open', async () => {
+    render(RekaDialogHost)
+
+    pressEscape()
+
+    await waitFor(() =>
+      expect(mockCommandExecute).toHaveBeenCalledWith(
+        'Comfy.Graph.ExitSubgraph'
+      )
+    )
+  })
+
+  it('lets reka close its dialog on Escape without exiting the subgraph', async () => {
+    render(RekaDialogHost)
+    open.value = true
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.getAttribute('data-state')).toBe('open')
+
+    const event = pressEscape()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+    await waitFor(() => expect(open.value).toBe(false))
+  })
+})

--- a/src/platform/keybindings/keybindingService.reka.test.ts
+++ b/src/platform/keybindings/keybindingService.reka.test.ts
@@ -8,6 +8,8 @@ import DialogContent from '@/components/ui/dialog/DialogContent.vue'
 import DialogDescription from '@/components/ui/dialog/DialogDescription.vue'
 import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
 import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
+import Popover from '@/components/ui/popover/Popover.vue'
+import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useCommandStore } from '@/stores/commandStore'
 
@@ -77,12 +79,34 @@ describe('keybindingService - reka dialog integration', () => {
       bubbles: true,
       cancelable: true
     })
-    window.dispatchEvent(event)
+    // eslint-disable-next-line testing-library/no-node-access -- reka focus-traps into DialogContent, so a real Escape originates inside the dialog
+    ;(document.activeElement ?? document.body).dispatchEvent(event)
     return event
   }
 
   it('runs the Escape command when no reka dialog is open', async () => {
     render(RekaDialogHost)
+
+    pressEscape()
+
+    await waitFor(() =>
+      expect(mockCommandExecute).toHaveBeenCalledWith(
+        'Comfy.Graph.ExitSubgraph'
+      )
+    )
+  })
+
+  it('executes a global keybinding while a real reka popover is open', async () => {
+    const PopoverHost = defineComponent({
+      name: 'PopoverHost',
+      setup: () => () =>
+        h(Popover, { open: true }, () =>
+          h(PopoverContent, null, () => 'Popover body')
+        )
+    })
+    render(PopoverHost)
+    const popover = await screen.findByRole('dialog')
+    expect(popover.getAttribute('data-state')).toBe('open')
 
     pressEscape()
 

--- a/src/platform/keybindings/keybindingService.reka.test.ts
+++ b/src/platform/keybindings/keybindingService.reka.test.ts
@@ -73,13 +73,13 @@ describe('keybindingService - reka dialog integration', () => {
     window.removeEventListener('keydown', keybindHandler)
   })
 
-  function pressEscape(): KeyboardEvent {
+  function pressKey(key: string): KeyboardEvent {
     const event = new KeyboardEvent('keydown', {
-      key: 'Escape',
+      key,
       bubbles: true,
       cancelable: true
     })
-    // eslint-disable-next-line testing-library/no-node-access -- reka focus-traps into DialogContent, so a real Escape originates inside the dialog
+    // eslint-disable-next-line testing-library/no-node-access -- reka focus-traps into DialogContent, so a real keypress originates inside the dialog
     ;(document.activeElement ?? document.body).dispatchEvent(event)
     return event
   }
@@ -87,7 +87,7 @@ describe('keybindingService - reka dialog integration', () => {
   it('runs the Escape command when no reka dialog is open', async () => {
     render(RekaDialogHost)
 
-    pressEscape()
+    pressKey('Escape')
 
     await waitFor(() =>
       expect(mockCommandExecute).toHaveBeenCalledWith(
@@ -108,11 +108,13 @@ describe('keybindingService - reka dialog integration', () => {
     const popover = await screen.findByRole('dialog')
     expect(popover.getAttribute('data-state')).toBe('open')
 
-    pressEscape()
+    // Probed with a plain key, not Escape: Escape would also assert that reka's
+    // own popover dismissal stays suppressed, which is not this guard's contract.
+    pressKey('w')
 
     await waitFor(() =>
       expect(mockCommandExecute).toHaveBeenCalledWith(
-        'Comfy.Graph.ExitSubgraph'
+        'Workspace.ToggleSidebarTab.workflows'
       )
     )
   })
@@ -123,7 +125,7 @@ describe('keybindingService - reka dialog integration', () => {
     const dialog = await screen.findByRole('dialog')
     expect(dialog.getAttribute('data-state')).toBe('open')
 
-    const event = pressEscape()
+    const event = pressKey('Escape')
 
     expect(event.defaultPrevented).toBe(false)
     expect(mockCommandExecute).not.toHaveBeenCalled()

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -73,7 +73,8 @@ export function useKeybindingService() {
           event.key === 'Escape' &&
           !event.ctrlKey &&
           !event.altKey &&
-          !event.metaKey
+          !event.metaKey &&
+          !event.shiftKey
         ) {
           return
         }

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -19,8 +19,7 @@ const POPPER_WRAPPER_SELECTOR = '[data-reka-popper-content-wrapper]'
  * working. Only popover content is positioned inside a popper wrapper.
  */
 function hasOpenRekaDialog(): boolean {
-  const openContent = document.querySelectorAll(OPEN_REKA_CONTENT_SELECTOR)
-  return Array.from(openContent).some(
+  return Array.from(document.querySelectorAll(OPEN_REKA_CONTENT_SELECTOR)).some(
     (content) => content.closest(POPPER_WRAPPER_SELECTOR) === null
   )
 }

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -12,9 +12,9 @@ const OPEN_REKA_CONTENT_SELECTOR = '[role="dialog"][data-state="open"]'
 const POPPER_WRAPPER_SELECTOR = '[data-reka-popper-content-wrapper]'
 
 /**
- * Reka marks open dialog content with `role="dialog"`, but reuses that role for
- * `PopoverContent`, which is non-modal and must keep global keybindings
- * working. Only popover content is positioned inside a popper wrapper.
+ * Reka reuses `role="dialog"` for `PopoverContent`, so the role alone cannot
+ * tell dialog content from a popover. Only popover content is positioned
+ * inside a popper wrapper.
  */
 function isDialogContent(content: Element): boolean {
   return content.closest(POPPER_WRAPPER_SELECTOR) === null

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -12,16 +12,32 @@ const OPEN_REKA_CONTENT_SELECTOR = '[role="dialog"][data-state="open"]'
 const POPPER_WRAPPER_SELECTOR = '[data-reka-popper-content-wrapper]'
 
 /**
- * Dialogs built directly on reka's `DialogRoot` never register with
- * `dialogStore`, so its stack cannot see them. Reka marks open dialog content
- * with `role="dialog"` + `data-state="open"`, but reuses that same pair for
+ * Reka marks open dialog content with `role="dialog"`, but reuses that role for
  * `PopoverContent`, which is non-modal and must keep global keybindings
  * working. Only popover content is positioned inside a popper wrapper.
  */
+function isDialogContent(content: Element): boolean {
+  return content.closest(POPPER_WRAPPER_SELECTOR) === null
+}
+
+/**
+ * Dialogs built directly on reka's `DialogRoot` never register with
+ * `dialogStore`, so its stack cannot see them.
+ */
 function hasOpenRekaDialog(): boolean {
   return Array.from(document.querySelectorAll(OPEN_REKA_CONTENT_SELECTOR)).some(
-    (content) => content.closest(POPPER_WRAPPER_SELECTOR) === null
+    isDialogContent
   )
+}
+
+/**
+ * Whether the event originated inside the open dialog rather than a popover
+ * layered over it, so dialog-scoped shortcuts fire while background commands
+ * pressed inside a popover stay suppressed.
+ */
+function isTargetInDialog(target: HTMLElement): boolean {
+  const content = target.closest?.('[role="dialog"]')
+  return content != null && isDialogContent(content)
 }
 
 export function useKeybindingService() {
@@ -78,8 +94,7 @@ export function useKeybindingService() {
         ) {
           return
         }
-        const inDialog = target.closest?.('[role="dialog"]') != null
-        if (!inDialog) {
+        if (!isTargetInDialog(target)) {
           return
         }
       }

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -8,6 +8,23 @@ import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import { useKeybindingStore } from './keybindingStore'
 
+const OPEN_REKA_CONTENT_SELECTOR = '[role="dialog"][data-state="open"]'
+const POPPER_WRAPPER_SELECTOR = '[data-reka-popper-content-wrapper]'
+
+/**
+ * Dialogs built directly on reka's `DialogRoot` never register with
+ * `dialogStore`, so its stack cannot see them. Reka marks open dialog content
+ * with `role="dialog"` + `data-state="open"`, but reuses that same pair for
+ * `PopoverContent`, which is non-modal and must keep global keybindings
+ * working. Only popover content is positioned inside a popper wrapper.
+ */
+function hasOpenRekaDialog(): boolean {
+  const openContent = document.querySelectorAll(OPEN_REKA_CONTENT_SELECTOR)
+  return Array.from(openContent).some(
+    (content) => content.closest(POPPER_WRAPPER_SELECTOR) === null
+  )
+}
+
 export function useKeybindingService() {
   const keybindingStore = useKeybindingStore()
   const commandStore = useCommandStore()
@@ -44,23 +61,23 @@ export function useKeybindingService() {
           return
         }
       }
-      if (
-        event.key === 'Escape' &&
-        !event.ctrlKey &&
-        !event.altKey &&
-        !event.metaKey
-      ) {
-        if (dialogStore.dialogStack.length > 0) {
-          return
-        }
-      }
-
       /**
        * Block global keybindings from triggering background actions while a
-       * modal dialog is open. Keybindings whose event target lives inside an
-       * open dialog still fire, so dialog-scoped shortcuts keep working.
+       * dialog is open. Keybindings whose event target lives inside an open
+       * dialog still fire, so dialog-scoped shortcuts keep working. Escape is
+       * the exception: it belongs to the dialog, and must also skip the
+       * `preventDefault()` below, since reka dismisses its own dialogs only
+       * while the event is not already default-prevented.
        */
-      if (dialogStore.dialogStack.length > 0) {
+      if (dialogStore.dialogStack.length > 0 || hasOpenRekaDialog()) {
+        if (
+          event.key === 'Escape' &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.metaKey
+        ) {
+          return
+        }
         const inDialog = target.closest?.('[role="dialog"]') != null
         if (!inDialog) {
           return


### PR DESCRIPTION
## Summary

Global keybindings were not suppressed while a dialog built directly on reka's `DialogRoot` was open, so Escape ran `Comfy.Graph.ExitSubgraph` behind the modal and its `preventDefault()` also stopped reka from dismissing the dialog.

## Changes

- **What**: `keybindHandler`'s modal guard gated only on `dialogStore.dialogStack.length > 0`, which never sees dialogs built directly on reka's `DialogRoot`/`DialogContent`. The guard now also detects open reka dialog content in the DOM (`[role="dialog"][data-state="open"]`), and the Escape early-return moved inside that guard so it precedes `event.preventDefault()`. Reka gives `PopoverContent` the same `role`/`data-state` pair, so popover content is excluded via its popper wrapper to keep global keybindings working while a non-modal popover is open.

  The Escape early-return also gained `!event.shiftKey`. It already required no ctrl/alt/meta; without the shift term a user-registered `Shift+Escape` binding took the bare-Escape carve-out and never fired, even targeted inside the dialog. It now falls through to the containment check and behaves like any other binding. This matches `EditKeybindingContent.vue:50-55`, the capture UI, which uses the same four-modifier test to decide that a modified Escape is bindable. Bare Escape and the ctrl/alt/meta cases are unchanged.

## Review Focus

- **The popover exclusion is the risky branch.** It relies on `[data-reka-popper-content-wrapper]`, an internal reka attribute. In reka-ui 2.5.0 exactly two components render `role="dialog"` (`Dialog/DialogContentImpl.js:77` and `Popover/PopoverContentImpl.js:144`), and only the popover one is wrapped by `Popper/PopperContent.js:227`, so the discriminator is exhaustive today. `reka-ui` is pinned exactly in `pnpm-workspace.yaml`, so it cannot drift silently, and a test against real `Popover` primitives fails if the wrapper ever disappears.

- **Non-modal reka dialogs are now also blocked, which is a deliberate accepted behavior change.** `CustomizationDialog.vue` uses `:modal="false"` and is mounted outside `dialogStore`, so it previously did not block global keybindings and now does once focus leaves it. Reka 2.5.0 emits no per-element modality marker in the DOM (no `aria-modal`), so a DOM-level guard cannot distinguish modality; gating on it would mean keying off a global `document.body.style.pointerEvents` side effect that mis-fires whenever an unrelated modal dropdown is open. Every other non-modal reka dialog in the repo routes through `dialogStore` and already blocked, so this converges an outlier rather than diverging.

- **Scope is Escape in practice.** Reka focuses into dialog content on open, so for the dialogs in this repo the pre-existing `inDialog` containment check already lets non-Escape keybindings through. The behavior this actually changes is Escape.

- **PrimeVue-backed dialogs are not matched by the new predicate** — they emit `role="dialog"` with no `data-state`. Those registered through `dialogStore` remain covered by the existing `dialogStack` term. Note that not all of them are: `NodeSearchBoxPopover.vue` is a PrimeVue `Dialog` whose visibility is a plain ref in `searchBoxStore.ts` and which mounts directly in `GraphCanvas.vue`, so it sits outside both terms. That is pre-existing and unchanged by this PR, not something it introduces.

- **Escape behavior with no dialog open is unchanged** — it still reaches `preventDefault()` and exits the subgraph.

- **The containment check now applies the same popover exclusion.** `isTargetInDialog()` was a bare `[role="dialog"]` match, so a key pressed inside a popover layered over an open dialog counted as in-dialog and fired a background command. Both halves of the guard now share one `isDialogContent` helper. Measured blast radius is four cases, all keys pressed inside popover content while a dialog is open. Note this check serves `dialogStore` dialogs too, so it applies to both dialog systems.

- **Shift+Escape now reaches `preventDefault()`.** Because it no longer takes the bare-Escape carve-out, a `Shift+Escape` pressed inside an open dialog runs its binding and prevents the default, so reka does not dismiss the dialog on that combo. That is the point of treating it as an ordinary binding, but it is a second-order effect worth naming.

- **The popover exclusion deliberately preserves a same-class defect.** With only a popover open the guard is not entered, so Escape still reaches `preventDefault()` and reka does not dismiss the popover while `Comfy.Graph.ExitSubgraph` runs behind it. That is the symptom this PR fixes for dialogs, left live for popovers. It is pre-existing on `main` and unchanged here; fixing it means deciding whether Escape belongs to a non-modal popover at all, which is its own PR.

## Verification

Verified in a running dev server: inside a subgraph with a standalone reka dialog open, Escape closed the dialog and left the subgraph intact; a second Escape with no dialog open exited the subgraph; with a reka popover open, a global keybinding still fired.

`pnpm vitest run src/platform/keybindings/` → 119 passed. `lint`, `format:check`, `typecheck`, `knip` all clean.
