### PR TITLE
fix: send locale to Customer.io profiles

### DIFF
--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -54,6 +54,8 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
   })
 }))
 
+import { i18n } from '@/i18n'
+
 import {
   CustomerIoTelemetryProvider,
   EVENT_SOURCE
@@ -90,6 +92,7 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.analytics.reset.mockReset().mockResolvedValue(undefined)
     hoisted.analytics.register.mockResolvedValue(undefined)
     hoisted.userEmail.value = null
+    i18n.global.locale.value = 'en'
     window.__CONFIG__ = {} as typeof window.__CONFIG__
   })
 
@@ -218,9 +221,33 @@ describe('CustomerIoTelemetryProvider', () => {
     await vi.waitFor(() =>
       expect(hoisted.analytics.identify).toHaveBeenCalledWith(
         'test-uid-7f3a9c',
-        { email: 'user@example.com' }
+        { email: 'user@example.com', locale: 'en' }
       )
     )
+  })
+
+  it('updates the identified user when the active locale changes', async () => {
+    createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.userEmail.value = 'user@example.com'
+    hoisted.resolveUser('test-uid-7f3a9c')
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+        'test-uid-7f3a9c',
+        { email: 'user@example.com', locale: 'en' }
+      )
+    )
+
+    i18n.global.locale.value = 'fr'
+
+    await vi.waitFor(() =>
+      expect(hoisted.analytics.identify).toHaveBeenCalledWith(
+        'test-uid-7f3a9c',
+        { email: 'user@example.com', locale: 'fr' }
+      )
+    )
+    i18n.global.locale.value = 'en'
   })
 
   it('identifies with the configured user_id override without waiting for auth', async () => {
@@ -233,10 +260,9 @@ describe('CustomerIoTelemetryProvider', () => {
     })
     await vi.dynamicImportSettled()
 
-    expect(hoisted.analytics.identify).toHaveBeenCalledWith(
-      'forced-uid',
-      undefined
-    )
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid', {
+      locale: 'en'
+    })
     expect(hoisted.onUserResolved).toHaveBeenCalledOnce()
   })
 
@@ -255,7 +281,8 @@ describe('CustomerIoTelemetryProvider', () => {
 
     expect(hoisted.analytics.identify).toHaveBeenCalledOnce()
     expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid', {
-      email: 'restored@example.com'
+      email: 'restored@example.com',
+      locale: 'en'
     })
   })
 
@@ -277,7 +304,7 @@ describe('CustomerIoTelemetryProvider', () => {
       expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
         2,
         'forced-uid',
-        { email: 'returning@example.com' }
+        { email: 'returning@example.com', locale: 'en' }
       )
     )
     expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
@@ -324,9 +351,9 @@ describe('CustomerIoTelemetryProvider', () => {
 
     await vi.waitFor(() =>
       expect(hoisted.analytics.identify.mock.calls).toEqual([
-        ['current-uid', { email: 'current@example.com' }],
-        ['queued-uid', { email: 'queued@example.com' }],
-        ['current-uid', { email: 'current@example.com' }]
+        ['current-uid', { email: 'current@example.com', locale: 'en' }],
+        ['queued-uid', { email: 'queued@example.com', locale: 'en' }],
+        ['current-uid', { email: 'current@example.com', locale: 'en' }]
       ])
     )
     expect(activeUser).toBe('current-uid')
@@ -488,7 +515,8 @@ describe('CustomerIoTelemetryProvider', () => {
     await vi.dynamicImportSettled()
 
     expect(hoisted.analytics.identify).toHaveBeenCalledWith('uid-1', {
-      email: 'person@example.com'
+      email: 'person@example.com',
+      locale: 'en'
     })
     expect(hoisted.analytics.track).not.toHaveBeenCalled()
 
@@ -629,8 +657,8 @@ describe('CustomerIoTelemetryProvider', () => {
 
     await vi.waitFor(() =>
       expect(hoisted.analytics.identify.mock.calls).toEqual([
-        ['firebase-uid', { email: 'person@example.com' }],
-        ['forced-uid', undefined]
+        ['firebase-uid', { email: 'person@example.com', locale: 'en' }],
+        ['forced-uid', { locale: 'en' }]
       ])
     )
     expect(hoisted.analytics.track.mock.invocationCallOrder[0]).toBeLessThan(
@@ -690,7 +718,7 @@ describe('CustomerIoTelemetryProvider', () => {
     await vi.waitFor(() =>
       expect(hoisted.analytics.identify).toHaveBeenCalledWith(
         'uid-without-email',
-        undefined
+        { locale: 'en' }
       )
     )
     await vi.waitFor(() =>
@@ -811,7 +839,7 @@ describe('CustomerIoTelemetryProvider', () => {
       expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(
         2,
         'resolved-uid',
-        { email: 'first@example.com' }
+        { email: 'first@example.com', locale: 'en' }
       )
     )
   })

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -1,7 +1,9 @@
 import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
 import { omit, withTimeout } from 'es-toolkit'
+import { watch } from 'vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { i18n } from '@/i18n'
 import type { AuthUserInfo } from '@/types/authTypes'
 
 import { TelemetryEvents } from '../../types'
@@ -30,6 +32,7 @@ interface QueuedEvent {
 interface CustomerIoIdentity {
   userId: string
   email?: string
+  locale: string
 }
 
 /**
@@ -55,7 +58,9 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       site_id: siteId,
       user_id: userIdOverride
     } = window.__CONFIG__?.customer_io ?? {}
-    this.sessionIdentity = userIdOverride ? { userId: userIdOverride } : null
+    this.sessionIdentity = userIdOverride
+      ? { userId: userIdOverride, locale: i18n.global.locale.value }
+      : null
     if (!writeKey || !siteId) {
       this.isEnabled = false
       return
@@ -80,16 +85,22 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         const identifyResolvedUser = (user: AuthUserInfo) => {
           const identity = {
             userId: userIdOverride || user.id,
-            email: currentUser.userEmail.value || undefined
+            email: currentUser.userEmail.value || undefined,
+            locale: i18n.global.locale.value
           }
           this.sessionIdentity = identity
           return this.enqueueOperation(() => this.identify(identity))
         }
 
         if (userIdOverride && !currentUser.resolvedUserInfo.value) {
-          void this.enqueueOperation(() =>
-            this.identify({ userId: userIdOverride })
-          )
+          void this.enqueueOperation(() => {
+            const identity = {
+              userId: userIdOverride,
+              locale: i18n.global.locale.value
+            }
+            this.sessionIdentity = identity
+            return this.identify(identity)
+          })
         }
         currentUser.onUserResolved((user) => {
           void identifyResolvedUser(user)
@@ -97,6 +108,12 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         currentUser.onUserLogout(() => {
           this.sessionIdentity = null
           void this.enqueueOperation(() => this.resetIdentity())
+        })
+        watch(i18n.global.locale, (locale) => {
+          if (!this.sessionIdentity) return
+          const identity = { ...this.sessionIdentity, locale }
+          this.sessionIdentity = identity
+          void this.enqueueOperation(() => this.identify(identity))
         })
 
         void this.flushQueue()
@@ -151,7 +168,8 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
 
     if (
       this.identifiedUser?.userId === identity.userId &&
-      this.identifiedUser.email === identity.email
+      this.identifiedUser.email === identity.email &&
+      this.identifiedUser.locale === identity.locale
     ) {
       return
     }
@@ -161,7 +179,9 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
       await withTimeout(async () => {
         await analytics.identify(
           identity.userId,
-          identity.email ? { email: identity.email } : undefined
+          identity.email
+            ? { email: identity.email, locale: identity.locale }
+            : { locale: identity.locale }
         )
       }, SDK_OPERATION_TIMEOUT_MS)
     } catch (error) {
@@ -239,7 +259,8 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
     const identity = metadata.user_id
       ? {
           userId: metadata.user_id,
-          email: metadata.email || undefined
+          email: metadata.email || undefined,
+          locale: i18n.global.locale.value
         }
       : undefined
     this.track(


### PR DESCRIPTION
## Summary

Send each identified cloud user's active frontend locale to Customer.io so localized messages can match profile language preferences.

## Changes

- **What**: Add `locale` to Customer.io identify traits on sign-in and re-identify the active session when the Vue i18n locale changes.

## Review Focus

Locale updates reuse the provider's serialized identity queue and preserve its reset/restore ordering. This follows Customer.io's [Identify trait](https://docs.customer.io/integrations/data-in/source-spec/identify-spec/) and [localization attribute](https://docs.customer.io/messaging/channels/localization/attribute/) guidance.

[Linear: GTM-371](https://linear.app/comfyorg/issue/GTM-371/send-frontend-locale-to-customerio-for-localized-messaging)

## Testing

- `pnpm test:unit src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts` (42 passed)
- Commit hooks: oxfmt, type-aware oxlint, ESLint, typecheck
- Push hook: knip