### PR TITLE
fix: keep Hub title independent from workflow name

### DIFF
--- a/browser_tests/tests/dialogs/publishDialog.spec.ts
+++ b/browser_tests/tests/dialogs/publishDialog.spec.ts
@@ -97,7 +97,7 @@ test.describe('Publish dialog - Describe step', () => {
     await saveAndOpenPublishDialog(comfyPage, publishDialog, 'test-describe-wf')
   })
 
-  test('allows editing the workflow name', async ({ publishDialog }) => {
+  test('allows editing the Hub title', async ({ publishDialog }) => {
     await publishDialog.nameInput.clear()
     await publishDialog.nameInput.fill('My Custom Workflow')
     await expect(publishDialog.nameInput).toHaveValue('My Custom Workflow')
@@ -255,6 +255,34 @@ test.describe('Publish dialog - unsaved workflow', () => {
     ).toBeVisible()
     // Nav should be hidden when save is required
     await expect(publishDialog.nav).toBeHidden()
+  })
+})
+
+test.describe('Publish dialog - workflow identity', () => {
+  test.beforeEach(async ({ comfyPage, publishApi, publishDialog }) => {
+    await comfyPage.featureFlags.setFlags(PUBLISH_FEATURE_FLAGS)
+    await publishApi.setupDefaultMocks({ hasProfile: true })
+    await saveAndOpenPublishDialog(
+      comfyPage,
+      publishDialog,
+      'test-independent-title-wf'
+    )
+  })
+
+  test('keeps the saved workflow path when the Hub title differs', async ({
+    comfyPage,
+    publishDialog
+  }) => {
+    await publishDialog.nameInput.clear()
+    await publishDialog.nameInput.fill('Different Hub title')
+    await publishDialog.goToStep('Finish publishing')
+    await expect(publishDialog.finishStep).toBeVisible()
+
+    await publishDialog.publishButton.click()
+    await expect(publishDialog.root).toBeHidden({ timeout: 10_000 })
+    await expect
+      .poll(() => comfyPage.workflow.getActiveWorkflowPath())
+      .toBe('workflows/test-independent-title-wf.json')
   })
 })
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3711,7 +3711,7 @@
     "stepDescribe": "Describe your workflow",
     "stepExamples": "Add output examples",
     "stepFinish": "Finish publishing",
-    "workflowName": "Workflow name",
+    "workflowName": "Hub title",
     "workflowNamePlaceholder": "Tip: enter a descriptive name that's easy to search",
     "workflowDescription": "Workflow description",
     "workflowDescriptionPlaceholder": "What makes your workflow exciting and special? Be specific so people know what to expect.",
@@ -3753,8 +3753,6 @@
     "createProfileCta": "Create a profile",
     "publishFailedTitle": "Publish failed",
     "publishFailedDescription": "Something went wrong while publishing your workflow. Please try again.",
-    "renameFailedTitle": "Rename failed",
-    "renameFailedDescription": "Your workflow was published successfully, but renaming the local file failed. Rename it again to match.",
     "publishSuccessTitle": "Published successfully",
     "publishSuccessDescription": "Your workflow is now live on ComfyHub."
   },

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -266,54 +266,23 @@ describe('ComfyHubPublishDialog', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('renames the local workflow when the published name differs', async () => {
+  it('keeps the local workflow name when the Hub title differs', async () => {
     renderComponent()
     await flushPromises()
-    if (mockFormDataHolder.value) mockFormDataHolder.value.name = 'renamed'
+    if (mockFormDataHolder.value) {
+      mockFormDataHolder.value.name = 'Published title'
+    }
 
     await userEvent.click(screen.getByTestId('publish'))
     await flushPromises()
 
-    expect(mockRenameWorkflow).toHaveBeenCalledWith(
-      expect.anything(),
-      'workflows/renamed.json'
+    expect(mockSubmitToComfyHub).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Published title' })
     )
-    expect(mockSubmitToComfyHub.mock.invocationCallOrder[0]).toBeLessThan(
-      mockRenameWorkflow.mock.invocationCallOrder[0]
-    )
-  })
-
-  it('does not rename when the published name matches the file name', async () => {
-    renderComponent()
-    await flushPromises()
-    if (mockFormDataHolder.value) mockFormDataHolder.value.name = 'test'
-
-    await userEvent.click(screen.getByTestId('publish'))
-    await flushPromises()
-
     expect(mockRenameWorkflow).not.toHaveBeenCalled()
   })
 
-  it('still reports success but warns when the post-publish rename fails', async () => {
-    mockRenameWorkflow.mockRejectedValueOnce(new Error('rename failed'))
-    renderComponent()
-    await flushPromises()
-    if (mockFormDataHolder.value) mockFormDataHolder.value.name = 'renamed'
-
-    await userEvent.click(screen.getByTestId('publish'))
-    await flushPromises()
-
-    expect(mockSubmitToComfyHub).toHaveBeenCalledOnce()
-    expect(mockToastAdd).toHaveBeenCalledWith(
-      expect.objectContaining({ severity: 'warn' })
-    )
-    expect(mockToastAdd).toHaveBeenCalledWith(
-      expect.objectContaining({ severity: 'success' })
-    )
-    expect(onClose).toHaveBeenCalledOnce()
-  })
-
-  it('does not rename or close when publish submission fails', async () => {
+  it('does not close when publish submission fails', async () => {
     mockSubmitToComfyHub.mockRejectedValueOnce(new Error('submit failed'))
     renderComponent()
     await flushPromises()
@@ -323,7 +292,6 @@ describe('ComfyHubPublishDialog', () => {
     await flushPromises()
 
     expect(mockSubmitToComfyHub).toHaveBeenCalledOnce()
-    expect(mockRenameWorkflow).not.toHaveBeenCalled()
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error' })
     )
@@ -333,49 +301,19 @@ describe('ComfyHubPublishDialog', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('does not refetch publish status when the rename changes the path mid-publish', async () => {
-    mockRenameWorkflow.mockImplementationOnce(async () => {
-      setActiveWorkflow({
-        path: 'workflows/renamed.json',
-        filename: 'renamed.json',
-        directory: 'workflows',
-        isTemporary: false,
-        isModified: false
-      })
-    })
+  it('caches the Hub title under the unchanged workflow path', async () => {
     renderComponent()
     await flushPromises()
-    mockGetPublishStatus.mockClear()
-    if (mockFormDataHolder.value) mockFormDataHolder.value.name = 'renamed'
-
-    await userEvent.click(screen.getByTestId('publish'))
-    await flushPromises()
-
-    expect(mockGetPublishStatus).not.toHaveBeenCalledWith(
-      'workflows/renamed.json'
-    )
-  })
-
-  it('caches the prefill under the renamed path after publish', async () => {
-    mockRenameWorkflow.mockImplementationOnce(async () => {
-      setActiveWorkflow({
-        path: 'workflows/renamed.json',
-        filename: 'renamed.json',
-        directory: 'workflows',
-        isTemporary: false,
-        isModified: false
-      })
-    })
-    renderComponent()
-    await flushPromises()
-    if (mockFormDataHolder.value) mockFormDataHolder.value.name = 'renamed'
+    if (mockFormDataHolder.value) {
+      mockFormDataHolder.value.name = 'Published title'
+    }
 
     await userEvent.click(screen.getByTestId('publish'))
     await flushPromises()
 
     expect(mockCachePublishPrefill).toHaveBeenCalledWith(
-      'workflows/renamed.json',
-      expect.anything()
+      'workflows/test.json',
+      expect.objectContaining({ name: 'Published title' })
     )
   })
 
@@ -386,6 +324,7 @@ describe('ComfyHubPublishDialog', () => {
       shareUrl: 'http://localhost/?share=abc123',
       publishedAt: new Date(),
       prefill: {
+        name: 'Published title',
         description: 'Existing description',
         tags: ['art', 'upscale'],
         thumbnailType: 'video',
@@ -397,6 +336,7 @@ describe('ComfyHubPublishDialog', () => {
     await flushPromises()
 
     expect(mockApplyPrefill).toHaveBeenCalledWith({
+      name: 'Published title',
       description: 'Existing description',
       tags: ['art', 'upscale'],
       thumbnailType: 'video',

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
@@ -207,27 +207,6 @@ function handleRequireProfile() {
   openProfileCreationStep()
 }
 
-async function syncWorkflowName(): Promise<void> {
-  const workflow = workflowStore.activeWorkflow
-  if (!workflow || workflow.isTemporary) return
-
-  const desiredName = formData.value.name.trim().replace(/\.json$/i, '')
-  const currentName = workflow.filename.replace(/\.json$/i, '')
-  if (!desiredName || desiredName === currentName) return
-
-  const newPath = buildWorkflowPath(workflow.directory, desiredName)
-  try {
-    await workflowService.renameWorkflow(workflow, newPath)
-  } catch (error) {
-    console.error('Failed to rename workflow after publish:', error)
-    toast.add({
-      severity: 'warn',
-      summary: t('comfyHubPublish.renameFailedTitle'),
-      detail: t('comfyHubPublish.renameFailedDescription')
-    })
-  }
-}
-
 async function handlePublish(): Promise<void> {
   if (isPublishing.value) {
     return
@@ -236,7 +215,6 @@ async function handlePublish(): Promise<void> {
   isPublishing.value = true
   try {
     await submitToComfyHub(formData.value)
-    await syncWorkflowName()
     const path = workflowStore.activeWorkflow?.path
     if (path) {
       cachePublishPrefill(path, formData.value)

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.test.ts
@@ -12,7 +12,8 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   })
 }))
 
-const { useComfyHubPublishWizard } = await import('./useComfyHubPublishWizard')
+const { cachePublishPrefill, getCachedPrefill, useComfyHubPublishWizard } =
+  await import('./useComfyHubPublishWizard')
 
 describe('useComfyHubPublishWizard', () => {
   beforeEach(() => {
@@ -144,6 +145,23 @@ describe('useComfyHubPublishWizard', () => {
   })
 
   describe('applyPrefill', () => {
+    it('restores the published Hub title instead of the workflow filename', () => {
+      const { applyPrefill, formData } = useComfyHubPublishWizard()
+
+      applyPrefill({ name: 'Published title' })
+
+      expect(formData.value.name).toBe('Published title')
+    })
+
+    it('does not overwrite a Hub title edited before prefill resolves', () => {
+      const { applyPrefill, formData } = useComfyHubPublishWizard()
+      formData.value.name = 'New title'
+
+      applyPrefill({ name: 'Published title' })
+
+      expect(formData.value.name).toBe('New title')
+    })
+
     it('restores the existing thumbnail URL into the form', () => {
       const { applyPrefill, formData } = useComfyHubPublishWizard()
       applyPrefill({ thumbnailUrl: 'https://cdn.example.com/thumb.png' })
@@ -197,5 +215,16 @@ describe('useComfyHubPublishWizard', () => {
         'https://cdn.example.com/sample.png'
       )
     })
+  })
+
+  it('caches the published Hub title by workflow path', () => {
+    const { formData } = useComfyHubPublishWizard()
+    formData.value.name = 'Published title'
+
+    cachePublishPrefill('workflows/cache-title.json', formData.value)
+
+    expect(getCachedPrefill('workflows/cache-title.json')).toEqual(
+      expect.objectContaining({ name: 'Published title' })
+    )
   })
 })

--- a/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubPublishWizard.ts
@@ -51,6 +51,7 @@ function extractPrefillFromFormData(
   formData: ComfyHubPublishFormData
 ): PublishPrefill {
   return {
+    name: formData.name || undefined,
     description: formData.description || undefined,
     tags: formData.tags.length > 0 ? normalizeTags(formData.tags) : undefined,
     thumbnailType: formData.thumbnailType,
@@ -109,6 +110,10 @@ export function useComfyHubPublishWizard() {
       : (prefill.thumbnailUrl ?? current.thumbnailUrl)
     formData.value = {
       ...current,
+      name:
+        current.name === defaults.name
+          ? (prefill.name ?? current.name)
+          : current.name,
       description:
         current.description === defaults.description
           ? (prefill.description ?? current.description)

--- a/src/platform/workflow/sharing/schemas/shareSchemas.test.ts
+++ b/src/platform/workflow/sharing/schemas/shareSchemas.test.ts
@@ -59,12 +59,14 @@ describe('zSharedWorkflowResponse name sanitization', () => {
 describe('zHubWorkflowPrefillResponse tag tolerance', () => {
   it('drops a malformed tag without discarding the rest of the prefill', () => {
     const result = zHubWorkflowPrefillResponse.safeParse({
+      name: 'Published title',
       description: 'A cool workflow',
       thumbnail_url: 'https://cdn.example.com/thumb.png',
       tags: [{ name: 'art', display_name: 'Art' }, 'rawtag', { name: 'broken' }]
     })
 
     expect(result.success).toBe(true)
+    expect(result.data?.name).toBe('Published title')
     expect(result.data?.tags).toEqual(['Art', 'rawtag'])
     expect(result.data?.description).toBe('A cool workflow')
     expect(result.data?.thumbnail_url).toBe('https://cdn.example.com/thumb.png')

--- a/src/platform/workflow/sharing/schemas/shareSchemas.test.ts
+++ b/src/platform/workflow/sharing/schemas/shareSchemas.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  zHubWorkflowPrefillResponse,
-  zSharedWorkflowResponse
-} from '@/platform/workflow/sharing/schemas/shareSchemas'
+import { zSharedWorkflowResponse } from '@/platform/workflow/sharing/schemas/shareSchemas'
 
 function makePayload(name: string) {
   return {
@@ -53,22 +50,5 @@ describe('zSharedWorkflowResponse name sanitization', () => {
   it('trims whitespace from sanitized names', () => {
     const result = zSharedWorkflowResponse.parse(makePayload('  spaced name  '))
     expect(result.name).toBe('spaced name')
-  })
-})
-
-describe('zHubWorkflowPrefillResponse tag tolerance', () => {
-  it('drops a malformed tag without discarding the rest of the prefill', () => {
-    const result = zHubWorkflowPrefillResponse.safeParse({
-      name: 'Published title',
-      description: 'A cool workflow',
-      thumbnail_url: 'https://cdn.example.com/thumb.png',
-      tags: [{ name: 'art', display_name: 'Art' }, 'rawtag', { name: 'broken' }]
-    })
-
-    expect(result.success).toBe(true)
-    expect(result.data?.name).toBe('Published title')
-    expect(result.data?.tags).toEqual(['Art', 'rawtag'])
-    expect(result.data?.description).toBe('A cool workflow')
-    expect(result.data?.thumbnail_url).toBe('https://cdn.example.com/thumb.png')
   })
 })

--- a/src/platform/workflow/sharing/schemas/shareSchemas.ts
+++ b/src/platform/workflow/sharing/schemas/shareSchemas.ts
@@ -20,6 +20,7 @@ const zPrefillTagList = z
   .transform((tags) => tags.filter((tag): tag is string => tag !== undefined))
 
 export const zHubWorkflowPrefillResponse = z.object({
+  name: z.string().nullish(),
   description: z.string().nullish(),
   tags: zPrefillTagList.nullish(),
   sample_image_urls: z.array(z.string()).nullish(),

--- a/src/platform/workflow/sharing/schemas/shareSchemas.ts
+++ b/src/platform/workflow/sharing/schemas/shareSchemas.ts
@@ -10,25 +10,6 @@ export const zPublishRecordResponse = z.object({
   assets: z.array(zAssetInfo).optional()
 })
 
-const zPrefillTag = z
-  .object({ name: z.string(), display_name: z.string() })
-  .transform((label) => label.display_name)
-  .or(z.string())
-
-const zPrefillTagList = z
-  .array(zPrefillTag.optional().catch(undefined))
-  .transform((tags) => tags.filter((tag): tag is string => tag !== undefined))
-
-export const zHubWorkflowPrefillResponse = z.object({
-  name: z.string().nullish(),
-  description: z.string().nullish(),
-  tags: zPrefillTagList.nullish(),
-  sample_image_urls: z.array(z.string()).nullish(),
-  thumbnail_type: z.enum(['image', 'video', 'image_comparison']).nullish(),
-  thumbnail_url: z.string().nullish(),
-  thumbnail_comparison_url: z.string().nullish()
-})
-
 /**
  * Strips path separators and control characters from a workflow name to prevent
  * path traversal when the name is later used as part of a file path.

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -176,6 +176,7 @@ describe(useWorkflowShareService, () => {
 
       if (path === '/hub/workflows/wf-prefill') {
         return mockJsonResponse({
+          name: 'Published title',
           description: 'A cool workflow',
           tags: [
             { name: 'art', display_name: 'Art' },
@@ -194,6 +195,7 @@ describe(useWorkflowShareService, () => {
 
     expect(status.isPublished).toBe(true)
     expect(status.prefill).toEqual({
+      name: 'Published title',
       description: 'A cool workflow',
       tags: ['Art', 'Upscale'],
       thumbnailType: 'imageComparison',

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { HubWorkflowDetail } from '@comfyorg/ingest-types'
+
 import type { AssetInfo } from '@/schemas/apiSchema'
 import { useWorkflowShareService } from '@/platform/workflow/sharing/services/workflowShareService'
 
@@ -175,16 +177,24 @@ describe(useWorkflowShareService, () => {
       }
 
       if (path === '/hub/workflows/wf-prefill') {
-        return mockJsonResponse({
+        const detail = {
+          share_id: 'wf-prefill',
+          workflow_id: 'wf-prefill',
           name: 'Published title',
+          status: 'approved',
           description: 'A cool workflow',
           tags: [
             { name: 'art', display_name: 'Art' },
             { name: 'upscale', display_name: 'Upscale' }
           ],
           thumbnail_type: 'image_comparison',
-          sample_image_urls: ['https://example.com/img1.png']
-        })
+          sample_image_urls: ['https://example.com/img1.png'],
+          workflow_json: {},
+          assets: [],
+          profile: { username: 'builder' }
+        } satisfies HubWorkflowDetail
+
+        return mockJsonResponse(detail)
       }
 
       return mockJsonResponse({}, false, 404)
@@ -202,6 +212,29 @@ describe(useWorkflowShareService, () => {
       sampleImageUrls: ['https://example.com/img1.png']
     })
     expect(mockFetchApi).toHaveBeenNthCalledWith(2, '/hub/workflows/wf-prefill')
+  })
+
+  it('rejects hub workflow details that violate the generated contract', async () => {
+    mockFetchApi
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          workflow_id: 'wf-invalid',
+          share_id: 'wf-invalid',
+          publish_time: '2026-02-23T00:00:00Z',
+          listed: true
+        })
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          name: 'Incomplete response'
+        })
+      )
+
+    const service = useWorkflowShareService()
+    const status = await service.getPublishStatus('wf-invalid')
+
+    expect(status.isPublished).toBe(true)
+    expect(status.prefill).toBeNull()
   })
 
   it('returns null prefill when hub workflow details are unavailable', async () => {

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -1,4 +1,8 @@
-import type { ImportPublishedAssetsRequest } from '@comfyorg/ingest-types'
+import type {
+  HubWorkflowDetail,
+  ImportPublishedAssetsRequest
+} from '@comfyorg/ingest-types'
+import { zGetHubWorkflowResponse } from '@comfyorg/ingest-types/zod'
 
 import type {
   PublishPrefill,
@@ -11,7 +15,6 @@ import type { ThumbnailType } from '@/platform/workflow/sharing/types/comfyHubTy
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { AssetInfo } from '@/schemas/apiSchema'
 import {
-  zHubWorkflowPrefillResponse,
   zPublishRecordResponse,
   zSharedWorkflowResponse
 } from '@/platform/workflow/sharing/schemas/shareSchemas'
@@ -41,24 +44,14 @@ function mapApiThumbnailType(
   return value
 }
 
-interface PrefillMetadataFields {
-  name?: string | null
-  description?: string | null
-  tags?: string[] | null
-  thumbnail_type?: 'image' | 'video' | 'image_comparison' | null
-  thumbnail_url?: string | null
-  thumbnail_comparison_url?: string | null
-  sample_image_urls?: string[] | null
-}
-
-function extractPrefill(fields: PrefillMetadataFields): PublishPrefill | null {
-  const name = fields.name ?? undefined
-  const description = fields.description ?? undefined
-  const tags = fields.tags ?? undefined
+function extractPrefill(fields: HubWorkflowDetail): PublishPrefill | null {
+  const name = fields.name
+  const description = fields.description
+  const tags = fields.tags?.map((tag) => tag.display_name)
   const thumbnailType = mapApiThumbnailType(fields.thumbnail_type)
-  const thumbnailUrl = fields.thumbnail_url ?? undefined
-  const thumbnailComparisonUrl = fields.thumbnail_comparison_url ?? undefined
-  const sampleImageUrls = fields.sample_image_urls ?? undefined
+  const thumbnailUrl = fields.thumbnail_url
+  const thumbnailComparisonUrl = fields.thumbnail_comparison_url
+  const sampleImageUrls = fields.sample_image_urls
 
   if (
     !name &&
@@ -84,7 +77,7 @@ function extractPrefill(fields: PrefillMetadataFields): PublishPrefill | null {
 }
 
 function decodeHubWorkflowPrefill(payload: unknown): PublishPrefill | null {
-  const result = zHubWorkflowPrefillResponse.safeParse(payload)
+  const result = zGetHubWorkflowResponse.safeParse(payload)
   if (!result.success) return null
   return extractPrefill(result.data)
 }

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -42,6 +42,7 @@ function mapApiThumbnailType(
 }
 
 interface PrefillMetadataFields {
+  name?: string | null
   description?: string | null
   tags?: string[] | null
   thumbnail_type?: 'image' | 'video' | 'image_comparison' | null
@@ -51,6 +52,7 @@ interface PrefillMetadataFields {
 }
 
 function extractPrefill(fields: PrefillMetadataFields): PublishPrefill | null {
+  const name = fields.name ?? undefined
   const description = fields.description ?? undefined
   const tags = fields.tags ?? undefined
   const thumbnailType = mapApiThumbnailType(fields.thumbnail_type)
@@ -59,6 +61,7 @@ function extractPrefill(fields: PrefillMetadataFields): PublishPrefill | null {
   const sampleImageUrls = fields.sample_image_urls ?? undefined
 
   if (
+    !name &&
     !description &&
     !tags?.length &&
     !thumbnailType &&
@@ -70,6 +73,7 @@ function extractPrefill(fields: PrefillMetadataFields): PublishPrefill | null {
   }
 
   return {
+    name,
     description,
     tags,
     thumbnailType,

--- a/src/platform/workflow/sharing/types/shareTypes.ts
+++ b/src/platform/workflow/sharing/types/shareTypes.ts
@@ -12,6 +12,7 @@ export interface WorkflowPublishResult {
 }
 
 export interface PublishPrefill {
+  name?: string
   description?: string
   tags?: string[]
   thumbnailType?: ThumbnailType


### PR DESCRIPTION
## Summary

Keep the public Hub title independent from the underlying workflow filename.

## Changes

- **What**: Remove the post-publish workflow rename, restore the existing Hub title when updating, and clarify the English field label.
- **Root cause**: The publish dialog copied the Hub title back into the local workflow filename even though the API models them separately.
- **Contract**: Validate Hub details with the code-generated `zGetHubWorkflowResponse` before mapping them into publish prefill data.
- **Tests**: Cover independent titles, server/cached title prefill, generated-contract validation, and the unchanged workflow path in Playwright.

## Review Focus

Verify that publishing or updating a Hub title leaves the workflow path unchanged and reopening the dialog preserves the published title.

- Fixes [GTM-309](https://linear.app/comfyorg/issue/GTM-309/bug-publishing-app-title-renames-the-underlying-workflowworkspace)