### PR TITLE
FE-1392: sanitize and normalize billing telemetry

### DIFF
--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.test.ts
@@ -10,7 +10,7 @@ const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
 const mockCloseDialog = vi.fn()
 const mockTrackTopUpPurchase = vi.fn()
-const mockTrackApiCreditTopupFailed = vi.fn()
+const mockTrackBillingEvent = vi.fn()
 const mockIsSubscriptionEnabled = vi.fn(() => true)
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: false }))
 
@@ -47,7 +47,7 @@ vi.mock('@/stores/dialogStore', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackApiCreditTopupButtonPurchaseClicked: mockTrackTopUpPurchase,
-    trackApiCreditTopupFailed: mockTrackApiCreditTopupFailed
+    trackBillingEvent: mockTrackBillingEvent
   })
 }))
 
@@ -160,13 +160,18 @@ describe('TopUpCreditsDialogContentLegacy', () => {
   })
 
   it('tracks the failure and surfaces a toast when the purchase rejects', async () => {
-    mockPurchaseCreditsDirect.mockRejectedValue(new Error('card declined'))
+    mockPurchaseCreditsDirect.mockRejectedValue(
+      new Error('declined for person@example.com')
+    )
 
     renderDialog()
     await clickBuyCredits()
 
-    expect(mockTrackApiCreditTopupFailed).toHaveBeenCalledWith({
-      error_message: 'card declined'
+    expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+      operation: 'topup',
+      stage: 'failed',
+      outcome: 'failure',
+      failure_category: 'unknown'
     })
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -177,14 +182,17 @@ describe('TopUpCreditsDialogContentLegacy', () => {
     expect(mockShowSettings).not.toHaveBeenCalled()
   })
 
-  it('reports the unknown-error message when the rejection is not an Error', async () => {
+  it('uses the same bounded category when the rejection is not an Error', async () => {
     mockPurchaseCreditsDirect.mockRejectedValue('boom')
 
     renderDialog()
     await clickBuyCredits()
 
-    expect(mockTrackApiCreditTopupFailed).toHaveBeenCalledWith({
-      error_message: 'An unknown error occurred'
+    expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+      operation: 'topup',
+      stage: 'failed',
+      outcome: 'failure',
+      failure_category: 'unknown'
     })
   })
 })

--- a/src/components/dialog/content/TopUpCreditsDialogContentLegacy.vue
+++ b/src/components/dialog/content/TopUpCreditsDialogContentLegacy.vue
@@ -273,7 +273,12 @@ async function handleBuy() {
 
     const errorMessage =
       error instanceof Error ? error.message : t('credits.topUp.unknownError')
-    telemetry?.trackApiCreditTopupFailed({ error_message: errorMessage })
+    telemetry?.trackBillingEvent({
+      operation: 'topup',
+      stage: 'failed',
+      outcome: 'failure',
+      failure_category: 'unknown'
+    })
     toast.add({
       severity: 'error',
       summary: t('credits.topUp.purchaseError'),

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -29,7 +29,7 @@ const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockAccessBillingPortal = vi.fn()
 const mockReportError = vi.fn()
 const mockTrackBeginCheckout = vi.fn()
-const mockTrackSubscriptionCheckoutFailed = vi.fn()
+const mockTrackBillingEvent = vi.fn()
 const mockUserId = ref<string | undefined>('user-123')
 const mockGetAuthHeader = vi.fn(() =>
   Promise.resolve({ Authorization: 'Bearer test-token' })
@@ -124,7 +124,7 @@ vi.mock('@/stores/authStore', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackBeginCheckout: mockTrackBeginCheckout,
-    trackSubscriptionCheckoutFailed: mockTrackSubscriptionCheckoutFailed
+    trackBillingEvent: mockTrackBillingEvent
   })
 }))
 
@@ -448,7 +448,7 @@ describe('PricingTable', () => {
       mockIsActiveSubscription.value = false
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
-        json: async () => ({ message: 'card declined' })
+        json: async () => ({ message: 'declined for person@example.com' })
       } as Response)
 
       renderComponent()
@@ -461,11 +461,15 @@ describe('PricingTable', () => {
       await userEvent.click(subscribeButton!)
       await flushPromises()
 
-      expect(mockTrackSubscriptionCheckoutFailed).toHaveBeenCalledWith({
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'subscription_checkout',
+        stage: 'failed',
+        outcome: 'failure',
         tier: 'standard',
         cycle: 'yearly',
         checkout_type: 'new',
-        error_message: expect.stringContaining('card declined')
+        payment_intent_source: undefined,
+        failure_category: 'unknown'
       })
       expect(mockReportError).toHaveBeenCalled()
     })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -535,12 +535,15 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
             { paymentIntentSource: reason }
           )
         } catch (error) {
-          telemetry?.trackSubscriptionCheckoutFailed({
+          telemetry?.trackBillingEvent({
+            operation: 'subscription_checkout',
+            stage: 'failed',
+            outcome: 'failure',
             tier: tierKey,
             cycle: currentBillingCycle.value,
             checkout_type: 'new',
-            error_message:
-              error instanceof Error ? error.message : 'unknown error'
+            payment_intent_source: reason,
+            failure_category: 'unknown'
           })
           throw error
         }

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { TelemetryRegistry } from './TelemetryRegistry'
-import type { TelemetryProvider } from './types'
+import type { BillingTelemetryEvent, TelemetryProvider } from './types'
 
 describe('TelemetryRegistry', () => {
   it('dispatches trackSearchQuery to every registered provider', () => {
@@ -135,51 +135,6 @@ describe('TelemetryRegistry', () => {
     expect(b.trackResubscribeClicked).toHaveBeenCalledExactlyOnceWith(payload)
   })
 
-  it('dispatches resubscribe succeeded/failed outcomes to every registered provider', () => {
-    const a: TelemetryProvider = {
-      trackResubscribeSucceeded: vi.fn(),
-      trackResubscribeFailed: vi.fn()
-    }
-    const b: TelemetryProvider = {
-      trackResubscribeSucceeded: vi.fn(),
-      trackResubscribeFailed: vi.fn()
-    }
-    const registry = new TelemetryRegistry()
-    registry.registerProvider(a)
-    registry.registerProvider(b)
-
-    const succeeded = { source: 'settings_billing_panel' as const }
-    const failed = {
-      source: 'settings_billing_panel' as const,
-      error_message: 'card declined'
-    }
-    registry.trackResubscribeSucceeded(succeeded)
-    registry.trackResubscribeFailed(failed)
-
-    expect(a.trackResubscribeSucceeded).toHaveBeenCalledExactlyOnceWith(
-      succeeded
-    )
-    expect(b.trackResubscribeSucceeded).toHaveBeenCalledExactlyOnceWith(
-      succeeded
-    )
-    expect(a.trackResubscribeFailed).toHaveBeenCalledExactlyOnceWith(failed)
-    expect(b.trackResubscribeFailed).toHaveBeenCalledExactlyOnceWith(failed)
-  })
-
-  it('dispatches trackApiCreditTopupFailed to every registered provider', () => {
-    const a: TelemetryProvider = { trackApiCreditTopupFailed: vi.fn() }
-    const b: TelemetryProvider = { trackApiCreditTopupFailed: vi.fn() }
-    const registry = new TelemetryRegistry()
-    registry.registerProvider(a)
-    registry.registerProvider(b)
-
-    const payload = { error_message: 'card declined' }
-    registry.trackApiCreditTopupFailed(payload)
-
-    expect(a.trackApiCreditTopupFailed).toHaveBeenCalledExactlyOnceWith(payload)
-    expect(b.trackApiCreditTopupFailed).toHaveBeenCalledExactlyOnceWith(payload)
-  })
-
   it('dispatches trackWorkspaceInviteFailed to every registered provider', () => {
     const a: TelemetryProvider = { trackWorkspaceInviteFailed: vi.fn() }
     const b: TelemetryProvider = { trackWorkspaceInviteFailed: vi.fn() }
@@ -202,115 +157,24 @@ describe('TelemetryRegistry', () => {
     )
   })
 
-  it('dispatches billing-operation failure and timeout telemetry to every registered provider', () => {
-    const a: TelemetryProvider = {
-      trackBillingOperationFailed: vi.fn(),
-      trackBillingOperationTimeout: vi.fn()
-    }
-    const b: TelemetryProvider = {
-      trackBillingOperationFailed: vi.fn(),
-      trackBillingOperationTimeout: vi.fn()
-    }
+  it('dispatches the same canonical billing event to every provider', () => {
+    const a: TelemetryProvider = { trackBillingEvent: vi.fn() }
+    const b: TelemetryProvider = { trackBillingEvent: vi.fn() }
     const registry = new TelemetryRegistry()
     registry.registerProvider(a)
     registry.registerProvider(b)
 
-    const failed = {
+    const event: BillingTelemetryEvent = {
+      operation: 'operation',
+      stage: 'failed',
+      outcome: 'failure',
       billing_op_id: 'op-1',
-      operation_type: 'subscription' as const,
-      failure_reason: 'declined'
+      operation_type: 'subscription',
+      failure_category: 'provider_decline'
     }
-    const timedOut = {
-      billing_op_id: 'op-2',
-      operation_type: 'topup' as const
-    }
-    registry.trackBillingOperationFailed(failed)
-    registry.trackBillingOperationTimeout(timedOut)
+    registry.trackBillingEvent(event)
 
-    expect(a.trackBillingOperationFailed).toHaveBeenCalledExactlyOnceWith(
-      failed
-    )
-    expect(b.trackBillingOperationFailed).toHaveBeenCalledExactlyOnceWith(
-      failed
-    )
-    expect(a.trackBillingOperationTimeout).toHaveBeenCalledExactlyOnceWith(
-      timedOut
-    )
-    expect(b.trackBillingOperationTimeout).toHaveBeenCalledExactlyOnceWith(
-      timedOut
-    )
-  })
-
-  it('dispatches the downgrade-to-personal lifecycle events to every registered provider', () => {
-    const a: TelemetryProvider = {
-      trackDowngradeToPersonalStarted: vi.fn(),
-      trackDowngradeToPersonalSucceeded: vi.fn(),
-      trackDowngradeToPersonalFailed: vi.fn()
-    }
-    const b: TelemetryProvider = {
-      trackDowngradeToPersonalStarted: vi.fn(),
-      trackDowngradeToPersonalSucceeded: vi.fn(),
-      trackDowngradeToPersonalFailed: vi.fn()
-    }
-    const registry = new TelemetryRegistry()
-    registry.registerProvider(a)
-    registry.registerProvider(b)
-
-    const started = { member_removal_count: 2 }
-    const succeeded = {
-      member_removal_count: 2,
-      member_removal_failures: 0,
-      target_tier: 'standard' as const
-    }
-    const failed = {
-      member_removal_count: 2,
-      member_removal_failures: 1,
-      failure_reason: 'network error'
-    }
-    registry.trackDowngradeToPersonalStarted(started)
-    registry.trackDowngradeToPersonalSucceeded(succeeded)
-    registry.trackDowngradeToPersonalFailed(failed)
-
-    expect(a.trackDowngradeToPersonalStarted).toHaveBeenCalledExactlyOnceWith(
-      started
-    )
-    expect(b.trackDowngradeToPersonalStarted).toHaveBeenCalledExactlyOnceWith(
-      started
-    )
-    expect(a.trackDowngradeToPersonalSucceeded).toHaveBeenCalledExactlyOnceWith(
-      succeeded
-    )
-    expect(b.trackDowngradeToPersonalSucceeded).toHaveBeenCalledExactlyOnceWith(
-      succeeded
-    )
-    expect(a.trackDowngradeToPersonalFailed).toHaveBeenCalledExactlyOnceWith(
-      failed
-    )
-    expect(b.trackDowngradeToPersonalFailed).toHaveBeenCalledExactlyOnceWith(
-      failed
-    )
-  })
-
-  it('dispatches trackSubscriptionCheckoutFailed to every registered provider', () => {
-    const a: TelemetryProvider = { trackSubscriptionCheckoutFailed: vi.fn() }
-    const b: TelemetryProvider = { trackSubscriptionCheckoutFailed: vi.fn() }
-    const registry = new TelemetryRegistry()
-    registry.registerProvider(a)
-    registry.registerProvider(b)
-
-    const payload = {
-      tier: 'pro' as const,
-      cycle: 'monthly' as const,
-      checkout_type: 'new' as const,
-      error_message: 'card declined'
-    }
-    registry.trackSubscriptionCheckoutFailed(payload)
-
-    expect(a.trackSubscriptionCheckoutFailed).toHaveBeenCalledExactlyOnceWith(
-      payload
-    )
-    expect(b.trackSubscriptionCheckoutFailed).toHaveBeenCalledExactlyOnceWith(
-      payload
-    )
+    expect(a.trackBillingEvent).toHaveBeenCalledExactlyOnceWith(event)
+    expect(b.trackBillingEvent).toHaveBeenCalledExactlyOnceWith(event)
   })
 })

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -2,15 +2,11 @@ import type { AuditLog } from '@/services/customerEventsService'
 
 import type {
   AddCreditsClickMetadata,
-  ApiCreditTopupFailedMetadata,
   AuthErrorMetadata,
   AuthMetadata,
   BeginCheckoutMetadata,
-  BillingOperationOutcomeMetadata,
+  BillingTelemetryEvent,
   DefaultViewSetMetadata,
-  DowngradeToPersonalFailedMetadata,
-  DowngradeToPersonalStartedMetadata,
-  DowngradeToPersonalSucceededMetadata,
   EnterLinearMetadata,
   ExecutionErrorMetadata,
   ExecutionOutcomeMetadata,
@@ -25,7 +21,6 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   ResubscribeClickMetadata,
-  ResubscribeOutcomeMetadata,
   RunButtonProperties,
   ShareFlowMetadata,
   ShareLinkOpenedMetadata,
@@ -33,7 +28,6 @@ import type {
   SharedWorkflowRunMetadata,
   ShellLayoutMetadata,
   SubscriptionCancellationMetadata,
-  SubscriptionCheckoutFailedMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -129,14 +123,6 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackResubscribeClicked?.(metadata))
   }
 
-  trackResubscribeSucceeded(metadata: ResubscribeOutcomeMetadata): void {
-    this.dispatch((provider) => provider.trackResubscribeSucceeded?.(metadata))
-  }
-
-  trackResubscribeFailed(metadata: ResubscribeOutcomeMetadata): void {
-    this.dispatch((provider) => provider.trackResubscribeFailed?.(metadata))
-  }
-
   trackAddApiCreditButtonClicked(metadata?: AddCreditsClickMetadata): void {
     this.dispatch((provider) =>
       provider.trackAddApiCreditButtonClicked?.(metadata)
@@ -153,10 +139,6 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackApiCreditTopupSucceeded?.())
   }
 
-  trackApiCreditTopupFailed(metadata?: ApiCreditTopupFailedMetadata): void {
-    this.dispatch((provider) => provider.trackApiCreditTopupFailed?.(metadata))
-  }
-
   trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
     this.dispatch((provider) => provider.trackWorkspaceInviteSent?.(metadata))
   }
@@ -165,50 +147,8 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackWorkspaceInviteFailed?.(metadata))
   }
 
-  trackBillingOperationFailed(metadata: BillingOperationOutcomeMetadata): void {
-    this.dispatch((provider) =>
-      provider.trackBillingOperationFailed?.(metadata)
-    )
-  }
-
-  trackBillingOperationTimeout(
-    metadata: BillingOperationOutcomeMetadata
-  ): void {
-    this.dispatch((provider) =>
-      provider.trackBillingOperationTimeout?.(metadata)
-    )
-  }
-
-  trackDowngradeToPersonalStarted(
-    metadata: DowngradeToPersonalStartedMetadata
-  ): void {
-    this.dispatch((provider) =>
-      provider.trackDowngradeToPersonalStarted?.(metadata)
-    )
-  }
-
-  trackDowngradeToPersonalSucceeded(
-    metadata: DowngradeToPersonalSucceededMetadata
-  ): void {
-    this.dispatch((provider) =>
-      provider.trackDowngradeToPersonalSucceeded?.(metadata)
-    )
-  }
-
-  trackDowngradeToPersonalFailed(
-    metadata: DowngradeToPersonalFailedMetadata
-  ): void {
-    this.dispatch((provider) =>
-      provider.trackDowngradeToPersonalFailed?.(metadata)
-    )
-  }
-
-  trackSubscriptionCheckoutFailed(
-    metadata: SubscriptionCheckoutFailedMetadata
-  ): void {
-    this.dispatch((provider) =>
-      provider.trackSubscriptionCheckoutFailed?.(metadata)
-    )
+  trackBillingEvent(event: BillingTelemetryEvent): void {
+    this.dispatch((provider) => provider.trackBillingEvent?.(event))
   }
 
   trackRunButton(properties: RunButtonProperties): void {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { BillingTelemetryEvent } from '../../types'
+import { TelemetryEvents } from '../../types'
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const { addDurationVital, getInternalContext } = vi.hoisted(() => ({
+const { addAction, addDurationVital, getInternalContext } = vi.hoisted(() => ({
+  addAction: vi.fn(),
   addDurationVital: vi.fn(),
   getInternalContext: vi.fn()
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addDurationVital, getInternalContext }
+  datadogRum: { addAction, addDurationVital, getInternalContext }
 }))
 
 afterEach(() => {
@@ -17,6 +20,28 @@ afterEach(() => {
 })
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('records the same canonical billing name and context as PostHog', () => {
+    const event: BillingTelemetryEvent = {
+      operation: 'operation',
+      stage: 'failed',
+      outcome: 'failure',
+      billing_op_id: 'opaque-op-id',
+      operation_type: 'subscription',
+      tier: 'pro',
+      cycle: 'monthly',
+      checkout_type: 'new',
+      payment_intent_source: 'subscribe_to_run',
+      failure_category: 'provider_decline'
+    }
+
+    new DatadogRumTelemetryProvider().trackBillingEvent(event)
+
+    expect(addAction).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.BILLING_OPERATION_FAILED,
+      event
+    )
+  })
+
   it.for(['success', 'failure'] as const)(
     'records a workflow vital with a %s outcome',
     (outcome) => {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,8 +1,17 @@
 import { datadogRum } from '@datadog/browser-rum'
 
-import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
+import type {
+  BillingTelemetryEvent,
+  ExecutionOutcomeMetadata,
+  TelemetryProvider
+} from '../../types'
+import { getBillingTelemetryEventName } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackBillingEvent(event: BillingTelemetryEvent): void {
+    datadogRum.addAction(getBillingTelemetryEventName(event), event)
+  }
+
   trackExecutionOutcome({
     startTime,
     outcome

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -3,6 +3,7 @@ import type * as VueModule from 'vue'
 import type { Ref } from 'vue'
 import { nextTick, ref } from 'vue'
 
+import type { BillingTelemetryEvent } from '../../types'
 import { TelemetryEvents } from '../../types'
 
 const hoisted = vi.hoisted(() => {
@@ -418,38 +419,6 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
-    it('captures resubscribe succeeded and failed outcomes', async () => {
-      const provider = createProvider()
-      await vi.dynamicImportSettled()
-
-      provider.trackResubscribeSucceeded({ source: 'settings_billing_panel' })
-      provider.trackResubscribeFailed({
-        source: 'settings_billing_panel',
-        error_message: 'card declined'
-      })
-
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.RESUBSCRIBE_SUCCEEDED,
-        { source: 'settings_billing_panel' }
-      )
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.RESUBSCRIBE_FAILED,
-        { source: 'settings_billing_panel', error_message: 'card declined' }
-      )
-    })
-
-    it('captures api credit topup failures with their error message', async () => {
-      const provider = createProvider()
-      await vi.dynamicImportSettled()
-
-      provider.trackApiCreditTopupFailed({ error_message: 'card declined' })
-
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.API_CREDIT_TOPUP_FAILED,
-        { error_message: 'card declined' }
-      )
-    })
-
     it('captures workspace invite failures with attempted/failed counts', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()
@@ -466,92 +435,129 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
-    it('captures billing-operation failure and timeout outcomes', async () => {
-      const provider = createProvider()
-      await vi.dynamicImportSettled()
-
-      provider.trackBillingOperationFailed({
-        billing_op_id: 'op-1',
-        operation_type: 'subscription',
-        failure_reason: 'declined'
-      })
-      provider.trackBillingOperationTimeout({
-        billing_op_id: 'op-2',
-        operation_type: 'topup'
-      })
-
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.BILLING_OPERATION_FAILED,
+    it.for<[BillingTelemetryEvent, string]>([
+      [
         {
-          billing_op_id: 'op-1',
-          operation_type: 'subscription',
-          failure_reason: 'declined'
-        }
-      )
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.BILLING_OPERATION_TIMEOUT,
-        { billing_op_id: 'op-2', operation_type: 'topup' }
-      )
-    })
-
-    it('captures the downgrade-to-personal lifecycle events', async () => {
-      const provider = createProvider()
-      await vi.dynamicImportSettled()
-
-      provider.trackDowngradeToPersonalStarted({ member_removal_count: 2 })
-      provider.trackDowngradeToPersonalSucceeded({
-        member_removal_count: 2,
-        member_removal_failures: 0,
-        target_tier: 'standard'
-      })
-      provider.trackDowngradeToPersonalFailed({
-        member_removal_count: 2,
-        member_removal_failures: 1,
-        failure_reason: 'network error'
-      })
-
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.DOWNGRADE_TO_PERSONAL_STARTED,
-        { member_removal_count: 2 }
-      )
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.DOWNGRADE_TO_PERSONAL_SUCCEEDED,
+          operation: 'subscription_checkout',
+          stage: 'succeeded',
+          outcome: 'success',
+          billing_op_id: 'op-checkout',
+          tier: 'pro',
+          cycle: 'monthly',
+          checkout_type: 'new'
+        },
+        TelemetryEvents.BILLING_SUBSCRIPTION_CHECKOUT_SUCCEEDED
+      ],
+      [
         {
-          member_removal_count: 2,
-          member_removal_failures: 0,
-          target_tier: 'standard'
-        }
-      )
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.DOWNGRADE_TO_PERSONAL_FAILED,
-        {
-          member_removal_count: 2,
-          member_removal_failures: 1,
-          failure_reason: 'network error'
-        }
-      )
-    })
-
-    it('captures subscription checkout failures on the legacy rail', async () => {
-      const provider = createProvider()
-      await vi.dynamicImportSettled()
-
-      provider.trackSubscriptionCheckoutFailed({
-        tier: 'pro',
-        cycle: 'monthly',
-        checkout_type: 'new',
-        error_message: 'card declined'
-      })
-
-      expect(hoisted.mockCapture).toHaveBeenCalledWith(
-        TelemetryEvents.SUBSCRIPTION_CHECKOUT_FAILED,
-        {
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
           tier: 'pro',
           cycle: 'monthly',
           checkout_type: 'new',
-          error_message: 'card declined'
-        }
-      )
+          failure_category: 'unknown'
+        },
+        TelemetryEvents.BILLING_SUBSCRIPTION_CHECKOUT_FAILED
+      ],
+      [
+        {
+          operation: 'operation',
+          stage: 'failed',
+          outcome: 'failure',
+          billing_op_id: 'opaque-op-id',
+          operation_type: 'subscription',
+          tier: 'pro',
+          cycle: 'monthly',
+          checkout_type: 'new',
+          payment_intent_source: 'subscribe_to_run',
+          failure_category: 'provider_decline'
+        },
+        TelemetryEvents.BILLING_OPERATION_FAILED
+      ],
+      [
+        {
+          operation: 'operation',
+          stage: 'timeout',
+          outcome: 'failure',
+          billing_op_id: 'op-timeout',
+          operation_type: 'topup',
+          failure_category: 'poll_timeout'
+        },
+        TelemetryEvents.BILLING_OPERATION_TIMEOUT
+      ],
+      [
+        {
+          operation: 'resubscribe',
+          stage: 'succeeded',
+          outcome: 'success',
+          source: 'settings_billing_panel'
+        },
+        TelemetryEvents.BILLING_RESUBSCRIBE_SUCCEEDED
+      ],
+      [
+        {
+          operation: 'resubscribe',
+          stage: 'failed',
+          outcome: 'failure',
+          source: 'settings_billing_panel',
+          failure_category: 'unknown'
+        },
+        TelemetryEvents.BILLING_RESUBSCRIBE_FAILED
+      ],
+      [
+        { operation: 'topup', stage: 'succeeded', outcome: 'success' },
+        TelemetryEvents.BILLING_TOPUP_SUCCEEDED
+      ],
+      [
+        {
+          operation: 'topup',
+          stage: 'failed',
+          outcome: 'failure',
+          failure_category: 'provider_decline'
+        },
+        TelemetryEvents.BILLING_TOPUP_FAILED
+      ],
+      [
+        {
+          operation: 'downgrade_to_personal',
+          stage: 'started',
+          outcome: 'pending',
+          member_removal_count: 2,
+          member_removal_failures: 0
+        },
+        TelemetryEvents.BILLING_DOWNGRADE_TO_PERSONAL_STARTED
+      ],
+      [
+        {
+          operation: 'downgrade_to_personal',
+          stage: 'succeeded',
+          outcome: 'success',
+          member_removal_count: 2,
+          member_removal_failures: 0,
+          target_tier: 'standard'
+        },
+        TelemetryEvents.BILLING_DOWNGRADE_TO_PERSONAL_SUCCEEDED
+      ],
+      [
+        {
+          operation: 'downgrade_to_personal',
+          stage: 'failed',
+          outcome: 'failure',
+          member_removal_count: 2,
+          member_removal_failures: 1,
+          failure_category: 'unknown',
+          error_code: 'member_removal_failed'
+        },
+        TelemetryEvents.BILLING_DOWNGRADE_TO_PERSONAL_FAILED
+      ]
+    ])('captures canonical billing event %#', async ([event, eventName]) => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackBillingEvent(event)
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(eventName, event)
     })
 
     it('captures begin_checkout with intent metadata', async () => {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -11,15 +11,11 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 import type {
   AddCreditsClickMetadata,
-  ApiCreditTopupFailedMetadata,
   AuthErrorMetadata,
   AuthMetadata,
   BeginCheckoutMetadata,
-  BillingOperationOutcomeMetadata,
+  BillingTelemetryEvent,
   DefaultViewSetMetadata,
-  DowngradeToPersonalFailedMetadata,
-  DowngradeToPersonalStartedMetadata,
-  DowngradeToPersonalSucceededMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
   ShareLinkOpenedMetadata,
@@ -33,13 +29,11 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   ResubscribeClickMetadata,
-  ResubscribeOutcomeMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
   SharedWorkflowRunMetadata,
   ShellLayoutMetadata,
   SubscriptionCancellationMetadata,
-  SubscriptionCheckoutFailedMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -58,7 +52,11 @@ import type {
   WorkspaceInviteFailedMetadata,
   WorkspaceInviteMetadata
 } from '../../types'
-import { CANCELLATION_STAGE_EVENTS, TelemetryEvents } from '../../types'
+import {
+  CANCELLATION_STAGE_EVENTS,
+  getBillingTelemetryEventName,
+  TelemetryEvents
+} from '../../types'
 import { normalizeSurveyResponses } from '../../utils/surveyNormalization'
 
 const DEFAULT_DISABLED_EVENTS = [
@@ -411,14 +409,6 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.RESUBSCRIBE_BUTTON_CLICKED, metadata)
   }
 
-  trackResubscribeSucceeded(metadata: ResubscribeOutcomeMetadata): void {
-    this.trackEvent(TelemetryEvents.RESUBSCRIBE_SUCCEEDED, metadata)
-  }
-
-  trackResubscribeFailed(metadata: ResubscribeOutcomeMetadata): void {
-    this.trackEvent(TelemetryEvents.RESUBSCRIBE_FAILED, metadata)
-  }
-
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void {
     this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED, {
       credit_amount: amount
@@ -429,10 +419,6 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
   }
 
-  trackApiCreditTopupFailed(metadata?: ApiCreditTopupFailedMetadata): void {
-    this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_FAILED, metadata)
-  }
-
   trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
     this.trackEvent(TelemetryEvents.WORKSPACE_INVITE_SENT, metadata)
   }
@@ -441,38 +427,8 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.WORKSPACE_INVITE_FAILED, metadata)
   }
 
-  trackBillingOperationFailed(metadata: BillingOperationOutcomeMetadata): void {
-    this.trackEvent(TelemetryEvents.BILLING_OPERATION_FAILED, metadata)
-  }
-
-  trackBillingOperationTimeout(
-    metadata: BillingOperationOutcomeMetadata
-  ): void {
-    this.trackEvent(TelemetryEvents.BILLING_OPERATION_TIMEOUT, metadata)
-  }
-
-  trackDowngradeToPersonalStarted(
-    metadata: DowngradeToPersonalStartedMetadata
-  ): void {
-    this.trackEvent(TelemetryEvents.DOWNGRADE_TO_PERSONAL_STARTED, metadata)
-  }
-
-  trackDowngradeToPersonalSucceeded(
-    metadata: DowngradeToPersonalSucceededMetadata
-  ): void {
-    this.trackEvent(TelemetryEvents.DOWNGRADE_TO_PERSONAL_SUCCEEDED, metadata)
-  }
-
-  trackDowngradeToPersonalFailed(
-    metadata: DowngradeToPersonalFailedMetadata
-  ): void {
-    this.trackEvent(TelemetryEvents.DOWNGRADE_TO_PERSONAL_FAILED, metadata)
-  }
-
-  trackSubscriptionCheckoutFailed(
-    metadata: SubscriptionCheckoutFailedMetadata
-  ): void {
-    this.trackEvent(TelemetryEvents.SUBSCRIPTION_CHECKOUT_FAILED, metadata)
+  trackBillingEvent(event: BillingTelemetryEvent): void {
+    this.trackEvent(getBillingTelemetryEventName(event), event)
   }
 
   trackRunButton(properties: RunButtonProperties): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -557,7 +557,7 @@ export interface WorkspaceInviteFailedMetadata extends Record<string, unknown> {
   failed_count: number
 }
 
-export type BillingFailureCategory =
+type BillingFailureCategory =
   | 'validation'
   | 'network'
   | 'api_rejected'
@@ -568,7 +568,7 @@ export type BillingFailureCategory =
   | 'rendering'
   | 'unknown'
 
-export type BillingErrorCode =
+type BillingErrorCode =
   | 'downgrade_not_allowed'
   | 'member_removal_failed'
   | 'missing_checkout_response'

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -557,64 +557,106 @@ export interface WorkspaceInviteFailedMetadata extends Record<string, unknown> {
   failed_count: number
 }
 
-/**
- * Shared shape for the billing-operation poller's terminal-failure events.
- * Used for both a definite failure and a client-side poll timeout.
- */
-export interface BillingOperationOutcomeMetadata extends Record<
-  string,
-  unknown
-> {
+export type BillingFailureCategory =
+  | 'validation'
+  | 'network'
+  | 'api_rejected'
+  | 'provider_decline'
+  | 'redirect'
+  | 'poll_timeout'
+  | 'stale_operation'
+  | 'rendering'
+  | 'unknown'
+
+export type BillingErrorCode =
+  | 'downgrade_not_allowed'
+  | 'member_removal_failed'
+  | 'missing_checkout_response'
+  | 'missing_payment_method_url'
+  | 'payment_popup_blocked'
+
+export interface BillingFailure {
+  failure_category: BillingFailureCategory
+  error_code?: BillingErrorCode
+}
+
+type BillingStarted = {
+  stage: 'started'
+  outcome: 'pending'
+}
+
+type BillingSucceeded = {
+  stage: 'succeeded'
+  outcome: 'success'
+}
+
+type BillingFailed = BillingFailure & {
+  stage: 'failed'
+  outcome: 'failure'
+}
+
+type BillingTimedOut = {
+  stage: 'timeout'
+  outcome: 'failure'
+  failure_category: 'poll_timeout'
+}
+
+type SubscriptionCheckoutBillingEvent = {
+  operation: 'subscription_checkout'
+  billing_op_id?: string
+  tier?: SubscriptionCheckoutTier
+  cycle?: BillingCycle
+  checkout_type?: SubscriptionCheckoutType
+  payment_intent_source?: PaymentIntentSource
+} & (BillingSucceeded | BillingFailed)
+
+type BillingOperationBillingEvent = {
+  operation: 'operation'
   billing_op_id: string
   operation_type: 'subscription' | 'topup' | 'cancel'
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
-  failure_reason?: string
-}
+  checkout_type?: SubscriptionCheckoutType
+  payment_intent_source?: PaymentIntentSource
+} & (BillingFailed | BillingTimedOut)
 
-export interface ResubscribeOutcomeMetadata extends Record<string, unknown> {
+type ResubscribeBillingEvent = {
+  operation: 'resubscribe'
   source: ResubscribeClickMetadata['source']
-  /** Present only on the failed event. */
-  error_message?: string
-}
+  payment_intent_source?: PaymentIntentSource
+} & (BillingSucceeded | BillingFailed)
 
-export interface ApiCreditTopupFailedMetadata extends Record<string, unknown> {
-  error_message?: string
-}
+type TopupBillingEvent = {
+  operation: 'topup'
+  billing_op_id?: string
+} & (BillingSucceeded | BillingFailed)
 
-export interface DowngradeToPersonalStartedMetadata extends Record<
-  string,
-  unknown
-> {
-  member_removal_count: number
-}
-
-export interface DowngradeToPersonalSucceededMetadata extends Record<
-  string,
-  unknown
-> {
+type DowngradeToPersonalBillingEvent = {
+  operation: 'downgrade_to_personal'
   member_removal_count: number
   member_removal_failures: number
   target_tier?: TierKey
-}
+} & (BillingStarted | BillingSucceeded | BillingFailed)
 
-export interface DowngradeToPersonalFailedMetadata extends Record<
-  string,
-  unknown
-> {
-  member_removal_count: number
-  member_removal_failures: number
-  failure_reason: string
-}
+export type BillingTelemetryEvent =
+  | SubscriptionCheckoutBillingEvent
+  | BillingOperationBillingEvent
+  | ResubscribeBillingEvent
+  | TopupBillingEvent
+  | DowngradeToPersonalBillingEvent
 
-export interface SubscriptionCheckoutFailedMetadata extends Record<
-  string,
-  unknown
-> {
-  tier: TierKey
-  cycle: BillingCycle
-  checkout_type: SubscriptionCheckoutType
-  error_message?: string
+type BillingTelemetryEventNameFor<T extends BillingTelemetryEvent> =
+  T extends BillingTelemetryEvent
+    ? `billing.${T['operation']}.${T['stage']}`
+    : never
+
+export type BillingTelemetryEventName =
+  BillingTelemetryEventNameFor<BillingTelemetryEvent>
+
+export function getBillingTelemetryEventName(
+  event: BillingTelemetryEvent
+): BillingTelemetryEventName {
+  return `billing.${event.operation}.${event.stage}` as BillingTelemetryEventName
 }
 
 /**
@@ -643,35 +685,14 @@ export interface TelemetryProvider {
     metadata?: SubscriptionCancellationMetadata
   ): void
   trackResubscribeClicked?(metadata: ResubscribeClickMetadata): void
-  trackResubscribeSucceeded?(metadata: ResubscribeOutcomeMetadata): void
-  trackResubscribeFailed?(metadata: ResubscribeOutcomeMetadata): void
   trackAddApiCreditButtonClicked?(metadata?: AddCreditsClickMetadata): void
   trackApiCreditTopupButtonPurchaseClicked?(amount: number): void
   trackApiCreditTopupSucceeded?(): void
-  trackApiCreditTopupFailed?(metadata?: ApiCreditTopupFailedMetadata): void
   trackWorkspaceInviteSent?(metadata: WorkspaceInviteMetadata): void
   trackWorkspaceInviteFailed?(metadata: WorkspaceInviteFailedMetadata): void
   trackRunButton?(properties: RunButtonProperties): void
 
-  // Workspace billing-operation poller events (subscribe, plan change, topup, cancel)
-  trackBillingOperationFailed?(metadata: BillingOperationOutcomeMetadata): void
-  trackBillingOperationTimeout?(metadata: BillingOperationOutcomeMetadata): void
-
-  // Team-to-personal downgrade lifecycle events
-  trackDowngradeToPersonalStarted?(
-    metadata: DowngradeToPersonalStartedMetadata
-  ): void
-  trackDowngradeToPersonalSucceeded?(
-    metadata: DowngradeToPersonalSucceededMetadata
-  ): void
-  trackDowngradeToPersonalFailed?(
-    metadata: DowngradeToPersonalFailedMetadata
-  ): void
-
-  // Legacy-rail subscribe checkout failure (before a checkout_url is obtained)
-  trackSubscriptionCheckoutFailed?(
-    metadata: SubscriptionCheckoutFailedMetadata
-  ): void
+  trackBillingEvent?(event: BillingTelemetryEvent): void
 
   // Credit top-up tracking (composition with internal utilities)
   startTopupTracking?(): void
@@ -777,22 +798,29 @@ export const TelemetryEvents = {
   SUBSCRIPTION_CANCEL_ABANDONED: 'app:subscription_cancel_abandoned',
   SUBSCRIPTION_CANCEL_FAILED: 'app:subscription_cancel_failed',
   RESUBSCRIBE_BUTTON_CLICKED: 'app:resubscribe_button_clicked',
-  RESUBSCRIBE_SUCCEEDED: 'app:resubscribe_succeeded',
-  RESUBSCRIBE_FAILED: 'app:resubscribe_failed',
   ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
   API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
     'app:api_credit_topup_button_purchase_clicked',
   API_CREDIT_TOPUP_SUCCEEDED: 'app:api_credit_topup_succeeded',
-  API_CREDIT_TOPUP_FAILED: 'app:api_credit_topup_failed',
   WORKSPACE_INVITE_SENT: 'app:workspace_invite_sent',
   WORKSPACE_INVITE_FAILED: 'app:workspace_invite_failed',
-  BILLING_OPERATION_FAILED: 'app:billing_operation_failed',
-  BILLING_OPERATION_TIMEOUT: 'app:billing_operation_timeout',
-  DOWNGRADE_TO_PERSONAL_STARTED: 'app:downgrade_to_personal_started',
-  DOWNGRADE_TO_PERSONAL_SUCCEEDED: 'app:downgrade_to_personal_succeeded',
-  DOWNGRADE_TO_PERSONAL_FAILED: 'app:downgrade_to_personal_failed',
-  SUBSCRIPTION_CHECKOUT_FAILED: 'app:subscription_checkout_failed',
   BEGIN_CHECKOUT: 'begin_checkout',
+
+  // Canonical Billing Lifecycle
+  BILLING_SUBSCRIPTION_CHECKOUT_SUCCEEDED:
+    'billing.subscription_checkout.succeeded',
+  BILLING_SUBSCRIPTION_CHECKOUT_FAILED: 'billing.subscription_checkout.failed',
+  BILLING_OPERATION_FAILED: 'billing.operation.failed',
+  BILLING_OPERATION_TIMEOUT: 'billing.operation.timeout',
+  BILLING_RESUBSCRIBE_SUCCEEDED: 'billing.resubscribe.succeeded',
+  BILLING_RESUBSCRIBE_FAILED: 'billing.resubscribe.failed',
+  BILLING_TOPUP_SUCCEEDED: 'billing.topup.succeeded',
+  BILLING_TOPUP_FAILED: 'billing.topup.failed',
+  BILLING_DOWNGRADE_TO_PERSONAL_STARTED:
+    'billing.downgrade_to_personal.started',
+  BILLING_DOWNGRADE_TO_PERSONAL_SUCCEEDED:
+    'billing.downgrade_to_personal.succeeded',
+  BILLING_DOWNGRADE_TO_PERSONAL_FAILED: 'billing.downgrade_to_personal.failed',
 
   // Onboarding Survey
   USER_SURVEY_OPENED: 'app:user_survey_opened',
@@ -913,10 +941,4 @@ export type TelemetryEventProperties =
   | SubscriptionMetadata
   | SubscriptionSuccessMetadata
   | WorkspaceInviteFailedMetadata
-  | BillingOperationOutcomeMetadata
-  | ResubscribeOutcomeMetadata
-  | ApiCreditTopupFailedMetadata
-  | DowngradeToPersonalStartedMetadata
-  | DowngradeToPersonalSucceededMetadata
-  | DowngradeToPersonalFailedMetadata
-  | SubscriptionCheckoutFailedMetadata
+  | BillingTelemetryEvent

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -15,6 +15,7 @@ const mockShowSettings = vi.fn()
 const mockToastAdd = vi.fn()
 const mockCloseDialog = vi.fn()
 const mockTrackTopUpPurchase = vi.fn()
+const mockTrackBillingEvent = vi.fn()
 const mockCanTopUp = vi.hoisted(() => ({ value: true }))
 const mockShouldUseWorkspaceBilling = vi.hoisted(() => ({ value: true }))
 
@@ -64,7 +65,7 @@ vi.mock('@/stores/dialogStore', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackApiCreditTopupButtonPurchaseClicked: mockTrackTopUpPurchase,
-    trackApiCreditTopupSucceeded: vi.fn()
+    trackBillingEvent: mockTrackBillingEvent
   })
 }))
 
@@ -167,6 +168,12 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(mockFetchBalance).toHaveBeenCalledOnce()
     expect(mockFetchStatus).toHaveBeenCalledOnce()
     expect(mockShowSettings).toHaveBeenCalledWith('workspace')
+    expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+      operation: 'topup',
+      stage: 'succeeded',
+      outcome: 'success',
+      billing_op_id: 'op-1'
+    })
   })
 
   it('does not refresh balance or status for a pending top-up', async () => {
@@ -178,6 +185,7 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     expect(mockStartOperation).toHaveBeenCalledWith('op-1', 'topup')
     expect(mockFetchBalance).not.toHaveBeenCalled()
     expect(mockFetchStatus).not.toHaveBeenCalled()
+    expect(mockTrackBillingEvent).not.toHaveBeenCalled()
   })
 
   it('does not refresh balance or status for a failed top-up', async () => {
@@ -188,6 +196,13 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
 
     expect(mockFetchBalance).not.toHaveBeenCalled()
     expect(mockFetchStatus).not.toHaveBeenCalled()
+    expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+      operation: 'topup',
+      stage: 'failed',
+      outcome: 'failure',
+      billing_op_id: 'op-1',
+      failure_category: 'unknown'
+    })
   })
 
   it('does not top up after the workspace role loses permission', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -270,7 +270,12 @@ async function handleBuy() {
     if (!response) return
 
     if (response.status === 'completed') {
-      telemetry?.trackApiCreditTopupSucceeded()
+      telemetry?.trackBillingEvent({
+        operation: 'topup',
+        stage: 'succeeded',
+        outcome: 'success',
+        billing_op_id: response.billing_op_id
+      })
       toast.add({
         severity: 'success',
         summary: t('credits.topUp.purchaseSuccess'),
@@ -282,6 +287,13 @@ async function handleBuy() {
     } else if (response.status === 'pending') {
       billingOperationStore.startOperation(response.billing_op_id, 'topup')
     } else {
+      telemetry?.trackBillingEvent({
+        operation: 'topup',
+        stage: 'failed',
+        outcome: 'failure',
+        billing_op_id: response.billing_op_id,
+        failure_category: 'unknown'
+      })
       toast.add({
         severity: 'error',
         summary: t('credits.topUp.purchaseError'),
@@ -293,6 +305,12 @@ async function handleBuy() {
 
     const errorMessage =
       error instanceof Error ? error.message : t('credits.topUp.unknownError')
+    telemetry?.trackBillingEvent({
+      operation: 'topup',
+      stage: 'failed',
+      outcome: 'failure',
+      failure_category: 'unknown'
+    })
     toast.add({
       severity: 'error',
       summary: t('credits.topUp.purchaseError'),

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -12,9 +12,7 @@ const mockFetchMembers = vi.hoisted(() => vi.fn())
 const mockSubscribe = vi.hoisted(() => vi.fn())
 const mockPreviewSubscribe = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
-const mockTrackDowngradeToPersonalStarted = vi.hoisted(() => vi.fn())
-const mockTrackDowngradeToPersonalSucceeded = vi.hoisted(() => vi.fn())
-const mockTrackDowngradeToPersonalFailed = vi.hoisted(() => vi.fn())
+const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 const mockPermissions = vi.hoisted(() => ({
   value: {
     canManageSubscription: true,
@@ -72,9 +70,7 @@ vi.mock('@/config/comfyApi', () => ({
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackDowngradeToPersonalStarted: mockTrackDowngradeToPersonalStarted,
-    trackDowngradeToPersonalSucceeded: mockTrackDowngradeToPersonalSucceeded,
-    trackDowngradeToPersonalFailed: mockTrackDowngradeToPersonalFailed
+    trackBillingEvent: mockTrackBillingEvent
   })
 }))
 
@@ -307,7 +303,10 @@ describe('useDowngradeToPersonal', () => {
       const result = await downgradeToPersonal('creator-annual')
 
       expect(result).toStrictEqual({ preview, response })
-      expect(mockTrackDowngradeToPersonalSucceeded).toHaveBeenCalledWith({
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'downgrade_to_personal',
+        stage: 'succeeded',
+        outcome: 'success',
         member_removal_count: 0,
         member_removal_failures: 0,
         target_tier: 'creator'
@@ -345,7 +344,14 @@ describe('useDowngradeToPersonal', () => {
         '_blank'
       )
       expect(mockStartOperation).toHaveBeenCalledWith('op-2', 'subscription', {
-        tier: undefined
+        tier: undefined,
+        cycle: undefined,
+        checkoutType: 'change',
+        downgradeToPersonal: {
+          memberRemovalCount: 1,
+          memberRemovalFailures: 0,
+          targetTier: undefined
+        }
       })
     })
 
@@ -401,8 +407,18 @@ describe('useDowngradeToPersonal', () => {
 
       expect(windowOpen).not.toHaveBeenCalled()
       expect(mockStartOperation).toHaveBeenCalledWith('op-4', 'subscription', {
-        tier: undefined
+        tier: undefined,
+        cycle: undefined,
+        checkoutType: 'change',
+        downgradeToPersonal: {
+          memberRemovalCount: 1,
+          memberRemovalFailures: 0,
+          targetTier: undefined
+        }
       })
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'succeeded' })
+      )
     })
 
     it('reports the generic failure when subscribe fails and no members were removed', async () => {
@@ -447,12 +463,16 @@ describe('useDowngradeToPersonal', () => {
 
       await downgradeToPersonal('founder-monthly')
 
-      expect(mockTrackDowngradeToPersonalStarted).toHaveBeenCalledWith({
-        member_removal_count: 2
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'downgrade_to_personal',
+        stage: 'started',
+        outcome: 'pending',
+        member_removal_count: 2,
+        member_removal_failures: 0
       })
     })
 
-    it('tracks a failed outcome with the removal-failure count and reason', async () => {
+    it('tracks a failed outcome without the member email', async () => {
       mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation((id: string) =>
         id === 'm2' ? Promise.reject(new Error('network')) : Promise.resolve()
@@ -463,25 +483,36 @@ describe('useDowngradeToPersonal', () => {
         'm2@example.com'
       )
 
-      expect(mockTrackDowngradeToPersonalFailed).toHaveBeenCalledWith({
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'downgrade_to_personal',
+        stage: 'failed',
+        outcome: 'failure',
         member_removal_count: 2,
         member_removal_failures: 1,
-        failure_reason: expect.stringContaining('m2@example.com')
+        target_tier: undefined,
+        failure_category: 'unknown',
+        error_code: 'member_removal_failed'
       })
-      expect(mockTrackDowngradeToPersonalSucceeded).not.toHaveBeenCalled()
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stage: 'succeeded' })
+      )
     })
 
-    it('falls back to a generic failure reason when a non-Error value is thrown', async () => {
+    it('uses a bounded unknown category when a non-Error value is thrown', async () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       mockPreviewSubscribe.mockRejectedValue('boom')
       const { downgradeToPersonal } = useDowngradeToPersonal()
 
       await expect(downgradeToPersonal('founder-monthly')).rejects.toBe('boom')
 
-      expect(mockTrackDowngradeToPersonalFailed).toHaveBeenCalledWith({
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'downgrade_to_personal',
+        stage: 'failed',
+        outcome: 'failure',
         member_removal_count: 1,
         member_removal_failures: 0,
-        failure_reason: 'unknown error'
+        target_tier: undefined,
+        failure_category: 'unknown'
       })
     })
   })

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -7,7 +7,9 @@ import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import { useTelemetry } from '@/platform/telemetry'
+import type { BillingFailure } from '@/platform/telemetry/types'
 import type {
   PreviewSubscribeResponse,
   SubscribeResponse
@@ -69,21 +71,35 @@ export function useDowngradeToPersonal() {
     const membersToRemove = removableMembers.value
     let memberRemovalFailures = 0
     let targetTier: TierKey | undefined
+    let targetCycle: BillingCycle | undefined
+    let telemetryFailure: BillingFailure = { failure_category: 'unknown' }
 
-    telemetry?.trackDowngradeToPersonalStarted({
-      member_removal_count: membersToRemove.length
+    telemetry?.trackBillingEvent({
+      operation: 'downgrade_to_personal',
+      stage: 'started',
+      outcome: 'pending',
+      member_removal_count: membersToRemove.length,
+      member_removal_failures: 0
     })
 
-    const trackSucceeded = () =>
-      telemetry?.trackDowngradeToPersonalSucceeded({
+    function trackSucceeded() {
+      telemetry?.trackBillingEvent({
+        operation: 'downgrade_to_personal',
+        stage: 'succeeded',
+        outcome: 'success',
         member_removal_count: membersToRemove.length,
         member_removal_failures: memberRemovalFailures,
         target_tier: targetTier
       })
+    }
 
     try {
       const preview = await previewSubscribe(planSlug)
       if (!preview?.allowed) {
+        telemetryFailure = {
+          failure_category: 'validation',
+          error_code: 'downgrade_not_allowed'
+        }
         throw new Error(
           preview?.reason || t('subscription.downgrade.notAllowed')
         )
@@ -92,6 +108,11 @@ export function useDowngradeToPersonal() {
       targetTier = preview.new_plan?.tier
         ? TIER_TO_KEY[preview.new_plan.tier]
         : undefined
+      targetCycle = preview.new_plan
+        ? preview.new_plan.duration === 'ANNUAL'
+          ? 'yearly'
+          : 'monthly'
+        : undefined
 
       for (const member of membersToRemove) {
         ensureCanDowngrade()
@@ -99,6 +120,10 @@ export function useDowngradeToPersonal() {
           await workspaceStore.removeMember(member.id)
         } catch (error) {
           memberRemovalFailures += 1
+          telemetryFailure = {
+            failure_category: 'unknown',
+            error_code: 'member_removal_failed'
+          }
           throw new Error(
             t('subscription.downgrade.memberRemovalFailed', {
               email: member.email
@@ -114,6 +139,10 @@ export function useDowngradeToPersonal() {
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
       })
       if (!response) {
+        telemetryFailure = {
+          failure_category: 'unknown',
+          error_code: 'missing_checkout_response'
+        }
         throw new Error(
           membersToRemove.length > 0
             ? t('subscription.downgrade.failedAfterMemberRemoval')
@@ -123,18 +152,34 @@ export function useDowngradeToPersonal() {
 
       if (response.status === 'needs_payment_method') {
         if (!response.payment_method_url) {
+          telemetryFailure = {
+            failure_category: 'redirect',
+            error_code: 'missing_payment_method_url'
+          }
           throw new Error(t('subscription.downgrade.paymentMethodRequired'))
         }
         const paymentTab = window.open(response.payment_method_url, '_blank')
         if (!paymentTab) {
+          telemetryFailure = {
+            failure_category: 'redirect',
+            error_code: 'payment_popup_blocked'
+          }
           throw new Error(t('subscription.downgrade.paymentPageBlocked'))
         }
         void billingOperationStore.startOperation(
           response.billing_op_id,
           'subscription',
-          { tier: targetTier }
+          {
+            tier: targetTier,
+            cycle: targetCycle,
+            checkoutType: 'change',
+            downgradeToPersonal: {
+              memberRemovalCount: membersToRemove.length,
+              memberRemovalFailures,
+              targetTier
+            }
+          }
         )
-        trackSucceeded()
         return null
       }
 
@@ -142,19 +187,31 @@ export function useDowngradeToPersonal() {
         void billingOperationStore.startOperation(
           response.billing_op_id,
           'subscription',
-          { tier: targetTier }
+          {
+            tier: targetTier,
+            cycle: targetCycle,
+            checkoutType: 'change',
+            downgradeToPersonal: {
+              memberRemovalCount: membersToRemove.length,
+              memberRemovalFailures,
+              targetTier
+            }
+          }
         )
-        trackSucceeded()
         return null
       }
 
       trackSucceeded()
       return { preview, response }
     } catch (error) {
-      telemetry?.trackDowngradeToPersonalFailed({
+      telemetry?.trackBillingEvent({
+        operation: 'downgrade_to_personal',
+        stage: 'failed',
+        outcome: 'failure',
         member_removal_count: membersToRemove.length,
         member_removal_failures: memberRemovalFailures,
-        failure_reason: error instanceof Error ? error.message : 'unknown error'
+        target_tier: targetTier,
+        ...telemetryFailure
       })
       throw error
     }

--- a/src/platform/workspace/composables/useResubscribe.test.ts
+++ b/src/platform/workspace/composables/useResubscribe.test.ts
@@ -8,8 +8,7 @@ const state = vi.hoisted(() => ({
   resubscribe: vi.fn(),
   toastAdd: vi.fn(),
   trackResubscribeClicked: vi.fn(),
-  trackResubscribeSucceeded: vi.fn(),
-  trackResubscribeFailed: vi.fn()
+  trackBillingEvent: vi.fn()
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -41,8 +40,7 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackResubscribeClicked: state.trackResubscribeClicked,
-    trackResubscribeSucceeded: state.trackResubscribeSucceeded,
-    trackResubscribeFailed: state.trackResubscribeFailed
+    trackBillingEvent: state.trackBillingEvent
   })
 }))
 
@@ -83,13 +81,21 @@ describe('useResubscribe', () => {
 
     expect(state.resubscribe).toHaveBeenCalledOnce()
     expect(state.trackResubscribeClicked).toHaveBeenCalledOnce()
+    expect(state.trackBillingEvent).toHaveBeenCalledWith({
+      operation: 'resubscribe',
+      stage: 'succeeded',
+      outcome: 'success',
+      source: 'settings_billing_panel'
+    })
     expect(state.toastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'success' })
     )
   })
 
   it('shows an error and resets loading when resubscription fails', async () => {
-    state.resubscribe.mockRejectedValueOnce(new Error('Resubscribe failed'))
+    state.resubscribe.mockRejectedValueOnce(
+      new Error('Resubscribe failed for person@example.com')
+    )
     const { handleResubscribe, isResubscribing } = useResubscribe()
 
     await handleResubscribe()
@@ -98,9 +104,16 @@ describe('useResubscribe', () => {
     expect(state.toastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
-        detail: 'Resubscribe failed'
+        detail: 'Resubscribe failed for person@example.com'
       })
     )
+    expect(state.trackBillingEvent).toHaveBeenCalledWith({
+      operation: 'resubscribe',
+      stage: 'failed',
+      outcome: 'failure',
+      source: 'settings_billing_panel',
+      failure_category: 'unknown'
+    })
     expect(isResubscribing.value).toBe(false)
   })
 })

--- a/src/platform/workspace/composables/useResubscribe.ts
+++ b/src/platform/workspace/composables/useResubscribe.ts
@@ -34,7 +34,10 @@ export function useResubscribe() {
     isResubscribing.value = true
     try {
       await resubscribe()
-      useTelemetry()?.trackResubscribeSucceeded({
+      useTelemetry()?.trackBillingEvent({
+        operation: 'resubscribe',
+        stage: 'succeeded',
+        outcome: 'success',
         source: 'settings_billing_panel'
       })
       toast.add({
@@ -47,9 +50,12 @@ export function useResubscribe() {
         error instanceof Error && error.message.trim()
           ? error.message
           : t('subscription.resubscribeFailed')
-      useTelemetry()?.trackResubscribeFailed({
+      useTelemetry()?.trackBillingEvent({
+        operation: 'resubscribe',
+        stage: 'failed',
+        outcome: 'failure',
         source: 'settings_billing_panel',
-        error_message: detail
+        failure_category: 'unknown'
       })
       toast.add({
         severity: 'error',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -79,7 +79,7 @@ const {
   mockToastAdd,
   mockStartOperation,
   mockTrackBeginCheckout,
-  mockTrackMonthlySubscriptionSucceeded,
+  mockTrackBillingEvent,
   mockShowDowngradeToPersonalDialog,
   mockUserId,
   mockIsTeamPlan,
@@ -95,7 +95,7 @@ const {
   mockToastAdd: vi.fn(),
   mockStartOperation: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
-  mockTrackMonthlySubscriptionSucceeded: vi.fn(),
+  mockTrackBillingEvent: vi.fn(),
   mockShowDowngradeToPersonalDialog: vi.fn(),
   mockUserId: { value: 'user-1' as string | null },
   mockIsTeamPlan: { value: false },
@@ -158,15 +158,11 @@ vi.mock('primevue/usetoast', () => ({
 }))
 
 const mockTrackResubscribeClicked = vi.hoisted(() => vi.fn())
-const mockTrackResubscribeSucceeded = vi.hoisted(() => vi.fn())
-const mockTrackResubscribeFailed = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackMonthlySubscriptionSucceeded: mockTrackMonthlySubscriptionSucceeded,
+    trackBillingEvent: mockTrackBillingEvent,
     trackResubscribeClicked: mockTrackResubscribeClicked,
-    trackResubscribeSucceeded: mockTrackResubscribeSucceeded,
-    trackResubscribeFailed: mockTrackResubscribeFailed,
     trackBeginCheckout: mockTrackBeginCheckout
   })
 }))
@@ -458,7 +454,7 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.previewData.value).toStrictEqual(preview)
       expect(checkout.checkoutStep.value).toBe('success')
-      expect(mockTrackMonthlySubscriptionSucceeded).not.toHaveBeenCalled()
+      expect(mockTrackBillingEvent).not.toHaveBeenCalled()
       expect(mockToastAdd).not.toHaveBeenCalled()
       expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -487,7 +483,16 @@ describe('useSubscriptionCheckout', () => {
       })
 
       expect(checkout.checkoutStep.value).toBe('success')
-      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'subscription_checkout',
+        stage: 'succeeded',
+        outcome: 'success',
+        tier: 'creator',
+        cycle: 'monthly',
+        checkout_type: 'change',
+        payment_intent_source: undefined,
+        billing_op_id: 'immediate-downgrade'
+      })
     })
   })
 
@@ -907,7 +912,16 @@ describe('useSubscriptionCheckout', () => {
         cancelUrl: 'https://platform.comfy.org/payment/failed'
       })
       expect(checkout.checkoutStep.value).toBe('success')
-      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'subscription_checkout',
+        stage: 'succeeded',
+        outcome: 'success',
+        tier: 'standard',
+        cycle: 'yearly',
+        checkout_type: 'new',
+        payment_intent_source: undefined,
+        billing_op_id: 'op-1'
+      })
       expect(mockFetchStatus).not.toHaveBeenCalled()
       expect(mockFetchBalance).not.toHaveBeenCalled()
     })
@@ -1009,7 +1023,12 @@ describe('useSubscriptionCheckout', () => {
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-no-url',
         'subscription',
-        { tier: 'standard', cycle: 'yearly' }
+        {
+          tier: 'standard',
+          cycle: 'yearly',
+          checkoutType: 'new',
+          paymentIntentSource: undefined
+        }
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1032,7 +1051,12 @@ describe('useSubscriptionCheckout', () => {
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-1',
         'subscription',
-        { tier: 'standard', cycle: 'yearly' }
+        {
+          tier: 'standard',
+          cycle: 'yearly',
+          checkoutType: 'new',
+          paymentIntentSource: undefined
+        }
       )
       expect(checkout.checkoutStep.value).toBe('success')
       openSpy.mockRestore()
@@ -1054,7 +1078,12 @@ describe('useSubscriptionCheckout', () => {
       expect(mockStartOperation).toHaveBeenCalledWith(
         'op-async-2',
         'subscription',
-        { tier: 'standard', cycle: 'yearly' }
+        {
+          tier: 'standard',
+          cycle: 'yearly',
+          checkoutType: 'new',
+          paymentIntentSource: undefined
+        }
       )
       expect(checkout.checkoutStep.value).toBe('preview')
     })
@@ -1161,20 +1190,37 @@ describe('useSubscriptionCheckout', () => {
         source: 'pricing_dialog',
         payment_intent_source: 'subscribe_to_run'
       })
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'resubscribe',
+        stage: 'succeeded',
+        outcome: 'success',
+        source: 'pricing_dialog',
+        payment_intent_source: 'subscribe_to_run'
+      })
     })
 
     it('shows error toast on failure', async () => {
       const checkout = await setup()
-      mockResubscribe.mockRejectedValueOnce(new Error('Resubscribe failed'))
+      mockResubscribe.mockRejectedValueOnce(
+        new Error('Resubscribe failed for person@example.com')
+      )
 
       await checkout.handleResubscribe()
 
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: 'error',
-          detail: 'Resubscribe failed'
+          detail: 'Resubscribe failed for person@example.com'
         })
       )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'resubscribe',
+        stage: 'failed',
+        outcome: 'failure',
+        source: 'pricing_dialog',
+        payment_intent_source: undefined,
+        failure_category: 'unknown'
+      })
     })
 
     it('does not resubscribe for a member', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -347,10 +347,14 @@ export function useSubscriptionCheckout(
 
     if (response.status === 'subscribed') {
       if (shouldTrackSubscriptionSuccess) {
-        telemetry?.trackMonthlySubscriptionSucceeded({
+        telemetry?.trackBillingEvent({
+          operation: 'subscription_checkout',
+          stage: 'succeeded',
+          outcome: 'success',
           tier: context.tier,
           cycle: context.cycle,
           checkout_type: context.checkoutType,
+          payment_intent_source: paymentIntentSource,
           billing_op_id: response.billing_op_id
         })
       }
@@ -390,7 +394,12 @@ export function useSubscriptionCheckout(
     const operation = await billingOperationStore.startOperation(
       opId,
       'subscription',
-      { tier: context.tier, cycle: context.cycle }
+      {
+        tier: context.tier,
+        cycle: context.cycle,
+        checkoutType: context.checkoutType,
+        paymentIntentSource
+      }
     )
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
   }
@@ -452,7 +461,13 @@ export function useSubscriptionCheckout(
     isResubscribing.value = true
     try {
       await resubscribe()
-      telemetry?.trackResubscribeSucceeded({ source: 'pricing_dialog' })
+      telemetry?.trackBillingEvent({
+        operation: 'resubscribe',
+        stage: 'succeeded',
+        outcome: 'success',
+        source: 'pricing_dialog',
+        payment_intent_source: paymentIntentSource
+      })
       toast.add({
         severity: 'success',
         summary: t('subscription.resubscribeSuccess'),
@@ -462,9 +477,13 @@ export function useSubscriptionCheckout(
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to resubscribe'
-      telemetry?.trackResubscribeFailed({
+      telemetry?.trackBillingEvent({
+        operation: 'resubscribe',
+        stage: 'failed',
+        outcome: 'failure',
         source: 'pricing_dialog',
-        error_message: message
+        payment_intent_source: paymentIntentSource,
+        failure_category: 'unknown'
       })
       toast.add({
         severity: 'error',

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -756,6 +756,23 @@ describe('useWorkspaceBilling', () => {
       expect(billing.isLoading.value).toBe(false)
     })
 
+    it('keeps the mutation successful when reconciliation fails', async () => {
+      mockWorkspaceApi.resubscribe.mockResolvedValue(undefined)
+      mockWorkspaceApi.getBillingStatus.mockRejectedValue(
+        new Error('status unavailable')
+      )
+      mockWorkspaceApi.getBillingBalance.mockRejectedValue(
+        new Error('balance unavailable')
+      )
+
+      const billing = setupBilling()
+
+      await expect(billing.resubscribe()).resolves.toBeUndefined()
+      expect(mockWorkspaceApi.resubscribe).toHaveBeenCalledOnce()
+      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledOnce()
+      expect(mockWorkspaceApi.getBillingBalance).toHaveBeenCalledOnce()
+    })
+
     it('sets error, rethrows, and skips the refresh when the API call fails', async () => {
       mockWorkspaceApi.resubscribe.mockRejectedValue(
         new Error('reactivation failed')

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -290,7 +290,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     error.value = null
     try {
       await workspaceApi.resubscribe()
-      await Promise.all([fetchStatus(), fetchBalance()])
+      await Promise.allSettled([fetchStatus(), fetchBalance()])
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to resubscribe'
       throw err

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -53,17 +53,11 @@ vi.mock('@/stores/dialogStore', () => ({
   })
 }))
 
-const mockTrackMonthlySubscriptionSucceeded = vi.fn()
-const mockTrackApiCreditTopupSucceeded = vi.fn()
-const mockTrackBillingOperationFailed = vi.fn()
-const mockTrackBillingOperationTimeout = vi.fn()
+const mockTrackBillingEvent = vi.fn()
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackMonthlySubscriptionSucceeded: mockTrackMonthlySubscriptionSucceeded,
-    trackApiCreditTopupSucceeded: mockTrackApiCreditTopupSucceeded,
-    trackBillingOperationFailed: mockTrackBillingOperationFailed,
-    trackBillingOperationTimeout: mockTrackBillingOperationTimeout
+    trackBillingEvent: mockTrackBillingEvent
   })
 }))
 
@@ -257,10 +251,51 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockTrackMonthlySubscriptionSucceeded).toHaveBeenCalledOnce()
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'subscription_checkout',
+        stage: 'succeeded',
+        outcome: 'success',
+        tier: undefined,
+        cycle: undefined,
+        checkout_type: undefined,
+        payment_intent_source: undefined,
+        billing_op_id: 'op-1'
+      })
     })
 
-    it('does not fire purchase telemetry on topup success', async () => {
+    it('emits downgrade success only after the billing operation succeeds', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-downgrade',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-downgrade', 'subscription', {
+        tier: 'creator',
+        cycle: 'monthly',
+        checkoutType: 'change',
+        downgradeToPersonal: {
+          memberRemovalCount: 2,
+          memberRemovalFailures: 0,
+          targetTier: 'creator'
+        }
+      })
+
+      expect(mockTrackBillingEvent).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'downgrade_to_personal',
+        stage: 'succeeded',
+        outcome: 'success',
+        member_removal_count: 2,
+        member_removal_failures: 0,
+        target_tier: 'creator'
+      })
+    })
+
+    it('fires canonical topup success telemetry', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'succeeded',
@@ -272,7 +307,12 @@ describe('billingOperationStore', () => {
 
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(mockTrackMonthlySubscriptionSucceeded).not.toHaveBeenCalled()
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'topup',
+        stage: 'succeeded',
+        outcome: 'success',
+        billing_op_id: 'op-1'
+      })
     })
 
     it('shows topup success message for topup operations', async () => {
@@ -314,7 +354,7 @@ describe('billingOperationStore', () => {
 
   describe('polling failure', () => {
     it('updates status and shows error toast on failure', async () => {
-      const errorMessage = 'Payment declined'
+      const errorMessage = 'Payment declined for person@example.com'
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'failed',
@@ -336,6 +376,18 @@ describe('billingOperationStore', () => {
         severity: 'error',
         summary: 'billingOperation.subscriptionFailed',
         detail: errorMessage
+      })
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith({
+        operation: 'operation',
+        stage: 'failed',
+        outcome: 'failure',
+        billing_op_id: 'op-1',
+        operation_type: 'subscription',
+        tier: undefined,
+        cycle: undefined,
+        checkout_type: undefined,
+        payment_intent_source: undefined,
+        failure_category: 'unknown'
       })
     })
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -4,10 +4,15 @@ import { computed, ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { t } from '@/i18n'
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useTelemetry } from '@/platform/telemetry'
-import type { SubscriptionCheckoutTier } from '@/platform/telemetry/types'
+import type {
+  PaymentIntentSource,
+  SubscriptionCheckoutTier,
+  SubscriptionCheckoutType
+} from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -24,6 +29,13 @@ type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
 export interface StartOperationMetadata {
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
+  checkoutType?: SubscriptionCheckoutType
+  paymentIntentSource?: PaymentIntentSource
+  downgradeToPersonal?: {
+    memberRemovalCount: number
+    memberRemovalFailures: number
+    targetTier?: TierKey
+  }
 }
 
 interface BillingOperation {
@@ -34,6 +46,9 @@ interface BillingOperation {
   startedAt: number
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
+  checkoutType?: SubscriptionCheckoutType
+  paymentIntentSource?: PaymentIntentSource
+  downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
 }
 
 type TerminalResolver = (operation: BillingOperation) => void
@@ -83,7 +98,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       errorMessage: null,
       startedAt: Date.now(),
       tier: metadata?.tier,
-      cycle: metadata?.cycle
+      cycle: metadata?.cycle,
+      checkoutType: metadata?.checkoutType,
+      paymentIntentSource: metadata?.paymentIntentSource,
+      downgradeToPersonal: metadata?.downgradeToPersonal
     }
 
     operations.value = new Map(operations.value).set(opId, operation)
@@ -165,14 +183,37 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     updateOperationStatus(opId, 'succeeded', null)
     cleanup(opId)
 
+    const telemetry = useTelemetry()
     if (operation.type === 'subscription') {
-      useTelemetry()?.trackMonthlySubscriptionSucceeded({
+      telemetry?.trackBillingEvent({
+        operation: 'subscription_checkout',
+        stage: 'succeeded',
+        outcome: 'success',
         tier: operation.tier,
         cycle: operation.cycle,
+        checkout_type: operation.checkoutType,
+        payment_intent_source: operation.paymentIntentSource,
         billing_op_id: opId
       })
+      if (operation.downgradeToPersonal) {
+        telemetry?.trackBillingEvent({
+          operation: 'downgrade_to_personal',
+          stage: 'succeeded',
+          outcome: 'success',
+          member_removal_count:
+            operation.downgradeToPersonal.memberRemovalCount,
+          member_removal_failures:
+            operation.downgradeToPersonal.memberRemovalFailures,
+          target_tier: operation.downgradeToPersonal.targetTier
+        })
+      }
     } else if (operation.type === 'topup') {
-      useTelemetry()?.trackApiCreditTopupSucceeded()
+      telemetry?.trackBillingEvent({
+        operation: 'topup',
+        stage: 'succeeded',
+        outcome: 'success',
+        billing_op_id: opId
+      })
     }
 
     const billingContext = useBillingContext()
@@ -222,13 +263,31 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     updateOperationStatus(opId, 'failed', errorMessage ?? defaultMessage)
     cleanup(opId)
 
-    useTelemetry()?.trackBillingOperationFailed({
+    const telemetry = useTelemetry()
+    telemetry?.trackBillingEvent({
+      operation: 'operation',
+      stage: 'failed',
+      outcome: 'failure',
       billing_op_id: opId,
       operation_type: operation.type,
       tier: operation.tier,
       cycle: operation.cycle,
-      failure_reason: errorMessage ?? defaultMessage
+      checkout_type: operation.checkoutType,
+      payment_intent_source: operation.paymentIntentSource,
+      failure_category: 'unknown'
     })
+    if (operation.downgradeToPersonal) {
+      telemetry?.trackBillingEvent({
+        operation: 'downgrade_to_personal',
+        stage: 'failed',
+        outcome: 'failure',
+        member_removal_count: operation.downgradeToPersonal.memberRemovalCount,
+        member_removal_failures:
+          operation.downgradeToPersonal.memberRemovalFailures,
+        target_tier: operation.downgradeToPersonal.targetTier,
+        failure_category: 'unknown'
+      })
+    }
 
     if (operation.type !== 'cancel') {
       useToastStore().add({
@@ -250,13 +309,31 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     updateOperationStatus(opId, 'timeout', message)
     cleanup(opId)
 
-    useTelemetry()?.trackBillingOperationTimeout({
+    const telemetry = useTelemetry()
+    telemetry?.trackBillingEvent({
+      operation: 'operation',
+      stage: 'timeout',
+      outcome: 'failure',
       billing_op_id: opId,
       operation_type: operation.type,
       tier: operation.tier,
       cycle: operation.cycle,
-      failure_reason: message
+      checkout_type: operation.checkoutType,
+      payment_intent_source: operation.paymentIntentSource,
+      failure_category: 'poll_timeout'
     })
+    if (operation.downgradeToPersonal) {
+      telemetry?.trackBillingEvent({
+        operation: 'downgrade_to_personal',
+        stage: 'failed',
+        outcome: 'failure',
+        member_removal_count: operation.downgradeToPersonal.memberRemovalCount,
+        member_removal_failures:
+          operation.downgradeToPersonal.memberRemovalFailures,
+        target_tier: operation.downgradeToPersonal.targetTier,
+        failure_category: 'poll_timeout'
+      })
+    }
 
     if (operation.type !== 'cancel') {
       useToastStore().add({


### PR DESCRIPTION
## Stacked on #14111

Implements [FE-1392](https://linear.app/comfyorg/issue/FE-1392/implement-sanitized-frontend-billing-data-logging-contract) as a privacy-safe telemetry layer on top of the billing events introduced by #14111.

## What changed

- Adds a typed canonical `billing.<operation>.<stage>` contract shared through the existing telemetry registry.
- Sends the same bounded billing event dimensions to PostHog and Datadog RUM.
- Replaces free-form `error_message` / `failure_reason` payloads with bounded `failure_category` and optional allowlisted `error_code`.
- Keeps user-facing error details in UI/toasts while preventing those strings, including member emails, from entering telemetry.
- Preserves safe context such as `billing_op_id`, operation type, tier, cycle, checkout type, source, and member-removal counts.
- Uses authoritative billing-operation poller completion for asynchronous downgrade and billing outcomes.

## Scope

This PR intentionally does not add FE-1387 sibling entry-point coverage or FE-1391's full RUM journey, abandonment, dashboard, and alert work.

## Validation

- 10 focused test files / 204 tests
- `pnpm typecheck`
- targeted ESLint
- type-aware oxlint: 0 warnings/errors
- oxfmt check
- commit hooks including stylelint and typecheck
