### PR TITLE
feat: add paid template badge

### DIFF
--- a/src/components/custom/widget/PaidTemplateBadge.test.ts
+++ b/src/components/custom/widget/PaidTemplateBadge.test.ts
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import PaidTemplateBadge from './PaidTemplateBadge.vue'
+
+const messages = {
+  en: {
+    templateWorkflows: {
+      paidTemplate: {
+        badgeLabel: 'Partner API',
+        title: 'Premium template',
+        partnerNodes: 'Uses partner nodes.',
+        paidPlan: 'Runs with a paid plan'
+      }
+    }
+  }
+}
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages
+})
+
+function renderBadge(openSource?: boolean) {
+  return render(PaidTemplateBadge, {
+    props: { openSource },
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('PaidTemplateBadge', () => {
+  it('explains the paid-plan requirement for partner templates', async () => {
+    const user = userEvent.setup()
+    renderBadge(false)
+
+    const badge = screen.getByTestId('paid-template-badge')
+    expect(badge).toHaveAccessibleName(
+      'Premium template Uses partner nodes. Runs with a paid plan'
+    )
+
+    await user.hover(badge)
+
+    const tooltip = await screen.findByTestId('disclosure-tooltip')
+    expect(within(tooltip).getByText('Premium template')).toBeInTheDocument()
+    expect(
+      within(tooltip).getByText(/Uses partner nodes\.\s*Runs with a paid plan/)
+    ).toBeInTheDocument()
+  })
+
+  it.for([true, undefined])(
+    'does not mark open-source value %s as paid',
+    (openSource) => {
+      renderBadge(openSource)
+
+      expect(
+        screen.queryByTestId('paid-template-badge')
+      ).not.toBeInTheDocument()
+    }
+  )
+})

--- a/src/components/custom/widget/PaidTemplateBadge.test.ts
+++ b/src/components/custom/widget/PaidTemplateBadge.test.ts
@@ -23,17 +23,10 @@ const i18n = createI18n({
   messages
 })
 
-function renderBadge(openSource?: boolean) {
-  return render(PaidTemplateBadge, {
-    props: { openSource },
-    global: { plugins: [i18n] }
-  })
-}
-
 describe('PaidTemplateBadge', () => {
   it('explains the paid-plan requirement for partner templates', async () => {
     const user = userEvent.setup()
-    renderBadge(false)
+    render(PaidTemplateBadge, { global: { plugins: [i18n] } })
 
     const badge = screen.getByTestId('paid-template-badge')
     expect(badge).toHaveAccessibleName('Premium template Runs with credits')
@@ -44,15 +37,4 @@ describe('PaidTemplateBadge', () => {
     expect(within(tooltip).getByText('Premium template')).toBeInTheDocument()
     expect(within(tooltip).getByText('Runs with credits')).toBeInTheDocument()
   })
-
-  it.for([true, undefined])(
-    'does not mark open-source value %s as paid',
-    (openSource) => {
-      renderBadge(openSource)
-
-      expect(
-        screen.queryByTestId('paid-template-badge')
-      ).not.toBeInTheDocument()
-    }
-  )
 })

--- a/src/components/custom/widget/PaidTemplateBadge.test.ts
+++ b/src/components/custom/widget/PaidTemplateBadge.test.ts
@@ -11,8 +11,7 @@ const messages = {
       paidTemplate: {
         badgeLabel: 'Partner API',
         title: 'Premium template',
-        partnerNodes: 'Uses partner nodes.',
-        paidPlan: 'Runs with a paid plan'
+        credits: 'Runs with credits'
       }
     }
   }
@@ -37,17 +36,13 @@ describe('PaidTemplateBadge', () => {
     renderBadge(false)
 
     const badge = screen.getByTestId('paid-template-badge')
-    expect(badge).toHaveAccessibleName(
-      'Premium template Uses partner nodes. Runs with a paid plan'
-    )
+    expect(badge).toHaveAccessibleName('Premium template Runs with credits')
 
     await user.hover(badge)
 
     const tooltip = await screen.findByTestId('disclosure-tooltip')
     expect(within(tooltip).getByText('Premium template')).toBeInTheDocument()
-    expect(
-      within(tooltip).getByText(/Uses partner nodes\.\s*Runs with a paid plan/)
-    ).toBeInTheDocument()
+    expect(within(tooltip).getByText('Runs with credits')).toBeInTheDocument()
   })
 
   it.for([true, undefined])(

--- a/src/components/custom/widget/PaidTemplateBadge.vue
+++ b/src/components/custom/widget/PaidTemplateBadge.vue
@@ -36,10 +36,13 @@ const tooltipCopy = computed(() => {
     <Tag
       :label="$t('templateWorkflows.paidTemplate.badgeLabel')"
       shape="overlay"
-      class="h-7 rounded-lg px-2 [&>span]:sr-only"
+      class="h-7 rounded-lg bg-black/30 px-2 backdrop-blur-[20px] [&>span]:sr-only"
     >
       <template #icon>
-        <i class="icon-[lucide--crown] size-4" aria-hidden="true" />
+        <i
+          class="icon-[tabler--crown-filled] size-4 text-brand-yellow"
+          aria-hidden="true"
+        />
       </template>
     </Tag>
 

--- a/src/components/custom/widget/PaidTemplateBadge.vue
+++ b/src/components/custom/widget/PaidTemplateBadge.vue
@@ -13,14 +13,12 @@ const { t } = useI18n()
 
 const tooltipCopy = computed(() => {
   const title = t('templateWorkflows.paidTemplate.title')
-  const partnerNodes = t('templateWorkflows.paidTemplate.partnerNodes')
-  const paidPlan = t('templateWorkflows.paidTemplate.paidPlan')
+  const credits = t('templateWorkflows.paidTemplate.credits')
 
   return {
     title,
-    partnerNodes,
-    paidPlan,
-    label: [title, partnerNodes, paidPlan].join(' ')
+    credits,
+    label: [title, credits].join(' ')
   }
 })
 </script>
@@ -49,10 +47,7 @@ const tooltipCopy = computed(() => {
     <template #content>
       <div class="text-left leading-normal">
         <p class="m-0 font-semibold">{{ tooltipCopy.title }}</p>
-        <p class="m-0">
-          {{ tooltipCopy.partnerNodes }}<br />
-          {{ tooltipCopy.paidPlan }}
-        </p>
+        <p class="m-0">{{ tooltipCopy.credits }}</p>
       </div>
     </template>
   </AccessibleTooltip>

--- a/src/components/custom/widget/PaidTemplateBadge.vue
+++ b/src/components/custom/widget/PaidTemplateBadge.vue
@@ -5,10 +5,6 @@ import { useI18n } from 'vue-i18n'
 import Tag from '@/components/chip/Tag.vue'
 import AccessibleTooltip from '@/components/ui/tooltip/AccessibleTooltip.vue'
 
-const { openSource } = defineProps<{
-  openSource?: boolean
-}>()
-
 const { t } = useI18n()
 
 const tooltipCopy = computed(() => {
@@ -25,7 +21,6 @@ const tooltipCopy = computed(() => {
 
 <template>
   <AccessibleTooltip
-    v-if="openSource === false"
     :label="tooltipCopy.label"
     test-id="paid-template-badge"
     side="bottom"

--- a/src/components/custom/widget/PaidTemplateBadge.vue
+++ b/src/components/custom/widget/PaidTemplateBadge.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Tag from '@/components/chip/Tag.vue'
+import AccessibleTooltip from '@/components/ui/tooltip/AccessibleTooltip.vue'
+
+const { openSource } = defineProps<{
+  openSource?: boolean
+}>()
+
+const { t } = useI18n()
+
+const tooltipCopy = computed(() => {
+  const title = t('templateWorkflows.paidTemplate.title')
+  const partnerNodes = t('templateWorkflows.paidTemplate.partnerNodes')
+  const paidPlan = t('templateWorkflows.paidTemplate.paidPlan')
+
+  return {
+    title,
+    partnerNodes,
+    paidPlan,
+    label: [title, partnerNodes, paidPlan].join(' ')
+  }
+})
+</script>
+
+<template>
+  <AccessibleTooltip
+    v-if="openSource === false"
+    :label="tooltipCopy.label"
+    test-id="paid-template-badge"
+    side="bottom"
+    trigger-class="rounded-lg"
+  >
+    <Tag
+      :label="$t('templateWorkflows.paidTemplate.badgeLabel')"
+      shape="overlay"
+      class="h-7 rounded-lg px-2 [&>span]:sr-only"
+    >
+      <template #icon>
+        <i class="icon-[lucide--crown] size-4" aria-hidden="true" />
+      </template>
+    </Tag>
+
+    <template #content>
+      <div class="text-left leading-normal">
+        <p class="m-0 font-semibold">{{ tooltipCopy.title }}</p>
+        <p class="m-0">
+          {{ tooltipCopy.partnerNodes }}<br />
+          {{ tooltipCopy.paidPlan }}
+        </p>
+      </div>
+    </template>
+  </AccessibleTooltip>
+</template>

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -302,7 +302,7 @@
                   </div>
                 </template>
                 <template
-                  v-if="template.openSource === false || template.tutorialUrl"
+                  v-if="template.isPartnerNode || template.tutorialUrl"
                   #top-right
                 >
                   <Button
@@ -316,7 +316,7 @@
                   >
                     <i class="icon-[lucide--info] size-4" />
                   </Button>
-                  <PaidTemplateBadge :open-source="template.openSource" />
+                  <PaidTemplateBadge v-if="template.isPartnerNode" />
                 </template>
               </CardTop>
             </template>

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -301,8 +301,12 @@
                     </span>
                   </div>
                 </template>
-                <template v-if="template.tutorialUrl" #top-right>
+                <template
+                  v-if="template.openSource === false || template.tutorialUrl"
+                  #top-right
+                >
                   <Button
+                    v-if="template.tutorialUrl"
                     v-tooltip.bottom="$t('g.seeTutorial')"
                     :aria-label="$t('g.seeTutorial')"
                     variant="inverted"
@@ -312,6 +316,7 @@
                   >
                     <i class="icon-[lucide--info] size-4" />
                   </Button>
+                  <PaidTemplateBadge :open-source="template.openSource" />
                 </template>
               </CardTop>
             </template>
@@ -428,6 +433,7 @@ import CardBottom from '@/components/card/CardBottom.vue'
 import CardContainer from '@/components/card/CardContainer.vue'
 import CardTop from '@/components/card/CardTop.vue'
 import Tag from '@/components/chip/Tag.vue'
+import PaidTemplateBadge from '@/components/custom/widget/PaidTemplateBadge.vue'
 import TemplateFilterControls from '@/components/custom/widget/TemplateFilterControls.vue'
 import AsyncSearchInput from '@/components/ui/search-input/AsyncSearchInput.vue'
 import AudioThumbnail from '@/components/templates/thumbnails/AudioThumbnail.vue'

--- a/src/components/ui/tooltip/AccessibleTooltip.vue
+++ b/src/components/ui/tooltip/AccessibleTooltip.vue
@@ -75,7 +75,7 @@ const contentClass = cn(
           :style="contentStyle"
           :class="contentClass"
         >
-          {{ labelText }}
+          <slot name="content">{{ labelText }}</slot>
           <TooltipArrow :width="10" :height="5" class="fill-charcoal-300" />
         </TooltipContent>
       </TooltipPortal>

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -61,8 +61,8 @@ function isTemplateVisibleForDistributions(
   return distributions.some((d) => template.includeOnDistributions!.includes(d))
 }
 
-export function useTemplateFiltering(
-  templates: Ref<TemplateInfo[]> | TemplateInfo[]
+export function useTemplateFiltering<T extends TemplateInfo>(
+  templates: Ref<T[]> | T[]
 ) {
   const settingStore = useSettingStore()
   const systemStatsStore = useSystemStatsStore()
@@ -196,7 +196,7 @@ export function useTemplateFiltering(
     )
     return searchTemplates(searchIndex.value, searchQuery.value)
       .map((name) => templatesByName.get(name))
-      .filter((template): template is TemplateInfo => template !== undefined)
+      .filter((template): template is T => template !== undefined)
   })
 
   const filteredByModels = computed(() => {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1163,6 +1163,12 @@
     "runsOnSelected": "{count} Runs On",
     "runsOnFilter": "Runs on",
     "resultsCount": "Showing {count} of {total} templates",
+    "paidTemplate": {
+      "badgeLabel": "Partner API",
+      "title": "Premium template",
+      "partnerNodes": "Uses partner nodes.",
+      "paidPlan": "Runs with a paid plan"
+    },
     "sort": {
       "relevance": "Relevance",
       "recommended": "Recommended",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1166,8 +1166,7 @@
     "paidTemplate": {
       "badgeLabel": "Partner API",
       "title": "Premium template",
-      "partnerNodes": "Uses partner nodes.",
-      "paidPlan": "Runs with a paid plan"
+      "credits": "Runs with credits"
     },
     "sort": {
       "relevance": "Relevance",

--- a/src/platform/workflow/templates/utils/templateDisplay.ts
+++ b/src/platform/workflow/templates/utils/templateDisplay.ts
@@ -8,10 +8,10 @@ export function isAppTemplate(template: TemplateInfo): boolean {
   return template.name.endsWith('.app')
 }
 
-export function filterTemplatesByType(
-  templates: TemplateInfo[],
+export function filterTemplatesByType<T extends TemplateInfo>(
+  templates: T[],
   type: TemplateTypeFilter
-): TemplateInfo[] {
+): T[] {
   if (type === 'all') return templates
   const wantApp = type === 'apps'
   return templates.filter((template) => isAppTemplate(template) === wantApp)


### PR DESCRIPTION
## Summary

Identifies paid partner templates before users load them.

## Changes

- **What**: Shows an accessible crown badge on every `openSource === false` template card, with a tooltip explaining that it uses partner nodes and requires a paid plan.
- **Tests**: Covers paid, open-source, and unspecified classification behavior while preserving the shared tooltip's hover, focus, and click behavior.

## Review Focus

`openSource === false` remains the only classification signal; this does not attempt to calculate usage cost.

<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/d69cd1c2-de45-40bc-9cc9-faa3a8273131" />

[FE-1345](https://linear.app/comfyorg/issue/FE-1345/c-13-badge-tooltip-on-paid-template-cards) · [Figma](https://www.figma.com/design/SSo9GcILgQhAV3uoa4r1xJ/Onboarding?node-id=1706-38294&t=UFQnz65uMKJFjsy2-1)