### PR TITLE
fix(workspace): restrict member credit limits to members

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -119,10 +119,12 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
             member.id,
             member.email.toLowerCase() === 'owner@example.com' ||
             member.id === mockOriginalOwnerId.value
-              ? [{ label: 'setCreditLimit' }]
+              ? []
               : [
                   { label: 'changeRole' },
-                  { label: 'setCreditLimit' },
+                  ...(member.role === 'member'
+                    ? [{ label: 'setCreditLimit' }]
+                    : []),
                   { label: 'removeMember' }
                 ]
           ])
@@ -334,17 +336,17 @@ describe('MembersPanelContent', () => {
       ).toHaveLength(1)
     })
 
-    it('shows a self-cap menu for the current user', () => {
+    it('hides the menu for the current user', () => {
       mockFilteredMembers.value = [
         createMember({ name: 'Owner User', email: 'owner@example.com' })
       ]
       renderComponent()
       expect(
         screen.queryAllByRole('button', { name: 'g.moreOptions' })
-      ).toHaveLength(1)
+      ).toHaveLength(0)
     })
 
-    it('shows a menu on both the creator and other rows', () => {
+    it('hides the creator menu and shows the member menu', () => {
       mockOriginalOwnerId.value = 'creator-1'
       mockFilteredMembers.value = [
         createMember({
@@ -360,8 +362,8 @@ describe('MembersPanelContent', () => {
       const creatorRow = screen.getByTestId('member-row-creator-1')
       const otherRow = screen.getByTestId('member-row-2')
       expect(
-        within(creatorRow).getByRole('button', { name: 'g.moreOptions' })
-      ).toBeInTheDocument()
+        within(creatorRow).queryByRole('button', { name: 'g.moreOptions' })
+      ).not.toBeInTheDocument()
       expect(
         within(otherRow).getByRole('button', { name: 'g.moreOptions' })
       ).toBeInTheDocument()

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -713,10 +713,15 @@ describe('useMembersPanel', () => {
       expect(roleItems.map((i) => i.checked)).toEqual([false, true])
     })
 
-    it('checks Owner for owner rows', async () => {
+    it('omits Set credit limit for owner rows', async () => {
       const panel = await setup()
       const items = panel.memberMenuItems(createMember({ role: 'owner' }))
       const roleItems = items[0].items ?? []
+
+      expect(items.map((item) => item.label)).toEqual([
+        'workspacePanel.members.actions.changeRole',
+        'workspacePanel.members.actions.removeMember'
+      ])
       expect(roleItems.map((i) => i.checked)).toEqual([true, false])
     })
 
@@ -796,16 +801,14 @@ describe('useMembersPanel', () => {
       expect(panel.memberMenuItems(createMember())).toEqual([])
     })
 
-    it('exposes only Set credit limit for the workspace creator', async () => {
+    it('returns no actions for the workspace creator', async () => {
       mockOriginalOwnerId.value = 'creator-1'
       const panel = await setup()
       const items = panel.memberMenuItems(
         createMember({ id: 'creator-1', role: 'owner' })
       )
 
-      expect(items.map((item) => item.label)).toEqual([
-        'workspacePanel.members.actions.setCreditLimit'
-      ])
+      expect(items).toEqual([])
     })
 
     it('omits the credit-limit action when the flag is disabled', async () => {
@@ -820,7 +823,7 @@ describe('useMembersPanel', () => {
       )
     })
 
-    it('gives the creator no menu when the flag is disabled', async () => {
+    it('keeps the creator menu hidden when the flag is disabled', async () => {
       mockBillingControlEnabled.value = false
       mockOriginalOwnerId.value = 'creator-1'
       const panel = await setup()

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -273,13 +273,8 @@ export function useMembersPanel() {
         })
     }
 
-    const creditLimitEnabled = flags.billingControlEnabled
-
-    // The creator and the current user can't change their own role or be
-    // removed; their only possible action is capping their own usage, so they
-    // get a menu at all only when credit limits are enabled.
     if (isCurrentUser(member) || isOriginalOwner(member)) {
-      return creditLimitEnabled ? [creditLimitItem] : []
+      return []
     }
 
     return [
@@ -290,7 +285,9 @@ export function useMembersPanel() {
           roleMenuItem(member, 'member', t('workspaceSwitcher.roleMember'))
         ]
       },
-      ...(creditLimitEnabled ? [creditLimitItem] : []),
+      ...(flags.billingControlEnabled && member.role === 'member'
+        ? [creditLimitItem]
+        : []),
       {
         label: t('workspacePanel.members.actions.removeMember'),
         command: () => handleRemoveMember(member)


### PR DESCRIPTION
## Summary

Aligns the per-member credit-limit row actions from #13716 with the finalized DES-504 permission model:

- show **Set credit limit** only for `member` rows
- remove the self-cap menu from the current user
- keep applicable role/removal actions for other owner rows while excluding the credit-limit action

## Design change

### As is

An Owner row exposes **Set credit limit** alongside its other member-management actions.

![As-is Owner menu includes Set credit limit](https://ampcode.com/user-content/artifacts/4950c1fb99675eaca25905f7d5d547c4346e68967ad7e21b2fe8f98d8ea04c2d-file.png)

### To be

The current user has no row menu. Other Owner rows retain applicable role/removal actions, but no longer expose **Set credit limit**.

![To-be Owner menu excludes Set credit limit](https://ampcode.com/user-content/artifacts/231de1c457ffadabc3134cd2ca15f85a76bee0fb1d16d22ed48134eeb83151c3-file.png)

Member rows continue to expose **Set credit limit**.

![To-be Member menu retains Set credit limit](https://ampcode.com/user-content/artifacts/459fee4ddb96c756e82ec35f26fab7b5b2046288bf3a71929151d417f020cce5-file.png)

## References

- [Slack handoff and Member-only correction](https://comfy-organization.slack.com/archives/C0BEE5503RQ/p1785196688399159?thread_ts=1784942043.389779&cid=C0BEE5503RQ)
- [Figma](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4639-19558)
- [Per-member credit limits / spend caps](https://www.notion.so/comfy-org/Per-member-credit-limits-spend-caps-3966d73d3650815eb813dc4dc15d4b89)

## Testing

- `pnpm test:unit src/platform/workspace/composables/useMembersPanel.test.ts src/platform/workspace/composables/useWorkspaceUI.test.ts src/platform/workspace/components/dialogs/settings/MemberListItem.test.ts src/platform/settings/composables/useSettingUI.test.ts` (107 tests)
- browser verification against both the parent commit and this PR with `billing_control_enabled=true`
- `pnpm typecheck`
- `pnpm lint:unstaged`
- targeted `oxfmt --check`

Follow-up to #13716. Relates FE-1277 and DES-504.