### PR TITLE
feat(workspace): member-facing credit number in the profile menu

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3100,6 +3100,14 @@
       "failedToDeleteWorkspace": "Failed to delete workspace",
       "failedToLeaveWorkspace": "Failed to leave workspace",
       "failedToFetchWorkspaces": "Failed to load workspaces"
+    },
+    "memberCredits": {
+      "edgeLead": "The workspace is low on credits.",
+      "edgeExplainer": "This is what you can spend right now, not your monthly limit.",
+      "monthlyLimit": "Monthly limit: {n}",
+      "requestLimitIncrease": "Request limit increase",
+      "notifyOwner": "Notify workspace owner",
+      "requested": "Your workspace owner has been notified by email"
     }
   },
   "teamWorkspacesDialog": {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -60,7 +60,7 @@
 
     <!-- Credits Section -->
 
-    <div class="flex items-center gap-2 px-4 py-2">
+    <div class="relative flex items-center gap-2 px-4 py-2">
       <i class="icon-[lucide--component] text-sm text-credit" />
       <Skeleton
         v-if="isLoadingBalance"
@@ -71,6 +71,39 @@
       <span v-else class="text-base font-semibold text-base-foreground">{{
         displayedCredits
       }}</span>
+      <span
+        v-if="isEdgeState"
+        @mouseenter="isEdgePopoverOpen = true"
+        @mouseleave="isEdgePopoverOpen = false"
+        @focusin="isEdgePopoverOpen = true"
+        @focusout="isEdgePopoverOpen = false"
+      >
+        <Button
+          variant="muted-textonly"
+          size="icon-sm"
+          :aria-label="$t('workspacePanel.memberCredits.edgeExplainer')"
+          data-testid="member-credits-info-button"
+        >
+          <i class="icon-[lucide--info]" />
+        </Button>
+      </span>
+      <div
+        v-if="isEdgeState && isEdgePopoverOpen && memberCap"
+        class="absolute top-1/2 right-full z-50 mr-3 w-72 -translate-y-1/2 rounded-lg border border-border-default bg-base-background p-3 shadow-lg"
+        data-testid="member-credits-edge-popover"
+      >
+        <p class="m-0 text-sm text-base-foreground">
+          {{ $t('workspacePanel.memberCredits.edgeLead') }}
+          {{ $t('workspacePanel.memberCredits.edgeExplainer') }}
+        </p>
+        <p class="m-0 mt-1 text-sm text-muted-foreground">
+          {{
+            $t('workspacePanel.memberCredits.monthlyLimit', {
+              n: memberCap.limit.toLocaleString()
+            })
+          }}
+        </p>
+      </div>
       <Button
         v-tooltip="{ value: $t('credits.unified.tooltip'), showDelay: 300 }"
         variant="muted-textonly"
@@ -123,6 +156,22 @@
           isCancelled
             ? $t('subscription.resubscribe')
             : $t('workspaceSwitcher.subscribe')
+        }}
+      </Button>
+    </div>
+
+    <div v-if="requestAction" class="px-4 py-1">
+      <Button
+        variant="secondary"
+        class="w-full"
+        :disabled="requestSent"
+        data-testid="member-credits-request-button"
+        @click="requestSent = true"
+      >
+        {{
+          requestSent
+            ? $t('workspacePanel.memberCredits.requested')
+            : $t(`workspacePanel.memberCredits.${requestAction}`)
         }}
       </Button>
     </div>
@@ -228,6 +277,7 @@ import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeB
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { useMemberCreditDisplay } from '@/platform/workspace/composables/useMemberCreditDisplay'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
@@ -277,8 +327,23 @@ const subscriptionDialog = useSubscriptionDialog()
 const { locale } = useI18n()
 const isLoadingBalance = isLoading
 
+const {
+  memberCap,
+  displayedNumber,
+  isEdgeState,
+  requestAction
+} = useMemberCreditDisplay()
+
+const requestSent = ref(false)
+const isEdgePopoverOpen = ref(false)
+
 const displayedCredits = computed(() => {
   if (initState.value !== 'ready') return ''
+
+  // Capped members see min(limit - used, workspace balance) rather than the
+  // raw pool -- the workspace total is not their spendable number (DES-504).
+  if (memberCap.value)
+    return Math.round(displayedNumber.value).toLocaleString(locale.value)
 
   // API field is named _micros but contains cents (naming inconsistency)
   const cents =

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -327,12 +327,8 @@ const subscriptionDialog = useSubscriptionDialog()
 const { locale } = useI18n()
 const isLoadingBalance = isLoading
 
-const {
-  memberCap,
-  displayedNumber,
-  isEdgeState,
-  requestAction
-} = useMemberCreditDisplay()
+const { memberCap, displayedNumber, isEdgeState, requestAction } =
+  useMemberCreditDisplay()
 
 const requestSent = ref(false)
 const isEdgePopoverOpen = ref(false)

--- a/src/platform/workspace/composables/useMemberCreditDisplay.test.ts
+++ b/src/platform/workspace/composables/useMemberCreditDisplay.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMemberCreditDisplay } from '@/platform/workspace/composables/useMemberCreditDisplay'
+
+const SELF = 'member@example.com'
+
+const mocks = vi.hoisted(() => ({
+  members: null as { value: unknown[] } | null,
+  balanceCents: null as { value: number } | null,
+  isInPersonalWorkspace: null as { value: boolean } | null
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', async () => {
+  const { computed } = await import('vue')
+  return { useCurrentUser: () => ({ userEmail: computed(() => SELF) }) }
+})
+
+vi.mock('@/composables/billing/useBillingContext', async () => {
+  const { computed, ref } = await import('vue')
+  const balanceCents = ref(0)
+  mocks.balanceCents = balanceCents
+  return {
+    useBillingContext: () => ({
+      balance: computed(() => ({
+        effectiveBalanceMicros: balanceCents.value
+      }))
+    })
+  }
+})
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { ref } = await import('vue')
+  const members = ref<unknown[]>([])
+  const isInPersonalWorkspace = ref(false)
+  mocks.members = members
+  mocks.isInPersonalWorkspace = isInPersonalWorkspace
+  return {
+    useTeamWorkspaceStore: () => ({
+      members,
+      isInPersonalWorkspace,
+      activeWorkspaceId: ref('ws-1'),
+      ensureMembersLoaded: vi.fn()
+    })
+  }
+})
+
+vi.mock('pinia', () => ({
+  storeToRefs: (store: Record<string, unknown>) => store
+}))
+
+/** The harness stores cents; 211 credits to the dollar. */
+function creditsToCents(credits: number) {
+  return Math.round((credits * 100) / 211)
+}
+
+function setup({
+  role = 'member',
+  limit = null as number | null,
+  used = 0,
+  balanceCredits = 50_000
+} = {}) {
+  mocks.members!.value = [
+    {
+      email: SELF,
+      role,
+      monthlyCreditLimit: limit,
+      creditsUsedThisMonth: used
+    }
+  ]
+  mocks.balanceCents!.value = creditsToCents(balanceCredits)
+  return useMemberCreditDisplay()
+}
+
+describe('useMemberCreditDisplay', () => {
+  beforeEach(() => {
+    mocks.isInPersonalWorkspace!.value = false
+  })
+
+  describe('capped member', () => {
+    it('shows their remaining limit while the pool is healthy', () => {
+      const { displayedNumber, isEdgeState, requestAction } = setup({
+        limit: 3000,
+        used: 1234
+      })
+      expect(Math.round(displayedNumber.value)).toBe(1766)
+      expect(isEdgeState.value).toBe(false)
+      expect(requestAction.value).toBeNull()
+    })
+
+    it('substitutes the pool when it is the smaller number, and explains it', () => {
+      const { displayedNumber, isEdgeState, requestAction } = setup({
+        limit: 3000,
+        used: 1234,
+        balanceCredits: 1500
+      })
+      expect(Math.round(displayedNumber.value)).toBe(1500)
+      expect(isEdgeState.value).toBe(true)
+      // No button in the edge state: a limit increase cannot help while the
+      // pool is what binds.
+      expect(requestAction.value).toBeNull()
+    })
+
+    it('subtracts spend before comparing, not after', () => {
+      // limit 3000 vs pool 700 would show 700 if spend were applied after the
+      // min; their real remaining is 500, which is smaller and must win.
+      const { displayedNumber, isEdgeState } = setup({
+        limit: 3000,
+        used: 2500,
+        balanceCredits: 700
+      })
+      expect(Math.round(displayedNumber.value)).toBe(500)
+      expect(isEdgeState.value).toBe(false)
+    })
+
+    it('offers a limit increase once the cap is spent', () => {
+      const { displayedNumber, isLimitReached, requestAction } = setup({
+        limit: 3000,
+        used: 3000
+      })
+      expect(Math.round(displayedNumber.value)).toBe(0)
+      expect(isLimitReached.value).toBe(true)
+      expect(requestAction.value).toBe('requestLimitIncrease')
+    })
+
+    it('offers a limit increase below the request floor', () => {
+      const { requestAction } = setup({ limit: 3000, used: 2000 })
+      expect(requestAction.value).toBe('requestLimitIncrease')
+    })
+  })
+
+  describe('uncapped member', () => {
+    it('shows the workspace balance with no request path', () => {
+      const { memberCap, displayedNumber, requestAction } = setup({
+        limit: null,
+        balanceCredits: 36_450
+      })
+      expect(memberCap.value).toBeNull()
+      expect(Math.round(displayedNumber.value)).toBe(36_450)
+      expect(requestAction.value).toBeNull()
+    })
+
+    it('still has no request path when the balance is merely low', () => {
+      // Uncapped members have exactly two states; low balance is not one.
+      const { requestAction } = setup({ limit: null, balanceCredits: 900 })
+      expect(requestAction.value).toBeNull()
+    })
+  })
+
+  describe('workspace out of credits', () => {
+    it('outranks limit-reached and routes to the owner', () => {
+      const { isWorkspaceOut, isLimitReached, requestAction } = setup({
+        limit: 3000,
+        used: 3000,
+        balanceCredits: 0
+      })
+      expect(isWorkspaceOut.value).toBe(true)
+      // Raising the cap would not help when the pool is dry.
+      expect(isLimitReached.value).toBe(false)
+      expect(requestAction.value).toBe('notifyOwner')
+    })
+
+    it('applies to uncapped members too', () => {
+      const { requestAction } = setup({ limit: null, balanceCredits: 0 })
+      expect(requestAction.value).toBe('notifyOwner')
+    })
+  })
+
+  describe('viewers who are not capped members', () => {
+    it('gives owners no cap and no request button', () => {
+      const { memberCap, requestAction } = setup({
+        role: 'owner',
+        limit: 3000,
+        balanceCredits: 0
+      })
+      expect(memberCap.value).toBeNull()
+      expect(requestAction.value).toBeNull()
+    })
+
+    it('does not apply in a personal workspace', () => {
+      const display = setup({ limit: 3000, used: 3000 })
+      mocks.isInPersonalWorkspace!.value = true
+      expect(display.memberCap.value).toBeNull()
+      expect(display.requestAction.value).toBeNull()
+    })
+  })
+})

--- a/src/platform/workspace/composables/useMemberCreditDisplay.ts
+++ b/src/platform/workspace/composables/useMemberCreditDisplay.ts
@@ -1,0 +1,107 @@
+import { storeToRefs } from 'pinia'
+import { computed, watchEffect } from 'vue'
+
+import { centsToCredits } from '@/base/credits/comfyCredits'
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+/** Placeholder until balance-at-top-up is instrumented (DES-504). */
+const REQUEST_BUTTON_FLOOR = 1500
+
+/**
+ * The member-facing credit display rule (DES-504): a capped member's number
+ * is min(limit − used, workspace balance); the info popover appears only when
+ * the balance is the smaller term. Zero states outrank the rule —
+ * workspace-out beats limit-reached. The number never changes colour, and
+ * both member surfaces derive their request button from `requestAction`.
+ */
+export function useMemberCreditDisplay() {
+  const workspaceStore = useTeamWorkspaceStore()
+  const { members, activeWorkspaceId, isInPersonalWorkspace } =
+    storeToRefs(workspaceStore)
+  const { userEmail } = useCurrentUser()
+  const { balance } = useBillingContext()
+
+  watchEffect(() => {
+    if (activeWorkspaceId.value && !isInPersonalWorkspace.value)
+      void workspaceStore.ensureMembersLoaded()
+  })
+
+  const selfMember = computed(() =>
+    members.value.find(
+      (m) => m.email.toLowerCase() === userEmail.value?.toLowerCase()
+    )
+  )
+
+  const memberCap = computed(() => {
+    const m = selfMember.value
+    if (isInPersonalWorkspace.value || !m || m.role !== 'member') return null
+    if (m.monthlyCreditLimit == null) return null
+    return {
+      limit: m.monthlyCreditLimit,
+      used: m.creditsUsedThisMonth ?? 0,
+      remaining: Math.max(
+        0,
+        m.monthlyCreditLimit - (m.creditsUsedThisMonth ?? 0)
+      )
+    }
+  })
+
+  const balanceCredits = computed(() =>
+    centsToCredits(
+      balance.value?.effectiveBalanceMicros ?? balance.value?.amountMicros ?? 0
+    )
+  )
+
+  const displayedNumber = computed(() =>
+    memberCap.value
+      ? Math.min(memberCap.value.remaining, balanceCredits.value)
+      : balanceCredits.value
+  )
+
+  const isWorkspaceOut = computed(() => balanceCredits.value <= 0)
+  const isLimitReached = computed(
+    () =>
+      memberCap.value !== null &&
+      memberCap.value.remaining <= 0 &&
+      !isWorkspaceOut.value
+  )
+  const isEdgeState = computed(
+    () =>
+      memberCap.value !== null &&
+      !isWorkspaceOut.value &&
+      !isLimitReached.value &&
+      balanceCredits.value < memberCap.value.remaining
+  )
+
+  const isTeamMemberViewer = computed(
+    () => !isInPersonalWorkspace.value && selfMember.value?.role === 'member'
+  )
+
+  const requestAction = computed(() => {
+    if (!isTeamMemberViewer.value) return null
+    if (isWorkspaceOut.value) return 'notifyOwner' as const
+    // Edge state shows no button — the popover alone explains the substituted
+    // number, and a limit increase wouldn't help while the pool binds.
+    if (isEdgeState.value) return null
+    // Uncapped members have exactly two states, healthy and workspace-out
+    // (2026-07-27): with no cap there is nothing workspace-specific to ask for
+    // short of the pool running dry, which the zero state already covers.
+    if (!memberCap.value) return null
+    if (displayedNumber.value > REQUEST_BUTTON_FLOOR) return null
+    return 'requestLimitIncrease' as const
+  })
+
+  return {
+    selfMember,
+    memberCap,
+    balanceCredits,
+    displayedNumber,
+    isWorkspaceOut,
+    isLimitReached,
+    isEdgeState,
+    isTeamMemberViewer,
+    requestAction
+  }
+}


### PR DESCRIPTION
Capped members currently see the raw workspace pool in the profile menu, which is not the number they can actually spend. This shows `min(monthlyCreditLimit − creditsUsedThisMonth, workspaceBalance)` instead, from a shared composable both member surfaces read.

- **Edge state** — when the pool is smaller than their remaining limit, a hover popover explains the substituted number. No button: a limit increase cannot help while the pool is what binds.
- **Request button** — appears at ≤ 1,500 credits, capped members only, secondary styling. Uncapped members have two states (healthy, workspace-out) and no low-balance ask.
- **Precedence** — workspace-out outranks limit-reached and routes to Notify workspace owner, since raising a cap does nothing when the pool is dry.

Owners are unaffected. Builds on the fields merged in #13716.

11 unit tests pin the state matrix, including the spend-before-min case flagged as a spec bug in DES-504.

- Design: DES-504 · [Figma 4639-19558](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=4639-19558)