### PR TITLE
feat(workspace): member credits tile in Plan & Credits

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3105,9 +3105,13 @@
       "edgeLead": "The workspace is low on credits.",
       "edgeExplainer": "This is what you can spend right now, not your monthly limit.",
       "monthlyLimit": "Monthly limit: {n}",
+      "monthlyLimitLabel": "Monthly limit",
+      "percentUsed": "{n}% used",
       "requestLimitIncrease": "Request limit increase",
       "notifyOwner": "Notify workspace owner",
-      "requested": "Your workspace owner has been notified by email"
+      "requested": "Your workspace owner has been notified by email",
+      "tileLabel": "Credits",
+      "resetsOn": "Resets {date}"
     }
   },
   "teamWorkspacesDialog": {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -327,12 +327,8 @@ const subscriptionDialog = useSubscriptionDialog()
 const { locale } = useI18n()
 const isLoadingBalance = isLoading
 
-const {
-  memberCap,
-  displayedNumber,
-  isEdgeState,
-  requestAction
-} = useMemberCreditDisplay()
+const { memberCap, displayedNumber, isEdgeState, requestAction } =
+  useMemberCreditDisplay()
 
 const requestSent = ref(false)
 const isEdgePopoverOpen = ref(false)

--- a/src/platform/workspace/components/MemberCreditsTile.vue
+++ b/src/platform/workspace/components/MemberCreditsTile.vue
@@ -1,0 +1,127 @@
+<template>
+  <div
+    class="@container relative flex flex-col gap-4 rounded-2xl border border-interface-stroke bg-modal-panel-background px-6 py-5"
+    data-testid="member-credits-tile"
+  >
+    <div class="flex flex-col gap-1">
+      <div class="text-sm text-muted">
+        {{ $t('workspacePanel.memberCredits.tileLabel') }} ·
+        {{
+          $t('workspacePanel.memberCredits.resetsOn', { date: resetDateLabel })
+        }}
+      </div>
+      <div class="flex items-baseline gap-2">
+        <i class="icon-[lucide--coins] size-4 self-center text-credit" />
+        <span class="text-2xl leading-none font-bold tabular-nums">{{
+          displayLabel
+        }}</span>
+        <span class="text-sm text-muted">{{
+          $t('subscription.remaining')
+        }}</span>
+      </div>
+    </div>
+
+    <div v-if="showBar && memberCap" class="flex flex-col gap-2">
+      <div class="flex items-center justify-between text-sm text-muted">
+        <span>{{ $t('workspacePanel.memberCredits.monthlyLimitLabel') }}</span>
+        <span class="tabular-nums">{{
+          $t('workspacePanel.memberCredits.percentUsed', {
+            n: Math.round(usagePercent)
+          })
+        }}</span>
+      </div>
+      <div
+        role="progressbar"
+        :aria-valuenow="memberCap.used"
+        :aria-valuemin="0"
+        :aria-valuemax="memberCap.limit"
+        :aria-label="
+          $t('workspacePanel.memberCredits.monthlyLimit', {
+            n: memberCap.limit.toLocaleString()
+          })
+        "
+        class="h-2 w-full overflow-hidden rounded-full bg-secondary-background-hover"
+      >
+        <div
+          class="h-full rounded-full bg-credit"
+          :style="{ width: `${usagePercent}%` }"
+        />
+      </div>
+    </div>
+
+    <div v-if="isEdgeState && memberCap" class="flex flex-col gap-1">
+      <p class="m-0 text-sm text-base-foreground">
+        {{ $t('workspacePanel.memberCredits.edgeLead') }}
+        {{ $t('workspacePanel.memberCredits.edgeExplainer') }}
+      </p>
+      <p class="m-0 text-sm text-muted-foreground">
+        {{
+          $t('workspacePanel.memberCredits.monthlyLimit', {
+            n: memberCap.limit.toLocaleString()
+          })
+        }}
+      </p>
+    </div>
+
+    <!-- tertiary, not secondary: the tile's own surface is secondary-background,
+         so a secondary button would be invisible on it (matches CreditsTile). -->
+    <Button
+      v-if="requestAction"
+      variant="tertiary"
+      class="w-full"
+      :disabled="requestSent"
+      data-testid="member-credits-tile-request-button"
+      @click="requestSent = true"
+    >
+      {{
+        requestSent
+          ? $t('workspacePanel.memberCredits.requested')
+          : $t(`workspacePanel.memberCredits.${requestAction}`)
+      }}
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useMemberCreditDisplay } from '@/platform/workspace/composables/useMemberCreditDisplay'
+
+const { locale } = useI18n()
+const { subscription } = useBillingContext()
+const {
+  memberCap,
+  displayedNumber,
+  isWorkspaceOut,
+  isEdgeState,
+  requestAction
+} = useMemberCreditDisplay()
+
+const requestSent = ref(false)
+
+const displayLabel = computed(() =>
+  Math.round(displayedNumber.value).toLocaleString(locale.value)
+)
+
+// The bar meters the member's own limit, so it survives limit-reached (full at
+// 100%) but hides in the edge state, where the number is the pool's, not theirs.
+const showBar = computed(() => !isEdgeState.value && !isWorkspaceOut.value)
+
+const usagePercent = computed(() => {
+  const cap = memberCap.value
+  if (!cap || cap.limit <= 0) return 0
+  return Math.min(100, (cap.used / cap.limit) * 100)
+})
+
+const resetDateLabel = computed(() => {
+  const iso = subscription.value?.renewalDate
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString(locale.value, {
+    month: 'short',
+    day: 'numeric'
+  })
+})
+</script>

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -246,7 +246,8 @@
 
         <div class="flex flex-col gap-6 pt-6 lg:flex-row lg:items-stretch">
           <div class="w-full lg:max-w-md">
-            <CreditsTile :zero-state="showZeroState" />
+            <MemberCreditsTile v-if="memberCap" />
+            <CreditsTile v-else :zero-state="showZeroState" />
           </div>
 
           <div
@@ -323,6 +324,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import CreditsTile from '@/platform/cloud/subscription/components/CreditsTile.vue'
+import MemberCreditsTile from '@/platform/workspace/components/MemberCreditsTile.vue'
 import SubscriptionFooterLinks from '@/platform/cloud/subscription/components/SubscriptionFooterLinks.vue'
 import DropdownMenu from '@/components/common/DropdownMenu.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
@@ -334,6 +336,7 @@ import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierB
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
 import { useWorkspaceMenuItems } from '@/platform/workspace/composables/useWorkspaceMenuItems'
 import { useWorkspacePlanPricing } from '@/platform/workspace/composables/useWorkspacePlanPricing'
+import { useMemberCreditDisplay } from '@/platform/workspace/composables/useMemberCreditDisplay'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -346,6 +349,7 @@ const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
 const { permissions, isSubscriptionCancelled } = useWorkspaceUI()
+const { memberCap } = useMemberCreditDisplay()
 const { t, n, locale } = useI18n()
 
 const billingOperationStore = useBillingOperationStore()


### PR DESCRIPTION
Stacked on #14171 — review that first; this diff is only the tile.

Replaces the workspace credits tile for capped members with the same min-rule number the profile menu shows, from the shared composable, so the two surfaces cannot drift.

- **Usage bar** meters their own limit and stays visible at limit-reached (full, 100%). It hides only in the edge state, where the number belongs to the pool rather than the limit — a limit-denominated bar would contradict it.
- **Repeats the request button** so a member already in settings need not go back to the profile menu.
- **No Additional credits row and no workspace inventory** — workspace-level numbers a capped member cannot act on.

Mounts in `SubscriptionPanelContentWorkspace.vue`, main's Plan & Credits host.

- Design: DES-504 · [Figma 5271-18878](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=5271-18878)