### PR TITLE
fix(ci): remove needs-backport label via REST API

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -496,7 +496,7 @@ jobs:
       # already landed are skipped by "Filter already backported targets").
       - name: Remove needs-backport label
         if: steps.filter-targets.outputs.skip != 'true' && steps.backport.outputs.failed == ''
-        run: gh pr edit ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }} --remove-label "needs-backport"
+        run: gh api --method DELETE "repos/${{ github.repository }}/issues/${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}/labels/needs-backport" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Remove the `needs-backport` label via the GitHub REST API instead of `gh pr edit --remove-label`, which fails repo-wide on a deprecated `projectCards` GraphQL field for label/title/body/assignee mutations — so the label was likely never actually cleared after a successful backport.

## Changes

- **What**: In the `Remove needs-backport label` step, replace `gh pr edit <PR> --remove-label "needs-backport"` with `gh api --method DELETE "repos/{owner}/{repo}/issues/{pr}/labels/needs-backport" || true`. The `|| true` tolerates the 404 returned when the label is already absent. The step's `if:` condition and `env:` are unchanged.

## Review Focus

- Stacked on #14152 (`glary/backport-resilient-partial-failure`) — this PR is based on that branch and must merge after it. GitHub will auto-retarget to `main` once #14152 merges.
- REST endpoint verified against GitHub docs: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}` returns 404 when the label is not present.
