### PR TITLE
fix(ci): route backport PR-creation notices through a durable channel

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -371,9 +371,20 @@ jobs:
             fi
             echo "::warning::Could not comment on PR #${PR_NUMBER} (${context}); opening a tracking issue instead."
             local title="Backport of #${PR_NUMBER} to ${target} failed"
-            gh issue create --title "${title}" --body "${body}" --label backport \
-              || gh issue create --title "${title}" --body "${body}" \
-              || echo "::warning::Also failed to open a tracking issue for #${PR_NUMBER} (${context})."
+            # gh issue create is not idempotent, so a blind retry can file the
+            # issue twice when the first call actually succeeded but timed out.
+            # Only drop --label when gh specifically rejected the label.
+            local err
+            if err=$(gh issue create --title "${title}" --body "${body}" --label backport 2>&1); then
+              return
+            fi
+            echo "${err}"
+            if grep -qi "label.*not found\|could not add label\|'backport' not found" <<<"${err}"; then
+              gh issue create --title "${title}" --body "${body}" \
+                || echo "::warning::Also failed to open a tracking issue for #${PR_NUMBER} (${context})."
+            else
+              echo "::warning::Could not open a tracking issue for #${PR_NUMBER} (${context})."
+            fi
           }
 
           for backport in ${{ steps.backport.outputs.success }}; do

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -356,6 +356,26 @@ jobs:
             PR_AUTHOR=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
           fi
 
+          # A merged PR can be locked (the CLA check locks merged PRs), which
+          # makes `gh pr comment` fail and would otherwise silently drop the
+          # "PR creation failed, backport manually" notice — leaving a pushed
+          # branch stranded with nobody told, the gap that left PRs
+          # #14018-#14021 to be recreated by hand. Fall back to a tracking
+          # issue that mentions the author. Bash functions don't cross steps,
+          # so this mirrors the `notify()` helper in "Comment on failures".
+          notify() {
+            local body="$1"
+            local context="$2"
+            if gh pr comment "${PR_NUMBER}" --body "${body}"; then
+              return
+            fi
+            echo "::warning::Could not comment on PR #${PR_NUMBER} (${context}); opening a tracking issue instead."
+            local title="Backport of #${PR_NUMBER} to ${target} failed"
+            gh issue create --title "${title}" --body "${body}" --label backport \
+              || gh issue create --title "${title}" --body "${body}" \
+              || echo "::warning::Also failed to open a tracking issue for #${PR_NUMBER} (${context})."
+          }
+
           for backport in ${{ steps.backport.outputs.success }}; do
             IFS=':' read -r target branch <<< "${backport}"
 
@@ -372,12 +392,11 @@ jobs:
               if [ -n "${PR_NUM}" ]; then
                 gh pr merge "${PR_NUM}" --auto --squash --repo "${{ github.repository }}" \
                   || echo "::warning::Failed to enable auto-merge for PR #${PR_NUM}"
-                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}"
+                gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Successfully backported to #${PR_NUM}" || true
               fi
             else
               echo "::error::Failed to create PR for ${target}: ${PR_URL}"
-              # Still try to comment on the original PR about the failure
-              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`"
+              notify "@${PR_AUTHOR} Backport branch created but PR creation failed for \`${target}\`. Please create the PR manually from branch \`${branch}\`" "PR creation failed for ${target} (branch ${branch})"
             fi
           done
 


### PR DESCRIPTION
## Summary

Make the "Create PR for each successful backport" step's notifications survive a locked PR so a failed PR creation is never reported to nobody.

## Changes

- **What**: In `.github/workflows/pr-backport.yaml`, the "Create PR for each successful backport" step commented on the original merged PR via raw `gh pr comment`. A merged PR is locked by the repo's CLA check, so the comment fails with `issue is locked`; with no `set -e` the step doesn't abort but the notice is silently lost. The high-stakes case is the PR-creation-failure notice ("branch created but PR creation failed, create it manually") — losing it strands a pushed backport branch with nobody told. This is the same class of bug that left PRs #14018–#14021 to be recreated by hand.

  Added a small `notify()` helper inside the step (bash functions don't cross steps, so it needs its own) that tries `gh pr comment` and, on failure, falls back to `gh issue create` (`--label backport` with a no-label retry, then a `::warning::`). The PR-creation-failure notice is routed through it. The lower-stakes success notice is left as a best-effort `gh pr comment ... || true` — routing it through the same helper would mint a misleadingly-titled "... failed" tracking issue on success.

  Only that one step is touched. The job already declares `issues: write`, and the step runs with `GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}`; no permissions were changed.

## Review Focus

Follow-up to #14152, which added the equivalent `notify()` helper to the sibling "Comment on failures" step; this PR mirrors that approach for the untouched "Create PR" step. #14152 rewrites the `Backport commits`, `Comment on failures`, `Cleanup`, and label-removal steps; this PR stays entirely within `Create PR for each successful backport`, so the two merge cleanly in either order.

This is bash-in-YAML control flow with no unit-extractable logic, so there is no vitest to add. Validated with `actionlint` (no new shellcheck findings vs. `origin/main`) and `yamllint` (clean).