### PR TITLE
fix(subscription): don't paywall runs before subscription status loads

### DIFF
--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
+import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useCoreCommands } from '@/composables/useCoreCommands'
 import { useExternalLink } from '@/composables/useExternalLink'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -56,6 +57,7 @@ vi.mock('@/scripts/app', () => {
         }
       }),
       openClipspace: vi.fn(),
+      queuePrompt: vi.fn().mockResolvedValue(undefined),
       refreshComboInNodes: vi.fn().mockResolvedValue(undefined),
       canvas: mockCanvas,
       rootGraph: {
@@ -135,7 +137,8 @@ vi.mock('@/services/litegraphService', () => ({
 const mockTrackHelpResourceClicked = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({
-    trackHelpResourceClicked: mockTrackHelpResourceClicked
+    trackHelpResourceClicked: mockTrackHelpResourceClicked,
+    trackWorkflowExecution: vi.fn()
   }))
 }))
 
@@ -217,6 +220,8 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
     isActiveSubscription: { value: true },
+    isInitialized: { value: true },
+    fetchStatus: vi.fn(),
     showSubscriptionDialog: vi.fn()
   }))
 }))
@@ -762,6 +767,80 @@ describe('useCoreCommands', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
+    })
+  })
+
+  describe('run subscription gate', () => {
+    const getQueuePromptCommand = () =>
+      useCoreCommands().find((cmd) => cmd.id === 'Comfy.QueuePrompt')
+
+    it('fetches the subscription status before paywalling a run', async () => {
+      const isActiveSubscription = ref(false)
+      const isInitialized = ref(false)
+      const fetchStatus = vi.fn(async () => {
+        // Status resolves, but there is genuinely no active subscription.
+        isInitialized.value = true
+      })
+      const showSubscriptionDialog = vi.fn()
+      vi.mocked(useBillingContext).mockReturnValueOnce(
+        fromPartial({
+          isActiveSubscription,
+          isInitialized,
+          fetchStatus,
+          showSubscriptionDialog
+        })
+      )
+
+      await getQueuePromptCommand()?.function()
+
+      expect(fetchStatus).toHaveBeenCalledOnce()
+      expect(showSubscriptionDialog).toHaveBeenCalledWith({
+        reason: 'subscribe_to_run'
+      })
+      expect(app.queuePrompt).not.toHaveBeenCalled()
+    })
+
+    it('runs without paywalling once the status loads as active', async () => {
+      const isActiveSubscription = ref(false)
+      const isInitialized = ref(false)
+      const fetchStatus = vi.fn(async () => {
+        isInitialized.value = true
+        isActiveSubscription.value = true
+      })
+      const showSubscriptionDialog = vi.fn()
+      vi.mocked(useBillingContext).mockReturnValueOnce(
+        fromPartial({
+          isActiveSubscription,
+          isInitialized,
+          fetchStatus,
+          showSubscriptionDialog
+        })
+      )
+
+      await getQueuePromptCommand()?.function()
+
+      expect(fetchStatus).toHaveBeenCalledOnce()
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      expect(app.queuePrompt).toHaveBeenCalled()
+    })
+
+    it('does not re-fetch when the subscription is already active', async () => {
+      const fetchStatus = vi.fn()
+      const showSubscriptionDialog = vi.fn()
+      vi.mocked(useBillingContext).mockReturnValueOnce(
+        fromPartial({
+          isActiveSubscription: ref(true),
+          isInitialized: ref(true),
+          fetchStatus,
+          showSubscriptionDialog
+        })
+      )
+
+      await getQueuePromptCommand()?.function()
+
+      expect(fetchStatus).not.toHaveBeenCalled()
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      expect(app.queuePrompt).toHaveBeenCalled()
     })
   })
 })

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -76,7 +76,25 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 export function useCoreCommands(): ComfyCommand[] {
-  const { isActiveSubscription, showSubscriptionDialog } = useBillingContext()
+  const {
+    isActiveSubscription,
+    isInitialized,
+    fetchStatus,
+    showSubscriptionDialog
+  } = useBillingContext()
+
+  // Subscription status loads async after auth and reads as inactive until then,
+  // so fetch it before paywalling a run to avoid a false gate on eager clicks.
+  const blockedFromRun = async (): Promise<boolean> => {
+    if (!isActiveSubscription.value && !isInitialized.value) {
+      await fetchStatus()
+    }
+    if (!isActiveSubscription.value) {
+      showSubscriptionDialog({ reason: 'subscribe_to_run' })
+      return true
+    }
+    return false
+  }
   const workflowService = useWorkflowService()
   const workflowStore = useWorkflowStore()
   const settingsDialog = useSettingsDialog()
@@ -508,8 +526,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (await blockedFromRun()) {
           return
         }
 
@@ -531,8 +548,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (await blockedFromRun()) {
           return
         }
 
@@ -553,8 +569,7 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (await blockedFromRun()) {
           return
         }
 


### PR DESCRIPTION
## Summary

New free-tier signups who click **Run** before the async cloud subscription status finishes loading are shown the "subscribe to run" paywall instead of running — even though they have an active 5-run free-tier allowance. Deliberate testers (who pause before clicking) work; eager real users mostly hit the paywall.

## Changes

- **What**: The three Queue Prompt run commands gated directly on `isActiveSubscription`, which coerces a not-yet-loaded (`null`) `subscriptionStatus` to `false` (`useSubscription.ts` `subscriptionStatus.value?.is_active ?? false`). They now go through a shared `blockedFromRun()` guard that fetches the subscription status first — only when it hasn't loaded and isn't already active — before deciding whether to paywall. This mirrors the existing `requireActiveSubscription` pattern (`await fetchSubscriptionStatus()` then check).
- Added regression tests: no paywall while the status is still loading, runs once it resolves active, and no extra fetch when already active.

## Review Focus

- `blockedFromRun` only fetches in the load window (`!isActiveSubscription && !isInitialized`), so the happy path and the genuinely-unsubscribed path add no extra request.
- Applies to all three run entrypoints: `Comfy.QueuePrompt`, `Comfy.QueuePromptFront`, `Comfy.QueueSelectedOutputNodes`.
- `isInitialized` / `fetchStatus` come from the same `activeContext` as `isActiveSubscription` in `useBillingContext`, so they stay consistent across the legacy / consolidated billing paths.
