### PR TITLE
feat(assets): add asset filter search

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -300,6 +300,7 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly searchInput: Locator
   public readonly settingsButton: Locator
   public readonly filterButton: Locator
+  public readonly filterSearchInput: Locator
 
   // --- Filter menu (cloud-only) ---
   public readonly mediaTypeFilterMenuItem: Locator
@@ -356,6 +357,7 @@ export class AssetsSidebarTab extends SidebarTab {
     this.searchInput = page.getByPlaceholder('Search Assets...')
     this.settingsButton = page.getByRole('button', { name: 'View settings' })
     this.filterButton = page.getByRole('button', { name: 'Filter by' })
+    this.filterSearchInput = page.getByRole('textbox', { name: 'Filter by' })
     this.mediaTypeFilterMenuItem = page.getByRole('menuitem', {
       name: /Media type/
     })

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -224,6 +224,18 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
     await page.keyboard.press('ArrowUp')
     await expect(pastWeek).toBeFocused()
 
+    await page.keyboard.press('ArrowUp')
+    await expect(tab.filterSearchInput).toBeFocused()
+
+    await page.keyboard.press('ArrowUp')
+    await expect(pastMonth).toBeFocused()
+
+    await page.keyboard.press('ArrowDown')
+    await expect(tab.filterSearchInput).toBeFocused()
+
+    await page.keyboard.press('ArrowDown')
+    await expect(pastWeek).toBeFocused()
+
     await page.keyboard.press('Enter')
 
     await expect(pastWeek).toHaveAttribute('aria-checked', 'true')

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -208,12 +208,8 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
     await tab.openFilterMenu()
     await tab.filterSearchInput.fill('past')
 
-    const pastWeek = page.getByRole('menuitemcheckbox', {
-      name: 'Past 7 days'
-    })
-    const pastMonth = page.getByRole('menuitemcheckbox', {
-      name: 'Past 30 days'
-    })
+    const pastWeek = tab.dateFilterOption('Past 7 days')
+    const pastMonth = tab.dateFilterOption('Past 30 days')
 
     await tab.filterSearchInput.press('ArrowDown')
     await expect(pastWeek).toBeFocused()

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -197,6 +197,40 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
     await expect(tab.assetCards).toHaveCount(1)
   })
 
+  test('Search results support arrow navigation and Enter selection', async ({
+    comfyPage,
+    page
+  }) => {
+    const tab = comfyPage.menu.assetsTab
+    await tab.open()
+    await tab.waitForAssets()
+
+    await tab.openFilterMenu()
+    await tab.filterSearchInput.fill('past')
+
+    const pastWeek = page.getByRole('menuitemcheckbox', {
+      name: 'Past 7 days'
+    })
+    const pastMonth = page.getByRole('menuitemcheckbox', {
+      name: 'Past 30 days'
+    })
+
+    await tab.filterSearchInput.press('ArrowDown')
+    await expect(pastWeek).toBeFocused()
+
+    await page.keyboard.press('ArrowDown')
+    await expect(pastMonth).toBeFocused()
+
+    await page.keyboard.press('ArrowUp')
+    await expect(pastWeek).toBeFocused()
+
+    await page.keyboard.press('Enter')
+
+    await expect(pastWeek).toHaveAttribute('aria-checked', 'true')
+    await expect(tab.filterButton).toHaveAttribute('aria-expanded', 'true')
+    await expect(tab.assetCards).toHaveCount(2)
+  })
+
   test('Date and media filters compose and applied controls can clear them', async ({
     comfyPage,
     page

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -229,6 +229,10 @@ test.describe('Assets sidebar - attribute filters', { tag: '@cloud' }, () => {
     await expect(pastWeek).toHaveAttribute('aria-checked', 'true')
     await expect(tab.filterButton).toHaveAttribute('aria-expanded', 'true')
     await expect(tab.assetCards).toHaveCount(2)
+
+    await page.keyboard.press('Escape')
+
+    await expect(tab.filterButton).toHaveAttribute('aria-expanded', 'false')
   })
 
   test('Date and media filters compose and applied controls can clear them', async ({

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -905,6 +905,8 @@
       "filterMediaType": "Media type",
       "filterDate": "Date",
       "filterGroupAttribute": "Attribute",
+      "filterBy": "Filter by...",
+      "filterNoMatches": "No matches",
       "dateAll": "All time",
       "dateToday": "Today",
       "datePastWeek": "Past 7 days",

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -80,6 +80,68 @@ const dateLabels = [
 ]
 
 describe('MediaAssetFilterMenu', () => {
+  it('focuses the filter search when the menu opens', async () => {
+    const { user } = renderMenu()
+    await openMenu(user)
+
+    const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
+    expect(searchInput).toHaveAttribute('placeholder', 'Filter by...')
+    expect(searchInput).toHaveFocus()
+  })
+
+  it('finds and toggles a media type without closing the menu', async () => {
+    const { onMediaTypeUpdate, user } = renderMenu()
+    await openMenu(user)
+
+    await user.type(screen.getByRole('textbox', { name: 'Filter by' }), 'VIDEO')
+
+    expect(screen.queryByRole('menuitem', { name: /Media type/ })).toBeNull()
+    const videoResult = screen.getByRole('menuitemcheckbox', {
+      name: 'Video'
+    })
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Image' })).toBeNull()
+
+    await user.click(videoResult)
+
+    expect(onMediaTypeUpdate).toHaveBeenCalledWith(['video'])
+    expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
+    expect(screen.getByRole('textbox', { name: 'Filter by' })).toBeVisible()
+  })
+
+  it('finds and toggles date options without closing the menu', async () => {
+    const { onDateUpdate, user } = renderMenu()
+    await openMenu(user)
+
+    await user.type(screen.getByRole('textbox', { name: 'Filter by' }), 'past')
+
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Past 7 days' })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Past 30 days' })
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole('menuitemcheckbox', { name: 'Past 7 days' })
+    )
+
+    expect(onDateUpdate).toHaveBeenCalledWith('week')
+    expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
+  })
+
+  it('shows an empty state when no filter options match', async () => {
+    const { user } = renderMenu()
+    await openMenu(user)
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Filter by' }),
+      'not-a-filter'
+    )
+
+    expect(screen.getByText('No matches')).toBeVisible()
+    expect(screen.queryAllByRole('menuitemcheckbox')).toHaveLength(0)
+  })
+
   it('groups media type and date under the Attribute section', async () => {
     const { user } = renderMenu()
     await openMenu(user)

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -129,6 +129,35 @@ describe('MediaAssetFilterMenu', () => {
     expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
   })
 
+  it('navigates matching options and toggles the focused result', async () => {
+    const { onDateUpdate, user } = renderMenu()
+    await openMenu(user)
+
+    const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
+    await user.type(searchInput, 'past')
+
+    const pastWeek = screen.getByRole('menuitemcheckbox', {
+      name: 'Past 7 days'
+    })
+    const pastMonth = screen.getByRole('menuitemcheckbox', {
+      name: 'Past 30 days'
+    })
+
+    await user.keyboard('{ArrowDown}')
+    expect(pastWeek).toHaveFocus()
+
+    await user.keyboard('{ArrowDown}')
+    expect(pastMonth).toHaveFocus()
+
+    await user.keyboard('{ArrowUp}')
+    expect(pastWeek).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+
+    expect(onDateUpdate).toHaveBeenCalledWith('week')
+    expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
+  })
+
   it('shows an empty state when no filter options match', async () => {
     const { user } = renderMenu()
     await openMenu(user)

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -108,25 +108,45 @@ describe('MediaAssetFilterMenu', () => {
     expect(screen.getByRole('textbox', { name: 'Filter by' })).toBeVisible()
   })
 
-  it('finds and toggles date options without closing the menu', async () => {
+  it('finds and selects date options without closing the menu', async () => {
     const { onDateUpdate, user } = renderMenu()
     await openMenu(user)
 
     await user.type(screen.getByRole('textbox', { name: 'Filter by' }), 'past')
 
     expect(
-      screen.getByRole('menuitemcheckbox', { name: 'Past 7 days' })
+      screen.getByRole('menuitemradio', { name: 'Past 7 days' })
     ).toBeVisible()
     expect(
-      screen.getByRole('menuitemcheckbox', { name: 'Past 30 days' })
+      screen.getByRole('menuitemradio', { name: 'Past 30 days' })
     ).toBeVisible()
 
-    await user.click(
-      screen.getByRole('menuitemcheckbox', { name: 'Past 7 days' })
-    )
+    await user.click(screen.getByRole('menuitemradio', { name: 'Past 7 days' }))
 
     expect(onDateUpdate).toHaveBeenCalledWith('week')
     expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
+  })
+
+  it('keeps the selected date active and clears it with All time', async () => {
+    const { onDateUpdate, user } = renderMenu({ dateFilter: 'week' })
+    await openMenu(user)
+
+    const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
+    await user.type(searchInput, 'past')
+
+    const pastWeek = screen.getByRole('menuitemradio', {
+      name: 'Past 7 days'
+    })
+    expect(pastWeek).toHaveAttribute('aria-checked', 'true')
+
+    await user.click(pastWeek)
+    expect(onDateUpdate).not.toHaveBeenCalled()
+
+    await user.clear(searchInput)
+    await user.type(searchInput, 'all')
+    await user.click(screen.getByRole('menuitemradio', { name: 'All time' }))
+
+    expect(onDateUpdate).toHaveBeenLastCalledWith('')
   })
 
   it('navigates matching options and toggles the focused result', async () => {
@@ -136,10 +156,10 @@ describe('MediaAssetFilterMenu', () => {
     const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
     await user.type(searchInput, 'past')
 
-    const pastWeek = screen.getByRole('menuitemcheckbox', {
+    const pastWeek = screen.getByRole('menuitemradio', {
       name: 'Past 7 days'
     })
-    const pastMonth = screen.getByRole('menuitemcheckbox', {
+    const pastMonth = screen.getByRole('menuitemradio', {
       name: 'Past 30 days'
     })
 
@@ -169,10 +189,10 @@ describe('MediaAssetFilterMenu', () => {
     const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
     await user.type(searchInput, 'past')
 
-    const pastWeek = screen.getByRole('menuitemcheckbox', {
+    const pastWeek = screen.getByRole('menuitemradio', {
       name: 'Past 7 days'
     })
-    const pastMonth = screen.getByRole('menuitemcheckbox', {
+    const pastMonth = screen.getByRole('menuitemradio', {
       name: 'Past 30 days'
     })
 

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -242,6 +242,7 @@ describe('MediaAssetFilterMenu', () => {
 
     expect(screen.getByText('No matches')).toBeVisible()
     expect(screen.queryAllByRole('menuitemcheckbox')).toHaveLength(0)
+    expect(screen.queryAllByRole('menuitemradio')).toHaveLength(0)
   })
 
   it('groups media type and date under the Attribute section', async () => {

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -162,6 +162,55 @@ describe('MediaAssetFilterMenu', () => {
     expect(screen.queryByRole('menu', { name: 'Filter by' })).toBeNull()
   })
 
+  it('loops focus between the search input and matching options', async () => {
+    const { user } = renderMenu()
+    await openMenu(user)
+
+    const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
+    await user.type(searchInput, 'past')
+
+    const pastWeek = screen.getByRole('menuitemcheckbox', {
+      name: 'Past 7 days'
+    })
+    const pastMonth = screen.getByRole('menuitemcheckbox', {
+      name: 'Past 30 days'
+    })
+
+    await user.keyboard('{ArrowDown}')
+    expect(pastWeek).toHaveFocus()
+    await user.keyboard('{ArrowDown}')
+    expect(pastMonth).toHaveFocus()
+    await user.keyboard('{ArrowDown}')
+    expect(searchInput).toHaveFocus()
+
+    await user.keyboard('{ArrowUp}')
+    expect(pastMonth).toHaveFocus()
+    await user.keyboard('{ArrowUp}')
+    expect(pastWeek).toHaveFocus()
+    await user.keyboard('{ArrowUp}')
+    expect(searchInput).toHaveFocus()
+  })
+
+  it('loops focus when search has one matching option', async () => {
+    const { user } = renderMenu()
+    await openMenu(user)
+
+    const searchInput = screen.getByRole('textbox', { name: 'Filter by' })
+    await user.type(searchInput, 'video')
+
+    const video = screen.getByRole('menuitemcheckbox', { name: 'Video' })
+
+    await user.keyboard('{ArrowDown}')
+    expect(video).toHaveFocus()
+    await user.keyboard('{ArrowDown}')
+    expect(searchInput).toHaveFocus()
+
+    await user.keyboard('{ArrowUp}')
+    expect(video).toHaveFocus()
+    await user.keyboard('{ArrowUp}')
+    expect(searchInput).toHaveFocus()
+  })
+
   it('shows an empty state when no filter options match', async () => {
     const { user } = renderMenu()
     await openMenu(user)

--- a/src/platform/assets/components/MediaAssetFilterMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetFilterMenu.test.ts
@@ -156,6 +156,10 @@ describe('MediaAssetFilterMenu', () => {
 
     expect(onDateUpdate).toHaveBeenCalledWith('week')
     expect(screen.getByRole('menu', { name: 'Filter by' })).toBeVisible()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('menu', { name: 'Filter by' })).toBeNull()
   })
 
   it('shows an empty state when no filter options match', async () => {

--- a/src/platform/assets/components/MediaAssetFilterMenu.vue
+++ b/src/platform/assets/components/MediaAssetFilterMenu.vue
@@ -1,11 +1,73 @@
 <template>
-  <DropdownMenuLabel
-    class="px-2 pt-1 pb-1.5 text-xs font-semibold text-muted-foreground uppercase"
-  >
+  <div class="flex h-8 items-center gap-2 px-2">
+    <i
+      aria-hidden="true"
+      class="icon-[lucide--search] size-4 shrink-0 text-muted-foreground"
+    />
+    <input
+      ref="searchInput"
+      v-model="searchQuery"
+      type="text"
+      :aria-label="$t('assetBrowser.filterBy')"
+      :placeholder="$t('sideToolbar.mediaAssets.filterBy')"
+      class="min-w-0 flex-1 border-none bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+      @keydown="handleSearchKeydown"
+    />
+  </div>
+  <DropdownMenuSeparator class="my-1 h-px bg-border-subtle" />
+
+  <template v-if="isSearching">
+    <template v-if="matchingMediaTypes.length">
+      <DropdownMenuLabel :class="groupLabelClass">
+        {{ $t('sideToolbar.mediaAssets.filterMediaType') }}
+      </DropdownMenuLabel>
+      <DropdownMenuCheckboxItem
+        v-for="filter in matchingMediaTypes"
+        :key="filter.value"
+        :model-value="mediaTypeFilters.includes(filter.value)"
+        :class="menuItemClass"
+        @click="toggleMediaType(filter.value)"
+        @select.prevent
+      >
+        <span class="flex-1">{{ $t(filter.label) }}</span>
+        <DropdownMenuItemIndicator class="size-4 shrink-0">
+          <i class="icon-[lucide--check]" />
+        </DropdownMenuItemIndicator>
+      </DropdownMenuCheckboxItem>
+    </template>
+
+    <template v-if="matchingDates.length">
+      <DropdownMenuLabel :class="groupLabelClass">
+        {{ $t('sideToolbar.mediaAssets.filterDate') }}
+      </DropdownMenuLabel>
+      <DropdownMenuCheckboxItem
+        v-for="filter in matchingDates"
+        :key="filter.value"
+        :model-value="dateFilter === filter.value"
+        :class="menuItemClass"
+        @click="toggleDateFilter(filter.value)"
+        @select.prevent
+      >
+        <span class="flex-1">{{ $t(filter.label) }}</span>
+        <DropdownMenuItemIndicator class="size-4 shrink-0">
+          <i class="icon-[lucide--check]" />
+        </DropdownMenuItemIndicator>
+      </DropdownMenuCheckboxItem>
+    </template>
+
+    <div
+      v-if="!hasSearchResults"
+      class="px-2 py-1.5 text-sm text-muted-foreground"
+    >
+      {{ $t('sideToolbar.mediaAssets.filterNoMatches') }}
+    </div>
+  </template>
+
+  <DropdownMenuLabel v-if="!isSearching" :class="groupLabelClass">
     {{ $t('sideToolbar.mediaAssets.filterGroupAttribute') }}
   </DropdownMenuLabel>
 
-  <DropdownMenuSub>
+  <DropdownMenuSub v-if="!isSearching">
     <DropdownMenuSubTrigger :class="menuItemClass">
       <i class="icon-[lucide--image] size-4 shrink-0 text-muted-foreground" />
       <span class="flex-1 text-left">
@@ -41,7 +103,7 @@
     </DropdownMenuPortal>
   </DropdownMenuSub>
 
-  <DropdownMenuSub>
+  <DropdownMenuSub v-if="!isSearching">
     <DropdownMenuSubTrigger :class="menuItemClass">
       <i
         class="icon-[lucide--calendar] size-4 shrink-0 text-muted-foreground"
@@ -90,10 +152,13 @@ import {
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger
 } from 'reka-ui'
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import {
   dateFilterOptions,
@@ -108,10 +173,37 @@ const mediaTypeFilters = defineModel<string[]>('mediaTypeFilters', {
   required: true
 })
 
+const { t } = useI18n()
+const searchInput = ref<HTMLInputElement>()
+const searchQuery = ref('')
+const normalizedQuery = computed(() => searchQuery.value.trim().toLowerCase())
+const isSearching = computed(() => normalizedQuery.value.length > 0)
+const matchingMediaTypes = computed(() =>
+  mediaTypeFilterOptions.filter((filter) =>
+    t(filter.label).toLowerCase().includes(normalizedQuery.value)
+  )
+)
+const matchingDates = computed(() =>
+  dateFilterOptions.filter(
+    (filter) =>
+      filter.value &&
+      t(filter.label).toLowerCase().includes(normalizedQuery.value)
+  )
+)
+const hasSearchResults = computed(
+  () => matchingMediaTypes.value.length > 0 || matchingDates.value.length > 0
+)
+
 const menuItemClass =
   'flex h-8 cursor-pointer items-center gap-2 rounded-lg px-2 text-sm outline-none data-highlighted:bg-secondary-background-hover'
+const groupLabelClass =
+  'px-2 pt-1 pb-1.5 text-xs font-semibold text-muted-foreground uppercase'
 const submenuClass =
   'z-1700 min-w-40 rounded-lg border border-border-subtle bg-base-background p-2 shadow-sm'
+
+onMounted(() => {
+  void nextTick(() => searchInput.value?.focus())
+})
 
 function toggleMediaType(type: string) {
   if (mediaTypeFilters.value.includes(type)) {
@@ -120,6 +212,21 @@ function toggleMediaType(type: string) {
     )
   } else {
     mediaTypeFilters.value = [...mediaTypeFilters.value, type]
+  }
+}
+
+function toggleDateFilter(value: MediaAssetDateFilter) {
+  dateFilter.value = dateFilter.value === value ? '' : value
+}
+
+function handleSearchKeydown(event: KeyboardEvent) {
+  if (
+    event.key.length === 1 &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey
+  ) {
+    event.stopPropagation()
   }
 }
 </script>

--- a/src/platform/assets/components/MediaAssetFilterMenu.vue
+++ b/src/platform/assets/components/MediaAssetFilterMenu.vue
@@ -27,6 +27,7 @@
         :model-value="mediaTypeFilters.includes(filter.value)"
         :class="menuItemClass"
         @click="toggleMediaType(filter.value)"
+        @keydown="handleSearchResultKeydown"
         @select.prevent
       >
         <span class="flex-1">{{ $t(filter.label) }}</span>
@@ -46,6 +47,7 @@
         :model-value="dateFilter === filter.value"
         :class="menuItemClass"
         @click="toggleDateFilter(filter.value)"
+        @keydown="handleSearchResultKeydown"
         @select.prevent
       >
         <span class="flex-1">{{ $t(filter.label) }}</span>
@@ -220,6 +222,18 @@ function toggleDateFilter(value: MediaAssetDateFilter) {
 }
 
 function handleSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    const results = getSearchResults()
+    const result = event.key === 'ArrowDown' ? results.at(0) : results.at(-1)
+
+    if (result) {
+      event.preventDefault()
+      event.stopPropagation()
+      result.focus()
+    }
+    return
+  }
+
   if (
     event.key.length === 1 &&
     !event.ctrlKey &&
@@ -228,5 +242,28 @@ function handleSearchKeydown(event: KeyboardEvent) {
   ) {
     event.stopPropagation()
   }
+}
+
+function handleSearchResultKeydown(event: KeyboardEvent) {
+  const results = getSearchResults()
+  const currentIndex = results.indexOf(event.currentTarget as HTMLElement)
+  const movingPastEnd =
+    event.key === 'ArrowDown' && currentIndex === results.length - 1
+  const movingBeforeStart = event.key === 'ArrowUp' && currentIndex === 0
+
+  if (!movingPastEnd && !movingBeforeStart) return
+
+  event.preventDefault()
+  event.stopPropagation()
+  searchInput.value?.focus()
+}
+
+function getSearchResults() {
+  const menu = searchInput.value?.closest('[role="menu"]')
+  return menu
+    ? Array.from(
+        menu.querySelectorAll<HTMLElement>('[role="menuitemcheckbox"]')
+      )
+    : []
 }
 </script>

--- a/src/platform/assets/components/MediaAssetFilterMenu.vue
+++ b/src/platform/assets/components/MediaAssetFilterMenu.vue
@@ -41,20 +41,22 @@
       <DropdownMenuLabel :class="groupLabelClass">
         {{ $t('sideToolbar.mediaAssets.filterDate') }}
       </DropdownMenuLabel>
-      <DropdownMenuCheckboxItem
-        v-for="filter in matchingDates"
-        :key="filter.value"
-        :model-value="dateFilter === filter.value"
-        :class="menuItemClass"
-        @click="toggleDateFilter(filter.value)"
-        @keydown="handleSearchResultKeydown"
-        @select.prevent
-      >
-        <span class="flex-1">{{ $t(filter.label) }}</span>
-        <DropdownMenuItemIndicator class="size-4 shrink-0">
-          <i class="icon-[lucide--check]" />
-        </DropdownMenuItemIndicator>
-      </DropdownMenuCheckboxItem>
+      <DropdownMenuRadioGroup :model-value="dateFilter">
+        <DropdownMenuRadioItem
+          v-for="filter in matchingDates"
+          :key="filter.value"
+          :value="filter.value"
+          :class="menuItemClass"
+          @click="dateFilter = filter.value"
+          @keydown="handleSearchResultKeydown"
+          @select.prevent
+        >
+          <span class="flex-1">{{ $t(filter.label) }}</span>
+          <DropdownMenuItemIndicator class="size-4 shrink-0">
+            <i class="icon-[lucide--check]" />
+          </DropdownMenuItemIndicator>
+        </DropdownMenuRadioItem>
+      </DropdownMenuRadioGroup>
     </template>
 
     <div
@@ -186,10 +188,8 @@ const matchingMediaTypes = computed(() =>
   )
 )
 const matchingDates = computed(() =>
-  dateFilterOptions.filter(
-    (filter) =>
-      filter.value &&
-      t(filter.label).toLowerCase().includes(normalizedQuery.value)
+  dateFilterOptions.filter((filter) =>
+    t(filter.label).toLowerCase().includes(normalizedQuery.value)
   )
 )
 const hasSearchResults = computed(
@@ -215,10 +215,6 @@ function toggleMediaType(type: string) {
   } else {
     mediaTypeFilters.value = [...mediaTypeFilters.value, type]
   }
-}
-
-function toggleDateFilter(value: MediaAssetDateFilter) {
-  dateFilter.value = dateFilter.value === value ? '' : value
 }
 
 function handleSearchKeydown(event: KeyboardEvent) {
@@ -262,7 +258,9 @@ function getSearchResults() {
   const menu = searchInput.value?.closest('[role="menu"]')
   return menu
     ? Array.from(
-        menu.querySelectorAll<HTMLElement>('[role="menuitemcheckbox"]')
+        menu.querySelectorAll<HTMLElement>(
+          '[role="menuitemcheckbox"], [role="menuitemradio"]'
+        )
       )
     : []
 }

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -67,6 +67,7 @@ describe('keybindingService - Escape key handling', () => {
   function createKeyboardEvent(
     key: string,
     options: {
+      target?: Element
       ctrlKey?: boolean
       altKey?: boolean
       metaKey?: boolean
@@ -84,7 +85,7 @@ describe('keybindingService - Escape key handling', () => {
     })
 
     event.preventDefault = vi.fn()
-    event.composedPath = vi.fn(() => [document.body])
+    event.composedPath = vi.fn(() => [options.target ?? document.body])
 
     return event
   }
@@ -125,6 +126,20 @@ describe('keybindingService - Escape key handling', () => {
     const event = createKeyboardEvent('Escape', { ctrlKey: true })
     await keybindingService.keybindHandler(event)
 
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('should leave Escape events from menus to the menu', async () => {
+    const menu = document.createElement('div')
+    menu.setAttribute('role', 'menu')
+    const menuItem = document.createElement('div')
+    menuItem.setAttribute('role', 'menuitemcheckbox')
+    menu.appendChild(menuItem)
+
+    const event = createKeyboardEvent('Escape', { target: menuItem })
+    await keybindingService.keybindHandler(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
     expect(mockCommandExecute).not.toHaveBeenCalled()
   })
 

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -21,6 +21,10 @@ export function useKeybindingService() {
     }
 
     const target = event.composedPath()[0] as HTMLElement
+    if (event.key === 'Escape' && target.closest?.('[role="menu"]')) {
+      return
+    }
+
     if (
       keyCombo.isReservedByTextInput &&
       (target.tagName === 'TEXTAREA' ||

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -21,6 +21,7 @@ export function useKeybindingService() {
     }
 
     const target = event.composedPath()[0] as HTMLElement
+    // Let the active menu own Escape without also triggering the global shortcut.
     if (event.key === 'Escape' && target.closest?.('[role="menu"]')) {
       return
     }


### PR DESCRIPTION
## Summary

Add search and keyboard navigation to the Media Assets filter menu.

Follow-up to #14166.
[FE-1367](https://linear.app/comfyorg/issue/FE-1367/assets-view-options-media-assets-sidebar-filtering-search-view-modes)

## Changes

- Filter Media type and Date options by label
- Support looping Arrow Up / Down navigation between the search input and results
- Toggle focused options with Enter without closing the menu
- Let Escape close the filter menu after keyboard selection
- Show an empty state when no options match

## Review Focus

- Focus behavior with single and multiple search results
- Escape handling remains unchanged outside menus

## Screenshots

https://github.com/user-attachments/assets/3cf4f018-b3c5-466c-be94-2ee2ca294982
