### PR TITLE
fix(ui): keep MultiSelect search focusable inside modal dialogs

### DIFF
--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -181,7 +181,7 @@ describe('MultiSelect', () => {
     })
   })
 
-  it('keeps focus on the search input when nested in a trapped focus scope', async () => {
+  it('lets the user type in the search box when nested in a trapped focus scope', async () => {
     const user = userEvent.setup()
     const InTrap = {
       components: { FocusScope, MultiSelect },
@@ -200,13 +200,15 @@ describe('MultiSelect', () => {
     })
 
     await user.click(screen.getByRole('button'))
-    await new Promise((resolve) => setTimeout(resolve))
+    await nextTick()
 
-    const searchBox = findContentElement()?.querySelector('input')
-    searchBox?.focus()
-    await new Promise((resolve) => setTimeout(resolve))
+    const searchBox = screen.getByPlaceholderText('Search')
+    await user.click(searchBox)
+    await user.type(searchBox, 'query')
+    await nextTick()
 
     expect(document.activeElement).toBe(searchBox)
+    expect(searchBox).toHaveValue('query')
 
     unmount()
   })

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -207,7 +207,7 @@ describe('MultiSelect', () => {
     await user.type(searchBox, 'query')
     await nextTick()
 
-    expect(document.activeElement).toBe(searchBox)
+    expect(searchBox).toHaveFocus()
     expect(searchBox).toHaveValue('query')
 
     unmount()

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,6 +1,7 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { FocusScope } from 'reka-ui'
 import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -178,5 +179,35 @@ describe('MultiSelect', () => {
 
       unmount()
     })
+  })
+
+  it('keeps focus on the search input when nested in a trapped focus scope', async () => {
+    const user = userEvent.setup()
+    const InTrap = {
+      components: { FocusScope, MultiSelect },
+      template: `
+        <FocusScope trapped as-child>
+          <div>
+            <MultiSelect v-model="sel" :options="options" :show-search-box="true" />
+          </div>
+        </FocusScope>`,
+      setup: () => ({ sel: ref([]), options })
+    }
+
+    const { unmount } = render(InTrap, {
+      container: document.body.appendChild(document.createElement('div')),
+      global: { plugins: [i18n] }
+    })
+
+    await user.click(screen.getByRole('button'))
+    await new Promise((resolve) => setTimeout(resolve))
+
+    const searchBox = findContentElement()?.querySelector('input')
+    searchBox?.focus()
+    await new Promise((resolve) => setTimeout(resolve))
+
+    expect(document.activeElement).toBe(searchBox)
+
+    unmount()
   })
 })

--- a/src/components/ui/multi-select/MultiSelect.vue
+++ b/src/components/ui/multi-select/MultiSelect.vue
@@ -56,79 +56,81 @@
         @keydown="onContentKeydown"
         @focus-outside="preventFocusDismiss"
       >
-        <div v-if="showSearchBox" class="px-2 pt-2 pb-0">
-          <div
-            class="flex items-center gap-2 rounded-lg border border-solid border-border-default px-3 py-1.5"
-          >
-            <i
-              class="icon-[lucide--search] shrink-0 text-sm text-muted-foreground"
-            />
-            <ComboboxInput
-              v-model="searchQuery"
-              :placeholder="searchPlaceholder ?? t('g.search')"
-              class="w-full border-none bg-transparent text-sm outline-none"
-            />
-          </div>
-        </div>
-
-        <div
-          v-if="hasActions"
-          :class="
-            cn(
-              'flex shrink-0 items-center justify-between px-2',
-              actionsPlacement === 'header'
-                ? 'mt-2 border-b border-border-default pb-4'
-                : 'order-last mt-2 border-t border-border-default pt-3 pb-1'
-            )
-          "
-        >
-          <span
-            v-if="showSelectedCount"
-            class="px-1 text-sm text-muted-foreground"
-          >
-            {{ $t('g.itemsSelected', { count: selectedCount }) }}
-          </span>
-          <Button
-            v-if="showClearButton"
-            variant="textonly"
-            size="md"
-            @click.stop="selectedItems = []"
-          >
-            {{ $t('g.clearAll') }}
-          </Button>
-        </div>
-
-        <ComboboxViewport
-          :class="
-            cn(
-              'flex flex-col gap-0 p-0 text-sm',
-              'scrollbar-custom overflow-y-auto',
-              'min-w-(--reka-combobox-trigger-width)'
-            )
-          "
-          :style="{ maxHeight: `min(${listMaxHeight}, 50vh)` }"
-        >
-          <ComboboxItem
-            v-for="opt in filteredOptions"
-            :key="opt.value"
-            :value="opt"
-            :class="cn('group', selectItemVariants({ layout: 'multi' }))"
-          >
+        <FocusScope class="contents" @mount-auto-focus.prevent>
+          <div v-if="showSearchBox" class="px-2 pt-2 pb-0">
             <div
-              class="flex size-4 shrink-0 items-center justify-center rounded-sm transition-all duration-200 group-data-[state=checked]:bg-primary-background group-data-[state=unchecked]:bg-secondary-background [&>span]:flex"
+              class="flex items-center gap-2 rounded-lg border border-solid border-border-default px-3 py-1.5"
             >
-              <ComboboxItemIndicator>
-                <i
-                  class="icon-[lucide--check] text-xs font-bold text-base-foreground"
-                />
-              </ComboboxItemIndicator>
+              <i
+                class="icon-[lucide--search] shrink-0 text-sm text-muted-foreground"
+              />
+              <ComboboxInput
+                v-model="searchQuery"
+                :placeholder="searchPlaceholder ?? t('g.search')"
+                class="w-full border-none bg-transparent text-sm outline-none"
+              />
             </div>
-            <span>{{ opt.name }}</span>
-          </ComboboxItem>
-          <ComboboxEmpty :class="selectEmptyMessageClass">
-            {{ $t('g.noResultsFound') }}
-          </ComboboxEmpty>
-        </ComboboxViewport>
+          </div>
+
+          <div
+            v-if="hasActions"
+            :class="
+              cn(
+                'flex shrink-0 items-center justify-between px-2',
+                actionsPlacement === 'header'
+                  ? 'mt-2 border-b border-border-default pb-4'
+                  : 'order-last mt-2 border-t border-border-default pt-3 pb-1'
+              )
+            "
+          >
+            <span
+              v-if="showSelectedCount"
+              class="px-1 text-sm text-muted-foreground"
+            >
+              {{ $t('g.itemsSelected', { count: selectedCount }) }}
+            </span>
+            <Button
+              v-if="showClearButton"
+              variant="textonly"
+              size="md"
+              @click.stop="selectedItems = []"
+            >
+              {{ $t('g.clearAll') }}
+            </Button>
+          </div>
+
+          <ComboboxViewport
+            :class="
+              cn(
+                'flex flex-col gap-0 p-0 text-sm',
+                'scrollbar-custom overflow-y-auto',
+                'min-w-(--reka-combobox-trigger-width)'
+              )
+            "
+            :style="{ maxHeight: `min(${listMaxHeight}, 50vh)` }"
+          >
+            <ComboboxItem
+              v-for="opt in filteredOptions"
+              :key="opt.value"
+              :value="opt"
+              :class="cn('group', selectItemVariants({ layout: 'multi' }))"
+            >
+              <div
+                class="flex size-4 shrink-0 items-center justify-center rounded-sm transition-all duration-200 group-data-[state=checked]:bg-primary-background group-data-[state=unchecked]:bg-secondary-background [&>span]:flex"
+              >
+                <ComboboxItemIndicator>
+                  <i
+                    class="icon-[lucide--check] text-xs font-bold text-base-foreground"
+                  />
+                </ComboboxItemIndicator>
+              </div>
+              <span>{{ opt.name }}</span>
+            </ComboboxItem>
+            <ComboboxEmpty :class="selectEmptyMessageClass">
+              {{ $t('g.noResultsFound') }}
+            </ComboboxEmpty>
+          </ComboboxViewport>
+        </FocusScope>
       </ComboboxContent>
     </ComboboxPortal>
   </ComboboxRoot>
@@ -148,7 +150,8 @@ import {
   ComboboxPortal,
   ComboboxRoot,
   ComboboxTrigger,
-  ComboboxViewport
+  ComboboxViewport,
+  FocusScope
 } from 'reka-ui'
 import { computed, ref } from 'vue'
 import type { StyleValue } from 'vue'


### PR DESCRIPTION
## Summary

Search boxes inside the Templates modal filter dropdowns (Model, Use Case, Runs On) were dead. Clicking them did nothing and you couldn't type. They work again now.

## Why it happened

The dropdown renders its content in a portal on `document.body`, outside the dialog. A modal Reka dialog traps focus with a FocusScope, and that trap pulls focus back inside the dialog whenever it lands anywhere outside. Since the portalled search input lives outside the dialog, clicking it handed focus over for a split second and the trap immediately snapped it back to the trigger button, so the input could never hold focus and typing went nowhere.

Reka's Select and Popover don't hit this because they each mount their own FocusScope. Combobox (what MultiSelect uses) doesn't, so nothing paused the dialog's trap.

One thing worth flagging: this was not the `pointer-events: none` issue it first looked like. Measured in the browser, the input had `pointer-events: auto` and was fully clickable. It was purely focus.

## Changes

- Wrap the MultiSelect dropdown content in a `FocusScope`. Its only job is to sit on the focus-scope stack while the dropdown is open, which pauses the dialog's trap so the search input can keep focus. Same approach Reka's own Select and Popover use.
- The wrapper uses `display: contents`, so it adds no layout box and no accessibility node. Every role (searchbox, listbox, option) is untouched.
- **Breaking:** none. SingleSelect needs no change (Reka's Select already has its own FocusScope), and nothing changes outside a dialog.

## Review Focus

The big-looking diff is mostly re-indentation from wrapping the content, `git diff -w` shows the real change is the FocusScope plus one import. The one judgment call is `class="contents"` on the FocusScope instead of `as-child` onto a styled div, since there's no natural single wrapper here and this keeps the diff and DOM minimal. Happy to switch if you'd rather match NodeSearchContent's `as-child` shape.

## Testing

- Added a unit test in `MultiSelect.test.ts` that renders the dropdown inside a trapped `FocusScope` (standing in for the dialog) and asserts the search input keeps focus. Verified it fails without the fix and passes with it.
- Checked by hand in a real browser against Cloud: open a filter, click the search box, type, and the list filters.

Fixes FE-1380.


https://github.com/user-attachments/assets/3e130fcc-bed6-46ab-b5b3-7e1418280b17


