### PR TITLE
feat(video): VIDEO_EDIT rich widget with trim and crop editors

### DIFF
--- a/src/components/videoEdit/VideoEditPanel.test.ts
+++ b/src/components/videoEdit/VideoEditPanel.test.ts
@@ -1,0 +1,228 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+import VideoEditPanel from './VideoEditPanel.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      videoEdit: {
+        trimVideo: 'Trim Video',
+        cropVideo: 'Crop Video',
+        startFrame: 'Start Frame',
+        endFrame: 'End Frame',
+        duration: 'Duration',
+        frames: 'Number of Frames',
+        fileSize: 'File Size',
+        resolution: '{width} × {height}',
+        loadingVideo: 'Loading video preview',
+        setStartFrame: 'Reset start frame',
+        setEndFrame: 'Reset end frame',
+        durationZero: '0s',
+        durationSeconds: '{count}s',
+        selectedOfTotal: '{selected} / {total}',
+        fileSizeUnknown: '—',
+        fileSizeBytes: '{count} B',
+        fileSizeKilobytes: '{count} KB',
+        fileSizeMegabytes: '{count} MB',
+        noVideoSource: 'Select or connect a video to preview and edit'
+      },
+      imageCrop: {
+        ratio: 'Ratio',
+        custom: 'Custom',
+        lockRatio: 'Lock ratio',
+        unlockRatio: 'Unlock ratio'
+      }
+    }
+  }
+})
+
+function stub(testId: string) {
+  return defineComponent({
+    setup: () => () => h('div', { 'data-testid': testId })
+  })
+}
+
+const ToggleStub = defineComponent({
+  props: {
+    widget: { type: Object, required: true },
+    modelValue: { type: Boolean, default: false }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('button', {
+        'data-testid': `toggle-${props.widget.name}`,
+        onClick: () => emit('update:modelValue', !props.modelValue)
+      })
+  }
+})
+
+type PanelProps = ComponentProps<typeof VideoEditPanel>
+
+function renderPanel(props: Partial<PanelProps> = {}) {
+  return render(VideoEditPanel, {
+    props: {
+      features: ['trim', 'crop'],
+      videoUrl: '/api/view?filename=clip.mp4',
+      thumbnails: ['data:image/jpeg;base64,one'],
+      totalFrames: 100,
+      duration: 10,
+      fps: 10,
+      fileSize: 2048,
+      width: 1920,
+      height: 1080,
+      loading: false,
+      ...props
+    } as PanelProps,
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: {} },
+      stubs: {
+        VideoFilmstripTrim: stub('stub-filmstrip'),
+        VideoCropOverlay: stub('stub-crop-overlay'),
+        WidgetInputNumberInput: stub('stub-number-input'),
+        WidgetBoundingBox: stub('stub-bounding-box'),
+        WidgetToggleSwitch: ToggleStub,
+        Loader: stub('stub-loader'),
+        Select: stub('stub-select'),
+        SelectTrigger: stub('stub-select-trigger'),
+        SelectValue: stub('stub-select-value'),
+        SelectContent: stub('stub-select-content'),
+        SelectItem: stub('stub-select-item'),
+        Button: stub('stub-lock-button')
+      }
+    }
+  })
+}
+
+describe('VideoEditPanel', () => {
+  it('shows an empty state without a video source', () => {
+    renderPanel({ videoUrl: undefined })
+
+    expect(screen.getByTestId('video-edit-empty')).toBeTruthy()
+    expect(screen.queryByTestId('video-preview')).toBeNull()
+    expect(screen.queryByTestId('toggle-trim_enabled')).toBeNull()
+  })
+
+  it('renders only the toggles of the enabled features', () => {
+    renderPanel({ features: ['trim'] })
+
+    expect(screen.getByTestId('toggle-trim_enabled')).toBeTruthy()
+    expect(screen.queryByTestId('toggle-crop_enabled')).toBeNull()
+  })
+
+  it('keeps the filmstrip visible but collapses trim controls until enabled', async () => {
+    renderPanel({ features: ['trim'] })
+
+    expect(screen.getByTestId('stub-filmstrip')).toBeTruthy()
+    expect(screen.queryByTestId('stub-number-input')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('toggle-trim_enabled'))
+
+    expect(screen.getAllByTestId('stub-number-input')).toHaveLength(2)
+  })
+
+  it('expands the crop editor when the crop toggle is enabled', async () => {
+    renderPanel({ features: ['crop'] })
+
+    expect(screen.queryByTestId('stub-crop-overlay')).toBeNull()
+    expect(screen.queryByTestId('stub-bounding-box')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('toggle-crop_enabled'))
+
+    expect(screen.getByTestId('stub-crop-overlay')).toBeTruthy()
+    expect(screen.getByTestId('stub-bounding-box')).toBeTruthy()
+  })
+
+  it('resets the trim bounds from the reset frame buttons', async () => {
+    const updates: Array<[string, number]> = []
+    renderPanel({
+      features: ['trim'],
+      startFrame: 30,
+      endFrame: 60,
+      'onUpdate:startFrame': (value: number) => updates.push(['start', value]),
+      'onUpdate:endFrame': (value: number) => updates.push(['end', value])
+    } as Partial<PanelProps>)
+
+    await userEvent.click(screen.getByTestId('toggle-trim_enabled'))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Reset start frame' })
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Reset end frame' })
+    )
+
+    expect(updates).toContainEqual(['start', 0])
+    expect(updates).toContainEqual(['end', 99])
+  })
+
+  it('disables the reset buttons at the trim extremes', async () => {
+    renderPanel({ features: ['trim'], startFrame: 0, endFrame: 99 })
+
+    await userEvent.click(screen.getByTestId('toggle-trim_enabled'))
+
+    expect(
+      screen.getByRole('button', { name: 'Reset start frame' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Reset end frame' })
+    ).toBeDisabled()
+  })
+
+  it('disables the reset buttons while the filmstrip is still loading', async () => {
+    renderPanel({
+      features: ['trim'],
+      startFrame: 30,
+      endFrame: 60,
+      loading: true
+    })
+
+    await userEvent.click(screen.getByTestId('toggle-trim_enabled'))
+
+    expect(
+      screen.getByRole('button', { name: 'Reset start frame' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Reset end frame' })
+    ).toBeDisabled()
+  })
+
+  it('shows a loading overlay while the filmstrip loads', () => {
+    renderPanel({ loading: true })
+
+    expect(screen.getByTestId('video-preview-loading')).toBeTruthy()
+  })
+
+  it('shows selected/total metadata when trim is a feature', () => {
+    renderPanel({
+      features: ['trim'],
+      startFrame: 0,
+      endFrame: 99
+    })
+
+    expect(screen.getByText('10s / 10s')).toBeTruthy()
+    expect(screen.getByText('100 / 100')).toBeTruthy()
+    expect(screen.getByText('2 KB')).toBeTruthy()
+  })
+
+  it('shows plain totals when trim is not a feature', () => {
+    renderPanel({ features: ['crop'] })
+
+    expect(screen.getByText('10s')).toBeTruthy()
+    expect(screen.getByText('100')).toBeTruthy()
+  })
+
+  it('renders the source resolution', () => {
+    renderPanel()
+
+    expect(screen.getByText('1920 × 1080')).toBeTruthy()
+  })
+})

--- a/src/components/videoEdit/VideoEditPanel.vue
+++ b/src/components/videoEdit/VideoEditPanel.vue
@@ -1,0 +1,446 @@
+<template>
+  <div class="flex flex-col gap-2" @pointerdown.stop>
+    <div
+      v-if="!videoUrl"
+      data-testid="video-edit-empty"
+      class="flex min-h-24 flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-node-stroke bg-node-component-surface p-4 text-center"
+    >
+      <i class="icon-[lucide--film] size-6 text-muted-foreground" />
+      <p class="m-0 text-sm text-muted-foreground">
+        {{ t('videoEdit.noVideoSource') }}
+      </p>
+    </div>
+    <div
+      v-else
+      data-testid="video-preview-container"
+      class="relative w-full"
+      :style="videoAspectRatioStyle"
+    >
+      <div
+        class="relative size-full overflow-hidden rounded-lg bg-node-component-surface"
+      >
+        <video
+          ref="videoRef"
+          data-testid="video-preview"
+          :src="videoUrl"
+          class="size-full object-contain"
+          preload="metadata"
+          crossorigin="anonymous"
+          playsinline
+          @loadedmetadata="handleVideoMetadata"
+          @timeupdate="handleTimeUpdate"
+        />
+        <VideoCropOverlay
+          v-if="hasCrop && cropEnabled && !loading && width > 0 && height > 0"
+          v-model="cropBounds"
+          :source-width="width"
+          :source-height="height"
+          :locked-ratio="lockedRatio"
+        />
+        <div
+          v-if="loading"
+          class="absolute inset-0 flex flex-col items-center justify-center gap-0 bg-node-component-surface"
+          data-testid="video-preview-loading"
+          :aria-busy="true"
+          :aria-label="t('videoEdit.loadingVideo')"
+        >
+          <Loader size="md" variant="loader-circle" />
+          <p class="text-sm text-muted-foreground">
+            {{ t('videoEdit.loadingVideo') }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="videoUrl"
+      class="grid grid-cols-[minmax(80px,min-content)_minmax(125px,1fr)] gap-1"
+    >
+      <WidgetToggleSwitch
+        v-if="hasTrim"
+        v-model="trimEnabled"
+        class="col-span-full grid grid-cols-subgrid"
+        :widget="trimToggleWidget"
+      />
+
+      <VideoFilmstripTrim
+        v-if="hasTrim"
+        v-model:start-frame="startFrame"
+        v-model:end-frame="endFrame"
+        v-model:playhead-frame="playheadFrame"
+        v-model:is-playing="isPlaying"
+        class="col-span-full"
+        :trim-enabled="trimEnabled"
+        :total-frames="effectiveTotalFrames"
+        :thumbnails="thumbnails"
+        @scrub="handleScrub"
+      />
+
+      <WidgetInputNumberInput
+        v-if="hasTrim && trimEnabled"
+        v-model="startFrame"
+        root-class="col-span-full grid grid-cols-subgrid items-center"
+        :widget="startFrameWidget"
+      />
+
+      <WidgetInputNumberInput
+        v-if="hasTrim && trimEnabled"
+        v-model="endFrame"
+        root-class="col-span-full grid grid-cols-subgrid items-center"
+        :widget="endFrameWidget"
+      />
+
+      <div
+        v-if="hasTrim && trimEnabled"
+        class="col-span-full grid grid-cols-2 gap-1"
+      >
+        <button
+          v-tooltip="t('videoEdit.setStartFrame')"
+          type="button"
+          :class="WidgetInputActionButtonClass"
+          :disabled="setStartFrameDisabled"
+          :aria-label="t('videoEdit.setStartFrame')"
+          @click="setStartFrame"
+        >
+          <i class="icon-[lucide--skip-back] size-4" />
+        </button>
+        <button
+          v-tooltip="t('videoEdit.setEndFrame')"
+          type="button"
+          :class="WidgetInputActionButtonClass"
+          :disabled="setEndFrameDisabled"
+          :aria-label="t('videoEdit.setEndFrame')"
+          @click="setEndFrame"
+        >
+          <i class="icon-[lucide--skip-forward] size-4" />
+        </button>
+      </div>
+
+      <WidgetToggleSwitch
+        v-if="hasCrop"
+        v-model="cropEnabled"
+        class="col-span-full grid grid-cols-subgrid"
+        :widget="cropToggleWidget"
+      />
+
+      <div
+        v-if="hasCrop && cropEnabled"
+        class="col-span-full flex items-center gap-2"
+      >
+        <label class="text-xs text-muted-foreground">
+          {{ t('imageCrop.ratio') }}
+        </label>
+        <Select v-model="selectedRatio" :disabled="!canLockRatio">
+          <SelectTrigger
+            class="h-7 w-24 text-xs"
+            :aria-label="t('imageCrop.ratio')"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="key in ratioKeys" :key="key" :value="key">
+              {{ key === 'custom' ? t('imageCrop.custom') : key }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          size="icon"
+          :variant="isLockEnabled ? 'primary' : 'secondary'"
+          class="size-7"
+          :disabled="!canLockRatio"
+          :aria-label="
+            isLockEnabled
+              ? t('imageCrop.unlockRatio')
+              : t('imageCrop.lockRatio')
+          "
+          @click="isLockEnabled = !isLockEnabled"
+        >
+          <i
+            :class="
+              isLockEnabled
+                ? 'icon-[lucide--lock] size-3.5'
+                : 'icon-[lucide--lock-open] size-3.5'
+            "
+          />
+        </Button>
+      </div>
+
+      <WidgetBoundingBox
+        v-if="hasCrop && cropEnabled"
+        v-model="cropBounds"
+        class="col-span-full"
+        :disabled="loading || width <= 0"
+      />
+
+      <div
+        class="col-span-full mt-2 grid grid-cols-subgrid gap-y-0.5 border-t border-node-stroke py-2"
+      >
+        <div
+          v-for="row in metadataRows"
+          :key="row.label"
+          class="col-span-full grid grid-cols-subgrid py-0.5 text-sm"
+        >
+          <span class="truncate text-muted-foreground">{{ row.label }}</span>
+          <span class="text-right text-base-foreground">{{ row.value }}</span>
+        </div>
+      </div>
+      <p
+        v-if="resolutionLabel"
+        class="col-span-full m-0 border-t border-node-stroke py-3 text-center text-sm text-base-foreground"
+      >
+        {{ resolutionLabel }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, toRef, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import WidgetBoundingBox from '@/components/boundingbox/WidgetBoundingBox.vue'
+import Loader from '@/components/loader/Loader.vue'
+import Button from '@/components/ui/button/Button.vue'
+import Select from '@/components/ui/select/Select.vue'
+import SelectContent from '@/components/ui/select/SelectContent.vue'
+import SelectItem from '@/components/ui/select/SelectItem.vue'
+import SelectTrigger from '@/components/ui/select/SelectTrigger.vue'
+import SelectValue from '@/components/ui/select/SelectValue.vue'
+import VideoCropOverlay from '@/components/videoEdit/VideoCropOverlay.vue'
+import VideoFilmstripTrim from '@/components/videoEdit/VideoFilmstripTrim.vue'
+import { useCropRatioLock } from '@/composables/video/useCropRatioLock'
+import { useTrimPlayback } from '@/composables/video/useTrimPlayback'
+import { useVideoEditFormats } from '@/composables/video/useVideoEditFormats'
+import { DEFAULT_VIDEO_FPS } from '@/composables/video/useVideoFilmstrip'
+import type { VideoEditFeature } from '@/lib/litegraph/src/types/widgets'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { WidgetInputBaseClass } from '@/renderer/extensions/vueNodes/widgets/components/layout'
+import WidgetInputNumberInput from '@/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue'
+import WidgetToggleSwitch from '@/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.vue'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { frameToTime, timeToFrame } from '@/utils/videoFrameUtil'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const WidgetInputActionButtonClass = cn(
+  WidgetInputBaseClass,
+  'flex h-8 cursor-pointer items-center justify-center',
+  'not-disabled:hover:bg-component-node-widget-background-hovered',
+  'disabled:cursor-not-allowed disabled:bg-component-node-widget-background-disabled',
+  'disabled:text-muted-foreground disabled:opacity-50',
+  'disabled:hover:bg-component-node-widget-background-disabled'
+)
+
+const {
+  features,
+  videoUrl,
+  thumbnails,
+  totalFrames,
+  duration,
+  fps,
+  fileSize,
+  width,
+  height,
+  loading = false
+} = defineProps<{
+  features: VideoEditFeature[]
+  videoUrl?: string
+  thumbnails: string[]
+  totalFrames: number
+  duration: number
+  fps: number
+  fileSize?: number
+  width: number
+  height: number
+  loading?: boolean
+}>()
+
+const startFrame = defineModel<number>('startFrame', { default: 0 })
+const endFrame = defineModel<number>('endFrame', { default: 0 })
+const playheadFrame = defineModel<number>('playheadFrame', { default: 0 })
+const cropBounds = defineModel<Bounds>('cropBounds', {
+  default: () => ({ x: 0, y: 0, width: 0, height: 0 })
+})
+const trimEnabled = defineModel<boolean>('trimEnabled', { default: false })
+const cropEnabled = defineModel<boolean>('cropEnabled', { default: false })
+
+const { t } = useI18n()
+const { formatDuration, formatFileSize } = useVideoEditFormats()
+
+const videoRef = useTemplateRef<HTMLVideoElement>('videoRef')
+const videoIntrinsicSize = ref<{ width: number; height: number } | null>(null)
+
+const hasTrim = computed(() => features.includes('trim'))
+const hasCrop = computed(() => features.includes('crop'))
+
+const effectiveTotalFrames = computed(() => Math.max(totalFrames, 1))
+const frameMax = computed(() => Math.max(totalFrames - 1, 0))
+
+const toTime = (frame: number) =>
+  frameToTime(frame, duration, totalFrames, fps || DEFAULT_VIDEO_FPS)
+const toFrame = (time: number) =>
+  timeToFrame(time, duration, totalFrames, fps || DEFAULT_VIDEO_FPS)
+
+const { isPlaying, seekPreviewToFrame, handleScrub, handleTimeUpdate } =
+  useTrimPlayback({
+    videoRef,
+    frameMax,
+    startFrame,
+    endFrame,
+    playheadFrame,
+    hasTrimTimeline: hasTrim,
+    frameToTime: toTime,
+    timeToFrame: toFrame
+  })
+
+const { lockedRatio, ratioKeys, selectedRatio, isLockEnabled, canLockRatio } =
+  useCropRatioLock(cropBounds, {
+    sourceWidth: toRef(() => width),
+    sourceHeight: toRef(() => height)
+  })
+
+const setStartFrameDisabled = computed(
+  () => !videoUrl || loading || startFrame.value <= 0
+)
+
+const setEndFrameDisabled = computed(
+  () => !videoUrl || loading || endFrame.value >= frameMax.value
+)
+
+function setStartFrame() {
+  isPlaying.value = false
+  startFrame.value = 0
+  void seekPreviewToFrame(0)
+}
+
+function setEndFrame() {
+  isPlaying.value = false
+  endFrame.value = frameMax.value
+  void seekPreviewToFrame(frameMax.value)
+}
+
+const trimToggleWidget = computed(
+  (): SimplifiedWidget<boolean> => ({
+    name: 'trim_enabled',
+    label: t('videoEdit.trimVideo'),
+    type: 'toggle',
+    value: trimEnabled.value
+  })
+)
+
+const cropToggleWidget = computed(
+  (): SimplifiedWidget<boolean> => ({
+    name: 'crop_enabled',
+    label: t('videoEdit.cropVideo'),
+    type: 'toggle',
+    value: cropEnabled.value
+  })
+)
+
+const startFrameWidget = computed(
+  (): SimplifiedWidget<number> => ({
+    name: 'start_frame',
+    label: t('videoEdit.startFrame'),
+    type: 'number',
+    value: startFrame.value,
+    options: {
+      min: 0,
+      max: Math.max(endFrame.value - 1, 0),
+      step: 1,
+      step2: 1,
+      precision: 0,
+      disabled: !videoUrl || loading
+    }
+  })
+)
+
+const endFrameWidget = computed(
+  (): SimplifiedWidget<number> => ({
+    name: 'end_frame',
+    label: t('videoEdit.endFrame'),
+    type: 'number',
+    value: endFrame.value,
+    options: {
+      min: Math.min(startFrame.value + 1, effectiveTotalFrames.value - 1),
+      max: Math.max(effectiveTotalFrames.value - 1, 0),
+      step: 1,
+      step2: 1,
+      precision: 0,
+      disabled: !videoUrl || loading
+    }
+  })
+)
+
+const videoAspectRatioStyle = computed(() => {
+  const intrinsic = videoIntrinsicSize.value
+  const aspectWidth = width || intrinsic?.width
+  const aspectHeight = height || intrinsic?.height
+  if (aspectWidth && aspectHeight) {
+    return { aspectRatio: `${aspectWidth} / ${aspectHeight}` }
+  }
+  return { aspectRatio: '16 / 9' }
+})
+
+const selectedDurationSeconds = computed(() =>
+  Math.max(toTime(endFrame.value + 1) - toTime(startFrame.value), 0)
+)
+
+const selectedFrameCount = computed(() =>
+  Math.max(endFrame.value - startFrame.value + 1, 0)
+)
+
+const metadataRows = computed(() => [
+  {
+    label: t('videoEdit.duration'),
+    value: hasTrim.value
+      ? t('videoEdit.selectedOfTotal', {
+          selected: formatDuration(selectedDurationSeconds.value),
+          total: formatDuration(duration)
+        })
+      : formatDuration(duration)
+  },
+  {
+    label: t('videoEdit.frames'),
+    value: hasTrim.value
+      ? t('videoEdit.selectedOfTotal', {
+          selected: selectedFrameCount.value,
+          total: effectiveTotalFrames.value
+        })
+      : String(effectiveTotalFrames.value)
+  },
+  {
+    label: t('videoEdit.fileSize'),
+    value: formatFileSize(fileSize)
+  }
+])
+
+const resolutionLabel = computed(() => {
+  const intrinsic = videoIntrinsicSize.value
+  const displayWidth = width || intrinsic?.width
+  const displayHeight = height || intrinsic?.height
+  if (!displayWidth || !displayHeight) return ''
+  return t('videoEdit.resolution', {
+    width: displayWidth,
+    height: displayHeight
+  })
+})
+
+watch(
+  toRef(() => videoUrl),
+  () => {
+    playheadFrame.value = 0
+    isPlaying.value = false
+    videoIntrinsicSize.value = null
+  }
+)
+
+function handleVideoMetadata() {
+  const video = videoRef.value
+  if (video?.videoWidth && video.videoHeight) {
+    videoIntrinsicSize.value = {
+      width: video.videoWidth,
+      height: video.videoHeight
+    }
+  }
+  if (hasTrim.value) void seekPreviewToFrame(playheadFrame.value)
+}
+</script>

--- a/src/components/videoEdit/WidgetVideoEdit.test.ts
+++ b/src/components/videoEdit/WidgetVideoEdit.test.ts
@@ -1,0 +1,191 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import type { VideoEditValue } from '@/lib/litegraph/src/types/widgets'
+import { toNodeId } from '@/types/nodeId'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetVideoEdit from './WidgetVideoEdit.vue'
+
+const hostNode = { id: 'host' }
+const locatorNode = { id: 'inner' }
+
+const mocks = vi.hoisted(() => ({
+  getNodeByLocatorId: vi.fn(),
+  resolvedSource: undefined as unknown
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    rootGraph: {},
+    canvas: { graph: { getNodeById: () => hostNode } }
+  }
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByLocatorId: mocks.getNodeByLocatorId
+}))
+
+vi.mock('@/composables/video/useVideoSourceUrl', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: createRef } = require('vue')
+  return {
+    useVideoSourceUrl: (node: { value: unknown }) => {
+      mocks.resolvedSource = node.value
+      return { videoUrl: createRef('/api/view?filename=clip.mp4') }
+    }
+  }
+})
+
+vi.mock('@/composables/video/useVideoFilmstrip', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: createRef } = require('vue')
+  return {
+    DEFAULT_VIDEO_FPS: 20,
+    useVideoFilmstrip: () => ({
+      thumbnails: createRef([]),
+      duration: createRef(10),
+      totalFrames: createRef(100),
+      width: createRef(1920),
+      height: createRef(1080),
+      fps: createRef(10),
+      fileSize: createRef(1024),
+      loading: createRef(false)
+    })
+  }
+})
+
+const recorded: { props?: Record<string, unknown> } = {}
+
+const PanelStub = defineComponent({
+  props: [
+    'features',
+    'videoUrl',
+    'thumbnails',
+    'totalFrames',
+    'duration',
+    'fps',
+    'fileSize',
+    'width',
+    'height',
+    'loading',
+    'startFrame',
+    'endFrame',
+    'cropBounds',
+    'trimEnabled',
+    'cropEnabled'
+  ],
+  emits: [
+    'update:startFrame',
+    'update:endFrame',
+    'update:cropBounds',
+    'update:trimEnabled',
+    'update:cropEnabled'
+  ],
+  setup(props, { emit }) {
+    recorded.props = props
+    return () =>
+      h('button', {
+        'data-testid': 'emit-start-frame',
+        onClick: () => emit('update:startFrame', 10)
+      })
+  }
+})
+
+function createWidget(
+  options: Record<string, unknown> = {},
+  extra: Record<string, unknown> = {}
+): SimplifiedWidget<VideoEditValue> {
+  return {
+    name: 'edit',
+    type: 'videoedit',
+    value: {},
+    options,
+    ...extra
+  } as SimplifiedWidget<VideoEditValue>
+}
+
+function renderWidget(widget = createWidget()) {
+  const modelValue = ref<VideoEditValue>({})
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(WidgetVideoEdit, {
+          widget,
+          nodeId: toNodeId('node-1'),
+          modelValue: modelValue.value,
+          'onUpdate:modelValue': (value: VideoEditValue) => {
+            modelValue.value = value
+          }
+        })
+    }
+  })
+  render(Host, {
+    global: {
+      stubs: { VideoEditPanel: PanelStub }
+    }
+  })
+  return { modelValue }
+}
+
+describe('WidgetVideoEdit', () => {
+  beforeEach(() => {
+    recorded.props = undefined
+    mocks.resolvedSource = undefined
+    mocks.getNodeByLocatorId.mockReset()
+  })
+
+  it('resolves the source from the host node when no locator is present', () => {
+    renderWidget()
+
+    expect(mocks.getNodeByLocatorId).not.toHaveBeenCalled()
+    expect(mocks.resolvedSource).toBe(hostNode)
+  })
+
+  it('resolves a promoted widget through its node locator id', () => {
+    mocks.getNodeByLocatorId.mockReturnValue(locatorNode)
+
+    renderWidget(createWidget({}, { nodeLocatorId: 'sub:42' }))
+
+    expect(mocks.getNodeByLocatorId).toHaveBeenCalledWith({}, 'sub:42')
+    expect(mocks.resolvedSource).toBe(locatorNode)
+  })
+
+  it('falls back to the host node when the locator resolves to nothing', () => {
+    mocks.getNodeByLocatorId.mockReturnValue(null)
+
+    renderWidget(createWidget({}, { nodeLocatorId: 'sub:42' }))
+
+    expect(mocks.resolvedSource).toBe(hostNode)
+  })
+
+  it('defaults to both features when the widget options omit them', () => {
+    renderWidget()
+
+    expect(recorded.props?.features).toEqual(['trim', 'crop'])
+  })
+
+  it('passes the features from the widget options to the panel', () => {
+    renderWidget(createWidget({ features: ['trim'] }))
+
+    expect(recorded.props?.features).toEqual(['trim'])
+  })
+
+  it('feeds the resolved source url and probed metadata to the panel', () => {
+    renderWidget()
+
+    expect(recorded.props?.videoUrl).toBe('/api/view?filename=clip.mp4')
+    expect(recorded.props?.duration).toBe(10)
+    expect(recorded.props?.totalFrames).toBe(100)
+  })
+
+  it('writes trim seconds into the model when the panel moves a frame handle', async () => {
+    const { modelValue } = renderWidget()
+
+    await userEvent.click(screen.getByTestId('emit-start-frame'))
+
+    expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+  })
+})

--- a/src/components/videoEdit/WidgetVideoEdit.vue
+++ b/src/components/videoEdit/WidgetVideoEdit.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="w-full" :data-widget-name="widget.name">
+    <VideoEditPanel
+      v-model:start-frame="startFrame"
+      v-model:end-frame="endFrame"
+      v-model:crop-bounds="cropBounds"
+      v-model:trim-enabled="trimEnabled"
+      v-model:crop-enabled="cropEnabled"
+      :features="features"
+      :video-url="videoUrl"
+      :thumbnails="thumbnails"
+      :total-frames="totalFrames"
+      :duration="duration"
+      :fps="fps"
+      :file-size="fileSize"
+      :width="width"
+      :height="height"
+      :loading="loading"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import VideoEditPanel from '@/components/videoEdit/VideoEditPanel.vue'
+import { useVideoEditModel } from '@/composables/video/useVideoEditModel'
+import { useVideoFilmstrip } from '@/composables/video/useVideoFilmstrip'
+import { useVideoSourceUrl } from '@/composables/video/useVideoSourceUrl'
+import type {
+  IWidgetVideoEditOptions,
+  VideoEditFeature,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import { app } from '@/scripts/app'
+import type { NodeId } from '@/types/nodeId'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+
+const { widget, nodeId } = defineProps<{
+  widget: SimplifiedWidget<VideoEditValue, IWidgetVideoEditOptions>
+  nodeId: NodeId
+}>()
+
+const modelValue = defineModel<VideoEditValue>({
+  default: () => ({})
+})
+
+const features = computed(
+  (): VideoEditFeature[] => widget.options?.features ?? ['trim', 'crop']
+)
+
+const node = computed(() => {
+  const locatorId = widget.nodeLocatorId
+  const owner = locatorId && getNodeByLocatorId(app.rootGraph, locatorId)
+  return owner || app.canvas.graph?.getNodeById(nodeId)
+})
+
+const { videoUrl } = useVideoSourceUrl(node)
+
+const {
+  thumbnails,
+  duration,
+  totalFrames,
+  width,
+  height,
+  fps,
+  fileSize,
+  loading
+} = useVideoFilmstrip(videoUrl)
+
+const { startFrame, endFrame, cropBounds, trimEnabled, cropEnabled } =
+  useVideoEditModel(modelValue, {
+    duration,
+    totalFrames,
+    fps,
+    width,
+    height
+  })
+</script>

--- a/src/composables/video/useVideoEditModel.test.ts
+++ b/src/composables/video/useVideoEditModel.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope } from 'vue'
+
+import type { VideoEditValue } from '@/lib/litegraph/src/types/widgets'
+
+import { useVideoEditModel } from './useVideoEditModel'
+
+describe('useVideoEditModel', () => {
+  let scope: EffectScope | undefined
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  function createModel(
+    initial: VideoEditValue = {},
+    { duration = 10, fps = 10 } = {}
+  ) {
+    const modelValue = ref<VideoEditValue>(initial)
+    scope = effectScope()
+    const model = scope.run(() =>
+      useVideoEditModel(modelValue, {
+        duration: ref(duration),
+        totalFrames: ref(100),
+        fps: ref(fps),
+        width: ref(1920),
+        height: ref(1080)
+      })
+    )!
+    return { modelValue, ...model }
+  }
+
+  describe('trim frames', () => {
+    it('spans the full range for the default no-op value', () => {
+      const { startFrame, endFrame } = createModel()
+
+      expect(startFrame.value).toBe(0)
+      expect(endFrame.value).toBe(99)
+    })
+
+    it('serializes boundaries that cover the selected frames exactly', () => {
+      const { modelValue, startFrame, endFrame } = createModel()
+
+      startFrame.value = 10
+      endFrame.value = 80
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 7.1 })
+      expect(startFrame.value).toBe(10)
+      expect(endFrame.value).toBe(80)
+    })
+
+    it('writes start_time in seconds and keeps trimming to the end', () => {
+      const { modelValue, startFrame } = createModel()
+
+      startFrame.value = 10
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+    })
+
+    it('writes an explicit duration when the end handle moves off the last frame', () => {
+      const { modelValue, endFrame } = createModel()
+
+      endFrame.value = 80
+
+      expect(modelValue.value.trim).toEqual({ start_time: 0, duration: 8.1 })
+    })
+
+    it('normalizes duration back to 0 when the end returns to the last frame', () => {
+      const { modelValue, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      endFrame.value = 99
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+    })
+
+    it('falls back to fps for conversions when the duration is unknown', () => {
+      const { modelValue, startFrame } = createModel({}, { duration: 0 })
+
+      startFrame.value = 10
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0 })
+    })
+
+    it('derives frames from an explicit trim window', () => {
+      const { startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      expect(startFrame.value).toBe(10)
+      expect(endFrame.value).toBe(79)
+    })
+
+    it('keeps the end time fixed when the start moves inside an explicit window', () => {
+      const { modelValue, startFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      startFrame.value = 20
+
+      expect(modelValue.value.trim).toEqual({ start_time: 2, duration: 6 })
+    })
+
+    it('clamps the start handle below the end handle instead of collapsing', () => {
+      const { modelValue, startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      startFrame.value = 90
+
+      expect(modelValue.value.trim).toEqual({ start_time: 7.8, duration: 0.2 })
+      expect(endFrame.value).toBe(79)
+    })
+
+    it('clamps the end handle above the start handle instead of snapping to the video end', () => {
+      const { modelValue, startFrame, endFrame } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      endFrame.value = 5
+
+      expect(modelValue.value.trim).toEqual({ start_time: 1, duration: 0.2 })
+      expect(startFrame.value).toBe(10)
+      expect(endFrame.value).toBe(11)
+    })
+  })
+
+  describe('crop bounds', () => {
+    it('shows the full frame for zero crop values', () => {
+      const { cropBounds } = createModel()
+
+      expect(cropBounds.value).toEqual({
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1080
+      })
+    })
+
+    it('rounds and stores a partial crop', () => {
+      const { modelValue, cropBounds } = createModel()
+
+      cropBounds.value = { x: 10.4, y: 20.6, width: 640.2, height: 360.5 }
+
+      expect(modelValue.value.crop).toEqual({
+        x: 10,
+        y: 21,
+        width: 640,
+        height: 361
+      })
+    })
+
+    it('clamps a rounded crop to stay inside the source frame', () => {
+      const { modelValue, cropBounds } = createModel()
+
+      cropBounds.value = { x: 10.6, y: 8.4, width: 1909.6, height: 1075.6 }
+
+      const crop = modelValue.value.crop!
+      expect(crop.x + crop.width).toBeLessThanOrEqual(1920)
+      expect(crop.y + crop.height).toBeLessThanOrEqual(1080)
+    })
+
+    it('normalizes a full-frame crop back to zeros', () => {
+      const { modelValue, cropBounds } = createModel({
+        crop: { x: 10, y: 10, width: 100, height: 100 }
+      })
+
+      cropBounds.value = { x: 0, y: 0, width: 1920, height: 1080 }
+
+      expect(modelValue.value.crop).toEqual({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      })
+    })
+  })
+
+  describe('section toggles', () => {
+    it('starts disabled for no-op values', () => {
+      const { trimEnabled, cropEnabled } = createModel()
+
+      expect(trimEnabled.value).toBe(false)
+      expect(cropEnabled.value).toBe(false)
+    })
+
+    it('starts enabled for active values', () => {
+      const { trimEnabled, cropEnabled } = createModel({
+        trim: { start_time: 1, duration: 0 },
+        crop: { x: 0, y: 0, width: 640, height: 360 }
+      })
+
+      expect(trimEnabled.value).toBe(true)
+      expect(cropEnabled.value).toBe(true)
+    })
+
+    it('resets the trim section when toggled off', () => {
+      const { modelValue, trimEnabled } = createModel({
+        trim: { start_time: 1, duration: 7 }
+      })
+
+      trimEnabled.value = false
+
+      expect(modelValue.value.trim).toEqual({ start_time: 0, duration: 0 })
+    })
+
+    it('resets the crop section when toggled off', () => {
+      const { modelValue, cropEnabled } = createModel({
+        crop: { x: 10, y: 10, width: 640, height: 360 }
+      })
+
+      cropEnabled.value = false
+
+      expect(modelValue.value.crop).toEqual({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      })
+    })
+
+    it('expands the editor without touching the value when toggled on', () => {
+      const { modelValue, trimEnabled } = createModel()
+
+      trimEnabled.value = true
+
+      expect(trimEnabled.value).toBe(true)
+      expect(modelValue.value.trim).toBeUndefined()
+    })
+
+    it('auto-enables a section when an active value arrives later', async () => {
+      const { modelValue, cropEnabled } = createModel()
+      expect(cropEnabled.value).toBe(false)
+
+      modelValue.value = {
+        ...modelValue.value,
+        crop: { x: 5, y: 5, width: 100, height: 100 }
+      }
+      await nextTick()
+
+      expect(cropEnabled.value).toBe(true)
+    })
+  })
+})

--- a/src/composables/video/useVideoEditModel.ts
+++ b/src/composables/video/useVideoEditModel.ts
@@ -1,0 +1,167 @@
+import { computed, ref, watch } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import type {
+  VideoEditTrim,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import type { Bounds } from '@/renderer/core/layout/types'
+import { frameToTime, roundSeconds, timeToFrame } from '@/utils/videoFrameUtil'
+
+interface UseVideoEditModelOptions {
+  duration: Ref<number>
+  totalFrames: Ref<number>
+  fps: Ref<number>
+  width: Ref<number>
+  height: Ref<number>
+}
+
+export function useVideoEditModel(
+  modelValue: Ref<VideoEditValue>,
+  options: UseVideoEditModelOptions
+) {
+  const { duration, totalFrames, fps, width, height } = options
+
+  const frameMax = computed(() => Math.max(totalFrames.value - 1, 0))
+
+  const toTime = (frame: number) =>
+    frameToTime(frame, duration.value, totalFrames.value, fps.value)
+  const toFrame = (time: number) =>
+    timeToFrame(time, duration.value, totalFrames.value, fps.value)
+
+  const trimSection = computed(
+    () => modelValue.value.trim ?? { start_time: 0, duration: 0 }
+  )
+
+  const trimsToVideoEnd = computed(() => trimSection.value.duration === 0)
+
+  const endTimeSeconds = computed(() =>
+    trimsToVideoEnd.value
+      ? duration.value
+      : trimSection.value.start_time + trimSection.value.duration
+  )
+
+  function setTrim(trim: VideoEditTrim) {
+    modelValue.value = { ...modelValue.value, trim }
+  }
+
+  const currentEndFrame = () =>
+    trimsToVideoEnd.value
+      ? frameMax.value
+      : clamp(toFrame(endTimeSeconds.value) - 1, 0, frameMax.value)
+
+  const startFrame = computed({
+    get: () => clamp(toFrame(trimSection.value.start_time), 0, frameMax.value),
+    set: (frame) => {
+      const maxStart = Math.max(currentEndFrame() - 1, 0)
+      const startTime = roundSeconds(toTime(clamp(frame, 0, maxStart)))
+      setTrim({
+        start_time: startTime,
+        duration: trimsToVideoEnd.value
+          ? 0
+          : roundSeconds(Math.max(endTimeSeconds.value - startTime, 0))
+      })
+    }
+  })
+
+  const endFrame = computed({
+    get: () => currentEndFrame(),
+    set: (frame) => {
+      const minEnd = clamp(
+        toFrame(trimSection.value.start_time) + 1,
+        0,
+        frameMax.value
+      )
+      const clamped = clamp(frame, minEnd, frameMax.value)
+      setTrim({
+        start_time: trimSection.value.start_time,
+        duration:
+          clamped >= frameMax.value
+            ? 0
+            : roundSeconds(
+                Math.max(toTime(clamped + 1) - trimSection.value.start_time, 0)
+              )
+      })
+    }
+  })
+
+  const cropBounds = computed<Bounds>({
+    get: () => {
+      const crop = modelValue.value.crop
+      if (!crop || crop.width <= 0 || crop.height <= 0) {
+        return { x: 0, y: 0, width: width.value, height: height.value }
+      }
+      return { ...crop }
+    },
+    set: (next) => {
+      const coversFullFrame =
+        next.x <= 0 &&
+        next.y <= 0 &&
+        next.width >= width.value &&
+        next.height >= height.value
+      if (coversFullFrame) {
+        modelValue.value = {
+          ...modelValue.value,
+          crop: { x: 0, y: 0, width: 0, height: 0 }
+        }
+        return
+      }
+      const x = clamp(Math.round(next.x), 0, width.value)
+      const y = clamp(Math.round(next.y), 0, height.value)
+      modelValue.value = {
+        ...modelValue.value,
+        crop: {
+          x,
+          y,
+          width: clamp(Math.round(next.width), 0, width.value - x),
+          height: clamp(Math.round(next.height), 0, height.value - y)
+        }
+      }
+    }
+  })
+
+  const hasActiveTrim = () => {
+    const trim = modelValue.value.trim
+    return !!trim && (trim.start_time > 0 || trim.duration > 0)
+  }
+
+  const hasActiveCrop = () => {
+    const crop = modelValue.value.crop
+    return !!crop && crop.width > 0 && crop.height > 0
+  }
+
+  const trimEnabledState = ref(hasActiveTrim())
+  const cropEnabledState = ref(hasActiveCrop())
+
+  const trimEnabled = computed({
+    get: () => trimEnabledState.value,
+    set: (enabled) => {
+      trimEnabledState.value = enabled
+      if (!enabled) setTrim({ start_time: 0, duration: 0 })
+    }
+  })
+
+  const cropEnabled = computed({
+    get: () => cropEnabledState.value,
+    set: (enabled) => {
+      cropEnabledState.value = enabled
+      if (!enabled) {
+        modelValue.value = {
+          ...modelValue.value,
+          crop: { x: 0, y: 0, width: 0, height: 0 }
+        }
+      }
+    }
+  })
+
+  watch(hasActiveTrim, (active) => {
+    if (active) trimEnabledState.value = true
+  })
+  watch(hasActiveCrop, (active) => {
+    if (active) cropEnabledState.value = true
+  })
+
+  return { startFrame, endFrame, cropBounds, trimEnabled, cropEnabled }
+}

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -146,6 +146,7 @@ export type IWidget =
   | ICurveWidget
   | IPainterWidget
   | IRangeWidget
+  | IVideoEditWidget
   | IBoundingBoxesWidget
   | IColorsWidget
 
@@ -385,6 +386,31 @@ export interface IRangeWidget extends IBaseWidget<
 > {
   type: 'range'
   value: RangeValue
+}
+
+export interface VideoEditTrim {
+  start_time: number
+  duration: number
+}
+
+export interface VideoEditValue {
+  trim?: VideoEditTrim
+  crop?: Bounds
+}
+
+export type VideoEditFeature = 'trim' | 'crop'
+
+export interface IWidgetVideoEditOptions extends IWidgetOptions {
+  features?: VideoEditFeature[]
+}
+
+export interface IVideoEditWidget extends IBaseWidget<
+  VideoEditValue,
+  'videoedit',
+  IWidgetVideoEditOptions
+> {
+  type: 'videoedit'
+  value: VideoEditValue
 }
 
 /**

--- a/src/lib/litegraph/src/widgets/VideoEditWidget.ts
+++ b/src/lib/litegraph/src/widgets/VideoEditWidget.ts
@@ -1,0 +1,14 @@
+import type { IVideoEditWidget } from '../types/widgets'
+import { BaseWidget } from './BaseWidget'
+import type { WidgetEventOptions } from './BaseWidget'
+
+export class VideoEditWidget
+  extends BaseWidget<IVideoEditWidget>
+  implements IVideoEditWidget
+{
+  override type = 'videoedit' as const
+
+  drawWidget(): void {}
+
+  onClick(_options: WidgetEventOptions): void {}
+}

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -25,6 +25,7 @@ import { BoundingBoxesWidget } from './BoundingBoxesWidget'
 import { ColorsWidget } from './ColorsWidget'
 import { PainterWidget } from './PainterWidget'
 import { RangeWidget } from './RangeWidget'
+import { VideoEditWidget } from './VideoEditWidget'
 import { ImageCropWidget } from './ImageCropWidget'
 import { KnobWidget } from './KnobWidget'
 import { LegacyWidget } from './LegacyWidget'
@@ -64,6 +65,7 @@ export type WidgetTypeMap = {
   curve: CurveWidget
   painter: PainterWidget
   range: RangeWidget
+  videoedit: VideoEditWidget
   boundingboxes: BoundingBoxesWidget
   colors: ColorsWidget
   [key: string]: BaseWidget
@@ -148,6 +150,8 @@ export function toConcreteWidget<TWidget extends IWidget | IBaseWidget>(
       return toClass(PainterWidget, narrowedWidget, node)
     case 'range':
       return toClass(RangeWidget, narrowedWidget, node)
+    case 'videoedit':
+      return toClass(VideoEditWidget, narrowedWidget, node)
     case 'boundingboxes':
       return toClass(BoundingBoxesWidget, narrowedWidget, node)
     case 'colors':

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1959,6 +1959,7 @@
     "UPSCALE_MODEL": "UPSCALE_MODEL",
     "VAE": "VAE",
     "VIDEO": "VIDEO",
+    "VIDEO_EDIT": "VIDEO_EDIT",
     "VOXEL": "VOXEL",
     "WAN_CAMERA_EMBEDDING": "WAN_CAMERA_EMBEDDING",
     "WEBCAM": "WEBCAM"
@@ -2216,19 +2217,32 @@
     "swatchTitle": "Click edit · drag reorder · right-click remove"
   },
   "videoEdit": {
+    "trimVideo": "Trim Video",
+    "cropVideo": "Crop Video",
+    "startFrame": "Start Frame",
+    "endFrame": "End Frame",
+    "duration": "Duration",
+    "frames": "Number of Frames",
+    "fileSize": "File Size",
+    "resolution": "{width} × {height}",
     "play": "Play",
     "pause": "Pause",
+    "loadingVideo": "Loading video preview",
     "loadingFilmstrip": "Loading filmstrip…",
     "seekVideo": "Seek video",
     "adjustStartFrame": "Adjust start frame",
     "adjustEndFrame": "Adjust end frame",
     "adjustCrop": "Adjust crop region",
+    "setStartFrame": "Reset start frame",
+    "setEndFrame": "Reset end frame",
     "durationZero": "0s",
     "durationSeconds": "{count}s",
+    "selectedOfTotal": "{selected} / {total}",
     "fileSizeUnknown": "—",
     "fileSizeBytes": "{count} B",
     "fileSizeKilobytes": "{count} KB",
-    "fileSizeMegabytes": "{count} MB"
+    "fileSizeMegabytes": "{count} MB",
+    "noVideoSource": "Select or connect a video to preview and edit"
   },
   "toastMessages": {
     "nothingToQueue": "Nothing to queue",

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -776,6 +776,10 @@ const hasVideoInput = computed(() => {
   )
 })
 
+const hasVideoEditWidget = computed(
+  () => nodeData.widgets?.some((widget) => widget.type === 'videoedit') ?? false
+)
+
 const nodeMedia = computed(() => {
   const newOutputs = nodeOutputs.nodeOutputs[nodeOutputLocatorId.value]
   const node = lgraphNode.value
@@ -799,6 +803,8 @@ const nodeMedia = computed(() => {
     (!node.previewMediaType && hasVideoInput.value)
       ? 'video'
       : 'image'
+
+  if (type === 'video' && hasVideoEditWidget.value) return undefined
 
   return { type, urls } as const
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import { useVideoEditWidget } from './useVideoEditWidget'
+
+function createNode(widgetType = 'videoedit') {
+  const addWidget = vi.fn(
+    (
+      type: string,
+      name: string,
+      value: unknown,
+      _cb: unknown,
+      options: unknown
+    ) => ({
+      type: widgetType === 'videoedit' ? type : widgetType,
+      name,
+      value,
+      options
+    })
+  )
+  return { node: { addWidget } as unknown as LGraphNode, addWidget }
+}
+
+describe('useVideoEditWidget', () => {
+  it('creates default sections for all features', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, { type: 'VIDEO_EDIT', name: 'edit' })
+
+    const [type, name, value, , options] = addWidget.mock.calls[0]
+    expect(type).toBe('videoedit')
+    expect(name).toBe('edit')
+    expect(value).toEqual({
+      trim: { start_time: 0, duration: 0 },
+      crop: { x: 0, y: 0, width: 0, height: 0 }
+    })
+    expect(options).toMatchObject({
+      features: ['trim', 'crop'],
+      serialize: true,
+      canvasOnly: false,
+      hideInPanel: true
+    })
+  })
+
+  it('only creates the sections listed in features', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, {
+      type: 'VIDEO_EDIT',
+      name: 'trim',
+      features: ['trim']
+    })
+
+    const [, , value, , options] = addWidget.mock.calls[0]
+    expect(value).toEqual({ trim: { start_time: 0, duration: 0 } })
+    expect(options).toMatchObject({ features: ['trim'] })
+  })
+
+  it('prefers an explicit default value from the spec', () => {
+    const { node, addWidget } = createNode()
+
+    useVideoEditWidget()(node, {
+      type: 'VIDEO_EDIT',
+      name: 'edit',
+      default: { trim: { start_time: 1.5, duration: 2 } }
+    })
+
+    const [, , value] = addWidget.mock.calls[0]
+    expect(value).toEqual({ trim: { start_time: 1.5, duration: 2 } })
+  })
+
+  it('throws when the node produces an unexpected widget type', () => {
+    const { node } = createNode('number')
+
+    expect(() =>
+      useVideoEditWidget()(node, { type: 'VIDEO_EDIT', name: 'edit' })
+    ).toThrow('Unexpected widget type')
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget.ts
@@ -1,0 +1,48 @@
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  IVideoEditWidget,
+  IWidgetVideoEditOptions,
+  VideoEditValue
+} from '@/lib/litegraph/src/types/widgets'
+import type {
+  InputSpec as InputSpecV2,
+  VideoEditInputSpec
+} from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+export const useVideoEditWidget = (): ComfyWidgetConstructorV2 => {
+  return (node: LGraphNode, inputSpec: InputSpecV2): IVideoEditWidget => {
+    const spec = inputSpec as VideoEditInputSpec
+    const features = spec.features ?? ['trim', 'crop']
+
+    const defaultValue: VideoEditValue = spec.default ?? {
+      ...(features.includes('trim') && {
+        trim: { start_time: 0, duration: 0 }
+      }),
+      ...(features.includes('crop') && {
+        crop: { x: 0, y: 0, width: 0, height: 0 }
+      })
+    }
+
+    const options: IWidgetVideoEditOptions = {
+      features,
+      serialize: true,
+      canvasOnly: false,
+      hideInPanel: true
+    }
+
+    const rawWidget = node.addWidget(
+      'videoedit',
+      spec.name,
+      structuredClone(defaultValue),
+      () => {},
+      options
+    )
+
+    if (rawWidget.type !== 'videoedit') {
+      throw new Error(`Unexpected widget type: ${rawWidget.type}`)
+    }
+
+    return rawWidget as IVideoEditWidget
+  }
+}

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -75,6 +75,9 @@ const WidgetRange = defineAsyncComponent(
 const WidgetBoundingBoxes = defineAsyncComponent(
   () => import('@/components/boundingBoxes/WidgetBoundingBoxes.vue')
 )
+const WidgetVideoEdit = defineAsyncComponent(
+  () => import('@/components/videoEdit/WidgetVideoEdit.vue')
+)
 const WidgetColors = defineAsyncComponent(
   () => import('@/components/palette/WidgetColors.vue')
 )
@@ -246,6 +249,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
     }
   ],
   [
+    'videoedit',
+    {
+      component: WidgetVideoEdit,
+      aliases: ['VIDEO_EDIT'],
+      essential: false
+    }
+  ],
+  [
     'colors',
     {
       component: WidgetColors,
@@ -293,7 +304,8 @@ const EXPANDING_TYPES = [
   'painter',
   'imagecompare',
   'range',
-  'boundingboxes'
+  'boundingboxes',
+  'videoedit'
 ] as const
 
 export function shouldExpand(type: string): boolean {

--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -189,6 +189,31 @@ const zRangeInputSpec = zBaseInputOptions.extend({
   value_max: z.number().optional()
 })
 
+const zVideoEditValue = z.object({
+  trim: z
+    .object({
+      start_time: z.number(),
+      duration: z.number()
+    })
+    .optional(),
+  crop: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number(),
+      height: z.number()
+    })
+    .optional()
+})
+
+const zVideoEditInputSpec = zBaseInputOptions.extend({
+  type: z.literal('VIDEO_EDIT'),
+  name: z.string(),
+  isOptional: z.boolean().optional(),
+  features: z.array(z.enum(['trim', 'crop'])).optional(),
+  default: zVideoEditValue.optional()
+})
+
 const zCustomInputSpec = zBaseInputOptions.extend({
   type: z.string(),
   name: z.string(),
@@ -213,6 +238,7 @@ const zInputSpec = z.union([
   zTextareaInputSpec,
   zCurveInputSpec,
   zRangeInputSpec,
+  zVideoEditInputSpec,
   zCustomInputSpec
 ])
 
@@ -261,6 +287,7 @@ export type BoundingBoxesInputSpec = z.infer<typeof zBoundingBoxesInputSpec>
 export type TextareaInputSpec = z.infer<typeof zTextareaInputSpec>
 export type CurveInputSpec = z.infer<typeof zCurveInputSpec>
 export type RangeInputSpec = z.infer<typeof zRangeInputSpec>
+export type VideoEditInputSpec = z.infer<typeof zVideoEditInputSpec>
 export type CustomInputSpec = z.infer<typeof zCustomInputSpec>
 
 export type InputSpec = z.infer<typeof zInputSpec>

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -26,6 +26,7 @@ import { usePainterWidget } from '@/renderer/extensions/vueNodes/widgets/composa
 import { useRangeWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useRangeWidget'
 import { useStringWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget'
 import { useTextareaWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useTextareaWidget'
+import { useVideoEditWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useVideoEditWidget'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
@@ -236,6 +237,7 @@ export const ComfyWidgets = {
   TEXTAREA: transformWidgetConstructorV2ToV1(useTextareaWidget()),
   CURVE: transformWidgetConstructorV2ToV1(useCurveWidget()),
   RANGE: transformWidgetConstructorV2ToV1(useRangeWidget()),
+  VIDEO_EDIT: transformWidgetConstructorV2ToV1(useVideoEditWidget()),
   BOUNDING_BOXES: transformWidgetConstructorV2ToV1(useBoundingBoxesWidget()),
   COLORS: transformWidgetConstructorV2ToV1(useColorsWidget()),
   ...dynamicWidgets

--- a/src/utils/videoFrameUtil.ts
+++ b/src/utils/videoFrameUtil.ts
@@ -5,21 +5,21 @@ function isUsableFps(fps: number | undefined): fps is number {
 export function frameToTime(
   frame: number,
   duration: number,
-  frameMax: number,
+  totalFrames: number,
   fallbackFps?: number
 ): number {
-  if (duration > 0 && frameMax > 0) return (frame / frameMax) * duration
+  if (duration > 0 && totalFrames > 0) return (frame / totalFrames) * duration
   return isUsableFps(fallbackFps) ? frame / fallbackFps : 0
 }
 
 export function timeToFrame(
   time: number,
   duration: number,
-  frameMax: number,
+  totalFrames: number,
   fallbackFps?: number
 ): number {
-  if (duration > 0 && frameMax > 0) {
-    return Math.round((time / duration) * frameMax)
+  if (duration > 0 && totalFrames > 0) {
+    return Math.round((time / duration) * totalFrames)
   }
   return isUsableFps(fallbackFps) ? Math.round(time * fallbackFps) : 0
 }


### PR DESCRIPTION
This is seperate last part for the big PR of video edit, crop, trim PR https://github.com/Comfy-Org/ComfyUI_frontend/pull/14118

## Summary

Wires the VIDEO_EDIT input type end to end and assembles the editor UI from the previously merged building blocks:
- litegraph: VideoEditValue/VideoEditTrim widget value types, VideoEditWidget class and widgetMap/constructor registration
- schema/registry: VIDEO_EDIT zod spec in nodeDefSchemaV2, widget registry entry rendering WidgetVideoEdit
- useVideoEditModel: canonical seconds/pixels edit state with frame-based setters, enable toggles, and handle crossover clamps
- VideoEditPanel: trim timeline (filmstrip + range handles + playback) and crop overlay with ratio lock, driven by backend video metadata
- WidgetVideoEdit: widget shell resolving the source video via useVideoSourceUrl and suppressing the default node media preview
