### PR TITLE
FE-1405: hide sourcemap references in prod builds (kill .js.map 404 noise)

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -544,7 +544,11 @@ export default defineConfig({
   build: {
     minify: SHOULD_MINIFY,
     target: 'es2022',
-    sourcemap: GENERATE_SOURCEMAP,
+    // Use 'hidden' so sourcemaps are still generated (for Sentry upload) but the
+    // browser-facing `//# sourceMappingURL=` comment is NOT injected into the JS
+    // bundles. This kills the ~57k/3d `/assets/*.js.map` 404 noise in prod
+    // (the .map files aren't served) without losing Sentry symbolication. See FE-1405.
+    sourcemap: GENERATE_SOURCEMAP ? 'hidden' : false,
     // Exclude heavy optional vendor chunks from initial module preload
     // These chunks are only needed when their features are used (3D, terminal, etc.)
     modulePreload: {


### PR DESCRIPTION
## What & why

Prod bundles ship a `//# sourceMappingURL=<file>.js.map` reference in every JS chunk, but the `.map` files are **not served** by the frontend. Browsers dutifully request them, producing **~57k `/assets/*.js.map` 404s over 3 days**. That noise drowns out the real, actionable `/assets/*.js` 404 signal (genuine missing bundles).

## The fix

Change Vite's `build.sourcemap` from `true` to `'hidden'` when sourcemap generation is enabled.

- `true` → generates `.map` files **and** injects the browser-facing `//# sourceMappingURL=` comment.
- `'hidden'` → still generates `.map` files on disk, but **strips the `sourceMappingURL` comment**.

Result: the `.map` files remain available for Sentry to upload (symbolication preserved), but browsers no longer request the unserved `.map` files, so the 404 noise disappears.

## Exactly what changed

`vite.config.mts` (one line + explanatory comment):

```diff
-    sourcemap: GENERATE_SOURCEMAP,
+    sourcemap: GENERATE_SOURCEMAP ? 'hidden' : false,
```

`GENERATE_SOURCEMAP` (`process.env.GENERATE_SOURCEMAP !== 'false'`, default `true`) is only referenced at this one site — grep-confirmed — so the toggle semantics are unchanged: sourcemaps on by default, `GENERATE_SOURCEMAP=false` still fully disables them.

## Reviewer note — Sentry upload consideration

The Sentry vite plugin (`sentryVitePlugin`) is gated independently on `DISTRIBUTION === 'cloud'` + `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` + `!IS_DEV` — it does **not** depend on `GENERATE_SOURCEMAP`. It consumes the on-disk `.map` files (and deletes them post-upload via `filesToDeleteAfterUpload: ['**/*.map']`, except the prod project which keeps them). Because `'hidden'` still **emits** the `.map` files to disk, the plugin's upload behavior is unaffected — only the in-bundle `sourceMappingURL` comment is removed. **Sentry symbolication is preserved.**

Open question for the reviewer: Sentry generally recommends `'hidden'` for exactly this scenario, and it correlates uploads by release/debug-id rather than the `sourceMappingURL` comment, so this should be a no-op for symbolication. Worth a sanity check on the next prod release that a fresh error still symbolicates in Sentry.

## How verified

- Confirmed the current config: `build.sourcemap: GENERATE_SOURCEMAP` (a boolean defaulting to `true`), i.e. maps + `sourceMappingURL` comment shipped in prod.
- Grep-confirmed `GENERATE_SOURCEMAP` has exactly one usage site.
- Confirmed `'hidden'` is a valid literal for Vite's `build.sourcemap` union type.
- Type-strip + bundle-checked `vite.config.mts` with esbuild (`--bundle --packages=external`) — parses cleanly, exit 0. A full `pnpm build` / `vue-tsc` over the whole project was not run (heavy); the change is a single literal swap in a typed union, verified by inspection + the esbuild parse.

Linear: FE-1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)