### PR TITLE
[backport cloud/1.47] frontend observability stack

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -110,6 +110,24 @@ jobs:
           fi
           echo '✅ No PostHog references found'
 
+      - name: Scan dist for Datadog RUM references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Datadog RUM references...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -e '@datadog/browser-rum' \
+            -e '041a9897-5516-4b1f-a245-1a9aa6895488' \
+            -e 'pub7704486e5b64eb4ff6f62891cda45559' \
+            -e 'comfy-cloud-frontend' \
+            dist; then
+            echo '❌ ERROR: Datadog RUM references found in dist assets!'
+            echo 'Datadog RUM must be properly tree-shaken from OSS builds.'
+            exit 1
+          fi
+          echo '✅ No Datadog RUM references found'
+
       - name: Scan dist for Customer.io telemetry references
         run: |
           set -euo pipefail

--- a/index.html
+++ b/index.html
@@ -162,6 +162,6 @@
       })()
     </script>
     <div id="vue-app"></div>
-    <script type="module" src="src/main.ts"></script>
+    <script type="module" src="src/bootstrap.ts"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@comfyorg/shared-frontend-utils": "workspace:*",
     "@comfyorg/tailwind-utils": "workspace:*",
     "@customerio/cdp-analytics-browser": "catalog:",
+    "@datadog/browser-rum": "catalog:",
     "@floating-ui/vue": "catalog:",
     "@formkit/auto-animate": "catalog:",
     "@iconify/json": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@customerio/cdp-analytics-browser':
       specifier: ^0.5.3
       version: 0.5.3
+    '@datadog/browser-rum':
+      specifier: ^6.33.0
+      version: 6.33.0
     '@eslint/js':
       specifier: ^10.0.1
       version: 10.0.1
@@ -471,6 +474,9 @@ importers:
       '@customerio/cdp-analytics-browser':
         specifier: 'catalog:'
         version: 0.5.3
+      '@datadog/browser-rum':
+        specifier: 'catalog:'
+        version: 6.33.0
       '@floating-ui/vue':
         specifier: 'catalog:'
         version: 1.1.11(vue@3.5.34(typescript@5.9.3))
@@ -1512,6 +1518,20 @@ packages:
 
   '@cyberalien/svg-utils@1.2.15':
     resolution: {integrity: sha512-ZbKU6npzW5PNocdoLVJYfKzaP+c/RpT6JUkoaKrW1DOcw6lyXub8XtcNpI3xok6FnyNjS6ZbsrrtjTnS9yeZAQ==}
+
+  '@datadog/browser-core@6.33.0':
+    resolution: {integrity: sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==}
+
+  '@datadog/browser-rum-core@6.33.0':
+    resolution: {integrity: sha512-Ais4x7zQBrBI6JyILYwFAmjUsqy0iQp2C7JcEEfzU4YYYcVO3DGpyVuYYrqHT27jY1QToHY8EnQUr3Yaj6saDA==}
+
+  '@datadog/browser-rum@6.33.0':
+    resolution: {integrity: sha512-zdxs1PyKt1RQ/fdxsmaCJUeBhB+leCIaPJBcum7uDi/DL8nuu9A9NUc5qGVPlY9zc12v7t2NI8bLpOrMjv+jTg==}
+    peerDependencies:
+      '@datadog/browser-logs': 6.33.0
+    peerDependenciesMeta:
+      '@datadog/browser-logs':
+        optional: true
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -9796,6 +9816,17 @@ snapshots:
   '@cyberalien/svg-utils@1.2.15':
     dependencies:
       '@iconify/types': 2.0.0
+
+  '@datadog/browser-core@6.33.0': {}
+
+  '@datadog/browser-rum-core@6.33.0':
+    dependencies:
+      '@datadog/browser-core': 6.33.0
+
+  '@datadog/browser-rum@6.33.0':
+    dependencies:
+      '@datadog/browser-core': 6.33.0
+      '@datadog/browser-rum-core': 6.33.0
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   '@astrojs/vue': ^6.0.1
   '@comfyorg/comfyui-electron-types': 0.6.2
   '@customerio/cdp-analytics-browser': ^0.5.3
+  '@datadog/browser-rum': ^6.33.0
   '@eslint/js': ^10.0.1
   '@floating-ui/vue': ^1.1.11
   '@formkit/auto-animate': ^0.9.0

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,6 @@
 if (__DISTRIBUTION__ === 'cloud') {
   const { initDatadogRum } = await import('@/platform/telemetry/initDatadogRum')
-  initDatadogRum()
+  void initDatadogRum().catch(() => {})
 }
 
 await import('./main')

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,8 @@
+if (__DISTRIBUTION__ === 'cloud') {
+  const { initDatadogRum } = await import('@/platform/telemetry/initDatadogRum')
+  initDatadogRum()
+}
+
+await import('./main')
+
+export {}

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -8,9 +8,8 @@ import type {
   BillingTelemetryEvent,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
-  ShareFlowMetadata,
-  ShareLinkOpenedMetadata,
   ExecutionErrorMetadata,
+  ExecutionOutcomeMetadata,
   ExecutionSuccessMetadata,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
@@ -25,6 +24,8 @@ import type {
   PageVisibilityMetadata,
   ResubscribeClickMetadata,
   RunButtonProperties,
+  ShareFlowMetadata,
+  ShareLinkOpenedMetadata,
   SettingChangedMetadata,
   SharedWorkflowRunMetadata,
   ShellLayoutMetadata,
@@ -285,6 +286,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackWorkflowExecution(): void {
     this.dispatch((provider) => provider.trackWorkflowExecution?.())
+  }
+
+  trackExecutionOutcome(metadata: ExecutionOutcomeMetadata): void {
+    this.dispatch((provider) => provider.trackExecutionOutcome?.(metadata))
   }
 
   trackExecutionError(metadata: ExecutionErrorMetadata): void {

--- a/src/platform/telemetry/datadogRumBeforeSend.test.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.test.ts
@@ -1,0 +1,62 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import type { RumErrorEvent } from '@datadog/browser-rum'
+import { describe, expect, it } from 'vitest'
+
+import { classifyRumErrorOrigin, rumBeforeSend } from './datadogRumBeforeSend'
+
+function createErrorEvent(message: string, stack?: string): RumErrorEvent {
+  return fromPartial<RumErrorEvent>({
+    type: 'error',
+    error: { message, source: 'source', stack }
+  })
+}
+
+describe('rumBeforeSend', () => {
+  it('drops known third-party network noise', () => {
+    const event = createErrorEvent(
+      'Failed to fetch https://px.ads.linkedin.com/pixel'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(false)
+  })
+
+  it('keeps application errors and tags their origin', () => {
+    const event = createErrorEvent(
+      'Application failed',
+      'at render (https://cloud.comfy.org/assets/app.js:1:2)'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
+    expect(event.context).toEqual({ error: { origin: 'first_party' } })
+  })
+
+  it('tags custom extension errors with their folder', () => {
+    const event = createErrorEvent(
+      'Extension failed',
+      'at run (https://cloud.comfy.org/extensions/comfyui-foo/main.js:1:2)'
+    )
+
+    expect(rumBeforeSend(event, fromPartial({}))).toBe(true)
+    expect(event.context).toEqual({
+      error: { origin: 'extension', extension: 'comfyui-foo' }
+    })
+  })
+})
+
+describe('classifyRumErrorOrigin', () => {
+  it('uses the first recognizable in-app stack frame', () => {
+    const stack = [
+      'at external (https://cdn.example.com/library.js:1:2)',
+      'at cloud (https://cloud.comfy.org/extensions/cloud/main.js:1:2)',
+      'at custom (https://cloud.comfy.org/extensions/comfyui-foo/main.js:1:2)'
+    ].join('\n')
+
+    expect(classifyRumErrorOrigin(stack)).toEqual({ origin: 'first_party' })
+  })
+
+  it('classifies stacks without in-app frames as third party', () => {
+    expect(
+      classifyRumErrorOrigin('at external (https://cdn.example.com/app.js:1:2)')
+    ).toEqual({ origin: 'third_party' })
+  })
+})

--- a/src/platform/telemetry/datadogRumBeforeSend.ts
+++ b/src/platform/telemetry/datadogRumBeforeSend.ts
@@ -1,0 +1,72 @@
+import type { RumBeforeSend, RumErrorEvent } from '@datadog/browser-rum'
+
+const RUM_NOISE_HOSTS = [
+  'facebook.com',
+  'px.ads.linkedin.com',
+  'browser-intake-us5-datadoghq.com',
+  'e2.sy-d.io',
+  'google-analytics.com',
+  'googletagmanager.com'
+]
+
+const FIRST_PARTY_EXTENSION_FOLDERS = new Set(['cloud', 'core'])
+
+type RumErrorOrigin =
+  | { origin: 'first_party' }
+  | { origin: 'extension'; extension: string }
+  | { origin: 'third_party' }
+
+export function classifyRumErrorOrigin(stack?: string): RumErrorOrigin {
+  if (!stack) return { origin: 'third_party' }
+
+  for (const line of stack.split('\n')) {
+    const extensionFolder = /\/extensions\/([^/?#]+)\//.exec(line)?.[1]
+    if (extensionFolder) {
+      return FIRST_PARTY_EXTENSION_FOLDERS.has(extensionFolder)
+        ? { origin: 'first_party' }
+        : { origin: 'extension', extension: extensionFolder }
+    }
+
+    if (line.includes('/assets/')) return { origin: 'first_party' }
+  }
+
+  return { origin: 'third_party' }
+}
+
+function shouldKeepRumEvent(event: Parameters<RumBeforeSend>[0]): boolean {
+  if (event.type !== 'error') return true
+
+  const message = event.error.message
+  if (message.startsWith('intervention:')) return false
+  if (message.includes('ResizeObserver loop')) return false
+
+  const isNetworkNoise =
+    message.includes('csp_violation') || message.includes('Failed to fetch')
+  return (
+    !isNetworkNoise || !RUM_NOISE_HOSTS.some((host) => message.includes(host))
+  )
+}
+
+function tagRumErrorOrigin(event: RumErrorEvent): void {
+  try {
+    const errorOrigin = classifyRumErrorOrigin(event.error.stack)
+    const existingErrorContext = event.context?.error
+    const errorContext =
+      typeof existingErrorContext === 'object' && existingErrorContext !== null
+        ? existingErrorContext
+        : {}
+
+    event.context = {
+      ...event.context,
+      error: { ...errorContext, ...errorOrigin }
+    }
+  } catch {
+    return
+  }
+}
+
+export const rumBeforeSend: RumBeforeSend = (event) => {
+  if (!shouldKeepRumEvent(event)) return false
+  if (event.type === 'error') tagRumErrorOrigin(event)
+  return true
+}

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  getInitConfiguration: vi.fn(),
+  init: vi.fn()
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: hoisted
+}))
+
+import { rumBeforeSend } from './datadogRumBeforeSend'
+import { initDatadogRum } from './initDatadogRum'
+
+describe('initDatadogRum', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.getInitConfiguration.mockReturnValue(undefined)
+  })
+
+  it.for([
+    { hostname: 'cloud.comfy.org', env: 'prod-v2' },
+    { hostname: 'stagingcloud.comfy.org', env: 'stg-v2' },
+    { hostname: 'testcloud.comfy.org', env: 'test-v2' },
+    { hostname: 'fe-pr-13691.testenvs.comfy.org', env: 'test-v2' }
+  ])('initializes $hostname with the $env environment', ({ hostname, env }) => {
+    initDatadogRum(hostname)
+
+    expect(hoisted.init).toHaveBeenCalledWith({
+      clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
+      applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
+      site: 'us5.datadoghq.com',
+      service: 'comfy-cloud-frontend',
+      env,
+      version: __COMFYUI_FRONTEND_VERSION__,
+      beforeSend: rumBeforeSend,
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 0,
+      allowedTracingUrls: [expect.any(RegExp)]
+    })
+  })
+
+  it.for([
+    'localhost',
+    'testenvs.comfy.org',
+    'eviltestenvs.comfy.org',
+    'preview.testenvs.comfy.org.example.com'
+  ])('does not initialize on unknown hostname %s', (hostname) => {
+    initDatadogRum(hostname)
+
+    expect(hoisted.init).not.toHaveBeenCalled()
+  })
+
+  it('does not initialize twice', () => {
+    hoisted.getInitConfiguration.mockReturnValue({})
+
+    initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.init).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -1,9 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const hoisted = vi.hoisted(() => ({
-  getInitConfiguration: vi.fn(),
-  init: vi.fn()
-}))
+const hoisted = vi.hoisted(() => {
+  const context: Record<string, unknown> = {}
+
+  return {
+    context,
+    fetch: vi.fn<typeof fetch>(),
+    getInitConfiguration: vi.fn(),
+    init: vi.fn(),
+    setGlobalContextProperty: vi.fn((key: string, value: unknown) => {
+      context[key] = value
+    })
+  }
+})
 
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: hoisted
@@ -14,8 +23,21 @@ import { initDatadogRum } from './initDatadogRum'
 
 describe('initDatadogRum', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+    for (const key of Object.keys(hoisted.context)) {
+      delete hoisted.context[key]
+    }
+    hoisted.setGlobalContextProperty.mockImplementation((key, value) => {
+      hoisted.context[key] = value
+    })
+    hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
     hoisted.getInitConfiguration.mockReturnValue(undefined)
+    vi.stubGlobal('fetch', hoisted.fetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it.for([
@@ -23,21 +45,167 @@ describe('initDatadogRum', () => {
     { hostname: 'stagingcloud.comfy.org', env: 'stg-v2' },
     { hostname: 'testcloud.comfy.org', env: 'test-v2' },
     { hostname: 'fe-pr-13691.testenvs.comfy.org', env: 'test-v2' }
-  ])('initializes $hostname with the $env environment', ({ hostname, env }) => {
-    initDatadogRum(hostname)
+  ])(
+    'initializes $hostname with the $env environment',
+    async ({ hostname, env }) => {
+      await initDatadogRum(hostname)
 
-    expect(hoisted.init).toHaveBeenCalledWith({
-      clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
-      applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
-      site: 'us5.datadoghq.com',
-      service: 'comfy-cloud-frontend',
-      env,
-      version: __COMFYUI_FRONTEND_VERSION__,
-      beforeSend: rumBeforeSend,
-      sessionSampleRate: 100,
-      sessionReplaySampleRate: 0,
-      allowedTracingUrls: [expect.any(RegExp)]
+      expect(hoisted.init).toHaveBeenCalledWith({
+        clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
+        applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
+        site: 'us5.datadoghq.com',
+        service: 'comfy-cloud-frontend',
+        env,
+        version: __COMFYUI_FRONTEND_VERSION__,
+        beforeSend: rumBeforeSend,
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 0,
+        allowedTracingUrls: [expect.any(RegExp)]
+      })
+    }
+  )
+
+  it('tags canary traffic with its bucket and frontend version', async () => {
+    let resolveProbe: (response: Response) => void
+    hoisted.fetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve
+      })
+    )
+    hoisted.init.mockImplementation(() => {
+      expect(hoisted.context).toEqual({
+        bucket: 'canary',
+        version: __COMFYUI_FRONTEND_COMMIT__
+      })
     })
+
+    const initialization = initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.init).not.toHaveBeenCalled()
+    resolveProbe!(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'canary',
+          'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__
+        }
+      })
+    )
+    await initialization
+
+    expect(hoisted.context).toEqual({
+      bucket: 'canary',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('serializes concurrent initialization', async () => {
+    let resolveProbe: (response: Response) => void
+    hoisted.fetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve
+      })
+    )
+
+    const firstInitialization = initDatadogRum('cloud.comfy.org')
+    const secondInitialization = initDatadogRum('cloud.comfy.org')
+
+    resolveProbe!(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'canary',
+          'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__
+        }
+      })
+    )
+    await Promise.all([firstInitialization, secondInitialization])
+
+    expect(hoisted.fetch).toHaveBeenCalledOnce()
+    expect(hoisted.init).toHaveBeenCalledOnce()
+    expect(hoisted.context).toEqual({
+      bucket: 'canary',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+  })
+
+  it('defaults the bucket to stable and tracks its frontend version', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: { 'X-Frontend-Version': __COMFYUI_FRONTEND_COMMIT__ }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({
+      bucket: 'stable',
+      version: __COMFYUI_FRONTEND_COMMIT__
+    })
+  })
+
+  it('leaves traffic unclassified when the frontend version is absent', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: { 'X-Frontend-Bucket': 'canary' }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+  })
+
+  it('leaves traffic unclassified when the probe reaches another version', async () => {
+    hoisted.fetch.mockResolvedValue(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Bucket': 'stable',
+          'X-Frontend-Version': 'another-frontend-commit'
+        }
+      })
+    )
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+  })
+
+  it('leaves traffic unclassified when the header probe fails', async () => {
+    hoisted.fetch.mockResolvedValue(new Response(null, { status: 503 }))
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('initializes RUM when the header probe rejects', async () => {
+    hoisted.fetch.mockRejectedValue(new Error('network error'))
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
+  })
+
+  it('initializes RUM when the header probe times out', async () => {
+    const abortController = new AbortController()
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(abortController.signal)
+    hoisted.fetch.mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Timed out', 'AbortError'))
+          })
+        })
+    )
+
+    const initialization = initDatadogRum('cloud.comfy.org')
+    abortController.abort()
+    await initialization
+
+    expect(hoisted.context).toEqual({})
+    expect(hoisted.init).toHaveBeenCalledOnce()
   })
 
   it.for([
@@ -45,16 +213,16 @@ describe('initDatadogRum', () => {
     'testenvs.comfy.org',
     'eviltestenvs.comfy.org',
     'preview.testenvs.comfy.org.example.com'
-  ])('does not initialize on unknown hostname %s', (hostname) => {
-    initDatadogRum(hostname)
+  ])('does not initialize on unknown hostname %s', async (hostname) => {
+    await initDatadogRum(hostname)
 
     expect(hoisted.init).not.toHaveBeenCalled()
   })
 
-  it('does not initialize twice', () => {
+  it('does not initialize twice', async () => {
     hoisted.getInitConfiguration.mockReturnValue({})
 
-    initDatadogRum('cloud.comfy.org')
+    await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.init).not.toHaveBeenCalled()
   })

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -17,9 +17,13 @@ const hoisted = vi.hoisted(() => {
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: hoisted
 }))
+vi.mock('./manualRefreshTracker', () => ({
+  trackUserManualRefresh: vi.fn()
+}))
 
 import { rumBeforeSend } from './datadogRumBeforeSend'
 import { initDatadogRum } from './initDatadogRum'
+import { trackUserManualRefresh } from './manualRefreshTracker'
 
 describe('initDatadogRum', () => {
   beforeEach(() => {
@@ -225,5 +229,15 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.init).not.toHaveBeenCalled()
+  })
+
+  it('tracks manual refreshes only once RUM is initialized', async () => {
+    await initDatadogRum('localhost')
+
+    expect(vi.mocked(trackUserManualRefresh)).not.toHaveBeenCalled()
+
+    await initDatadogRum('cloud.comfy.org')
+
+    expect(vi.mocked(trackUserManualRefresh)).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -1,0 +1,29 @@
+import { datadogRum } from '@datadog/browser-rum'
+
+import { rumBeforeSend } from './datadogRumBeforeSend'
+
+const DATADOG_ENV_BY_HOSTNAME = new Map([
+  ['cloud.comfy.org', 'prod-v2'],
+  ['stagingcloud.comfy.org', 'stg-v2'],
+  ['testcloud.comfy.org', 'test-v2']
+])
+
+export function initDatadogRum(hostname = window.location.hostname): void {
+  const env =
+    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
+    (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
+  if (!env || datadogRum.getInitConfiguration()) return
+
+  datadogRum.init({
+    clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
+    applicationId: '041a9897-5516-4b1f-a245-1a9aa6895488',
+    site: 'us5.datadoghq.com',
+    service: 'comfy-cloud-frontend',
+    env,
+    version: __COMFYUI_FRONTEND_VERSION__,
+    beforeSend: rumBeforeSend,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 0,
+    allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
+  })
+}

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -7,12 +7,30 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['stagingcloud.comfy.org', 'stg-v2'],
   ['testcloud.comfy.org', 'test-v2']
 ])
+const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
+let initializationPromise: Promise<void> | undefined
 
-export function initDatadogRum(hostname = window.location.hostname): void {
-  const env =
-    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
-    (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
-  if (!env || datadogRum.getInitConfiguration()) return
+async function setFrontendContext(): Promise<void> {
+  const response = await fetch(window.location.origin, {
+    method: 'HEAD',
+    cache: 'no-store',
+    signal: AbortSignal.timeout(FRONTEND_CONTEXT_FETCH_TIMEOUT_MS)
+  })
+  if (!response.ok) return
+
+  const frontendVersion = response.headers.get('X-Frontend-Version')
+  if (frontendVersion !== __COMFYUI_FRONTEND_COMMIT__) return
+
+  datadogRum.setGlobalContextProperty(
+    'bucket',
+    response.headers.get('X-Frontend-Bucket') ?? 'stable'
+  )
+  datadogRum.setGlobalContextProperty('version', frontendVersion)
+}
+
+async function initializeDatadogRum(env: string): Promise<void> {
+  await setFrontendContext().catch(() => {})
+  if (datadogRum.getInitConfiguration()) return
 
   datadogRum.init({
     clientToken: 'pub7704486e5b64eb4ff6f62891cda45559',
@@ -26,4 +44,18 @@ export function initDatadogRum(hostname = window.location.hostname): void {
     sessionReplaySampleRate: 0,
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
+}
+
+export function initDatadogRum(
+  hostname = window.location.hostname
+): Promise<void> {
+  const env =
+    DATADOG_ENV_BY_HOSTNAME.get(hostname) ??
+    (hostname.endsWith('.testenvs.comfy.org') ? 'test-v2' : undefined)
+  if (!env || datadogRum.getInitConfiguration()) return Promise.resolve()
+
+  initializationPromise ??= initializeDatadogRum(env).finally(() => {
+    initializationPromise = undefined
+  })
+  return initializationPromise
 }

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -1,6 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum'
 
 import { rumBeforeSend } from './datadogRumBeforeSend'
+import { trackUserManualRefresh } from './manualRefreshTracker'
 
 const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['cloud.comfy.org', 'prod-v2'],
@@ -44,6 +45,7 @@ async function initializeDatadogRum(env: string): Promise<void> {
     sessionReplaySampleRate: 0,
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
+  trackUserManualRefresh()
 }
 
 export function initDatadogRum(

--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -28,7 +28,8 @@ export async function initTelemetry(): Promise<void> {
       { PostHogTelemetryProvider },
       { ClickHouseTelemetryProvider },
       { SyftTelemetryProvider },
-      { CustomerIoTelemetryProvider }
+      { CustomerIoTelemetryProvider },
+      { DatadogRumTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
       import('./providers/cloud/MixpanelTelemetryProvider'),
@@ -37,7 +38,8 @@ export async function initTelemetry(): Promise<void> {
       import('./providers/cloud/PostHogTelemetryProvider'),
       import('./providers/cloud/ClickHouseTelemetryProvider'),
       import('./providers/cloud/SyftTelemetryProvider'),
-      import('./providers/cloud/CustomerIoTelemetryProvider')
+      import('./providers/cloud/CustomerIoTelemetryProvider'),
+      import('./providers/cloud/DatadogRumTelemetryProvider')
     ])
 
     const registry = new TelemetryRegistry()
@@ -48,6 +50,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new ClickHouseTelemetryProvider())
     registry.registerProvider(new SyftTelemetryProvider())
     registry.registerProvider(new CustomerIoTelemetryProvider())
+    registry.registerProvider(new DatadogRumTelemetryProvider())
 
     setTelemetryRegistry(registry)
   })()

--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -29,7 +29,8 @@ export async function initTelemetry(): Promise<void> {
       { ClickHouseTelemetryProvider },
       { SyftTelemetryProvider },
       { CustomerIoTelemetryProvider },
-      { DatadogRumTelemetryProvider }
+      { DatadogRumTelemetryProvider },
+      { SentryTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
       import('./providers/cloud/MixpanelTelemetryProvider'),
@@ -39,7 +40,8 @@ export async function initTelemetry(): Promise<void> {
       import('./providers/cloud/ClickHouseTelemetryProvider'),
       import('./providers/cloud/SyftTelemetryProvider'),
       import('./providers/cloud/CustomerIoTelemetryProvider'),
-      import('./providers/cloud/DatadogRumTelemetryProvider')
+      import('./providers/cloud/DatadogRumTelemetryProvider'),
+      import('./providers/cloud/SentryTelemetryProvider')
     ])
 
     const registry = new TelemetryRegistry()
@@ -51,6 +53,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new SyftTelemetryProvider())
     registry.registerProvider(new CustomerIoTelemetryProvider())
     registry.registerProvider(new DatadogRumTelemetryProvider())
+    registry.registerProvider(new SentryTelemetryProvider())
 
     setTelemetryRegistry(registry)
   })()

--- a/src/platform/telemetry/manualRefreshTracker.test.ts
+++ b/src/platform/telemetry/manualRefreshTracker.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  addAction: vi.fn(),
+  getInternalContext: vi.fn()
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: hoisted
+}))
+
+import { trackUserManualRefresh } from './manualRefreshTracker'
+
+function mockNavigationType(type: string): void {
+  vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+    { type } as PerformanceNavigationTiming
+  ])
+}
+
+describe('trackUserManualRefresh', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    hoisted.getInternalContext.mockReturnValue({ session_id: 'session-1' })
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('counts reloads within the same session', () => {
+    mockNavigationType('reload')
+
+    trackUserManualRefresh()
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction.mock.calls).toEqual([
+      ['user_manual_refresh', { refresh_count: 1 }],
+      ['user_manual_refresh', { refresh_count: 2 }]
+    ])
+  })
+
+  it('restarts the count for a new session', () => {
+    mockNavigationType('reload')
+
+    trackUserManualRefresh()
+    hoisted.getInternalContext.mockReturnValue({ session_id: 'session-2' })
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction).toHaveBeenLastCalledWith('user_manual_refresh', {
+      refresh_count: 1
+    })
+  })
+
+  it('ignores a non-reload navigation', () => {
+    mockNavigationType('navigate')
+
+    trackUserManualRefresh()
+
+    expect(hoisted.addAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/telemetry/manualRefreshTracker.ts
+++ b/src/platform/telemetry/manualRefreshTracker.ts
@@ -1,0 +1,33 @@
+import { datadogRum } from '@datadog/browser-rum'
+
+const REFRESH_COUNT_KEY = 'Comfy.ManualRefreshCount'
+
+function nextRefreshCount(sessionId: string): number {
+  const [storedSessionId, storedCount] = (
+    localStorage.getItem(REFRESH_COUNT_KEY) ?? ''
+  ).split(':')
+  const count = storedSessionId === sessionId ? Number(storedCount) + 1 : 1
+  localStorage.setItem(REFRESH_COUNT_KEY, `${sessionId}:${count}`)
+  return count
+}
+
+/**
+ * Report a page reload as a RUM action carrying its running count within the
+ * current RUM session, so refresh bursts are queryable by threshold.
+ *
+ * Must be called after `datadogRum.init()`, which is what makes the session id
+ * available.
+ */
+export function trackUserManualRefresh(): void {
+  const [navigationEntry] = performance.getEntriesByType(
+    'navigation'
+  ) as PerformanceNavigationTiming[]
+  if (navigationEntry?.type !== 'reload') return
+
+  const sessionId = datadogRum.getInternalContext()?.session_id
+  if (!sessionId) return
+
+  datadogRum.addAction('user_manual_refresh', {
+    refresh_count: nextRefreshCount(sessionId)
+  })
+}

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -2,12 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const { addDurationVital } = vi.hoisted(() => ({
-  addDurationVital: vi.fn()
+const { addDurationVital, getInternalContext } = vi.hoisted(() => ({
+  addDurationVital: vi.fn(),
+  getInternalContext: vi.fn()
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addDurationVital }
+  datadogRum: { addDurationVital, getInternalContext }
 }))
 
 afterEach(() => {
@@ -19,6 +20,7 @@ describe('DatadogRumTelemetryProvider', () => {
   it.for(['success', 'failure'] as const)(
     'records a workflow vital with a %s outcome',
     (outcome) => {
+      getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
       vi.spyOn(performance, 'now').mockReturnValue(142)
 
       new DatadogRumTelemetryProvider().trackExecutionOutcome({
@@ -26,10 +28,12 @@ describe('DatadogRumTelemetryProvider', () => {
         outcome
       })
 
+      expect(getInternalContext).toHaveBeenCalledWith(42)
       expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
         startTime: performance.timeOrigin + 42,
         duration: 100,
         context: {
+          origin_view_id: 'view-a',
           outcome,
           product: 'cloud_generation'
         }

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
+
+const { addDurationVital } = vi.hoisted(() => ({
+  addDurationVital: vi.fn()
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: { addDurationVital }
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('DatadogRumTelemetryProvider', () => {
+  it.for(['success', 'failure'] as const)(
+    'records a workflow vital with a %s outcome',
+    (outcome) => {
+      vi.spyOn(performance, 'now').mockReturnValue(142)
+
+      new DatadogRumTelemetryProvider().trackExecutionOutcome({
+        startTime: 42,
+        outcome
+      })
+
+      expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
+        startTime: performance.timeOrigin + 42,
+        duration: 100,
+        context: {
+          outcome,
+          product: 'cloud_generation'
+        }
+      })
+    }
+  )
+})

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,3 +1,19 @@
-import type { TelemetryProvider } from '../../types'
+import { datadogRum } from '@datadog/browser-rum'
 
-export class DatadogRumTelemetryProvider implements TelemetryProvider {}
+import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
+
+export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackExecutionOutcome({
+    startTime,
+    outcome
+  }: ExecutionOutcomeMetadata): void {
+    datadogRum.addDurationVital('workflow_execution', {
+      startTime: performance.timeOrigin + startTime,
+      duration: performance.now() - startTime,
+      context: {
+        outcome,
+        product: 'cloud_generation'
+      }
+    })
+  }
+}

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -1,0 +1,3 @@
+import type { TelemetryProvider } from '../../types'
+
+export class DatadogRumTelemetryProvider implements TelemetryProvider {}

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -7,12 +7,14 @@ export class DatadogRumTelemetryProvider implements TelemetryProvider {
     startTime,
     outcome
   }: ExecutionOutcomeMetadata): void {
+    const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
     datadogRum.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
       duration: performance.now() - startTime,
       context: {
         outcome,
-        product: 'cloud_generation'
+        product: 'cloud_generation',
+        ...(originViewId && { origin_view_id: originViewId })
       }
     })
   }

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ExecutionContext, ShellLayoutMetadata } from '../../types'
+import { SentryTelemetryProvider } from './SentryTelemetryProvider'
+
+const mocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
+  setContext: vi.fn(),
+  setUser: vi.fn(),
+  onUserLogout: vi.fn(),
+  resolvedUserId: 'existing-user' as string | undefined,
+  workflowIsModified: true,
+  executionContext: {
+    is_template: false,
+    workflow_name: 'private-workflow-name',
+    custom_node_count: 2,
+    api_node_count: 1,
+    toolkit_node_count: 1,
+    subgraph_count: 3,
+    total_node_count: 12,
+    has_api_nodes: true,
+    api_node_names: ['PrivateApiNode'],
+    has_toolkit_nodes: true,
+    toolkit_node_names: ['PrivateToolkitNode']
+  } satisfies ExecutionContext
+}))
+
+vi.mock('@sentry/vue', () => ({
+  addBreadcrumb: mocks.addBreadcrumb,
+  setContext: mocks.setContext,
+  setUser: mocks.setUser
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    onUserLogout: mocks.onUserLogout,
+    resolvedUserInfo: {
+      value: mocks.resolvedUserId
+        ? {
+            id: mocks.resolvedUserId
+          }
+        : null
+    }
+  })
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    activeWorkflow: {
+      isModified: mocks.workflowIsModified
+    }
+  })
+}))
+
+vi.mock('../../utils/getExecutionContext', () => ({
+  getExecutionContext: () => mocks.executionContext
+}))
+
+const shellLayout: ShellLayoutMetadata = {
+  view_mode: 'graph',
+  is_app_mode: false,
+  dock_state: 'docked',
+  actionbar_position: 'top',
+  active_sidebar_tab: 'node-library',
+  right_side_panel_open: false,
+  bottom_panel_open: true,
+  open_workflow_tabs: 2
+}
+
+describe('SentryTelemetryProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolvedUserId = 'existing-user'
+    mocks.workflowIsModified = true
+  })
+
+  it('identifies resolved and newly authenticated users and clears logout', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackUserLoggedIn()
+    provider.trackAuth({ user_id: 'new-user' })
+
+    expect(mocks.setUser).toHaveBeenNthCalledWith(1, { id: 'existing-user' })
+    expect(mocks.setUser).toHaveBeenNthCalledWith(2, { id: 'new-user' })
+    expect(mocks.onUserLogout).toHaveBeenCalledOnce()
+
+    const onLogout = mocks.onUserLogout.mock.calls[0][0]
+    onLogout()
+
+    expect(mocks.setUser).toHaveBeenLastCalledWith(null)
+  })
+
+  it('sets bounded app context without workflow names or node-name arrays', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackShellLayout(shellLayout)
+
+    expect(mocks.setContext).toHaveBeenCalledExactlyOnceWith(
+      'ComfyUI App State',
+      {
+        ...shellLayout,
+        workflow_is_modified: true,
+        is_template: false,
+        custom_node_count: 2,
+        api_node_count: 1,
+        toolkit_node_count: 1,
+        subgraph_count: 3,
+        total_node_count: 12,
+        has_api_nodes: true,
+        has_toolkit_nodes: true
+      }
+    )
+  })
+
+  it('records privacy-safe node and execution breadcrumbs', () => {
+    const provider = new SentryTelemetryProvider()
+
+    provider.trackNodeAdded({
+      node_type: 'KSampler',
+      source: 'search_modal'
+    })
+    provider.trackWorkflowExecution()
+    provider.trackExecutionError({
+      jobId: 'private-job-id',
+      nodeId: 'private-node-id',
+      nodeType: 'KSampler',
+      error: 'private exception details'
+    })
+    provider.trackExecutionSuccess({ jobId: 'private-job-id' })
+
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(1, {
+      category: 'workflow',
+      message: 'node_added',
+      level: 'info',
+      data: {
+        node_type: 'KSampler',
+        source: 'search_modal'
+      }
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(2, {
+      category: 'workflow.execution',
+      message: 'started',
+      level: 'info'
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(3, {
+      category: 'workflow.execution',
+      message: 'failed',
+      level: 'error',
+      data: { node_type: 'KSampler' }
+    })
+    expect(mocks.addBreadcrumb).toHaveBeenNthCalledWith(4, {
+      category: 'workflow.execution',
+      message: 'succeeded',
+      level: 'info'
+    })
+    expect(mocks.setContext).toHaveBeenCalledWith('Workflow Execution', {
+      status: 'failure',
+      node_type: 'KSampler'
+    })
+  })
+})

--- a/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/SentryTelemetryProvider.ts
@@ -1,0 +1,119 @@
+import * as Sentry from '@sentry/vue'
+
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+import type {
+  AuthMetadata,
+  ExecutionErrorMetadata,
+  ExecutionSuccessMetadata,
+  NodeAddedMetadata,
+  ShellLayoutMetadata,
+  TelemetryProvider
+} from '../../types'
+import { getExecutionContext } from '../../utils/getExecutionContext'
+
+export class SentryTelemetryProvider implements TelemetryProvider {
+  private shellLayout: ShellLayoutMetadata | null = null
+  private isWatchingLogout = false
+
+  trackAuth({ user_id }: AuthMetadata): void {
+    this.setUser(user_id)
+  }
+
+  trackUserLoggedIn(): void {
+    this.setUser(useCurrentUser().resolvedUserInfo.value?.id)
+  }
+
+  trackShellLayout(metadata: ShellLayoutMetadata): void {
+    this.shellLayout = metadata
+    this.updateAppContext()
+  }
+
+  trackNodeAdded({ node_type, source }: NodeAddedMetadata): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow',
+      message: 'node_added',
+      level: 'info',
+      data: { node_type, source }
+    })
+  }
+
+  trackWorkflowExecution(): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'started',
+      level: 'info'
+    })
+    Sentry.setContext('Workflow Execution', { status: 'running' })
+    this.updateAppContext()
+  }
+
+  trackExecutionError({ nodeType }: ExecutionErrorMetadata): void {
+    const data = nodeType ? { node_type: nodeType } : undefined
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'failed',
+      level: 'error',
+      data
+    })
+    Sentry.setContext('Workflow Execution', {
+      status: 'failure',
+      ...data
+    })
+    this.updateAppContext()
+  }
+
+  trackExecutionSuccess(_metadata: ExecutionSuccessMetadata): void {
+    Sentry.addBreadcrumb({
+      category: 'workflow.execution',
+      message: 'succeeded',
+      level: 'info'
+    })
+    Sentry.setContext('Workflow Execution', { status: 'success' })
+    this.updateAppContext()
+  }
+
+  private setUser(userId: string | undefined): void {
+    if (!userId) return
+
+    Sentry.setUser({ id: userId })
+    this.watchForLogout()
+  }
+
+  private watchForLogout(): void {
+    if (this.isWatchingLogout) return
+
+    this.isWatchingLogout = true
+    useCurrentUser().onUserLogout(() => {
+      Sentry.setUser(null)
+    })
+  }
+
+  private updateAppContext(): void {
+    const {
+      is_template,
+      custom_node_count,
+      api_node_count,
+      toolkit_node_count,
+      subgraph_count,
+      total_node_count,
+      has_api_nodes,
+      has_toolkit_nodes
+    } = getExecutionContext()
+    const activeWorkflow = useWorkflowStore().activeWorkflow
+
+    Sentry.setContext('ComfyUI App State', {
+      ...(this.shellLayout ?? {}),
+      workflow_is_modified: activeWorkflow?.isModified ?? false,
+      is_template,
+      custom_node_count,
+      api_node_count,
+      toolkit_node_count,
+      subgraph_count,
+      total_node_count,
+      has_api_nodes,
+      has_toolkit_nodes
+    })
+  }
+}

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -182,6 +182,11 @@ export interface ExecutionErrorMetadata {
   error?: string
 }
 
+export interface ExecutionOutcomeMetadata {
+  startTime: number
+  outcome: 'success' | 'failure'
+}
+
 /**
  * Execution success metadata
  */
@@ -815,6 +820,7 @@ export interface TelemetryProvider {
 
   // Workflow execution events
   trackWorkflowExecution?(): void
+  trackExecutionOutcome?(metadata: ExecutionOutcomeMetadata): void
   trackExecutionError?(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess?(metadata: ExecutionSuccessMetadata): void
   trackSharedWorkflowRun?(metadata: SharedWorkflowRunMetadata): void

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1664,6 +1664,7 @@ export class ComfyApp {
           // user switches tabs while the request is in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const startTime = performance.now()
           const p = await this.graphToPrompt(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           try {
@@ -1687,6 +1688,7 @@ export class ComfyApp {
                   id: res.prompt_id,
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
+                  startTime,
                   workflow: queuedWorkflow
                 })
               }

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldLoadExtension } from './extensionService'
+
+describe('shouldLoadExtension', () => {
+  it('skips the legacy Cloud RUM extension in cloud builds', () => {
+    expect(shouldLoadExtension('/extensions/cloud/rum.js', true)).toBe(false)
+  })
+
+  it('keeps the legacy path available outside cloud builds', () => {
+    expect(shouldLoadExtension('/extensions/cloud/rum.js', false)).toBe(true)
+  })
+
+  it('skips core extensions that load through the core entry point', () => {
+    expect(shouldLoadExtension('/extensions/core/foo.js', false)).toBe(false)
+  })
+
+  it('loads other extensions', () => {
+    expect(shouldLoadExtension('/extensions/comfyui-foo/main.js', true)).toBe(
+      true
+    )
+  })
+})

--- a/src/services/extensionService.test.ts
+++ b/src/services/extensionService.test.ts
@@ -3,13 +3,19 @@ import { describe, expect, it } from 'vitest'
 import { shouldLoadExtension } from './extensionService'
 
 describe('shouldLoadExtension', () => {
-  it('skips the legacy Cloud RUM extension in cloud builds', () => {
-    expect(shouldLoadExtension('/extensions/cloud/rum.js', true)).toBe(false)
-  })
+  it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
+    'skips the inlined Cloud extension %s in cloud builds',
+    (extension) => {
+      expect(shouldLoadExtension(extension, true)).toBe(false)
+    }
+  )
 
-  it('keeps the legacy path available outside cloud builds', () => {
-    expect(shouldLoadExtension('/extensions/cloud/rum.js', false)).toBe(true)
-  })
+  it.for(['/extensions/cloud/rum.js', '/extensions/cloud/sentry.js'])(
+    'keeps the legacy path %s available outside cloud builds',
+    (extension) => {
+      expect(shouldLoadExtension(extension, false)).toBe(true)
+    }
+  )
 
   it('skips core extensions that load through the core entry point', () => {
     expect(shouldLoadExtension('/extensions/core/foo.js', false)).toBe(false)

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -15,6 +15,16 @@ import type { AuthUserInfo } from '@/types/authTypes'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
 
+const LEGACY_CLOUD_RUM_EXTENSION = '/extensions/cloud/rum.js'
+
+export function shouldLoadExtension(
+  extension: string,
+  isCloudBuild: boolean
+): boolean {
+  if (extension.includes('extensions/core')) return false
+  return !isCloudBuild || extension !== LEGACY_CLOUD_RUM_EXTENSION
+}
+
 export const useExtensionService = () => {
   const extensionStore = useExtensionStore()
   const settingStore = useSettingStore()
@@ -41,7 +51,9 @@ export const useExtensionService = () => {
     extensionStore.captureCoreExtensions()
     await Promise.all(
       extensions
-        .filter((extension) => !extension.includes('extensions/core'))
+        .filter((extension) =>
+          shouldLoadExtension(extension, __DISTRIBUTION__ === 'cloud')
+        )
         .map(async (ext) => {
           try {
             await import(/* @vite-ignore */ api.fileURL(ext))

--- a/src/services/extensionService.ts
+++ b/src/services/extensionService.ts
@@ -15,14 +15,17 @@ import type { AuthUserInfo } from '@/types/authTypes'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
 
-const LEGACY_CLOUD_RUM_EXTENSION = '/extensions/cloud/rum.js'
+const INLINED_CLOUD_EXTENSIONS = new Set([
+  '/extensions/cloud/rum.js',
+  '/extensions/cloud/sentry.js'
+])
 
 export function shouldLoadExtension(
   extension: string,
   isCloudBuild: boolean
 ): boolean {
   if (extension.includes('extensions/core')) return false
-  return !isCloudBuild || extension !== LEGACY_CLOUD_RUM_EXTENSION
+  return !isCloudBuild || !INLINED_CLOUD_EXTENSIONS.has(extension)
 }
 
 export const useExtensionService = () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -21,6 +21,7 @@ const {
   mockOpenWorkflows,
   mockShowTextPreview,
   mockTrackExecutionError,
+  mockTrackExecutionOutcome,
   mockTrackExecutionSuccess,
   mockTrackSharedWorkflowRun
 } = await vi.hoisted(async () => {
@@ -33,6 +34,7 @@ const {
     mockOpenWorkflows: shallowRef<{ path: string }[]>([]),
     mockShowTextPreview: vi.fn(),
     mockTrackExecutionError: vi.fn(),
+    mockTrackExecutionOutcome: vi.fn(),
     mockTrackExecutionSuccess: vi.fn(),
     mockTrackSharedWorkflowRun: vi.fn()
   }
@@ -92,6 +94,7 @@ vi.mock('@/platform/distribution/types', async () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackExecutionError: mockTrackExecutionError,
+    trackExecutionOutcome: mockTrackExecutionOutcome,
     trackExecutionSuccess: mockTrackExecutionSuccess,
     trackSharedWorkflowRun: mockTrackSharedWorkflowRun
   })
@@ -614,6 +617,7 @@ describe('useExecutionStore - workflowStatus', () => {
       nodes: ['1'],
       id: jobId,
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+      startTime: 42,
       workflow
     })
   }
@@ -631,6 +635,7 @@ describe('useExecutionStore - workflowStatus', () => {
     callStoreJob('job-1', workflowA)
     fireExecutionStart('job-1')
 
+    expect(mockTrackExecutionOutcome).not.toHaveBeenCalled()
     expect(store.getWorkflowStatus(workflowA)).toBe('running')
   })
 
@@ -648,7 +653,13 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionSuccess('job-1')
 
     callStoreJob('job-1', workflowA)
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledOnce()
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'success'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
+    expect(store.queuedJobs['job-1']).toBeUndefined()
   })
 
   it('flushes terminal failed when WS errors before storeJob', () => {
@@ -656,6 +667,10 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionError('job-1')
 
     callStoreJob('job-1', workflowA)
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'failure'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('failed')
   })
 
@@ -672,6 +687,10 @@ describe('useExecutionStore - workflowStatus', () => {
     fireExecutionStart('job-1')
     fireExecutionSuccess('job-1')
 
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
+      startTime: 42,
+      outcome: 'success'
+    })
     expect(store.getWorkflowStatus(workflowA)).toBe('completed')
   })
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -51,6 +51,7 @@ interface QueuedJob {
    * value is a boolean indicating if the node has been executed.
    */
   nodes: Record<string, boolean>
+  startTime?: number
   /**
    * The workflow that is queued to be executed
    */
@@ -177,6 +178,19 @@ export const useExecutionStore = defineStore('execution', () => {
     mutateStatus((m) => m.set(workflow, status))
   }
 
+  function trackExecutionOutcome(
+    jobId: string,
+    status: WorkflowExecutionStatus
+  ) {
+    if (status === 'running') return
+    const startTime = queuedJobs.value[jobId]?.startTime
+    if (startTime === undefined) return
+    useTelemetry()?.trackExecutionOutcome({
+      startTime,
+      outcome: status === 'completed' ? 'success' : 'failure'
+    })
+  }
+
   function setWorkflowStatus(jobId: string, status: WorkflowExecutionStatus) {
     const workflow = jobIdToWorkflow.get(jobId)
     if (!workflow) {
@@ -184,6 +198,7 @@ export const useExecutionStore = defineStore('execution', () => {
       return
     }
     applyWorkflowStatus(workflow, status)
+    trackExecutionOutcome(jobId, status)
   }
 
   function clearWorkflowStatus(workflow: ComfyWorkflow) {
@@ -718,11 +733,13 @@ export const useExecutionStore = defineStore('execution', () => {
     nodes,
     id,
     promptOutput,
+    startTime,
     workflow
   }: {
     nodes: string[]
     id: JobId
     promptOutput: ComfyApiWorkflow
+    startTime?: number
     workflow: ComfyWorkflow
   }) {
     queuedJobs.value[id] ??= { nodes: {} }
@@ -735,6 +752,7 @@ export const useExecutionStore = defineStore('execution', () => {
       ...queuedJob.nodes
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
+    queuedJob.startTime = startTime
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
     queuedJob.shareId = workflow?.shareId
@@ -761,6 +779,10 @@ export const useExecutionStore = defineStore('execution', () => {
     // Don't let a stale 'running' overwrite a terminal status already set.
     if (pending === 'running' && workflowStatus.value.has(workflow)) return
     applyWorkflowStatus(workflow, pending)
+    trackExecutionOutcome(jobId, pending)
+    if (pending === 'running' || activeJobId.value === jobId) return
+    delete queuedJobs.value[jobId]
+    jobIdToWorkflow.delete(jobId)
   }
 
   // ~0.65 MB at capacity (32 char GUID key + 50 char path value)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -614,6 +614,11 @@ export default defineConfig({
               test: /[\\/]node_modules[\\/]@sentry[\\/]/,
               priority: 15
             },
+            {
+              name: 'vendor-datadog',
+              test: /[\\/]node_modules[\\/]@datadog[\\/]/,
+              priority: 15
+            },
 
             // UI component libraries
             {


### PR DESCRIPTION
## Summary

Backport the ordered frontend observability stack to `cloud/1.47` for the next 1.47 hotfix.

## Changes

Applied in dependency order:

1. #13691 — initialize Cloud RUM from frontend bootstrap
2. #13708 — initialize the Datadog RUM telemetry provider
3. #13767 — record workflow execution vitals
4. #13764 — attribute workflow vitals to origin views
5. #14060 — tag RUM traffic with bucket and version
6. #14094 — inline Cloud Sentry telemetry
7. #14083 — track manual refresh actions

## Review Focus

All six commits added after #13691 cherry-picked cleanly with no manual conflict resolution:

- `80ebc1832b376d9f2a00f672c698e010195977e3`
- `131881284842d436e7f2794fd2b2c541032a3430`
- `b5d17f9106390bfd5e1259d3a20249e611d93817`
- `928435602c4e5a052eb9a7d57e872455f947d0d1`
- `1039660f9b279efb767147e2e31e4d3e4c9f0788`
- `112952b226a5c68df7a90ed462c104dee8ab490f`

For #13691, the `package.json` conflict preserved the target-only `@floating-ui/vue` dependency while adding Datadog in catalog order. The `pnpm-lock.yaml` conflict retained the target branch's dependency versions and regenerated only the Datadog dependency graph.

## Validation

- 7 focused Vitest files: 132 tests passed
- Full unit run: 995/997 files passed; two unrelated tests timed out while the core and cloud suites ran concurrently
- Isolated rerun of both timed-out files: 2 files and 8 tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `git diff --check`
