### PR TITLE
feat(website): replace affiliate brand asset downloads with brand portal CTA

### DIFF
--- a/apps/website/src/components/blocks/BrandAssetsGrid01.vue
+++ b/apps/website/src/components/blocks/BrandAssetsGrid01.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
+import Button from '../ui/button/Button.vue'
+
 type Asset = {
   id: string
   title: string
-  download: string
   preview: string
+}
+
+type Cta = {
+  label: string
+  href: string
 }
 
 defineProps<{
   heading: string
   subheading: string
-  downloadLabel: string
+  cta: Cta
   assets: readonly Asset[]
 }>()
 </script>
@@ -46,20 +52,18 @@ defineProps<{
             decoding="async"
           />
         </div>
-        <div class="flex flex-1 flex-col gap-2 p-5">
+        <div class="p-5">
           <h3 class="text-base font-light text-primary-comfy-canvas">
             {{ asset.title }}
           </h3>
-          <a
-            :href="asset.download"
-            :download="asset.download.split('/').pop()"
-            class="text-primary-comfy-yellow mt-auto inline-flex items-center gap-1 text-sm font-bold tracking-wider uppercase hover:underline"
-          >
-            {{ downloadLabel }}
-            <span aria-hidden="true">↓</span>
-          </a>
         </div>
       </li>
     </ul>
+
+    <div class="mt-12 flex justify-center">
+      <Button as="a" :href="cta.href" variant="outline" size="default">
+        {{ cta.label }}
+      </Button>
+    </div>
   </section>
 </template>

--- a/apps/website/src/data/affiliateBrandAssets.ts
+++ b/apps/website/src/data/affiliateBrandAssets.ts
@@ -1,11 +1,8 @@
 import type { LocalizedText } from '../i18n/translations'
 
-import { BRAND_ASSETS_ZIP } from './brandAssets'
-
 interface AffiliateBrandAsset {
   id: string
   title: LocalizedText
-  download: string
   preview: string
 }
 
@@ -13,25 +10,21 @@ export const affiliateBrandAssets: readonly AffiliateBrandAsset[] = [
   {
     id: 'core-logo',
     title: { en: 'Core Logo', 'zh-CN': '核心标志' },
-    download: BRAND_ASSETS_ZIP,
     preview: '/icons/logo.svg'
   },
   {
     id: 'logomark',
     title: { en: 'Logomark', 'zh-CN': '标志符号' },
-    download: BRAND_ASSETS_ZIP,
     preview: '/icons/logomark.svg'
   },
   {
     id: 'icon',
     title: { en: 'Icon', 'zh-CN': '图标' },
-    download: BRAND_ASSETS_ZIP,
     preview: '/affiliates/brand/comfy-color-combo-yellow.svg'
   },
   {
     id: 'amplified-logomark',
     title: { en: 'Amplified Logomark', 'zh-CN': '放大版标志符号' },
-    download: BRAND_ASSETS_ZIP,
     preview: '/affiliates/brand/comfy-amplified-logo.png'
   }
 ] as const

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4608,9 +4608,9 @@ const translations = {
     en: 'Banners, screenshots, and talking points are in your affiliate dashboard after approval.',
     'zh-CN': '横幅图、截图和宣传文案将在获批后于联盟仪表盘中提供。'
   },
-  'affiliate.assets.downloadLabel': {
-    en: 'Download zip',
-    'zh-CN': '下载压缩包'
+  'affiliate.assets.ctaLabel': {
+    en: 'Go to brand portal',
+    'zh-CN': '前往品牌门户'
   },
 
   // AffiliateFAQSection

--- a/apps/website/src/templates/affiliate/BrandAssetsSection.vue
+++ b/apps/website/src/templates/affiliate/BrandAssetsSection.vue
@@ -2,15 +2,17 @@
 import type { Locale } from '../../i18n/translations'
 
 import BrandAssetsGrid01 from '../../components/blocks/BrandAssetsGrid01.vue'
+import { getRoutes } from '../../config/routes'
 import { affiliateBrandAssets } from '../../data/affiliateBrandAssets'
 import { t } from '../../i18n/translations'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
+const routes = getRoutes(locale)
+
 const assets = affiliateBrandAssets.map((asset) => ({
   id: asset.id,
   title: asset.title[locale],
-  download: asset.download,
   preview: asset.preview
 }))
 </script>
@@ -19,7 +21,10 @@ const assets = affiliateBrandAssets.map((asset) => ({
   <BrandAssetsGrid01
     :heading="t('affiliate.assets.heading', locale)"
     :subheading="t('affiliate.assets.subheading', locale)"
-    :download-label="t('affiliate.assets.downloadLabel', locale)"
+    :cta="{
+      label: t('affiliate.assets.ctaLabel', locale),
+      href: routes.brand
+    }"
     :assets="assets"
   />
 </template>


### PR DESCRIPTION
## Summary

On the Affiliates page's brand assets block:

- Removed the per-logo "Download zip" links from the logo grid
- Added a single outlined yellow **GO TO BRAND PORTAL** CTA below the grid, linking to `/brand` (locale-aware via `getRoutes`)
- Dropped the now-unused `download` field from `affiliateBrandAssets` data
- Replaced the `affiliate.assets.downloadLabel` i18n key with `affiliate.assets.ctaLabel` (en/zh-CN)

## Testing

- `astro check` typecheck passes with 0 errors
- All 274 unit tests pass (`pnpm test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)