### PR TITLE
feat(billing): disclose that changing plans on a cancelled subscription resumes it

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2913,7 +2913,8 @@
         "confirmButton": "Confirm & reactivate",
         "confirmButtonWithCharge": "Confirm & reactivate — {amount} today",
         "checkboxLabel": "I understand I'll be charged {amount} today",
-        "confirmationRequired": "Your subscription is cancelled — please confirm the reactivation charge before continuing"
+        "confirmationRequired": "Your subscription is cancelled — please confirm the reactivation charge before continuing",
+        "amountChanged": "The charge amount changed since you confirmed it — please review and try again"
       }
     },
     "success": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2914,7 +2914,8 @@
         "confirmButtonWithCharge": "Confirm & reactivate — {amount} today",
         "checkboxLabel": "I understand I'll be charged {amount} today",
         "confirmationRequired": "Your subscription is cancelled — please confirm the reactivation charge before continuing",
-        "amountChanged": "The charge amount changed since you confirmed it — please review and try again"
+        "amountChanged": "The charge amount changed since you confirmed it — please review and try again",
+        "unavailable": "We can't confirm this reactivation right now — please choose your plan again"
       }
     },
     "success": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2898,7 +2898,17 @@
       "confirm": "Confirm",
       "subscribeToPlan": "Subscribe to {plan}",
       "switchToPlan": "Switch to {plan}",
-      "backToAllPlans": "Back to all plans"
+      "backToAllPlans": "Back to all plans",
+      "reactivation": {
+        "title": "Reactivating your subscription",
+        "titleAnnual": "Reactivating your subscription — full year billed today",
+        "upgradeBody": "Your {plan} was set to end on {date}. Upgrading now reactivates it — you'll be charged {amount} today, and it will renew automatically on {nextDate} instead of ending.",
+        "downgradeBody": "Your {plan} was set to end on {date}. Switching to {newPlan} reactivates it — you won't be charged today, but it will now renew automatically on {nextDate} at the new price instead of ending.",
+        "durationChangeBody": "Your {plan} was set to end on {date}. Switching to annual billing reactivates it and charges the full year, {amount}, today. It will then renew annually on {nextDate} instead of ending.",
+        "confirmButton": "Confirm & reactivate",
+        "confirmButtonWithCharge": "Confirm & reactivate — {amount} today",
+        "checkboxLabel": "I understand I'll be charged {amount} today"
+      }
     },
     "success": {
       "allSet": "You're all set",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2648,7 +2648,8 @@
       "paymentPageBlocked": "Couldn't open the payment page — please try again",
       "memberRemovalFailed": "Couldn't remove {email} from the team — some members may already be removed and your plan was not changed",
       "failedAfterMemberRemoval": "Team members were removed, but the plan change didn't complete — please try again or contact support",
-      "reactivationConfirmationRequired": "Please confirm the reactivation charge before continuing"
+      "reactivationConfirmationRequired": "Please confirm the reactivation charge before continuing",
+      "reactivationAmountChanged": "The charge amount changed since you confirmed it — please review and try again"
     },
     "partnerNodesBalance": "\"Partner Nodes\" Credit Balance",
     "partnerNodesDescription": "For running commercial/proprietary models",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2637,6 +2637,8 @@
     "downgrade": {
       "title": "Change to {plan} plan?",
       "body": "All other members of this workspace will be immediately removed.",
+      "bodyReactivation": "Your subscription is cancelled. Changing your plan will resume it, and you'll be charged {amount} today.",
+      "bodyRemovalAndReactivation": "All other members of this workspace will be immediately removed. Your subscription is cancelled, so changing your plan will also resume it, and you'll be charged {amount} today.",
       "confirmationPhrase": "I understand",
       "confirmationPrompt": "Type \"{phrase}\" to confirm.",
       "confirm": "Change plan",
@@ -2645,7 +2647,8 @@
       "paymentMethodRequired": "A payment method is required to change plans",
       "paymentPageBlocked": "Couldn't open the payment page — please try again",
       "memberRemovalFailed": "Couldn't remove {email} from the team — some members may already be removed and your plan was not changed",
-      "failedAfterMemberRemoval": "Team members were removed, but the plan change didn't complete — please try again or contact support"
+      "failedAfterMemberRemoval": "Team members were removed, but the plan change didn't complete — please try again or contact support",
+      "reactivationConfirmationRequired": "Please confirm the reactivation charge before continuing"
     },
     "partnerNodesBalance": "\"Partner Nodes\" Credit Balance",
     "partnerNodesDescription": "For running commercial/proprietary models",
@@ -2905,9 +2908,11 @@
         "upgradeBody": "Your {plan} was set to end on {date}. Upgrading now reactivates it — you'll be charged {amount} today, and it will renew automatically on {nextDate} instead of ending.",
         "downgradeBody": "Your {plan} was set to end on {date}. Switching to {newPlan} reactivates it — you won't be charged today, but it will now renew automatically on {nextDate} at the new price instead of ending.",
         "durationChangeBody": "Your {plan} was set to end on {date}. Switching to annual billing reactivates it and charges the full year, {amount}, today. It will then renew annually on {nextDate} instead of ending.",
+        "durationChangeBodyMonthly": "Your {plan} was set to end on {date}. Switching to monthly billing reactivates it — you'll be charged {amount} today, and it will renew automatically on {nextDate} instead of ending.",
         "confirmButton": "Confirm & reactivate",
         "confirmButtonWithCharge": "Confirm & reactivate — {amount} today",
-        "checkboxLabel": "I understand I'll be charged {amount} today"
+        "checkboxLabel": "I understand I'll be charged {amount} today",
+        "confirmationRequired": "Your subscription is cancelled — please confirm the reactivation charge before continuing"
       }
     },
     "success": {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -612,6 +612,7 @@ type BillingErrorCode =
   | 'missing_payment_method_url'
   | 'payment_popup_blocked'
   | 'reactivation_not_confirmed'
+  | 'reactivation_amount_changed'
 
 export interface BillingFailure {
   failure_category: BillingFailureCategory

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -611,6 +611,7 @@ type BillingErrorCode =
   | 'missing_checkout_response'
   | 'missing_payment_method_url'
   | 'payment_popup_blocked'
+  | 'reactivation_not_confirmed'
 
 export interface BillingFailure {
   failure_category: BillingFailureCategory

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -448,6 +448,25 @@ describe('workspaceApi', () => {
       expect(result).toEqual(data)
     })
 
+    it('subscribe() sends confirm_reactivation when reactivating a cancelled subscription', async () => {
+      const data = { billing_op_id: 'op-1c', status: 'subscribed' }
+      mockAxiosInstance.post.mockResolvedValue({ data })
+
+      const result = await workspaceApi.subscribe('pro-monthly', {
+        confirmReactivation: true
+      })
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/billing/subscribe',
+        expect.objectContaining({
+          plan_slug: 'pro-monthly',
+          confirm_reactivation: true
+        }),
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(data)
+    })
+
     it('cancelSubscription() sends POST with idempotency_key', async () => {
       const data = { billing_op_id: 'op-2', cancel_at: '2026-05-01' }
       mockAxiosInstance.post.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -168,6 +168,8 @@ interface SubscribeRequest {
   /** Required for the per-credit Team plan; selects the slider stop. */
   team_credit_stop_id?: string
   billing_cycle?: SubscribeBillingCycle
+  /** Required to change plans while the current subscription is cancelled; server rejects the change without it. */
+  confirm_reactivation?: boolean
 }
 
 export interface SubscribeOptions {
@@ -175,6 +177,7 @@ export interface SubscribeOptions {
   cancelUrl?: string
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
+  confirmReactivation?: boolean
 }
 
 export interface PreviewSubscribeOptions {
@@ -687,7 +690,8 @@ export const workspaceApi = {
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,
-          billing_cycle: options.billingCycle
+          billing_cycle: options.billingCycle,
+          confirm_reactivation: options.confirmReactivation
         } satisfies SubscribeRequest,
         { headers }
       )

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.stories.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.stories.ts
@@ -65,13 +65,14 @@ function plan(
 }
 
 function cancelledSubscription(
-  tier: NonNullable<SubscriptionInfo['tier']>
+  tier: NonNullable<SubscriptionInfo['tier']>,
+  duration: NonNullable<SubscriptionInfo['duration']> = 'MONTHLY'
 ): SubscriptionInfo {
   return {
     isActive: true,
     tier,
-    duration: 'MONTHLY',
-    planSlug: `${tier.toLowerCase()}-monthly`,
+    duration,
+    planSlug: `${tier.toLowerCase()}-${duration.toLowerCase()}`,
     renewalDate: null,
     endDate: CANCEL_DATE,
     isCancelled: true,
@@ -199,7 +200,7 @@ export const ReactivatingAnnualToMonthly: Story = story(
     current_plan: plan('CREATOR', 'ANNUAL', 33_600, CANCEL_DATE),
     new_plan: plan('CREATOR', 'MONTHLY', 3500, NEXT_MONTHLY_RENEWAL)
   } satisfies PreviewSubscribeResponse,
-  cancelledSubscription('CREATOR')
+  cancelledSubscription('CREATOR', 'ANNUAL')
 )
 
 /**

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.stories.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.stories.ts
@@ -1,0 +1,223 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { SubscriptionInfo } from '@/composables/billing/types'
+import { i18n } from '@/i18n'
+import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import { setBillingContextMock } from '@/storybook/mocks/useBillingContext'
+
+import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
+
+type PreviewPlanInfo = PreviewSubscribeResponse['new_plan']
+
+/**
+ * The reactivation-disclosure banner on the single-plan change preview: a
+ * cancelled-but-not-lapsed subscription resumes silently on any plan change,
+ * so the banner discloses that plus the exact charge (and, above the current
+ * plan's monthly total, a consent checkbox gating the confirm button). The
+ * banner reads `subscription`/`isInitialized` from `useBillingContext`, not
+ * from `previewData`, so each story drives it through the Storybook stub
+ * (`setBillingContextMock`) rather than props.
+ */
+const meta: Meta<typeof SubscriptionTransitionPreviewWorkspace> = {
+  title: 'Components/SubscriptionTransitionPreviewWorkspace',
+  component: SubscriptionTransitionPreviewWorkspace,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template:
+        '<div class="mx-auto flex h-[680px] w-[460px] flex-col rounded-2xl border border-border-default bg-secondary-background p-12"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const TODAY = '2026-08-01T00:00:00Z'
+// The date the pre-existing cancellation was set to lapse; still active until
+// then, which is what makes a plan change on this subscription a reactivation.
+const CANCEL_DATE = '2026-08-25T00:00:00Z'
+const NEXT_MONTHLY_RENEWAL = '2026-09-01T00:00:00Z'
+const NEXT_ANNUAL_RENEWAL = '2027-08-01T00:00:00Z'
+const NEXT_MONTHLY_AFTER_CANCEL = '2026-09-25T00:00:00Z'
+
+function plan(
+  tier: PreviewPlanInfo['tier'],
+  duration: PreviewPlanInfo['duration'],
+  priceCents: number,
+  periodEnd: string
+): PreviewPlanInfo {
+  return {
+    slug: `${tier.toLowerCase()}-${duration.toLowerCase()}`,
+    tier,
+    duration,
+    price_cents: priceCents,
+    credits_cents: 0,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: priceCents,
+      total_credits_cents: 0
+    },
+    period_end: periodEnd
+  }
+}
+
+function cancelledSubscription(
+  tier: NonNullable<SubscriptionInfo['tier']>
+): SubscriptionInfo {
+  return {
+    isActive: true,
+    tier,
+    duration: 'MONTHLY',
+    planSlug: `${tier.toLowerCase()}-monthly`,
+    renewalDate: null,
+    endDate: CANCEL_DATE,
+    isCancelled: true,
+    hasFunds: true
+  }
+}
+
+const notCancelledSubscription: SubscriptionInfo = {
+  isActive: true,
+  tier: 'STANDARD',
+  duration: 'MONTHLY',
+  planSlug: 'standard-monthly',
+  renewalDate: NEXT_MONTHLY_RENEWAL,
+  endDate: null,
+  isCancelled: false,
+  hasFunds: true
+}
+
+function story(
+  previewData: PreviewSubscribeResponse,
+  subscription: SubscriptionInfo
+): Story {
+  return {
+    args: { previewData },
+    beforeEach() {
+      // Dates render through both a local Intl formatter and vue-i18n's n(),
+      // so pin the locale rather than inherit the developer's.
+      i18n.global.locale.value = 'en'
+      setBillingContextMock({ subscription })
+    }
+  }
+}
+
+/**
+ * Ordinary upgrade, subscription not cancelled — the reactivation banner
+ * must not leak into a normal plan change.
+ */
+export const NotCancelled: Story = story(
+  {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: TODAY,
+    is_immediate: true,
+    cost_today_cents: 1500,
+    cost_next_period_cents: 3500,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('STANDARD', 'MONTHLY', 2000, NEXT_MONTHLY_RENEWAL),
+    new_plan: plan('CREATOR', 'MONTHLY', 3500, NEXT_MONTHLY_RENEWAL)
+  } satisfies PreviewSubscribeResponse,
+  notCancelledSubscription
+)
+
+/**
+ * Cancelled, immediate upgrade — exact-cents charge ($54.54), guarding the
+ * regression where this path rounded the charge shown to the user.
+ */
+export const ReactivatingUpgrade: Story = story(
+  {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: TODAY,
+    is_immediate: true,
+    cost_today_cents: 5454,
+    cost_next_period_cents: 10_000,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('CREATOR', 'MONTHLY', 3500, CANCEL_DATE),
+    new_plan: plan('PRO', 'MONTHLY', 10_000, NEXT_MONTHLY_RENEWAL)
+  } satisfies PreviewSubscribeResponse,
+  cancelledSubscription('CREATOR')
+)
+
+/**
+ * Cancelled, scheduled downgrade — $0 today. The most important state: no
+ * money moves, so the copy alone must make the reactivation unmissable.
+ */
+export const ReactivatingDowngrade: Story = story(
+  {
+    allowed: true,
+    transition_type: 'downgrade',
+    effective_at: CANCEL_DATE,
+    is_immediate: false,
+    cost_today_cents: 0,
+    cost_next_period_cents: 3500,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('PRO', 'MONTHLY', 10_000, CANCEL_DATE),
+    new_plan: plan('CREATOR', 'MONTHLY', 3500, NEXT_MONTHLY_AFTER_CANCEL)
+  } satisfies PreviewSubscribeResponse,
+  cancelledSubscription('PRO')
+)
+
+/** Cancelled, monthly-to-annual — the full year is billed today. */
+export const ReactivatingMonthlyToAnnual: Story = story(
+  {
+    allowed: true,
+    transition_type: 'duration_change',
+    effective_at: TODAY,
+    is_immediate: true,
+    cost_today_cents: 33_600,
+    cost_next_period_cents: 33_600,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('CREATOR', 'MONTHLY', 3500, CANCEL_DATE),
+    new_plan: plan('CREATOR', 'ANNUAL', 33_600, NEXT_ANNUAL_RENEWAL)
+  } satisfies PreviewSubscribeResponse,
+  cancelledSubscription('CREATOR')
+)
+
+/**
+ * Cancelled, annual-to-monthly — the other cadence direction, which used to
+ * wrongly show the annual copy and now has its own wording.
+ */
+export const ReactivatingAnnualToMonthly: Story = story(
+  {
+    allowed: true,
+    transition_type: 'duration_change',
+    effective_at: TODAY,
+    is_immediate: true,
+    cost_today_cents: 1234,
+    cost_next_period_cents: 3500,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('CREATOR', 'ANNUAL', 33_600, CANCEL_DATE),
+    new_plan: plan('CREATOR', 'MONTHLY', 3500, NEXT_MONTHLY_RENEWAL)
+  } satisfies PreviewSubscribeResponse,
+  cancelledSubscription('CREATOR')
+)
+
+/**
+ * Cancelled, charge above the current plan's monthly total — the consent
+ * checkbox renders and the confirm button stays disabled until it's ticked.
+ */
+export const ReactivatingAboveThreshold: Story = story(
+  {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: TODAY,
+    is_immediate: true,
+    cost_today_cents: 8000,
+    cost_next_period_cents: 10_000,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: plan('STANDARD', 'MONTHLY', 2000, CANCEL_DATE),
+    new_plan: plan('PRO', 'MONTHLY', 10_000, NEXT_MONTHLY_RENEWAL)
+  } satisfies PreviewSubscribeResponse,
+  cancelledSubscription('STANDARD')
+)

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -19,7 +19,8 @@ vi.mock('vue-i18n', () => ({
 // Not cancelled: keeps the reactivation banner out of these baseline scenarios.
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    subscription: { value: { isCancelled: false, endDate: null } }
+    subscription: { value: { isCancelled: false, endDate: null } },
+    isInitialized: { value: true }
   })
 }))
 

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -16,6 +16,13 @@ vi.mock('vue-i18n', () => ({
   })
 }))
 
+// Not cancelled: keeps the reactivation banner out of these baseline scenarios.
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    subscription: { value: { isCancelled: false, endDate: null } }
+  })
+}))
+
 const globalOptions = {
   mocks: { $t: (key: string) => key },
   stubs: {

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -196,7 +196,7 @@
 
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { formatUsdFromCents } from '@/base/credits/comfyCredits'
@@ -231,19 +231,19 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { subscription } = useBillingContext()
+const { subscription, isInitialized } = useBillingContext()
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)
 }
 
-function formatDate(dateStr: string): string {
+function formatDate(date: string | Date): string {
   return new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
     timeZone: 'UTC'
-  }).format(new Date(dateStr))
+  }).format(typeof date === 'string' ? new Date(date) : date)
 }
 
 function money(usd: number): string {
@@ -305,37 +305,56 @@ const reactivationVariant = computed<
       return null
   }
 })
+// Requires the data the banner and threshold math actually read
+// (subscription.endDate, previewData.current_plan) — without it the banner
+// would render broken copy or force the checkbox on a bogus $0 threshold.
 const isReactivating = computed(
-  () => isCancelled.value && reactivationVariant.value !== null
+  () =>
+    isCancelled.value &&
+    reactivationVariant.value !== null &&
+    !!subscription.value?.endDate &&
+    !!previewData.current_plan
 )
 
 const cancelDate = computed(() =>
   subscription.value?.endDate ? formatDate(subscription.value.endDate) : ''
 )
 
-// PreviewPlanInfo.price_cents isn't duration-normalized; divide ANNUAL by 12 to
-// get a monthly-equivalent, matching PricingTableWorkspace's getPriceFromApi.
+// seat_summary.total_cost_cents is the whole-subscription price; price_cents
+// is per-seat and understates the threshold on multi-seat team plans. Divide
+// ANNUAL by 12 to get a monthly-equivalent, matching
+// PricingTableWorkspace's getPriceFromApi.
 const currentMonthlyPriceCents = computed(() => {
   const plan = previewData.current_plan
   if (!plan) return 0
-  return plan.duration === 'ANNUAL' ? plan.price_cents / 12 : plan.price_cents
+  const totalCents = plan.seat_summary.total_cost_cents
+  return currentIsYearly.value ? totalCents / 12 : totalCents
 })
 const chargeCents = computed(() => previewData.cost_today_cents)
+// The downgrade variant's copy always says "you won't be charged today" with
+// no amount shown, so it never gets the checkbox even if cost_today_cents is
+// unexpectedly positive.
 const exceedsMonthlyThreshold = computed(
   () =>
-    isReactivating.value && chargeCents.value > currentMonthlyPriceCents.value
+    isReactivating.value &&
+    reactivationVariant.value !== 'downgrade' &&
+    chargeCents.value > currentMonthlyPriceCents.value
 )
 const chargeDisplay = computed(
-  () =>
-    `$${formatUsdFromCents({
-      cents: chargeCents.value,
-      numberOptions: { maximumFractionDigits: 0 }
-    })}`
+  () => `$${formatUsdFromCents({ cents: chargeCents.value })}`
 )
 
 const reactivationConfirmed = ref(false)
+// A checked box is consent to *this* charge; a later charge change (e.g. a
+// different preview loads) must not carry that consent forward.
+watch(chargeCents, () => {
+  reactivationConfirmed.value = false
+})
+
 const confirmDisabled = computed(
-  () => exceedsMonthlyThreshold.value && !reactivationConfirmed.value
+  () =>
+    !isInitialized.value ||
+    (exceedsMonthlyThreshold.value && !reactivationConfirmed.value)
 )
 const confirmReactivation = computed(
   () =>
@@ -344,7 +363,7 @@ const confirmReactivation = computed(
 )
 
 const bannerTitle = computed(() =>
-  reactivationVariant.value === 'duration_change'
+  reactivationVariant.value === 'duration_change' && newIsYearly.value
     ? t('subscription.preview.reactivation.titleAnnual')
     : t('subscription.preview.reactivation.title')
 )
@@ -355,7 +374,9 @@ const bannerBodyKey = computed<string>(() => {
     case 'downgrade':
       return 'subscription.preview.reactivation.downgradeBody'
     case 'duration_change':
-      return 'subscription.preview.reactivation.durationChangeBody'
+      return newIsYearly.value
+        ? 'subscription.preview.reactivation.durationChangeBody'
+        : 'subscription.preview.reactivation.durationChangeBodyMonthly'
     default:
       return ''
   }
@@ -407,11 +428,17 @@ const refillLabel = computed(() =>
 )
 
 const effectiveDateLabel = computed(() => formatDate(previewData.effective_at))
-const nextPaymentDate = computed(() =>
-  previewData.new_plan.period_end
-    ? formatDate(previewData.new_plan.period_end)
-    : effectiveDateLabel.value
-)
+// Without an explicit period_end, fall back to one billing period after
+// activation rather than the activation date itself — the activation date
+// reads as "renews today" for an immediate reactivation, which is wrong.
+const nextPaymentDate = computed(() => {
+  if (previewData.new_plan.period_end) {
+    return formatDate(previewData.new_plan.period_end)
+  }
+  const fallback = new Date(previewData.effective_at)
+  fallback.setUTCMonth(fallback.getUTCMonth() + (newIsYearly.value ? 12 : 1))
+  return formatDate(fallback)
+})
 const currentPeriodEnd = computed(() =>
   previewData.current_plan?.period_end
     ? formatDate(previewData.current_plan.period_end)

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -178,7 +178,7 @@
         class="w-full rounded-lg"
         :loading="isLoading"
         :disabled="confirmDisabled"
-        @click="$emit('confirm')"
+        @click="$emit('confirm', confirmReactivation)"
       >
         {{ confirmCta }}
       </Button>
@@ -224,7 +224,9 @@ const {
 }>()
 
 defineEmits<{
-  confirm: []
+  /** True only once the reactivation banner was shown and confirmed (checkbox
+   *  ticked above the charge threshold, since confirmDisabled gates the button). */
+  confirm: [confirmReactivation: boolean]
   back: []
 }>()
 
@@ -334,6 +336,11 @@ const chargeDisplay = computed(
 const reactivationConfirmed = ref(false)
 const confirmDisabled = computed(
   () => exceedsMonthlyThreshold.value && !reactivationConfirmed.value
+)
+const confirmReactivation = computed(
+  () =>
+    isReactivating.value &&
+    (!exceedsMonthlyThreshold.value || reactivationConfirmed.value)
 )
 
 const bannerTitle = computed(() =>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -231,7 +231,7 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { subscription, isInitialized } = useBillingContext()
+const { subscription } = useBillingContext()
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)
@@ -351,9 +351,13 @@ watch(chargeCents, () => {
   reactivationConfirmed.value = false
 })
 
+// isInitialized is aggregate (status + balance + plans); a balance or plans
+// failure must not permanently disable an otherwise-valid, already-loaded
+// subscription status. subscription is null exactly until status has loaded
+// at least once, so gate on that instead.
 const confirmDisabled = computed(
   () =>
-    !isInitialized.value ||
+    subscription.value === null ||
     (exceedsMonthlyThreshold.value && !reactivationConfirmed.value)
 )
 const confirmReactivation = computed(
@@ -428,6 +432,23 @@ const refillLabel = computed(() =>
 )
 
 const effectiveDateLabel = computed(() => formatDate(previewData.effective_at))
+// Date.setUTCMonth rolls a day-of-month past the target month's end into the
+// following month (e.g. Jan 31 + 1mo => Mar 3); clamp to the target month's
+// last day instead.
+function addUtcMonthsClamped(date: Date, months: number): Date {
+  const year = date.getUTCFullYear()
+  const targetMonthIndex = date.getUTCMonth() + months
+  const lastDayOfTargetMonth = new Date(
+    Date.UTC(year, targetMonthIndex + 1, 0)
+  ).getUTCDate()
+  return new Date(
+    Date.UTC(
+      year,
+      targetMonthIndex,
+      Math.min(date.getUTCDate(), lastDayOfTargetMonth)
+    )
+  )
+}
 // Without an explicit period_end, fall back to one billing period after
 // activation rather than the activation date itself — the activation date
 // reads as "renews today" for an immediate reactivation, which is wrong.
@@ -435,8 +456,10 @@ const nextPaymentDate = computed(() => {
   if (previewData.new_plan.period_end) {
     return formatDate(previewData.new_plan.period_end)
   }
-  const fallback = new Date(previewData.effective_at)
-  fallback.setUTCMonth(fallback.getUTCMonth() + (newIsYearly.value ? 12 : 1))
+  const fallback = addUtcMonthsClamped(
+    new Date(previewData.effective_at),
+    newIsYearly.value ? 12 : 1
+  )
   return formatDate(fallback)
 })
 const currentPeriodEnd = computed(() =>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -16,10 +16,10 @@
           <i class="pi pi-info-circle" />
         </div>
         <div class="flex flex-col gap-2">
-          <p class="m-0 text-sm font-bold text-text-primary">
+          <p class="m-0 text-sm font-bold text-base-foreground">
             {{ bannerTitle }}
           </p>
-          <p class="m-0 text-sm text-text-secondary">
+          <p class="m-0 text-sm text-muted-foreground">
             <i18n-t :keypath="bannerBodyKey" tag="span">
               <template #plan>{{ currentTierName }}</template>
               <template #date>{{ cancelDate }}</template>
@@ -40,12 +40,12 @@
           </p>
           <label
             v-if="exceedsMonthlyThreshold"
-            class="flex items-center gap-2 pt-1 text-sm text-text-secondary"
+            class="flex items-center gap-2 pt-1 text-sm text-muted-foreground"
           >
             <input
               v-model="reactivationConfirmed"
               type="checkbox"
-              class="size-4 rounded-sm border-border-default"
+              class="size-4 rounded-sm border-interface-stroke"
             />
             {{
               $t('subscription.preview.reactivation.checkboxLabel', {

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -6,6 +6,56 @@
     class="mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm"
   >
     <div>
+      <div
+        v-if="isReactivating"
+        class="mb-6 flex gap-3 rounded-2xl border border-warning-background bg-warning-background/20 p-4"
+      >
+        <div
+          class="flex size-8 shrink-0 items-center justify-center rounded-full text-warning-background"
+        >
+          <i class="pi pi-info-circle" />
+        </div>
+        <div class="flex flex-col gap-2">
+          <p class="m-0 text-sm font-bold text-text-primary">
+            {{ bannerTitle }}
+          </p>
+          <p class="m-0 text-sm text-text-secondary">
+            <i18n-t :keypath="bannerBodyKey" tag="span">
+              <template #plan>{{ currentTierName }}</template>
+              <template #date>{{ cancelDate }}</template>
+              <template #newPlan>{{ newTierName }}</template>
+              <template #nextDate>{{ nextPaymentDate }}</template>
+              <template #amount>
+                <span
+                  :class="
+                    cn(
+                      'font-bold text-base-foreground',
+                      exceedsMonthlyThreshold && 'text-base font-extrabold'
+                    )
+                  "
+                  >{{ chargeDisplay }}</span
+                >
+              </template>
+            </i18n-t>
+          </p>
+          <label
+            v-if="exceedsMonthlyThreshold"
+            class="flex items-center gap-2 pt-1 text-sm text-text-secondary"
+          >
+            <input
+              v-model="reactivationConfirmed"
+              type="checkbox"
+              class="size-4 rounded-sm border-border-default"
+            />
+            {{
+              $t('subscription.preview.reactivation.checkboxLabel', {
+                amount: chargeDisplay
+              })
+            }}
+          </label>
+        </div>
+      </div>
+
       <!-- Plan Header -->
       <div class="flex flex-col gap-2">
         <span class="text-sm font-semibold text-base-foreground">
@@ -127,6 +177,7 @@
         size="lg"
         class="w-full rounded-lg"
         :loading="isLoading"
+        :disabled="confirmDisabled"
         @click="$emit('confirm')"
       >
         {{ confirmCta }}
@@ -144,10 +195,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { cn } from '@comfyorg/tailwind-utils'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { formatUsdFromCents } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
@@ -175,6 +229,7 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
+const { subscription } = useBillingContext()
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)
@@ -230,6 +285,74 @@ const currentPlanLabel = computed(() =>
     ? t('subscription.tierNameYearly', { name: currentTierName.value })
     : currentTierName.value
 )
+
+const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+
+const reactivationVariant = computed<
+  'upgrade' | 'downgrade' | 'duration_change' | null
+>(() => {
+  if (!isCancelled.value) return null
+  switch (previewData.transition_type) {
+    case 'upgrade':
+      return 'upgrade'
+    case 'downgrade':
+      return 'downgrade'
+    case 'duration_change':
+      return 'duration_change'
+    default:
+      return null
+  }
+})
+const isReactivating = computed(
+  () => isCancelled.value && reactivationVariant.value !== null
+)
+
+const cancelDate = computed(() =>
+  subscription.value?.endDate ? formatDate(subscription.value.endDate) : ''
+)
+
+// PreviewPlanInfo.price_cents isn't duration-normalized; divide ANNUAL by 12 to
+// get a monthly-equivalent, matching PricingTableWorkspace's getPriceFromApi.
+const currentMonthlyPriceCents = computed(() => {
+  const plan = previewData.current_plan
+  if (!plan) return 0
+  return plan.duration === 'ANNUAL' ? plan.price_cents / 12 : plan.price_cents
+})
+const chargeCents = computed(() => previewData.cost_today_cents)
+const exceedsMonthlyThreshold = computed(
+  () =>
+    isReactivating.value && chargeCents.value > currentMonthlyPriceCents.value
+)
+const chargeDisplay = computed(
+  () =>
+    `$${formatUsdFromCents({
+      cents: chargeCents.value,
+      numberOptions: { maximumFractionDigits: 0 }
+    })}`
+)
+
+const reactivationConfirmed = ref(false)
+const confirmDisabled = computed(
+  () => exceedsMonthlyThreshold.value && !reactivationConfirmed.value
+)
+
+const bannerTitle = computed(() =>
+  reactivationVariant.value === 'duration_change'
+    ? t('subscription.preview.reactivation.titleAnnual')
+    : t('subscription.preview.reactivation.title')
+)
+const bannerBodyKey = computed<string>(() => {
+  switch (reactivationVariant.value) {
+    case 'upgrade':
+      return 'subscription.preview.reactivation.upgradeBody'
+    case 'downgrade':
+      return 'subscription.preview.reactivation.downgradeBody'
+    case 'duration_change':
+      return 'subscription.preview.reactivation.durationChangeBody'
+    default:
+      return ''
+  }
+})
 
 const newMonthlyUsd = computed(() => {
   const cents = previewData.new_plan.price_cents
@@ -293,11 +416,22 @@ const confirmTitle = computed(() =>
     ? t('subscription.preview.confirmUpgradeTitle')
     : t('subscription.preview.confirmChangeTitle')
 )
-const confirmCta = computed(() =>
-  isImmediate.value
+const confirmCta = computed(() => {
+  if (reactivationVariant.value === 'downgrade') {
+    return t('subscription.preview.reactivation.confirmButton')
+  }
+  if (
+    reactivationVariant.value === 'upgrade' ||
+    reactivationVariant.value === 'duration_change'
+  ) {
+    return t('subscription.preview.reactivation.confirmButtonWithCharge', {
+      amount: chargeDisplay.value
+    })
+  }
+  return isImmediate.value
     ? t('subscription.preview.confirmUpgradeCta')
     : t('subscription.preview.confirmChange')
-)
+})
 const totalNote = computed(() =>
   isImmediate.value
     ? t('subscription.preview.nextPaymentDue', { date: nextPaymentDate.value })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -451,20 +451,20 @@ const confirmTitle = computed(() =>
     : t('subscription.preview.confirmChangeTitle')
 )
 const confirmCta = computed(() => {
+  // Gated on isReactivating, not reactivationVariant: the banner and the
+  // emitted confirmReactivation use the same stricter gate, so the label
+  // must never promise a reactivation the click won't actually confirm.
+  if (!isReactivating.value) {
+    return isImmediate.value
+      ? t('subscription.preview.confirmUpgradeCta')
+      : t('subscription.preview.confirmChange')
+  }
   if (reactivationVariant.value === 'downgrade') {
     return t('subscription.preview.reactivation.confirmButton')
   }
-  if (
-    reactivationVariant.value === 'upgrade' ||
-    reactivationVariant.value === 'duration_change'
-  ) {
-    return t('subscription.preview.reactivation.confirmButtonWithCharge', {
-      amount: chargeDisplay.value
-    })
-  }
-  return isImmediate.value
-    ? t('subscription.preview.confirmUpgradeCta')
-    : t('subscription.preview.confirmChange')
+  return t('subscription.preview.reactivation.confirmButtonWithCharge', {
+    amount: chargeDisplay.value
+  })
 })
 const totalNote = computed(() =>
   isImmediate.value

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -11,15 +11,17 @@ import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPrev
 // Real i18n plugin (not the mocked `vue-i18n` module used by the sibling
 // SubscriptionTransitionPreviewWorkspace.test.ts) so <i18n-t> resolves and
 // renders its named slots for these reactivation-banner assertions.
-const { mockSubscription } = vi.hoisted(() => ({
+const { mockSubscription, mockIsInitialized } = vi.hoisted(() => ({
   mockSubscription: {
     value: null as { isCancelled: boolean; endDate: string | null } | null
-  }
+  },
+  mockIsInitialized: { value: true }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    subscription: computed(() => mockSubscription.value)
+    subscription: computed(() => mockSubscription.value),
+    isInitialized: computed(() => mockIsInitialized.value)
   })
 }))
 
@@ -69,9 +71,13 @@ const i18n = createI18n({
               "Your {plan} was set to end on {date}. Switching to {newPlan} reactivates it — you won't be charged today, but it will now renew automatically on {nextDate} at the new price instead of ending.",
             durationChangeBody:
               'Your {plan} was set to end on {date}. Switching to annual billing reactivates it and charges the full year, {amount}, today. It will then renew annually on {nextDate} instead of ending.',
+            durationChangeBodyMonthly:
+              "Your {plan} was set to end on {date}. Switching to monthly billing reactivates it — you'll be charged {amount} today, and it will renew automatically on {nextDate} instead of ending.",
             confirmButton: 'Confirm & reactivate',
             confirmButtonWithCharge: 'Confirm & reactivate — {amount} today',
-            checkboxLabel: "I understand I'll be charged {amount} today"
+            checkboxLabel: "I understand I'll be charged {amount} today",
+            confirmationRequired:
+              'Your subscription is cancelled — please confirm the reactivation charge before continuing'
           }
         }
       }
@@ -128,6 +134,10 @@ function renderComponent(previewData: PreviewSubscribeResponse) {
 }
 
 describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () => {
+  beforeEach(() => {
+    mockIsInitialized.value = true
+  })
+
   describe('banner visibility', () => {
     it('does not render when the subscription is not cancelled', () => {
       mockSubscription.value = { isCancelled: false, endDate: null }
@@ -166,12 +176,12 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(bodyText).toContain(
         "Upgrading now reactivates it — you'll be charged"
       )
-      expect(bodyText).toContain('$15')
+      expect(bodyText).toContain('$15.00')
       expect(bodyText).toContain('today, and it will renew automatically on')
       expect(bodyText).toContain('Sep 15, 2026')
       expect(
         screen.getByRole('button', {
-          name: 'Confirm & reactivate — $15 today'
+          name: 'Confirm & reactivate — $15.00 today'
         })
       ).toBeInTheDocument()
     })
@@ -256,11 +266,69 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         )
       ).toBeInTheDocument()
       expect(bodyText).toContain('charges the full year')
-      expect(bodyText).toContain('$336')
+      expect(bodyText).toContain('$336.00')
       expect(bodyText).toContain('today')
       expect(
         screen.getByRole('button', {
-          name: 'Confirm & reactivate — $336 today'
+          name: 'Confirm & reactivate — $336.00 today'
+        })
+      ).toBeInTheDocument()
+    })
+
+    it('shows the monthly-target duration-change copy and title, distinct from the annual variant', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 1200,
+          current_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 24_000,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 24_000,
+              total_credits_cents: 0
+            }
+          },
+          new_plan: {
+            slug: 'standard-monthly',
+            tier: 'STANDARD',
+            duration: 'MONTHLY',
+            price_cents: 2000,
+            credits_cents: 0,
+            period_end: '2026-09-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 2000,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      // Not the annual-only title/copy: an annual→monthly switch doesn't
+      // charge a full year.
+      expect(
+        screen.queryByText(
+          'Reactivating your subscription — full year billed today'
+        )
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText('Reactivating your subscription')
+      ).toBeInTheDocument()
+      expect(bodyText).not.toContain('charges the full year')
+      expect(bodyText).toContain('Switching to monthly billing reactivates it')
+      expect(bodyText).toContain('$12.00')
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $12.00 today'
         })
       ).toBeInTheDocument()
     })
@@ -279,7 +347,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
       expect(
         screen.getByRole('button', {
-          name: 'Confirm & reactivate — $15 today'
+          name: 'Confirm & reactivate — $15.00 today'
         })
       ).toBeEnabled()
     })
@@ -311,7 +379,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       )
 
       const confirmButton = screen.getByRole('button', {
-        name: 'Confirm & reactivate — $336 today'
+        name: 'Confirm & reactivate — $336.00 today'
       })
       const checkbox = screen.getByRole('checkbox')
       expect(confirmButton).toBeDisabled()
@@ -319,6 +387,36 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       await user.click(checkbox)
 
       expect(confirmButton).toBeEnabled()
+    })
+
+    it('uses the whole-subscription seat total, not the per-seat price, on a multi-seat team plan', () => {
+      // 3 seats at 2000/seat = 6000 total; a 5000 charge is below the
+      // per-seat price (2000) x... actually below the *total* (6000) so no
+      // checkbox should appear even though it exceeds the per-seat price.
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({
+          transition_type: 'upgrade',
+          cost_today_cents: 5000,
+          current_plan: {
+            slug: 'team-per-credit-monthly',
+            tier: 'PRO',
+            duration: 'MONTHLY',
+            price_cents: 2000,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 3,
+              total_cost_cents: 6000,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
     })
   })
 
@@ -346,7 +444,9 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       )
 
       await user.click(
-        screen.getByRole('button', { name: 'Confirm & reactivate — $15 today' })
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $15.00 today'
+        })
       )
 
       expect(emitted().confirm).toEqual([[true]])
@@ -378,13 +478,205 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         })
       )
       const confirmButton = screen.getByRole('button', {
-        name: 'Confirm & reactivate — $336 today'
+        name: 'Confirm & reactivate — $336.00 today'
       })
 
       await user.click(screen.getByRole('checkbox'))
       await user.click(confirmButton)
 
       expect(emitted().confirm).toEqual([[true]])
+    })
+
+    it('emits the exact fractional charge, not rounded to whole dollars', () => {
+      // 5454 cents is $54.54; the old maximumFractionDigits:0 formatting
+      // would have rounded this to "$55", misstating what the user is
+      // actually charged on the one control meant to secure their consent.
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({ transition_type: 'upgrade', cost_today_cents: 5454 })
+      )
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $54.54 today'
+        })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('confirm gating on load state', () => {
+    it('disables confirm while billing context has not finished initializing, even below the charge threshold', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      mockIsInitialized.value = false
+      renderComponent(
+        makePreview({ transition_type: 'downgrade', is_immediate: false })
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Confirm change' })
+      ).toBeDisabled()
+    })
+
+    it('re-enables confirm once billing context finishes initializing', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      mockIsInitialized.value = true
+      renderComponent(
+        makePreview({ transition_type: 'downgrade', is_immediate: false })
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Confirm change' })
+      ).toBeEnabled()
+    })
+  })
+
+  describe('missing reactivation data', () => {
+    it('hides the banner when the subscription has no end date', () => {
+      mockSubscription.value = { isCancelled: true, endDate: null }
+      renderComponent(makePreview({ transition_type: 'upgrade' }))
+
+      expect(
+        screen.queryByText('Reactivating your subscription')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    })
+
+    it('hides the banner when the preview carries no current_plan', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({ transition_type: 'upgrade', current_plan: undefined })
+      )
+
+      expect(
+        screen.queryByText('Reactivating your subscription')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('reactivation consent lifetime', () => {
+    it('resets a ticked checkbox when the charge amount changes', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { rerender } = renderComponent(
+        makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 33_600,
+          new_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 33_600,
+            credits_cents: 0,
+            period_end: '2027-08-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 33_600,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+      await user.click(screen.getByRole('checkbox'))
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $336.00 today'
+        })
+      ).toBeEnabled()
+
+      // A different preview loads (e.g. user went back and re-previewed) with
+      // a higher charge; the earlier tick must not carry over as consent.
+      await rerender({
+        previewData: makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 50_000,
+          new_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 50_000,
+            credits_cents: 0,
+            period_end: '2027-08-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 50_000,
+              total_credits_cents: 0
+            }
+          }
+        })
+      })
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked()
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $500.00 today'
+        })
+      ).toBeDisabled()
+    })
+  })
+
+  describe('downgrade variant checkbox suppression', () => {
+    it('never shows a checkbox for the downgrade variant, even if cost_today_cents is unexpectedly positive', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({
+          transition_type: 'downgrade',
+          is_immediate: false,
+          // A downgrade should never charge today; this asserts the FE
+          // doesn't surface a contradictory checkbox even if it did.
+          cost_today_cents: 999_999
+        })
+      )
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Confirm & reactivate' })
+      ).toBeEnabled()
+    })
+  })
+
+  describe('next payment date fallback', () => {
+    it('falls back to one month after activation for a monthly plan with no period_end', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'upgrade',
+          effective_at: '2026-08-01T00:00:00Z',
+          new_plan: {
+            slug: 'creator-monthly',
+            tier: 'CREATOR',
+            duration: 'MONTHLY',
+            price_cents: 3500,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 3500,
+              total_credits_cents: 0
+            }
+            // No period_end.
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      // Not the activation date itself (which would misreport as "renews
+      // today"); one month later instead.
+      expect(bodyText).not.toContain('renew automatically on Aug 1, 2026')
+      expect(bodyText).toContain('renew automatically on Sep 1, 2026')
     })
   })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -1,0 +1,338 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+
+import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
+
+// Real i18n plugin (not the mocked `vue-i18n` module used by the sibling
+// SubscriptionTransitionPreviewWorkspace.test.ts) so <i18n-t> resolves and
+// renders its named slots for these reactivation-banner assertions.
+const { mockSubscription } = vi.hoisted(() => ({
+  mockSubscription: {
+    value: null as { isCancelled: boolean; endDate: string | null } | null
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    subscription: computed(() => mockSubscription.value)
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      subscription: {
+        usdPerMonth: 'USD / mo',
+        billedMonthly: 'Billed monthly',
+        billedYearly: '{total} Billed yearly',
+        tierNameYearly: '{name} Yearly',
+        tiers: {
+          standard: { name: 'Standard' },
+          creator: { name: 'Creator' }
+        },
+        preview: {
+          switchesToday: 'Switches today',
+          startsOn: 'Starts {date}',
+          yearlySubscription: 'Yearly subscription',
+          newMonthlySubscription: 'New monthly subscription',
+          creditFromCurrent: 'Credit from current {plan}',
+          currentMonthly: 'monthly plan',
+          commitment: 'commitment',
+          creditsYoullGetToday: "Credits you'll get today",
+          eachMonthCreditsRefill: 'Each month credits refill to',
+          refillReplacesNote: 'Replaces your monthly refill.',
+          afterThat: 'After that',
+          creditsRefillMonthlyTo: 'Credits refill monthly to',
+          billedEachMonth: '{amount} billed each month.',
+          totalDueToday: 'Total due today',
+          nextPaymentDue: 'Next payment due {date}.',
+          confirmUpgradeTitle: 'Confirm your upgrade',
+          confirmUpgradeCta: 'Confirm upgrade',
+          confirmChange: 'Confirm change',
+          confirmChangeTitle: 'Review your scheduled change',
+          stayOnUntil: "You'll stay on {plan} until {date}.",
+          backToAllPlans: 'Back to all plans',
+          reactivation: {
+            title: 'Reactivating your subscription',
+            titleAnnual:
+              'Reactivating your subscription — full year billed today',
+            upgradeBody:
+              "Your {plan} was set to end on {date}. Upgrading now reactivates it — you'll be charged {amount} today, and it will renew automatically on {nextDate} instead of ending.",
+            downgradeBody:
+              "Your {plan} was set to end on {date}. Switching to {newPlan} reactivates it — you won't be charged today, but it will now renew automatically on {nextDate} at the new price instead of ending.",
+            durationChangeBody:
+              'Your {plan} was set to end on {date}. Switching to annual billing reactivates it and charges the full year, {amount}, today. It will then renew annually on {nextDate} instead of ending.',
+            confirmButton: 'Confirm & reactivate',
+            confirmButtonWithCharge: 'Confirm & reactivate — {amount} today',
+            checkboxLabel: "I understand I'll be charged {amount} today"
+          }
+        }
+      }
+    }
+  }
+})
+
+function makePreview(
+  overrides: Partial<PreviewSubscribeResponse>
+): PreviewSubscribeResponse {
+  return {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: '2026-08-01T00:00:00Z',
+    is_immediate: true,
+    cost_today_cents: 1500,
+    cost_next_period_cents: 3500,
+    credits_today_cents: 0,
+    credits_next_period_cents: 0,
+    current_plan: {
+      slug: 'standard-monthly',
+      tier: 'STANDARD',
+      duration: 'MONTHLY',
+      price_cents: 2000,
+      credits_cents: 0,
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: 2000,
+        total_credits_cents: 0
+      }
+    },
+    new_plan: {
+      slug: 'creator-monthly',
+      tier: 'CREATOR',
+      duration: 'MONTHLY',
+      price_cents: 3500,
+      credits_cents: 0,
+      period_end: '2026-09-15T00:00:00Z',
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: 3500,
+        total_credits_cents: 0
+      }
+    },
+    ...overrides
+  }
+}
+
+function renderComponent(previewData: PreviewSubscribeResponse) {
+  return render(SubscriptionTransitionPreviewWorkspace, {
+    props: { previewData },
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () => {
+  describe('banner visibility', () => {
+    it('does not render when the subscription is not cancelled', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      renderComponent(makePreview({ transition_type: 'upgrade' }))
+
+      expect(
+        screen.queryByText('Reactivating your subscription')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not render for a downgrade when not cancelled', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      renderComponent(makePreview({ transition_type: 'downgrade' }))
+
+      expect(
+        screen.queryByText('Reactivating your subscription')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('banner copy', () => {
+    it('shows the upgrade variant copy and charge-inclusive button label', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({ transition_type: 'upgrade', cost_today_cents: 1500 })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(
+        screen.getByText('Reactivating your subscription')
+      ).toBeInTheDocument()
+      expect(bodyText).toContain('Your Standard was set to end on Aug 15, 2026')
+      expect(bodyText).toContain(
+        "Upgrading now reactivates it — you'll be charged"
+      )
+      expect(bodyText).toContain('$15')
+      expect(bodyText).toContain('today, and it will renew automatically on')
+      expect(bodyText).toContain('Sep 15, 2026')
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $15 today'
+        })
+      ).toBeInTheDocument()
+    })
+
+    it('shows the downgrade variant copy with no charge mentioned and a plain button label', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-20T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'downgrade',
+          is_immediate: false,
+          cost_today_cents: 0,
+          current_plan: {
+            slug: 'creator-monthly',
+            tier: 'CREATOR',
+            duration: 'MONTHLY',
+            price_cents: 3500,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 3500,
+              total_credits_cents: 0
+            }
+          },
+          new_plan: {
+            slug: 'standard-monthly',
+            tier: 'STANDARD',
+            duration: 'MONTHLY',
+            price_cents: 1000,
+            credits_cents: 0,
+            period_end: '2026-09-20T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 1000,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(bodyText).toContain('Your Creator was set to end on Aug 20, 2026')
+      expect(bodyText).toContain('Switching to Standard reactivates it')
+      expect(bodyText).toContain("you won't be charged today")
+      expect(bodyText).toContain('Sep 20, 2026')
+      expect(
+        screen.getByRole('button', { name: 'Confirm & reactivate' })
+      ).toBeInTheDocument()
+    })
+
+    it('shows the duration-change variant title and full-year charge copy', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 33_600,
+          new_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 33_600,
+            credits_cents: 0,
+            period_end: '2027-08-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 33_600,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(
+        screen.getByText(
+          'Reactivating your subscription — full year billed today'
+        )
+      ).toBeInTheDocument()
+      expect(bodyText).toContain('charges the full year')
+      expect(bodyText).toContain('$336')
+      expect(bodyText).toContain('today')
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $336 today'
+        })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('charge threshold', () => {
+    it('shows no checkbox and an enabled confirm when the charge is at or below the current monthly price', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({ transition_type: 'upgrade', cost_today_cents: 1500 })
+      )
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $15 today'
+        })
+      ).toBeEnabled()
+    })
+
+    it('requires the checkbox before enabling confirm when the charge exceeds the current monthly price', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      renderComponent(
+        makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 33_600,
+          new_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 33_600,
+            credits_cents: 0,
+            period_end: '2027-08-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 33_600,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+
+      const confirmButton = screen.getByRole('button', {
+        name: 'Confirm & reactivate — $336 today'
+      })
+      const checkbox = screen.getByRole('checkbox')
+      expect(confirmButton).toBeDisabled()
+
+      await user.click(checkbox)
+
+      expect(confirmButton).toBeEnabled()
+    })
+  })
+
+  describe('confirm', () => {
+    it('emits confirm when clicked', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      const { emitted } = renderComponent(
+        makePreview({ transition_type: 'downgrade', is_immediate: false })
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Confirm change' }))
+
+      expect(emitted().confirm).toBeTruthy()
+    })
+  })
+})

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -11,17 +11,15 @@ import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPrev
 // Real i18n plugin (not the mocked `vue-i18n` module used by the sibling
 // SubscriptionTransitionPreviewWorkspace.test.ts) so <i18n-t> resolves and
 // renders its named slots for these reactivation-banner assertions.
-const { mockSubscription, mockIsInitialized } = vi.hoisted(() => ({
+const { mockSubscription } = vi.hoisted(() => ({
   mockSubscription: {
     value: null as { isCancelled: boolean; endDate: string | null } | null
-  },
-  mockIsInitialized: { value: true }
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    subscription: computed(() => mockSubscription.value),
-    isInitialized: computed(() => mockIsInitialized.value)
+    subscription: computed(() => mockSubscription.value)
   })
 }))
 
@@ -134,10 +132,6 @@ function renderComponent(previewData: PreviewSubscribeResponse) {
 }
 
 describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () => {
-  beforeEach(() => {
-    mockIsInitialized.value = true
-  })
-
   describe('banner visibility', () => {
     it('does not render when the subscription is not cancelled', () => {
       mockSubscription.value = { isCancelled: false, endDate: null }
@@ -508,9 +502,8 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('confirm gating on load state', () => {
-    it('disables confirm while billing context has not finished initializing, even below the charge threshold', () => {
-      mockSubscription.value = { isCancelled: false, endDate: null }
-      mockIsInitialized.value = false
+    it('disables confirm while subscription status has not loaded yet, even below the charge threshold', () => {
+      mockSubscription.value = null
       renderComponent(
         makePreview({ transition_type: 'downgrade', is_immediate: false })
       )
@@ -520,9 +513,8 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       ).toBeDisabled()
     })
 
-    it('re-enables confirm once billing context finishes initializing', () => {
+    it('re-enables confirm once subscription status has loaded', () => {
       mockSubscription.value = { isCancelled: false, endDate: null }
-      mockIsInitialized.value = true
       renderComponent(
         makePreview({ transition_type: 'downgrade', is_immediate: false })
       )
@@ -691,6 +683,96 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       // today"); one month later instead.
       expect(bodyText).not.toContain('renew automatically on Aug 1, 2026')
       expect(bodyText).toContain('renew automatically on Sep 1, 2026')
+    })
+
+    it('clamps a Jan 31 + 1 month fallback to Feb 28, not Mar 3', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-01-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'upgrade',
+          effective_at: '2026-01-31T00:00:00Z',
+          new_plan: {
+            slug: 'creator-monthly',
+            tier: 'CREATOR',
+            duration: 'MONTHLY',
+            price_cents: 3500,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 3500,
+              total_credits_cents: 0
+            }
+            // No period_end.
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(bodyText).not.toContain('renew automatically on Mar')
+      expect(bodyText).toContain('renew automatically on Feb 28, 2026')
+    })
+
+    it('clamps a Feb 29 leap-day + 12 months fallback to Feb 28 the next year', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2028-02-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'upgrade',
+          effective_at: '2028-02-29T00:00:00Z',
+          new_plan: {
+            slug: 'creator-annual',
+            tier: 'CREATOR',
+            duration: 'ANNUAL',
+            price_cents: 33_600,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 33_600,
+              total_credits_cents: 0
+            }
+            // No period_end.
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(bodyText).not.toContain('renew automatically on Mar')
+      expect(bodyText).toContain('renew automatically on Feb 28, 2029')
+    })
+
+    it('clamps a Mar 31 + 1 month fallback to Apr 30, not May 1', () => {
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-03-15T00:00:00Z'
+      }
+      const { container } = renderComponent(
+        makePreview({
+          transition_type: 'upgrade',
+          effective_at: '2026-03-31T00:00:00Z',
+          new_plan: {
+            slug: 'creator-monthly',
+            tier: 'CREATOR',
+            duration: 'MONTHLY',
+            price_cents: 3500,
+            credits_cents: 0,
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 3500,
+              total_credits_cents: 0
+            }
+            // No period_end.
+          }
+        })
+      )
+      const bodyText = container.textContent ?? ''
+
+      expect(bodyText).not.toContain('renew automatically on May')
+      expect(bodyText).toContain('renew automatically on Apr 30, 2026')
     })
   })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -542,6 +542,14 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         screen.queryByText('Reactivating your subscription')
       ).not.toBeInTheDocument()
       expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+      // The button label must not claim reactivation when the banner (and
+      // the consent it collects) never rendered.
+      expect(
+        screen.getByRole('button', { name: 'Confirm upgrade' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /Confirm & reactivate/ })
+      ).not.toBeInTheDocument()
     })
 
     it('hides the banner when the preview carries no current_plan', () => {
@@ -555,6 +563,12 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
 
       expect(
         screen.queryByText('Reactivating your subscription')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Confirm upgrade' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /Confirm & reactivate/ })
       ).not.toBeInTheDocument()
     })
   })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -323,7 +323,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('confirm', () => {
-    it('emits confirm when clicked', async () => {
+    it('emits confirmReactivation false when the subscription is not cancelled', async () => {
       const user = userEvent.setup()
       mockSubscription.value = { isCancelled: false, endDate: null }
       const { emitted } = renderComponent(
@@ -332,7 +332,59 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
 
       await user.click(screen.getByRole('button', { name: 'Confirm change' }))
 
-      expect(emitted().confirm).toBeTruthy()
+      expect(emitted().confirm).toEqual([[false]])
+    })
+
+    it('emits confirmReactivation true below the charge threshold, with no checkbox to tick', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { emitted } = renderComponent(
+        makePreview({ transition_type: 'upgrade', cost_today_cents: 1500 })
+      )
+
+      await user.click(
+        screen.getByRole('button', { name: 'Confirm & reactivate — $15 today' })
+      )
+
+      expect(emitted().confirm).toEqual([[true]])
+    })
+
+    it('emits confirmReactivation true above the threshold only once the checkbox is ticked', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = {
+        isCancelled: true,
+        endDate: '2026-08-15T00:00:00Z'
+      }
+      const { emitted } = renderComponent(
+        makePreview({
+          transition_type: 'duration_change',
+          cost_today_cents: 33_600,
+          new_plan: {
+            slug: 'standard-annual',
+            tier: 'STANDARD',
+            duration: 'ANNUAL',
+            price_cents: 33_600,
+            credits_cents: 0,
+            period_end: '2027-08-15T00:00:00Z',
+            seat_summary: {
+              seat_count: 1,
+              total_cost_cents: 33_600,
+              total_credits_cents: 0
+            }
+          }
+        })
+      )
+      const confirmButton = screen.getByRole('button', {
+        name: 'Confirm & reactivate — $336 today'
+      })
+
+      await user.click(screen.getByRole('checkbox'))
+      await user.click(confirmButton)
+
+      expect(emitted().confirm).toEqual([[true]])
     })
   })
 })

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
@@ -32,6 +32,10 @@ const i18n = createI18n({
         downgrade: {
           title: 'Change to {plan} plan?',
           body: 'All other members of this workspace will be immediately removed.',
+          bodyReactivation:
+            "Your subscription is cancelled. Changing your plan will resume it, and you'll be charged {amount} today.",
+          bodyRemovalAndReactivation:
+            "All other members of this workspace will be immediately removed. Your subscription is cancelled, so changing your plan will also resume it, and you'll be charged {amount} today.",
           confirmationPhrase: 'I understand',
           confirmationPrompt: 'Type "{phrase}" to confirm.',
           confirm: 'Change plan',
@@ -91,10 +95,53 @@ describe('DowngradeRemoveMembersDialogContent', () => {
     await user.type(getPhraseInput(), 'I understand')
     await user.click(getChangePlanButton())
 
-    expect(onConfirm).toHaveBeenCalledWith('founder-monthly')
+    expect(onConfirm).toHaveBeenCalledWith('founder-monthly', false)
     expect(mockCloseDialog).toHaveBeenCalledWith({
       key: 'downgrade-remove-members'
     })
+  })
+
+  it('shows the removal-only body when reactivation is not required', () => {
+    mountComponent()
+
+    expect(
+      screen.getByText(
+        'All other members of this workspace will be immediately removed.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows the reactivation charge and forwards confirmReactivation true when only reactivation is required', async () => {
+    const { user, onConfirm } = mountComponent({
+      requiresRemoval: false,
+      requiresReactivation: true,
+      chargeCents: 1500
+    })
+
+    expect(
+      screen.getByText(
+        "Your subscription is cancelled. Changing your plan will resume it, and you'll be charged $15.00 today."
+      )
+    ).toBeInTheDocument()
+
+    await user.type(getPhraseInput(), 'I understand')
+    await user.click(getChangePlanButton())
+
+    expect(onConfirm).toHaveBeenCalledWith('founder-monthly', true)
+  })
+
+  it('shows the combined removal-and-reactivation body when both are required', () => {
+    mountComponent({
+      requiresRemoval: true,
+      requiresReactivation: true,
+      chargeCents: 5454
+    })
+
+    expect(
+      screen.getByText(
+        "All other members of this workspace will be immediately removed. Your subscription is cancelled, so changing your plan will also resume it, and you'll be charged $54.54 today."
+      )
+    ).toBeInTheDocument()
   })
 
   it('closes without calling onConfirm when cancelled', async () => {

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
@@ -102,7 +102,7 @@ describe('DowngradeRemoveMembersDialogContent', () => {
   })
 
   it('shows the removal-only body when reactivation is not required', () => {
-    mountComponent()
+    mountComponent({ requiresRemoval: true, requiresReactivation: false })
 
     expect(
       screen.getByText(

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.test.ts
@@ -49,7 +49,7 @@ const i18n = createI18n({
 function mountComponent(props: Record<string, unknown> = {}) {
   const user = userEvent.setup()
   const onConfirm = vi.fn().mockResolvedValue(undefined)
-  render(DowngradeRemoveMembersDialogContent, {
+  const { rerender } = render(DowngradeRemoveMembersDialogContent, {
     props: {
       planName: 'Founder',
       planSlug: 'founder-monthly',
@@ -60,7 +60,7 @@ function mountComponent(props: Record<string, unknown> = {}) {
       plugins: [i18n]
     }
   })
-  return { user, onConfirm }
+  return { user, onConfirm, rerender }
 }
 
 const getPhraseInput = () => screen.getByRole('textbox')
@@ -165,5 +165,27 @@ describe('DowngradeRemoveMembersDialogContent', () => {
       expect.objectContaining({ severity: 'error' })
     )
     expect(mockCloseDialog).not.toHaveBeenCalled()
+  })
+
+  // Regression guard: a drift refresh (dialogService's onConfirm handler)
+  // updates requiresReactivation/chargeCents on this already-mounted dialog
+  // in place. The typed "I understand" was an acknowledgment of the PRIOR
+  // amount, so it must not silently carry forward and leave the destructive
+  // CTA enabled for a charge the user never actually saw. A service-level
+  // test that calls onConfirm directly can't see this — it's local state on
+  // the mounted component, so it needs a mount + rerender.
+  it('clears the typed confirmation and re-disables Change plan when reactivation props drift after the phrase is typed', async () => {
+    const { user, rerender } = mountComponent({
+      requiresReactivation: true,
+      chargeCents: 1500
+    })
+
+    await user.type(getPhraseInput(), 'I understand')
+    expect(getChangePlanButton()).toBeEnabled()
+
+    await rerender({ requiresReactivation: true, chargeCents: 2000 })
+
+    expect(getPhraseInput()).toHaveValue('')
+    expect(getChangePlanButton()).toBeDisabled()
   })
 })

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue
@@ -22,7 +22,7 @@
     <!-- Body -->
     <div class="flex flex-col gap-4 p-4">
       <p class="m-0 text-sm text-muted-foreground">
-        {{ $t('subscription.downgrade.body') }}
+        {{ bodyText }}
       </p>
       <label class="flex flex-col gap-2 text-sm text-muted-foreground">
         {{ $t('subscription.downgrade.confirmationPrompt', { phrase }) }}
@@ -60,14 +60,28 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { formatUsdFromCents } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { useDialogStore } from '@/stores/dialogStore'
 
-const { planName, planSlug, onConfirm } = defineProps<{
+const {
+  planName,
+  planSlug,
+  requiresRemoval = false,
+  requiresReactivation = false,
+  chargeCents = 0,
+  onConfirm
+} = defineProps<{
   planName: string
   planSlug: string
-  onConfirm: (planSlug: string) => Promise<void>
+  /** Members are being removed on this change. */
+  requiresRemoval?: boolean
+  /** Subscription is cancelled and this change resumes it; the BE requires
+   *  explicit confirmation of the charge or it rejects the change. */
+  requiresReactivation?: boolean
+  chargeCents?: number
+  onConfirm: (planSlug: string, confirmReactivation: boolean) => Promise<void>
 }>()
 
 const { t } = useI18n()
@@ -81,6 +95,23 @@ const isLoading = ref(false)
 
 const isConfirmed = computed(() => typedValue.value === phrase)
 
+const chargeDisplay = computed(
+  () => `$${formatUsdFromCents({ cents: chargeCents })}`
+)
+const bodyText = computed(() => {
+  if (requiresRemoval && requiresReactivation) {
+    return t('subscription.downgrade.bodyRemovalAndReactivation', {
+      amount: chargeDisplay.value
+    })
+  }
+  if (requiresReactivation) {
+    return t('subscription.downgrade.bodyReactivation', {
+      amount: chargeDisplay.value
+    })
+  }
+  return t('subscription.downgrade.body')
+})
+
 function onClose() {
   if (isLoading.value) return
   dialogStore.closeDialog({ key: 'downgrade-remove-members' })
@@ -90,7 +121,7 @@ async function onConfirmDowngrade() {
   if (!isConfirmed.value || isLoading.value) return
   isLoading.value = true
   try {
-    await onConfirm(planSlug)
+    await onConfirm(planSlug, requiresReactivation)
     dialogStore.closeDialog({ key: 'downgrade-remove-members' })
   } catch (error) {
     toast.add({

--- a/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/DowngradeRemoveMembersDialogContent.vue
@@ -57,7 +57,7 @@
 
 <script setup lang="ts">
 import { useToast } from 'primevue/usetoast'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { formatUsdFromCents } from '@/base/credits/comfyCredits'
@@ -92,6 +92,14 @@ const phrase = t('subscription.downgrade.confirmationPhrase')
 
 const typedValue = ref('')
 const isLoading = ref(false)
+
+// A drift-recovered dialog (see dialogService's onConfirm handler) updates
+// these props in place with corrected values; the typed acknowledgment was
+// for the PRIOR amount/status and must not silently carry forward to a
+// charge the user never actually saw.
+watch([() => requiresReactivation, () => chargeCents], () => {
+  typedValue.value = ''
+})
 
 const isConfirmed = computed(() => typedValue.value === phrase)
 

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -7,6 +7,7 @@ import { useDowngradeToPersonal } from './useDowngradeToPersonal'
 
 const mockMembers = ref<WorkspaceMember[]>([])
 const mockUserEmail = ref<string | null>(null)
+const mockSubscription = ref<{ isCancelled: boolean } | null>(null)
 const mockRemoveMember = vi.hoisted(() => vi.fn())
 const mockFetchMembers = vi.hoisted(() => vi.fn())
 const mockSubscribe = vi.hoisted(() => vi.fn())
@@ -49,7 +50,8 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     subscribe: mockSubscribe,
-    previewSubscribe: mockPreviewSubscribe
+    previewSubscribe: mockPreviewSubscribe,
+    subscription: mockSubscription
   })
 }))
 
@@ -107,6 +109,7 @@ describe('useDowngradeToPersonal', () => {
     vi.resetAllMocks()
     mockMembers.value = []
     mockUserEmail.value = null
+    mockSubscription.value = null
     mockPreviewSubscribe.mockResolvedValue({ allowed: true })
     mockSubscribe.mockResolvedValue({
       billing_op_id: 'op-1',
@@ -231,7 +234,63 @@ describe('useDowngradeToPersonal', () => {
       expect(mockRemoveMember).not.toHaveBeenCalledWith('owner')
       expect(mockSubscribe).toHaveBeenCalledWith('founder-monthly', {
         returnUrl: 'https://platform.test/payment/success',
-        cancelUrl: 'https://platform.test/payment/failed'
+        cancelUrl: 'https://platform.test/payment/failed',
+        confirmReactivation: false
+      })
+    })
+
+    it('removes nobody and never subscribes when the subscription is cancelled and reactivation is not confirmed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockMembers.value = teamWithOwnerAnd('m1', 'm2')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.reactivationConfirmationRequired'
+      )
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('removes members and forwards confirmReactivation once explicitly confirmed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await downgradeToPersonal('founder-monthly', true)
+
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
+      expect(mockSubscribe).toHaveBeenCalledWith('founder-monthly', {
+        returnUrl: 'https://platform.test/payment/success',
+        cancelUrl: 'https://platform.test/payment/failed',
+        confirmReactivation: true
+      })
+    })
+
+    it('does not require reactivation confirmation for a brand-new subscription even if cancelled', async () => {
+      // A `new_subscription` transition has nothing to reactivate.
+      mockSubscription.value = { isCancelled: true }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'new_subscription'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await downgradeToPersonal('founder-monthly')
+
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
+      expect(mockSubscribe).toHaveBeenCalledWith('founder-monthly', {
+        returnUrl: 'https://platform.test/payment/success',
+        cancelUrl: 'https://platform.test/payment/failed',
+        confirmReactivation: false
       })
     })
 
@@ -514,6 +573,48 @@ describe('useDowngradeToPersonal', () => {
         target_tier: undefined,
         failure_category: 'unknown'
       })
+    })
+  })
+
+  describe('previewDowngrade', () => {
+    it('reports requiresReactivationConfirmation for a cancelled subscription changing plans', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 0
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      const result = await previewDowngrade('founder-monthly')
+
+      expect(result.requiresReactivationConfirmation).toBe(true)
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+    })
+
+    it('reports no reactivation requirement when the subscription is not cancelled', async () => {
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      const result = await previewDowngrade('founder-monthly')
+
+      expect(result.requiresReactivationConfirmation).toBe(false)
+    })
+
+    it('throws the BE reason without removing members when the transition is disallowed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: false,
+        reason: 'Outstanding balance'
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      await expect(previewDowngrade('founder-monthly')).rejects.toThrow(
+        'Outstanding balance'
+      )
     })
   })
 

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -113,7 +113,11 @@ describe('useDowngradeToPersonal', () => {
     vi.resetAllMocks()
     mockMembers.value = []
     mockUserEmail.value = null
-    mockSubscription.value = null
+    // Once loaded (isInitialized true), subscription is never null in
+    // production — it's at least a FREE-tier record. Default to that
+    // loaded-and-active shape; tests that need "not loaded yet" set
+    // subscription back to null explicitly alongside isInitialized: false.
+    mockSubscription.value = { isCancelled: false }
     mockIsInitialized.value = true
     mockPreviewSubscribe.mockResolvedValue({ allowed: true })
     mockFetchStatus.mockResolvedValue(undefined)
@@ -352,6 +356,29 @@ describe('useDowngradeToPersonal', () => {
       mockPreviewSubscribe.mockResolvedValue({
         allowed: true,
         transition_type: 'new_subscription'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await downgradeToPersonal('founder-monthly')
+
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
+      expect(mockSubscribe).toHaveBeenCalledWith('founder-monthly', {
+        returnUrl: 'https://platform.test/payment/success',
+        cancelUrl: 'https://platform.test/payment/failed',
+        confirmReactivation: false
+      })
+    })
+
+    // Regression guard: isInitialized is aggregate (status + balance +
+    // plans). A balance/plans failure must not force reactivation onto an
+    // otherwise-valid, already-loaded, active subscription.
+    it('removes members and subscribes without requiring reactivation when isInitialized is false but subscription status is loaded and active', async () => {
+      mockIsInitialized.value = false
+      mockSubscription.value = { isCancelled: false }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
       })
       const { downgradeToPersonal } = useDowngradeToPersonal()
 
@@ -666,6 +693,24 @@ describe('useDowngradeToPersonal', () => {
     it('reports no reactivation requirement when the subscription is known and not cancelled', async () => {
       mockSubscription.value = { isCancelled: false }
       mockIsInitialized.value = true
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      const result = await previewDowngrade('founder-monthly')
+
+      expect(result.requiresReactivationConfirmation).toBe(false)
+    })
+
+    // Regression guard: isInitialized only becomes true once status, balance,
+    // AND plans have all loaded — a balance/plans failure must not force
+    // reactivation onto an otherwise-valid, already-loaded, active
+    // subscription. Gate on status readiness (subscription !== null) instead.
+    it('reports no reactivation requirement when isInitialized is false but subscription status is loaded and active', async () => {
+      mockSubscription.value = { isCancelled: false }
+      mockIsInitialized.value = false
       mockPreviewSubscribe.mockResolvedValue({
         allowed: true,
         transition_type: 'downgrade'

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -8,6 +8,7 @@ import { useDowngradeToPersonal } from './useDowngradeToPersonal'
 const mockMembers = ref<WorkspaceMember[]>([])
 const mockUserEmail = ref<string | null>(null)
 const mockSubscription = ref<{ isCancelled: boolean } | null>(null)
+const mockIsInitialized = ref(true)
 const mockRemoveMember = vi.hoisted(() => vi.fn())
 const mockFetchMembers = vi.hoisted(() => vi.fn())
 const mockSubscribe = vi.hoisted(() => vi.fn())
@@ -51,7 +52,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     subscribe: mockSubscribe,
     previewSubscribe: mockPreviewSubscribe,
-    subscription: mockSubscription
+    subscription: mockSubscription,
+    isInitialized: mockIsInitialized
   })
 }))
 
@@ -110,6 +112,7 @@ describe('useDowngradeToPersonal', () => {
     mockMembers.value = []
     mockUserEmail.value = null
     mockSubscription.value = null
+    mockIsInitialized.value = true
     mockPreviewSubscribe.mockResolvedValue({ allowed: true })
     mockSubscribe.mockResolvedValue({
       billing_op_id: 'op-1',
@@ -255,16 +258,17 @@ describe('useDowngradeToPersonal', () => {
       expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
-    it('removes members and forwards confirmReactivation once explicitly confirmed', async () => {
+    it('removes members and forwards confirmReactivation once explicitly confirmed with the matching charge', async () => {
       mockSubscription.value = { isCancelled: true }
       mockMembers.value = teamWithOwnerAnd('m1')
       mockPreviewSubscribe.mockResolvedValue({
         allowed: true,
-        transition_type: 'downgrade'
+        transition_type: 'downgrade',
+        cost_today_cents: 1500
       })
       const { downgradeToPersonal } = useDowngradeToPersonal()
 
-      await downgradeToPersonal('founder-monthly', true)
+      await downgradeToPersonal('founder-monthly', true, 1500)
 
       expect(mockRemoveMember).toHaveBeenCalledWith('m1')
       expect(mockSubscribe).toHaveBeenCalledWith('founder-monthly', {
@@ -272,6 +276,45 @@ describe('useDowngradeToPersonal', () => {
         cancelUrl: 'https://platform.test/payment/failed',
         confirmReactivation: true
       })
+    })
+
+    it('refuses to bill when the fresh preview cost no longer matches the confirmed charge', async () => {
+      // The user consented to $15.00; pricing moved to $20.00 before this
+      // fresh preview — billing on the new figure would charge an amount
+      // never actually shown to the user.
+      mockSubscription.value = { isCancelled: true }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 2000
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(
+        downgradeToPersonal('founder-monthly', true, 1500)
+      ).rejects.toThrow('subscription.downgrade.reactivationAmountChanged')
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('requires reactivation confirmation when subscription state has not loaded yet', async () => {
+      // isInitialized false means "cancelled or not" is unknown; must not
+      // default to "not cancelled" and skip disclosure.
+      mockIsInitialized.value = false
+      mockSubscription.value = null
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.reactivationConfirmationRequired'
+      )
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
     it('does not require reactivation confirmation for a brand-new subscription even if cancelled', async () => {
@@ -592,7 +635,9 @@ describe('useDowngradeToPersonal', () => {
       expect(mockRemoveMember).not.toHaveBeenCalled()
     })
 
-    it('reports no reactivation requirement when the subscription is not cancelled', async () => {
+    it('reports no reactivation requirement when the subscription is known and not cancelled', async () => {
+      mockSubscription.value = { isCancelled: false }
+      mockIsInitialized.value = true
       mockPreviewSubscribe.mockResolvedValue({
         allowed: true,
         transition_type: 'downgrade'
@@ -602,6 +647,20 @@ describe('useDowngradeToPersonal', () => {
       const result = await previewDowngrade('founder-monthly')
 
       expect(result.requiresReactivationConfirmation).toBe(false)
+    })
+
+    it('requires reactivation confirmation when subscription state has not loaded, even with no cached subscription', async () => {
+      mockSubscription.value = null
+      mockIsInitialized.value = false
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      const result = await previewDowngrade('founder-monthly')
+
+      expect(result.requiresReactivationConfirmation).toBe(true)
     })
 
     it('throws the BE reason without removing members when the transition is disallowed', async () => {

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -13,6 +13,7 @@ const mockRemoveMember = vi.hoisted(() => vi.fn())
 const mockFetchMembers = vi.hoisted(() => vi.fn())
 const mockSubscribe = vi.hoisted(() => vi.fn())
 const mockPreviewSubscribe = vi.hoisted(() => vi.fn())
+const mockFetchStatus = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockTrackBillingEvent = vi.hoisted(() => vi.fn())
 const mockPermissions = vi.hoisted(() => ({
@@ -53,7 +54,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     subscribe: mockSubscribe,
     previewSubscribe: mockPreviewSubscribe,
     subscription: mockSubscription,
-    isInitialized: mockIsInitialized
+    isInitialized: mockIsInitialized,
+    fetchStatus: mockFetchStatus
   })
 }))
 
@@ -114,6 +116,7 @@ describe('useDowngradeToPersonal', () => {
     mockSubscription.value = null
     mockIsInitialized.value = true
     mockPreviewSubscribe.mockResolvedValue({ allowed: true })
+    mockFetchStatus.mockResolvedValue(undefined)
     mockSubscribe.mockResolvedValue({
       billing_op_id: 'op-1',
       status: 'subscribed'
@@ -294,6 +297,31 @@ describe('useDowngradeToPersonal', () => {
       await expect(
         downgradeToPersonal('founder-monthly', true, 1500)
       ).rejects.toThrow('subscription.downgrade.reactivationAmountChanged')
+      expect(mockRemoveMember).not.toHaveBeenCalled()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+    })
+
+    it('refuses to remove members when a status refresh discovers a cancellation the cached read missed', async () => {
+      // Mirrors the previewDowngrade race: the subscription looked active at
+      // the time of the earlier preview, but was cancelled before this
+      // confirm call. The pre-billing status refresh must catch it so
+      // members are never removed for a doomed request.
+      mockSubscription.value = { isCancelled: false }
+      mockFetchStatus.mockImplementation(() => {
+        mockSubscription.value = { isCancelled: true }
+        return Promise.resolve()
+      })
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        'subscription.downgrade.reactivationConfirmationRequired'
+      )
+      expect(mockFetchStatus).toHaveBeenCalled()
       expect(mockRemoveMember).not.toHaveBeenCalled()
       expect(mockSubscribe).not.toHaveBeenCalled()
     })
@@ -674,6 +702,27 @@ describe('useDowngradeToPersonal', () => {
       await expect(previewDowngrade('founder-monthly')).rejects.toThrow(
         'Outstanding balance'
       )
+    })
+
+    it('reports the cancellation discovered by refreshing status, not the stale cached read', async () => {
+      // The cached subscription (loaded earlier) still says "not cancelled";
+      // the status refresh this call triggers is what discovers the
+      // cancellation, so the decision must reflect the refreshed value.
+      mockSubscription.value = { isCancelled: false }
+      mockFetchStatus.mockImplementation(() => {
+        mockSubscription.value = { isCancelled: true }
+        return Promise.resolve()
+      })
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade'
+      })
+      const { previewDowngrade } = useDowngradeToPersonal()
+
+      const result = await previewDowngrade('founder-monthly')
+
+      expect(mockFetchStatus).toHaveBeenCalled()
+      expect(result.requiresReactivationConfirmation).toBe(true)
     })
   })
 

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -33,7 +33,7 @@ export interface DowngradePreview {
 /** Thrown by `downgradeToPersonal` before any member is removed, so a caller
  *  can collect consent and retry with `confirmReactivation: true` instead of
  *  losing team members on a request the BE was always going to reject. */
-class ReactivationConfirmationRequiredError extends Error {
+export class ReactivationConfirmationRequiredError extends Error {
   constructor(public readonly preview: PreviewSubscribeResponse) {
     super(t('subscription.downgrade.reactivationConfirmationRequired'))
   }
@@ -42,7 +42,7 @@ class ReactivationConfirmationRequiredError extends Error {
 /** Thrown by `downgradeToPersonal` when the amount a caller confirmed no
  *  longer matches a fresh preview taken right before billing — refuses to
  *  charge an amount the user never actually saw and consented to. */
-class ReactivationAmountChangedError extends Error {
+export class ReactivationAmountChangedError extends Error {
   constructor(public readonly preview: PreviewSubscribeResponse) {
     super(t('subscription.downgrade.reactivationAmountChanged'))
   }

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -39,6 +39,15 @@ class ReactivationConfirmationRequiredError extends Error {
   }
 }
 
+/** Thrown by `downgradeToPersonal` when the amount a caller confirmed no
+ *  longer matches a fresh preview taken right before billing — refuses to
+ *  charge an amount the user never actually saw and consented to. */
+class ReactivationAmountChangedError extends Error {
+  constructor(public readonly preview: PreviewSubscribeResponse) {
+    super(t('subscription.downgrade.reactivationAmountChanged'))
+  }
+}
+
 /**
  * Team-plan downgrade to personal: validate via `previewSubscribe`, remove
  * every member except the original owner, then initiate the tier change.
@@ -48,7 +57,8 @@ class ReactivationConfirmationRequiredError extends Error {
 export function useDowngradeToPersonal() {
   const workspaceStore = useTeamWorkspaceStore()
   const { members } = storeToRefs(workspaceStore)
-  const { subscribe, previewSubscribe, subscription } = useBillingContext()
+  const { subscribe, previewSubscribe, subscription, isInitialized } =
+    useBillingContext()
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
   const { permissions } = useWorkspaceUI()
@@ -82,10 +92,11 @@ export function useDowngradeToPersonal() {
   function requiresReactivationConfirmation(
     preview: PreviewSubscribeResponse
   ): boolean {
-    return (
-      (subscription.value?.isCancelled ?? false) &&
-      preview.transition_type !== 'new_subscription'
-    )
+    if (preview.transition_type === 'new_subscription') return false
+    // Billing context not yet loaded means "cancelled or not" is unknown, not
+    // "not cancelled" — fail closed so an unloaded subscription can't skip
+    // the reactivation disclosure.
+    return !isInitialized.value || (subscription.value?.isCancelled ?? false)
   }
 
   /** Read-only preview so a caller can decide whether to collect reactivation
@@ -106,7 +117,11 @@ export function useDowngradeToPersonal() {
 
   async function downgradeToPersonal(
     planSlug: string,
-    confirmReactivation = false
+    confirmReactivation = false,
+    /** The `cost_today_cents` the caller displayed and got consent for.
+     *  Compared against this call's own fresh preview so a price change
+     *  between that consent and this charge can't slip through unnoticed. */
+    confirmedChargeCents?: number
   ): Promise<DowngradeToPersonalResult | null> {
     ensureCanDowngrade()
 
@@ -159,12 +174,21 @@ export function useDowngradeToPersonal() {
       // Guard before touching membership: the BE rejects this subscribe
       // without confirm_reactivation, so members must never be removed for a
       // transition that's going to fail on consent anyway.
-      if (requiresReactivationConfirmation(preview) && !confirmReactivation) {
-        telemetryFailure = {
-          failure_category: 'validation',
-          error_code: 'reactivation_not_confirmed'
+      if (requiresReactivationConfirmation(preview)) {
+        if (!confirmReactivation) {
+          telemetryFailure = {
+            failure_category: 'validation',
+            error_code: 'reactivation_not_confirmed'
+          }
+          throw new ReactivationConfirmationRequiredError(preview)
         }
-        throw new ReactivationConfirmationRequiredError(preview)
+        if (preview.cost_today_cents !== confirmedChargeCents) {
+          telemetryFailure = {
+            failure_category: 'validation',
+            error_code: 'reactivation_amount_changed'
+          }
+          throw new ReactivationAmountChangedError(preview)
+        }
       }
 
       for (const member of membersToRemove) {

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -33,7 +33,7 @@ export interface DowngradePreview {
 /** Thrown by `downgradeToPersonal` before any member is removed, so a caller
  *  can collect consent and retry with `confirmReactivation: true` instead of
  *  losing team members on a request the BE was always going to reject. */
-export class ReactivationConfirmationRequiredError extends Error {
+class ReactivationConfirmationRequiredError extends Error {
   constructor(public readonly preview: PreviewSubscribeResponse) {
     super(t('subscription.downgrade.reactivationConfirmationRequired'))
   }

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -23,16 +23,32 @@ export interface DowngradeToPersonalResult {
   response: SubscribeResponse
 }
 
+export interface DowngradePreview {
+  preview: PreviewSubscribeResponse
+  /** Cancelled subscription + a real plan change: the BE requires
+   *  `confirm_reactivation` on the subscribe call or it rejects the change. */
+  requiresReactivationConfirmation: boolean
+}
+
+/** Thrown by `downgradeToPersonal` before any member is removed, so a caller
+ *  can collect consent and retry with `confirmReactivation: true` instead of
+ *  losing team members on a request the BE was always going to reject. */
+export class ReactivationConfirmationRequiredError extends Error {
+  constructor(public readonly preview: PreviewSubscribeResponse) {
+    super(t('subscription.downgrade.reactivationConfirmationRequired'))
+  }
+}
+
 /**
  * Team-plan downgrade to personal: validate via `previewSubscribe`, remove
  * every member except the original owner, then initiate the tier change.
- * BE seam (BE-1337): removal email and an atomic downgrade endpoint are
- * BE-owned; until then the FE orchestrates the two steps non-atomically.
+ * The removal-email and an atomic downgrade endpoint are backend-owned future
+ * work; until then the frontend orchestrates the two steps non-atomically.
  */
 export function useDowngradeToPersonal() {
   const workspaceStore = useTeamWorkspaceStore()
   const { members } = storeToRefs(workspaceStore)
-  const { subscribe, previewSubscribe } = useBillingContext()
+  const { subscribe, previewSubscribe, subscription } = useBillingContext()
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
   const { permissions } = useWorkspaceUI()
@@ -63,8 +79,34 @@ export function useDowngradeToPersonal() {
     ensureCanDowngrade()
   }
 
+  function requiresReactivationConfirmation(
+    preview: PreviewSubscribeResponse
+  ): boolean {
+    return (
+      (subscription.value?.isCancelled ?? false) &&
+      preview.transition_type !== 'new_subscription'
+    )
+  }
+
+  /** Read-only preview so a caller can decide whether to collect reactivation
+   *  consent before ever invoking `downgradeToPersonal`. */
+  async function previewDowngrade(planSlug: string): Promise<DowngradePreview> {
+    ensureCanDowngrade()
+    const preview = await previewSubscribe(planSlug)
+    if (!preview?.allowed) {
+      throw new Error(preview?.reason || t('subscription.downgrade.notAllowed'))
+    }
+    ensureCanDowngrade()
+    return {
+      preview,
+      requiresReactivationConfirmation:
+        requiresReactivationConfirmation(preview)
+    }
+  }
+
   async function downgradeToPersonal(
-    planSlug: string
+    planSlug: string,
+    confirmReactivation = false
   ): Promise<DowngradeToPersonalResult | null> {
     ensureCanDowngrade()
 
@@ -114,6 +156,17 @@ export function useDowngradeToPersonal() {
           : 'monthly'
         : undefined
 
+      // Guard before touching membership: the BE rejects this subscribe
+      // without confirm_reactivation, so members must never be removed for a
+      // transition that's going to fail on consent anyway.
+      if (requiresReactivationConfirmation(preview) && !confirmReactivation) {
+        telemetryFailure = {
+          failure_category: 'validation',
+          error_code: 'reactivation_not_confirmed'
+        }
+        throw new ReactivationConfirmationRequiredError(preview)
+      }
+
       for (const member of membersToRemove) {
         ensureCanDowngrade()
         try {
@@ -136,7 +189,8 @@ export function useDowngradeToPersonal() {
       ensureCanDowngrade()
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
+        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+        confirmReactivation
       })
       if (!response) {
         telemetryFailure = {
@@ -221,6 +275,7 @@ export function useDowngradeToPersonal() {
     removableMembers,
     hasOtherMembers,
     refreshMembers,
+    previewDowngrade,
     downgradeToPersonal
   }
 }

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -57,13 +57,8 @@ export class ReactivationAmountChangedError extends Error {
 export function useDowngradeToPersonal() {
   const workspaceStore = useTeamWorkspaceStore()
   const { members } = storeToRefs(workspaceStore)
-  const {
-    subscribe,
-    previewSubscribe,
-    subscription,
-    isInitialized,
-    fetchStatus
-  } = useBillingContext()
+  const { subscribe, previewSubscribe, subscription, fetchStatus } =
+    useBillingContext()
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
   const { permissions } = useWorkspaceUI()
@@ -98,10 +93,15 @@ export function useDowngradeToPersonal() {
     preview: PreviewSubscribeResponse
   ): boolean {
     if (preview.transition_type === 'new_subscription') return false
-    // Billing context not yet loaded means "cancelled or not" is unknown, not
-    // "not cancelled" — fail closed so an unloaded subscription can't skip
-    // the reactivation disclosure.
-    return !isInitialized.value || (subscription.value?.isCancelled ?? false)
+    // subscription is null exactly until status has loaded at least once, so
+    // a null read means "cancelled or not" is unknown, not "not cancelled" —
+    // fail closed. Gate on status readiness rather than aggregate
+    // isInitialized (status + balance + plans): a balance/plans failure must
+    // not permanently force reactivation onto an otherwise-valid, active
+    // subscription. Mirrors the same fix in the transition preview component.
+    return (
+      subscription.value === null || (subscription.value?.isCancelled ?? false)
+    )
   }
 
   /** Read-only preview so a caller can decide whether to collect reactivation

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -57,8 +57,13 @@ class ReactivationAmountChangedError extends Error {
 export function useDowngradeToPersonal() {
   const workspaceStore = useTeamWorkspaceStore()
   const { members } = storeToRefs(workspaceStore)
-  const { subscribe, previewSubscribe, subscription, isInitialized } =
-    useBillingContext()
+  const {
+    subscribe,
+    previewSubscribe,
+    subscription,
+    isInitialized,
+    fetchStatus
+  } = useBillingContext()
   const billingOperationStore = useBillingOperationStore()
   const { userEmail } = useCurrentUser()
   const { permissions } = useWorkspaceUI()
@@ -108,6 +113,10 @@ export function useDowngradeToPersonal() {
       throw new Error(preview?.reason || t('subscription.downgrade.notAllowed'))
     }
     ensureCanDowngrade()
+    // `subscription` is a cached snapshot from the last billing-context load,
+    // which can predate a cancellation; refresh it before reading isCancelled
+    // so this decision reflects the current server state, not a stale one.
+    await fetchStatus()
     return {
       preview,
       requiresReactivationConfirmation:
@@ -173,7 +182,10 @@ export function useDowngradeToPersonal() {
 
       // Guard before touching membership: the BE rejects this subscribe
       // without confirm_reactivation, so members must never be removed for a
-      // transition that's going to fail on consent anyway.
+      // transition that's going to fail on consent anyway. Refresh the
+      // cached subscription first — it can predate a cancellation that
+      // happened after the earlier previewDowngrade() call.
+      await fetchStatus()
       if (requiresReactivationConfirmation(preview)) {
         if (!confirmReactivation) {
           telemetryFailure = {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -781,11 +781,13 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    // Regression guard: confirmReactivation must come from the
-    // disclosure banner's own confirm action, never be re-derived from
-    // subscription.isCancelled (which is true for every reactivation request
-    // and would make the server-side consent check vacuous).
-    it('does not forward confirmReactivation true for a cancelled subscription unless the disclosure was confirmed', async () => {
+    // Regression guard: confirmReactivation must come from the disclosure
+    // banner's own confirm action, never be re-derived from
+    // subscription.isCancelled. A path with no banner (team-new fallback)
+    // always calls in with confirmReactivation=false, so a cancelled
+    // subscription must block the request rather than silently send it and
+    // let the BE reject it with no way for the user to consent.
+    it('blocks the team subscribe and shows an error for a cancelled subscription with no confirmation', async () => {
       mockSubscription.value = { isCancelled: true }
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
@@ -797,18 +799,12 @@ describe('useSubscriptionCheckout', () => {
         },
         billingCycle: 'monthly'
       })
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'subscribed',
-        billing_op_id: 'op-team-1'
-      })
-      mockFetchStatus.mockResolvedValueOnce(undefined)
-      mockFetchBalance.mockResolvedValueOnce(undefined)
 
       await checkout.handleTeamSubscribe()
 
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'team_per_credit_monthly',
-        expect.objectContaining({ confirmReactivation: false })
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
       )
     })
 
@@ -1296,27 +1292,23 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    // Regression guard: confirmReactivation must come from the
-    // disclosure banner's own confirm action, never be re-derived from
-    // subscription.isCancelled (which is true for every reactivation request
-    // and would make the server-side consent check vacuous).
-    it('does not forward confirmReactivation true for a cancelled subscription unless the disclosure was confirmed', async () => {
+    // Regression guard: confirmReactivation must come from the disclosure
+    // banner's own confirm action, never be re-derived from
+    // subscription.isCancelled. A path with no banner (add-payment preview)
+    // always calls in with confirmReactivation=false, so a cancelled
+    // subscription must block the request rather than silently send it and
+    // let the BE reject it with no way for the user to consent.
+    it('blocks the subscribe and shows an error for a cancelled subscription with no confirmation', async () => {
       mockSubscription.value = { isCancelled: true }
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'subscribed',
-        billing_op_id: 'op-3'
-      })
-      mockFetchStatus.mockResolvedValueOnce(undefined)
-      mockFetchBalance.mockResolvedValueOnce(undefined)
 
       await checkout.handleConfirmTransition()
 
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'standard-yearly',
-        expect.objectContaining({ confirmReactivation: false })
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
       )
     })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -84,7 +84,8 @@ const {
   mockUserId,
   mockIsTeamPlan,
   mockShouldUseWorkspaceBilling,
-  mockPermissions
+  mockPermissions,
+  mockSubscription
 } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(),
   mockPreviewSubscribe: vi.fn(),
@@ -107,7 +108,8 @@ const {
       canManageSubscriptionLifecycle: true,
       canDowngradeToPersonal: true
     }
-  }
+  },
+  mockSubscription: { value: null as { isCancelled: boolean } | null }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -119,7 +121,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     fetchStatus: mockFetchStatus,
     fetchBalance: mockFetchBalance,
     isTeamPlan: computed(() => mockIsTeamPlan.value),
-    resubscribe: mockResubscribe
+    resubscribe: mockResubscribe,
+    subscription: computed(() => mockSubscription.value)
   })
 }))
 
@@ -220,6 +223,7 @@ describe('useSubscriptionCheckout', () => {
       canManageSubscriptionLifecycle: true,
       canDowngradeToPersonal: true
     }
+    mockSubscription.value = null
     emit = vi.fn()
   })
 
@@ -738,7 +742,8 @@ describe('useSubscriptionCheckout', () => {
         teamCreditStopId: 'team_700',
         billingCycle: 'monthly',
         returnUrl: 'https://platform.comfy.org/payment/success',
-        cancelUrl: 'https://platform.comfy.org/payment/failed'
+        cancelUrl: 'https://platform.comfy.org/payment/failed',
+        confirmReactivation: false
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
@@ -747,6 +752,33 @@ describe('useSubscriptionCheckout', () => {
           checkout_type: 'new',
           billing_op_id: 'op-team-1'
         })
+      )
+    })
+
+    it('forwards confirmReactivation true for a team change when the current subscription is cancelled', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly'
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-reactivate'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleTeamSubscribe()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({ confirmReactivation: true })
       )
     })
 
@@ -930,7 +962,8 @@ describe('useSubscriptionCheckout', () => {
 
       expect(mockSubscribe).toHaveBeenCalledWith('standard-yearly', {
         returnUrl: 'https://platform.comfy.org/payment/success',
-        cancelUrl: 'https://platform.comfy.org/payment/failed'
+        cancelUrl: 'https://platform.comfy.org/payment/failed',
+        confirmReactivation: false
       })
       expect(checkout.checkoutStep.value).toBe('success')
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
@@ -1211,6 +1244,26 @@ describe('useSubscriptionCheckout', () => {
           severity: 'error',
           detail: 'Transition error'
         })
+      )
+    })
+
+    it('forwards confirmReactivation true when the current subscription is cancelled', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-reactivate'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleConfirmTransition()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ confirmReactivation: true })
       )
     })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -619,6 +619,94 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.previewData.value).toBeNull()
     })
 
+    // Regression guard: a cancelled personal subscriber picking Team has no
+    // existing team plan to "change", so isChange is false — but this is a
+    // reactivation, not a fresh subscribe, and the consent-less add-payment
+    // screen that isChange:false would otherwise route to can never collect
+    // confirm_reactivation.
+    it('previews a cancelled personal subscriber choosing Team, even though nothing existing is changing', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 70_000
+      })
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: false
+      })
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        {
+          teamCreditStopId: 'team_700',
+          billingCycle: 'monthly'
+        }
+      )
+      expect(checkout.previewData.value).not.toBeNull()
+      expect(checkout.previewVariant.value).toBe('team-change')
+    })
+
+    it('bounces a cancelled subscriber back to pricing when the preview does not qualify', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'new_subscription',
+        is_immediate: true
+      })
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: false
+      })
+
+      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+      expect(checkout.selectedTeamStop.value).toBeNull()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+
+    it('bounces a cancelled subscriber back to pricing when the preview request fails', async () => {
+      mockSubscription.value = { isCancelled: true }
+      mockPreviewSubscribe.mockRejectedValueOnce(new Error('not supported'))
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: false
+      })
+
+      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error', detail: 'not supported' })
+      )
+    })
+
     it('does not prepare a team checkout for a member', async () => {
       mockPermissions.value.canManageSubscription = false
       const checkout = await setup()
@@ -981,6 +1069,66 @@ describe('useSubscriptionCheckout', () => {
         })
       )
     })
+
+    it('refreshes stale cancellation state before a team submit and lets a retry succeed after the subscription is cancelled elsewhere', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      expect(checkout.previewVariant.value).toBe('team-change')
+
+      mockFetchStatus.mockImplementationOnce(() => {
+        mockSubscription.value = { isCancelled: true }
+        return Promise.resolve()
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 110_000
+      })
+
+      await checkout.handleTeamSubscribe()
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+      expect(checkout.previewData.value?.cost_today_cents).toBe(110_000)
+
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 110_000
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-retry-active-to-cancelled'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({ confirmReactivation: true })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
   })
 
   describe('handleBackToPricing', () => {
@@ -1010,7 +1158,7 @@ describe('useSubscriptionCheckout', () => {
   })
 
   describe('handleAddCreditCard', () => {
-    it('shows existing success immediately without owning reconciliation', async () => {
+    it('shows existing success immediately without owning post-response reconciliation', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -1018,7 +1166,7 @@ describe('useSubscriptionCheckout', () => {
         status: 'subscribed',
         billing_op_id: 'op-1'
       })
-      mockFetchStatus.mockReturnValueOnce(new Promise(() => {}))
+      mockFetchStatus.mockResolvedValueOnce(undefined)
       mockFetchBalance.mockReturnValueOnce(new Promise(() => {}))
 
       await checkout.handleAddCreditCard()
@@ -1039,7 +1187,10 @@ describe('useSubscriptionCheckout', () => {
         payment_intent_source: undefined,
         billing_op_id: 'op-1'
       })
-      expect(mockFetchStatus).not.toHaveBeenCalled()
+      // Refreshed once, pre-submit, to keep the reactivation guard honest —
+      // but balance reconciliation after a successful response is still not
+      // this composable's job.
+      expect(mockFetchStatus).toHaveBeenCalledTimes(1)
       expect(mockFetchBalance).not.toHaveBeenCalled()
     })
 
@@ -1434,6 +1585,64 @@ describe('useSubscriptionCheckout', () => {
       expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
       expect(emit).not.toHaveBeenCalled()
       expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('refreshes stale cancellation state before submit and lets a retry succeed after the subscription is cancelled elsewhere', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1500
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      expect(checkout.checkoutStep.value).toBe('preview')
+
+      // Cancelled in another tab while this confirm screen stays open; the
+      // banner never showed here because it wasn't cancelled when the
+      // preview loaded, so this submit still carries confirmReactivation=false.
+      mockFetchStatus.mockImplementationOnce(() => {
+        mockSubscription.value = { isCancelled: true }
+        return Promise.resolve()
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1600
+      })
+
+      await checkout.handleConfirmTransition()
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+      // The blocked confirm screen's preview is refreshed to the real,
+      // current transaction rather than the stale pre-cancellation one.
+      expect(checkout.previewData.value?.cost_today_cents).toBe(1600)
+
+      // Retry, now that the reactivation banner (driven by the refreshed
+      // previewData) is showing and the charge has been consented to.
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1600
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-retry-active-to-cancelled'
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ confirmReactivation: true })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
     })
   })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -931,6 +931,116 @@ describe('useSubscriptionCheckout', () => {
           detail: 'subscription.preview.reactivation.amountChanged'
         })
       )
+      // Regression guard: the rejected drift preview must still be installed
+      // so the confirm screen shows the new amount and a retry compares
+      // against what's on screen, instead of repeating this same rejection
+      // forever against the stale original amount.
+      expect(checkout.previewData.value?.cost_today_cents).toBe(120_000)
+
+      // Retry now that the updated amount is showing and re-consented to.
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 120_000
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-retry-amount-changed'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({ confirmReactivation: true })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
+
+    // Regression guard: fetchStatus() and the reactivation guard must run
+    // inside the same protected/loading section as the rest of the submit,
+    // so a refresh failure surfaces the normal error toast/telemetry and
+    // clears loading, instead of escaping uncaught while the CTA stays
+    // enabled for a concurrent submit.
+    it('surfaces an error and clears loading when the pre-submit status refresh rejects', async () => {
+      const checkout = await setup()
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly'
+      })
+      mockFetchStatus.mockRejectedValueOnce(new Error('status unavailable'))
+
+      const submitPromise = checkout.handleTeamSubscribe()
+      expect(checkout.isSubscribing.value).toBe(true)
+      await submitPromise
+
+      expect(checkout.isSubscribing.value).toBe(false)
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'status unavailable'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure'
+        })
+      )
+    })
+
+    // Regression guard: drift recovery must reuse the same reactivation-
+    // capable predicate as the initial cancelled-Team preview. A refreshed
+    // preview that comes back as a fresh subscribe can't feed the banner or
+    // emit confirm_reactivation, so installing it as a team-change would
+    // strand every retry; this must bounce back to pricing instead.
+    it('bounces to pricing when a status-drift refresh returns a preview that cannot collect reactivation consent', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      expect(checkout.previewVariant.value).toBe('team-change')
+
+      mockFetchStatus.mockImplementationOnce(() => {
+        mockSubscription.value = { isCancelled: true }
+        return Promise.resolve()
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'new_subscription',
+        is_immediate: true
+      })
+
+      await checkout.handleTeamSubscribe()
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+      expect(checkout.previewData.value).toBeNull()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
     })
 
     it('uses the annual plan slug for the yearly cycle', async () => {
@@ -1530,6 +1640,30 @@ describe('useSubscriptionCheckout', () => {
           detail: 'subscription.preview.reactivation.amountChanged'
         })
       )
+      // Regression guard: the rejected drift preview must still be installed
+      // so the confirm screen shows the new amount and a retry compares
+      // against what's on screen, instead of repeating this same rejection
+      // forever against the stale original amount.
+      expect(checkout.previewData.value?.cost_today_cents).toBe(2000)
+
+      // Retry now that the updated amount is showing and re-consented to.
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 2000
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-retry-amount-changed'
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ confirmReactivation: true })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
     })
 
     it('re-previews and bills once the confirmed charge still matches', async () => {
@@ -1611,6 +1745,7 @@ describe('useSubscriptionCheckout', () => {
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
         transition_type: 'upgrade',
+        is_immediate: true,
         cost_today_cents: 1600
       })
 
@@ -1620,6 +1755,7 @@ describe('useSubscriptionCheckout', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
+      expect(checkout.checkoutStep.value).toBe('preview')
       // The blocked confirm screen's preview is refreshed to the real,
       // current transaction rather than the stale pre-cancellation one.
       expect(checkout.previewData.value?.cost_today_cents).toBe(1600)
@@ -1629,6 +1765,7 @@ describe('useSubscriptionCheckout', () => {
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
         transition_type: 'upgrade',
+        is_immediate: true,
         cost_today_cents: 1600
       })
       mockSubscribe.mockResolvedValueOnce({

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -781,7 +781,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    // Regression guard for BE-4782: confirmReactivation must come from the
+    // Regression guard: confirmReactivation must come from the
     // disclosure banner's own confirm action, never be re-derived from
     // subscription.isCancelled (which is true for every reactivation request
     // and would make the server-side consent check vacuous).
@@ -1296,7 +1296,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    // Regression guard for BE-4782: confirmReactivation must come from the
+    // Regression guard: confirmReactivation must come from the
     // disclosure banner's own confirm action, never be re-derived from
     // subscription.isCancelled (which is true for every reactivation request
     // and would make the server-side consent check vacuous).

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -808,6 +808,43 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('refuses to bill a team reactivation when a fresh preview no longer matches the confirmed charge', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 120_000
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'subscription.preview.reactivation.amountChanged'
+        })
+      )
+    })
+
     it('uses the annual plan slug for the yearly cycle', async () => {
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
@@ -1310,6 +1347,72 @@ describe('useSubscriptionCheckout', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
+    })
+
+    it('refuses to bill when a fresh preview no longer matches the confirmed charge', async () => {
+      // The user saw and consented to $15.00; proration moved the price to
+      // $20.00 before this confirm click — billing on the new figure would
+      // charge an amount never actually shown to the user.
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1500
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 2000
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'subscription.preview.reactivation.amountChanged'
+        })
+      )
+    })
+
+    it('re-previews and bills once the confirmed charge still matches', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1500
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        cost_today_cents: 1500
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-reactivate-checked'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledTimes(2)
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ confirmReactivation: true })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
     })
 
     it('does not submit a previewed plan after permission is revoked', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -755,8 +755,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    it('forwards confirmReactivation true for a team change when the current subscription is cancelled', async () => {
-      mockSubscription.value = { isCancelled: true }
+    it('forwards confirmReactivation true when the disclosure banner reports consent', async () => {
       const checkout = await setup()
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -774,11 +773,42 @@ describe('useSubscriptionCheckout', () => {
       mockFetchStatus.mockResolvedValueOnce(undefined)
       mockFetchBalance.mockResolvedValueOnce(undefined)
 
-      await checkout.handleTeamSubscribe()
+      await checkout.handleTeamSubscribe(true)
 
       expect(mockSubscribe).toHaveBeenCalledWith(
         'team_per_credit_monthly',
         expect.objectContaining({ confirmReactivation: true })
+      )
+    })
+
+    // Regression guard for BE-4782: confirmReactivation must come from the
+    // disclosure banner's own confirm action, never be re-derived from
+    // subscription.isCancelled (which is true for every reactivation request
+    // and would make the server-side consent check vacuous).
+    it('does not forward confirmReactivation true for a cancelled subscription unless the disclosure was confirmed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly'
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-1'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleTeamSubscribe()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({ confirmReactivation: false })
       )
     })
 
@@ -1247,8 +1277,7 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
-    it('forwards confirmReactivation true when the current subscription is cancelled', async () => {
-      mockSubscription.value = { isCancelled: true }
+    it('forwards confirmReactivation true when the disclosure banner reports consent', async () => {
       const checkout = await setup()
       checkout.selectedTierKey.value = 'standard'
       checkout.selectedBillingCycle.value = 'yearly'
@@ -1259,11 +1288,35 @@ describe('useSubscriptionCheckout', () => {
       mockFetchStatus.mockResolvedValueOnce(undefined)
       mockFetchBalance.mockResolvedValueOnce(undefined)
 
-      await checkout.handleConfirmTransition()
+      await checkout.handleConfirmTransition(true)
 
       expect(mockSubscribe).toHaveBeenCalledWith(
         'standard-yearly',
         expect.objectContaining({ confirmReactivation: true })
+      )
+    })
+
+    // Regression guard for BE-4782: confirmReactivation must come from the
+    // disclosure banner's own confirm action, never be re-derived from
+    // subscription.isCancelled (which is true for every reactivation request
+    // and would make the server-side consent check vacuous).
+    it('does not forward confirmReactivation true for a cancelled subscription unless the disclosure was confirmed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'standard'
+      checkout.selectedBillingCycle.value = 'yearly'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-3'
+      })
+      mockFetchStatus.mockResolvedValueOnce(undefined)
+      mockFetchBalance.mockResolvedValueOnce(undefined)
+
+      await checkout.handleConfirmTransition()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({ confirmReactivation: false })
       )
     })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/platform/telemetry/types'
 import type {
   Plan,
+  PreviewSubscribeOptions,
   PreviewSubscribeResponse,
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
@@ -59,6 +60,12 @@ type PreviewVariant =
   | 'personal-change'
   | 'personal-new'
   | null
+
+/** Thrown by `assertReactivationAmountUnchanged` when a fresh preview's
+ *  `cost_today_cents` no longer matches what the reactivation banner showed
+ *  and the user consented to. Caught by the surrounding try/catch and
+ *  surfaced through the same toast as any other subscribe failure. */
+class ReactivationAmountChangedError extends Error {}
 
 export function findPlanSlug(
   plans: Plan[],
@@ -124,6 +131,29 @@ export function useSubscriptionCheckout(
       summary: t('g.error'),
       detail: t('subscription.preview.reactivation.confirmationRequired')
     })
+  }
+
+  // subscribe() recomputes the transaction independently of the preview the
+  // banner showed, so proration or team-seat state can drift while the
+  // screen is open. Re-preview right before billing and refuse if the
+  // amount moved — mirrors the guard useDowngradeToPersonal applies before
+  // a team-to-personal downgrade.
+  async function assertReactivationAmountUnchanged(
+    planSlug: string,
+    options?: PreviewSubscribeOptions
+  ): Promise<void> {
+    const freshPreview = await previewSubscribe(planSlug, options)
+    if (!freshPreview?.allowed) {
+      throw new Error(freshPreview?.reason || t('subscription.subscribeFailed'))
+    }
+    if (
+      freshPreview.cost_today_cents !==
+      (previewData.value?.cost_today_cents ?? 0)
+    ) {
+      throw new ReactivationAmountChangedError(
+        t('subscription.preview.reactivation.amountChanged')
+      )
+    }
   }
 
   function canSelectTierPlan(): boolean {
@@ -317,6 +347,9 @@ export function useSubscriptionCheckout(
         notifyReactivationConfirmationRequired()
         return
       }
+      if (confirmReactivation && isCancelled.value) {
+        await assertReactivationAmountUnchanged(planSlug)
+      }
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
@@ -478,6 +511,12 @@ export function useSubscriptionCheckout(
     isSubscribing.value = true
     try {
       const planSlug = getTeamPlanSlug(billingCycle)
+      if (confirmReactivation && isCancelled.value) {
+        await assertReactivationAmountUnchanged(planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+      }
       const response = await subscribe(planSlug, {
         teamCreditStopId: stop.id,
         billingCycle,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -88,7 +88,8 @@ export function useSubscriptionCheckout(
     plans,
     fetchPlans,
     isTeamPlan,
-    resubscribe
+    resubscribe,
+    subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const { permissions } = useWorkspaceUI()
@@ -299,7 +300,8 @@ export function useSubscriptionCheckout(
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
+        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+        confirmReactivation: subscription.value?.isCancelled ?? false
       })
 
       if (response) {
@@ -456,7 +458,8 @@ export function useSubscriptionCheckout(
         teamCreditStopId: stop.id,
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`
+        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+        confirmReactivation: subscription.value?.isCancelled ?? false
       })
 
       if (response) {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -88,8 +88,7 @@ export function useSubscriptionCheckout(
     plans,
     fetchPlans,
     isTeamPlan,
-    resubscribe,
-    subscription
+    resubscribe
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const { permissions } = useWorkspaceUI()
@@ -280,7 +279,7 @@ export function useSubscriptionCheckout(
     emit('close', true)
   }
 
-  async function handleSubscription() {
+  async function handleSubscription(confirmReactivation = false) {
     if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
 
     const tierKey = selectedTierKey.value
@@ -301,7 +300,7 @@ export function useSubscriptionCheckout(
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation: subscription.value?.isCancelled ?? false
+        confirmReactivation
       })
 
       if (response) {
@@ -435,7 +434,7 @@ export function useSubscriptionCheckout(
     if (operation.status === 'succeeded') checkoutStep.value = 'success'
   }
 
-  async function handleTeamSubscription() {
+  async function handleTeamSubscription(confirmReactivation = false) {
     if (!permissions.value.canManageSubscription) return
 
     const teamCheckout = selectedTeamCheckout.value
@@ -459,7 +458,7 @@ export function useSubscriptionCheckout(
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation: subscription.value?.isCancelled ?? false
+        confirmReactivation
       })
 
       if (response) {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -134,6 +134,21 @@ export function useSubscriptionCheckout(
     })
   }
 
+  // Shared by the initial cancelled-Team preview (handleSubscribeTeamClick)
+  // and drift recovery (refreshPreviewOnReactivationBlock): a preview can
+  // only feed the reactivation banner if it's allowed, immediate, and an
+  // existing-plan change — new_subscription and scheduled changes route to
+  // screens that can't render the disclosure or emit confirm_reactivation.
+  function isReactivationCapablePreview(
+    preview: PreviewSubscribeResponse | null | undefined
+  ): boolean {
+    return (
+      !!preview?.allowed &&
+      preview.is_immediate &&
+      preview.transition_type !== 'new_subscription'
+    )
+  }
+
   // subscribe() recomputes the transaction independently of the preview the
   // banner showed, so proration or team-seat state can drift while the
   // screen is open. Re-preview right before billing and refuse if the
@@ -147,10 +162,15 @@ export function useSubscriptionCheckout(
     if (!freshPreview?.allowed) {
       throw new Error(freshPreview?.reason || t('subscription.subscribeFailed'))
     }
-    if (
+    const amountChanged =
       freshPreview.cost_today_cents !==
       (previewData.value?.cost_today_cents ?? 0)
-    ) {
+    // Install regardless of outcome: on drift this is what makes the confirm
+    // screen show the new amount and resets prior consent (via the
+    // component's own chargeCents watcher), so the next attempt compares
+    // against what's on screen instead of repeating this same failure.
+    previewData.value = freshPreview
+    if (amountChanged) {
       throw new ReactivationAmountChangedError(
         t('subscription.preview.reactivation.amountChanged')
       )
@@ -160,21 +180,34 @@ export function useSubscriptionCheckout(
   // The reactivation guard below reads cached `subscription.isCancelled`. If
   // the subscription was cancelled in another tab after this preview loaded,
   // that cache is stale and the guard blocks a request the banner never
-  // actually disclosed as a reactivation — re-fetching here, right before the
-  // guard, keeps a retry from repeating the identical stale request forever.
-  // Mirrors the fetchStatus() call useDowngradeToPersonal makes before its
-  // own reactivation guard.
+  // actually disclosed as a reactivation. Refresh here, right before the
+  // guard, so a retry sees the real current transaction — but only install
+  // the refresh if it can actually feed the banner; one that can't (e.g. it
+  // comes back as a fresh subscribe) would leave every retry blocked on a
+  // screen that can never collect consent, so send the user back to pricing
+  // instead. Mirrors the fetchStatus() call useDowngradeToPersonal makes
+  // before its own reactivation guard.
   async function refreshPreviewOnReactivationBlock(
     planSlug: string,
     options?: PreviewSubscribeOptions
   ): Promise<void> {
+    let freshPreview: PreviewSubscribeResponse | null = null
     try {
-      const freshPreview = await previewSubscribe(planSlug, options)
-      if (freshPreview?.allowed) previewData.value = freshPreview
+      freshPreview = await previewSubscribe(planSlug, options)
     } catch {
-      // Best-effort: the confirm screen keeps its prior preview and the
-      // guard above still blocks on the freshly-fetched status.
+      // Treated the same as an incapable preview below.
     }
+    if (isReactivationCapablePreview(freshPreview)) {
+      previewData.value = freshPreview
+      notifyReactivationConfirmationRequired()
+      return
+    }
+    handleBackToPricing()
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t('subscription.preview.reactivation.unavailable')
+    })
   }
 
   function canSelectTierPlan(): boolean {
@@ -337,11 +370,7 @@ export function useSubscriptionCheckout(
       previewError = error
     }
 
-    const isReactivationCapable =
-      response?.allowed &&
-      response.is_immediate &&
-      response.transition_type !== 'new_subscription'
-    if (isReactivationCapable) {
+    if (isReactivationCapablePreview(response)) {
       previewData.value = response
       return
     }
@@ -394,7 +423,6 @@ export function useSubscriptionCheckout(
       await fetchStatus()
       if (!confirmReactivation && isCancelled.value) {
         await refreshPreviewOnReactivationBlock(planSlug)
-        notifyReactivationConfirmationRequired()
         return
       }
       if (confirmReactivation && isCancelled.value) {
@@ -554,18 +582,16 @@ export function useSubscriptionCheckout(
     const billingCycle = selectedBillingCycle.value
     const planSlug = getTeamPlanSlug(billingCycle)
 
-    await fetchStatus()
-    if (!confirmReactivation && isCancelled.value) {
-      await refreshPreviewOnReactivationBlock(planSlug, {
-        teamCreditStopId: stop.id,
-        billingCycle
-      })
-      notifyReactivationConfirmationRequired()
-      return
-    }
-
     isSubscribing.value = true
     try {
+      await fetchStatus()
+      if (!confirmReactivation && isCancelled.value) {
+        await refreshPreviewOnReactivationBlock(planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+        return
+      }
       if (confirmReactivation && isCancelled.value) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -94,6 +94,7 @@ export function useSubscriptionCheckout(
     previewSubscribe,
     plans,
     fetchPlans,
+    fetchStatus,
     isTeamPlan,
     resubscribe,
     subscription
@@ -153,6 +154,26 @@ export function useSubscriptionCheckout(
       throw new ReactivationAmountChangedError(
         t('subscription.preview.reactivation.amountChanged')
       )
+    }
+  }
+
+  // The reactivation guard below reads cached `subscription.isCancelled`. If
+  // the subscription was cancelled in another tab after this preview loaded,
+  // that cache is stale and the guard blocks a request the banner never
+  // actually disclosed as a reactivation — re-fetching here, right before the
+  // guard, keeps a retry from repeating the identical stale request forever.
+  // Mirrors the fetchStatus() call useDowngradeToPersonal makes before its
+  // own reactivation guard.
+  async function refreshPreviewOnReactivationBlock(
+    planSlug: string,
+    options?: PreviewSubscribeOptions
+  ): Promise<void> {
+    try {
+      const freshPreview = await previewSubscribe(planSlug, options)
+      if (freshPreview?.allowed) previewData.value = freshPreview
+    } catch {
+      // Best-effort: the confirm screen keeps its prior preview and the
+      // guard above still blocks on the freshly-fetched status.
     }
   }
 
@@ -296,23 +317,50 @@ export function useSubscriptionCheckout(
     previewData.value = null
     checkoutStep.value = 'preview'
 
-    if (!payload.isChange || !payload.stop.id) return
+    // A cancelled subscriber picking Team is a reactivation even when
+    // nothing existing is "changing" (isChange false, e.g. a first-time Team
+    // pick): the add-payment screen this would otherwise fall back to can't
+    // collect confirm_reactivation, so it always needs a real,
+    // reactivation-capable preview instead of the consent-less fallback.
+    const needsPreview = payload.isChange || isCancelled.value
+    if (!needsPreview || !payload.stop.id) return
+
+    let response: PreviewSubscribeResponse | null = null
+    let previewError: unknown
     try {
       const planSlug = getTeamPlanSlug(payload.billingCycle)
-      const response = await previewSubscribe(planSlug, {
+      response = await previewSubscribe(planSlug, {
         teamCreditStopId: payload.stop.id,
         billingCycle: payload.billingCycle
       })
-      if (
-        response?.allowed &&
-        response.is_immediate &&
-        response.transition_type !== 'new_subscription'
-      ) {
-        previewData.value = response
-      }
-    } catch {
-      // Preview is best-effort; keep the display-only confirm on any failure.
+    } catch (error) {
+      previewError = error
     }
+
+    const isReactivationCapable =
+      response?.allowed &&
+      response.is_immediate &&
+      response.transition_type !== 'new_subscription'
+    if (isReactivationCapable) {
+      previewData.value = response
+      return
+    }
+    // Not cancelled: preview is best-effort, keep the display-only confirm.
+    if (!isCancelled.value) return
+
+    // Cancelled with no qualifying preview: the add-payment fallback has no
+    // way to collect confirm_reactivation, so every submit from it would be
+    // an unrecoverable dead end. Surface the failure instead.
+    toast.add({
+      severity: 'error',
+      summary: t('subscription.teamPlan.name'),
+      detail:
+        previewError instanceof Error
+          ? previewError.message
+          : response?.reason || t('subscription.subscribeFailed')
+    })
+    checkoutStep.value = 'pricing'
+    selectedTeamCheckout.value = null
   }
 
   function handleBackToPricing() {
@@ -343,7 +391,9 @@ export function useSubscriptionCheckout(
       const planSlug = getApiPlanSlug(tierKey, billingCycle)
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
+      await fetchStatus()
       if (!confirmReactivation && isCancelled.value) {
+        await refreshPreviewOnReactivationBlock(planSlug)
         notifyReactivationConfirmationRequired()
         return
       }
@@ -500,17 +550,22 @@ export function useSubscriptionCheckout(
       return
     }
 
+    const { stop, checkoutType } = teamCheckout
+    const billingCycle = selectedBillingCycle.value
+    const planSlug = getTeamPlanSlug(billingCycle)
+
+    await fetchStatus()
     if (!confirmReactivation && isCancelled.value) {
+      await refreshPreviewOnReactivationBlock(planSlug, {
+        teamCreditStopId: stop.id,
+        billingCycle
+      })
       notifyReactivationConfirmationRequired()
       return
     }
 
-    const { stop, checkoutType } = teamCheckout
-    const billingCycle = selectedBillingCycle.value
-
     isSubscribing.value = true
     try {
-      const planSlug = getTeamPlanSlug(billingCycle)
       if (confirmReactivation && isCancelled.value) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -88,7 +88,8 @@ export function useSubscriptionCheckout(
     plans,
     fetchPlans,
     isTeamPlan,
-    resubscribe
+    resubscribe,
+    subscription
   } = useBillingContext()
   const { shouldUseWorkspaceBilling } = useBillingRouting()
   const { permissions } = useWorkspaceUI()
@@ -109,6 +110,21 @@ export function useSubscriptionCheckout(
     () => selectedTeamCheckout.value?.stop ?? null
   )
   const isTeamCheckout = computed(() => selectedTeamCheckout.value !== null)
+  const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+
+  // A cancelled subscription needs confirm_reactivation, and the only place
+  // that can honestly collect it is the reactivation banner. Paths with no
+  // banner (add-payment preview, a preview-less team-new fallback) always
+  // call in with confirmReactivation=false, so block here instead of sending
+  // a request the BE is guaranteed to reject with no way for the user to
+  // consent.
+  function notifyReactivationConfirmationRequired(): void {
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t('subscription.preview.reactivation.confirmationRequired')
+    })
+  }
 
   function canSelectTierPlan(): boolean {
     return (
@@ -297,6 +313,10 @@ export function useSubscriptionCheckout(
       const planSlug = getApiPlanSlug(tierKey, billingCycle)
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
+      if (!confirmReactivation && isCancelled.value) {
+        notifyReactivationConfirmationRequired()
+        return
+      }
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
@@ -444,6 +464,11 @@ export function useSubscriptionCheckout(
         summary: t('subscription.teamPlan.name'),
         detail: t('subscription.teamPlan.unavailable')
       })
+      return
+    }
+
+    if (!confirmReactivation && isCancelled.value) {
+      notifyReactivationConfirmationRequired()
       return
     }
 

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -11,6 +11,7 @@ const closeDialog = vi.hoisted(() => vi.fn())
 const isDialogOpen = vi.hoisted(() => vi.fn())
 const toastAdd = vi.hoisted(() => vi.fn())
 const refreshMembers = vi.hoisted(() => vi.fn())
+const previewDowngrade = vi.hoisted(() => vi.fn())
 const downgradeToPersonal = vi.hoisted(() => vi.fn())
 const hasOtherMembers = vi.hoisted(() => ({ value: false }))
 const openDialogKeys = ref<string[]>([])
@@ -47,6 +48,7 @@ vi.mock('@/platform/workspace/composables/useDowngradeToPersonal', () => ({
   useDowngradeToPersonal: () => ({
     hasOtherMembers,
     refreshMembers,
+    previewDowngrade,
     downgradeToPersonal
   })
 }))
@@ -64,6 +66,14 @@ describe('showDowngradeToPersonalDialog', () => {
     hasOtherMembers.value = false
     openDialogKeys.value = []
     refreshMembers.mockResolvedValue(undefined)
+    previewDowngrade.mockResolvedValue({
+      preview: {
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 0
+      },
+      requiresReactivationConfirmation: false
+    })
     downgradeToPersonal.mockResolvedValue(undefined)
     isDialogOpen.mockImplementation((key: string) =>
       openDialogKeys.value.includes(key)
@@ -123,11 +133,38 @@ describe('showDowngradeToPersonalDialog', () => {
     })
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('downgrade-remove-members')
+    expect(args.props.requiresRemoval).toBe(true)
+    expect(args.props.requiresReactivation).toBe(false)
     expect(args.dialogComponentProps.closable).toBe(false)
     expect(args.dialogComponentProps.dismissableMask).toBe(false)
 
     args.dialogComponentProps.onClose()
     await expect(resultPromise).resolves.toBeNull()
+  })
+
+  it('shows the confirm dialog for a cancelled subscription even with no other members', async () => {
+    hasOtherMembers.value = false
+    previewDowngrade.mockResolvedValue({
+      preview: {
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 1500
+      },
+      requiresReactivationConfirmation: true
+    })
+
+    const resultPromise =
+      useDialogService().showDowngradeToPersonalDialog(options)
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+
+    expect(downgradeToPersonal).not.toHaveBeenCalled()
+    const [args] = showDialog.mock.calls[0]
+    expect(args.props.requiresRemoval).toBe(false)
+    expect(args.props.requiresReactivation).toBe(true)
+    expect(args.props.chargeCents).toBe(1500)
+
+    args.dialogComponentProps.onClose()
+    await resultPromise
   })
 
   it('returns the downgrade result after member confirmation', async () => {
@@ -143,10 +180,32 @@ describe('showDowngradeToPersonalDialog', () => {
     await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
     const [args] = showDialog.mock.calls[0]
 
-    await args.props.onConfirm('standard-monthly')
+    await args.props.onConfirm('standard-monthly', false)
 
-    expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly')
+    expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly', false)
     await expect(resultPromise).resolves.toStrictEqual(result)
+  })
+
+  it('forwards the confirmed reactivation flag from the dialog to downgradeToPersonal', async () => {
+    hasOtherMembers.value = true
+    previewDowngrade.mockResolvedValue({
+      preview: {
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 1500
+      },
+      requiresReactivationConfirmation: true
+    })
+
+    const resultPromise =
+      useDialogService().showDowngradeToPersonalDialog(options)
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    const [args] = showDialog.mock.calls[0]
+
+    await args.props.onConfirm('standard-monthly', true)
+
+    expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly', true)
+    await resultPromise
   })
 
   it('returns null when the confirmation is removed without closing', async () => {
@@ -183,6 +242,21 @@ describe('showDowngradeToPersonalDialog', () => {
 
     expect(toastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'error', detail: 'network' })
+    )
+    expect(showDialog).not.toHaveBeenCalled()
+    expect(downgradeToPersonal).not.toHaveBeenCalled()
+  })
+
+  it('toasts and aborts when the preview fails', async () => {
+    previewDowngrade.mockRejectedValue(new Error('Outstanding balance'))
+
+    await useDialogService().showDowngradeToPersonalDialog(options)
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Outstanding balance'
+      })
     )
     expect(showDialog).not.toHaveBeenCalled()
     expect(downgradeToPersonal).not.toHaveBeenCalled()

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -9,6 +9,7 @@ import { ref } from 'vue'
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
 const isDialogOpen = vi.hoisted(() => vi.fn())
+const updateDialog = vi.hoisted(() => vi.fn())
 const toastAdd = vi.hoisted(() => vi.fn())
 const refreshMembers = vi.hoisted(() => vi.fn())
 const previewDowngrade = vi.hoisted(() => vi.fn())
@@ -16,8 +17,33 @@ const downgradeToPersonal = vi.hoisted(() => vi.fn())
 const hasOtherMembers = vi.hoisted(() => ({ value: false }))
 const openDialogKeys = ref<string[]>([])
 
+const {
+  ReactivationConfirmationRequiredError,
+  ReactivationAmountChangedError
+} = vi.hoisted(() => {
+  class ReactivationConfirmationRequiredError extends Error {
+    constructor(public preview: { cost_today_cents: number }) {
+      super('reactivation confirmation required')
+    }
+  }
+  class ReactivationAmountChangedError extends Error {
+    constructor(public preview: { cost_today_cents: number }) {
+      super('reactivation amount changed')
+    }
+  }
+  return {
+    ReactivationConfirmationRequiredError,
+    ReactivationAmountChangedError
+  }
+})
+
 vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: () => ({ showDialog, closeDialog, isDialogOpen })
+  useDialogStore: () => ({
+    showDialog,
+    closeDialog,
+    isDialogOpen,
+    updateDialog
+  })
 }))
 
 vi.mock('@/i18n', () => ({
@@ -50,7 +76,9 @@ vi.mock('@/platform/workspace/composables/useDowngradeToPersonal', () => ({
     refreshMembers,
     previewDowngrade,
     downgradeToPersonal
-  })
+  }),
+  ReactivationConfirmationRequiredError,
+  ReactivationAmountChangedError
 }))
 
 vi.mock(
@@ -214,6 +242,113 @@ describe('showDowngradeToPersonalDialog', () => {
       1500
     )
     await resultPromise
+  })
+
+  it('updates the open dialog with fresh values and lets a retry succeed after status drift', async () => {
+    // Open-time state: not cancelled, so the dialog was never told to send
+    // confirmReactivation. The subscription gets cancelled before the user
+    // clicks confirm; downgradeToPersonal's own fresh preview catches it.
+    hasOtherMembers.value = true
+    previewDowngrade.mockResolvedValue({
+      preview: {
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 0
+      },
+      requiresReactivationConfirmation: false
+    })
+    downgradeToPersonal.mockRejectedValueOnce(
+      new ReactivationConfirmationRequiredError({ cost_today_cents: 1500 })
+    )
+    const result = {
+      preview: { allowed: true, transition_type: 'downgrade' },
+      response: { billing_op_id: 'op-retry', status: 'subscribed' }
+    }
+    downgradeToPersonal.mockResolvedValueOnce(result)
+
+    const resultPromise =
+      useDialogService().showDowngradeToPersonalDialog(options)
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    const [args] = showDialog.mock.calls[0]
+    expect(args.props.requiresReactivation).toBe(false)
+    expect(args.props.chargeCents).toBe(0)
+
+    await expect(
+      args.props.onConfirm('standard-monthly', false)
+    ).rejects.toThrow(ReactivationConfirmationRequiredError)
+
+    expect(updateDialog).toHaveBeenCalledWith({
+      key: 'downgrade-remove-members',
+      contentProps: { requiresReactivation: true, chargeCents: 1500 }
+    })
+    expect(downgradeToPersonal).toHaveBeenNthCalledWith(
+      1,
+      'standard-monthly',
+      false,
+      0
+    )
+
+    // Retry: the dialog's onConfirm closure now carries the corrected values.
+    await args.props.onConfirm('standard-monthly', true)
+
+    expect(downgradeToPersonal).toHaveBeenNthCalledWith(
+      2,
+      'standard-monthly',
+      true,
+      1500
+    )
+    await expect(resultPromise).resolves.toStrictEqual(result)
+  })
+
+  it('updates the open dialog with fresh values and lets a retry succeed after amount drift', async () => {
+    hasOtherMembers.value = true
+    previewDowngrade.mockResolvedValue({
+      preview: {
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 1500
+      },
+      requiresReactivationConfirmation: true
+    })
+    downgradeToPersonal.mockRejectedValueOnce(
+      new ReactivationAmountChangedError({ cost_today_cents: 2000 })
+    )
+    const result = {
+      preview: { allowed: true, transition_type: 'downgrade' },
+      response: { billing_op_id: 'op-retry-amount', status: 'subscribed' }
+    }
+    downgradeToPersonal.mockResolvedValueOnce(result)
+
+    const resultPromise =
+      useDialogService().showDowngradeToPersonalDialog(options)
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledOnce())
+    const [args] = showDialog.mock.calls[0]
+    expect(args.props.chargeCents).toBe(1500)
+
+    await expect(
+      args.props.onConfirm('standard-monthly', true)
+    ).rejects.toThrow(ReactivationAmountChangedError)
+
+    expect(updateDialog).toHaveBeenCalledWith({
+      key: 'downgrade-remove-members',
+      contentProps: { requiresReactivation: true, chargeCents: 2000 }
+    })
+    expect(downgradeToPersonal).toHaveBeenNthCalledWith(
+      1,
+      'standard-monthly',
+      true,
+      1500
+    )
+
+    await args.props.onConfirm('standard-monthly', true)
+
+    expect(downgradeToPersonal).toHaveBeenNthCalledWith(
+      2,
+      'standard-monthly',
+      true,
+      2000
+    )
+    await expect(resultPromise).resolves.toStrictEqual(result)
   })
 
   it('returns null when the confirmation is removed without closing', async () => {

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -182,7 +182,11 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await args.props.onConfirm('standard-monthly', false)
 
-    expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly', false)
+    expect(downgradeToPersonal).toHaveBeenCalledWith(
+      'standard-monthly',
+      false,
+      0
+    )
     await expect(resultPromise).resolves.toStrictEqual(result)
   })
 
@@ -204,7 +208,11 @@ describe('showDowngradeToPersonalDialog', () => {
 
     await args.props.onConfirm('standard-monthly', true)
 
-    expect(downgradeToPersonal).toHaveBeenCalledWith('standard-monthly', true)
+    expect(downgradeToPersonal).toHaveBeenCalledWith(
+      'standard-monthly',
+      true,
+      1500
+    )
     await resultPromise
   })
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -667,9 +667,10 @@ export const useDialogService = () => {
   }
 
   /**
-   * Downgrade a team plan to a personal plan (FE-977). Skips the type-"I
-   * understand" confirm dialog when the workspace has no other members;
-   * failures on that path surface as an error toast.
+   * Downgrade a team plan to a personal plan. Skips the type-"I understand"
+   * confirm dialog only when there's nothing to confirm: no other members to
+   * remove and no reactivation charge to disclose. Failures on that fast
+   * path surface as an error toast.
    */
   async function showDowngradeToPersonalDialog(options: {
     planName: string
@@ -677,12 +678,21 @@ export const useDialogService = () => {
   }): Promise<DowngradeToPersonalResult | null> {
     const { useDowngradeToPersonal } =
       await import('@/platform/workspace/composables/useDowngradeToPersonal')
-    const { hasOtherMembers, refreshMembers, downgradeToPersonal } =
-      useDowngradeToPersonal()
+    const {
+      hasOtherMembers,
+      refreshMembers,
+      previewDowngrade,
+      downgradeToPersonal
+    } = useDowngradeToPersonal()
 
+    let requiresReactivation = false
+    let chargeCents = 0
     try {
       await refreshMembers()
-      if (!hasOtherMembers.value) {
+      const preview = await previewDowngrade(options.planSlug)
+      requiresReactivation = preview.requiresReactivationConfirmation
+      chargeCents = preview.preview.cost_today_cents
+      if (!hasOtherMembers.value && !requiresReactivation) {
         return await downgradeToPersonal(options.planSlug)
       }
     } catch (error) {
@@ -717,8 +727,14 @@ export const useDialogService = () => {
         props: {
           planName: options.planName,
           planSlug: options.planSlug,
-          onConfirm: async (planSlug: string) => {
-            const result = await downgradeToPersonal(planSlug)
+          requiresRemoval: hasOtherMembers.value,
+          requiresReactivation,
+          chargeCents,
+          onConfirm: async (planSlug: string, confirmReactivation: boolean) => {
+            const result = await downgradeToPersonal(
+              planSlug,
+              confirmReactivation
+            )
             resolveResult(result)
           }
         },

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -733,7 +733,8 @@ export const useDialogService = () => {
           onConfirm: async (planSlug: string, confirmReactivation: boolean) => {
             const result = await downgradeToPersonal(
               planSlug,
-              confirmReactivation
+              confirmReactivation,
+              chargeCents
             )
             resolveResult(result)
           }

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -676,8 +676,11 @@ export const useDialogService = () => {
     planName: string
     planSlug: string
   }): Promise<DowngradeToPersonalResult | null> {
-    const { useDowngradeToPersonal } =
-      await import('@/platform/workspace/composables/useDowngradeToPersonal')
+    const {
+      useDowngradeToPersonal,
+      ReactivationConfirmationRequiredError,
+      ReactivationAmountChangedError
+    } = await import('@/platform/workspace/composables/useDowngradeToPersonal')
     const {
       hasOtherMembers,
       refreshMembers,
@@ -731,12 +734,33 @@ export const useDialogService = () => {
           requiresReactivation,
           chargeCents,
           onConfirm: async (planSlug: string, confirmReactivation: boolean) => {
-            const result = await downgradeToPersonal(
-              planSlug,
-              confirmReactivation,
-              chargeCents
-            )
-            resolveResult(result)
+            try {
+              const result = await downgradeToPersonal(
+                planSlug,
+                confirmReactivation,
+                chargeCents
+              )
+              resolveResult(result)
+            } catch (error) {
+              // A fresh preview inside downgradeToPersonal() found the
+              // dialog's captured state (open-time cancellation/charge) is
+              // stale and refused to bill it. Push the corrected values into
+              // the still-open dialog so a retry sends what these errors'
+              // own preview says is actually true, instead of repeating the
+              // same rejected request forever.
+              if (
+                error instanceof ReactivationConfirmationRequiredError ||
+                error instanceof ReactivationAmountChangedError
+              ) {
+                requiresReactivation = true
+                chargeCents = error.preview.cost_today_cents
+                dialogStore.updateDialog({
+                  key: dialogKey,
+                  contentProps: { requiresReactivation, chargeCents }
+                })
+              }
+              throw error
+            }
           }
         },
         dialogComponentProps: {


### PR DESCRIPTION
Tells a user that changing plans while their subscription is cancelled will **resume it**.

## Why

A subscription can be cancelled but still active — it runs to the end of the period already paid for. Backend work landing alongside this lets those users change plans, and doing so **clears the pending cancellation**: the subscription stops ending and starts renewing again.

That is a bigger change than "swap my plan", triggered by what looks like an ordinary plan click. Without a disclosure, someone who deliberately cancelled ends up subscribed indefinitely and never told.

## What changes

When the current subscription is cancelled, the transition preview gains a banner above the plan comparison and the primary button becomes **"Confirm & reactivate"**. The copy differs per case because the consequence does:

| Case | Today | What the user needs to notice |
|---|---|---|
| **Upgrade** | prorated charge | charged now, and it renews instead of ending |
| **Downgrade** | **nothing** | easiest to miss — no charge, but it now renews at the new price instead of ending |
| **Monthly → annual** | full year | largest charge of the three |

Because the downgrade case has no money attached, the copy leads with *reactivates*, not with a number.

Above the current plan's monthly price the amount renders larger and higher-contrast, and the confirm button is **disabled** behind an explicit "I understand I'll be charged $X today" checkbox. Standard proration styling renders a $6 upgrade and a $336 annual charge identically, and only one of those deserves a second look.

## The load-bearing part

`confirm_reactivation` is a **server-checked** flag — the API refuses the change without it, and records it for audit.

An earlier commit on this branch derived it from `subscription.isCancelled`, which made it true in exactly the circumstances the server demanded it. The check could therefore never fail, and the audit record asserted consent for requests where no disclosure was ever shown. Consent is now computed by the component that actually rendered the banner and emitted on `confirm`; the composable only forwards it. That distinction is the entire point of the field, so it has a regression test that fails against the old wiring.

## Scope notes

- `PricingTableWorkspace.vue` is untouched deliberately — a different-tier click while cancelled already routes through this preview, and the "Resubscribe to X" button hits a different endpoint whose label is already explicit.
- Team and personal paths are both wired.
- The pre-existing `SubscriptionTransitionPreviewWorkspace.test.ts` is untouched: its `vue-i18n` module mock is incompatible with `<i18n-t>`, so the new tests live in a sibling file.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, `pnpm knip` clean, `pnpm format` no diff.

Consent is asserted on the **request payload**, not on component state — a test that only checked the checkbox toggles a local ref would pass with the bug fully intact.

Six Storybook states cover the banner (baseline, upgrade, downgrade, monthly→annual, annual→monthly, above-threshold); rendered screenshots are in a comment below.

## Found while reviewing, not fixed here

The credit line reads **"Credit from current monthly plan" on an annual→monthly switch**, where the current plan is annual. `creditFromPlanLabel` returns the monthly string for *any* cadence change and never reads the current subscription's duration. This is on `main` today, is not touched by this branch, and affects every cadence change rather than just the reactivation path — so it wants its own PR rather than widening this one. It is visible in the annual→monthly screenshot below.
