### PR TITLE
[FE-1250] Persist workspace auto-reload settings

### DIFF
--- a/browser_tests/tests/autoReloadPersistence.spec.ts
+++ b/browser_tests/tests/autoReloadPersistence.spec.ts
@@ -1,0 +1,180 @@
+import { expect } from '@playwright/test'
+import type { Page, Request } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type {
+  AutoReloadResponse,
+  UpdateAutoReloadRequest,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
+
+import {
+  cloudAppFixture as test,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
+import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const workspaces = [
+  {
+    id: 'ws-personal',
+    name: 'Personal Workspace',
+    type: 'personal',
+    role: 'owner',
+    created_at: '2026-01-01T00:00:00Z',
+    joined_at: '2026-01-01T00:00:00Z'
+  },
+  {
+    id: 'ws-team',
+    name: 'My Team',
+    type: 'team',
+    role: 'owner',
+    created_at: '2026-01-02T00:00:00Z',
+    joined_at: '2026-01-02T00:00:00Z'
+  }
+] satisfies WorkspaceWithRole[]
+
+const persistedByWorkspace: Record<string, AutoReloadResponse> = {
+  'ws-personal': {
+    configured: true,
+    enabled: true,
+    threshold_credits: 1000,
+    reload_credits: 5000,
+    monthly_budget_cents: 50_000,
+    spent_this_cycle_cents: 2500
+  },
+  'ws-team': {
+    configured: true,
+    enabled: true,
+    threshold_credits: 3000,
+    reload_credits: 7000,
+    monthly_budget_cents: null,
+    spent_this_cycle_cents: 0
+  }
+}
+
+function workspaceIdFromAuth(request: Request) {
+  const authorization = request.headers().authorization
+  expect(authorization).toMatch(/^Bearer (mock-workspace-token|token-ws-)/)
+  return authorization === 'Bearer token-ws-team' ? 'ws-team' : 'ws-personal'
+}
+
+async function openWorkspaceSettings(page: Page) {
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const dialog = page.getByTestId('settings-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('nav').getByRole('button', { name: 'Workspace' }).click()
+  return dialog
+}
+
+test.describe('Auto-reload persistence', { tag: '@cloud' }, () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCloudBoot(page, {
+      features: {
+        team_workspaces_enabled: true,
+        billing_control_enabled: true
+      } satisfies RemoteConfig,
+      settings: {
+        'Comfy.Assets.UseAssetAPI': false,
+        'Comfy.TutorialCompleted': true
+      }
+    })
+    await mockBilling(page)
+    await bootCloud(page)
+
+    await page.route('**/api/workspaces', (route) =>
+      route.fulfill(jsonRoute({ workspaces }))
+    )
+    await page.route('**/api/auth/token', async (route) => {
+      const body = JSON.parse(route.request().postData() ?? '{}') as {
+        workspace_id?: string
+      }
+      const workspaceId = body.workspace_id ?? 'ws-personal'
+      const selected = workspaces.find(({ id }) => id === workspaceId)!
+      const response: WorkspaceTokenResponse = {
+        token: `token-${workspaceId}`,
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        workspace: {
+          id: selected.id,
+          name: selected.name,
+          type: selected.type
+        },
+        role: selected.role,
+        permissions: []
+      }
+      await route.fulfill(jsonRoute(response))
+    })
+    await page.route('**/api/workspace/members**', (route) =>
+      route.fulfill(
+        jsonRoute({
+          members: [],
+          pagination: { offset: 0, limit: 50, total: 0 }
+        })
+      )
+    )
+    await page.route('**/api/billing/auto-reload', async (route) => {
+      const request = route.request()
+      const workspaceId = workspaceIdFromAuth(request)
+      if (request.method() === 'GET') {
+        await route.fulfill(jsonRoute(persistedByWorkspace[workspaceId]))
+        return
+      }
+
+      expect(request.method()).toBe('PUT')
+      const payload = JSON.parse(
+        request.postData() ?? '{}'
+      ) as UpdateAutoReloadRequest
+      expect(payload).toEqual({
+        enabled: false,
+        threshold_credits: 1000,
+        reload_credits: 5000,
+        monthly_budget_cents: 50_000
+      })
+      persistedByWorkspace[workspaceId] = {
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: 2500
+      }
+      await route.fulfill(jsonRoute(persistedByWorkspace[workspaceId]))
+    })
+
+    await page.goto(APP_URL)
+    await waitForCloudApp(page)
+  })
+
+  test('uses authenticated GET/PUT and rehydrates after reload and workspace switch', async ({
+    page
+  }) => {
+    test.setTimeout(90_000)
+    let dialog = await openWorkspaceSettings(page)
+    await expect(dialog.getByText('5,000', { exact: true })).toBeVisible()
+
+    await dialog
+      .getByRole('switch', { name: 'Enable credit auto-reload' })
+      .click()
+    await expect(dialog.getByText('Off', { exact: true })).toBeVisible()
+
+    await page.reload()
+    await waitForCloudApp(page)
+    dialog = await openWorkspaceSettings(page)
+    await expect(dialog.getByText('Off', { exact: true })).toBeVisible()
+    await expect(dialog.getByText('5,000', { exact: true })).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByText('Personal Workspace', { exact: true }).click()
+    await page.getByText('My Team', { exact: true }).click()
+    await waitForCloudApp(page)
+
+    dialog = await openWorkspaceSettings(page)
+    await expect(dialog.getByText('7,000', { exact: true })).toBeVisible()
+    await expect(dialog.getByText('Enabled', { exact: true })).toBeVisible()
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2946,6 +2946,9 @@
         "cta": "Set up auto-reload"
       },
       "enabled": "Enabled",
+      "loadFailed": "Auto-reload settings couldn't be loaded.",
+      "loading": "Loading auto-reload settings…",
+      "retry": "Try again",
       "subtitle": "Automatically add credits when your balance runs low, within an optional monthly budget.",
       "tile": {
         "label": "Auto-reload",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -8,6 +8,7 @@ const {
   mockAxiosInstance: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     patch: vi.fn(),
     delete: vi.fn(),
     interceptors: { response: { use: vi.fn() } }
@@ -294,6 +295,15 @@ describe('workspaceApi', () => {
   })
 
   describe('billing', () => {
+    const autoReload = {
+      configured: true,
+      enabled: true,
+      threshold_credits: 1000,
+      reload_credits: 5000,
+      monthly_budget_cents: 50_000,
+      spent_this_cycle_cents: 2500
+    }
+
     it('getBillingStatus() sends GET /billing/status', async () => {
       const data = { is_active: true, has_funds: true }
       mockAxiosInstance.get.mockResolvedValue({ data })
@@ -322,6 +332,60 @@ describe('workspaceApi', () => {
         }
       )
       expect(result).toEqual(data)
+    })
+
+    it('getAutoReload() sends authenticated GET /billing/auto-reload', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: autoReload })
+
+      const result = await workspaceApi.getAutoReload()
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/billing/auto-reload',
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(autoReload)
+    })
+
+    it('updateAutoReload() sends the exact authenticated PUT payload', async () => {
+      const payload = {
+        enabled: false,
+        threshold_credits: 2000,
+        reload_credits: 6000,
+        monthly_budget_cents: null
+      }
+      mockAxiosInstance.put.mockResolvedValue({
+        data: { ...autoReload, ...payload }
+      })
+
+      const result = await workspaceApi.updateAutoReload(payload)
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+        '/api/billing/auto-reload',
+        payload,
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual({ ...autoReload, ...payload })
+    })
+
+    it('updateAutoReload() wraps API errors', async () => {
+      mockAxiosInstance.put.mockRejectedValue({
+        isAxiosError: true,
+        response: { status: 503, data: { message: 'Unavailable' } },
+        message: 'Request failed'
+      })
+
+      await expect(
+        workspaceApi.updateAutoReload({
+          enabled: true,
+          threshold_credits: 1000,
+          reload_credits: 5000,
+          monthly_budget_cents: null
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkspaceApiError',
+        status: 503,
+        message: 'Unavailable'
+      })
     })
 
     it('getBillingPlans() sends GET /billing/plans', async () => {

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -309,6 +309,22 @@ export interface BillingOpStatusResponse {
   completed_at?: string
 }
 
+export interface AutoReloadResponse {
+  configured: boolean
+  enabled: boolean
+  threshold_credits: number | null
+  reload_credits: number | null
+  monthly_budget_cents: number | null
+  spent_this_cycle_cents: number
+}
+
+export interface UpdateAutoReloadRequest {
+  enabled: boolean
+  threshold_credits: number
+  reload_credits: number
+  monthly_budget_cents: number | null
+}
+
 interface BillingEvent {
   event_type: string
   event_id: string
@@ -599,6 +615,35 @@ export const workspaceApi = {
     try {
       const response = await workspaceApiClient.get<BillingBalanceResponse>(
         api.apiURL('/billing/balance'),
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async getAutoReload(): Promise<AutoReloadResponse> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.get<AutoReloadResponse>(
+        api.apiURL('/billing/auto-reload'),
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async updateAutoReload(
+    payload: UpdateAutoReloadRequest
+  ): Promise<AutoReloadResponse> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.put<AutoReloadResponse>(
+        api.apiURL('/billing/auto-reload'),
+        payload,
         { headers }
       )
       return response.data

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
@@ -15,6 +15,14 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 const dialogStoreMocks = vi.hoisted(() => ({
   closeDialog: vi.fn()
 }))
+const mockWorkspaceApi = vi.hoisted(() => ({
+  getAutoReload: vi.fn(),
+  updateAutoReload: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: mockWorkspaceApi
+}))
 
 const mockCanAccess = ref(true)
 const mockAccessFrozen = ref(false)
@@ -64,11 +72,28 @@ function setConfig(overrides: Partial<AutoReloadConfig> = {}) {
 }
 
 describe('AutoReloadDialogContent', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await autoReload.scopeToWorkspace(null)
+    vi.resetAllMocks()
     dialogStoreMocks.closeDialog.mockReset()
     mockCanAccess.value = true
     mockAccessFrozen.value = false
-    autoReload.scopeToWorkspace('workspace-a')
+    mockWorkspaceApi.getAutoReload.mockResolvedValue({
+      configured: false,
+      enabled: false,
+      threshold_credits: null,
+      reload_credits: null,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 0
+    })
+    mockWorkspaceApi.updateAutoReload.mockImplementation((payload) =>
+      Promise.resolve({
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: autoReload.config.spentThisCycleCents
+      })
+    )
+    await autoReload.scopeToWorkspace('workspace-a')
     setConfig()
   })
 
@@ -323,6 +348,23 @@ describe('AutoReloadDialogContent', () => {
     expect(dialogStoreMocks.closeDialog).toHaveBeenCalledWith({
       key: 'auto-reload'
     })
+  })
+
+  it('keeps the dialog open and persisted state unchanged after a failed update', async () => {
+    const user = userEvent.setup()
+    setConfig({ configured: true, enabled: false, thresholdCredits: 2500 })
+    const before = { ...autoReload.config }
+    mockWorkspaceApi.updateAutoReload.mockRejectedValueOnce(
+      new Error('Unable to save')
+    )
+    renderDialog()
+    dialogStoreMocks.closeDialog.mockClear()
+
+    await user.click(screen.getByRole('button', { name: 'Update' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to save')
+    expect(dialogStoreMocks.closeDialog).not.toHaveBeenCalled()
+    expect({ ...autoReload.config }).toEqual(before)
   })
 
   it('keeps Update disabled when the threshold is empty', async () => {

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
@@ -211,13 +211,16 @@
         </ToggleGroupItem>
       </ToggleGroup>
       <div class="flex items-center gap-4">
+        <span v-if="error" role="alert" class="text-danger text-sm">
+          {{ error }}
+        </span>
         <Button variant="muted-textonly" size="lg" @click="onClose">
           {{ $t('workspacePanel.autoReload.dialog.cancel') }}
         </Button>
         <Button
           variant="secondary"
           size="lg"
-          :disabled="!canUpdate"
+          :disabled="!canUpdate || isMutating"
           @click="onUpdate"
         >
           {{ $t('workspacePanel.autoReload.dialog.update') }}
@@ -255,13 +258,13 @@ import { storeToRefs } from 'pinia'
 const { t, n: fmtNumber, locale } = useI18n()
 const { workspaceId } = defineProps<{ workspaceId: string | null }>()
 const dialogStore = useDialogStore()
-const { config, save, scopeToWorkspace } = useAutoReload()
+const { config, error, isMutating, save, scopeToWorkspace } = useAutoReload()
 const { activeWorkspaceId } = storeToRefs(useTeamWorkspaceStore())
 const { canConfigure } = useAutoReloadAccess()
 const canConfigureWorkspace = computed(
   () => canConfigure.value && activeWorkspaceId.value === workspaceId
 )
-scopeToWorkspace(activeWorkspaceId.value)
+void scopeToWorkspace(activeWorkspaceId.value)
 
 type Unit = 'credits' | 'usd'
 const unitOptions: Unit[] = ['credits', 'usd']
@@ -508,7 +511,7 @@ function onClose() {
 }
 
 watch(activeWorkspaceId, (workspaceId) => {
-  scopeToWorkspace(workspaceId)
+  void scopeToWorkspace(workspaceId)
   onClose()
 })
 
@@ -520,18 +523,22 @@ watch(
   { immediate: true }
 )
 
-function onUpdate() {
+async function onUpdate() {
   if (!canConfigureWorkspace.value) {
     onClose()
     return
   }
   if (!canUpdate.value) return
-  save({
+  const saved = await save({
     thresholdCredits: thresholdCredits.value,
     reloadCredits: reloadCredits.value,
     monthlyBudgetCents:
       budgetEnabled.value && budgetCents.value > 0 ? budgetCents.value : null
   })
-  onClose()
+    .then(() => true)
+    .catch(() => false)
+  if (saved) {
+    onClose()
+  }
 }
 </script>

--- a/src/platform/workspace/components/dialogs/settings/AutoReloadSection.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/AutoReloadSection.test.ts
@@ -13,6 +13,14 @@ import type { AutoReloadConfig } from '@/platform/workspace/composables/useAutoR
 const dialogMocks = vi.hoisted(() => ({
   showAutoReloadDialog: vi.fn()
 }))
+const mockWorkspaceApi = vi.hoisted(() => ({
+  getAutoReload: vi.fn(),
+  updateAutoReload: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: mockWorkspaceApi
+}))
 
 const mockCanAccess = ref(true)
 const mockAccessFrozen = ref(false)
@@ -62,11 +70,28 @@ function setConfig(overrides: Partial<AutoReloadConfig> = {}) {
 }
 
 describe('AutoReloadSection', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await autoReload.scopeToWorkspace(null)
+    vi.resetAllMocks()
     dialogMocks.showAutoReloadDialog.mockReset()
     mockCanAccess.value = true
     mockAccessFrozen.value = false
-    autoReload.scopeToWorkspace('workspace-a')
+    mockWorkspaceApi.getAutoReload.mockResolvedValue({
+      configured: false,
+      enabled: false,
+      threshold_credits: null,
+      reload_credits: null,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 0
+    })
+    mockWorkspaceApi.updateAutoReload.mockImplementation((payload) =>
+      Promise.resolve({
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: autoReload.config.spentThisCycleCents
+      })
+    )
+    await autoReload.scopeToWorkspace('workspace-a')
     setConfig({ configured: false, enabled: false, monthlyBudgetCents: null })
   })
 
@@ -220,6 +245,6 @@ describe('AutoReloadSection', () => {
     await nextTick()
 
     expect(autoReload.config.configured).toBe(false)
-    expect(screen.getByText('Set up auto-reload')).toBeInTheDocument()
+    expect(await screen.findByText('Set up auto-reload')).toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
+++ b/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
@@ -27,7 +27,7 @@
           <Switch
             :model-value="displayEnabled"
             class="disabled:opacity-100"
-            :disabled="frozen"
+            :disabled="frozen || isMutating"
             :aria-label="$t('workspacePanel.autoReload.toggleLabel')"
             @update:model-value="handleEnabledChange"
           />
@@ -44,7 +44,30 @@
       </div>
     </div>
 
-    <div v-if="!isConfigured" class="grid grid-cols-1 gap-4 @4xl:grid-cols-2">
+    <p v-if="error" role="alert" class="text-danger m-0 text-sm">
+      {{ error }}
+    </p>
+
+    <div v-if="isLoading" role="status" class="text-sm text-muted-foreground">
+      {{ $t('workspacePanel.autoReload.loading') }}
+    </div>
+
+    <div
+      v-else-if="!isInitialized"
+      class="flex items-center justify-between gap-4"
+    >
+      <span class="text-sm text-muted-foreground">
+        {{ $t('workspacePanel.autoReload.loadFailed') }}
+      </span>
+      <Button variant="secondary" size="lg" @click="retry">
+        {{ $t('workspacePanel.autoReload.retry') }}
+      </Button>
+    </div>
+
+    <div
+      v-else-if="!isConfigured"
+      class="grid grid-cols-1 gap-4 @4xl:grid-cols-2"
+    >
       <div
         class="flex flex-col gap-3 rounded-xl bg-modal-panel-background px-6 py-5"
       >
@@ -160,14 +183,21 @@ const {
   budgetUsedFraction,
   isPaused,
   isWarning,
+  isInitialized,
+  isLoading,
+  isMutating,
+  error,
   setEnabled,
-  scopeToWorkspace
+  scopeToWorkspace,
+  retry
 } = useAutoReload()
 const { activeWorkspaceId } = storeToRefs(useTeamWorkspaceStore())
 const { canConfigureNow } = useAutoReloadAccess()
 
-scopeToWorkspace(activeWorkspaceId.value)
-watch(activeWorkspaceId, scopeToWorkspace)
+void scopeToWorkspace(activeWorkspaceId.value)
+watch(activeWorkspaceId, (workspaceId) => {
+  void scopeToWorkspace(workspaceId)
+})
 
 const displayEnabled = computed(() => !frozen && isEnabled.value)
 let isAlive = true
@@ -190,9 +220,9 @@ function openConfig() {
   })
 }
 
-function handleEnabledChange(value: boolean) {
+async function handleEnabledChange(value: boolean) {
   if (frozen || !canConfigureNow()) return
-  setEnabled(value)
+  await setEnabled(value).catch(() => undefined)
 }
 
 function fmtCredits(value: number) {

--- a/src/platform/workspace/composables/useAutoReload.test.ts
+++ b/src/platform/workspace/composables/useAutoReload.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockWorkspaceApi = vi.hoisted(() => ({
+  getAutoReload: vi.fn(),
+  updateAutoReload: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: mockWorkspaceApi
+}))
 
 import {
   deriveAutoReloadState,
@@ -158,49 +167,210 @@ describe('deriveAutoReloadState', () => {
 
 describe('useAutoReload', () => {
   const autoReload = useAutoReload()
+  const unconfiguredResponse = {
+    configured: false,
+    enabled: false,
+    threshold_credits: null,
+    reload_credits: null,
+    monthly_budget_cents: null,
+    spent_this_cycle_cents: 0
+  }
 
-  beforeEach(() => {
-    Object.assign(autoReload.config, {
+  beforeEach(async () => {
+    await autoReload.scopeToWorkspace(null)
+    vi.resetAllMocks()
+    mockWorkspaceApi.getAutoReload.mockResolvedValue(unconfiguredResponse)
+  })
+
+  it('maps the persisted six-field configuration', async () => {
+    mockWorkspaceApi.getAutoReload.mockResolvedValue({
+      configured: true,
+      enabled: true,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: 25_000,
+      spent_this_cycle_cents: 1200
+    })
+
+    await autoReload.scopeToWorkspace('workspace-a')
+
+    expect(autoReload.config).toEqual({
+      configured: true,
+      enabled: true,
+      thresholdCredits: 2000,
+      reloadCredits: 6000,
+      monthlyBudgetCents: 25_000,
+      spentThisCycleCents: 1200
+    })
+    expect(autoReload.isInitialized.value).toBe(true)
+    expect(autoReload.isLoading.value).toBe(false)
+  })
+
+  it('uses setup defaults only for an unconfigured response', async () => {
+    await autoReload.scopeToWorkspace('workspace-a')
+
+    expect(autoReload.config).toEqual({
       configured: false,
       enabled: false,
       thresholdCredits: 1000,
       reloadCredits: 5000,
       monthlyBudgetCents: null,
       spentThisCycleCents: 0
-    } satisfies AutoReloadConfig)
+    })
   })
 
-  it('saves a configuration and enables auto-reload', () => {
-    autoReload.save({
-      thresholdCredits: 2000,
-      reloadCredits: 6000,
-      monthlyBudgetCents: 25_000
+  it('retries the initial read once before succeeding', async () => {
+    mockWorkspaceApi.getAutoReload
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockResolvedValueOnce(unconfiguredResponse)
+
+    await autoReload.scopeToWorkspace('workspace-a')
+
+    expect(mockWorkspaceApi.getAutoReload).toHaveBeenCalledTimes(2)
+    expect(autoReload.isInitialized.value).toBe(true)
+    expect(autoReload.error.value).toBeNull()
+  })
+
+  it('exposes a terminal read error and supports a successful retry', async () => {
+    mockWorkspaceApi.getAutoReload.mockRejectedValue(new Error('offline'))
+
+    await autoReload.scopeToWorkspace('workspace-a')
+
+    expect(mockWorkspaceApi.getAutoReload).toHaveBeenCalledTimes(2)
+    expect(autoReload.isInitialized.value).toBe(false)
+    expect(autoReload.error.value).toBe('offline')
+
+    mockWorkspaceApi.getAutoReload.mockResolvedValue(unconfiguredResponse)
+    await autoReload.retry()
+
+    expect(autoReload.isInitialized.value).toBe(true)
+    expect(autoReload.error.value).toBeNull()
+  })
+
+  it('ignores a late response from the previous workspace', async () => {
+    let resolveOlder!: (value: typeof unconfiguredResponse) => void
+    const older = new Promise<typeof unconfiguredResponse>((resolve) => {
+      resolveOlder = resolve
     })
+    mockWorkspaceApi.getAutoReload
+      .mockReturnValueOnce(older)
+      .mockResolvedValueOnce({
+        ...unconfiguredResponse,
+        configured: true,
+        enabled: true,
+        threshold_credits: 3000,
+        reload_credits: 7000
+      })
+
+    const firstLoad = autoReload.scopeToWorkspace('workspace-a')
+    const secondLoad = autoReload.scopeToWorkspace('workspace-b')
+    await secondLoad
+    resolveOlder(unconfiguredResponse)
+    await firstLoad
 
     expect(autoReload.config).toMatchObject({
+      configured: true,
+      thresholdCredits: 3000,
+      reloadCredits: 7000
+    })
+  })
+
+  it('saves the exact payload and applies the canonical response', async () => {
+    await autoReload.scopeToWorkspace('workspace-a')
+    mockWorkspaceApi.updateAutoReload.mockResolvedValue({
       configured: true,
       enabled: true,
+      threshold_credits: 2100,
+      reload_credits: 6100,
+      monthly_budget_cents: 26_000,
+      spent_this_cycle_cents: 500
+    })
+
+    await autoReload.save({
       thresholdCredits: 2000,
       reloadCredits: 6000,
       monthlyBudgetCents: 25_000
     })
+
+    expect(mockWorkspaceApi.updateAutoReload).toHaveBeenCalledWith({
+      enabled: true,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: 25_000
+    })
+    expect(autoReload.config).toEqual({
+      configured: true,
+      enabled: true,
+      thresholdCredits: 2100,
+      reloadCredits: 6100,
+      monthlyBudgetCents: 26_000,
+      spentThisCycleCents: 500
+    })
   })
 
-  it('updates the enabled state without discarding the configuration', () => {
-    autoReload.save({
-      thresholdCredits: 2000,
-      reloadCredits: 6000,
-      monthlyBudgetCents: null
-    })
-
-    autoReload.setEnabled(false)
-
-    expect(autoReload.isEnabled.value).toBe(false)
-    expect(autoReload.config).toMatchObject({
+  it('disables with retained settings and applies the canonical response', async () => {
+    mockWorkspaceApi.getAutoReload.mockResolvedValue({
       configured: true,
+      enabled: true,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 400
+    })
+    await autoReload.scopeToWorkspace('workspace-a')
+    mockWorkspaceApi.updateAutoReload.mockResolvedValue({
+      configured: true,
+      enabled: false,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 400
+    })
+
+    await autoReload.setEnabled(false)
+
+    expect(mockWorkspaceApi.updateAutoReload).toHaveBeenCalledWith({
+      enabled: false,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: null
+    })
+    expect(autoReload.isEnabled.value).toBe(false)
+  })
+
+  it('keeps persisted state after a failed PUT and succeeds when retried', async () => {
+    await autoReload.scopeToWorkspace('workspace-a')
+    const before = { ...autoReload.config }
+    mockWorkspaceApi.updateAutoReload.mockRejectedValueOnce(
+      new Error('save failed')
+    )
+
+    await expect(
+      autoReload.save({
+        thresholdCredits: 2000,
+        reloadCredits: 6000,
+        monthlyBudgetCents: null
+      })
+    ).rejects.toThrow('save failed')
+
+    expect({ ...autoReload.config }).toEqual(before)
+    expect(autoReload.error.value).toBe('save failed')
+
+    mockWorkspaceApi.updateAutoReload.mockResolvedValue({
+      configured: true,
+      enabled: true,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 0
+    })
+    await autoReload.save({
       thresholdCredits: 2000,
       reloadCredits: 6000,
       monthlyBudgetCents: null
     })
+
+    expect(autoReload.config.configured).toBe(true)
+    expect(autoReload.error.value).toBeNull()
   })
 })

--- a/src/platform/workspace/composables/useAutoReload.ts
+++ b/src/platform/workspace/composables/useAutoReload.ts
@@ -1,6 +1,11 @@
-import { computed, reactive } from 'vue'
+import { computed, reactive, ref } from 'vue'
 
 import { creditsToCents } from '@/base/credits/comfyCredits'
+import type {
+  AutoReloadResponse,
+  UpdateAutoReloadRequest
+} from '@/platform/workspace/api/workspaceApi'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 export interface AutoReloadConfig {
   configured: boolean
@@ -89,19 +94,103 @@ function createDefaultConfig(): AutoReloadConfig {
   }
 }
 
-// No production auto-reload endpoint exists yet. This state intentionally
-// starts unconfigured and does not imply persistence across a page reload.
 const config = reactive<AutoReloadConfig>(createDefaultConfig())
+const isInitialized = ref(false)
+const isLoading = ref(false)
+const isMutating = ref(false)
+const error = ref<string | null>(null)
 let scopedWorkspaceId: string | null | undefined
+let latestReadId = 0
+let latestMutationId = 0
+
+function mapAutoReloadResponse(response: AutoReloadResponse): AutoReloadConfig {
+  if (!response.configured) return createDefaultConfig()
+
+  return {
+    configured: true,
+    enabled: response.enabled,
+    thresholdCredits: response.threshold_credits ?? 0,
+    reloadCredits: response.reload_credits ?? 0,
+    monthlyBudgetCents: response.monthly_budget_cents,
+    spentThisCycleCents: response.spent_this_cycle_cents
+  }
+}
+
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error ? err.message : fallback
+}
 
 function resetConfig() {
   Object.assign(config, createDefaultConfig())
 }
 
-function scopeToWorkspace(workspaceId: string | null) {
-  if (scopedWorkspaceId === workspaceId) return
+async function load(workspaceId: string, requestId: number) {
+  isLoading.value = true
+  error.value = null
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const response = await workspaceApi.getAutoReload()
+      if (requestId !== latestReadId || scopedWorkspaceId !== workspaceId)
+        return
+
+      Object.assign(config, mapAutoReloadResponse(response))
+      isInitialized.value = true
+      isLoading.value = false
+      return
+    } catch (err) {
+      if (requestId !== latestReadId || scopedWorkspaceId !== workspaceId)
+        return
+      if (attempt === 0) continue
+
+      error.value = errorMessage(err, 'Failed to load auto-reload settings')
+      isLoading.value = false
+    }
+  }
+}
+
+function scopeToWorkspace(workspaceId: string | null): Promise<void> {
+  if (scopedWorkspaceId === workspaceId) return Promise.resolve()
   scopedWorkspaceId = workspaceId
+  latestReadId++
+  latestMutationId++
   resetConfig()
+  isInitialized.value = false
+  isLoading.value = false
+  isMutating.value = false
+  error.value = null
+
+  if (workspaceId === null) return Promise.resolve()
+  return load(workspaceId, latestReadId)
+}
+
+function retry(): Promise<void> {
+  if (scopedWorkspaceId == null) return Promise.resolve()
+  return load(scopedWorkspaceId, ++latestReadId)
+}
+
+async function update(payload: UpdateAutoReloadRequest): Promise<void> {
+  const workspaceId = scopedWorkspaceId
+  if (workspaceId == null) throw new Error('No active workspace')
+
+  const mutationId = ++latestMutationId
+  isMutating.value = true
+  error.value = null
+  try {
+    const response = await workspaceApi.updateAutoReload(payload)
+    if (mutationId === latestMutationId && scopedWorkspaceId === workspaceId) {
+      Object.assign(config, mapAutoReloadResponse(response))
+    }
+  } catch (err) {
+    if (mutationId === latestMutationId && scopedWorkspaceId === workspaceId) {
+      error.value = errorMessage(err, 'Failed to save auto-reload settings')
+    }
+    throw err
+  } finally {
+    if (mutationId === latestMutationId && scopedWorkspaceId === workspaceId) {
+      isMutating.value = false
+    }
+  }
 }
 
 export function useAutoReload() {
@@ -118,20 +207,30 @@ export function useAutoReload() {
   const isPaused = computed(() => state.value.isPaused)
   const isWarning = computed(() => state.value.isWarning)
 
-  function setEnabled(value: boolean) {
-    config.enabled = value
+  async function setEnabled(value: boolean) {
+    await update({
+      enabled: value,
+      threshold_credits: config.thresholdCredits,
+      reload_credits: config.reloadCredits,
+      monthly_budget_cents: config.monthlyBudgetCents
+    })
   }
 
-  function save(next: AutoReloadSettings) {
-    config.configured = true
-    config.enabled = true
-    config.thresholdCredits = next.thresholdCredits
-    config.reloadCredits = next.reloadCredits
-    config.monthlyBudgetCents = next.monthlyBudgetCents
+  async function save(next: AutoReloadSettings) {
+    await update({
+      enabled: true,
+      threshold_credits: next.thresholdCredits,
+      reload_credits: next.reloadCredits,
+      monthly_budget_cents: next.monthlyBudgetCents
+    })
   }
 
   return {
     config,
+    isInitialized,
+    isLoading,
+    isMutating,
+    error,
     isConfigured,
     isEnabled,
     hasBudget,
@@ -145,6 +244,7 @@ export function useAutoReload() {
     isWarning,
     setEnabled,
     save,
-    scopeToWorkspace
+    scopeToWorkspace,
+    retry
   }
 }


### PR DESCRIPTION
## Summary

Connects the auto-reload settings UI to the authenticated workspace GET/PUT API while preserving the existing six-field state and interactions.

## Changes

- **What**: Adds exact `/api/billing/auto-reload` wire types and client methods; retries the initial read once; isolates stale workspace responses; applies only canonical PUT responses; exposes loading, error, and retry UI; adds focused unit and Playwright coverage.
- **Dependencies**: Stacked on #13762. Keep `billing_control_enabled` disabled until cloud schema, billing-api, ingest, and Gateway rollout is complete.

## Review Focus

Verify the public PUT contains only `enabled`, `threshold_credits`, `reload_credits`, and `monthly_budget_cents`, and that workspace changes invalidate late GET/PUT responses without process-local fallback.

## Validation

- `pnpm test:unit src/platform/workspace/api/workspaceApi.test.ts src/platform/workspace/composables/useAutoReload.test.ts src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts src/platform/workspace/components/dialogs/settings/AutoReloadSection.test.ts`
- `pnpm test:browser:local browser_tests/tests/autoReloadPersistence.spec.ts` against `pnpm dev:cloud`
- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm lint:unstaged`
- `pnpm format:check`
