### PR TITLE
fix(onboarding): emit tour step_shown once per step, not on back-navigation

### DIFF
--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -436,6 +436,29 @@ describe('onboardingTourStore', () => {
     expect(store.step?.coachId).toBe('inputs-list')
   })
 
+  it('emits step_shown once per step, not again on back-navigation', async () => {
+    registerAppModeTargets()
+    const store = mountStore()
+    store.replayTour('appMode')
+    await nextTick()
+
+    store.next() // landing -> inputs-list
+    await nextTick()
+    store.next() // inputs-list -> app-run-button
+    await nextTick()
+    store.back() // back to inputs-list (already seen)
+    await nextTick()
+    store.next() // forward to app-run-button again (already seen)
+    await nextTick()
+
+    const shownFor = (coachId: CoachId) =>
+      telemetry.track.mock.calls.filter(
+        ([stage, meta]) => stage === 'step_shown' && meta?.coach_id === coachId
+      )
+    expect(shownFor('inputs-list')).toHaveLength(1)
+    expect(shownFor('app-run-button')).toHaveLength(1)
+  })
+
   it('reports step index 0 while no tour is active', () => {
     const store = mountStore()
     expect(store.countedStepIdx).toBe(0)

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -88,6 +88,10 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
   const backLabel = computed(() => t('onboardingCoachmarks.back'))
 
+  // step_shown is a per-step impression — it fires the first time each step is
+  // reached in a run, not again on back-navigation (which re-enters showStep).
+  const shownStepIndices = new Set<number>()
+
   async function showStep(idx: number) {
     const nextStep = steps.value[idx]
     if (!nextStep) return
@@ -127,7 +131,10 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
       }
     }
     stepIdx.value = idx
-    trackTour('step_shown')
+    if (!shownStepIndices.has(idx)) {
+      shownStepIndices.add(idx)
+      trackTour('step_shown')
+    }
   }
 
   function openSidebarTab(tabId: string) {
@@ -199,6 +206,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     if (!resolved.length) return
     steps.value = resolved
     activeTour.value = entryPath
+    shownStepIndices.clear()
     trackTour('started')
     void showStep(0)
   }


### PR DESCRIPTION
## Summary

The onboarding tour's `step_shown` telemetry double-counts a step's impression when the user navigates **back**: `back()` re-enters `showStep()`, which emitted `step_shown` unconditionally. This inflates the per-step onboarding funnel. (Surfaced in review of the graph-mode first-run tour stack, but the bug lives in the already-merged shared engine, so it also affects App mode — hence a standalone fix off `main`.)

## Changes

- **What**: `onboardingTourStore` now tracks the step indices already shown in the current tour run and emits `step_shown` only on the **first** entry to each step. `back()` (and any forward re-entry to a step already seen) no longer re-fires it. The set resets per run in `startTour`.
- Navigation behavior is unchanged — `showStep` still renders the step on back-navigation; only the telemetry emit is gated.
- Applies to every tour on the shared engine (App mode + the graph-mode first-run tour).

## Review Focus

- Only the `trackTour('step_shown')` emit is gated behind the seen-set; the visual step transition is untouched.
- Regression test added: `step_shown` fires exactly once for each step across `next → next → back → next`.
