### PR TITLE
[backport cloud/1.47] feat: add workflow context to RUM events

### DIFF
--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -517,7 +517,7 @@ export function useCoreCommands(): ComfyCommand[] {
 
         useTelemetry()?.trackWorkflowExecution()
 
-        await app.queuePrompt(0, batchCount)
+        await app.queuePrompt(0, batchCount, { intent: metadata })
       }
     },
     {
@@ -540,7 +540,7 @@ export function useCoreCommands(): ComfyCommand[] {
 
         useTelemetry()?.trackWorkflowExecution()
 
-        await app.queuePrompt(-1, batchCount)
+        await app.queuePrompt(-1, batchCount, { intent: metadata })
       }
     },
     {
@@ -584,7 +584,10 @@ export function useCoreCommands(): ComfyCommand[] {
           return
         }
         useTelemetry()?.trackWorkflowExecution()
-        await app.queuePrompt(0, batchCount, executionIds)
+        await app.queuePrompt(0, batchCount, {
+          queueNodeIds: executionIds,
+          intent: metadata
+        })
       }
     },
     {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -11,33 +11,182 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: { addDurationVital, getInternalContext }
 }))
 
+const workflowExecutionIntent = {
+  trigger_source: 'keybinding'
+} as const
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
 describe('DatadogRumTelemetryProvider', () => {
-  it.for(['success', 'failure'] as const)(
-    'records a workflow vital with a %s outcome',
-    (outcome) => {
-      getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
-      vi.spyOn(performance, 'now').mockReturnValue(142)
+  it('records one successful workflow vital with every stage', () => {
+    getInternalContext.mockReturnValue({ view: { id: 'view-a' } })
 
-      new DatadogRumTelemetryProvider().trackExecutionOutcome({
+    new DatadogRumTelemetryProvider().trackExecutionOutcome({
+      startTime: 42,
+      submissionAcceptedAt: 62,
+      executionStartedAt: 92,
+      endTime: 142,
+      success: true,
+      failureReason: '',
+      ...workflowExecutionIntent,
+      workflowContext: {
+        workflow_type: 'custom',
+        view_mode: 'graph',
+        execution_scope: 'full',
+        total_node_count: 42,
+        executable_node_count: 12,
+        custom_node_count: 3,
+        api_node_count: 1,
+        subgraph_count: 2
+      }
+    })
+
+    expect(getInternalContext).toHaveBeenCalledWith(42)
+    expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
+      startTime: performance.timeOrigin + 42,
+      duration: 100,
+      context: {
+        api_node_count: 1,
+        custom_node_count: 3,
+        executable_node_count: 12,
+        execution_duration_ms: 50,
+        execution_scope: 'full',
+        execution_started_at_unix_ms: performance.timeOrigin + 92,
+        failure_reason: '',
+        origin_view_id: 'view-a',
+        queue_wait_duration_ms: 30,
+        submission_accepted_at_unix_ms: performance.timeOrigin + 62,
+        submission_duration_ms: 20,
+        subgraph_count: 2,
+        success: true,
+        terminal_stage: 'execution',
+        total_node_count: 42,
+        trigger_source: 'keybinding',
+        view_mode: 'graph',
+        workflow_ended_at_unix_ms: performance.timeOrigin + 142,
+        workflow_started_at_unix_ms: performance.timeOrigin + 42,
+        workflow_type: 'custom'
+      }
+    })
+  })
+
+  it.for([
+    {
+      name: 'submission',
+      metadata: {
         startTime: 42,
-        outcome
-      })
+        endTime: 62,
+        success: false,
+        failureReason: 'submission_rejected',
+        ...workflowExecutionIntent
+      },
+      duration: 20,
+      context: {
+        success: false,
+        failure_reason: 'submission_rejected',
+        terminal_stage: 'submission',
+        workflow_started_at_unix_ms: performance.timeOrigin + 42,
+        workflow_ended_at_unix_ms: performance.timeOrigin + 62,
+        submission_duration_ms: 20,
+        trigger_source: 'keybinding'
+      }
+    },
+    {
+      name: 'queue wait',
+      metadata: {
+        startTime: 42,
+        submissionAcceptedAt: 62,
+        endTime: 82,
+        success: false,
+        failureReason: 'execution_failed',
+        ...workflowExecutionIntent
+      },
+      duration: 40,
+      context: {
+        success: false,
+        failure_reason: 'execution_failed',
+        terminal_stage: 'queue_wait',
+        workflow_started_at_unix_ms: performance.timeOrigin + 42,
+        submission_accepted_at_unix_ms: performance.timeOrigin + 62,
+        workflow_ended_at_unix_ms: performance.timeOrigin + 82,
+        submission_duration_ms: 20,
+        queue_wait_duration_ms: 20,
+        trigger_source: 'keybinding'
+      }
+    },
+    {
+      name: 'execution',
+      metadata: {
+        startTime: 42,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: false,
+        failureReason: 'execution_failed',
+        ...workflowExecutionIntent
+      },
+      duration: 100,
+      context: {
+        success: false,
+        failure_reason: 'execution_failed',
+        terminal_stage: 'execution',
+        workflow_started_at_unix_ms: performance.timeOrigin + 42,
+        submission_accepted_at_unix_ms: performance.timeOrigin + 62,
+        execution_started_at_unix_ms: performance.timeOrigin + 92,
+        workflow_ended_at_unix_ms: performance.timeOrigin + 142,
+        submission_duration_ms: 20,
+        queue_wait_duration_ms: 30,
+        execution_duration_ms: 50,
+        trigger_source: 'keybinding'
+      }
+    }
+  ] as const)(
+    'records a failed workflow vital ending during $name',
+    ({ metadata, duration, context }) => {
+      getInternalContext.mockReturnValue(undefined)
 
-      expect(getInternalContext).toHaveBeenCalledWith(42)
+      new DatadogRumTelemetryProvider().trackExecutionOutcome(metadata)
+
       expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
         startTime: performance.timeOrigin + 42,
-        duration: 100,
-        context: {
-          origin_view_id: 'view-a',
-          outcome,
-          product: 'cloud_generation'
-        }
+        duration,
+        context
       })
     }
   )
+
+  it('keeps stage timestamps monotonic when execution finishes before the submission response', () => {
+    getInternalContext.mockReturnValue(undefined)
+
+    new DatadogRumTelemetryProvider().trackExecutionOutcome({
+      startTime: 42,
+      executionStartedAt: 52,
+      submissionAcceptedAt: 62,
+      endTime: 58,
+      success: false,
+      failureReason: 'execution_failed',
+      ...workflowExecutionIntent
+    })
+
+    expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
+      startTime: performance.timeOrigin + 42,
+      duration: 20,
+      context: {
+        success: false,
+        failure_reason: 'execution_failed',
+        terminal_stage: 'execution',
+        trigger_source: 'keybinding',
+        workflow_started_at_unix_ms: performance.timeOrigin + 42,
+        submission_accepted_at_unix_ms: performance.timeOrigin + 62,
+        execution_started_at_unix_ms: performance.timeOrigin + 62,
+        workflow_ended_at_unix_ms: performance.timeOrigin + 62,
+        submission_duration_ms: 20,
+        queue_wait_duration_ms: 0,
+        execution_duration_ms: 0
+      }
+    })
+  })
 })

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -5,15 +5,63 @@ import type { ExecutionOutcomeMetadata, TelemetryProvider } from '../../types'
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
   trackExecutionOutcome({
     startTime,
-    outcome
+    submissionAcceptedAt,
+    executionStartedAt,
+    endTime,
+    success,
+    failureReason,
+    workflowContext,
+    trigger_source
   }: ExecutionOutcomeMetadata): void {
     const originViewId = datadogRum.getInternalContext(startTime)?.view?.id
+    const submissionStageAcceptedAt =
+      submissionAcceptedAt === undefined
+        ? undefined
+        : Math.max(startTime, submissionAcceptedAt)
+    const executionStageStartedAt =
+      executionStartedAt === undefined
+        ? undefined
+        : Math.max(executionStartedAt, submissionStageAcceptedAt ?? startTime)
+    const workflowEndedAt = Math.max(
+      endTime,
+      executionStageStartedAt ?? submissionStageAcceptedAt ?? startTime
+    )
+    const terminalStage =
+      executionStageStartedAt !== undefined
+        ? 'execution'
+        : submissionAcceptedAt !== undefined
+          ? 'queue_wait'
+          : 'submission'
+
     datadogRum.addDurationVital('workflow_execution', {
       startTime: performance.timeOrigin + startTime,
-      duration: performance.now() - startTime,
+      duration: workflowEndedAt - startTime,
       context: {
-        outcome,
-        product: 'cloud_generation',
+        success,
+        failure_reason: failureReason,
+        terminal_stage: terminalStage,
+        trigger_source,
+        workflow_started_at_unix_ms: performance.timeOrigin + startTime,
+        ...(submissionStageAcceptedAt !== undefined && {
+          submission_accepted_at_unix_ms:
+            performance.timeOrigin + submissionStageAcceptedAt
+        }),
+        ...(executionStageStartedAt !== undefined && {
+          execution_started_at_unix_ms:
+            performance.timeOrigin + executionStageStartedAt
+        }),
+        workflow_ended_at_unix_ms: performance.timeOrigin + workflowEndedAt,
+        submission_duration_ms:
+          (submissionStageAcceptedAt ?? workflowEndedAt) - startTime,
+        ...(submissionStageAcceptedAt !== undefined && {
+          queue_wait_duration_ms:
+            (executionStageStartedAt ?? workflowEndedAt) -
+            submissionStageAcceptedAt
+        }),
+        ...(executionStageStartedAt !== undefined && {
+          execution_duration_ms: workflowEndedAt - executionStageStartedAt
+        }),
+        ...(workflowContext ?? {}),
         ...(originViewId && { origin_view_id: originViewId })
       }
     })

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -182,10 +182,51 @@ export interface ExecutionErrorMetadata {
   error?: string
 }
 
-export interface ExecutionOutcomeMetadata {
-  startTime: number
-  outcome: 'success' | 'failure'
+export interface WorkflowExecutionContext {
+  workflow_type: 'template' | 'custom'
+  view_mode: AppMode
+  execution_scope: 'full' | 'partial'
+  total_node_count: number
+  executable_node_count: number
+  custom_node_count: number
+  api_node_count: number
+  subgraph_count: number
 }
+
+export interface WorkflowQueueIntent {
+  trigger_source?: ExecutionTriggerSource
+}
+
+export interface WorkflowExecutionIntent {
+  trigger_source: ExecutionTriggerSource
+}
+
+export type WorkflowExecutionFailureReason =
+  | 'prompt_build_failed'
+  | 'submission_rejected'
+  | 'submission_failed'
+  | 'execution_failed'
+  | 'execution_interrupted'
+
+interface ExecutionOutcomeBaseMetadata extends WorkflowExecutionIntent {
+  startTime: number
+  submissionAcceptedAt?: number
+  executionStartedAt?: number
+  endTime: number
+  workflowContext?: WorkflowExecutionContext
+}
+
+export type ExecutionOutcomeMetadata = ExecutionOutcomeBaseMetadata &
+  (
+    | {
+        success: true
+        failureReason: ''
+      }
+    | {
+        success: false
+        failureReason: WorkflowExecutionFailureReason
+      }
+  )
 
 /**
  * Execution success metadata
@@ -982,12 +1023,25 @@ export const CANCELLATION_STAGE_EVENTS = {
   failed: TelemetryEvents.SUBSCRIPTION_CANCEL_FAILED
 } as const
 
-export type ExecutionTriggerSource =
-  | 'button'
-  | 'keybinding'
-  | 'legacy_ui'
-  | 'unknown'
-  | 'linear'
+const executionTriggerSources = [
+  'button',
+  'keybinding',
+  'legacy_ui',
+  'unknown',
+  'linear',
+  'auto_queue'
+] as const
+
+export type ExecutionTriggerSource = (typeof executionTriggerSources)[number]
+
+export function normalizeExecutionTriggerSource(
+  value: unknown
+): ExecutionTriggerSource {
+  return (
+    executionTriggerSources.find((triggerSource) => triggerSource === value) ??
+    'unknown'
+  )
+}
 
 /**
  * Union type for all possible telemetry event properties

--- a/src/platform/telemetry/utils/workflowExecutionContext.test.ts
+++ b/src/platform/telemetry/utils/workflowExecutionContext.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ExecutionContext } from '@/platform/telemetry/types'
+
+import { toWorkflowExecutionContext } from './workflowExecutionContext'
+
+const baseExecutionContext: ExecutionContext = {
+  is_template: false,
+  workflow_name: 'Private client workflow',
+  custom_node_count: 3,
+  api_node_count: 1,
+  subgraph_count: 2,
+  total_node_count: 42,
+  has_api_nodes: true,
+  api_node_names: ['PartnerNode'],
+  has_toolkit_nodes: false,
+  toolkit_node_names: [],
+  toolkit_node_count: 0
+}
+
+const baseOptions = {
+  executableNodeCount: 12,
+  executionScope: 'partial' as const,
+  viewMode: 'graph' as const
+}
+
+describe('toWorkflowExecutionContext', () => {
+  it('returns bounded workflow dimensions without workflow content', () => {
+    expect(
+      toWorkflowExecutionContext(baseExecutionContext, baseOptions)
+    ).toEqual({
+      workflow_type: 'custom',
+      view_mode: 'graph',
+      execution_scope: 'partial',
+      total_node_count: 42,
+      executable_node_count: 12,
+      custom_node_count: 3,
+      api_node_count: 1,
+      subgraph_count: 2
+    })
+  })
+
+  it('identifies template workflows', () => {
+    expect(
+      toWorkflowExecutionContext(
+        { ...baseExecutionContext, is_template: true },
+        baseOptions
+      ).workflow_type
+    ).toBe('template')
+  })
+})

--- a/src/platform/telemetry/utils/workflowExecutionContext.ts
+++ b/src/platform/telemetry/utils/workflowExecutionContext.ts
@@ -1,0 +1,31 @@
+import type {
+  ExecutionContext,
+  WorkflowExecutionContext
+} from '@/platform/telemetry/types'
+import type { AppMode } from '@/utils/appMode'
+
+interface WorkflowExecutionContextOptions {
+  executableNodeCount: number
+  executionScope: WorkflowExecutionContext['execution_scope']
+  viewMode: AppMode
+}
+
+export function toWorkflowExecutionContext(
+  executionContext: ExecutionContext,
+  {
+    executableNodeCount,
+    executionScope,
+    viewMode
+  }: WorkflowExecutionContextOptions
+): WorkflowExecutionContext {
+  return {
+    workflow_type: executionContext.is_template ? 'template' : 'custom',
+    view_mode: viewMode,
+    execution_scope: executionScope,
+    total_node_count: executionContext.total_node_count,
+    executable_node_count: executableNodeCount,
+    custom_node_count: executionContext.custom_node_count,
+    api_node_count: executionContext.api_node_count,
+    subgraph_count: executionContext.subgraph_count
+  }
+}

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -9,7 +9,7 @@ import type {
   ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
-import { ComfyApp } from './app'
+import { ComfyApp, app as singletonApp } from './app'
 import { createNode } from '@/utils/litegraphUtil'
 import {
   pasteAudioNode,
@@ -21,11 +21,16 @@ import {
 } from '@/composables/usePaste'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
-import { api } from '@/scripts/api'
+import { setTelemetryRegistry } from '@/platform/telemetry'
+import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
+import * as executionContextUtils from '@/platform/telemetry/utils/getExecutionContext'
+
+import { PromptExecutionError, api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import type { NodeError } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
 import {
   createTestRootGraph,
   createTestSubgraph,
@@ -189,6 +194,23 @@ describe('ComfyApp', () => {
   })
 
   describe('queuePrompt', () => {
+    function prepareEmptyPromptQueue() {
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/review.json',
+        modified: 0,
+        size: 0
+      })
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: {},
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+    }
+
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
       const workflow = new ComfyWorkflow({
@@ -218,6 +240,7 @@ describe('ComfyApp', () => {
         }
       }
       Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
       mockWorkspaceWorkflow.activeWorkflow = workflow
       vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
         output: promptOutput,
@@ -241,6 +264,293 @@ describe('ComfyApp', () => {
         'workflows/review.json'
       )
       expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
+
+    it('stores workflow telemetry metadata for every accepted batch submission', async () => {
+      prepareEmptyPromptQueue()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome: vi.fn() })
+      setTelemetryRegistry(registry)
+      vi.spyOn(api, 'queuePrompt')
+        .mockResolvedValueOnce({
+          prompt_id: 'job-1',
+          error: ''
+        })
+        .mockResolvedValueOnce({
+          prompt_id: 'job-2',
+          error: ''
+        })
+
+      try {
+        await app.queuePrompt(0, 2, {
+          intent: { trigger_source: 'button' }
+        })
+
+        expect(useExecutionStore().queuedJobs['job-1']).toMatchObject({
+          workflowExecutionIntent: {
+            trigger_source: 'button'
+          },
+          workflowContext: {
+            workflow_type: 'custom',
+            view_mode: 'graph',
+            execution_scope: 'full',
+            total_node_count: 0,
+            executable_node_count: 0,
+            custom_node_count: 0,
+            api_node_count: 0,
+            subgraph_count: 0
+          }
+        })
+        expect(useExecutionStore().queuedJobs['job-2']).toMatchObject({
+          workflowExecutionIntent: {
+            trigger_source: 'button'
+          }
+        })
+      } finally {
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('tracks a resolved prompt rejection at the submission stage', async () => {
+      prepareEmptyPromptQueue()
+      const trackExecutionOutcome = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome })
+      setTelemetryRegistry(registry)
+      const now = vi.spyOn(performance, 'now').mockReturnValue(42)
+      vi.spyOn(api, 'queuePrompt').mockImplementation(async () => {
+        now.mockReturnValue(62)
+        return {
+          error: 'Prompt rejected'
+        }
+      })
+
+      try {
+        await app.queuePrompt(0)
+
+        expect(trackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+          startTime: 42,
+          endTime: 62,
+          success: false,
+          failureReason: 'submission_rejected',
+          trigger_source: 'unknown',
+          workflowContext: {
+            workflow_type: 'custom',
+            view_mode: 'graph',
+            execution_scope: 'full',
+            total_node_count: 0,
+            executable_node_count: 0,
+            custom_node_count: 0,
+            api_node_count: 0,
+            subgraph_count: 0
+          }
+        })
+      } finally {
+        now.mockRestore()
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('tracks a rejected queue request at the submission stage', async () => {
+      prepareEmptyPromptQueue()
+      const trackExecutionOutcome = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome })
+      setTelemetryRegistry(registry)
+      const now = vi.spyOn(performance, 'now').mockReturnValue(42)
+      vi.spyOn(api, 'queuePrompt').mockImplementation(async () => {
+        now.mockReturnValue(62)
+        throw new PromptExecutionError({
+          error: {
+            type: 'prompt_no_outputs',
+            message: 'Prompt has no outputs',
+            details: ''
+          }
+        })
+      })
+
+      try {
+        await app.queuePrompt(0)
+
+        expect(trackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+          startTime: 42,
+          endTime: 62,
+          success: false,
+          failureReason: 'submission_rejected',
+          trigger_source: 'unknown',
+          workflowContext: {
+            workflow_type: 'custom',
+            view_mode: 'graph',
+            execution_scope: 'full',
+            total_node_count: 0,
+            executable_node_count: 0,
+            custom_node_count: 0,
+            api_node_count: 0,
+            subgraph_count: 0
+          }
+        })
+      } finally {
+        now.mockRestore()
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('tracks prompt construction failures at the submission stage', async () => {
+      prepareEmptyPromptQueue()
+      const trackExecutionOutcome = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome })
+      setTelemetryRegistry(registry)
+      const now = vi.spyOn(performance, 'now').mockReturnValue(42)
+      vi.spyOn(app, 'graphToPrompt').mockImplementation(async () => {
+        now.mockReturnValue(62)
+        throw new Error('Prompt construction failed')
+      })
+
+      try {
+        await expect(app.queuePrompt(0)).rejects.toThrow(
+          'Prompt construction failed'
+        )
+        expect(trackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+          startTime: 42,
+          endTime: 62,
+          success: false,
+          failureReason: 'prompt_build_failed',
+          trigger_source: 'unknown'
+        })
+      } finally {
+        now.mockRestore()
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('stores execution intent when workflow context collection fails', async () => {
+      prepareEmptyPromptQueue()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome: vi.fn() })
+      setTelemetryRegistry(registry)
+      vi.spyOn(
+        executionContextUtils,
+        'getExecutionContext'
+      ).mockImplementationOnce(() => {
+        throw new Error('Context unavailable')
+      })
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      try {
+        await app.queuePrompt(0, 1, {
+          intent: { trigger_source: 'button' }
+        })
+
+        expect(useExecutionStore().queuedJobs['job-1']).toMatchObject({
+          workflowExecutionIntent: {
+            trigger_source: 'button'
+          }
+        })
+        expect(
+          useExecutionStore().queuedJobs['job-1']?.workflowContext
+        ).toBeUndefined()
+      } finally {
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('normalizes runtime queue intent from extension callers', async () => {
+      prepareEmptyPromptQueue()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome: vi.fn() })
+      setTelemetryRegistry(registry)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      try {
+        await Reflect.apply(app.queuePrompt, app, [
+          0,
+          1,
+          {
+            intent: {
+              trigger_source: 'private-workflow-name'
+            }
+          }
+        ])
+
+        expect(
+          useExecutionStore().queuedJobs['job-1']?.workflowExecutionIntent
+        ).toEqual({
+          trigger_source: 'unknown'
+        })
+      } finally {
+        setTelemetryRegistry(null)
+      }
+    })
+
+    it('preserves legacy partial execution calls from extensions', async () => {
+      prepareEmptyPromptQueue()
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+      const queueNodeIds = [createNodeExecutionId([1])]
+
+      await app.queuePrompt(0, 1, queueNodeIds)
+
+      expect(api.queuePrompt).toHaveBeenCalledWith(
+        0,
+        expect.anything(),
+        expect.objectContaining({
+          partialExecutionTargets: queueNodeIds
+        })
+      )
+    })
+
+    it('skips workflow context collection without telemetry', async () => {
+      prepareEmptyPromptQueue()
+      const getExecutionContext = vi.spyOn(
+        executionContextUtils,
+        'getExecutionContext'
+      )
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      await app.queuePrompt(0)
+
+      expect(getExecutionContext).not.toHaveBeenCalled()
+    })
+
+    it('retains workflow telemetry metadata when the queue UI refresh fails', async () => {
+      prepareEmptyPromptQueue()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome: vi.fn() })
+      setTelemetryRegistry(registry)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+      vi.spyOn(app.ui.queue, 'update').mockRejectedValue(
+        new Error('Queue UI refresh failed')
+      )
+
+      try {
+        await expect(
+          app.queuePrompt(0, 1, {
+            intent: { trigger_source: 'button' }
+          })
+        ).rejects.toThrow('Queue UI refresh failed')
+        expect(useExecutionStore().queuedJobs['job-1']).toMatchObject({
+          workflowExecutionIntent: {
+            trigger_source: 'button'
+          }
+        })
+      } finally {
+        setTelemetryRegistry(null)
+      }
     })
   })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -29,8 +29,17 @@ import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { installNodeAddedTelemetry } from '@/platform/telemetry/nodeAdded/installNodeAddedTelemetry'
+import { normalizeExecutionTriggerSource } from '@/platform/telemetry/types'
+import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionContext'
 import { groupMissingNodesByPack } from '@/platform/telemetry/utils/groupMissingNodesByPack'
-import type { WorkflowOpenSource } from '@/platform/telemetry/types'
+import { toWorkflowExecutionContext } from '@/platform/telemetry/utils/workflowExecutionContext'
+import type {
+  ExecutionContext,
+  WorkflowExecutionContext,
+  WorkflowExecutionIntent,
+  WorkflowOpenSource,
+  WorkflowQueueIntent
+} from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
@@ -113,6 +122,7 @@ import {
   verifyMediaCandidates
 } from '@/platform/missingMedia/missingMediaScan'
 
+import { getWorkflowMode } from '@/utils/appMode'
 import { anyItemOverlapsRect } from '@/utils/mathUtil'
 import {
   collectAllNodes,
@@ -221,6 +231,15 @@ type Clipspace = {
   combinedIndex: number
 }
 
+/**
+ * Optional inputs to {@link ComfyApp.queuePrompt}. `intent` is telemetry
+ * attribution only and never affects what gets executed.
+ */
+export interface QueuePromptOptions {
+  queueNodeIds?: NodeExecutionId[]
+  intent?: WorkflowQueueIntent
+}
+
 export class ComfyApp {
   /**
    * List of entries to queue
@@ -230,6 +249,7 @@ export class ComfyApp {
     batchCount: number
     requestId: number
     queueNodeIds?: NodeExecutionId[]
+    workflowQueueIntent?: WorkflowQueueIntent
   }[] = []
   private nextQueueRequestId = 1
   /**
@@ -1614,11 +1634,31 @@ export class ComfyApp {
 
   async queuePrompt(
     number: number,
+    batchCount?: number,
+    options?: QueuePromptOptions
+  ): Promise<boolean>
+  async queuePrompt(
+    number: number,
+    batchCount: number,
+    queueNodeIds: NodeExecutionId[]
+  ): Promise<boolean>
+  async queuePrompt(
+    number: number,
     batchCount: number = 1,
-    queueNodeIds?: NodeExecutionId[]
+    optionsOrQueueNodeIds: QueuePromptOptions | NodeExecutionId[] = {}
   ): Promise<boolean> {
+    const options = Array.isArray(optionsOrQueueNodeIds)
+      ? { queueNodeIds: optionsOrQueueNodeIds }
+      : optionsOrQueueNodeIds
+    const { queueNodeIds, intent } = options
     const requestId = this.nextQueueRequestId++
-    this.queueItems.push({ number, batchCount, queueNodeIds, requestId })
+    this.queueItems.push({
+      number,
+      batchCount,
+      queueNodeIds,
+      requestId,
+      workflowQueueIntent: intent
+    })
     api.dispatchCustomEvent('promptQueueing', {
       requestId,
       batchCount
@@ -1632,6 +1672,7 @@ export class ComfyApp {
     this.processingQueue = true
     const executionStore = useExecutionStore()
     const executionErrorStore = useExecutionErrorStore()
+    const telemetry = useTelemetry()
     executionErrorStore.clearAllErrors()
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
@@ -1640,15 +1681,37 @@ export class ComfyApp {
 
     try {
       while (this.queueItems.length) {
-        const { number, batchCount, queueNodeIds, requestId } =
-          this.queueItems.pop()!
+        const {
+          number,
+          batchCount,
+          queueNodeIds,
+          requestId,
+          workflowQueueIntent
+        } = this.queueItems.pop()!
         let queuedCount = 0
+        const workflowExecutionIntent: WorkflowExecutionIntent = {
+          trigger_source: normalizeExecutionTriggerSource(
+            workflowQueueIntent?.trigger_source
+          )
+        }
         const previewMethod = useSettingStore().get(
           'Comfy.Execution.PreviewMethod'
         )
 
         const isPartialExecution = !!queueNodeIds?.length
         for (let i = 0; i < batchCount; i++) {
+          let executionContext: ExecutionContext | undefined
+          if (telemetry) {
+            try {
+              executionContext = getExecutionContext()
+            } catch (error) {
+              console.error(
+                '[Telemetry] Workflow context collection failed',
+                error
+              )
+            }
+          }
+
           // Allow widgets to run callbacks before a prompt has been queued
           // e.g. random seed before every gen
           forEachNode(this.rootGraph, (node) => {
@@ -1665,8 +1728,27 @@ export class ComfyApp {
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
           const startTime = performance.now()
-          const p = await this.graphToPrompt(this.rootGraph)
+          const p = await this.graphToPrompt(this.rootGraph).catch(
+            (error: unknown) => {
+              telemetry?.trackExecutionOutcome({
+                startTime,
+                endTime: performance.now(),
+                success: false,
+                failureReason: 'prompt_build_failed',
+                ...workflowExecutionIntent
+              })
+              throw error
+            }
+          )
           const queuedNodes = collectAllNodes(this.rootGraph)
+          let workflowContext: WorkflowExecutionContext | undefined
+          if (executionContext) {
+            workflowContext = toWorkflowExecutionContext(executionContext, {
+              executableNodeCount: Object.keys(p.output).length,
+              executionScope: isPartialExecution ? 'partial' : 'full',
+              viewMode: getWorkflowMode(queuedWorkflow)
+            })
+          }
           try {
             api.authToken = comfyOrgAuthToken
             api.apiKey = comfyOrgApiKey ?? undefined
@@ -1674,8 +1756,19 @@ export class ComfyApp {
               partialExecutionTargets: queueNodeIds,
               previewMethod
             })
+            const responseReceivedAt = performance.now()
             delete api.authToken
             delete api.apiKey
+            if (!res.prompt_id) {
+              telemetry?.trackExecutionOutcome({
+                startTime,
+                endTime: responseReceivedAt,
+                success: false,
+                failureReason: 'submission_rejected',
+                ...workflowExecutionIntent,
+                ...(workflowContext && { workflowContext })
+              })
+            }
             const nodeErrors = res.node_errors
             const hasNodeErrors =
               nodeErrors && Object.keys(nodeErrors).length > 0
@@ -1689,7 +1782,10 @@ export class ComfyApp {
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
                   startTime,
-                  workflow: queuedWorkflow
+                  submissionAcceptedAt: responseReceivedAt,
+                  workflow: queuedWorkflow,
+                  workflowContext,
+                  workflowExecutionIntent
                 })
               }
             } catch (error) {
@@ -1705,6 +1801,17 @@ export class ComfyApp {
               this.canvas.draw(true, true)
             }
           } catch (error: unknown) {
+            telemetry?.trackExecutionOutcome({
+              startTime,
+              endTime: performance.now(),
+              success: false,
+              failureReason:
+                error instanceof PromptExecutionError
+                  ? 'submission_rejected'
+                  : 'submission_failed',
+              ...workflowExecutionIntent,
+              ...(workflowContext && { workflowContext })
+            })
             const preconditionResponseError =
               error instanceof PromptExecutionError &&
               typeof error.response.error === 'object'

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -441,7 +441,9 @@ export class ComfyUI {
       if (this.autoQueueMode === 'change' && this.autoQueueEnabled === true) {
         if (this.lastQueueSize === 0) {
           this.graphHasChanged = false
-          app.queuePrompt(0, this.batchCount)
+          app.queuePrompt(0, this.batchCount, {
+            intent: { trigger_source: 'auto_queue' }
+          })
         } else {
           this.graphHasChanged = true
         }
@@ -487,11 +489,14 @@ export class ComfyUI {
           id: 'queue-button',
           textContent: 'Queue Prompt',
           onclick: () => {
-            useRunButtonTelemetry().trackRunButton({
+            const workflowQueueIntent = {
               trigger_source: 'legacy_ui'
-            })
+            } as const
+            useRunButtonTelemetry().trackRunButton(workflowQueueIntent)
             useTelemetry()?.trackWorkflowExecution()
-            app.queuePrompt(0, this.batchCount)
+            app.queuePrompt(0, this.batchCount, {
+              intent: workflowQueueIntent
+            })
           }
         }),
         $el('div', {}, [
@@ -595,11 +600,14 @@ export class ComfyUI {
             id: 'queue-front-button',
             textContent: 'Queue Front',
             onclick: () => {
-              useRunButtonTelemetry().trackRunButton({
+              const workflowQueueIntent = {
                 trigger_source: 'legacy_ui'
-              })
+              } as const
+              useRunButtonTelemetry().trackRunButton(workflowQueueIntent)
               useTelemetry()?.trackWorkflowExecution()
-              app.queuePrompt(-1, this.batchCount)
+              app.queuePrompt(-1, this.batchCount, {
+                intent: workflowQueueIntent
+              })
             }
           }),
           $el('button', {
@@ -711,7 +719,9 @@ export class ComfyUI {
         (this.autoQueueMode === 'instant' || this.graphHasChanged) &&
         !app.lastExecutionError
       ) {
-        app.queuePrompt(0, this.batchCount)
+        app.queuePrompt(0, this.batchCount, {
+          intent: { trigger_source: 'auto_queue' }
+        })
         status.exec_info.queue_remaining += this.batchCount
         this.graphHasChanged = false
       }

--- a/src/services/autoQueueService.ts
+++ b/src/services/autoQueueService.ts
@@ -19,7 +19,9 @@ export function setupAutoQueueHandler() {
       } else {
         graphHasChanged = false
         // Queue the prompt in the background
-        void app.queuePrompt(0, queueSettingsStore.batchCount)
+        void app.queuePrompt(0, queueSettingsStore.batchCount, {
+          intent: { trigger_source: 'auto_queue' }
+        })
         internalCount++
       }
     }
@@ -34,7 +36,9 @@ export function setupAutoQueueHandler() {
           (queueSettingsStore.mode === 'change' && graphHasChanged)
         ) {
           graphHasChanged = false
-          await app.queuePrompt(0, queueSettingsStore.batchCount)
+          await app.queuePrompt(0, queueSettingsStore.batchCount, {
+            intent: { trigger_source: 'auto_queue' }
+          })
         }
       }
     },

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -45,6 +45,10 @@ const mockAppModeState = vi.hoisted(() => ({
   isAppMode: { value: false }
 }))
 
+const defaultWorkflowExecutionIntent = {
+  trigger_source: 'unknown'
+} as const
+
 vi.mock('@/composables/useAppMode', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
@@ -618,6 +622,7 @@ describe('useExecutionStore - workflowStatus', () => {
       id: jobId,
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
       startTime: 42,
+      submissionAcceptedAt: 62,
       workflow
     })
   }
@@ -648,30 +653,49 @@ describe('useExecutionStore - workflowStatus', () => {
   })
 
   it('flushes terminal completed when WS finishes before storeJob', () => {
-    // Instant-finish race: WS fires start+success before HTTP response.
-    fireExecutionStart('job-1')
-    fireExecutionSuccess('job-1')
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
 
-    callStoreJob('job-1', workflowA)
-    expect(mockTrackExecutionOutcome).toHaveBeenCalledOnce()
-    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
-      startTime: 42,
-      outcome: 'success'
-    })
-    expect(store.getWorkflowStatus(workflowA)).toBe('completed')
-    expect(store.queuedJobs['job-1']).toBeUndefined()
+    try {
+      fireExecutionStart('job-1')
+      now.mockReturnValue(142)
+      fireExecutionSuccess('job-1')
+
+      callStoreJob('job-1', workflowA)
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: true,
+        failureReason: ''
+      })
+      expect(store.getWorkflowStatus(workflowA)).toBe('completed')
+      expect(store.queuedJobs['job-1']).toBeUndefined()
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it('flushes terminal failed when WS errors before storeJob', () => {
-    // Invalid-workflow path: execution_error fires before HTTP response.
-    fireExecutionError('job-1')
+    const now = vi.spyOn(performance, 'now').mockReturnValue(82)
 
-    callStoreJob('job-1', workflowA)
-    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
-      startTime: 42,
-      outcome: 'failure'
-    })
-    expect(store.getWorkflowStatus(workflowA)).toBe('failed')
+    try {
+      fireExecutionError('job-1')
+
+      callStoreJob('job-1', workflowA)
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        endTime: 82,
+        success: false,
+        failureReason: 'execution_failed'
+      })
+      expect(store.getWorkflowStatus(workflowA)).toBe('failed')
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it('drops pending status on interrupt before storeJob', () => {
@@ -682,32 +706,154 @@ describe('useExecutionStore - workflowStatus', () => {
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
 
-  it('sets completed on execution_success', () => {
-    callStoreJob('job-1', workflowA)
-    fireExecutionStart('job-1')
+  it('tracks every stage when execution succeeds', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
+
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      now.mockReturnValue(142)
+      fireExecutionSuccess('job-1')
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: true,
+        failureReason: ''
+      })
+      expect(store.getWorkflowStatus(workflowA)).toBe('completed')
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('tracks a workflow outcome only once for duplicate terminal events', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
+
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      now.mockReturnValue(142)
+      fireExecutionSuccess('job-1')
+      fireExecutionSuccess('job-1')
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledOnce()
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('keeps timing metadata until success after executing clears', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
+
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      apiEventHandlers.get('executing')!(
+        new CustomEvent('executing', { detail: null })
+      )
+      now.mockReturnValue(142)
+      fireExecutionSuccess('job-1')
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: true,
+        failureReason: ''
+      })
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('tracks completion with the workflow context captured for the job', () => {
+    const workflowContext = {
+      workflow_type: 'custom',
+      view_mode: 'graph',
+      execution_scope: 'partial',
+      total_node_count: 42,
+      executable_node_count: 12,
+      custom_node_count: 3,
+      api_node_count: 1,
+      subgraph_count: 2
+    } as const
+
+    store.storeJob({
+      nodes: ['1'],
+      id: 'job-1',
+      promptOutput: { '1': createPromptNode('Node', 'TestNode') },
+      startTime: 42,
+      workflow: workflowA,
+      workflowContext,
+      workflowExecutionIntent: {
+        trigger_source: 'button'
+      }
+    })
     fireExecutionSuccess('job-1')
 
-    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith({
-      startTime: 42,
-      outcome: 'success'
-    })
-    expect(store.getWorkflowStatus(workflowA)).toBe('completed')
+    expect(mockTrackExecutionOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startTime: 42,
+        success: true,
+        failureReason: '',
+        trigger_source: 'button',
+        workflowContext
+      })
+    )
   })
 
-  it('sets failed on execution_error', () => {
-    callStoreJob('job-1', workflowA)
-    fireExecutionStart('job-1')
-    fireExecutionError('job-1')
+  it('tracks the execution stage when execution fails', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
 
-    expect(store.getWorkflowStatus(workflowA)).toBe('failed')
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      now.mockReturnValue(142)
+      fireExecutionError('job-1')
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: false,
+        failureReason: 'execution_failed'
+      })
+      expect(store.getWorkflowStatus(workflowA)).toBe('failed')
+    } finally {
+      now.mockRestore()
+    }
   })
 
-  it('skips status badge on user-initiated interrupt', () => {
-    callStoreJob('job-1', workflowA)
-    fireExecutionStart('job-1')
-    fireExecutionInterrupted('job-1')
+  it('tracks an interrupted execution without showing a failed badge', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
 
-    expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      now.mockReturnValue(142)
+      fireExecutionInterrupted('job-1')
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: false,
+        failureReason: 'execution_interrupted'
+      })
+      expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it('evicts the oldest pending status once the buffer cap is exceeded', () => {
@@ -768,27 +914,42 @@ describe('useExecutionStore - workflowStatus', () => {
     expect(store.getWorkflowStatus(workflowA)).toBeUndefined()
   })
 
-  it('drops service-level errors without writing failed', () => {
-    callStoreJob('job-1', workflowA)
-    fireExecutionStart('job-1')
-    expect(store.getWorkflowStatus(workflowA)).toBe('running')
+  it('tracks service-level failures without writing failed', () => {
+    const now = vi.spyOn(performance, 'now').mockReturnValue(92)
 
-    // Service-level error: empty node_id triggers the short-circuit branch.
-    const handler = apiEventHandlers.get('execution_error')
-    handler!(
-      new CustomEvent('execution_error', {
-        detail: {
-          prompt_id: 'job-1',
-          node_id: '',
-          node_type: '',
-          exception_message: 'Job has stagnated',
-          exception_type: 'StagnationError',
-          traceback: []
-        }
+    try {
+      callStoreJob('job-1', workflowA)
+      fireExecutionStart('job-1')
+      expect(store.getWorkflowStatus(workflowA)).toBe('running')
+
+      now.mockReturnValue(142)
+      const handler = apiEventHandlers.get('execution_error')
+      handler!(
+        new CustomEvent('execution_error', {
+          detail: {
+            prompt_id: 'job-1',
+            node_id: '',
+            node_type: '',
+            exception_message: 'Job has stagnated',
+            exception_type: 'StagnationError',
+            traceback: []
+          }
+        })
+      )
+
+      expect(mockTrackExecutionOutcome).toHaveBeenCalledExactlyOnceWith({
+        startTime: 42,
+        ...defaultWorkflowExecutionIntent,
+        submissionAcceptedAt: 62,
+        executionStartedAt: 92,
+        endTime: 142,
+        success: false,
+        failureReason: 'execution_failed'
       })
-    )
-
-    expect(store.getWorkflowStatus(workflowA)).toBe('running')
+      expect(store.getWorkflowStatus(workflowA)).toBe('running')
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it('drops pending failed when service-level error fires before storeJob', () => {
@@ -1339,7 +1500,10 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
 
       expect(store.activeJobId).toBe('job-1')
-      expect(store.queuedJobs['job-1']).toEqual({ nodes: {} })
+      expect(store.queuedJobs['job-1']).toEqual({
+        nodes: {},
+        executionStartedAt: expect.any(Number)
+      })
     })
 
     it('clears transient errors while preserving validation errors', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -6,6 +6,11 @@ import { useAppMode } from '@/composables/useAppMode'
 import { isCloud } from '@/platform/distribution/types'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTelemetry } from '@/platform/telemetry'
+import type {
+  WorkflowExecutionContext,
+  WorkflowExecutionFailureReason,
+  WorkflowExecutionIntent
+} from '@/platform/telemetry/types'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type {
@@ -52,6 +57,11 @@ interface QueuedJob {
    */
   nodes: Record<string, boolean>
   startTime?: number
+  submissionAcceptedAt?: number
+  executionStartedAt?: number
+  outcomeTracked?: boolean
+  workflowContext?: WorkflowExecutionContext
+  workflowExecutionIntent?: WorkflowExecutionIntent
   /**
    * The workflow that is queued to be executed
    */
@@ -72,6 +82,10 @@ interface QueuedJob {
    */
   viewMode?: AppMode
   isAppMode?: boolean
+}
+
+const defaultWorkflowExecutionIntent: WorkflowExecutionIntent = {
+  trigger_source: 'unknown'
 }
 
 function buildExecutionNodeLookup(
@@ -96,6 +110,14 @@ function buildExecutionNodeLookup(
 export const MAX_PROGRESS_JOBS = 1000
 
 export type WorkflowExecutionStatus = 'running' | 'completed' | 'failed'
+
+interface WorkflowStatusUpdate {
+  status: WorkflowExecutionStatus
+  executionStartedAt?: number
+  endTime?: number
+  failureReason?: WorkflowExecutionFailureReason
+  showStatus?: boolean
+}
 
 export const WORKFLOW_STATUS_I18N_KEYS: Record<
   WorkflowExecutionStatus,
@@ -142,17 +164,22 @@ export const useExecutionStore = defineStore('execution', () => {
 
   // Buffers statuses arriving before storeJob attaches the workflow.
   // FIFO-capped to bound growth if a matching storeJob never fires.
-  const pendingWorkflowStatusByJobId = new Map<
-    string,
-    WorkflowExecutionStatus
-  >()
+  const pendingWorkflowStatusByJobId = new Map<string, WorkflowStatusUpdate>()
 
   function bufferPendingWorkflowStatus(
     jobId: string,
-    status: WorkflowExecutionStatus
+    update: WorkflowStatusUpdate
   ) {
+    const existing = pendingWorkflowStatusByJobId.get(jobId)
+    const executionStartedAt =
+      update.executionStartedAt ??
+      queuedJobs.value[jobId]?.executionStartedAt ??
+      existing?.executionStartedAt
     pendingWorkflowStatusByJobId.delete(jobId)
-    pendingWorkflowStatusByJobId.set(jobId, status)
+    pendingWorkflowStatusByJobId.set(jobId, {
+      ...update,
+      ...(executionStartedAt !== undefined && { executionStartedAt })
+    })
     while (pendingWorkflowStatusByJobId.size > MAX_PROGRESS_JOBS) {
       const oldest = pendingWorkflowStatusByJobId.keys().next().value
       if (oldest === undefined) break
@@ -180,25 +207,61 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function trackExecutionOutcome(
     jobId: string,
-    status: WorkflowExecutionStatus
+    { status, endTime, failureReason }: WorkflowStatusUpdate
   ) {
-    if (status === 'running') return
-    const startTime = queuedJobs.value[jobId]?.startTime
-    if (startTime === undefined) return
-    useTelemetry()?.trackExecutionOutcome({
+    if (status === 'running' || endTime === undefined) return
+    const queuedJob = queuedJobs.value[jobId]
+    const startTime = queuedJob?.startTime
+    const workflowExecutionIntent = queuedJob?.workflowExecutionIntent
+    if (
+      !queuedJob ||
+      queuedJob.outcomeTracked ||
+      startTime === undefined ||
+      workflowExecutionIntent === undefined
+    )
+      return
+
+    queuedJob.outcomeTracked = true
+    const metadata = {
       startTime,
-      outcome: status === 'completed' ? 'success' : 'failure'
+      ...workflowExecutionIntent,
+      ...(queuedJob.submissionAcceptedAt !== undefined && {
+        submissionAcceptedAt: queuedJob.submissionAcceptedAt
+      }),
+      ...(queuedJob.executionStartedAt !== undefined && {
+        executionStartedAt: queuedJob.executionStartedAt
+      }),
+      endTime,
+      ...(queuedJob.workflowContext && {
+        workflowContext: queuedJob.workflowContext
+      })
+    }
+    const telemetry = useTelemetry()
+    if (status === 'completed') {
+      telemetry?.trackExecutionOutcome({
+        ...metadata,
+        success: true,
+        failureReason: ''
+      })
+      return
+    }
+    telemetry?.trackExecutionOutcome({
+      ...metadata,
+      success: false,
+      failureReason: failureReason ?? 'execution_failed'
     })
   }
 
-  function setWorkflowStatus(jobId: string, status: WorkflowExecutionStatus) {
+  function setWorkflowStatus(jobId: string, update: WorkflowStatusUpdate) {
     const workflow = jobIdToWorkflow.get(jobId)
     if (!workflow) {
-      bufferPendingWorkflowStatus(jobId, status)
+      bufferPendingWorkflowStatus(jobId, update)
       return
     }
-    applyWorkflowStatus(workflow, status)
-    trackExecutionOutcome(jobId, status)
+    if (update.showStatus !== false) {
+      applyWorkflowStatus(workflow, update.status)
+    }
+    trackExecutionOutcome(jobId, update)
   }
 
   function clearWorkflowStatus(workflow: ComfyWorkflow) {
@@ -399,7 +462,11 @@ export const useExecutionStore = defineStore('execution', () => {
       const path = queuedJobs.value[activeJobId.value]?.workflow?.path
       if (path) ensureSessionWorkflowPath(activeJobId.value, path)
     }
-    setWorkflowStatus(activeJobId.value, 'running')
+    queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
+    setWorkflowStatus(activeJobId.value, {
+      status: 'running',
+      executionStartedAt: queuedJobs.value[activeJobId.value].executionStartedAt
+    })
   }
 
   function handleExecutionCached(e: CustomEvent<ExecutionCachedWsMessage>) {
@@ -413,8 +480,12 @@ export const useExecutionStore = defineStore('execution', () => {
     e: CustomEvent<ExecutionInterruptedWsMessage>
   ) {
     const jobId = e.detail.prompt_id
-    // User-initiated stop is not a failure — drop the badge entirely.
-    pendingWorkflowStatusByJobId.delete(jobId)
+    setWorkflowStatus(jobId, {
+      status: 'failed',
+      endTime: performance.now(),
+      failureReason: 'execution_interrupted',
+      showStatus: false
+    })
     const workflow = jobIdToWorkflow.get(jobId)
     if (workflow) clearWorkflowStatus(workflow)
     if (activeJobId.value) clearInitializationByJobId(activeJobId.value)
@@ -428,7 +499,10 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
     const jobId = e.detail.prompt_id
-    setWorkflowStatus(jobId, 'completed')
+    setWorkflowStatus(jobId, {
+      status: 'completed',
+      endTime: performance.now()
+    })
     const queuedJob = queuedJobs.value[jobId]
     const telemetry = useTelemetry()
     if (queuedJob) {
@@ -455,9 +529,6 @@ export const useExecutionStore = defineStore('execution', () => {
 
     // Update the executing nodes list
     if (e.detail == null) {
-      if (activeJobId.value) {
-        delete queuedJobs.value[activeJobId.value]
-      }
       activeJobId.value = null
     }
   }
@@ -542,6 +613,13 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
+    const endTime = performance.now()
+    setWorkflowStatus(e.detail.prompt_id, {
+      status: 'failed',
+      endTime,
+      failureReason: 'execution_failed',
+      showStatus: false
+    })
     useTelemetry()?.trackExecutionError({
       jobId: e.detail.prompt_id,
       nodeId: String(e.detail.node_id),
@@ -553,7 +631,6 @@ export const useExecutionStore = defineStore('execution', () => {
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
       // Pre-flight validation isn't a runtime failure — no badge.
       if (handleCloudValidationError(e.detail)) {
-        pendingWorkflowStatusByJobId.delete(e.detail.prompt_id)
         return
       }
     }
@@ -564,11 +641,14 @@ export const useExecutionStore = defineStore('execution', () => {
 
     // Service-level errors (e.g. "Job has stagnated") have no associated node.
     if (handleServiceLevelError(e.detail)) {
-      pendingWorkflowStatusByJobId.delete(e.detail.prompt_id)
       return
     }
 
-    setWorkflowStatus(e.detail.prompt_id, 'failed')
+    setWorkflowStatus(e.detail.prompt_id, {
+      status: 'failed',
+      endTime,
+      failureReason: 'execution_failed'
+    })
     executionErrorStore.lastExecutionError = e.detail
     clearInitializationByJobId(e.detail.prompt_id)
     resetExecutionState(e.detail.prompt_id)
@@ -695,9 +775,7 @@ export const useExecutionStore = defineStore('execution', () => {
       useJobPreviewStore().clearPreview(jobId)
       jobIdToWorkflow.delete(jobId)
     }
-    if (activeJobId.value) {
-      delete queuedJobs.value[activeJobId.value]
-    }
+    if (jobId) delete queuedJobs.value[jobId]
     activeJobId.value = null
     _executingNodeProgress.value = null
     executionErrorStore.clearPromptError()
@@ -734,13 +812,19 @@ export const useExecutionStore = defineStore('execution', () => {
     id,
     promptOutput,
     startTime,
-    workflow
+    submissionAcceptedAt,
+    workflow,
+    workflowContext,
+    workflowExecutionIntent = defaultWorkflowExecutionIntent
   }: {
     nodes: string[]
     id: JobId
     promptOutput: ComfyApiWorkflow
     startTime?: number
+    submissionAcceptedAt?: number
     workflow: ComfyWorkflow
+    workflowContext?: WorkflowExecutionContext
+    workflowExecutionIntent?: WorkflowExecutionIntent
   }) {
     queuedJobs.value[id] ??= { nodes: {} }
     const queuedJob = queuedJobs.value[id]
@@ -753,6 +837,9 @@ export const useExecutionStore = defineStore('execution', () => {
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
     queuedJob.startTime = startTime
+    queuedJob.submissionAcceptedAt = submissionAcceptedAt
+    queuedJob.workflowContext = workflowContext
+    queuedJob.workflowExecutionIntent = workflowExecutionIntent
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
     queuedJob.shareId = workflow?.shareId
@@ -776,11 +863,15 @@ export const useExecutionStore = defineStore('execution', () => {
     const pending = pendingWorkflowStatusByJobId.get(jobId)
     if (pending === undefined || !workflow) return
     pendingWorkflowStatusByJobId.delete(jobId)
+    queuedJobs.value[jobId].executionStartedAt = pending.executionStartedAt
     // Don't let a stale 'running' overwrite a terminal status already set.
-    if (pending === 'running' && workflowStatus.value.has(workflow)) return
-    applyWorkflowStatus(workflow, pending)
+    if (pending.status === 'running' && workflowStatus.value.has(workflow))
+      return
+    if (pending.showStatus !== false) {
+      applyWorkflowStatus(workflow, pending.status)
+    }
     trackExecutionOutcome(jobId, pending)
-    if (pending === 'running' || activeJobId.value === jobId) return
+    if (pending.status === 'running' || activeJobId.value === jobId) return
     delete queuedJobs.value[jobId]
     jobIdToWorkflow.delete(jobId)
   }


### PR DESCRIPTION
## Summary

Backport #14084 to `cloud/1.47`, resolving the release-branch conflicts without importing unrelated newer-`main` billing or governance behavior.

## Changes

- **What**: Adds bounded workflow context, queue-trigger attribution, submission/queue/execution timing, and one terminal `workflow_execution` vital per attempt.
- **Dependencies**: Builds on the frontend observability stack already backported in #14211.

## Review Focus

The conflict resolution keeps the 1.47 execution-error store API and Cloud-only free-tier run tracking while applying #14084's structured workflow status and timing metadata.

Validation:
- 4 focused Vitest files, 136 tests passed
- `pnpm typecheck`
- Commit hooks: oxfmt, Oxlint, ESLint
- Pre-push `pnpm knip`
- `git diff --check`

Created by Codex