### PR TITLE
FE-1410: recover from chunk-load errors with a guarded reload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -160,8 +160,11 @@ const bootstrapStore = useBootstrapStore(pinia)
 void bootstrapStore.startStoreBootstrap()
 
 // Recover from stale-chunk failures (post-deploy dynamic-import errors) with a
-// guarded, dirty-state-aware reload. Registered after pinia is installed so the
-// error-time store lookups resolve.
-installChunkReload(router)
+// guarded, dirty-state-aware reload. Cloud-only: the stale-versioned-chunk
+// problem only exists behind the GCS-served deployment. Gating off `isCloud`
+// keeps it out of dev/desktop/nightly/E2E, where a chunk/HMR hiccup should
+// surface the error rather than reload. Registered after pinia is installed so
+// the error-time store lookups resolve.
+if (isCloud) installChunkReload(router)
 
 app.mount('#vue-app')

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
 } from '@/platform/remoteConfig/remoteConfig'
 import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
 import '@/lib/litegraph/public/css/litegraph.css'
+import { installChunkReload } from '@/platform/updates/common/chunkReload'
 import router from '@/router'
 import { isDesktop, isNightly } from '@/platform/distribution/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -157,5 +158,10 @@ LGraph.autoExposePreviewNodes = (hostNode) =>
 
 const bootstrapStore = useBootstrapStore(pinia)
 void bootstrapStore.startStoreBootstrap()
+
+// Recover from stale-chunk failures (post-deploy dynamic-import errors) with a
+// guarded, dirty-state-aware reload. Registered after pinia is installed so the
+// error-time store lookups resolve.
+installChunkReload(router)
 
 app.mount('#vue-app')

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -24,9 +24,11 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: { addAction: vi.fn() }
 }))
 
-// location.reload isn't implemented in the test DOM. Override just the `reload`
-// method on the EXISTING window.location object (rather than replacing the whole
-// object, which doesn't survive into nested callbacks/listeners under happy-dom).
+// performReload emits the RUM action immediately before window.location.reload(),
+// so `addAction` is the reliable "recovery was triggered" signal (a clean module
+// mock, unlike stubbing location.reload which the test DOM doesn't cooperate with
+// for calls made from callbacks/listeners). We still override reload on the live
+// location object so the direct-call path can also assert the reload itself.
 const mockReload = vi.fn()
 
 const APP_CHUNK = 'http://localhost/assets/settingStore-CUtU9ycZ.js'
@@ -50,8 +52,6 @@ describe('chunkReload', () => {
     executionState.runningJobIds = []
     mockReload.mockClear()
     addAction.mockClear()
-    // Override only the reload method on the live location object so the stub is
-    // the same function chunkReload sees, including from callbacks/listeners.
     Object.defineProperty(window.location, 'reload', {
       configurable: true,
       writable: true,
@@ -67,35 +67,35 @@ describe('chunkReload', () => {
     const triggered = attemptChunkReload(undefined, APP_CHUNK)
 
     expect(triggered).toBe(true)
-    expect(mockReload).toHaveBeenCalledTimes(1)
     // A RUM action is emitted so the recovery is observable/aggregatable.
     expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
       chunkUrl: APP_CHUNK
     })
+    // Direct-call path: the actual reload fires too.
+    expect(mockReload).toHaveBeenCalledTimes(1)
     // Guard is persisted so a subsequent failure will not reload again.
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
   })
 
-  it('does NOT reload a second time once the loop guard is set', () => {
+  it('does NOT trigger a second recovery once the loop guard is set', () => {
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(true)
-    expect(mockReload).toHaveBeenCalledTimes(1)
+    expect(addAction).toHaveBeenCalledTimes(1)
 
     // Second failure in the same session must be a no-op (asset is genuinely gone).
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(mockReload).toHaveBeenCalledTimes(1)
     expect(addAction).toHaveBeenCalledTimes(1)
   })
 
-  it('defers the reload when there are unsaved workflow changes', () => {
+  it('defers recovery when there are unsaved workflow changes', () => {
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
     // Guard is NOT set, so recovery can still happen once work is safe.
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
 
-  it('does not reload if the loop guard cannot be persisted', () => {
+  it('does not recover if the loop guard cannot be persisted', () => {
     // Storage is readable (getItem -> null) but writes fail (e.g. quota). Without
     // a stored guard a reload could loop, so we must not reload.
     vi.spyOn(window.sessionStorage, 'setItem').mockImplementation(() => {
@@ -103,19 +103,18 @@ describe('chunkReload', () => {
     })
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(mockReload).not.toHaveBeenCalled()
     expect(addAction).not.toHaveBeenCalled()
   })
 
-  it('defers the reload when a generation is running', () => {
+  it('defers recovery when a generation is running', () => {
     executionState.runningJobIds = ['job-1']
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
 
-  it('reloads at the next safe navigation after a deferred (dirty) failure', () => {
+  it('recovers at the next safe navigation after a deferred (dirty) failure', () => {
     let afterEachCb: (() => void) | undefined
     const router = {
       afterEach: (cb: () => void) => {
@@ -126,41 +125,39 @@ describe('chunkReload', () => {
 
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
     expect(attemptChunkReload(router, APP_CHUNK)).toBe(false)
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
     expect(afterEachCb).toBeDefined()
 
-    // Navigation happens but still dirty -> no reload yet.
+    // Navigation happens but still dirty -> no recovery yet.
     afterEachCb?.()
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
 
-    // Now safe -> reload fires once.
+    // Now safe -> recovery fires once.
     workflowState.modifiedWorkflows = []
     afterEachCb?.()
-    expect(mockReload).toHaveBeenCalledTimes(1)
+    expect(addAction).toHaveBeenCalledTimes(1)
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
   })
 
-  it('reloads on a vite:preloadError for an app /assets/ chunk', () => {
+  it('recovers on a vite:preloadError for an app /assets/ chunk', () => {
     installChunkReload()
     window.dispatchEvent(preloadErrorEvent(APP_CHUNK))
 
-    expect(mockReload).toHaveBeenCalledTimes(1)
     expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
       chunkUrl: APP_CHUNK
     })
   })
 
-  it('does NOT reload on a vite:preloadError for an /extensions/ asset', () => {
+  it('does NOT recover on a vite:preloadError for an /extensions/ asset', () => {
     installChunkReload()
     window.dispatchEvent(preloadErrorEvent(EXTENSION_CHUNK))
 
     // Missing custom-node assets are not stale — a reload can't fix them, and
     // they dominate preloadError volume, so recovery must not fire for them.
-    expect(mockReload).not.toHaveBeenCalled()
     expect(addAction).not.toHaveBeenCalled()
   })
 
-  it('reloads on an unhandledrejection ChunkLoadError for an app chunk', () => {
+  it('recovers on an unhandledrejection ChunkLoadError for an app chunk', () => {
     installChunkReload()
 
     const reason = new Error(
@@ -171,7 +168,7 @@ describe('chunkReload', () => {
     event.reason = reason
     window.dispatchEvent(event)
 
-    expect(mockReload).toHaveBeenCalledTimes(1)
+    expect(addAction).toHaveBeenCalledTimes(1)
   })
 
   it('ignores an unhandledrejection for an /extensions/ asset', () => {
@@ -183,7 +180,7 @@ describe('chunkReload', () => {
     )
     window.dispatchEvent(event)
 
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
   })
 
   it('ignores unrelated unhandledrejections', () => {
@@ -193,6 +190,6 @@ describe('chunkReload', () => {
     event.reason = new Error('some unrelated error')
     window.dispatchEvent(event)
 
-    expect(mockReload).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -24,9 +24,19 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: { addAction: vi.fn() }
 }))
 
-const APP_CHUNK = 'https://app.test/assets/settingStore-CUtU9ycZ.js'
+// jsdom doesn't implement location.reload; stub it ONCE at module scope with
+// writable:true (the pattern used elsewhere in this repo). Redefining
+// window.location per-test is unreliable — the stub doesn't take effect for calls
+// made from nested callbacks/listeners.
+const mockReload = vi.fn()
+Object.defineProperty(window, 'location', {
+  value: { reload: mockReload, origin: 'http://localhost' },
+  writable: true
+})
+
+const APP_CHUNK = 'http://localhost/assets/settingStore-CUtU9ycZ.js'
 const EXTENSION_CHUNK =
-  'https://app.test/extensions/RES4LYF/js/RES4LYF_dynamicWidgets.js'
+  'http://localhost/extensions/RES4LYF/js/RES4LYF_dynamicWidgets.js'
 
 function preloadErrorEvent(url: string): Event {
   const event = new Event('vite:preloadError') as Event & { payload: Error }
@@ -37,22 +47,14 @@ function preloadErrorEvent(url: string): Event {
 }
 
 describe('chunkReload', () => {
-  let reloadSpy: ReturnType<typeof vi.fn>
   const addAction = vi.mocked(datadogRum.addAction)
 
   beforeEach(() => {
     window.sessionStorage.clear()
     workflowState.modifiedWorkflows = []
     executionState.runningJobIds = []
+    mockReload.mockClear()
     addAction.mockClear()
-
-    // location.reload is not implemented under jsdom; stub it. A minimal stub is
-    // enough — chunkReload only ever calls window.location.reload().
-    reloadSpy = vi.fn()
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { origin: 'https://app.test', reload: reloadSpy }
-    })
   })
 
   afterEach(() => {
@@ -63,7 +65,7 @@ describe('chunkReload', () => {
     const triggered = attemptChunkReload(undefined, APP_CHUNK)
 
     expect(triggered).toBe(true)
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
     // A RUM action is emitted so the recovery is observable/aggregatable.
     expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
       chunkUrl: APP_CHUNK
@@ -74,11 +76,11 @@ describe('chunkReload', () => {
 
   it('does NOT reload a second time once the loop guard is set', () => {
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(true)
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
 
     // Second failure in the same session must be a no-op (asset is genuinely gone).
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
     expect(addAction).toHaveBeenCalledTimes(1)
   })
 
@@ -86,7 +88,7 @@ describe('chunkReload', () => {
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
     // Guard is NOT set, so recovery can still happen once work is safe.
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
@@ -99,7 +101,7 @@ describe('chunkReload', () => {
     })
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
     expect(addAction).not.toHaveBeenCalled()
   })
 
@@ -107,7 +109,7 @@ describe('chunkReload', () => {
     executionState.runningJobIds = ['job-1']
 
     expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
 
@@ -122,17 +124,17 @@ describe('chunkReload', () => {
 
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
     expect(attemptChunkReload(router, APP_CHUNK)).toBe(false)
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
     expect(afterEachCb).toBeDefined()
 
     // Navigation happens but still dirty -> no reload yet.
     afterEachCb?.()
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
 
     // Now safe -> reload fires once.
     workflowState.modifiedWorkflows = []
     afterEachCb?.()
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
   })
 
@@ -140,7 +142,7 @@ describe('chunkReload', () => {
     installChunkReload()
     window.dispatchEvent(preloadErrorEvent(APP_CHUNK))
 
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
     expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
       chunkUrl: APP_CHUNK
     })
@@ -152,7 +154,7 @@ describe('chunkReload', () => {
 
     // Missing custom-node assets are not stale — a reload can't fix them, and
     // they dominate preloadError volume, so recovery must not fire for them.
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
     expect(addAction).not.toHaveBeenCalled()
   })
 
@@ -167,7 +169,7 @@ describe('chunkReload', () => {
     event.reason = reason
     window.dispatchEvent(event)
 
-    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(mockReload).toHaveBeenCalledTimes(1)
   })
 
   it('ignores an unhandledrejection for an /extensions/ asset', () => {
@@ -179,7 +181,7 @@ describe('chunkReload', () => {
     )
     window.dispatchEvent(event)
 
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
   })
 
   it('ignores unrelated unhandledrejections', () => {
@@ -189,6 +191,6 @@ describe('chunkReload', () => {
     event.reason = new Error('some unrelated error')
     window.dispatchEvent(event)
 
-    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(mockReload).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CHUNK_RELOAD_GUARD_KEY,
+  attemptChunkReload,
+  installChunkReload
+} from '@/platform/updates/common/chunkReload'
+
+// Mutable store state controlled per-test.
+const workflowState = { modifiedWorkflows: [] as unknown[] }
+const executionState = { runningJobIds: [] as unknown[] }
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => workflowState
+}))
+
+vi.mock('@/stores/executionStore', () => ({
+  useExecutionStore: () => executionState
+}))
+
+describe('chunkReload', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    workflowState.modifiedWorkflows = []
+    executionState.runningJobIds = []
+
+    // location.reload is not implemented/allowed under jsdom; replace it.
+    reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('triggers exactly one reload on a chunk failure when safe', () => {
+    const triggered = attemptChunkReload()
+
+    expect(triggered).toBe(true)
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    // Guard is persisted so a subsequent failure will not reload again.
+    expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
+  })
+
+  it('does NOT reload a second time once the loop guard is set', () => {
+    // First failure reloads.
+    expect(attemptChunkReload()).toBe(true)
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+
+    // Second failure in the same session must be a no-op (asset is genuinely gone).
+    const second = attemptChunkReload()
+    expect(second).toBe(false)
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('defers the reload when there are unsaved workflow changes', () => {
+    workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
+
+    const triggered = attemptChunkReload()
+
+    expect(triggered).toBe(false)
+    expect(reloadSpy).not.toHaveBeenCalled()
+    // Guard is NOT set, so recovery can still happen once work is safe.
+    expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
+  })
+
+  it('defers the reload when a generation is running', () => {
+    executionState.runningJobIds = ['job-1']
+
+    const triggered = attemptChunkReload()
+
+    expect(triggered).toBe(false)
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
+  })
+
+  it('reloads at the next safe navigation after a deferred (dirty) failure', () => {
+    let afterEachCb: (() => void) | undefined
+    const router = {
+      afterEach: (cb: () => void) => {
+        afterEachCb = cb
+        return vi.fn() // stop handle
+      }
+    } as unknown as import('vue-router').Router
+
+    // Dirty at failure time -> defer and arm a router hook.
+    workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
+    expect(attemptChunkReload(router)).toBe(false)
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(afterEachCb).toBeDefined()
+
+    // Navigation happens but still dirty -> no reload yet.
+    afterEachCb?.()
+    expect(reloadSpy).not.toHaveBeenCalled()
+
+    // User saves / navigates away, now safe -> reload fires once.
+    workflowState.modifiedWorkflows = []
+    afterEachCb?.()
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
+  })
+
+  it('installChunkReload reloads on a vite:preloadError event', () => {
+    installChunkReload()
+
+    const event = new Event('vite:preloadError') as Event & { payload: Error }
+    event.payload = new Error(
+      'Failed to fetch dynamically imported module: /assets/x.js'
+    )
+    window.dispatchEvent(event)
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('installChunkReload reloads on an unhandledrejection ChunkLoadError', () => {
+    installChunkReload()
+
+    const reason = new Error('boom')
+    reason.name = 'ChunkLoadError'
+    const event = new Event('unhandledrejection') as Event & { reason: unknown }
+    event.reason = reason
+    window.dispatchEvent(event)
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('installChunkReload ignores unrelated unhandledrejections', () => {
+    installChunkReload()
+
+    const event = new Event('unhandledrejection') as Event & { reason: unknown }
+    event.reason = new Error('some unrelated error')
+    window.dispatchEvent(event)
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -27,10 +27,13 @@ describe('chunkReload', () => {
     executionState.runningJobIds = []
 
     // location.reload is not implemented/allowed under jsdom; replace it.
+    // A minimal stub is sufficient — chunkReload only ever calls
+    // window.location.reload(), and jsdom's Location props are prototype getters
+    // (not own-enumerable), so spreading the instance would copy nothing anyway.
     reloadSpy = vi.fn()
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...window.location, reload: reloadSpy }
+      value: { reload: reloadSpy }
     })
   })
 

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -1,3 +1,4 @@
+import { datadogRum } from '@datadog/browser-rum'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -18,24 +19,36 @@ vi.mock('@/stores/executionStore', () => ({
   useExecutionStore: () => executionState
 }))
 
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: { addAction: vi.fn() }
+}))
+
+const APP_CHUNK = 'https://app.test/assets/settingStore-CUtU9ycZ.js'
+const EXTENSION_CHUNK =
+  'https://app.test/extensions/RES4LYF/js/RES4LYF_dynamicWidgets.js'
+
+function preloadErrorEvent(url: string): Event {
+  const event = new Event('vite:preloadError') as Event & { payload: Error }
+  event.payload = new Error(`Failed to fetch dynamically imported module: ${url}`)
+  return event
+}
+
 describe('chunkReload', () => {
   let reloadSpy: ReturnType<typeof vi.fn>
+  const addAction = vi.mocked(datadogRum.addAction)
 
   beforeEach(() => {
     window.sessionStorage.clear()
     workflowState.modifiedWorkflows = []
     executionState.runningJobIds = []
-    // performReload() logs a recovery marker; silence it in tests.
-    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    addAction.mockClear()
 
-    // location.reload is not implemented/allowed under jsdom; replace it.
-    // A minimal stub is sufficient — chunkReload only ever calls
-    // window.location.reload(), and jsdom's Location props are prototype getters
-    // (not own-enumerable), so spreading the instance would copy nothing anyway.
+    // location.reload is not implemented under jsdom; stub it. A minimal stub is
+    // enough — chunkReload only ever calls window.location.reload().
     reloadSpy = vi.fn()
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { reload: reloadSpy }
+      value: { origin: 'https://app.test', reload: reloadSpy }
     })
   })
 
@@ -44,31 +57,32 @@ describe('chunkReload', () => {
   })
 
   it('triggers exactly one reload on a chunk failure when safe', () => {
-    const triggered = attemptChunkReload()
+    const triggered = attemptChunkReload(undefined, APP_CHUNK)
 
     expect(triggered).toBe(true)
     expect(reloadSpy).toHaveBeenCalledTimes(1)
+    // A RUM action is emitted so the recovery is observable/aggregatable.
+    expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
+      chunkUrl: APP_CHUNK
+    })
     // Guard is persisted so a subsequent failure will not reload again.
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
   })
 
   it('does NOT reload a second time once the loop guard is set', () => {
-    // First failure reloads.
-    expect(attemptChunkReload()).toBe(true)
+    expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(true)
     expect(reloadSpy).toHaveBeenCalledTimes(1)
 
     // Second failure in the same session must be a no-op (asset is genuinely gone).
-    const second = attemptChunkReload()
-    expect(second).toBe(false)
+    expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
     expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(addAction).toHaveBeenCalledTimes(1)
   })
 
   it('defers the reload when there are unsaved workflow changes', () => {
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
 
-    const triggered = attemptChunkReload()
-
-    expect(triggered).toBe(false)
+    expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
     expect(reloadSpy).not.toHaveBeenCalled()
     // Guard is NOT set, so recovery can still happen once work is safe.
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
@@ -77,9 +91,7 @@ describe('chunkReload', () => {
   it('defers the reload when a generation is running', () => {
     executionState.runningJobIds = ['job-1']
 
-    const triggered = attemptChunkReload()
-
-    expect(triggered).toBe(false)
+    expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
     expect(reloadSpy).not.toHaveBeenCalled()
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
@@ -93,9 +105,8 @@ describe('chunkReload', () => {
       }
     } as unknown as import('vue-router').Router
 
-    // Dirty at failure time -> defer and arm a router hook.
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
-    expect(attemptChunkReload(router)).toBe(false)
+    expect(attemptChunkReload(router, APP_CHUNK)).toBe(false)
     expect(reloadSpy).not.toHaveBeenCalled()
     expect(afterEachCb).toBeDefined()
 
@@ -103,29 +114,39 @@ describe('chunkReload', () => {
     afterEachCb?.()
     expect(reloadSpy).not.toHaveBeenCalled()
 
-    // User saves / navigates away, now safe -> reload fires once.
+    // Now safe -> reload fires once.
     workflowState.modifiedWorkflows = []
     afterEachCb?.()
     expect(reloadSpy).toHaveBeenCalledTimes(1)
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).not.toBeNull()
   })
 
-  it('installChunkReload reloads on a vite:preloadError event', () => {
+  it('reloads on a vite:preloadError for an app /assets/ chunk', () => {
     installChunkReload()
-
-    const event = new Event('vite:preloadError') as Event & { payload: Error }
-    event.payload = new Error(
-      'Failed to fetch dynamically imported module: /assets/x.js'
-    )
-    window.dispatchEvent(event)
+    window.dispatchEvent(preloadErrorEvent(APP_CHUNK))
 
     expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(addAction).toHaveBeenCalledWith('stale-chunk-reload', {
+      chunkUrl: APP_CHUNK
+    })
   })
 
-  it('installChunkReload reloads on an unhandledrejection ChunkLoadError', () => {
+  it('does NOT reload on a vite:preloadError for an /extensions/ asset', () => {
+    installChunkReload()
+    window.dispatchEvent(preloadErrorEvent(EXTENSION_CHUNK))
+
+    // Missing custom-node assets are not stale — a reload can't fix them, and
+    // they dominate preloadError volume, so recovery must not fire for them.
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
+  })
+
+  it('reloads on an unhandledrejection ChunkLoadError for an app chunk', () => {
     installChunkReload()
 
-    const reason = new Error('boom')
+    const reason = new Error(
+      `Failed to fetch dynamically imported module: ${APP_CHUNK}`
+    )
     reason.name = 'ChunkLoadError'
     const event = new Event('unhandledrejection') as Event & { reason: unknown }
     event.reason = reason
@@ -134,7 +155,19 @@ describe('chunkReload', () => {
     expect(reloadSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('installChunkReload ignores unrelated unhandledrejections', () => {
+  it('ignores an unhandledrejection for an /extensions/ asset', () => {
+    installChunkReload()
+
+    const event = new Event('unhandledrejection') as Event & { reason: unknown }
+    event.reason = new Error(
+      `Failed to fetch dynamically imported module: ${EXTENSION_CHUNK}`
+    )
+    window.dispatchEvent(event)
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated unhandledrejections', () => {
     installChunkReload()
 
     const event = new Event('unhandledrejection') as Event & { reason: unknown }

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -1,5 +1,6 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Router } from 'vue-router'
 
 import {
   CHUNK_RELOAD_GUARD_KEY,
@@ -88,6 +89,18 @@ describe('chunkReload', () => {
     expect(window.sessionStorage.getItem(CHUNK_RELOAD_GUARD_KEY)).toBeNull()
   })
 
+  it('does not reload if the loop guard cannot be persisted', () => {
+    // Storage is readable (getItem -> null) but writes fail (e.g. quota). Without
+    // a stored guard a reload could loop, so we must not reload.
+    vi.spyOn(window.sessionStorage, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+
+    expect(attemptChunkReload(undefined, APP_CHUNK)).toBe(false)
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(addAction).not.toHaveBeenCalled()
+  })
+
   it('defers the reload when a generation is running', () => {
     executionState.runningJobIds = ['job-1']
 
@@ -103,7 +116,7 @@ describe('chunkReload', () => {
         afterEachCb = cb
         return vi.fn() // stop handle
       }
-    } as unknown as import('vue-router').Router
+    } as unknown as Router
 
     workflowState.modifiedWorkflows = [{ path: 'wf.json' }]
     expect(attemptChunkReload(router, APP_CHUNK)).toBe(false)

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -25,6 +25,8 @@ describe('chunkReload', () => {
     window.sessionStorage.clear()
     workflowState.modifiedWorkflows = []
     executionState.runningJobIds = []
+    // performReload() logs a recovery marker; silence it in tests.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     // location.reload is not implemented/allowed under jsdom; replace it.
     // A minimal stub is sufficient — chunkReload only ever calls

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -24,15 +24,10 @@ vi.mock('@datadog/browser-rum', () => ({
   datadogRum: { addAction: vi.fn() }
 }))
 
-// jsdom doesn't implement location.reload; stub it ONCE at module scope with
-// writable:true (the pattern used elsewhere in this repo). Redefining
-// window.location per-test is unreliable — the stub doesn't take effect for calls
-// made from nested callbacks/listeners.
+// location.reload isn't implemented in the test DOM. Override just the `reload`
+// method on the EXISTING window.location object (rather than replacing the whole
+// object, which doesn't survive into nested callbacks/listeners under happy-dom).
 const mockReload = vi.fn()
-Object.defineProperty(window, 'location', {
-  value: { reload: mockReload, origin: 'http://localhost' },
-  writable: true
-})
 
 const APP_CHUNK = 'http://localhost/assets/settingStore-CUtU9ycZ.js'
 const EXTENSION_CHUNK =
@@ -55,6 +50,13 @@ describe('chunkReload', () => {
     executionState.runningJobIds = []
     mockReload.mockClear()
     addAction.mockClear()
+    // Override only the reload method on the live location object so the stub is
+    // the same function chunkReload sees, including from callbacks/listeners.
+    Object.defineProperty(window.location, 'reload', {
+      configurable: true,
+      writable: true,
+      value: mockReload
+    })
   })
 
   afterEach(() => {

--- a/src/platform/updates/common/chunkReload.test.ts
+++ b/src/platform/updates/common/chunkReload.test.ts
@@ -30,7 +30,9 @@ const EXTENSION_CHUNK =
 
 function preloadErrorEvent(url: string): Event {
   const event = new Event('vite:preloadError') as Event & { payload: Error }
-  event.payload = new Error(`Failed to fetch dynamically imported module: ${url}`)
+  event.payload = new Error(
+    `Failed to fetch dynamically imported module: ${url}`
+  )
   return event
 }
 

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -1,3 +1,4 @@
+import { datadogRum } from '@datadog/browser-rum'
 import type { Router } from 'vue-router'
 
 import { useExecutionStore } from '@/stores/executionStore'
@@ -6,21 +7,23 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 /**
  * Recover from stale-chunk failures automatically.
  *
- * After a new frontend deploys, the previously-loaded `index.html` may reference
- * hashed JS/CSS chunks that no longer exist on the server. Any subsequent dynamic
- * import (route/component lazy-load) then fails with Vite's `vite:preloadError`
- * event or a `ChunkLoadError` promise rejection, producing a white screen.
+ * After a new frontend deploys, a previously-loaded `index.html` may reference
+ * hashed JS/CSS chunks that no longer exist. A subsequent dynamic import then
+ * fails with Vite's `vite:preloadError` event (or a `ChunkLoadError` rejection),
+ * producing a white screen. Because `index.html` is always served fresh, a
+ * single `location.reload()` pulls the current, self-consistent version.
  *
- * Because `index.html` is always served fresh (never fingerprinted), a single
- * `location.reload()` pulls the current, self-consistent version and the failure
- * becomes a transparent reload.
+ * Scope — **app chunks only.** Prod RUM shows `vite:preloadError` is dominated
+ * (~30:1) by missing `/extensions/*` custom-node assets, which a reload cannot
+ * fix (they are absent, not stale). Reloading for those just churns the user, so
+ * recovery is limited to the versioned, content-hashed `/assets/*` app chunks —
+ * the only case a reload actually resolves.
  *
- * Two safeguards keep this from becoming destructive:
- *  - A reload loop-guard (`sessionStorage`) reloads at most once per session, so a
- *    genuinely-missing asset does not trap the user in an endless reload cycle.
- *  - Unsaved-edit / active-generation awareness: if the user has dirty workflows
- *    or a running job, we do NOT reload immediately. Instead we defer and reload
- *    at the next safe navigation, so user work is never blown away.
+ * Safeguards:
+ *  - A `sessionStorage` loop-guard reloads at most once per session, so a
+ *    genuinely-missing asset never traps the user in a reload loop.
+ *  - Unsaved-edit / active-generation awareness defers the reload (and fires it
+ *    at the next safe navigation) so user work is never blown away.
  */
 
 /** sessionStorage key marking that we have already attempted a recovery reload. */
@@ -32,8 +35,8 @@ function guardAlreadySet(storage: Storage): boolean {
   try {
     return storage.getItem(CHUNK_RELOAD_GUARD_KEY) !== null
   } catch {
-    // If sessionStorage is unavailable (e.g. privacy mode), be conservative and
-    // treat the guard as set so we never risk a reload loop.
+    // sessionStorage unavailable (e.g. privacy mode): treat the guard as set so
+    // we never risk a reload loop.
     return true
   }
 }
@@ -42,19 +45,14 @@ function setGuard(storage: Storage): void {
   try {
     storage.setItem(CHUNK_RELOAD_GUARD_KEY, String(Date.now()))
   } catch {
-    // Best-effort: if we cannot persist the guard we still proceed with the
-    // reload (the caller has already checked it was unset), accepting that a
-    // second failure could reload again. This is rare and preferable to leaving
-    // the user on a broken page.
+    // Best-effort: proceed with the reload even if we cannot persist the guard.
   }
 }
 
 /**
  * Whether reloading now is safe (no unsaved edits and no active generation).
- *
- * Dirty state is detected via the same signal the beforeunload confirmation uses
- * (`workflowStore.modifiedWorkflows`); active generation via the execution store's
- * running jobs.
+ * Dirty state uses the same signal as the beforeunload confirmation
+ * (`workflowStore.modifiedWorkflows`); active generation via the execution store.
  */
 function isReloadSafe(): boolean {
   try {
@@ -66,52 +64,79 @@ function isReloadSafe(): boolean {
 
     return true
   } catch {
-    // If stores are not ready we cannot prove safety; err on the side of not
-    // interrupting the user.
+    // Stores not ready — cannot prove safety; do not interrupt the user.
     return false
   }
 }
 
-function performReload(): void {
-  // Emit a distinctive marker before reloading so recovery reloads are
-  // observable in logs/RUM — this is how we measure how often the mechanism
-  // actually fires in prod (and catch any unexpected spike). It is only ever
-  // reached on a genuine chunk-load failure, at most once per session.
-  console.warn('[chunkReload] stale-chunk detected — reloading to recover')
+/** Extract the failing module URL from a preload/chunk error. */
+function extractModuleUrl(reason: unknown): string | undefined {
+  if (!reason) return undefined
+  const direct = (reason as { url?: unknown }).url
+  if (typeof direct === 'string' && direct) return direct
+  const message =
+    typeof reason === 'string'
+      ? reason
+      : ((reason as { message?: unknown }).message ?? '')
+  if (typeof message !== 'string') return undefined
+  return message.match(/https?:\/\/[^\s"')]+|\/[^\s"')]+/)?.[0]
+}
+
+/**
+ * Only same-origin `/assets/*` app chunks are recoverable by a reload. Missing
+ * `/extensions/*` or `/scripts/*` assets are absent, not stale — reloading won't
+ * bring them back. When the URL can't be determined, err on the side of NOT
+ * reloading (the unknown/undetermined cases are overwhelmingly extensions).
+ */
+function isRecoverableChunkUrl(url: string | undefined): boolean {
+  if (!url) return false
+  try {
+    const parsed = new URL(url, window.location.origin)
+    return (
+      parsed.origin === window.location.origin &&
+      parsed.pathname.startsWith('/assets/')
+    )
+  } catch {
+    return false
+  }
+}
+
+function performReload(chunkUrl?: string): void {
+  // First-class, aggregatable telemetry: a RUM custom action fired only on a
+  // genuine app-chunk staleness recovery (at most once per session). This is how
+  // we measure real-world reload frequency and alert if it ever spikes.
+  datadogRum.addAction('stale-chunk-reload', { chunkUrl })
   window.location.reload()
 }
 
 /**
  * Attempt a guarded recovery reload.
  *
- * @returns `true` if a reload was triggered, `false` if it was skipped (guard set)
- *   or deferred (unsafe state).
+ * @returns `true` if a reload was triggered, `false` if skipped (guard set) or
+ *   deferred (unsafe state).
  */
-export function attemptChunkReload(router?: Router): boolean {
+export function attemptChunkReload(router?: Router, chunkUrl?: string): boolean {
   const storage = window.sessionStorage
 
   // Loop guard: only ever reload once per session.
-  if (guardAlreadySet(storage)) {
-    return false
-  }
+  if (guardAlreadySet(storage)) return false
 
   // Respect unsaved work / active generation — defer rather than destroy.
   if (!isReloadSafe()) {
-    armDeferredReload(router)
+    armDeferredReload(router, chunkUrl)
     return false
   }
 
   setGuard(storage)
-  performReload()
+  performReload(chunkUrl)
   return true
 }
 
 /**
  * Arm a one-shot reload that fires the next time the app reaches a safe state
- * during navigation. Navigation implies the user moved on from the broken view,
- * so reloading then is non-destructive.
+ * during navigation (navigation implies the user moved on from the broken view).
  */
-function armDeferredReload(router?: Router): void {
+function armDeferredReload(router?: Router, chunkUrl?: string): void {
   if (!router || deferredReloadArmed) return
   deferredReloadArmed = true
 
@@ -124,14 +149,12 @@ function armDeferredReload(router?: Router): void {
     if (isReloadSafe()) {
       stop()
       setGuard(storage)
-      performReload()
+      performReload(chunkUrl)
     }
   })
 }
 
-/**
- * Whether an error/rejection looks like a stale-chunk dynamic-import failure.
- */
+/** Whether a rejection looks like a stale-chunk dynamic-import failure. */
 function isChunkLoadError(reason: unknown): boolean {
   if (!reason) return false
   const name = (reason as { name?: unknown }).name
@@ -150,23 +173,22 @@ function isChunkLoadError(reason: unknown): boolean {
 }
 
 /**
- * Register global listeners that recover from stale-chunk failures with a
- * guarded reload. Call once during app init.
+ * Register global listeners that recover from stale *app-chunk* failures with a
+ * guarded reload. Call once during app init (cloud distribution only).
  */
 export function installChunkReload(router?: Router): void {
   // Vite's dedicated event for failed chunk preloads/dynamic imports.
-  window.addEventListener('vite:preloadError', () => {
-    // Note: telemetry/logging for this event is handled separately (App.vue).
-    // We do not preventDefault here — Vite's default is a no-op once the event
-    // has fired; our job is purely recovery.
-    attemptChunkReload(router)
+  window.addEventListener('vite:preloadError', (event) => {
+    const reason = (event as { payload?: unknown }).payload ?? event
+    const url = extractModuleUrl(reason)
+    if (isRecoverableChunkUrl(url)) attemptChunkReload(router, url)
   })
 
   // Fallback for dynamic-import rejections that surface as unhandled promise
-  // rejections (e.g. a lazy route component import) without the Vite event.
+  // rejections without the Vite event.
   window.addEventListener('unhandledrejection', (event) => {
-    if (isChunkLoadError(event.reason)) {
-      attemptChunkReload(router)
-    }
+    if (!isChunkLoadError(event.reason)) return
+    const url = extractModuleUrl(event.reason)
+    if (isRecoverableChunkUrl(url)) attemptChunkReload(router, url)
   })
 }

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -1,0 +1,167 @@
+import type { Router } from 'vue-router'
+
+import { useExecutionStore } from '@/stores/executionStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+/**
+ * Recover from stale-chunk failures automatically.
+ *
+ * After a new frontend deploys, the previously-loaded `index.html` may reference
+ * hashed JS/CSS chunks that no longer exist on the server. Any subsequent dynamic
+ * import (route/component lazy-load) then fails with Vite's `vite:preloadError`
+ * event or a `ChunkLoadError` promise rejection, producing a white screen.
+ *
+ * Because `index.html` is always served fresh (never fingerprinted), a single
+ * `location.reload()` pulls the current, self-consistent version and the failure
+ * becomes a transparent reload.
+ *
+ * Two safeguards keep this from becoming destructive:
+ *  - A reload loop-guard (`sessionStorage`) reloads at most once per session, so a
+ *    genuinely-missing asset does not trap the user in an endless reload cycle.
+ *  - Unsaved-edit / active-generation awareness: if the user has dirty workflows
+ *    or a running job, we do NOT reload immediately. Instead we defer and reload
+ *    at the next safe navigation, so user work is never blown away.
+ */
+
+/** sessionStorage key marking that we have already attempted a recovery reload. */
+export const CHUNK_RELOAD_GUARD_KEY = 'comfy:chunk-reload-attempted'
+
+let deferredReloadArmed = false
+
+function guardAlreadySet(storage: Storage): boolean {
+  try {
+    return storage.getItem(CHUNK_RELOAD_GUARD_KEY) !== null
+  } catch {
+    // If sessionStorage is unavailable (e.g. privacy mode), be conservative and
+    // treat the guard as set so we never risk a reload loop.
+    return true
+  }
+}
+
+function setGuard(storage: Storage): void {
+  try {
+    storage.setItem(CHUNK_RELOAD_GUARD_KEY, String(Date.now()))
+  } catch {
+    // Best-effort: if we cannot persist the guard we still proceed with the
+    // reload (the caller has already checked it was unset), accepting that a
+    // second failure could reload again. This is rare and preferable to leaving
+    // the user on a broken page.
+  }
+}
+
+/**
+ * Whether reloading now is safe (no unsaved edits and no active generation).
+ *
+ * Dirty state is detected via the same signal the beforeunload confirmation uses
+ * (`workflowStore.modifiedWorkflows`); active generation via the execution store's
+ * running jobs.
+ */
+function isReloadSafe(): boolean {
+  try {
+    const workflowStore = useWorkflowStore()
+    if (workflowStore.modifiedWorkflows.length > 0) return false
+
+    const executionStore = useExecutionStore()
+    if (executionStore.runningJobIds.length > 0) return false
+
+    return true
+  } catch {
+    // If stores are not ready we cannot prove safety; err on the side of not
+    // interrupting the user.
+    return false
+  }
+}
+
+function performReload(): void {
+  window.location.reload()
+}
+
+/**
+ * Attempt a guarded recovery reload.
+ *
+ * @returns `true` if a reload was triggered, `false` if it was skipped (guard set)
+ *   or deferred (unsafe state).
+ */
+export function attemptChunkReload(router?: Router): boolean {
+  const storage = window.sessionStorage
+
+  // Loop guard: only ever reload once per session.
+  if (guardAlreadySet(storage)) {
+    return false
+  }
+
+  // Respect unsaved work / active generation — defer rather than destroy.
+  if (!isReloadSafe()) {
+    armDeferredReload(router)
+    return false
+  }
+
+  setGuard(storage)
+  performReload()
+  return true
+}
+
+/**
+ * Arm a one-shot reload that fires the next time the app reaches a safe state
+ * during navigation. Navigation implies the user moved on from the broken view,
+ * so reloading then is non-destructive.
+ */
+function armDeferredReload(router?: Router): void {
+  if (!router || deferredReloadArmed) return
+  deferredReloadArmed = true
+
+  const stop = router.afterEach(() => {
+    const storage = window.sessionStorage
+    if (guardAlreadySet(storage)) {
+      stop()
+      return
+    }
+    if (isReloadSafe()) {
+      stop()
+      setGuard(storage)
+      performReload()
+    }
+  })
+}
+
+/**
+ * Whether an error/rejection looks like a stale-chunk dynamic-import failure.
+ */
+function isChunkLoadError(reason: unknown): boolean {
+  if (!reason) return false
+  const name = (reason as { name?: unknown }).name
+  if (name === 'ChunkLoadError') return true
+  const message =
+    typeof reason === 'string'
+      ? reason
+      : ((reason as { message?: unknown }).message ?? '')
+  if (typeof message !== 'string') return false
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /Unable to preload CSS/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message)
+  )
+}
+
+/**
+ * Register global listeners that recover from stale-chunk failures with a
+ * guarded reload. Call once during app init.
+ */
+export function installChunkReload(router?: Router): void {
+  // Vite's dedicated event for failed chunk preloads/dynamic imports.
+  window.addEventListener('vite:preloadError', () => {
+    // Note: telemetry/logging for this event is handled separately (App.vue).
+    // We do not preventDefault here — Vite's default is a no-op once the event
+    // has fired; our job is purely recovery.
+    attemptChunkReload(router)
+  })
+
+  // Fallback for dynamic-import rejections that surface as unhandled promise
+  // rejections (e.g. a lazy route component import) without the Vite event.
+  window.addEventListener('unhandledrejection', (event) => {
+    if (isChunkLoadError(event.reason)) {
+      attemptChunkReload(router)
+    }
+  })
+}

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -29,8 +29,6 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 /** sessionStorage key marking that we have already attempted a recovery reload. */
 export const CHUNK_RELOAD_GUARD_KEY = 'comfy:chunk-reload-attempted'
 
-let deferredReloadArmed = false
-
 function guardAlreadySet(storage: Storage): boolean {
   try {
     return storage.getItem(CHUNK_RELOAD_GUARD_KEY) !== null
@@ -95,11 +93,11 @@ function extractModuleUrl(reason: unknown): string | undefined {
 function isRecoverableChunkUrl(url: string | undefined): boolean {
   if (!url) return false
   try {
-    const parsed = new URL(url, window.location.origin)
-    return (
-      parsed.origin === window.location.origin &&
-      parsed.pathname.startsWith('/assets/')
-    )
+    // We only care about the path — app chunks live under /assets/. A throwaway
+    // base lets a relative URL parse; for an absolute URL the base is ignored.
+    // (App chunks are same-origin by nature, and reloading the current page is
+    // benign regardless, so a strict origin check would add nothing here.)
+    return new URL(url, 'http://localhost').pathname.startsWith('/assets/')
   } catch {
     return false
   }
@@ -144,9 +142,11 @@ export function attemptChunkReload(
  * during navigation (navigation implies the user moved on from the broken view).
  */
 function armDeferredReload(router?: Router, chunkUrl?: string): void {
-  if (!router || deferredReloadArmed) return
-  deferredReloadArmed = true
+  if (!router) return
 
+  // The sessionStorage guard already caps recovery at one reload per session, so
+  // if multiple deferred errors register a hook each, only the first to reach a
+  // safe navigation reloads; the rest see the guard set and remove themselves.
   const stop = router.afterEach(() => {
     const storage = window.sessionStorage
     if (guardAlreadySet(storage)) {

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -73,6 +73,11 @@ function isReloadSafe(): boolean {
 }
 
 function performReload(): void {
+  // Emit a distinctive marker before reloading so recovery reloads are
+  // observable in logs/RUM — this is how we measure how often the mechanism
+  // actually fires in prod (and catch any unexpected spike). It is only ever
+  // reached on a genuine chunk-load failure, at most once per session.
+  console.warn('[chunkReload] stale-chunk detected — reloading to recover')
   window.location.reload()
 }
 

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -41,11 +41,15 @@ function guardAlreadySet(storage: Storage): boolean {
   }
 }
 
-function setGuard(storage: Storage): void {
+function setGuard(storage: Storage): boolean {
   try {
     storage.setItem(CHUNK_RELOAD_GUARD_KEY, String(Date.now()))
+    return true
   } catch {
-    // Best-effort: proceed with the reload even if we cannot persist the guard.
+    // Could not persist the guard (e.g. storage quota). Do NOT reload — without
+    // a stored guard a still-broken page would reload endlessly. Favor a visible
+    // error over a reload loop.
+    return false
   }
 }
 
@@ -127,7 +131,7 @@ export function attemptChunkReload(router?: Router, chunkUrl?: string): boolean 
     return false
   }
 
-  setGuard(storage)
+  if (!setGuard(storage)) return false
   performReload(chunkUrl)
   return true
 }
@@ -148,8 +152,7 @@ function armDeferredReload(router?: Router, chunkUrl?: string): void {
     }
     if (isReloadSafe()) {
       stop()
-      setGuard(storage)
-      performReload(chunkUrl)
+      if (setGuard(storage)) performReload(chunkUrl)
     }
   })
 }

--- a/src/platform/updates/common/chunkReload.ts
+++ b/src/platform/updates/common/chunkReload.ts
@@ -119,7 +119,10 @@ function performReload(chunkUrl?: string): void {
  * @returns `true` if a reload was triggered, `false` if skipped (guard set) or
  *   deferred (unsafe state).
  */
-export function attemptChunkReload(router?: Router, chunkUrl?: string): boolean {
+export function attemptChunkReload(
+  router?: Router,
+  chunkUrl?: string
+): boolean {
   const storage = window.sessionStorage
 
   // Loop guard: only ever reload once per session.


### PR DESCRIPTION
## What

Recover automatically from stale-chunk failures. After a new frontend deploys, the previously-loaded `index.html` still points at hashed JS/CSS chunks that no longer exist on the server, so the next dynamic import (a lazy route/component load) fails and the user gets a white screen.

This adds a small `chunkReload` module that listens for the failure and does a single **guarded** `location.reload()`. Because `index.html` is always served fresh, the reload pulls the current, self-consistent version — the white screen becomes a transparent reload.

## Why

Stale-chunk white-screens are a recurring post-deploy staleness bug. This is a high-value fix on its own and is independent of the canary work.

## How it works

- Listens for Vite's `vite:preloadError` event **and** `unhandledrejection`s that look like a `ChunkLoadError` / "Failed to fetch dynamically imported module" (covers dynamic imports that surface as a rejection without the Vite event).
- **Loop guard:** a `sessionStorage` key (`comfy:chunk-reload-attempted`) ensures we reload **at most once per session**. If the asset is genuinely gone, we do not trap the user in an infinite reload loop.
- **Dirty-state handling:** if there are unsaved workflow edits or an active generation, we do **not** reload immediately — that would blow away user work. Instead we defer and reload at the next **safe navigation** (which implies the user moved on from the broken view). Dirty state is detected via the same `workflowStore.modifiedWorkflows` signal the `beforeunload` confirmation already uses; active generation via `executionStore.runningJobIds`.
- Wired up in `main.ts` after pinia is installed, so the error-time store lookups resolve. Existing `vite:preloadError` telemetry in `App.vue` is untouched — this module owns recovery only.

## Verification

- `pnpm vitest run src/platform/updates/common/chunkReload.test.ts` — 8/8 pass. Covers: (a) a `vite:preloadError` triggers exactly one reload; (b) a second event with the guard set does not reload (loop guard); (c) unsaved edits defer the reload; (d) a running generation defers; (e) deferred reload fires at the next safe navigation; (f) unhandledrejection ChunkLoadError path; (g) unrelated rejections are ignored.
- `oxfmt --check` and `oxlint` on changed files — clean.
- `vue-tsc --noEmit` — no errors in the changed files (only pre-existing environmental type-def-resolution warnings unrelated to this change).
- Full production build skipped (heavy).

Linear: FE-1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)