### PR TITLE
feat: add ComfyUI frontend version to Datadog RUM

### DIFF
--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -25,10 +25,6 @@ import { rumBeforeSend } from './datadogRumBeforeSend'
 import { initDatadogRum } from './initDatadogRum'
 import { trackUserManualRefresh } from './manualRefreshTracker'
 
-const expectedReleaseMinor = __COMFYUI_FRONTEND_VERSION__
-  .split('.', 2)
-  .join('.')
-
 describe('initDatadogRum', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -83,7 +79,7 @@ describe('initDatadogRum', () => {
     hoisted.init.mockImplementation(() => {
       expect(hoisted.context).toEqual({
         bucket: 'canary',
-        release_minor: expectedReleaseMinor,
+        comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__,
         version: __COMFYUI_FRONTEND_COMMIT__
       })
     })
@@ -103,7 +99,7 @@ describe('initDatadogRum', () => {
 
     expect(hoisted.context).toEqual({
       bucket: 'canary',
-      release_minor: expectedReleaseMinor,
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
     expect(hoisted.init).toHaveBeenCalledOnce()
@@ -134,7 +130,7 @@ describe('initDatadogRum', () => {
     expect(hoisted.init).toHaveBeenCalledOnce()
     expect(hoisted.context).toEqual({
       bucket: 'canary',
-      release_minor: expectedReleaseMinor,
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
   })
@@ -150,7 +146,7 @@ describe('initDatadogRum', () => {
 
     expect(hoisted.context).toEqual({
       bucket: 'stable',
-      release_minor: expectedReleaseMinor,
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
   })
@@ -165,7 +161,7 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.context).toEqual({
-      release_minor: expectedReleaseMinor
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__
     })
   })
 
@@ -182,7 +178,7 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.context).toEqual({
-      release_minor: expectedReleaseMinor
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__
     })
   })
 
@@ -192,7 +188,7 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.context).toEqual({
-      release_minor: expectedReleaseMinor
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__
     })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })
@@ -203,7 +199,7 @@ describe('initDatadogRum', () => {
     await initDatadogRum('cloud.comfy.org')
 
     expect(hoisted.context).toEqual({
-      release_minor: expectedReleaseMinor
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__
     })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })
@@ -225,7 +221,7 @@ describe('initDatadogRum', () => {
     await initialization
 
     expect(hoisted.context).toEqual({
-      release_minor: expectedReleaseMinor
+      comfyui_frontend_version: __COMFYUI_FRONTEND_VERSION__
     })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -25,6 +25,10 @@ import { rumBeforeSend } from './datadogRumBeforeSend'
 import { initDatadogRum } from './initDatadogRum'
 import { trackUserManualRefresh } from './manualRefreshTracker'
 
+const expectedReleaseMinor = __COMFYUI_FRONTEND_VERSION__
+  .split('.', 2)
+  .join('.')
+
 describe('initDatadogRum', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -79,6 +83,7 @@ describe('initDatadogRum', () => {
     hoisted.init.mockImplementation(() => {
       expect(hoisted.context).toEqual({
         bucket: 'canary',
+        release_minor: expectedReleaseMinor,
         version: __COMFYUI_FRONTEND_COMMIT__
       })
     })
@@ -98,6 +103,7 @@ describe('initDatadogRum', () => {
 
     expect(hoisted.context).toEqual({
       bucket: 'canary',
+      release_minor: expectedReleaseMinor,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
     expect(hoisted.init).toHaveBeenCalledOnce()
@@ -128,6 +134,7 @@ describe('initDatadogRum', () => {
     expect(hoisted.init).toHaveBeenCalledOnce()
     expect(hoisted.context).toEqual({
       bucket: 'canary',
+      release_minor: expectedReleaseMinor,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
   })
@@ -143,6 +150,7 @@ describe('initDatadogRum', () => {
 
     expect(hoisted.context).toEqual({
       bucket: 'stable',
+      release_minor: expectedReleaseMinor,
       version: __COMFYUI_FRONTEND_COMMIT__
     })
   })
@@ -156,7 +164,9 @@ describe('initDatadogRum', () => {
 
     await initDatadogRum('cloud.comfy.org')
 
-    expect(hoisted.context).toEqual({})
+    expect(hoisted.context).toEqual({
+      release_minor: expectedReleaseMinor
+    })
   })
 
   it('leaves traffic unclassified when the probe reaches another version', async () => {
@@ -171,7 +181,9 @@ describe('initDatadogRum', () => {
 
     await initDatadogRum('cloud.comfy.org')
 
-    expect(hoisted.context).toEqual({})
+    expect(hoisted.context).toEqual({
+      release_minor: expectedReleaseMinor
+    })
   })
 
   it('leaves traffic unclassified when the header probe fails', async () => {
@@ -179,7 +191,9 @@ describe('initDatadogRum', () => {
 
     await initDatadogRum('cloud.comfy.org')
 
-    expect(hoisted.context).toEqual({})
+    expect(hoisted.context).toEqual({
+      release_minor: expectedReleaseMinor
+    })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })
 
@@ -188,7 +202,9 @@ describe('initDatadogRum', () => {
 
     await initDatadogRum('cloud.comfy.org')
 
-    expect(hoisted.context).toEqual({})
+    expect(hoisted.context).toEqual({
+      release_minor: expectedReleaseMinor
+    })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })
 
@@ -208,7 +224,9 @@ describe('initDatadogRum', () => {
     abortController.abort()
     await initialization
 
-    expect(hoisted.context).toEqual({})
+    expect(hoisted.context).toEqual({
+      release_minor: expectedReleaseMinor
+    })
     expect(hoisted.init).toHaveBeenCalledOnce()
   })
 

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -8,6 +8,9 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['stagingcloud.comfy.org', 'stg-v2'],
   ['testcloud.comfy.org', 'test-v2']
 ])
+const FRONTEND_RELEASE_MINOR = __COMFYUI_FRONTEND_VERSION__
+  .split('.', 2)
+  .join('.')
 const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
 let initializationPromise: Promise<void> | undefined
 
@@ -30,6 +33,7 @@ async function setFrontendContext(): Promise<void> {
 }
 
 async function initializeDatadogRum(env: string): Promise<void> {
+  datadogRum.setGlobalContextProperty('release_minor', FRONTEND_RELEASE_MINOR)
   await setFrontendContext().catch(() => {})
   if (datadogRum.getInitConfiguration()) return
 

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -8,9 +8,6 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['stagingcloud.comfy.org', 'stg-v2'],
   ['testcloud.comfy.org', 'test-v2']
 ])
-const FRONTEND_RELEASE_MINOR = __COMFYUI_FRONTEND_VERSION__
-  .split('.', 2)
-  .join('.')
 const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
 let initializationPromise: Promise<void> | undefined
 
@@ -33,7 +30,10 @@ async function setFrontendContext(): Promise<void> {
 }
 
 async function initializeDatadogRum(env: string): Promise<void> {
-  datadogRum.setGlobalContextProperty('release_minor', FRONTEND_RELEASE_MINOR)
+  datadogRum.setGlobalContextProperty(
+    'comfyui_frontend_version',
+    __COMFYUI_FRONTEND_VERSION__
+  )
   await setFrontendContext().catch(() => {})
   if (datadogRum.getInitConfiguration()) return
 


### PR DESCRIPTION
## Summary

Expose `comfyui_frontend_version` on Datadog RUM events so dashboard traffic can be filtered by the frontend release.

## Changes

- **What**: Set `comfyui_frontend_version` directly from `__COMFYUI_FRONTEND_VERSION__` before RUM initialization.
- **Tests**: Cover the new context for classified traffic and frontend-context probe failure paths.

## Review Focus

Confirm that the attribute name and build-time frontend version match the dashboard contract.

Created by Codex