### PR TITLE
feat(onboarding): first-run tour on curated templates (lean)

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -4,7 +4,10 @@ import { config as dotenvConfig } from 'dotenv'
 import MCR from 'monocart-coverage-reports'
 
 import { COVERAGE_OUTPUT_DIR } from '@e2e/coverageConfig'
-import { TOURS, TOUR_SEEN_SETTING } from '@/platform/onboarding/onboardingTours'
+import {
+  ENTRY_PATHS,
+  TOUR_SEEN_SETTING
+} from '@/platform/onboarding/onboardingTours'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
@@ -544,7 +547,7 @@ export const comfyPageFixture = base.extend<{
         // Set tutorial completed to true to avoid loading the tutorial workflow.
         'Comfy.TutorialCompleted': true,
         // An auto-opened tour's blocker would break unrelated tests.
-        [TOUR_SEEN_SETTING]: Object.keys(TOURS),
+        [TOUR_SEEN_SETTING]: [...ENTRY_PATHS],
         'Comfy.Queue.MaxHistoryItems': 64,
         'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
         // Disable toast warning about version compatibility, as they may or

--- a/browser_tests/tests/firstRunTourRolePins.spec.ts
+++ b/browser_tests/tests/firstRunTourRolePins.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test'
+
+import type {
+  ExportedSubgraph,
+  ISerialisedNode,
+  SerialisableGraph
+} from '@/lib/litegraph/src/types/serialisation'
+import { CURATED_TEMPLATE_IDS } from '@/renderer/extensions/firstRunTour/gettingStarted/tutorialCards'
+import { TOUR_ROLE_PINS } from '@/renderer/extensions/firstRunTour/roles/tourRolePins'
+import type {
+  RolePin,
+  RolePins
+} from '@/renderer/extensions/firstRunTour/roles/tourRolePins'
+import { templateApiFixture as test } from '@e2e/fixtures/templateApiFixture'
+
+const baseUrl = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const pinnedTemplates = Object.entries(TOUR_ROLE_PINS)
+
+function pinnedRoles(pins: RolePins): [string, RolePin][] {
+  const roles = { source: pins.source, prompt: pins.prompt, sink: pins.sink }
+  return Object.entries(roles).filter(
+    (entry): entry is [string, RolePin] => entry[1] !== undefined
+  )
+}
+
+/** Subgraph definitions nest, and so does the resolver's host-mapping. */
+function nodesOf(
+  graph: SerialisableGraph | ExportedSubgraph
+): ISerialisedNode[] {
+  return [
+    ...(graph.nodes ?? []),
+    ...(graph.definitions?.subgraphs ?? []).flatMap(nodesOf)
+  ]
+}
+
+function findNode(workflow: SerialisableGraph, id: number) {
+  return nodesOf(workflow).find((node) => String(node.id) === String(id))
+}
+
+test.describe('first-run tour role pins', { tag: '@workflow' }, () => {
+  test('every pinned node still exists with its pinned type', async ({
+    request
+  }) => {
+    const unserved: string[] = []
+
+    for (const [templateId, pins] of pinnedTemplates) {
+      const url = new URL(`/templates/${templateId}.json`, baseUrl).toString()
+      const response = await request.get(url)
+      if (!response.ok()) {
+        unserved.push(templateId)
+        continue
+      }
+
+      const workflow = (await response.json()) as SerialisableGraph
+      for (const [role, pin] of pinnedRoles(pins)) {
+        expect(
+          findNode(workflow, pin.id)?.type,
+          `${templateId} pins its ${role} to node ${pin.id}, which this backend no longer serves as a ${pin.type}`
+        ).toBe(pin.type)
+      }
+    }
+    if (unserved.length)
+      test.info().annotations.push({
+        type: 'unserved templates',
+        description: `pins unverified, not served by this backend: ${unserved.join(', ')}`
+      })
+    expect(
+      pinnedTemplates.length - unserved.length,
+      `the Getting Started grid needs ${CURATED_TEMPLATE_IDS.length} templates and this backend serves too few of these pins — unserved: ${unserved.join(', ')}`
+    ).toBeGreaterThanOrEqual(CURATED_TEMPLATE_IDS.length)
+  })
+})

--- a/browser_tests/tests/gettingStartedTour.spec.ts
+++ b/browser_tests/tests/gettingStartedTour.spec.ts
@@ -1,0 +1,305 @@
+import { expect, mergeTests } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { TOUR_ROLE_PINS } from '@/renderer/extensions/firstRunTour/roles/tourRolePins'
+import type { SupportedTemplateId } from '@/renderer/extensions/firstRunTour/roles/tourRolePins'
+
+import type { PromptResponse } from '@comfyorg/ingest-types'
+
+import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const wstest = mergeTests(test, webSocketFixture)
+
+const { firstRun } = enMessages.onboardingCoachmarks
+const GETTING_STARTED_TITLE = enMessages.gettingStarted.title
+const RUN_STEP_TITLE = firstRun.run.title
+const GENERATING_TITLE = firstRun.result.generating.title
+const RESULT_IMAGE_TITLE = firstRun.result.image.title
+const RESULT_FAILED_TITLE = firstRun.result.failed.title
+const CARD_TESTID_PREFIX = 'getting-started-card-'
+
+/** The prompt id the tour's run is queued under, so WS events can address it. */
+const TOUR_JOB_ID = 'first-run-tour-prompt'
+const LINKED_TEMPLATE_ID: SupportedTemplateId = 'image_z_image_turbo'
+
+/** A prompt the queue accepts, so the walk does not depend on the backend's models. */
+const QUEUED_PROMPT: PromptResponse = {
+  prompt_id: TOUR_JOB_ID,
+  number: 1,
+  node_errors: {}
+}
+
+const TOUR_FEATURE_FLAGS: RemoteConfig = {
+  onboarding_tour_enabled: true,
+  subscription_required: true
+}
+
+const ACTIVE_SUBSCRIPTION: CloudSubscriptionStatusResponse = {
+  is_active: true,
+  subscription_id: 'sub_first_run_tour',
+  renewal_date: '2099-01-01'
+}
+
+function isPinned(id: string): id is SupportedTemplateId {
+  return Object.hasOwn(TOUR_ROLE_PINS, id)
+}
+
+async function clearWorkflowHistory(page: Page) {
+  await page.evaluate(() => {
+    for (const key of Object.keys(localStorage))
+      if (key.startsWith('Comfy.Workflow.')) localStorage.removeItem(key)
+  })
+}
+
+/**
+ * The grid backfills whichever curated templates a backend does not serve, so
+ * the walk tours a card that is actually on screen rather than a fixed id.
+ */
+async function firstPinnedTemplateOnScreen(
+  page: Page
+): Promise<SupportedTemplateId> {
+  const cardTestIds = () =>
+    page
+      .locator(`[data-testid^="${CARD_TESTID_PREFIX}"]`)
+      .evaluateAll((cards) =>
+        cards.map((card) => card.getAttribute('data-testid') ?? '')
+      )
+
+  await expect
+    .poll(
+      async () =>
+        (await cardTestIds()).some((testId) =>
+          isPinned(testId.slice(CARD_TESTID_PREFIX.length))
+        ),
+      { message: 'the Getting Started grid never rendered a pinned template' }
+    )
+    .toBe(true)
+
+  const templateId = (await cardTestIds())
+    .map((testId) => testId.slice(CARD_TESTID_PREFIX.length))
+    .find(isPinned)
+
+  return templateId!
+}
+
+/**
+ * The walk the review asked for: a fresh user reaches Getting Started, picks a
+ * template, and the tour guides them through to a result.
+ */
+test.describe('First-run tour', { tag: ['@cloud', '@ui'] }, () => {
+  test.use({
+    initialSettings: {
+      'Comfy.TutorialCompleted': false,
+      'Comfy.OnboardingCoachmarks.Seen': ['appMode']
+    },
+    initialFeatureFlags: { onboarding_tour_enabled: true }
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/features', (route) =>
+      route.fulfill(jsonRoute(TOUR_FEATURE_FLAGS))
+    )
+    // Without this the toolbar offers Subscribe to Run, and the tour's paywall
+    // guard consumes that click instead of running anything.
+    await page.route('**/customers/cloud-subscription-status', (route) =>
+      route.fulfill(jsonRoute(ACTIVE_SUBSCRIPTION))
+    )
+    await page.addInitScript(() => {
+      const style = document.createElement('style')
+      style.textContent = '.p-toast { pointer-events: none !important; }'
+      document.addEventListener('DOMContentLoaded', () =>
+        document.head.append(style)
+      )
+    })
+  })
+
+  /**
+   * The shared half of the walk: a fresh user reaches Getting Started, picks a
+   * pinned template, and the tour guides them to Run — where the funded and
+   * paywalled branches part. The run is queued under a known id, so whoever
+   * goes on to click Run can address it over the websocket.
+   */
+  async function tourToRunStep(page: Page) {
+    const screen = page.getByRole('dialog', { name: GETTING_STARTED_TITLE })
+    const spotlight = page.getByTestId('coach-spotlight')
+    const card = page.getByTestId('coach-card')
+
+    await page.route('**/api/prompt', (route) =>
+      route.fulfill(jsonRoute(QUEUED_PROMPT))
+    )
+
+    await expect(screen).toBeVisible()
+
+    const templateId = await firstPinnedTemplateOnScreen(page)
+    await page.getByTestId(`${CARD_TESTID_PREFIX}${templateId}`).click()
+
+    await expect(screen).toBeHidden()
+    await expect(
+      spotlight,
+      'picking a template must spotlight the graph it loaded'
+    ).toBeVisible()
+    await expect(card).toContainText('Step 1 of')
+
+    const next = card.getByRole('button', { name: 'Next' })
+    const runTitle = card.getByText(RUN_STEP_TITLE)
+    await expect(async () => {
+      await next.click()
+      await expect(runTitle).toBeVisible({ timeout: 2_000 })
+    }).toPass({ timeout: 30_000 })
+
+    await expect(
+      next,
+      'the Run step must offer no way forward except running'
+    ).toBeHidden()
+
+    return { spotlight, card }
+  }
+
+  /** Clicks Run and waits for the Result step to admit the run is in flight. */
+  async function runFromTourStep(page: Page, card: Locator) {
+    await page.getByTestId('queue-button').click()
+
+    await expect(
+      card.getByText(GENERATING_TITLE),
+      'the run outlives its step, so the click moves the tour on and Result reports it'
+    ).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('coach-busy')).toBeVisible()
+  }
+
+  wstest(
+    'guides a first-run user from a template to a finished result',
+    async ({ comfyPage, getWebSocket }) => {
+      // A template load, three camera flights and a queued run do not fit the default budget.
+      test.slow()
+      const { page } = comfyPage
+      const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+
+      const { card } = await tourToRunStep(page)
+      await runFromTourStep(page, card)
+
+      execution.executionStart(TOUR_JOB_ID)
+      execution.executionSuccess(TOUR_JOB_ID)
+
+      await expect(
+        card.getByText(RESULT_IMAGE_TITLE),
+        'the run finished, so the Result step has to stop saying it is still coming'
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(
+        page.getByTestId('coach-busy'),
+        'nothing is in flight once the run succeeds'
+      ).toBeHidden()
+    }
+  )
+
+  wstest(
+    'tells a first-run user when the run produced nothing',
+    async ({ comfyPage, getWebSocket }) => {
+      test.slow()
+      const { page } = comfyPage
+      const execution = new ExecutionHelper(comfyPage, await getWebSocket())
+
+      const { card } = await tourToRunStep(page)
+      await runFromTourStep(page, card)
+
+      execution.executionStart(TOUR_JOB_ID)
+      execution.executionError(TOUR_JOB_ID, '1', 'the run blew up')
+
+      await expect(
+        card.getByText(RESULT_FAILED_TITLE),
+        'announcing a result that does not exist is the bug D2 filed'
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByTestId('coach-busy')).toBeHidden()
+    }
+  )
+
+  test.describe('without a subscription', () => {
+    test.beforeEach(async ({ page }) => {
+      await mockBilling(page)
+    })
+
+    test('leaves the nudge until the upgrade dialog closes', async ({
+      comfyPage
+    }) => {
+      test.slow()
+      const { page } = comfyPage
+      const { spotlight } = await tourToRunStep(page)
+      const nudge = page.getByTestId('first-run-nudge')
+      const upgradeDialog = page.getByTestId('dialog-overlay')
+
+      await page.getByTestId('subscribe-to-run-button').click()
+
+      await expect(upgradeDialog).toBeVisible()
+      await expect(
+        spotlight,
+        'a tour parked on a button that will never run has nowhere to go'
+      ).toBeHidden()
+
+      await page.keyboard.press('Escape')
+
+      await expect(upgradeDialog).toBeHidden()
+      await expect(
+        nudge,
+        'the tour ended, so the user still needs somewhere to go next'
+      ).toBeVisible({ timeout: 10_000 })
+    })
+  })
+
+  test('starts no tour for a user who takes the blank canvas', async ({
+    comfyPage
+  }) => {
+    const { page } = comfyPage
+
+    await page.getByTestId('getting-started-blank').click()
+
+    await expect(
+      page.getByRole('dialog', { name: GETTING_STARTED_TITLE })
+    ).toBeHidden()
+    await expect(page.getByTestId('coach-spotlight')).toBeHidden()
+  })
+
+  test.describe('arriving on a template link', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await clearWorkflowHistory(comfyPage.page)
+      await comfyPage.setup({
+        clearStorage: false,
+        url: `/?template=${LINKED_TEMPLATE_ID}`
+      })
+    })
+
+    test('tours the template the link loaded', async ({ comfyPage }) => {
+      const { page } = comfyPage
+
+      await expect(
+        page.getByRole('dialog', { name: GETTING_STARTED_TITLE }),
+        'the link already chose a workflow, so there is nothing to choose'
+      ).toBeHidden()
+      await expect(page.getByTestId('coach-spotlight')).toBeVisible()
+      await expect(page.getByTestId('coach-card')).toContainText('Step 1 of')
+    })
+  })
+
+  test.describe('arriving on a link that loads nothing', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await clearWorkflowHistory(comfyPage.page)
+      await comfyPage.setup({
+        clearStorage: false,
+        url: '/?template=no_such_template_exists'
+      })
+    })
+
+    test('offers no tour', async ({ comfyPage }) => {
+      await expect(
+        comfyPage.page.getByTestId('coach-spotlight'),
+        'touring a graph the user never asked for is worse than no tour'
+      ).toBeHidden()
+    })
+  })
+})

--- a/src/components/actionbar/ComfyActionbar.vue
+++ b/src/components/actionbar/ComfyActionbar.vue
@@ -30,7 +30,7 @@
           "
         />
         <Suspense @resolve="comfyRunButtonResolved">
-          <ComfyRunButton />
+          <ComfyRunButton v-coachmark="FIRST_RUN_COACH_IDS.runButton" />
         </Suspense>
         <Button
           v-tooltip.bottom="cancelJobTooltipConfig"
@@ -115,6 +115,8 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
+import { FIRST_RUN_COACH_IDS } from '@/platform/onboarding/onboardingTours'
+import { vCoachmark } from '@/platform/onboarding/vCoachmark'
 import { useQueueStore } from '@/stores/queueStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import { cn } from '@comfyorg/tailwind-utils'

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -179,6 +179,8 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
+import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
+import { useFirstRunEntry } from '@/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
 import { requestSlotLayoutSyncForAllNodes } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
@@ -504,6 +506,8 @@ useEventListener(
 onMounted(async () => {
   comfyApp.vueAppReady = true
   workspaceStore.spinner = true
+  let startupOutcome: StartupOutcome | undefined
+  let urlTemplateId: string | undefined
   try {
     // ChangeTracker needs to be initialized before setup, as it will overwrite
     // some listeners of litegraph canvas.
@@ -559,13 +563,20 @@ onMounted(async () => {
     )
 
     // Restore saved workflow and workflow tabs state
-    await workflowPersistence.initializeWorkflow()
+    startupOutcome = await workflowPersistence.initializeWorkflow()
     await workflowPersistence.restoreWorkflowTabsState()
-    await workflowPersistence.loadTemplateFromUrlIfPresent()
+    urlTemplateId = await workflowPersistence.loadTemplateFromUrlIfPresent()
+    await useFirstRunEntry().handleStartupOutcome(startupOutcome)
   } finally {
     workspaceStore.spinner = false
   }
-  await workflowPersistence.loadSharedWorkflowFromUrlIfPresent()
+  const sharedStatus =
+    await workflowPersistence.loadSharedWorkflowFromUrlIfPresent()
+  await useFirstRunEntry().handleUrlWorkflow(
+    startupOutcome,
+    urlTemplateId,
+    sharedStatus
+  )
 
   comfyApp.canvas.onSelectionChange = useChainCallback(
     comfyApp.canvas.onSelectionChange,

--- a/src/components/tab/TabList.vue
+++ b/src/components/tab/TabList.vue
@@ -1,5 +1,8 @@
 <template>
-  <div role="tablist" class="flex w-full items-center gap-2">
+  <div
+    role="tablist"
+    :class="cn('flex w-full items-center gap-2', customClass)"
+  >
     <slot />
   </div>
 </template>
@@ -7,7 +10,11 @@
 <script setup lang="ts" generic="T extends string = string">
 import { provide } from 'vue'
 
+import { cn } from '@comfyorg/tailwind-utils'
+
 import { TAB_LIST_INJECTION_KEY } from './tabKeys'
+
+const { class: customClass = '' } = defineProps<{ class?: string }>()
 
 const modelValue = defineModel<T>({ required: true })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -38,7 +38,7 @@ export enum ServerFeatureFlag {
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
   FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
   SIGNUP_TURNSTILE = 'signup_turnstile',
-  SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags'
+  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
 }
 
 /**
@@ -238,9 +238,10 @@ export function useFeatureFlags() {
         'off'
       )
     },
-    get supportsModelTypeTags() {
-      return api.getServerFeature(
-        ServerFeatureFlag.SUPPORTS_MODEL_TYPE_TAGS,
+    get onboardingTourEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.ONBOARDING_TOUR_ENABLED,
+        remoteConfig.value.onboarding_tour_enabled,
         false
       )
     }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -900,8 +900,6 @@
       "filterAudio": "Audio",
       "filter3D": "3D",
       "filterText": "Text",
-      "viewGridSmall": "Grid (small)",
-      "viewGridLarge": "Grid (large)",
       "viewSettings": "View settings"
     },
     "backToAssets": "Back to all assets",
@@ -977,8 +975,6 @@
       "noBookmarkedNodes": "No bookmarks yet"
     },
     "modelLibrary": "Model Library",
-    "modelLibraryLoadFailed": "Failed to load models. Check the server connection and use Refresh to retry.",
-    "searchResultsCapped": "Showing the first {limit} matches. Refine your search to see more specific results.",
     "downloads": "Downloads",
     "queueProgressOverlay": {
       "title": "Queue Progress",
@@ -1094,7 +1090,7 @@
     "onChangeTooltip": "The workflow will be queued once a change is made",
     "runWorkflow": "Run workflow (Shift to queue at front)",
     "runWorkflowFront": "Run workflow (Queue at front)",
-    "runWorkflowMissingResources": "Workflow contains missing resources.",
+    "runWorkflowDisabled": "Workflow contains unsupported nodes (highlighted red). Remove these to run the workflow.",
     "run": "Run",
     "stopRunInstant": "Stop Run (Instant)",
     "stopRunInstantTooltip": "Stop running",
@@ -1167,11 +1163,6 @@
     "runsOnSelected": "{count} Runs On",
     "runsOnFilter": "Runs on",
     "resultsCount": "Showing {count} of {total} templates",
-    "paidTemplate": {
-      "badgeLabel": "Partner API",
-      "title": "Premium template",
-      "credits": "Runs with credits"
-    },
     "sort": {
       "relevance": "Relevance",
       "recommended": "Recommended",
@@ -1570,7 +1561,6 @@
     "Canvas Navigation": "Canvas Navigation",
     "PlanCredits": "Plan & Credits",
     "Members": "Members",
-    "Allowlist": "Allowlist",
     "Vue Nodes": "Nodes 2.0",
     "VueNodes": "Nodes 2.0",
     "Nodes 2_0": "Nodes 2.0",
@@ -2223,19 +2213,7 @@
     "swatchTitle": "Click edit · drag reorder · right-click remove"
   },
   "videoEdit": {
-    "play": "Play",
-    "pause": "Pause",
-    "loadingFilmstrip": "Loading filmstrip…",
-    "seekVideo": "Seek video",
-    "adjustStartFrame": "Adjust start frame",
-    "adjustEndFrame": "Adjust end frame",
-    "adjustCrop": "Adjust crop region",
-    "durationZero": "0s",
-    "durationSeconds": "{count}s",
-    "fileSizeUnknown": "—",
-    "fileSizeBytes": "{count} B",
-    "fileSizeKilobytes": "{count} KB",
-    "fileSizeMegabytes": "{count} MB"
+    "adjustCrop": "Adjust crop region"
   },
   "toastMessages": {
     "nothingToQueue": "Nothing to queue",
@@ -3028,39 +3006,6 @@
       "noMembers": "No members",
       "searchPlaceholder": "Search..."
     },
-    "partnerNodes": {
-      "title": "Partner node access",
-      "unrestricted": "Unrestricted",
-      "restricted": "Restricted",
-      "accessMode": "Partner node access mode",
-      "unrestrictedDescription": "Partner nodes from every provider are available to everyone. Disabling providers will set this to Restricted.",
-      "restrictedDescription": "Only partner nodes from enabled providers are available. Changes can take up to 10 minutes to apply.",
-      "searchPlaceholder": "Search providers and partner nodes...",
-      "tableLabel": "Partner node providers",
-      "columns": {
-        "provider": "Provider",
-        "nodes": "Nodes"
-      },
-      "nodeCount": "{count} enabled",
-      "enableAll": "Enable all",
-      "disableAll": "Disable all",
-      "toggleProvider": "Set access for {provider}",
-      "disableAllTitle": "Disable all providers?",
-      "disableAllMessage": "All providers will be turned off. Partner nodes will be unavailable while access is restricted.",
-      "restrictAccessTitle": "Restrict access to partner nodes?",
-      "restrictAccessMessage": "Workspace members will only be able to use partner nodes from providers that you enable.",
-      "restrictAccessHint": "This can take up to 10 minutes to apply across your workspace.",
-      "allowAllAccessTitle": "Allow access to all partner nodes?",
-      "allowAllAccessMessage": "Partner nodes from every provider will become available to every workspace member.",
-      "allowAllAccessHint": "This can take up to 10 minutes to apply across your workspace.",
-      "saveError": "Partner node access couldn't be updated. Try again.",
-      "loading": "Loading partner node access",
-      "loadError": "Partner node access couldn't be loaded.",
-      "unavailable": "Partner node access is unavailable for this workspace.",
-      "retry": "Try again",
-      "ownerOnly": "Only workspace owners can update partner node access.",
-      "noResults": "No providers or partner nodes found"
-    },
     "menu": {
       "editWorkspace": "Edit workspace details",
       "leaveWorkspace": "Leave Workspace",
@@ -3546,7 +3491,6 @@
     "processingModelDescription": "You can close this dialog. The download will continue in the background.",
     "providerCivitai": "Civitai",
     "providerHuggingFace": "Hugging Face",
-    "searchModels": "Search models",
     "selectFrameworks": "Select Frameworks",
     "selectModelType": "Select model type",
     "selectProjects": "Select Projects",
@@ -3601,8 +3545,6 @@
       "modelTagging": "Model Tagging",
       "modelType": "Model Type",
       "selectModelType": "Select model type...",
-      "modelTypeCoreReadonly": "Model type cannot be changed on core, moving the file is not yet supported.",
-      "modelTypeImmutableReadonly": "Model type cannot be changed for a read-only model.",
       "compatibleBaseModels": "Compatible Base Models",
       "addBaseModel": "Add base model...",
       "baseModelUnknown": "Base model unknown",
@@ -3769,7 +3711,7 @@
     "stepDescribe": "Describe your workflow",
     "stepExamples": "Add output examples",
     "stepFinish": "Finish publishing",
-    "workflowName": "Hub title",
+    "workflowName": "Workflow name",
     "workflowNamePlaceholder": "Tip: enter a descriptive name that's easy to search",
     "workflowDescription": "Workflow description",
     "workflowDescriptionPlaceholder": "What makes your workflow exciting and special? Be specific so people know what to expect.",
@@ -3811,6 +3753,8 @@
     "createProfileCta": "Create a profile",
     "publishFailedTitle": "Publish failed",
     "publishFailedDescription": "Something went wrong while publishing your workflow. Please try again.",
+    "renameFailedTitle": "Rename failed",
+    "renameFailedDescription": "Your workflow was published successfully, but renaming the local file failed. Rename it again to match.",
     "publishSuccessTitle": "Published successfully",
     "publishSuccessDescription": "Your workflow is now live on ComfyHub."
   },
@@ -4259,13 +4203,6 @@
         "toastTitle": "Validation failed",
         "toastMessage": "{nodeName} returned an unrecognized validation error."
       },
-      "PARTNER_NODE_DISABLED": {
-        "title": "Disabled node",
-        "message": "This node has been disabled by your workspace policy. Use a different node.",
-        "itemLabel": "{nodeName}",
-        "toastTitle": "Partner nodes",
-        "toastMessage": "This node has been disabled by your workspace policy."
-      },
       "exception_during_inner_validation": {
         "title": "Validation failed",
         "message": "The workflow couldn't validate a connected node.",
@@ -4705,6 +4642,26 @@
     "processingVideo": "Processing video…",
     "running": "Running…"
   },
+  "gettingStarted": {
+    "title": "Let's make something",
+    "subtitle": "Pick a ready-made workflow to start from, or begin with a blank canvas.",
+    "tabsLabel": "Getting started options",
+    "startBlank": "Start with a blank canvas",
+    "retry": "Try again",
+    "loadFailed": "We couldn't load the templates.",
+    "templateFailed": "We couldn't open this template.",
+    "retryTemplate": "Retry {title}",
+    "tabs": {
+      "templates": "Templates",
+      "tutorials": "Tutorials"
+    },
+    "tutorials": {
+      "interfaceOverview": "Interface overview",
+      "textToImage": "Text to image",
+      "imageToImage": "Image to image",
+      "inpaint": "Inpainting"
+    }
+  },
   "onboardingCoachmarks": {
     "stepLabel": "Step {current} of {total}",
     "skip": "Skip",
@@ -4734,6 +4691,62 @@
       "assets": {
         "title": "Find all your assets",
         "body": "Every generation and import lives in Media Assets. Open it anytime to browse, download, or reuse past work."
+      }
+    },
+    "firstRun": {
+      "upload": {
+        "i2v": {
+          "title": "Start with an image",
+          "body": "This picture is your first frame. Swap in your own whenever you like."
+        },
+        "image-edit": {
+          "title": "Start with an image",
+          "body": "This is the picture you'll edit. Swap in your own whenever you like."
+        },
+        "other": {
+          "title": "Start with an image",
+          "body": "This image feeds the workflow. Swap in your own whenever you like."
+        }
+      },
+      "prompt": {
+        "t2i": {
+          "title": "Describe what you want",
+          "body": "Your image gets built from this description. Try anything you like."
+        },
+        "i2v": {
+          "title": "Describe how it should move",
+          "body": "The image sets the scene. This tells it what happens next."
+        },
+        "image-edit": {
+          "title": "Say what to change",
+          "body": "Your image stays as it is. Describe what you want different."
+        },
+        "other": {
+          "title": "Tell it what to make",
+          "body": "This is your prompt. Change it to change your result."
+        }
+      },
+      "run": {
+        "title": "Run your workflow",
+        "body": "Press Run to start generating your result."
+      },
+      "result": {
+        "generating": {
+          "title": "Hang tight",
+          "body": "Your result lands right here the moment it's ready."
+        },
+        "failed": {
+          "title": "That run didn't finish",
+          "body": "Nothing landed here. Close the tour and try running again."
+        },
+        "image": {
+          "title": "And there it is",
+          "body": "Your new image lands right here — ready to download or share."
+        },
+        "video": {
+          "title": "And there it is",
+          "body": "Your new video lands right here — ready to download or share."
+        }
       }
     }
   }

--- a/src/platform/onboarding/TourOverlay.vue
+++ b/src/platform/onboarding/TourOverlay.vue
@@ -23,6 +23,7 @@
     :counted-step-idx="tour.countedStepIdx"
     :counted-steps-total="tour.countedStepsTotal"
     :waiting-for-target="tour.waitingForTarget"
+    :opening="tour.opening"
     @advance="tour.next"
     @back="tour.back"
     @skip="tour.skip"

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -1,0 +1,210 @@
+import userEvent from '@testing-library/user-event'
+import { cleanup, render, screen } from '@testing-library/vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import TourSpotlight from './TourSpotlight.vue'
+import { CARD_GLIDE_MS } from './coachmarkLayout'
+import { clearCoachmarks, registerCoachmark } from './coachmarkRegistry'
+import { COACH_IDS, FIRST_RUN_COACH_IDS } from './onboardingTours'
+import type { CoachStep } from './onboardingTours'
+
+vi.mock('@primeuix/utils/zindex', () => ({
+  ZIndex: { set: vi.fn(), clear: vi.fn() }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function spotlightStep(overrides: Partial<CoachStep> = {}): CoachStep {
+  return { name: 'step', placement: 'right', ...overrides }
+}
+
+const baseProps = {
+  title: 'Title',
+  body: 'Body',
+  isLast: false,
+  canGoBack: false,
+  primaryLabel: 'Next',
+  skipLabel: 'Skip',
+  backLabel: 'Back',
+  countedStepIdx: 0,
+  countedStepsTotal: 1,
+  waitingForTarget: false
+}
+
+function renderSpotlight(
+  props: Partial<ComponentProps<typeof TourSpotlight>> = {}
+) {
+  return render(TourSpotlight, {
+    props: { step: spotlightStep(), ...baseProps, ...props },
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('TourSpotlight interactive and masked steps', () => {
+  afterEach(() => {
+    cleanup()
+    clearCoachmarks()
+    document.body.replaceChildren()
+    vi.useRealTimers()
+  })
+
+  it('keeps the blocking scrim and no hit region on a plain step', () => {
+    renderSpotlight()
+    expect(screen.getByTestId('coach-blocker')).toBeTruthy()
+    expect(screen.queryByTestId('coach-hit-region')).toBeNull()
+    expect(screen.queryByTestId('coach-mask-hole')).toBeNull()
+  })
+
+  it('replaces the blocker with a pass-through hit region on an interactive step', () => {
+    renderSpotlight({ step: spotlightStep({ interactive: true }) })
+    expect(screen.queryByTestId('coach-blocker')).toBeNull()
+    expect(screen.getByTestId('coach-hit-region')).toBeTruthy()
+  })
+
+  it('covers the viewport with an evenodd region, so its holes pass input through', () => {
+    renderSpotlight({ step: spotlightStep({ interactive: true }) })
+
+    const region = screen.getByTestId('coach-hit-region')
+    expect(region.getAttribute('fill-rule')).toBe('evenodd')
+    expect(region.getAttribute('d')).toBe('M0 0H1024V768H0Z')
+  })
+
+  it('still skips on Escape during an interactive step', async () => {
+    const user = userEvent.setup()
+    const { emitted } = renderSpotlight({
+      step: spotlightStep({ interactive: true })
+    })
+    await user.keyboard('{Escape}')
+    expect(emitted().skip).toHaveLength(1)
+  })
+
+  it('transitions the ring between DOM targets, which move on discrete events', () => {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = () => new DOMRect(10, 10, 80, 40)
+    document.body.append(el)
+    registerCoachmark(COACH_IDS.inputsList, el)
+
+    renderSpotlight({
+      step: spotlightStep({ coachId: COACH_IDS.inputsList })
+    })
+
+    expect(screen.getByTestId('coach-spotlight').className).toContain(
+      'transition-[left,top,width,height,opacity]'
+    )
+  })
+
+  it('rides a virtual target instead of transitioning after it', () => {
+    registerCoachmark(COACH_IDS.inputsList, {
+      getBoundingClientRect: () => new DOMRect(10, 10, 80, 40)
+    })
+
+    renderSpotlight({
+      step: spotlightStep({ coachId: COACH_IDS.inputsList })
+    })
+
+    expect(
+      screen.getByTestId('coach-spotlight').className,
+      'a transition makes the ring lag a target that moves every frame'
+    ).not.toContain('transition-[left,top,width,height,opacity]')
+  })
+
+  it('holds the opening card back until its tour has framed itself', () => {
+    renderSpotlight({ opening: true })
+    const card = screen.getByRole('dialog', { hidden: true })
+
+    expect(
+      card.style.opacity,
+      'the first card has nowhere to travel from, so it fades in once the view is still'
+    ).toBe('0')
+    expect(
+      card.className,
+      'a hidden card must not swallow clicks meant for the app'
+    ).toContain('pointer-events-none')
+    expect(
+      card.className,
+      'a card that pops in reads as a glitch rather than an arrival'
+    ).toContain('transition')
+  })
+
+  it('keeps the card on screen once the tour is under way', async () => {
+    const { rerender } = renderSpotlight({ opening: true })
+
+    await rerender({ opening: false, step: spotlightStep({ name: 'later' }) })
+
+    expect(
+      screen.getByRole('dialog').style.opacity,
+      'a card that fades out on every step reads as a restart, not a next step'
+    ).toBe('1')
+  })
+
+  it('glides to a new canvas target, then rides it', async () => {
+    vi.useFakeTimers()
+    registerCoachmark(FIRST_RUN_COACH_IDS.prompt, {
+      getBoundingClientRect: () => new DOMRect(10, 10, 80, 40)
+    })
+
+    renderSpotlight({
+      step: spotlightStep({ coachId: FIRST_RUN_COACH_IDS.prompt })
+    })
+    const card = () => screen.getByRole('dialog', { hidden: true }).className
+
+    expect(
+      card(),
+      'a card that jumps to the next node leaves the user hunting for it'
+    ).toContain('transition-[left,top,opacity]')
+
+    vi.advanceTimersByTime(CARD_GLIDE_MS)
+    await nextTick()
+    expect(
+      card(),
+      'transitioning after a camera that moves every frame leaves the card lagging it'
+    ).not.toContain('transition-[left,top,opacity]')
+  })
+
+  it('spins while the app is still working on what the step asked for', async () => {
+    let working = true
+    const { rerender } = renderSpotlight({
+      step: spotlightStep({ busy: () => working })
+    })
+
+    expect(
+      screen.getByTestId('coach-busy'),
+      'a card that reads the same whether a job is running or stalled says nothing'
+    ).toBeTruthy()
+
+    working = false
+    await rerender({ step: spotlightStep({ busy: () => working }) })
+    expect(screen.queryByTestId('coach-busy')).toBeNull()
+  })
+
+  it('points a cursor back at the target from the card edge facing it', async () => {
+    registerCoachmark(FIRST_RUN_COACH_IDS.prompt, {
+      getBoundingClientRect: () => new DOMRect(10, 10, 80, 40)
+    })
+
+    const { rerender } = renderSpotlight({
+      step: spotlightStep({ coachId: FIRST_RUN_COACH_IDS.prompt, cursor: true })
+    })
+    expect(
+      screen.getByTestId('coach-cursor').className,
+      'the card sits right of the target, so the cursor must ride its left edge'
+    ).toContain('-left-7')
+
+    await rerender({
+      step: spotlightStep({ coachId: FIRST_RUN_COACH_IDS.prompt })
+    })
+    expect(
+      screen.queryByTestId('coach-cursor'),
+      'a step that did not ask for a cursor must not grow one'
+    ).toBeNull()
+  })
+})

--- a/src/platform/onboarding/TourSpotlight.vue
+++ b/src/platform/onboarding/TourSpotlight.vue
@@ -1,35 +1,105 @@
 <template>
   <div ref="overlayRef" class="pointer-events-none fixed inset-0">
+    <svg
+      v-if="useMaskScrim"
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 size-full"
+    >
+      <mask :id="maskId">
+        <rect width="100%" height="100%" fill="white" />
+        <rect
+          v-if="scrimHole"
+          data-testid="coach-mask-hole"
+          v-bind="scrimHole"
+          rx="12"
+          fill="black"
+          :class="
+            !isVirtualTarget &&
+            'motion-safe:transition-[x,y,width,height] motion-safe:duration-300'
+          "
+        />
+      </mask>
+      <rect
+        width="100%"
+        height="100%"
+        class="fill-coach-scrim"
+        :mask="`url(#${maskId})`"
+      />
+      <path
+        v-if="step.interactive"
+        data-testid="coach-hit-region"
+        :d="hitRegionPath"
+        fill="transparent"
+        fill-rule="evenodd"
+        class="pointer-events-auto"
+      />
+    </svg>
     <div
+      v-if="!step.interactive"
+      data-testid="coach-blocker"
       :class="
         cn(
           'pointer-events-auto absolute inset-0',
-          !targetRect && 'bg-coach-scrim'
+          !useMaskScrim && !targetRect && 'bg-coach-scrim'
         )
       "
     />
     <div
       aria-hidden="true"
       data-testid="coach-spotlight"
-      class="pointer-events-none absolute rounded-xl shadow-[0_0_0_9999px_var(--color-coach-scrim)] outline-2 outline-coach-ring motion-safe:transition-[left,top,width,height,opacity] motion-safe:duration-300"
+      :class="
+        cn(
+          'pointer-events-none absolute rounded-xl outline-2 outline-coach-ring',
+          !isVirtualTarget &&
+            'motion-safe:transition-[left,top,width,height,opacity] motion-safe:duration-300',
+          !useMaskScrim && 'shadow-[0_0_0_9999px_var(--color-coach-scrim)]'
+        )
+      "
       :style="spotlightStyle"
     />
     <FocusScope
       as-child
-      :trapped="!waitingForTarget"
+      :trapped="!waitingForTarget && !opening && !step.interactive"
       loop
       @mount-auto-focus.prevent
     >
       <div
         ref="cardRef"
+        data-testid="coach-card"
         role="dialog"
         aria-modal="true"
         :aria-labelledby="titleId"
         :aria-describedby="`${subtitleId} ${bodyId}`"
-        class="pointer-events-auto absolute max-h-[calc(100vh-var(--comfy-topbar-height)-2rem)] overflow-y-auto motion-safe:transition-[left,top] motion-safe:duration-300"
+        :class="
+          cn(
+            'absolute motion-safe:duration-300',
+            glides
+              ? 'motion-safe:transition-[left,top,opacity]'
+              : 'motion-safe:transition-opacity',
+            cardVisible ? 'pointer-events-auto' : 'pointer-events-none'
+          )
+        "
         :style="cardStyle"
       >
+        <i
+          v-if="cursorEdgeClass"
+          data-testid="coach-cursor"
+          :class="
+            cn(
+              'absolute icon-[lucide--mouse-pointer-2] size-4 text-base-foreground drop-shadow-md',
+              cursorEdgeClass
+            )
+          "
+          aria-hidden="true"
+        />
+        <i
+          v-if="step.busy?.()"
+          data-testid="coach-busy"
+          class="absolute top-4 right-4 z-10 icon-[lucide--loader-circle] size-3.5 animate-spin text-muted-foreground"
+          aria-hidden="true"
+        />
         <CoachmarkCard
+          class="max-h-[calc(100vh-var(--comfy-topbar-height)-2rem)] overflow-y-auto"
           :subtitle="
             t('onboardingCoachmarks.stepLabel', {
               current: countedStepIdx + 1,
@@ -64,6 +134,7 @@
                 {{ backLabel }}
               </Button>
               <Button
+                v-if="!step.selfAdvancing"
                 ref="primaryButton"
                 variant="inverted"
                 size="md"
@@ -105,7 +176,8 @@ import {
   CARD_WIDTH,
   SPOTLIGHT_PAD,
   VIEWPORT_MARGIN,
-  clampSpotlight,
+  CARD_GLIDE_MS,
+  clampSpotlightRect,
   noTargetCardLeft
 } from './coachmarkLayout'
 import type { CoachStep } from './onboardingTours'
@@ -122,7 +194,8 @@ const {
   backLabel,
   countedStepIdx,
   countedStepsTotal,
-  waitingForTarget
+  waitingForTarget,
+  opening = false
 } = defineProps<{
   step: CoachStep
   title: string
@@ -135,6 +208,8 @@ const {
   countedStepIdx: number
   countedStepsTotal: number
   waitingForTarget: boolean
+  /** The tour's first step is still framing itself; its card has yet to appear. */
+  opening?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -152,8 +227,14 @@ const overlayRef = ref<HTMLElement | null>(null)
 const cardRef = ref<HTMLElement | null>(null)
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 
-const { targetRect, targetEl, floatingStyles, isPositioned } =
-  useCoachmarkTarget(() => step, cardRef)
+const {
+  targetRect,
+  targetEl,
+  isVirtualTarget,
+  floatingStyles,
+  isPositioned,
+  placement
+} = useCoachmarkTarget(() => step, cardRef)
 
 // Last step's "Done" already dismisses, so hide Skip there.
 const showSkip = computed(() => !isLast)
@@ -196,9 +277,9 @@ watch(
 )
 
 watch(
-  [() => step, () => waitingForTarget],
+  [() => step, () => waitingForTarget, () => opening],
   () => {
-    if (!waitingForTarget) void focusPrimary()
+    if (!waitingForTarget && !opening) void focusPrimary()
   },
   { immediate: true }
 )
@@ -211,29 +292,95 @@ function viewport() {
   return { width: windowWidth.value, height: windowHeight.value }
 }
 
+const maskId = useId()
+
+const useMaskScrim = computed(() => !!step.interactive)
+
+const scrimHole = computed(() =>
+  targetRect.value
+    ? clampSpotlightRect(targetRect.value, SPOTLIGHT_PAD, viewport())
+    : null
+)
+
 const spotlightStyle = computed(() => {
-  const r = targetRect.value
-  if (!r) return { opacity: '0' }
-  return { ...clampSpotlight(r, SPOTLIGHT_PAD, viewport()), opacity: '1' }
+  const hole = scrimHole.value
+  if (!hole?.width || !hole.height) return { opacity: '0' }
+  return {
+    left: `${hole.x}px`,
+    top: `${hole.y}px`,
+    width: `${hole.width}px`,
+    height: `${hole.height}px`,
+    opacity: '1'
+  }
 })
+
+// Evenodd viewport path whose hole lets pointer events through to the page.
+const hitRegionPath = computed(() => {
+  const { width, height } = viewport()
+  const hole = scrimHole.value
+  const viewportPath = `M0 0H${width}V${height}H0Z`
+  if (!hole) return viewportPath
+  return `${viewportPath}M${hole.x} ${hole.y}h${hole.width}v${hole.height}h${-hole.width}Z`
+})
+
+/**
+ * The card travels to a new target under a transition, then drops it: a target
+ * that keeps moving has to be ridden, or the card lags a frame behind it.
+ */
+const glides = ref(true)
+watch(
+  () => step,
+  (_step, _previous, onCleanup) => {
+    if (!isVirtualTarget.value) return
+    glides.value = true
+    const timer = setTimeout(() => (glides.value = false), CARD_GLIDE_MS)
+    onCleanup(() => clearTimeout(timer))
+  },
+  { immediate: true }
+)
+watch(isVirtualTarget, (virtual) => {
+  if (!virtual) glides.value = true
+})
+
+/** Hidden until Floating UI has placed it; only the opening card has to fade in. */
+const cardVisible = computed(
+  () => !opening && (!targetEl.value || isPositioned.value)
+)
 
 const cardStyle = computed(() => {
   const width = `${CARD_WIDTH}px`
   const maxWidth = `calc(100vw - ${VIEWPORT_MARGIN * 2}px)`
+  const opacity = cardVisible.value ? '1' : '0'
   if (!targetEl.value) {
     return {
       width,
       maxWidth,
       left: `${noTargetCardLeft(windowWidth.value)}px`,
-      top: '30%'
+      top: '30%',
+      opacity
     }
   }
-  // Hidden until Floating UI positions it, avoiding a first-frame jump.
-  return {
-    ...floatingStyles.value,
-    width,
-    maxWidth,
-    opacity: isPositioned.value ? '1' : '0'
-  }
+  return { ...floatingStyles.value, width, maxWidth, opacity }
+})
+
+/** Floats the cursor in the gap on the card edge facing the target. */
+const CURSOR_EDGE_CLASS = {
+  top: '-top-7 left-1/2 -translate-x-1/2 rotate-45',
+  bottom: '-bottom-7 left-1/2 -translate-x-1/2 -rotate-[135deg]',
+  left: '-left-7 top-1/2 -translate-y-1/2 -rotate-45',
+  right: '-right-7 top-1/2 -translate-y-1/2 rotate-[135deg]'
+} as const
+
+const TARGET_FACING_EDGE = {
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left'
+} as const
+
+const cursorEdgeClass = computed(() => {
+  if (!step.cursor || !targetEl.value) return ''
+  const side = placement.value.split('-')[0] as keyof typeof TARGET_FACING_EDGE
+  return CURSOR_EDGE_CLASS[TARGET_FACING_EDGE[side]]
 })
 </script>

--- a/src/platform/onboarding/coachmarkLayout.ts
+++ b/src/platform/onboarding/coachmarkLayout.ts
@@ -15,14 +15,25 @@ const SPOTLIGHT_EDGE_INSET = 2
 export const CARD_WIDTH = 300
 export const VIEWPORT_MARGIN = 12
 export const CARD_GAP = 16
+/** Wide enough for the cursor glyph to sit centred between card and target. */
+export const CURSOR_GAP = 40
+/** The card's travel to a new target; whatever moves that target waits it out. */
+export const CARD_GLIDE_MS = 300
 // Kept tight so the spotlight glow doesn't spill onto an adjacent clickable control.
 export const SPOTLIGHT_PAD = 4
 
-export function clampSpotlight(
+export interface SpotlightRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export function clampSpotlightRect(
   r: DOMRect,
   pad: number,
   viewport: Viewport
-): BoxStyle {
+): SpotlightRect {
   const left = Math.max(SPOTLIGHT_EDGE_INSET, r.left - pad)
   const top = Math.max(SPOTLIGHT_EDGE_INSET, r.top - pad)
   const right = Math.min(viewport.width - SPOTLIGHT_EDGE_INSET, r.right + pad)
@@ -31,10 +42,24 @@ export function clampSpotlight(
     r.bottom + pad
   )
   return {
-    left: `${left}px`,
-    top: `${top}px`,
-    width: `${Math.max(0, right - left)}px`,
-    height: `${Math.max(0, bottom - top)}px`
+    x: left,
+    y: top,
+    width: Math.max(0, right - left),
+    height: Math.max(0, bottom - top)
+  }
+}
+
+export function clampSpotlight(
+  r: DOMRect,
+  pad: number,
+  viewport: Viewport
+): BoxStyle {
+  const { x, y, width, height } = clampSpotlightRect(r, pad, viewport)
+  return {
+    left: `${x}px`,
+    top: `${y}px`,
+    width: `${width}px`,
+    height: `${height}px`
   }
 }
 

--- a/src/platform/onboarding/coachmarkRegistry.ts
+++ b/src/platform/onboarding/coachmarkRegistry.ts
@@ -1,30 +1,46 @@
+import type { VirtualElement } from '@floating-ui/vue'
 import { shallowReactive, watch } from 'vue'
 
 import type { CoachId } from './onboardingTours'
 
-const EMPTY: readonly HTMLElement[] = []
+/** A virtual target that announces its own motion, so nothing has to poll it. */
+export interface MovingTarget extends VirtualElement {
+  onMove: (notify: () => void) => () => void
+}
+
+/**
+ * Coachmark target: HTMLElement (from v-coachmark) or VirtualElement.
+ * Both expose getBoundingClientRect.
+ */
+export type CoachTarget = HTMLElement | VirtualElement
+
+export function isMovingTarget(target: CoachTarget): target is MovingTarget {
+  return 'onMove' in target && typeof target.onMove === 'function'
+}
+
+const EMPTY: readonly CoachTarget[] = []
 
 /** Laid out — a registered target that is currently visible and has a size. */
-export function isLaidOut(el: HTMLElement): boolean {
+export function isLaidOut(el: CoachTarget): boolean {
   const r = el.getBoundingClientRect()
   return r.width > 0 && r.height > 0
 }
 
 // An id can map to several elements (e.g. responsive variants); consumers pick
 // the first laid-out one.
-const registry = shallowReactive(new Map<CoachId, readonly HTMLElement[]>())
+const registry = shallowReactive(new Map<CoachId, readonly CoachTarget[]>())
 
-export function registerCoachmark(id: CoachId, el: HTMLElement) {
+export function registerCoachmark(id: CoachId, el: CoachTarget) {
   registry.set(id, [...(registry.get(id) ?? EMPTY), el])
 }
 
-export function unregisterCoachmark(id: CoachId, el: HTMLElement) {
+export function unregisterCoachmark(id: CoachId, el: CoachTarget) {
   const next = (registry.get(id) ?? EMPTY).filter((entry) => entry !== el)
   if (next.length) registry.set(id, next)
   else registry.delete(id)
 }
 
-export function coachmarkElements(id: CoachId): readonly HTMLElement[] {
+export function coachmarkElements(id: CoachId): readonly CoachTarget[] {
   return registry.get(id) ?? EMPTY
 }
 

--- a/src/platform/onboarding/coachmarkRegistry.virtualTarget.test.ts
+++ b/src/platform/onboarding/coachmarkRegistry.virtualTarget.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearCoachmarks,
+  coachmarkElements,
+  registerCoachmark,
+  targetMounted,
+  waitForTarget
+} from './coachmarkRegistry'
+import type { CoachTarget } from './coachmarkRegistry'
+
+function virtualTarget(rect: DOMRect): CoachTarget {
+  return { getBoundingClientRect: () => rect }
+}
+
+describe('coachmarkRegistry with virtual targets', () => {
+  afterEach(clearCoachmarks)
+
+  it('registers a virtual target alongside elements', () => {
+    const el = document.createElement('div')
+    const virtual = virtualTarget(new DOMRect(0, 0, 80, 30))
+    registerCoachmark('outputs', el)
+    registerCoachmark('outputs', virtual)
+    expect(coachmarkElements('outputs')).toEqual([el, virtual])
+  })
+
+  it('counts a virtual target with a sized rect as mounted', () => {
+    registerCoachmark('outputs', virtualTarget(new DOMRect(5, 5, 80, 30)))
+    expect(targetMounted('outputs')).toBe(true)
+  })
+
+  it('ignores a virtual target reporting a zero-sized rect', () => {
+    registerCoachmark('outputs', virtualTarget(new DOMRect()))
+    expect(targetMounted('outputs')).toBe(false)
+  })
+
+  it('resolves a pending wait when a sized virtual target registers', async () => {
+    const signal = new AbortController().signal
+    const found = waitForTarget('outputs', signal, 1000)
+    registerCoachmark('outputs', virtualTarget(new DOMRect(0, 0, 80, 30)))
+    await expect(found).resolves.toBe(true)
+  })
+})

--- a/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.registeredTour.test.ts
@@ -1,0 +1,230 @@
+import { createPinia, disposePinia, setActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import type { Ref } from 'vue'
+
+import type { AppMode } from '@/utils/appMode'
+
+import { clearCoachmarks } from './coachmarkRegistry'
+import { TOUR_SEEN_SETTING, registerTour } from './onboardingTours'
+import type { CoachStep } from './onboardingTours'
+import { useOnboardingTourStore } from './onboardingTourStore'
+
+const settings = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: (key: string) =>
+      settings.store.get(key) ?? (key === TOUR_SEEN_SETTING ? [] : undefined),
+    set: (key: string, value: unknown) => {
+      settings.store.set(key, value)
+      return Promise.resolve()
+    }
+  })
+}))
+
+const telemetry = vi.hoisted(() => ({ track: vi.fn() }))
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackOnboardingTour: telemetry.track })
+}))
+
+const appModeMock = vi.hoisted(() => ({ mode: null as Ref<AppMode> | null }))
+vi.mock('@/composables/useAppMode', async () => {
+  const { ref } = await import('vue')
+  appModeMock.mode = ref<AppMode>('graph')
+  return { useAppMode: () => ({ mode: appModeMock.mode }) }
+})
+vi.mock('@/stores/appModeStore', () => ({
+  useAppModeStore: () => ({ hasOutputs: false })
+}))
+
+function step(name: string, overrides: Partial<CoachStep> = {}): CoachStep {
+  return { name, placement: 'center', ...overrides }
+}
+
+function stages(): string[] {
+  return telemetry.track.mock.calls.map(([stage]) => stage)
+}
+
+let pinia: Pinia | undefined
+
+function mountStore() {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  return useOnboardingTourStore()
+}
+
+describe('onboardingTourStore — runtime-resolved tours', () => {
+  afterEach(() => {
+    if (pinia) disposePinia(pinia)
+    pinia = undefined
+    clearCoachmarks()
+    settings.store.clear()
+    telemetry.track.mockClear()
+  })
+
+  it('reports no start for an entry no one registered', async () => {
+    vi.resetModules()
+    const { useOnboardingTourStore: freshStore } =
+      await import('./onboardingTourStore')
+    pinia = createPinia()
+    setActivePinia(pinia)
+    const store = freshStore()
+
+    await expect(store.startTour('firstRun')).resolves.toBe(false)
+    expect(store.activeTour).toBeNull()
+  })
+
+  it('reports no start when the resolver produces no steps', async () => {
+    registerTour('firstRun', () => Promise.resolve([]))
+    const store = mountStore()
+
+    await expect(store.startTour('firstRun')).resolves.toBe(false)
+    expect(store.activeTour, 'an empty resolution must not open a tour').toBe(
+      null
+    )
+    expect(stages()).not.toContain('started')
+  })
+
+  it('runs the steps its resolver builds', async () => {
+    registerTour('firstRun', () =>
+      Promise.resolve([step('upload'), step('run')])
+    )
+    const store = mountStore()
+
+    await expect(store.startTour('firstRun')).resolves.toBe(true)
+    expect(store.activeTour).toBe('firstRun')
+    expect(store.countedStepsTotal).toBe(2)
+    expect(store.step?.name).toBe('upload')
+  })
+
+  it('ends the tour as completed when a consumer completes it', async () => {
+    registerTour('firstRun', () => Promise.resolve([step('run')]))
+    const store = mountStore()
+    await store.startTour('firstRun')
+
+    store.complete()
+
+    expect(stages()).toContain('completed')
+    expect(stages()).not.toContain('skipped')
+    expect(store.activeTour).toBeNull()
+  })
+
+  it('holds the step until its onEnter settles, so framing precedes the copy', async () => {
+    let release = () => {}
+    const entered = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    registerTour('firstRun', () =>
+      Promise.resolve([step('upload', { onEnter: () => entered })])
+    )
+    const store = mountStore()
+
+    await store.startTour('firstRun')
+    await nextTick()
+    expect(stages()).not.toContain('step_shown')
+
+    release()
+    await entered
+    await nextTick()
+    expect(stages()).toContain('step_shown')
+  })
+
+  it('opens only until the first step has framed itself', async () => {
+    let release = () => {}
+    const framed = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    registerTour('firstRun', () =>
+      Promise.resolve([
+        step('upload', { onEnter: () => framed }),
+        step('prompt', { onEnter: () => Promise.resolve() })
+      ])
+    )
+    const store = mountStore()
+
+    await store.startTour('firstRun')
+    await nextTick()
+    expect(store.opening).toBe(true)
+
+    release()
+    await framed
+    await nextTick()
+    expect(store.opening).toBe(false)
+
+    store.next()
+    await nextTick()
+    expect(
+      store.opening,
+      'a card that hides itself on every step reads as a restart, not a next step'
+    ).toBe(false)
+  })
+
+  it('offers no way back into a step that only its own action leaves', async () => {
+    registerTour('firstRun', () =>
+      Promise.resolve([
+        step('prompt'),
+        step('run', { selfAdvancing: true }),
+        step('result')
+      ])
+    )
+    const store = mountStore()
+    await store.startTour('firstRun')
+    await nextTick()
+
+    store.next()
+    await nextTick()
+    expect(store.canGoBack, 'Run is reachable from the step before it').toBe(
+      true
+    )
+
+    store.next()
+    await nextTick()
+    expect(
+      store.canGoBack,
+      'Back into Run strands the user on a step whose only exit queues a second run'
+    ).toBe(false)
+  })
+
+  it('postpones a tour something else blocked, so it is offered again', async () => {
+    registerTour('firstRun', () => Promise.resolve([step('run')]))
+    const store = mountStore()
+    await store.startTour('firstRun')
+
+    store.postpone()
+
+    expect(
+      telemetry.track,
+      'a postponement counted as a plain skip reads as a user who refused the tour'
+    ).toHaveBeenCalledWith(
+      'skipped',
+      expect.objectContaining({ skip_reason: 'postponed' })
+    )
+    expect(store.activeTour).toBeNull()
+    await expect(
+      store.startTour('firstRun'),
+      'a user turned away at the paywall has still not had their tour'
+    ).resolves.toBe(true)
+  })
+
+  it('aborts a step onEnter signal when the tour ends, so framing cannot outlive it', async () => {
+    let signal: AbortSignal | undefined
+    registerTour('firstRun', () =>
+      Promise.resolve([
+        step('upload', {
+          onEnter: (s) => {
+            signal = s
+            return new Promise<void>(() => {})
+          }
+        })
+      ])
+    )
+    const store = mountStore()
+    await store.startTour('firstRun')
+    await nextTick()
+
+    store.skip()
+
+    expect(signal?.aborted).toBe(true)
+  })
+})

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -467,7 +467,7 @@ describe('onboardingTourStore', () => {
     expect(store.primaryLabel).toBe('Done')
   })
 
-  it('reports the user-visible step numbering, omitting it for the landing', async () => {
+  it('reports the user-visible step numbering, marking the landing instead', async () => {
     registerAppModeTargets()
     const store = mountStore()
     store.replayTour('appMode')
@@ -479,10 +479,16 @@ describe('onboardingTourStore', () => {
     )
     expect(started?.[1]).toEqual({ tour: 'appMode', step_count: 4 })
 
+    // Unnumbered, but flagged — so a bail here is a value to group on rather
+    // than an absent step_number analytics has to infer from.
     const landingShown = telemetry.track.mock.calls.find(
       ([stage]) => stage === 'step_shown'
     )
-    expect(landingShown?.[1]).toEqual({ tour: 'appMode', step_count: 4 })
+    expect(landingShown?.[1]).toEqual({
+      tour: 'appMode',
+      step_count: 4,
+      is_landing: true
+    })
 
     store.next()
     await nextTick()
@@ -495,6 +501,26 @@ describe('onboardingTourStore', () => {
       step_number: 1,
       coach_id: 'inputs-list'
     })
+  })
+
+  it('marks a skip taken on the landing', async () => {
+    registerAppModeTargets()
+    const store = mountStore()
+    store.replayTour('appMode')
+    await nextTick()
+
+    store.skip()
+    await nextTick()
+
+    // Most abandonment happens on the landing, so the skip has to say so.
+    const skipped = telemetry.track.mock.calls.find(
+      ([stage]) => stage === 'skipped'
+    )
+    expect(skipped?.[1]).toMatchObject({
+      tour: 'appMode',
+      is_landing: true
+    })
+    expect(skipped?.[1]).not.toHaveProperty('step_number')
   })
 
   it('advancing off the landing does not mark the tour skipped', async () => {

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, readonly, ref, shallowRef, watch } from 'vue'
 
 import { t, te } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -12,7 +12,11 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 import { targetMounted, waitForTarget } from './coachmarkRegistry'
-import { TOURS, TOUR_SEEN_SETTING, resolveSteps } from './onboardingTours'
+import {
+  TOUR_SEEN_SETTING,
+  resolveSteps,
+  tourDefinition
+} from './onboardingTours'
 import type { CoachStep, EntryPath } from './onboardingTours'
 import { useTourTriggers } from './useTourTriggers'
 
@@ -29,6 +33,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
   const steps = shallowRef<CoachStep[]>([])
   const stepIdx = ref(0)
   const waitingForTarget = ref(false)
+  const opening = ref(false)
   const activeTour = ref<EntryPath | null>(null)
   let stepController: AbortController | null = null
 
@@ -43,8 +48,10 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     const s = step.value
     return s ? countedSteps.value.indexOf(s) : 0
   })
-  // Back navigates the numbered steps only — never into the landing.
-  const canGoBack = computed(() => countedStepIdx.value > 0)
+  const canGoBack = computed(
+    () =>
+      countedStepIdx.value > 0 && !steps.value[stepIdx.value - 1]?.selfAdvancing
+  )
 
   function trackTour(
     stage: OnboardingTourStage,
@@ -127,6 +134,15 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
       }
     }
     stepIdx.value = idx
+    if (nextStep.onEnter) {
+      try {
+        await nextStep.onEnter(signal)
+      } catch (error) {
+        if (!signal.aborted) console.error('coachmark onEnter failed', error)
+      }
+      if (signal.aborted) return
+    }
+    opening.value = false
     trackTour('step_shown')
   }
 
@@ -152,6 +168,19 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     finish('skipped')
   }
 
+  /** Ends the tour as completed, for consumers whose last step self-completes. */
+  function complete() {
+    finish('completed')
+  }
+
+  /**
+   * Ends the tour without marking it seen: something outside it barred the way,
+   * so the user has not had their tour yet and is offered it again.
+   */
+  function postpone() {
+    finish('skipped', { markSeen: false, skipReason: 'postponed' })
+  }
+
   function finish(
     outcome: 'completed' | 'skipped',
     {
@@ -162,6 +191,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     trackTour(outcome, outcome === 'skipped' ? skipReason : undefined)
     stepController?.abort()
     waitingForTarget.value = false
+    opening.value = false
     steps.value = []
     stepIdx.value = 0
     if (markSeen && activeTour.value) markTourSeen(activeTour.value)
@@ -172,7 +202,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     watch(
       trigger.autoOpen,
       (visible) => {
-        if (visible) startTour(entryPath)
+        if (visible) void startTour(entryPath)
       },
       { immediate: true }
     )
@@ -192,22 +222,36 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     void settingStore.set(TOUR_SEEN_SETTING, [...seen, entryPath])
   }
 
-  function startTour(entryPath: EntryPath, force = false) {
-    if (steps.value.length) return
-    if (!force && hasSeenTour(entryPath)) return
-    const resolved = resolveSteps(TOURS[entryPath], targetMounted)
-    if (!resolved.length) return
+  async function begin(entryPath: EntryPath): Promise<boolean> {
+    if (steps.value.length) return false
+    const definition = tourDefinition(entryPath)
+    if (!definition) return false
+    const built = Array.isArray(definition) ? definition : await definition()
+    // A resolver settling late may have let a concurrent start fill steps first.
+    if (steps.value.length) return false
+    const resolved = resolveSteps(built, targetMounted)
+    if (!resolved.length) return false
     steps.value = resolved
     activeTour.value = entryPath
+    opening.value = true
     trackTour('started')
     void showStep(0)
+    return true
+  }
+
+  /** Starts an unseen tour; false when nothing started. */
+  async function startTour(entryPath: EntryPath): Promise<boolean> {
+    if (hasSeenTour(entryPath)) return false
+    return begin(entryPath)
   }
 
   function replayTour(entryPath: EntryPath) {
-    startTour(entryPath, true)
+    void begin(entryPath)
   }
 
   return {
+    activeTour: readonly(activeTour),
+    opening: readonly(opening),
     step,
     isLast,
     canGoBack,
@@ -219,9 +263,12 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     countedStepIdx,
     countedStepsTotal,
     waitingForTarget,
+    startTour,
     replayTour,
     next,
     back,
-    skip
+    skip,
+    complete,
+    postpone
   }
 })

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -67,6 +67,12 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
           step_number: countedStepIdx.value + 1,
           coach_id: step.value?.coachId
         }),
+      // The landing carries no number, so without this a bail there is only
+      // visible as a missing step_number — indistinguishable from a dropped
+      // property. Most abandonment happens here, so it gets a positive marker.
+      ...(stage !== 'started' && step.value?.landing === true
+        ? { is_landing: true }
+        : {}),
       ...(skipReason && { skip_reason: skipReason })
     })
   }

--- a/src/platform/onboarding/onboardingTours.ts
+++ b/src/platform/onboarding/onboardingTours.ts
@@ -1,4 +1,7 @@
-export type EntryPath = 'appMode'
+/** Every tour, including ones whose steps a consumer registers at runtime. */
+export const ENTRY_PATHS = ['appMode', 'firstRun'] as const
+
+export type EntryPath = (typeof ENTRY_PATHS)[number]
 
 /** Setting holding the tours the user has completed or dismissed. */
 export const TOUR_SEEN_SETTING = 'Comfy.OnboardingCoachmarks.Seen'
@@ -21,13 +24,28 @@ export const COACH_IDS = {
   assetsPanel: 'assets-panel'
 } as const
 
-export type CoachId = (typeof COACH_IDS)[keyof typeof COACH_IDS]
+/**
+ * Graph-view anchors for the first-run tour. Kept out of {@link COACH_IDS}
+ * because the drift guard iterates that map and asserts each id resolves in
+ * App mode, where none of these exist.
+ */
+export const FIRST_RUN_COACH_IDS = {
+  runButton: 'first-run-run-button',
+  source: 'first-run-source',
+  prompt: 'first-run-prompt',
+  sink: 'first-run-sink'
+} as const
+
+export type CoachId =
+  | (typeof COACH_IDS)[keyof typeof COACH_IDS]
+  | (typeof FIRST_RUN_COACH_IDS)[keyof typeof FIRST_RUN_COACH_IDS]
 
 export interface CoachStep {
   /**
    * Derives the step's translation keys:
    * `onboardingCoachmarks.<tour>.<name>.title|body`, plus optional
-   * `primary`/`skip` button-label overrides.
+   * `primary`/`skip` button-label overrides. Read inside a reactive effect, so
+   * a getter here re-resolves the copy as the step's subject changes.
    */
   name: string
   /** Element to spotlight (the first laid-out registered candidate wins). */
@@ -40,7 +58,23 @@ export interface CoachStep {
   /** Renders the landing dialog instead of a spotlight. */
   landing?: boolean
   image?: string
+  /** Lets pointer input through the scrim's holes and releases the focus trap. */
+  interactive?: boolean
+  /** Draws a pointer glyph on the card edge facing the target. */
+  cursor?: boolean
+  /** The app is still doing what this step asked for; the card shows a spinner. */
+  busy?: () => boolean
+  /**
+   * Offers no primary action: the only way past this step is doing the thing it
+   * asks for in the app, and the consumer advances once that happens.
+   */
+  selfAdvancing?: boolean
+  /** Runs when the step is shown; the signal aborts on leaving the step. */
+  onEnter?: (signal: AbortSignal) => void | Promise<void>
 }
+
+/** A tour's steps: a fixed list, or a resolver that builds them at start. */
+export type TourDefinition = CoachStep[] | (() => Promise<CoachStep[]>)
 
 /**
  * Fixes the running step set (and so the step count) at tour start: drops steps
@@ -55,7 +89,7 @@ export function resolveSteps(
   )
 }
 
-export const TOURS: Record<EntryPath, CoachStep[]> = {
+const TOURS: Partial<Record<EntryPath, TourDefinition>> = {
   appMode: [
     {
       name: 'landing',
@@ -89,4 +123,16 @@ export const TOURS: Record<EntryPath, CoachStep[]> = {
       openSidebarTab: 'assets'
     }
   ]
+}
+
+/**
+ * Registers a tour whose steps are built by a higher layer — the layer rules
+ * forbid this one from importing them. Re-registering replaces the definition.
+ */
+export function registerTour(entry: EntryPath, definition: TourDefinition) {
+  TOURS[entry] = definition
+}
+
+export function tourDefinition(entry: EntryPath): TourDefinition | undefined {
+  return TOURS[entry]
 }

--- a/src/platform/onboarding/useCoachmarkTarget.ts
+++ b/src/platform/onboarding/useCoachmarkTarget.ts
@@ -4,8 +4,18 @@ import { useEventListener } from '@vueuse/core'
 import { computed, ref, toValue, watch, watchEffect } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 
-import { CARD_GAP, VIEWPORT_MARGIN, topSafeInset } from './coachmarkLayout'
-import { coachmarkElements, isLaidOut } from './coachmarkRegistry'
+import {
+  CARD_GAP,
+  CURSOR_GAP,
+  VIEWPORT_MARGIN,
+  topSafeInset
+} from './coachmarkLayout'
+import {
+  coachmarkElements,
+  isLaidOut,
+  isMovingTarget
+} from './coachmarkRegistry'
+import type { CoachTarget } from './coachmarkRegistry'
 import type { CoachPlacement, CoachStep } from './onboardingTours'
 
 // A target animating in via CSS transform reports through neither scroll nor
@@ -36,7 +46,7 @@ const captureReference: Middleware = {
 }
 
 function middleware(step: CoachStep | null, topInset: number): Middleware[] {
-  const list: Middleware[] = [offset(CARD_GAP)]
+  const list: Middleware[] = [offset(step?.cursor ? CURSOR_GAP : CARD_GAP)]
   if (!step?.placement || step.placement === 'auto') list.push(flip())
   // shift only guards the main axis by default; crossAxis keeps vertically-
   // centred placements (leftCenter) on-screen too.
@@ -63,13 +73,17 @@ export function useCoachmarkTarget(
   step: MaybeRefOrGetter<CoachStep | null>,
   cardRef: Ref<HTMLElement | null>
 ) {
-  const candidateEls = computed<readonly HTMLElement[]>(() => {
+  const candidateEls = computed<readonly CoachTarget[]>(() => {
     const id = toValue(step)?.coachId
     return id ? coachmarkElements(id) : []
   })
 
-  const targetEl = computed<HTMLElement | null>(
+  const targetEl = computed<CoachTarget | null>(
     () => candidateEls.value.find(isLaidOut) ?? null
+  )
+
+  const isVirtualTarget = computed(
+    () => !!targetEl.value && !(targetEl.value instanceof Element)
   )
 
   // The top bar's height only changes on resize, so read it once and refresh
@@ -79,16 +93,20 @@ export function useCoachmarkTarget(
     topInset.value = topSafeInset()
   })
 
-  const { floatingStyles, middlewareData, isPositioned, update } = useFloating(
-    targetEl,
-    cardRef,
-    {
+  const { floatingStyles, middlewareData, isPositioned, placement, update } =
+    useFloating(targetEl, cardRef, {
       strategy: 'fixed',
       transform: false,
       placement: () => floatingPlacement(toValue(step)),
       middleware: () => middleware(toValue(step), topInset.value)
-    }
-  )
+    })
+
+  watchEffect((onCleanup) => {
+    const el = targetEl.value
+    if (!el || !isMovingTarget(el)) return
+    void update()
+    onCleanup(el.onMove(() => void update()))
+  })
 
   const targetRect = computed<DOMRect | null>(() => {
     const data = middlewareData.value.captureReference as
@@ -122,15 +140,22 @@ export function useCoachmarkTarget(
   })
 
   watchEffect((onCleanup) => {
-    const reference = targetEl.value
+    const anchor = targetEl.value
     const floating = cardRef.value
-    if (!reference || !floating) return
+    if (!anchor || !floating) return
     onCleanup(
-      autoUpdate(reference, floating, update, {
+      autoUpdate(anchor, floating, update, {
         animationFrame: trackMotion.value
       })
     )
   })
 
-  return { targetEl, targetRect, floatingStyles, isPositioned }
+  return {
+    targetEl,
+    targetRect,
+    isVirtualTarget,
+    floatingStyles,
+    isPositioned,
+    placement
+  }
 }

--- a/src/platform/onboarding/useCoachmarkTarget.virtualTarget.test.ts
+++ b/src/platform/onboarding/useCoachmarkTarget.virtualTarget.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+import { COACH_IDS } from './onboardingTours'
+import type { CoachStep } from './onboardingTours'
+import { clearCoachmarks, registerCoachmark } from './coachmarkRegistry'
+import { useCoachmarkTarget } from './useCoachmarkTarget'
+
+const COACH_ID = COACH_IDS.inputsList
+
+function virtualStep(): CoachStep {
+  return { name: 'inputs', placement: 'auto', coachId: COACH_ID }
+}
+
+/** A target under a moving camera, which reports its motion to whoever asks. */
+function movingTarget() {
+  const listeners = new Set<() => void>()
+  return {
+    getBoundingClientRect: () => new DOMRect(10, 10, 80, 40),
+    onMove: (notify: () => void) => {
+      listeners.add(notify)
+      return () => listeners.delete(notify)
+    },
+    listenerCount: () => listeners.size
+  }
+}
+
+function mountTarget(target: { getBoundingClientRect: () => DOMRect }) {
+  registerCoachmark(COACH_ID, target)
+  const scope = effectScope()
+  const card = ref<HTMLElement | null>(document.createElement('div'))
+  const api = scope.run(() => useCoachmarkTarget(ref(virtualStep()), card))
+  return { scope, api }
+}
+
+describe('useCoachmarkTarget with a virtual target', () => {
+  afterEach(() => {
+    clearCoachmarks()
+  })
+
+  it('follows a target that reports its own motion', async () => {
+    const target = movingTarget()
+    const { scope } = mountTarget(target)
+    await nextTick()
+
+    expect(
+      target.listenerCount(),
+      'a target the camera carries moves with no DOM event to announce it'
+    ).toBe(1)
+    scope.stop()
+  })
+
+  it('stops listening once the step is over', async () => {
+    const target = movingTarget()
+    const { scope } = mountTarget(target)
+    await nextTick()
+
+    scope.stop()
+
+    expect(
+      target.listenerCount(),
+      'a subscription outliving its tour follows the target forever'
+    ).toBe(0)
+  })
+
+  it('leaves a still target alone, having nothing to subscribe to', async () => {
+    const { scope, api } = mountTarget({
+      getBoundingClientRect: () => new DOMRect(10, 10, 80, 40)
+    })
+    await nextTick()
+
+    expect(
+      api?.isVirtualTarget.value,
+      'a plain rect still counts as virtual, so the ring must not tween after it'
+    ).toBe(true)
+    scope.stop()
+  })
+})

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -103,6 +103,7 @@ export type RemoteConfig = {
   private_models_enabled?: boolean
   onboarding_survey_enabled?: boolean
   onboarding_survey?: OnboardingSurvey
+  onboarding_tour_enabled?: boolean
   /** Full hosted (external) survey URL embedded in the Nodes Manager modal on Cloud. */
   manager_survey_url?: string
   linear_toggle_enabled?: boolean

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -99,21 +99,25 @@ export type OnboardingTourStage =
   | 'step_shown'
   | 'completed'
   | 'skipped'
+  | 'nudge_shown'
+  | 'explore_templates_clicked'
 
 export type OnboardingTourSkipReason =
   | 'user'
   | 'target_timeout'
   | 'trigger_lost'
+  | 'postponed'
 
 /**
  * `step_number` is 1-based and matches the "Step N of M" indicator the user
  * sees, with `step_count` as M. Both `step_number` and `coach_id` are absent
  * for steps with no numbered spotlight (e.g. the landing). `skip_reason` is
- * present only on the `skipped` stage.
+ * present only on the `skipped` stage, and `step_count` only on the stages that
+ * happen inside the step sequence — the nudge stages follow the tour's end.
  */
 export interface OnboardingTourMetadata {
   tour: string
-  step_count: number
+  step_count?: number
   step_number?: number
   coach_id?: string
   skip_reason?: OnboardingTourSkipReason
@@ -182,51 +186,10 @@ export interface ExecutionErrorMetadata {
   error?: string
 }
 
-export interface WorkflowExecutionContext {
-  workflow_type: 'template' | 'custom'
-  view_mode: AppMode
-  execution_scope: 'full' | 'partial'
-  total_node_count: number
-  executable_node_count: number
-  custom_node_count: number
-  api_node_count: number
-  subgraph_count: number
-}
-
-export interface WorkflowQueueIntent {
-  trigger_source?: ExecutionTriggerSource
-}
-
-export interface WorkflowExecutionIntent {
-  trigger_source: ExecutionTriggerSource
-}
-
-export type WorkflowExecutionFailureReason =
-  | 'prompt_build_failed'
-  | 'submission_rejected'
-  | 'submission_failed'
-  | 'execution_failed'
-  | 'execution_interrupted'
-
-interface ExecutionOutcomeBaseMetadata extends WorkflowExecutionIntent {
+export interface ExecutionOutcomeMetadata {
   startTime: number
-  submissionAcceptedAt?: number
-  executionStartedAt?: number
-  endTime: number
-  workflowContext?: WorkflowExecutionContext
+  outcome: 'success' | 'failure'
 }
-
-export type ExecutionOutcomeMetadata = ExecutionOutcomeBaseMetadata &
-  (
-    | {
-        success: true
-        failureReason: ''
-      }
-    | {
-        success: false
-        failureReason: WorkflowExecutionFailureReason
-      }
-  )
 
 /**
  * Execution success metadata
@@ -474,18 +437,6 @@ export interface UiButtonClickMetadata {
 }
 
 /**
- * Widget (input/parameter) favorite toggle tracking metadata.
- * Used to measure discoverability of the right side panel favoriting feature.
- */
-export interface WidgetFavoriteToggledMetadata {
-  node_type: string
-  widget_name: string
-  widget_type: string
-  is_favorited: boolean
-  source: 'right_side_panel'
-}
-
-/**
  * Help center opened metadata
  */
 export interface HelpCenterOpenedMetadata {
@@ -611,168 +562,20 @@ interface EcommerceMetadata {
 
 export interface SubscriptionSuccessMetadata extends Record<string, unknown> {
   user_id?: string
-  checkout_attempt_id?: string
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkout_type?: SubscriptionCheckoutType
+  checkout_attempt_id: string
+  tier: TierKey
+  cycle: BillingCycle
+  checkout_type: SubscriptionCheckoutType
   previous_tier?: TierKey
   payment_intent_source?: PaymentIntentSource
-  /** Present when the success is reported off the workspace billing-op poller. */
-  billing_op_id?: string
-  value?: number
-  currency?: string
-  ecommerce?: EcommerceMetadata
+  value: number
+  currency: string
+  ecommerce: EcommerceMetadata
 }
 
 export interface WorkspaceInviteMetadata extends Record<string, unknown> {
   source: 'post_upgrade_success' | 'settings_members'
   count: number
-}
-
-export interface WorkspaceInviteFailedMetadata extends Record<string, unknown> {
-  source: WorkspaceInviteMetadata['source']
-  attempted_count: number
-  failed_count: number
-}
-
-type BillingFailureCategory =
-  | 'validation'
-  | 'network'
-  | 'api_rejected'
-  | 'provider_decline'
-  | 'redirect'
-  | 'poll_timeout'
-  | 'stale_operation'
-  | 'rendering'
-  | 'unknown'
-
-type BillingErrorCode =
-  | 'downgrade_not_allowed'
-  | 'member_removal_failed'
-  | 'missing_checkout_response'
-  | 'missing_payment_method_url'
-  | 'payment_popup_blocked'
-
-export interface BillingFailure {
-  failure_category: BillingFailureCategory
-  error_code?: BillingErrorCode
-}
-
-type BillingStarted = {
-  stage: 'started'
-  outcome: 'pending'
-}
-
-type BillingSucceeded = {
-  stage: 'succeeded'
-  outcome: 'success'
-}
-
-type BillingFailed = BillingFailure & {
-  stage: 'failed'
-  outcome: 'failure'
-}
-
-type BillingTimedOut = {
-  stage: 'timeout'
-  outcome: 'failure'
-  failure_category: 'poll_timeout'
-}
-
-type SubscriptionCheckoutBillingEvent = {
-  operation: 'subscription_checkout'
-  billing_op_id?: string
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkout_type?: SubscriptionCheckoutType
-  payment_intent_source?: PaymentIntentSource
-} & (BillingSucceeded | BillingFailed)
-
-type BillingOperationBillingEvent = {
-  operation: 'operation'
-  billing_op_id: string
-  operation_type: 'subscription' | 'topup' | 'cancel'
-  tier?: SubscriptionCheckoutTier
-  cycle?: BillingCycle
-  checkout_type?: SubscriptionCheckoutType
-  payment_intent_source?: PaymentIntentSource
-} & (BillingSucceeded | BillingFailed | BillingTimedOut)
-
-type ResubscribeBillingEvent = {
-  operation: 'resubscribe'
-  source: ResubscribeClickMetadata['source']
-  payment_intent_source?: PaymentIntentSource
-} & (BillingSucceeded | BillingFailed)
-
-type TopupBillingEvent = {
-  operation: 'topup'
-  billing_op_id?: string
-} & (BillingSucceeded | BillingFailed)
-
-type DowngradeToPersonalBillingEvent = {
-  operation: 'downgrade_to_personal'
-  member_removal_count: number
-  member_removal_failures: number
-  target_tier?: TierKey
-} & (BillingStarted | BillingSucceeded | BillingFailed)
-
-export type BillingTelemetryEvent =
-  | SubscriptionCheckoutBillingEvent
-  | BillingOperationBillingEvent
-  | ResubscribeBillingEvent
-  | TopupBillingEvent
-  | DowngradeToPersonalBillingEvent
-
-type BillingTelemetryEventNameFor<T extends BillingTelemetryEvent> =
-  T extends BillingTelemetryEvent
-    ? `billing.${T['operation']}.${T['stage']}`
-    : never
-
-export type BillingTelemetryEventName =
-  BillingTelemetryEventNameFor<BillingTelemetryEvent>
-
-export function getBillingTelemetryEventName(
-  event: BillingTelemetryEvent
-): BillingTelemetryEventName {
-  return `billing.${event.operation}.${event.stage}` as BillingTelemetryEventName
-}
-
-export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
-  return {
-    operation: event.operation,
-    stage: event.stage,
-    outcome: event.outcome,
-    ...('billing_op_id' in event &&
-      event.billing_op_id !== undefined && {
-        billing_op_id: event.billing_op_id
-      }),
-    ...('operation_type' in event && {
-      operation_type: event.operation_type
-    }),
-    ...('tier' in event && event.tier !== undefined && { tier: event.tier }),
-    ...('cycle' in event &&
-      event.cycle !== undefined && { cycle: event.cycle }),
-    ...('checkout_type' in event &&
-      event.checkout_type !== undefined && {
-        checkout_type: event.checkout_type
-      }),
-    ...('payment_intent_source' in event &&
-      event.payment_intent_source !== undefined && {
-        payment_intent_source: event.payment_intent_source
-      }),
-    ...('source' in event && { source: event.source }),
-    ...('failure_category' in event && {
-      failure_category: event.failure_category
-    }),
-    ...('error_code' in event &&
-      event.error_code !== undefined && { error_code: event.error_code }),
-    ...('member_removal_count' in event && {
-      member_removal_count: event.member_removal_count,
-      member_removal_failures: event.member_removal_failures
-    }),
-    ...('target_tier' in event &&
-      event.target_tier !== undefined && { target_tier: event.target_tier })
-  }
 }
 
 /**
@@ -805,10 +608,7 @@ export interface TelemetryProvider {
   trackApiCreditTopupButtonPurchaseClicked?(amount: number): void
   trackApiCreditTopupSucceeded?(): void
   trackWorkspaceInviteSent?(metadata: WorkspaceInviteMetadata): void
-  trackWorkspaceInviteFailed?(metadata: WorkspaceInviteFailedMetadata): void
   trackRunButton?(properties: RunButtonProperties): void
-
-  trackBillingEvent?(event: BillingTelemetryEvent): void
 
   // Credit top-up tracking (composition with internal utilities)
   startTopupTracking?(): void
@@ -884,9 +684,6 @@ export interface TelemetryProvider {
   // Generic UI button click events
   trackUiButtonClicked?(metadata: UiButtonClickMetadata): void
 
-  // Right side panel widget favorite events
-  trackWidgetFavoriteToggled?(metadata: WidgetFavoriteToggledMetadata): void
-
   // Page view tracking
   trackPageView?(pageName: string, properties?: PageViewMetadata): void
 }
@@ -928,25 +725,7 @@ export const TelemetryEvents = {
     'app:api_credit_topup_button_purchase_clicked',
   API_CREDIT_TOPUP_SUCCEEDED: 'app:api_credit_topup_succeeded',
   WORKSPACE_INVITE_SENT: 'app:workspace_invite_sent',
-  WORKSPACE_INVITE_FAILED: 'app:workspace_invite_failed',
   BEGIN_CHECKOUT: 'begin_checkout',
-
-  // Canonical Billing Lifecycle
-  BILLING_SUBSCRIPTION_CHECKOUT_SUCCEEDED:
-    'billing.subscription_checkout.succeeded',
-  BILLING_SUBSCRIPTION_CHECKOUT_FAILED: 'billing.subscription_checkout.failed',
-  BILLING_OPERATION_SUCCEEDED: 'billing.operation.succeeded',
-  BILLING_OPERATION_FAILED: 'billing.operation.failed',
-  BILLING_OPERATION_TIMEOUT: 'billing.operation.timeout',
-  BILLING_RESUBSCRIBE_SUCCEEDED: 'billing.resubscribe.succeeded',
-  BILLING_RESUBSCRIBE_FAILED: 'billing.resubscribe.failed',
-  BILLING_TOPUP_SUCCEEDED: 'billing.topup.succeeded',
-  BILLING_TOPUP_FAILED: 'billing.topup.failed',
-  BILLING_DOWNGRADE_TO_PERSONAL_STARTED:
-    'billing.downgrade_to_personal.started',
-  BILLING_DOWNGRADE_TO_PERSONAL_SUCCEEDED:
-    'billing.downgrade_to_personal.succeeded',
-  BILLING_DOWNGRADE_TO_PERSONAL_FAILED: 'billing.downgrade_to_personal.failed',
 
   // Onboarding Survey
   USER_SURVEY_OPENED: 'app:user_survey_opened',
@@ -957,6 +736,9 @@ export const TelemetryEvents = {
   ONBOARDING_TOUR_STEP_SHOWN: 'app:onboarding_tour_step_shown',
   ONBOARDING_TOUR_COMPLETED: 'app:onboarding_tour_completed',
   ONBOARDING_TOUR_SKIPPED: 'app:onboarding_tour_skipped',
+  ONBOARDING_TOUR_NUDGE_SHOWN: 'app:onboarding_tour_nudge_shown',
+  ONBOARDING_TOUR_EXPLORE_TEMPLATES_CLICKED:
+    'app:onboarding_tour_explore_templates_clicked',
 
   // Email Verification
   USER_EMAIL_VERIFY_OPENED: 'app:user_email_verify_opened',
@@ -1014,9 +796,6 @@ export const TelemetryEvents = {
   // Generic UI Button Click
   UI_BUTTON_CLICKED: 'app:ui_button_clicked',
 
-  // Right Side Panel Widget Favorites
-  WIDGET_FAVORITE_TOGGLED: 'app:widget_favorite_toggled',
-
   // Page View
   PAGE_VIEW: 'app:page_view'
 } as const
@@ -1031,7 +810,10 @@ export const OnboardingTourEvents: Record<
   started: TelemetryEvents.ONBOARDING_TOUR_STARTED,
   step_shown: TelemetryEvents.ONBOARDING_TOUR_STEP_SHOWN,
   completed: TelemetryEvents.ONBOARDING_TOUR_COMPLETED,
-  skipped: TelemetryEvents.ONBOARDING_TOUR_SKIPPED
+  skipped: TelemetryEvents.ONBOARDING_TOUR_SKIPPED,
+  nudge_shown: TelemetryEvents.ONBOARDING_TOUR_NUDGE_SHOWN,
+  explore_templates_clicked:
+    TelemetryEvents.ONBOARDING_TOUR_EXPLORE_TEMPLATES_CLICKED
 }
 
 export const CANCELLATION_STAGE_EVENTS = {
@@ -1041,25 +823,12 @@ export const CANCELLATION_STAGE_EVENTS = {
   failed: TelemetryEvents.SUBSCRIPTION_CANCEL_FAILED
 } as const
 
-const executionTriggerSources = [
-  'button',
-  'keybinding',
-  'legacy_ui',
-  'unknown',
-  'linear',
-  'auto_queue'
-] as const
-
-export type ExecutionTriggerSource = (typeof executionTriggerSources)[number]
-
-export function normalizeExecutionTriggerSource(
-  value: unknown
-): ExecutionTriggerSource {
-  return (
-    executionTriggerSources.find((triggerSource) => triggerSource === value) ??
-    'unknown'
-  )
-}
+export type ExecutionTriggerSource =
+  | 'button'
+  | 'keybinding'
+  | 'legacy_ui'
+  | 'unknown'
+  | 'linear'
 
 /**
  * Union type for all possible telemetry event properties
@@ -1088,7 +857,6 @@ export type TelemetryEventProperties =
   | TemplateFilterMetadata
   | SettingChangedMetadata
   | UiButtonClickMetadata
-  | WidgetFavoriteToggledMetadata
   | HelpCenterOpenedMetadata
   | HelpResourceClickedMetadata
   | HelpCenterClosedMetadata
@@ -1100,5 +868,3 @@ export type TelemetryEventProperties =
   | DefaultViewSetMetadata
   | SubscriptionMetadata
   | SubscriptionSuccessMetadata
-  | WorkspaceInviteFailedMetadata
-  | BillingTelemetryEvent

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -111,15 +111,18 @@ export type OnboardingTourSkipReason =
 /**
  * `step_number` is 1-based and matches the "Step N of M" indicator the user
  * sees, with `step_count` as M. Both `step_number` and `coach_id` are absent
- * for steps with no numbered spotlight (e.g. the landing). `skip_reason` is
- * present only on the `skipped` stage, and `step_count` only on the stages that
- * happen inside the step sequence — the nudge stages follow the tour's end.
+ * for steps with no numbered spotlight (e.g. the landing); `is_landing` marks
+ * those instead, so a bail on the landing is a value analytics can group on
+ * rather than an absent field it has to infer from. `skip_reason` is present
+ * only on the `skipped` stage, and `step_count` only on the stages that happen
+ * inside the step sequence — the nudge stages follow the tour's end.
  */
 export interface OnboardingTourMetadata {
   tour: string
   step_count?: number
   step_number?: number
   coach_id?: string
+  is_landing?: boolean
   skip_reason?: OnboardingTourSkipReason
 }
 

--- a/src/platform/workflow/persistence/base/draftTypes.ts
+++ b/src/platform/workflow/persistence/base/draftTypes.ts
@@ -85,3 +85,12 @@ export interface OpenPathsPointer {
 export const MAX_DRAFTS = 32
 
 export const PERSIST_DEBOUNCE_MS = 512
+
+/** What startup did with the workflow, for callers deciding what to show next. */
+export type StartupOutcome =
+  /** A previously open workflow was loaded. */
+  | 'restored'
+  /** Nothing to restore; a blank workflow was loaded. */
+  | 'fresh'
+  /** Blank, but a `?share=`/`?template=` load is still inbound. */
+  | 'url-intent'

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -9,7 +9,8 @@ import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowPersistenceV2 } from './useWorkflowPersistenceV2'
 
 const settingMocks = vi.hoisted(() => ({
-  persistRef: null as { value: boolean } | null
+  persistRef: null as { value: boolean } | null,
+  values: {} as Record<string, unknown>
 }))
 
 vi.mock('@/platform/settings/settingStore', async () => {
@@ -20,9 +21,11 @@ vi.mock('@/platform/settings/settingStore', async () => {
       get: vi.fn((key: string) => {
         if (key === 'Comfy.Workflow.Persist')
           return settingMocks.persistRef!.value
-        return undefined
+        return settingMocks.values[key]
       }),
-      set: vi.fn()
+      set: vi.fn((key: string, value: unknown) => {
+        settingMocks.values[key] = value
+      })
     }))
   }
 })
@@ -187,6 +190,7 @@ describe('useWorkflowPersistenceV2', () => {
     sessionStorage.clear()
     vi.clearAllMocks()
     settingMocks.persistRef!.value = true
+    settingMocks.values = {}
     mocks.state.graphChangedHandler = null
     mocks.state.currentGraph = { initial: true }
     mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
@@ -555,67 +559,43 @@ describe('useWorkflowPersistenceV2', () => {
   })
 
   describe('loadDefaultWorkflow', () => {
-    it('opens templates browser for first-time users', async () => {
+    it('reports a fresh start for first-time users', async () => {
       const { initializeWorkflow } = mountWorkflowPersistence()
-      await initializeWorkflow()
 
+      await expect(initializeWorkflow()).resolves.toBe('fresh')
       expect(loadBlankWorkflowMock).toHaveBeenCalled()
-      expect(commandStoreMocks.execute).toHaveBeenCalledWith(
-        'Comfy.BrowseTemplates'
-      )
     })
 
-    it('does not open templates browser when share param is in URL', async () => {
-      routeMocks.query = { share: 'test-share-id' }
+    it('still reports fresh on a reload before the user chose anything', async () => {
+      await mountWorkflowPersistence().initializeWorkflow()
 
-      const { initializeWorkflow } = mountWorkflowPersistence()
-      await initializeWorkflow()
-
-      expect(loadBlankWorkflowMock).toHaveBeenCalled()
-      expect(commandStoreMocks.execute).not.toHaveBeenCalledWith(
-        'Comfy.BrowseTemplates'
-      )
+      await expect(
+        mountWorkflowPersistence().initializeWorkflow(),
+        'Startup must not mark the tutorial completed; a user who reloads before choosing anything would be stranded as a returning user'
+      ).resolves.toBe('fresh')
     })
 
-    it('does not open templates browser when share intent is preserved across /user-select redirect', async () => {
-      // No-local-user flow: ?share=... was captured into sessionStorage and the
-      // URL query was dropped during the /user-select redirect before
-      // initializeWorkflow() runs.
-      preservedQueryMocks.payloads.share = { share: 'test-share-id' }
+    it.for([
+      ['share param in URL', () => (routeMocks.query = { share: 'id' })],
+      [
+        'share intent preserved across /user-select redirect',
+        () => (preservedQueryMocks.payloads.share = { share: 'id' })
+      ],
+      ['template param in URL', () => (routeMocks.query = { template: 'id' })],
+      [
+        'template intent preserved across /user-select redirect',
+        () => (preservedQueryMocks.payloads.template = { template: 'id' })
+      ]
+    ] as const)(
+      'reports url-intent, not fresh, with %s',
+      async ([, applyIntent]) => {
+        applyIntent()
 
-      const { initializeWorkflow } = mountWorkflowPersistence()
-      await initializeWorkflow()
+        const { initializeWorkflow } = mountWorkflowPersistence()
 
-      expect(loadBlankWorkflowMock).toHaveBeenCalled()
-      expect(commandStoreMocks.execute).not.toHaveBeenCalledWith(
-        'Comfy.BrowseTemplates'
-      )
-    })
-
-    it('does not open templates browser when template param is in URL', async () => {
-      routeMocks.query = { template: 'default-template-id' }
-
-      const { initializeWorkflow } = mountWorkflowPersistence()
-      await initializeWorkflow()
-
-      expect(loadBlankWorkflowMock).toHaveBeenCalled()
-      expect(commandStoreMocks.execute).not.toHaveBeenCalledWith(
-        'Comfy.BrowseTemplates'
-      )
-    })
-
-    it('does not open templates browser when template intent is preserved across /user-select redirect', async () => {
-      preservedQueryMocks.payloads.template = {
-        template: 'default-template-id'
+        await expect(initializeWorkflow()).resolves.toBe('url-intent')
+        expect(loadBlankWorkflowMock).toHaveBeenCalled()
       }
-
-      const { initializeWorkflow } = mountWorkflowPersistence()
-      await initializeWorkflow()
-
-      expect(loadBlankWorkflowMock).toHaveBeenCalled()
-      expect(commandStoreMocks.execute).not.toHaveBeenCalledWith(
-        'Comfy.BrowseTemplates'
-      )
-    })
+    )
   })
 })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -29,6 +29,7 @@ import {
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
 import { PERSIST_DEBOUNCE_MS } from '../base/draftTypes'
+import type { StartupOutcome } from '../base/draftTypes'
 import { clearAllV2Storage } from '../base/storageIO'
 import { migrateV1toV2 } from '../migration/migrateV1toV2'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
@@ -37,7 +38,6 @@ import { useSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composab
 import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
-import { useCommandStore } from '@/stores/commandStore'
 
 export function useWorkflowPersistenceV2() {
   const { t } = useI18n()
@@ -174,16 +174,16 @@ export function useWorkflowPersistenceV2() {
   const hasTemplateUrlIntent = () =>
     hasPreservedIntent(TEMPLATE_NAMESPACE, 'template')
 
-  const loadDefaultWorkflow = async () => {
-    if (!settingStore.get('Comfy.TutorialCompleted')) {
-      await settingStore.set('Comfy.TutorialCompleted', true)
-      await useWorkflowService().loadBlankWorkflow()
-      if (!hasSharedWorkflowIntent() && !hasTemplateUrlIntent()) {
-        await useCommandStore().execute('Comfy.BrowseTemplates')
-      }
-    } else {
+  const resolveStartupOutcome = async (): Promise<StartupOutcome> => {
+    if (settingStore.get('Comfy.TutorialCompleted')) {
       await comfyApp.loadGraphData()
+      return 'restored'
     }
+
+    await useWorkflowService().loadBlankWorkflow()
+    return hasSharedWorkflowIntent() || hasTemplateUrlIntent()
+      ? 'url-intent'
+      : 'fresh'
   }
 
   const getRestorableTabState = () => {
@@ -198,27 +198,24 @@ export function useWorkflowPersistenceV2() {
     return { paths, activeIndex }
   }
 
-  const initializeWorkflow = async () => {
+  const initializeWorkflow = async (): Promise<StartupOutcome> => {
     if (!workflowPersistenceEnabled.value) {
-      await loadDefaultWorkflow()
-      return
+      return await resolveStartupOutcome()
     }
 
     try {
       if (getRestorableTabState()) {
         // GraphCanvas calls restoreWorkflowTabsState next; skip the single-workflow
         // fallback here so the saved tab order and active index drive startup.
-        return
+        return 'restored'
       }
 
       await workflowStore.loadWorkflows()
       const restored = await loadPreviousWorkflowFromStorage()
-      if (!restored) {
-        await loadDefaultWorkflow()
-      }
+      return restored ? 'restored' : await resolveStartupOutcome()
     } catch (err) {
       console.error('Error loading previous workflow', err)
-      await loadDefaultWorkflow()
+      return await resolveStartupOutcome()
     }
   }
 
@@ -226,9 +223,9 @@ export function useWorkflowPersistenceV2() {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
 
-    if (hasTemplateUrl) {
-      await templateUrlLoader.loadTemplateFromUrl()
-    }
+    return hasTemplateUrl
+      ? await templateUrlLoader.loadTemplateFromUrl()
+      : undefined
   }
 
   const loadSharedWorkflowFromUrlIfPresent = async () => {
@@ -303,7 +300,7 @@ export function useWorkflowPersistenceV2() {
       await workflowStore.loadWorkflows()
     } catch (err) {
       console.error('Error loading workflows for tab restore', err)
-      await loadDefaultWorkflow()
+      await resolveStartupOutcome()
       tabStateRestored = true
       return
     }

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -20,7 +20,7 @@ import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 
-type SharedWorkflowUrlLoadStatus =
+export type SharedWorkflowUrlLoadStatus =
   | 'not-present'
   | 'loaded'
   | 'loaded-without-assets'

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -63,8 +63,9 @@ export function useTemplateUrlLoader() {
   /**
    * Loads template from URL query parameters if present
    * Handles errors internally and shows appropriate user feedback
+   * @returns the id of the template that loaded, if one did
    */
-  const loadTemplateFromUrl = async () => {
+  const loadTemplateFromUrl = async (): Promise<string | undefined> => {
     const templateParam = route.query.template
 
     if (!templateParam || typeof templateParam !== 'string') {
@@ -121,11 +122,15 @@ export function useTemplateUrlLoader() {
             templateName: templateParam
           })
         })
-      } else if (modeParam === 'linear') {
+        return
+      }
+
+      if (modeParam === 'linear') {
         // Set linear mode after successful template load
         useTelemetry()?.trackEnterLinear({ source: 'template_url' })
         canvasStore.linearMode = true
       }
+      return sourceParam === 'default' ? templateParam : undefined
     } catch (error) {
       console.error(
         '[useTemplateUrlLoader] Failed to load template from URL:',

--- a/src/renderer/extensions/firstRunTour/FirstRunTour.vue
+++ b/src/renderer/extensions/firstRunTour/FirstRunTour.vue
@@ -1,0 +1,13 @@
+<template>
+  <GettingStartedScreen v-if="gettingStartedVisible" />
+</template>
+
+<script setup lang="ts">
+import GettingStartedScreen from './gettingStarted/GettingStartedScreen.vue'
+import { useFirstRunEntry } from './gettingStarted/firstRunEntry'
+import { useFirstRunTourController } from './tour/useFirstRunTourController'
+
+const { gettingStartedVisible } = useFirstRunEntry()
+
+useFirstRunTourController()
+</script>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedCard.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedCard.vue
@@ -1,0 +1,107 @@
+<template>
+  <div
+    v-if="skeleton"
+    :data-testid="testid"
+    class="relative aspect-square overflow-hidden rounded-2xl"
+  >
+    <Skeleton class="absolute inset-0 rounded-2xl" />
+    <Skeleton class="absolute inset-x-4 bottom-4 h-4 w-2/3 rounded-md" />
+  </div>
+  <div
+    v-else
+    ref="cardRef"
+    role="button"
+    :tabindex="loading ? -1 : 0"
+    :aria-disabled="loading"
+    :data-testid="testid"
+    :aria-label="failed ? t('gettingStarted.retryTemplate', { title }) : title"
+    :aria-busy="loading"
+    class="group/card focus-visible:ring-ring relative cursor-pointer overflow-hidden rounded-2xl focus-visible:ring-1 focus-visible:outline-none"
+    @click="onSelect"
+    @keydown.enter.prevent="onSelect"
+    @keydown.space.prevent="onSelect"
+  >
+    <DefaultThumbnail
+      :src="imageSrc"
+      :alt="title"
+      :is-hovered
+      :is-video
+      :hover-zoom="5"
+    />
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 bg-linear-to-b from-black/60 via-black/20 via-50% to-black/70 transition-opacity duration-300 ease-out group-hover/card:opacity-0"
+    />
+    <div
+      v-if="badgeIcon"
+      aria-hidden="true"
+      class="pointer-events-none absolute top-3 right-3 flex size-7 items-center justify-center rounded-full bg-black/50 text-base-foreground backdrop-blur-sm"
+    >
+      <i :class="cn(badgeIcon, 'size-4')" />
+    </div>
+    <h3
+      class="absolute inset-x-0 bottom-0 m-0 truncate p-4 text-sm font-semibold text-base-foreground drop-shadow-md"
+      :title
+    >
+      {{ title }}
+    </h3>
+    <div
+      v-if="loading"
+      aria-live="polite"
+      class="absolute inset-0 flex items-center justify-center bg-base-background/70 backdrop-blur-md"
+    >
+      <Loader size="md" />
+    </div>
+    <div
+      v-else-if="failed"
+      class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 bg-base-background/80 p-4 backdrop-blur-md"
+    >
+      <span class="text-center text-xs font-medium text-base-foreground">
+        {{ t('gettingStarted.templateFailed') }}
+      </span>
+      <span class="text-xs font-semibold text-primary">
+        {{ t('gettingStarted.retry') }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useElementHover } from '@vueuse/core'
+import Loader from '@/components/loader/Loader.vue'
+import { useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+import DefaultThumbnail from '@/components/templates/thumbnails/DefaultThumbnail.vue'
+import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
+
+const {
+  imageSrc = '',
+  title = '',
+  loading
+} = defineProps<{
+  imageSrc?: string
+  title?: string
+  loading?: boolean
+  /** Shows an inline error; selecting the card again retries. */
+  failed?: boolean
+  skeleton?: boolean
+  isVideo?: boolean
+  badgeIcon?: string
+  testid?: string
+}>()
+
+const emit = defineEmits<{ select: [] }>()
+
+const { t } = useI18n()
+
+const cardRef = useTemplateRef<HTMLElement>('cardRef')
+const isHovered = useElementHover(cardRef)
+
+function onSelect() {
+  if (loading) return
+  emit('select')
+}
+</script>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,0 +1,208 @@
+import { createTestingPinia } from '@pinia/testing'
+import userEvent from '@testing-library/user-event'
+import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import { CURATED_TEMPLATE_IDS } from './tutorialCards'
+
+const mocks = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  beginTour: vi.fn(),
+  loadTemplate: vi.fn(),
+  loadCatalog: vi.fn(),
+  isLoaded: true,
+  toastAdd: vi.fn(),
+  loadingTemplateId: { value: null as string | null }
+}))
+
+vi.mock('./firstRunEntry', () => ({
+  useFirstRunEntry: () => ({ dismissGettingStarted: mocks.dismiss })
+}))
+
+vi.mock('../tour/useFirstRunTourController', () => ({
+  useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
+}))
+
+vi.mock(
+  '@/platform/workflow/templates/composables/useTemplateWorkflows',
+  async () => {
+    const { ref } = await import('vue')
+    mocks.loadingTemplateId = ref<string | null>(null)
+    return {
+      useTemplateWorkflows: () => ({
+        loadWorkflowTemplate: mocks.loadTemplate,
+        loadingTemplateId: mocks.loadingTemplateId,
+        getTemplateThumbnailUrl: () => 'thumb.png',
+        getTemplateTitle: (template: { name: string }) => template.name
+      })
+    }
+  }
+)
+
+vi.mock(
+  '@/platform/workflow/templates/repositories/workflowTemplatesStore',
+  () => ({
+    useWorkflowTemplatesStore: () => ({
+      get isLoaded() {
+        return mocks.isLoaded
+      },
+      loadWorkflowTemplates: mocks.loadCatalog,
+      getTemplateByName: (name: string) => ({ name })
+    })
+  })
+)
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: mocks.toastAdd })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+async function renderScreen() {
+  const { default: GettingStartedScreen } =
+    await import('./GettingStartedScreen.vue')
+  return render(GettingStartedScreen, { global: { plugins: [i18n] } })
+}
+
+describe('GettingStartedScreen', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    mocks.isLoaded = true
+    mocks.loadTemplate.mockResolvedValue(true)
+    mocks.loadCatalog.mockResolvedValue(undefined)
+    mocks.beginTour.mockResolvedValue(true)
+    mocks.loadingTemplateId.value = null
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.replaceChildren()
+  })
+
+  async function pickFirstTemplate() {
+    await userEvent.click(
+      screen.getByTestId(`getting-started-card-${CURATED_TEMPLATE_IDS[0]}`)
+    )
+  }
+
+  it('loads the chosen template and tours it', async () => {
+    await renderScreen()
+
+    await pickFirstTemplate()
+
+    await waitFor(() =>
+      expect(mocks.loadTemplate).toHaveBeenCalledWith(
+        CURATED_TEMPLATE_IDS[0],
+        'default'
+      )
+    )
+    expect(mocks.beginTour).toHaveBeenCalledWith(CURATED_TEMPLATE_IDS[0])
+    expect(mocks.dismiss).toHaveBeenCalled()
+  })
+
+  it('ignores a second pick while one is still loading', async () => {
+    await renderScreen()
+    mocks.loadingTemplateId.value = CURATED_TEMPLATE_IDS[0]
+
+    await userEvent.click(
+      screen.getByTestId(`getting-started-card-${CURATED_TEMPLATE_IDS[1]}`)
+    )
+
+    expect(
+      mocks.loadTemplate,
+      'a second template loading over the first leaves the tour on the wrong graph'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('leaves the user on the loaded graph when the template has no tour', async () => {
+    mocks.beginTour.mockResolvedValue(false)
+    await renderScreen()
+
+    await pickFirstTemplate()
+
+    await waitFor(() =>
+      expect(
+        mocks.dismiss,
+        'the graph is loaded and usable, so the takeover must not strand the user on it'
+      ).toHaveBeenCalled()
+    )
+  })
+
+  describe('exits', () => {
+    it('offers a blank-canvas action', async () => {
+      await renderScreen()
+
+      await userEvent.click(screen.getByTestId('getting-started-blank'))
+
+      expect(
+        mocks.dismiss,
+        'A first-run user must always have a visible way out of the takeover'
+      ).toHaveBeenCalled()
+    })
+
+    it('exits on Escape', async () => {
+      await renderScreen()
+
+      await userEvent.keyboard('{Escape}')
+
+      expect(
+        mocks.dismiss,
+        'Escape must follow the same safe dismissal path as the blank-canvas action'
+      ).toHaveBeenCalled()
+    })
+  })
+
+  describe('failures', () => {
+    it('surfaces a failed template load and keeps the screen up to retry', async () => {
+      mocks.loadTemplate.mockResolvedValue(false)
+      await renderScreen()
+
+      await pickFirstTemplate()
+
+      await waitFor(() => expect(mocks.toastAdd).toHaveBeenCalled())
+      expect(
+        mocks.dismiss,
+        'A failed load must not dismiss the screen; the user would be left on a bare canvas'
+      ).not.toHaveBeenCalled()
+      expect(screen.getByText(enMessages.gettingStarted.retry)).toBeTruthy()
+    })
+
+    it('retries a catalog load that resolved without loading anything', async () => {
+      mocks.isLoaded = false
+      await renderScreen()
+
+      const retry = await screen.findByTestId(
+        'getting-started-retry-catalog',
+        undefined,
+        {
+          timeout: 1000
+        }
+      )
+      mocks.loadCatalog.mockImplementation(() => {
+        mocks.isLoaded = true
+        return Promise.resolve(undefined)
+      })
+      await userEvent.click(retry)
+
+      expect(
+        mocks.loadCatalog,
+        'The store swallows fetch errors and resolves with isLoaded false, so a failed catalog must be detected without a rejection'
+      ).toHaveBeenCalledTimes(2)
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId('getting-started-retry-catalog'),
+          'A successful retry must replace the error state with the grid'
+        ).toBeNull()
+      )
+    })
+  })
+})

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.vue
@@ -1,0 +1,238 @@
+<template>
+  <Teleport to="body">
+    <FocusScope as-child trapped loop>
+      <div
+        ref="screenRef"
+        class="fixed inset-0 z-2000 flex overflow-y-auto bg-base-background focus:outline-none"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="t('gettingStarted.title')"
+        tabindex="-1"
+        @keydown.escape.capture.prevent="dismissGettingStarted()"
+      >
+        <div class="m-auto flex w-full flex-col items-center gap-8 px-8 py-16">
+          <div class="flex flex-col items-center gap-3">
+            <h1
+              class="m-0 text-center text-4xl/11 font-medium text-base-foreground"
+            >
+              {{ t('gettingStarted.title') }}
+            </h1>
+            <p class="m-0 text-center text-base/5 text-muted-foreground">
+              {{ t('gettingStarted.subtitle') }}
+            </p>
+          </div>
+
+          <TabList
+            v-model="activeTab"
+            class="w-auto gap-1 rounded-full border border-border-subtle p-0.5"
+            :aria-label="t('gettingStarted.tabsLabel')"
+          >
+            <Tab
+              v-for="tab in tabs"
+              :key="tab.value"
+              :value="tab.value"
+              class="gap-2.5 rounded-full px-3 text-xs font-medium text-base-foreground hover:opacity-100 data-[state=active]:bg-tertiary-background data-[state=inactive]:opacity-70"
+            >
+              <i :class="cn(tab.icon, 'size-3.5')" aria-hidden="true" />
+              {{ t(tab.labelKey) }}
+            </Tab>
+          </TabList>
+
+          <div class="w-full max-w-5xl">
+            <TabPanel
+              v-for="tab in tabs"
+              :key="tab.value"
+              :value="tab.value"
+              :model-value="activeTab"
+            >
+              <div
+                v-if="tab.value === 'templates'"
+                class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
+              >
+                <template v-if="templatesStore.isLoaded">
+                  <GettingStartedTemplateCard
+                    v-for="template in cards"
+                    :key="template.name"
+                    :template
+                    :loading="loadingTemplateId === template.name"
+                    :failed="failedTemplateId === template.name"
+                    class="min-w-0"
+                    @select="onSelectTemplate"
+                  />
+                </template>
+                <div
+                  v-else-if="catalogFailed"
+                  class="col-span-full flex flex-col items-center gap-4 py-16"
+                >
+                  <p class="m-0 text-center text-sm text-muted-foreground">
+                    {{ t('gettingStarted.loadFailed') }}
+                  </p>
+                  <Button
+                    variant="secondary"
+                    data-testid="getting-started-retry-catalog"
+                    @click="loadCatalog"
+                  >
+                    {{ t('gettingStarted.retry') }}
+                  </Button>
+                </div>
+                <template v-else>
+                  <GettingStartedCard
+                    v-for="id in CURATED_TEMPLATE_IDS"
+                    :key="id"
+                    skeleton
+                    testid="getting-started-card-skeleton"
+                    class="min-w-0"
+                  />
+                </template>
+              </div>
+
+              <div
+                v-else
+                class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4"
+              >
+                <GettingStartedCard
+                  v-for="(tutorial, index) in tutorialCards"
+                  :key="tutorial.id"
+                  :image-src="
+                    tutorialThumbnail(tutorial.thumbnailTemplate, index)
+                  "
+                  :title="t(tutorial.titleKey)"
+                  :badge-icon="TUTORIAL_BADGE_ICON"
+                  :testid="`getting-started-tutorial-${tutorial.id}`"
+                  class="min-w-0"
+                  @select="openTutorial(tutorial.url)"
+                />
+              </div>
+            </TabPanel>
+          </div>
+
+          <Button
+            variant="muted-textonly"
+            data-testid="getting-started-blank"
+            @click="dismissGettingStarted()"
+          >
+            {{ t('gettingStarted.startBlank') }}
+          </Button>
+        </div>
+      </div>
+    </FocusScope>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { FocusScope } from 'reka-ui'
+import { computed, nextTick, onMounted, ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { cn } from '@comfyorg/tailwind-utils'
+
+import Tab from '@/components/tab/Tab.vue'
+import TabList from '@/components/tab/TabList.vue'
+import TabPanel from '@/components/tab/TabPanel.vue'
+import Button from '@/components/ui/button/Button.vue'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+
+import GettingStartedCard from './GettingStartedCard.vue'
+import GettingStartedTemplateCard from './GettingStartedTemplateCard.vue'
+import { useFirstRunTourController } from '../tour/useFirstRunTourController'
+import { useFirstRunEntry } from './firstRunEntry'
+import type { TutorialCard } from './tutorialCards'
+import {
+  CURATED_TEMPLATE_IDS,
+  FALLBACK_TEMPLATE_IDS,
+  TUTORIAL_BADGE_ICON,
+  tutorialCards
+} from './tutorialCards'
+
+type TabValue = 'templates' | 'tutorials'
+
+const tabs = [
+  {
+    value: 'templates' as const,
+    labelKey: 'gettingStarted.tabs.templates',
+    icon: 'icon-[lucide--layout-template]'
+  },
+  {
+    value: 'tutorials' as const,
+    labelKey: 'gettingStarted.tabs.tutorials',
+    icon: 'icon-[lucide--tv-minimal-play]'
+  }
+]
+
+const { t } = useI18n()
+
+const { dismissGettingStarted } = useFirstRunEntry()
+const { beginTour } = useFirstRunTourController()
+const templatesStore = useWorkflowTemplatesStore()
+const { loadWorkflowTemplate, getTemplateThumbnailUrl, loadingTemplateId } =
+  useTemplateWorkflows()
+
+const activeTab = ref<TabValue>('templates')
+const failedTemplateId = ref<string | null>(null)
+const catalogFailed = ref(false)
+
+const screenRef = useTemplateRef<HTMLElement>('screenRef')
+
+function resolveTemplates(ids: readonly string[]) {
+  return ids
+    .map((id) => templatesStore.getTemplateByName(id))
+    .filter((template) => template !== undefined)
+}
+
+/** Tops the grid back up to its skeleton count when curated data is incomplete. */
+const cards = computed(() => {
+  const curated = resolveTemplates(CURATED_TEMPLATE_IDS)
+  const chosen = new Set(curated.map((template) => template.name))
+  const backfill = resolveTemplates(FALLBACK_TEMPLATE_IDS).filter(
+    (template) => !chosen.has(template.name)
+  )
+  return [...curated, ...backfill].slice(0, CURATED_TEMPLATE_IDS.length)
+})
+
+async function loadCatalog() {
+  catalogFailed.value = false
+  await templatesStore.loadWorkflowTemplates()
+  catalogFailed.value = !templatesStore.isLoaded
+}
+
+// Nothing else loads the catalog on this path, so load it (and take focus) on open.
+onMounted(() => {
+  if (!templatesStore.isLoaded) void loadCatalog()
+  void nextTick(() => screenRef.value?.focus())
+})
+
+function tutorialThumbnail(
+  id: TutorialCard['thumbnailTemplate'],
+  index: number
+) {
+  const fallbacks = cards.value
+  const template =
+    templatesStore.getTemplateByName(id) ??
+    (fallbacks.length ? fallbacks[index % fallbacks.length] : undefined)
+  return template ? getTemplateThumbnailUrl(template, 'default') : ''
+}
+
+function openTutorial(url: string) {
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+async function onSelectTemplate(id: string) {
+  if (loadingTemplateId.value) return
+  failedTemplateId.value = null
+
+  if (await loadWorkflowTemplate(id, 'default')) {
+    await dismissGettingStarted()
+    await beginTour(id)
+    return
+  }
+
+  failedTemplateId.value = id
+  useToastStore().add({
+    severity: 'error',
+    summary: t('g.error'),
+    detail: t('gettingStarted.templateFailed')
+  })
+}
+</script>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedTemplateCard.vue
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedTemplateCard.vue
@@ -1,0 +1,38 @@
+<template>
+  <GettingStartedCard
+    :image-src="thumbnailSrc"
+    :title
+    :loading
+    :failed
+    :is-video="isVideo"
+    :testid="`getting-started-card-${template.name}`"
+    @select="emit('select', template.name)"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
+import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
+
+import GettingStartedCard from './GettingStartedCard.vue'
+
+const { template } = defineProps<{
+  template: TemplateInfo
+  loading?: boolean
+  failed?: boolean
+}>()
+
+const emit = defineEmits<{ select: [id: string] }>()
+
+const { getTemplateThumbnailUrl, getTemplateTitle } = useTemplateWorkflows()
+
+const thumbnailSrc = computed(() =>
+  getTemplateThumbnailUrl(template, 'default')
+)
+const title = computed(() => getTemplateTitle(template, 'default'))
+const isVideo = computed(
+  () => template.mediaType === 'video' || template.mediaSubtype === 'webp'
+)
+</script>

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.test.ts
@@ -1,0 +1,241 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as VueUseCoreModule from '@vueuse/core'
+
+import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
+
+type VueUseCore = typeof VueUseCoreModule
+
+const mocks = vi.hoisted(() => ({
+  isCloud: true,
+  isDesktopWidth: true,
+  subscriptionEnabled: true,
+  isNewUser: true as boolean | null,
+  tourFlag: true,
+  execute: vi.fn(),
+  settings: {} as Record<string, unknown>,
+  setSetting: vi.fn(),
+  beginTour: vi.fn()
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mocks.isCloud
+  }
+}))
+
+vi.mock('@vueuse/core', async (importOriginal) => ({
+  ...(await importOriginal<VueUseCore>()),
+  useBreakpoints: () => ({
+    greaterOrEqual: () => ({
+      get value() {
+        return mocks.isDesktopWidth
+      }
+    })
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
+  useSubscription: () => ({
+    isSubscriptionEnabled: () => mocks.subscriptionEnabled
+  })
+}))
+
+vi.mock('@/services/useNewUserService', () => ({
+  useNewUserService: () => ({ isNewUser: () => mocks.isNewUser })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get onboardingTourEnabled() {
+        return mocks.tourFlag
+      }
+    }
+  })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({ execute: mocks.execute })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: (key: string) => mocks.settings[key],
+    set: mocks.setSetting
+  })
+}))
+
+vi.mock('../tour/useFirstRunTourController', () => ({
+  useFirstRunTourController: () => ({ beginTour: mocks.beginTour })
+}))
+
+// createSharedComposable caches across calls; each test needs its own instance.
+async function freshEntry() {
+  vi.resetModules()
+  const { useFirstRunEntry } = await import('./firstRunEntry')
+  return useFirstRunEntry()
+}
+
+describe('useFirstRunEntry', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    mocks.isCloud = true
+    mocks.isDesktopWidth = true
+    mocks.subscriptionEnabled = true
+    mocks.isNewUser = true
+    mocks.tourFlag = true
+    mocks.settings = {}
+  })
+
+  describe('what a fresh user sees', () => {
+    it('shows Getting Started to a candidate', async () => {
+      const entry = await freshEntry()
+
+      await entry.handleStartupOutcome('fresh')
+
+      expect(entry.gettingStartedVisible.value).toBe(true)
+      expect(mocks.execute).not.toHaveBeenCalled()
+    })
+
+    const disqualifiers: [string, () => void][] = [
+      ['not on cloud', () => void (mocks.isCloud = false)],
+      ['below the md breakpoint', () => void (mocks.isDesktopWidth = false)],
+      ['subscription disabled', () => void (mocks.subscriptionEnabled = false)],
+      ['a returning user', () => void (mocks.isNewUser = false)],
+      ['new-user state undetermined', () => void (mocks.isNewUser = null)],
+      ['the tour flag off', () => void (mocks.tourFlag = false)]
+    ]
+
+    it.for(disqualifiers)(
+      'opens the template browser instead, with %s',
+      async ([, disqualify]) => {
+        disqualify()
+        const entry = await freshEntry()
+
+        await entry.handleStartupOutcome('fresh')
+
+        expect(
+          entry.gettingStartedVisible.value,
+          'A non-candidate must keep the existing template-browser flow'
+        ).toBe(false)
+        expect(mocks.execute).toHaveBeenCalledWith('Comfy.BrowseTemplates')
+      }
+    )
+  })
+
+  it.for(['restored', 'url-intent'] as const)(
+    'leaves a %s startup untouched',
+    async (outcome: StartupOutcome) => {
+      const entry = await freshEntry()
+
+      await entry.handleStartupOutcome(outcome)
+
+      expect(entry.gettingStartedVisible.value).toBe(false)
+      expect(mocks.execute).not.toHaveBeenCalled()
+      expect(
+        mocks.setSetting,
+        'A URL intent must not burn the first-run flag; the user never chose anything'
+      ).not.toHaveBeenCalled()
+    }
+  )
+
+  describe('a workflow that arrived by URL', () => {
+    it.for(['loaded', 'loaded-without-assets'] as const)(
+      'offers the tour over a shared workflow that %s, which has no template id',
+      async (sharedStatus) => {
+        const entry = await freshEntry()
+
+        await entry.handleUrlWorkflow('url-intent', undefined, sharedStatus)
+
+        expect(
+          mocks.beginTour,
+          'a share link is the case no pin can ever cover'
+        ).toHaveBeenCalledWith(undefined)
+      }
+    )
+
+    it('passes a template id through so its pins beat the heuristic', async () => {
+      const entry = await freshEntry()
+
+      await entry.handleUrlWorkflow('url-intent', 'image_z_image_turbo')
+
+      expect(mocks.beginTour).toHaveBeenCalledWith('image_z_image_turbo')
+    })
+
+    it.for(['failed', 'cancelled', 'not-present'] as const)(
+      'offers no tour when nothing the user asked for arrived (%s)',
+      async (sharedStatus) => {
+        const entry = await freshEntry()
+
+        await entry.handleUrlWorkflow('url-intent', undefined, sharedStatus)
+
+        expect(
+          mocks.beginTour,
+          'touring a graph the user never asked for is worse than no tour'
+        ).not.toHaveBeenCalled()
+      }
+    )
+
+    it('leaves a non-candidate alone', async () => {
+      mocks.isNewUser = false
+      const entry = await freshEntry()
+
+      await entry.handleUrlWorkflow('url-intent')
+
+      expect(
+        mocks.beginTour,
+        'a returning user opening a share link must not be toured'
+      ).not.toHaveBeenCalled()
+    })
+
+    it.for(['fresh', 'restored'] as const)(
+      'does not fire on a %s startup',
+      async (outcome: StartupOutcome) => {
+        const entry = await freshEntry()
+
+        await entry.handleUrlWorkflow(outcome)
+
+        expect(
+          mocks.beginTour,
+          'only a URL intent has a workflow on the canvas to tour'
+        ).not.toHaveBeenCalled()
+      }
+    )
+  })
+
+  it('keeps the screen up when eligibility changes underneath it', async () => {
+    const entry = await freshEntry()
+    await entry.handleStartupOutcome('fresh')
+
+    mocks.isDesktopWidth = false
+    mocks.tourFlag = false
+    mocks.subscriptionEnabled = false
+
+    expect(
+      entry.gettingStartedVisible.value,
+      'Candidacy gates entry only; a resize or flag refresh must not unmount the screen mid-interaction'
+    ).toBe(true)
+  })
+
+  it('marks the tutorial completed only once the user acts', async () => {
+    const entry = await freshEntry()
+    await entry.handleStartupOutcome('fresh')
+
+    expect(
+      mocks.setSetting,
+      'Showing the screen must not persist completion; a reload here has to re-enter onboarding'
+    ).not.toHaveBeenCalled()
+
+    await entry.dismissGettingStarted()
+
+    expect(entry.gettingStartedVisible.value).toBe(false)
+    expect(mocks.setSetting).toHaveBeenCalledWith(
+      'Comfy.TutorialCompleted',
+      true
+    )
+  })
+})

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
@@ -1,0 +1,79 @@
+import {
+  breakpointsTailwind,
+  createSharedComposable,
+  useBreakpoints
+} from '@vueuse/core'
+import { readonly, ref } from 'vue'
+
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
+import type { SharedWorkflowUrlLoadStatus } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
+import { useNewUserService } from '@/services/useNewUserService'
+import { useCommandStore } from '@/stores/commandStore'
+
+import { useFirstRunTourController } from '../tour/useFirstRunTourController'
+
+/**
+ * Decides what a first-time user sees once startup reports its outcome: the
+ * Getting Started screen for first-run tour candidates, the template browser
+ * for everyone else.
+ */
+export const useFirstRunEntry = createSharedComposable(() => {
+  const settingStore = useSettingStore()
+  const gettingStartedVisible = ref(false)
+
+  function isFirstRunCandidate(): boolean {
+    if (!isCloud) return false
+    if (!useBreakpoints(breakpointsTailwind).greaterOrEqual('md').value)
+      return false
+    if (!useSubscription().isSubscriptionEnabled()) return false
+    if (useNewUserService().isNewUser() !== true) return false
+    return useFeatureFlags().flags.onboardingTourEnabled
+  }
+
+  /**
+   * Candidacy is read once, here: a later breakpoint, flag or subscription
+   * change must not unmount the screen out from under the user.
+   */
+  async function handleStartupOutcome(outcome: StartupOutcome) {
+    if (outcome !== 'fresh') return
+    if (isFirstRunCandidate()) {
+      gettingStartedVisible.value = true
+      return
+    }
+    await useCommandStore().execute('Comfy.BrowseTemplates')
+  }
+
+  /**
+   * A share or template link loads its workflow instead of the Getting Started
+   * screen, so the tour is offered over whatever arrived. The engine declines
+   * to repeat a tour the user has already seen.
+   */
+  async function handleUrlWorkflow(
+    outcome: StartupOutcome | undefined,
+    templateId?: string,
+    sharedStatus?: SharedWorkflowUrlLoadStatus
+  ) {
+    if (outcome !== 'url-intent' || !isFirstRunCandidate()) return
+    const shareLoaded =
+      sharedStatus === 'loaded' || sharedStatus === 'loaded-without-assets'
+    if (templateId === undefined && !shareLoaded) return
+    await useFirstRunTourController().beginTour(templateId)
+  }
+
+  /** The only writer of the seen flag, so it lands on a real user action. */
+  async function dismissGettingStarted() {
+    gettingStartedVisible.value = false
+    await settingStore.set('Comfy.TutorialCompleted', true)
+  }
+
+  return {
+    gettingStartedVisible: readonly(gettingStartedVisible),
+    handleStartupOutcome,
+    handleUrlWorkflow,
+    dismissGettingStarted
+  }
+})

--- a/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
@@ -1,0 +1,55 @@
+/** The templates the Getting Started grid offers, in order. */
+export const CURATED_TEMPLATE_IDS = [
+  'image_krea2_turbo_t2i',
+  'image_z_image_turbo',
+  'video_ltx2_3_i2v',
+  'video_wan2_2_14B_i2v'
+] as const
+
+/** Fills the grid, in order, when a curated template is missing from the data. */
+export const FALLBACK_TEMPLATE_IDS = [
+  'gsc_advanced_3_2',
+  'image_qwen_image_edit_2509',
+  'templates-qwen_multiangle.app',
+  'gsc_advanced_3_1'
+] as const
+
+export const TUTORIAL_BADGE_ICON = 'icon-[lucide--graduation-cap]'
+
+export interface TutorialCard {
+  id: string
+  titleKey: string
+  url: string
+  thumbnailTemplate: (typeof CURATED_TEMPLATE_IDS)[number]
+}
+
+/**
+ * Thumbnails are offset from the Templates tab's order so the two grids don't
+ * read as the same four images in the same places.
+ */
+export const tutorialCards: readonly TutorialCard[] = [
+  {
+    id: 'interface-overview',
+    titleKey: 'gettingStarted.tutorials.interfaceOverview',
+    url: 'https://docs.comfy.org/interface/overview',
+    thumbnailTemplate: 'image_z_image_turbo'
+  },
+  {
+    id: 'text-to-image',
+    titleKey: 'gettingStarted.tutorials.textToImage',
+    url: 'https://docs.comfy.org/tutorials/basic/text-to-image',
+    thumbnailTemplate: 'video_ltx2_3_i2v'
+  },
+  {
+    id: 'image-to-image',
+    titleKey: 'gettingStarted.tutorials.imageToImage',
+    url: 'https://docs.comfy.org/tutorials/basic/image-to-image',
+    thumbnailTemplate: 'video_wan2_2_14B_i2v'
+  },
+  {
+    id: 'inpaint',
+    titleKey: 'gettingStarted.tutorials.inpaint',
+    url: 'https://docs.comfy.org/tutorials/basic/inpaint',
+    thumbnailTemplate: 'image_krea2_turbo_t2i'
+  }
+]

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
@@ -1,0 +1,116 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { toNodeId } from '@/types/nodeId'
+
+import { resolveTourRoles } from './resolveTourRoles'
+import { TOUR_ROLE_PINS } from './tourRolePins'
+import type { RolePin } from './tourRolePins'
+
+const TEMPLATE_ID = 'video_wan2_2_14B_i2v'
+const { source, prompt, sink, mediaKind } = TOUR_ROLE_PINS[TEMPLATE_ID]
+
+if (!source || !prompt) {
+  throw new Error(
+    `${TEMPLATE_ID} must pin a source and a prompt for this suite`
+  )
+}
+
+function addPinnedNode(graph: LGraph | Subgraph, pin: RolePin) {
+  const node = new LGraphNode(pin.type, pin.type)
+  node.id = toNodeId(pin.id)
+  graph.add(node)
+  return node
+}
+
+/** Mirrors a loaded template: a subgraph definition registered on the root graph, plus its instance. */
+function addHostedSubgraph(root: LGraph, parent: LGraph | Subgraph = root) {
+  const subgraph = createTestSubgraph({ rootGraph: root })
+  root.subgraphs.set(subgraph.id, subgraph)
+  const host = createTestSubgraphNode(subgraph, { parentGraph: parent })
+  parent.add(host)
+  return { subgraph, host }
+}
+
+describe('resolveTourRoles', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('spotlights a prompt pinned inside a subgraph through its root-graph host', () => {
+    const root = createTestRootGraph()
+    const { subgraph, host } = addHostedSubgraph(root)
+    addPinnedNode(root, source)
+    addPinnedNode(root, sink)
+    addPinnedNode(subgraph, prompt)
+
+    expect(resolveTourRoles(root, TEMPLATE_ID)).toEqual({
+      source: toNodeId(source.id),
+      promptHost: host.id,
+      sink: toNodeId(sink.id),
+      mediaKind
+    })
+  })
+
+  it('host-maps every role, not only the prompt', () => {
+    const root = createTestRootGraph()
+    const { subgraph, host } = addHostedSubgraph(root)
+    addPinnedNode(subgraph, source)
+    addPinnedNode(subgraph, prompt)
+    addPinnedNode(subgraph, sink)
+
+    const roles = resolveTourRoles(root, TEMPLATE_ID)
+
+    expect(roles?.source, 'source pinned inside a subgraph').toBe(host.id)
+    expect(roles?.sink, 'sink pinned inside a subgraph').toBe(host.id)
+  })
+
+  it('walks nested subgraphs up to the outermost host', () => {
+    const root = createTestRootGraph()
+    const outer = addHostedSubgraph(root)
+    const inner = addHostedSubgraph(root, outer.subgraph)
+    addPinnedNode(inner.subgraph, prompt)
+
+    expect(resolveTourRoles(root, TEMPLATE_ID)?.promptHost).toBe(outer.host.id)
+  })
+
+  it('degrades a pin the live graph no longer contains to null', () => {
+    const root = createTestRootGraph()
+    addPinnedNode(root, sink)
+
+    expect(resolveTourRoles(root, TEMPLATE_ID)).toEqual({
+      source: null,
+      promptHost: null,
+      sink: toNodeId(sink.id),
+      mediaKind
+    })
+  })
+
+  it('ignores a pinned id the live graph fills with a different node', () => {
+    const root = createTestRootGraph()
+    const impostor = new LGraphNode('LoadImage', 'LoadImage')
+    impostor.id = toNodeId(sink.id)
+    root.add(impostor)
+
+    expect(
+      resolveTourRoles(root, TEMPLATE_ID)?.sink,
+      'ids are plain numbers, so another workflow can hold this one'
+    ).toBeNull()
+  })
+
+  it('gives an unrecognised template no roles, so no tour runs', () => {
+    const root = createTestRootGraph()
+    addPinnedNode(root, sink)
+
+    expect(
+      resolveTourRoles(root, 'some_shared_workflow'),
+      'the tour only runs on templates it pins'
+    ).toBeNull()
+    expect(resolveTourRoles(root, undefined)).toBeNull()
+  })
+})

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
@@ -1,0 +1,62 @@
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { NodeId } from '@/types/nodeId'
+import {
+  getExecutionIdByNode,
+  getRootParentNode
+} from '@/utils/graphTraversalUtil'
+import { resolveNode } from '@/utils/litegraphUtil'
+
+import { TOUR_ROLE_PINS } from './tourRolePins'
+import type {
+  RolePin,
+  SupportedTemplateId,
+  TourMediaKind
+} from './tourRolePins'
+
+export interface ResolvedRoles {
+  source: NodeId | null
+  promptHost: NodeId | null
+  sink: NodeId | null
+  mediaKind: TourMediaKind
+}
+
+/** The root-graph node a role is spotlit through: itself, or the subgraph node holding it. */
+function rootHost(
+  node: LGraphNode | null | undefined,
+  root: LGraph
+): NodeId | null {
+  if (!node) return null
+  if (node.graph === root) return node.id
+  const executionId = getExecutionIdByNode(root, node)
+  return executionId ? (getRootParentNode(root, executionId)?.id ?? null) : null
+}
+
+/** The pinned type is the guard: an id alone matches any graph that has it. */
+function resolvePin(pin: RolePin | undefined, root: LGraph): NodeId | null {
+  if (!pin) return null
+  const node = resolveNode(pin.id, root)
+  return node?.type === pin.type ? rootHost(node, root) : null
+}
+
+/**
+ * Validates a curated template's pins against the live graph. The tour only
+ * runs on templates it pins, so an unknown or absent id yields no roles and no
+ * tour. A pin the graph no longer contains degrades to null so its step is
+ * omitted rather than spotlighting a node that is gone.
+ */
+export function resolveTourRoles(
+  graph: LGraph,
+  templateId?: string
+): ResolvedRoles | null {
+  if (templateId === undefined || !Object.hasOwn(TOUR_ROLE_PINS, templateId))
+    return null
+  const pins = TOUR_ROLE_PINS[templateId as SupportedTemplateId]
+
+  return {
+    source: resolvePin(pins.source, graph),
+    promptHost: resolvePin(pins.prompt, graph),
+    sink: resolvePin(pins.sink, graph),
+    mediaKind: pins.mediaKind
+  }
+}

--- a/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
+++ b/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
@@ -1,0 +1,80 @@
+import type {
+  CURATED_TEMPLATE_IDS,
+  FALLBACK_TEMPLATE_IDS
+} from '../gettingStarted/tutorialCards'
+
+/** Every id the Getting Started grid can offer, so no card can ship unpinned. */
+export type SupportedTemplateId =
+  | (typeof CURATED_TEMPLATE_IDS)[number]
+  | (typeof FALLBACK_TEMPLATE_IDS)[number]
+
+export type TourMediaKind = 'image' | 'video'
+
+/**
+ * A pinned node. The type is pinned alongside the id so an upstream renumber
+ * that leaves the id occupied by a different node fails the drift guard.
+ */
+export interface RolePin {
+  id: number
+  type: string
+}
+
+export interface RolePins {
+  /** Absent for text-to-image, which has nothing to upload. */
+  source?: RolePin
+  /** Absent when the template exposes no prompt the user can edit. */
+  prompt?: RolePin
+  sink: RolePin
+  mediaKind: TourMediaKind
+}
+
+/**
+ * The templates the tour supports, pinned by hand. A prompt pinned inside a
+ * subgraph is spotlit through the root-graph node hosting it.
+ */
+export const TOUR_ROLE_PINS: Record<SupportedTemplateId, RolePins> = {
+  image_krea2_turbo_t2i: {
+    prompt: { id: 19, type: 'PrimitiveStringMultiline' },
+    sink: { id: 29, type: 'SaveImage' },
+    mediaKind: 'image'
+  },
+  image_z_image_turbo: {
+    prompt: { id: 27, type: 'CLIPTextEncode' },
+    sink: { id: 9, type: 'SaveImage' },
+    mediaKind: 'image'
+  },
+  video_ltx2_3_i2v: {
+    source: { id: 269, type: 'LoadImage' },
+    prompt: { id: 319, type: 'PrimitiveStringMultiline' },
+    sink: { id: 75, type: 'SaveVideo' },
+    mediaKind: 'video'
+  },
+  video_wan2_2_14B_i2v: {
+    source: { id: 97, type: 'LoadImage' },
+    prompt: { id: 93, type: 'CLIPTextEncode' },
+    sink: { id: 108, type: 'SaveVideo' },
+    mediaKind: 'video'
+  },
+  gsc_advanced_3_2: {
+    source: { id: 479, type: 'LoadImage' },
+    sink: { id: 415, type: 'SaveVideo' },
+    mediaKind: 'video'
+  },
+  image_qwen_image_edit_2509: {
+    source: { id: 78, type: 'LoadImage' },
+    prompt: { id: 435, type: 'PrimitiveStringMultiline' },
+    sink: { id: 60, type: 'SaveImage' },
+    mediaKind: 'image'
+  },
+  'templates-qwen_multiangle.app': {
+    source: { id: 1, type: 'LoadImage' },
+    sink: { id: 2, type: 'SaveImage' },
+    mediaKind: 'image'
+  },
+  gsc_advanced_3_1: {
+    source: { id: 483, type: 'LoadImage' },
+    prompt: { id: 1235, type: 'GeminiNanoBanana2' },
+    sink: { id: 1237, type: 'SaveVideo' },
+    mediaKind: 'video'
+  }
+}

--- a/src/renderer/extensions/firstRunTour/roles/tourSequence.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/tourSequence.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { toNodeId } from '@/types/nodeId'
+
+import type { ResolvedRoles } from './resolveTourRoles'
+import { sequenceBuilder } from './tourSequence'
+
+const SOURCE = toNodeId(97)
+const PROMPT_HOST = toNodeId(129)
+const SINK = toNodeId(108)
+
+function roles(overrides: Partial<ResolvedRoles> = {}): ResolvedRoles {
+  return {
+    source: null,
+    promptHost: null,
+    sink: null,
+    mediaKind: 'image',
+    ...overrides
+  }
+}
+
+describe('sequenceBuilder', () => {
+  it.for([
+    {
+      shape: 'image to video',
+      roles: roles({ source: SOURCE, promptHost: PROMPT_HOST, sink: SINK }),
+      kinds: ['upload', 'prompt', 'run', 'result']
+    },
+    {
+      shape: 'text to image',
+      roles: roles({ promptHost: PROMPT_HOST, sink: SINK }),
+      kinds: ['prompt', 'run', 'result']
+    },
+    {
+      shape: 'no editable prompt',
+      roles: roles({ source: SOURCE, sink: SINK }),
+      kinds: ['upload', 'run', 'result']
+    },
+    {
+      shape: 'nothing resolved',
+      roles: roles(),
+      kinds: ['run']
+    }
+  ])('omits the steps $shape cannot offer', ({ roles, kinds }) => {
+    expect(sequenceBuilder(roles).map((step) => step.kind)).toEqual(kinds)
+  })
+
+  it('hands the result step the sink and its media kind', () => {
+    const steps = sequenceBuilder(
+      roles({ promptHost: PROMPT_HOST, sink: SINK, mediaKind: 'video' })
+    )
+
+    expect(steps.at(-1)).toEqual({
+      kind: 'result',
+      nodeId: SINK,
+      mediaKind: 'video'
+    })
+  })
+})

--- a/src/renderer/extensions/firstRunTour/roles/tourSequence.ts
+++ b/src/renderer/extensions/firstRunTour/roles/tourSequence.ts
@@ -1,0 +1,25 @@
+import type { NodeId } from '@/types/nodeId'
+
+import type { ResolvedRoles } from './resolveTourRoles'
+import type { TourMediaKind } from './tourRolePins'
+
+export type TourStep =
+  | { kind: 'upload'; nodeId: NodeId }
+  | { kind: 'prompt'; nodeId: NodeId }
+  | { kind: 'run' }
+  | { kind: 'result'; nodeId: NodeId; mediaKind: TourMediaKind }
+
+/** A role that did not resolve omits its step; Run targets the toolbar, not the graph. */
+export function sequenceBuilder({
+  source,
+  promptHost,
+  sink,
+  mediaKind
+}: ResolvedRoles): TourStep[] {
+  return [
+    ...(source ? [{ kind: 'upload' as const, nodeId: source }] : []),
+    ...(promptHost ? [{ kind: 'prompt' as const, nodeId: promptHost }] : []),
+    { kind: 'run' as const },
+    ...(sink ? [{ kind: 'result' as const, nodeId: sink, mediaKind }] : [])
+  ]
+}

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+
+import {
+  CARD_GLIDE_MS,
+  CARD_WIDTH,
+  CURSOR_GAP
+} from '@/platform/onboarding/coachmarkLayout'
+
+import { focusFill, frameNode } from './cameraFraming'
+
+const FOCUS_MS = 450
+const VIEWPORT = { width: 1280, height: 720 }
+
+function scaleFor(bounds: ReadOnlyRect, fill: number): number {
+  return Math.min(
+    (fill * VIEWPORT.width) / Math.max(bounds[2], 300),
+    (fill * VIEWPORT.height) / Math.max(bounds[3], 300)
+  )
+}
+
+const appState = vi.hoisted(() => ({ canvas: undefined as unknown }))
+vi.mock('@/scripts/app', () => ({
+  app: {
+    get canvas() {
+      return appState.canvas
+    }
+  }
+}))
+
+const camera = {
+  animateToBounds: vi.fn(),
+  setDirty: vi.fn(),
+  ds: { fitToBounds: vi.fn() }
+}
+
+let canvasRect = new DOMRect(0, 0, VIEWPORT.width, VIEWPORT.height)
+
+function mountCanvas(): LGraphNode {
+  const graph = new LGraph()
+  const node = new LGraphNode('node')
+  node.pos = [100, 200]
+  node.size = [50, 60]
+  graph.add(node)
+  node.updateArea()
+  appState.canvas = {
+    ...camera,
+    graph,
+    canvas: { getBoundingClientRect: () => canvasRect }
+  }
+  return node
+}
+
+function setReducedMotion(reduce: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches: reduce }))
+  )
+}
+
+describe('focusFill', () => {
+  it('frames a small node without magnifying it past legibility', () => {
+    const bounds: ReadOnlyRect = [0, 0, 120, 80]
+
+    expect(
+      scaleFor(bounds, focusFill(bounds, VIEWPORT)),
+      'a node blown up to fill the viewport reads as a bug, not a spotlight'
+    ).toBeCloseTo(0.6)
+  })
+
+  it('keeps a wide node clear of the column the card sits in', () => {
+    const bounds: ReadOnlyRect = [0, 0, 4000, 200]
+    const cardColumn = CARD_WIDTH + CURSOR_GAP * 2
+
+    const framedWidth =
+      bounds[2] * scaleFor(bounds, focusFill(bounds, VIEWPORT))
+    const freePerSide = (VIEWPORT.width - framedWidth) / 2
+
+    expect(
+      freePerSide,
+      'the fit centres the node, so half the free width is all the card gets'
+    ).toBeGreaterThanOrEqual(cardColumn - 1)
+  })
+
+  it('still frames something on a viewport too narrow for the card columns', () => {
+    const narrow = { width: CARD_WIDTH + CURSOR_GAP * 2, height: 720 }
+
+    expect(
+      focusFill([0, 0, 120, 80], narrow),
+      'reserving both columns anyway solves a negative width, and zooms the camera inside out'
+    ).toBeGreaterThan(0)
+  })
+})
+
+describe('frameNode', () => {
+  const runningSteps: AbortController[] = []
+
+  /** Framing a step, torn down like the engine does: by aborting its signal. */
+  function frameStep(nodeId: NodeId): Promise<void> {
+    const controller = new AbortController()
+    runningSteps.push(controller)
+    return frameNode(nodeId, controller.signal).catch(() => {})
+  }
+
+  function endRunningSteps() {
+    runningSteps.forEach((controller) => controller.abort())
+    runningSteps.length = 0
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setReducedMotion(false)
+    canvasRect = new DOMRect(0, 0, VIEWPORT.width, VIEWPORT.height)
+  })
+
+  afterEach(() => {
+    endRunningSteps()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    camera.animateToBounds.mockClear()
+    camera.ds.fitToBounds.mockClear()
+    appState.canvas = undefined
+  })
+
+  it('holds the camera until the card has glided to the new step', async () => {
+    const node = mountCanvas()
+    void frameStep(node.id)
+
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS - 1)
+    expect(
+      camera.animateToBounds,
+      'the camera must not move while the card is still gliding'
+    ).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(camera.animateToBounds).toHaveBeenCalledWith(
+      node.boundingRect,
+      expect.objectContaining({
+        duration: FOCUS_MS,
+        zoom: expect.any(Number)
+      })
+    )
+  })
+
+  it('frames the opening step at once, having no glide to wait out', async () => {
+    const node = mountCanvas()
+    const controller = new AbortController()
+    runningSteps.push(controller)
+
+    void frameNode(node.id, controller.signal, { glide: false }).catch(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(
+      camera.animateToBounds,
+      'a scrim that lands and then sits still before moving reads as a stall'
+    ).toHaveBeenCalled()
+  })
+
+  it('resolves only once the camera has landed', async () => {
+    const node = mountCanvas()
+    let settled = false
+    void frameStep(node.id).then(() => (settled = true))
+
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS + FOCUS_MS - 1)
+    expect(
+      settled,
+      'the step reveals its copy on this promise, and copy over a moving view is unreadable'
+    ).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(settled).toBe(true)
+  })
+
+  it('frames instantly under reduced motion rather than skipping the node', async () => {
+    setReducedMotion(true)
+    const node = mountCanvas()
+
+    await frameStep(node.id)
+
+    expect(camera.ds.fitToBounds).toHaveBeenCalledWith(
+      node.boundingRect,
+      expect.objectContaining({ zoom: expect.any(Number) })
+    )
+    expect(
+      camera.animateToBounds,
+      'a zero-duration animateToBounds throws'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('leaves the camera alone when the step ends during the glide', async () => {
+    const node = mountCanvas()
+    const controller = new AbortController()
+
+    void frameNode(node.id, controller.signal).catch(() => {})
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS)
+
+    expect(camera.animateToBounds).not.toHaveBeenCalled()
+  })
+
+  it('re-solves the fill on resize, since it is a fraction of the viewport', async () => {
+    const node = mountCanvas()
+    void frameStep(node.id)
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS)
+    const framedFill = camera.animateToBounds.mock.calls[0]?.[1].zoom
+
+    const resized = { width: 640, height: 480 }
+    canvasRect = new DOMRect(0, 0, resized.width, resized.height)
+    window.dispatchEvent(new Event('resize'))
+
+    const refitFill = camera.ds.fitToBounds.mock.calls[0]?.[1].zoom
+    expect(refitFill).not.toBe(framedFill)
+    expect(
+      refitFill,
+      'a fill kept from the old viewport reserves the wrong room for the card'
+    ).toBe(focusFill(node.boundingRect, resized))
+  })
+
+  it('leaves the camera alone when a resize collapses the viewport', async () => {
+    const node = mountCanvas()
+    void frameStep(node.id)
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS)
+
+    canvasRect = new DOMRect(0, 0, 640, 0)
+    window.dispatchEvent(new Event('resize'))
+
+    expect(
+      camera.ds.fitToBounds,
+      'dividing by a collapsed height hands the camera a NaN zoom it never recovers from'
+    ).not.toHaveBeenCalled()
+  })
+
+  it('stops re-fitting once the step ends', async () => {
+    const node = mountCanvas()
+    const controller = new AbortController()
+    void frameNode(node.id, controller.signal).catch(() => {})
+    await vi.advanceTimersByTimeAsync(CARD_GLIDE_MS)
+
+    controller.abort()
+    window.dispatchEvent(new Event('resize'))
+
+    expect(camera.ds.fitToBounds).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for a node the graph no longer holds', async () => {
+    mountCanvas()
+
+    await frameStep(toNodeId('missing'))
+
+    expect(camera.animateToBounds).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.ts
@@ -1,0 +1,86 @@
+import { delay } from 'es-toolkit'
+
+import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+import {
+  CARD_GLIDE_MS,
+  CARD_WIDTH,
+  CURSOR_GAP
+} from '@/platform/onboarding/coachmarkLayout'
+import { app } from '@/scripts/app'
+import type { NodeId } from '@/types/nodeId'
+
+const FOCUS_DURATION_MS = 450
+/** Never magnify past this: the aim is a node that reads, not one that dominates. */
+const MAX_FOCUS_SCALE = 0.6
+const CARD_COLUMN = CARD_WIDTH + CURSOR_GAP * 2
+
+interface Viewport {
+  width: number
+  height: number
+}
+
+/**
+ * Fill fraction that frames `bounds` beside the card. The fit centres the node
+ * and so splits the free width evenly, hence room for a card column on each
+ * side. Inverts litegraph's fit, which solves each axis as
+ * `(fill * side) / max(bound, 300)` and takes the smaller, so the binding axis
+ * has to be handed the larger fill.
+ */
+export function focusFill(bounds: ReadOnlyRect, viewport: Viewport): number {
+  const [, , width, height] = bounds
+  const sideRoom = viewport.width - CARD_COLUMN * 2
+  const usableWidth = sideRoom > 0 ? sideRoom : viewport.width
+  const scale = Math.min(
+    usableWidth / Math.max(width, 1),
+    viewport.height / Math.max(height, 1),
+    MAX_FOCUS_SCALE
+  )
+  return Math.max(
+    (scale * Math.max(width, 300)) / viewport.width,
+    (scale * Math.max(height, 300)) / viewport.height
+  )
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** Re-solves the fill each time: it is a fraction of a viewport that can resize. */
+function fitInstantly(bounds: ReadOnlyRect) {
+  const canvas = app.canvas
+  const viewport = canvas?.canvas.getBoundingClientRect()
+  if (!canvas || !viewport?.width || !viewport.height) return
+  canvas.ds.fitToBounds(bounds, { zoom: focusFill(bounds, viewport) })
+  canvas.setDirty(true, true)
+}
+
+/**
+ * Brings a node into view for the step that spotlights it. Resolves once the
+ * camera has landed, so an opening tour reveals its card on a still view.
+ *
+ * @param glide Wait out the card's travel to this step first, so only one thing
+ * moves at a time. The tour's first card has nowhere to travel from.
+ */
+export async function frameNode(
+  nodeId: NodeId,
+  signal: AbortSignal,
+  { glide = true }: { glide?: boolean } = {}
+): Promise<void> {
+  const canvas = app.canvas
+  const node = canvas?.graph?.getNodeById(nodeId)
+  const viewport = canvas?.canvas.getBoundingClientRect()
+  if (!canvas || !node || !viewport?.width || !viewport.height) return
+
+  const bounds = node.boundingRect
+
+  window.addEventListener('resize', () => fitInstantly(bounds), { signal })
+
+  if (prefersReducedMotion()) return fitInstantly(bounds)
+
+  if (glide) await delay(CARD_GLIDE_MS, { signal })
+  canvas.animateToBounds(bounds, {
+    zoom: focusFill(bounds, viewport),
+    duration: FOCUS_DURATION_MS
+  })
+  await delay(FOCUS_DURATION_MS, { signal })
+}

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DragAndScale } from '@/lib/litegraph/src/DragAndScale'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+
+import { canvasNodeTarget, canvasTransformValid } from './canvasCoachTarget'
+
+interface FakeCanvas {
+  graph: LGraph
+  ds: DragAndScale
+  canvas: { getBoundingClientRect: () => DOMRect }
+}
+
+const appState = vi.hoisted(() => ({ canvas: undefined as unknown }))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    get canvas() {
+      return appState.canvas
+    }
+  }
+}))
+
+/** The real camera, so the target maps through the same maths the canvas does. */
+function makeDs(offset: [number, number] = [10, 20], scale = 2): DragAndScale {
+  const ds = new DragAndScale(document.createElement('canvas'))
+  ds.offset = offset
+  ds.scale = scale
+  return ds
+}
+
+function mountCanvas(ds: DragAndScale = makeDs()): LGraph {
+  const graph = new LGraph()
+  appState.canvas = {
+    graph,
+    ds,
+    canvas: { getBoundingClientRect: () => new DOMRect(5, 7, 800, 600) }
+  } satisfies FakeCanvas
+  return graph
+}
+
+function addNode(
+  graph: LGraph,
+  pos: [number, number],
+  size: [number, number]
+): LGraphNode {
+  const node = new LGraphNode('node')
+  node.pos = pos
+  node.size = size
+  graph.add(node)
+  node.updateArea()
+  return node
+}
+
+describe('canvasCoachTarget', () => {
+  afterEach(() => {
+    appState.canvas = undefined
+  })
+
+  it('maps a node through the camera transform, including its title bar', () => {
+    const graph = mountCanvas()
+    const node = addNode(graph, [100, 200], [50, 60])
+    const title = LiteGraph.NODE_TITLE_HEIGHT
+
+    const rect = canvasNodeTarget(node.id).getBoundingClientRect()
+
+    expect(rect.x).toBe((100 + 10) * 2 + 5)
+    expect(rect.y).toBe((200 - title + 20) * 2 + 7)
+    expect(rect.width).toBe(50 * 2)
+    expect(rect.height).toBe((60 + title) * 2)
+  })
+
+  it('reports a zero-sized rect for an unknown node, so it is not laid out', () => {
+    mountCanvas()
+    const rect = canvasNodeTarget(toNodeId('missing')).getBoundingClientRect()
+    expect(rect.width).toBe(0)
+    expect(rect.height).toBe(0)
+  })
+
+  it('reports a zero-sized rect for a node the render loop has not measured', () => {
+    const graph = mountCanvas()
+    const node = new LGraphNode('node')
+    node.pos = [100, 200]
+    node.size = [50, 60]
+    graph.add(node)
+    expect(canvasNodeTarget(node.id).getBoundingClientRect().width).toBe(0)
+  })
+
+  it('reports a zero-sized rect while no canvas exists', () => {
+    const rect = canvasNodeTarget(toNodeId(1)).getBoundingClientRect()
+    expect(rect.width).toBe(0)
+  })
+
+  it('validates the camera transform', () => {
+    expect(canvasTransformValid()).toBe(false)
+
+    mountCanvas(makeDs([Number.NaN, 0], 1))
+    expect(canvasTransformValid()).toBe(false)
+
+    mountCanvas(makeDs([0, 0], 0))
+    expect(canvasTransformValid()).toBe(false)
+
+    mountCanvas()
+    expect(canvasTransformValid()).toBe(true)
+  })
+})

--- a/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.ts
+++ b/src/renderer/extensions/firstRunTour/tour/canvasCoachTarget.ts
@@ -1,0 +1,49 @@
+import { watch } from 'vue'
+
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { MovingTarget } from '@/platform/onboarding/coachmarkRegistry'
+import { useTransformState } from '@/renderer/core/layout/transform/useTransformState'
+import { app } from '@/scripts/app'
+import type { NodeId } from '@/types/nodeId'
+
+function nodeClientRect(nodeId: NodeId): DOMRect | null {
+  const lgCanvas: LGraphCanvas | undefined = app.canvas
+  const node = lgCanvas?.graph?.getNodeById(nodeId)
+  if (!lgCanvas || !node) return null
+  const [x, y, width, height] = node.boundingRect
+  const { scale } = lgCanvas.ds
+  const [left, top] = lgCanvas.ds.convertOffsetToCanvas([x, y])
+  const host = lgCanvas.canvas.getBoundingClientRect()
+  return new DOMRect(
+    left + host.left,
+    top + host.top,
+    width * scale,
+    height * scale
+  )
+}
+
+/**
+ * A canvas node as a coachmark target; zero-sized until it is measurable.
+ * Moves with the camera, which `TransformPane` already mirrors per frame.
+ */
+export function canvasNodeTarget(nodeId: NodeId): MovingTarget {
+  const { camera } = useTransformState()
+  return {
+    getBoundingClientRect: () => nodeClientRect(nodeId) ?? new DOMRect(),
+    onMove: (notify) =>
+      watch(() => [camera.x, camera.y, camera.z], notify, { flush: 'post' })
+  }
+}
+
+/** True once the canvas camera transform can place canvas targets on screen. */
+export function canvasTransformValid(): boolean {
+  const lgCanvas: LGraphCanvas | undefined = app.canvas
+  if (!lgCanvas) return false
+  const { offset, scale } = lgCanvas.ds
+  return (
+    Number.isFinite(scale) &&
+    scale > 0 &&
+    Number.isFinite(offset[0]) &&
+    Number.isFinite(offset[1])
+  )
+}

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { DragAndScale } from '@/lib/litegraph/src/DragAndScale'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  clearCoachmarks,
+  targetMounted
+} from '@/platform/onboarding/coachmarkRegistry'
+import { FIRST_RUN_COACH_IDS } from '@/platform/onboarding/onboardingTours'
+import { toNodeId } from '@/types/nodeId'
+
+import { TOUR_ROLE_PINS } from '../roles/tourRolePins'
+import type { RolePin } from '../roles/tourRolePins'
+import {
+  firstRunTourSteps,
+  releaseFirstRunTargets
+} from './firstRunTourDefinition'
+import type { RunState } from './firstRunTourDefinition'
+
+const FROM_IMAGE = 'image_qwen_image_edit_2509'
+const FROM_TEXT = 'image_z_image_turbo'
+const VIDEO = 'gsc_advanced_3_1'
+const NO_PROMPT = 'gsc_advanced_3_2'
+
+const runState = ref<RunState>('idle')
+const framings: { glide?: boolean }[] = []
+
+vi.mock('./cameraFraming', () => ({
+  frameNode: (_id: unknown, _signal: AbortSignal, options = {}) => {
+    framings.push(options)
+    return Promise.resolve()
+  }
+}))
+
+function buildSteps(templateId: keyof typeof TOUR_ROLE_PINS | string) {
+  return firstRunTourSteps(templateId, runState)
+}
+
+const appState = vi.hoisted(() => ({ graph: undefined as LGraph | undefined }))
+vi.mock('@/scripts/app', () => ({
+  app: {
+    get rootGraph() {
+      return appState.graph
+    },
+    get canvas() {
+      return appState.graph
+        ? {
+            graph: appState.graph,
+            ds: new DragAndScale(document.createElement('canvas')),
+            canvas: { getBoundingClientRect: () => new DOMRect(0, 0, 800, 600) }
+          }
+        : undefined
+    }
+  }
+}))
+
+/** A live graph holding the template's pinned nodes, measured as the renderer would. */
+function loadTemplate(templateId: keyof typeof TOUR_ROLE_PINS): LGraph {
+  const graph = new LGraph()
+  const { source, prompt, sink } = TOUR_ROLE_PINS[templateId]
+  for (const pin of [source, prompt, sink].filter(
+    (candidate): candidate is RolePin => candidate !== undefined
+  )) {
+    const node = new LGraphNode(pin.type, pin.type)
+    node.id = toNodeId(pin.id)
+    node.pos = [pin.id, pin.id]
+    node.size = [120, 80]
+    graph.add(node)
+    node.updateArea()
+  }
+  appState.graph = graph
+  return graph
+}
+
+describe('firstRunTourSteps', () => {
+  afterEach(() => {
+    releaseFirstRunTargets()
+    clearCoachmarks()
+    appState.graph = undefined
+    runState.value = 'idle'
+    framings.length = 0
+  })
+
+  it('gives a template the tour does not support no steps', async () => {
+    loadTemplate(FROM_IMAGE)
+
+    await expect(buildSteps('some_shared_workflow')).resolves.toEqual([])
+  })
+
+  it('gives no steps when every pin has drifted and only Run is left', async () => {
+    appState.graph = new LGraph()
+
+    await expect(
+      buildSteps(FROM_IMAGE),
+      'a lone "click Run" step is not worth taking over the screen for'
+    ).resolves.toEqual([])
+  })
+
+  it.for<{ templateId: keyof typeof TOUR_ROLE_PINS; names: string[] }>([
+    {
+      templateId: FROM_IMAGE,
+      names: ['upload.image-edit', 'prompt.image-edit', 'run', 'result.image']
+    },
+    { templateId: FROM_TEXT, names: ['prompt.t2i', 'run', 'result.image'] },
+    {
+      templateId: VIDEO,
+      names: ['upload.i2v', 'prompt.i2v', 'run', 'result.video']
+    },
+    { templateId: NO_PROMPT, names: ['upload.other', 'run', 'result.video'] }
+  ])(
+    'names $templateId steps for what the workflow does',
+    async ({ templateId, names }) => {
+      loadTemplate(templateId)
+
+      const steps = await buildSteps(templateId)
+
+      expect(steps.map((step) => step.name)).toEqual(names)
+    }
+  )
+
+  it('frames the opening step without waiting out a glide it has no room for', async () => {
+    loadTemplate(FROM_IMAGE)
+    const [first, second] = await buildSteps(FROM_IMAGE)
+
+    await first.onEnter?.(new AbortController().signal)
+    expect(
+      framings,
+      'the opening card has nowhere to travel from, so the camera must not stall for it'
+    ).toEqual([{ glide: false }])
+
+    void second.onEnter?.(new AbortController().signal)
+    expect(framings.at(-1)).toEqual({ glide: true })
+  })
+
+  it('reports the run through the Result step, which outlives it', async () => {
+    loadTemplate(FROM_TEXT)
+    const result = (await buildSteps(FROM_TEXT)).at(-1)
+
+    runState.value = 'generating'
+    expect(result?.name).toBe('result.generating')
+    expect(result?.busy?.()).toBe(true)
+
+    runState.value = 'failed'
+    expect(
+      result?.name,
+      'a run that produced nothing must not be announced as a result'
+    ).toBe('result.failed')
+    expect(result?.busy?.()).toBe(false)
+
+    runState.value = 'idle'
+    expect(result?.name).toBe('result.image')
+  })
+
+  it('lets only interactive steps take pointer input', async () => {
+    loadTemplate(FROM_IMAGE)
+
+    const interactive = (await buildSteps(FROM_IMAGE))
+      .filter((step) => step.interactive)
+      .map((step) => step.name)
+
+    expect(interactive).toEqual(['prompt.image-edit', 'run'])
+  })
+
+  it('registers each spotlit node so the engine can find it', async () => {
+    loadTemplate(FROM_IMAGE)
+
+    await buildSteps(FROM_IMAGE)
+    expect(targetMounted(FIRST_RUN_COACH_IDS.source)).toBe(true)
+    expect(targetMounted(FIRST_RUN_COACH_IDS.sink)).toBe(true)
+
+    releaseFirstRunTargets()
+    expect(
+      targetMounted(FIRST_RUN_COACH_IDS.source),
+      'a finished tour must not leave its targets behind'
+    ).toBe(false)
+  })
+})

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
@@ -1,0 +1,131 @@
+import type { VirtualElement } from '@floating-ui/vue'
+import type { Ref } from 'vue'
+
+import {
+  registerCoachmark,
+  unregisterCoachmark
+} from '@/platform/onboarding/coachmarkRegistry'
+import { FIRST_RUN_COACH_IDS } from '@/platform/onboarding/onboardingTours'
+import type { CoachId, CoachStep } from '@/platform/onboarding/onboardingTours'
+import { app } from '@/scripts/app'
+
+import { resolveTourRoles } from '../roles/resolveTourRoles'
+import type { ResolvedRoles } from '../roles/resolveTourRoles'
+import { sequenceBuilder } from '../roles/tourSequence'
+import type { TourStep } from '../roles/tourSequence'
+import { frameNode } from './cameraFraming'
+import { canvasNodeTarget } from './canvasCoachTarget'
+
+/** How far the run has got, which is all the Run step's copy has to report. */
+export type RunState = 'idle' | 'generating' | 'succeeded' | 'failed'
+
+/**
+ * What the workflow does. The Upload and Prompt steps mean something different
+ * in each, so it selects their copy.
+ */
+type TourShape = 't2i' | 'i2v' | 'image-edit' | 'other'
+
+const COACH_ID: Record<TourStep['kind'], CoachId> = {
+  upload: FIRST_RUN_COACH_IDS.source,
+  prompt: FIRST_RUN_COACH_IDS.prompt,
+  run: FIRST_RUN_COACH_IDS.runButton,
+  result: FIRST_RUN_COACH_IDS.sink
+}
+
+const registered: [CoachId, VirtualElement][] = []
+
+/** Drops the canvas targets a finished tour registered. */
+export function releaseFirstRunTargets() {
+  for (const [id, target] of registered) unregisterCoachmark(id, target)
+  registered.length = 0
+}
+
+function registerCanvasTargets(sequence: TourStep[]) {
+  for (const step of sequence) {
+    if (step.kind === 'run') continue
+    const id = COACH_ID[step.kind]
+    const target = canvasNodeTarget(step.nodeId)
+    registerCoachmark(id, target)
+    registered.push([id, target])
+  }
+}
+
+function tourShape({
+  source,
+  promptHost,
+  sink,
+  mediaKind
+}: ResolvedRoles): TourShape {
+  if (!promptHost || !sink) return 'other'
+  if (!source) return 't2i'
+  return mediaKind === 'video' ? 'i2v' : 'image-edit'
+}
+
+interface StepContext {
+  shape: TourShape
+  runState: Ref<RunState>
+}
+
+/**
+ * A step's variant is part of its name, so the engine resolves the copy from
+ * `onboardingCoachmarks.firstRun.<name>` without knowing what a template is.
+ */
+function toCoachStep(
+  step: TourStep,
+  index: number,
+  { shape, runState }: StepContext
+): CoachStep {
+  const common = {
+    coachId: COACH_ID[step.kind],
+    deferTarget: true,
+    cursor: true,
+    interactive: step.kind === 'prompt' || step.kind === 'run'
+  }
+
+  if (step.kind === 'run')
+    return { ...common, name: 'run', placement: 'bottom', selfAdvancing: true }
+
+  const framed = {
+    ...common,
+    placement: 'auto' as const,
+    onEnter: (signal: AbortSignal) =>
+      frameNode(step.nodeId, signal, { glide: index > 0 })
+  }
+
+  // The run outlives the step that starts it, so Result is where it reports.
+  if (step.kind === 'result')
+    return {
+      ...framed,
+      get name() {
+        if (runState.value === 'generating') return 'result.generating'
+        if (runState.value === 'failed') return 'result.failed'
+        return `result.${step.mediaKind}`
+      },
+      busy: () => runState.value === 'generating'
+    }
+
+  return { ...framed, name: `${step.kind}.${shape}` }
+}
+
+/**
+ * Builds the first-run tour for a curated template. An id the tour does not
+ * pin, or a template whose pins the live graph no longer satisfies, leaves
+ * nothing worth guiding anyone through ("click Run" alone is not a tour), so it
+ * yields no steps and the engine reports that it did not start.
+ */
+export async function firstRunTourSteps(
+  templateId: string | undefined,
+  runState: Ref<RunState>
+): Promise<CoachStep[]> {
+  releaseFirstRunTargets()
+  const graph = app.rootGraph
+  const roles = graph ? resolveTourRoles(graph, templateId) : null
+  if (!roles) return []
+
+  const sequence = sequenceBuilder(roles)
+  if (sequence.every((step) => step.kind === 'run')) return []
+
+  registerCanvasTargets(sequence)
+  const context: StepContext = { shape: tourShape(roles), runState }
+  return sequence.map((step, index) => toCoachStep(step, index, context))
+}

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -1,0 +1,370 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope, Ref } from 'vue'
+
+import type { CoachStep } from '@/platform/onboarding/onboardingTours'
+
+const TOUR_WORKFLOW = { path: 'tour.json' }
+const OTHER_WORKFLOW = { path: 'other.json' }
+const INTRO_PREVIEW_MS = 500
+
+const mocks = vi.hoisted(() => ({
+  canRunWorkflows: { value: true },
+  showSubscriptionDialog: vi.fn(),
+  workflowStatus: { value: new Map<unknown, string>() },
+  executionErrors: { hasNodeError: false, hasPromptError: false },
+  activeWorkflow: null as unknown,
+  transformValid: true,
+  steps: [] as CoachStep[],
+  runState: { value: 'idle' } as Ref<string>,
+  releaseFirstRunTargets: vi.fn(),
+  engine: {
+    activeTour: null as string | null,
+    step: null as CoachStep | null,
+    isLast: false,
+    startTour: vi.fn(),
+    next: vi.fn(),
+    complete: vi.fn(),
+    skip: vi.fn(),
+    postpone: vi.fn()
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    canRunWorkflows: mocks.canRunWorkflows,
+    showSubscriptionDialog: mocks.showSubscriptionDialog
+  })
+}))
+
+vi.mock('@/stores/executionStore', async () => {
+  const { shallowRef } = await import('vue')
+  mocks.workflowStatus = shallowRef(new Map<unknown, string>())
+  return {
+    useExecutionStore: () => ({
+      getWorkflowStatus: (workflow: unknown) =>
+        mocks.workflowStatus.value.get(workflow)
+    })
+  }
+})
+
+vi.mock('@/stores/executionErrorStore', async () => {
+  const { reactive } = await import('vue')
+  mocks.executionErrors = reactive({
+    hasNodeError: false,
+    hasPromptError: false
+  })
+  return { useExecutionErrorStore: () => mocks.executionErrors }
+})
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    get activeWorkflow() {
+      return mocks.activeWorkflow
+    }
+  })
+}))
+
+vi.mock('./canvasCoachTarget', () => ({
+  canvasTransformValid: () => mocks.transformValid
+}))
+
+vi.mock('./firstRunTourDefinition', () => ({
+  firstRunTourSteps: (_templateId: string, runState: Ref<string>) => {
+    mocks.runState = runState
+    return Promise.resolve(mocks.steps)
+  },
+  releaseFirstRunTargets: mocks.releaseFirstRunTargets
+}))
+
+vi.mock('@/platform/onboarding/onboardingTourStore', async () => {
+  const { reactive } = await import('vue')
+  mocks.engine = reactive(mocks.engine)
+  return { useOnboardingTourStore: () => mocks.engine }
+})
+
+function runStep(): CoachStep {
+  return { name: 'run', placement: 'bottom', selfAdvancing: true }
+}
+
+let controllerScope: EffectScope | undefined
+let resolveRegisteredTour: () => Promise<unknown>
+
+/** Scoped so each controller's document listener dies with its test. */
+async function freshController() {
+  controllerScope?.stop()
+  vi.resetModules()
+  controllerScope = effectScope()
+  const tours = await import('@/platform/onboarding/onboardingTours')
+  resolveRegisteredTour = async () => {
+    const definition = tours.tourDefinition('firstRun')
+    return Array.isArray(definition) ? definition : definition?.()
+  }
+  const { useFirstRunTourController } =
+    await import('./useFirstRunTourController')
+  return controllerScope.run(() => useFirstRunTourController())!
+}
+
+/** A started tour sitting on its Run step, the state every run outcome acts on. */
+async function tourOnRunStep() {
+  mocks.steps = [runStep()]
+  mocks.activeWorkflow = TOUR_WORKFLOW
+  mocks.engine.startTour.mockImplementation(async () => {
+    await resolveRegisteredTour()
+    mocks.engine.activeTour = 'firstRun'
+    mocks.engine.step = runStep()
+    return true
+  })
+  const controller = await freshController()
+
+  const starting = controller.beginTour('image_z_image_turbo')
+  await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+  return { controller, started: await starting }
+}
+
+function finishRun(workflow: unknown, status: string) {
+  mocks.workflowStatus.value = new Map(mocks.workflowStatus.value).set(
+    workflow,
+    status
+  )
+  return nextTick()
+}
+
+function mountRunButton(
+  testId: 'queue-button' | 'subscribe-to-run-button',
+  onClick: () => void
+): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.dataset.testid = testId
+  button.addEventListener('click', onClick)
+  document.body.appendChild(button)
+  return button
+}
+
+describe('useFirstRunTourController', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mocks.canRunWorkflows = ref(true)
+    mocks.workflowStatus.value = new Map()
+    mocks.executionErrors.hasNodeError = false
+    mocks.executionErrors.hasPromptError = false
+    mocks.activeWorkflow = null
+    mocks.transformValid = true
+    mocks.steps = []
+    mocks.engine.activeTour = null
+    mocks.engine.step = null
+    mocks.engine.isLast = false
+  })
+
+  afterEach(() => {
+    controllerScope?.stop()
+    controllerScope = undefined
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+  })
+
+  describe('starting', () => {
+    it('does not start before the canvas can place a spotlight', async () => {
+      mocks.transformValid = false
+      const controller = await freshController()
+
+      await expect(controller.beginTour('image_z_image_turbo')).resolves.toBe(
+        false
+      )
+    })
+
+    it('leaves the workflow undimmed before taking the screen over', async () => {
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+      void controller.beginTour('image_z_image_turbo')
+
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS - 1)
+      expect(
+        mocks.engine.startTour,
+        'a user who just picked a template deserves a look at it before the scrim'
+      ).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mocks.engine.startTour).toHaveBeenCalledWith('firstRun')
+    })
+
+    it('hands back the canvas targets when the engine turns the start down', async () => {
+      mocks.steps = [runStep()]
+      mocks.engine.startTour.mockImplementation(async () => {
+        await resolveRegisteredTour()
+        return false
+      })
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+      await starting
+
+      expect(
+        mocks.releaseFirstRunTargets,
+        'resolving the steps registered them, and no tour will end to release them'
+      ).toHaveBeenCalled()
+    })
+  })
+
+  describe('run outcome', () => {
+    it('moves on with the Run click rather than waiting out the run', async () => {
+      await tourOnRunStep()
+
+      mountRunButton('queue-button', () => {}).click()
+
+      expect(
+        mocks.engine.next,
+        'a run takes minutes; a tour parked on a button the user already pressed reads as broken'
+      ).toHaveBeenCalled()
+      expect(mocks.runState.value).toBe('generating')
+    })
+
+    it('completes the tour when Run is its last step', async () => {
+      await tourOnRunStep()
+      mocks.engine.isLast = true
+
+      mountRunButton('queue-button', () => {}).click()
+
+      expect(mocks.engine.complete).toHaveBeenCalled()
+    })
+
+    it('ignores a run that finished for another workflow', async () => {
+      await tourOnRunStep()
+      mocks.activeWorkflow = OTHER_WORKFLOW
+
+      await finishRun(OTHER_WORKFLOW, 'failed')
+
+      expect(
+        mocks.runState.value,
+        'a job the tour did not start must not speak for the tour'
+      ).toBe('idle')
+    })
+
+    it('says so when the run produced nothing', async () => {
+      await tourOnRunStep()
+
+      await finishRun(TOUR_WORKFLOW, 'failed')
+
+      expect(
+        mocks.runState.value,
+        'announcing a result that does not exist is the bug D2 filed'
+      ).toBe('failed')
+    })
+
+    it('reports a run still in flight', async () => {
+      await tourOnRunStep()
+
+      await finishRun(TOUR_WORKFLOW, 'running')
+
+      expect(mocks.runState.value).toBe('generating')
+    })
+
+    it('tells a run that landed apart from one that never started', async () => {
+      await tourOnRunStep()
+      await finishRun(TOUR_WORKFLOW, 'running')
+
+      await finishRun(TOUR_WORKFLOW, 'completed')
+
+      expect(
+        mocks.runState.value,
+        'sharing a state with never-ran leaves the Result step unable to tell them apart'
+      ).toBe('succeeded')
+    })
+
+    it('gives up on a run the queue refused', async () => {
+      await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+
+      mocks.executionErrors.hasNodeError = true
+      await nextTick()
+
+      expect(
+        mocks.runState.value,
+        'a refused prompt never executes, so no status will ever end the wait'
+      ).toBe('failed')
+    })
+
+    it('leaves errors alone until the tour has run something', async () => {
+      await tourOnRunStep()
+
+      mocks.executionErrors.hasPromptError = true
+      await nextTick()
+
+      expect(
+        mocks.runState.value,
+        'errors already on screen when the tour reaches Run are not its run'
+      ).toBe('idle')
+    })
+  })
+
+  describe('the paywall', () => {
+    it('consumes a Run click it is going to refuse', async () => {
+      await tourOnRunStep()
+      mocks.canRunWorkflows.value = false
+      const underlyingHandler = vi.fn()
+      const click = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      })
+      mountRunButton(
+        'subscribe-to-run-button',
+        underlyingHandler
+      ).dispatchEvent(click)
+
+      expect(
+        underlyingHandler,
+        'a refused run must never reach the handler that queues it'
+      ).not.toHaveBeenCalled()
+      expect(
+        click.defaultPrevented,
+        'the browser activates the button on its own unless the click is cancelled'
+      ).toBe(true)
+      expect(mocks.showSubscriptionDialog).toHaveBeenCalled()
+      expect(
+        mocks.engine.postpone,
+        'whoever subscribes off the back of this still has their first run ahead of them'
+      ).toHaveBeenCalled()
+      expect(mocks.engine.skip).not.toHaveBeenCalled()
+    })
+
+    it('lets a funded run through untouched', async () => {
+      await tourOnRunStep()
+      const underlyingHandler = vi.fn()
+
+      mountRunButton('queue-button', underlyingHandler).click()
+
+      expect(underlyingHandler).toHaveBeenCalled()
+      expect(mocks.engine.postpone).not.toHaveBeenCalled()
+    })
+
+    it('does not walk the tour on for a run it just refused', async () => {
+      await tourOnRunStep()
+      mocks.canRunWorkflows.value = false
+
+      mountRunButton('subscribe-to-run-button', () => {}).click()
+
+      expect(
+        mocks.engine.next,
+        'nothing was queued, so there is no result to send the user to'
+      ).not.toHaveBeenCalled()
+    })
+
+    it('does not end a running tour when funds run out mid-step', async () => {
+      await tourOnRunStep()
+
+      mocks.canRunWorkflows.value = false
+      await nextTick()
+
+      expect(
+        mocks.engine.postpone,
+        'the paywall is keyed to the click, so an active tour survives losing eligibility'
+      ).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -1,0 +1,124 @@
+import { createSharedComposable, useEventListener } from '@vueuse/core'
+import { delay } from 'es-toolkit'
+import { computed, ref, shallowRef, watch } from 'vue'
+
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
+import { registerTour } from '@/platform/onboarding/onboardingTours'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+import { canvasTransformValid } from './canvasCoachTarget'
+import {
+  firstRunTourSteps,
+  releaseFirstRunTargets
+} from './firstRunTourDefinition'
+import type { RunState } from './firstRunTourDefinition'
+
+const RUN_BUTTON_SELECTOR =
+  '[data-testid="queue-button"], [data-testid="subscribe-to-run-button"]'
+
+/** An undimmed look at the workflow the user chose, before the tour dims it. */
+const INTRO_PREVIEW_MS = 500
+
+function useFirstRunTourControllerInternal() {
+  const engine = useOnboardingTourStore()
+  const billing = useBillingContext()
+  const executionStore = useExecutionStore()
+  const executionErrorStore = useExecutionErrorStore()
+  const workflowStore = useWorkflowStore()
+
+  const tourWorkflow = shallowRef<ComfyWorkflow | null>(null)
+  const runState = ref<RunState>('idle')
+  const onRunStep = computed(
+    () => engine.activeTour === 'firstRun' && engine.step?.name === 'run'
+  )
+
+  /**
+   * A run outlives the step that starts it, so the click moves the tour on and
+   * the Result step reports how it goes. A run the paywall will refuse never
+   * queues at all, so that click is consumed and the tour postponed — whoever
+   * subscribes off the back of it still has their first run ahead of them.
+   */
+  useEventListener(
+    document,
+    'click',
+    (event: MouseEvent) => {
+      if (!onRunStep.value) return
+      if (!(event.target instanceof Element)) return
+      if (!event.target.closest(RUN_BUTTON_SELECTOR)) return
+
+      if (!billing.canRunWorkflows.value) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        billing.showSubscriptionDialog({ reason: 'out_of_credits' })
+        engine.postpone()
+        return
+      }
+
+      runState.value = 'generating'
+      if (engine.isLast) engine.complete()
+      else engine.next()
+    },
+    { capture: true }
+  )
+
+  /**
+   * The queue maps each job to the workflow that submitted it, so a job from
+   * anywhere else cannot speak for this tour.
+   */
+  watch(
+    () => executionStore.getWorkflowStatus(tourWorkflow.value),
+    (status) => {
+      if (!status || engine.activeTour !== 'firstRun') return
+      if (status === 'running') runState.value = 'generating'
+      else runState.value = status === 'failed' ? 'failed' : 'succeeded'
+    }
+  )
+
+  /**
+   * A prompt the queue refuses is never executed, so no status ever reports it
+   * and the error it raises instead is the only word the Result step gets.
+   */
+  watch(
+    () =>
+      executionErrorStore.hasNodeError || executionErrorStore.hasPromptError,
+    (refused) => {
+      if (refused && runState.value === 'generating') runState.value = 'failed'
+    }
+  )
+
+  watch(
+    () => engine.activeTour === 'firstRun',
+    (active) => {
+      if (active) return
+      releaseFirstRunTargets()
+      tourWorkflow.value = null
+      runState.value = 'idle'
+    }
+  )
+
+  /** False when this graph has no tour to give; the caller keeps it loaded. */
+  async function beginTour(templateId?: string): Promise<boolean> {
+    if (!canvasTransformValid()) return false
+
+    tourWorkflow.value = workflowStore.activeWorkflow ?? null
+    runState.value = 'idle'
+    registerTour('firstRun', () => firstRunTourSteps(templateId, runState))
+    await delay(INTRO_PREVIEW_MS)
+    const started = await engine.startTour('firstRun')
+    if (!started) {
+      releaseFirstRunTargets()
+      tourWorkflow.value = null
+    }
+    return started
+  }
+
+  return { beginTour }
+}
+
+export const useFirstRunTourController = createSharedComposable(
+  useFirstRunTourControllerInternal
+)

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -191,6 +191,7 @@ vi.mock('@/components/toast/GlobalToast.vue', () => stubModule)
 vi.mock('@/components/toast/RerouteMigrationToast.vue', () => stubModule)
 vi.mock('@/components/MenuHamburger.vue', () => stubModule)
 vi.mock('@/components/dialog/UnloadWindowConfirmDialog.vue', () => stubModule)
+vi.mock('@/renderer/extensions/firstRunTour/FirstRunTour.vue', () => stubModule)
 
 describe('GraphView - reconnect wiring', () => {
   beforeEach(() => {

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -30,6 +30,7 @@
   <UnloadWindowConfirmDialog v-if="!isDesktop" />
   <MenuHamburger />
   <TourOverlay v-if="graphReady" />
+  <FirstRunTour />
 </template>
 
 <script setup lang="ts">
@@ -51,6 +52,7 @@ import MenuHamburger from '@/components/MenuHamburger.vue'
 import UnloadWindowConfirmDialog from '@/components/dialog/UnloadWindowConfirmDialog.vue'
 import GraphCanvas from '@/components/graph/GraphCanvas.vue'
 import TourOverlay from '@/platform/onboarding/TourOverlay.vue'
+import FirstRunTour from '@/renderer/extensions/firstRunTour/FirstRunTour.vue'
 import GlobalToast from '@/components/toast/GlobalToast.vue'
 import InviteAcceptedToast from '@/platform/workspace/components/toasts/InviteAcceptedToast.vue'
 import RerouteMigrationToast from '@/components/toast/RerouteMigrationToast.vue'


### PR DESCRIPTION
## Summary

A first-run guided tour for new cloud users, built as a single change off `main`: pick a curated template on the Getting Started screen, then get walked through upload, prompt, run, and result, spotlit on the canvas.

## Changes

- **What**: A first-run tour on the shared coachmark engine. The Getting Started screen (curated templates + tutorials, gated to new cloud users behind `onboardingTourEnabled`) hands a picked template to a tour controller. Roles (source / prompt / sink) resolve from a per-template pin map, drive a step sequence, and are spotlit as canvas targets while the camera frames each node. The Run step passes clicks through to the real Run button, handles the paywall, and the Result step reports the run outcome. Reuses the existing template catalog/loader, litegraph's `animateToBounds`/`fitToBounds` camera, and Floating UI positioning; the only new engine capability is a canvas-node coachmark target (a `VirtualElement` rect provider).
- **Scope**: The tour runs only on templates it pins. An id it does not pin, or pins the live graph no longer satisfies, yields no steps and the engine reports it did not start. There is deliberately **no arbitrary-graph role inference** (heuristically guessing prompt/source/sink off an uncurated graph) and **no post-tour nudge** in this PR.
- **Breaking**: None. New-user startup still falls back to the existing template browser (`Comfy.BrowseTemplates`) for anyone who is not a tour candidate.

## Review Focus

- This is a leaner, consolidated take on the `#14140`–`#14145` stack: same engine foundation and much of the same tour/controller/camera logic, minus the speculative arbitrary-graph inference and the nudge, landed as one PR instead of six. Reviewing the scope cut (curated-pins-only) is the main call: it trades shared-workflow / uncurated-URL tours for a far smaller, less fragile surface.
- Curated coverage is guarded by an e2e check (`firstRunTourRolePins.spec.ts`) that fails if any pinned node is missing or changed type in a served template, so template drift surfaces in CI rather than as a dead step.
- `resolveTourRoles` degrades any individual unmet pin to `null` (the step is omitted) rather than dropping the whole tour, and host-maps pins that live inside subgraphs to their root-graph node.
- Tests kept thorough (unit + e2e across roles, camera framing, canvas targets, the controller's run/result/paywall states, and the Getting Started entry gating).

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->
