### PR TITLE
fix(ci): reuse pnpm store across E2E jobs

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PNPM_CONFIG_STORE_DIR: /tmp/comfyui-frontend-pnpm-store
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -78,17 +81,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Setup Node.js and restore pnpm store
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: './pnpm-lock.yaml'
       - name: Download built frontend
         uses: actions/download-artifact@v7
         with:
           name: frontend-dist
           path: dist/
 
-      - name: Start ComfyUI server
-        uses: ./.github/actions/start-comfyui-server
-
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
+
+      - name: Start ComfyUI server
+        uses: ./.github/actions/start-comfyui-server
 
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
@@ -136,17 +145,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Setup Node.js and restore pnpm store
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: './pnpm-lock.yaml'
       - name: Download built frontend
         uses: actions/download-artifact@v7
         with:
           name: ${{ (matrix.browser == 'cloud' || matrix.browser == 'mobile-safari') && 'frontend-dist-cloud' || 'frontend-dist' }}
           path: dist/
 
-      - name: Start ComfyUI server
-        uses: ./.github/actions/start-comfyui-server
-
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
+
+      - name: Start ComfyUI server
+        uses: ./.github/actions/start-comfyui-server
 
       # Run tests (browsers pre-installed in container)
       - name: Run Playwright tests (${{ matrix.browser }})
@@ -156,7 +171,7 @@ jobs:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
 
       - name: Generate HTML and JSON reports
-        if: always()
+        if: ${{ !cancelled() && steps.playwright.outcome != 'skipped' }}
         run: |
           # Generate HTML report from blob
           pnpm exec playwright merge-reports --reporter=html ./blob-report


### PR DESCRIPTION
## Summary

Reuse the pnpm store prepared by the E2E setup job across containerized Playwright jobs so transient npm registry slowness does not fail individual shards before tests start.

## Changes

- Use a fixed workflow-scoped pnpm store path and restore it in both E2E matrices.
- Install frontend dependencies before starting the ComfyUI server.
- Skip report generation when the Playwright step never ran.

## Root cause

The workflow currently launches 16 Chromium shards and 5 browser jobs that each perform a cold install of roughly 1,600 packages. In repeated runs, several jobs timed out during dependency download while Playwright itself never started. Failed installs could also reach report generation and trigger another pnpm dependency check.

## Dependency

The first draft run confirmed that setup and container jobs resolve the same cache key and store path, but `0.0.21` still misses because the setup runner uses zstd while the container falls back to gzip. This draft depends on [comfyui-ci-container#28](https://github.com/Comfy-Org/comfyui-ci-container/pull/28), whose Docker build passes, and the resulting frontend container-version bump.

## Review Focus

This remains a draft until a published container with zstd verifies cache hits in every matrix job. Shard count and timeout values are intentionally unchanged.

## Validation

- YAML parse and oxfmt check
- Pre-commit formatting, linting, and root typecheck
- Pre-push Knip
- First live run confirmed the fixed store path and isolated the remaining compression-version mismatch
- The dependent container image builds successfully

Observed in [run 30415457048](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30415457048).