### PR TITLE
feat: add runtime release feature gates

### DIFF
--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -9,10 +9,10 @@ The ComfyUI feature flags system enables capability negotiation between frontend
 Capability flags describe what a local ComfyUI server and its client support.
 They use the WebSocket negotiation documented below.
 
-Cloud release flags control gradual rollouts. Cloud evaluates them for the
-authenticated user and returns boolean values under
-`/api/features.release_flags`. Frontend consumers use `useFeatureGate()` and
-default to `false` until an authenticated response resolves the flag:
+Cloud release flags control gradual rollouts. Frontend consumers pass any
+PostHog key to `useFeatureGate()`. Cloud evaluates it for the authenticated user;
+no Cloud registration is required. Consumers default to `false` until the
+evaluation resolves:
 
 ```typescript
 const { value: isEnabled, recordExposure } = useFeatureGate(

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -4,6 +4,27 @@
 
 The ComfyUI feature flags system enables capability negotiation between frontend and backend, allowing both sides to communicate their supported features and adapt behavior accordingly. This ensures backward compatibility while enabling progressive enhancement of features.
 
+## Capability flags and release flags
+
+Capability flags describe what a local ComfyUI server and its client support.
+They use the WebSocket negotiation documented below.
+
+Cloud release flags control gradual rollouts. Cloud evaluates them for the
+authenticated user and returns boolean values under
+`/api/features.release_flags`. Frontend consumers use `useFeatureGate()` and
+default to `false` until an authenticated response resolves the flag:
+
+```typescript
+const { value: isEnabled, recordExposure } = useFeatureGate(
+  'might_be_risky_feature_foo'
+)
+```
+
+Call `recordExposure()` only when the user reaches the decision point. It records
+the resolved key and value once per browser tab session in Datadog and PostHog.
+Frontend gating is not authorization. Cloud must enforce risky behavior
+independently.
+
 ## System Architecture
 
 ### High-Level Flow

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -16,7 +16,7 @@ default to `false` until an authenticated response resolves the flag:
 
 ```typescript
 const { value: isEnabled, recordExposure } = useFeatureGate(
-  'might_be_risky_feature_foo'
+  'fastlane_feature_flag_foo'
 )
 ```
 

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  remoteConfig,
+  remoteConfigState
+} from '@/platform/remoteConfig/remoteConfig'
+import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
+import { setTelemetryRegistry } from '@/platform/telemetry'
+import type { TelemetryProvider } from '@/platform/telemetry/types'
+
+import { useFeatureGate } from './useFeatureGate'
+
+describe('useFeatureGate', () => {
+  beforeEach(() => {
+    remoteConfig.value = {}
+    remoteConfigState.value = 'unloaded'
+    sessionStorage.clear()
+    setTelemetryRegistry(null)
+  })
+
+  it('stays off until authenticated config resolves the flag on', () => {
+    remoteConfig.value = {
+      release_flags: { might_be_risky_feature_foo: true }
+    }
+    remoteConfigState.value = 'anonymous'
+
+    const { value } = useFeatureGate('might_be_risky_feature_foo')
+
+    expect(value.value).toBe(false)
+
+    remoteConfigState.value = 'authenticated'
+
+    expect(value.value).toBe(true)
+  })
+
+  it('records each resolved key and value once per session', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const provider: TelemetryProvider = { trackFeatureFlagExposure }
+    const registry = new TelemetryRegistry()
+    registry.registerProvider(provider)
+    setTelemetryRegistry(registry)
+    remoteConfig.value = {
+      release_flags: { might_be_risky_feature_foo: true }
+    }
+    remoteConfigState.value = 'authenticated'
+
+    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
+
+    recordExposure()
+    recordExposure()
+
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'might_be_risky_feature_foo',
+      true
+    )
+  })
+})

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -122,4 +122,26 @@ describe('useFeatureGate', () => {
       false
     )
   })
+
+  it('deduplicates in memory when session storage reads are unavailable', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    setTelemetryRegistry(registry)
+    remoteConfigState.value = 'authenticated'
+    vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
+      throw new Error('Storage unavailable')
+    })
+
+    const { recordExposure } = useFeatureGate('storage_read_unavailable_flag')
+
+    expect(() => {
+      recordExposure()
+      recordExposure()
+    }).not.toThrow()
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'storage_read_unavailable_flag',
+      false
+    )
+  })
 })

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -101,6 +101,57 @@ describe('useFeatureGate', () => {
     )
   })
 
+  it.for([
+    {
+      name: 'registered OFF',
+      key: 'registered_off',
+      state: 'authenticated' as const,
+      releaseFlags: { registered_off: false } as Record<string, boolean>,
+      expected: false
+    },
+    {
+      name: 'registered ON',
+      key: 'registered_on',
+      state: 'authenticated' as const,
+      releaseFlags: { registered_on: true } as Record<string, boolean>,
+      expected: true
+    },
+    {
+      name: 'unregistered',
+      key: 'unregistered',
+      state: 'authenticated' as const,
+      releaseFlags: {} as Record<string, boolean>,
+      expected: false
+    },
+    {
+      name: 'evaluation failed',
+      key: 'evaluation_failed',
+      state: 'error' as const,
+      releaseFlags: {} as Record<string, boolean>,
+      expected: false
+    }
+  ])(
+    'fails closed and records the resolved decision for $name',
+    ({ key, state, releaseFlags, expected }) => {
+      const trackFeatureFlagExposure = vi.fn()
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackFeatureFlagExposure })
+      setTelemetryRegistry(registry)
+      remoteConfig.value = { release_flags: releaseFlags }
+      remoteConfigState.value = state
+
+      const { value, recordExposure } = useFeatureGate(key)
+      recordExposure()
+      recordExposure()
+
+      expect(value.value).toBe(expected)
+      expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+        key,
+        expected
+      )
+    }
+  )
+
   it('deduplicates in memory when session storage writes are unavailable', () => {
     const trackFeatureFlagExposure = vi.fn()
     const registry = new TelemetryRegistry()

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -79,31 +79,6 @@ describe('useFeatureGate', () => {
     expect(() => recordExposure()).not.toThrow()
   })
 
-  it('deduplicates in memory when session storage is unavailable', () => {
-    const trackFeatureFlagExposure = vi.fn()
-    const registry = new TelemetryRegistry()
-    registry.registerProvider({ trackFeatureFlagExposure })
-    setTelemetryRegistry(registry)
-    remoteConfigState.value = 'authenticated'
-    vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
-      throw new Error('Storage unavailable')
-    })
-    vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
-      throw new Error('Storage unavailable')
-    })
-
-    const { recordExposure } = useFeatureGate('storage_unavailable_flag')
-
-    expect(() => {
-      recordExposure()
-      recordExposure()
-    }).not.toThrow()
-    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
-      'storage_unavailable_flag',
-      false
-    )
-  })
-
   it('records each resolved key and value once per session', () => {
     const trackFeatureFlagExposure = vi.fn()
     const provider: TelemetryProvider = { trackFeatureFlagExposure }
@@ -123,6 +98,28 @@ describe('useFeatureGate', () => {
     expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
       'might_be_risky_feature_foo',
       true
+    )
+  })
+
+  it('deduplicates in memory when session storage writes are unavailable', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    setTelemetryRegistry(registry)
+    remoteConfigState.value = 'authenticated'
+    vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
+      throw new Error('Storage unavailable')
+    })
+
+    const { recordExposure } = useFeatureGate('storage_unavailable_flag')
+
+    expect(() => {
+      recordExposure()
+      recordExposure()
+    }).not.toThrow()
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'storage_unavailable_flag',
+      false
     )
   })
 })

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   remoteConfig,
@@ -14,8 +14,13 @@ describe('useFeatureGate', () => {
   beforeEach(() => {
     remoteConfig.value = {}
     remoteConfigState.value = 'unloaded'
+    localStorage.clear()
     sessionStorage.clear()
     setTelemetryRegistry(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('stays off until authenticated config resolves the flag on', () => {
@@ -31,6 +36,72 @@ describe('useFeatureGate', () => {
     remoteConfigState.value = 'authenticated'
 
     expect(value.value).toBe(true)
+  })
+
+  it('defaults missing flags to off', () => {
+    remoteConfigState.value = 'authenticated'
+
+    const { value } = useFeatureGate('missing_flag')
+
+    expect(value.value).toBe(false)
+  })
+
+  it('gives a boolean development override precedence', () => {
+    localStorage.setItem('ff:might_be_risky_feature_foo', 'false')
+    remoteConfig.value = {
+      release_flags: { might_be_risky_feature_foo: true }
+    }
+    remoteConfigState.value = 'authenticated'
+
+    const { value } = useFeatureGate('might_be_risky_feature_foo')
+
+    expect(value.value).toBe(false)
+  })
+
+  it('does not record exposure before authenticated config resolves', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    setTelemetryRegistry(registry)
+
+    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
+
+    recordExposure()
+
+    expect(trackFeatureFlagExposure).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when telemetry is unavailable', () => {
+    remoteConfigState.value = 'authenticated'
+
+    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
+
+    expect(() => recordExposure()).not.toThrow()
+  })
+
+  it('deduplicates in memory when session storage is unavailable', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    setTelemetryRegistry(registry)
+    remoteConfigState.value = 'authenticated'
+    vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
+      throw new Error('Storage unavailable')
+    })
+    vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
+      throw new Error('Storage unavailable')
+    })
+
+    const { recordExposure } = useFeatureGate('storage_unavailable_flag')
+
+    expect(() => {
+      recordExposure()
+      recordExposure()
+    }).not.toThrow()
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'storage_unavailable_flag',
+      false
+    )
   })
 
   it('records each resolved key and value once per session', () => {

--- a/src/composables/useFeatureGate.test.ts
+++ b/src/composables/useFeatureGate.test.ts
@@ -1,19 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  remoteConfig,
-  remoteConfigState
-} from '@/platform/remoteConfig/remoteConfig'
-import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
+import { api } from '@/scripts/api'
 import { setTelemetryRegistry } from '@/platform/telemetry'
-import type { TelemetryProvider } from '@/platform/telemetry/types'
+import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
 
 import { useFeatureGate } from './useFeatureGate'
 
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn()
+  }
+}))
+
+const fetchApi = vi.mocked(api.fetchApi)
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function featureFlagResponse(flags: Record<string, boolean>) {
+  return new Response(JSON.stringify({ flags }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
 describe('useFeatureGate', () => {
   beforeEach(() => {
-    remoteConfig.value = {}
-    remoteConfigState.value = 'unloaded'
+    fetchApi.mockReset()
+    remoteConfigState.value = 'anonymous'
     localStorage.clear()
     sessionStorage.clear()
     setTelemetryRegistry(null)
@@ -23,128 +36,80 @@ describe('useFeatureGate', () => {
     vi.restoreAllMocks()
   })
 
-  it('stays off until authenticated config resolves the flag on', () => {
-    remoteConfig.value = {
-      release_flags: { might_be_risky_feature_foo: true }
-    }
-    remoteConfigState.value = 'anonymous'
-
-    const { value } = useFeatureGate('might_be_risky_feature_foo')
-
-    expect(value.value).toBe(false)
-
-    remoteConfigState.value = 'authenticated'
-
-    expect(value.value).toBe(true)
-  })
-
-  it('defaults missing flags to off', () => {
-    remoteConfigState.value = 'authenticated'
-
-    const { value } = useFeatureGate('missing_flag')
-
-    expect(value.value).toBe(false)
-  })
-
-  it('gives a boolean development override precedence', () => {
-    localStorage.setItem('ff:might_be_risky_feature_foo', 'false')
-    remoteConfig.value = {
-      release_flags: { might_be_risky_feature_foo: true }
-    }
-    remoteConfigState.value = 'authenticated'
-
-    const { value } = useFeatureGate('might_be_risky_feature_foo')
-
-    expect(value.value).toBe(false)
-  })
-
-  it('does not record exposure before authenticated config resolves', () => {
-    const trackFeatureFlagExposure = vi.fn()
-    const registry = new TelemetryRegistry()
-    registry.registerProvider({ trackFeatureFlagExposure })
-    setTelemetryRegistry(registry)
-
-    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
-
-    recordExposure()
-
-    expect(trackFeatureFlagExposure).not.toHaveBeenCalled()
-  })
-
-  it('does not throw when telemetry is unavailable', () => {
-    remoteConfigState.value = 'authenticated'
-
-    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
-
-    expect(() => recordExposure()).not.toThrow()
-  })
-
-  it('records each resolved key and value once per session', () => {
-    const trackFeatureFlagExposure = vi.fn()
-    const provider: TelemetryProvider = { trackFeatureFlagExposure }
-    const registry = new TelemetryRegistry()
-    registry.registerProvider(provider)
-    setTelemetryRegistry(registry)
-    remoteConfig.value = {
-      release_flags: { might_be_risky_feature_foo: true }
-    }
-    remoteConfigState.value = 'authenticated'
-
-    const { recordExposure } = useFeatureGate('might_be_risky_feature_foo')
-
-    recordExposure()
-    recordExposure()
-
-    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
-      'might_be_risky_feature_foo',
-      true
+  it('evaluates any PostHog key after authentication', async () => {
+    fetchApi.mockResolvedValue(
+      featureFlagResponse({ feature_flag_foobar: true })
     )
+    const gate = useFeatureGate('feature_flag_foobar')
+
+    expect(gate.value.value).toBe(false)
+    expect(gate.state.value).toBe('unloaded')
+
+    remoteConfigState.value = 'authenticated'
+    await flushPromises()
+
+    expect(fetchApi).toHaveBeenCalledWith('/feature-flags/evaluate', {
+      body: expect.any(String),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      signal: expect.any(AbortSignal)
+    })
+    expect(JSON.parse(fetchApi.mock.calls.at(-1)![1]!.body as string)).toEqual({
+      keys: expect.arrayContaining(['feature_flag_foobar'])
+    })
+    expect(gate.value.value).toBe(true)
+    expect(gate.state.value).toBe('resolved')
   })
 
   it.for([
     {
-      name: 'registered OFF',
+      name: 'PostHog OFF',
       key: 'registered_off',
-      state: 'authenticated' as const,
-      releaseFlags: { registered_off: false } as Record<string, boolean>,
-      expected: false
+      response: featureFlagResponse({ registered_off: false }),
+      expected: false,
+      expectedState: 'resolved'
     },
     {
-      name: 'registered ON',
+      name: 'PostHog ON',
       key: 'registered_on',
-      state: 'authenticated' as const,
-      releaseFlags: { registered_on: true } as Record<string, boolean>,
-      expected: true
+      response: featureFlagResponse({ registered_on: true }),
+      expected: true,
+      expectedState: 'resolved'
     },
     {
-      name: 'unregistered',
+      name: 'missing',
       key: 'unregistered',
-      state: 'authenticated' as const,
-      releaseFlags: {} as Record<string, boolean>,
-      expected: false
+      response: featureFlagResponse({}),
+      expected: false,
+      expectedState: 'resolved'
     },
     {
       name: 'evaluation failed',
       key: 'evaluation_failed',
-      state: 'error' as const,
-      releaseFlags: {} as Record<string, boolean>,
-      expected: false
+      response: new Error('Cloud unavailable'),
+      expected: false,
+      expectedState: 'error'
     }
   ])(
     'fails closed and records the resolved decision for $name',
-    ({ key, state, releaseFlags, expected }) => {
+    async ({ key, response, expected, expectedState }) => {
       const trackFeatureFlagExposure = vi.fn()
       const registry = new TelemetryRegistry()
       registry.registerProvider({ trackFeatureFlagExposure })
       setTelemetryRegistry(registry)
-      remoteConfig.value = { release_flags: releaseFlags }
-      remoteConfigState.value = state
+      if (response instanceof Error) {
+        fetchApi.mockRejectedValue(response)
+      } else {
+        fetchApi.mockResolvedValue(response)
+      }
+      const gate = useFeatureGate(key)
+      remoteConfigState.value = 'authenticated'
+      await flushPromises()
+      gate.recordExposure()
+      gate.recordExposure()
 
-      const { value, recordExposure } = useFeatureGate(key)
-      recordExposure()
-      recordExposure()
-
-      expect(value.value).toBe(expected)
+      expect(gate.value.value).toBe(expected)
+      expect(gate.state.value).toBe(expectedState)
       expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
         key,
         expected
@@ -152,47 +117,32 @@ describe('useFeatureGate', () => {
     }
   )
 
-  it('deduplicates in memory when session storage writes are unavailable', () => {
-    const trackFeatureFlagExposure = vi.fn()
-    const registry = new TelemetryRegistry()
-    registry.registerProvider({ trackFeatureFlagExposure })
-    setTelemetryRegistry(registry)
+  it('gives a boolean development override precedence', () => {
+    localStorage.setItem('ff:local_override', 'true')
+    fetchApi.mockResolvedValue(featureFlagResponse({}))
     remoteConfigState.value = 'authenticated'
-    vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
-      throw new Error('Storage unavailable')
-    })
+    fetchApi.mockClear()
 
-    const { recordExposure } = useFeatureGate('storage_unavailable_flag')
+    const gate = useFeatureGate('local_override')
 
-    expect(() => {
-      recordExposure()
-      recordExposure()
-    }).not.toThrow()
-    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
-      'storage_unavailable_flag',
-      false
-    )
+    expect(gate.value.value).toBe(true)
+    expect(gate.state.value).toBe('resolved')
+    expect(fetchApi).not.toHaveBeenCalled()
   })
 
-  it('deduplicates in memory when session storage reads are unavailable', () => {
+  it('does not record exposure before evaluation resolves', () => {
     const trackFeatureFlagExposure = vi.fn()
     const registry = new TelemetryRegistry()
     registry.registerProvider({ trackFeatureFlagExposure })
     setTelemetryRegistry(registry)
+    fetchApi.mockReturnValue(new Promise(() => {}))
+
+    const gate = useFeatureGate('pending_flag')
     remoteConfigState.value = 'authenticated'
-    vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
-      throw new Error('Storage unavailable')
-    })
 
-    const { recordExposure } = useFeatureGate('storage_read_unavailable_flag')
+    expect(gate.state.value).toBe('loading')
+    gate.recordExposure()
 
-    expect(() => {
-      recordExposure()
-      recordExposure()
-    }).not.toThrow()
-    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
-      'storage_read_unavailable_flag',
-      false
-    )
+    expect(trackFeatureFlagExposure).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -1,0 +1,37 @@
+import { computed } from 'vue'
+
+import {
+  remoteConfig,
+  remoteConfigState
+} from '@/platform/remoteConfig/remoteConfig'
+import { useTelemetry } from '@/platform/telemetry'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
+
+export function useFeatureGate(key: string) {
+  const value = computed(() => {
+    const override = getDevOverride<boolean>(key)
+    if (typeof override === 'boolean') return override
+    if (remoteConfigState.value !== 'authenticated') return false
+
+    const resolvedValue = remoteConfig.value.release_flags?.[key]
+    return typeof resolvedValue === 'boolean' ? resolvedValue : false
+  })
+
+  function recordExposure(): void {
+    if (remoteConfigState.value !== 'authenticated') return
+
+    const exposureKey = `feature-flag-exposure:${key}:${value.value}`
+    if (sessionStorage.getItem(exposureKey) !== null) return
+
+    const telemetry = useTelemetry()
+    if (!telemetry) return
+
+    telemetry.trackFeatureFlagExposure(key, value.value)
+    sessionStorage.setItem(exposureKey, '1')
+  }
+
+  return {
+    value,
+    recordExposure
+  }
+}

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -8,32 +8,24 @@ import { useTelemetry } from '@/platform/telemetry'
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
 const fallbackRecordedExposures = new Set<string>()
-let useFallbackExposureStorage = false
 
 function hasRecordedExposure(key: string): boolean {
-  if (useFallbackExposureStorage) {
-    return fallbackRecordedExposures.has(key)
-  }
-
   try {
-    return sessionStorage.getItem(key) !== null
+    return (
+      sessionStorage.getItem(key) !== null || fallbackRecordedExposures.has(key)
+    )
   } catch {
-    useFallbackExposureStorage = true
     return fallbackRecordedExposures.has(key)
   }
 }
 
 function markExposureRecorded(key: string): void {
-  if (useFallbackExposureStorage) {
-    fallbackRecordedExposures.add(key)
-    return
-  }
+  fallbackRecordedExposures.add(key)
 
   try {
     sessionStorage.setItem(key, '1')
   } catch {
-    useFallbackExposureStorage = true
-    fallbackRecordedExposures.add(key)
+    return
   }
 }
 

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -40,7 +40,12 @@ export function useFeatureGate(key: string) {
   })
 
   function recordExposure(): void {
-    if (remoteConfigState.value !== 'authenticated') return
+    if (
+      remoteConfigState.value !== 'authenticated' &&
+      remoteConfigState.value !== 'error'
+    ) {
+      return
+    }
 
     const exposureKey = `feature-flag-exposure:${key}:${value.value}`
     if (hasRecordedExposure(exposureKey)) return

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -1,13 +1,129 @@
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import type { Ref } from 'vue'
 
-import {
-  remoteConfig,
-  remoteConfigState
-} from '@/platform/remoteConfig/remoteConfig'
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
+import { api } from '@/scripts/api'
 import { useTelemetry } from '@/platform/telemetry'
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
+type FeatureGateState = 'unloaded' | 'loading' | 'resolved' | 'error'
+
+const FEATURE_GATE_TIMEOUT_MS = 5_000
+
+interface FeatureGateEntry {
+  state: Ref<FeatureGateState>
+  value: Ref<boolean>
+}
+
+const entries = new Map<string, FeatureGateEntry>()
 const fallbackRecordedExposures = new Set<string>()
+let generation = 0
+let pendingRefresh: { generation: number; promise: Promise<void> } | null = null
+let refreshAgain = false
+
+function failClosed(state: FeatureGateState): void {
+  for (const entry of entries.values()) {
+    entry.value.value = false
+    entry.state.value = state
+  }
+}
+
+function getFeatureGateEntry(key: string): FeatureGateEntry {
+  const existingEntry = entries.get(key)
+  if (existingEntry) return existingEntry
+
+  const entry: FeatureGateEntry = {
+    state: ref('unloaded'),
+    value: ref(false)
+  }
+  entries.set(key, entry)
+  return entry
+}
+
+watch(
+  remoteConfigState,
+  (state) => {
+    generation++
+    pendingRefresh = null
+    refreshAgain = false
+    if (state === 'authenticated') {
+      void refreshFeatureGates()
+      return
+    }
+    failClosed(state === 'error' ? 'error' : 'unloaded')
+  },
+  { flush: 'sync' }
+)
+
+export function refreshFeatureGates(): Promise<void> {
+  if (remoteConfigState.value !== 'authenticated' || entries.size === 0) {
+    return Promise.resolve()
+  }
+
+  if (pendingRefresh?.generation === generation) {
+    refreshAgain = true
+    return pendingRefresh.promise
+  }
+
+  const requestGeneration = generation
+  const keys = [...entries.keys()]
+  for (const key of keys) {
+    const entry = entries.get(key)
+    if (entry) entry.state.value = 'loading'
+  }
+
+  const promise = api
+    .fetchApi('/feature-flags/evaluate', {
+      body: JSON.stringify({ keys }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      signal: AbortSignal.timeout(FEATURE_GATE_TIMEOUT_MS)
+    })
+    .then(async (response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const payload = (await response.json()) as {
+        flags?: Record<string, unknown>
+      }
+      if (
+        generation !== requestGeneration ||
+        remoteConfigState.value !== 'authenticated'
+      ) {
+        return
+      }
+
+      for (const key of keys) {
+        const entry = entries.get(key)
+        if (!entry) continue
+        entry.value.value =
+          typeof payload.flags?.[key] === 'boolean' ? payload.flags[key] : false
+        entry.state.value = 'resolved'
+      }
+    })
+    .catch(() => {
+      if (
+        generation !== requestGeneration ||
+        remoteConfigState.value !== 'authenticated'
+      ) {
+        return
+      }
+      for (const key of keys) {
+        const entry = entries.get(key)
+        if (!entry) continue
+        entry.value.value = false
+        entry.state.value = 'error'
+      }
+    })
+    .finally(() => {
+      if (pendingRefresh?.promise === promise) pendingRefresh = null
+      if (refreshAgain && generation === requestGeneration) {
+        refreshAgain = false
+        void refreshFeatureGates()
+      }
+    })
+
+  pendingRefresh = { generation: requestGeneration, promise }
+  return promise
+}
 
 function hasRecordedExposure(key: string): boolean {
   try {
@@ -30,22 +146,29 @@ function markExposureRecorded(key: string): void {
 }
 
 export function useFeatureGate(key: string) {
-  const value = computed(() => {
-    const override = getDevOverride<boolean>(key)
-    if (typeof override === 'boolean') return override
-    if (remoteConfigState.value !== 'authenticated') return false
+  const override = getDevOverride<boolean>(key)
+  const entry = getFeatureGateEntry(key)
+  if (
+    typeof override !== 'boolean' &&
+    remoteConfigState.value === 'authenticated'
+  ) {
+    void refreshFeatureGates()
+  }
 
-    const resolvedValue = remoteConfig.value.release_flags?.[key]
-    return typeof resolvedValue === 'boolean' ? resolvedValue : false
+  const state = computed<FeatureGateState>(() => {
+    if (typeof override === 'boolean') return 'resolved'
+    if (remoteConfigState.value === 'error') return 'error'
+    if (remoteConfigState.value !== 'authenticated') return 'unloaded'
+    return entry.state.value
+  })
+  const value = computed(() => {
+    if (typeof override === 'boolean') return override
+    if (state.value !== 'resolved') return false
+    return entry.value.value
   })
 
   function recordExposure(): void {
-    if (
-      remoteConfigState.value !== 'authenticated' &&
-      remoteConfigState.value !== 'error'
-    ) {
-      return
-    }
+    if (state.value !== 'resolved' && state.value !== 'error') return
 
     const exposureKey = `feature-flag-exposure:${key}:${value.value}`
     if (hasRecordedExposure(exposureKey)) return
@@ -58,6 +181,7 @@ export function useFeatureGate(key: string) {
   }
 
   return {
+    state,
     value,
     recordExposure
   }

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -7,6 +7,28 @@ import {
 import { useTelemetry } from '@/platform/telemetry'
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
+const fallbackRecordedExposures = new Set<string>()
+
+function hasRecordedExposure(key: string): boolean {
+  if (fallbackRecordedExposures.has(key)) return true
+
+  try {
+    return sessionStorage.getItem(key) !== null
+  } catch {
+    return false
+  }
+}
+
+function markExposureRecorded(key: string): void {
+  fallbackRecordedExposures.add(key)
+
+  try {
+    sessionStorage.setItem(key, '1')
+  } catch {
+    return
+  }
+}
+
 export function useFeatureGate(key: string) {
   const value = computed(() => {
     const override = getDevOverride<boolean>(key)
@@ -21,13 +43,13 @@ export function useFeatureGate(key: string) {
     if (remoteConfigState.value !== 'authenticated') return
 
     const exposureKey = `feature-flag-exposure:${key}:${value.value}`
-    if (sessionStorage.getItem(exposureKey) !== null) return
+    if (hasRecordedExposure(exposureKey)) return
 
     const telemetry = useTelemetry()
     if (!telemetry) return
 
     telemetry.trackFeatureFlagExposure(key, value.value)
-    sessionStorage.setItem(exposureKey, '1')
+    markExposureRecorded(exposureKey)
   }
 
   return {

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -8,19 +8,31 @@ import { useTelemetry } from '@/platform/telemetry'
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
 const fallbackRecordedExposures = new Set<string>()
+let useFallbackExposureStorage = false
 
 function hasRecordedExposure(key: string): boolean {
+  if (useFallbackExposureStorage) {
+    return fallbackRecordedExposures.has(key)
+  }
+
   try {
     return sessionStorage.getItem(key) !== null
   } catch {
+    useFallbackExposureStorage = true
     return fallbackRecordedExposures.has(key)
   }
 }
 
 function markExposureRecorded(key: string): void {
+  if (useFallbackExposureStorage) {
+    fallbackRecordedExposures.add(key)
+    return
+  }
+
   try {
     sessionStorage.setItem(key, '1')
   } catch {
+    useFallbackExposureStorage = true
     fallbackRecordedExposures.add(key)
   }
 }

--- a/src/composables/useFeatureGate.ts
+++ b/src/composables/useFeatureGate.ts
@@ -10,22 +10,18 @@ import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 const fallbackRecordedExposures = new Set<string>()
 
 function hasRecordedExposure(key: string): boolean {
-  if (fallbackRecordedExposures.has(key)) return true
-
   try {
     return sessionStorage.getItem(key) !== null
   } catch {
-    return false
+    return fallbackRecordedExposures.has(key)
   }
 }
 
 function markExposureRecorded(key: string): void {
-  fallbackRecordedExposures.add(key)
-
   try {
     sessionStorage.setItem(key, '1')
   } catch {
-    return
+    fallbackRecordedExposures.add(key)
   }
 }
 

--- a/src/extensions/core/cloudRemoteConfig.test.ts
+++ b/src/extensions/core/cloudRemoteConfig.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
+
+const mocks = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return {
+    isActiveSubscription: ref(false),
+    isLoggedIn: ref(true),
+    refreshRemoteConfig: vi.fn(),
+    registerExtension: vi.fn(),
+    resolvedUserInfo: ref<{ id: string } | null>({ id: 'user-a' })
+  }
+})
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    isLoggedIn: mocks.isLoggedIn,
+    resolvedUserInfo: mocks.resolvedUserInfo
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: mocks.isActiveSubscription
+  })
+}))
+
+vi.mock('@/platform/remoteConfig/refreshRemoteConfig', () => ({
+  refreshRemoteConfig: mocks.refreshRemoteConfig
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: mocks.registerExtension
+  })
+}))
+
+await import('./cloudRemoteConfig')
+
+describe('cloudRemoteConfig', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.isLoggedIn.value = true
+    mocks.resolvedUserInfo.value = { id: 'user-a' }
+    remoteConfigState.value = 'authenticated'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fails closed immediately when the authenticated user changes', async () => {
+    const extension = mocks.registerExtension.mock.calls[0][0]
+    await extension.setup()
+
+    mocks.resolvedUserInfo.value = { id: 'user-b' }
+
+    expect(remoteConfigState.value).toBe('anonymous')
+  })
+})

--- a/src/extensions/core/cloudRemoteConfig.test.ts
+++ b/src/extensions/core/cloudRemoteConfig.test.ts
@@ -7,6 +7,7 @@ const mocks = await vi.hoisted(async () => {
   return {
     isActiveSubscription: ref(false),
     isLoggedIn: ref(true),
+    refreshFeatureGates: vi.fn(),
     refreshRemoteConfig: vi.fn(),
     registerExtension: vi.fn(),
     resolvedUserInfo: ref<{ id: string } | null>({ id: 'user-a' })
@@ -18,6 +19,10 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
     isLoggedIn: mocks.isLoggedIn,
     resolvedUserInfo: mocks.resolvedUserInfo
   })
+}))
+
+vi.mock('@/composables/useFeatureGate', () => ({
+  refreshFeatureGates: mocks.refreshFeatureGates
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -43,6 +48,8 @@ describe('cloudRemoteConfig', () => {
     vi.useFakeTimers()
     mocks.isLoggedIn.value = true
     mocks.resolvedUserInfo.value = { id: 'user-a' }
+    mocks.refreshFeatureGates.mockClear()
+    mocks.refreshRemoteConfig.mockClear()
     remoteConfigState.value = 'authenticated'
   })
 
@@ -57,5 +64,25 @@ describe('cloudRemoteConfig', () => {
     mocks.resolvedUserInfo.value = { id: 'user-b' }
 
     expect(remoteConfigState.value).toBe('anonymous')
+  })
+
+  it('refreshes registered gates after remote config resolves', async () => {
+    let resolveRemoteConfig: () => void
+    mocks.refreshRemoteConfig.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRemoteConfig = resolve
+      })
+    )
+    const extension = mocks.registerExtension.mock.calls[0][0]
+    await extension.setup()
+    await vi.advanceTimersByTimeAsync(256)
+
+    expect(mocks.refreshRemoteConfig).toHaveBeenCalled()
+    expect(mocks.refreshFeatureGates).not.toHaveBeenCalled()
+
+    resolveRemoteConfig!()
+    await vi.runAllTicks()
+
+    expect(mocks.refreshFeatureGates).toHaveBeenCalled()
   })
 })

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -3,6 +3,7 @@ import { watch } from 'vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { refreshFeatureGates } from '@/composables/useFeatureGate'
 import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useExtensionService } from '@/services/extensionService'
@@ -17,10 +18,12 @@ useExtensionService().registerExtension({
   setup: async () => {
     const { isLoggedIn, resolvedUserInfo } = useCurrentUser()
     const { isActiveSubscription } = useBillingContext()
-    const refreshAuthenticatedConfig = () =>
-      refreshRemoteConfig({
+    const refreshAuthenticatedConfig = async () => {
+      await refreshRemoteConfig({
         getSessionId: () => resolvedUserInfo.value?.id ?? null
       })
+      await refreshFeatureGates()
+    }
 
     watch(
       resolvedUserInfo,
@@ -46,6 +49,6 @@ useExtensionService().registerExtension({
 
     setInterval(() => {
       if (isLoggedIn.value) void refreshAuthenticatedConfig()
-    }, 60_000)
+    }, 30_000)
   }
 })

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -13,8 +13,12 @@ useExtensionService().registerExtension({
   name: 'Comfy.Cloud.RemoteConfig',
 
   setup: async () => {
-    const { isLoggedIn } = useCurrentUser()
+    const { isLoggedIn, resolvedUserInfo } = useCurrentUser()
     const { isActiveSubscription } = useBillingContext()
+    const refreshAuthenticatedConfig = () =>
+      refreshRemoteConfig({
+        getSessionId: () => resolvedUserInfo.value?.id ?? null
+      })
 
     // Refresh config when auth or subscription status changes
     // Primary auth refresh is handled by WorkspaceAuthGate on mount
@@ -23,13 +27,13 @@ useExtensionService().registerExtension({
       [isLoggedIn, isActiveSubscription],
       () => {
         if (!isLoggedIn.value) return
-        void refreshRemoteConfig()
+        void refreshAuthenticatedConfig()
       },
       { debounce: 256, immediate: true }
     )
 
     setInterval(() => {
-      if (isLoggedIn.value) void refreshRemoteConfig()
+      if (isLoggedIn.value) void refreshAuthenticatedConfig()
     }, 60_000)
   }
 })

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -1,7 +1,9 @@
 import { watchDebounced } from '@vueuse/core'
+import { watch } from 'vue'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
 import { useExtensionService } from '@/services/extensionService'
 
@@ -19,6 +21,16 @@ useExtensionService().registerExtension({
       refreshRemoteConfig({
         getSessionId: () => resolvedUserInfo.value?.id ?? null
       })
+
+    watch(
+      resolvedUserInfo,
+      (user, previousUser) => {
+        if (user?.id !== previousUser?.id) {
+          remoteConfigState.value = 'anonymous'
+        }
+      },
+      { flush: 'sync' }
+    )
 
     // Refresh config when auth or subscription status changes
     // Primary auth refresh is handled by WorkspaceAuthGate on mount

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -24,7 +24,7 @@ useExtensionService().registerExtension({
     // Primary auth refresh is handled by WorkspaceAuthGate on mount
     // This watcher handles subscription changes and acts as a backup for auth
     watchDebounced(
-      [isLoggedIn, isActiveSubscription],
+      [isLoggedIn, resolvedUserInfo, isActiveSubscription],
       () => {
         if (!isLoggedIn.value) return
         void refreshAuthenticatedConfig()

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -28,6 +28,8 @@ useExtensionService().registerExtension({
       { debounce: 256, immediate: true }
     )
 
-    setInterval(() => void refreshRemoteConfig(), 60_000)
+    setInterval(() => {
+      if (isLoggedIn.value) void refreshRemoteConfig()
+    }, 60_000)
   }
 })

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -28,7 +28,6 @@ useExtensionService().registerExtension({
       { debounce: 256, immediate: true }
     )
 
-    // Poll for config updates every 10 minutes (with auth)
-    setInterval(() => void refreshRemoteConfig(), 600_000)
+    setInterval(() => void refreshRemoteConfig(), 60_000)
   }
 })

--- a/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
@@ -7,23 +7,18 @@ const mocks = await vi.hoisted(async () => {
   return {
     enabled: ref(false),
     fetchApi: vi.fn().mockResolvedValue(new Response()),
+    gateState: ref<'unloaded' | 'loading' | 'resolved' | 'error'>('unloaded'),
     recordExposure: vi.fn(),
-    registerExtension: vi.fn(),
-    remoteConfigState: ref<
-      'unloaded' | 'anonymous' | 'authenticated' | 'error'
-    >('anonymous')
+    registerExtension: vi.fn()
   }
 })
 
 vi.mock('@/composables/useFeatureGate', () => ({
   useFeatureGate: () => ({
+    state: mocks.gateState,
     value: mocks.enabled,
     recordExposure: mocks.recordExposure
   })
-}))
-
-vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
-  remoteConfigState: mocks.remoteConfigState
 }))
 
 vi.mock('@/scripts/api', () => ({
@@ -47,8 +42,8 @@ describe('fastLaneFeatureFlagDemo', () => {
     scope = effectScope()
     mocks.enabled.value = false
     mocks.fetchApi.mockClear()
+    mocks.gateState.value = 'unloaded'
     mocks.recordExposure.mockClear()
-    mocks.remoteConfigState.value = 'anonymous'
   })
 
   afterEach(() => {
@@ -59,16 +54,16 @@ describe('fastLaneFeatureFlagDemo', () => {
     const extension = mocks.registerExtension.mock.calls[0][0]
     scope.run(() => extension.setup())
 
-    mocks.remoteConfigState.value = 'authenticated'
+    mocks.gateState.value = 'resolved'
     await nextTick()
 
     expect(mocks.recordExposure).toHaveBeenCalledOnce()
     expect(mocks.fetchApi).not.toHaveBeenCalled()
 
-    mocks.remoteConfigState.value = 'anonymous'
+    mocks.gateState.value = 'unloaded'
     await nextTick()
     mocks.enabled.value = true
-    mocks.remoteConfigState.value = 'authenticated'
+    mocks.gateState.value = 'resolved'
     await nextTick()
 
     expect(mocks.recordExposure).toHaveBeenCalledTimes(2)
@@ -79,7 +74,7 @@ describe('fastLaneFeatureFlagDemo', () => {
     const extension = mocks.registerExtension.mock.calls[0][0]
     scope.run(() => extension.setup())
 
-    mocks.remoteConfigState.value = 'error'
+    mocks.gateState.value = 'error'
     await nextTick()
 
     expect(mocks.recordExposure).toHaveBeenCalledOnce()

--- a/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
@@ -1,5 +1,6 @@
-import { nextTick } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+import type { EffectScope } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = await vi.hoisted(async () => {
   const { ref } = await import('vue')
@@ -40,16 +41,23 @@ vi.mock('@/services/extensionService', () => ({
 await import('./fastLaneFeatureFlagDemo')
 
 describe('fastLaneFeatureFlagDemo', () => {
+  let scope: EffectScope
+
   beforeEach(() => {
+    scope = effectScope()
     mocks.enabled.value = false
     mocks.fetchApi.mockClear()
     mocks.recordExposure.mockClear()
     mocks.remoteConfigState.value = 'anonymous'
   })
 
+  afterEach(() => {
+    scope.stop()
+  })
+
   it('records resolved decisions and only calls Cloud when enabled', async () => {
     const extension = mocks.registerExtension.mock.calls[0][0]
-    extension.setup()
+    scope.run(() => extension.setup())
 
     mocks.remoteConfigState.value = 'authenticated'
     await nextTick()
@@ -65,5 +73,16 @@ describe('fastLaneFeatureFlagDemo', () => {
 
     expect(mocks.recordExposure).toHaveBeenCalledTimes(2)
     expect(mocks.fetchApi).toHaveBeenCalledExactlyOnceWith('/fastlane-demo')
+  })
+
+  it('records an evaluation failure as OFF without calling Cloud', async () => {
+    const extension = mocks.registerExtension.mock.calls[0][0]
+    scope.run(() => extension.setup())
+
+    mocks.remoteConfigState.value = 'error'
+    await nextTick()
+
+    expect(mocks.recordExposure).toHaveBeenCalledOnce()
+    expect(mocks.fetchApi).not.toHaveBeenCalled()
   })
 })

--- a/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.test.ts
@@ -1,0 +1,69 @@
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return {
+    enabled: ref(false),
+    fetchApi: vi.fn().mockResolvedValue(new Response()),
+    recordExposure: vi.fn(),
+    registerExtension: vi.fn(),
+    remoteConfigState: ref<
+      'unloaded' | 'anonymous' | 'authenticated' | 'error'
+    >('anonymous')
+  }
+})
+
+vi.mock('@/composables/useFeatureGate', () => ({
+  useFeatureGate: () => ({
+    value: mocks.enabled,
+    recordExposure: mocks.recordExposure
+  })
+}))
+
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfigState: mocks.remoteConfigState
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: mocks.fetchApi
+  }
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: mocks.registerExtension
+  })
+}))
+
+await import('./fastLaneFeatureFlagDemo')
+
+describe('fastLaneFeatureFlagDemo', () => {
+  beforeEach(() => {
+    mocks.enabled.value = false
+    mocks.fetchApi.mockClear()
+    mocks.recordExposure.mockClear()
+    mocks.remoteConfigState.value = 'anonymous'
+  })
+
+  it('records resolved decisions and only calls Cloud when enabled', async () => {
+    const extension = mocks.registerExtension.mock.calls[0][0]
+    extension.setup()
+
+    mocks.remoteConfigState.value = 'authenticated'
+    await nextTick()
+
+    expect(mocks.recordExposure).toHaveBeenCalledOnce()
+    expect(mocks.fetchApi).not.toHaveBeenCalled()
+
+    mocks.remoteConfigState.value = 'anonymous'
+    await nextTick()
+    mocks.enabled.value = true
+    mocks.remoteConfigState.value = 'authenticated'
+    await nextTick()
+
+    expect(mocks.recordExposure).toHaveBeenCalledTimes(2)
+    expect(mocks.fetchApi).toHaveBeenCalledExactlyOnceWith('/fastlane-demo')
+  })
+})

--- a/src/extensions/core/fastLaneFeatureFlagDemo.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.ts
@@ -1,0 +1,31 @@
+import { watch } from 'vue'
+
+import { useFeatureGate } from '@/composables/useFeatureGate'
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
+import { api } from '@/scripts/api'
+import { useExtensionService } from '@/services/extensionService'
+
+const flagKey = 'fastlane_feature_flag_foo'
+
+useExtensionService().registerExtension({
+  name: 'Comfy.Cloud.FastLaneFeatureFlagDemo',
+
+  setup: () => {
+    const { value: enabled, recordExposure } = useFeatureGate(flagKey)
+
+    watch(
+      [remoteConfigState, enabled],
+      ([state, isEnabled]) => {
+        if (state !== 'authenticated') return
+
+        recordExposure()
+        if (!isEnabled) return
+
+        void api.fetchApi('/fastlane-demo').catch((error: unknown) => {
+          console.warn('Fast Lane demo server gate rejected:', error)
+        })
+      },
+      { immediate: true }
+    )
+  }
+})

--- a/src/extensions/core/fastLaneFeatureFlagDemo.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.ts
@@ -16,7 +16,7 @@ useExtensionService().registerExtension({
     watch(
       [remoteConfigState, enabled],
       ([state, isEnabled]) => {
-        if (state !== 'authenticated') return
+        if (state !== 'authenticated' && state !== 'error') return
 
         recordExposure()
         if (!isEnabled) return

--- a/src/extensions/core/fastLaneFeatureFlagDemo.ts
+++ b/src/extensions/core/fastLaneFeatureFlagDemo.ts
@@ -1,7 +1,6 @@
 import { watch } from 'vue'
 
 import { useFeatureGate } from '@/composables/useFeatureGate'
-import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
 import { api } from '@/scripts/api'
 import { useExtensionService } from '@/services/extensionService'
 
@@ -11,12 +10,12 @@ useExtensionService().registerExtension({
   name: 'Comfy.Cloud.FastLaneFeatureFlagDemo',
 
   setup: () => {
-    const { value: enabled, recordExposure } = useFeatureGate(flagKey)
+    const { state, value: enabled, recordExposure } = useFeatureGate(flagKey)
 
     watch(
-      [remoteConfigState, enabled],
+      [state, enabled],
       ([state, isEnabled]) => {
-        if (state !== 'authenticated' && state !== 'error') return
+        if (state !== 'resolved' && state !== 'error') return
 
         recordExposure()
         if (!isEnabled) return

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -36,6 +36,7 @@ import './widgetInputs'
 // Cloud-only extensions - tree-shaken in OSS builds
 if (isCloud) {
   await import('./cloudRemoteConfig')
+  await import('./fastLaneFeatureFlagDemo')
   await import('./cloudBadges')
   await import('./cloudSessionCookie')
 }

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -265,11 +265,8 @@ describe('refreshRemoteConfig', () => {
       expect(window.__CONFIG__).toEqual({})
     })
 
-    it('clears release flags but preserves other config on 500 response', async () => {
-      const existingConfig = {
-        subscription_required: true,
-        release_flags: { might_be_risky_feature_foo: true }
-      }
+    it('preserves config but marks authenticated refresh errors', async () => {
+      const existingConfig = { subscription_required: true }
       remoteConfig.value = existingConfig
       window.__CONFIG__ = existingConfig
 
@@ -279,9 +276,8 @@ describe('refreshRemoteConfig', () => {
 
       await refreshAuthenticated()
 
-      const safeConfig = { subscription_required: true }
-      expect(remoteConfig.value).toEqual(safeConfig)
-      expect(window.__CONFIG__).toEqual(safeConfig)
+      expect(remoteConfig.value).toEqual(existingConfig)
+      expect(window.__CONFIG__).toEqual(existingConfig)
       expect(remoteConfigState.value).toBe('error')
     })
   })

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -109,23 +109,45 @@ describe('refreshRemoteConfig', () => {
       expect(init?.signal).toBeUndefined()
     })
 
-    it('discards a response from a previous authenticated session', async () => {
-      let resolveResponse: (response: Response) => void
-      vi.mocked(api.fetchApi).mockReturnValue(
-        new Promise((resolve) => {
-          resolveResponse = resolve
-        })
-      )
+    it('keeps the new session refresh deduplicated when the old one settles', async () => {
+      let resolveOldResponse: (response: Response) => void
+      let resolveNewResponse: (response: Response) => void
+      vi.mocked(api.fetchApi)
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveOldResponse = resolve
+          })
+        )
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveNewResponse = resolve
+          })
+        )
 
-      const staleRefresh = refreshAuthenticated()
+      const oldRefresh = refreshAuthenticated()
+      await vi.waitFor(() => expect(api.fetchApi).toHaveBeenCalledOnce())
+
       sessionId = 'user-b'
-      resolveResponse!(
+      const newRefresh = refreshAuthenticated()
+      await vi.waitFor(() => expect(api.fetchApi).toHaveBeenCalledTimes(2))
+
+      resolveOldResponse!(
         mockSuccessResponse({ feature1: true, feature2: 'stale' })
       )
-      await staleRefresh
+      await oldRefresh
 
-      expect(remoteConfig.value).toEqual({})
-      expect(window.__CONFIG__).toEqual({})
+      const repeatedNewRefresh = refreshAuthenticated()
+      expect(repeatedNewRefresh).toBe(newRefresh)
+      expect(api.fetchApi).toHaveBeenCalledTimes(2)
+
+      resolveNewResponse!(
+        mockSuccessResponse({ feature1: true, feature2: 'current' })
+      )
+      await Promise.all([newRefresh, repeatedNewRefresh])
+
+      const currentConfig = { feature1: true, feature2: 'current' }
+      expect(remoteConfig.value).toEqual(currentConfig)
+      expect(window.__CONFIG__).toEqual(currentConfig)
     })
 
     it('starts a new request after a failed authenticated refresh', async () => {

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -56,6 +56,11 @@ describe('refreshRemoteConfig', () => {
       await Promise.all([firstRefresh, secondRefresh])
 
       expect(api.fetchApi).toHaveBeenCalledOnce()
+
+      vi.mocked(api.fetchApi).mockResolvedValueOnce(mockSuccessResponse())
+      await refreshRemoteConfig()
+
+      expect(api.fetchApi).toHaveBeenCalledTimes(2)
     })
 
     it('uses api.fetchApi when useAuth is true', async () => {

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -39,6 +39,25 @@ describe('refreshRemoteConfig', () => {
   })
 
   describe('with auth (default)', () => {
+    it('deduplicates concurrent authenticated refreshes', async () => {
+      let resolveResponse: (response: Response) => void
+      const pendingResponse = new Promise<Response>((resolve) => {
+        resolveResponse = resolve
+      })
+      vi.mocked(api.fetchApi).mockReturnValue(pendingResponse)
+
+      const firstRefresh = refreshRemoteConfig()
+      const secondRefresh = refreshRemoteConfig()
+
+      expect(secondRefresh).toBe(firstRefresh)
+      await vi.waitFor(() => expect(api.fetchApi).toHaveBeenCalledOnce())
+
+      resolveResponse!(mockSuccessResponse())
+      await Promise.all([firstRefresh, secondRefresh])
+
+      expect(api.fetchApi).toHaveBeenCalledOnce()
+    })
+
     it('uses api.fetchApi when useAuth is true', async () => {
       vi.mocked(api.fetchApi).mockResolvedValue(mockSuccessResponse())
 

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -136,6 +136,9 @@ describe('refreshRemoteConfig', () => {
       )
       await oldRefresh
 
+      expect(remoteConfig.value).toEqual({})
+      expect(window.__CONFIG__).toEqual({})
+
       const repeatedNewRefresh = refreshAuthenticated()
       expect(repeatedNewRefresh).toBe(newRefresh)
       expect(api.fetchApi).toHaveBeenCalledTimes(2)

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -143,8 +143,11 @@ describe('refreshRemoteConfig', () => {
       expect(window.__CONFIG__).toEqual({})
     })
 
-    it('preserves config on 500 response', async () => {
-      const existingConfig = { subscription_required: true }
+    it('clears release flags but preserves other config on 500 response', async () => {
+      const existingConfig = {
+        subscription_required: true,
+        release_flags: { might_be_risky_feature_foo: true }
+      }
       remoteConfig.value = existingConfig
       window.__CONFIG__ = existingConfig
 
@@ -154,8 +157,9 @@ describe('refreshRemoteConfig', () => {
 
       await refreshRemoteConfig()
 
-      expect(remoteConfig.value).toEqual(existingConfig)
-      expect(window.__CONFIG__).toEqual(existingConfig)
+      const safeConfig = { subscription_required: true }
+      expect(remoteConfig.value).toEqual(safeConfig)
+      expect(window.__CONFIG__).toEqual(safeConfig)
     })
   })
 })

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -16,6 +16,13 @@ vi.stubGlobal('fetch', vi.fn())
 
 describe('refreshRemoteConfig', () => {
   const mockConfig = { feature1: true, feature2: 'value' }
+  let sessionId = 'user-a'
+
+  function refreshAuthenticated() {
+    return refreshRemoteConfig({
+      getSessionId: () => sessionId
+    })
+  }
 
   function mockSuccessResponse(config = mockConfig) {
     return {
@@ -36,6 +43,7 @@ describe('refreshRemoteConfig', () => {
     vi.clearAllMocks()
     remoteConfig.value = {}
     window.__CONFIG__ = {}
+    sessionId = 'user-a'
   })
 
   describe('with auth (default)', () => {
@@ -46,8 +54,8 @@ describe('refreshRemoteConfig', () => {
       })
       vi.mocked(api.fetchApi).mockReturnValue(pendingResponse)
 
-      const firstRefresh = refreshRemoteConfig()
-      const secondRefresh = refreshRemoteConfig()
+      const firstRefresh = refreshAuthenticated()
+      const secondRefresh = refreshAuthenticated()
 
       expect(secondRefresh).toBe(firstRefresh)
       await vi.waitFor(() => expect(api.fetchApi).toHaveBeenCalledOnce())
@@ -58,7 +66,7 @@ describe('refreshRemoteConfig', () => {
       expect(api.fetchApi).toHaveBeenCalledOnce()
 
       vi.mocked(api.fetchApi).mockResolvedValueOnce(mockSuccessResponse())
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       expect(api.fetchApi).toHaveBeenCalledTimes(2)
     })
@@ -66,7 +74,10 @@ describe('refreshRemoteConfig', () => {
     it('uses api.fetchApi when useAuth is true', async () => {
       vi.mocked(api.fetchApi).mockResolvedValue(mockSuccessResponse())
 
-      await refreshRemoteConfig({ useAuth: true })
+      await refreshRemoteConfig({
+        useAuth: true,
+        getSessionId: () => sessionId
+      })
 
       expect(api.fetchApi).toHaveBeenCalledWith(
         '/features',
@@ -80,7 +91,7 @@ describe('refreshRemoteConfig', () => {
     it('uses api.fetchApi by default', async () => {
       vi.mocked(api.fetchApi).mockResolvedValue(mockSuccessResponse())
 
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       expect(api.fetchApi).toHaveBeenCalled()
       expect(global.fetch).not.toHaveBeenCalled()
@@ -89,10 +100,44 @@ describe('refreshRemoteConfig', () => {
     it('does not pass an abort signal on the authed branch (so it is never aborted)', async () => {
       vi.mocked(api.fetchApi).mockResolvedValue(mockSuccessResponse())
 
-      await refreshRemoteConfig({ useAuth: true })
+      await refreshRemoteConfig({
+        useAuth: true,
+        getSessionId: () => sessionId
+      })
 
       const init = vi.mocked(api.fetchApi).mock.calls[0][1]
       expect(init?.signal).toBeUndefined()
+    })
+
+    it('discards a response from a previous authenticated session', async () => {
+      let resolveResponse: (response: Response) => void
+      vi.mocked(api.fetchApi).mockReturnValue(
+        new Promise((resolve) => {
+          resolveResponse = resolve
+        })
+      )
+
+      const staleRefresh = refreshAuthenticated()
+      sessionId = 'user-b'
+      resolveResponse!(
+        mockSuccessResponse({ feature1: true, feature2: 'stale' })
+      )
+      await staleRefresh
+
+      expect(remoteConfig.value).toEqual({})
+      expect(window.__CONFIG__).toEqual({})
+    })
+
+    it('starts a new request after a failed authenticated refresh', async () => {
+      vi.mocked(api.fetchApi)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(mockSuccessResponse())
+
+      await refreshAuthenticated()
+      await refreshAuthenticated()
+
+      expect(api.fetchApi).toHaveBeenCalledTimes(2)
+      expect(remoteConfig.value).toEqual(mockConfig)
     })
   })
 
@@ -141,7 +186,7 @@ describe('refreshRemoteConfig', () => {
         mockErrorResponse(401, 'Unauthorized')
       )
 
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       expect(remoteConfig.value).toEqual({})
       expect(window.__CONFIG__).toEqual({})
@@ -152,7 +197,7 @@ describe('refreshRemoteConfig', () => {
         mockErrorResponse(403, 'Forbidden')
       )
 
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       expect(remoteConfig.value).toEqual({})
       expect(window.__CONFIG__).toEqual({})
@@ -161,7 +206,7 @@ describe('refreshRemoteConfig', () => {
     it('clears config on fetch error', async () => {
       vi.mocked(api.fetchApi).mockRejectedValue(new Error('Network error'))
 
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       expect(remoteConfig.value).toEqual({})
       expect(window.__CONFIG__).toEqual({})
@@ -179,7 +224,7 @@ describe('refreshRemoteConfig', () => {
         mockErrorResponse(500, 'Internal Server Error')
       )
 
-      await refreshRemoteConfig()
+      await refreshAuthenticated()
 
       const safeConfig = { subscription_required: true }
       expect(remoteConfig.value).toEqual(safeConfig)

--- a/src/platform/remoteConfig/refreshRemoteConfig.test.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '@/scripts/api'
 
 import { refreshRemoteConfig } from './refreshRemoteConfig'
-import { remoteConfig } from './remoteConfig'
+import { remoteConfig, remoteConfigState } from './remoteConfig'
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -42,6 +42,7 @@ describe('refreshRemoteConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     remoteConfig.value = {}
+    remoteConfigState.value = 'unloaded'
     window.__CONFIG__ = {}
     sessionId = 'user-a'
   })
@@ -97,7 +98,7 @@ describe('refreshRemoteConfig', () => {
       expect(global.fetch).not.toHaveBeenCalled()
     })
 
-    it('does not pass an abort signal on the authed branch (so it is never aborted)', async () => {
+    it('passes an AbortSignal on the authenticated branch', async () => {
       vi.mocked(api.fetchApi).mockResolvedValue(mockSuccessResponse())
 
       await refreshRemoteConfig({
@@ -106,7 +107,34 @@ describe('refreshRemoteConfig', () => {
       })
 
       const init = vi.mocked(api.fetchApi).mock.calls[0][1]
-      expect(init?.signal).toBeUndefined()
+      expect(init?.signal).toBeInstanceOf(AbortSignal)
+    })
+
+    it('clears a shared authenticated refresh after timeout', async () => {
+      vi.useFakeTimers()
+      try {
+        vi.mocked(api.fetchApi).mockImplementation((_route, init) => {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'))
+            })
+          })
+        })
+
+        const firstRefresh = refreshAuthenticated()
+        const secondRefresh = refreshAuthenticated()
+
+        expect(secondRefresh).toBe(firstRefresh)
+        await vi.advanceTimersByTimeAsync(5_000)
+        await Promise.all([firstRefresh, secondRefresh])
+
+        vi.mocked(api.fetchApi).mockResolvedValueOnce(mockSuccessResponse())
+        await refreshAuthenticated()
+
+        expect(api.fetchApi).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('keeps the new session refresh deduplicated when the old one settles', async () => {
@@ -254,6 +282,7 @@ describe('refreshRemoteConfig', () => {
       const safeConfig = { subscription_required: true }
       expect(remoteConfig.value).toEqual(safeConfig)
       expect(window.__CONFIG__).toEqual(safeConfig)
+      expect(remoteConfigState.value).toBe('error')
     })
   })
 })

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -76,7 +76,14 @@ export async function refreshRemoteConfig(
       window.__CONFIG__ = {}
       remoteConfig.value = {}
       remoteConfigState.value = 'error'
+      return
     }
+
+    const safeConfig = { ...remoteConfig.value }
+    delete safeConfig.release_flags
+    window.__CONFIG__ = safeConfig
+    remoteConfig.value = safeConfig
+    remoteConfigState.value = 'error'
   } catch (error) {
     console.error('Failed to fetch remote config:', error)
     window.__CONFIG__ = {}

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -5,6 +5,7 @@ import {
   remoteConfig,
   remoteConfigState
 } from './remoteConfig'
+import type { RemoteConfig } from './types'
 
 const FEATURES_FETCH_TIMEOUT_MS = 5_000
 
@@ -82,7 +83,9 @@ async function performRefreshRemoteConfig(
       return
     }
 
-    const safeConfig = { ...remoteConfig.value }
+    const safeConfig: RemoteConfig & {
+      release_flags?: Record<string, boolean>
+    } = { ...remoteConfig.value }
     delete safeConfig.release_flags
     window.__CONFIG__ = safeConfig
     remoteConfig.value = safeConfig

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -11,13 +11,14 @@ import {
 // on timeout the catch below clears remoteConfig and consumers fall back to build-time defaults.
 const FEATURES_FETCH_TIMEOUT_MS = 5_000
 
-interface RefreshRemoteConfigOptions {
-  /**
-   * Whether to use authenticated API (default: true).
-   * Set to false during bootstrap before auth is initialized.
-   */
-  useAuth?: boolean
-}
+type RefreshRemoteConfigOptions =
+  | {
+      useAuth: false
+    }
+  | {
+      useAuth?: true
+      getSessionId: () => string | null
+    }
 
 async function fetchRemoteConfig(
   useAuth: boolean,
@@ -39,17 +40,25 @@ async function fetchRemoteConfig(
  * - 'authenticated' when loaded with auth
  * - 'error' when load fails
  */
-async function performRefreshRemoteConfig(useAuth: boolean): Promise<void> {
+async function performRefreshRemoteConfig(
+  useAuth: boolean,
+  sessionId?: string | null,
+  getSessionId?: () => string | null
+): Promise<void> {
   const controller = useAuth ? null : new AbortController()
   const timeoutId = controller
     ? setTimeout(() => controller.abort(), FEATURES_FETCH_TIMEOUT_MS)
     : null
+  const sessionIsCurrent = () => !useAuth || getSessionId?.() === sessionId
 
   try {
     const response = await fetchRemoteConfig(useAuth, controller?.signal)
+    if (!sessionIsCurrent()) return
 
     if (response.ok) {
       const config = await response.json()
+      if (!sessionIsCurrent()) return
+
       window.__CONFIG__ = config
       remoteConfig.value = config
       remoteConfigState.value = useAuth ? 'authenticated' : 'anonymous'
@@ -81,6 +90,8 @@ async function performRefreshRemoteConfig(useAuth: boolean): Promise<void> {
     remoteConfig.value = safeConfig
     remoteConfigState.value = 'error'
   } catch (error) {
+    if (!sessionIsCurrent()) return
+
     console.error('Failed to fetch remote config:', error)
     window.__CONFIG__ = {}
     remoteConfig.value = {}
@@ -90,17 +101,35 @@ async function performRefreshRemoteConfig(useAuth: boolean): Promise<void> {
   }
 }
 
-let authenticatedRefreshPromise: Promise<void> | null = null
+interface AuthenticatedRefresh {
+  sessionId: string | null
+  token: object
+  promise: Promise<void>
+}
+
+let authenticatedRefresh: AuthenticatedRefresh | null = null
 
 export function refreshRemoteConfig(
-  options: RefreshRemoteConfigOptions = {}
+  options: RefreshRemoteConfigOptions
 ): Promise<void> {
-  const { useAuth = true } = options
+  const useAuth = options.useAuth !== false
   if (!useAuth) return performRefreshRemoteConfig(false)
-  if (authenticatedRefreshPromise) return authenticatedRefreshPromise
+  const { getSessionId } = options
+  const sessionId = getSessionId()
+  if (authenticatedRefresh?.sessionId === sessionId) {
+    return authenticatedRefresh.promise
+  }
 
-  authenticatedRefreshPromise = performRefreshRemoteConfig(true).finally(() => {
-    authenticatedRefreshPromise = null
+  const token = {}
+  const promise = performRefreshRemoteConfig(
+    true,
+    sessionId,
+    getSessionId
+  ).finally(() => {
+    if (authenticatedRefresh?.token === token) {
+      authenticatedRefresh = null
+    }
   })
-  return authenticatedRefreshPromise
+  authenticatedRefresh = { sessionId, token, promise }
+  return promise
 }

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -6,9 +6,6 @@ import {
   remoteConfigState
 } from './remoteConfig'
 
-// Cap the bootstrap fetch so a wedged /features endpoint can never block app.mount indefinitely.
-// A same-origin GET against the local comfyui server should resolve in well under a second;
-// on timeout the catch below clears remoteConfig and consumers fall back to build-time defaults.
 const FEATURES_FETCH_TIMEOUT_MS = 5_000
 
 type RefreshRemoteConfigOptions =
@@ -28,7 +25,7 @@ async function fetchRemoteConfig(
   if (!useAuth) {
     return fetch(api.apiURL('/features'), { cache: 'no-store', signal })
   }
-  return api.fetchApi('/features', { cache: 'no-store' })
+  return api.fetchApi('/features', { cache: 'no-store', signal })
 }
 
 /**
@@ -45,14 +42,15 @@ async function performRefreshRemoteConfig(
   sessionId?: string | null,
   getSessionId?: () => string | null
 ): Promise<void> {
-  const controller = useAuth ? null : new AbortController()
-  const timeoutId = controller
-    ? setTimeout(() => controller.abort(), FEATURES_FETCH_TIMEOUT_MS)
-    : null
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    FEATURES_FETCH_TIMEOUT_MS
+  )
   const sessionIsCurrent = () => !useAuth || getSessionId?.() === sessionId
 
   try {
-    const response = await fetchRemoteConfig(useAuth, controller?.signal)
+    const response = await fetchRemoteConfig(useAuth, controller.signal)
     if (!sessionIsCurrent()) return
 
     if (response.ok) {
@@ -97,7 +95,7 @@ async function performRefreshRemoteConfig(
     remoteConfig.value = {}
     remoteConfigState.value = 'error'
   } finally {
-    if (timeoutId !== null) clearTimeout(timeoutId)
+    clearTimeout(timeoutId)
   }
 }
 

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -39,11 +39,7 @@ async function fetchRemoteConfig(
  * - 'authenticated' when loaded with auth
  * - 'error' when load fails
  */
-export async function refreshRemoteConfig(
-  options: RefreshRemoteConfigOptions = {}
-): Promise<void> {
-  const { useAuth = true } = options
-
+async function performRefreshRemoteConfig(useAuth: boolean): Promise<void> {
   const controller = useAuth ? null : new AbortController()
   const timeoutId = controller
     ? setTimeout(() => controller.abort(), FEATURES_FETCH_TIMEOUT_MS)
@@ -92,4 +88,19 @@ export async function refreshRemoteConfig(
   } finally {
     if (timeoutId !== null) clearTimeout(timeoutId)
   }
+}
+
+let authenticatedRefreshPromise: Promise<void> | null = null
+
+export function refreshRemoteConfig(
+  options: RefreshRemoteConfigOptions = {}
+): Promise<void> {
+  const { useAuth = true } = options
+  if (!useAuth) return performRefreshRemoteConfig(false)
+  if (authenticatedRefreshPromise) return authenticatedRefreshPromise
+
+  authenticatedRefreshPromise = performRefreshRemoteConfig(true).finally(() => {
+    authenticatedRefreshPromise = null
+  })
+  return authenticatedRefreshPromise
 }

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -129,7 +129,6 @@ export type RemoteConfig = {
   // Always funnel it through normalizeTurnstileMode before trusting it as a
   // TurnstileMode — that resolver is the single narrowing boundary.
   signup_turnstile?: string
-  release_flags?: Record<string, boolean>
 }
 
 /**

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -129,6 +129,7 @@ export type RemoteConfig = {
   // Always funnel it through normalizeTurnstileMode before trusting it as a
   // TurnstileMode — that resolver is the single narrowing boundary.
   signup_turnstile?: string
+  release_flags?: Record<string, boolean>
 }
 
 /**

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -4,6 +4,20 @@ import { TelemetryRegistry } from './TelemetryRegistry'
 import type { BillingTelemetryEvent, TelemetryProvider } from './types'
 
 describe('TelemetryRegistry', () => {
+  it('dispatches feature flag exposure to supporting providers', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    registry.registerProvider({})
+
+    registry.trackFeatureFlagExposure('might_be_risky_feature_foo', false)
+
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'might_be_risky_feature_foo',
+      false
+    )
+  })
+
   it('dispatches trackSearchQuery to every registered provider', () => {
     const a: TelemetryProvider = { trackSearchQuery: vi.fn() }
     const b: TelemetryProvider = { trackSearchQuery: vi.fn() }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -74,6 +74,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     })
   }
 
+  trackFeatureFlagExposure(key: string, value: boolean): void {
+    this.dispatch((provider) => provider.trackFeatureFlagExposure?.(key, value))
+  }
+
   trackSignupOpened(): void {
     this.dispatch((provider) => provider.trackSignupOpened?.())
   }

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -64,6 +64,7 @@ describe('initDatadogRum', () => {
         beforeSend: rumBeforeSend,
         sessionSampleRate: 100,
         sessionReplaySampleRate: 0,
+        enableExperimentalFeatures: ['feature_flags'],
         allowedTracingUrls: [expect.any(RegExp)]
       })
     }

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -47,6 +47,7 @@ async function initializeDatadogRum(env: string): Promise<void> {
     beforeSend: rumBeforeSend,
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,
+    enableExperimentalFeatures: ['feature_flags'],
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
   trackUserManualRefresh()

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -4,14 +4,25 @@ import type { BillingTelemetryEvent } from '../../types'
 import { TelemetryEvents } from '../../types'
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const { addAction, addDurationVital, getInternalContext } = vi.hoisted(() => ({
+const {
+  addAction,
+  addDurationVital,
+  addFeatureFlagEvaluation,
+  getInternalContext
+} = vi.hoisted(() => ({
   addAction: vi.fn(),
   addDurationVital: vi.fn(),
+  addFeatureFlagEvaluation: vi.fn(),
   getInternalContext: vi.fn()
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addAction, addDurationVital, getInternalContext }
+  datadogRum: {
+    addAction,
+    addDurationVital,
+    addFeatureFlagEvaluation,
+    getInternalContext
+  }
 }))
 
 const workflowExecutionIntent = {
@@ -24,6 +35,18 @@ afterEach(() => {
 })
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('records a feature flag exposure', () => {
+    new DatadogRumTelemetryProvider().trackFeatureFlagExposure(
+      'might_be_risky_feature_foo',
+      false
+    )
+
+    expect(addFeatureFlagEvaluation).toHaveBeenCalledExactlyOnceWith(
+      'might_be_risky_feature_foo',
+      false
+    )
+  })
+
   it('records the same canonical billing name and context as PostHog', () => {
     const event: BillingTelemetryEvent = {
       operation: 'operation',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -11,6 +11,10 @@ import {
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackFeatureFlagExposure(key: string, value: boolean): void {
+    datadogRum.addFeatureFlagEvaluation(key, value)
+  }
+
   trackBillingEvent(event: BillingTelemetryEvent): void {
     datadogRum.addAction(
       getBillingTelemetryEventName(event),

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -354,6 +354,25 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('flushes a feature flag exposure recorded before initialization', async () => {
+      const provider = createProvider()
+
+      provider.trackFeatureFlagExposure('might_be_risky_feature_foo', false)
+
+      expect(hoisted.mockCapture).not.toHaveBeenCalled()
+
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockCapture).toHaveBeenCalledExactlyOnceWith(
+        '$feature_flag_called',
+        {
+          $feature_flag: 'might_be_risky_feature_foo',
+          $feature_flag_response: false,
+          feature_flag_value: false
+        }
+      )
+    })
+
     it('captures events after initialization', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -338,6 +338,22 @@ describe('PostHogTelemetryProvider', () => {
   })
 
   describe('event tracking', () => {
+    it('records a feature flag exposure with PostHog standard properties', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackFeatureFlagExposure('might_be_risky_feature_foo', true)
+
+      expect(hoisted.mockCapture).toHaveBeenCalledExactlyOnceWith(
+        '$feature_flag_called',
+        {
+          $feature_flag: 'might_be_risky_feature_foo',
+          $feature_flag_response: true,
+          feature_flag_value: true
+        }
+      )
+    })
+
     it('captures events after initialization', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -81,8 +81,8 @@ const TELEMETRY_EVENT_SET = new Set<TelemetryEventName>(
 )
 
 interface QueuedEvent {
-  eventName: TelemetryEventName
-  properties?: TelemetryEventProperties
+  eventName: TelemetryEventName | '$feature_flag_called'
+  properties?: TelemetryEventProperties | Record<string, unknown>
 }
 
 interface DesktopEntryProps {
@@ -259,11 +259,16 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   }
 
   private captureRaw(
-    eventName: TelemetryEventName,
+    eventName: TelemetryEventName | '$feature_flag_called',
     properties?: Record<string, unknown>
   ): void {
     if (!this.isEnabled) return
-    if (this.disabledEvents.has(eventName)) return
+    if (
+      eventName !== '$feature_flag_called' &&
+      this.disabledEvents.has(eventName)
+    ) {
+      return
+    }
 
     if (this.isInitialized && this.posthog) {
       try {
@@ -272,11 +277,16 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         console.error('Failed to track PostHog event:', error)
       }
     } else {
-      this.eventQueue.push({
-        eventName,
-        properties: properties as TelemetryEventProperties
-      })
+      this.eventQueue.push({ eventName, properties })
     }
+  }
+
+  trackFeatureFlagExposure(key: string, value: boolean): void {
+    this.captureRaw('$feature_flag_called', {
+      $feature_flag: key,
+      $feature_flag_response: value,
+      feature_flag_value: value
+    })
   }
 
   private configureDisabledEvents(config: Partial<RemoteConfig> | null): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -780,6 +780,8 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
  * All methods are optional - providers only implement what they need.
  */
 export interface TelemetryProvider {
+  trackFeatureFlagExposure?(key: string, value: boolean): void
+
   // Authentication flow events
   trackSignupOpened?(): void
   trackAuth?(metadata: AuthMetadata): void

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -179,7 +179,13 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(mockRefreshRemoteConfig).toHaveBeenCalledWith({ useAuth: true })
+      expect(mockRefreshRemoteConfig).toHaveBeenCalledWith({
+        useAuth: true,
+        getSessionId: expect.any(Function)
+      })
+      expect(mockRefreshRemoteConfig.mock.calls[0][0].getSessionId()).toBe(
+        'user-123'
+      )
     })
 
     it('renders slot when teamWorkspacesEnabled is false', async () => {

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -65,7 +65,10 @@ async function initialize(): Promise<void> {
     // This ensures teamWorkspacesEnabled reflects the authenticated user's state
     // Timeout prevents hanging if server is slow/unresponsive
     await Promise.race([
-      refreshRemoteConfig({ useAuth: true }),
+      refreshRemoteConfig({
+        useAuth: true,
+        getSessionId: () => currentUser.value?.uid ?? null
+      }),
       promiseTimeout(CONFIG_REFRESH_TIMEOUT_MS).then(() => {
         throw new Error('Config refresh timeout')
       })


### PR DESCRIPTION
## Summary

Use any PostHog key without Cloud registration.

- `useFeatureGate(key)` requests Cloud evaluation and defaults to `false`.
- Missing, timed-out, or failed evaluations fail closed.
- Registered keys refresh every 30 seconds.
- Exposure records the resolved boolean in PostHog and Datadog once per tab.
- The demo calls `/api/fastlane-demo` only when enabled.

Depends on https://github.com/Comfy-Org/cloud/pull/5711.

## Validation

- 145 focused tests pass.
- Typecheck, lint, format, knip, and local CodeRabbit pass.
- CI is running on `c3fc1c4ff7c80b978ff2dadda831926fd67ef010`.

Created by Codex