### PR TITLE
fix: keep missing node packs across runs

### DIFF
--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -316,7 +316,7 @@ describe('useWorkflowService', () => {
       )
     })
 
-    it('should cache missing nodes before clearing the current store', () => {
+    it('should cache missing nodes without clearing the current store', () => {
       const activeWorkflow = createModeTestWorkflow({
         path: 'workflows/test.json'
       })
@@ -330,7 +330,9 @@ describe('useWorkflowService', () => {
       expect(activeWorkflow.pendingWarnings?.missingNodeTypes).toEqual(
         missingNodeTypes
       )
-      expect(missingNodesStore.missingNodesError).toBeNull()
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual(
+        missingNodeTypes
+      )
     })
 
     it('should save active workflow state through the V2 draft store', () => {

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -316,6 +316,23 @@ describe('useWorkflowService', () => {
       )
     })
 
+    it('should cache missing nodes before clearing the current store', () => {
+      const activeWorkflow = createModeTestWorkflow({
+        path: 'workflows/test.json'
+      })
+      workflowStore.activeWorkflow = activeWorkflow
+      const missingNodesStore = useMissingNodesErrorStore()
+      const missingNodeTypes = ['MissingGroupNode']
+      missingNodesStore.setMissingNodeTypes(missingNodeTypes)
+
+      useWorkflowService().beforeLoadNewGraph()
+
+      expect(activeWorkflow.pendingWarnings?.missingNodeTypes).toEqual(
+        missingNodeTypes
+      )
+      expect(missingNodesStore.missingNodesError).toBeNull()
+    })
+
     it('should save active workflow state through the V2 draft store', () => {
       vi.spyOn(useSettingStore(), 'get').mockImplementation((key: string) => {
         return key === 'Comfy.Workflow.Persist'

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -430,8 +430,6 @@ export const useWorkflowService = () => {
       // Save subgraph viewport before the canvas gets overwritten
       useSubgraphNavigationStore().saveCurrentViewport()
     }
-
-    missingNodesErrorStore.setMissingNodeTypes([])
   }
 
   /**

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -430,6 +430,8 @@ export const useWorkflowService = () => {
       // Save subgraph viewport before the canvas gets overwritten
       useSubgraphNavigationStore().saveCurrentViewport()
     }
+
+    missingNodesErrorStore.setMissingNodeTypes([])
   }
 
   /**

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -235,12 +235,15 @@ describe('ComfyApp', () => {
         workflow: createWorkflowGraphData()
       })
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      return graph
     }
 
-    it('preserves missing node packs when submitting a prompt', async () => {
-      prepareEmptyPromptQueue()
+    it('preserves live missing node packs when submitting a prompt', async () => {
+      const graph = prepareEmptyPromptQueue()
+      const nodeType = 'test/UninstalledLiveNode'
+      graph.add(new LGraphNode('Uninstalled Live Node', nodeType))
       const missingNodesStore = useMissingNodesErrorStore()
-      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      missingNodesStore.setMissingNodeTypes([nodeType])
       vi.spyOn(api, 'queuePrompt').mockResolvedValue({
         prompt_id: 'job-1',
         error: ''
@@ -249,8 +252,36 @@ describe('ComfyApp', () => {
       await app.queuePrompt(0)
 
       expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
-        'MissingGroupNode'
+        expect.objectContaining({ type: nodeType })
       ])
+    })
+
+    it('retires API-only missing node packs after a successful submission', async () => {
+      prepareEmptyPromptQueue()
+      const nodeType = 'test/UninstalledApiNode'
+      const missingNodesStore = useMissingNodesErrorStore()
+      app.loadApiJson(
+        {
+          '1': {
+            class_type: nodeType,
+            inputs: {},
+            _meta: { title: 'Uninstalled API Node' }
+          }
+        },
+        ''
+      )
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([nodeType])
+      expect(useExecutionErrorStore().hasMissingError).toBe(true)
+
+      await app.queuePrompt(0)
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
+      expect(useExecutionErrorStore().hasMissingError).toBe(false)
     })
 
     it('shows the error overlay for successful prompt responses with node errors', async () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -815,6 +815,14 @@ describe('ComfyApp', () => {
         await app.handleFile(createTestFile('a1111.png', 'image/png'))
 
         expect(missingNodesStore.missingNodesError).toBeNull()
+        expect(mockWorkspaceWorkflow.createNewTemporary).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            nodes: expect.arrayContaining([
+              expect.objectContaining({ type: 'CheckpointLoaderSimple' })
+            ])
+          })
+        )
       } finally {
         for (const nodeType of nodeTypes) {
           LiteGraph.unregisterNodeType(nodeType)

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -785,6 +785,7 @@ describe('ComfyApp', () => {
       expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
         'MissingGroupNode'
       ])
+      expect(mockWorkspaceWorkflow.createNewTemporary).not.toHaveBeenCalled()
     })
 
     it('clears missing node packs after importing A1111 parameters', async () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -22,6 +22,7 @@ import {
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { setTelemetryRegistry } from '@/platform/telemetry'
 import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
 import * as executionContextUtils from '@/platform/telemetry/utils/getExecutionContext'
@@ -69,10 +70,13 @@ const {
     invokeExtensionsAsync: vi.fn()
   },
   mockNodeOutputStore: {
-    refreshNodeOutputs: vi.fn()
+    refreshNodeOutputs: vi.fn(),
+    resetAllOutputsAndPreviews: vi.fn()
   },
   mockWorkspaceWorkflow: {
-    activeWorkflow: null as ComfyWorkflow | null
+    activeWorkflow: null as ComfyWorkflow | null,
+    createNewTemporary: vi.fn(),
+    openWorkflow: vi.fn()
   },
   mockRefreshMissingModelPipeline: vi.fn()
 }))
@@ -127,6 +131,13 @@ vi.mock('@/services/extensionService', () => ({
 
 vi.mock('@/stores/nodeOutputStore', () => ({
   useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
+}))
+
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: vi.fn(() => ({
+    saveCurrentViewport: vi.fn(),
+    updateHash: vi.fn()
+  }))
 }))
 
 vi.mock('@/stores/workspaceStore', () => ({
@@ -192,6 +203,13 @@ describe('ComfyApp', () => {
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
     mockWorkspaceWorkflow.activeWorkflow = null
+    const temporaryWorkflow = new ComfyWorkflow({
+      path: 'workflows/temporary.json',
+      modified: 0,
+      size: 0
+    })
+    mockWorkspaceWorkflow.createNewTemporary.mockReturnValue(temporaryWorkflow)
+    mockWorkspaceWorkflow.openWorkflow.mockResolvedValue(temporaryWorkflow)
     mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
     mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
@@ -218,6 +236,22 @@ describe('ComfyApp', () => {
       })
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
+
+    it('preserves missing node packs when submitting a prompt', async () => {
+      prepareEmptyPromptQueue()
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      await app.queuePrompt(0)
+
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+        'MissingGroupNode'
+      ])
+    })
 
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
@@ -692,6 +726,36 @@ describe('ComfyApp', () => {
 
       await expect(firstQueue).resolves.toBe(true)
       expect(useExecutionErrorStore().lastNodeErrors).toBeNull()
+    })
+  })
+
+  describe('workflow lifecycle', () => {
+    it('clears missing node packs when loading another workflow', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      app.canvasElRef.value = document.createElement('canvas')
+      mockCanvas.setDirty = vi.fn()
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+
+      await app.loadGraphData(createWorkflowGraphData(), false, false, null, {
+        deferWarnings: true,
+        skipAssetScans: true
+      })
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
+    })
+
+    it('clears missing node packs when clearing the workflow', () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+
+      app.clean()
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
     })
   })
 

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type {
   ComfyApiWorkflow,
@@ -730,19 +730,45 @@ describe('ComfyApp', () => {
   })
 
   describe('workflow lifecycle', () => {
-    it('clears missing node packs when loading another workflow', async () => {
+    it('clears missing node packs before loading API JSON without missing nodes', () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
-      app.canvasElRef.value = document.createElement('canvas')
-      mockCanvas.setDirty = vi.fn()
       const missingNodesStore = useMissingNodesErrorStore()
       missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      const nodeType = 'test/RegisteredApiNode'
+      class RegisteredApiNode extends LGraphNode {}
+      LiteGraph.registerNodeType(nodeType, RegisteredApiNode)
 
-      await app.loadGraphData(createWorkflowGraphData(), false, false, null, {
-        deferWarnings: true,
-        skipAssetScans: true
+      try {
+        app.loadApiJson(
+          {
+            '1': {
+              class_type: nodeType,
+              inputs: {},
+              _meta: { title: 'Registered API Node' }
+            }
+          },
+          ''
+        )
+
+        expect(missingNodesStore.missingNodesError).toBeNull()
+      } finally {
+        LiteGraph.unregisterNodeType(nodeType)
+      }
+    })
+
+    it('clears missing node packs before importing A1111 parameters', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        parameters: 'A1111 parameters without generation metadata'
       })
+
+      await app.handleFile(createTestFile('.png', 'image/png'))
 
       expect(missingNodesStore.missingNodesError).toBeNull()
     })

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -76,7 +76,8 @@ const {
   mockWorkspaceWorkflow: {
     activeWorkflow: null as ComfyWorkflow | null,
     createNewTemporary: vi.fn(),
-    openWorkflow: vi.fn()
+    openWorkflow: vi.fn(),
+    getWorkflowByPath: vi.fn(() => null)
   },
   mockRefreshMissingModelPipeline: vi.fn()
 }))
@@ -235,15 +236,24 @@ describe('ComfyApp', () => {
         workflow: createWorkflowGraphData()
       })
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
-      return graph
     }
 
     it('preserves missing node packs when submitting a prompt', async () => {
-      const graph = prepareEmptyPromptQueue()
+      prepareEmptyPromptQueue()
       const nodeType = 'test/UninstalledLiveNode'
-      graph.add(new LGraphNode('Uninstalled Live Node', nodeType))
       const missingNodesStore = useMissingNodesErrorStore()
+      const executionErrorStore = useExecutionErrorStore()
       missingNodesStore.setMissingNodeTypes([nodeType])
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
       vi.spyOn(api, 'queuePrompt').mockResolvedValue({
         prompt_id: 'job-1',
         error: ''
@@ -252,6 +262,7 @@ describe('ComfyApp', () => {
       await app.queuePrompt(0)
 
       expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([nodeType])
+      expect(executionErrorStore.lastExecutionError).toBeNull()
     })
 
     it('shows the error overlay for successful prompt responses with node errors', async () => {
@@ -759,7 +770,7 @@ describe('ComfyApp', () => {
       }
     })
 
-    it('clears missing node packs before importing A1111 parameters', async () => {
+    it('preserves missing node packs when A1111 parameters do not import', async () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
       Reflect.set(singletonApp, 'rootGraphInternal', graph)
@@ -769,9 +780,46 @@ describe('ComfyApp', () => {
         parameters: 'A1111 parameters without generation metadata'
       })
 
-      await app.handleFile(createTestFile('.png', 'image/png'))
+      await app.handleFile(createTestFile('a1111-bail.png', 'image/png'))
 
-      expect(missingNodesStore.missingNodesError).toBeNull()
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+        'MissingGroupNode'
+      ])
+    })
+
+    it('clears missing node packs after importing A1111 parameters', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        parameters:
+          'positive\nNegative prompt: negative\nSteps: 20, Sampler: Euler, CFG scale: 7, Seed: 1, Size: 512x512, Model: model.safetensors'
+      })
+      vi.spyOn(api, 'getEmbeddings').mockResolvedValue([])
+      const nodeTypes = [
+        'CheckpointLoaderSimple',
+        'CLIPSetLastLayer',
+        'CLIPTextEncode',
+        'KSampler',
+        'EmptyLatentImage',
+        'VAEDecode',
+        'SaveImage'
+      ]
+      for (const nodeType of nodeTypes) {
+        LiteGraph.registerNodeType(nodeType, class extends LGraphNode {})
+      }
+
+      try {
+        await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+        expect(missingNodesStore.missingNodesError).toBeNull()
+      } finally {
+        for (const nodeType of nodeTypes) {
+          LiteGraph.unregisterNodeType(nodeType)
+        }
+      }
     })
 
     it('clears missing node packs when clearing the workflow', () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -238,7 +238,7 @@ describe('ComfyApp', () => {
       return graph
     }
 
-    it('preserves live missing node packs when submitting a prompt', async () => {
+    it('preserves missing node packs when submitting a prompt', async () => {
       const graph = prepareEmptyPromptQueue()
       const nodeType = 'test/UninstalledLiveNode'
       graph.add(new LGraphNode('Uninstalled Live Node', nodeType))
@@ -251,37 +251,7 @@ describe('ComfyApp', () => {
 
       await app.queuePrompt(0)
 
-      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
-        expect.objectContaining({ type: nodeType })
-      ])
-    })
-
-    it('retires API-only missing node packs after a successful submission', async () => {
-      prepareEmptyPromptQueue()
-      const nodeType = 'test/UninstalledApiNode'
-      const missingNodesStore = useMissingNodesErrorStore()
-      app.loadApiJson(
-        {
-          '1': {
-            class_type: nodeType,
-            inputs: {},
-            _meta: { title: 'Uninstalled API Node' }
-          }
-        },
-        ''
-      )
-      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
-        prompt_id: 'job-1',
-        error: ''
-      })
-
       expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([nodeType])
-      expect(useExecutionErrorStore().hasMissingError).toBe(true)
-
-      await app.queuePrompt(0)
-
-      expect(missingNodesStore.missingNodesError).toBeNull()
-      expect(useExecutionErrorStore().hasMissingError).toBe(false)
     })
 
     it('shows the error overlay for successful prompt responses with node errors', async () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1685,7 +1685,7 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     const executionErrorStore = useExecutionErrorStore()
     const telemetry = useTelemetry()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
@@ -2409,7 +2409,7 @@ export class ComfyApp {
     const nodeOutputStore = useNodeOutputStore()
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
     useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1222,6 +1222,7 @@ export class ComfyApp {
       silentAssetErrors = false
     } = options
     useWorkflowService().beforeLoadNewGraph()
+    useMissingNodesErrorStore().setMissingNodeTypes([])
 
     if (skipAssetScans) {
       // Only reset candidates; preserve UI state (fileSizes, etc.)
@@ -2409,6 +2410,7 @@ export class ComfyApp {
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
     executionErrorStore.clearAllErrors()
+    useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1753,6 +1753,7 @@ export class ComfyApp {
               throw error
             }
           )
+          rescanAndSurfaceMissingNodes(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           let workflowContext: WorkflowExecutionContext | undefined
           if (executionContext) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2059,7 +2059,10 @@ export class ComfyApp {
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
       useWorkflowService().beforeLoadNewGraph()
-      importA1111(this.rootGraph, parameters)
+      const graphWasReplaced = await importA1111(this.rootGraph, parameters)
+      if (graphWasReplaced) {
+        useMissingNodesErrorStore().setMissingNodeTypes([])
+      }
       useWorkflowService().afterLoadNewGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
@@ -2198,6 +2201,7 @@ export class ComfyApp {
     const missingNodeTypes = Object.values(apiData).filter(
       (n) => !LiteGraph.registered_node_types[n.class_type]
     )
+    useMissingNodesErrorStore().setMissingNodeTypes([])
     if (missingNodeTypes.length) {
       this.showMissingNodesError(missingNodeTypes.map((t) => t.class_type))
     }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2201,10 +2201,7 @@ export class ComfyApp {
     const missingNodeTypes = Object.values(apiData).filter(
       (n) => !LiteGraph.registered_node_types[n.class_type]
     )
-    useMissingNodesErrorStore().setMissingNodeTypes([])
-    if (missingNodeTypes.length) {
-      this.showMissingNodesError(missingNodeTypes.map((t) => t.class_type))
-    }
+    this.showMissingNodesError(missingNodeTypes.map((t) => t.class_type))
 
     const ids = Object.keys(apiData)
     app.rootGraph.clear()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2062,12 +2062,12 @@ export class ComfyApp {
       const graphWasReplaced = await importA1111(this.rootGraph, parameters)
       if (graphWasReplaced) {
         useMissingNodesErrorStore().setMissingNodeTypes([])
+        useWorkflowService().afterLoadNewGraph(
+          fileName,
+          this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
+        )
+        return
       }
-      useWorkflowService().afterLoadNewGraph(
-        fileName,
-        this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
-      )
-      return
     }
 
     this.showErrorOnFileLoad(file)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1753,7 +1753,6 @@ export class ComfyApp {
               throw error
             }
           )
-          rescanAndSurfaceMissingNodes(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           let workflowContext: WorkflowExecutionContext | undefined
           if (executionContext) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1222,7 +1222,6 @@ export class ComfyApp {
       silentAssetErrors = false
     } = options
     useWorkflowService().beforeLoadNewGraph()
-    useMissingNodesErrorStore().setMissingNodeTypes([])
 
     if (skipAssetScans) {
       // Only reset candidates; preserve UI state (fileSizes, etc.)

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -183,7 +183,7 @@ interface LoraEntry {
 export async function importA1111(
   graph: LGraph,
   parameters: string
-): Promise<void> {
+): Promise<boolean> {
   const p = parameters.lastIndexOf('\nSteps:')
   if (p > -1) {
     const embeddings = await api.getEmbeddings()
@@ -193,7 +193,7 @@ export async function importA1111(
       .match(
         new RegExp('\\s*([^:]+:\\s*([^"\\{].*?|".*?"|\\{.*?\\}))\\s*(,|$)', 'g')
       )
-    if (!matchResult) return
+    if (!matchResult) return false
 
     const opts: Record<string, string> = matchResult.reduce(
       (acc: Record<string, string>, n: string) => {
@@ -231,7 +231,7 @@ export async function importA1111(
         !saveNode
       ) {
         console.error('Failed to create required nodes for A1111 import')
-        return
+        return false
       }
 
       let hrSamplerNode: LGraphNode | null = null
@@ -551,6 +551,8 @@ export async function importA1111(
       }
 
       console.warn('Unhandled parameters:', opts)
+      return true
     }
   }
+  return false
 }

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -849,7 +849,7 @@ describe('clearAllErrors', () => {
     missingNodesStore = useMissingNodesErrorStore()
   })
 
-  it('resets all error categories and closes error overlay', () => {
+  it('resets run errors while preserving missing setup state', () => {
     executionErrorStore.recordExecutionError({
       prompt_id: 'test',
       timestamp: 0,
@@ -889,8 +889,10 @@ describe('clearAllErrors', () => {
     expect(executionErrorStore.lastExecutionError).toBeNull()
     expect(executionErrorStore.lastPromptError).toBeNull()
     expect(executionErrorStore.lastNodeErrors).toBeNull()
-    expect(missingNodesStore.missingNodesError).toBeNull()
+    expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+      { type: 'MissingNode', hint: '' }
+    ])
     expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
-    expect(executionErrorStore.hasAnyError).toBe(false)
+    expect(executionErrorStore.hasAnyError).toBe(true)
   })
 })

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import type { MissingNodeType } from '@/types/comfy'
 import {
   createBoundaryLinkedSubgraph,
   createTestRootGraph,
@@ -879,9 +878,7 @@ describe('clearRunErrors', () => {
         class_type: 'Test'
       }
     })
-    missingNodesStore.setMissingNodeTypes(
-      fromAny<MissingNodeType[], unknown>([{ type: 'MissingNode', hint: '' }])
-    )
+    missingNodesStore.setMissingNodeTypes([{ type: 'MissingNode', hint: '' }])
     executionErrorStore.showErrorOverlay()
 
     executionErrorStore.clearRunErrors()
@@ -893,5 +890,6 @@ describe('clearRunErrors', () => {
       { type: 'MissingNode', hint: '' }
     ])
     expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
+    expect(executionErrorStore.hasAnyError).toBe(true)
   })
 })

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -838,7 +838,7 @@ describe('hasMissingError', () => {
   })
 })
 
-describe('clearAllErrors', () => {
+describe('clearRunErrors', () => {
   let executionErrorStore: ReturnType<typeof useExecutionErrorStore>
   let missingNodesStore: ReturnType<typeof useMissingNodesErrorStore>
 
@@ -849,7 +849,7 @@ describe('clearAllErrors', () => {
     missingNodesStore = useMissingNodesErrorStore()
   })
 
-  it('resets run errors while preserving missing setup state', () => {
+  it('resets run errors while preserving missing node packs', () => {
     executionErrorStore.recordExecutionError({
       prompt_id: 'test',
       timestamp: 0,
@@ -884,7 +884,7 @@ describe('clearAllErrors', () => {
     )
     executionErrorStore.showErrorOverlay()
 
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
 
     expect(executionErrorStore.lastExecutionError).toBeNull()
     expect(executionErrorStore.lastPromptError).toBeNull()
@@ -893,6 +893,5 @@ describe('clearAllErrors', () => {
       { type: 'MissingNode', hint: '' }
     ])
     expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
-    expect(executionErrorStore.hasAnyError).toBe(true)
   })
 })

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -83,11 +83,11 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /** Clear errors tied to the previous run.
-   *  Missing node, model, and media state is preserved because submission does
-   *  not resolve setup issues. Workflow load clears all three; explicit
-   *  workflow clean also clears missing nodes. */
-  function clearAllErrors() {
+  /**
+   * `clearMissingModels()` also resets imported model download task IDs and
+   * file sizes, unlike `setMissingModels([])`.
+   */
+  function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null
     lastNodeErrors.value = null
@@ -549,7 +549,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     recordPromptError,
 
     // Clearing
-    clearAllErrors,
+    clearRunErrors,
     clearExecutionStartErrors,
     clearPromptError,
 

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -83,10 +83,11 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /**
-   * `clearMissingModels()` also resets imported model download task IDs and
-   * file sizes, unlike `setMissingModels([])`.
-   */
+  /** Clear errors tied to the previous run: execution, prompt, and node errors.
+   *  Missing node, model, and media state is deliberately preserved — a missing
+   *  resource can sit on a branch the run never executed, so a submission says
+   *  nothing about whether it is still missing, and installing a node pack needs
+   *  a backend restart. Missing state is cleared where the graph is replaced. */
   function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -83,15 +83,14 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /** Clear all error state.
-   *  Missing model state is intentionally preserved here to avoid wiping
-   *  in-progress model repairs (importTaskIds, URL inputs, etc.).
-   *  Missing models are cleared separately during workflow load/clean paths. */
+  /** Clear errors tied to the previous run.
+   *  Missing node, model, and media state is preserved because submission does
+   *  not resolve setup issues. Workflow load clears all three; explicit
+   *  workflow clean also clears missing nodes. */
   function clearAllErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null
     lastNodeErrors.value = null
-    missingNodesStore.setMissingNodeTypes([])
     isErrorOverlayOpen.value = false
   }
 

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -87,7 +87,8 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
    *  Missing node, model, and media state is deliberately preserved — a missing
    *  resource can sit on a branch the run never executed, so a submission says
    *  nothing about whether it is still missing, and installing a node pack needs
-   *  a backend restart. Missing state is cleared where the graph is replaced. */
+   *  a backend restart. Missing nodes are cleared by `ComfyApp.clean` and by the
+   *  file-import paths that rebuild the graph. */
   function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null


### PR DESCRIPTION
## Summary

Missing node packs were wiped from the Issues/Errors panel on every prompt submission, while missing model and media state was deliberately preserved. This aligns node packs with the other two.

## Why this matters now

#14177 (FE-1388) replaced the Run-button warning icon's independent derivation with a store read:

```diff
-const hasMissingNodes = computed(() => graphHasMissingNodes(app.rootGraph, nodeDefStore.nodeDefsByName))
+const { hasMissingError } = storeToRefs(useExecutionErrorStore())
```

Before that, the icon re-derived from the graph on every access, so `clearAllErrors()` on submit could not affect it. After it, the icon is a pure read of `missingNodeTypes` — so the submit-time wipe started flipping the Run button from `triangle-alert` back to `play` on the first submission. This closes that window.

Blame also shows the submit-time clear was an omission rather than a decision: the commit that introduced missing-node state added the clear in the same stroke with no comment and no test, while adding 97 lines of tests for the adjacent API. The `clearAllErrors()` call in `queuePrompt` predates missing-node state by ~20 months.

## Changes

- `clearAllErrors` renamed to `clearRunErrors`, and it no longer clears missing-node state. The name now matches what it does: it resets the three categories this store owns and leaves the three that live in other stores.
- Missing-node state is cleared where the graph is actually replaced: `loadApiJson`, the `importA1111` branch (gated on the import having happened), and `clean()`.
- `importA1111` returns `Promise<boolean>` so the caller can tell whether the graph was rebuilt, and is now awaited. When it reports `false` the caller no longer finalizes a workflow — it falls through to `showErrorOnFileLoad`, which already reports an unusable file. Previously a failed import still registered the *unchanged* graph under the dropped file's name.

## Review focus

**Why the clear is not in `beforeLoadNewGraph()`.** That looked like the natural funnel — all three documented graph-load entry points call it — but it is wrong in both directions:

- `importA1111` calls it and then has four early returns (`pnginfo.ts:188/196/210/234`) that leave the graph untouched, so the card was wiped while every missing node was still on the canvas.
- `loadGraphData` never needed it: it re-derives the whole list on every path, either via `clean()` or via `showPendingWarnings` -> `surfaceMissingNodes(... ?? [])`. Clearing at the top only opened a window in which `hasAnyError` was briefly false, during which the right-panel `watchEffect` reassigned the active tab from Errors to Parameters and never restored it — so every undo on a workflow whose only error was a missing pack silently switched the panel.

**Why `clean()` keeps its own clear.** It is not a caller of `beforeLoadNewGraph`, and it is reached standalone from `Comfy.ClearWorkflow` and the legacy Clear button.

**Awaiting `importA1111`** is required to read its return value, and it also fixes a latent ordering bug: the function's first suspension point precedes its only graph mutation, so `rootGraph.serialize()` on the next line previously captured the *outgoing* graph — the new tab was born dirty against a stale baseline. A prior PR (#7840) fixed this and was reverted pending a split that never landed.

Every production line is mutation-proved: reverting it fails the test that names it, restoring it passes.

## Findings for the team — not fixed here

**1. Should an API-format load silently drop unsupported nodes?** `loadApiJson` does `const node = LiteGraph.createNode(data.class_type); if (!node) continue` — the node is never added to the graph. Normal workflow loads do not do this; the established idiom elsewhere in the codebase is to build a placeholder `LGraphNode` with `has_errors = true` (see `LGraph.ts`'s subgraph-unpack path).

The consequence is visible today, independent of this PR: open an API JSON referencing an uninstalled node and you get a "Missing Node Packs" card for a node that exists on no canvas. Because the entry carries no `nodeId`, every targeted remover preserves it by design, the card renders no Install/Locate/Apply action (those require a known pack), and the Errors tab has no dismiss control. Previously the submit-time wipe cleared it as a side effect; with that gone, the only exits are loading another workflow or reloading the page.

If the silent drop is unintentional, creating the placeholder fixes this class outright — the entry anchors to a node, deleting the node retires it, and API loads behave like every other load. If it is intentional, we need a dismiss affordance for unknown-pack groups instead. Either way it is a separate change; flagging it here so the decision is made deliberately rather than inherited.

**2. `beforeLoadNewGraph()` runs unconditionally on the A1111 branch, and it clears DOM widgets.** `app.ts:2061` calls it before we know whether the import will do anything. `importA1111` has four early returns that leave the graph untouched — the most reachable being a `parameters` chunk with `Steps:` but no `\nNegative prompt:` (`pnginfo.ts:210`). On those paths `domWidgetStore.clear()` has already run, no node is re-added to recreate the widget state, and the user's current workflow loses its textareas until it is reloaded; a thumbnail is captured and a draft persisted for a load that never happened.

This is pre-existing — `main` calls it unconditionally on this branch too — and gating it is not a one-liner, because three of the four bail conditions are only knowable after real work (`getEmbeddings`, the regex match, `createNode`). It needs `importA1111` split into a parse step and an apply step, with `beforeLoadNewGraph()` between them. Same territory as the reverted #7840.

**3. Drag-and-drop takes a different path than the file button.** The drop handler calls `showPendingWarnings()` after an un-awaited `afterLoadNewGraph`, so a freshly created temporary workflow (whose `pendingWarnings` is `null`) can re-apply an empty list over the store — wiping the card even when the graph was not replaced. This is pre-existing and unchanged by this PR (the `app.ts` delta does not touch that hunk), and it is the same class as (1). Worth folding into the same follow-up.

**4. Pre-existing and out of scope:** `Comfy.ClearWorkflow` clears missing nodes but not missing models or media, so those go stale on a manual clear. Same before and after this PR.
