### PR TITLE
feat: report assertion failures to Datadog RUM on cloud builds

### DIFF
--- a/src/base/assert.ts
+++ b/src/base/assert.ts
@@ -17,6 +17,10 @@ export function setAssertReporter(fn: AssertReporter | null): void {
  * - Always: console.error
  * - DEV: throws (surfaces bugs immediately)
  * - Otherwise: delegates to registered reporter (Sentry, toast, etc.)
+ *
+ * Reporters forward `message` to external telemetry, so it must be a static
+ * description of the invariant. Never interpolate user data (workflow names,
+ * paths, prompts) into it.
  */
 export function assert(condition: unknown, message: string): asserts condition {
   if (condition) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
   configValueOrDefault,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
+import { reportAssertFailureToRum } from '@/platform/telemetry/assertRumReporter'
 import { syncHostUserIdWithFirebaseAuth } from '@/platform/telemetry/hostUserIdSync'
 import '@/lib/litegraph/public/css/litegraph.css'
 import router from '@/router'
@@ -98,6 +99,9 @@ Sentry.init({
 setAssertReporter((message) => {
   if (isDesktop) {
     Sentry.captureMessage(message, { level: 'warning' })
+  }
+  if (isCloud) {
+    reportAssertFailureToRum(message)
   }
   if (isNightly) {
     useToastStore(pinia).add({

--- a/src/platform/telemetry/assertRumReporter.test.ts
+++ b/src/platform/telemetry/assertRumReporter.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { reportedErrors } = vi.hoisted(() => ({
+  reportedErrors: [] as { error: Error; context: unknown }[]
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    addError: (error: Error, context: unknown) => {
+      reportedErrors.push({ error, context })
+    }
+  }
+}))
+
+async function loadReporter() {
+  vi.resetModules()
+  return import('./assertRumReporter')
+}
+
+describe('reportAssertFailureToRum', () => {
+  beforeEach(() => {
+    reportedErrors.length = 0
+  })
+
+  it('reports each distinct message to RUM exactly once', async () => {
+    const { reportAssertFailureToRum } = await loadReporter()
+
+    reportAssertFailureToRum('[Assertion failed]: node missing')
+    reportAssertFailureToRum('[Assertion failed]: node missing')
+    reportAssertFailureToRum('[Assertion failed]: widget missing')
+
+    await vi.waitFor(() => expect(reportedErrors).toHaveLength(2))
+    expect(reportedErrors.map(({ error }) => error.message)).toEqual([
+      '[Assertion failed]: node missing',
+      '[Assertion failed]: widget missing'
+    ])
+    expect(reportedErrors[0].context).toEqual({ source: 'invariant-assert' })
+  })
+
+  it('stops reporting once the per-session cap is reached', async () => {
+    const { reportAssertFailureToRum } = await loadReporter()
+
+    for (let i = 0; i < 25; i++) {
+      reportAssertFailureToRum(`[Assertion failed]: failure ${i}`)
+    }
+
+    await vi.waitFor(() => expect(reportedErrors).toHaveLength(20))
+    expect(reportedErrors.at(-1)?.error.message).toBe(
+      '[Assertion failed]: failure 19'
+    )
+  })
+
+  it('builds the error synchronously so the stack holds the call site', async () => {
+    const { reportAssertFailureToRum } = await loadReporter()
+
+    function assertingCallSite() {
+      reportAssertFailureToRum('[Assertion failed]: stack check')
+    }
+    assertingCallSite()
+
+    await vi.waitFor(() => expect(reportedErrors).toHaveLength(1))
+    expect(reportedErrors[0].error.stack).toContain('assertingCallSite')
+  })
+})

--- a/src/platform/telemetry/assertRumReporter.test.ts
+++ b/src/platform/telemetry/assertRumReporter.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { reportedErrors } = vi.hoisted(() => ({
-  reportedErrors: [] as { error: Error; context: unknown }[]
+const { reportedErrors, rumState } = vi.hoisted(() => ({
+  reportedErrors: [] as { error: Error; context: unknown }[],
+  rumState: { failuresRemaining: 0 }
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
   datadogRum: {
     addError: (error: Error, context: unknown) => {
+      if (rumState.failuresRemaining > 0) {
+        rumState.failuresRemaining--
+        throw new Error('RUM unavailable')
+      }
       reportedErrors.push({ error, context })
     }
   }
@@ -20,6 +25,7 @@ async function loadReporter() {
 describe('reportAssertFailureToRum', () => {
   beforeEach(() => {
     reportedErrors.length = 0
+    rumState.failuresRemaining = 0
   })
 
   it('reports each distinct message to RUM exactly once', async () => {
@@ -48,6 +54,20 @@ describe('reportAssertFailureToRum', () => {
     expect(reportedErrors.at(-1)?.error.message).toBe(
       '[Assertion failed]: failure 19'
     )
+  })
+
+  it('retries a message whose send failed instead of consuming its cap slot', async () => {
+    const { reportAssertFailureToRum } = await loadReporter()
+    const message = '[Assertion failed]: transient send failure'
+    rumState.failuresRemaining = 1
+
+    reportAssertFailureToRum(message)
+
+    await vi.waitFor(() => {
+      reportAssertFailureToRum(message)
+      expect(reportedErrors).toHaveLength(1)
+    })
+    expect(reportedErrors[0].error.message).toBe(message)
   })
 
   it('builds the error synchronously so the stack holds the call site', async () => {

--- a/src/platform/telemetry/assertRumReporter.ts
+++ b/src/platform/telemetry/assertRumReporter.ts
@@ -21,10 +21,15 @@ export function reportAssertFailureToRum(message: string): void {
   // Built here, before awaiting the SDK, so the stack holds the assert call site.
   const error = new Error(message)
 
-  rumModule ??= import('@datadog/browser-rum')
-  void rumModule
+  const pending = (rumModule ??= import('@datadog/browser-rum'))
+  void pending
     .then(({ datadogRum }) => {
       datadogRum.addError(error, { source: 'invariant-assert' })
     })
-    .catch(() => {})
+    .catch(() => {
+      // Release the message and the cached import so a transient failure
+      // doesn't silently disable reporting for the rest of the session.
+      if (rumModule === pending) rumModule = undefined
+      reportedMessages.delete(message)
+    })
 }

--- a/src/platform/telemetry/assertRumReporter.ts
+++ b/src/platform/telemetry/assertRumReporter.ts
@@ -1,0 +1,30 @@
+import type * as DatadogRumModule from '@datadog/browser-rum'
+
+const MAX_REPORTS_PER_SESSION = 20
+
+const reportedMessages = new Set<string>()
+
+let rumModule: Promise<typeof DatadogRumModule> | undefined
+
+/**
+ * Send an assertion failure to Datadog RUM Error Tracking (cloud builds only).
+ *
+ * Invariants can fire from render loops, so reports are deduplicated by exact
+ * message and capped per session. The RUM SDK is imported lazily because it is
+ * only ever loaded on cloud, where `bootstrap.ts` has already resolved it.
+ */
+export function reportAssertFailureToRum(message: string): void {
+  if (reportedMessages.has(message)) return
+  if (reportedMessages.size >= MAX_REPORTS_PER_SESSION) return
+  reportedMessages.add(message)
+
+  // Built here, before awaiting the SDK, so the stack holds the assert call site.
+  const error = new Error(message)
+
+  rumModule ??= import('@datadog/browser-rum')
+  void rumModule
+    .then(({ datadogRum }) => {
+      datadogRum.addError(error, { source: 'invariant-assert' })
+    })
+    .catch(() => {})
+}

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -168,6 +168,11 @@ describe('ChangeTracker', () => {
           false,
           expect.stringContaining('captureCanvasState')
         )
+        // Assert messages reach external telemetry on cloud builds.
+        expect(mockAssert).not.toHaveBeenCalledWith(
+          false,
+          expect.stringContaining('/test/workflow.json')
+        )
       })
     })
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -29,15 +29,14 @@ const reportedInactiveCalls = new Set<string>()
 /**
  * Report a ChangeTracker method being called on an inactive tracker.
  * Deduplicates per method+workflow per session to avoid signal noise on hot paths.
+ * The workflow path stays in the local dedup key: assert messages are shipped to
+ * external telemetry on cloud builds, so they must not carry user data.
  */
 function reportInactiveTrackerCall(method: string, workflowPath: string) {
   const key = `${method}:${workflowPath}`
   if (reportedInactiveCalls.has(key)) return
   reportedInactiveCalls.add(key)
-  assert(
-    false,
-    `ChangeTracker.${method}() called on inactive tracker for: ${workflowPath}`
-  )
+  assert(false, `ChangeTracker.${method}() called on inactive tracker`)
 }
 
 export class ChangeTracker {


### PR DESCRIPTION
## ELI-5

When the app catches itself in an impossible state it calls `assert()`. Today that failure gets shouted into the browser console and nowhere else on cloud production, so nobody ever hears it. This wires those failures into Datadog Error Tracking for cloud builds — with a mute button so a broken render loop can't flood the pipe.

## Summary

Assertion failures are invisible on cloud production: the only assert reporter (`src/main.ts`) reports to Sentry when `isDesktop` and toasts when `isNightly`, and both are false on cloud, leaving invariant failures console-only. This adds an `isCloud` branch that forwards them to Datadog RUM Error Tracking, which is already initialised for cloud in `src/bootstrap.ts`.

## Changes

- **What**: new `src/platform/telemetry/assertRumReporter.ts` — `reportAssertFailureToRum(message)` sends `datadogRum.addError(new Error(message), { source: 'invariant-assert' })`, deduplicated by exact message and capped at 20 reports per session. `src/main.ts` calls it from a new `isCloud` branch inside the existing `setAssertReporter` callback; the desktop and nightly branches are untouched, and `src/base/assert.ts` (contract and console behaviour) is unchanged.
- **Dependencies**: none — `@datadog/browser-rum` is already a dependency and is loaded on cloud by `bootstrap.ts` before `main.ts` runs, so the lazy `import()` resolves from the module cache.

## Review Focus

`addError` rather than `addAction`: errors land in Error Tracking with stack traces and message-based grouping, which is what makes them monitorable/alertable. The existing `rumBeforeSend` filter passes them through — its drop rules only match `intervention:`, `ResizeObserver loop`, and network noise from a host allowlist — and it auto-tags `error.origin: first_party` from the `/assets/` stack frames.

The `Error` is constructed synchronously in the reporter, before the dynamic `import()` is awaited, so its stack captures the real `assert()` call site (`assert()` invokes the reporter synchronously). There is a unit test that fails if this construction moves into the `.then` callback — verified by mutating the source.

Two judgment calls worth a look:

1. The module promise is cached (`rumModule ??= import('@datadog/browser-rum')`) instead of calling `import()` per report. On cloud this is behaviourally identical — the module registry already caches the module — but it means a rejected import is cached too, so a one-off chunk-load failure would silently disable assert reporting for the rest of the session rather than retrying on the next assert. Given `bootstrap.ts` has already resolved the SDK on cloud, that failure path is close to unreachable, and dropping telemetry beats retrying a broken import up to 20 times. It also matters for testability: Vitest 4's mocker re-runs the `vi.mock` factory on each dynamic import, so without the cache the second and subsequent reports land on throwaway mock instances and the dedupe/cap behaviour can't be observed.
2. The dedupe `Set` doubles as the cap counter — every reported message is added to it, so `reportedMessages.size` is the report count. One piece of state, no separate counter to keep in sync.

Bundle impact: `main.ts` gains a static import of the ~30-line reporter module, not of the RUM SDK. The SDK reference is an erased `import type` plus a lazy `import()`, and `isCloud` folds to a build-time constant, so non-cloud builds dead-code-eliminate the call and drop the module entirely.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip`, and `pnpm vitest run src/platform/telemetry/assertRumReporter.test.ts src/base/assert.test.ts` (11 passed) are all green. New tests cover per-message dedupe, the 20-per-session cap, and synchronous error construction.

This change is purely additive — it adds a reporting path and denies no capability, so there is no capability-denial claim to falsify.
