### PR TITLE
wip nux lite

### DIFF
--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -8,6 +8,7 @@
         value: queueButtonTooltip,
         showDelay: 600
       }"
+      v-coachmark="COACH_IDS.graphRunButton"
       :variant="queueButtonVariant"
       size="unset"
       :class="queueActionButtonClass"
@@ -79,6 +80,8 @@ import TinyChevronIcon from '@/components/actionbar/TinyChevronIcon.vue'
 import Button from '@/components/ui/button/Button.vue'
 import ButtonGroup from '@/components/ui/button-group/ButtonGroup.vue'
 import { isCloud } from '@/platform/distribution/types'
+import { COACH_IDS } from '@/platform/onboarding/onboardingTours'
+import { vCoachmark } from '@/platform/onboarding/vCoachmark'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -14,6 +14,8 @@ import type {
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { isCoachKey, COACH_IDS } from '@/platform/onboarding/onboardingTours'
+import type { CoachId } from '@/platform/onboarding/onboardingTours'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
@@ -124,6 +126,7 @@ export interface VueNodeData {
   showAdvanced?: boolean
   subgraphId?: string | null
   titleMode?: TitleMode
+  tourStep?: CoachId
   widgets?: SafeWidgetData[]
 }
 
@@ -451,7 +454,7 @@ export function extractVueNodeData(node: LGraphNode): VueNodeData {
 
   const apiNode = node.constructor?.nodeData?.api_node ?? false
   const badges = node.badges
-
+  const tourStep = node.properties.tourStep
   return {
     id: node.id,
     title: typeof node.title === 'string' ? node.title : '',
@@ -472,7 +475,8 @@ export function extractVueNodeData(node: LGraphNode): VueNodeData {
     bgcolor: node.bgcolor || undefined,
     resizable: node.resizable,
     shape: node.shape,
-    showAdvanced: node.showAdvanced
+    showAdvanced: node.showAdvanced,
+    tourStep: isCoachKey(tourStep) ? COACH_IDS[tourStep] : undefined
   }
 }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4737,6 +4737,20 @@
         "title": "Find all your assets",
         "body": "Every generation and import lives in Media Assets. Open it anytime to browse, download, or reuse past work."
       }
+    },
+    "graph": {
+      "nodeReference": {
+        "title": "Start with an image",
+        "body": "This picture will be used as reference. Swap in your own whenever you like."
+      },
+      "nodePrompt": {
+        "title": "Describe what you want",
+        "body": "Your image gets built from this description. Try anything you like."
+      },
+      "run": {
+        "title": "Run your workflow",
+        "body": "Press Run to start generating your result."
+      }
     }
   }
 }

--- a/src/platform/onboarding/TourSpotlight.vue
+++ b/src/platform/onboarding/TourSpotlight.vue
@@ -7,6 +7,7 @@
           !targetRect && 'bg-coach-scrim'
         )
       "
+      :style="blockerStyle"
     />
     <div
       aria-hidden="true"
@@ -23,7 +24,7 @@
       <div
         ref="cardRef"
         role="dialog"
-        aria-modal="true"
+        :aria-modal="!allowsTargetInteraction"
         :aria-labelledby="titleId"
         :aria-describedby="`${subtitleId} ${bodyId}`"
         class="pointer-events-auto absolute max-h-[calc(100vh-var(--comfy-topbar-height)-2rem)] overflow-y-auto motion-safe:transition-[left,top] motion-safe:duration-300"
@@ -105,6 +106,7 @@ import {
   CARD_WIDTH,
   SPOTLIGHT_PAD,
   VIEWPORT_MARGIN,
+  blockerClipPath,
   clampSpotlight,
   noTargetCardLeft
 } from './coachmarkLayout'
@@ -154,6 +156,8 @@ const { width: windowWidth, height: windowHeight } = useWindowSize()
 
 const { targetRect, targetEl, floatingStyles, isPositioned } =
   useCoachmarkTarget(() => step, cardRef)
+
+const allowsTargetInteraction = computed(() => countedStepIdx % 2 === 0)
 
 // Last step's "Done" already dismisses, so hide Skip there.
 const showSkip = computed(() => !isLast)
@@ -215,6 +219,13 @@ const spotlightStyle = computed(() => {
   const r = targetRect.value
   if (!r) return { opacity: '0' }
   return { ...clampSpotlight(r, SPOTLIGHT_PAD, viewport()), opacity: '1' }
+})
+
+const blockerStyle = computed(() => {
+  const r = targetRect.value
+  if (r && allowsTargetInteraction.value)
+    return { clipPath: blockerClipPath(r) }
+  return {}
 })
 
 const cardStyle = computed(() => {

--- a/src/platform/onboarding/coachmarkLayout.ts
+++ b/src/platform/onboarding/coachmarkLayout.ts
@@ -38,6 +38,14 @@ export function clampSpotlight(
   }
 }
 
+export function blockerClipPath(r: DOMRect): string {
+  const x1 = `${r.left}px`
+  const y1 = `${r.top}px`
+  const x2 = `${r.right}px`
+  const y2 = `${r.bottom}px`
+  return `polygon(evenodd, 0 0, 100% 0, 100% 100%, 0 100%, 0 0, ${x1} ${y1}, ${x1} ${y2}, ${x2} ${y2}, ${x2} ${y1}, ${x1} ${y1})`
+}
+
 export function noTargetCardLeft(viewportWidth: number): number {
   return Math.max(VIEWPORT_MARGIN, (viewportWidth - CARD_WIDTH) / 2)
 }

--- a/src/platform/onboarding/onboardingTours.ts
+++ b/src/platform/onboarding/onboardingTours.ts
@@ -1,4 +1,7 @@
-export type EntryPath = 'appMode'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { app } from '@/scripts/app'
+
+export type EntryPath = 'appMode' | 'graph'
 
 /** Setting holding the tours the user has completed or dismissed. */
 export const TOUR_SEEN_SETTING = 'Comfy.OnboardingCoachmarks.Seen'
@@ -18,10 +21,15 @@ export const COACH_IDS = {
   appRunButton: 'app-run-button',
   inputsList: 'inputs-list',
   outputs: 'outputs',
-  assetsPanel: 'assets-panel'
+  assetsPanel: 'assets-panel',
+
+  nodeReference: 'node-reference',
+  nodePrompt: 'node-prompt',
+  graphRunButton: 'graph-run-button'
 } as const
 
-export type CoachId = (typeof COACH_IDS)[keyof typeof COACH_IDS]
+type CoachKey = keyof typeof COACH_IDS
+export type CoachId = (typeof COACH_IDS)[CoachKey]
 
 export interface CoachStep {
   /**
@@ -40,6 +48,10 @@ export interface CoachStep {
   /** Renders the landing dialog instead of a spotlight. */
   landing?: boolean
   image?: string
+}
+
+export function isCoachKey(val: unknown): val is CoachKey {
+  return typeof val === 'string' && val in COACH_IDS
 }
 
 /**
@@ -88,5 +100,41 @@ export const TOURS: Record<EntryPath, CoachStep[]> = {
       deferTarget: true,
       openSidebarTab: 'assets'
     }
-  ]
+  ],
+  get graph(): CoachStep[] {
+    const nodeKeys: CoachKey[] = ['nodeReference', 'nodePrompt']
+    const { nodes } = app.graph
+    const nodeSteps: [CoachKey, LGraphNode][] = nodeKeys.flatMap((key) => {
+      const node = nodes.find((n) => n.properties.tourStep === key)
+      return node ? [[key, node]] : []
+    })
+
+    const visible = new Set(app.canvas.visible_nodes.map((node) => node.id))
+    if (!nodeSteps.map(([, node]) => node.id).every((id) => visible.has(id))) {
+      app.canvas.selectItems(nodeSteps.map(([, node]) => node))
+      app.canvas.fitViewToSelectionAnimated()
+      app.canvas.selectItems([])
+    }
+    return [
+      ...nodeSteps.map(([key]) => ({
+        name: key,
+        coachId: COACH_IDS[key],
+        placement: 'auto' as const,
+        deferTarget: true
+      })),
+      {
+        name: 'run',
+        coachId: COACH_IDS.graphRunButton,
+        placement: 'auto' as const,
+        deferTarget: true
+      },
+      {
+        name: 'assets',
+        coachId: COACH_IDS.assetsPanel,
+        placement: 'auto' as const,
+        deferTarget: true,
+        openSidebarTab: 'assets'
+      }
+    ]
+  }
 }

--- a/src/platform/onboarding/useTourTriggers.ts
+++ b/src/platform/onboarding/useTourTriggers.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
 
 import { useAppMode } from '@/composables/useAppMode'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 
 import type { EntryPath } from './onboardingTours'
@@ -16,14 +17,26 @@ export interface TourTrigger {
 export function useTourTriggers(): [EntryPath, TourTrigger][] {
   const { mode } = useAppMode()
   const appModeStore = useAppModeStore()
+  const settingStore = useSettingStore()
   const desktopLayout = useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
   const inAppMode = computed(() => desktopLayout.value && mode.value === 'app')
+
+  const inGraphMode = computed(() => mode.value === 'graph')
   return [
     [
       'appMode',
       {
         holds: inAppMode,
         autoOpen: computed(() => inAppMode.value && appModeStore.hasOutputs)
+      }
+    ],
+    [
+      'graph',
+      {
+        holds: inGraphMode,
+        autoOpen: computed(
+          () => !settingStore.get('Comfy.TutorialCompleted') || true
+        )
       }
     ]
   ]

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -5,6 +5,7 @@
   <div
     v-else
     ref="nodeContainerRef"
+    v-coachmark="nodeData.tourStep"
     tabindex="0"
     :data-node-id="nodeData.id"
     :data-collapsed="isCollapsed || undefined"
@@ -268,6 +269,7 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 import { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { TitleMode } from '@/lib/litegraph/src/types/globalEnums'
+import { vCoachmark } from '@/platform/onboarding/vCoachmark'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'


### PR DESCRIPTION
A WIP lighter weight alternative implementation for new user tour.
- Leans closer into the app tour implementation
- Places real v-coachmarks on node elements
- provides a means for manual overrides on workflows.
  - (not implemented) but would still support in repo overrides
- (unfinished) improved click through state. Can pan the canvas, but only modify the active node.
- No polling
- Targeting 1/10th the code size. No complexity spirit demon here.