### PR TITLE
fix: preserve grouped asset selection across views

### DIFF
--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -303,7 +303,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
     await expect(
       groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'false')
+    ).toHaveAttribute('aria-pressed', 'mixed')
     await expect(
       groupedCard.getByRole('button', { name: 'See more outputs' })
     ).toHaveText('1/2')

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -311,6 +311,13 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await tab.openSettingsMenu()
     await tab.listViewOption.click()
     await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+    const groupedListItem = tab.listViewItems.filter({
+      hasText: 'multi-output-a'
+    })
+    await expect(groupedListItem).toHaveAttribute('aria-pressed', 'mixed')
+    await expect(
+      groupedListItem.getByRole('button', { name: 'See more outputs' })
+    ).toHaveText('1/2')
 
     await tab.gridLargeOption.click()
     await expect(
@@ -330,6 +337,54 @@ test.describe('FE-130 assets sidebar route mocks', () => {
         .getAssetCardByName('multi-output-b')
         .getByRole('button', { name: /multi-output-b.*asset/ })
     ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('toggles an inherited list child selection and preserves it in grid', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    const tab = comfyPage.menu.assetsTab
+
+    await jobsRoutes.mockJobsHistory([multiOutputJob])
+    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
+
+    await comfyPage.setup()
+    await tab.open()
+    await tab.openSettingsMenu()
+    await tab.listViewOption.click()
+
+    await tab.listViewItems.filter({ hasText: 'multi-output-a' }).click()
+    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+
+    await tab.listViewItems
+      .filter({ hasText: 'multi-output-a' })
+      .getByRole('button', { name: 'See more outputs' })
+      .click()
+    await expect(
+      tab.listViewItems.filter({ hasText: 'multi-output-b' })
+    ).toHaveAttribute('aria-pressed', 'true')
+
+    await comfyPage.page.keyboard.down('ControlOrMeta')
+    await tab.listViewItems.filter({ hasText: 'multi-output-b' }).click()
+    await comfyPage.page.keyboard.up('ControlOrMeta')
+
+    await expect(
+      tab.listViewItems.filter({ hasText: 'multi-output-a' })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+    await expect(
+      tab.listViewItems.filter({ hasText: 'multi-output-b' })
+    ).toHaveAttribute('aria-pressed', 'false')
+    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+
+    await tab.gridLargeOption.click()
+
+    const groupedCard = tab.getAssetCardByName('multi-output-a')
+    await expect(
+      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+    await expect(
+      groupedCard.getByRole('button', { name: 'See more outputs' })
+    ).toHaveText('1/2')
   })
 
   test('deletes a generated output asset through explicit history refresh', async ({

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -301,7 +301,9 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await tab.backToAssetsButton.click()
 
     await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
-    await expect(groupedCard).toHaveAttribute('data-selected', 'false')
+    await expect(
+      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+    ).toHaveAttribute('aria-pressed', 'false')
     await expect(
       groupedCard.getByRole('button', { name: 'See more outputs' })
     ).toHaveText('1/2')
@@ -309,14 +311,16 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
 
     await expect(tab.selectedCards).toHaveCount(1)
-    await expect(tab.getAssetCardByName('multi-output-a')).toHaveAttribute(
-      'data-selected',
-      'true'
-    )
-    await expect(tab.getAssetCardByName('multi-output-b')).toHaveAttribute(
-      'data-selected',
-      'false'
-    )
+    await expect(
+      tab
+        .getAssetCardByName('multi-output-a')
+        .getByRole('button', { name: /multi-output-a.*asset/ })
+    ).toHaveAttribute('aria-pressed', 'true')
+    await expect(
+      tab
+        .getAssetCardByName('multi-output-b')
+        .getByRole('button', { name: /multi-output-b.*asset/ })
+    ).toHaveAttribute('aria-pressed', 'false')
   })
 
   test('deletes a generated output asset through explicit history refresh', async ({

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -258,133 +258,127 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     ).toHaveJSProperty('naturalWidth', 1)
   })
 
-  test('preserves a grouped selection when opening its outputs', async ({
-    comfyPage,
-    jobsRoutes
-  }) => {
-    const tab = comfyPage.menu.assetsTab
-
-    await jobsRoutes.mockJobsHistory([multiOutputJob])
-    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
-
-    await comfyPage.setup()
-    await tab.open()
-
-    const groupedCard = tab.getAssetCardByName('multi-output-a')
-    await groupedCard.click()
-    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
-
-    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
-
-    await expect(tab.selectedCards).toHaveCount(2)
-    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
-  })
-
-  test('preserves partial output selection when leaving and reopening a folder', async ({
-    comfyPage,
-    jobsRoutes
-  }) => {
-    const tab = comfyPage.menu.assetsTab
-
-    await jobsRoutes.mockJobsHistory([multiOutputJob])
-    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
-
-    await comfyPage.setup()
-    await tab.open()
-
-    const groupedCard = tab.getAssetCardByName('multi-output-a')
-    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
-
-    await tab.getAssetCardByName('multi-output-a').click()
-    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
-
-    await tab.backToAssetsButton.click()
-
-    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
-    await expect(
-      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'mixed')
-    await expect(
-      groupedCard.getByRole('button', { name: 'See more outputs' })
-    ).toHaveText('1/2')
-
-    await tab.openSettingsMenu()
-    await tab.listViewOption.click()
-    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
-    const groupedListItem = tab.listViewItems.filter({
-      hasText: 'multi-output-a'
+  test.describe('grouped output selection', () => {
+    test.beforeEach(async ({ comfyPage, jobsRoutes }) => {
+      await jobsRoutes.mockJobsHistory([multiOutputJob])
+      await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
+      await comfyPage.setup()
+      await comfyPage.menu.assetsTab.open()
     })
-    await expect(groupedListItem).toHaveAttribute('aria-pressed', 'mixed')
-    await expect(
-      groupedListItem.getByRole('button', { name: 'See more outputs' })
-    ).toHaveText('1/2')
 
-    await tab.gridLargeOption.click()
-    await expect(
-      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'mixed')
+    test('preserves a grouped selection when opening its outputs', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.assetsTab
 
-    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
+      const groupedCard = tab.getAssetCardByName('multi-output-a')
+      await groupedCard.click()
+      await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
 
-    await expect(tab.selectedCards).toHaveCount(1)
-    await expect(
-      tab
-        .getAssetCardByName('multi-output-a')
-        .getByRole('button', { name: /multi-output-a.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'true')
-    await expect(
-      tab
-        .getAssetCardByName('multi-output-b')
-        .getByRole('button', { name: /multi-output-b.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'false')
-  })
+      await groupedCard
+        .getByRole('button', { name: 'See more outputs' })
+        .click()
 
-  test('toggles an inherited list child selection and preserves it in grid', async ({
-    comfyPage,
-    jobsRoutes
-  }) => {
-    const tab = comfyPage.menu.assetsTab
+      await expect(tab.selectedCards).toHaveCount(2)
+      await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+    })
 
-    await jobsRoutes.mockJobsHistory([multiOutputJob])
-    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
+    test('preserves partial output selection when leaving and reopening a folder', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.assetsTab
 
-    await comfyPage.setup()
-    await tab.open()
-    await tab.openSettingsMenu()
-    await tab.listViewOption.click()
+      const groupedCard = tab.getAssetCardByName('multi-output-a')
+      await groupedCard
+        .getByRole('button', { name: 'See more outputs' })
+        .click()
 
-    await tab.listViewItems.filter({ hasText: 'multi-output-a' }).click()
-    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+      await tab.getAssetCardByName('multi-output-a').click()
+      await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
 
-    await tab.listViewItems
-      .filter({ hasText: 'multi-output-a' })
-      .getByRole('button', { name: 'See more outputs' })
-      .click()
-    await expect(
-      tab.listViewItems.filter({ hasText: 'multi-output-b' })
-    ).toHaveAttribute('aria-pressed', 'true')
+      await tab.backToAssetsButton.click()
 
-    await comfyPage.page.keyboard.down('ControlOrMeta')
-    await tab.listViewItems.filter({ hasText: 'multi-output-b' }).click()
-    await comfyPage.page.keyboard.up('ControlOrMeta')
+      await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+      await expect(
+        groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+      ).toHaveAttribute('aria-pressed', 'mixed')
+      await expect(
+        groupedCard.getByRole('button', { name: 'See more outputs' })
+      ).toHaveText('1/2')
 
-    await expect(
-      tab.listViewItems.filter({ hasText: 'multi-output-a' })
-    ).toHaveAttribute('aria-pressed', 'mixed')
-    await expect(
-      tab.listViewItems.filter({ hasText: 'multi-output-b' })
-    ).toHaveAttribute('aria-pressed', 'false')
-    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+      await tab.openSettingsMenu()
+      await tab.listViewOption.click()
+      await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+      const groupedListItem = tab.listViewItems.filter({
+        hasText: 'multi-output-a'
+      })
+      await expect(groupedListItem).toHaveAttribute('aria-pressed', 'mixed')
+      await expect(
+        groupedListItem.getByRole('button', { name: 'See more outputs' })
+      ).toHaveText('1/2')
 
-    await tab.gridLargeOption.click()
+      await tab.gridLargeOption.click()
+      await expect(
+        groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+      ).toHaveAttribute('aria-pressed', 'mixed')
 
-    const groupedCard = tab.getAssetCardByName('multi-output-a')
-    await expect(
-      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
-    ).toHaveAttribute('aria-pressed', 'mixed')
-    await expect(
-      groupedCard.getByRole('button', { name: 'See more outputs' })
-    ).toHaveText('1/2')
+      await groupedCard
+        .getByRole('button', { name: 'See more outputs' })
+        .click()
+
+      await expect(
+        tab
+          .getAssetCardByName('multi-output-a')
+          .getByRole('button', { name: /multi-output-a.*asset/ })
+      ).toHaveAttribute('aria-pressed', 'true')
+      await expect(
+        tab
+          .getAssetCardByName('multi-output-b')
+          .getByRole('button', { name: /multi-output-b.*asset/ })
+      ).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    test('toggles an inherited list child selection and preserves it in grid', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.assetsTab
+
+      await tab.openSettingsMenu()
+      await tab.listViewOption.click()
+
+      await tab.listViewItems.filter({ hasText: 'multi-output-a' }).click()
+      await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+
+      await tab.listViewItems
+        .filter({ hasText: 'multi-output-a' })
+        .getByRole('button', { name: 'See more outputs' })
+        .click()
+      await expect(
+        tab.listViewItems.filter({ hasText: 'multi-output-b' })
+      ).toHaveAttribute('aria-pressed', 'true')
+
+      await comfyPage.page.keyboard.down('ControlOrMeta')
+      await tab.listViewItems.filter({ hasText: 'multi-output-b' }).click()
+      await comfyPage.page.keyboard.up('ControlOrMeta')
+
+      await expect(
+        tab.listViewItems.filter({ hasText: 'multi-output-a' })
+      ).toHaveAttribute('aria-pressed', 'mixed')
+      await expect(
+        tab.listViewItems.filter({ hasText: 'multi-output-b' })
+      ).toHaveAttribute('aria-pressed', 'false')
+      await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+
+      await tab.gridLargeOption.click()
+
+      const groupedCard = tab.getAssetCardByName('multi-output-a')
+      await expect(
+        groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+      ).toHaveAttribute('aria-pressed', 'mixed')
+      await expect(
+        groupedCard.getByRole('button', { name: 'See more outputs' })
+      ).toHaveText('1/2')
+    })
   })
 
   test('deletes a generated output asset through explicit history refresh', async ({

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -308,6 +308,15 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       groupedCard.getByRole('button', { name: 'See more outputs' })
     ).toHaveText('1/2')
 
+    await tab.openSettingsMenu()
+    await tab.listViewOption.click()
+    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+
+    await tab.gridLargeOption.click()
+    await expect(
+      groupedCard.getByRole('button', { name: /multi-output-a.*asset/ })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+
     await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
 
     await expect(tab.selectedCards).toHaveCount(1)

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -258,6 +258,67 @@ test.describe('FE-130 assets sidebar route mocks', () => {
     ).toHaveJSProperty('naturalWidth', 1)
   })
 
+  test('preserves a grouped selection when opening its outputs', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    const tab = comfyPage.menu.assetsTab
+
+    await jobsRoutes.mockJobsHistory([multiOutputJob])
+    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
+
+    await comfyPage.setup()
+    await tab.open()
+
+    const groupedCard = tab.getAssetCardByName('multi-output-a')
+    await groupedCard.click()
+    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+
+    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
+
+    await expect(tab.selectedCards).toHaveCount(2)
+    await expect(tab.selectionCountButton).toHaveText(/\b2 selected\b/)
+  })
+
+  test('preserves partial output selection when leaving and reopening a folder', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    const tab = comfyPage.menu.assetsTab
+
+    await jobsRoutes.mockJobsHistory([multiOutputJob])
+    await jobsRoutes.mockJobDetail('multi-output', multiOutputJobDetail)
+
+    await comfyPage.setup()
+    await tab.open()
+
+    const groupedCard = tab.getAssetCardByName('multi-output-a')
+    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
+
+    await tab.getAssetCardByName('multi-output-a').click()
+    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+
+    await tab.backToAssetsButton.click()
+
+    await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
+    await expect(groupedCard).toHaveAttribute('data-selected', 'false')
+    await expect(
+      groupedCard.getByRole('button', { name: 'See more outputs' })
+    ).toHaveText('1/2')
+
+    await groupedCard.getByRole('button', { name: 'See more outputs' }).click()
+
+    await expect(tab.selectedCards).toHaveCount(1)
+    await expect(tab.getAssetCardByName('multi-output-a')).toHaveAttribute(
+      'data-selected',
+      'true'
+    )
+    await expect(tab.getAssetCardByName('multi-output-b')).toHaveAttribute(
+      'data-selected',
+      'false'
+    )
+  })
+
   test('deletes a generated output asset through explicit history refresh', async ({
     comfyPage,
     jobsRoutes

--- a/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
+++ b/browser_tests/tests/sidebar/assetsSidebarTab.spec.ts
@@ -369,6 +369,7 @@ test.describe('FE-130 assets sidebar route mocks', () => {
       ).toHaveAttribute('aria-pressed', 'false')
       await expect(tab.selectionCountButton).toHaveText(/\b1 selected\b/)
 
+      await tab.openSettingsMenu()
       await tab.gridLargeOption.click()
 
       const groupedCard = tab.getAssetCardByName('multi-output-a')

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -11,6 +11,7 @@
         <MediaAssetCard
           :asset="item.asset"
           :selected="isSelected(item.asset.id)"
+          :partially-selected="isPartiallySelected(item.asset)"
           :show-output-count="showOutputCount(item.asset)"
           :output-count="getOutputCount(item.asset)"
           :selected-output-count="getSelectedOutputCount(item.asset)"
@@ -37,6 +38,7 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 const {
   assets,
   isSelected,
+  isPartiallySelected,
   showOutputCount,
   getOutputCount,
   getSelectedOutputCount,
@@ -44,6 +46,7 @@ const {
 } = defineProps<{
   assets: AssetItem[]
   isSelected: (assetId: string) => boolean
+  isPartiallySelected: (asset: AssetItem) => boolean
   showOutputCount: (asset: AssetItem) => boolean
   getOutputCount: (asset: AssetItem) => number
   getSelectedOutputCount: (asset: AssetItem) => number

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -13,6 +13,7 @@
           :selected="isSelected(item.asset.id)"
           :show-output-count="showOutputCount(item.asset)"
           :output-count="getOutputCount(item.asset)"
+          :selected-output-count="getSelectedOutputCount(item.asset)"
           @select="emit('select-asset', item.asset)"
           @toggle-selection="emit('toggle-asset-selection', item.asset)"
           @context-menu="emit('context-menu', $event, item.asset)"
@@ -33,14 +34,21 @@ import { getMediaAssetGridColumns } from '@/platform/assets/components/mediaAsse
 import type { MediaAssetGridMode } from '@/platform/assets/components/mediaAssetViewOptions'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 
-const { assets, isSelected, showOutputCount, getOutputCount, gridMode } =
-  defineProps<{
-    assets: AssetItem[]
-    isSelected: (assetId: string) => boolean
-    showOutputCount: (asset: AssetItem) => boolean
-    getOutputCount: (asset: AssetItem) => number
-    gridMode: MediaAssetGridMode
-  }>()
+const {
+  assets,
+  isSelected,
+  showOutputCount,
+  getOutputCount,
+  getSelectedOutputCount,
+  gridMode
+} = defineProps<{
+  assets: AssetItem[]
+  isSelected: (assetId: string) => boolean
+  showOutputCount: (asset: AssetItem) => boolean
+  getOutputCount: (asset: AssetItem) => number
+  getSelectedOutputCount: (asset: AssetItem) => number
+  gridMode: MediaAssetGridMode
+}>()
 
 const emit = defineEmits<{
   (e: 'select-asset', asset: AssetItem): void

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -193,28 +193,17 @@ describe('AssetsSidebarListView', () => {
     ).toHaveAttribute('aria-pressed', 'mixed')
   })
 
-  it('derives selected state from each asset', () => {
-    const parent = buildAsset('parent', 'parent.png')
-    const child = buildAsset('child', 'child.png')
+  it('resolves selected state from the asset', () => {
+    const asset = buildAsset('selected', 'selected.png')
 
-    renderListView(
-      [
-        buildOutputItem(parent),
-        {
-          ...buildOutputItem(child),
-          isChild: true
-        }
-      ],
-      {
-        isSelected: (asset: AssetItem) =>
-          asset.id === parent.id || asset.id === child.id
-      }
-    )
-
-    const rows = screen.getAllByRole('button', {
-      name: 'assetBrowser.ariaLabel.assetCard'
+    renderListView([buildOutputItem(asset)], {
+      isSelected: (candidate: AssetItem) => candidate.id === asset.id
     })
-    expect(rows[0]).toHaveAttribute('aria-pressed', 'true')
-    expect(rows[1]).toHaveAttribute('aria-pressed', 'true')
+
+    expect(
+      screen.getByRole('button', {
+        name: 'assetBrowser.ariaLabel.assetCard'
+      })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.test.ts
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/vue'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import { defineComponent } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -44,6 +44,7 @@ const AssetsListItemStub = defineComponent({
     primaryText: { type: String, default: '' },
     secondaryText: { type: String, default: '' },
     stackCount: { type: Number, default: 0 },
+    selectedStackCount: { type: Number, default: 0 },
     stackIndicatorLabel: { type: String, default: '' },
     stackExpanded: { type: Boolean, default: false },
     progressTotalPercent: { type: Number, default: undefined },
@@ -78,6 +79,8 @@ function renderListView(
       assetItems,
       selectableAssets: [],
       isSelected: () => false,
+      isPartiallySelected: () => false,
+      getSelectedOutputCount: () => 0,
       isStackExpanded: () => false,
       toggleStack: async () => {},
       ...props
@@ -170,5 +173,48 @@ describe('AssetsSidebarListView', () => {
     await fireEvent.dblClick(stub)
 
     expect(onPreviewAsset).toHaveBeenCalledWith(imageAsset)
+  })
+
+  it('exposes a partially selected output group as mixed', () => {
+    const groupedAsset = {
+      ...buildAsset('grouped-asset', 'grouped.png'),
+      user_metadata: { outputCount: 2 }
+    } satisfies AssetItem
+
+    renderListView([buildOutputItem(groupedAsset)], {
+      isPartiallySelected: () => true,
+      getSelectedOutputCount: () => 1
+    })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'assetBrowser.ariaLabel.assetCard'
+      })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+  })
+
+  it('derives selected state from each asset', () => {
+    const parent = buildAsset('parent', 'parent.png')
+    const child = buildAsset('child', 'child.png')
+
+    renderListView(
+      [
+        buildOutputItem(parent),
+        {
+          ...buildOutputItem(child),
+          isChild: true
+        }
+      ],
+      {
+        isSelected: (asset: AssetItem) =>
+          asset.id === parent.id || asset.id === child.id
+      }
+    )
+
+    const rows = screen.getAllByRole('button', {
+      name: 'assetBrowser.ariaLabel.assetCard'
+    })
+    expect(rows[0]).toHaveAttribute('aria-pressed', 'true')
+    expect(rows[1]).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarListView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarListView.vue
@@ -25,9 +25,18 @@
                 type: getAssetMediaType(item.asset)
               })
             "
+            :aria-pressed="
+              isSelected(item.asset)
+                ? true
+                : isPartiallySelected(item.asset)
+                  ? 'mixed'
+                  : false
+            "
             :class="
               cn(
-                getAssetCardClass(isSelected(item.asset.id)),
+                getAssetCardClass(
+                  isSelected(item.asset) || isPartiallySelected(item.asset)
+                ),
                 item.isChild && 'pl-6'
               )
             "
@@ -38,6 +47,7 @@
             :primary-text="getAssetPrimaryText(item.asset)"
             :secondary-text="getAssetSecondaryText(item.asset)"
             :stack-count="getStackCount(item.asset)"
+            :selected-stack-count="getSelectedOutputCount(item.asset)"
             :stack-indicator-label="t('mediaAsset.actions.seeMoreOutputs')"
             :stack-expanded="isStackExpanded(item.asset)"
             @mouseenter="onAssetEnter(item.asset.id)"
@@ -91,12 +101,16 @@ const {
   assetItems,
   selectableAssets,
   isSelected,
+  isPartiallySelected,
+  getSelectedOutputCount,
   isStackExpanded,
   toggleStack
 } = defineProps<{
   assetItems: OutputStackListItem[]
   selectableAssets: AssetItem[]
-  isSelected: (assetId: string) => boolean
+  isSelected: (asset: AssetItem) => boolean
+  isPartiallySelected: (asset: AssetItem) => boolean
+  getSelectedOutputCount: (asset: AssetItem) => number
   isStackExpanded: (asset: AssetItem) => boolean
   toggleStack: (asset: AssetItem) => Promise<void>
 }>()
@@ -171,11 +185,11 @@ function getStackCount(asset: AssetItem): number | undefined {
   return undefined
 }
 
-function getAssetCardClass(selected: boolean): string {
+function getAssetCardClass(highlighted: boolean): string {
   return cn(
     'w-full text-text-primary transition-colors hover:bg-secondary-background-hover',
     'cursor-pointer',
-    selected &&
+    highlighted &&
       'bg-secondary-background-hover ring-1 ring-modal-card-border-highlighted ring-inset'
   )
 }

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -133,7 +133,7 @@ const assetsGridStub = {
     <div v-for="asset in assets" :key="asset.id">
       <button
         :aria-label="'Select ' + asset.name"
-        :data-selected="isSelected(asset.id)"
+        :aria-pressed="isSelected(asset.id)"
         @click.stop="$emit('select-asset', asset)"
       />
       <button
@@ -237,10 +237,10 @@ describe('AssetsSidebarTab folder navigation', () => {
 
     expect(
       screen.getByRole('button', { name: 'Select multi-output-a.png' })
-    ).toHaveAttribute('data-selected', 'true')
+    ).toHaveAttribute('aria-pressed', 'true')
     expect(
       screen.getByRole('button', { name: 'Select multi-output-b.png' })
-    ).toHaveAttribute('data-selected', 'true')
+    ).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByTestId('selection-count')).toHaveTextContent(
       '2 selected'
     )
@@ -276,9 +276,9 @@ describe('AssetsSidebarTab folder navigation', () => {
 
     expect(
       screen.getByRole('button', { name: 'Select multi-output-a.png' })
-    ).toHaveAttribute('data-selected', 'true')
+    ).toHaveAttribute('aria-pressed', 'true')
     expect(
       screen.getByRole('button', { name: 'Select multi-output-b.png' })
-    ).toHaveAttribute('data-selected', 'false')
+    ).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -379,39 +379,28 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(childA).toHaveAttribute('aria-pressed', 'true')
     expect(childB).toHaveAttribute('aria-pressed', 'true')
 
-    await user.keyboard('{Control>}')
-    await user.click(
-      screen.getByRole('button', {
-        name: 'List select multi-output-b.png'
-      })
-    )
-    await user.keyboard('{/Control}')
+    async function toggleChildB() {
+      await user.keyboard('{Control>}')
+      await user.click(childB)
+      await user.keyboard('{/Control}')
+    }
+
+    await toggleChildB()
 
     expect(parent).toHaveAttribute('aria-pressed', 'mixed')
-    expect(childA).toHaveAttribute('aria-pressed', 'true')
     expect(childB).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByTestId('selection-count')).toHaveTextContent(
       '1 selected'
     )
 
-    await user.keyboard('{Control>}')
-    await user.click(childB)
-    await user.keyboard('{/Control}')
+    await toggleChildB()
 
-    expect(parent).toHaveAttribute('aria-pressed', 'true')
-    expect(childA).toHaveAttribute('aria-pressed', 'true')
     expect(childB).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByTestId('selection-count')).toHaveTextContent(
       '2 selected'
     )
 
-    await user.keyboard('{Control>}')
-    await user.click(childB)
-    await user.keyboard('{/Control}')
-
-    expect(parent).toHaveAttribute('aria-pressed', 'mixed')
-    expect(childA).toHaveAttribute('aria-pressed', 'true')
-    expect(childB).toHaveAttribute('aria-pressed', 'false')
+    await toggleChildB()
 
     await user.click(screen.getByRole('button', { name: 'Show grid view' }))
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,6 +1,7 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -20,6 +21,32 @@ const folderAsset = vi.hoisted(
         outputCount: 2
       }
     }) satisfies AssetItem
+)
+
+const folderAssets = vi.hoisted(
+  () =>
+    [
+      {
+        id: 'multi-output-1--multi-output-a.png',
+        name: 'multi-output-a.png',
+        tags: ['output'],
+        user_metadata: {
+          jobId: 'multi-output-job',
+          nodeId: '1',
+          subfolder: ''
+        }
+      },
+      {
+        id: 'multi-output-1--multi-output-b.png',
+        name: 'multi-output-b.png',
+        tags: ['output'],
+        user_metadata: {
+          jobId: 'multi-output-job',
+          nodeId: '1',
+          subfolder: ''
+        }
+      }
+    ] satisfies AssetItem[]
 )
 
 vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
@@ -45,28 +72,6 @@ vi.mock('@/platform/assets/composables/useAssetGridSelection', async () => {
   }
 })
 
-vi.mock('@/platform/assets/composables/useAssetSelection', async () => {
-  const { ref } = await import('vue')
-
-  return {
-    useAssetSelection: () => ({
-      isSelected: vi.fn().mockReturnValue(false),
-      selectedIds: ref(new Set<string>()),
-      handleAssetClick: vi.fn(),
-      selectAll: vi.fn(),
-      setSelectedIds: vi.fn(),
-      hasSelection: ref(false),
-      clearSelection: vi.fn(),
-      getSelectedAssets: vi.fn().mockReturnValue([]),
-      reconcileSelection: vi.fn(),
-      getOutputCount: vi.fn().mockReturnValue(2),
-      getTotalOutputCount: vi.fn().mockReturnValue(0),
-      activate: vi.fn(),
-      deactivate: vi.fn()
-    })
-  }
-})
-
 vi.mock('@/platform/assets/composables/useMediaAssetActions', () => ({
   useMediaAssetActions: () => ({
     downloadAssets: vi.fn(),
@@ -79,7 +84,7 @@ vi.mock('@/platform/assets/composables/useMediaAssetActions', () => ({
 
 vi.mock('@/platform/assets/utils/outputAssetUtil', async (importOriginal) => ({
   ...(await importOriginal()),
-  resolveOutputAssetItems: vi.fn().mockResolvedValue([folderAsset])
+  resolveOutputAssetItems: vi.fn().mockResolvedValue(folderAssets)
 }))
 
 vi.mock('primevue/usetoast', () => ({
@@ -110,18 +115,43 @@ const sidebarTabTemplateStub = {
       <div data-testid="folder-title"><slot name="alt-title" /></div>
       <div data-testid="folder-controls"><slot name="header" /></div>
       <slot name="body" />
+      <slot name="footer" />
     </section>
   `
 }
 
 const assetsGridStub = {
-  props: ['assets'],
-  emits: ['output-count-click'],
+  props: [
+    'assets',
+    'isSelected',
+    'showOutputCount',
+    'getOutputCount',
+    'getSelectedOutputCount'
+  ],
+  emits: ['output-count-click', 'select-asset'],
   template: `
-    <button
-      aria-label="Enter output folder"
-      @click="$emit('output-count-click', assets[0])"
-    />
+    <div v-for="asset in assets" :key="asset.id">
+      <button
+        :aria-label="'Select ' + asset.name"
+        :data-selected="isSelected(asset.id)"
+        @click.stop="$emit('select-asset', asset)"
+      />
+      <button
+        v-if="showOutputCount(asset)"
+        aria-label="Enter output folder"
+        @click.stop="$emit('output-count-click', asset)"
+      >
+        <template
+          v-if="
+            getSelectedOutputCount?.(asset) > 0 &&
+            getSelectedOutputCount(asset) < getOutputCount(asset)
+          "
+        >
+          {{ getSelectedOutputCount(asset) }}/{{ getOutputCount(asset) }}
+        </template>
+        <template v-else>{{ getOutputCount(asset) }}</template>
+      </button>
+    </div>
   `
 }
 
@@ -129,10 +159,15 @@ const buttonStub = {
   template: '<button><slot /></button>'
 }
 
+const selectionBarStub = {
+  props: ['count'],
+  template: '<div data-testid="selection-count">{{ count }} selected</div>'
+}
+
 function renderTab() {
   return render(AssetsSidebarTab, {
     global: {
-      plugins: [i18n],
+      plugins: [i18n, createTestingPinia({ stubActions: false })],
       directives: {
         tooltip: {}
       },
@@ -142,7 +177,7 @@ function renderTab() {
         AssetsSidebarListView: true,
         Button: buttonStub,
         MediaAssetFilterBar: true,
-        MediaAssetSelectionBar: true,
+        MediaAssetSelectionBar: selectionBarStub,
         MediaLightbox: true,
         MediaAssetContextMenu: true,
         NoResultsPlaceholder: true,
@@ -153,6 +188,10 @@ function renderTab() {
 }
 
 describe('AssetsSidebarTab folder navigation', () => {
+  beforeEach(() => {
+    localStorage.setItem('Comfy.Assets.Sidebar.ViewMode', 'grid')
+  })
+
   it('places accessible folder actions beside the job ID', async () => {
     renderTab()
     await userEvent.click(
@@ -180,5 +219,66 @@ describe('AssetsSidebarTab folder navigation', () => {
       screen.queryByRole('button', { name: 'Back to all assets' })
     ).not.toBeInTheDocument()
     expect(screen.queryByText('multi-output-job')).not.toBeInTheDocument()
+  })
+
+  it('preserves a grouped selection when entering the output folder', async () => {
+    renderTab()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Select multi-output.png' })
+    )
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '2 selected'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output-a.png' })
+    ).toHaveAttribute('data-selected', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output-b.png' })
+    ).toHaveAttribute('data-selected', 'true')
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '2 selected'
+    )
+  })
+
+  it('preserves a partial output selection when leaving and reopening the folder', async () => {
+    renderTab()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Select multi-output-a.png' })
+    )
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '1 selected'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Back to all assets' })
+    )
+
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '1 selected'
+    )
+    expect(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    ).toHaveTextContent('1/2')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output-a.png' })
+    ).toHaveAttribute('data-selected', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output-b.png' })
+    ).toHaveAttribute('data-selected', 'false')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -124,6 +124,7 @@ const assetsGridStub = {
   props: [
     'assets',
     'isSelected',
+    'isPartiallySelected',
     'showOutputCount',
     'getOutputCount',
     'getSelectedOutputCount'
@@ -133,7 +134,13 @@ const assetsGridStub = {
     <div v-for="asset in assets" :key="asset.id">
       <button
         :aria-label="'Select ' + asset.name"
-        :aria-pressed="isSelected(asset.id)"
+        :aria-pressed="
+          isSelected(asset.id)
+            ? 'true'
+            : isPartiallySelected?.(asset)
+              ? 'mixed'
+              : 'false'
+        "
         @click.stop="$emit('select-asset', asset)"
       />
       <button
@@ -269,6 +276,9 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(
       screen.getByRole('button', { name: 'Enter output folder' })
     ).toHaveTextContent('1/2')
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output.png' })
+    ).toHaveAttribute('aria-pressed', 'mixed')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Enter output folder' })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -171,6 +171,21 @@ const selectionBarStub = {
   template: '<div data-testid="selection-count">{{ count }} selected</div>'
 }
 
+const filterBarStub = {
+  props: ['viewMode'],
+  emits: ['update:viewMode'],
+  template: `
+    <button
+      aria-label="Show list view"
+      @click="$emit('update:viewMode', 'list')"
+    />
+    <button
+      aria-label="Show grid view"
+      @click="$emit('update:viewMode', 'grid')"
+    />
+  `
+}
+
 function renderTab() {
   return render(AssetsSidebarTab, {
     global: {
@@ -183,7 +198,7 @@ function renderTab() {
         AssetsSidebarGridView: assetsGridStub,
         AssetsSidebarListView: true,
         Button: buttonStub,
-        MediaAssetFilterBar: true,
+        MediaAssetFilterBar: filterBarStub,
         MediaAssetSelectionBar: selectionBarStub,
         MediaLightbox: true,
         MediaAssetContextMenu: true,
@@ -276,6 +291,20 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(
       screen.getByRole('button', { name: 'Enter output folder' })
     ).toHaveTextContent('1/2')
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output.png' })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show list view' })
+    )
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '1 selected'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Show grid view' })
+    )
     expect(
       screen.getByRole('button', { name: 'Select multi-output.png' })
     ).toHaveAttribute('aria-pressed', 'mixed')

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -162,6 +162,40 @@ const assetsGridStub = {
   `
 }
 
+const assetsListStub = {
+  props: [
+    'assetItems',
+    'selectableAssets',
+    'isSelected',
+    'isPartiallySelected',
+    'getSelectedOutputCount',
+    'toggleStack'
+  ],
+  emits: ['select-asset'],
+  template: `
+    <button
+      v-if="assetItems.length"
+      aria-label="Expand list group"
+      @click.stop="toggleStack(assetItems[0].asset)"
+    />
+    <button
+      v-for="item in assetItems"
+      :key="item.key"
+      :aria-label="'List select ' + item.asset.name"
+      :aria-pressed="
+        isSelected(item.asset)
+          ? 'true'
+          : isPartiallySelected(item.asset)
+            ? 'mixed'
+            : 'false'
+      "
+      @click.stop="$emit('select-asset', item.asset, selectableAssets)"
+    >
+      {{ getSelectedOutputCount(item.asset) }}
+    </button>
+  `
+}
+
 const buttonStub = {
   template: '<button><slot /></button>'
 }
@@ -196,7 +230,7 @@ function renderTab() {
       stubs: {
         SidebarTabTemplate: sidebarTabTemplateStub,
         AssetsSidebarGridView: assetsGridStub,
-        AssetsSidebarListView: true,
+        AssetsSidebarListView: assetsListStub,
         Button: buttonStub,
         MediaAssetFilterBar: filterBarStub,
         MediaAssetSelectionBar: selectionBarStub,
@@ -319,5 +353,73 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(
       screen.getByRole('button', { name: 'Select multi-output-b.png' })
     ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('toggles an inherited child selection in list view and preserves it in grid view', async () => {
+    localStorage.setItem('Comfy.Assets.Sidebar.ViewMode', 'list')
+    const user = userEvent.setup()
+    renderTab()
+
+    await user.click(
+      screen.getByRole('button', { name: 'List select multi-output.png' })
+    )
+    await user.click(screen.getByRole('button', { name: 'Expand list group' }))
+
+    const parent = screen.getByRole('button', {
+      name: 'List select multi-output.png'
+    })
+    const childA = await screen.findByRole('button', {
+      name: 'List select multi-output-a.png'
+    })
+    const childB = screen.getByRole('button', {
+      name: 'List select multi-output-b.png'
+    })
+
+    expect(parent).toHaveAttribute('aria-pressed', 'true')
+    expect(childA).toHaveAttribute('aria-pressed', 'true')
+    expect(childB).toHaveAttribute('aria-pressed', 'true')
+
+    await user.keyboard('{Control>}')
+    await user.click(
+      screen.getByRole('button', {
+        name: 'List select multi-output-b.png'
+      })
+    )
+    await user.keyboard('{/Control}')
+
+    expect(parent).toHaveAttribute('aria-pressed', 'mixed')
+    expect(childA).toHaveAttribute('aria-pressed', 'true')
+    expect(childB).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '1 selected'
+    )
+
+    await user.keyboard('{Control>}')
+    await user.click(childB)
+    await user.keyboard('{/Control}')
+
+    expect(parent).toHaveAttribute('aria-pressed', 'true')
+    expect(childA).toHaveAttribute('aria-pressed', 'true')
+    expect(childB).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('selection-count')).toHaveTextContent(
+      '2 selected'
+    )
+
+    await user.keyboard('{Control>}')
+    await user.click(childB)
+    await user.keyboard('{/Control}')
+
+    expect(parent).toHaveAttribute('aria-pressed', 'mixed')
+    expect(childA).toHaveAttribute('aria-pressed', 'true')
+    expect(childB).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(screen.getByRole('button', { name: 'Show grid view' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Select multi-output.png' })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+    expect(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    ).toHaveTextContent('1/2')
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -120,9 +120,10 @@
         <div v-else class="size-full">
           <AssetsSidebarGridView
             :assets="displayAssets"
-            :is-selected
+            :is-selected="isGridAssetSelected"
             :show-output-count
             :get-output-count
+            :get-selected-output-count
             :grid-mode
             @select-asset="handleAssetSelect"
             @toggle-asset-selection="handleAssetSelectionToggle"
@@ -312,7 +313,8 @@ const {
   getOutputCount,
   getTotalOutputCount,
   activate: activateSelection,
-  deactivate: deactivateSelection
+  deactivate: deactivateSelection,
+  cmdOrCtrlKey
 } = useAssetSelection()
 
 const panelRef = useTemplateRef('panelRef')
@@ -357,6 +359,7 @@ const {
   [] as AssetItem[],
   { immediate: false, resetOnExecute: true }
 )
+const folderAssetsByJobId = ref<Record<string, AssetItem[]>>({})
 
 // Base assets before search filtering
 const baseAssets = computed(() => {
@@ -388,6 +391,92 @@ const visibleAssets = computed(() => {
   return listViewSelectableAssets.value
 })
 
+const selectionAssets = computed(() => {
+  if (isListView.value) {
+    return visibleAssets.value
+  }
+
+  if (isInFolderView.value) {
+    const cachedFolderAssets = folderJobId.value
+      ? (folderAssetsByJobId.value[folderJobId.value] ?? [])
+      : []
+    return uniqueAssets([
+      ...mediaAssets.value,
+      ...cachedFolderAssets,
+      ...visibleAssets.value
+    ])
+  }
+
+  const cachedChildren = visibleAssets.value.flatMap((asset) => {
+    const jobId = getAssetJobId(asset)
+    return jobId ? (folderAssetsByJobId.value[jobId] ?? []) : []
+  })
+  return uniqueAssets([...visibleAssets.value, ...cachedChildren])
+})
+
+function uniqueAssets(assets: AssetItem[]): AssetItem[] {
+  return [...new Map(assets.map((asset) => [asset.id, asset])).values()]
+}
+
+function getAssetJobId(asset: AssetItem): string | undefined {
+  return getOutputAssetMetadata(asset.user_metadata)?.jobId
+}
+
+function getCachedFolderAssets(asset: AssetItem): AssetItem[] {
+  const jobId = getAssetJobId(asset)
+  return jobId ? (folderAssetsByJobId.value[jobId] ?? []) : []
+}
+
+function getSelectedChildIds(asset: AssetItem): string[] {
+  return getCachedFolderAssets(asset)
+    .filter((child) => isSelected(child.id))
+    .map(({ id }) => id)
+}
+
+function getSelectedOutputCount(asset: AssetItem): number {
+  if (isSelected(asset.id)) {
+    return getOutputCount(asset)
+  }
+  return getSelectedChildIds(asset).length
+}
+
+function isGridAssetSelected(assetId: string): boolean {
+  if (isSelected(assetId)) {
+    return true
+  }
+  if (isInFolderView.value) return false
+
+  const asset = visibleAssets.value.find((item) => item.id === assetId)
+  if (!asset) return false
+
+  const selectedOutputCount = getSelectedOutputCount(asset)
+  return (
+    selectedOutputCount > 0 && selectedOutputCount === getOutputCount(asset)
+  )
+}
+
+function toggleGroupedSelection(asset: AssetItem): boolean {
+  if (isSelected(asset.id)) return false
+
+  const cachedChildren = getCachedFolderAssets(asset)
+  const selectedChildIds = getSelectedChildIds(asset)
+  if (selectedChildIds.length === 0) return false
+
+  const groupedIds = new Set([
+    asset.id,
+    ...cachedChildren.map((child) => child.id)
+  ])
+  const remainingIds = [...selectedIds.value].filter(
+    (id) => !groupedIds.has(id)
+  )
+  const isFullySelected = selectedChildIds.length === getOutputCount(asset)
+  setSelectedIds(
+    isFullySelected ? remainingIds : [...remainingIds, asset.id],
+    selectionAssets.value
+  )
+  return true
+}
+
 const { marqueeStyle } = useAssetGridSelection({
   marqueeContainerRef: marqueePanelRef,
   hoverTargetRef: marqueePanelRef,
@@ -404,7 +493,7 @@ const previewableVisibleAssets = computed(() =>
   )
 )
 
-const selectedAssets = computed(() => getSelectedAssets(visibleAssets.value))
+const selectedAssets = computed(() => getSelectedAssets(selectionAssets.value))
 
 const totalOutputCount = computed(() =>
   getTotalOutputCount(selectedAssets.value)
@@ -428,10 +517,11 @@ const showEmptyState = computed(
     !loading.value && !isFolderLoading.value && displayAssets.value.length === 0
 )
 
-watch(visibleAssets, (newAssets) => {
-  // Alternative: keep hidden selections and surface them in UI; for now prune
-  // so selection stays consistent with what this view can act on.
-  reconcileSelection(newAssets)
+watch(selectionAssets, (assets) => {
+  reconcileSelection(assets)
+})
+
+watch(visibleAssets, () => {
   if (currentGalleryAssetId.value && galleryActiveIndex.value !== -1) {
     const newIndex = previewableVisibleAssets.value.findIndex(
       (asset) => asset.id === currentGalleryAssetId.value
@@ -488,6 +578,15 @@ watch(
 )
 
 function handleAssetSelect(asset: AssetItem, assets?: AssetItem[]) {
+  if (
+    !isInFolderView.value &&
+    cmdOrCtrlKey.value &&
+    toggleGroupedSelection(asset)
+  ) {
+    emit('assetSelected', asset)
+    return
+  }
+
   const assetList = assets ?? visibleAssets.value
   const index = assetList.findIndex((a) => a.id === asset.id)
   emit('assetSelected', asset)
@@ -495,6 +594,11 @@ function handleAssetSelect(asset: AssetItem, assets?: AssetItem[]) {
 }
 
 function handleAssetSelectionToggle(asset: AssetItem) {
+  if (!isInFolderView.value && toggleGroupedSelection(asset)) {
+    emit('assetSelected', asset)
+    return
+  }
+
   const index = visibleAssets.value.findIndex((item) => item.id === asset.id)
   emit('assetSelected', asset)
   toggleAssetSelection(asset, index, visibleAssets.value)
@@ -618,6 +722,22 @@ const enterFolderView = async (asset: AssetItem) => {
       detail: t('sideToolbar.folderView.errorDetail')
     })
     exitFolderView()
+    return
+  }
+
+  folderAssetsByJobId.value = {
+    ...folderAssetsByJobId.value,
+    [jobId]: folderAssets.value
+  }
+
+  if (isSelected(asset.id)) {
+    setSelectedIds(
+      [
+        ...[...selectedIds.value].filter((id) => id !== asset.id),
+        ...folderAssets.value.map(({ id }) => id)
+      ],
+      selectionAssets.value
+    )
   }
 }
 
@@ -627,6 +747,7 @@ const exitFolderView = () => {
   expectedFolderCount.value = 0
   folderAssets.value = []
   searchQuery.value = ''
+  setSelectedIds([...selectedIds.value], [])
 }
 
 onMounted(() => {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -422,6 +422,21 @@ function getAssetJobId(asset: AssetItem): string | undefined {
   return getOutputAssetMetadata(asset.user_metadata)?.jobId
 }
 
+const visibleAssetById = computed(
+  () => new Map(visibleAssets.value.map((asset) => [asset.id, asset]))
+)
+
+const outputGroupParentByJobId = computed(() => {
+  const parents = new Map<string, AssetItem>()
+  for (const asset of displayAssets.value) {
+    const jobId = getAssetJobId(asset)
+    if (jobId && getOutputCount(asset) > 1 && !parents.has(jobId)) {
+      parents.set(jobId, asset)
+    }
+  }
+  return parents
+})
+
 function getResolvedOutputAssets(asset: AssetItem): AssetItem[] {
   const jobId = getAssetJobId(asset)
   return jobId ? (resolvedOutputAssetsByJobId.value[jobId] ?? []) : []
@@ -446,7 +461,7 @@ function isGridAssetSelected(assetId: string): boolean {
   }
   if (isInFolderView.value) return false
 
-  const asset = visibleAssets.value.find((item) => item.id === assetId)
+  const asset = visibleAssetById.value.get(assetId)
   if (!asset) return false
 
   const selectedOutputCount = getSelectedOutputCount(asset)
@@ -461,10 +476,7 @@ function getListOutputGroupParent(asset: AssetItem): AssetItem | undefined {
   const jobId = getAssetJobId(asset)
   if (!jobId) return
 
-  return displayAssets.value.find(
-    (candidate) =>
-      getAssetJobId(candidate) === jobId && getOutputCount(candidate) > 1
-  )
+  return outputGroupParentByJobId.value.get(jobId)
 }
 
 function isListAssetSelected(asset: AssetItem): boolean {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -393,10 +393,6 @@ const visibleAssets = computed(() => {
 })
 
 const selectionAssets = computed(() => {
-  if (isListView.value) {
-    return visibleAssets.value
-  }
-
   if (isInFolderView.value) {
     const cachedFolderAssets = folderJobId.value
       ? (folderAssetsByJobId.value[folderJobId.value] ?? [])

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -108,8 +108,10 @@
         <AssetsSidebarListView
           v-if="isListView"
           :asset-items="listViewAssetItems"
-          :is-selected="isSelected"
+          :is-selected="isListAssetSelected"
+          :is-partially-selected="isAssetPartiallySelected"
           :selectable-assets="listViewSelectableAssets"
+          :get-selected-output-count
           :is-stack-expanded="isListViewStackExpanded"
           :toggle-stack="toggleListViewStack"
           @select-asset="handleAssetSelect"
@@ -121,7 +123,7 @@
           <AssetsSidebarGridView
             :assets="displayAssets"
             :is-selected="isGridAssetSelected"
-            :is-partially-selected="isGridAssetPartiallySelected"
+            :is-partially-selected="isAssetPartiallySelected"
             :show-output-count
             :get-output-count
             :get-selected-output-count
@@ -360,7 +362,7 @@ const {
   [] as AssetItem[],
   { immediate: false, resetOnExecute: true }
 )
-const folderAssetsByJobId = ref<Record<string, AssetItem[]>>({})
+const resolvedOutputAssetsByJobId = ref<Record<string, AssetItem[]>>({})
 
 // Base assets before search filtering
 const baseAssets = computed(() => {
@@ -384,7 +386,8 @@ const {
   isStackExpanded: isListViewStackExpanded,
   toggleStack: toggleListViewStack
 } = useOutputStacks({
-  assets: computed(() => displayAssets.value)
+  assets: computed(() => displayAssets.value),
+  childrenByJobId: resolvedOutputAssetsByJobId
 })
 
 const visibleAssets = computed(() => {
@@ -395,7 +398,7 @@ const visibleAssets = computed(() => {
 const selectionAssets = computed(() => {
   if (isInFolderView.value) {
     const cachedFolderAssets = folderJobId.value
-      ? (folderAssetsByJobId.value[folderJobId.value] ?? [])
+      ? (resolvedOutputAssetsByJobId.value[folderJobId.value] ?? [])
       : []
     return uniqueAssets([
       ...mediaAssets.value,
@@ -406,7 +409,7 @@ const selectionAssets = computed(() => {
 
   const cachedChildren = visibleAssets.value.flatMap((asset) => {
     const jobId = getAssetJobId(asset)
-    return jobId ? (folderAssetsByJobId.value[jobId] ?? []) : []
+    return jobId ? (resolvedOutputAssetsByJobId.value[jobId] ?? []) : []
   })
   return uniqueAssets([...visibleAssets.value, ...cachedChildren])
 })
@@ -419,13 +422,13 @@ function getAssetJobId(asset: AssetItem): string | undefined {
   return getOutputAssetMetadata(asset.user_metadata)?.jobId
 }
 
-function getCachedFolderAssets(asset: AssetItem): AssetItem[] {
+function getResolvedOutputAssets(asset: AssetItem): AssetItem[] {
   const jobId = getAssetJobId(asset)
-  return jobId ? (folderAssetsByJobId.value[jobId] ?? []) : []
+  return jobId ? (resolvedOutputAssetsByJobId.value[jobId] ?? []) : []
 }
 
 function getSelectedChildIds(asset: AssetItem): string[] {
-  return getCachedFolderAssets(asset)
+  return getResolvedOutputAssets(asset)
     .filter((child) => isSelected(child.id))
     .map(({ id }) => id)
 }
@@ -452,7 +455,28 @@ function isGridAssetSelected(assetId: string): boolean {
   )
 }
 
-function isGridAssetPartiallySelected(asset: AssetItem): boolean {
+function getListOutputGroupParent(asset: AssetItem): AssetItem | undefined {
+  if (isInFolderView.value || getOutputCount(asset) > 1) return
+
+  const jobId = getAssetJobId(asset)
+  if (!jobId) return
+
+  return displayAssets.value.find(
+    (candidate) =>
+      getAssetJobId(candidate) === jobId && getOutputCount(candidate) > 1
+  )
+}
+
+function isListAssetSelected(asset: AssetItem): boolean {
+  if (isSelected(asset.id)) return true
+
+  const parent = getListOutputGroupParent(asset)
+  if (parent) return isSelected(parent.id)
+
+  return isGridAssetSelected(asset.id)
+}
+
+function isAssetPartiallySelected(asset: AssetItem): boolean {
   if (isInFolderView.value || isSelected(asset.id)) return false
 
   const selectedOutputCount = getSelectedOutputCount(asset)
@@ -460,9 +484,9 @@ function isGridAssetPartiallySelected(asset: AssetItem): boolean {
 }
 
 function toggleGroupedSelection(asset: AssetItem): boolean {
-  if (isSelected(asset.id)) return false
+  if (isSelected(asset.id) || getOutputCount(asset) <= 1) return false
 
-  const cachedChildren = getCachedFolderAssets(asset)
+  const cachedChildren = getResolvedOutputAssets(asset)
   const selectedChildIds = getSelectedChildIds(asset)
   if (selectedChildIds.length === 0) return false
 
@@ -478,6 +502,25 @@ function toggleGroupedSelection(asset: AssetItem): boolean {
     isFullySelected ? remainingIds : [...remainingIds, asset.id],
     selectionAssets.value
   )
+  return true
+}
+
+function toggleInheritedListChildSelection(asset: AssetItem): boolean {
+  if (!isListView.value || !cmdOrCtrlKey.value) return false
+
+  const parent = getListOutputGroupParent(asset)
+  if (!parent || !isSelected(parent.id)) return false
+
+  const children = getResolvedOutputAssets(parent)
+  const groupedIds = new Set([parent.id, ...children.map((child) => child.id)])
+  const remainingIds = [...selectedIds.value].filter(
+    (id) => !groupedIds.has(id)
+  )
+  const selectedChildIds = children
+    .filter((child) => child.id !== asset.id)
+    .map((child) => child.id)
+
+  setSelectedIds([...remainingIds, ...selectedChildIds], selectionAssets.value)
   return true
 }
 
@@ -582,6 +625,11 @@ watch(
 )
 
 function handleAssetSelect(asset: AssetItem, assets?: AssetItem[]) {
+  if (toggleInheritedListChildSelection(asset)) {
+    emit('assetSelected', asset)
+    return
+  }
+
   if (
     !isInFolderView.value &&
     cmdOrCtrlKey.value &&
@@ -729,8 +777,8 @@ const enterFolderView = async (asset: AssetItem) => {
     return
   }
 
-  folderAssetsByJobId.value = {
-    ...folderAssetsByJobId.value,
+  resolvedOutputAssetsByJobId.value = {
+    ...resolvedOutputAssetsByJobId.value,
     [jobId]: folderAssets.value
   }
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -121,6 +121,7 @@
           <AssetsSidebarGridView
             :assets="displayAssets"
             :is-selected="isGridAssetSelected"
+            :is-partially-selected="isGridAssetPartiallySelected"
             :show-output-count
             :get-output-count
             :get-selected-output-count
@@ -453,6 +454,13 @@ function isGridAssetSelected(assetId: string): boolean {
   return (
     selectedOutputCount > 0 && selectedOutputCount === getOutputCount(asset)
   )
+}
+
+function isGridAssetPartiallySelected(asset: AssetItem): boolean {
+  if (isInFolderView.value || isSelected(asset.id)) return false
+
+  const selectedOutputCount = getSelectedOutputCount(asset)
+  return selectedOutputCount > 0 && selectedOutputCount < getOutputCount(asset)
 }
 
 function toggleGroupedSelection(asset: AssetItem): boolean {

--- a/src/platform/assets/components/AssetsListItem.test.ts
+++ b/src/platform/assets/components/AssetsListItem.test.ts
@@ -75,4 +75,18 @@ describe('AssetsListItem', () => {
 
     expect(emitted()['preview-click']).toHaveLength(1)
   })
+
+  it('shows the selected fraction for a partially selected stack', () => {
+    render(AssetsListItem, {
+      props: {
+        stackCount: 2,
+        selectedStackCount: 1,
+        stackIndicatorLabel: 'See more outputs'
+      }
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'See more outputs' })
+    ).toHaveTextContent('1/2')
+  })
 })

--- a/src/platform/assets/components/AssetsListItem.vue
+++ b/src/platform/assets/components/AssetsListItem.vue
@@ -117,7 +117,18 @@
         @click.stop="emit('stack-toggle')"
       >
         <i aria-hidden="true" class="icon-[lucide--layers] size-4" />
-        <span class="text-xs leading-none">{{ stackCount }}</span>
+        <span class="text-xs leading-none">
+          <template
+            v-if="
+              typeof selectedStackCount === 'number' &&
+              selectedStackCount > 0 &&
+              selectedStackCount < stackCount
+            "
+          >
+            {{ selectedStackCount }}/{{ stackCount }}
+          </template>
+          <template v-else>{{ stackCount }}</template>
+        </span>
         <i
           aria-hidden="true"
           :class="
@@ -157,6 +168,7 @@ const {
   primaryText,
   secondaryText,
   stackCount,
+  selectedStackCount,
   stackIndicatorLabel,
   stackExpanded = false,
   progressTotalPercent,
@@ -172,6 +184,7 @@ const {
   primaryText?: string
   secondaryText?: string
   stackCount?: number
+  selectedStackCount?: number
   stackIndicatorLabel?: string
   stackExpanded?: boolean
   progressTotalPercent?: number

--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -208,6 +208,16 @@ describe('MediaAssetCard', () => {
     )
   })
 
+  it('exposes partial selection without reporting a full selection', () => {
+    renderCard({ loading: false, partiallySelected: true })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'assetBrowser.ariaLabel.assetCard'
+      })
+    ).toHaveAttribute('aria-pressed', 'mixed')
+  })
+
   it('shows image format and dimensions without file size', () => {
     renderCard({
       loading: false,

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -146,7 +146,15 @@
             @click.stop="handleOutputCountClick"
           >
             <i class="icon-[lucide--layers] size-4" />
-            <span>{{ outputCount }}</span>
+            <span
+              v-if="
+                selectedOutputCount > 0 &&
+                selectedOutputCount < (outputCount ?? 0)
+              "
+            >
+              {{ selectedOutputCount }}/{{ outputCount }}
+            </span>
+            <span v-else>{{ outputCount }}</span>
           </Button>
         </div>
       </div>
@@ -201,12 +209,20 @@ function getTopComponent(kind: PreviewKind) {
   return mediaComponents.top[kind] || mediaComponents.top.other
 }
 
-const { asset, loading, selected, showOutputCount, outputCount } = defineProps<{
+const {
+  asset,
+  loading,
+  selected,
+  showOutputCount,
+  outputCount,
+  selectedOutputCount = 0
+} = defineProps<{
   asset?: AssetItem
   loading?: boolean
   selected?: boolean
   showOutputCount?: boolean
   outputCount?: number
+  selectedOutputCount?: number
 }>()
 
 const assetsStore = useAssetsStore()

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -9,7 +9,7 @@
       cn(
         'flex cursor-pointer flex-col overflow-hidden rounded-lg p-2 transition-colors duration-200',
         'group gap-2 select-none',
-        selected
+        selected || partiallySelected
           ? 'ring-3 ring-modal-card-border-highlighted ring-inset'
           : 'hover:bg-modal-card-background-hovered/20'
       )
@@ -69,7 +69,7 @@
             type: fileKind
           })
         "
-        :aria-pressed="selected ?? false"
+        :aria-pressed="selected ? true : partiallySelected ? 'mixed' : false"
         @click.stop="emit('toggle-selection')"
       >
         <i
@@ -213,6 +213,7 @@ const {
   asset,
   loading,
   selected,
+  partiallySelected,
   showOutputCount,
   outputCount,
   selectedOutputCount = 0
@@ -220,6 +221,7 @@ const {
   asset?: AssetItem
   loading?: boolean
   selected?: boolean
+  partiallySelected?: boolean
   showOutputCount?: boolean
   outputCount?: number
   selectedOutputCount?: number

--- a/src/platform/assets/composables/useOutputStacks.test.ts
+++ b/src/platform/assets/composables/useOutputStacks.test.ts
@@ -76,8 +76,7 @@ describe('useOutputStacks', () => {
     expect(mocks.resolveOutputAssetItems).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: 'job-1' }),
       {
-        createdAt: parent.created_at,
-        excludeOutputKey: 'node-1-outputs-parent.png'
+        createdAt: parent.created_at
       }
     )
     expect(isStackExpanded(parent)).toBe(true)
@@ -95,6 +94,60 @@ describe('useOutputStacks', () => {
       isChild: true
     })
     expect(selectableAssets.value).toEqual([parent, childA, childB])
+  })
+
+  it('stores resolved children in a provided shared cache', async () => {
+    const parent = createAsset({ id: 'parent', name: 'parent.png' })
+    const child = createAsset({
+      id: 'child',
+      name: 'child.png',
+      user_metadata: undefined
+    })
+    const childrenByJobId = ref<Record<string, AssetItem[]>>({})
+
+    vi.mocked(mocks.resolveOutputAssetItems).mockResolvedValue([child])
+
+    const { toggleStack } = useOutputStacks({
+      assets: ref([parent]),
+      childrenByJobId
+    })
+
+    await toggleStack(parent)
+
+    expect(childrenByJobId.value['job-1']).toEqual([child])
+  })
+
+  it('excludes the representative output from a prepopulated shared cache', async () => {
+    const parent = createAsset({ id: 'parent', name: 'parent.png' })
+    const representative = createAsset({
+      id: 'representative',
+      name: 'parent.png'
+    })
+    const sibling = createAsset({
+      id: 'sibling',
+      name: 'sibling.png',
+      user_metadata: {
+        jobId: 'job-1',
+        nodeId: 'node-2',
+        subfolder: 'outputs'
+      }
+    })
+    const childrenByJobId = ref<Record<string, AssetItem[]>>({
+      'job-1': [representative, sibling]
+    })
+
+    const { assetItems, toggleStack } = useOutputStacks({
+      assets: ref([parent]),
+      childrenByJobId
+    })
+
+    await toggleStack(parent)
+
+    expect(assetItems.value.map((item) => item.asset.id)).toEqual([
+      parent.id,
+      sibling.id
+    ])
+    expect(mocks.resolveOutputAssetItems).not.toHaveBeenCalled()
   })
 
   it('collapses an expanded stack when toggled again', async () => {

--- a/src/platform/assets/composables/useOutputStacks.ts
+++ b/src/platform/assets/composables/useOutputStacks.ts
@@ -16,11 +16,14 @@ export type OutputStackListItem = {
 
 type UseOutputStacksOptions = {
   assets: Ref<AssetItem[]>
+  childrenByJobId?: Ref<Record<string, AssetItem[]>>
 }
 
-export function useOutputStacks({ assets }: UseOutputStacksOptions) {
+export function useOutputStacks({
+  assets,
+  childrenByJobId = ref<Record<string, AssetItem[]>>({})
+}: UseOutputStacksOptions) {
   const expandedStackJobIds = ref<Set<string>>(new Set())
-  const stackChildrenByJobId = ref<Record<string, AssetItem[]>>({})
   const loadingStackJobIds = ref<Set<string>>(new Set())
 
   const assetItems = computed<OutputStackListItem[]>(() => {
@@ -37,7 +40,7 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
         continue
       }
 
-      const children = stackChildrenByJobId.value[jobId] ?? []
+      const children = getStackChildren(asset, jobId)
       for (const child of children) {
         items.push({
           key: `asset-${child.id}`,
@@ -65,6 +68,25 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
     return expandedStackJobIds.value.has(jobId)
   }
 
+  function getStackChildren(asset: AssetItem, jobId: string): AssetItem[] {
+    const representativeOutputKey = getStackOutputKey(asset)
+    if (!representativeOutputKey) {
+      return childrenByJobId.value[jobId] ?? []
+    }
+    return (childrenByJobId.value[jobId] ?? []).filter(
+      (child) => getStackOutputKey(child) !== representativeOutputKey
+    )
+  }
+
+  function getStackOutputKey(asset: AssetItem): string | null {
+    const metadata = getOutputAssetMetadata(asset.user_metadata)
+    return getOutputKey({
+      nodeId: metadata?.nodeId,
+      subfolder: metadata?.subfolder,
+      filename: asset.name
+    })
+  }
+
   async function toggleStack(asset: AssetItem) {
     const jobId = getStackJobId(asset)
     if (!jobId) return
@@ -76,7 +98,7 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
       return
     }
 
-    if (!stackChildrenByJobId.value[jobId]?.length) {
+    if (!childrenByJobId.value[jobId]?.length) {
       if (loadingStackJobIds.value.has(jobId)) {
         return
       }
@@ -94,8 +116,8 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
         return
       }
 
-      stackChildrenByJobId.value = {
-        ...stackChildrenByJobId.value,
+      childrenByJobId.value = {
+        ...childrenByJobId.value,
         [jobId]: children
       }
     }
@@ -111,17 +133,9 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
       return []
     }
 
-    const excludeOutputKey =
-      getOutputKey({
-        nodeId: metadata.nodeId,
-        subfolder: metadata.subfolder,
-        filename: asset.name
-      }) ?? undefined
-
     try {
       return await resolveOutputAssetItems(metadata, {
-        createdAt: asset.created_at,
-        excludeOutputKey
+        createdAt: asset.created_at
       })
     } catch (error) {
       console.error('Failed to resolve stack children:', error)


### PR DESCRIPTION
## Summary

Preserve full and partial grouped-output selection when navigating into “more outputs” and switching between grid and list views. [FE-1375](https://linear.app/comfyorg/issue/FE-1375/bug-asset-selection-state-lost-when-navigating-tofrom-more-outputs)

The selection model could retain either a group parent ID or individual output IDs, while list expansion kept its own child cache. That prevented views from consistently deriving the same full or partial state.

## Changes

- **What**: Share resolved output children across views; inherit full parent selection in expanded list children; support Cmd/Ctrl child toggles; show highlighted mixed parents with selected/total counts.
- **Dependencies**: None.

## Review Focus

- Full parent selections are normalized into child IDs only when an inherited child is toggled.
- The representative output remains hidden from expanded list children while staying available for selection accounting.