### PR TITLE
feat: persist workspace auto-reload settings

### DIFF
--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -2,7 +2,12 @@ import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
-import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
+import type {
+  AutoReloadResponse,
+  BillingStatusResponse,
+  UpdateAutoReloadRequest,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
@@ -152,6 +157,82 @@ async function mockCloudBoot(page: Page, billingControlEnabled = true) {
   )
 }
 
+async function mockAutoReloadContract(page: Page) {
+  const workspaces: WorkspaceWithRole[] = [
+    workspace('personal', 'owner'),
+    workspace('team', 'owner')
+  ]
+  const savedByWorkspace = new Map<string, AutoReloadResponse>()
+  const putRequests: UpdateAutoReloadRequest[] = []
+
+  await page.unroute('**/api/features')
+  await page.route('**/api/features', (route) =>
+    route.fulfill(
+      jsonRoute({
+        team_workspaces_enabled: true,
+        billing_control_enabled: true
+      } satisfies RemoteConfig)
+    )
+  )
+  await page.unroute('**/api/workspaces')
+  await page.route('**/api/workspaces', (route) =>
+    route.fulfill(jsonRoute({ workspaces }))
+  )
+  await page.unroute('**/api/auth/token')
+  await page.route('**/api/auth/token', async (route) => {
+    const body = route.request().postDataJSON() as { workspace_id?: string }
+    const selected =
+      workspaces.find((candidate) => candidate.id === body.workspace_id) ??
+      workspaces[0]
+    await route.fulfill(
+      jsonRoute({
+        token: `token-${selected.id}`,
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        workspace: {
+          id: selected.id,
+          name: selected.name,
+          type: selected.type
+        },
+        role: selected.role,
+        permissions: []
+      })
+    )
+  })
+  await page.route('**/api/billing/auto-reload', async (route) => {
+    const authorization = await route.request().headerValue('authorization')
+    expect(authorization).toMatch(/^Bearer token-ws-(personal|team)$/)
+    const workspaceId = authorization!.replace('Bearer token-', '')
+    const current =
+      savedByWorkspace.get(workspaceId) ??
+      ({
+        configured: false,
+        enabled: false,
+        threshold_credits: null,
+        reload_credits: null,
+        monthly_budget_cents: null,
+        spent_this_cycle_cents: 0
+      } satisfies AutoReloadResponse)
+
+    if (route.request().method() === 'GET') {
+      await route.fulfill(jsonRoute(current))
+      return
+    }
+
+    expect(route.request().method()).toBe('PUT')
+    const payload = route.request().postDataJSON() as UpdateAutoReloadRequest
+    putRequests.push(payload)
+    const updated: AutoReloadResponse = {
+      configured: true,
+      ...payload,
+      spent_this_cycle_cents: 0
+    }
+    savedByWorkspace.set(workspaceId, updated)
+    await route.fulfill(jsonRoute(updated))
+  })
+
+  return { putRequests }
+}
+
 async function mockBalance(
   page: Page,
   balance: { amount: number; monthly: number; prepaid: number }
@@ -231,6 +312,50 @@ test.describe('Credits tile (Plan & Credits)', { tag: '@cloud' }, () => {
     await expect(content.getByRole('button', { name: 'Activity' })).toHaveCount(
       0
     )
+  })
+
+  test('persists auto-reload with the authenticated workspace contract', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
+    await mockCloudBoot(page)
+    const { putRequests } = await mockAutoReloadContract(page)
+
+    let content = await openPlanAndCredits(page)
+    await content.getByRole('button', { name: 'Set up auto-reload' }).click()
+    await page.getByRole('button', { name: 'Update' }).click()
+
+    expect(putRequests).toEqual([
+      {
+        enabled: true,
+        threshold_credits: 1000,
+        reload_credits: 5000,
+        monthly_budget_cents: null
+      }
+    ])
+    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
+
+    await page.reload()
+    content = await openPlanAndCredits(page)
+    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
+
+    await page.getByTestId('settings-dialog').getByLabel('Close').click()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    await page.getByText('My Team', { exact: true }).click()
+
+    content = await openPlanAndCredits(page)
+    await expect(
+      content.getByRole('button', { name: 'Set up auto-reload' })
+    ).toBeVisible()
+
+    await page.getByTestId('settings-dialog').getByLabel('Close').click()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    await page.getByText('Personal Workspace', { exact: true }).click()
+
+    content = await openPlanAndCredits(page)
+    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
   })
 
   test('renders the unified tile with breakdown and add-credits', async ({

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -333,11 +333,15 @@ test.describe('Credits tile (Plan & Credits)', { tag: '@cloud' }, () => {
         monthly_budget_cents: null
       }
     ])
-    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Edit', exact: true })
+    ).toBeVisible()
 
     await page.reload()
     content = await openPlanAndCredits(page)
-    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Edit', exact: true })
+    ).toBeVisible()
 
     await page.getByTestId('settings-dialog').getByLabel('Close').click()
     await page.getByRole('button', { name: 'Current user' }).click()
@@ -355,7 +359,9 @@ test.describe('Credits tile (Plan & Credits)', { tag: '@cloud' }, () => {
     await page.getByText('Personal Workspace', { exact: true }).click()
 
     content = await openPlanAndCredits(page)
-    await expect(content.getByRole('button', { name: 'Edit' })).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Edit', exact: true })
+    ).toBeVisible()
   })
 
   test('renders the unified tile with breakdown and add-credits', async ({

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2992,11 +2992,15 @@
       },
       "disabled": "Disabled",
       "edit": "Edit",
+      "loadError": "Couldn’t load auto-reload settings.",
+      "loading": "Loading auto-reload settings…",
       "empty": {
         "body": "Keep your workflows running with auto-reloaded credits. Set a monthly budget so charges don't surprise you.",
         "cta": "Set up auto-reload"
       },
       "enabled": "Enabled",
+      "retry": "Try again",
+      "saveError": "Couldn’t save auto-reload settings. Try again.",
       "subtitle": "Automatically add credits when your balance runs low, within an optional monthly budget.",
       "tile": {
         "label": "Auto-reload",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   mockAxiosInstance,
   mockGetAuthHeaderOrThrow,
-  mockGetFirebaseAuthHeaderOrThrow
+  mockGetFirebaseAuthHeaderOrThrow,
+  mockWorkspaceStore
 } = vi.hoisted(() => ({
   mockAxiosInstance: {
     get: vi.fn(),
@@ -14,7 +15,8 @@ const {
     interceptors: { response: { use: vi.fn() } }
   },
   mockGetAuthHeaderOrThrow: vi.fn(),
-  mockGetFirebaseAuthHeaderOrThrow: vi.fn()
+  mockGetFirebaseAuthHeaderOrThrow: vi.fn(),
+  mockWorkspaceStore: { activeWorkspaceId: 'workspace-a' as string | null }
 }))
 
 vi.mock('axios', () => ({
@@ -48,6 +50,10 @@ vi.mock('@/stores/authStore', () => ({
   })
 }))
 
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => mockWorkspaceStore
+}))
+
 import { workspaceApi } from './workspaceApi'
 
 const AUTH_HEADER = { Authorization: 'Bearer test-token' }
@@ -55,6 +61,7 @@ const AUTH_HEADER = { Authorization: 'Bearer test-token' }
 describe('workspaceApi', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockWorkspaceStore.activeWorkspaceId = 'workspace-a'
     mockGetAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
     mockGetFirebaseAuthHeaderOrThrow.mockResolvedValue(AUTH_HEADER)
   })
@@ -390,7 +397,7 @@ describe('workspaceApi', () => {
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/billing/auto-reload',
-        { headers: AUTH_HEADER }
+        { headers: AUTH_HEADER, timeout: 15_000 }
       )
       expect(result).toEqual(data)
     })
@@ -414,9 +421,27 @@ describe('workspaceApi', () => {
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/billing/auto-reload',
         payload,
-        { headers: AUTH_HEADER }
+        { headers: AUTH_HEADER, timeout: 15_000 }
       )
       expect(result).toEqual(data)
+    })
+
+    it('aborts an update if the workspace changes while resolving auth', async () => {
+      mockWorkspaceStore.activeWorkspaceId = 'workspace-b'
+
+      await expect(
+        workspaceApi.updateAutoReload(
+          {
+            enabled: false,
+            threshold_credits: 1000,
+            reload_credits: 5000,
+            monthly_budget_cents: null
+          },
+          'workspace-a'
+        )
+      ).rejects.toThrow('Active workspace changed')
+
+      expect(mockAxiosInstance.put).not.toHaveBeenCalled()
     })
 
     it('getAutoReload() exposes auth and API failures', async () => {

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -8,6 +8,7 @@ const {
   mockAxiosInstance: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     patch: vi.fn(),
     delete: vi.fn(),
     interceptors: { response: { use: vi.fn() } }
@@ -372,6 +373,75 @@ describe('workspaceApi', () => {
         }
       )
       expect(result).toEqual(data)
+    })
+
+    it('getAutoReload() sends authenticated GET /billing/auto-reload', async () => {
+      const data = {
+        configured: false,
+        enabled: false,
+        threshold_credits: null,
+        reload_credits: null,
+        monthly_budget_cents: null,
+        spent_this_cycle_cents: 0
+      }
+      mockAxiosInstance.get.mockResolvedValue({ data })
+
+      const result = await workspaceApi.getAutoReload()
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/billing/auto-reload',
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(data)
+    })
+
+    it('updateAutoReload() sends the exact authenticated PUT payload', async () => {
+      const payload = {
+        enabled: true,
+        threshold_credits: 2000,
+        reload_credits: 6000,
+        monthly_budget_cents: null
+      }
+      const data = {
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: 0
+      }
+      mockAxiosInstance.put.mockResolvedValue({ data })
+
+      const result = await workspaceApi.updateAutoReload(payload)
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+        '/api/billing/auto-reload',
+        payload,
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(data)
+    })
+
+    it('getAutoReload() exposes auth and API failures', async () => {
+      const authError = new Error('not authenticated')
+      mockGetAuthHeaderOrThrow.mockRejectedValueOnce(authError)
+      await expect(workspaceApi.getAutoReload()).rejects.toBe(authError)
+
+      const axiosError = {
+        isAxiosError: true,
+        response: { status: 503, data: { message: 'Unavailable' } },
+        message: 'Request failed'
+      }
+      mockAxiosInstance.put.mockRejectedValueOnce(axiosError)
+      await expect(
+        workspaceApi.updateAutoReload({
+          enabled: false,
+          threshold_credits: 1000,
+          reload_credits: 5000,
+          monthly_budget_cents: 10_000
+        })
+      ).rejects.toMatchObject({
+        name: 'WorkspaceApiError',
+        status: 503,
+        message: 'Unavailable'
+      })
     })
 
     it('getBillingPlans() sends GET /billing/plans', async () => {

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -288,6 +288,22 @@ export interface BillingBalanceResponse {
   currency: string
 }
 
+export interface AutoReloadResponse {
+  configured: boolean
+  enabled: boolean
+  threshold_credits: number | null
+  reload_credits: number | null
+  monthly_budget_cents: number | null
+  spent_this_cycle_cents: number
+}
+
+export interface UpdateAutoReloadRequest {
+  enabled: boolean
+  threshold_credits: number
+  reload_credits: number
+  monthly_budget_cents: number | null
+}
+
 interface CreateTopupRequest {
   amount_cents: number
   idempotency_key?: string
@@ -620,6 +636,35 @@ export const workspaceApi = {
     try {
       const response = await workspaceApiClient.get<BillingBalanceResponse>(
         api.apiURL('/billing/balance'),
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async getAutoReload(): Promise<AutoReloadResponse> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.get<AutoReloadResponse>(
+        api.apiURL('/billing/auto-reload'),
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async updateAutoReload(
+    payload: UpdateAutoReloadRequest
+  ): Promise<AutoReloadResponse> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.put<AutoReloadResponse>(
+        api.apiURL('/billing/auto-reload'),
+        payload,
         { headers }
       )
       return response.data

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceId,
   WorkspaceInviteId
 } from '@/platform/workspace/workspaceTypes'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserId } from '@/types/authTypes'
@@ -303,6 +304,8 @@ export interface UpdateAutoReloadRequest {
   reload_credits: number
   monthly_budget_cents: number | null
 }
+
+const AUTO_RELOAD_TIMEOUT_MS = 15_000
 
 interface CreateTopupRequest {
   amount_cents: number
@@ -649,7 +652,7 @@ export const workspaceApi = {
     try {
       const response = await workspaceApiClient.get<AutoReloadResponse>(
         api.apiURL('/billing/auto-reload'),
-        { headers }
+        { headers, timeout: AUTO_RELOAD_TIMEOUT_MS }
       )
       return response.data
     } catch (err) {
@@ -658,14 +661,21 @@ export const workspaceApi = {
   },
 
   async updateAutoReload(
-    payload: UpdateAutoReloadRequest
+    payload: UpdateAutoReloadRequest,
+    expectedWorkspaceId?: string
   ): Promise<AutoReloadResponse> {
     const headers = await getAuthHeaderOrThrow()
+    if (
+      expectedWorkspaceId &&
+      useTeamWorkspaceStore().activeWorkspaceId !== expectedWorkspaceId
+    ) {
+      throw new Error('Active workspace changed before auto-reload update')
+    }
     try {
       const response = await workspaceApiClient.put<AutoReloadResponse>(
         api.apiURL('/billing/auto-reload'),
         payload,
-        { headers }
+        { headers, timeout: AUTO_RELOAD_TIMEOUT_MS }
       )
       return response.data
     } catch (err) {

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
@@ -7,6 +7,7 @@ import { createI18n } from 'vue-i18n'
 
 import { creditsToCents, usdToCredits } from '@/base/credits/comfyCredits'
 import enMessages from '@/locales/en/main.json'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import AutoReloadDialogContent from '@/platform/workspace/components/dialogs/AutoReloadDialogContent.vue'
 import { useAutoReload } from '@/platform/workspace/composables/useAutoReload'
 import type { AutoReloadConfig } from '@/platform/workspace/composables/useAutoReload'
@@ -27,6 +28,13 @@ vi.mock('@/platform/workspace/composables/useAutoReloadAccess', () => ({
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => dialogStoreMocks
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getAutoReload: vi.fn(),
+    updateAutoReload: vi.fn()
+  }
 }))
 
 const autoReload = useAutoReload()
@@ -64,11 +72,28 @@ function setConfig(overrides: Partial<AutoReloadConfig> = {}) {
 }
 
 describe('AutoReloadDialogContent', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetAllMocks()
     dialogStoreMocks.closeDialog.mockReset()
     mockCanAccess.value = true
     mockAccessFrozen.value = false
-    autoReload.scopeToWorkspace('workspace-a')
+    vi.mocked(workspaceApi.getAutoReload).mockResolvedValue({
+      configured: false,
+      enabled: false,
+      threshold_credits: null,
+      reload_credits: null,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 0
+    })
+    vi.mocked(workspaceApi.updateAutoReload).mockImplementation(
+      async (payload) => ({
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: 0
+      })
+    )
+    await autoReload.scopeToWorkspace(null)
+    await autoReload.scopeToWorkspace('workspace-a')
     setConfig()
   })
 
@@ -398,6 +423,23 @@ describe('AutoReloadDialogContent', () => {
       key: 'auto-reload'
     })
     await user.click(screen.getByRole('button', { name: 'Update' }))
+    expect(autoReload.config.configured).toBe(false)
+  })
+
+  it('keeps the dialog open and reports a failed save for retry', async () => {
+    const user = userEvent.setup()
+    vi.mocked(workspaceApi.updateAutoReload).mockRejectedValueOnce(
+      new Error('save failed')
+    )
+    renderDialog()
+    dialogStoreMocks.closeDialog.mockClear()
+
+    await user.click(screen.getByRole('button', { name: 'Update' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Couldn’t save auto-reload settings. Try again.'
+    )
+    expect(dialogStoreMocks.closeDialog).not.toHaveBeenCalled()
     expect(autoReload.config.configured).toBe(false)
   })
 })

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.test.ts
@@ -441,5 +441,17 @@ describe('AutoReloadDialogContent', () => {
     )
     expect(dialogStoreMocks.closeDialog).not.toHaveBeenCalled()
     expect(autoReload.config.configured).toBe(false)
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(autoReload.error.value).toBeNull()
+  })
+
+  it('does not show an error from an earlier section update', () => {
+    autoReload.error.value = 'toggle failed'
+
+    renderDialog()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(autoReload.error.value).toBeNull()
   })
 })

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
@@ -191,6 +191,10 @@
       </p>
     </div>
 
+    <p v-if="error" class="text-danger m-0 px-4 text-sm" role="alert">
+      {{ $t('workspacePanel.autoReload.saveError') }}
+    </p>
+
     <div
       class="flex items-center justify-between border-t border-border-default p-4"
     >
@@ -255,13 +259,13 @@ import { storeToRefs } from 'pinia'
 const { t, n: fmtNumber, locale } = useI18n()
 const { workspaceId } = defineProps<{ workspaceId: string | null }>()
 const dialogStore = useDialogStore()
-const { config, save, scopeToWorkspace } = useAutoReload()
+const { config, error, isSaving, save, scopeToWorkspace } = useAutoReload()
 const { activeWorkspaceId } = storeToRefs(useTeamWorkspaceStore())
 const { canConfigure } = useAutoReloadAccess()
 const canConfigureWorkspace = computed(
   () => canConfigure.value && activeWorkspaceId.value === workspaceId
 )
-scopeToWorkspace(activeWorkspaceId.value)
+void scopeToWorkspace(activeWorkspaceId.value)
 
 type Unit = 'credits' | 'usd'
 const unitOptions: Unit[] = ['credits', 'usd']
@@ -500,7 +504,11 @@ const budgetWarning = computed(() => {
 })
 
 const canUpdate = computed(
-  () => !thresholdError.value && !reloadError.value && !budgetError.value
+  () =>
+    !isSaving.value &&
+    !thresholdError.value &&
+    !reloadError.value &&
+    !budgetError.value
 )
 
 function onClose() {
@@ -508,7 +516,7 @@ function onClose() {
 }
 
 watch(activeWorkspaceId, (workspaceId) => {
-  scopeToWorkspace(workspaceId)
+  void scopeToWorkspace(workspaceId)
   onClose()
 })
 
@@ -520,18 +528,22 @@ watch(
   { immediate: true }
 )
 
-function onUpdate() {
+async function onUpdate() {
   if (!canConfigureWorkspace.value) {
     onClose()
     return
   }
   if (!canUpdate.value) return
-  save({
-    thresholdCredits: thresholdCredits.value,
-    reloadCredits: reloadCredits.value,
-    monthlyBudgetCents:
-      budgetEnabled.value && budgetCents.value > 0 ? budgetCents.value : null
-  })
-  onClose()
+  try {
+    await save({
+      thresholdCredits: thresholdCredits.value,
+      reloadCredits: reloadCredits.value,
+      monthlyBudgetCents:
+        budgetEnabled.value && budgetCents.value > 0 ? budgetCents.value : null
+    })
+    onClose()
+  } catch {
+    return
+  }
 }
 </script>

--- a/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/AutoReloadDialogContent.vue
@@ -259,12 +259,14 @@ import { storeToRefs } from 'pinia'
 const { t, n: fmtNumber, locale } = useI18n()
 const { workspaceId } = defineProps<{ workspaceId: string | null }>()
 const dialogStore = useDialogStore()
-const { config, error, isSaving, save, scopeToWorkspace } = useAutoReload()
+const { config, error, isSaving, save, scopeToWorkspace, clearError } =
+  useAutoReload()
 const { activeWorkspaceId } = storeToRefs(useTeamWorkspaceStore())
 const { canConfigure } = useAutoReloadAccess()
 const canConfigureWorkspace = computed(
   () => canConfigure.value && activeWorkspaceId.value === workspaceId
 )
+clearError()
 void scopeToWorkspace(activeWorkspaceId.value)
 
 type Unit = 'credits' | 'usd'
@@ -512,6 +514,7 @@ const canUpdate = computed(
 )
 
 function onClose() {
+  clearError()
   dialogStore.closeDialog({ key: 'auto-reload' })
 }
 

--- a/src/platform/workspace/components/dialogs/settings/AutoReloadSection.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/AutoReloadSection.test.ts
@@ -6,6 +6,7 @@ import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import AutoReloadSection from '@/platform/workspace/components/dialogs/settings/AutoReloadSection.vue'
 import { useAutoReload } from '@/platform/workspace/composables/useAutoReload'
 import type { AutoReloadConfig } from '@/platform/workspace/composables/useAutoReload'
@@ -25,6 +26,13 @@ vi.mock('@/platform/workspace/composables/useAutoReloadAccess', () => ({
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => dialogMocks
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getAutoReload: vi.fn(),
+    updateAutoReload: vi.fn()
+  }
 }))
 
 const i18n = createI18n({
@@ -62,11 +70,28 @@ function setConfig(overrides: Partial<AutoReloadConfig> = {}) {
 }
 
 describe('AutoReloadSection', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetAllMocks()
     dialogMocks.showAutoReloadDialog.mockReset()
     mockCanAccess.value = true
     mockAccessFrozen.value = false
-    autoReload.scopeToWorkspace('workspace-a')
+    vi.mocked(workspaceApi.getAutoReload).mockResolvedValue({
+      configured: false,
+      enabled: false,
+      threshold_credits: null,
+      reload_credits: null,
+      monthly_budget_cents: null,
+      spent_this_cycle_cents: 0
+    })
+    vi.mocked(workspaceApi.updateAutoReload).mockImplementation(
+      async (payload) => ({
+        configured: true,
+        ...payload,
+        spent_this_cycle_cents: 0
+      })
+    )
+    await autoReload.scopeToWorkspace(null)
+    await autoReload.scopeToWorkspace('workspace-a')
     setConfig({ configured: false, enabled: false, monthlyBudgetCents: null })
   })
 
@@ -177,6 +202,7 @@ describe('AutoReloadSection', () => {
     await user.click(
       screen.getByRole('switch', { name: 'Enable credit auto-reload' })
     )
+    await nextTick()
     expect(autoReload.isEnabled.value).toBe(true)
   })
 
@@ -191,6 +217,44 @@ describe('AutoReloadSection', () => {
     )
 
     expect(autoReload.isEnabled.value).toBe(true)
+  })
+
+  it('keeps the canonical enabled state and reports a failed update', async () => {
+    const user = userEvent.setup()
+    setConfig({ enabled: true })
+    vi.mocked(workspaceApi.updateAutoReload).mockRejectedValueOnce(
+      new Error('save failed')
+    )
+    renderSection()
+
+    await user.click(
+      screen.getByRole('switch', { name: 'Enable credit auto-reload' })
+    )
+
+    expect(autoReload.isEnabled.value).toBe(true)
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Couldn’t save auto-reload settings. Try again.'
+    )
+  })
+
+  it('blocks configuration changes while an update is pending', async () => {
+    const user = userEvent.setup()
+    setConfig({ enabled: true })
+    vi.mocked(workspaceApi.updateAutoReload).mockImplementationOnce(
+      () => new Promise(() => {})
+    )
+    renderSection()
+
+    await user.click(
+      screen.getByRole('switch', { name: 'Enable credit auto-reload' })
+    )
+
+    expect(
+      screen.getByRole('switch', { name: 'Enable credit auto-reload' })
+    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(dialogMocks.showAutoReloadDialog).not.toHaveBeenCalled()
   })
 
   it('freezes all controls for a plan that cannot spend', async () => {
@@ -220,6 +284,20 @@ describe('AutoReloadSection', () => {
     await nextTick()
 
     expect(autoReload.config.configured).toBe(false)
-    expect(screen.getByText('Set up auto-reload')).toBeInTheDocument()
+    expect(await screen.findByText('Set up auto-reload')).toBeInTheDocument()
+  })
+
+  it('shows a retry action after the initial read fails twice', async () => {
+    vi.mocked(workspaceApi.getAutoReload).mockRejectedValue(
+      new Error('unavailable')
+    )
+    await autoReload.scopeToWorkspace('workspace-b')
+
+    renderSection(false, 'workspace-b')
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Couldn’t load auto-reload settings.'
+    )
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeEnabled()
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
+++ b/src/platform/workspace/components/dialogs/settings/AutoReloadSection.vue
@@ -21,13 +21,16 @@
           {{ $t('workspacePanel.autoReload.subtitle') }}
         </span>
       </div>
-      <div v-if="isConfigured" class="flex shrink-0 items-center gap-3">
+      <div
+        v-if="isInitialized && isConfigured"
+        class="flex shrink-0 items-center gap-3"
+      >
         <span class="flex items-center gap-2 text-sm text-muted-foreground">
           {{ enabledLabel }}
           <Switch
             :model-value="displayEnabled"
             class="disabled:opacity-100"
-            :disabled="frozen"
+            :disabled="frozen || isSaving"
             :aria-label="$t('workspacePanel.autoReload.toggleLabel')"
             @update:model-value="handleEnabledChange"
           />
@@ -36,7 +39,7 @@
           variant="secondary"
           size="lg"
           class="disabled:opacity-100"
-          :disabled="frozen"
+          :disabled="frozen || isSaving"
           @click="openConfig"
         >
           {{ $t('workspacePanel.autoReload.edit') }}
@@ -44,7 +47,23 @@
       </div>
     </div>
 
-    <div v-if="!isConfigured" class="grid grid-cols-1 gap-4 @4xl:grid-cols-2">
+    <div v-if="isLoading" class="text-sm text-muted-foreground" role="status">
+      {{ $t('workspacePanel.autoReload.loading') }}
+    </div>
+
+    <div v-else-if="error && !isInitialized" class="flex items-center gap-3">
+      <span class="text-danger text-sm" role="alert">
+        {{ $t('workspacePanel.autoReload.loadError') }}
+      </span>
+      <Button variant="secondary" size="lg" @click="retry">
+        {{ $t('workspacePanel.autoReload.retry') }}
+      </Button>
+    </div>
+
+    <div
+      v-else-if="!isConfigured"
+      class="grid grid-cols-1 gap-4 @4xl:grid-cols-2"
+    >
       <div
         class="flex flex-col gap-3 rounded-xl bg-modal-panel-background px-6 py-5"
       >
@@ -126,6 +145,14 @@
         </template>
       </div>
     </div>
+
+    <p
+      v-if="error && isInitialized"
+      class="text-danger m-0 text-sm"
+      role="alert"
+    >
+      {{ $t('workspacePanel.autoReload.saveError') }}
+    </p>
   </div>
 </template>
 
@@ -160,14 +187,19 @@ const {
   budgetUsedFraction,
   isPaused,
   isWarning,
+  isLoading,
+  isSaving,
+  isInitialized,
+  error,
   setEnabled,
-  scopeToWorkspace
+  scopeToWorkspace,
+  retry
 } = useAutoReload()
 const { activeWorkspaceId } = storeToRefs(useTeamWorkspaceStore())
 const { canConfigureNow } = useAutoReloadAccess()
 
-scopeToWorkspace(activeWorkspaceId.value)
-watch(activeWorkspaceId, scopeToWorkspace)
+void scopeToWorkspace(activeWorkspaceId.value)
+watch(activeWorkspaceId, (workspaceId) => void scopeToWorkspace(workspaceId))
 
 const displayEnabled = computed(() => !frozen && isEnabled.value)
 let isAlive = true
@@ -178,7 +210,7 @@ onScopeDispose(() => {
 const { showAutoReloadDialog } = useDialogService()
 
 function openConfig() {
-  if (frozen || !canConfigureNow()) return
+  if (frozen || isSaving.value || !canConfigureNow()) return
   const workspaceId = activeWorkspaceId.value
   void showAutoReloadDialog({
     workspaceId,
@@ -186,13 +218,14 @@ function openConfig() {
       isAlive &&
       activeWorkspaceId.value === workspaceId &&
       canConfigureNow() &&
+      !isSaving.value &&
       !frozen
   })
 }
 
 function handleEnabledChange(value: boolean) {
-  if (frozen || !canConfigureNow()) return
-  setEnabled(value)
+  if (frozen || isSaving.value || !canConfigureNow()) return
+  void setEnabled(value).catch(() => {})
 }
 
 function fmtCredits(value: number) {

--- a/src/platform/workspace/composables/useAutoReload.test.ts
+++ b/src/platform/workspace/composables/useAutoReload.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import type { AutoReloadResponse } from '@/platform/workspace/api/workspaceApi'
 
 import {
   deriveAutoReloadState,
@@ -6,6 +9,39 @@ import {
   useAutoReload
 } from '@/platform/workspace/composables/useAutoReload'
 import type { AutoReloadConfig } from '@/platform/workspace/composables/useAutoReload'
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getAutoReload: vi.fn(),
+    updateAutoReload: vi.fn()
+  }
+}))
+
+const unconfiguredResponse: AutoReloadResponse = {
+  configured: false,
+  enabled: false,
+  threshold_credits: null,
+  reload_credits: null,
+  monthly_budget_cents: null,
+  spent_this_cycle_cents: 0
+}
+
+const configuredResponse: AutoReloadResponse = {
+  configured: true,
+  enabled: true,
+  threshold_credits: 2000,
+  reload_credits: 6000,
+  monthly_budget_cents: 25_000,
+  spent_this_cycle_cents: 1200
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
 
 const configured: AutoReloadConfig = {
   configured: true,
@@ -159,48 +195,184 @@ describe('deriveAutoReloadState', () => {
 describe('useAutoReload', () => {
   const autoReload = useAutoReload()
 
-  beforeEach(() => {
-    Object.assign(autoReload.config, {
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    await autoReload.scopeToWorkspace(null)
+    vi.mocked(workspaceApi.getAutoReload).mockResolvedValue(
+      unconfiguredResponse
+    )
+    await autoReload.scopeToWorkspace('workspace-a')
+  })
+
+  it('maps persisted settings and only supplies defaults for an unconfigured response', async () => {
+    expect(autoReload.config).toEqual({
       configured: false,
       enabled: false,
       thresholdCredits: 1000,
       reloadCredits: 5000,
       monthlyBudgetCents: null,
       spentThisCycleCents: 0
-    } satisfies AutoReloadConfig)
-  })
-
-  it('saves a configuration and enables auto-reload', () => {
-    autoReload.save({
-      thresholdCredits: 2000,
-      reloadCredits: 6000,
-      monthlyBudgetCents: 25_000
     })
+    expect(autoReload.isInitialized.value).toBe(true)
 
-    expect(autoReload.config).toMatchObject({
+    vi.mocked(workspaceApi.getAutoReload).mockResolvedValueOnce(
+      configuredResponse
+    )
+    await autoReload.scopeToWorkspace('workspace-b')
+
+    expect(autoReload.config).toEqual({
       configured: true,
       enabled: true,
       thresholdCredits: 2000,
       reloadCredits: 6000,
-      monthlyBudgetCents: 25_000
+      monthlyBudgetCents: 25_000,
+      spentThisCycleCents: 1200
     })
   })
 
-  it('updates the enabled state without discarding the configuration', () => {
-    autoReload.save({
+  it('retries the initial GET once and exposes a retryable terminal error', async () => {
+    vi.mocked(workspaceApi.getAutoReload)
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockResolvedValueOnce(configuredResponse)
+
+    await autoReload.scopeToWorkspace('workspace-b')
+
+    expect(workspaceApi.getAutoReload).toHaveBeenCalledTimes(3)
+    expect(autoReload.config.configured).toBe(true)
+    expect(autoReload.error.value).toBeNull()
+
+    vi.mocked(workspaceApi.getAutoReload).mockRejectedValue(
+      new Error('still unavailable')
+    )
+    await autoReload.scopeToWorkspace('workspace-c')
+
+    expect(workspaceApi.getAutoReload).toHaveBeenCalledTimes(5)
+    expect(autoReload.isInitialized.value).toBe(false)
+    expect(autoReload.error.value).toBe('still unavailable')
+
+    vi.mocked(workspaceApi.getAutoReload).mockResolvedValueOnce(
+      configuredResponse
+    )
+    await autoReload.retry()
+    expect(autoReload.isInitialized.value).toBe(true)
+    expect(autoReload.error.value).toBeNull()
+  })
+
+  it('discards a late GET after a workspace switch', async () => {
+    const stale = deferred<AutoReloadResponse>()
+    vi.mocked(workspaceApi.getAutoReload)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce(configuredResponse)
+
+    const oldLoad = autoReload.scopeToWorkspace('workspace-b')
+    await autoReload.scopeToWorkspace('workspace-c')
+    stale.resolve({
+      ...configuredResponse,
+      threshold_credits: 9999
+    })
+    await oldLoad
+
+    expect(autoReload.config.thresholdCredits).toBe(2000)
+  })
+
+  it('sends the exact save payload and applies only the canonical response', async () => {
+    vi.mocked(workspaceApi.updateAutoReload).mockResolvedValue({
+      ...configuredResponse,
+      threshold_credits: 2100,
+      reload_credits: 6100,
+      monthly_budget_cents: null
+    })
+
+    await autoReload.save({
       thresholdCredits: 2000,
       reloadCredits: 6000,
       monthlyBudgetCents: null
     })
 
-    autoReload.setEnabled(false)
-
-    expect(autoReload.isEnabled.value).toBe(false)
+    expect(workspaceApi.updateAutoReload).toHaveBeenCalledWith({
+      enabled: true,
+      threshold_credits: 2000,
+      reload_credits: 6000,
+      monthly_budget_cents: null
+    })
     expect(autoReload.config).toMatchObject({
       configured: true,
-      thresholdCredits: 2000,
-      reloadCredits: 6000,
+      enabled: true,
+      thresholdCredits: 2100,
+      reloadCredits: 6100,
       monthlyBudgetCents: null
     })
+  })
+
+  it('disables and re-enables with retained numeric settings', async () => {
+    Object.assign(autoReload.config, {
+      configured: true,
+      enabled: true,
+      thresholdCredits: 2200,
+      reloadCredits: 6200,
+      monthlyBudgetCents: 30_000,
+      spentThisCycleCents: 0
+    } satisfies AutoReloadConfig)
+    vi.mocked(workspaceApi.updateAutoReload)
+      .mockResolvedValueOnce({
+        configured: true,
+        enabled: false,
+        threshold_credits: 2200,
+        reload_credits: 6200,
+        monthly_budget_cents: 30_000,
+        spent_this_cycle_cents: 0
+      })
+      .mockResolvedValueOnce({
+        configured: true,
+        enabled: true,
+        threshold_credits: 2200,
+        reload_credits: 6200,
+        monthly_budget_cents: 30_000,
+        spent_this_cycle_cents: 0
+      })
+
+    await autoReload.setEnabled(false)
+    await autoReload.setEnabled(true)
+
+    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(1, {
+      enabled: false,
+      threshold_credits: 2200,
+      reload_credits: 6200,
+      monthly_budget_cents: 30_000
+    })
+    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(2, {
+      enabled: true,
+      threshold_credits: 2200,
+      reload_credits: 6200,
+      monthly_budget_cents: 30_000
+    })
+    expect(autoReload.isEnabled.value).toBe(true)
+  })
+
+  it('keeps persisted state and remains retryable after a failed PUT', async () => {
+    const before = { ...autoReload.config }
+    vi.mocked(workspaceApi.updateAutoReload)
+      .mockRejectedValueOnce(new Error('save failed'))
+      .mockResolvedValueOnce(configuredResponse)
+
+    await expect(
+      autoReload.save({
+        thresholdCredits: 2000,
+        reloadCredits: 6000,
+        monthlyBudgetCents: 25_000
+      })
+    ).rejects.toThrow('save failed')
+
+    expect({ ...autoReload.config }).toEqual(before)
+    expect(autoReload.error.value).toBe('save failed')
+
+    await autoReload.save({
+      thresholdCredits: 2000,
+      reloadCredits: 6000,
+      monthlyBudgetCents: 25_000
+    })
+
+    expect(autoReload.error.value).toBeNull()
+    expect(autoReload.config.configured).toBe(true)
   })
 })

--- a/src/platform/workspace/composables/useAutoReload.test.ts
+++ b/src/platform/workspace/composables/useAutoReload.test.ts
@@ -289,12 +289,15 @@ describe('useAutoReload', () => {
       monthlyBudgetCents: null
     })
 
-    expect(workspaceApi.updateAutoReload).toHaveBeenCalledWith({
-      enabled: true,
-      threshold_credits: 2000,
-      reload_credits: 6000,
-      monthly_budget_cents: null
-    })
+    expect(workspaceApi.updateAutoReload).toHaveBeenCalledWith(
+      {
+        enabled: true,
+        threshold_credits: 2000,
+        reload_credits: 6000,
+        monthly_budget_cents: null
+      },
+      'workspace-a'
+    )
     expect(autoReload.config).toMatchObject({
       configured: true,
       enabled: true,
@@ -334,18 +337,26 @@ describe('useAutoReload', () => {
     await autoReload.setEnabled(false)
     await autoReload.setEnabled(true)
 
-    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(1, {
-      enabled: false,
-      threshold_credits: 2200,
-      reload_credits: 6200,
-      monthly_budget_cents: 30_000
-    })
-    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(2, {
-      enabled: true,
-      threshold_credits: 2200,
-      reload_credits: 6200,
-      monthly_budget_cents: 30_000
-    })
+    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(
+      1,
+      {
+        enabled: false,
+        threshold_credits: 2200,
+        reload_credits: 6200,
+        monthly_budget_cents: 30_000
+      },
+      'workspace-a'
+    )
+    expect(workspaceApi.updateAutoReload).toHaveBeenNthCalledWith(
+      2,
+      {
+        enabled: true,
+        threshold_credits: 2200,
+        reload_credits: 6200,
+        monthly_budget_cents: 30_000
+      },
+      'workspace-a'
+    )
     expect(autoReload.isEnabled.value).toBe(true)
   })
 
@@ -374,5 +385,13 @@ describe('useAutoReload', () => {
 
     expect(autoReload.error.value).toBeNull()
     expect(autoReload.config.configured).toBe(true)
+  })
+
+  it('uses a visible fallback for errors with an empty message', async () => {
+    vi.mocked(workspaceApi.getAutoReload).mockRejectedValue(new Error(''))
+
+    await autoReload.scopeToWorkspace('workspace-b')
+
+    expect(autoReload.error.value).toBe('Failed to load auto-reload settings')
   })
 })

--- a/src/platform/workspace/composables/useAutoReload.ts
+++ b/src/platform/workspace/composables/useAutoReload.ts
@@ -129,7 +129,7 @@ function mapResponse(response: AutoReloadResponse): AutoReloadConfig {
 }
 
 function errorMessage(err: unknown, fallback: string) {
-  return err instanceof Error ? err.message : fallback
+  return err instanceof Error && err.message ? err.message : fallback
 }
 
 async function load(workspaceId: string, generation: number, retry: boolean) {
@@ -187,6 +187,10 @@ function retry(): Promise<void> {
   return load(scopedWorkspaceId, requestGeneration, false)
 }
 
+function clearError() {
+  error.value = null
+}
+
 function toRequest(
   enabled: boolean,
   settings: AutoReloadSettings
@@ -208,7 +212,7 @@ async function update(payload: UpdateAutoReloadRequest): Promise<void> {
   error.value = null
 
   try {
-    const response = await workspaceApi.updateAutoReload(payload)
+    const response = await workspaceApi.updateAutoReload(payload, workspaceId)
     if (
       generation === requestGeneration &&
       workspaceId === scopedWorkspaceId &&
@@ -285,6 +289,7 @@ export function useAutoReload() {
     setEnabled,
     save,
     scopeToWorkspace,
-    retry
+    retry,
+    clearError
   }
 }

--- a/src/platform/workspace/composables/useAutoReload.ts
+++ b/src/platform/workspace/composables/useAutoReload.ts
@@ -1,6 +1,11 @@
-import { computed, reactive } from 'vue'
+import { computed, reactive, ref } from 'vue'
 
 import { creditsToCents } from '@/base/credits/comfyCredits'
+import type {
+  AutoReloadResponse,
+  UpdateAutoReloadRequest
+} from '@/platform/workspace/api/workspaceApi'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 
 export interface AutoReloadConfig {
   configured: boolean
@@ -89,19 +94,147 @@ function createDefaultConfig(): AutoReloadConfig {
   }
 }
 
-// No production auto-reload endpoint exists yet. This state intentionally
-// starts unconfigured and does not imply persistence across a page reload.
 const config = reactive<AutoReloadConfig>(createDefaultConfig())
+const isLoading = ref(false)
+const isSaving = ref(false)
+const isInitialized = ref(false)
+const error = ref<string | null>(null)
 let scopedWorkspaceId: string | null | undefined
+let requestGeneration = 0
+let mutationId = 0
 
 function resetConfig() {
   Object.assign(config, createDefaultConfig())
 }
 
-function scopeToWorkspace(workspaceId: string | null) {
-  if (scopedWorkspaceId === workspaceId) return
+function mapResponse(response: AutoReloadResponse): AutoReloadConfig {
+  const thresholdCredits =
+    response.threshold_credits ??
+    (response.configured ? null : createDefaultConfig().thresholdCredits)
+  const reloadCredits =
+    response.reload_credits ??
+    (response.configured ? null : createDefaultConfig().reloadCredits)
+  if (thresholdCredits === null || reloadCredits === null) {
+    throw new Error('Configured auto-reload settings are incomplete')
+  }
+
+  return {
+    configured: response.configured,
+    enabled: response.enabled,
+    thresholdCredits,
+    reloadCredits,
+    monthlyBudgetCents: response.monthly_budget_cents,
+    spentThisCycleCents: response.spent_this_cycle_cents
+  }
+}
+
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error ? err.message : fallback
+}
+
+async function load(workspaceId: string, generation: number, retry: boolean) {
+  isLoading.value = true
+  error.value = null
+  const attempts = retry ? 2 : 1
+
+  try {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        const response = await workspaceApi.getAutoReload()
+        if (
+          generation !== requestGeneration ||
+          workspaceId !== scopedWorkspaceId
+        ) {
+          return
+        }
+        Object.assign(config, mapResponse(response))
+        isInitialized.value = true
+        return
+      } catch (err) {
+        if (
+          generation !== requestGeneration ||
+          workspaceId !== scopedWorkspaceId
+        ) {
+          return
+        }
+        if (attempt === attempts - 1) {
+          error.value = errorMessage(err, 'Failed to load auto-reload settings')
+        }
+      }
+    }
+  } finally {
+    if (generation === requestGeneration && workspaceId === scopedWorkspaceId) {
+      isLoading.value = false
+    }
+  }
+}
+
+function scopeToWorkspace(workspaceId: string | null): Promise<void> {
+  if (scopedWorkspaceId === workspaceId) return Promise.resolve()
   scopedWorkspaceId = workspaceId
+  const generation = ++requestGeneration
+  mutationId++
   resetConfig()
+  isInitialized.value = false
+  isLoading.value = false
+  isSaving.value = false
+  error.value = null
+  return workspaceId ? load(workspaceId, generation, true) : Promise.resolve()
+}
+
+function retry(): Promise<void> {
+  if (!scopedWorkspaceId || isLoading.value) return Promise.resolve()
+  return load(scopedWorkspaceId, requestGeneration, false)
+}
+
+function toRequest(
+  enabled: boolean,
+  settings: AutoReloadSettings
+): UpdateAutoReloadRequest {
+  return {
+    enabled,
+    threshold_credits: settings.thresholdCredits,
+    reload_credits: settings.reloadCredits,
+    monthly_budget_cents: settings.monthlyBudgetCents
+  }
+}
+
+async function update(payload: UpdateAutoReloadRequest): Promise<void> {
+  const workspaceId = scopedWorkspaceId
+  if (!workspaceId) throw new Error('No active workspace')
+  const generation = requestGeneration
+  const currentMutationId = ++mutationId
+  isSaving.value = true
+  error.value = null
+
+  try {
+    const response = await workspaceApi.updateAutoReload(payload)
+    if (
+      generation === requestGeneration &&
+      workspaceId === scopedWorkspaceId &&
+      currentMutationId === mutationId
+    ) {
+      Object.assign(config, mapResponse(response))
+      isInitialized.value = true
+    }
+  } catch (err) {
+    if (
+      generation === requestGeneration &&
+      workspaceId === scopedWorkspaceId &&
+      currentMutationId === mutationId
+    ) {
+      error.value = errorMessage(err, 'Failed to save auto-reload settings')
+    }
+    throw err
+  } finally {
+    if (
+      generation === requestGeneration &&
+      workspaceId === scopedWorkspaceId &&
+      currentMutationId === mutationId
+    ) {
+      isSaving.value = false
+    }
+  }
 }
 
 export function useAutoReload() {
@@ -118,16 +251,18 @@ export function useAutoReload() {
   const isPaused = computed(() => state.value.isPaused)
   const isWarning = computed(() => state.value.isWarning)
 
-  function setEnabled(value: boolean) {
-    config.enabled = value
+  async function setEnabled(value: boolean): Promise<void> {
+    await update(
+      toRequest(value, {
+        thresholdCredits: config.thresholdCredits,
+        reloadCredits: config.reloadCredits,
+        monthlyBudgetCents: config.monthlyBudgetCents
+      })
+    )
   }
 
-  function save(next: AutoReloadSettings) {
-    config.configured = true
-    config.enabled = true
-    config.thresholdCredits = next.thresholdCredits
-    config.reloadCredits = next.reloadCredits
-    config.monthlyBudgetCents = next.monthlyBudgetCents
+  async function save(next: AutoReloadSettings): Promise<void> {
+    await update(toRequest(true, next))
   }
 
   return {
@@ -143,8 +278,13 @@ export function useAutoReload() {
     reloadsLeft,
     isPaused,
     isWarning,
+    isLoading,
+    isSaving,
+    isInitialized,
+    error,
     setEnabled,
     save,
-    scopeToWorkspace
+    scopeToWorkspace,
+    retry
   }
 }


### PR DESCRIPTION
## Summary

Connect auto-reload settings to the authenticated workspace GET/PUT API while preserving existing setup, edit, toggle, and budget behavior.

## Changes

- **What**: Adds the auto-reload wire contract, canonical response mapping, initial retry and workspace stale-response protection, bounded requests, and async loading/error UI.
- **Tests**: Covers exact authenticated requests, defaults and response mapping, retry/error/race behavior, failed and canonical mutations, and a Playwright persistence contract.

## Review Focus

Workspace-switch handling around in-flight reads and writes, and canonical PUT response application.

## Screenshots (if applicable)

No visual redesign.