### PR TITLE
fix: isolate workflow state across auth transitions

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -34,7 +34,7 @@ const mockDialogService = vi.hoisted(() => ({
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockTrackAuthFailed = vi.hoisted(() => vi.fn())
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
-const mockClearAllV2Storage = vi.hoisted(() => vi.fn())
+const mockClearAllWorkflowStorage = vi.hoisted(() => vi.fn())
 
 const knownAuthErrorCodes = new Set([
   'auth/invalid-credential',
@@ -68,7 +68,7 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
 }))
 
 vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
-  clearAllV2Storage: mockClearAllV2Storage
+  clearAllWorkflowStorage: mockClearAllWorkflowStorage
 }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
@@ -140,7 +140,7 @@ describe('useAuthActions.logout', () => {
     expect(mockDialogService.confirm).not.toHaveBeenCalled()
     expect(mockWorkflowService.saveWorkflow).not.toHaveBeenCalled()
     expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
-    expect(mockClearAllV2Storage).not.toHaveBeenCalled()
+    expect(mockClearAllWorkflowStorage).not.toHaveBeenCalled()
   })
 
   it('logs out without prompting when no workflows are modified', async () => {
@@ -158,9 +158,9 @@ describe('useAuthActions.logout', () => {
 
     await logout()
 
-    expect(mockClearAllV2Storage).toHaveBeenCalledOnce()
+    expect(mockClearAllWorkflowStorage).toHaveBeenCalledOnce()
     expect(mockAuthStore.logout.mock.invocationCallOrder[0]).toBeLessThan(
-      mockClearAllV2Storage.mock.invocationCallOrder[0]
+      mockClearAllWorkflowStorage.mock.invocationCallOrder[0]
     )
   })
 
@@ -170,7 +170,7 @@ describe('useAuthActions.logout', () => {
 
     await logout()
 
-    expect(mockClearAllV2Storage).not.toHaveBeenCalled()
+    expect(mockClearAllWorkflowStorage).not.toHaveBeenCalled()
   })
 
   it('cancels sign-out when the dialog is dismissed (null)', async () => {

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -34,6 +34,7 @@ const mockDialogService = vi.hoisted(() => ({
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockTrackAuthFailed = vi.hoisted(() => vi.fn())
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
+const mockClearAllV2Storage = vi.hoisted(() => vi.fn())
 
 const knownAuthErrorCodes = new Set([
   'auth/invalid-credential',
@@ -64,6 +65,10 @@ vi.mock('@/platform/telemetry', () => ({
 
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: vi.fn(() => mockToastStore)
+}))
+
+vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
+  clearAllV2Storage: mockClearAllV2Storage
 }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
@@ -135,6 +140,7 @@ describe('useAuthActions.logout', () => {
     expect(mockDialogService.confirm).not.toHaveBeenCalled()
     expect(mockWorkflowService.saveWorkflow).not.toHaveBeenCalled()
     expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
+    expect(mockClearAllV2Storage).not.toHaveBeenCalled()
   })
 
   it('logs out without prompting when no workflows are modified', async () => {
@@ -145,6 +151,26 @@ describe('useAuthActions.logout', () => {
     expect(mockDialogService.confirm).not.toHaveBeenCalled()
     expect(mockWorkflowService.saveWorkflow).not.toHaveBeenCalled()
     expect(mockAuthStore.logout).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears persisted workflows after cloud logout and before navigation', async () => {
+    const { logout } = useAuthActions()
+
+    await logout()
+
+    expect(mockClearAllV2Storage).toHaveBeenCalledOnce()
+    expect(mockAuthStore.logout.mock.invocationCallOrder[0]).toBeLessThan(
+      mockClearAllV2Storage.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not clear cloud workflows when logout fails', async () => {
+    mockAuthStore.logout.mockRejectedValueOnce(new Error('network failed'))
+    const { logout } = useAuthActions()
+
+    await logout()
+
+    expect(mockClearAllV2Storage).not.toHaveBeenCalled()
   })
 
   it('cancels sign-out when the dialog is dismissed (null)', async () => {

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -154,14 +154,22 @@ describe('useAuthActions.logout', () => {
   })
 
   it('clears persisted workflows after cloud logout and before navigation', async () => {
+    const navigationSpy = vi
+      .spyOn(window.location, 'href', 'set')
+      .mockImplementation(() => {})
     const { logout } = useAuthActions()
 
     await logout()
 
-    expect(mockClearAllWorkflowStorage).toHaveBeenCalledOnce()
+    expect(mockClearAllWorkflowStorage).toHaveBeenCalledExactlyOnceWith({
+      blockWrites: true
+    })
     expect(mockAuthStore.logout.mock.invocationCallOrder[0]).toBeLessThan(
       mockClearAllWorkflowStorage.mock.invocationCallOrder[0]
     )
+    expect(
+      mockClearAllWorkflowStorage.mock.invocationCallOrder[0]
+    ).toBeLessThan(navigationSpy.mock.invocationCallOrder[0])
   })
 
   it('does not clear cloud workflows when logout fails', async () => {

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -113,7 +113,7 @@ export const useAuthActions = () => {
     }
 
     await authStore.logout()
-    if (isCloud) clearAllWorkflowStorage()
+    if (isCloud) clearAllWorkflowStorage({ blockWrites: true })
 
     toastStore.add({
       severity: 'success',

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -10,6 +10,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { AuthFlowAction } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { clearAllV2Storage } from '@/platform/workflow/persistence/base/storageIO'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useDialogService } from '@/services/dialogService'
@@ -112,6 +113,8 @@ export const useAuthActions = () => {
     }
 
     await authStore.logout()
+    if (isCloud) clearAllV2Storage()
+
     toastStore.add({
       severity: 'success',
       summary: t('auth.signOut.success'),

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -10,7 +10,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { AuthFlowAction } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { clearAllV2Storage } from '@/platform/workflow/persistence/base/storageIO'
+import { clearAllWorkflowStorage } from '@/platform/workflow/persistence/base/storageIO'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useDialogService } from '@/services/dialogService'
@@ -113,7 +113,7 @@ export const useAuthActions = () => {
     }
 
     await authStore.logout()
-    if (isCloud) clearAllV2Storage()
+    if (isCloud) clearAllWorkflowStorage()
 
     toastStore.add({
       severity: 'success',

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DraftIndexV2, DraftPayloadV2 } from './draftTypes'
 import {
-  clearAllV2Storage,
+  clearAllWorkflowStorage,
   deleteOrphanPayloads,
   deletePayload,
   deletePayloads,
@@ -282,33 +282,39 @@ describe('storageIO', () => {
     })
   })
 
-  describe('clearAllV2Storage', () => {
-    it('clears all V2 keys from localStorage', () => {
+  describe('clearAllWorkflowStorage', () => {
+    it('clears all restorable workflow keys from localStorage', () => {
       localStorage.setItem('Comfy.Workflow.DraftIndex.v2:ws-1', '{}')
       localStorage.setItem('Comfy.Workflow.Draft.v2:ws-1:abc', '{}')
       localStorage.setItem('Comfy.Workflow.Draft.v2:ws-2:def', '{}')
+      localStorage.setItem('Comfy.Workflow.LastActivePath:ws-1', '{}')
+      localStorage.setItem('Comfy.Workflow.LastOpenPaths:ws-1', '{}')
+      localStorage.setItem('Comfy.Workflow.Drafts:ws-1', '{}')
+      localStorage.setItem('Comfy.Workflow.DraftOrder:ws-1', '[]')
+      localStorage.setItem('Comfy.Workflow.Drafts', '{}')
+      localStorage.setItem('Comfy.Workflow.DraftOrder', '[]')
+      localStorage.setItem('Comfy.OpenWorkflowsPaths', '[]')
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', '0')
+      localStorage.setItem('workflow', '{}')
       localStorage.setItem('unrelated', 'keep')
 
-      clearAllV2Storage()
+      clearAllWorkflowStorage()
 
       expect(
-        localStorage.getItem('Comfy.Workflow.DraftIndex.v2:ws-1')
-      ).toBeNull()
-      expect(
-        localStorage.getItem('Comfy.Workflow.Draft.v2:ws-1:abc')
-      ).toBeNull()
-      expect(
-        localStorage.getItem('Comfy.Workflow.Draft.v2:ws-2:def')
-      ).toBeNull()
+        [...Array(localStorage.length)].map((_, index) =>
+          localStorage.key(index)
+        )
+      ).toEqual(['unrelated'])
       expect(localStorage.getItem('unrelated')).toBe('keep')
     })
 
-    it('clears all V2 keys from sessionStorage', () => {
+    it('clears all restorable workflow keys from sessionStorage', () => {
       sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
       sessionStorage.setItem('Comfy.Workflow.OpenPaths:client-2', '{}')
+      sessionStorage.setItem('workflow:client-1', '{}')
       sessionStorage.setItem('unrelated', 'keep')
 
-      clearAllV2Storage()
+      clearAllWorkflowStorage()
 
       expect(
         sessionStorage.getItem('Comfy.Workflow.ActivePath:client-1')
@@ -316,6 +322,7 @@ describe('storageIO', () => {
       expect(
         sessionStorage.getItem('Comfy.Workflow.OpenPaths:client-2')
       ).toBeNull()
+      expect(sessionStorage.getItem('workflow:client-1')).toBeNull()
       expect(sessionStorage.getItem('unrelated')).toBe('keep')
     })
 
@@ -324,7 +331,7 @@ describe('storageIO', () => {
       sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
       markStorageUnavailable()
 
-      clearAllV2Storage()
+      clearAllWorkflowStorage()
 
       expect(
         localStorage.getItem('Comfy.Workflow.LastActivePath:personal')

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -295,6 +295,7 @@ describe('storageIO', () => {
       localStorage.setItem('Comfy.Workflow.DraftOrder', '[]')
       localStorage.setItem('Comfy.OpenWorkflowsPaths', '[]')
       localStorage.setItem('Comfy.ActiveWorkflowIndex', '0')
+      localStorage.setItem('Comfy.PreviousWorkflow', 'workflows/old.json')
       localStorage.setItem('workflow', '{}')
       localStorage.setItem('unrelated', 'keep')
 
@@ -311,6 +312,13 @@ describe('storageIO', () => {
     it('clears all restorable workflow keys from sessionStorage', () => {
       sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
       sessionStorage.setItem('Comfy.Workflow.OpenPaths:client-2', '{}')
+      sessionStorage.setItem('Comfy.PreviousWorkflow', 'workflows/old.json')
+      sessionStorage.setItem(
+        'Comfy.PreviousWorkflow:client-1',
+        'workflows/old.json'
+      )
+      sessionStorage.setItem('Comfy.OpenWorkflowsPaths:client-1', '[]')
+      sessionStorage.setItem('Comfy.ActiveWorkflowIndex:client-1', '0')
       sessionStorage.setItem('workflow:client-1', '{}')
       sessionStorage.setItem('unrelated', 'keep')
 
@@ -324,6 +332,34 @@ describe('storageIO', () => {
       ).toBeNull()
       expect(sessionStorage.getItem('workflow:client-1')).toBeNull()
       expect(sessionStorage.getItem('unrelated')).toBe('keep')
+    })
+
+    it('blocks workflow writes after cleanup starts', () => {
+      clearAllWorkflowStorage({ blockWrites: true })
+
+      expect(
+        writeIndex('ws-1', {
+          v: 2,
+          updatedAt: 1,
+          order: [],
+          entries: {}
+        })
+      ).toBe(false)
+      expect(
+        writePayload('ws-1', 'draft-1', { data: '{}', updatedAt: 1 })
+      ).toBe(false)
+      writeActivePath('client-1', {
+        workspaceId: 'ws-1',
+        path: 'workflows/a.json'
+      })
+      writeOpenPaths('client-1', {
+        workspaceId: 'ws-1',
+        paths: ['workflows/a.json'],
+        activeIndex: 0
+      })
+
+      expect(localStorage).toHaveLength(0)
+      expect(sessionStorage).toHaveLength(0)
     })
 
     it('clears persisted workflows after storage writes are disabled', () => {

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -7,6 +7,7 @@ import {
   deletePayload,
   deletePayloads,
   getPayloadKeys,
+  markStorageUnavailable,
   readActivePath,
   readIndex,
   readOpenPaths,
@@ -316,6 +317,21 @@ describe('storageIO', () => {
         sessionStorage.getItem('Comfy.Workflow.OpenPaths:client-2')
       ).toBeNull()
       expect(sessionStorage.getItem('unrelated')).toBe('keep')
+    })
+
+    it('clears persisted workflows after storage writes are disabled', () => {
+      localStorage.setItem('Comfy.Workflow.LastActivePath:personal', '{}')
+      sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
+      markStorageUnavailable()
+
+      clearAllV2Storage()
+
+      expect(
+        localStorage.getItem('Comfy.Workflow.LastActivePath:personal')
+      ).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.Workflow.ActivePath:client-1')
+      ).toBeNull()
     })
   })
 })

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -330,15 +330,26 @@ describe('storageIO', () => {
       expect(
         sessionStorage.getItem('Comfy.Workflow.OpenPaths:client-2')
       ).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.PreviousWorkflow:client-1')
+      ).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.OpenWorkflowsPaths:client-1')
+      ).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.ActiveWorkflowIndex:client-1')
+      ).toBeNull()
       expect(sessionStorage.getItem('workflow:client-1')).toBeNull()
       expect(sessionStorage.getItem('unrelated')).toBe('keep')
     })
 
-    it('blocks workflow writes after cleanup starts', () => {
-      clearAllWorkflowStorage({ blockWrites: true })
+    it('blocks workflow writes after cleanup starts', async () => {
+      const isolatedStorageIO = await import('./storageIO')
+
+      isolatedStorageIO.clearAllWorkflowStorage({ blockWrites: true })
 
       expect(
-        writeIndex('ws-1', {
+        isolatedStorageIO.writeIndex('ws-1', {
           v: 2,
           updatedAt: 1,
           order: [],
@@ -346,13 +357,16 @@ describe('storageIO', () => {
         })
       ).toBe(false)
       expect(
-        writePayload('ws-1', 'draft-1', { data: '{}', updatedAt: 1 })
+        isolatedStorageIO.writePayload('ws-1', 'draft-1', {
+          data: '{}',
+          updatedAt: 1
+        })
       ).toBe(false)
-      writeActivePath('client-1', {
+      isolatedStorageIO.writeActivePath('client-1', {
         workspaceId: 'ws-1',
         path: 'workflows/a.json'
       })
-      writeOpenPaths('client-1', {
+      isolatedStorageIO.writeOpenPaths('client-1', {
         workspaceId: 'ws-1',
         paths: ['workflows/a.json'],
         activeIndex: 0

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -372,22 +372,31 @@ function writeStorage(storage: Storage, key: string, value: string): void {
   }
 }
 
-/**
- * Clears all V2 workflow persistence data from storage.
- * Used during signout to prevent data leakage.
- */
-export function clearAllV2Storage(): void {
-  const prefixes = [
+export function clearAllWorkflowStorage(): void {
+  const localPrefixes = [
     StorageKeys.prefixes.draftIndex,
     StorageKeys.prefixes.draftPayload,
     StorageKeys.prefixes.lastActivePath,
-    StorageKeys.prefixes.lastOpenPaths
+    StorageKeys.prefixes.lastOpenPaths,
+    'Comfy.Workflow.Drafts:',
+    'Comfy.Workflow.DraftOrder:'
+  ]
+  const localKeys = [
+    'Comfy.Workflow.Drafts',
+    'Comfy.Workflow.DraftOrder',
+    'Comfy.OpenWorkflowsPaths',
+    'Comfy.ActiveWorkflowIndex',
+    'workflow'
   ]
 
   try {
     for (let i = localStorage.length - 1; i >= 0; i--) {
       const key = localStorage.key(i)
-      if (key && prefixes.some((prefix) => key.startsWith(prefix))) {
+      if (
+        key &&
+        (localKeys.includes(key) ||
+          localPrefixes.some((prefix) => key.startsWith(prefix)))
+      ) {
         try {
           localStorage.removeItem(key)
         } catch {
@@ -401,7 +410,8 @@ export function clearAllV2Storage(): void {
 
   const sessionPrefixes = [
     StorageKeys.prefixes.activePath,
-    StorageKeys.prefixes.openPaths
+    StorageKeys.prefixes.openPaths,
+    'workflow:'
   ]
 
   try {

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -14,6 +14,7 @@ import { StorageKeys } from './storageKeys'
 
 /** Flag indicating if storage is available */
 let storageAvailable = true
+let workflowWritesBlocked = false
 
 export function isStorageAvailable(): boolean {
   return storageAvailable
@@ -69,7 +70,7 @@ export function readIndex(workspaceId: string): DraftIndexV2 | null {
  * Writes the draft index to localStorage.
  */
 export function writeIndex(workspaceId: string, index: DraftIndexV2): boolean {
-  if (!storageAvailable) return false
+  if (!storageAvailable || workflowWritesBlocked) return false
 
   try {
     const key = StorageKeys.draftIndex(workspaceId)
@@ -109,7 +110,7 @@ export function writePayload(
   draftKey: string,
   payload: DraftPayloadV2
 ): boolean {
-  if (!storageAvailable) return false
+  if (!storageAvailable || workflowWritesBlocked) return false
 
   try {
     const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
@@ -365,6 +366,8 @@ function readLocalPointer<T>(
 }
 
 function writeStorage(storage: Storage, key: string, value: string): void {
+  if (!storageAvailable || workflowWritesBlocked) return
+
   try {
     storage.setItem(key, value)
   } catch {
@@ -372,7 +375,11 @@ function writeStorage(storage: Storage, key: string, value: string): void {
   }
 }
 
-export function clearAllWorkflowStorage(): void {
+export function clearAllWorkflowStorage(
+  options: { blockWrites?: boolean } = {}
+): void {
+  if (options.blockWrites) workflowWritesBlocked = true
+
   const localPrefixes = [
     StorageKeys.prefixes.draftIndex,
     StorageKeys.prefixes.draftPayload,
@@ -386,6 +393,7 @@ export function clearAllWorkflowStorage(): void {
     'Comfy.Workflow.DraftOrder',
     'Comfy.OpenWorkflowsPaths',
     'Comfy.ActiveWorkflowIndex',
+    'Comfy.PreviousWorkflow',
     'workflow'
   ]
 
@@ -411,13 +419,25 @@ export function clearAllWorkflowStorage(): void {
   const sessionPrefixes = [
     StorageKeys.prefixes.activePath,
     StorageKeys.prefixes.openPaths,
+    'Comfy.PreviousWorkflow:',
+    'Comfy.OpenWorkflowsPaths:',
+    'Comfy.ActiveWorkflowIndex:',
     'workflow:'
+  ]
+  const sessionKeys = [
+    'Comfy.PreviousWorkflow',
+    'Comfy.OpenWorkflowsPaths',
+    'Comfy.ActiveWorkflowIndex'
   ]
 
   try {
     for (let i = sessionStorage.length - 1; i >= 0; i--) {
       const key = sessionStorage.key(i)
-      if (key && sessionPrefixes.some((prefix) => key.startsWith(prefix))) {
+      if (
+        key &&
+        (sessionKeys.includes(key) ||
+          sessionPrefixes.some((prefix) => key.startsWith(prefix)))
+      ) {
         try {
           sessionStorage.removeItem(key)
         } catch {

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -377,8 +377,6 @@ function writeStorage(storage: Storage, key: string, value: string): void {
  * Used during signout to prevent data leakage.
  */
 export function clearAllV2Storage(): void {
-  if (!storageAvailable) return
-
   const prefixes = [
     StorageKeys.prefixes.draftIndex,
     StorageKeys.prefixes.draftPayload,

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -29,7 +29,7 @@ import {
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
 import { PERSIST_DEBOUNCE_MS } from '../base/draftTypes'
-import { clearAllV2Storage } from '../base/storageIO'
+import { clearAllWorkflowStorage } from '../base/storageIO'
 import { migrateV1toV2 } from '../migration/migrateV1toV2'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowTabState } from './useWorkflowTabState'
@@ -60,7 +60,7 @@ export function useWorkflowPersistenceV2() {
   // Clear workflow persistence storage when user signs out (cloud only)
   onUserLogout(() => {
     if (isCloud) {
-      clearAllV2Storage()
+      clearAllWorkflowStorage()
     }
   })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -344,16 +344,27 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.initState).toBe('error')
     })
 
-    it('continues initialization even if token exchange fails', async () => {
+    it('does not activate a workspace when token exchange fails', async () => {
+      vi.useFakeTimers()
       mockWorkspaceAuthStore.switchWorkspace.mockRejectedValue(
         new Error('Token exchange failed')
       )
 
       const store = useTeamWorkspaceStore()
-      await store.initialize()
+      const initialization = store.initialize()
+      const rejection = expect(initialization).rejects.toThrow(
+        'Token exchange failed'
+      )
 
-      expect(store.initState).toBe('ready')
-      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(2000)
+      await vi.advanceTimersByTimeAsync(4000)
+      await rejection
+
+      expect(store.initState).toBe('error')
+      expect(store.activeWorkspaceId).toBeNull()
+      expect(store.error).toEqual(new Error('Token exchange failed'))
+      vi.useRealTimers()
     })
   })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -316,14 +316,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           const personal = workspaces.value.find((w) => w.type === 'personal')
           const fallbackWorkspaceId = personal?.id ?? workspaces.value[0].id
 
-          try {
-            await workspaceAuthStore.switchWorkspace(fallbackWorkspaceId)
-          } catch {
-            if (isStaleIdentity(generation)) return
-            console.error(
-              '[teamWorkspaceStore] Token exchange failed during fallback'
-            )
-          }
+          await workspaceAuthStore.switchWorkspace(fallbackWorkspaceId)
 
           if (isStaleIdentity(generation)) return
 
@@ -359,15 +352,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
         }
 
         // 4. Exchange Firebase token for workspace token
-        try {
-          await workspaceAuthStore.switchWorkspace(targetWorkspaceId)
-        } catch {
-          if (isStaleIdentity(generation)) return
-          // Log but don't fail initialization - API calls will fall back to Firebase token
-          console.error(
-            '[teamWorkspaceStore] Token exchange failed during init'
-          )
-        }
+        await workspaceAuthStore.switchWorkspace(targetWorkspaceId)
 
         if (isStaleIdentity(generation)) return
 


### PR DESCRIPTION
## Summary

Fixes **QA report items CF148-005 and CF148-006** by failing workspace initialization closed and synchronously clearing workflow persistence before Cloud logout navigation.

Reported in the [Cloud 1.48 QA thread](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785337736169649?thread_ts=1785169746.169899&cid=C0932CGKT5K).

## Changes

- **CF148-005**: Workspace initialization no longer reports `ready` after scoped-token exchange fails, so stale canvas/draft state cannot render under another selected workspace.
- **CF148-006**: Successful Cloud logout clears V2 and migratable legacy workflow state before navigation; a terminal write barrier prevents queued persistence writes from recreating cleared state.
- Cleanup remains targeted and preserves unrelated local/session storage.

## When these issues were introduced

- **CF148-005**: The fail-open workspace initialization behavior was introduced on **2026-01-21** by PR #8194 ([`66e6f2498`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/66e6f249804a9c732eb799d51d6f34cc4a7bf974)). Global app gating later became fail-open in PR #8350. PR #14183 fixed the app-level startup gate; this PR adds the store-level defense.
- **CF148-006**: The race became possible on **2026-02-21** in PR #8520 ([`40aa7c5974`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/40aa7c59740d5e291ae40171df94d6a50a1cd83a)), when workflow cleanup became a Vue watcher callback while Cloud logout already hard-navigated immediately (hard navigation was introduced by PR #6564).

## Review Focus

Confirm failed workspace authentication never reaches `ready`, and that only terminal Cloud logout blocks later workflow writes.

## Screenshots

The captures use deterministic mocked Cloud transitions to make both failure modes reproducible.

### CF148-005 — AS IS

Workspace B is selected while a Workspace A-only dirty draft remains visible.

### CF148-005 — TO BE

Failed workspace authentication keeps the app gated; no previous workspace canvas or draft renders.

![CF148-005 AS IS and TO BE](https://ampcode.com/user-content/artifacts/8bc3e2b55e7a41313868d1d42b53270526a62edc04eaad872e5229cd21dbb192-file.png)

![CF148-005 AS IS and TO BE animation](https://ampcode.com/user-content/artifacts/23335ab80cf47f51f7d67e1015dec90a538526687d05d7de399fe4c6418d6361-file.gif)

### CF148-006 — AS IS

A closed workflow returns after logout and the next login because cleanup can lose the race with navigation.

### CF148-006 — TO BE

Workflow storage is cleared synchronously before redirect and terminal late writes are rejected, so no stale workflow restores after login.

![CF148-006 AS IS and TO BE](https://ampcode.com/user-content/artifacts/a26cdcd3b95c787d93fa705e998451390ecdda7599faeb3e0e93bf1b7ea6b610-file.png)

![CF148-006 AS IS and TO BE animation](https://ampcode.com/user-content/artifacts/835709f0e960c8f457e9a7f25a9b424f2c3a38d44c45067378c009ac87e9de58-file.gif)

## Verification

- `pnpm test:unit src/composables/auth/useAuthActions.test.ts src/platform/workspace/stores/teamWorkspaceStore.test.ts src/platform/workflow/persistence/base/storageIO.test.ts` — 119 passed
- `pnpm typecheck`
- `pnpm lint:unstaged`
- `pnpm knip`
- `git diff --check`
