### PR TITLE
fix: retry failed subscription checkout (BE-5054)

### DIFF
--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -19,6 +19,7 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
+  mockBillingContextScopes,
   mockTeamWorkspacesEnabled,
   mockConsolidatedBillingEnabled,
   mockIsPersonal,
@@ -28,11 +29,13 @@ const {
   mockLegacyFetchStatus,
   mockLegacyFetchBalance,
   mockLegacySubscribe,
+  mockLegacySubscriptionTier,
   mockPurchaseCredits,
   mockUpdateActiveWorkspace,
   mockSetWorkspaceBillingRail,
   mockBillingStatus
 } = vi.hoisted(() => ({
+  mockBillingContextScopes: [] as Array<{ stop: () => void }>,
   mockTeamWorkspacesEnabled: { value: false },
   mockConsolidatedBillingEnabled: { value: false },
   mockIsPersonal: { value: true },
@@ -42,6 +45,7 @@ const {
   mockLegacyFetchStatus: vi.fn().mockResolvedValue(undefined),
   mockLegacyFetchBalance: vi.fn().mockResolvedValue(undefined),
   mockLegacySubscribe: vi.fn().mockResolvedValue(undefined),
+  mockLegacySubscriptionTier: { value: 'PRO' },
   mockPurchaseCredits: vi.fn(),
   mockUpdateActiveWorkspace: vi.fn(),
   mockSetWorkspaceBillingRail: vi.fn(),
@@ -56,10 +60,17 @@ const {
 }))
 
 vi.mock('@vueuse/core', async (importOriginal) => {
+  const { effectScope } = await import('vue')
   const original = await importOriginal()
   return {
     ...(original as Record<string, unknown>),
-    createSharedComposable: (fn: (...args: unknown[]) => unknown) => fn
+    createSharedComposable:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) => {
+        const scope = effectScope()
+        mockBillingContextScopes.push(scope)
+        return scope.run(() => fn(...args))
+      }
   }
 })
 
@@ -126,7 +137,9 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
     isActiveSubscription: { value: true },
-    subscriptionTier: { value: 'PRO' },
+    get subscriptionTier() {
+      return mockLegacySubscriptionTier
+    },
     subscriptionDuration: { value: 'MONTHLY' },
     subscriptionStatus: {
       value: { renewal_date: '2025-01-01T00:00:00Z', end_date: null }
@@ -189,12 +202,15 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
 
 describe('useBillingContext', () => {
   beforeEach(() => {
+    for (const scope of mockBillingContextScopes) scope.stop()
+    mockBillingContextScopes.length = 0
     setActivePinia(createPinia())
     vi.clearAllMocks()
     mockTeamWorkspacesEnabled.value = false
     mockConsolidatedBillingEnabled.value = false
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
+    mockLegacySubscriptionTier.value = 'PRO'
     mockSetWorkspaceBillingRail.mockImplementation(
       (_workspaceId: string, billingRail: BillingRail) => {
         mockBillingRail.value = billingRail
@@ -318,6 +334,7 @@ describe('useBillingContext', () => {
     ]
 
     const context = useBillingContext()
+    await context.initialize()
     vi.clearAllMocks()
 
     expect(context.type.value).toBe('legacy')
@@ -328,7 +345,7 @@ describe('useBillingContext', () => {
 
     expect(mockFetchPlans).toHaveBeenCalledOnce()
     expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
-    expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
+    expect(workspaceApi.getBillingStatus).toHaveBeenCalledOnce()
 
     await context.previewSubscribe('creator-annual')
     await context.subscribe('creator-annual')
@@ -344,6 +361,37 @@ describe('useBillingContext', () => {
     )
     expect(mockLegacySubscribe).not.toHaveBeenCalled()
     expect(mockPurchaseCredits).toHaveBeenCalledWith(5)
+  })
+
+  it('exposes workspace payment failure while preserving legacy account state', async () => {
+    mockTeamWorkspacesEnabled.value = true
+    mockConsolidatedBillingEnabled.value = true
+    mockBillingRail.value = 'legacy_stripe'
+    mockLegacySubscriptionTier.value = 'FREE'
+    mockBillingStatus.value = {
+      is_active: false,
+      has_funds: false,
+      billing_status: 'payment_failed'
+    }
+
+    const context = useBillingContext()
+    await context.initialize()
+
+    expect(context.type.value).toBe('legacy')
+    expect(context.subscription.value).toMatchObject({
+      isActive: true,
+      tier: 'FREE'
+    })
+    expect(context.balance.value?.amountMicros).toBe(5000000)
+    expect(context.billingStatus.value).toBe('payment_failed')
+    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(workspaceApi.getBillingStatus).toHaveBeenCalledOnce()
+
+    vi.clearAllMocks()
+    await context.fetchStatus()
+
+    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(workspaceApi.getBillingStatus).toHaveBeenCalledOnce()
   })
 
   it('switches billing adapters before refreshing a migrated balance', async () => {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -107,6 +107,7 @@ function useBillingContextInternal(): BillingContext {
   const isInitialized = ref(false)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  let pendingInitialization: Promise<void> | null = null
 
   const activeContext = computed(() =>
     type.value === 'legacy' ? getLegacyBilling() : getWorkspaceBilling()
@@ -179,7 +180,7 @@ function useBillingContextInternal(): BillingContext {
   )
 
   const billingStatus = computed(() =>
-    toValue(activeContext.value.billingStatus)
+    toValue(checkoutContext.value.billingStatus)
   )
   const subscriptionStatus = computed(() =>
     toValue(activeContext.value.subscriptionStatus)
@@ -226,13 +227,18 @@ function useBillingContextInternal(): BillingContext {
     isInitialized.value = false
     isLoading.value = false
     error.value = null
+    pendingInitialization = null
   }
 
-  // type flips when the team-workspaces or consolidated-billing flag resolves
-  // from authenticated config, swapping the active backend. Reset then reinit
-  // on every workspace-id or type change.
+  // type and shouldUseUnifiedPricing can flip when authenticated config resolves,
+  // swapping the account, checkout, or status backend. Reset then reinit on
+  // every workspace-id or routing change.
   watch(
-    [() => store.activeWorkspace?.id, () => type.value],
+    [
+      () => store.activeWorkspace?.id,
+      () => type.value,
+      () => shouldUseUnifiedPricing.value
+    ],
     async ([newWorkspaceId]) => {
       resetBillingState()
       if (!newWorkspaceId) return
@@ -248,26 +254,75 @@ function useBillingContextInternal(): BillingContext {
 
   async function initialize(): Promise<void> {
     if (isInitialized.value) return
+    if (!pendingInitialization) {
+      pendingInitialization = initializeBilling()
+    }
 
+    const initialization = pendingInitialization
+    try {
+      await initialization
+    } finally {
+      if (pendingInitialization === initialization) {
+        pendingInitialization = null
+      }
+    }
+  }
+
+  async function initializeBilling(): Promise<void> {
     const adapter = activeContext.value
+    const statusAdapter = checkoutContext.value
     isLoading.value = true
     error.value = null
     try {
       await adapter.initialize()
-      if (activeContext.value !== adapter) return
+      if (statusAdapter !== adapter) {
+        const [statusInitialization] = await Promise.allSettled([
+          statusAdapter.fetchStatus()
+        ])
+        if (statusInitialization.status === 'rejected') {
+          console.error(
+            'Failed to initialize workspace billing status:',
+            statusInitialization.reason
+          )
+        }
+      }
+      if (
+        activeContext.value !== adapter ||
+        checkoutContext.value !== statusAdapter
+      ) {
+        return
+      }
       isInitialized.value = true
     } catch (err) {
-      if (activeContext.value !== adapter) return
+      if (
+        activeContext.value !== adapter ||
+        checkoutContext.value !== statusAdapter
+      ) {
+        return
+      }
       error.value =
         err instanceof Error ? err.message : 'Failed to initialize billing'
       throw err
     } finally {
-      if (activeContext.value === adapter) isLoading.value = false
+      if (
+        activeContext.value === adapter &&
+        checkoutContext.value === statusAdapter
+      ) {
+        isLoading.value = false
+      }
     }
   }
 
   async function fetchStatus(): Promise<void> {
-    return activeContext.value.fetchStatus()
+    const adapter = activeContext.value
+    const statusAdapter = checkoutContext.value
+    if (statusAdapter === adapter) return adapter.fetchStatus()
+
+    const [accountRefresh] = await Promise.allSettled([
+      adapter.fetchStatus(),
+      statusAdapter.fetchStatus()
+    ])
+    if (accountRefresh.status === 'rejected') throw accountRefresh.reason
   }
 
   async function fetchBalance(): Promise<void> {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2930,7 +2930,8 @@
       "warning": {
         "title": "Payment declined",
         "body": "Your last payment didn't go through. Your subscription will pause on {date} unless payment is updated.",
-        "bodyNoDate": "Your last payment didn't go through. Update payment to avoid a pause."
+        "bodyNoDate": "Your last payment didn't go through. Update payment to avoid a pause.",
+        "retryBody": "Replace your payment method to retry this subscription."
       },
       "paused": {
         "title": "Subscription paused",
@@ -2950,7 +2951,8 @@
         "body": "Members keep full access until then. Reactivate to keep your shared credits and seats.",
         "reactivate": "Reactivate plan"
       },
-      "updatePayment": "Update payment"
+      "updatePayment": "Update payment",
+      "retryPayment": "Replace and retry"
     },
     "invite": "Invite",
     "inviteMember": "Invite member",

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -21,6 +21,7 @@ const state = vi.hoisted(() => ({
   isActiveSubscription: true,
   isTeamPlan: true,
   billingStatus: 'paid' as string | null,
+  subscriptionStatus: 'active' as string | null,
   subscription: {
     hasFunds: true,
     isCancelled: false,
@@ -33,6 +34,7 @@ const state = vi.hoisted(() => ({
   canTopUp: true,
   showTopUpCreditsDialog: vi.fn(),
   manageSubscription: vi.fn(),
+  showSubscriptionDialog: vi.fn(),
   handleResubscribe: vi.fn()
 }))
 
@@ -53,9 +55,11 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isActiveSubscription: computed(() => state.isActiveSubscription),
     isTeamPlan: computed(() => state.isTeamPlan),
     billingStatus: computed(() => state.billingStatus as BillingStatus | null),
+    subscriptionStatus: computed(() => state.subscriptionStatus),
     subscription: computed(() => state.subscription),
     renewalDate: computed(() => state.renewalDate),
-    manageSubscription: state.manageSubscription
+    manageSubscription: state.manageSubscription,
+    showSubscriptionDialog: state.showSubscriptionDialog
   })
 }))
 
@@ -94,7 +98,8 @@ const i18n = createI18n({
             title: 'Payment declined',
             body: "Your last payment didn't go through. Your subscription will pause on {date} unless payment is updated.",
             bodyNoDate:
-              "Your last payment didn't go through. Update payment to avoid a pause."
+              "Your last payment didn't go through. Update payment to avoid a pause.",
+            retryBody: 'Replace your payment method to retry this subscription.'
           },
           paused: {
             title: 'Subscription paused',
@@ -117,7 +122,8 @@ const i18n = createI18n({
             body: 'Members keep full access until then. Reactivate to keep your shared credits and seats.',
             reactivate: 'Reactivate plan'
           },
-          updatePayment: 'Update payment'
+          updatePayment: 'Update payment',
+          retryPayment: 'Replace and retry'
         }
       }
     }
@@ -162,6 +168,7 @@ describe('BillingStatusBanner', () => {
     state.isActiveSubscription = true
     state.isTeamPlan = true
     state.billingStatus = 'paid'
+    state.subscriptionStatus = 'active'
     state.subscription = { hasFunds: true, isCancelled: false, endDate: null }
     state.renewalDate = null
     state.workspaceType = 'team'
@@ -267,6 +274,23 @@ describe('BillingStatusBanner', () => {
     expect(
       screen.getByRole('button', { name: 'Update payment' })
     ).toBeInTheDocument()
+  })
+
+  it('opens subscription recovery for a failed initial subscription', async () => {
+    paymentFailedState()
+    state.subscriptionStatus = null
+    renderBanner()
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Replace your payment method to retry this subscription'
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Replace and retry' })
+    )
+    expect(state.showSubscriptionDialog).toHaveBeenCalledWith({
+      reason: 'settings_billing_panel'
+    })
+    expect(state.manageSubscription).not.toHaveBeenCalled()
   })
 
   it('does not expose payment controls to members', () => {

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -57,6 +57,14 @@
         >
           {{ $t('workspacePanel.billingStatus.updatePayment') }}
         </Button>
+        <Button
+          v-else-if="banner.action === 'retryPayment'"
+          variant="inverted"
+          size="lg"
+          @click="handleRetryPayment"
+        >
+          {{ $t('workspacePanel.billingStatus.retryPayment') }}
+        </Button>
       </div>
     </div>
   </div>
@@ -74,10 +82,20 @@ import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogService } from '@/services/dialogService'
 
-type BannerAction = 'addCredits' | 'reactivate' | 'updatePayment'
+type BannerAction =
+  | 'addCredits'
+  | 'reactivate'
+  | 'updatePayment'
+  | 'retryPayment'
 
 const { t, d } = useI18n()
-const { renewalDate, subscription, manageSubscription } = useBillingContext()
+const {
+  renewalDate,
+  subscription,
+  subscriptionStatus,
+  manageSubscription,
+  showSubscriptionDialog
+} = useBillingContext()
 const { permissions } = useWorkspaceUI()
 const { kind, dismiss } = useBillingBanner()
 const { isResubscribing, handleResubscribe } = useResubscribe()
@@ -122,6 +140,15 @@ const banner = computed<BannerView | null>(() => {
         dismissible: false
       }
     case 'paymentFailed':
+      if (subscriptionStatus.value !== 'active') {
+        return {
+          muted: false,
+          title: t(`${bs}.warning.title`),
+          body: t(`${bs}.warning.retryBody`),
+          action: 'retryPayment',
+          dismissible: false
+        }
+      }
       return {
         muted: false,
         title: t(`${bs}.warning.title`),
@@ -161,5 +188,8 @@ function handleAddCredits() {
 }
 function handleUpdatePayment() {
   void manageSubscription()
+}
+function handleRetryPayment() {
+  showSubscriptionDialog({ reason: 'settings_billing_panel' })
 }
 </script>

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -67,6 +67,12 @@ describe('deriveBillingBanner', () => {
     expect(derive(paymentFailed)).toBe('paymentFailed')
   })
 
+  it('shows payment recovery before an initial subscription has plan identity', () => {
+    expect(derive({ ...paymentFailed, isTeamPlan: false })).toBe(
+      'paymentFailed'
+    )
+  })
+
   it('prioritizes payment failure over out of credits for owners', () => {
     expect(derive({ ...paymentFailed, hasFunds: false })).toBe('paymentFailed')
   })

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -26,26 +26,22 @@ export interface BillingBannerInputs {
   outOfCreditsDismissed: boolean
 }
 
-// The single billing banner slot, in priority order: paused > paymentFailed >
-// outOfCredits > ending. billingControlEnabled is the FE-1246 kill switch: the
-// whole banner is behind it so a PostHog rollback hides it for everyone. Then
-// gated on the team PLAN rather than the workspace type, because personal
-// workspaces are due to gain team plans (BE-1526) — a workspace-type gate would
-// then hide the banner from real team subscribers.
 export function deriveBillingBanner(
   inputs: BillingBannerInputs
 ): BillingBannerKind | null {
-  if (!inputs.billingControlEnabled || !inputs.isTeamPlan || !inputs.isLoaded) {
+  if (!inputs.billingControlEnabled || !inputs.isLoaded) {
     return null
   }
 
-  // Both sit above the isActiveSubscription gate because the backend folds
-  // billing_status into is_active: paused and payment_failed each report
-  // is_active=false, so either check would be dead code below it.
-  if (inputs.billingStatus === 'paused') return 'paused'
-  if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
+  const canManagePaymentFailure =
+    inputs.billingStatus === 'payment_failed' && inputs.canManage
+  if (canManagePaymentFailure) {
     return 'paymentFailed'
   }
+
+  if (!inputs.isTeamPlan) return null
+
+  if (inputs.billingStatus === 'paused') return 'paused'
 
   // Inactive workspaces surface a run-lock modal, not this banner. Members hit
   // this on payment_failed, which is per design — only billing managers see it.

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -389,6 +389,7 @@ describe('billingOperationStore', () => {
         payment_intent_source: undefined,
         failure_category: 'unknown'
       })
+      expect(mockFetchStatus).toHaveBeenCalledOnce()
     })
 
     it('uses default message when no error_message in response', async () => {
@@ -408,6 +409,7 @@ describe('billingOperationStore', () => {
         summary: 'billingOperation.topupFailed',
         detail: undefined
       })
+      expect(mockFetchStatus).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -150,7 +150,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       }
 
       if (response.status === 'failed') {
-        handleFailure(opId, response.error_message ?? null)
+        await handleFailure(opId, response.error_message ?? null)
         return
       }
 
@@ -262,7 +262,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     resolveTerminal(opId)
   }
 
-  function handleFailure(opId: string, errorMessage: string | null) {
+  async function handleFailure(opId: string, errorMessage: string | null) {
     const operation = operations.value.get(opId)
     if (!operation) return
 
@@ -270,6 +270,11 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     updateOperationStatus(opId, 'failed', errorMessage ?? defaultMessage)
     cleanup(opId)
+
+    const billingStatusRefresh =
+      operation.type === 'subscription'
+        ? useBillingContext().fetchStatus()
+        : Promise.resolve()
 
     const telemetry = useTelemetry()
     telemetry?.trackBillingEvent({
@@ -305,6 +310,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       })
     }
 
+    await Promise.allSettled([billingStatusRefresh])
     resolveTerminal(opId)
   }
 


### PR DESCRIPTION
## Description
Adds the owner-facing recovery path for a failed initial subscription:
- distinguishes an initial/ended subscription failure from a payment failure on an active subscription
- reopens the pricing/checkout dialog for the intended plan so the backend can require a replacement payment method
- keeps Billing Portal as the action for active-subscription payment failures
- keeps members on the truthful admin-contact state with no payment action

This PR is independently reviewable, but must not be deployed before the backend sequence is deployed: cloud #5731 first, then cloud #5732. Older backend behavior can silently reuse the declined default.

Linear: https://linear.app/comfyorg/issue/BE-5054/let-users-replace-a-failed-payment-method-and-successfully-retry

## How has this been tested?
- `pnpm test:unit src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts` (14 tests)
- `pnpm typecheck`
- `pnpm format:check`
- targeted ESLint for the changed Vue/test files

## Screenshots or screen capture
Not included; this reuses the existing billing status banner and subscription dialog.