### PR TITLE
[backport cloud/1.47] fix: gate cloud startup on workspace auth

### DIFF
--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -9,6 +9,11 @@ async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
 }
 
+const mockCaptureException = vi.hoisted(() => vi.fn())
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
+}))
+
 const mockIsInitialized = ref(false)
 const mockCurrentUser = ref<object | null>(null)
 
@@ -24,14 +29,38 @@ vi.mock('@/platform/remoteConfig/refreshRemoteConfig', () => ({
   refreshRemoteConfig: (options: unknown) => mockRefreshRemoteConfig(options)
 }))
 
+const mockRemoteConfigState = vi.hoisted(() => ({
+  value: 'authenticated' as
+    | 'uninitialized'
+    | 'anonymous'
+    | 'authenticated'
+    | 'error'
+}))
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfigState: mockRemoteConfigState
+}))
+
 const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: false }))
+const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
       get teamWorkspacesEnabled() {
         return mockTeamWorkspacesEnabled.value
+      },
+      get unifiedCloudAuthEnabled() {
+        return mockUnifiedCloudAuthEnabled.value
       }
     }
+  })
+}))
+
+const mockMintAtLogin = vi.fn()
+const mockGetUnifiedToken = vi.fn()
+vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
+  useWorkspaceAuthStore: () => ({
+    mintAtLogin: mockMintAtLogin,
+    getUnifiedToken: mockGetUnifiedToken
   })
 }))
 
@@ -39,10 +68,16 @@ const mockWorkspaceStoreInitialize = vi.fn()
 const mockWorkspaceStoreInitState = vi.hoisted(() => ({
   value: 'uninitialized' as string
 }))
+const mockActiveWorkspaceId = vi.hoisted(() => ({
+  value: 'workspace-123' as string | null
+}))
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     get initState() {
       return mockWorkspaceStoreInitState.value
+    },
+    get activeWorkspaceId() {
+      return mockActiveWorkspaceId.value
     },
     initialize: mockWorkspaceStoreInitialize
   })
@@ -76,9 +111,16 @@ describe('WorkspaceAuthGate', () => {
     mockIsInitialized.value = false
     mockCurrentUser.value = null
     mockTeamWorkspacesEnabled.value = false
+    mockUnifiedCloudAuthEnabled.value = false
+    mockRemoteConfigState.value = 'authenticated'
     mockWorkspaceStoreInitState.value = 'uninitialized'
+    mockActiveWorkspaceId.value = 'workspace-123'
     mockRefreshRemoteConfig.mockResolvedValue(undefined)
-    mockWorkspaceStoreInitialize.mockResolvedValue(undefined)
+    mockWorkspaceStoreInitialize.mockImplementation(async () => {
+      mockWorkspaceStoreInitState.value = 'ready'
+    })
+    mockMintAtLogin.mockResolvedValue(true)
+    mockGetUnifiedToken.mockReturnValue('cloud-jwt')
   })
 
   const i18n = createI18n({ legacy: false })
@@ -150,6 +192,18 @@ describe('WorkspaceAuthGate', () => {
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
     })
 
+    it('mints unified auth after refreshing authenticated flags', async () => {
+      mockRefreshRemoteConfig.mockImplementation(async () => {
+        mockUnifiedCloudAuthEnabled.value = true
+      })
+
+      mountComponent()
+      await flushPromises()
+
+      expect(mockMintAtLogin).toHaveBeenCalledOnce()
+      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+    })
+
     it('initializes workspace store when teamWorkspacesEnabled is true', async () => {
       mockTeamWorkspacesEnabled.value = true
 
@@ -182,22 +236,28 @@ describe('WorkspaceAuthGate', () => {
     })
   })
 
-  describe('error handling - graceful degradation', () => {
+  describe('error handling', () => {
     beforeEach(() => {
       mockIsInitialized.value = true
       mockCurrentUser.value = { uid: 'user-123' }
     })
 
-    it('renders slot when remote config refresh fails', async () => {
-      mockRefreshRemoteConfig.mockRejectedValue(new Error('Network error'))
+    it('keeps the app gated when remote config refresh fails', async () => {
+      const error = new Error('Network error')
+      mockRefreshRemoteConfig.mockRejectedValue(error)
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        tags: {
+          error_type: 'workspace_auth_gate_initialization_failure'
+        }
+      })
     })
 
-    it('renders slot when remote config refresh times out', async () => {
+    it('keeps the app gated when remote config refresh times out', async () => {
       vi.useFakeTimers()
       try {
         // Never-resolving promise simulates a hanging request
@@ -212,14 +272,33 @@ describe('WorkspaceAuthGate', () => {
         // Advance past the 10 second timeout
         await vi.advanceTimersByTimeAsync(10_001)
 
-        // Should render slot after timeout (graceful degradation)
-        expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+        expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
       } finally {
         vi.useRealTimers()
       }
     })
 
-    it('renders slot when workspace store initialization fails', async () => {
+    it('keeps the app gated when authenticated config is unavailable', async () => {
+      mockRemoteConfigState.value = 'error'
+
+      mountComponent()
+      await flushPromises()
+
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+    })
+
+    it('keeps the app gated when unified auth initialization fails', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockMintAtLogin.mockResolvedValue(false)
+
+      mountComponent()
+      await flushPromises()
+
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
+    })
+
+    it('keeps the app gated when workspace store initialization fails', async () => {
       mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitialize.mockRejectedValue(
         new Error('Workspace init failed')
@@ -228,7 +307,28 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+    })
+
+    it('keeps the app gated when workspace setup clears unified auth', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockTeamWorkspacesEnabled.value = true
+      mockGetUnifiedToken.mockReturnValue(undefined)
+
+      mountComponent()
+      await flushPromises()
+
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+    })
+
+    it('keeps the app gated without a ready workspace context', async () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockWorkspaceStoreInitState.value = 'loading'
+
+      mountComponent()
+      await flushPromises()
+
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -18,6 +18,7 @@
  * The splash loader in index.html (z-9999) covers the screen during this
  * phase, so no separate loading indicator is needed here.
  */
+import { captureException } from '@sentry/vue'
 import { promiseTimeout, until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { onMounted, ref } from 'vue'
@@ -25,7 +26,9 @@ import { onMounted, ref } from 'vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import { remoteConfigState } from '@/platform/remoteConfig/remoteConfig'
 import { refreshRemoteConfig } from '@/platform/remoteConfig/refreshRemoteConfig'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -61,24 +64,26 @@ async function initialize(): Promise<void> {
     // Step 3: Refresh feature flags with auth context
     // This ensures teamWorkspacesEnabled reflects the authenticated user's state
     // Timeout prevents hanging if server is slow/unresponsive
-    try {
-      await Promise.race([
-        refreshRemoteConfig({ useAuth: true }),
-        promiseTimeout(CONFIG_REFRESH_TIMEOUT_MS).then(() => {
-          throw new Error('Config refresh timeout')
-        })
-      ])
-    } catch (error) {
-      console.warn(
-        '[WorkspaceAuthGate] Failed to refresh remote config:',
-        error
-      )
-      // Continue - feature flags will use defaults (teamWorkspacesEnabled=false)
-      // App will render with Firebase auth fallback
+    await Promise.race([
+      refreshRemoteConfig({ useAuth: true }),
+      promiseTimeout(CONFIG_REFRESH_TIMEOUT_MS).then(() => {
+        throw new Error('Config refresh timeout')
+      })
+    ])
+    if (remoteConfigState.value !== 'authenticated') {
+      throw new Error('Failed to load authenticated remote config')
     }
 
     // Step 4: THE CHECKPOINT - Are we in workspace mode?
     const { flags } = useFeatureFlags()
+    const workspaceAuthStore = useWorkspaceAuthStore()
+    if (flags.unifiedCloudAuthEnabled) {
+      const authenticated = await workspaceAuthStore.mintAtLogin()
+      if (!authenticated) {
+        throw new Error('Failed to initialize unified cloud auth')
+      }
+    }
+
     if (!flags.teamWorkspacesEnabled) {
       // Not in workspace mode - use existing Firebase auth flow
       // No additional initialization needed
@@ -88,6 +93,12 @@ async function initialize(): Promise<void> {
 
     // Step 5: WORKSPACE MODE - Full initialization
     await initializeWorkspaceMode()
+    if (
+      flags.unifiedCloudAuthEnabled &&
+      !workspaceAuthStore.getUnifiedToken()
+    ) {
+      throw new Error('Unified cloud auth was cleared during workspace setup')
+    }
 
     // Step 6: Resume any pending pricing flow from team workspace creation
     // Only safe after workspace store initialized successfully — the pricing
@@ -96,12 +107,15 @@ async function initialize(): Promise<void> {
     if (workspaceStore.initState === 'ready') {
       subscriptionDialog.resumePendingPricingFlow()
     }
+
+    isReady.value = true
   } catch (error) {
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
-  } finally {
-    // Always render (graceful degradation)
-    // If workspace init failed, API calls fall back to Firebase token
-    isReady.value = true
+    captureException(error, {
+      tags: {
+        error_type: 'workspace_auth_gate_initialization_failure'
+      }
+    })
   }
 }
 
@@ -111,18 +125,15 @@ async function initializeWorkspaceMode(): Promise<void> {
   // - Fetching workspace list
   // - Switching to last used workspace if needed
   // - Setting active workspace
-  try {
-    const workspaceStore = useTeamWorkspaceStore()
-    if (workspaceStore.initState === 'uninitialized') {
-      await workspaceStore.initialize()
-    }
-  } catch (error) {
-    // Log but don't block - workspace UI features may not work but app will render
-    // API calls will fall back to Firebase token
-    console.warn(
-      '[WorkspaceAuthGate] Failed to initialize workspace store:',
-      error
-    )
+  const workspaceStore = useTeamWorkspaceStore()
+  if (workspaceStore.initState === 'uninitialized') {
+    await workspaceStore.initialize()
+  }
+  if (
+    workspaceStore.initState !== 'ready' ||
+    !workspaceStore.activeWorkspaceId
+  ) {
+    throw new Error('Failed to initialize workspace context')
   }
 }
 


### PR DESCRIPTION
## Summary

Backports #14183 to `cloud/1.47`, which is currently deployed to `frontend-rc.testenvs.comfy.org`.

The RC report showed the same fail-open authentication behavior as the staging incident: protected canvas endpoints returned repeated 403 `auth_type_not_allowed` responses while the frontend continued rendering a blank canvas. The `cloud/1.48` and `core/1.48` backports already exist, but RC tracks `cloud/1.47` and did not contain the fix.

## How this solves it

- Keeps Cloud startup gated until authenticated remote config and required Cloud/workspace auth are ready.
- Re-mints unified Cloud auth after authenticated flags are refreshed.
- Prevents protected canvas requests from falling back to an unacceptable Firebase credential.
- Reports initialization failures to Sentry with `error_type=workspace_auth_gate_initialization_failure`.

## Backport

- Original: #14183
- Cherry-picked commit: `de436a787abeb7b4333ab46deb80529a8c0d1604`
- Applied cleanly to `cloud/1.47`; no conflict resolution or behavior changes were required.

## Validation

- `pnpm test:unit src/platform/workspace/auth/WorkspaceAuthGate.test.ts` — 16 passed
- `pnpm typecheck`
- `git diff --check origin/cloud/1.47...HEAD`
