### PR TITLE
fix: show subscription-specific billing errors

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2585,6 +2585,7 @@
     "subscriptionProcessing": "Processing payment — setting up your workspace...",
     "subscriptionSuccess": "Subscription updated successfully",
     "subscriptionFailed": "Subscription update failed",
+    "subscriptionFailedDetail": "We couldn't update your subscription. Please try again.",
     "subscriptionTimeout": "Subscription verification timed out",
     "topupProcessing": "Processing payment — adding credits...",
     "topupSuccess": "Credits added successfully",

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -353,12 +353,11 @@ describe('billingOperationStore', () => {
   })
 
   describe('polling failure', () => {
-    it('updates status and shows error toast on failure', async () => {
-      const errorMessage = 'Payment declined for person@example.com'
+    it('does not expose backend details on subscription failure', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'failed',
-        error_message: errorMessage,
+        error_message: 'workflow failed',
         started_at: new Date().toISOString()
       })
 
@@ -369,13 +368,15 @@ describe('billingOperationStore', () => {
 
       const operation = store.getOperation('op-1')
       expect(operation?.status).toBe('failed')
-      expect(operation?.errorMessage).toBe(errorMessage)
+      expect(operation?.errorMessage).toBe(
+        'billingOperation.subscriptionFailedDetail'
+      )
       expect(store.hasPendingOperations).toBe(false)
 
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'error',
         summary: 'billingOperation.subscriptionFailed',
-        detail: errorMessage
+        detail: 'billingOperation.subscriptionFailedDetail'
       })
       expect(mockTrackBillingEvent).toHaveBeenCalledWith({
         operation: 'operation',
@@ -407,6 +408,28 @@ describe('billingOperationStore', () => {
         severity: 'error',
         summary: 'billingOperation.topupFailed',
         detail: undefined
+      })
+    })
+
+    it('preserves backend details on top-up failure', async () => {
+      const errorMessage = 'Payment method declined'
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: errorMessage,
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.errorMessage).toBe(errorMessage)
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'billingOperation.topupFailed',
+        detail: errorMessage
       })
     })
   })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -267,8 +267,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     if (!operation) return
 
     const defaultMessage = failureMessage(operation.type)
+    const detail =
+      operation.type === 'subscription'
+        ? t('billingOperation.subscriptionFailedDetail')
+        : errorMessage
 
-    updateOperationStatus(opId, 'failed', errorMessage ?? defaultMessage)
+    updateOperationStatus(opId, 'failed', detail ?? defaultMessage)
     cleanup(opId)
 
     const telemetry = useTelemetry()
@@ -301,7 +305,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       useToastStore().add({
         severity: 'error',
         summary: defaultMessage,
-        detail: errorMessage ?? undefined
+        detail: detail ?? undefined
       })
     }
 


### PR DESCRIPTION
## Summary

Fixes **QA report item CF148-003**: a subscription update failure toast used the correct title but exposed the unrelated backend detail `workflow failed` as its body.

Slack evidence: https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785336642900919?thread_ts=1785169746.169899&cid=C0932CGKT5K

## Changes

- **What**: Replaces every free-form terminal subscription failure detail with localized recovery guidance. The current API exposes no typed failure code, so backend workflow text is not treated as a user-facing contract.
- **Unchanged**: Non-subscription billing operations retain their existing detail behavior.
- **Tests**: Covers subscription-detail redaction and top-up-detail preservation.

## Regression provenance

The behavior was introduced on **2026-02-06** by PR #8508 (`c5431de123`), which began passing the billing operation's raw `error_message` directly to the subscription failure toast body.

## Review Focus

Confirm that terminal subscription failures always use safe localized copy rather than matching a backend sentence. A backend follow-up should add stable failure codes so actionable subscription states can be localized selectively.

## Screenshots

### CF148-003 — AS IS

Title: `Subscription update failed`  
Body: `workflow failed`

### CF148-003 — TO BE

Title: `Subscription update failed`  
Body: `We couldn't update your subscription. Please try again.`

![CF148-003 AS IS and TO BE](https://ampcode.com/user-content/artifacts/c800a7edfc7f9d40590768935eb3d691eeb013b9c5f6ce7d3182a68f9358c5fd-file.png)

![CF148-003 AS IS and TO BE animation](https://ampcode.com/user-content/artifacts/33e0c0a12e9aa9bf43dd04632745d46e4641242edab184508825180cadf96b9f-file.gif)

## Verification

- `pnpm test:unit src/platform/workspace/stores/billingOperationStore.test.ts` — 35 passed
- `pnpm typecheck`
- `pnpm lint:unstaged`
- `pnpm knip`
- `git diff --check`
