### PR TITLE
fix(telemetry): restore enriched PostHog execution events

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -416,7 +416,7 @@ describe('PostHogTelemetryProvider', () => {
         has_toolkit_nodes: true,
         toolkit_node_names: ['LoadImage'],
         trigger_source: 'keybinding',
-        view_mode: 'normal',
+        view_mode: 'graph',
         is_app_mode: false,
         dock_state: 'docked'
       })

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -16,6 +16,21 @@ const hoisted = vi.hoisted(() => {
   const mockReset = vi.fn()
   const mockOnUserResolved = vi.fn()
   const mockOnUserLogout = vi.fn()
+  const executionContext = {
+    is_template: true,
+    workflow_name: 'image_qwen_image_edit_2509',
+    template_source: 'comfy',
+    template_category: 'image',
+    custom_node_count: 2,
+    api_node_count: 1,
+    toolkit_node_count: 1,
+    subgraph_count: 0,
+    total_node_count: 4,
+    has_api_nodes: true,
+    api_node_names: ['OpenAIImageNode'],
+    has_toolkit_nodes: true,
+    toolkit_node_names: ['LoadImage']
+  }
   const refs = {
     tier: null as unknown as Ref<string | null>,
     remoteConfig: null as unknown as Ref<Record<string, unknown> | null>
@@ -31,6 +46,7 @@ const hoisted = vi.hoisted(() => {
     mockReset,
     mockOnUserResolved,
     mockOnUserLogout,
+    executionContext,
     refs,
     mockPosthog: {
       default: {
@@ -59,6 +75,10 @@ vi.mock('@/platform/remoteConfig/remoteConfig', async () => {
 })
 
 vi.mock('posthog-js', () => hoisted.mockPosthog)
+
+vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
+  getExecutionContext: () => hoisted.executionContext
+}))
 
 vi.mock('@/composables/billing/useBillingContext', async () => {
   const { ref } = await vi.importActual<typeof VueModule>('vue')
@@ -376,6 +396,80 @@ describe('PostHogTelemetryProvider', () => {
         {
           error_code: 'auth/user-not-found',
           auth_action: 'email_sign_in'
+        }
+      )
+    })
+
+    it('captures enriched execution starts with client attribution', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackRunButton({
+        subscribe_to_run: false,
+        workflow_type: 'template',
+        workflow_name: 'image_qwen_image_edit_2509',
+        custom_node_count: 2,
+        total_node_count: 4,
+        subgraph_count: 0,
+        has_api_nodes: true,
+        api_node_names: ['OpenAIImageNode'],
+        has_toolkit_nodes: true,
+        toolkit_node_names: ['LoadImage'],
+        trigger_source: 'keybinding',
+        view_mode: 'normal',
+        is_app_mode: false,
+        dock_state: 'docked'
+      })
+      provider.trackWorkflowExecution()
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.EXECUTION_START,
+        {
+          ...hoisted.executionContext,
+          trigger_source: 'keybinding',
+          event_source: 'web-sdk'
+        }
+      )
+
+      provider.trackWorkflowExecution()
+
+      expect(hoisted.mockCapture).toHaveBeenLastCalledWith(
+        TelemetryEvents.EXECUTION_START,
+        {
+          ...hoisted.executionContext,
+          trigger_source: 'unknown',
+          event_source: 'web-sdk'
+        }
+      )
+    })
+
+    it('captures execution outcomes with client attribution', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackExecutionSuccess({ jobId: 'job-1' })
+      provider.trackExecutionError({
+        jobId: 'job-2',
+        nodeId: 'node-3',
+        nodeType: 'LoadImage',
+        error: 'failed'
+      })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.EXECUTION_SUCCESS,
+        {
+          jobId: 'job-1',
+          event_source: 'web-sdk'
+        }
+      )
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.EXECUTION_ERROR,
+        {
+          jobId: 'job-2',
+          nodeId: 'node-3',
+          nodeType: 'LoadImage',
+          error: 'failed',
+          event_source: 'web-sdk'
         }
       )
     })

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -8,6 +8,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionContext'
 
 import type {
   AddCreditsClickMetadata,
@@ -17,6 +18,9 @@ import type {
   BillingTelemetryEvent,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  ExecutionErrorMetadata,
+  ExecutionSuccessMetadata,
+  ExecutionTriggerSource,
   ShareFlowMetadata,
   ShareLinkOpenedMetadata,
   HelpCenterClosedMetadata,
@@ -63,6 +67,8 @@ import {
   TelemetryEvents
 } from '../../types'
 import { normalizeSurveyResponses } from '../../utils/surveyNormalization'
+
+const EXECUTION_EVENT_SOURCE = 'web-sdk'
 
 const DEFAULT_DISABLED_EVENTS = [
   TelemetryEvents.WORKFLOW_OPENED,
@@ -114,6 +120,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   private eventQueue: QueuedEvent[] = []
   private pendingFirstAuthAt = new Map<string, string>()
   private isInitialized = false
+  private lastTriggerSource: ExecutionTriggerSource | undefined
   private disabledEvents = new Set<TelemetryEventName>(DEFAULT_DISABLED_EVENTS)
   private desktopEntryProps: DesktopEntryProps | null = null
   private stopSubscriptionTierWatch: WatchStopHandle | null = null
@@ -440,6 +447,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   }
 
   trackRunButton(properties: RunButtonProperties): void {
+    this.lastTriggerSource = properties.trigger_source
     this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, properties)
   }
 
@@ -588,6 +596,29 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackSharedWorkflowRun(metadata: SharedWorkflowRunMetadata): void {
     this.trackEvent(TelemetryEvents.SHARED_WORKFLOW_RUN, metadata)
+  }
+
+  trackWorkflowExecution(): void {
+    this.captureRaw(TelemetryEvents.EXECUTION_START, {
+      ...getExecutionContext(),
+      trigger_source: this.lastTriggerSource ?? 'unknown',
+      event_source: EXECUTION_EVENT_SOURCE
+    })
+    this.lastTriggerSource = undefined
+  }
+
+  trackExecutionError(metadata: ExecutionErrorMetadata): void {
+    this.captureRaw(TelemetryEvents.EXECUTION_ERROR, {
+      ...metadata,
+      event_source: EXECUTION_EVENT_SOURCE
+    })
+  }
+
+  trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
+    this.captureRaw(TelemetryEvents.EXECUTION_SUCCESS, {
+      ...metadata,
+      event_source: EXECUTION_EVENT_SOURCE
+    })
   }
 
   trackSettingChanged(metadata: SettingChangedMetadata): void {


### PR DESCRIPTION
## Summary

Restore client-enriched execution telemetry to PostHog after #12717 removed it based on a server-side equivalence that does not hold for template attribution.

## Changes

- **What**: Restore `execution_start`, `execution_success`, and `execution_error` capture in `PostHogTelemetryProvider`. `execution_start` again includes `getExecutionContext()` properties such as `workflow_name` and `is_template`, preserves the initiating run-button `trigger_source`, and all three events carry `event_source: web-sdk` to distinguish the client path.
- **Breaking**: None. GTM remains unchanged and Mixpanel is not restored.
- **Dependencies**: This restores the signal consumed by [data-platform#238](https://github.com/Comfy-Org/data-platform/pull/238); that PR remains responsible for adding `app_runs` to Algolia.

## Review Focus

[#12717](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12717) assumed backend execution events were an equivalent PostHog source of truth. They do not include the client-derived template identity required by downstream consumers. This is therefore a targeted PostHog restoration rather than a literal revert: it keeps the GTM path, leaves Mixpanel removed, and adds an explicit source tag for de-duplication/filtering.

This PR restores telemetry only; it does not change the current Hub or in-app ranking formula. Context: [Slack thread](https://comfy-organization.slack.com/archives/C09NWURUPMF/p1782422035782759?thread_ts=1782422035.782759&cid=C09NWURUPMF).

## Testing

- `vitest run src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts --reporter=verbose` — 67 passed
- `oxfmt --check` on both changed files
- `eslint` on both changed files
- `git diff --check`