### PR TITLE
feat: instrument Allowlist actions

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -260,6 +260,26 @@ export default defineConfig([
     }
   },
   {
+    name: 'comfy/feature-flags-through-composable',
+    files: ['src/**/*.{ts,tsx,mts,vue}'],
+    ignores: [
+      '**/*.test.ts',
+      '**/*.spec.ts',
+      'src/composables/useFeatureFlags.ts'
+    ],
+    rules: {
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'api',
+          property: 'getServerFeature',
+          message:
+            'Define and read feature flags through useFeatureFlags() so Datadog receives every evaluation.'
+        }
+      ]
+    }
+  },
+  {
     files: ['**/*.spec.ts'],
     ignores: ['browser_tests/tests/**/*.spec.ts', 'apps/*/e2e/**/*.spec.ts'],
     rules: {

--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -87,6 +87,7 @@ const mockTrackUiButtonClicked = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
+    trackFeatureFlagExposure: vi.fn(),
     trackUiButtonClicked: mockTrackUiButtonClicked
   })
 }))

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -35,8 +35,10 @@ describe('showConfirmDialog Reka renderer opt-in', () => {
   })
 
   it('forwards the confirm section components and caller props', () => {
+    const onClose = vi.fn()
     showConfirmDialog({
       key: 'confirm-test',
+      onClose,
       headerProps: { title: 'Title' },
       props: { promptText: 'Prompt' },
       footerProps: { confirmText: 'Delete' }
@@ -50,5 +52,6 @@ describe('showConfirmDialog Reka renderer opt-in', () => {
     expect(args.headerProps).toEqual({ title: 'Title' })
     expect(args.props).toEqual({ promptText: 'Prompt' })
     expect(args.footerProps).toEqual({ confirmText: 'Delete' })
+    expect(args.dialogComponentProps.onClose).toBe(onClose)
   })
 })

--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -7,6 +7,7 @@ import type { ComponentAttrs } from 'vue-component-type-helpers'
 
 interface ConfirmDialogOptions {
   key?: string
+  onClose?: () => void
   headerProps?: ComponentAttrs<typeof ConfirmHeader>
   props?: ComponentAttrs<typeof ConfirmBody>
   footerProps?: ComponentAttrs<typeof ConfirmFooter>
@@ -16,7 +17,7 @@ export function showConfirmDialog(
   options: ConfirmDialogOptions = {}
 ): DialogInstance {
   const dialogStore = useDialogStore()
-  const { key, headerProps, props, footerProps } = options
+  const { key, onClose, headerProps, props, footerProps } = options
   return dialogStore.showDialog({
     key,
     headerComponent: ConfirmHeader,
@@ -28,6 +29,7 @@ export function showConfirmDialog(
     dialogComponentProps: {
       renderer: 'reka',
       size: 'md',
+      onClose,
       // Confirm sections carry their own padding — zero out the dialog
       // chrome padding, like the PrimeVue `pt` overrides did.
       headerClass: 'p-0',

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -70,7 +70,13 @@ describe('useFeatureFlags', () => {
           undefined
         ],
         ['maxUploadSize', ServerFeatureFlag.MAX_UPLOAD_SIZE, undefined],
+        ['assetsEnabled', ServerFeatureFlag.ASSETS, false],
         ['supportsManagerV4', ServerFeatureFlag.MANAGER_SUPPORTS_V4, undefined],
+        [
+          'managerSupportsCsrfPost',
+          ServerFeatureFlag.MANAGER_SUPPORTS_CSRF_POST,
+          undefined
+        ],
         [
           'modelUploadButtonEnabled',
           ServerFeatureFlag.MODEL_UPLOAD_BUTTON_ENABLED,

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -15,6 +15,8 @@ import {
 } from '@/platform/remoteConfig/remoteConfig'
 import { api } from '@/scripts/api'
 
+const mockTrackFeatureFlagExposure = vi.hoisted(() => vi.fn())
+
 // Mock the API module
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -28,9 +30,19 @@ vi.mock('@/platform/distribution/types', () => ({
   isNightly: false
 }))
 
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackFeatureFlagExposure: mockTrackFeatureFlagExposure
+  })
+}))
+
 describe('useFeatureFlags', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   describe('flags object', () => {
@@ -39,6 +51,114 @@ describe('useFeatureFlags', () => {
 
       expect(isReadonly(flags)).toBe(true)
       expect(isReactive(flags)).toBe(true)
+    })
+
+    it('reports each resolved production feature flag', () => {
+      vi.stubEnv('DEV', false)
+      vi.mocked(distributionTypes).isCloud = false
+      vi.mocked(distributionTypes).isNightly = false
+      remoteConfig.value = {}
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      const cases = [
+        [
+          'supportsPreviewMetadata',
+          ServerFeatureFlag.SUPPORTS_PREVIEW_METADATA,
+          undefined
+        ],
+        ['maxUploadSize', ServerFeatureFlag.MAX_UPLOAD_SIZE, undefined],
+        ['supportsManagerV4', ServerFeatureFlag.MANAGER_SUPPORTS_V4, undefined],
+        [
+          'modelUploadButtonEnabled',
+          ServerFeatureFlag.MODEL_UPLOAD_BUTTON_ENABLED,
+          false
+        ],
+        ['assetRenameEnabled', ServerFeatureFlag.ASSET_RENAME_ENABLED, false],
+        [
+          'privateModelsEnabled',
+          ServerFeatureFlag.PRIVATE_MODELS_ENABLED,
+          false
+        ],
+        [
+          'onboardingSurveyEnabled',
+          ServerFeatureFlag.ONBOARDING_SURVEY_ENABLED,
+          false
+        ],
+        ['linearToggleEnabled', ServerFeatureFlag.LINEAR_TOGGLE_ENABLED, false],
+        [
+          'teamWorkspacesEnabled',
+          ServerFeatureFlag.TEAM_WORKSPACES_ENABLED,
+          false
+        ],
+        [
+          'partnerNodeGovernanceEnabled',
+          ServerFeatureFlag.PARTNER_NODE_GOVERNANCE_ENABLED,
+          false
+        ],
+        ['userSecretsEnabled', ServerFeatureFlag.USER_SECRETS_ENABLED, false],
+        ['nodeReplacementsEnabled', ServerFeatureFlag.NODE_REPLACEMENTS, false],
+        [
+          'nodeLibraryEssentialsEnabled',
+          ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED,
+          false
+        ],
+        [
+          'workflowSharingEnabled',
+          ServerFeatureFlag.WORKFLOW_SHARING_ENABLED,
+          false
+        ],
+        [
+          'comfyHubUploadEnabled',
+          ServerFeatureFlag.COMFYHUB_UPLOAD_ENABLED,
+          false
+        ],
+        [
+          'comfyHubProfileGateEnabled',
+          ServerFeatureFlag.COMFYHUB_PROFILE_GATE_ENABLED,
+          false
+        ],
+        ['showSignInButton', ServerFeatureFlag.SHOW_SIGNIN_BUTTON, undefined],
+        [
+          'unifiedCloudAuthEnabled',
+          ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
+          false
+        ],
+        [
+          'consolidatedBillingEnabled',
+          ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED,
+          false
+        ],
+        [
+          'billingControlEnabled',
+          ServerFeatureFlag.BILLING_CONTROL_ENABLED,
+          false
+        ],
+        [
+          'freeTierJobAllowanceEnabled',
+          ServerFeatureFlag.FREE_TIER_JOB_ALLOWANCE_ENABLED,
+          false
+        ],
+        ['signupTurnstileMode', ServerFeatureFlag.SIGNUP_TURNSTILE, 'off'],
+        [
+          'supportsModelTypeTags',
+          ServerFeatureFlag.SUPPORTS_MODEL_TYPE_TAGS,
+          false
+        ]
+      ] as const
+
+      for (const [property, key, expectedValue] of cases) {
+        expect(flags[property]).toBe(expectedValue)
+        expect(mockTrackFeatureFlagExposure).toHaveBeenLastCalledWith(
+          key,
+          expectedValue
+        )
+      }
+
+      expect(Object.keys(flags)).toEqual(cases.map(([property]) => property))
+      expect(mockTrackFeatureFlagExposure).toHaveBeenCalledTimes(cases.length)
     })
 
     it('should access supportsPreviewMetadata', () => {
@@ -114,6 +234,10 @@ describe('useFeatureFlags', () => {
       expect(api.getServerFeature).toHaveBeenCalledWith(
         'custom.feature',
         'default'
+      )
+      expect(mockTrackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+        'custom.feature',
+        'custom-value'
       )
     })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -41,6 +41,41 @@ export enum ServerFeatureFlag {
   SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags'
 }
 
+interface FeatureFlagDefinition<T> {
+  key: string
+  resolve: (key: string) => T
+}
+
+type FeatureFlagDefinitions = Record<string, FeatureFlagDefinition<unknown>>
+
+type ResolvedFeatureFlags<T extends FeatureFlagDefinitions> = {
+  readonly [K in keyof T]: T[K] extends FeatureFlagDefinition<infer V>
+    ? V
+    : never
+}
+
+function defineFeatureFlag<T>(
+  key: string,
+  resolve: (key: string) => T
+): FeatureFlagDefinition<T> {
+  return { key, resolve }
+}
+
+function createFeatureFlags<const T extends FeatureFlagDefinitions>(
+  definitions: T
+): ResolvedFeatureFlags<T> {
+  const flags: Record<string, unknown> = {}
+
+  for (const [property, { key, resolve }] of Object.entries(definitions)) {
+    Object.defineProperty(flags, property, {
+      enumerable: true,
+      get: () => resolve(key)
+    })
+  }
+
+  return flags as ResolvedFeatureFlags<T>
+}
+
 /**
  * Resolves a feature flag value with dev override > remoteConfig > serverFeature priority.
  */
@@ -78,173 +113,161 @@ function resolveAuthGatedFlag(
  * Composable for reactive access to server-side feature flags
  */
 export function useFeatureFlags() {
-  const flags = reactive({
-    get supportsPreviewMetadata() {
-      return api.getServerFeature(ServerFeatureFlag.SUPPORTS_PREVIEW_METADATA)
-    },
-    get maxUploadSize() {
-      return api.getServerFeature(ServerFeatureFlag.MAX_UPLOAD_SIZE)
-    },
-    get supportsManagerV4() {
-      return api.getServerFeature(ServerFeatureFlag.MANAGER_SUPPORTS_V4)
-    },
-    get modelUploadButtonEnabled() {
-      return resolveFlag(
+  const flags = reactive(
+    createFeatureFlags({
+      supportsPreviewMetadata: defineFeatureFlag(
+        ServerFeatureFlag.SUPPORTS_PREVIEW_METADATA,
+        (key) => api.getServerFeature(key)
+      ),
+      maxUploadSize: defineFeatureFlag(
+        ServerFeatureFlag.MAX_UPLOAD_SIZE,
+        (key) => api.getServerFeature(key)
+      ),
+      supportsManagerV4: defineFeatureFlag(
+        ServerFeatureFlag.MANAGER_SUPPORTS_V4,
+        (key) => api.getServerFeature(key)
+      ),
+      modelUploadButtonEnabled: defineFeatureFlag(
         ServerFeatureFlag.MODEL_UPLOAD_BUTTON_ENABLED,
-        remoteConfig.value.model_upload_button_enabled,
-        false
-      )
-    },
-    get assetRenameEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(
+            key,
+            remoteConfig.value.model_upload_button_enabled,
+            false
+          )
+      ),
+      assetRenameEnabled: defineFeatureFlag(
         ServerFeatureFlag.ASSET_RENAME_ENABLED,
-        remoteConfig.value.asset_rename_enabled,
-        false
-      )
-    },
-    get privateModelsEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.asset_rename_enabled, false)
+      ),
+      privateModelsEnabled: defineFeatureFlag(
         ServerFeatureFlag.PRIVATE_MODELS_ENABLED,
-        remoteConfig.value.private_models_enabled,
-        false
-      )
-    },
-    get onboardingSurveyEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.private_models_enabled, false)
+      ),
+      onboardingSurveyEnabled: defineFeatureFlag(
         ServerFeatureFlag.ONBOARDING_SURVEY_ENABLED,
-        remoteConfig.value.onboarding_survey_enabled,
-        false
-      )
-    },
-    get linearToggleEnabled() {
-      if (isNightly) return true
-
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.onboarding_survey_enabled, false)
+      ),
+      linearToggleEnabled: defineFeatureFlag(
         ServerFeatureFlag.LINEAR_TOGGLE_ENABLED,
-        remoteConfig.value.linear_toggle_enabled,
-        false
-      )
-    },
-    /**
-     * Whether team workspaces feature is enabled.
-     * IMPORTANT: Returns false until authenticated remote config is loaded.
-     * This ensures we never use workspace tokens when the feature is disabled,
-     * and prevents race conditions during initialization.
-     */
-    get teamWorkspacesEnabled() {
-      return resolveAuthGatedFlag(
+        (key) =>
+          isNightly
+            ? true
+            : resolveFlag(key, remoteConfig.value.linear_toggle_enabled, false)
+      ),
+      /**
+       * Whether team workspaces feature is enabled.
+       * IMPORTANT: Returns false until authenticated remote config is loaded.
+       * This ensures we never use workspace tokens when the feature is disabled,
+       * and prevents race conditions during initialization.
+       */
+      teamWorkspacesEnabled: defineFeatureFlag(
         ServerFeatureFlag.TEAM_WORKSPACES_ENABLED,
-        remoteConfig.value.team_workspaces_enabled,
-        cachedTeamWorkspacesEnabled
-      )
-    },
-    get partnerNodeGovernanceEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveAuthGatedFlag(
+            key,
+            remoteConfig.value.team_workspaces_enabled,
+            cachedTeamWorkspacesEnabled
+          )
+      ),
+      partnerNodeGovernanceEnabled: defineFeatureFlag(
         ServerFeatureFlag.PARTNER_NODE_GOVERNANCE_ENABLED,
-        remoteConfig.value.partner_node_governance_enabled,
-        false
-      )
-    },
-    get userSecretsEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(
+            key,
+            remoteConfig.value.partner_node_governance_enabled,
+            false
+          )
+      ),
+      userSecretsEnabled: defineFeatureFlag(
         ServerFeatureFlag.USER_SECRETS_ENABLED,
-        remoteConfig.value.user_secrets_enabled,
-        false
-      )
-    },
-    get nodeReplacementsEnabled() {
-      return api.getServerFeature(ServerFeatureFlag.NODE_REPLACEMENTS, false)
-    },
-    get nodeLibraryEssentialsEnabled() {
-      if (isNightly || import.meta.env.DEV) return true
-
-      return (
-        remoteConfig.value.node_library_essentials_enabled ??
-        api.getServerFeature(
-          ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED,
-          false
-        )
-      )
-    },
-    get workflowSharingEnabled() {
-      // UI is also gated on `isCloud` in TopMenuSection; default false
-      // to match other flags' opt-in convention.
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.user_secrets_enabled, false)
+      ),
+      nodeReplacementsEnabled: defineFeatureFlag(
+        ServerFeatureFlag.NODE_REPLACEMENTS,
+        (key) => api.getServerFeature(key, false)
+      ),
+      nodeLibraryEssentialsEnabled: defineFeatureFlag(
+        ServerFeatureFlag.NODE_LIBRARY_ESSENTIALS_ENABLED,
+        (key) =>
+          isNightly || import.meta.env.DEV
+            ? true
+            : (remoteConfig.value.node_library_essentials_enabled ??
+              api.getServerFeature(key, false))
+      ),
+      workflowSharingEnabled: defineFeatureFlag(
         ServerFeatureFlag.WORKFLOW_SHARING_ENABLED,
-        remoteConfig.value.workflow_sharing_enabled,
-        false
-      )
-    },
-    get comfyHubUploadEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.workflow_sharing_enabled, false)
+      ),
+      comfyHubUploadEnabled: defineFeatureFlag(
         ServerFeatureFlag.COMFYHUB_UPLOAD_ENABLED,
-        remoteConfig.value.comfyhub_upload_enabled,
-        false
-      )
-    },
-    get comfyHubProfileGateEnabled() {
-      return resolveFlag(
+        (key) =>
+          resolveFlag(key, remoteConfig.value.comfyhub_upload_enabled, false)
+      ),
+      comfyHubProfileGateEnabled: defineFeatureFlag(
         ServerFeatureFlag.COMFYHUB_PROFILE_GATE_ENABLED,
-        remoteConfig.value.comfyhub_profile_gate_enabled,
-        false
-      )
-    },
-    get showSignInButton(): boolean | undefined {
-      return api.getServerFeature<boolean | undefined>(
+        (key) =>
+          resolveFlag(
+            key,
+            remoteConfig.value.comfyhub_profile_gate_enabled,
+            false
+          )
+      ),
+      showSignInButton: defineFeatureFlag(
         ServerFeatureFlag.SHOW_SIGNIN_BUTTON,
-        undefined
-      )
-    },
-    get unifiedCloudAuthEnabled() {
-      return resolveFlag(
+        (key) => api.getServerFeature<boolean | undefined>(key, undefined)
+      ),
+      unifiedCloudAuthEnabled: defineFeatureFlag(
         ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
-        remoteConfig.value.unified_cloud_auth,
-        false
-      )
-    },
-    /**
-     * Whether personal workspaces use the consolidated (workspace-scoped)
-     * billing flow. While false (default), personal workspaces stay on the
-     * legacy per-user billing flow; team workspaces are unaffected.
-     */
-    get consolidatedBillingEnabled() {
-      return resolveAuthGatedFlag(
+        (key) => resolveFlag(key, remoteConfig.value.unified_cloud_auth, false)
+      ),
+      /**
+       * Whether personal workspaces use the consolidated (workspace-scoped)
+       * billing flow. While false (default), personal workspaces stay on the
+       * legacy per-user billing flow; team workspaces are unaffected.
+       */
+      consolidatedBillingEnabled: defineFeatureFlag(
         ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED,
-        remoteConfig.value.consolidated_billing_enabled,
-        cachedConsolidatedBillingEnabled
-      )
-    },
-    get billingControlEnabled() {
-      return resolveAuthGatedFlag(
+        (key) =>
+          resolveAuthGatedFlag(
+            key,
+            remoteConfig.value.consolidated_billing_enabled,
+            cachedConsolidatedBillingEnabled
+          )
+      ),
+      billingControlEnabled: defineFeatureFlag(
         ServerFeatureFlag.BILLING_CONTROL_ENABLED,
-        remoteConfig.value.billing_control_enabled,
-        cachedBillingControlEnabled
-      )
-    },
-    get freeTierJobAllowanceEnabled() {
-      const config = remoteConfig.value as typeof remoteConfig.value & {
-        free_tier_job_allowance_enabled?: boolean
-      }
-      return resolveFlag(
+        (key) =>
+          resolveAuthGatedFlag(
+            key,
+            remoteConfig.value.billing_control_enabled,
+            cachedBillingControlEnabled
+          )
+      ),
+      freeTierJobAllowanceEnabled: defineFeatureFlag(
         ServerFeatureFlag.FREE_TIER_JOB_ALLOWANCE_ENABLED,
-        config.free_tier_job_allowance_enabled,
-        false
-      )
-    },
-    get signupTurnstileMode() {
-      return resolveFlag(
+        (key) => {
+          const config = remoteConfig.value as typeof remoteConfig.value & {
+            free_tier_job_allowance_enabled?: boolean
+          }
+          return resolveFlag(key, config.free_tier_job_allowance_enabled, false)
+        }
+      ),
+      signupTurnstileMode: defineFeatureFlag(
         ServerFeatureFlag.SIGNUP_TURNSTILE,
-        remoteConfig.value.signup_turnstile,
-        'off'
-      )
-    },
-    get supportsModelTypeTags() {
-      return api.getServerFeature(
+        (key) => resolveFlag(key, remoteConfig.value.signup_turnstile, 'off')
+      ),
+      supportsModelTypeTags: defineFeatureFlag(
         ServerFeatureFlag.SUPPORTS_MODEL_TYPE_TAGS,
-        false
+        (key) => api.getServerFeature(key, false)
       )
-    }
-  })
+    })
+  )
 
   const featureFlag = <T = unknown>(featurePath: string, defaultValue?: T) =>
     computed(() => api.getServerFeature(featurePath, defaultValue))

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -9,6 +9,8 @@ import {
   isAuthenticatedConfigLoaded,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
+import { useTelemetry } from '@/platform/telemetry'
+import type { FeatureFlagValue } from '@/platform/telemetry/types'
 import { api } from '@/scripts/api'
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
@@ -41,12 +43,23 @@ export enum ServerFeatureFlag {
   SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags'
 }
 
-interface FeatureFlagDefinition<T> {
+function reportFeatureFlagEvaluation<T extends FeatureFlagValue>(
+  flagKey: string,
+  value: T
+): T {
+  useTelemetry()?.trackFeatureFlagExposure(flagKey, value)
+  return value
+}
+
+interface FeatureFlagDefinition<T extends FeatureFlagValue> {
   key: string
   resolve: (key: string) => T
 }
 
-type FeatureFlagDefinitions = Record<string, FeatureFlagDefinition<unknown>>
+type FeatureFlagDefinitions = Record<
+  string,
+  FeatureFlagDefinition<FeatureFlagValue>
+>
 
 type ResolvedFeatureFlags<T extends FeatureFlagDefinitions> = {
   readonly [K in keyof T]: T[K] extends FeatureFlagDefinition<infer V>
@@ -54,7 +67,7 @@ type ResolvedFeatureFlags<T extends FeatureFlagDefinitions> = {
     : never
 }
 
-function defineFeatureFlag<T>(
+function defineFeatureFlag<T extends FeatureFlagValue>(
   key: string,
   resolve: (key: string) => T
 ): FeatureFlagDefinition<T> {
@@ -69,7 +82,7 @@ function createFeatureFlags<const T extends FeatureFlagDefinitions>(
   for (const [property, { key, resolve }] of Object.entries(definitions)) {
     Object.defineProperty(flags, property, {
       enumerable: true,
-      get: () => resolve(key)
+      get: () => reportFeatureFlagEvaluation(key, resolve(key))
     })
   }
 
@@ -269,8 +282,16 @@ export function useFeatureFlags() {
     })
   )
 
-  const featureFlag = <T = unknown>(featurePath: string, defaultValue?: T) =>
-    computed(() => api.getServerFeature(featurePath, defaultValue))
+  const featureFlag = <T extends FeatureFlagValue = FeatureFlagValue>(
+    featurePath: string,
+    defaultValue?: T
+  ) =>
+    computed(() =>
+      reportFeatureFlagEvaluation(
+        featurePath,
+        api.getServerFeature(featurePath, defaultValue)
+      )
+    )
 
   return {
     flags: readonly(flags),

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -20,7 +20,9 @@ import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 export enum ServerFeatureFlag {
   SUPPORTS_PREVIEW_METADATA = 'supports_preview_metadata',
   MAX_UPLOAD_SIZE = 'max_upload_size',
+  ASSETS = 'assets',
   MANAGER_SUPPORTS_V4 = 'extension.manager.supports_v4',
+  MANAGER_SUPPORTS_CSRF_POST = 'extension.manager.supports_csrf_post',
   MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
   ASSET_RENAME_ENABLED = 'asset_rename_enabled',
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
@@ -136,8 +138,15 @@ export function useFeatureFlags() {
         ServerFeatureFlag.MAX_UPLOAD_SIZE,
         (key) => api.getServerFeature(key)
       ),
+      assetsEnabled: defineFeatureFlag(ServerFeatureFlag.ASSETS, (key) =>
+        api.getServerFeature(key, false)
+      ),
       supportsManagerV4: defineFeatureFlag(
         ServerFeatureFlag.MANAGER_SUPPORTS_V4,
+        (key) => api.getServerFeature(key)
+      ),
+      managerSupportsCsrfPost: defineFeatureFlag(
+        ServerFeatureFlag.MANAGER_SUPPORTS_CSRF_POST,
         (key) => api.getServerFeature(key)
       ),
       modelUploadButtonEnabled: defineFeatureFlag(

--- a/src/platform/assets/utils/assetPreviewUtil.test.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.test.ts
@@ -11,7 +11,7 @@ const mockFetchApi = vi.hoisted(() => vi.fn())
 const mockApiURL = vi.hoisted(() =>
   vi.fn((path: string) => `http://localhost:8188${path}`)
 )
-const mockGetServerFeature = vi.hoisted(() => vi.fn(() => false))
+const mockFeatureFlags = vi.hoisted(() => ({ assetsEnabled: false }))
 const mockIsAssetAPIEnabled = vi.hoisted(() => vi.fn(() => false))
 const mockUploadAssetFromBase64 = vi.hoisted(() => vi.fn())
 const mockUpdateAsset = vi.hoisted(() => vi.fn())
@@ -21,9 +21,12 @@ vi.mock('@/scripts/api', () => ({
   api: {
     fetchApi: mockFetchApi,
     apiURL: mockApiURL,
-    api_base: '',
-    getServerFeature: mockGetServerFeature
+    api_base: ''
   }
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFeatureFlags })
 }))
 
 vi.mock('@/platform/assets/services/assetService', () => ({
@@ -82,7 +85,10 @@ const localAssetWithPreview = {
 }
 
 describe('isAssetPreviewSupported', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFeatureFlags.assetsEnabled = false
+  })
 
   it('returns true when asset API is enabled (cloud)', () => {
     mockIsAssetAPIEnabled.mockReturnValue(true)
@@ -90,13 +96,13 @@ describe('isAssetPreviewSupported', () => {
   })
 
   it('returns true when server assets feature is enabled (local)', () => {
-    mockGetServerFeature.mockReturnValue(true)
+    mockFeatureFlags.assetsEnabled = true
     expect(isAssetPreviewSupported()).toBe(true)
   })
 
   it('returns false when neither is enabled', () => {
     mockIsAssetAPIEnabled.mockReturnValue(false)
-    mockGetServerFeature.mockReturnValue(false)
+    mockFeatureFlags.assetsEnabled = false
     expect(isAssetPreviewSupported()).toBe(false)
   })
 })

--- a/src/platform/assets/utils/assetPreviewUtil.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.ts
@@ -1,3 +1,4 @@
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { assetService } from '@/platform/assets/services/assetService'
 import { api } from '@/scripts/api'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -12,7 +13,7 @@ interface AssetRecord {
 
 export function isAssetPreviewSupported(): boolean {
   return (
-    assetService.isAssetAPIEnabled() || api.getServerFeature('assets', false)
+    assetService.isAssetAPIEnabled() || useFeatureFlags().flags.assetsEnabled
   )
 }
 

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -124,7 +124,8 @@ vi.mock('@/stores/authStore', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackBeginCheckout: mockTrackBeginCheckout,
-    trackBillingEvent: mockTrackBillingEvent
+    trackBillingEvent: mockTrackBillingEvent,
+    trackFeatureFlagExposure: vi.fn()
   })
 }))
 

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -33,7 +33,8 @@ const {
   mockTelemetry: {
     trackSubscription: vi.fn(),
     trackMonthlySubscriptionSucceeded: vi.fn(),
-    trackMonthlySubscriptionCancelled: vi.fn()
+    trackMonthlySubscriptionCancelled: vi.fn(),
+    trackFeatureFlagExposure: vi.fn()
   },
   mockUserId: { value: 'user-123' },
   mockLocalStorage: (() => {

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -13,7 +13,8 @@ const {
   mockLocalStorage
 } = vi.hoisted(() => ({
   mockTelemetry: {
-    trackBeginCheckout: vi.fn()
+    trackBeginCheckout: vi.fn(),
+    trackFeatureFlagExposure: vi.fn()
   },
   mockGetAuthHeader: vi.fn(() =>
     Promise.resolve({ Authorization: 'Bearer test-token' })

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -3,11 +3,17 @@ import type { NodeReplacementResponse } from './types'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ServerFeatureFlag } from '@/composables/useFeatureFlags'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 import { useNodeReplacementStore } from './nodeReplacementStore'
+
+const mockFeatureFlags = vi.hoisted(() => ({
+  nodeReplacementsEnabled: true
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFeatureFlags })
+}))
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn()
@@ -15,12 +21,6 @@ vi.mock('@/platform/settings/settingStore', () => ({
 
 vi.mock('./nodeReplacementService', () => ({
   fetchNodeReplacements: vi.fn()
-}))
-
-vi.mock('@/scripts/api', () => ({
-  api: {
-    getServerFeature: vi.fn()
-  }
 }))
 
 function mockSettingStore(enabled: boolean) {
@@ -38,14 +38,7 @@ function mockSettingStore(enabled: boolean) {
 function createStore(settingEnabled = true, serverFeatureEnabled = true) {
   setActivePinia(createPinia())
   mockSettingStore(settingEnabled)
-  vi.mocked(api.getServerFeature).mockImplementation(
-    (flag: string, defaultValue?: unknown) => {
-      if (flag === ServerFeatureFlag.NODE_REPLACEMENTS) {
-        return serverFeatureEnabled
-      }
-      return defaultValue
-    }
-  )
+  mockFeatureFlags.nodeReplacementsEnabled = serverFeatureEnabled
   return useNodeReplacementStore()
 }
 

--- a/src/platform/nodeReplacement/nodeReplacementStore.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.ts
@@ -3,13 +3,13 @@ import type { NodeReplacement, NodeReplacementResponse } from './types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
-import { ServerFeatureFlag } from '@/composables/useFeatureFlags'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { api } from '@/scripts/api'
 import { fetchNodeReplacements } from './nodeReplacementService'
 
 export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
   const settingStore = useSettingStore()
+  const { flags } = useFeatureFlags()
   const replacements = ref<NodeReplacementResponse>({})
   const isLoaded = ref(false)
   const isEnabled = computed(() =>
@@ -18,8 +18,7 @@ export const useNodeReplacementStore = defineStore('nodeReplacement', () => {
 
   async function load() {
     if (!isEnabled.value || isLoaded.value) return
-    if (!api.getServerFeature(ServerFeatureFlag.NODE_REPLACEMENTS, false))
-      return
+    if (!flags.nodeReplacementsEnabled) return
 
     try {
       replacements.value = await fetchNodeReplacements()

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -4,6 +4,20 @@ import { TelemetryRegistry } from './TelemetryRegistry'
 import type { BillingTelemetryEvent, TelemetryProvider } from './types'
 
 describe('TelemetryRegistry', () => {
+  it('dispatches feature flag exposures to supporting providers', () => {
+    const trackFeatureFlagExposure = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackFeatureFlagExposure })
+    registry.registerProvider({})
+
+    registry.trackFeatureFlagExposure('signup_turnstile', 'shadow')
+
+    expect(trackFeatureFlagExposure).toHaveBeenCalledExactlyOnceWith(
+      'signup_turnstile',
+      'shadow'
+    )
+  })
+
   it('dispatches trackSearchQuery to every registered provider', () => {
     const a: TelemetryProvider = { trackSearchQuery: vi.fn() }
     const b: TelemetryProvider = { trackSearchQuery: vi.fn() }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -11,6 +11,7 @@ import type {
   ExecutionErrorMetadata,
   ExecutionOutcomeMetadata,
   ExecutionSuccessMetadata,
+  FeatureFlagValue,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -72,6 +73,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
         console.error('[Telemetry] Provider dispatch failed', error)
       }
     })
+  }
+
+  trackFeatureFlagExposure(key: string, value: FeatureFlagValue): void {
+    this.dispatch((provider) => provider.trackFeatureFlagExposure?.(key, value))
   }
 
   trackSignupOpened(): void {

--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -64,6 +64,12 @@ describe('initDatadogRum', () => {
         beforeSend: rumBeforeSend,
         sessionSampleRate: 100,
         sessionReplaySampleRate: 0,
+        trackFeatureFlagsForEvents: [
+          'action',
+          'vital',
+          'long_task',
+          'resource'
+        ],
         allowedTracingUrls: [expect.any(RegExp)]
       })
     }

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -47,6 +47,7 @@ async function initializeDatadogRum(env: string): Promise<void> {
     beforeSend: rumBeforeSend,
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,
+    trackFeatureFlagsForEvents: ['action', 'vital', 'long_task', 'resource'],
     allowedTracingUrls: [/^https:\/\/[^/]+\.comfy\.org/]
   })
   trackUserManualRefresh()

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -4,14 +4,25 @@ import type { BillingTelemetryEvent } from '../../types'
 import { TelemetryEvents } from '../../types'
 import { DatadogRumTelemetryProvider } from './DatadogRumTelemetryProvider'
 
-const { addAction, addDurationVital, getInternalContext } = vi.hoisted(() => ({
+const {
+  addAction,
+  addDurationVital,
+  addFeatureFlagEvaluation,
+  getInternalContext
+} = vi.hoisted(() => ({
   addAction: vi.fn(),
   addDurationVital: vi.fn(),
+  addFeatureFlagEvaluation: vi.fn(),
   getInternalContext: vi.fn()
 }))
 
 vi.mock('@datadog/browser-rum', () => ({
-  datadogRum: { addAction, addDurationVital, getInternalContext }
+  datadogRum: {
+    addAction,
+    addDurationVital,
+    addFeatureFlagEvaluation,
+    getInternalContext
+  }
 }))
 
 const workflowExecutionIntent = {
@@ -24,6 +35,18 @@ afterEach(() => {
 })
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('records feature flag evaluations in Datadog RUM', () => {
+    new DatadogRumTelemetryProvider().trackFeatureFlagExposure(
+      'extension.manager.supports_v4',
+      'shadow'
+    )
+
+    expect(addFeatureFlagEvaluation).toHaveBeenCalledExactlyOnceWith(
+      'extension_manager_supports_v4',
+      'shadow'
+    )
+  })
+
   it('records the same canonical billing name and context as PostHog', () => {
     const event: BillingTelemetryEvent = {
       operation: 'operation',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -3,6 +3,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   BillingTelemetryEvent,
   ExecutionOutcomeMetadata,
+  FeatureFlagValue,
   TelemetryProvider
 } from '../../types'
 import {
@@ -11,6 +12,13 @@ import {
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackFeatureFlagExposure(key: string, value: FeatureFlagValue): void {
+    datadogRum.addFeatureFlagEvaluation(
+      key.replace(/[.:+\-=&|><!{}[\]^"~*?\\\s]/g, '_'),
+      value
+    )
+  }
+
   trackBillingEvent(event: BillingTelemetryEvent): void {
     datadogRum.addAction(
       getBillingTelemetryEventName(event),

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -407,6 +407,7 @@ export type SearchSurface =
   | 'node_modal'
   | 'node_sidebar'
   | 'apps'
+  | 'allowlist'
   | 'templates'
   | 'settings'
 

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -781,7 +781,11 @@ export function getBillingTelemetryEventPayload(event: BillingTelemetryEvent) {
  * Telemetry provider interface for individual providers.
  * All methods are optional - providers only implement what they need.
  */
+export type FeatureFlagValue = string | number | boolean | null | undefined
+
 export interface TelemetryProvider {
+  trackFeatureFlagExposure?(key: string, value: FeatureFlagValue): void
+
   // Authentication flow events
   trackSignupOpened?(): void
   trackAuth?(metadata: AuthMetadata): void

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -242,6 +242,91 @@ describe('PartnerNodeAccessPanel', () => {
     expect(mockTrackUiButtonClicked).not.toHaveBeenCalled()
   })
 
+  it('tracks provider and bulk policy actions in order', async () => {
+    const user = userEvent.setup()
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('switch', {
+        name: 'Set access for OpenAI (inc. Sora)'
+      })
+    )
+    await user.click(screen.getByRole('button', { name: 'Enable all' }))
+    await user.click(screen.getByRole('button', { name: 'Disable all' }))
+    const options = mockShowConfirmDialog.mock.calls[0][0]
+    options.onClose()
+
+    expect(mockTrackUiButtonClicked.mock.calls.map(([event]) => event)).toEqual(
+      [
+        {
+          button_id: 'workspace_allowlist_opened',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_provider_disable_clicked',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_enable_all_clicked',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_disable_all_clicked',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_disable_all_cancelled',
+          element_group: 'workspace_allowlist'
+        }
+      ]
+    )
+  })
+
+  it('tracks access mode selection and confirmation in order', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('radio', { name: 'Restricted' }))
+    const options = mockShowConfirmDialog.mock.calls[0][0]
+    await options.footerProps.onConfirm()
+    options.onClose()
+
+    expect(mockTrackUiButtonClicked.mock.calls.map(([event]) => event)).toEqual(
+      [
+        {
+          button_id: 'workspace_allowlist_opened',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_access_restricted_selected',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_access_restricted_confirmed',
+          element_group: 'workspace_allowlist'
+        }
+      ]
+    )
+  })
+
+  it('tracks access dialog dismissal as cancellation', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('radio', { name: 'Restricted' }))
+    const options = mockShowConfirmDialog.mock.calls[0][0]
+    options.onClose()
+
+    expect(mockTrackUiButtonClicked).toHaveBeenLastCalledWith({
+      button_id: 'workspace_allowlist_access_restricted_cancelled',
+      element_group: 'workspace_allowlist'
+    })
+  })
+
   it('sorts providers from the Provider column header', async () => {
     const user = userEvent.setup()
     mockPolicy.value = {

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.test.ts
@@ -27,6 +27,8 @@ const {
   mockSetProviderEnabled,
   mockShowConfirmDialog,
   mockStatus,
+  mockTrackUiButtonClicked,
+  mockUseSearchQueryTracking,
   mockWorkspaceRole
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
@@ -45,6 +47,8 @@ const {
     mockSetProviderEnabled: vi.fn(),
     mockShowConfirmDialog: vi.fn(),
     mockStatus: ref('configured'),
+    mockTrackUiButtonClicked: vi.fn(),
+    mockUseSearchQueryTracking: vi.fn(),
     mockWorkspaceRole: ref<'owner' | 'member'>('owner')
   }
 })
@@ -86,6 +90,17 @@ vi.mock('@/stores/nodeDefStore', () => ({
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({ workspaceRole: mockWorkspaceRole })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackFeatureFlagExposure: vi.fn(),
+    trackUiButtonClicked: mockTrackUiButtonClicked
+  })
+}))
+
+vi.mock('@/platform/telemetry/searchQuery/useSearchQueryTracking', () => ({
+  useSearchQueryTracking: mockUseSearchQueryTracking
 }))
 
 const i18n = createI18n({
@@ -157,6 +172,74 @@ describe('PartnerNodeAccessPanel', () => {
 
     expect(screen.getByText('Create image')).toBeTruthy()
     expect(screen.getByText('Create video')).toBeTruthy()
+  })
+
+  it('tracks opening and search telemetry for the Allowlist surface', () => {
+    renderComponent()
+
+    expect(mockTrackUiButtonClicked).toHaveBeenCalledExactlyOnceWith({
+      button_id: 'workspace_allowlist_opened',
+      element_group: 'workspace_allowlist'
+    })
+    expect(mockUseSearchQueryTracking).toHaveBeenCalledExactlyOnceWith(
+      'allowlist',
+      expect.objectContaining({ value: '' }),
+      expect.objectContaining({ value: expect.any(Array) })
+    )
+  })
+
+  it('tracks sorting and explicit provider expansion in order', async () => {
+    const user = userEvent.setup()
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Provider' }))
+    await user.click(screen.getByRole('button', { name: 'Nodes' }))
+    await user.click(screen.getByRole('button', { name: 'OpenAI (inc. Sora)' }))
+
+    expect(mockTrackUiButtonClicked.mock.calls.map(([event]) => event)).toEqual(
+      [
+        {
+          button_id: 'workspace_allowlist_opened',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_sort_provider_descending',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_sort_nodes_descending',
+          element_group: 'workspace_allowlist'
+        },
+        {
+          button_id: 'workspace_allowlist_provider_expanded',
+          element_group: 'workspace_allowlist'
+        }
+      ]
+    )
+  })
+
+  it('does not track expansion intent while search forces providers open', async () => {
+    const user = userEvent.setup()
+    mockPolicy.value = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: true }]
+    }
+    renderComponent()
+
+    await user.type(
+      screen.getByRole('combobox', {
+        name: 'Search providers and partner nodes...'
+      }),
+      'Create'
+    )
+    mockTrackUiButtonClicked.mockClear()
+    await user.click(screen.getByRole('button', { name: 'OpenAI (inc. Sora)' }))
+
+    expect(mockTrackUiButtonClicked).not.toHaveBeenCalled()
   })
 
   it('sorts providers from the Provider column header', async () => {
@@ -619,5 +702,9 @@ describe('PartnerNodeAccessPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Try again' }))
 
     expect(mockLoadPolicy).toHaveBeenCalledOnce()
+    expect(mockTrackUiButtonClicked).toHaveBeenCalledWith({
+      button_id: 'workspace_allowlist_retry_clicked',
+      element_group: 'workspace_allowlist'
+    })
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
@@ -477,10 +477,14 @@ async function performSave(action: () => Promise<void>) {
 }
 
 function saveProviderChange(providerId: string, enabled: boolean) {
+  trackAllowlistAction(
+    `workspace_allowlist_provider_${enabled ? 'enable' : 'disable'}_clicked`
+  )
   void performSave(() => setProviderEnabled(providerId, enabled))
 }
 
 async function handleEnableAll() {
+  trackAllowlistAction('workspace_allowlist_enable_all_clicked')
   await performSave(() => setAllProvidersEnabled(true))
 }
 
@@ -504,7 +508,14 @@ function confirmDisableAll() {
   const canConfirm = createPolicyConfirmationGuard()
   if (!canConfirm) return
 
+  trackAllowlistAction('workspace_allowlist_disable_all_clicked')
+  let confirmationSubmitted = false
   const dialog = showConfirmDialog({
+    onClose: () => {
+      if (!confirmationSubmitted) {
+        trackAllowlistAction('workspace_allowlist_disable_all_cancelled')
+      }
+    },
     headerProps: { title: t('workspacePanel.partnerNodes.disableAllTitle') },
     props: { promptText: t('workspacePanel.partnerNodes.disableAllMessage') },
     footerProps: {
@@ -513,10 +524,12 @@ function confirmDisableAll() {
       optionsDisabled: isSaving,
       onCancel: () => dialogStore.closeDialog(dialog),
       onConfirm: async () => {
+        confirmationSubmitted = true
         if (!canConfirm()) {
           dialogStore.closeDialog(dialog)
           return
         }
+        trackAllowlistAction('workspace_allowlist_disable_all_confirmed')
         await performSave(() => setAllProvidersEnabled(false))
         dialogStore.closeDialog(dialog)
       }
@@ -537,8 +550,16 @@ function confirmAccessModeChange(
   const canConfirm = createPolicyConfirmationGuard()
   if (!canConfirm) return
 
+  const mode = enabled ? 'restricted' : 'unrestricted'
+  trackAllowlistAction(`workspace_allowlist_access_${mode}_selected`)
   const key = enabled ? 'restrictAccess' : 'allowAllAccess'
+  let confirmationSubmitted = false
   const dialog = showConfirmDialog({
+    onClose: () => {
+      if (!confirmationSubmitted) {
+        trackAllowlistAction(`workspace_allowlist_access_${mode}_cancelled`)
+      }
+    },
     headerProps: {
       title: t(`workspacePanel.partnerNodes.${key}Title`)
     },
@@ -553,10 +574,12 @@ function confirmAccessModeChange(
       optionsDisabled: isSaving,
       onCancel: () => dialogStore.closeDialog(dialog),
       onConfirm: async () => {
+        confirmationSubmitted = true
         if (!canConfirm()) {
           dialogStore.closeDialog(dialog)
           return
         }
+        trackAllowlistAction(`workspace_allowlist_access_${mode}_confirmed`)
         await performSave(action)
         dialogStore.closeDialog(dialog)
       }

--- a/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
+++ b/src/platform/workspace/components/dialogs/settings/PartnerNodeAccessPanel.vue
@@ -85,7 +85,7 @@
       <p class="text-sm text-muted-foreground">
         {{ $t('workspacePanel.partnerNodes.loadError') }}
       </p>
-      <Button variant="secondary" @click="loadPolicy">
+      <Button variant="secondary" @click="retryLoadPolicy">
         {{ $t('workspacePanel.partnerNodes.retry') }}
       </Button>
     </div>
@@ -317,7 +317,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import ToggleSwitch from 'primevue/toggleswitch'
@@ -328,6 +328,8 @@ import Button from '@/components/ui/button/Button.vue'
 import { buttonVariants } from '@/components/ui/button/button.variants'
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
+import { useTelemetry } from '@/platform/telemetry'
+import { useSearchQueryTracking } from '@/platform/telemetry/searchQuery/useSearchQueryTracking'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
@@ -420,15 +422,28 @@ const sortedProviders = computed(() =>
   })
 )
 
+useSearchQueryTracking('allowlist', searchQuery, sortedProviders)
+onMounted(() => trackAllowlistAction('workspace_allowlist_opened'))
+
+function trackAllowlistAction(buttonId: `workspace_allowlist_${string}`): void {
+  useTelemetry()?.trackUiButtonClicked({
+    button_id: buttonId,
+    element_group: 'workspace_allowlist'
+  })
+}
+
 function sortBy(field: SortField) {
   if (sortField.value === field) {
     sortDirection.value =
       sortDirection.value === 'ascending' ? 'descending' : 'ascending'
-    return
+  } else {
+    sortField.value = field
+    sortDirection.value = field === 'provider' ? 'ascending' : 'descending'
   }
 
-  sortField.value = field
-  sortDirection.value = field === 'provider' ? 'ascending' : 'descending'
+  trackAllowlistAction(
+    `workspace_allowlist_sort_${field}_${sortDirection.value}`
+  )
 }
 
 function toggleExpanded(providerId: string) {
@@ -436,6 +451,13 @@ function toggleExpanded(providerId: string) {
   if (nextIds.has(providerId)) nextIds.delete(providerId)
   else nextIds.add(providerId)
   expandedProviderIds.value = nextIds
+  if (searchQuery.value.trim()) return
+
+  trackAllowlistAction(
+    `workspace_allowlist_provider_${
+      nextIds.has(providerId) ? 'expanded' : 'collapsed'
+    }`
+  )
 }
 
 function isProviderExpanded(providerId: string) {
@@ -460,6 +482,11 @@ function saveProviderChange(providerId: string, enabled: boolean) {
 
 async function handleEnableAll() {
   await performSave(() => setAllProvidersEnabled(true))
+}
+
+function retryLoadPolicy() {
+  trackAllowlistAction('workspace_allowlist_retry_clicked')
+  void loadPolicy()
 }
 
 function createPolicyConfirmationGuard() {

--- a/src/workbench/extensions/manager/composables/useManagerState.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.test.ts
@@ -10,13 +10,17 @@ import {
   useManagerState
 } from '@/workbench/extensions/manager/composables/useManagerState'
 
+const mockFeatureFlags = vi.hoisted(() => ({
+  supportsManagerV4: undefined as boolean | undefined,
+  managerSupportsCsrfPost: undefined as boolean | undefined
+}))
+
 // Mock dependencies that are not stores
 vi.mock('@/i18n', () => ({ t: (key: string) => key }))
 
 vi.mock('@/scripts/api', () => ({
   api: {
     getClientFeatureFlags: vi.fn(),
-    getServerFeature: vi.fn(),
     getSystemStats: vi.fn()
   }
 }))
@@ -25,7 +29,7 @@ vi.mock('@/composables/useFeatureFlags', () => {
   const featureFlag = vi.fn()
   return {
     useFeatureFlags: vi.fn(() => ({
-      flags: { supportsManagerV4: false },
+      flags: mockFeatureFlags,
       featureFlag
     }))
   }
@@ -93,12 +97,8 @@ const mockServerFeatures = (flags: {
   supports_v4?: boolean
   supports_csrf_post?: boolean
 }) => {
-  vi.mocked(api.getServerFeature).mockImplementation((name: string) => {
-    if (name === 'extension.manager.supports_v4') return flags.supports_v4
-    if (name === 'extension.manager.supports_csrf_post')
-      return flags.supports_csrf_post
-    return undefined
-  })
+  mockFeatureFlags.supportsManagerV4 = flags.supports_v4
+  mockFeatureFlags.managerSupportsCsrfPost = flags.supports_csrf_post
 }
 
 describe('useManagerState', () => {
@@ -122,7 +122,7 @@ describe('useManagerState', () => {
 
     // Set default mock returns
     vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
-    vi.mocked(api.getServerFeature).mockReturnValue(undefined)
+    mockServerFeatures({})
   })
 
   describe('managerUIState property', () => {
@@ -217,7 +217,7 @@ describe('useManagerState', () => {
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
-      vi.mocked(api.getServerFeature).mockReturnValue(undefined)
+      mockServerFeatures({})
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)

--- a/src/workbench/extensions/manager/composables/useManagerState.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.ts
@@ -1,6 +1,7 @@
 import { storeToRefs } from 'pinia'
 import { computed, readonly, watch } from 'vue'
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { t } from '@/i18n'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -38,6 +39,7 @@ const showIncompatibleToast = (): void => {
 
 export function useManagerState() {
   const systemStatsStore = useSystemStatsStore()
+  const { flags } = useFeatureFlags()
   const { systemStats, isInitialized: systemInitialized } =
     storeToRefs(systemStatsStore)
   const managerDialog = useManagerDialog()
@@ -59,13 +61,8 @@ export function useManagerState() {
       const clientSupportsV4 =
         api.getClientFeatureFlags().supports_manager_v4_ui ?? false
 
-      const serverSupportsV4 = api.getServerFeature(
-        'extension.manager.supports_v4'
-      )
-
-      const supportsCsrfPost = api.getServerFeature(
-        'extension.manager.supports_csrf_post'
-      )
+      const serverSupportsV4 = flags.supportsManagerV4
+      const supportsCsrfPost = flags.managerSupportsCsrfPost
 
       // Check command line args first (highest priority)
       // --enable-manager flag enables the manager (opposite of old --disable-manager)


### PR DESCRIPTION
## Summary

Instrument Allowlist actions behind `partner_node_governance_enabled`, with automatic Datadog feature-flag evaluation for current and future flag reads.

## Changes

- Track search, sort, expand, retry, policy clicks, confirmations, and cancellations.
- Attach evaluated flags to RUM actions, resources, vitals, and long tasks.
- Skip search-forced expansion; count Escape and close dismissals.

## Review Focus

- Allowlist event semantics.
- Datadog flag normalization, privacy, and runtime overhead.

## Verification

- 226 focused tests, typecheck, lint, format, and knip.
- [Datadog RUM evidence](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14273#issuecomment-5137877775) from rebased head `b0ac82d`.

Created by Codex
