### PR TITLE
ci: reuse pnpm store across E2E shards

### DIFF
--- a/.github/actions/setup-e2e-dependencies/action.yaml
+++ b/.github/actions/setup-e2e-dependencies/action.yaml
@@ -1,0 +1,37 @@
+name: Setup E2E Dependencies
+description: 'Install pnpm dependencies using a shared offline-capable store'
+inputs:
+  setup_node:
+    description: 'Set up the Node.js version declared in .nvmrc'
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+    - name: Setup Node.js
+      if: ${{ inputs.setup_node == 'true' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Restore pnpm store
+      id: pnpm-store
+      uses: actions/cache@v5 # v5.0.2
+      with:
+        path: .pnpm-store
+        key: e2e-pnpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc', 'package.json', 'pnpm-lock.yaml') }}
+        restore-keys: |
+          e2e-pnpm-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Install dependencies offline
+      if: ${{ steps.pnpm-store.outputs.cache-hit == 'true' }}
+      shell: bash
+      run: pnpm install --offline --frozen-lockfile --store-dir .pnpm-store
+
+    - name: Install dependencies
+      if: ${{ steps.pnpm-store.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: pnpm install --frozen-lockfile --store-dir .pnpm-store

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -32,12 +32,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Setup frontend
-        uses: ./.github/actions/setup-frontend
+      - name: Setup E2E dependencies
+        uses: ./.github/actions/setup-e2e-dependencies
         with:
-          include_build_step: true
+          setup_node: true
+      - name: Build frontend
+        run: pnpm build
+        env:
+          VITE_USE_LEGACY_DEFAULT_GRAPH: 'true'
 
-      # Upload only built dist/ (containerized test jobs will pnpm install without cache)
       - name: Upload built frontend
         uses: actions/upload-artifact@v6
         with:
@@ -87,8 +90,8 @@ jobs:
       - name: Start ComfyUI server
         uses: ./.github/actions/start-comfyui-server
 
-      - name: Install frontend deps
-        run: pnpm install --frozen-lockfile
+      - name: Setup E2E dependencies
+        uses: ./.github/actions/setup-e2e-dependencies
 
       # Run sharded tests (browsers pre-installed in container)
       - name: Run Playwright tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
@@ -145,8 +148,8 @@ jobs:
       - name: Start ComfyUI server
         uses: ./.github/actions/start-comfyui-server
 
-      - name: Install frontend deps
-        run: pnpm install --frozen-lockfile
+      - name: Setup E2E dependencies
+        uses: ./.github/actions/setup-e2e-dependencies
 
       # Run tests (browsers pre-installed in container)
       - name: Run Playwright tests (${{ matrix.browser }})


### PR DESCRIPTION
## Summary

Reuse a lockfile-keyed pnpm store so E2E matrix jobs install dependencies offline instead of each hitting the package registry.

## Changes

- **What**: Add a shared E2E dependency action that warms the store in `setup`, then restores it for all 21 Playwright matrix jobs.
- **Dependencies**: None.

On a cache miss, `setup` performs the single online install and saves the completed store before the matrix starts. Exact cache hits use `pnpm install --offline --frozen-lockfile`.

The [example failure](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30477317120/job/90662806917) spent 4m33s in dependency installation before a registry timeout. Green-run install time is expected to remain roughly neutral; the gain is removing that failure mode and its roughly 22-minute rerun penalty.

## Review Focus

The cache key includes OS, architecture, Node version, root package manifest, and lockfile. A partial restore remains online so pnpm can fill missing packages before the exact cache is saved.

## Screenshots (if applicable)

Not applicable.
