### PR TITLE
fix: isolate and preserve workflow drafts on workspace switch

### DIFF
--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -349,6 +349,7 @@ describe('storageIO', () => {
 
       isolatedStorageIO.clearAllWorkflowStorage({ blockWrites: true })
 
+      expect(isolatedStorageIO.isStorageAvailable()).toBe(false)
       expect(
         isolatedStorageIO.writeIndex('ws-1', {
           v: 2,
@@ -405,13 +406,15 @@ describe('storageIO', () => {
       sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
       sessionStorage.setItem('Comfy.Workflow.OpenPaths:client-1', '{}')
       sessionStorage.setItem('workflow:client-1', '{}')
+      sessionStorage.setItem('unrelated', 'keep')
 
       clearWorkflowRestoreState()
 
       expect(localStorage.getItem('Comfy.OpenWorkflowsPaths')).toBeNull()
       expect(localStorage.getItem('Comfy.ActiveWorkflowIndex')).toBeNull()
       expect(localStorage.getItem('workflow')).toBeNull()
-      expect(sessionStorage).toHaveLength(0)
+      expect(sessionStorage).toHaveLength(1)
+      expect(sessionStorage.getItem('unrelated')).toBe('keep')
       expect(localStorage.getItem('Comfy.Workflow.DraftIndex.v2:ws-1')).toBe(
         '{}'
       )

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -413,6 +413,13 @@ describe('storageIO', () => {
       expect(localStorage.getItem('Comfy.OpenWorkflowsPaths')).toBeNull()
       expect(localStorage.getItem('Comfy.ActiveWorkflowIndex')).toBeNull()
       expect(localStorage.getItem('workflow')).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.Workflow.ActivePath:client-1')
+      ).toBeNull()
+      expect(
+        sessionStorage.getItem('Comfy.Workflow.OpenPaths:client-1')
+      ).toBeNull()
+      expect(sessionStorage.getItem('workflow:client-1')).toBeNull()
       expect(sessionStorage).toHaveLength(1)
       expect(sessionStorage.getItem('unrelated')).toBe('keep')
       expect(localStorage.getItem('Comfy.Workflow.DraftIndex.v2:ws-1')).toBe(

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DraftIndexV2, DraftPayloadV2 } from './draftTypes'
 import {
   clearAllWorkflowStorage,
+  clearWorkflowRestoreState,
   deleteOrphanPayloads,
   deletePayload,
   deletePayloads,
@@ -389,6 +390,38 @@ describe('storageIO', () => {
       expect(
         sessionStorage.getItem('Comfy.Workflow.ActivePath:client-1')
       ).toBeNull()
+    })
+  })
+
+  describe('clearWorkflowRestoreState', () => {
+    it('clears cross-workspace restore state without deleting scoped drafts', () => {
+      localStorage.setItem('Comfy.Workflow.DraftIndex.v2:ws-1', '{}')
+      localStorage.setItem('Comfy.Workflow.Draft.v2:ws-1:abc', '{}')
+      localStorage.setItem('Comfy.Workflow.LastOpenPaths:ws-1', '{}')
+      localStorage.setItem('Comfy.Workflow.Drafts:ws-1', '{}')
+      localStorage.setItem('Comfy.OpenWorkflowsPaths', '["a.json"]')
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', '0')
+      localStorage.setItem('workflow', '{}')
+      sessionStorage.setItem('Comfy.Workflow.ActivePath:client-1', '{}')
+      sessionStorage.setItem('Comfy.Workflow.OpenPaths:client-1', '{}')
+      sessionStorage.setItem('workflow:client-1', '{}')
+
+      clearWorkflowRestoreState()
+
+      expect(localStorage.getItem('Comfy.OpenWorkflowsPaths')).toBeNull()
+      expect(localStorage.getItem('Comfy.ActiveWorkflowIndex')).toBeNull()
+      expect(localStorage.getItem('workflow')).toBeNull()
+      expect(sessionStorage).toHaveLength(0)
+      expect(localStorage.getItem('Comfy.Workflow.DraftIndex.v2:ws-1')).toBe(
+        '{}'
+      )
+      expect(localStorage.getItem('Comfy.Workflow.Draft.v2:ws-1:abc')).toBe(
+        '{}'
+      )
+      expect(localStorage.getItem('Comfy.Workflow.LastOpenPaths:ws-1')).toBe(
+        '{}'
+      )
+      expect(localStorage.getItem('Comfy.Workflow.Drafts:ws-1')).toBe('{}')
     })
   })
 })

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -375,6 +375,64 @@ function writeStorage(storage: Storage, key: string, value: string): void {
   }
 }
 
+const legacyLocalRestoreKeys = [
+  'Comfy.Workflow.Drafts',
+  'Comfy.Workflow.DraftOrder',
+  'Comfy.OpenWorkflowsPaths',
+  'Comfy.ActiveWorkflowIndex',
+  'Comfy.PreviousWorkflow',
+  'workflow'
+]
+
+const sessionRestorePrefixes = [
+  StorageKeys.prefixes.activePath,
+  StorageKeys.prefixes.openPaths,
+  'Comfy.PreviousWorkflow:',
+  'Comfy.OpenWorkflowsPaths:',
+  'Comfy.ActiveWorkflowIndex:',
+  'workflow:'
+]
+
+const sessionRestoreKeys = [
+  'Comfy.PreviousWorkflow',
+  'Comfy.OpenWorkflowsPaths',
+  'Comfy.ActiveWorkflowIndex'
+]
+
+function removeStorageKeys(
+  storage: Storage,
+  keys: string[],
+  prefixes: string[] = []
+): void {
+  try {
+    for (let i = storage.length - 1; i >= 0; i--) {
+      const key = storage.key(i)
+      if (
+        key &&
+        (keys.includes(key) ||
+          prefixes.some((prefix) => key.startsWith(prefix)))
+      ) {
+        try {
+          storage.removeItem(key)
+        } catch {
+          continue
+        }
+      }
+    }
+  } catch {
+    return
+  }
+}
+
+export function clearWorkflowRestoreState(
+  options: { blockWrites?: boolean } = {}
+): void {
+  if (options.blockWrites) workflowWritesBlocked = true
+
+  removeStorageKeys(localStorage, legacyLocalRestoreKeys)
+  removeStorageKeys(sessionStorage, sessionRestoreKeys, sessionRestorePrefixes)
+}
+
 export function clearAllWorkflowStorage(
   options: { blockWrites?: boolean } = {}
 ): void {
@@ -388,64 +446,7 @@ export function clearAllWorkflowStorage(
     'Comfy.Workflow.Drafts:',
     'Comfy.Workflow.DraftOrder:'
   ]
-  const localKeys = [
-    'Comfy.Workflow.Drafts',
-    'Comfy.Workflow.DraftOrder',
-    'Comfy.OpenWorkflowsPaths',
-    'Comfy.ActiveWorkflowIndex',
-    'Comfy.PreviousWorkflow',
-    'workflow'
-  ]
 
-  try {
-    for (let i = localStorage.length - 1; i >= 0; i--) {
-      const key = localStorage.key(i)
-      if (
-        key &&
-        (localKeys.includes(key) ||
-          localPrefixes.some((prefix) => key.startsWith(prefix)))
-      ) {
-        try {
-          localStorage.removeItem(key)
-        } catch {
-          // Ignore
-        }
-      }
-    }
-  } catch {
-    // Ignore
-  }
-
-  const sessionPrefixes = [
-    StorageKeys.prefixes.activePath,
-    StorageKeys.prefixes.openPaths,
-    'Comfy.PreviousWorkflow:',
-    'Comfy.OpenWorkflowsPaths:',
-    'Comfy.ActiveWorkflowIndex:',
-    'workflow:'
-  ]
-  const sessionKeys = [
-    'Comfy.PreviousWorkflow',
-    'Comfy.OpenWorkflowsPaths',
-    'Comfy.ActiveWorkflowIndex'
-  ]
-
-  try {
-    for (let i = sessionStorage.length - 1; i >= 0; i--) {
-      const key = sessionStorage.key(i)
-      if (
-        key &&
-        (sessionKeys.includes(key) ||
-          sessionPrefixes.some((prefix) => key.startsWith(prefix)))
-      ) {
-        try {
-          sessionStorage.removeItem(key)
-        } catch {
-          // Ignore
-        }
-      }
-    }
-  } catch {
-    // Ignore
-  }
+  removeStorageKeys(localStorage, legacyLocalRestoreKeys, localPrefixes)
+  removeStorageKeys(sessionStorage, sessionRestoreKeys, sessionRestorePrefixes)
 }

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -17,7 +17,7 @@ let storageAvailable = true
 let workflowWritesBlocked = false
 
 export function isStorageAvailable(): boolean {
-  return storageAvailable
+  return storageAvailable && !workflowWritesBlocked
 }
 
 export function markStorageUnavailable(): void {

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -15,6 +15,18 @@ import { StorageKeys } from './storageKeys'
 /** Flag indicating if storage is available */
 let storageAvailable = true
 let workflowWritesBlocked = false
+const pendingPersistenceFlushes = new Set<() => void>()
+
+export function registerWorkflowPersistenceFlush(
+  flush: () => void
+): () => void {
+  pendingPersistenceFlushes.add(flush)
+  return () => pendingPersistenceFlushes.delete(flush)
+}
+
+function flushPendingWorkflowPersistence(): void {
+  for (const flush of pendingPersistenceFlushes) flush()
+}
 
 export function isStorageAvailable(): boolean {
   return storageAvailable && !workflowWritesBlocked
@@ -427,10 +439,19 @@ function removeStorageKeys(
 export function clearWorkflowRestoreState(
   options: { blockWrites?: boolean } = {}
 ): void {
-  if (options.blockWrites) workflowWritesBlocked = true
+  if (options.blockWrites) {
+    prepareWorkflowWorkspaceTransition()
+    return
+  }
 
   removeStorageKeys(localStorage, legacyLocalRestoreKeys)
   removeStorageKeys(sessionStorage, sessionRestoreKeys, sessionRestorePrefixes)
+}
+
+export function prepareWorkflowWorkspaceTransition(): void {
+  flushPendingWorkflowPersistence()
+  workflowWritesBlocked = true
+  clearWorkflowRestoreState()
 }
 
 export function clearAllWorkflowStorage(

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { StorageKeys } from '../base/storageKeys'
+import { clearWorkflowRestoreState } from '../base/storageIO'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowPersistenceV2 } from './useWorkflowPersistenceV2'
 
@@ -617,5 +620,62 @@ describe('useWorkflowPersistenceV2', () => {
         'Comfy.BrowseTemplates'
       )
     })
+  })
+
+  it('flushes the final source-workspace edit before blocking transition writes', async () => {
+    const sourceWorkspaceId = 'workspace-a'
+    const destinationWorkspaceId = 'workspace-b'
+    sessionStorage.setItem(
+      WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+      JSON.stringify({ id: sourceWorkspaceId, type: 'team' })
+    )
+
+    const workflowStore = useWorkflowStore()
+    const workflow = await workflowStore
+      .createTemporary('WorkspaceA.json')
+      .load()
+    workflowStore.activeWorkflow = workflow
+    mountWorkflowPersistence()
+
+    mocks.state.currentGraph = {
+      nodes: [],
+      extra: { marker: 'workspace-a-final-edit' }
+    }
+    mocks.state.graphChangedHandler?.()
+
+    const sourcePayloadKey = StorageKeys.draftPayload(
+      workflow.path,
+      sourceWorkspaceId
+    )
+    const destinationPayloadKey = StorageKeys.draftPayload(
+      workflow.path,
+      destinationWorkspaceId
+    )
+    expect(localStorage.getItem(sourcePayloadKey)).toBeNull()
+
+    clearWorkflowRestoreState({ blockWrites: true })
+    sessionStorage.setItem(
+      WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+      JSON.stringify({ id: destinationWorkspaceId, type: 'team' })
+    )
+    mocks.state.currentGraph = {
+      nodes: [],
+      extra: { marker: 'late-source-write' }
+    }
+    mocks.state.graphChangedHandler?.()
+    await vi.runAllTimersAsync()
+
+    const sourcePayload = JSON.parse(localStorage.getItem(sourcePayloadKey)!)
+    expect(JSON.parse(sourcePayload.data)).toEqual({
+      nodes: [],
+      extra: { marker: 'workspace-a-final-edit' }
+    })
+    expect(localStorage.getItem(destinationPayloadKey)).toBeNull()
+    expect(
+      sessionStorage.getItem(StorageKeys.activePath('test-client'))
+    ).toBeNull()
+    expect(
+      sessionStorage.getItem(StorageKeys.openPaths('test-client'))
+    ).toBeNull()
   })
 })

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -29,7 +29,10 @@ import {
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
 import { PERSIST_DEBOUNCE_MS } from '../base/draftTypes'
-import { clearAllWorkflowStorage } from '../base/storageIO'
+import {
+  clearAllWorkflowStorage,
+  registerWorkflowPersistenceFlush
+} from '../base/storageIO'
 import { migrateV1toV2 } from '../migration/migrateV1toV2'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowTabState } from './useWorkflowTabState'
@@ -131,6 +134,9 @@ export function useWorkflowPersistenceV2() {
 
   // Debounced version for graphChanged events
   const debouncedPersist = debounce(persistCurrentWorkflow, PERSIST_DEBOUNCE_MS)
+  const unregisterPersistenceFlush = registerWorkflowPersistenceFlush(() =>
+    debouncedPersist.flush()
+  )
 
   const loadPreviousWorkflowFromStorage = async () => {
     const sessionPath = tabState.getActivePath()
@@ -253,6 +259,7 @@ export function useWorkflowPersistenceV2() {
   // Clean up event listener when component unmounts
   tryOnScopeDispose(() => {
     api.removeEventListener('graphChanged', debouncedPersist)
+    unregisterPersistenceFlush()
     debouncedPersist.cancel()
   })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -31,6 +31,12 @@ vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
   useWorkspaceAuthStore: () => mockWorkspaceAuthStore
 }))
 
+const mockClearWorkflowRestoreState = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
+  clearWorkflowRestoreState: mockClearWorkflowRestoreState
+}))
+
 const mockEnsureSessionCookie = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/auth/session/useSessionCookie', () => ({
@@ -379,14 +385,25 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockReload).not.toHaveBeenCalled()
     })
 
-    it('clears context and reloads for valid workspace', async () => {
+    it('clears workflow restore state before switching workspaces', async () => {
       const store = useTeamWorkspaceStore()
       await store.initialize()
 
       await store.switchWorkspace(mockTeamWorkspace.id)
 
+      expect(mockClearWorkflowRestoreState).toHaveBeenCalledExactlyOnceWith({
+        blockWrites: true
+      })
       expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
+      expect(
+        mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+      )
+      expect(
+        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+      ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
     })
 
     it('sets isSwitching flag during operation', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -226,6 +226,27 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceAuthStore.switchWorkspace).not.toHaveBeenCalled()
     })
 
+    it('clears transient restore state before falling back from a missing session workspace', async () => {
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = {
+        ...mockTeamWorkspace,
+        id: 'missing-workspace'
+      }
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(mockClearWorkflowRestoreState).toHaveBeenCalledExactlyOnceWith()
+      expect(
+        mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+      )
+      expect(mockWorkspaceAuthStore.switchWorkspace).toHaveBeenCalledWith(
+        mockPersonalWorkspace.id
+      )
+    })
+
     it('falls back to localStorage if no session', async () => {
       mockLocalStorage.getItem.mockReturnValue(mockTeamWorkspace.id)
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -32,9 +32,11 @@ vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
 }))
 
 const mockClearWorkflowRestoreState = vi.hoisted(() => vi.fn())
+const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
-  clearWorkflowRestoreState: mockClearWorkflowRestoreState
+  clearWorkflowRestoreState: mockClearWorkflowRestoreState,
+  prepareWorkflowWorkspaceTransition: mockPrepareWorkflowWorkspaceTransition
 }))
 
 const mockEnsureSessionCookie = vi.hoisted(() => vi.fn())
@@ -144,11 +146,9 @@ const mockMemberWorkspace = {
 }
 
 function expectCleanupBeforeContextAndReload(): void {
-  expect(mockClearWorkflowRestoreState).toHaveBeenCalledExactlyOnceWith({
-    blockWrites: true
-  })
+  expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
   expect(
-    mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+    mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
   ).toBeLessThan(
     mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
   )
@@ -426,13 +426,11 @@ describe('useTeamWorkspaceStore', () => {
 
       await store.switchWorkspace(mockTeamWorkspace.id)
 
-      expect(mockClearWorkflowRestoreState).toHaveBeenCalledExactlyOnceWith({
-        blockWrites: true
-      })
+      expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
       expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
       expect(
-        mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+        mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
       ).toBeLessThan(
         mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
       )
@@ -540,14 +538,13 @@ describe('useTeamWorkspaceStore', () => {
         store.forgetRevokedActiveWorkspace(workspace.id)
 
         expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(reloads)
-        expect(mockClearWorkflowRestoreState).toHaveBeenCalledTimes(reloads)
+        expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledTimes(
+          reloads
+        )
         expect(mockReload).toHaveBeenCalledTimes(reloads)
         if (reloads === 1) {
-          expect(mockClearWorkflowRestoreState).toHaveBeenCalledWith({
-            blockWrites: true
-          })
           expect(
-            mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+            mockPrepareWorkflowWorkspaceTransition.mock.invocationCallOrder[0]
           ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
         }
       }

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -143,6 +143,20 @@ const mockMemberWorkspace = {
   joined_at: '2026-03-01T00:00:00Z'
 }
 
+function expectCleanupBeforeContextAndReload(): void {
+  expect(mockClearWorkflowRestoreState).toHaveBeenCalledExactlyOnceWith({
+    blockWrites: true
+  })
+  expect(
+    mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+  ).toBeLessThan(
+    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+  )
+  expect(
+    mockWorkspaceAuthStore.clearWorkspaceContext.mock.invocationCallOrder[0]
+  ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
+}
+
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -526,7 +540,16 @@ describe('useTeamWorkspaceStore', () => {
         store.forgetRevokedActiveWorkspace(workspace.id)
 
         expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(reloads)
+        expect(mockClearWorkflowRestoreState).toHaveBeenCalledTimes(reloads)
         expect(mockReload).toHaveBeenCalledTimes(reloads)
+        if (reloads === 1) {
+          expect(mockClearWorkflowRestoreState).toHaveBeenCalledWith({
+            blockWrites: true
+          })
+          expect(
+            mockClearWorkflowRestoreState.mock.invocationCallOrder[0]
+          ).toBeLessThan(mockReload.mock.invocationCallOrder[0])
+        }
       }
     )
 
@@ -567,6 +590,7 @@ describe('useTeamWorkspaceStore', () => {
       )
       expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
+      expectCleanupBeforeContextAndReload()
     })
 
     it('sets isCreating flag during operation', async () => {
@@ -638,6 +662,7 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.delete).toHaveBeenCalledWith(mockTeamWorkspace.id)
       expect(mockWorkspaceAuthStore.clearWorkspaceContext).toHaveBeenCalled()
       expect(mockReload).toHaveBeenCalled()
+      expectCleanupBeforeContextAndReload()
     })
 
     it('throws when trying to delete personal workspace', async () => {
@@ -704,6 +729,7 @@ describe('useTeamWorkspaceStore', () => {
         mockPersonalWorkspace.id
       )
       expect(mockReload).toHaveBeenCalled()
+      expectCleanupBeforeContextAndReload()
     })
 
     it('forwards personal workspace leave and clears its persisted ID', async () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -5,7 +5,10 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
-import { clearWorkflowRestoreState } from '@/platform/workflow/persistence/base/storageIO'
+import {
+  clearWorkflowRestoreState,
+  prepareWorkflowWorkspaceTransition
+} from '@/platform/workflow/persistence/base/storageIO'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 
 import type {
@@ -422,7 +425,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const revoked = workspaces.value.find((w) => w.id === workspaceId)
     if (revoked?.type === 'personal') return
 
-    clearWorkflowRestoreState({ blockWrites: true })
+    prepareWorkflowWorkspaceTransition()
     clearLastWorkspaceId()
     window.location.reload()
   }
@@ -457,7 +460,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       if (isStaleIdentity(generation)) return
 
       // Clear current workspace context and persist new workspace ID
-      clearWorkflowRestoreState({ blockWrites: true })
+      prepareWorkflowWorkspaceTransition()
       workspaceAuthStore.clearWorkspaceContext()
       setLastWorkspaceId(workspaceId)
 
@@ -490,7 +493,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       workspaces.value = [...workspaces.value, workspaceState]
 
       // Clear context and switch to new workspace
-      clearWorkflowRestoreState({ blockWrites: true })
+      prepareWorkflowWorkspaceTransition()
       workspaceAuthStore.clearWorkspaceContext()
       // Clear any preserved invite query to prevent stale invites from being
       // processed after the reload (prevents owner adding themselves as member)
@@ -534,7 +537,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       if (targetId === activeWorkspaceId.value) {
         // Deleted active workspace - go to personal
         const personal = personalWorkspace.value
-        clearWorkflowRestoreState({ blockWrites: true })
+        prepareWorkflowWorkspaceTransition()
         workspaceAuthStore.clearWorkspaceContext()
         if (personal) {
           setLastWorkspaceId(personal.id)
@@ -591,7 +594,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       (workspace) =>
         workspace.type === 'personal' && workspace.id !== current.id
     )
-    clearWorkflowRestoreState({ blockWrites: true })
+    prepareWorkflowWorkspaceTransition()
     workspaceAuthStore.clearWorkspaceContext()
     if (personal) {
       setLastWorkspaceId(personal.id)

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -5,6 +5,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { clearWorkflowRestoreState } from '@/platform/workflow/persistence/base/storageIO'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 
 import type {
@@ -420,6 +421,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     const revoked = workspaces.value.find((w) => w.id === workspaceId)
     if (revoked?.type === 'personal') return
 
+    clearWorkflowRestoreState({ blockWrites: true })
     clearLastWorkspaceId()
     window.location.reload()
   }
@@ -454,6 +456,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       if (isStaleIdentity(generation)) return
 
       // Clear current workspace context and persist new workspace ID
+      clearWorkflowRestoreState({ blockWrites: true })
       workspaceAuthStore.clearWorkspaceContext()
       setLastWorkspaceId(workspaceId)
 
@@ -486,6 +489,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       workspaces.value = [...workspaces.value, workspaceState]
 
       // Clear context and switch to new workspace
+      clearWorkflowRestoreState({ blockWrites: true })
       workspaceAuthStore.clearWorkspaceContext()
       // Clear any preserved invite query to prevent stale invites from being
       // processed after the reload (prevents owner adding themselves as member)
@@ -529,6 +533,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       if (targetId === activeWorkspaceId.value) {
         // Deleted active workspace - go to personal
         const personal = personalWorkspace.value
+        clearWorkflowRestoreState({ blockWrites: true })
         workspaceAuthStore.clearWorkspaceContext()
         if (personal) {
           setLastWorkspaceId(personal.id)
@@ -585,6 +590,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       (workspace) =>
         workspace.type === 'personal' && workspace.id !== current.id
     )
+    clearWorkflowRestoreState({ blockWrites: true })
     workspaceAuthStore.clearWorkspaceContext()
     if (personal) {
       setLastWorkspaceId(personal.id)

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -312,6 +312,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
           }
 
           // Session workspace not found (deleted/access revoked) - fallback to default
+          clearWorkflowRestoreState()
           workspaceAuthStore.clearWorkspaceContext()
 
           const personal = workspaces.value.find((w) => w.type === 'personal')


### PR DESCRIPTION
## Summary

Follow-up to #14266: flushes the source workspace's pending draft, clears transient restore pointers, and blocks later persistence writes before a successful workspace switch changes auth context and reloads.

Denys' [cross-check on the #14266 test environment](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785351064538329?thread_ts=1785169746.169899&cid=C0932CGKT5K) confirmed that the successful-switch path still reproduced the Cloud 1.48 QA report.

## Root cause

#14266 fixed failed token exchange and logout, but a successful switch still cleared the current workspace context before reload without first draining and stopping workflow persistence or removing transitional restore state. A save queued inside the 512 ms debounce window could be lost or resolve against the destination identity, while unscoped legacy and per-tab session pointers survived the reload. Workspace A tabs and dirty content could then restore in Workspace B.

The transition sequence was introduced with workspace switching in #8194 on 2026-01-21. The user-visible tabs/unsaved-edit leak became possible when draft and tab-state persistence shipped in #8519 on 2026-02-19; #8520 added workspace scoping two days later but did not add a transition write barrier.

The earlier #14266 browser fixture seeded already-scoped V2 state, which naturally stayed isolated and therefore missed this transition path.

## Reproduction

1. Open Workspace A and leave one or more workflow tabs with unsaved edits.
2. Switch successfully to Workspace B (the team-to-personal path is deterministic because the cleared context resolves to `personal`).
3. After reload, observe Workspace A's tabs and dirty content in Workspace B.

## Changes

- Flush pending workflow persistence while the source workspace is still active, then block later writes before changing workspace auth context.
- Treat the terminal write barrier as unavailable storage so delayed saves cannot enter quota eviction and delete preserved drafts.
- Remove only unscoped legacy and per-tab session restore pointers during workspace-changing reloads.
- Preserve workspace-scoped V1/V2 draft payloads and indexes, so returning to Workspace A can restore Workspace A's own work.
- Clear transitional restore state when initialization falls back from a deleted or revoked session workspace.
- Reuse the same targeted key-removal primitive for full logout cleanup.

## Review Focus

Confirm the transition ordering is flush source draft → block writes → clear transient pointers → clear auth context → reload, and that scoped draft keys are preserved.

## Screenshots

### AS IS

Workspace B is active, but Workspace A's private Markdown Note and dirty workflow remain visible.

![AS IS — Workspace A private content visible in Workspace B](https://ampcode.com/user-content/artifacts/5de321d78b00b1b147cbd0bdae37d8f4957ed65dba9e542d5da1c49d842bb441-file.png)

![AS IS reproduction](https://ampcode.com/user-content/artifacts/6b84ba3dd1a98b1dbcae0df5ec7579d7501fe748b04fd391bd3f12d401ec6468-file.gif)

Also see [Denys' independent reproduction recording](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785351064538329?thread_ts=1785169746.169899&cid=C0932CGKT5K).

### TO BE

After the same successful switch, Workspace B initializes without Workspace A's private note or workflow state. The default destination workflow may still be dirty in this mocked environment; the isolation assertion is that the source-only `Workspace A only` note and restore pointers are absent.

![TO BE — Workspace B has no Workspace A private content](https://ampcode.com/user-content/artifacts/f5a4c0b0ddca66b9a5eb72dac19f296d1d65e341f58277890d376b2788b90693-file.png)

![TO BE verification](https://ampcode.com/user-content/artifacts/a6cef058cfd29cbeec913fd3369adc3373ab730f861a37854d44bf4acb96f97a-file.gif)

Verified at final head `4c102a62c` on the [#14290 test deployment](https://fe-pr-14290.testenvs.comfy.org/) in both Team → Personal and Personal → Team directions. In both directions, source-only workflow content, the dirty source tab, unscoped workflow data, and per-tab active/open restore pointers were absent after the switch.

## Verification

- Deterministic red → green regression proof using the exact same checked-in behavioral test:
  - Before the flush fix (`bfb4e8a69`): **fails** — a Workspace A edit queued inside the 512 ms debounce window has no A-scoped payload after transition (`sourcePayload` is `null`).
  - After the flush fix (`4c102a62c`): **passes** — Workspace A's final edit is stored under A, a post-barrier write cannot create a Workspace B payload, and per-tab active/open restore pointers are removed.
- Earlier transition-order regression proof:
  - #14266 (`9ef6fe55f`): **fails** — `clearWorkflowRestoreState({ blockWrites: true })` received 0 calls during a valid workspace switch.
  - #14290: **passes** — the workspace transition boundary runs exactly once before auth context is cleared and before reload.
- `pnpm test:unit src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts src/platform/workflow/persistence/base/storageIO.test.ts src/platform/workspace/stores/teamWorkspaceStore.test.ts` — 121 passed
- `pnpm typecheck`
- `pnpm exec eslint src/platform/workflow/persistence/base/storageIO.ts src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts src/platform/workspace/stores/teamWorkspaceStore.ts src/platform/workspace/stores/teamWorkspaceStore.test.ts`
- `pnpm exec oxfmt --check ...`
- `pnpm knip` (pre-push hook)
- `git diff --check`

The deployment fixture separately verifies the browser-visible outcome using mocked Cloud workspace APIs. The checked-in unit regression is the CI gate for transition ordering and scoped-draft preservation; the screenshots and GIFs document the end-to-end user behavior.
