### PR TITLE
test(assets): assert accessible reason on immutable-on-cloud read-only field

### DIFF
--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -179,7 +179,11 @@ describe('ModelInfoPanel', () => {
       mockDistribution.isCloud = true
       renderPanel(createMockAsset({ is_immutable: true }))
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
-      expect(screen.getByText('Checkpoint')).toBeInTheDocument()
+      const field = screen.getByText('Checkpoint')
+      expect(field).toHaveAttribute('aria-disabled', 'true')
+      expect(field).toHaveAccessibleDescription(
+        'assetBrowser.modelInfo.modelTypeImmutableReadonly'
+      )
     })
 
     it('blames immutability, not core, for a read-only immutable asset on cloud', () => {


### PR DESCRIPTION
## Summary

Follow-up to #13302: the immutable-on-cloud read-only model-type test asserted only that the value renders, so it could pass with the aria description missing.

## Changes

- **What**: Mirror the off-cloud test's `aria-disabled` and `toHaveAccessibleDescription` assertions in the immutable-on-cloud case, so the accessible-reason wiring is covered in both dimensions of the editability gate.

## Review Focus

Test-only change; requested on #13302 after it merged.