### PR TITLE
feat(onboarding): tour roles off an unpinned graph

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -179,6 +179,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import TransformPane from '@/renderer/core/layout/transform/TransformPane.vue'
+import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
 import { useFirstRunEntry } from '@/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry'
 import MiniMap from '@/renderer/extensions/minimap/MiniMap.vue'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
@@ -505,6 +506,8 @@ useEventListener(
 onMounted(async () => {
   comfyApp.vueAppReady = true
   workspaceStore.spinner = true
+  let startupOutcome: StartupOutcome | undefined
+
   try {
     // ChangeTracker needs to be initialized before setup, as it will overwrite
     // some listeners of litegraph canvas.
@@ -560,14 +563,16 @@ onMounted(async () => {
     )
 
     // Restore saved workflow and workflow tabs state
-    const startupOutcome = await workflowPersistence.initializeWorkflow()
+    startupOutcome = await workflowPersistence.initializeWorkflow()
     await workflowPersistence.restoreWorkflowTabsState()
     await workflowPersistence.loadTemplateFromUrlIfPresent()
     await useFirstRunEntry().handleStartupOutcome(startupOutcome)
   } finally {
     workspaceStore.spinner = false
   }
-  await workflowPersistence.loadSharedWorkflowFromUrlIfPresent()
+  const sharedStatus =
+    await workflowPersistence.loadSharedWorkflowFromUrlIfPresent()
+  await useFirstRunEntry().handleUrlWorkflow(startupOutcome, sharedStatus)
 
   comfyApp.canvas.onSelectionChange = useChainCallback(
     comfyApp.canvas.onSelectionChange,

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -20,7 +20,7 @@ import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 
-type SharedWorkflowUrlLoadStatus =
+export type SharedWorkflowUrlLoadStatus =
   | 'not-present'
   | 'loaded'
   | 'loaded-without-assets'

--- a/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry.ts
@@ -10,6 +10,7 @@ import { useSubscription } from '@/platform/cloud/subscription/composables/useSu
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { StartupOutcome } from '@/platform/workflow/persistence/base/draftTypes'
+import type { SharedWorkflowUrlLoadStatus } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
 import { useNewUserService } from '@/services/useNewUserService'
 import { useCommandStore } from '@/stores/commandStore'
 
@@ -32,6 +33,20 @@ export const useFirstRunEntry = createSharedComposable(() => {
     await useCommandStore().execute('Comfy.BrowseTemplates')
   }
 
+  async function handleUrlWorkflow(
+    outcome: StartupOutcome | undefined,
+    sharedStatus: SharedWorkflowUrlLoadStatus
+  ) {
+    if (outcome !== 'url-intent' || !isCandidate()) return
+    const template = new URLSearchParams(window.location.search).get('template')
+    const shareLoaded =
+      sharedStatus === 'loaded' || sharedStatus === 'loaded-without-assets'
+    if (!template && !shareLoaded) return
+    const { useFirstRunTourController } =
+      await import('../tour/useFirstRunTourController')
+    await useFirstRunTourController().beginTour(template ?? undefined)
+  }
+
   async function dismissGettingStarted() {
     gettingStartedVisible.value = false
     await useSettingStore().set('Comfy.TutorialCompleted', true)
@@ -40,6 +55,7 @@ export const useFirstRunEntry = createSharedComposable(() => {
   return {
     gettingStartedVisible: readonly(gettingStartedVisible),
     handleStartupOutcome,
+    handleUrlWorkflow,
     dismissGettingStarted
   }
 })

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -1,0 +1,95 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { createTestRootGraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+
+import { heuristicRoles } from './heuristicRoles'
+
+class OutputNode extends LGraphNode {
+  static override nodeData = { output_node: true }
+}
+
+function addNode(
+  graph: LGraph,
+  type: string,
+  options: {
+    title?: string
+    prompts?: string[]
+    out?: string[]
+    in?: string[]
+  } = {}
+) {
+  const node = new LGraphNode(type, type)
+  if (options.title) node.title = options.title
+  for (const name of options.prompts ?? [])
+    node.addWidget('text', name, '', () => {}, { multiline: true })
+  for (const type_ of options.out ?? []) node.addOutput(type_, type_)
+  for (const name of options.in ?? []) node.addInput(name, 'CONDITIONING')
+  graph.add(node)
+  return node
+}
+
+function addSink(graph: LGraph) {
+  const producer = addNode(graph, 'VAEDecode', { out: ['IMAGE'] })
+  const sink = new OutputNode('SaveImage', 'SaveImage')
+  sink.addInput('images', 'IMAGE')
+  graph.add(sink)
+  producer.connect(0, sink, 0)
+  return sink
+}
+
+describe('heuristicRoles', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('takes the prompt wired to positive when negative comes first', () => {
+    const graph = createTestRootGraph()
+    addSink(graph)
+    const sampler = addNode(graph, 'KSampler', { in: ['positive', 'negative'] })
+    const negative = addNode(graph, 'CLIPTextEncode', {
+      prompts: ['text'],
+      out: ['CONDITIONING']
+    })
+    const positive = addNode(graph, 'CLIPTextEncode', {
+      prompts: ['text'],
+      out: ['CONDITIONING']
+    })
+    negative.connect(0, sampler, 1)
+    positive.connect(0, sampler, 0)
+    expect(heuristicRoles(graph)?.prompt).toBe(positive)
+  })
+
+  it('keeps a node carrying a negative box alongside a prompt box', () => {
+    const graph = createTestRootGraph()
+    addSink(graph)
+    const node = addNode(graph, 'WanApi', {
+      prompts: ['negative_prompt', 'prompt']
+    })
+    expect(heuristicRoles(graph)?.prompt).toBe(node)
+  })
+
+  it('offers no prompt when the only text box is negative', () => {
+    const graph = createTestRootGraph()
+    addSink(graph)
+    addNode(graph, 'CLIPTextEncode', {
+      title: 'Negative Prompt',
+      prompts: ['text']
+    })
+    expect(heuristicRoles(graph)?.prompt).toBeNull()
+  })
+
+  it('offers no prompt when two candidates tie', () => {
+    const graph = createTestRootGraph()
+    addSink(graph)
+    addNode(graph, 'A', { prompts: ['value'] })
+    addNode(graph, 'B', { prompts: ['value'] })
+    expect(heuristicRoles(graph)?.prompt).toBeNull()
+  })
+
+  it('gives a graph with no wired output node no tour', () => {
+    const graph = createTestRootGraph()
+    addNode(graph, 'CLIPTextEncode', { prompts: ['text'] })
+    expect(heuristicRoles(graph)).toBeNull()
+  })
+})

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
@@ -1,0 +1,99 @@
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import {
+  collectAllNodes,
+  getExecutionIdByNode,
+  isExecutionPathActive
+} from '@/utils/graphTraversalUtil'
+import { filterOutputNodes } from '@/utils/nodeFilterUtil'
+
+import type { TourMediaKind } from './tourRolePins'
+
+export interface HeuristicRoles {
+  prompt: LGraphNode | null
+  sink: LGraphNode
+  mediaKind: TourMediaKind
+}
+
+const MEDIA: Partial<Record<string, TourMediaKind>> = {
+  IMAGE: 'image',
+  VIDEO: 'video'
+}
+
+const words = (label: unknown) =>
+  String(label ?? '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+
+function promptScore(node: LGraphNode, fed: string[]): number {
+  if (node.isVirtualNode) return -1
+  const boxes = (node.widgets ?? []).filter(
+    (widget) => widget.type === 'customtext' || widget.options?.multiline
+  )
+  if (!boxes.length) return -1
+  return Math.max(
+    ...boxes.map((box) => {
+      const own = [...words(node.title), ...words(box.name)]
+      if ([...own, ...fed].some((w) => w === 'negative' || w === 'system'))
+        return -1
+      if (fed.includes('positive')) return 3
+      if (own.includes('positive')) return 2
+      if (own.includes('prompt')) return 1
+      return 0
+    })
+  )
+}
+
+function findPrompt(nodes: LGraphNode[]): LGraphNode | null {
+  const fedNames = new Map<LGraphNode, string[]>()
+  for (const consumer of nodes)
+    (consumer.inputs ?? []).forEach((input, slot) => {
+      const producer = consumer.getInputNode(slot)
+      if (producer)
+        fedNames.set(producer, [
+          ...(fedNames.get(producer) ?? []),
+          ...words(input.name)
+        ])
+    })
+  const ranked = nodes
+    .map((node) => ({
+      node,
+      score: promptScore(node, fedNames.get(node) ?? [])
+    }))
+    .filter(({ score }) => score >= 0)
+    .sort((a, b) => b.score - a.score)
+  const [best, next] = ranked
+  if (!best) return null
+  return !next || best.score > next.score ? best.node : null
+}
+
+function findSink(nodes: LGraphNode[]) {
+  const sinks = filterOutputNodes(nodes).flatMap((node) => {
+    const input = (node.inputs ?? []).find(
+      (i) => i.link != null && MEDIA[String(i.type).toUpperCase()]
+    )
+    return input
+      ? [{ node, mediaKind: MEDIA[String(input.type).toUpperCase()]! }]
+      : []
+  })
+  const [first] = sinks
+  return first && sinks.every((sink) => sink.mediaKind === first.mediaKind)
+    ? first
+    : null
+}
+
+export function heuristicRoles(graph: LGraph): HeuristicRoles | null {
+  const active = collectAllNodes(graph).filter((node) => {
+    const executionId = getExecutionIdByNode(graph, node)
+    return executionId ? isExecutionPathActive(graph, executionId) : false
+  })
+  const sink = findSink(active)
+  if (!sink) return null
+  return {
+    prompt: findPrompt(active),
+    sink: sink.node,
+    mediaKind: sink.mediaKind
+  }
+}

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.ts
@@ -7,6 +7,7 @@ import {
 } from '@/utils/graphTraversalUtil'
 import { resolveNode } from '@/utils/litegraphUtil'
 
+import { heuristicRoles } from './heuristicRoles'
 import { TOUR_ROLE_PINS } from './tourRolePins'
 import type {
   RolePin,
@@ -21,7 +22,8 @@ export interface ResolvedRoles {
   mediaKind: TourMediaKind
 }
 
-function rootHost(node: LGraphNode, root: LGraph): LGraphNode | null {
+function rootHost(node: LGraphNode | null, root: LGraph): LGraphNode | null {
+  if (!node) return null
   if (node.graph === root) return node
   const executionId = getExecutionIdByNode(root, node)
   return executionId ? getRootParentNode(root, executionId) : null
@@ -35,9 +37,18 @@ function resolvePin(pin: RolePin | undefined, root: LGraph): NodeId | null {
 
 export function resolveTourRoles(
   graph: LGraph,
-  templateId: string
+  templateId?: string
 ): ResolvedRoles | null {
-  if (!Object.hasOwn(TOUR_ROLE_PINS, templateId)) return null
+  if (templateId === undefined || !Object.hasOwn(TOUR_ROLE_PINS, templateId)) {
+    const roles = heuristicRoles(graph)
+    if (!roles) return null
+    return {
+      source: null,
+      promptHost: rootHost(roles.prompt, graph)?.id ?? null,
+      sink: rootHost(roles.sink, graph)?.id ?? null,
+      mediaKind: roles.mediaKind
+    }
+  }
   const pins = TOUR_ROLE_PINS[templateId as SupportedTemplateId]
   return {
     source: resolvePin(pins.source, graph),

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
@@ -63,7 +63,7 @@ function nodeStep(name: string, coachId: CoachId, nodeId: NodeId): CoachStep {
 }
 
 export async function firstRunTourSteps(
-  templateId: string,
+  templateId: string | undefined,
   runState: Readonly<Ref<RunState>>
 ): Promise<CoachStep[]> {
   releaseFirstRunTargets()

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -80,7 +80,7 @@ function useFirstRunTourControllerInternal() {
     }
   )
 
-  async function beginTour(templateId: string): Promise<boolean> {
+  async function beginTour(templateId?: string): Promise<boolean> {
     if (!settingStore.get('Comfy.VueNodes.Enabled'))
       await settingStore.set('Comfy.VueNodes.Enabled', true)
     tourWorkflow.value = workflowStore.activeWorkflow ?? null


### PR DESCRIPTION
## Summary

Last of the chain (6/6): a first-run candidate arriving via `?share=` or `?template=` link skipped the Getting Started grid — a workflow already loaded — so roles are inferred from the graph itself and the tour runs over whatever landed on canvas. Pins still win where they exist.

## Changes

- **What**: `heuristicRoles` — sink = declared output node with a wired IMAGE/VIDEO input (no sink or disagreeing media kinds → no tour), prompt = ranked scoring over multiline text widgets (wired-to-`positive` beats a "positive" label beats a "prompt" label; `negative`/`system` disqualify; ties → null, never guess); `resolveTourRoles` falls back to it for unknown/absent template ids; `handleUrlWorkflow` fires only on `url-intent` startup + first-run candidate + something actually loaded.
- Both prompt signal classes are load-bearing for disjoint real workflows: wiring is the only disambiguator for classic txt2img twin `CLIPTextEncode` shares; labels are the only signal API-node workflows have (Wan/Kling boxes carry no conditioning wiring).

## Review Focus

- Cut vs #14145 (873 → ~260): source/upload inference (v1 tours prompt→run→result on shares), subgraph exposed-port label harvesting (degrades to "no prompt step", not a wrong spotlight), the 3-file template-id plumbing (the entry reads `location.search` once), ~400 of 460 test lines (5 disjoint behaviors pinned).
- A failed `?template=` load falls out correctly: empty canvas has no sink, so no tour.