### PR TITLE
fix: isolate drafts during workspace auth recovery

### DIFF
--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -186,13 +186,10 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
     await comfyPage.toast.closeToasts()
     await page.getByRole('button', { name: 'Current user' }).click()
     await page.getByTestId('workspace-switcher-trigger').click()
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-      page
-        .getByTestId('workspace-switcher-panel')
-        .getByText(TEAM_WORKSPACE_NAME, { exact: true })
-        .click()
-    ])
+    await page
+      .getByTestId('workspace-switcher-panel')
+      .getByText(TEAM_WORKSPACE_NAME, { exact: true })
+      .click()
     await comfyPage.waitForAppReady()
 
     await expect
@@ -204,13 +201,10 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
 
     await page.getByRole('button', { name: 'Current user' }).click()
     await page.getByTestId('workspace-switcher-trigger').click()
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-      page
-        .getByTestId('workspace-switcher-panel')
-        .getByText(PERSONAL_WORKSPACE_NAME, { exact: true })
-        .click()
-    ])
+    await page
+      .getByTestId('workspace-switcher-panel')
+      .getByText(PERSONAL_WORKSPACE_NAME, { exact: true })
+      .click()
     await comfyPage.waitForAppReady()
 
     await expect
@@ -227,13 +221,10 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
 
     await page.getByRole('button', { name: 'Current user' }).click()
     await page.getByTestId('workspace-switcher-trigger').click()
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-      page
-        .getByTestId('workspace-switcher-panel')
-        .getByText(TEAM_WORKSPACE_NAME, { exact: true })
-        .click()
-    ])
+    await page
+      .getByTestId('workspace-switcher-panel')
+      .getByText(TEAM_WORKSPACE_NAME, { exact: true })
+      .click()
     await comfyPage.waitForAppReady()
 
     await expect

--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -8,11 +8,15 @@ import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
 const LONG_WORKSPACE_NAME =
   'Quantum Renaissance Collective for Hyperdimensional Latent Diffusion Research and Experimental Workflow Engineering'
+const TEAM_WORKSPACE_NAME = 'Team Workspace'
 
 // text-sm rows render a single 20px line; a wrapped name is 40px+.
 const SINGLE_LINE_MAX_HEIGHT_PX = 28
 
-const mockRemoteConfig: RemoteConfig = { team_workspaces_enabled: true }
+const mockRemoteConfig: RemoteConfig = {
+  team_workspaces_enabled: true,
+  unified_cloud_auth: true
+}
 
 const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
   workspaces: [
@@ -31,20 +35,16 @@ const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
       created_at: '2026-01-02T00:00:00Z',
       joined_at: '2026-01-02T00:00:00Z',
       role: 'member'
+    },
+    {
+      id: 'ws-team',
+      name: TEAM_WORKSPACE_NAME,
+      type: 'team',
+      created_at: '2026-01-03T00:00:00Z',
+      joined_at: '2026-01-03T00:00:00Z',
+      role: 'owner'
     }
   ]
-}
-
-const mockTokenResponse: WorkspaceTokenResponse = {
-  token: 'mock-workspace-token',
-  expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-  workspace: {
-    id: 'ws-personal',
-    name: PERSONAL_WORKSPACE_NAME,
-    type: 'personal'
-  },
-  role: 'owner',
-  permissions: []
 }
 
 const test = comfyPageFixture.extend({
@@ -69,13 +69,36 @@ const test = comfyPageFixture.extend({
       })
     })
 
-    await page.route('**/api/auth/token', (route) =>
-      route.fulfill({
+    await page.route('**/api/auth/token', async (route) => {
+      const requestBody = route.request().postDataJSON() as {
+        workspace_id?: string
+      }
+      const workspaceId = requestBody.workspace_id ?? 'ws-personal'
+      const workspace = mockListWorkspacesResponse.workspaces.find(
+        ({ id }) => id === workspaceId
+      )
+      if (!workspace) {
+        await route.fulfill({ status: 404 })
+        return
+      }
+
+      const response: WorkspaceTokenResponse = {
+        token: `mock-workspace-token-${workspace.id}`,
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        workspace: {
+          id: workspace.id,
+          name: workspace.name,
+          type: workspace.type
+        },
+        role: workspace.role,
+        permissions: []
+      }
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(mockTokenResponse)
+        body: JSON.stringify(response)
       })
-    )
+    })
 
     await page.route('**/api/auth/session', (route) =>
       route.fulfill({ status: 204 })
@@ -140,5 +163,89 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
       )
     ).toBeVisible()
     await expect(page.getByPlaceholder('Ex: Comfy Org')).toBeVisible()
+  })
+
+  test('isolates all open workflow tabs between workspaces', async ({
+    comfyPage
+  }) => {
+    test.slow()
+    const page = comfyPage.page
+    const suffix = Date.now().toString(36)
+    const personalWorkflows = [`personal-a-${suffix}`, `personal-b-${suffix}`]
+    const teamWorkflows = [`team-a-${suffix}`, `team-b-${suffix}`]
+
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Topbar'
+    )
+    await comfyPage.menu.topbar.saveWorkflow(personalWorkflows[0])
+    await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
+    await comfyPage.menu.topbar.saveWorkflow(personalWorkflows[1])
+
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page
+        .getByTestId('workspace-switcher-panel')
+        .getByText(TEAM_WORKSPACE_NAME, { exact: true })
+        .click()
+    ])
+    await comfyPage.waitForAppReady()
+
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .not.toEqual(expect.arrayContaining(personalWorkflows))
+    await comfyPage.menu.topbar.saveWorkflow(teamWorkflows[0])
+    await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
+    await comfyPage.menu.topbar.saveWorkflow(teamWorkflows[1])
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page
+        .getByTestId('workspace-switcher-panel')
+        .getByText(PERSONAL_WORKSPACE_NAME, { exact: true })
+        .click()
+    ])
+    await comfyPage.waitForAppReady()
+
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .toEqual(personalWorkflows)
+    await expect(comfyPage.menu.topbar.getActiveTab()).toContainText(
+      personalWorkflows[1]
+    )
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .toEqual(personalWorkflows)
+
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page
+        .getByTestId('workspace-switcher-panel')
+        .getByText(TEAM_WORKSPACE_NAME, { exact: true })
+        .click()
+    ])
+    await comfyPage.waitForAppReady()
+
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .toEqual(teamWorkflows)
+    await expect(comfyPage.menu.topbar.getActiveTab()).toContainText(
+      teamWorkflows[1]
+    )
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await expect
+      .poll(() => comfyPage.menu.topbar.getTabNames())
+      .toEqual(teamWorkflows)
   })
 })

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -9,12 +9,10 @@ import {
   deletePayloads,
   getPayloadKeys,
   markStorageUnavailable,
-  prepareWorkflowWorkspaceTransition,
   readActivePath,
   readIndex,
   readOpenPaths,
   readPayload,
-  registerWorkflowPersistenceFlush,
   writeActivePath,
   writeIndex,
   writeOpenPaths,
@@ -397,21 +395,37 @@ describe('storageIO', () => {
   })
 
   describe('clearWorkflowRestoreState', () => {
-    it('blocks writes and clears restore state when a persistence flush fails', () => {
+    it('blocks writes and clears restore state when a persistence flush fails', async () => {
+      const isolatedStorageIO = await import('./storageIO')
       localStorage.setItem('workflow', '{}')
       const successfulFlush = vi.fn()
-      const unregisterFailedFlush = registerWorkflowPersistenceFlush(() => {
-        throw new DOMException('Storage unavailable', 'SecurityError')
-      })
+      const flushError = new DOMException(
+        'Storage unavailable',
+        'SecurityError'
+      )
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
+      const unregisterFailedFlush =
+        isolatedStorageIO.registerWorkflowPersistenceFlush(() => {
+          throw flushError
+        })
       const unregisterSuccessfulFlush =
-        registerWorkflowPersistenceFlush(successfulFlush)
+        isolatedStorageIO.registerWorkflowPersistenceFlush(successfulFlush)
 
-      expect(() => prepareWorkflowWorkspaceTransition()).not.toThrow()
+      expect(() =>
+        isolatedStorageIO.prepareWorkflowWorkspaceTransition()
+      ).not.toThrow()
 
       expect(successfulFlush).toHaveBeenCalledOnce()
       expect(localStorage.getItem('workflow')).toBeNull()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to flush pending workflow persistence',
+        flushError
+      )
       unregisterFailedFlush()
       unregisterSuccessfulFlush()
+      consoleWarnSpy.mockRestore()
     })
 
     it('clears cross-workspace restore state without deleting scoped drafts', () => {

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -9,10 +9,12 @@ import {
   deletePayloads,
   getPayloadKeys,
   markStorageUnavailable,
+  prepareWorkflowWorkspaceTransition,
   readActivePath,
   readIndex,
   readOpenPaths,
   readPayload,
+  registerWorkflowPersistenceFlush,
   writeActivePath,
   writeIndex,
   writeOpenPaths,
@@ -395,6 +397,23 @@ describe('storageIO', () => {
   })
 
   describe('clearWorkflowRestoreState', () => {
+    it('blocks writes and clears restore state when a persistence flush fails', () => {
+      localStorage.setItem('workflow', '{}')
+      const successfulFlush = vi.fn()
+      const unregisterFailedFlush = registerWorkflowPersistenceFlush(() => {
+        throw new DOMException('Storage unavailable', 'SecurityError')
+      })
+      const unregisterSuccessfulFlush =
+        registerWorkflowPersistenceFlush(successfulFlush)
+
+      expect(() => prepareWorkflowWorkspaceTransition()).not.toThrow()
+
+      expect(successfulFlush).toHaveBeenCalledOnce()
+      expect(localStorage.getItem('workflow')).toBeNull()
+      unregisterFailedFlush()
+      unregisterSuccessfulFlush()
+    })
+
     it('clears cross-workspace restore state without deleting scoped drafts', () => {
       localStorage.setItem('Comfy.Workflow.DraftIndex.v2:ws-1', '{}')
       localStorage.setItem('Comfy.Workflow.Draft.v2:ws-1:abc', '{}')

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -25,7 +25,13 @@ export function registerWorkflowPersistenceFlush(
 }
 
 function flushPendingWorkflowPersistence(): void {
-  for (const flush of pendingPersistenceFlushes) flush()
+  for (const flush of pendingPersistenceFlushes) {
+    try {
+      flush()
+    } catch {
+      continue
+    }
+  }
 }
 
 export function isStorageAvailable(): boolean {
@@ -449,7 +455,7 @@ export function clearWorkflowRestoreState(
 }
 
 export function prepareWorkflowWorkspaceTransition(): void {
-  flushPendingWorkflowPersistence()
+  if (!workflowWritesBlocked) flushPendingWorkflowPersistence()
   workflowWritesBlocked = true
   clearWorkflowRestoreState()
 }

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -28,8 +28,8 @@ function flushPendingWorkflowPersistence(): void {
   for (const flush of pendingPersistenceFlushes) {
     try {
       flush()
-    } catch {
-      continue
+    } catch (error) {
+      console.warn('Failed to flush pending workflow persistence', error)
     }
   }
 }

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -535,8 +535,9 @@ describe('useTeamWorkspaceStore', () => {
         await store.initialize()
         store.activeWorkspaceId = workspace.id
 
-        store.forgetRevokedActiveWorkspace(workspace.id)
+        const handled = store.forgetRevokedActiveWorkspace(workspace.id)
 
+        expect(handled).toBe(true)
         expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(reloads)
         expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledTimes(
           reloads
@@ -555,8 +556,9 @@ describe('useTeamWorkspaceStore', () => {
       await store.initialize()
       store.activeWorkspaceId = mockTeamWorkspace.id
 
-      store.forgetRevokedActiveWorkspace('some-other-workspace')
+      const handled = store.forgetRevokedActiveWorkspace('some-other-workspace')
 
+      expect(handled).toBe(false)
       expect(mockReload).not.toHaveBeenCalled()
     })
   })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -415,15 +415,12 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     }
   }
 
-  /**
-   * Drop a revoked/deleted active workspace and reload so init falls back to the
-   * personal workspace. Skips the personal workspace to avoid a reload loop.
-   */
+  /** Returns whether the revoked workspace was handled, with or without reload. */
   function forgetRevokedActiveWorkspace(workspaceId: string): boolean {
     if (activeWorkspaceId.value !== workspaceId) return false
 
     const revoked = workspaces.value.find((w) => w.id === workspaceId)
-    if (revoked?.type === 'personal') return false
+    if (revoked?.type === 'personal') return true
 
     prepareWorkflowWorkspaceTransition()
     clearLastWorkspaceId()

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -419,15 +419,16 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Drop a revoked/deleted active workspace and reload so init falls back to the
    * personal workspace. Skips the personal workspace to avoid a reload loop.
    */
-  function forgetRevokedActiveWorkspace(workspaceId: string): void {
-    if (activeWorkspaceId.value !== workspaceId) return
+  function forgetRevokedActiveWorkspace(workspaceId: string): boolean {
+    if (activeWorkspaceId.value !== workspaceId) return false
 
     const revoked = workspaces.value.find((w) => w.id === workspaceId)
-    if (revoked?.type === 'personal') return
+    if (revoked?.type === 'personal') return false
 
     prepareWorkflowWorkspaceTransition()
     clearLastWorkspaceId()
     window.location.reload()
+    return true
   }
 
   /**

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -112,8 +112,7 @@ function expectedExpiresAtMs(expiresAt: string): string {
 describe('useWorkspaceAuthStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    vi.clearAllMocks()
-    mockPrepareWorkflowWorkspaceTransition.mockReset()
+    vi.resetAllMocks()
     vi.useFakeTimers()
     sessionStorage.clear()
     mockTeamWorkspacesEnabled.value = true

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1205,6 +1205,7 @@ describe('useWorkspaceAuthStore', () => {
         workspaceWhenRevocationHandled = sessionStorage.getItem(
           WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
         )
+        return true
       })
 
       await store.switchWorkspace('workspace-123')

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -6,6 +6,10 @@ import {
   WorkspaceAuthError
 } from '@/platform/workspace/stores/workspaceAuthStore'
 
+import {
+  getWorkspaceId,
+  StorageKeys
+} from '@/platform/workflow/persistence/base/storageKeys'
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
 const mockGetIdToken = vi.fn()
@@ -109,6 +113,7 @@ describe('useWorkspaceAuthStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockPrepareWorkflowWorkspaceTransition.mockReset()
     vi.useFakeTimers()
     sessionStorage.clear()
     mockTeamWorkspacesEnabled.value = true
@@ -1873,7 +1878,7 @@ describe('useWorkspaceAuthStore', () => {
 
         expect(workspaceToken.value).toBe('workspace-token-abc')
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Failed to persist workspace context to sessionStorage'
+          'Failed to persist workspace identity to sessionStorage'
         )
       } finally {
         vi.stubGlobal('sessionStorage', originalSessionStorage)
@@ -2084,6 +2089,53 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
     })
 
+    it('scopes workflow persistence to each unified workspace', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const secondWorkspace = {
+        ...mockWorkspaceWithRole,
+        id: 'workspace-456'
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockTokenResponse)
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                ...mockTokenResponse,
+                workspace: secondWorkspace
+              })
+          })
+      )
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-123')
+
+      expect(store.currentWorkspace).toEqual(mockWorkspaceWithRole)
+      expect(getWorkspaceId()).toBe('workspace-123')
+      expect(StorageKeys.draftIndex(getWorkspaceId())).toBe(
+        'Comfy.Workflow.DraftIndex.v2:workspace-123'
+      )
+
+      await store.switchWorkspace('workspace-456')
+
+      expect(store.currentWorkspace).toEqual(secondWorkspace)
+      expect(getWorkspaceId()).toBe('workspace-456')
+      expect(StorageKeys.draftIndex(getWorkspaceId())).toBe(
+        'Comfy.Workflow.DraftIndex.v2:workspace-456'
+      )
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBe(JSON.stringify(secondWorkspace))
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBeNull()
+    })
+
     it('does not retry an old workspace request with a new workspace token', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
@@ -2237,7 +2289,7 @@ describe('useWorkspaceAuthStore', () => {
       vi.stubGlobal('fetch', mockFetch)
 
       const store = useWorkspaceAuthStore()
-      const { unifiedToken } = storeToRefs(store)
+      const { currentWorkspace, unifiedToken } = storeToRefs(store)
       await store.mintAtLogin()
       expect(mockFetch).toHaveBeenCalledTimes(1)
 
@@ -2255,6 +2307,12 @@ describe('useWorkspaceAuthStore', () => {
         })
       )
       expect(unifiedToken.value).toBeNull()
+      expect(currentWorkspace.value).toBeNull()
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBeNull()
+      expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
+      expect(mockReload).toHaveBeenCalledOnce()
     })
 
     it('remintUnifiedOnce does not toast or clear the slot on a transient re-mint failure', async () => {

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -16,6 +16,13 @@ const mockCurrentUser = vi.hoisted((): { value: { uid: string } | null } => ({
   value: null
 }))
 const mockForgetRevokedActiveWorkspace = vi.fn()
+const mockPrepareWorkflowWorkspaceTransition = vi.hoisted(() => vi.fn())
+const mockReload = vi.fn()
+
+vi.stubGlobal('location', {
+  reload: mockReload,
+  origin: 'http://localhost'
+})
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
@@ -31,6 +38,10 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     forgetRevokedActiveWorkspace: mockForgetRevokedActiveWorkspace
   })
+}))
+
+vi.mock('@/platform/workflow/persistence/base/storageIO', () => ({
+  prepareWorkflowWorkspaceTransition: mockPrepareWorkflowWorkspaceTransition
 }))
 
 vi.mock('@/platform/auth/session/useSessionCookie', () => ({
@@ -1184,6 +1195,12 @@ describe('useWorkspaceAuthStore', () => {
 
       const store = useWorkspaceAuthStore()
       const { currentWorkspace, workspaceToken } = storeToRefs(store)
+      let workspaceWhenRevocationHandled: string | null = null
+      mockForgetRevokedActiveWorkspace.mockImplementation(() => {
+        workspaceWhenRevocationHandled = sessionStorage.getItem(
+          WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
+        )
+      })
 
       await store.switchWorkspace('workspace-123')
       expect(workspaceToken.value).toBe('workspace-token-abc')
@@ -1197,6 +1214,9 @@ describe('useWorkspaceAuthStore', () => {
       })
 
       expect(workspaceToken.value).toBeNull()
+      expect(workspaceWhenRevocationHandled).toBe(
+        JSON.stringify(mockWorkspaceWithRole)
+      )
     })
   })
 
@@ -1330,6 +1350,50 @@ describe('useWorkspaceAuthStore', () => {
   })
 
   describe('refreshToken retry/race paths', () => {
+    it('ends an expired workspace session behind the workflow write barrier', async () => {
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const expiresAt = Date.now() + 3600 * 1000
+      const mockFetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...mockTokenResponse,
+            expires_at: new Date(expiresAt).toISOString()
+          })
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-123')
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ message: 'Server error' })
+      })
+      vi.setSystemTime(expiresAt + 1)
+      mockPrepareWorkflowWorkspaceTransition.mockImplementation(() => {
+        expect(
+          sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+        ).toBe(JSON.stringify(mockWorkspaceWithRole))
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const refreshPromise = store.refreshToken()
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(2000)
+      await vi.advanceTimersByTimeAsync(4000)
+      await refreshPromise
+
+      expect(mockPrepareWorkflowWorkspaceTransition).toHaveBeenCalledOnce()
+      expect(mockReload).toHaveBeenCalledOnce()
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBeNull()
+    })
+
     it('retries up to 3 times with exponential backoff on TOKEN_EXCHANGE_FAILED, then preserves valid context', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
 

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import { t } from '@/i18n'
+import { prepareWorkflowWorkspaceTransition } from '@/platform/workflow/persistence/base/storageIO'
 import {
   TOKEN_REFRESH_BUFFER_MS,
   WORKSPACE_STORAGE_KEYS
@@ -172,31 +173,31 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
   function scheduleClearAtExpiry(): void {
     if (workspaceTokenExpiresAt.value === null) {
-      clearWorkspaceContext()
+      endWorkspaceSession()
       return
     }
 
     const timeUntilExpiry = workspaceTokenExpiresAt.value - Date.now()
     if (timeUntilExpiry <= 0) {
-      clearWorkspaceContext()
+      endWorkspaceSession()
       return
     }
 
     stopRefreshTimer()
     refreshTimerId = setTimeout(() => {
-      clearWorkspaceContext()
+      endWorkspaceSession()
     }, timeUntilExpiry)
   }
 
   function scheduleTokenRefreshRetry(delayMs: number): boolean {
     if (workspaceTokenExpiresAt.value === null) {
-      clearWorkspaceContext()
+      endWorkspaceSession()
       return false
     }
 
     const timeUntilExpiry = workspaceTokenExpiresAt.value - Date.now()
     if (timeUntilExpiry <= 0) {
-      clearWorkspaceContext()
+      endWorkspaceSession()
       return false
     }
 
@@ -536,12 +537,13 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   ): void {
     if (isPermanentRecoveryFailure(err)) {
       const hadContext = currentWorkspace.value !== null
-      clearWorkspaceContext()
+      endWorkspaceSession(
+        failedWorkspaceId && isWorkspaceSelectionInvalid(err)
+          ? failedWorkspaceId
+          : undefined
+      )
       if (hadContext) {
         surfacePermanentAuthError(err)
-      }
-      if (failedWorkspaceId && isWorkspaceSelectionInvalid(err)) {
-        useTeamWorkspaceStore().forgetRevokedActiveWorkspace(failedWorkspaceId)
       }
     }
     startRecoveryCooldown()
@@ -644,10 +646,9 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
         if (isPermanentError) {
           if (!isStaleWorkspaceRequest(capturedRequestId)) {
             console.error('Workspace access revoked or auth invalid:', err)
-            clearWorkspaceContext()
-            if (isWorkspaceSelectionInvalid(err)) {
-              useTeamWorkspaceStore().forgetRevokedActiveWorkspace(workspaceId)
-            }
+            endWorkspaceSession(
+              isWorkspaceSelectionInvalid(err) ? workspaceId : undefined
+            )
           }
           return
         }
@@ -681,7 +682,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
           }
 
           console.error('Failed to refresh workspace token after retries:', err)
-          clearWorkspaceContext()
+          endWorkspaceSession()
         }
       }
     }
@@ -958,6 +959,18 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     error.value = null
     clearSessionStorage()
     clearUnifiedContext()
+  }
+
+  function endWorkspaceSession(revokedWorkspaceId?: string): void {
+    const hadContext = currentWorkspace.value !== null
+    if (hadContext) prepareWorkflowWorkspaceTransition()
+    const reloadRequested = revokedWorkspaceId
+      ? useTeamWorkspaceStore().forgetRevokedActiveWorkspace(revokedWorkspaceId)
+      : false
+    clearWorkspaceContext()
+    if ((hadContext || revokedWorkspaceId !== undefined) && !reloadRequested) {
+      window.location.reload()
+    }
   }
 
   return {

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -231,17 +231,25 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     )
   }
 
+  function persistWorkspaceIdentity(workspace: WorkspaceWithRole): void {
+    try {
+      sessionStorage.setItem(
+        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
+        JSON.stringify(workspace)
+      )
+    } catch {
+      console.warn('Failed to persist workspace identity to sessionStorage')
+    }
+  }
+
   function persistToSession(
     workspace: WorkspaceWithRole,
     token: string,
     expiresAt: number,
     ownerUid: string
   ): void {
+    persistWorkspaceIdentity(workspace)
     try {
-      sessionStorage.setItem(
-        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
-        JSON.stringify(workspace)
-      )
       sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, token)
       sessionStorage.setItem(
         WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
@@ -249,7 +257,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       )
       sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.OWNER_UID, ownerUid)
     } catch {
-      console.warn('Failed to persist workspace context to sessionStorage')
+      console.warn('Failed to persist workspace token to sessionStorage')
     }
   }
 
@@ -785,6 +793,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       return false
     }
 
+    currentWorkspace.value = mintedToken.workspace
+    persistWorkspaceIdentity(mintedToken.workspace)
     unifiedToken.value = mintedToken.token
     unifiedTokenOwnerUid.value = mintedToken.ownerUid
     issuedUnifiedTokenContexts.set(mintedToken.token, {
@@ -818,7 +828,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   async function switchUnifiedWorkspace(workspaceId: string): Promise<void> {
-    clearUnifiedContext()
+    clearWorkspaceContext()
     const { useSessionCookie } =
       await import('@/platform/auth/session/useSessionCookie')
     await useSessionCookie().ensureSessionCookie()
@@ -849,7 +859,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // the proactive + reactive paths alarm the user once, not once per caller.
       if (isPermanentAuthError(err)) {
         if (getUnifiedToken()) surfacePermanentAuthError(err)
-        clearUnifiedContext()
+        endWorkspaceSession()
       } else {
         console.warn('Unified token refresh failed:', err)
       }
@@ -904,7 +914,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // guard the toast on a live token so a concurrent burst surfaces it once.
       if (isPermanentAuthError(err)) {
         if (getUnifiedToken()) surfacePermanentAuthError(err)
-        clearUnifiedContext()
+        endWorkspaceSession()
       } else {
         console.warn('Unified reactive re-mint failed:', err)
       }

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -859,7 +859,11 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // the proactive + reactive paths alarm the user once, not once per caller.
       if (isPermanentAuthError(err)) {
         if (getUnifiedToken()) surfacePermanentAuthError(err)
-        endWorkspaceSession()
+        endWorkspaceSession(
+          isWorkspaceSelectionInvalid(err)
+            ? (currentWorkspace.value?.id ?? undefined)
+            : undefined
+        )
       } else {
         console.warn('Unified token refresh failed:', err)
       }
@@ -914,7 +918,11 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
       // guard the toast on a live token so a concurrent burst surfaces it once.
       if (isPermanentAuthError(err)) {
         if (getUnifiedToken()) surfacePermanentAuthError(err)
-        endWorkspaceSession()
+        endWorkspaceSession(
+          isWorkspaceSelectionInvalid(err)
+            ? (currentWorkspace.value?.id ?? undefined)
+            : undefined
+        )
       } else {
         console.warn('Unified reactive re-mint failed:', err)
       }
@@ -974,11 +982,14 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   function endWorkspaceSession(revokedWorkspaceId?: string): void {
     const hadContext = currentWorkspace.value !== null
     if (hadContext) prepareWorkflowWorkspaceTransition()
-    const reloadRequested = revokedWorkspaceId
+    const revokedWorkspaceHandled = revokedWorkspaceId
       ? useTeamWorkspaceStore().forgetRevokedActiveWorkspace(revokedWorkspaceId)
       : false
     clearWorkspaceContext()
-    if ((hadContext || revokedWorkspaceId !== undefined) && !reloadRequested) {
+    const shouldReload = revokedWorkspaceId
+      ? !revokedWorkspaceHandled
+      : hadContext
+    if (shouldReload) {
       window.location.reload()
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #14290 and [review #4813556736](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14290#pullrequestreview-4813556736): closes the remaining draft-isolation holes in runtime auth recovery and `unified_cloud_auth` workspace scoping.

The latest staging reproduction is captured in [this Slack report](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785370090022269?thread_ts=1785169746.169899&cid=C0932CGKT5K). Staging currently contains the #14290 backport, but not this follow-up.

## Root cause

There were two independent gaps:

1. Runtime auth recovery cleared `currentWorkspace` before workflow persistence crossed the terminal transition boundary. A pending team-workspace save could flush after scope resolution fell back to `personal`, and expiry paths could leave the mounted editor persisting under that scope. One throwing flush callback could also skip later callbacks, the write fence, and restore-state cleanup.
2. Under `unified_cloud_auth`, successful token minting populated only `unifiedToken`; it did not populate or persist the workspace identity. Workflow persistence derives its draft/tab namespace from `Comfy.Workspace.Current`, so every team workspace fell back to the shared `personal` namespace even during a normal workspace session.

The review's initialization concern remains intentionally unchanged: `WorkspaceAuthGate` keeps the routed editor unmounted until initialization finishes, so no persistence debounce exists during startup fallback. Installing a terminal fence there without a reload would permanently block workflow writes.

## Reproduction

1. Enable `unified_cloud_auth` and open workspace A.
2. Open multiple workflow tabs and make an unsaved edit.
3. Switch to workspace B and wait for the reload.
4. Observe workspace A's tabs/active workflow/draft restored in workspace B.
5. Edit in B and switch back to A; B's state can now replace or appear alongside A's state.

**AS IS:** both workspaces resolve workflow persistence to `Comfy.Workflow.*:personal`, so drafts and restore pointers are shared.

**TO BE:** each successful unified mint commits the response workspace identity before the editor mounts or resumes. Workspace A and B resolve distinct draft/index/restore namespaces; terminal auth failure flushes and fences the source workspace before identity is cleared and the page reloads.

## Changes

- Flush and fence workflow persistence while the source workspace identity is still active, then clear auth context and reload for terminal runtime recovery paths.
- Keep revoked-workspace handling ordered before auth context removal and report whether it already requested reload.
- Make transition flush callbacks independent and the transition boundary idempotent.
- Persist the authoritative workspace returned by unified token minting without writing unified credentials into the legacy token slots.
- Clear stale workspace identity before a unified switch and route permanent unified refresh/re-mint failures through the same terminal persistence boundary.

## Review focus

Confirm:

- unified workspace A and B resolve distinct workflow persistence keys;
- unified credentials remain separate from legacy workspace token storage;
- runtime recovery ordering is source flush → write fence → revoked-workspace handling → auth clear → reload;
- startup initialization remains unchanged.

## Screenshots and recordings

- [AS IS screenshot](https://ampcode.com/user-content/artifacts/5de321d78b00b1b147cbd0bdae37d8f4957ed65dba9e542d5da1c49d842bb441-file.png) and [reproduction GIF](https://ampcode.com/user-content/artifacts/6b84ba3dd1a98b1dbcae0df5ec7579d7501fe748b04fd391bd3f12d401ec6468-file.gif)
- [TO BE screenshot](https://ampcode.com/user-content/artifacts/f5a4c0b0ddca66b9a5eb72dac19f296d1d65e341f58277890d376b2788b90693-file.png) and [verification GIF](https://ampcode.com/user-content/artifacts/a6cef058cfd29cbeec913fd3369adc3373ab730f861a37854d44bf4acb96f97a-file.gif)
- [Latest staging AS IS recording](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785370090022269?thread_ts=1785169746.169899&cid=C0932CGKT5K)

## Red → Green proof

The unified workspace-scoping regression test was run unchanged before and after the fix:

- **RED:** unified switch completed, but `currentWorkspace` was `null`; persistence resolved to `personal` instead of `workspace-123`.
- **GREEN:** sequential unified switches resolve `Comfy.Workflow.DraftIndex.v2:workspace-123` and `Comfy.Workflow.DraftIndex.v2:workspace-456`, while legacy token storage remains empty.

The earlier runtime recovery tests also prove RED → GREEN for revocation ordering, expiry fencing/reload, and exception-safe persistence cleanup.

## Verification

- `useWorkspaceAuth.test.ts`: 93 passed
- `teamWorkspaceStore.test.ts`: 78 passed
- `storageIO.test.ts`: 24 passed
- `storageKeys.test.ts`: 12 passed
- `useWorkflowPersistenceV2.test.ts`: 20 passed
- `vue-tsc --noEmit`
- ESLint and oxfmt on changed files
- `git diff --check`

Staging remains expected to reproduce until this PR is merged, backported to Cloud 1.48, deployed, and the workspace A → B → A flow is reverified there.