### PR TITLE
fix: defer Desktop login approval until after the user-check reload

### DIFF
--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import type { RouteRecordRaw } from 'vue-router'
 
 /**
  * Every test drives a real in-memory router and the real preserved-query
  * manager: the tracker strips the code from the URL at capture time, so the
- * stash is the only carrier, and redemption fires from router.afterEach, an
+ * stash is the only carrier, and redemption fires from router.beforeResolve, an
  * auth watcher, and a delayed retry after a transient failure.
  *
  * The fake clock (installed for every test) keeps those retry timers from
@@ -85,15 +86,19 @@ function expectedFetchOptions(code: string) {
   }
 }
 
-// The triggers fire-and-forget the redemption; a zero-length advance of the
-// fake clock yields the event loop so the whole mocked promise chain settles.
+// The watcher and retry triggers fire-and-forget the redemption; a zero-length
+// advance of the fake clock yields the event loop so mocked promises settle.
 async function flushRedemption() {
   await vi.advanceTimersByTimeAsync(0)
 }
 
 // vi.resetModules() also resets the preserved-query manager's in-memory map,
 // so the manager must be imported alongside the module under test.
-async function setup() {
+async function setup(
+  routes: RouteRecordRaw[] = [
+    { path: '/:pathMatch(.*)*', component: { template: '<div />' } }
+  ]
+) {
   const { installDesktopLoginRedemption } =
     await import('./desktopLoginRedemption')
   const { capturePreservedQuery, getPreservedQueryParam } =
@@ -101,7 +106,7 @@ async function setup() {
 
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }]
+    routes
   })
   installDesktopLoginRedemption(router)
 
@@ -196,14 +201,69 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    await trigger()
+    const navigation = trigger()
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
     expect(mockFetch).not.toHaveBeenCalled()
 
     approve(true)
-    await flushRedemption()
+    await navigation
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('finishes redemption before the signed-in user-check navigation completes', async () => {
+    const { router, stashedCode } = await setup([
+      {
+        path: '/cloud/login',
+        component: { template: '<div />' },
+        beforeEnter: () =>
+          mockAuthStore.currentUser ? { name: 'cloud-user-check' } : true
+      },
+      {
+        path: '/cloud/user-check',
+        name: 'cloud-user-check',
+        component: { template: '<div />' }
+      }
+    ])
+    const { installPreservedQueryTracker } =
+      await import('@/platform/navigation/preservedQueryTracker')
+    installPreservedQueryTracker(router, [
+      {
+        namespace: NAMESPACE,
+        keys: ['desktop_login_code'],
+        stripAfterCapture: true
+      }
+    ])
+    let approve!: (value: boolean) => void
+    mockConfirm.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        approve = resolve
+      })
+    )
+    mockFetch.mockResolvedValue(okResponse())
+    const userCheckNavigationCompleted = vi.fn()
+    router.afterEach((to) => {
+      if (to.name === 'cloud-user-check') {
+        userCheckNavigationCompleted(stashedCode())
+      }
+    })
+
+    const navigation = router.push(
+      `/cloud/login?desktop_login_code=${VALID_CODE}`
+    )
+
+    await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
+    expect(userCheckNavigationCompleted).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    approve(true)
+    await navigation
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(userCheckNavigationCompleted).toHaveBeenCalledTimes(1)
+    expect(userCheckNavigationCompleted).toHaveBeenCalledWith(undefined)
+    expect(stashedCode()).toBeUndefined()
   })
 
   it.for([
@@ -532,7 +592,7 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    await trigger()
+    const navigation = trigger()
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
 
     // The session swaps to user-2 while user-1's dialog is open: the stale
@@ -545,7 +605,7 @@ describe('installDesktopLoginRedemption', () => {
     mockAuthStore.currentUser = secondUser
     await flushRedemption()
     approve(true)
-    await flushRedemption()
+    await navigation
 
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
@@ -575,7 +635,7 @@ describe('installDesktopLoginRedemption', () => {
         })
       )
 
-      await trigger()
+      const navigation = trigger()
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
       // A second code arrives while the first redemption is in flight; it
@@ -584,6 +644,7 @@ describe('installDesktopLoginRedemption', () => {
       mockFetch.mockResolvedValue(okResponse())
       resolveFirstFetch(firstResponse())
 
+      await navigation
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
       expect(mockConfirm).toHaveBeenCalledTimes(2)
       expect(mockFetch).toHaveBeenLastCalledWith(
@@ -605,12 +666,12 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    await router.push('/burst-1')
-    await router.push('/burst-2')
+    const firstNavigation = router.push('/burst-1')
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
+    const secondNavigation = router.push('/burst-2')
 
     approve(true)
-    await flushRedemption()
+    await Promise.all([firstNavigation, secondNavigation])
 
     expect(mockConfirm).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledTimes(1)

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -238,9 +238,7 @@ describe('installDesktopLoginRedemption', () => {
     ])
     mockFetch.mockResolvedValue(okResponse())
 
-    // The desktop login link lands on /cloud/login; the signed-in guard
-    // forwards to user-check, which ends the handoff in a hard reload. No
-    // prompt may open mid-handoff: the reload would destroy it.
+    // Signed-in landing forwards to user-check; no prompt may open there.
     await router.push(`/cloud/login?desktop_login_code=${VALID_CODE}`)
     await flushRedemption()
 
@@ -249,8 +247,7 @@ describe('installDesktopLoginRedemption', () => {
     expect(mockFetch).not.toHaveBeenCalled()
     expect(stashedCode()).toBe(VALID_CODE)
 
-    // UserCheckView hard-reloads `/`: module state is gone, the
-    // sessionStorage stash is not. The reloaded app prompts exactly once.
+    // user-check hard-reloads `/`; only the sessionStorage stash survives.
     vi.resetModules()
     const reloaded = await setup()
     await reloaded.trigger()
@@ -280,8 +277,7 @@ describe('installDesktopLoginRedemption', () => {
     await flushRedemption()
     expect(mockConfirm).not.toHaveBeenCalled()
 
-    // Signing in on the login page fires the auth watcher mid-handoff; the
-    // prompt must wait for the post-reload triggers on a stable route.
+    // Signing in on the login page fires the auth watcher mid-handoff.
     mockAuthStore.currentUser = {
       uid: 'user-1',
       getIdToken: mockUserGetIdToken

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -6,7 +6,7 @@ import type { RouteRecordRaw } from 'vue-router'
 /**
  * Every test drives a real in-memory router and the real preserved-query
  * manager: the tracker strips the code from the URL at capture time, so the
- * stash is the only carrier, and redemption fires from router.beforeResolve, an
+ * stash is the only carrier, and redemption fires from router.afterEach, an
  * auth watcher, and a delayed retry after a transient failure.
  *
  * The fake clock (installed for every test) keeps those retry timers from
@@ -86,8 +86,8 @@ function expectedFetchOptions(code: string) {
   }
 }
 
-// The watcher and retry triggers fire-and-forget the redemption; a zero-length
-// advance of the fake clock yields the event loop so mocked promises settle.
+// The triggers fire-and-forget the redemption; a zero-length advance of the
+// fake clock yields the event loop so the whole mocked promise chain settles.
 async function flushRedemption() {
   await vi.advanceTimersByTimeAsync(0)
 }
@@ -201,28 +201,30 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    const navigation = trigger()
+    await trigger()
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
     expect(mockFetch).not.toHaveBeenCalled()
 
     approve(true)
-    await navigation
+    await flushRedemption()
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
-  it('finishes redemption before the signed-in user-check navigation completes', async () => {
+  it('defers the prompt during the signed-in login handoff and redeems once after the reload', async () => {
     const { router, stashedCode } = await setup([
       {
         path: '/cloud/login',
         component: { template: '<div />' },
+        meta: { defersDesktopLoginRedemption: true },
         beforeEnter: () =>
           mockAuthStore.currentUser ? { name: 'cloud-user-check' } : true
       },
       {
         path: '/cloud/user-check',
         name: 'cloud-user-check',
-        component: { template: '<div />' }
+        component: { template: '<div />' },
+        meta: { defersDesktopLoginRedemption: true }
       }
     ])
     const { installPreservedQueryTracker } =
@@ -234,36 +236,61 @@ describe('installDesktopLoginRedemption', () => {
         stripAfterCapture: true
       }
     ])
-    let approve!: (value: boolean) => void
-    mockConfirm.mockReturnValue(
-      new Promise<boolean>((resolve) => {
-        approve = resolve
-      })
-    )
     mockFetch.mockResolvedValue(okResponse())
-    const userCheckNavigationCompleted = vi.fn()
-    router.afterEach((to) => {
-      if (to.name === 'cloud-user-check') {
-        userCheckNavigationCompleted(stashedCode())
-      }
-    })
 
-    const navigation = router.push(
-      `/cloud/login?desktop_login_code=${VALID_CODE}`
-    )
+    // The desktop login link lands on /cloud/login; the signed-in guard
+    // forwards to user-check, which ends the handoff in a hard reload. No
+    // prompt may open mid-handoff: the reload would destroy it.
+    await router.push(`/cloud/login?desktop_login_code=${VALID_CODE}`)
+    await flushRedemption()
 
-    await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
-    expect(userCheckNavigationCompleted).not.toHaveBeenCalled()
+    expect(router.currentRoute.value.name).toBe('cloud-user-check')
+    expect(mockConfirm).not.toHaveBeenCalled()
     expect(mockFetch).not.toHaveBeenCalled()
+    expect(stashedCode()).toBe(VALID_CODE)
 
-    approve(true)
-    await navigation
+    // UserCheckView hard-reloads `/`: module state is gone, the
+    // sessionStorage stash is not. The reloaded app prompts exactly once.
+    vi.resetModules()
+    const reloaded = await setup()
+    await reloaded.trigger()
 
     expect(mockConfirm).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    expect(userCheckNavigationCompleted).toHaveBeenCalledTimes(1)
-    expect(userCheckNavigationCompleted).toHaveBeenCalledWith(undefined)
-    expect(stashedCode()).toBeUndefined()
+    expect(mockFetch).toHaveBeenCalledWith(
+      REDEEM_URL,
+      expectedFetchOptions(VALID_CODE)
+    )
+    expect(reloaded.stashedCode()).toBeUndefined()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps deferring when the session appears while still on a handoff route', async () => {
+    const { router, seedStash, stashedCode } = await setup([
+      {
+        path: '/cloud/login',
+        component: { template: '<div />' },
+        meta: { defersDesktopLoginRedemption: true }
+      }
+    ])
+    seedStash(VALID_CODE)
+    mockAuthStore.currentUser = null
+
+    await router.push('/cloud/login')
+    await flushRedemption()
+    expect(mockConfirm).not.toHaveBeenCalled()
+
+    // Signing in on the login page fires the auth watcher mid-handoff; the
+    // prompt must wait for the post-reload triggers on a stable route.
+    mockAuthStore.currentUser = {
+      uid: 'user-1',
+      getIdToken: mockUserGetIdToken
+    }
+    await flushRedemption()
+
+    expect(mockConfirm).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(stashedCode()).toBe(VALID_CODE)
   })
 
   it.for([
@@ -592,7 +619,7 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    const navigation = trigger()
+    await trigger()
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
 
     // The session swaps to user-2 while user-1's dialog is open: the stale
@@ -605,7 +632,7 @@ describe('installDesktopLoginRedemption', () => {
     mockAuthStore.currentUser = secondUser
     await flushRedemption()
     approve(true)
-    await navigation
+    await flushRedemption()
 
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
@@ -635,7 +662,7 @@ describe('installDesktopLoginRedemption', () => {
         })
       )
 
-      const navigation = trigger()
+      await trigger()
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
       // A second code arrives while the first redemption is in flight; it
@@ -644,7 +671,6 @@ describe('installDesktopLoginRedemption', () => {
       mockFetch.mockResolvedValue(okResponse())
       resolveFirstFetch(firstResponse())
 
-      await navigation
       await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
       expect(mockConfirm).toHaveBeenCalledTimes(2)
       expect(mockFetch).toHaveBeenLastCalledWith(
@@ -666,12 +692,12 @@ describe('installDesktopLoginRedemption', () => {
     )
     mockFetch.mockResolvedValue(okResponse())
 
-    const firstNavigation = router.push('/burst-1')
+    await router.push('/burst-1')
+    await router.push('/burst-2')
     await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1))
-    const secondNavigation = router.push('/burst-2')
 
     approve(true)
-    await Promise.all([firstNavigation, secondNavigation])
+    await flushRedemption()
 
     expect(mockConfirm).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledTimes(1)

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -50,8 +50,6 @@ let retriggerRequested = false
 
 let authWatcherInstalled = false
 
-// Set at install time so redeemCode can consult the current route: the auth
-// watcher and retry timers trigger drains with no navigation context.
 let activeRouter: Router | null = null
 
 function onAuthHandoffRoute(): boolean {
@@ -140,11 +138,8 @@ async function redeemCode(code: string): Promise<void> {
   const user = useAuthStore().currentUser
   if (!user) return
 
-  // Mid auth handoff (login → user-check): UserCheckView ends the handoff
-  // with a hard reload that would destroy an open approval dialog and any
-  // in-flight redemption, re-prompting after the reload. The stash survives
-  // the reload in sessionStorage; the reloaded app redeems on a stable,
-  // fully themed route via its own navigation and auth-watcher triggers.
+  // Mid-handoff the imminent hard reload would destroy an open dialog; keep
+  // the stash and let the reloaded app prompt on a stable route.
   if (onAuthHandoffRoute()) return
 
   if (!(await confirmRedemption(state, user.uid))) {
@@ -272,9 +267,8 @@ function installAuthWatcherOnce(): void {
  * router.ts) strips the code from the URL at capture time, so the
  * sessionStorage-backed stash is the only place it lives.
  *
- * Routes flagged `meta.defersDesktopLoginRedemption` (the cloud auth
- * handoff) suppress the approval prompt, deferring redemption until the
- * handoff's hard reload lands the app on a stable route.
+ * Routes flagged `meta.defersDesktopLoginRedemption` suppress the prompt:
+ * the auth handoff ends in a hard reload that only the stash survives.
  */
 export function installDesktopLoginRedemption(router: Router): void {
   activeRouter = router

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -45,7 +45,7 @@ const codeStates = new Map<string, CodeRedemptionState>()
 // Coalesces concurrent triggers into one drain; a trigger arriving mid-drain
 // (e.g. the auth watcher firing while the dialog is open) is replayed as one
 // more pass instead of being dropped.
-let draining = false
+let drainPromise: Promise<void> | null = null
 let retriggerRequested = false
 
 let authWatcherInstalled = false
@@ -205,13 +205,7 @@ async function redeemCode(code: string): Promise<void> {
   handleTransientFailure(code, state, `status ${response.status}`)
 }
 
-async function redeemPendingDesktopLoginCode(): Promise<void> {
-  // Never rejects: the triggers fire-and-forget this.
-  if (draining) {
-    retriggerRequested = true
-    return
-  }
-  draining = true
+async function drainPendingDesktopLoginCode(): Promise<void> {
   try {
     do {
       retriggerRequested = false
@@ -227,9 +221,19 @@ async function redeemPendingDesktopLoginCode(): Promise<void> {
     } while (retriggerRequested)
   } catch (error) {
     console.error('[DesktopLoginRedemption] Redemption failed:', error)
-  } finally {
-    draining = false
   }
+}
+
+function redeemPendingDesktopLoginCode(): Promise<void> {
+  if (drainPromise) {
+    retriggerRequested = true
+    return drainPromise
+  }
+
+  drainPromise = drainPendingDesktopLoginCode().finally(() => {
+    drainPromise = null
+  })
+  return drainPromise
 }
 
 function installAuthWatcherOnce(): void {
@@ -256,8 +260,8 @@ function installAuthWatcherOnce(): void {
  * the only place it lives.
  */
 export function installDesktopLoginRedemption(router: Router): void {
-  router.afterEach(() => {
+  router.beforeResolve(() => {
     installAuthWatcherOnce()
-    void redeemPendingDesktopLoginCode()
+    return redeemPendingDesktopLoginCode()
   })
 }

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -45,10 +45,20 @@ const codeStates = new Map<string, CodeRedemptionState>()
 // Coalesces concurrent triggers into one drain; a trigger arriving mid-drain
 // (e.g. the auth watcher firing while the dialog is open) is replayed as one
 // more pass instead of being dropped.
-let drainPromise: Promise<void> | null = null
+let draining = false
 let retriggerRequested = false
 
 let authWatcherInstalled = false
+
+// Set at install time so redeemCode can consult the current route: the auth
+// watcher and retry timers trigger drains with no navigation context.
+let activeRouter: Router | null = null
+
+function onAuthHandoffRoute(): boolean {
+  return (
+    activeRouter?.currentRoute.value.meta.defersDesktopLoginRedemption === true
+  )
+}
 
 function getCodeState(code: string): CodeRedemptionState {
   const existing = codeStates.get(code)
@@ -130,6 +140,13 @@ async function redeemCode(code: string): Promise<void> {
   const user = useAuthStore().currentUser
   if (!user) return
 
+  // Mid auth handoff (login → user-check): UserCheckView ends the handoff
+  // with a hard reload that would destroy an open approval dialog and any
+  // in-flight redemption, re-prompting after the reload. The stash survives
+  // the reload in sessionStorage; the reloaded app redeems on a stable,
+  // fully themed route via its own navigation and auth-watcher triggers.
+  if (onAuthHandoffRoute()) return
+
   if (!(await confirmRedemption(state, user.uid))) {
     // Declined/dismissed: drop the code without an error.
     settle(code, state)
@@ -205,7 +222,13 @@ async function redeemCode(code: string): Promise<void> {
   handleTransientFailure(code, state, `status ${response.status}`)
 }
 
-async function drainPendingDesktopLoginCode(): Promise<void> {
+async function redeemPendingDesktopLoginCode(): Promise<void> {
+  // Never rejects: the triggers fire-and-forget this.
+  if (draining) {
+    retriggerRequested = true
+    return
+  }
+  draining = true
   try {
     do {
       retriggerRequested = false
@@ -221,19 +244,9 @@ async function drainPendingDesktopLoginCode(): Promise<void> {
     } while (retriggerRequested)
   } catch (error) {
     console.error('[DesktopLoginRedemption] Redemption failed:', error)
+  } finally {
+    draining = false
   }
-}
-
-function redeemPendingDesktopLoginCode(): Promise<void> {
-  if (drainPromise) {
-    retriggerRequested = true
-    return drainPromise
-  }
-
-  drainPromise = drainPendingDesktopLoginCode().finally(() => {
-    drainPromise = null
-  })
-  return drainPromise
 }
 
 function installAuthWatcherOnce(): void {
@@ -256,12 +269,17 @@ function installAuthWatcherOnce(): void {
  * the cloud backend; redeeming the code from a signed-in browser session,
  * with the user's approval, releases a one-time custom token to that poll
  * and signs the desktop app in. The preserved-query tracker (configured in
- * router.ts) strips the code from the URL at capture time, so the stash is
- * the only place it lives.
+ * router.ts) strips the code from the URL at capture time, so the
+ * sessionStorage-backed stash is the only place it lives.
+ *
+ * Routes flagged `meta.defersDesktopLoginRedemption` (the cloud auth
+ * handoff) suppress the approval prompt, deferring redemption until the
+ * handoff's hard reload lands the app on a stable route.
  */
 export function installDesktopLoginRedemption(router: Router): void {
-  router.beforeResolve(() => {
+  activeRouter = router
+  router.afterEach(() => {
     installAuthWatcherOnce()
-    return redeemPendingDesktopLoginCode()
+    void redeemPendingDesktopLoginCode()
   })
 }

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -45,6 +45,11 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
     path: '/cloud',
     component: () =>
       import('@/platform/cloud/onboarding/components/CloudLayoutView.vue'),
+    // The onboarding handoff ends in UserCheckView's hard reload, which would
+    // destroy an open desktop-login approval dialog mid-prompt; redemption
+    // stays deferred until the reload lands on a stable route. See
+    // desktopLoginRedemption.ts.
+    meta: { defersDesktopLoginRedemption: true },
     children: [
       {
         path: 'login',
@@ -128,6 +133,7 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
     path: '/oauth',
     component: () =>
       import('@/platform/cloud/onboarding/components/OAuthLayoutView.vue'),
+    meta: { defersDesktopLoginRedemption: true },
     children: [
       {
         path: 'consent',

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -131,8 +131,6 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
     path: '/oauth',
     component: () =>
       import('@/platform/cloud/onboarding/components/OAuthLayoutView.vue'),
-    // Not flagged like /cloud: consent waits for the user and then leaves the
-    // app for the client's redirect URI, so deferral would starve the code.
     children: [
       {
         path: 'consent',

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -131,7 +131,8 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
     path: '/oauth',
     component: () =>
       import('@/platform/cloud/onboarding/components/OAuthLayoutView.vue'),
-    meta: { defersDesktopLoginRedemption: true },
+    // Not flagged like /cloud: consent waits for the user and then leaves the
+    // app for the client's redirect URI, so deferral would starve the code.
     children: [
       {
         path: 'consent',

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -45,10 +45,8 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
     path: '/cloud',
     component: () =>
       import('@/platform/cloud/onboarding/components/CloudLayoutView.vue'),
-    // The onboarding handoff ends in UserCheckView's hard reload, which would
-    // destroy an open desktop-login approval dialog mid-prompt; redemption
-    // stays deferred until the reload lands on a stable route. See
-    // desktopLoginRedemption.ts.
+    // UserCheckView's hard reload would destroy the desktop-login approval
+    // dialog mid-prompt (see desktopLoginRedemption.ts).
     meta: { defersDesktopLoginRedemption: true },
     children: [
       {


### PR DESCRIPTION
I know it's not ideal, this is just for the release version, next change will be a dedicated auth code page and not a dialog.

## Summary

Prevents the Desktop login approval dialog from opening during the login → user-check handoff, where it rendered unthemed over a blank page and was then destroyed and re-prompted by `UserCheckView`'s hard reload.

## Changes

- **What**: Routes under `/cloud` and `/oauth` are flagged `meta.defersDesktopLoginRedemption`; redemption keeps the code stashed while the current route carries the flag. The sessionStorage-backed stash survives the hard reload, and the reloaded app redeems once — via its existing navigation/auth-watcher triggers — on a stable, fully themed route. The trigger stays a non-blocking `router.afterEach`.
- **Root cause**: The signed-in `/cloud/login` guard redirected to `cloud-user-check` while the fire-and-forget redemption opened approval concurrently. `UserCheckView` then hard-reloaded `/`; sessionStorage retained `desktop_login_code`, but module-local approval state was lost, so the new app instance prompted again. Prompting anywhere in the handoff has the same failure mode, and before the reload no view is mounted, so the dialog also ignored the user's theme.
- **Impact**: One prompt per code, shown after the loading screen on the post-reload route. Desktop redemption completes a few seconds later (after reload + Firebase session restore); the desktop app is polling, so this is unobservable. Auth watching, retries, account-change handling, and OAuth routing are unchanged.

## Review Focus

The regression test drives the full journey: signed-in `/cloud/login?desktop_login_code=...` → user-check with no prompt and the code still stashed, then a simulated reload (module reset, sessionStorage intact) → exactly one prompt, one redemption, cleared stash.

## Validation

- `pnpm test:unit src/platform/cloud/onboarding/desktopLoginRedemption.test.ts src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts src/platform/navigation/preservedQueryTracker.test.ts` (51 passed)
- File-scoped ESLint and oxfmt checks
- `pnpm typecheck`