### PR TITLE
feat(video): resolve video metadata from the Assets API

### DIFF
--- a/src/utils/videoMetadataUtil.test.ts
+++ b/src/utils/videoMetadataUtil.test.ts
@@ -10,13 +10,18 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
-const metadata = {
-  fps: 30,
-  duration: 4.2,
-  frame_count: 126,
-  width: 1920,
-  height: 1080,
-  size: 1024
+const videoAsset = {
+  id: 'asset-1',
+  name: 'a.mp4',
+  size: 2048,
+  metadata: {
+    kind: 'video',
+    width: 1280,
+    height: 720,
+    duration: 2.5,
+    fps: 24,
+    frame_count: 60
+  }
 }
 
 function mockResponse(ok: boolean, body?: unknown) {
@@ -31,17 +36,86 @@ describe('fetchVideoMetadata', () => {
     vi.clearAllMocks()
   })
 
-  it('queries the backend with the view resource params', async () => {
-    mockResponse(true, metadata)
+  it('resolves metadata from the matching asset record', async () => {
+    mockResponse(true, { assets: [videoAsset] })
 
     const result = await fetchVideoMetadata(
       'http://localhost:8188/api/view?filename=a.mp4&subfolder=clips&type=input&rand=0.1'
     )
 
     expect(api.fetchApi).toHaveBeenCalledWith(
-      '/video_metadata?filename=a.mp4&subfolder=clips&type=input'
+      '/assets?include_tags=input%2Cclips&name_contains=a.mp4&limit=100'
     )
-    expect(result).toEqual(metadata)
+    expect(result).toEqual({
+      fps: 24,
+      duration: 2.5,
+      frame_count: 60,
+      width: 1280,
+      height: 720,
+      size: 2048
+    })
+  })
+
+  it('defaults the tag filter to input when the url has no type', async () => {
+    mockResponse(true, { assets: [videoAsset] })
+
+    await fetchVideoMetadata('/api/view?filename=a.mp4')
+
+    expect(api.fetchApi).toHaveBeenCalledWith(
+      '/assets?include_tags=input&name_contains=a.mp4&limit=100'
+    )
+  })
+
+  it('ignores assets whose name does not match exactly', async () => {
+    mockResponse(true, { assets: [{ ...videoAsset, name: 'not-a.mp4' }] })
+
+    const result = await fetchVideoMetadata(
+      '/api/view?filename=a.mp4&type=input'
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('still returns the file size when the asset lacks video metadata', async () => {
+    mockResponse(true, {
+      assets: [
+        {
+          id: 'asset-1',
+          name: 'a.mp4',
+          size: 4096,
+          metadata: { kind: 'image' }
+        }
+      ]
+    })
+
+    const result = await fetchVideoMetadata(
+      '/api/view?filename=a.mp4&type=input'
+    )
+
+    expect(result).toEqual({
+      fps: null,
+      duration: null,
+      frame_count: null,
+      width: null,
+      height: null,
+      size: 4096
+    })
+  })
+
+  it('returns undefined when the assets API is unavailable', async () => {
+    mockResponse(false)
+
+    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined for malformed responses', async () => {
+    mockResponse(true, { unexpected: true })
+
+    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
+
+    expect(result).toBeUndefined()
   })
 
   it('returns undefined for non-view urls without fetching', async () => {
@@ -57,22 +131,6 @@ describe('fetchVideoMetadata', () => {
     )
 
     expect(api.fetchApi).not.toHaveBeenCalled()
-    expect(result).toBeUndefined()
-  })
-
-  it('returns undefined when the backend lacks the endpoint', async () => {
-    mockResponse(false)
-
-    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
-
-    expect(result).toBeUndefined()
-  })
-
-  it('returns undefined for malformed responses', async () => {
-    mockResponse(true, { unexpected: true })
-
-    const result = await fetchVideoMetadata('/api/view?filename=a.mp4')
-
     expect(result).toBeUndefined()
   })
 })

--- a/src/utils/videoMetadataUtil.ts
+++ b/src/utils/videoMetadataUtil.ts
@@ -2,16 +2,39 @@ import { z } from 'zod'
 
 import { api } from '@/scripts/api'
 
-const zVideoMetadata = z.object({
-  fps: z.number().positive().finite().nullable(),
-  duration: z.number().nonnegative().finite().nullable(),
-  frame_count: z.number().int().nonnegative().nullable(),
+export interface VideoMetadata {
+  fps: number | null
+  duration: number | null
+  frame_count: number | null
+  width: number | null
+  height: number | null
+  size?: number
+}
+
+const zAssetVideoMetadata = z.object({
+  kind: z.literal('video'),
   width: z.number().int().positive(),
   height: z.number().int().positive(),
-  size: z.number().nonnegative().finite()
+  duration: z.number().nonnegative().finite().nullish(),
+  fps: z.number().positive().finite().nullish(),
+  frame_count: z.number().int().nonnegative().nullish()
 })
 
-export type VideoMetadata = z.infer<typeof zVideoMetadata>
+const zAssetListResponse = z.object({
+  assets: z.array(
+    z.object({
+      name: z.string(),
+      size: z.number().nonnegative().finite().optional(),
+      metadata: z.record(z.unknown()).nullish()
+    })
+  )
+})
+
+interface ViewFileRef {
+  filename: string
+  subfolder: string | null
+  type: string | null
+}
 
 function isTrustedOrigin(url: URL): boolean {
   if (url.origin === window.location.origin) return true
@@ -23,7 +46,7 @@ function isTrustedOrigin(url: URL): boolean {
   }
 }
 
-function viewQueryFromUrl(videoUrl: string): string | undefined {
+function parseViewUrl(videoUrl: string): ViewFileRef | undefined {
   let url: URL
   try {
     url = new URL(videoUrl, window.location.origin)
@@ -36,24 +59,53 @@ function viewQueryFromUrl(videoUrl: string): string | undefined {
   const filename = url.searchParams.get('filename')
   if (!filename) return undefined
 
-  const params = new URLSearchParams({ filename })
-  for (const key of ['subfolder', 'type'] as const) {
-    const value = url.searchParams.get(key)
-    if (value !== null) params.set(key, value)
+  return {
+    filename,
+    subfolder: url.searchParams.get('subfolder') || null,
+    type: url.searchParams.get('type') || null
   }
-  return params.toString()
 }
 
 export async function fetchVideoMetadata(
   videoUrl: string
 ): Promise<VideoMetadata | undefined> {
-  const query = viewQueryFromUrl(videoUrl)
-  if (!query) return undefined
+  const file = parseViewUrl(videoUrl)
+  if (!file) return undefined
+
+  const includeTags = [file.type ?? 'input']
+  if (file.subfolder) includeTags.push(file.subfolder)
+  const params = new URLSearchParams({
+    include_tags: includeTags.join(','),
+    name_contains: file.filename,
+    limit: '100'
+  })
 
   try {
-    const response = await api.fetchApi(`/video_metadata?${query}`)
+    const response = await api.fetchApi(`/assets?${params}`)
     if (!response.ok) return undefined
-    return zVideoMetadata.parse(await response.json())
+    const { assets } = zAssetListResponse.parse(await response.json())
+    const asset = assets.find((entry) => entry.name === file.filename)
+    if (!asset) return undefined
+
+    const parsed = zAssetVideoMetadata.safeParse(asset.metadata)
+    if (!parsed.success) {
+      return {
+        fps: null,
+        duration: null,
+        frame_count: null,
+        width: null,
+        height: null,
+        size: asset.size
+      }
+    }
+    return {
+      fps: parsed.data.fps ?? null,
+      duration: parsed.data.duration ?? null,
+      frame_count: parsed.data.frame_count ?? null,
+      width: parsed.data.width,
+      height: parsed.data.height,
+      size: asset.size
+    }
   } catch {
     return undefined
   }


### PR DESCRIPTION
## Summary
Now the VIDEO_EDIT widget is merged, this replaces the /video_metadata probe with the Assets API as the metadata source. fetchVideoMetadata matches the /view URL to an asset record (type/subfolder tags + exact name) and reads duration/fps/frame_count/width/height from the asset metadata field populated by asset ingest. 

Requires --enable-assets and the backend feat/asset-video-metadata branch.
