### PR TITLE
feat: show scheduled subscription changes

### DIFF
--- a/src/composables/billing/types.ts
+++ b/src/composables/billing/types.ts
@@ -24,6 +24,9 @@ export interface SubscriptionInfo {
   tier: SubscriptionTier | null
   duration: SubscriptionDuration | null
   planSlug: string | null
+  scheduledPlanSlug?: string | null
+  /** ISO 8601; format at the display site. */
+  changeAt?: string | null
   /** ISO 8601; format at the display site. */
   renewalDate: string | null
   /** ISO 8601; format at the display site. */

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2629,6 +2629,7 @@
     "expiresDate": "Expires {date}",
     "renewsOnDate": "Renews on {date}",
     "endsOnDate": "Ends on {date}",
+    "changesToPlanOnDate": "Changes to {plan} on {date}",
     "manageSubscription": "Manage subscription",
     "manageBilling": "Manage billing",
     "changePlan": "Change plan",

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -275,6 +275,8 @@ export interface BillingStatusResponse {
   subscription_tier?: SubscriptionTier
   subscription_duration?: SubscriptionDuration
   plan_slug?: string
+  scheduled_plan_slug?: string
+  change_at?: string
   billing_status?: BillingStatus
   pending_billing_op_id?: string
   action_url?: string

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -11,6 +11,7 @@ import * as tierPricing from '@/platform/cloud/subscription/constants/tierPricin
 import type {
   BillingSubscriptionStatus,
   CurrentTeamCreditStop,
+  Plan,
   TeamCreditStops
 } from '@/platform/workspace/api/workspaceApi'
 
@@ -58,6 +59,8 @@ const mockSubscriptionStatus = ref<BillingSubscriptionStatus>('active')
 const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockRenewalDate = ref<string | null>(RENEWAL_DATE_ISO)
 const mockEndDate = ref<string | null>(END_DATE_ISO)
+const mockScheduledPlanSlug = ref<string | null>(null)
+const mockChangeAt = ref<string | null>(null)
 const mockHasSubscription = ref(true)
 const mockIsActiveSubscription = ref(true)
 const mockIsInPersonalWorkspace = ref(false)
@@ -107,6 +110,22 @@ const mockUiConfig = ref<MenuUiConfig>(ownerUiConfig)
 const mockSubscriptionTier = ref<SubscriptionInfo['tier']>('PRO')
 const mockPlanSlug = ref('team-monthly')
 const mockHasTeamPlan = ref(true)
+const mockPlans = ref<Plan[]>([
+  {
+    slug: 'pro-annual',
+    tier: 'PRO',
+    duration: 'ANNUAL',
+    price_cents: 96000,
+    credits_cents: 253200,
+    max_seats: 1,
+    availability: { available: true },
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 96000,
+      total_credits_cents: 253200
+    }
+  }
+])
 
 const mockSubscription = computed<SubscriptionInfo | null>(() =>
   mockHasSubscription.value
@@ -115,6 +134,8 @@ const mockSubscription = computed<SubscriptionInfo | null>(() =>
         tier: mockSubscriptionTier.value,
         duration: mockSubscriptionDuration.value,
         planSlug: mockPlanSlug.value,
+        scheduledPlanSlug: mockScheduledPlanSlug.value,
+        changeAt: mockChangeAt.value,
         renewalDate: mockRenewalDate.value,
         endDate: mockEndDate.value,
         isCancelled: mockSubscriptionStatus.value === 'canceled',
@@ -136,6 +157,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isFreeTier: computed(() => false),
     isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
+    plans: mockPlans,
     subscriptionStatus: mockSubscriptionStatus,
     teamCreditStops: mockTeamCreditStops,
     currentTeamCreditStop: mockCurrentTeamCreditStop,
@@ -277,6 +299,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockSubscriptionStatus.value = 'active'
     mockRenewalDate.value = RENEWAL_DATE_ISO
     mockEndDate.value = END_DATE_ISO
+    mockScheduledPlanSlug.value = null
+    mockChangeAt.value = null
     mockHasSubscription.value = true
     mockIsActiveSubscription.value = true
     mockIsInPersonalWorkspace.value = false
@@ -350,6 +374,26 @@ describe('SubscriptionPanelContentWorkspace', () => {
       'data-show-invoice-history',
       'true'
     )
+  })
+
+  it('shows a scheduled plan change instead of the renewal date', () => {
+    mockScheduledPlanSlug.value = 'pro-annual'
+    mockChangeAt.value = END_DATE_ISO
+    renderComponent()
+
+    expect(
+      screen.getByText(`Changes to Pro on ${formatPanelDate(END_DATE_ISO)}`)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/^Renews on/i)).not.toBeInTheDocument()
+  })
+
+  it('does not show an incomplete scheduled plan change', () => {
+    mockScheduledPlanSlug.value = 'missing-plan'
+    mockChangeAt.value = END_DATE_ISO
+    renderComponent()
+
+    expect(screen.queryByText(/^Changes to/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Renews on/i)).not.toBeInTheDocument()
   })
 
   it.for([null, 'not-a-date', '2026-02-31T12:00:00Z'])(
@@ -485,6 +529,8 @@ describe('SubscriptionPanelContentWorkspace', () => {
   it('shows dated cancellation copy while a cancelled plan remains active', async () => {
     const user = userEvent.setup()
     mockSubscriptionStatus.value = 'canceled'
+    mockScheduledPlanSlug.value = 'pro-annual'
+    mockChangeAt.value = RENEWAL_DATE_ISO
     mockCanLeaveWorkspace.value = false
     renderComponent()
 
@@ -499,6 +545,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(
       screen.queryByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
     ).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Changes to/i)).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Manage billing' })
     ).toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -356,6 +356,7 @@ const {
   isFreeTier: isFreeTierPlan,
   isTeamPlan,
   subscription,
+  plans,
   subscriptionStatus,
   isLoading,
   error,
@@ -447,6 +448,23 @@ const formattedEndDate = computed(() =>
   formatSubscriptionDate(subscription.value?.endDate, locale.value)
 )
 
+const formattedChangeDate = computed(() =>
+  formatSubscriptionDate(subscription.value?.changeAt, locale.value)
+)
+
+const scheduledPlanName = computed(() => {
+  const scheduledPlan = plans.value.find(
+    (plan) => plan.slug === subscription.value?.scheduledPlanSlug
+  )
+  if (!scheduledPlan) return ''
+  if (scheduledPlan.slug.startsWith('team')) {
+    return t('subscription.teamPlanName')
+  }
+  return t(
+    `subscription.tiers.${resolveSubscriptionTierKey(scheduledPlan.tier)}.name`
+  )
+})
+
 const showSubscriptionStateCard = computed(
   () => isSubscriptionCancelled.value || isSubscriptionEnded.value
 )
@@ -474,6 +492,14 @@ const planDateDisplay = computed(() => {
   if (isSubscriptionCancelled.value) {
     return formattedEndDate.value
       ? t('subscription.endsOnDate', { date: formattedEndDate.value })
+      : ''
+  }
+  if (subscription.value?.scheduledPlanSlug || subscription.value?.changeAt) {
+    return scheduledPlanName.value && formattedChangeDate.value
+      ? t('subscription.changesToPlanOnDate', {
+          plan: scheduledPlanName.value,
+          date: formattedChangeDate.value
+        })
       : ''
   }
   return formattedRenewalDate.value

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -237,7 +237,9 @@ describe('useWorkspaceBilling', () => {
         ...activeStatus,
         billing_rail: 'stripe',
         subscription_status: 'canceled',
-        cancel_at: '2026-06-01T00:00:00Z'
+        cancel_at: '2026-06-01T00:00:00Z',
+        scheduled_plan_slug: 'pro-annual',
+        change_at: '2026-07-01T00:00:00Z'
       })
 
       const billing = setupBilling()
@@ -248,6 +250,8 @@ describe('useWorkspaceBilling', () => {
         tier: 'CREATOR',
         duration: 'MONTHLY',
         planSlug: 'creator-monthly',
+        scheduledPlanSlug: 'pro-annual',
+        changeAt: '2026-07-01T00:00:00Z',
         renewalDate: '2026-05-01T00:00:00Z',
         endDate: '2026-06-01T00:00:00Z',
         isCancelled: true,

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -95,6 +95,8 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       tier: status.subscription_tier ?? null,
       duration: status.subscription_duration ?? null,
       planSlug: status.plan_slug ?? null,
+      scheduledPlanSlug: status.scheduled_plan_slug ?? null,
+      changeAt: status.change_at ?? null,
       renewalDate: status.renewal_date ?? null,
       endDate: status.cancel_at ?? null,
       isCancelled: status.subscription_status === 'canceled',


### PR DESCRIPTION
## Summary

Shows the destination plan and effective date for scheduled subscription changes in Plan & Credits.

## AS IS

- After scheduling a plan change, Plan & Credits continues to show only `Renews on {date}`.
- Users cannot verify the destination plan or distinguish a normal renewal from a pending change without checking Stripe.

## TO BE

- A complete scheduled change shows `Changes to {plan} on {date}` in the existing plan subtitle.
- Cancellation/end-date copy remains higher priority.
- Renewal copy is suppressed while a change is pending.
- Incomplete or unresolvable scheduled-change details show no misleading fallback.

## Visuals

### Comparison

![AS IS and TO BE comparison](https://ampcode.com/user-content/artifacts/e1aa66871905174ea3c904fdd206d8b3343ca95827914cbe508d1b2cb37e60b8-file.png)

### Animated comparison

![Scheduled plan change indicator animation](https://ampcode.com/user-content/artifacts/fc6443ebe6ba612a373b98443dfb5273f2f85db147f702bb27a49f9c69d147fa-file.gif)

## Changes

- Maps `scheduled_plan_slug` and `change_at` from billing status.
- Resolves the destination plan from available billing plans.
- Renders localized scheduled-change copy in the existing subtitle.
- Covers API mapping, display, incomplete state, and cancellation precedence.

## Review Focus

The UI degrades safely until the cloud billing-status response populates the documented `scheduled_plan_slug` and `change_at` fields.

Related: [DES-605](https://linear.app/comfyorg/issue/DES-605/indicator-for-when-plan-is-due-to-change-and-cancellations)
