### PR TITLE
fix: suppress expected Desktop popup rejection

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -1,4 +1,5 @@
 import { FirebaseError } from 'firebase/app'
+import { AuthErrorCodes } from 'firebase/auth'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -286,6 +287,7 @@ describe('useAuthActions auth flow error telemetry', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     mockWorkflowStore.modifiedWorkflows = []
+    delete window.__comfyDesktop2
   })
 
   it('tracks email sign-in Firebase failures and still shows the error toast', async () => {
@@ -346,6 +348,38 @@ describe('useAuthActions auth flow error telemetry', () => {
     expect(mockTrackAuthFailed).toHaveBeenCalledExactlyOnceWith({
       error_code: 'auth/popup-closed-by-user',
       auth_action: 'github_sign_up'
+    })
+  })
+
+  it('ignores the popup rejection when Desktop takes over social sign-in', async () => {
+    window.__comfyDesktop2 = { isRemote: () => false }
+    mockAuthStore.loginWithGoogle.mockRejectedValueOnce(
+      new FirebaseError(AuthErrorCodes.POPUP_BLOCKED, 'msg')
+    )
+    const { signInWithGoogle } = useAuthActions()
+
+    await expect(signInWithGoogle()).resolves.toBeUndefined()
+
+    expect(mockTrackAuthFailed).not.toHaveBeenCalled()
+    expect(mockToastStore.add).not.toHaveBeenCalled()
+  })
+
+  it('reports a real popup-blocked failure outside Desktop', async () => {
+    mockAuthStore.loginWithGoogle.mockRejectedValueOnce(
+      new FirebaseError(AuthErrorCodes.POPUP_BLOCKED, 'msg')
+    )
+    const { signInWithGoogle } = useAuthActions()
+
+    await expect(signInWithGoogle()).resolves.toBeUndefined()
+
+    expect(mockTrackAuthFailed).toHaveBeenCalledExactlyOnceWith({
+      error_code: AuthErrorCodes.POPUP_BLOCKED,
+      auth_action: 'google_sign_in'
+    })
+    expect(mockToastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'auth.errors.generic'
     })
   })
 

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -18,6 +18,14 @@ import { useAuthStore } from '@/stores/authStore'
 import type { BillingPortalTargetTier } from '@/stores/authStore'
 import { usdToMicros } from '@/utils/formatUtil'
 
+function isDesktopAuthPopupTakeover(error: unknown): boolean {
+  return (
+    window.__comfyDesktop2 !== undefined &&
+    error instanceof FirebaseError &&
+    error.code === AuthErrorCodes.POPUP_BLOCKED
+  )
+}
+
 /**
  * Service for Firebase Auth actions.
  * All actions are wrapped with error handling.
@@ -32,6 +40,8 @@ export const useAuthActions = () => {
 
   const reportAuthFlowError =
     (authAction: AuthFlowAction) => (error: unknown) => {
+      if (isDesktopAuthPopupTakeover(error)) return
+
       useTelemetry()?.trackAuthFailed({
         error_code: error instanceof FirebaseError ? error.code : 'unknown',
         auth_action: authAction


### PR DESCRIPTION
## Summary

Suppress the expected Firebase popup rejection when Desktop takes over social sign-in in the system browser.

## Changes

- **What**: At the existing auth error boundary, ignore `auth/popup-blocked` only when the typed `window.__comfyDesktop2` bridge is present.
- **Impact**: Desktop no longer shows the false sign-in error or records it as an auth failure. Browser sign-in still reports a real popup-blocked failure normally.

## Review Focus

Desktop deliberately denies the embedded Firebase popup before continuing the same sign-in in the system browser. This handles that expected rejection at its source instead of removing a rendered toast from the DOM.

This is separate from [#14317](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14317) and does not change approval-dialog timing, navigation, or redemption.

## Validation

- `pnpm test:unit src/composables/auth/useAuthActions.test.ts` (22 passed)
- file-scoped ESLint
- file-scoped oxfmt check
- `git diff --check`