### PR TITLE
fix: restart timed-out billing operations

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -265,6 +265,22 @@ const PAYMENT_METHOD_REQUIRED_RESPONSE = {
   payment_method_url: 'https://pay.test/method'
 } satisfies SubscribeResponse
 
+const RETRIED_SUBSCRIPTION_OPERATION_ID = 'retried-subscription'
+const RETRIED_SUBSCRIPTION_ACTION_URL =
+  'https://verify.example/retried-subscription'
+
+const RETRIED_SUBSCRIPTION_RESPONSE = {
+  billing_op_id: RETRIED_SUBSCRIPTION_OPERATION_ID,
+  status: 'needs_payment_method',
+  payment_method_url: 'https://pay.test/retried-subscription'
+} satisfies SubscribeResponse
+
+const RETRIED_SUBSCRIPTION_OPERATION = {
+  id: RETRIED_SUBSCRIPTION_OPERATION_ID,
+  status: 'pending',
+  started_at: '2026-07-30T00:00:00Z'
+} satisfies BillingOpStatusResponse
+
 const UNEXPECTED_OPERATION_RESPONSE = {
   id: PAYMENT_METHOD_REQUIRED_RESPONSE.billing_op_id,
   status: 'failed',
@@ -572,6 +588,80 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     ).toBeVisible()
     expect(subscribeRequests).toHaveLength(0)
     await expect(page).not.toHaveURL(/[?&](pricing|cycle)=/)
+  })
+
+  test('restores pending checkout when retrying a timed-out operation', async ({
+    page
+  }) => {
+    const subscribeRequests: Request[] = []
+    const operationPollRequests: Request[] = []
+    await page.addInitScript(() => {
+      window.open = () => window
+    })
+    await setupCloudApp(page, workspace('personal', 'owner'), [])
+    await page.route('**/api/billing/status', (route) =>
+      route.fulfill(jsonRoute(LEGACY_ACTIVE_STANDARD_STATUS))
+    )
+    await page.route('**/api/billing/plans', (route) =>
+      route.fulfill(
+        jsonRoute({
+          plans: [CREATOR_ANNUAL_PLAN]
+        } satisfies BillingPlansResponse)
+      )
+    )
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(NEW_CREATOR_SUBSCRIPTION))
+    )
+    await page.route('**/api/billing/subscribe', (route) => {
+      subscribeRequests.push(route.request())
+      return route.fulfill(jsonRoute(RETRIED_SUBSCRIPTION_RESPONSE))
+    })
+    await page.route(
+      `**/api/billing/ops/${RETRIED_SUBSCRIPTION_OPERATION_ID}`,
+      (route) => {
+        operationPollRequests.push(route.request())
+        return route.fulfill(
+          jsonRoute({
+            ...RETRIED_SUBSCRIPTION_OPERATION,
+            ...(subscribeRequests.length > 1 && {
+              action_url: RETRIED_SUBSCRIPTION_ACTION_URL
+            })
+          } satisfies BillingOpStatusResponse)
+        )
+      }
+    )
+
+    await page.goto(`${APP_URL}/?pricing=creator&cycle=yearly`)
+
+    const subscribeButton = page.getByRole('button', {
+      name: 'Subscribe to Creator'
+    })
+    const backButton = page.getByRole('button', { name: 'Back', exact: true })
+    await cloudAppExpect(subscribeButton).toBeVisible()
+    await page.clock.install({ time: new Date('2026-07-30T00:00:00Z') })
+    await subscribeButton.click()
+    await expect.poll(() => subscribeRequests.length).toBe(1)
+    await expect.poll(() => operationPollRequests.length).toBeGreaterThan(0)
+    await expect(backButton).toBeDisabled()
+
+    await page.clock.fastForward(5 * 60_000 + 1)
+
+    await expect(backButton).toBeEnabled()
+    await expect(
+      page.getByText('Subscription verification timed out', { exact: true })
+    ).toBeVisible()
+    const pollCountAfterTimeout = operationPollRequests.length
+
+    await subscribeButton.click()
+
+    await expect.poll(() => subscribeRequests.length).toBe(2)
+    await expect(backButton).toBeDisabled()
+    await expect
+      .poll(() => operationPollRequests.length)
+      .toBeGreaterThan(pollCountAfterTimeout)
+    await expect(
+      page.getByRole('button', { name: 'Complete verification' })
+    ).toBeVisible()
   })
 
   test('cleans orphaned pricing params without opening the table', async ({

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -497,6 +497,32 @@ describe('billingOperationStore', () => {
       expect(store.getOperation('op-1')?.status).toBe('timeout')
     })
 
+    it('restarts a subscription operation after a polling timeout', async () => {
+      let status: 'pending' | 'succeeded' = 'pending'
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementation(
+        async () => ({
+          id: 'op-1',
+          status,
+          started_at: new Date().toISOString()
+        })
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 8001)
+      expect(store.getOperation('op-1')?.status).toBe('timeout')
+
+      status = 'succeeded'
+      const retry = store.startOperation('op-1', 'subscription')
+
+      expect(store.getOperation('op-1')?.status).toBe('pending')
+      expect(store.isSettingUp).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect((await retry).status).toBe('succeeded')
+    })
+
     it('allows five minutes to discover a subscription action', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -108,9 +108,10 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     initialActionUrl?: string
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
-    if (existing) {
+    if (existing && existing.status !== 'timeout') {
       return terminalPromises.get(opId) ?? Promise.resolve(existing)
     }
+    if (existing) clearOperation(opId)
 
     const actionUrl = validateActionUrl(initialActionUrl)
     const operation: BillingOperation = {


### PR DESCRIPTION
## Why this is needed

A 3DS/SCA subscription can spend up to five minutes waiting for the billing operation to expose its verification action. If that discovery window timed out, retrying **Subscribe** opened checkout again but left the confirmation dialog idle: the pending/loading state did not return, polling did not restart, and **Complete verification** could not appear until the page was refreshed.

This matches the [QA report in Slack](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785428216929989?thread_ts=1785373105.971169&cid=C0932CGKT5K).

## Root cause

`billingOperationStore.startOperation()` deduplicated every previously-seen operation ID. After the five-minute poll timeout, the timed-out operation stayed cached. The backend intentionally replayed the same billing operation ID on checkout retry, so the store returned that cached terminal operation instead of creating a new pending operation and polling it again.

## Regression assessment

This is a regression in the new 3DS/SCA retry flow added by #14242. The operation-ID deduplication predates that change and remains correct for in-flight and completed operations, but the newly introduced five-minute action-discovery timeout made a terminal `timeout` operation retryable. That state was not covered by the original browser scenarios.

## How this changes

- Treat only cached `timeout` operations as restartable.
- Clear the timed-out operation's stale promise/timer bookkeeping before recreating it as pending.
- Preserve existing deduplication for pending, succeeded, and failed operations.
- Restart polling immediately when the backend replays the same operation ID, restoring checkout loading state and allowing **Complete verification** to appear without a refresh.

## Tests

- **Unit regression:** timeout → retry same operation ID → pending/loading restored → polling succeeds.
- **E2E regression:** real checkout dialog → five-minute timeout via Playwright Clock → retry same operation ID → pending UI disabled state returns → polling restarts → **Complete verification** appears.
- The E2E test fails on the pre-fix implementation because the dialog remains idle, no second operation poll occurs, and the verification action stays hidden.

## AS IS

After timeout and retry, checkout remains idle with **Subscribe to Creator** still available. The timeout toast remains, no loading state starts, and there is no **Complete verification** action.

![AS IS — retry does not restart pending checkout](https://ampcode.com/user-content/artifacts/fca7fe5f36b4b62bd8732168de6904ce951551d4563d1eadff6c0b61db7a8ba1-file.png)

## TO BE

Retrying the same backend operation ID recreates the pending operation. The CTA returns to loading, polling resumes, and the verification action appears as soon as the operation exposes its action URL.

![TO BE — retry restores pending checkout and verification](https://ampcode.com/user-content/artifacts/8a56191138f59c77748e1e4e77440cd16d79ed2089db52e2ccf9bb229bde7793-file.png)

### Retry flow

![Timeout to retry to Complete verification](https://ampcode.com/user-content/artifacts/75b7eff15b564abde3b9a1155f9c847fc1778722263d6c205b71aa293ca5bd2c-file.gif)

## Review focus

The retry boundary in `startOperation()`: only timed-out operations are restarted; pending and other terminal operation deduplication is unchanged.
