### PR TITLE
fix: direct Team plan requests to support form

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -543,7 +543,7 @@ describe('MembersPanelContent', () => {
   })
 
   describe('contact us footer', () => {
-    it('opens discord in a new tab on a Team plan', async () => {
+    it('opens the Team plan request form in a new tab', async () => {
       const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
       renderComponent()
       expect(
@@ -553,7 +553,7 @@ describe('MembersPanelContent', () => {
         screen.getByText('workspacePanel.members.contactUs')
       )
       expect(openSpy).toHaveBeenCalledWith(
-        'https://discord.com/invite/comfyorg',
+        'https://comfy-org.portal.usepylon.com/forms/team-plan-requests',
         '_blank',
         'noopener,noreferrer'
       )

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -221,13 +221,15 @@
 <script setup lang="ts">
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
-import { useExternalLink } from '@/composables/useExternalLink'
 import MemberListItem from '@/platform/workspace/components/dialogs/settings/MemberListItem.vue'
 import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue'
 import PendingInvitesList from '@/platform/workspace/components/dialogs/settings/PendingInvitesList.vue'
 import WorkspaceMenuButton from '@/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue'
 import { useMembersPanel } from '@/platform/workspace/composables/useMembersPanel'
 import { cn } from '@comfyorg/tailwind-utils'
+
+const TEAM_PLAN_REQUEST_URL =
+  'https://comfy-org.portal.usepylon.com/forms/team-plan-requests'
 
 const {
   searchQuery,
@@ -260,9 +262,7 @@ const {
   handleRevokeInvite
 } = useMembersPanel()
 
-const { staticUrls } = useExternalLink()
-
 function handleContactUs() {
-  window.open(staticUrls.discord, '_blank', 'noopener,noreferrer')
+  window.open(TEAM_PLAN_REQUEST_URL, '_blank', 'noopener,noreferrer')
 }
 </script>


### PR DESCRIPTION
## Summary

Directs the Team plan members footer to the dedicated Pylon request form instead of Discord.

## Changes

- **What**: Update Settings → Members → Contact us to open the Team plan request form and cover the behavior with the existing component test.

## Review Focus

Confirm the Team-only footer opens the requested external form in a new tab.

## Screenshots

### AS IS

[Screen recording: Contact us opens Discord](https://comfy-organization.slack.com/archives/C0BEE5503RQ/p1785434393590089)

### TO BE

Contact us opens the dedicated Team Plan Requests form.

![Team Plan Requests form](https://ampcode.com/user-content/attachments/96066e5a9b6dbc8ec2a2dcea4b4ad88632b5256bbe44b8261e342bf2a0efeec3-file.png)
