### PR TITLE
fix(glsl): render all live previews through one shared WebGL context

### DIFF
--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -34,6 +34,7 @@ const mockRenderer = vi.hoisted(() => {
       setBoolUniform: vi.fn(),
       bindCurveTexture: vi.fn(),
       bindInputImage: vi.fn(),
+      isContextLost: vi.fn(() => false),
       render: vi.fn(),
       toBlob: vi.fn(() => Promise.resolve(new Blob(['x']))),
       dispose: vi.fn()

--- a/src/renderer/glsl/sharedGLContext.test.ts
+++ b/src/renderer/glsl/sharedGLContext.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { acquireSharedGL } from '@/renderer/glsl/sharedGLContext'
+
+interface MockGL {
+  getExtension: ReturnType<typeof vi.fn>
+  pixelStorei: ReturnType<typeof vi.fn>
+  isContextLost: ReturnType<typeof vi.fn>
+}
+
+let mockGL: MockGL
+let loseContext: ReturnType<typeof vi.fn>
+let getContextCalls: number
+
+function createMockGL(): MockGL {
+  return {
+    getExtension: vi.fn((name: string) => {
+      if (name === 'EXT_color_buffer_float') return {}
+      if (name === 'WEBGL_lose_context') return { loseContext }
+      return null
+    }),
+    pixelStorei: vi.fn(),
+    isContextLost: vi.fn(() => false)
+  }
+}
+
+vi.stubGlobal(
+  'OffscreenCanvas',
+  class {
+    width: number
+    height: number
+    constructor(w: number, h: number) {
+      this.width = w
+      this.height = h
+    }
+    getContext(contextId: string) {
+      if (contextId !== 'webgl2') return null
+      getContextCalls++
+      return mockGL as unknown as WebGL2RenderingContext
+    }
+  }
+)
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('acquireSharedGL', () => {
+  beforeEach(() => {
+    loseContext = vi.fn()
+    mockGL = createMockGL()
+    getContextCalls = 0
+  })
+
+  it('returns the same context for concurrent holders', () => {
+    const a = acquireSharedGL()
+    const b = acquireSharedGL()
+
+    expect(a).not.toBeNull()
+    expect(b?.gl).toBe(a?.gl)
+    expect(b?.canvas).toBe(a?.canvas)
+    expect(getContextCalls).toBe(1)
+
+    a?.release()
+    b?.release()
+  })
+
+  it('destroys the context only when the last holder releases', () => {
+    const a = acquireSharedGL()
+    const b = acquireSharedGL()
+
+    a?.release()
+    expect(loseContext).not.toHaveBeenCalled()
+
+    b?.release()
+    expect(loseContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores repeated release of the same handle', () => {
+    const a = acquireSharedGL()
+    const b = acquireSharedGL()
+
+    a?.release()
+    a?.release()
+    expect(loseContext).not.toHaveBeenCalled()
+
+    b?.release()
+    expect(loseContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates a fresh context after full release', () => {
+    const a = acquireSharedGL()
+    a?.release()
+
+    const b = acquireSharedGL()
+    expect(b).not.toBeNull()
+    expect(getContextCalls).toBe(2)
+
+    b?.release()
+  })
+
+  it('replaces a lost context on the next acquire', () => {
+    const a = acquireSharedGL()
+    mockGL.isContextLost.mockReturnValue(true)
+
+    const freshGL = createMockGL()
+    const staleGL = mockGL
+    mockGL = freshGL
+    const b = acquireSharedGL()
+
+    expect(b).not.toBeNull()
+    expect(b?.gl).not.toBe(staleGL)
+    expect(getContextCalls).toBe(2)
+
+    a?.release()
+    b?.release()
+  })
+
+  it('returns null when webgl2 is unavailable', () => {
+    const savedGL = mockGL
+    mockGL = null as unknown as MockGL
+    expect(acquireSharedGL()).toBeNull()
+    mockGL = savedGL
+  })
+
+  it('loses the context and returns null when EXT_color_buffer_float is missing', () => {
+    mockGL.getExtension = vi.fn((name: string) =>
+      name === 'WEBGL_lose_context' ? { loseContext } : null
+    )
+    expect(acquireSharedGL()).toBeNull()
+    expect(loseContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets UNPACK_FLIP_Y_WEBGL once at context creation', () => {
+    const a = acquireSharedGL()
+    const b = acquireSharedGL()
+
+    expect(mockGL.pixelStorei).toHaveBeenCalledTimes(1)
+
+    a?.release()
+    b?.release()
+  })
+})

--- a/src/renderer/glsl/sharedGLContext.ts
+++ b/src/renderer/glsl/sharedGLContext.ts
@@ -1,0 +1,58 @@
+export interface SharedGLHandle {
+  canvas: OffscreenCanvas
+  gl: WebGL2RenderingContext
+  release: () => void
+}
+
+interface SharedGL {
+  canvas: OffscreenCanvas
+  gl: WebGL2RenderingContext
+  refs: number
+}
+
+let current: SharedGL | null = null
+
+function loseContext(gl: WebGL2RenderingContext): void {
+  gl.getExtension('WEBGL_lose_context')?.loseContext()
+}
+
+function createSharedGL(): SharedGL | null {
+  const canvas = new OffscreenCanvas(1, 1)
+  const gl = canvas.getContext('webgl2', {
+    alpha: true,
+    premultipliedAlpha: false,
+    preserveDrawingBuffer: true
+  })
+  if (!gl) return null
+
+  if (!gl.getExtension('EXT_color_buffer_float')) {
+    loseContext(gl)
+    return null
+  }
+
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
+  return { canvas, gl, refs: 0 }
+}
+
+export function acquireSharedGL(): SharedGLHandle | null {
+  if (current?.gl.isContextLost()) current = null
+
+  current ??= createSharedGL()
+  if (!current) return null
+
+  const entry = current
+  entry.refs++
+  let released = false
+  return {
+    canvas: entry.canvas,
+    gl: entry.gl,
+    release() {
+      if (released) return
+      released = true
+      entry.refs--
+      if (entry.refs > 0) return
+      if (current === entry) current = null
+      loseContext(entry.gl)
+    }
+  }
+}

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -24,6 +24,7 @@ const mockRendererFactory = vi.hoisted(() => {
   const bindCurveTexture = vi.fn()
   const bindInputImage = vi.fn()
   const clearInputImage = vi.fn()
+  const isContextLost = vi.fn(() => false)
   const render = vi.fn()
   const toBlob = vi.fn(() => Promise.resolve(new Blob(['test'])))
   const dispose = vi.fn()
@@ -42,6 +43,7 @@ const mockRendererFactory = vi.hoisted(() => {
         bindCurveTexture,
         bindInputImage,
         clearInputImage,
+        isContextLost,
         render,
         toBlob,
         dispose
@@ -57,6 +59,7 @@ const mockRendererFactory = vi.hoisted(() => {
     bindCurveTexture,
     bindInputImage,
     clearInputImage,
+    isContextLost,
     render,
     toBlob,
     dispose
@@ -293,6 +296,25 @@ describe('useGLSLPreview', () => {
       const toBlobOrder = mockRendererFactory.toBlob.mock.invocationCallOrder[0]
       expect(compileOrder).toBeLessThan(renderOrder)
       expect(renderOrder).toBeLessThan(toBlobOrder)
+    })
+
+    it('recreates the renderer when its context was lost', async () => {
+      const node = createMockNode()
+      await setupAndRender(node)
+      expect(mockRendererFactory.init).toHaveBeenCalledTimes(1)
+
+      mockRendererFactory.isContextLost.mockReturnValueOnce(true)
+      delete mockNodeOutputs['1']
+      await nextTick()
+      mockNodeOutputs['1'] = {
+        images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
+      }
+      await nextTick()
+      vi.advanceTimersByTime(100)
+      for (let i = 0; i < 5; i++) await nextTick()
+
+      expect(mockRendererFactory.dispose).toHaveBeenCalledTimes(1)
+      expect(mockRendererFactory.init).toHaveBeenCalledTimes(2)
     })
 
     it('binds a resolved image to its original slot when an earlier slot is unresolved', async () => {

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -356,6 +356,11 @@ function createInnerPreview(
 
   function ensureRenderer(): ReturnType<typeof useGLSLRenderer> {
     const config = rendererConfig.value
+    if (renderer?.isContextLost()) {
+      renderer.dispose()
+      renderer = null
+      rendererReady = false
+    }
     if (renderer && lastRendererConfig) {
       const changed =
         config.maxInputs !== lastRendererConfig.maxInputs ||

--- a/src/renderer/glsl/useGLSLRenderer.test.ts
+++ b/src/renderer/glsl/useGLSLRenderer.test.ts
@@ -70,6 +70,7 @@ interface MockGL {
   disable: ReturnType<typeof vi.fn>
   clearColor: ReturnType<typeof vi.fn>
   clear: ReturnType<typeof vi.fn>
+  isContextLost: ReturnType<typeof vi.fn>
   [key: string]: unknown
 }
 
@@ -146,7 +147,8 @@ function createMockGLContext(): MockGL {
     clearColor: vi.fn(),
     clear: vi.fn(),
 
-    getExtension: vi.fn().mockReturnValue({ loseContext: vi.fn() })
+    getExtension: vi.fn().mockReturnValue({ loseContext: vi.fn() }),
+    isContextLost: vi.fn().mockReturnValue(false)
   }
 }
 
@@ -271,6 +273,7 @@ describe('useGLSLRenderer', () => {
         .mockReturnValueOnce(false)
       mockGL.getShaderInfoLog.mockReturnValue('ERROR: syntax error')
 
+      renderer.dispose()
       renderer = useGLSLRenderer()
       renderer.init(128, 128)
       const result = renderer.compileFragment(validSource)
@@ -585,6 +588,7 @@ describe('useGLSLRenderer', () => {
     })
 
     it('does nothing without a compiled program', () => {
+      renderer.dispose()
       renderer = useGLSLRenderer()
       renderer.init(128, 128)
       mockGL.drawArrays.mockClear()
@@ -622,6 +626,67 @@ describe('useGLSLRenderer', () => {
       await expect(renderer.toBlob()).rejects.toThrow(
         'Renderer not initialized'
       )
+    })
+  })
+
+  describe('shared context', () => {
+    it('reuses one context across renderer instances', () => {
+      renderer = useGLSLRenderer()
+      renderer.init(64, 64)
+      const second = useGLSLRenderer()
+      second.init(64, 64)
+
+      expect(mockGL.pixelStorei).toHaveBeenCalledWith(
+        mockGL.UNPACK_FLIP_Y_WEBGL,
+        true
+      )
+      expect(mockGL.pixelStorei).toHaveBeenCalledTimes(1)
+
+      second.dispose()
+    })
+
+    it('restores its own canvas size and viewport before rendering', () => {
+      renderer = useGLSLRenderer()
+      renderer.init(128, 128)
+      renderer.compileFragment(validSource)
+
+      const second = useGLSLRenderer()
+      second.init(256, 256)
+
+      mockGL.viewport.mockClear()
+      renderer.render()
+
+      expect(mockGL.viewport).toHaveBeenCalledWith(0, 0, 128, 128)
+      expect(mockGL.uniform2f).toHaveBeenCalledWith('u_resolution', 128, 128)
+
+      second.dispose()
+    })
+
+    it('reports context loss from the shared context', () => {
+      renderer = useGLSLRenderer()
+      expect(renderer.isContextLost()).toBe(false)
+
+      renderer.init(64, 64)
+      expect(renderer.isContextLost()).toBe(false)
+
+      mockGL.isContextLost.mockReturnValue(true)
+      expect(renderer.isContextLost()).toBe(true)
+    })
+
+    it('keeps the context alive until the last renderer disposes', () => {
+      const loseContext = vi.fn()
+      mockGL.getExtension.mockReturnValue({ loseContext })
+
+      renderer = useGLSLRenderer()
+      renderer.init(64, 64)
+      const second = useGLSLRenderer()
+      second.init(64, 64)
+
+      renderer.dispose()
+      expect(loseContext).not.toHaveBeenCalled()
+
+      second.dispose()
+      expect(loseContext).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/renderer/glsl/useGLSLRenderer.ts
+++ b/src/renderer/glsl/useGLSLRenderer.ts
@@ -1,4 +1,7 @@
 import { detectPassCount } from '@/renderer/glsl/glslUtils'
+import { acquireSharedGL } from '@/renderer/glsl/sharedGLContext'
+
+import type { SharedGLHandle } from '@/renderer/glsl/sharedGLContext'
 
 const VERTEX_SHADER_SOURCE = `#version 300 es
 out vec2 v_texCoord;
@@ -70,6 +73,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     ...Array.from({ length: maxCurves }, (_, i) => `u_curve${i}`)
   ]
 
+  let sharedGL: SharedGLHandle | null = null
   let canvas: OffscreenCanvas | null = null
   let gl: WebGL2RenderingContext | null = null
   let vertexShader: WebGLShader | null = null
@@ -88,6 +92,8 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
   let passCount = 1
   let disposed = false
   let lastCompiledSource: string | null = null
+  let fboWidth = 0
+  let fboHeight = 0
 
   function initPingPongFBOs(
     ctx: WebGL2RenderingContext,
@@ -195,21 +201,20 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     if (disposed) return false
 
     try {
-      canvas = new OffscreenCanvas(width, height)
-      const ctx = canvas.getContext('webgl2', {
-        alpha: true,
-        premultipliedAlpha: false,
-        preserveDrawingBuffer: true
-      })
-      if (!ctx) return false
+      sharedGL = acquireSharedGL()
+      if (!sharedGL) return false
 
-      gl = ctx
+      canvas = sharedGL.canvas
+      gl = sharedGL.gl
 
-      if (!gl.getExtension('EXT_color_buffer_float')) return false
+      canvas.width = width
+      canvas.height = height
+      gl.viewport(0, 0, width, height)
 
-      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)
       vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE)
       initPingPongFBOs(gl, width, height)
+      fboWidth = width
+      fboHeight = height
       return true
     } catch {
       dispose()
@@ -267,9 +272,13 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     if (canvas.width !== width || canvas.height !== height) {
       canvas.width = width
       canvas.height = height
-      gl.viewport(0, 0, width, height)
+    }
+    gl.viewport(0, 0, width, height)
+    if (fboWidth !== width || fboHeight !== height) {
       destroyPingPongFBOs()
       initPingPongFBOs(gl, width, height)
+      fboWidth = width
+      fboHeight = height
     }
   }
 
@@ -376,8 +385,18 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     }
   }
 
+  function isContextLost(): boolean {
+    return gl?.isContextLost() ?? false
+  }
+
   function render(): void {
     if (disposed || !program || !pingPongFBOs || !gl || !canvas) return
+
+    if (canvas.width !== fboWidth || canvas.height !== fboHeight) {
+      canvas.width = fboWidth
+      canvas.height = fboHeight
+    }
+    gl.viewport(0, 0, fboWidth, fboHeight)
 
     gl.useProgram(program)
     gl.disable(gl.BLEND)
@@ -491,8 +510,10 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
 
     uniformLocations.clear()
 
-    const ext = gl.getExtension('WEBGL_lose_context')
-    ext?.loseContext()
+    sharedGL?.release()
+    sharedGL = null
+    gl = null
+    canvas = null
   }
 
   return {
@@ -505,6 +526,7 @@ export function useGLSLRenderer(config: GLSLRendererConfig = DEFAULT_CONFIG) {
     bindCurveTexture,
     bindInputImage,
     clearInputImage,
+    isContextLost,
     render,
     readPixels,
     toBlob,


### PR DESCRIPTION
## Summary
Each GLSL preview node created its own OffscreenCanvas WebGL2 context. Browsers cap a page at ~16 live WebGL contexts and silently evict the oldest past the cap: isContextLost() turns true, no contextlost event fires for the OffscreenCanvas, and that node preview freezes with no recovery. 
Reproduced with 18 GLSL nodes: the 2 oldest contexts were evicted and stopped producing frames.

All renderers now draw through a single ref-counted shared context (same pattern as renderer/three/sharedWebGLRenderer), destroyed when the last renderer disposes and recreated if the browser loses it.
Renderers keep owning their programs, textures, and ping-pong FBOs; the canvas and viewport are re-applied per frame since other renderers resize them between frames. Interleaving is safe because each render pass stays within one synchronous block through the convertToBlob call, which snapshots the bitmap synchronously.
