### PR TITLE
refactor: model billing operations as an xstate machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "vue-router": "catalog:",
     "vuefire": "catalog:",
     "wwobjloader2": "catalog:",
+    "xstate": "catalog:",
     "yjs": "catalog:",
     "zod": "catalog:",
     "zod-validation-error": "catalog:"
@@ -164,6 +165,7 @@
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "@webgpu/types": "catalog:",
+    "@xstate/graph": "catalog:",
     "cross-env": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ catalogs:
     '@webgpu/types':
       specifier: ^0.1.66
       version: 0.1.71
+    '@xstate/graph':
+      specifier: ^3.0.4
+      version: 3.0.4
     algoliasearch:
       specifier: ^5.21.0
       version: 5.56.0
@@ -417,6 +420,9 @@ catalogs:
     wwobjloader2:
       specifier: ^6.2.1
       version: 6.2.1
+    xstate:
+      specifier: ^5.32.5
+      version: 5.32.5
     yjs:
       specifier: ^13.6.27
       version: 13.6.31
@@ -657,6 +663,9 @@ importers:
       wwobjloader2:
         specifier: 'catalog:'
         version: 6.2.1(three@0.184.0)
+      xstate:
+        specifier: 'catalog:'
+        version: 5.32.5
       yjs:
         specifier: 'catalog:'
         version: 13.6.31
@@ -742,6 +751,9 @@ importers:
       '@webgpu/types':
         specifier: 'catalog:'
         version: 0.1.71
+      '@xstate/graph':
+        specifier: 'catalog:'
+        version: 3.0.4(xstate@5.32.5)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -4816,6 +4828,11 @@ packages:
 
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
+  '@xstate/graph@3.0.4':
+    resolution: {integrity: sha512-b12RA7E//+7FJVrD09Td+BhHRJbeKZnK+98xXBd+JmccG360xVP1lyzVhUZPgBgwPdmIGBJqhKzmWYJQ9c8ojQ==}
+    peerDependencies:
+      xstate: ^5.19.4
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
@@ -9514,6 +9531,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xstate@5.32.5:
+    resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -13295,6 +13315,10 @@ snapshots:
   '@webgpu/types@0.1.71': {}
 
   '@xstate/fsm@1.6.5': {}
+
+  '@xstate/graph@3.0.4(xstate@5.32.5)':
+    dependencies:
+      xstate: 5.32.5
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
@@ -19009,6 +19033,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xstate@5.32.5: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,6 +72,7 @@ catalog:
   '@vueuse/core': ^14.3.0
   '@vueuse/integrations': ^14.3.0
   '@webgpu/types': ^0.1.66
+  '@xstate/graph': ^3.0.4
   algoliasearch: ^5.21.0
   astro: ^6.4.2
   axios: ^1.15.2
@@ -149,6 +150,7 @@ catalog:
   vue-tsc: ^3.3.7
   vuefire: ^3.2.1
   wwobjloader2: ^6.2.1
+  xstate: ^5.32.5
   yjs: ^13.6.27
   zod: ^3.23.8
   zod-to-json-schema: ^3.24.1

--- a/src/platform/workspace/machines/billingOperationActions.ts
+++ b/src/platform/workspace/machines/billingOperationActions.ts
@@ -1,0 +1,41 @@
+import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
+
+import type { BillingOperationContext } from './billingOperationContext'
+import {
+  ACTION_REQUIRED_INTERVAL_MS,
+  BACKOFF_MULTIPLIER,
+  MAX_INTERVAL_MS,
+  validateActionUrl
+} from './billingOperationContext'
+
+/**
+ * Backoff applies only until an action URL has been seen. From then on the
+ * operation is waiting on a person rather than on the backend, so it settles
+ * into a flat, slower cadence.
+ */
+export function nextIntervalMs(context: BillingOperationContext): number {
+  if (context.authenticationRequiredSeen) return ACTION_REQUIRED_INTERVAL_MS
+  return Math.min(context.intervalMs * BACKOFF_MULTIPLIER, MAX_INTERVAL_MS)
+}
+
+/**
+ * `authenticationRequiredSeen` is sticky: a withdrawn action URL does not
+ * return the operation to the short discovery budget.
+ */
+export function recordActionUrl(
+  context: BillingOperationContext,
+  response: BillingOpStatusResponse
+): Pick<BillingOperationContext, 'actionUrl' | 'authenticationRequiredSeen'> {
+  const actionUrl = validateActionUrl(response.action_url)
+  return {
+    actionUrl,
+    authenticationRequiredSeen:
+      context.authenticationRequiredSeen || actionUrl !== null
+  }
+}
+
+export function recordFailure(
+  response: BillingOpStatusResponse
+): Pick<BillingOperationContext, 'backendErrorMessage'> {
+  return { backendErrorMessage: response.error_message ?? null }
+}

--- a/src/platform/workspace/machines/billingOperationContext.ts
+++ b/src/platform/workspace/machines/billingOperationContext.ts
@@ -1,0 +1,47 @@
+export const INITIAL_INTERVAL_MS = 1000
+export const MAX_INTERVAL_MS = 8000
+export const ACTION_REQUIRED_INTERVAL_MS = 30_000
+export const BACKOFF_MULTIPLIER = 1.5
+export const TIMEOUT_MS = 120_000
+export const SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS = 5 * 60_000
+export const SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS = 23 * 60 * 60_000
+
+export type BillingOperationType = 'subscription' | 'topup' | 'cancel'
+
+export interface BillingOperationContext {
+  opId: string
+  type: BillingOperationType
+  workspaceId: string | null
+  startedAt: number
+  intervalMs: number
+  actionUrl: string | null
+  authenticationRequiredSeen: boolean
+  backendErrorMessage: string | null
+  /**
+   * Injected so the budget can be driven without fake timers. Production
+   * passes Date.now.
+   */
+  readNow: () => number
+}
+
+export interface BillingOperationInput {
+  opId: string
+  type: BillingOperationType
+  workspaceId: string | null
+  startedAt: number
+  initialActionUrl?: string
+  readNow?: () => number
+}
+
+/**
+ * Only https action URLs are surfaced. Anything else is discarded rather than
+ * shown, so a downgraded scheme cannot be presented as a payment link.
+ */
+export function validateActionUrl(value: string | undefined): string | null {
+  if (!value) return null
+  try {
+    return new URL(value).protocol === 'https:' ? value : null
+  } catch {
+    return null
+  }
+}

--- a/src/platform/workspace/machines/billingOperationGuards.ts
+++ b/src/platform/workspace/machines/billingOperationGuards.ts
@@ -1,0 +1,36 @@
+import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
+
+import type { BillingOperationContext } from './billingOperationContext'
+import {
+  SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS,
+  SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS,
+  TIMEOUT_MS
+} from './billingOperationContext'
+
+/**
+ * A subscription gets a short window to produce a payment action, then a long
+ * one to let a person complete it. Everything else gets a single flat budget.
+ */
+export function timeoutBudgetMs(
+  operation: Pick<
+    BillingOperationContext,
+    'type' | 'authenticationRequiredSeen'
+  >
+): number {
+  if (operation.type !== 'subscription') return TIMEOUT_MS
+  return operation.authenticationRequiredSeen
+    ? SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS
+    : SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS
+}
+
+export function hasTimedOut(context: BillingOperationContext): boolean {
+  return context.readNow() - context.startedAt > timeoutBudgetMs(context)
+}
+
+export function isSucceeded(response: BillingOpStatusResponse): boolean {
+  return response.status === 'succeeded'
+}
+
+export function isFailed(response: BillingOpStatusResponse): boolean {
+  return response.status === 'failed'
+}

--- a/src/platform/workspace/machines/billingOperationMachine.test.ts
+++ b/src/platform/workspace/machines/billingOperationMachine.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Model-based tests for billingOperationMachine.
+ *
+ * Instead of enumerating scenarios by hand, these generate every path the state
+ * graph admits from a declared response space, then assert invariants at every
+ * state each path visits. Hand-written tests cover the paths someone thought
+ * of; these cover the paths the machine actually has.
+ *
+ * `createTestModel` rejects machines containing `invoke`, so paths come from
+ * `getShortestPaths` and are walked directly.
+ */
+import { getShortestPaths } from '@xstate/graph'
+import { describe, expect, it } from 'vitest'
+import type { SnapshotFrom } from 'xstate'
+
+import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
+
+import type {
+  BillingOperationInput,
+  BillingOperationType
+} from './billingOperationContext'
+import {
+  ACTION_REQUIRED_INTERVAL_MS,
+  INITIAL_INTERVAL_MS,
+  MAX_INTERVAL_MS
+} from './billingOperationContext'
+import { timeoutBudgetMs } from './billingOperationGuards'
+import { billingOperationMachine } from './billingOperationMachine'
+
+const ACTION_URL = 'https://verify.example/token'
+const STARTED_AT = 1_000_000
+const DAY_MS = 24 * 60 * 60_000
+
+const WAITING_NODE_ID = billingOperationMachine.states.polling.states.waiting.id
+const POLL_ELAPSED = `xstate.after.pollDelay.${WAITING_NODE_ID}`
+const FETCH_DONE = 'xstate.done.actor.fetchStatus'
+const FETCH_ERROR = 'xstate.error.actor.fetchStatus'
+
+const OPERATION_TYPES: BillingOperationType[] = [
+  'subscription',
+  'topup',
+  'cancel'
+]
+
+type BillingOperationSnapshot = SnapshotFrom<typeof billingOperationMachine>
+
+function response(
+  overrides: Partial<BillingOpStatusResponse> = {}
+): BillingOpStatusResponse {
+  return {
+    id: 'op-1',
+    status: 'pending',
+    started_at: new Date(STARTED_AT).toISOString(),
+    ...overrides
+  }
+}
+
+/**
+ * The response space a poll can return. Traversal fans out over all of these at
+ * every `requesting` state, so response and machine state are explored in
+ * combination rather than sampled.
+ */
+const EXPLORED_EVENTS = [
+  ...[
+    response(),
+    response({ action_url: ACTION_URL }),
+    response({ action_url: 'http://verify.example/token' }),
+    response({ status: 'succeeded' }),
+    response({ status: 'failed', error_message: 'card declined' })
+  ].map((output) => ({ type: FETCH_DONE, output })),
+  { type: FETCH_ERROR, error: new Error('network') },
+  { type: POLL_ELAPSED }
+]
+
+interface ModelOptions {
+  now: number
+  type?: BillingOperationType
+  workspaceInactive?: boolean
+  initialActionUrl?: string
+}
+
+function pathsFor(options: ModelOptions) {
+  const machine = billingOperationMachine.provide({
+    guards: { isWorkspaceInactive: () => options.workspaceInactive ?? false }
+  })
+  const input: BillingOperationInput = {
+    opId: 'op-1',
+    type: options.type ?? 'subscription',
+    workspaceId: 'workspace-1',
+    startedAt: STARTED_AT,
+    initialActionUrl: options.initialActionUrl,
+    readNow: () => options.now
+  }
+  return getShortestPaths(machine, {
+    events: EXPLORED_EVENTS,
+    limit: 500,
+    input
+  })
+}
+
+/** Time never advances, so the budget is never exhausted. */
+const withinBudget: ModelOptions = { now: STARTED_AT }
+/** Time is far past any budget, so every evaluation is overdue. */
+const pastBudget: ModelOptions = { now: STARTED_AT + DAY_MS }
+
+function assertInvariants(snapshot: BillingOperationSnapshot) {
+  const { context } = snapshot
+
+  const isTerminal =
+    snapshot.matches('succeeded') ||
+    snapshot.matches('failed') ||
+    snapshot.matches('timedOut')
+
+  if (isTerminal) {
+    // The original store maintained this by hand on every terminal write.
+    expect(context.actionUrl).toBeNull()
+    return
+  }
+
+  // An action URL can only be present once authentication has been seen, and
+  // seeing it pins the cadence instead of letting backoff continue.
+  if (context.authenticationRequiredSeen) {
+    expect([INITIAL_INTERVAL_MS, ACTION_REQUIRED_INTERVAL_MS]).toContain(
+      context.intervalMs
+    )
+  } else {
+    expect(context.actionUrl).toBeNull()
+    expect(context.intervalMs).toBeLessThanOrEqual(MAX_INTERVAL_MS)
+  }
+}
+
+function walk(options: ModelOptions) {
+  const paths = pathsFor(options)
+  const visited = new Set<string>()
+
+  for (const path of paths) {
+    for (const step of path.steps) {
+      assertInvariants(step.state)
+      visited.add(JSON.stringify(step.state.value))
+    }
+    assertInvariants(path.state)
+    visited.add(JSON.stringify(path.state.value))
+  }
+
+  return { paths, visited }
+}
+
+function reachedStates(options: ModelOptions) {
+  return walk(options).visited
+}
+
+const REQUESTING = JSON.stringify({ polling: 'requesting' })
+const WAITING = JSON.stringify({ polling: 'waiting' })
+const EVALUATING = JSON.stringify({ polling: 'evaluating' })
+const SUCCEEDED = JSON.stringify('succeeded')
+const FAILED = JSON.stringify('failed')
+const TIMED_OUT = JSON.stringify('timedOut')
+
+describe('billingOperationMachine model', () => {
+  it('holds its invariants across every path within budget', () => {
+    const { paths, visited } = walk(withinBudget)
+
+    expect(paths.length).toBeGreaterThan(0)
+    expect([...visited]).toEqual(
+      expect.arrayContaining([REQUESTING, WAITING, SUCCEEDED, FAILED])
+    )
+  })
+
+  it('never lets an operation outlive a spent budget', () => {
+    const visited = reachedStates(pastBudget)
+
+    expect([...visited]).toContain(TIMED_OUT)
+    expect([...visited]).not.toContain(SUCCEEDED)
+    expect([...visited]).not.toContain(FAILED)
+  })
+
+  it('issues no request on any path while the workspace is inactive', () => {
+    const visited = reachedStates({ ...withinBudget, workspaceInactive: true })
+
+    expect([...visited]).not.toContain(REQUESTING)
+    expect([...visited]).toContain(WAITING)
+  })
+
+  it.for(OPERATION_TYPES)(
+    'times out a %s operation exactly at its own budget',
+    (type) => {
+      const budget = timeoutBudgetMs({
+        type,
+        authenticationRequiredSeen: false
+      })
+
+      const atBudget = reachedStates({ now: STARTED_AT + budget, type })
+      const pastIt = reachedStates({ now: STARTED_AT + budget + 1, type })
+
+      expect([...atBudget]).not.toContain(TIMED_OUT)
+      expect([...pastIt]).toContain(TIMED_OUT)
+      expect([...pastIt]).not.toContain(REQUESTING)
+    }
+  )
+
+  it('grants a recovered subscription the long authentication budget', () => {
+    const pastDiscovery =
+      STARTED_AT +
+      timeoutBudgetMs({
+        type: 'subscription',
+        authenticationRequiredSeen: false
+      }) +
+      1
+
+    const visited = reachedStates({
+      now: pastDiscovery,
+      type: 'subscription',
+      initialActionUrl: ACTION_URL
+    })
+
+    expect([...visited]).not.toContain(TIMED_OUT)
+    expect([...visited]).toContain(REQUESTING)
+  })
+
+  it('polls a recovered operation at the action cadence from the first wait', () => {
+    const paths = pathsFor({ ...withinBudget, initialActionUrl: ACTION_URL })
+
+    for (const path of paths) {
+      for (const step of path.steps) {
+        if (step.state.matches({ polling: 'waiting' })) {
+          expect(step.state.context.intervalMs).toBe(
+            ACTION_REQUIRED_INTERVAL_MS
+          )
+        }
+      }
+    }
+  })
+
+  it('never shortens the poll interval along any path', () => {
+    for (const path of pathsFor(withinBudget)) {
+      let previous = 0
+      for (const step of path.steps) {
+        expect(step.state.context.intervalMs).toBeGreaterThanOrEqual(previous)
+        previous = step.state.context.intervalMs
+      }
+    }
+  })
+
+  it('covers every settleable state across the budget models', () => {
+    const reachable = new Set<string>()
+    for (const options of [withinBudget, pastBudget]) {
+      for (const key of reachedStates(options)) reachable.add(key)
+    }
+
+    // `evaluating` is transient: its `always` transitions resolve within the
+    // same microstep, so it is never observable as a settled snapshot.
+    expect([...reachable]).not.toContain(EVALUATING)
+    expect([...reachable].sort()).toEqual(
+      [REQUESTING, WAITING, SUCCEEDED, FAILED, TIMED_OUT].sort()
+    )
+  })
+})

--- a/src/platform/workspace/machines/billingOperationMachine.ts
+++ b/src/platform/workspace/machines/billingOperationMachine.ts
@@ -1,0 +1,130 @@
+import { assign, fromPromise, setup } from 'xstate'
+
+import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
+
+import {
+  nextIntervalMs,
+  recordActionUrl,
+  recordFailure
+} from './billingOperationActions'
+import type {
+  BillingOperationContext,
+  BillingOperationInput
+} from './billingOperationContext'
+import {
+  INITIAL_INTERVAL_MS,
+  validateActionUrl
+} from './billingOperationContext'
+import { hasTimedOut, isFailed, isSucceeded } from './billingOperationGuards'
+
+export const billingOperationMachine = setup({
+  types: {
+    context: {} as BillingOperationContext,
+    input: {} as BillingOperationInput
+  },
+  actors: {
+    fetchStatus: fromPromise<BillingOpStatusResponse, { opId: string }>(() => {
+      throw new Error('fetchStatus implementation must be provided')
+    })
+  },
+  guards: {
+    // Supplied by the store; a machine with no workspace notion never suspends.
+    isWorkspaceInactive: () => false,
+    hasTimedOut: ({ context }) => hasTimedOut(context),
+    responseSucceeded: (_, params: { response: BillingOpStatusResponse }) =>
+      isSucceeded(params.response),
+    responseFailed: (_, params: { response: BillingOpStatusResponse }) =>
+      isFailed(params.response)
+  },
+  delays: {
+    pollDelay: ({ context }) => context.intervalMs
+  },
+  actions: {
+    advanceInterval: assign({
+      intervalMs: ({ context }) => nextIntervalMs(context)
+    }),
+    clearActionUrl: assign({ actionUrl: null })
+  }
+}).createMachine({
+  id: 'billingOperation',
+  context: ({ input }) => ({
+    opId: input.opId,
+    type: input.type,
+    workspaceId: input.workspaceId,
+    startedAt: input.startedAt,
+    intervalMs: INITIAL_INTERVAL_MS,
+    actionUrl: validateActionUrl(input.initialActionUrl),
+    authenticationRequiredSeen:
+      validateActionUrl(input.initialActionUrl) !== null,
+    backendErrorMessage: null,
+    readNow: input.readNow ?? Date.now
+  }),
+  initial: 'polling',
+  states: {
+    polling: {
+      initial: 'evaluating',
+      states: {
+        // Mirrors the guard cascade at the top of the original poll(): the
+        // budget is enforced first, and an operation whose workspace is no
+        // longer active waits without issuing a request.
+        evaluating: {
+          always: [
+            { guard: 'hasTimedOut', target: '#billingOperation.timedOut' },
+            { guard: 'isWorkspaceInactive', target: 'waiting' },
+            { target: 'requesting' }
+          ]
+        },
+        requesting: {
+          invoke: {
+            // Named so the done and error events have stable types that
+            // model-based traversal can enumerate.
+            id: 'fetchStatus',
+            src: 'fetchStatus',
+            input: ({ context }) => ({ opId: context.opId }),
+            onDone: [
+              // A response landing after a workspace switch is discarded
+              // whatever it says, then re-evaluated against the budget.
+              { guard: 'isWorkspaceInactive', target: 'evaluating' },
+              {
+                guard: {
+                  type: 'responseSucceeded',
+                  params: ({ event }) => ({ response: event.output })
+                },
+                target: '#billingOperation.succeeded'
+              },
+              {
+                guard: {
+                  type: 'responseFailed',
+                  params: ({ event }) => ({ response: event.output })
+                },
+                target: '#billingOperation.failed',
+                actions: assign(({ event }) => recordFailure(event.output))
+              },
+              // Checked after the terminal cases so a terminal response still
+              // wins, but before the action URL is recorded so a late one is
+              // never surfaced.
+              { guard: 'hasTimedOut', target: '#billingOperation.timedOut' },
+              {
+                target: 'waiting',
+                actions: assign(({ context, event }) =>
+                  recordActionUrl(context, event.output)
+                )
+              }
+            ],
+            onError: [
+              { guard: 'hasTimedOut', target: '#billingOperation.timedOut' },
+              { target: 'waiting' }
+            ]
+          }
+        },
+        waiting: {
+          entry: 'advanceInterval',
+          after: { pollDelay: { target: 'evaluating' } }
+        }
+      }
+    },
+    succeeded: { type: 'final', entry: 'clearActionUrl' },
+    failed: { type: 'final', entry: 'clearActionUrl' },
+    timedOut: { type: 'final', entry: 'clearActionUrl' }
+  }
+})

--- a/src/platform/workspace/stores/billingOperationStore.characterization.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.characterization.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Characterization tests for billingOperationStore.
+ *
+ * These pin down behavior that exists today but was not covered by
+ * billingOperationStore.test.ts. They are deliberately descriptive rather than
+ * prescriptive: where current behavior is surprising, the test name says so.
+ * They must keep passing across the XState conversion unchanged.
+ */
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
+
+const mockFetchStatus = vi.fn()
+const mockFetchBalance = vi.fn()
+const mockReconcileSubscriptionSuccess = vi.fn()
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    fetchStatus: mockFetchStatus,
+    fetchBalance: mockFetchBalance,
+    reconcileSubscriptionSuccess: mockReconcileSubscriptionSuccess
+  })
+}))
+
+const mockToastAdd = vi.fn()
+const mockToastRemove = vi.fn()
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({
+    add: mockToastAdd,
+    remove: mockToastRemove
+  })
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getBillingOpStatus: vi.fn()
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({
+    show: vi.fn(),
+    hide: vi.fn(),
+    showAbout: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: vi.fn()
+  })
+}))
+
+const mockTrackBillingEvent = vi.fn()
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackBillingEvent: mockTrackBillingEvent
+  })
+}))
+
+const mockActiveWorkspaceId = ref('workspace-1')
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    get activeWorkspaceId() {
+      return mockActiveWorkspaceId.value
+    },
+    updateActiveWorkspace: vi.fn()
+  })
+}))
+
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+
+import { useBillingOperationStore } from './billingOperationStore'
+
+const ACTION_URL = 'https://verify.example/sensitive-token'
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+function pending(
+  overrides: Partial<BillingOpStatusResponse> = {}
+): BillingOpStatusResponse {
+  return {
+    id: 'op-1',
+    status: 'pending',
+    started_at: new Date().toISOString(),
+    ...overrides
+  }
+}
+
+function statusCallCount() {
+  return vi.mocked(workspaceApi.getBillingOpStatus).mock.calls.length
+}
+
+describe('billingOperationStore characterization', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mockActiveWorkspaceId.value = 'workspace-1'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('inactive workspace suspends requests but not the clock', () => {
+    it('issues no further status requests while the workspace is inactive', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      mockActiveWorkspaceId.value = 'workspace-2'
+
+      // The first request is already in flight when startOperation returns.
+      expect(statusCallCount()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(statusCallCount()).toBe(1)
+      expect(store.getOperation('op-1')?.status).toBe('pending')
+    })
+
+    it('resumes requesting once the workspace becomes active again', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      mockActiveWorkspaceId.value = 'workspace-2'
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      const suspendedCalls = statusCallCount()
+      mockActiveWorkspaceId.value = 'workspace-1'
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(statusCallCount()).toBeGreaterThan(suspendedCalls)
+    })
+
+    it('keeps counting an inactive operation toward hasPendingOperations', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      mockActiveWorkspaceId.value = 'workspace-2'
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      // isSettingUp is workspace-scoped, hasPendingOperations is not.
+      expect(store.isSettingUp).toBe(false)
+      expect(store.hasPendingOperations).toBe(true)
+    })
+  })
+
+  describe('action-required cadence and budget', () => {
+    it('switches from exponential backoff to a flat 30s poll once an action URL is seen', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(
+        pending({ action_url: ACTION_URL })
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(statusCallCount()).toBe(1)
+
+      // Backoff would have polled at ~1.5s; the action cadence must not.
+      await vi.advanceTimersByTimeAsync(29_000)
+      expect(statusCallCount()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(1500)
+      expect(statusCallCount()).toBe(2)
+    })
+
+    it('survives far past the 5 minute discovery deadline once an action URL is seen', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce(pending({ action_url: ACTION_URL }))
+        .mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      await vi.advanceTimersByTimeAsync(30 * MINUTE)
+
+      expect(store.getOperation('op-1')?.status).toBe('pending')
+    })
+
+    it(
+      'times out an authenticated subscription only after 23 hours',
+      { timeout: 60_000 },
+      async () => {
+        vi.mocked(workspaceApi.getBillingOpStatus)
+          .mockResolvedValueOnce(pending({ action_url: ACTION_URL }))
+          .mockResolvedValue(pending())
+
+        const store = useBillingOperationStore()
+        void store.startOperation('op-1', 'subscription')
+        await vi.advanceTimersByTimeAsync(0)
+
+        await vi.advanceTimersByTimeAsync(22 * HOUR)
+        expect(store.getOperation('op-1')?.status).toBe('pending')
+
+        await vi.advanceTimersByTimeAsync(HOUR + MINUTE)
+        expect(store.getOperation('op-1')?.status).toBe('timeout')
+      }
+    )
+
+    it('keeps authenticationRequiredSeen set after the action URL is withdrawn', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce(pending({ action_url: ACTION_URL }))
+        .mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(store.getOperation('op-1')).toMatchObject({
+        actionUrl: null,
+        authenticationRequiredSeen: true
+      })
+    })
+
+    it('applies the 30s action cadence to a top-up but still times it out at 2 minutes', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(
+        pending({ action_url: ACTION_URL })
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.authenticationRequiredSeen).toBe(true)
+
+      // The long authentication budget is subscription-only.
+      await vi.advanceTimersByTimeAsync(2 * MINUTE + 30_000)
+
+      expect(store.getOperation('op-1')?.status).toBe('timeout')
+    })
+  })
+
+  describe('terminal precedence at the deadline', () => {
+    it('prefers a failure response that lands after the deadline over a timeout', async () => {
+      let resolveStatus!: (response: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'topup')
+      await vi.advanceTimersByTimeAsync(2 * MINUTE + 1)
+
+      resolveStatus({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'card declined',
+        started_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      const operation = await terminal
+      expect(operation.status).toBe('failed')
+      expect(operation.errorMessage).toBe('card declined')
+    })
+
+    it('clears the action URL when an operation ends in failure', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce(pending({ action_url: ACTION_URL }))
+        .mockResolvedValue({
+          id: 'op-1',
+          status: 'failed',
+          started_at: new Date().toISOString()
+        })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(store.getOperation('op-1')?.actionUrl).toBe(ACTION_URL)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(store.getOperation('op-1')).toMatchObject({
+        status: 'failed',
+        actionUrl: null
+      })
+    })
+  })
+
+  describe('processing toast lifecycle', () => {
+    it('removes the processing toast on failure', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+      const processingToast = mockToastAdd.mock.calls[0][0]
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockToastRemove).toHaveBeenCalledWith(processingToast)
+    })
+
+    it('removes the processing toast on timeout', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+      const processingToast = mockToastAdd.mock.calls[0][0]
+
+      await vi.advanceTimersByTimeAsync(2 * MINUTE + 10_000)
+
+      expect(mockToastRemove).toHaveBeenCalledWith(processingToast)
+    })
+  })
+
+  describe('top-up success refreshes balance, subscription success reconciles', () => {
+    it('fetches status and balance on top-up success', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'topup')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockFetchStatus).toHaveBeenCalled()
+      expect(mockFetchBalance).toHaveBeenCalled()
+      expect(mockReconcileSubscriptionSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearOperation', () => {
+    it('stops polling a pending operation', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      store.clearOperation('op-1')
+      const callsAtClear = statusCallCount()
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(statusCallCount()).toBe(callsAtClear)
+    })
+
+    it('leaves a restarted operation untouched by the previous run in-flight response', async () => {
+      let resolveStatus!: (response: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveStatus = resolve
+            })
+        )
+        .mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      store.clearOperation('op-1')
+      void store.startOperation('op-1', 'topup')
+
+      resolveStatus({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')).toMatchObject({
+        type: 'topup',
+        status: 'pending'
+      })
+    })
+  })
+
+  describe('backoff continuity across network errors', () => {
+    it('does not reset the backoff interval after a failed request', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce(pending())
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValue(pending())
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(statusCallCount()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(1500)
+      expect(statusCallCount()).toBe(2)
+
+      // Backoff continues from 1500 -> 2250 rather than restarting at 1000.
+      await vi.advanceTimersByTimeAsync(2249)
+      expect(statusCallCount()).toBe(2)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(statusCallCount()).toBe(3)
+    })
+  })
+})

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -33,7 +33,7 @@ import { useDialogStore } from '@/stores/dialogStore'
  * billingOperationMachine; to be replaced by a real feature flag and then
  * removed along with the legacy driver.
  */
-const USE_BILLING_OPERATION_MACHINE = false
+const USE_BILLING_OPERATION_MACHINE = true
 
 type OperationType = BillingOperationType
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -1,6 +1,8 @@
 import type { ToastMessageOptions } from 'primevue/toast'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import type { Actor, SnapshotFrom } from 'xstate'
+import { createActor, fromPromise } from 'xstate'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { t } from '@/i18n'
@@ -15,18 +17,25 @@ import type {
 } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import { nextIntervalMs } from '@/platform/workspace/machines/billingOperationActions'
+import type { BillingOperationType } from '@/platform/workspace/machines/billingOperationContext'
+import {
+  INITIAL_INTERVAL_MS,
+  validateActionUrl
+} from '@/platform/workspace/machines/billingOperationContext'
+import { timeoutBudgetMs } from '@/platform/workspace/machines/billingOperationGuards'
+import { billingOperationMachine } from '@/platform/workspace/machines/billingOperationMachine'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogStore } from '@/stores/dialogStore'
 
-const INITIAL_INTERVAL_MS = 1000
-const MAX_INTERVAL_MS = 8000
-const ACTION_REQUIRED_INTERVAL_MS = 30_000
-const BACKOFF_MULTIPLIER = 1.5
-const TIMEOUT_MS = 120_000
-const SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS = 5 * 60_000
-const SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS = 23 * 60 * 60_000
+/**
+ * Selects the polling driver. Temporary scaffolding for the migration to
+ * billingOperationMachine; to be replaced by a real feature flag and then
+ * removed along with the legacy driver.
+ */
+const USE_BILLING_OPERATION_MACHINE = false
 
-type OperationType = 'subscription' | 'topup' | 'cancel'
+type OperationType = BillingOperationType
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
 
 export interface StartOperationMetadata {
@@ -57,16 +66,24 @@ interface BillingOperation {
   downgradeToPersonal?: StartOperationMetadata['downgradeToPersonal']
 }
 
+type BillingOperationActor = Actor<typeof billingOperationMachine>
+type BillingOperationSnapshot = SnapshotFrom<typeof billingOperationMachine>
 type TerminalResolver = (operation: BillingOperation) => void
 
 export const useBillingOperationStore = defineStore('billingOperation', () => {
   const workspaceStore = useTeamWorkspaceStore()
   const operations = ref<Map<string, BillingOperation>>(new Map())
-  const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
-  const intervals = new Map<string, number>()
+  const metadataById = new Map<string, StartOperationMetadata>()
   const receivedToasts = new Map<string, ToastMessageOptions>()
   const terminalResolvers = new Map<string, TerminalResolver>()
   const terminalPromises = new Map<string, Promise<BillingOperation>>()
+
+  // Legacy driver state.
+  const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
+  const intervals = new Map<string, number>()
+
+  // Machine driver state.
+  const actors = new Map<string, BillingOperationActor>()
 
   const hasPendingOperations = computed(() =>
     [...operations.value.values()].some((op) => op.status === 'pending')
@@ -112,25 +129,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       return terminalPromises.get(opId) ?? Promise.resolve(existing)
     }
 
-    const actionUrl = validateActionUrl(initialActionUrl)
-    const operation: BillingOperation = {
-      opId,
-      type,
-      status: 'pending',
-      errorMessage: null,
-      startedAt: Date.now(),
-      actionUrl,
-      authenticationRequiredSeen: actionUrl !== null,
-      workspaceId: workspaceStore.activeWorkspaceId,
-      tier: metadata?.tier,
-      cycle: metadata?.cycle,
-      checkoutType: metadata?.checkoutType,
-      paymentIntentSource: metadata?.paymentIntentSource,
-      downgradeToPersonal: metadata?.downgradeToPersonal
-    }
-
-    operations.value = new Map(operations.value).set(opId, operation)
-    intervals.set(opId, INITIAL_INTERVAL_MS)
+    if (metadata) metadataById.set(opId, metadata)
 
     if (type !== 'cancel') {
       const messageKey =
@@ -152,9 +151,115 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     })
     terminalPromises.set(opId, terminal)
 
-    void poll(opId)
+    if (USE_BILLING_OPERATION_MACHINE) {
+      startWithMachine(opId, type, initialActionUrl)
+    } else {
+      startWithPolling(opId, type, metadata, initialActionUrl)
+    }
 
     return terminal
+  }
+
+  // Machine driver ------------------------------------------------------------
+
+  function snapshotStatus(snapshot: BillingOperationSnapshot): OperationStatus {
+    if (snapshot.matches('succeeded')) return 'succeeded'
+    if (snapshot.matches('failed')) return 'failed'
+    if (snapshot.matches('timedOut')) return 'timeout'
+    return 'pending'
+  }
+
+  function project(snapshot: BillingOperationSnapshot): BillingOperation {
+    const { context } = snapshot
+    const status = snapshotStatus(snapshot)
+    return {
+      opId: context.opId,
+      type: context.type,
+      status,
+      errorMessage: projectErrorMessage(
+        status,
+        context.type,
+        context.backendErrorMessage
+      ),
+      startedAt: context.startedAt,
+      actionUrl: context.actionUrl,
+      authenticationRequiredSeen: context.authenticationRequiredSeen,
+      workspaceId: context.workspaceId,
+      ...metadataById.get(context.opId)
+    }
+  }
+
+  function commit(snapshot: BillingOperationSnapshot) {
+    const operation = project(snapshot)
+    operations.value = new Map(operations.value).set(operation.opId, operation)
+  }
+
+  function startWithMachine(
+    opId: string,
+    type: OperationType,
+    initialActionUrl?: string
+  ) {
+    const actor = createActor(
+      billingOperationMachine.provide({
+        actors: {
+          fetchStatus: fromPromise(({ input }: { input: { opId: string } }) =>
+            workspaceApi.getBillingOpStatus(input.opId)
+          )
+        },
+        guards: {
+          isWorkspaceInactive: ({ context }) =>
+            context.workspaceId !== workspaceStore.activeWorkspaceId
+        }
+      }),
+      {
+        input: {
+          opId,
+          type,
+          workspaceId: workspaceStore.activeWorkspaceId,
+          startedAt: Date.now(),
+          initialActionUrl
+        }
+      }
+    )
+
+    actors.set(opId, actor)
+    commit(actor.getSnapshot())
+
+    actor.subscribe((snapshot) => {
+      commit(snapshot)
+      if (snapshot.status === 'done') {
+        void finalize(opId, snapshot.context.backendErrorMessage)
+      }
+    })
+
+    actor.start()
+  }
+
+  // Legacy driver -------------------------------------------------------------
+
+  function startWithPolling(
+    opId: string,
+    type: OperationType,
+    metadata?: StartOperationMetadata,
+    initialActionUrl?: string
+  ) {
+    const actionUrl = validateActionUrl(initialActionUrl)
+    const operation: BillingOperation = {
+      opId,
+      type,
+      status: 'pending',
+      errorMessage: null,
+      startedAt: Date.now(),
+      actionUrl,
+      authenticationRequiredSeen: actionUrl !== null,
+      workspaceId: workspaceStore.activeWorkspaceId,
+      ...metadata
+    }
+
+    operations.value = new Map(operations.value).set(opId, operation)
+    intervals.set(opId, INITIAL_INTERVAL_MS)
+
+    void poll(opId)
   }
 
   async function poll(opId: string) {
@@ -179,12 +284,19 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       }
 
       if (response.status === 'succeeded') {
-        await handleSuccess(opId)
+        updateOperationStatus(opId, 'succeeded', null)
+        void finalize(opId, null)
         return
       }
 
       if (response.status === 'failed') {
-        handleFailure(opId, response.error_message ?? null)
+        const backendErrorMessage = response.error_message ?? null
+        updateOperationStatus(
+          opId,
+          'failed',
+          projectErrorMessage('failed', operation.type, backendErrorMessage)
+        )
+        void finalize(opId, backendErrorMessage)
         return
       }
 
@@ -203,39 +315,24 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   function scheduleNextPoll(opId: string) {
     const operation = operations.value.get(opId)
     if (!operation || operation.status !== 'pending') return
-    const nextInterval = operation.authenticationRequiredSeen
-      ? ACTION_REQUIRED_INTERVAL_MS
-      : Math.min(
-          (intervals.get(opId) ?? INITIAL_INTERVAL_MS) * BACKOFF_MULTIPLIER,
-          MAX_INTERVAL_MS
-        )
+    const nextInterval = nextIntervalMs({
+      ...operation,
+      intervalMs: intervals.get(opId) ?? INITIAL_INTERVAL_MS,
+      backendErrorMessage: null,
+      readNow: Date.now
+    })
     intervals.set(opId, nextInterval)
 
     const timeoutId = setTimeout(() => void poll(opId), nextInterval)
     timeouts.set(opId, timeoutId)
   }
 
-  function validateActionUrl(value: string | undefined): string | null {
-    if (!value) return null
-    try {
-      const url = new URL(value)
-      return url.protocol === 'https:' ? value : null
-    } catch {
-      return null
-    }
-  }
-
-  function hasTimedOut(operation: BillingOperation): boolean {
-    const elapsed = Date.now() - operation.startedAt
-    if (operation.type !== 'subscription') return elapsed > TIMEOUT_MS
-    return operation.authenticationRequiredSeen
-      ? elapsed > SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS
-      : elapsed > SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS
-  }
-
   function stopIfTimedOut(opId: string, operation: BillingOperation): boolean {
-    if (!hasTimedOut(operation)) return false
-    handleTimeout(opId)
+    if (Date.now() - operation.startedAt <= timeoutBudgetMs(operation)) {
+      return false
+    }
+    updateOperationStatus(opId, 'timeout', timeoutMessage(operation.type))
+    void finalize(opId, null)
     return true
   }
 
@@ -250,13 +347,55 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     })
   }
 
-  async function handleSuccess(opId: string) {
+  function updateOperationStatus(
+    opId: string,
+    status: OperationStatus,
+    errorMessage: string | null
+  ) {
     const operation = operations.value.get(opId)
     if (!operation) return
 
-    updateOperationStatus(opId, 'succeeded', null)
+    const updated = { ...operation, status, errorMessage, actionUrl: null }
+    operations.value = new Map(operations.value).set(opId, updated)
+  }
+
+  // Shared terminal effects ---------------------------------------------------
+
+  function failureDetail(
+    type: OperationType,
+    backendErrorMessage: string | null
+  ) {
+    return type === 'subscription'
+      ? t('billingOperation.subscriptionFailedDetail')
+      : backendErrorMessage
+  }
+
+  function projectErrorMessage(
+    status: OperationStatus,
+    type: OperationType,
+    backendErrorMessage: string | null
+  ): string | null {
+    if (status === 'timeout') return timeoutMessage(type)
+    if (status !== 'failed') return null
+    return failureDetail(type, backendErrorMessage) ?? failureMessage(type)
+  }
+
+  async function finalize(opId: string, backendErrorMessage: string | null) {
+    const operation = operations.value.get(opId)
+    if (!operation) return
+
     cleanup(opId)
 
+    if (operation.status === 'succeeded') await handleSuccess(operation)
+    else if (operation.status === 'failed')
+      handleFailure(operation, backendErrorMessage)
+    else handleTimeout(operation)
+
+    resolveTerminal(opId)
+  }
+
+  async function handleSuccess(operation: BillingOperation) {
+    const opId = operation.opId
     const telemetry = useTelemetry()
     if (operation.type === 'subscription') {
       telemetry?.trackBillingEvent({
@@ -310,7 +449,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
     if (operation.type === 'cancel') {
       useTeamWorkspaceStore().updateActiveWorkspace({ isSubscribed: false })
-      resolveTerminal(opId)
       return
     }
 
@@ -321,40 +459,28 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       useSettingsDialog().show('workspace')
     }
 
-    const toastStore = useToastStore()
     const messageKey =
       operation.type === 'subscription'
         ? 'billingOperation.subscriptionSuccess'
         : 'billingOperation.topupSuccess'
 
-    toastStore.add({
+    useToastStore().add({
       severity: 'success',
       summary: t(messageKey),
       life: 5000
     })
-
-    resolveTerminal(opId)
   }
 
-  function handleFailure(opId: string, errorMessage: string | null) {
-    const operation = operations.value.get(opId)
-    if (!operation) return
-
-    const defaultMessage = failureMessage(operation.type)
-    const detail =
-      operation.type === 'subscription'
-        ? t('billingOperation.subscriptionFailedDetail')
-        : errorMessage
-
-    updateOperationStatus(opId, 'failed', detail ?? defaultMessage)
-    cleanup(opId)
-
+  function handleFailure(
+    operation: BillingOperation,
+    backendErrorMessage: string | null
+  ) {
     const telemetry = useTelemetry()
     telemetry?.trackBillingEvent({
       operation: 'operation',
       stage: 'failed',
       outcome: 'failure',
-      billing_op_id: opId,
+      billing_op_id: operation.opId,
       operation_type: operation.type,
       tier: operation.tier,
       cycle: operation.cycle,
@@ -375,32 +501,22 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       })
     }
 
-    if (operation.type !== 'cancel') {
-      useToastStore().add({
-        severity: 'error',
-        summary: defaultMessage,
-        detail: detail ?? undefined
-      })
-    }
+    if (operation.type === 'cancel') return
 
-    resolveTerminal(opId)
+    useToastStore().add({
+      severity: 'error',
+      summary: failureMessage(operation.type),
+      detail: failureDetail(operation.type, backendErrorMessage) ?? undefined
+    })
   }
 
-  function handleTimeout(opId: string) {
-    const operation = operations.value.get(opId)
-    if (!operation) return
-
-    const message = timeoutMessage(operation.type)
-
-    updateOperationStatus(opId, 'timeout', message)
-    cleanup(opId)
-
+  function handleTimeout(operation: BillingOperation) {
     const telemetry = useTelemetry()
     telemetry?.trackBillingEvent({
       operation: 'operation',
       stage: 'timeout',
       outcome: 'failure',
-      billing_op_id: opId,
+      billing_op_id: operation.opId,
       operation_type: operation.type,
       tier: operation.tier,
       cycle: operation.cycle,
@@ -421,14 +537,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       })
     }
 
-    if (operation.type !== 'cancel') {
-      useToastStore().add({
-        severity: 'error',
-        summary: message
-      })
-    }
+    if (operation.type === 'cancel') return
 
-    resolveTerminal(opId)
+    useToastStore().add({
+      severity: 'error',
+      summary: timeoutMessage(operation.type)
+    })
   }
 
   function failureMessage(type: OperationType) {
@@ -454,18 +568,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     terminalPromises.delete(opId)
   }
 
-  function updateOperationStatus(
-    opId: string,
-    status: OperationStatus,
-    errorMessage: string | null
-  ) {
-    const operation = operations.value.get(opId)
-    if (!operation) return
-
-    const updated = { ...operation, status, errorMessage, actionUrl: null }
-    operations.value = new Map(operations.value).set(opId, updated)
-  }
-
   function cleanup(opId: string) {
     const timeoutId = timeouts.get(opId)
     if (timeoutId) {
@@ -474,7 +576,6 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
     intervals.delete(opId)
 
-    // Remove the "received" toast
     const receivedToast = receivedToasts.get(opId)
     if (receivedToast) {
       useToastStore().remove(receivedToast)
@@ -484,6 +585,9 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   function clearOperation(opId: string) {
     cleanup(opId)
+    actors.get(opId)?.stop()
+    actors.delete(opId)
+    metadataById.delete(opId)
     const newMap = new Map(operations.value)
     newMap.delete(opId)
     operations.value = newMap


### PR DESCRIPTION
## Summary

Models the billing operation polling lifecycle as an XState machine, introduced behind a flag so the switch is one revertible line.

## Changes

- **What**: `pending` was hiding three distinct behaviors encoded across `authenticationRequiredSeen`, `actionUrl` and an inline workspace comparison, each with its own poll cadence and timeout budget. The budget guard was consulted at four call sites in `poll()`, and the rule that a terminal response beats a spent budget while a late `action_url` does not existed only as statement ordering. The machine owns state, timing and guard precedence; the store keeps its public surface and the ordered terminal effects.
- **Dependencies**: `xstate` (~13 kB gzip), `@xstate/graph` (dev)

Eight commits, each green, meant to be read in order:

| # | Commit | What it proves |
|---|---|---|
| 1 | `test:` characterize existing store | Behavior pinned against the **old** code |
| 2 | `build:` add xstate | Dependency only, no source change |
| 3 | `feat:` machine context + actions | Cadence and action-URL rules, standalone |
| 4 | `feat:` machine guards | One timeout budget instead of four call sites |
| 5 | `feat:` machine definition | The state graph; not yet reachable |
| 6 | `feat:` integrate behind flag, **default off** | Both drivers exist; behavior unchanged |
| 7 | `feat:` enable the machine | One line; all existing tests pass unchanged |
| 8 | `test:` model-based tests | Path-level properties over the whole graph |

### Demo URL 
https://stately.ai/registry/editor/embed/ab1e4e70-38e6-44e7-babb-db42b100947f?machineId=a6f56597-63ec-4468-8779-40517bf5afd1

## Review Focus

- **Commit 7 is the whole risk surface, and it is one line.** `USE_BILLING_OPERATION_MACHINE` is scaffolding for a real feature flag; reverting it restores the legacy driver, which commit 6 leaves fully intact. The legacy loop and the machine share one terminal effect path and one timeout budget function, so they cannot drift.
- **Behavior parity rests on commit 1.** The 16 characterization tests were validated against the old store by mutating it four ways (action cadence, stickiness, workspace suspension, 23h budget) and confirming each mutation failed a test. They then passed unchanged on the machine. The machine was mutation-checked the same way (5 mutations, all caught), as were the model tests (4 mutations, all caught).
- **The 23-hour authentication budget had no test coverage before this PR.** A constant governing how long a payment can stay open, entirely unpinned.
- **Guard order in `onDone` is load-bearing** and is where the old ordering rule becomes explicit: workspace check, then terminal responses, then budget, then `action_url`. Reordering any two changes behavior; each ordering is covered.
- **`polling.evaluating` is transient by design** — its `always` cascade mirrors the old guard order and resolves within one microstep, so it is never an observable snapshot. Commit 8 asserts this rather than treating it as dead state.
- **`xstate` lands in the main chunk**, not a lazy one: `router.ts` → `services/dialogService.ts` → `TopUpCreditsDialogContentWorkspace.vue` → this store is a fully static import chain. `SubscriptionPanel.vue` uses `defineAsyncComponent`, but `WorkspacePanelContent.vue` and `PlanCreditsPanelContent.vue` import the same component statically and defeat it. Worth fixing separately.

## Testing

- `pnpm typecheck`, `pnpm knip`, `pnpm lint` (0 errors): clean
- `pnpm test:unit`: 14288 passed / 1071 files. Two runs each surfaced a different unrelated intermittent failure (`GraphView.test.ts`, `onboardingCloudRoutes.test.ts`); both pass in isolation and the same code produced a clean 14284/0 run, so they are load flakes rather than regressions. CI is the arbiter.
- Store suites pass 60/60 on **both** drivers — flag off (commit 6) and flag on (commit 7).
- **E2E not validated.** The only billing-adjacent spec (`pricingTableDeepLink.spec.ts`, `@cloud`) fails all 14 tests in this environment and fails identically on base commit `e0ef062918`, so it is environment-gated (no cloud config), not a regression. Needs CI.
