### PR TITLE
[backport cloud/1.47] Fix cancelled plan changes using quoted previews

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -269,6 +269,23 @@ const UNEXPECTED_OPERATION_RESPONSE = {
   completed_at: '2026-07-20T00:00:01Z'
 } satisfies BillingOpStatusResponse
 
+const RECOVERED_3DS_OPERATION_ID = 'recovered-3ds-subscription'
+const RECOVERED_3DS_ACTION_URL = 'https://verify.example/3ds-session'
+
+const RECOVERED_3DS_STATUS = {
+  ...ACTIVE_TEAM_STATUS,
+  billing_status: 'pending_payment',
+  pending_billing_op_id: RECOVERED_3DS_OPERATION_ID,
+  action_url: RECOVERED_3DS_ACTION_URL
+} satisfies BillingStatusResponse
+
+const RECOVERED_3DS_OPERATION = {
+  id: RECOVERED_3DS_OPERATION_ID,
+  status: 'pending',
+  started_at: '2026-07-20T00:00:00Z',
+  action_url: RECOVERED_3DS_ACTION_URL
+} satisfies BillingOpStatusResponse
+
 const TRANSIENT_STATUS_ERROR = {
   code: 'billing_status_unavailable',
   message: 'Billing status is temporarily unavailable'
@@ -438,6 +455,36 @@ async function mockPopupBlockedCreatorDowngrade(page: Page) {
     balanceRefreshRequests,
     operationPollRequests
   }
+}
+
+async function mockRecovered3dsSubscription(page: Page) {
+  const statusRequests: Request[] = []
+  const operationPollRequests: Request[] = []
+  const subscribeRequests: Request[] = []
+
+  await page.route('**/api/billing/status', (route) => {
+    statusRequests.push(route.request())
+    return route.fulfill(jsonRoute(RECOVERED_3DS_STATUS))
+  })
+  await page.route(
+    `**/api/billing/ops/${RECOVERED_3DS_OPERATION_ID}`,
+    (route) => {
+      operationPollRequests.push(route.request())
+      return route.fulfill(jsonRoute(RECOVERED_3DS_OPERATION))
+    }
+  )
+  await page.route('**/api/billing/subscribe', (route) => {
+    subscribeRequests.push(route.request())
+    return route.fulfill({
+      ...jsonRoute({
+        code: 'unexpected_subscribe',
+        message: 'Recovered operations must not resubscribe'
+      } satisfies ErrorResponse),
+      status: 500
+    })
+  })
+
+  return { statusRequests, operationPollRequests, subscribeRequests }
 }
 
 const pricingHeading = (page: Page) =>
@@ -676,7 +723,7 @@ test.describe('Scheduled Team downgrade', { tag: '@cloud' }, () => {
     releasePostSubscribeRefresh = downgradeMock.releasePostSubscribeRefresh
   })
 
-  test('shows the existing success view when subscribe replays 200', async ({
+  test('completes the non-3DS flow when subscribe replays 200', async ({
     page
   }) => {
     test.slow()
@@ -705,6 +752,9 @@ test.describe('Scheduled Team downgrade', { tag: '@cloud' }, () => {
         name: "You're all set"
       })
       await expect(successHeading).toBeVisible()
+      await expect(
+        page.getByRole('button', { name: 'Complete verification' })
+      ).toBeHidden()
       await expect.poll(() => statusRefreshRequests.length).toBe(1)
       await expect.poll(() => balanceRefreshRequests.length).toBe(1)
       const successView = successHeading.locator('..').locator('..')
@@ -727,6 +777,64 @@ test.describe('Scheduled Team downgrade', { tag: '@cloud' }, () => {
     } finally {
       releasePostSubscribeRefresh()
     }
+  })
+})
+
+test.describe('Recovered 3DS subscription', { tag: '@cloud' }, () => {
+  let statusRequests: Request[]
+  let operationPollRequests: Request[]
+  let subscribeRequests: Request[]
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.open = (url, target, features) => {
+        document.documentElement.dataset.openedUrl = String(url)
+        document.documentElement.dataset.openedTarget = target ?? ''
+        document.documentElement.dataset.openedFeatures = features ?? ''
+        return window
+      }
+    })
+    await setupCloudApp(page, workspace('team', 'owner'), [
+      member({ email: SELF_EMAIL, role: 'owner', is_original_owner: true })
+    ])
+    const recoveryMock = await mockRecovered3dsSubscription(page)
+    statusRequests = recoveryMock.statusRequests
+    operationPollRequests = recoveryMock.operationPollRequests
+    subscribeRequests = recoveryMock.subscribeRequests
+  })
+
+  test('recovers on a fresh page without resubscribing and opens verification on click', async ({
+    page
+  }) => {
+    await page.goto(APP_URL)
+    await waitForCloudApp(page)
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('manage-plan-menu-item').click()
+    await expect.poll(() => statusRequests.length).toBeGreaterThan(0)
+    await expect.poll(() => operationPollRequests.length).toBeGreaterThan(0)
+
+    const verificationButton = page.getByRole('button', {
+      name: 'Complete verification'
+    })
+    await expect(verificationButton).toBeVisible()
+    await expect(page.locator('html')).not.toContainText(
+      RECOVERED_3DS_ACTION_URL
+    )
+    expect(subscribeRequests).toHaveLength(0)
+
+    await verificationButton.click()
+
+    await expect
+      .poll(() => page.locator('html').getAttribute('data-opened-url'))
+      .toBe(RECOVERED_3DS_ACTION_URL)
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-opened-target',
+      '_blank'
+    )
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-opened-features',
+      'noopener,noreferrer'
+    )
   })
 })
 

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -807,7 +807,9 @@ test.describe('Recovered 3DS subscription', { tag: '@cloud' }, () => {
     page
   }) => {
     await page.goto(APP_URL)
-    await waitForCloudApp(page)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
     await page.getByRole('button', { name: 'Current user' }).click()
     await page.getByTestId('manage-plan-menu-item').click()
     await expect.poll(() => statusRequests.length).toBeGreaterThan(0)

--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -879,6 +879,10 @@ export type BillingOpStatusResponse = {
    * When the operation completed (success or failure)
    */
   completed_at?: string
+  /**
+   * HTTPS URL for completing required customer authentication
+   */
+  action_url?: string
 }
 
 /**
@@ -1502,6 +1506,14 @@ export type BillingStatusResponse = {
    */
   plan_slug?: string
   billing_status?: BillingStatus
+  /**
+   * The workspace's in-flight billing operation, when one exists.
+   */
+  pending_billing_op_id?: string
+  /**
+   * The customer action URL for the pending operation, when action is required.
+   */
+  action_url?: string
   /**
    * Whether the workspace has available credits
    */

--- a/packages/ingest-types/src/zod.gen.ts
+++ b/packages/ingest-types/src/zod.gen.ts
@@ -506,7 +506,8 @@ export const zBillingOpStatusResponse = z.object({
   status: z.enum(['pending', 'succeeded', 'failed']),
   error_message: z.string().optional(),
   started_at: z.string().datetime(),
-  completed_at: z.string().datetime().optional()
+  completed_at: z.string().datetime().optional(),
+  action_url: z.string().optional()
 })
 
 /**
@@ -979,6 +980,8 @@ export const zBillingStatusResponse = z.object({
   subscription_duration: zSubscriptionDuration.optional(),
   plan_slug: z.string().optional(),
   billing_status: zBillingStatus.optional(),
+  pending_billing_op_id: z.string().optional(),
+  action_url: z.string().optional(),
   has_funds: z.boolean(),
   cancel_at: z.string().datetime().optional(),
   renewal_date: z.string().datetime().optional(),

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2783,6 +2783,7 @@
       "message": "Team billing is coming soon. You'll be able to subscribe to a plan for your workspace with per-seat pricing. Stay tuned for updates."
     },
     "preview": {
+      "completeVerification": "Complete verification",
       "confirmPayment": "Confirm your payment",
       "confirmPlanChange": "Confirm your plan change",
       "startingToday": "Starts today",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -453,14 +453,16 @@ describe('workspaceApi', () => {
       mockAxiosInstance.post.mockResolvedValue({ data })
 
       const result = await workspaceApi.subscribe('pro-monthly', {
-        confirmReactivation: true
+        confirmReactivation: true,
+        prorationAt: '2026-07-29T12:00:00Z'
       })
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/billing/subscribe',
         expect.objectContaining({
           plan_slug: 'pro-monthly',
-          confirm_reactivation: true
+          confirm_reactivation: true,
+          proration_at: '2026-07-29T12:00:00Z'
         }),
         { headers: AUTH_HEADER }
       )

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -566,7 +566,8 @@ describe('workspaceApi', () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/billing/ops/op-1',
         {
-          headers: AUTH_HEADER
+          headers: AUTH_HEADER,
+          timeout: 30_000
         }
       )
       expect(result).toEqual(data)

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -166,6 +166,7 @@ interface SubscribeRequest {
   billing_cycle?: SubscribeBillingCycle
   /** Required to change plans while the current subscription is cancelled; server rejects the change without it. */
   confirm_reactivation?: boolean
+  proration_at?: string
 }
 
 export interface SubscribeOptions {
@@ -174,6 +175,7 @@ export interface SubscribeOptions {
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
   confirmReactivation?: boolean
+  prorationAt?: string
 }
 
 export interface PreviewSubscribeOptions {
@@ -219,7 +221,10 @@ interface PaymentPortalResponse {
 
 interface PreviewPlanInfo {
   slug: string
-  tier: SubscriptionTier
+  // The billing preview contract includes the workspace-level Team tier even
+  // though the registry subscription tier used by the personal plan catalog
+  // does not.
+  tier: SubscriptionTier | 'TEAM'
   duration: SubscriptionDuration
   price_cents: number
   credits_cents: number
@@ -240,6 +245,7 @@ export interface PreviewSubscribeResponse {
   credits_next_period_cents: number
   current_plan?: PreviewPlanInfo
   new_plan: PreviewPlanInfo
+  proration_at?: string
 }
 
 export type BillingSubscriptionStatus =
@@ -687,7 +693,8 @@ export const workspaceApi = {
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
-          confirm_reactivation: options.confirmReactivation
+          confirm_reactivation: options.confirmReactivation,
+          proration_at: options.prorationAt
         } satisfies SubscribeRequest,
         { headers }
       )

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -269,6 +269,8 @@ export interface BillingStatusResponse {
   subscription_duration?: SubscriptionDuration
   plan_slug?: string
   billing_status?: BillingStatus
+  pending_billing_op_id?: string
+  action_url?: string
   has_funds: boolean
   cancel_at?: string
   renewal_date?: string
@@ -306,6 +308,7 @@ export interface BillingOpStatusResponse {
   error_message?: string
   started_at: string
   completed_at?: string
+  action_url?: string
 }
 
 interface BillingEvent {
@@ -807,7 +810,7 @@ export const workspaceApi = {
     try {
       const response = await workspaceApiClient.get<BillingOpStatusResponse>(
         api.apiURL(`/billing/ops/${opId}`),
-        { headers }
+        { headers, timeout: 30_000 }
       )
       return response.data
     } catch (err) {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -148,4 +148,39 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     )
     expect(emitted().addCreditCard).toBeTruthy()
   })
+
+  it('opens verification only from its button without exposing the URL', async () => {
+    const actionUrl = 'https://verify.example/sensitive-token'
+    const open = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    const { container } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', actionUrl },
+      global: globalOptions
+    })
+
+    expect(open).not.toHaveBeenCalled()
+    expect(container.innerHTML).not.toContain(actionUrl)
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.completeVerification'
+      })
+    )
+    expect(open).toHaveBeenCalledWith(
+      actionUrl,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('prevents leaving the preview while payment is pending', () => {
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', isLoading: true },
+      global: globalOptions
+    })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'subscription.preview.backToAllPlans'
+      })
+    ).toBeDisabled()
+  })
 })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -136,7 +136,16 @@
       <!-- Terms Agreement -->
       <SubscriptionTermsNote />
 
-      <!-- Add Credit Card Button -->
+      <Button
+        v-if="actionUrl"
+        variant="primary"
+        size="lg"
+        class="w-full rounded-lg"
+        @click="openVerification"
+      >
+        {{ $t('subscription.preview.completeVerification') }}
+      </Button>
+
       <Button
         variant="tertiary"
         size="lg"
@@ -151,6 +160,7 @@
       <Button
         variant="textonly"
         class="cursor-pointer text-center text-xs text-muted-foreground transition-colors hover:bg-none hover:text-base-foreground"
+        :disabled="isLoading"
         @click="$emit('back')"
       >
         {{ $t('subscription.preview.backToAllPlans') }}
@@ -186,6 +196,7 @@ interface Props {
   previewData?: PreviewSubscribeResponse | null
   /** Team-plan checkout (selected slider stop); overrides tier-derived display. */
   teamPlan?: TeamPlanSelection | null
+  actionUrl?: string | null
 }
 
 const {
@@ -193,7 +204,8 @@ const {
   billingCycle = 'monthly',
   isLoading = false,
   previewData = null,
-  teamPlan = null
+  teamPlan = null,
+  actionUrl = null
 } = defineProps<Props>()
 
 defineEmits<{
@@ -204,6 +216,11 @@ defineEmits<{
 const { t, n } = useI18n()
 
 const isFeaturesCollapsed = ref(true)
+
+function openVerification() {
+  if (!actionUrl) return
+  window.open(actionUrl, '_blank', 'noopener,noreferrer')
+}
 
 const tierName = computed(() =>
   teamPlan

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -14,6 +14,13 @@ import type {
 
 import SubscriptionPanelContentWorkspace from './SubscriptionPanelContentWorkspace.vue'
 
+const { mockIsSettingUp, mockSubscriptionActionOperation } = vi.hoisted(() => ({
+  mockIsSettingUp: { value: false },
+  mockSubscriptionActionOperation: {
+    value: undefined as { actionUrl: string } | undefined
+  }
+}))
+
 const RENEWAL_DATE_ISO = '2026-06-20T12:00:00Z'
 const END_DATE_ISO = '2026-01-20T12:00:00Z'
 
@@ -178,7 +185,14 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
 }))
 
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
-  useBillingOperationStore: () => ({ isSettingUp: false })
+  useBillingOperationStore: () => ({
+    get isSettingUp() {
+      return mockIsSettingUp.value
+    },
+    get subscriptionActionOperation() {
+      return mockSubscriptionActionOperation.value
+    }
+  })
 }))
 
 vi.mock('@/services/dialogService', () => ({
@@ -272,6 +286,41 @@ describe('SubscriptionPanelContentWorkspace', () => {
     }
     mockIsLoading.value = false
     mockError.value = null
+    mockIsSettingUp.value = false
+    mockSubscriptionActionOperation.value = undefined
+  })
+
+  it('keeps verification available in settings without exposing its URL', async () => {
+    const actionUrl = 'https://verify.example/sensitive-token'
+    const open = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    mockIsSettingUp.value = true
+    mockSubscriptionActionOperation.value = { actionUrl }
+    const { container } = renderComponent()
+
+    expect(open).not.toHaveBeenCalled()
+    expect(container.innerHTML).not.toContain(actionUrl)
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Complete verification' })
+    )
+    expect(open).toHaveBeenCalledWith(
+      actionUrl,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('hides verification from users without billing permission', () => {
+    mockIsSettingUp.value = true
+    mockCanManageSubscription.value = false
+    mockSubscriptionActionOperation.value = {
+      actionUrl: 'https://verify.example/sensitive-token'
+    }
+
+    renderComponent()
+
+    expect(
+      screen.queryByRole('button', { name: 'Complete verification' })
+    ).not.toBeInTheDocument()
   })
 
   it('renders the subscribed credit stop price and renewal subtitle', () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -9,6 +9,15 @@
         <i class="pi pi-spin pi-spinner" />
         <span>{{ $t('billingOperation.subscriptionProcessing') }}</span>
       </div>
+      <Button
+        v-if="subscriptionActionUrl && permissions.canManageSubscription"
+        variant="primary"
+        size="lg"
+        class="rounded-lg px-4 text-sm font-normal"
+        @click="openSubscriptionVerification"
+      >
+        {{ $t('subscription.preview.completeVerification') }}
+      </Button>
     </div>
 
     <!-- Billing data still loading: avoid rendering a false Free/$0 plan -->
@@ -350,6 +359,14 @@ const { t, n, locale } = useI18n()
 
 const billingOperationStore = useBillingOperationStore()
 const isSettingUp = computed(() => billingOperationStore.isSettingUp)
+const subscriptionActionUrl = computed(
+  () => billingOperationStore.subscriptionActionOperation?.actionUrl ?? null
+)
+
+function openSubscriptionVerification() {
+  if (!subscriptionActionUrl.value) return
+  window.open(subscriptionActionUrl.value, '_blank', 'noopener,noreferrer')
+}
 
 const {
   isActiveSubscription,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
     selectedTierKey: ref(null),
     selectedTeamStop: ref(null),
     selectedBillingCycle: ref('yearly'),
+    activeCheckoutActionUrl: ref(null),
     isPolling: ref(false),
     isTeamCheckout: computed(() => false),
     previewVariant: computed(() => null),

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -14,6 +14,7 @@
       variant="muted-textonly"
       class="absolute top-2.5 left-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
       :aria-label="$t('g.back')"
+      :disabled="isPolling"
       @click="handleBackToPricing"
     >
       <i class="pi pi-arrow-left text-xl" />
@@ -64,6 +65,7 @@
         :preview-data="previewData!"
         :team-plan="selectedTeamStop!"
         :is-loading="isSubscribing || isPolling"
+        :action-url="activeCheckoutActionUrl"
         @confirm="handleTeamSubscribe"
         @back="handleBackToPricing"
       />
@@ -73,6 +75,7 @@
         :team-plan="selectedTeamStop!"
         :billing-cycle="selectedBillingCycle"
         :is-loading="isSubscribing || isPolling"
+        :action-url="activeCheckoutActionUrl"
         @add-credit-card="handleTeamSubscribe"
         @back="handleBackToPricing"
       />
@@ -83,6 +86,7 @@
         :tier-key="selectedTierKey!"
         :billing-cycle="selectedBillingCycle"
         :is-loading="isSubscribing || isPolling"
+        :action-url="activeCheckoutActionUrl"
         @add-credit-card="handleAddCreditCard"
         @back="handleBackToPricing"
       />
@@ -91,6 +95,7 @@
         v-else-if="previewVariant === 'personal-change'"
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
+        :action-url="activeCheckoutActionUrl"
         @confirm="handleConfirmTransition"
         @back="handleBackToPricing"
       />
@@ -144,6 +149,7 @@ const {
   selectedTierKey,
   selectedTeamStop,
   selectedBillingCycle,
+  activeCheckoutActionUrl,
   isPolling,
   isTeamCheckout,
   previewVariant,
@@ -169,7 +175,12 @@ onMounted(() => {
 // Backspace mirrors the back arrow on the confirm step, but never while an
 // editable element is focused (let it delete text there).
 useEventListener(window, 'keydown', (event: KeyboardEvent) => {
-  if (event.key !== 'Backspace' || checkoutStep.value !== 'preview') return
+  if (
+    event.key !== 'Backspace' ||
+    checkoutStep.value !== 'preview' ||
+    isPolling.value
+  )
+    return
   const target = event.target
   if (
     target instanceof HTMLInputElement ||

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -64,8 +64,9 @@
         v-if="previewVariant === 'team-change'"
         :preview-data="previewData!"
         :team-plan="selectedTeamStop!"
-        :is-loading="isSubscribing || isPolling"
+        :is-loading="isLoadingPreview || isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :force-reactivation="reactivationRequired"
         @confirm="handleTeamSubscribe"
         @back="handleBackToPricing"
       />
@@ -74,7 +75,7 @@
         v-else-if="previewVariant === 'team-new'"
         :team-plan="selectedTeamStop!"
         :billing-cycle="selectedBillingCycle"
-        :is-loading="isSubscribing || isPolling"
+        :is-loading="isLoadingPreview || isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
         @add-credit-card="handleTeamSubscribe"
         @back="handleBackToPricing"
@@ -96,6 +97,7 @@
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :force-reactivation="reactivationRequired"
         @confirm="handleConfirmTransition"
         @back="handleBackToPricing"
       />
@@ -146,6 +148,7 @@ const {
   isSubscribing,
   isResubscribing,
   previewData,
+  reactivationRequired,
   selectedTierKey,
   selectedTeamStop,
   selectedBillingCycle,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.test.ts
@@ -120,6 +120,7 @@ describe('SubscriptionRequiredDialogContentWorkspace', () => {
       previewData: mockPreviewData,
       selectedTierKey: ref('standard'),
       selectedBillingCycle: ref('yearly'),
+      activeCheckoutActionUrl: ref(null),
       isPolling: ref(false),
       handleSubscribeClick: mockHandleSubscribeClick,
       handleBackToPricing: mockHandleBackToPricing,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -101,6 +101,7 @@
       :preview-data="previewData"
       :is-loading="isSubscribing || isPolling"
       :action-url="activeCheckoutActionUrl"
+      :force-reactivation="reactivationRequired"
       @confirm="handleConfirmTransition"
       @back="handleBackToPricing"
     />
@@ -152,6 +153,7 @@ const {
   isSubscribing,
   isResubscribing,
   previewData,
+  reactivationRequired,
   selectedTierKey,
   selectedBillingCycle,
   activeCheckoutActionUrl,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -8,6 +8,7 @@
       variant="muted-textonly"
       class="absolute top-2.5 left-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
       :aria-label="$t('g.back')"
+      :disabled="isPolling"
       @click="handleBackToPricing"
     >
       <i class="pi pi-arrow-left text-xl" />
@@ -85,6 +86,7 @@
       :tier-key="selectedTierKey!"
       :billing-cycle="selectedBillingCycle"
       :is-loading="isSubscribing || isPolling"
+      :action-url="activeCheckoutActionUrl"
       @add-credit-card="handleAddCreditCard"
       @back="handleBackToPricing"
     />
@@ -98,6 +100,7 @@
       "
       :preview-data="previewData"
       :is-loading="isSubscribing || isPolling"
+      :action-url="activeCheckoutActionUrl"
       @confirm="handleConfirmTransition"
       @back="handleBackToPricing"
     />
@@ -151,6 +154,7 @@ const {
   previewData,
   selectedTierKey,
   selectedBillingCycle,
+  activeCheckoutActionUrl,
   isPolling,
   handleSubscribeClick,
   handleBackToPricing,

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -128,6 +129,31 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     ).toBeTruthy()
     expect(screen.getByText('21,100')).toBeTruthy()
     expect(screen.getByText('$82.50')).toBeTruthy()
+  })
+
+  it('opens verification only from its button without exposing the URL', async () => {
+    const actionUrl = 'https://verify.example/sensitive-token'
+    const open = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    const { container } = render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({}),
+        actionUrl
+      },
+      global: globalOptions
+    })
+
+    expect(open).not.toHaveBeenCalled()
+    expect(container.innerHTML).not.toContain(actionUrl)
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.completeVerification'
+      })
+    )
+    expect(open).toHaveBeenCalledWith(
+      actionUrl,
+      '_blank',
+      'noopener,noreferrer'
+    )
   })
 
   it('renders a scheduled downgrade with the after-that block and no charge', () => {

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -173,6 +173,16 @@
       <SubscriptionTermsNote />
 
       <Button
+        v-if="actionUrl"
+        variant="primary"
+        size="lg"
+        class="w-full rounded-lg"
+        @click="openVerification"
+      >
+        {{ $t('subscription.preview.completeVerification') }}
+      </Button>
+
+      <Button
         variant="tertiary"
         size="lg"
         class="w-full rounded-lg"
@@ -186,6 +196,7 @@
       <Button
         variant="textonly"
         class="cursor-pointer text-center text-xs text-muted-foreground transition-colors hover:bg-none hover:text-base-foreground"
+        :disabled="isLoading"
         @click="$emit('back')"
       >
         {{ $t('subscription.preview.backToAllPlans') }}
@@ -214,13 +225,15 @@ type PersonalTierKey = 'standard' | 'creator' | 'pro'
 const {
   previewData,
   isLoading = false,
-  teamPlan = null
+  teamPlan = null,
+  actionUrl = null
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
   /** Set for a team credit-commit change: plan name + refill credits come from
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
+  actionUrl?: string | null
 }>()
 
 defineEmits<{
@@ -232,6 +245,11 @@ defineEmits<{
 
 const { t, n } = useI18n()
 const { subscription } = useBillingContext()
+
+function openVerification() {
+  if (!actionUrl) return
+  window.open(actionUrl, '_blank', 'noopener,noreferrer')
+}
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -226,7 +226,8 @@ const {
   previewData,
   isLoading = false,
   teamPlan = null,
-  actionUrl = null
+  actionUrl = null,
+  forceReactivation = false
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
@@ -234,6 +235,9 @@ const {
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
   actionUrl?: string | null
+  /** Server-authoritative fallback for legacy status reads that omit a
+   * scheduled cancellation until subscribe enforces the consent gate. */
+  forceReactivation?: boolean
 }>()
 
 defineEmits<{
@@ -253,6 +257,10 @@ function openVerification() {
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)
+}
+
+function isTeamTier(tier: string): boolean {
+  return tier.toUpperCase() === 'TEAM'
 }
 
 function formatDate(date: string | Date): string {
@@ -297,16 +305,22 @@ const newTierName = computed(() =>
     ? t('subscription.teamPlan.name')
     : formatTierName(previewData.new_plan.tier)
 )
-const currentTierName = computed(() =>
-  previewData.current_plan ? formatTierName(previewData.current_plan.tier) : ''
-)
+const currentTierName = computed(() => {
+  const tier = previewData.current_plan?.tier
+  if (!tier) return ''
+  return isTeamTier(tier)
+    ? t('subscription.teamPlan.name')
+    : formatTierName(tier)
+})
 const currentPlanLabel = computed(() =>
   currentIsYearly.value
     ? t('subscription.tierNameYearly', { name: currentTierName.value })
     : currentTierName.value
 )
 
-const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+const isCancelled = computed(
+  () => forceReactivation || (subscription.value?.isCancelled ?? false)
+)
 
 const reactivationVariant = computed<
   'upgrade' | 'downgrade' | 'duration_change' | null
@@ -326,16 +340,20 @@ const reactivationVariant = computed<
 // Requires the data the banner and threshold math actually read
 // (subscription.endDate, previewData.current_plan) — without it the banner
 // would render broken copy or force the checkbox on a bogus $0 threshold.
+const cancelAt = computed(
+  () => subscription.value?.endDate ?? previewData.current_plan?.period_end
+)
+
 const isReactivating = computed(
   () =>
     isCancelled.value &&
     reactivationVariant.value !== null &&
-    !!subscription.value?.endDate &&
+    !!cancelAt.value &&
     !!previewData.current_plan
 )
 
 const cancelDate = computed(() =>
-  subscription.value?.endDate ? formatDate(subscription.value.endDate) : ''
+  cancelAt.value ? formatDate(cancelAt.value) : ''
 )
 
 // seat_summary.total_cost_cents is the whole-subscription price; price_cents
@@ -363,11 +381,14 @@ const chargeDisplay = computed(
 )
 
 const reactivationConfirmed = ref(false)
-// A checked box is consent to *this* charge; a later charge change (e.g. a
-// different preview loads) must not carry that consent forward.
-watch(chargeCents, () => {
-  reactivationConfirmed.value = false
-})
+// A checked box is consent to this exact preview. A replacement preview must
+// not inherit that consent, even when its displayed charge is unchanged.
+watch(
+  () => previewData,
+  () => {
+    reactivationConfirmed.value = false
+  }
+)
 
 // isInitialized is aggregate (status + balance + plans); a balance or plans
 // failure must not permanently disable an otherwise-valid, already-loaded

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -37,6 +37,7 @@ const i18n = createI18n({
           standard: { name: 'Standard' },
           creator: { name: 'Creator' }
         },
+        teamPlan: { name: 'Team Plan' },
         preview: {
           switchesToday: 'Switches today',
           startsOn: 'Starts {date}',
@@ -124,9 +125,12 @@ function makePreview(
   }
 }
 
-function renderComponent(previewData: PreviewSubscribeResponse) {
+function renderComponent(
+  previewData: PreviewSubscribeResponse,
+  forceReactivation = false
+) {
   return render(SubscriptionTransitionPreviewWorkspace, {
-    props: { previewData },
+    props: { previewData, forceReactivation },
     global: { plugins: [i18n] }
   })
 }
@@ -149,6 +153,34 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(
         screen.queryByText('Reactivating your subscription')
       ).not.toBeInTheDocument()
+    })
+
+    it('uses a server-authoritative reactivation requirement when status omits the cancellation', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      const preview = makePreview({
+        transition_type: 'upgrade',
+        cost_today_cents: 2500
+      })
+      preview.current_plan!.tier = 'TEAM'
+      preview.current_plan!.period_end = '2026-08-29T00:00:00Z'
+
+      const { container } = renderComponent(preview, true)
+
+      expect(
+        screen.getByText('Reactivating your subscription')
+      ).toBeInTheDocument()
+      expect(container.textContent).toContain(
+        i18n.global.t('subscription.teamPlan.name')
+      )
+      expect(container.textContent).toContain('Aug 29, 2026')
+      expect(container.textContent).not.toContain(
+        'subscription.tiers.team.name'
+      )
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $25.00 today'
+        })
+      ).toBeDisabled()
     })
   })
 
@@ -566,7 +598,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('reactivation consent lifetime', () => {
-    it('resets a ticked checkbox when the charge amount changes', async () => {
+    it('resets a ticked checkbox when a replacement preview keeps the same charge', async () => {
       const user = userEvent.setup()
       mockSubscription.value = {
         isCancelled: true,
@@ -598,22 +630,24 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         })
       ).toBeEnabled()
 
-      // A different preview loads (e.g. user went back and re-previewed) with
-      // a higher charge; the earlier tick must not carry over as consent.
+      // A fresh quote can carry materially different billing state while
+      // displaying the same charge; the earlier tick must not carry over.
       await rerender({
         previewData: makePreview({
           transition_type: 'duration_change',
-          cost_today_cents: 50_000,
+          cost_today_cents: 33_600,
+          credits_next_period_cents: 1_000,
+          proration_at: '2026-08-01T00:01:00Z',
           new_plan: {
             slug: 'standard-annual',
             tier: 'STANDARD',
             duration: 'ANNUAL',
-            price_cents: 50_000,
+            price_cents: 33_600,
             credits_cents: 0,
             period_end: '2027-08-15T00:00:00Z',
             seat_summary: {
               seat_count: 1,
-              total_cost_cents: 50_000,
+              total_cost_cents: 33_600,
               total_credits_cents: 0
             }
           }
@@ -623,7 +657,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(screen.getByRole('checkbox')).not.toBeChecked()
       expect(
         screen.getByRole('button', {
-          name: 'Confirm & reactivate — $500.00 today'
+          name: 'Confirm & reactivate — $336.00 today'
         })
       ).toBeDisabled()
     })

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.test.ts
@@ -29,7 +29,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
-    hasPendingOperations: false,
+    hasPendingOperations: true,
+    isAddingCredits: false,
     startOperation: mockStartOperation
   })
 }))
@@ -157,6 +158,12 @@ describe('TopUpCreditsDialogContentWorkspace', () => {
     mockShouldUseWorkspaceBilling.value = true
     mockFetchBalance.mockResolvedValue(undefined)
     mockFetchStatus.mockResolvedValue(undefined)
+  })
+
+  it('allows a top-up while an unrelated billing operation is pending', () => {
+    renderDialog()
+
+    expect(screen.getByRole('button', { name: 'Add credits' })).toBeEnabled()
   })
 
   it('refreshes both balance and status after a completed top-up', async () => {

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -183,7 +183,7 @@ const { shouldUseWorkspaceBilling } = useBillingRouting()
 const { permissions } = useWorkspaceUI()
 
 const billingOperationStore = useBillingOperationStore()
-const isPolling = computed(() => billingOperationStore.hasPendingOperations)
+const isPolling = computed(() => billingOperationStore.isAddingCredits)
 
 // Constants
 const PRESET_AMOUNTS = [10, 25, 50, 100]

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 
-import { useDowngradeToPersonal } from './useDowngradeToPersonal'
+import {
+  ReactivationConfirmationRequiredError,
+  useDowngradeToPersonal
+} from './useDowngradeToPersonal'
 
 const mockMembers = ref<WorkspaceMember[]>([])
 const mockUserEmail = ref<string | null>(null)
@@ -219,7 +222,7 @@ describe('useDowngradeToPersonal', () => {
     })
 
     it('stops before submit when downgrade access is revoked during member removal', async () => {
-      mockMembers.value = teamWithOwnerAnd('m1')
+      mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation(async () => {
         mockPermissions.value.canDowngradeToPersonal = false
       })
@@ -330,6 +333,35 @@ describe('useDowngradeToPersonal', () => {
       expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
+    it('surfaces a hidden cancellation after member cleanup and forwards the quote timestamp', async () => {
+      mockSubscription.value = { isCancelled: false }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 1500,
+        proration_at: '2026-07-30T00:00:00Z'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        ReactivationConfirmationRequiredError
+      )
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'founder-monthly',
+        expect.objectContaining({
+          confirmReactivation: false,
+          prorationAt: '2026-07-30T00:00:00Z'
+        })
+      )
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
+    })
+
     it('requires reactivation confirmation when subscription state has not loaded yet', async () => {
       // isInitialized false means "cancelled or not" is unknown; must not
       // default to "not cancelled" and skip disclosure.
@@ -404,7 +436,7 @@ describe('useDowngradeToPersonal', () => {
       expect(mockSubscribe).toHaveBeenCalled()
     })
 
-    it('validates the transition before removing, then removes, then subscribes', async () => {
+    it('validates the transition before removing members, then subscribes', async () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       const calls: string[] = []
       mockPreviewSubscribe.mockImplementation(() => {
@@ -588,7 +620,7 @@ describe('useDowngradeToPersonal', () => {
       )
     })
 
-    it('reports members were already removed when subscribe fails after removal', async () => {
+    it('reports members were already removed when subscribe returns no response', async () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       mockSubscribe.mockResolvedValue(undefined)
       const { downgradeToPersonal } = useDowngradeToPersonal()
@@ -596,9 +628,10 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.failedAfterMemberRemoval'
       )
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
     })
 
-    it('surfaces which member failed and skips the plan change when removal throws', async () => {
+    it('surfaces which member failed and skips the plan change', async () => {
       mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation((id: string) =>
         id === 'm2' ? Promise.reject(new Error('network')) : Promise.resolve()

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -30,9 +30,9 @@ export interface DowngradePreview {
   requiresReactivationConfirmation: boolean
 }
 
-/** Thrown by `downgradeToPersonal` before any member is removed, so a caller
- *  can collect consent and retry with `confirmReactivation: true` instead of
- *  losing team members on a request the BE was always going to reject. */
+/** Thrown by `downgradeToPersonal` when the billing authority requires
+ *  reactivation consent, so the still-open confirmation can collect it and
+ *  retry with `confirmReactivation: true`. */
 export class ReactivationConfirmationRequiredError extends Error {
   constructor(public readonly preview: PreviewSubscribeResponse) {
     super(t('subscription.downgrade.reactivationConfirmationRequired'))
@@ -51,6 +51,8 @@ export class ReactivationAmountChangedError extends Error {
 /**
  * Team-plan downgrade to personal: validate via `previewSubscribe`, remove
  * every member except the original owner, then initiate the tier change.
+ * Billing is not committed until member cleanup succeeds, so a removal failure
+ * cannot leave a personal plan with Team members still attached.
  * The removal-email and an atomic downgrade endpoint are backend-owned future
  * work; until then the frontend orchestrates the two steps non-atomically.
  */
@@ -79,6 +81,15 @@ export function useDowngradeToPersonal() {
     if (!permissions.value.canDowngradeToPersonal) {
       throw new Error(t('subscription.downgrade.notAllowed'))
     }
+  }
+
+  function hasErrorCode(error: unknown, code: string): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === code
+    )
   }
 
   async function refreshMembers(): Promise<void> {
@@ -171,20 +182,21 @@ export function useDowngradeToPersonal() {
         )
       }
       ensureCanDowngrade()
-      targetTier = preview.new_plan?.tier
-        ? TIER_TO_KEY[preview.new_plan.tier]
-        : undefined
+      targetTier =
+        preview.new_plan?.tier && preview.new_plan.tier !== 'TEAM'
+          ? TIER_TO_KEY[preview.new_plan.tier]
+          : undefined
       targetCycle = preview.new_plan
         ? preview.new_plan.duration === 'ANNUAL'
           ? 'yearly'
           : 'monthly'
         : undefined
 
-      // Guard before touching membership: the BE rejects this subscribe
-      // without confirm_reactivation, so members must never be removed for a
-      // transition that's going to fail on consent anyway. Refresh the
-      // cached subscription first — it can predate a cancellation that
-      // happened after the earlier previewDowngrade() call.
+      // Catch cancellations visible to billing status before touching
+      // membership. Refresh first because the cached value can predate a
+      // cancellation that happened after previewDowngrade(); legacy-rail
+      // cancellations omitted by status are recovered from the later
+      // authority rejection while the confirmation remains open.
       await fetchStatus()
       if (requiresReactivationConfirmation(preview)) {
         if (!confirmReactivation) {
@@ -223,11 +235,27 @@ export function useDowngradeToPersonal() {
       }
 
       ensureCanDowngrade()
-      const response = await subscribe(planSlug, {
-        returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
-      })
+      let response: SubscribeResponse | void
+      try {
+        response = await subscribe(planSlug, {
+          returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
+          cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+          confirmReactivation,
+          ...(preview.proration_at && { prorationAt: preview.proration_at })
+        })
+      } catch (error) {
+        if (
+          !confirmReactivation &&
+          hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')
+        ) {
+          telemetryFailure = {
+            failure_category: 'validation',
+            error_code: 'reactivation_not_confirmed'
+          }
+          throw new ReactivationConfirmationRequiredError(preview)
+        }
+        throw error
+      }
       if (!response) {
         telemetryFailure = {
           failure_category: 'unknown',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, reactive } from 'vue'
 
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
-import type { Plan } from '@/platform/workspace/api/workspaceApi'
+import type {
+  Plan,
+  PreviewSubscribeResponse
+} from '@/platform/workspace/api/workspaceApi'
 
 import { findPlanSlug } from './useSubscriptionCheckout'
 
@@ -44,6 +47,70 @@ function makeCreatorMonthly(): Plan {
 
 function allPlans(): Plan[] {
   return [makeStandardYearly(), makeCreatorMonthly()]
+}
+
+interface ReactivationPreviewPlanInput {
+  slug: string
+  tier: PreviewSubscribeResponse['new_plan']['tier']
+  duration: PreviewSubscribeResponse['new_plan']['duration']
+  priceCents: number
+  creditsCents: number
+  periodEnd: string
+}
+
+interface ReactivationPreviewInput {
+  effectiveAt: string
+  costTodayCents: number
+  costNextPeriodCents: number
+  creditsTodayCents: number
+  creditsNextPeriodCents: number
+  currentPlan: ReactivationPreviewPlanInput
+  newPlan: ReactivationPreviewPlanInput
+}
+
+function makeReactivationAuthorityPreview({
+  effectiveAt,
+  costTodayCents,
+  costNextPeriodCents,
+  creditsTodayCents,
+  creditsNextPeriodCents,
+  currentPlan,
+  newPlan
+}: ReactivationPreviewInput): PreviewSubscribeResponse {
+  const makePlan = ({
+    slug,
+    tier,
+    duration,
+    priceCents,
+    creditsCents,
+    periodEnd
+  }: ReactivationPreviewPlanInput): PreviewSubscribeResponse['new_plan'] => ({
+    slug,
+    tier,
+    duration,
+    price_cents: priceCents,
+    credits_cents: creditsCents,
+    period_end: periodEnd,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: priceCents,
+      total_credits_cents: creditsCents
+    }
+  })
+
+  return {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: effectiveAt,
+    is_immediate: true,
+    cost_today_cents: costTodayCents,
+    cost_next_period_cents: costNextPeriodCents,
+    credits_today_cents: creditsTodayCents,
+    credits_next_period_cents: creditsNextPeriodCents,
+    proration_at: '2026-07-30T00:00:00Z',
+    current_plan: makePlan(currentPlan),
+    new_plan: makePlan(newPlan)
+  }
 }
 
 describe('findPlanSlug', () => {
@@ -598,6 +665,101 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
 
+    it('blocks confirmation until the Team change preview resolves', async () => {
+      let resolvePreview!: (preview: Partial<PreviewSubscribeResponse>) => void
+      mockPreviewSubscribe.mockImplementationOnce(
+        () =>
+          new Promise<Partial<PreviewSubscribeResponse>>((resolve) => {
+            resolvePreview = resolve
+          })
+      )
+      const checkout = await setup()
+
+      const selectionPromise = checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.isLoadingPreview.value).toBe(true)
+      await checkout.handleTeamSubscribe()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+
+      resolvePreview({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await selectionPromise
+
+      expect(checkout.isLoadingPreview.value).toBe(false)
+      expect(checkout.previewVariant.value).toBe('team-change')
+    })
+
+    it('discards a Team preview for a superseded stop and cycle', async () => {
+      let resolveStalePreview!: (
+        preview: Partial<PreviewSubscribeResponse>
+      ) => void
+      mockPreviewSubscribe
+        .mockImplementationOnce(
+          () =>
+            new Promise<Partial<PreviewSubscribeResponse>>((resolve) => {
+              resolveStalePreview = resolve
+            })
+        )
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'downgrade',
+          is_immediate: false,
+          cost_today_cents: 0
+        })
+      const checkout = await setup()
+
+      const staleSelection = checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 630
+        },
+        billingCycle: 'yearly',
+        isChange: true
+      })
+
+      resolveStalePreview({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await staleSelection
+
+      expect(checkout.selectedTeamStop.value?.id).toBe('team_700')
+      expect(checkout.selectedBillingCycle.value).toBe('yearly')
+      expect(checkout.previewData.value).toMatchObject({
+        transition_type: 'downgrade',
+        cost_today_cents: 0
+      })
+      expect(checkout.isLoadingPreview.value).toBe(false)
+    })
+
     it('falls back to the display-only confirm when the preview is a fresh subscription', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockResolvedValueOnce({
@@ -668,7 +830,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 70_000
+        cost_today_cents: 70_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       const checkout = await setup()
 
@@ -692,6 +855,53 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(checkout.previewData.value).not.toBeNull()
       expect(checkout.previewVariant.value).toBe('team-change')
+    })
+
+    it('shows the reactivation preview for a cancelled Team downgrade scheduled at period end', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const preview = {
+        allowed: true,
+        transition_type: 'downgrade' as const,
+        is_immediate: false,
+        cost_today_cents: 0,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      }
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(checkout.previewData.value).toEqual(preview)
+      expect(checkout.previewVariant.value).toBe('team-change')
+      expect(mockToastAdd).not.toHaveBeenCalled()
+
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        ...preview,
+        proration_at: '2026-07-29T12:01:00Z'
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-scheduled-reactivation'
+      })
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: undefined
+        })
+      )
     })
 
     it('bounces a cancelled subscriber back to pricing when the preview does not qualify', async () => {
@@ -907,6 +1117,186 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('keeps the quoted Team charge when fresh material state is unchanged', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_today_cents: 221_550,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        credits_today_cents: 221_548,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-quoted-reactivation'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledTimes(2)
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:00:00Z'
+        })
+      )
+    })
+
+    it('blocks a quoted Team charge when material preview state changed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_next_period_cents: 295_400,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_next_period_cents: 300_000,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(checkout.previewData.value?.credits_next_period_cents).toBe(
+        300_000
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+    })
+
+    it('refreshes an expired Team quote and submits only after reconfirmation', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        proration_at: '2026-07-29T12:14:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        proration_at: '2026-07-29T12:16:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1)
+      expect(checkout.previewData.value?.proration_at).toBe(
+        '2026-07-29T12:16:00Z'
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'team'
+        })
+      )
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-refreshed-quote'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        proration_at: '2026-07-29T12:16:05Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:16:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
+
     // Regression guard: confirmReactivation must come from the disclosure
     // banner's own confirm action, never be re-derived from
     // subscription.isCancelled. A path with no banner (team-new fallback)
@@ -941,7 +1331,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 105_000
+        cost_today_cents: 105_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -957,7 +1348,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 120_000
+        cost_today_cents: 120_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleTeamSubscribe(true)
@@ -980,7 +1372,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 120_000
+        cost_today_cents: 120_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',
@@ -1037,9 +1430,9 @@ describe('useSubscriptionCheckout', () => {
 
     // Regression guard: drift recovery must reuse the same reactivation-
     // capable predicate as the initial cancelled-Team preview. A refreshed
-    // preview that comes back as a fresh subscribe can't feed the banner or
-    // emit confirm_reactivation, so installing it as a team-change would
-    // strand every retry; this must bounce back to pricing instead.
+    // preview without the current-plan date can't feed the banner or emit
+    // confirm_reactivation, so installing it as a team-change would strand
+    // every retry; this must bounce back to pricing instead.
     it('bounces to pricing when a status-drift refresh returns a preview that cannot collect reactivation consent', async () => {
       mockSubscription.value = { isCancelled: false }
       const checkout = await setup()
@@ -1063,11 +1456,12 @@ describe('useSubscriptionCheckout', () => {
 
       mockFetchStatus.mockImplementationOnce(() => {
         mockSubscription.value = { isCancelled: true }
+        checkout.reactivationRequired.value = true
         return Promise.resolve()
       })
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
-        transition_type: 'new_subscription',
+        transition_type: 'upgrade',
         is_immediate: true
       })
 
@@ -1079,6 +1473,87 @@ describe('useSubscriptionCheckout', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
+    })
+
+    it('recovers when the subscribe authority sees a cancellation omitted by the status read', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      const preview = makeReactivationAuthorityPreview({
+        effectiveAt: '2026-08-30T00:00:00Z',
+        costTodayCents: 18_999,
+        costNextPeriodCents: 39_000,
+        creditsTodayCents: 42_200,
+        creditsNextPeriodCents: 84_400,
+        currentPlan: {
+          slug: 'team_per_credit_monthly',
+          tier: 'TEAM',
+          duration: 'MONTHLY',
+          priceCents: 20_000,
+          creditsCents: 42_200,
+          periodEnd: '2026-08-29T00:00:00Z'
+        },
+        newPlan: {
+          slug: 'team_per_credit_monthly',
+          tier: 'TEAM',
+          duration: 'MONTHLY',
+          priceCents: 39_000,
+          creditsCents: 84_400,
+          periodEnd: '2026-08-30T00:00:00Z'
+        }
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_400',
+          usd: 400,
+          credits: 84_400,
+          discountedUsd: 390
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+
+      await checkout.handleTeamSubscribe()
+
+      expect(checkout.reactivationRequired.value).toBe(true)
+      expect(checkout.previewData.value).toStrictEqual(preview)
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'team'
+        })
+      )
+
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-authoritative-reactivation'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-30T00:00:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
     })
 
     it('uses the annual plan slug for the yearly cycle', async () => {
@@ -1241,13 +1716,15 @@ describe('useSubscriptionCheckout', () => {
 
       mockFetchStatus.mockImplementationOnce(() => {
         mockSubscription.value = { isCancelled: true }
+        checkout.reactivationRequired.value = true
         return Promise.resolve()
       })
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 110_000
+        cost_today_cents: 110_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleTeamSubscribe()
@@ -1262,7 +1739,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 110_000
+        cost_today_cents: 110_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',
@@ -1348,6 +1826,16 @@ describe('useSubscriptionCheckout', () => {
 
       resolveOperation({ status: 'failed' })
       await payment
+    })
+
+    it('keeps the confirmation open while a submit is in flight', async () => {
+      const checkout = await setup()
+      checkout.checkoutStep.value = 'preview'
+      checkout.isSubscribing.value = true
+
+      checkout.handleBackToPricing()
+
+      expect(checkout.checkoutStep.value).toBe('preview')
     })
 
     it('does not apply an operation result after switching workspaces', async () => {
@@ -1722,6 +2210,242 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('recovers a personal transition when the subscribe authority requires reactivation consent', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      const preview = makeReactivationAuthorityPreview({
+        effectiveAt: '2026-08-29T00:00:00Z',
+        costTodayCents: 1500,
+        costNextPeriodCents: 1600,
+        creditsTodayCents: 3150,
+        creditsNextPeriodCents: 4200,
+        currentPlan: {
+          slug: 'creator-monthly',
+          tier: 'CREATOR',
+          duration: 'MONTHLY',
+          priceCents: 3500,
+          creditsCents: 7400,
+          periodEnd: '2026-08-29T00:00:00Z'
+        },
+        newPlan: {
+          slug: 'standard-yearly',
+          tier: 'STANDARD',
+          duration: 'ANNUAL',
+          priceCents: 1600,
+          creditsCents: 4200,
+          periodEnd: '2027-08-29T00:00:00Z'
+        }
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+
+      await checkout.handleConfirmTransition()
+
+      expect(checkout.reactivationRequired.value).toBe(true)
+      expect(checkout.previewData.value).toStrictEqual(preview)
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'standard'
+        })
+      )
+    })
+
+    it('keeps a pinned immediate duration-change quote when time-derived values drift', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      const currentPlan = {
+        slug: 'creator-monthly',
+        tier: 'CREATOR',
+        duration: 'MONTHLY',
+        price_cents: 3500,
+        credits_cents: 7400,
+        period_end: '2026-08-29T00:00:00Z'
+      }
+      const newPlan = {
+        slug: 'standard-yearly',
+        tier: 'STANDARD',
+        duration: 'ANNUAL',
+        price_cents: 1600,
+        credits_cents: 4200,
+        period_end: '2027-08-29T00:00:00Z'
+      }
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'duration_change',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        credits_today_cents: 3150,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: currentPlan,
+        new_plan: newPlan
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'duration_change',
+        is_immediate: true,
+        cost_today_cents: 1499,
+        credits_today_cents: 3148,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: currentPlan,
+        new_plan: newPlan
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-personal-quoted-reactivation'
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledTimes(2)
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:00:00Z'
+        })
+      )
+    })
+
+    it('refreshes an expired personal quote and submits only after reconfirmation', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        proration_at: '2026-07-29T12:00:00Z'
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1499,
+        proration_at: '2026-07-29T12:14:00Z'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1600,
+        proration_at: '2026-07-29T12:16:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1)
+      expect(checkout.previewData.value?.proration_at).toBe(
+        '2026-07-29T12:16:00Z'
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.amountChanged'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'standard'
+        })
+      )
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-personal-refreshed-quote'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1599,
+        proration_at: '2026-07-29T12:16:05Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'standard-yearly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:16:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
+
+    it('keeps the confirmation open when an expired-quote refresh fails', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        proration_at: '2026-07-29T12:00:00Z'
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1499
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockRejectedValueOnce(new Error('Preview offline'))
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: 'Preview offline' })
+      )
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.unavailable'
+        })
+      )
+    })
+
     // Regression guard: confirmReactivation must come from the disclosure
     // banner's own confirm action, never be re-derived from
     // subscription.isCancelled. A path with no banner (add-payment preview)
@@ -1878,7 +2602,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 1600
+        cost_today_cents: 1600,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleConfirmTransition()
@@ -1898,7 +2623,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 1600
+        cost_today_cents: 1600,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -78,12 +78,15 @@ const {
   mockResubscribe,
   mockToastAdd,
   mockStartOperation,
+  mockGetOperation,
+  mockSubscriptionActionOperation,
   mockTrackBeginCheckout,
   mockTrackBillingEvent,
   mockShowDowngradeToPersonalDialog,
   mockUserId,
   mockIsTeamPlan,
   mockShouldUseWorkspaceBilling,
+  mockSetActiveWorkspaceId,
   mockPermissions,
   mockSubscription
 } = vi.hoisted(() => ({
@@ -96,12 +99,23 @@ const {
   mockResubscribe: vi.fn(),
   mockToastAdd: vi.fn(),
   mockStartOperation: vi.fn(),
+  mockGetOperation: vi.fn(),
+  mockSubscriptionActionOperation: {
+    value: undefined as
+      | {
+          status: 'pending'
+          workspaceId: string
+          actionUrl: string
+        }
+      | undefined
+  },
   mockTrackBeginCheckout: vi.fn(),
   mockTrackBillingEvent: vi.fn(),
   mockShowDowngradeToPersonalDialog: vi.fn(),
   mockUserId: { value: 'user-1' as string | null },
   mockIsTeamPlan: { value: false },
   mockShouldUseWorkspaceBilling: { value: true },
+  mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(),
   mockPermissions: {
     value: {
       canManageSubscription: true,
@@ -158,9 +172,27 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
     startOperation: mockStartOperation,
-    hasPendingOperations: false
+    getOperation: mockGetOperation,
+    get subscriptionActionOperation() {
+      return mockSubscriptionActionOperation.value
+    }
   })
 }))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
+  const { ref } = await import('vue')
+  const activeWorkspaceId = ref('workspace-1')
+  mockSetActiveWorkspaceId.mockImplementation((workspaceId) => {
+    activeWorkspaceId.value = workspaceId
+  })
+  return {
+    useTeamWorkspaceStore: () => ({
+      get activeWorkspaceId() {
+        return activeWorkspaceId.value
+      }
+    })
+  }
+})
 
 vi.mock('@/config/comfyApi', () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.comfy.org'
@@ -211,13 +243,19 @@ describe('useSubscriptionCheckout', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
+    mockSubscriptionActionOperation.value = undefined
     mockPlans.value = allPlans()
     mockFetchPlans.mockResolvedValue(undefined)
-    mockStartOperation.mockResolvedValue({ status: 'succeeded' })
+    mockStartOperation.mockResolvedValue({
+      status: 'succeeded',
+      workspaceId: 'workspace-1'
+    })
+    mockGetOperation.mockReturnValue(undefined)
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
     mockUserId.value = 'user-1'
     mockIsTeamPlan.value = false
     mockShouldUseWorkspaceBilling.value = true
+    mockSetActiveWorkspaceId('workspace-1')
     mockPermissions.value = {
       canManageSubscription: true,
       canManageSubscriptionLifecycle: true,
@@ -1242,6 +1280,21 @@ describe('useSubscriptionCheckout', () => {
   })
 
   describe('handleBackToPricing', () => {
+    it('surfaces a subscription operation recovered from billing status', async () => {
+      mockSubscriptionActionOperation.value = {
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        actionUrl: 'https://verify.example/sensitive-token'
+      }
+
+      const checkout = await setup()
+
+      expect(checkout.activeCheckoutActionUrl.value).toBe(
+        'https://verify.example/sensitive-token'
+      )
+      expect(checkout.isPolling.value).toBe(true)
+    })
+
     it('resets to pricing step and clears preview data', async () => {
       const checkout = await setup()
       checkout.checkoutStep.value = 'preview'
@@ -1264,6 +1317,79 @@ describe('useSubscriptionCheckout', () => {
 
       expect(checkout.checkoutStep.value).toBe('pricing')
       expect(checkout.selectedTeamStop.value).toBeNull()
+    })
+
+    it('keeps the active payment preview open while polling', async () => {
+      const checkout = await setup()
+      checkout.checkoutStep.value = 'preview'
+      checkout.selectedTierKey.value = 'standard'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-pending'
+      })
+      mockGetOperation.mockImplementation((opId) =>
+        opId === 'op-pending'
+          ? { status: 'pending', workspaceId: 'workspace-1' }
+          : undefined
+      )
+      let resolveOperation!: (operation: { status: 'failed' }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOperation = resolve
+          })
+      )
+
+      const payment = checkout.handleAddCreditCard()
+      await vi.waitFor(() => expect(mockStartOperation).toHaveBeenCalledOnce())
+      checkout.handleBackToPricing()
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+
+      resolveOperation({ status: 'failed' })
+      await payment
+    })
+
+    it('does not apply an operation result after switching workspaces', async () => {
+      const checkout = await setup()
+      checkout.selectedTierKey.value = 'standard'
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'pending_payment',
+        billing_op_id: 'op-pending'
+      })
+      mockGetOperation.mockReturnValue({
+        status: 'pending',
+        workspaceId: 'workspace-1',
+        actionUrl: 'https://verify.example/sensitive-token'
+      })
+      let resolveOperation!: (operation: {
+        status: 'succeeded'
+        workspaceId: string
+      }) => void
+      mockStartOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOperation = resolve
+          })
+      )
+
+      const payment = checkout.handleAddCreditCard()
+      await vi.waitFor(() =>
+        expect(checkout.activeCheckoutActionUrl.value).not.toBeNull()
+      )
+
+      mockSetActiveWorkspaceId('workspace-2')
+
+      expect(checkout.activeCheckoutActionUrl.value).toBeNull()
+      expect(checkout.isPolling.value).toBe(false)
+
+      resolveOperation({
+        status: 'succeeded',
+        workspaceId: 'workspace-1'
+      })
+      await payment
+
+      expect(checkout.checkoutStep.value).not.toBe('success')
     })
   })
 
@@ -1392,7 +1518,10 @@ describe('useSubscriptionCheckout', () => {
         status: 'needs_payment_method',
         billing_op_id: 'op-no-url'
       })
-      mockStartOperation.mockResolvedValueOnce({ status: 'succeeded' })
+      mockStartOperation.mockResolvedValueOnce({
+        status: 'succeeded',
+        workspaceId: 'workspace-1'
+      })
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
       await checkout.handleAddCreditCard()
@@ -1421,7 +1550,10 @@ describe('useSubscriptionCheckout', () => {
         billing_op_id: 'op-async-1',
         payment_method_url: 'https://stripe.com/pay'
       })
-      mockStartOperation.mockResolvedValueOnce({ status: 'succeeded' })
+      mockStartOperation.mockResolvedValueOnce({
+        status: 'succeeded',
+        workspaceId: 'workspace-1'
+      })
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
       await checkout.handleAddCreditCard()

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -51,8 +51,7 @@ interface SubscriptionCheckoutOptions {
 
 /**
  * Which screen the `preview` step shows. Only a change prorates: a team change
- * carries `previewData` (handleSubscribeTeamClick sets it solely for an immediate
- * team transition), a personal change is anything other than `new_subscription`;
+ * carries `previewData`, a personal change is anything other than `new_subscription`;
  * the rest are display-only fresh-subscribe confirms.
  */
 type PreviewVariant =
@@ -62,10 +61,10 @@ type PreviewVariant =
   | 'personal-new'
   | null
 
-/** Thrown by `assertReactivationAmountUnchanged` when a fresh preview's
- *  `cost_today_cents` no longer matches what the reactivation banner showed
- *  and the user consented to. Caught by the surrounding try/catch and
- *  surfaced through the same toast as any other subscribe failure. */
+/** Thrown by `assertReactivationAmountUnchanged` when a fresh preview no
+ *  longer matches the billing state the reactivation banner showed and the
+ *  user consented to. Caught by the surrounding try/catch and surfaced
+ *  through the same toast as any other subscribe failure. */
 class ReactivationAmountChangedError extends Error {}
 
 export function findPlanSlug(
@@ -114,6 +113,12 @@ export function useSubscriptionCheckout(
   const previewData = ref<PreviewSubscribeResponse | null>(null)
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
+  let teamPreviewRequestId = 0
+  // Some legacy-rail status reads cannot expose a scheduled cancellation even
+  // though the subscribe authority can see it in Stripe. Once that authority
+  // rejects an unconfirmed change, keep the consent screen in reactivation
+  // mode until the user backs out or completes the change.
+  const reactivationRequired = ref(false)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
   const activeCheckoutOperationId = ref<string | null>(null)
   const activeCheckoutOperation = computed(() => {
@@ -153,47 +158,161 @@ export function useSubscriptionCheckout(
     })
   }
 
-  // Shared by the initial cancelled-Team preview (handleSubscribeTeamClick)
-  // and drift recovery (refreshPreviewOnReactivationBlock): a preview can
-  // only feed the reactivation banner if it's allowed, immediate, and an
-  // existing-plan change — new_subscription and scheduled changes route to
-  // screens that can't render the disclosure or emit confirm_reactivation.
+  function isExistingPlanPreview(
+    preview: PreviewSubscribeResponse | null | undefined
+  ): preview is PreviewSubscribeResponse & { allowed: true } {
+    return !!preview?.allowed && preview.transition_type !== 'new_subscription'
+  }
+
   function isReactivationCapablePreview(
     preview: PreviewSubscribeResponse | null | undefined
-  ): boolean {
+  ): preview is PreviewSubscribeResponse & { allowed: true } {
     return (
-      !!preview?.allowed &&
-      preview.is_immediate &&
-      preview.transition_type !== 'new_subscription'
+      isExistingPlanPreview(preview) &&
+      !!preview.current_plan &&
+      !!(subscription.value?.endDate ?? preview.current_plan.period_end)
     )
   }
 
-  // subscribe() recomputes the transaction independently of the preview the
-  // banner showed, so proration or team-seat state can drift while the
-  // screen is open. Re-preview right before billing and refuse if the
-  // amount moved — mirrors the guard useDowngradeToPersonal applies before
-  // a team-to-personal downgrade.
+  function reactivationMaterialSnapshot(
+    preview: PreviewSubscribeResponse,
+    ignoreTimeDerivedTodayValues = false
+  ): string {
+    const planSnapshot = (
+      plan: PreviewSubscribeResponse['new_plan'] | undefined
+    ) =>
+      plan
+        ? [
+            plan.slug,
+            plan.tier,
+            plan.duration,
+            plan.price_cents,
+            plan.credits_cents,
+            plan.seat_summary?.seat_count,
+            plan.seat_summary?.total_cost_cents,
+            plan.seat_summary?.total_credits_cents,
+            plan.period_start,
+            plan.period_end
+          ]
+        : null
+
+    return JSON.stringify([
+      preview.allowed,
+      preview.transition_type,
+      preview.is_immediate,
+      preview.is_immediate ? null : preview.effective_at,
+      preview.cost_next_period_cents,
+      ignoreTimeDerivedTodayValues ? null : preview.credits_today_cents,
+      preview.credits_next_period_cents,
+      planSnapshot(preview.current_plan),
+      planSnapshot(preview.new_plan)
+    ])
+  }
+
+  // Current backends return the exact proration instant used for the preview;
+  // subscribe() echoes it back so the charge cannot drift while the consent
+  // screen is open. A fresh preview still checks non-time-based plan, quantity,
+  // credit, and period state before the charge is submitted.
   async function assertReactivationAmountUnchanged(
     planSlug: string,
     options?: PreviewSubscribeOptions
   ): Promise<void> {
+    const confirmedPreview = previewData.value
     const freshPreview = await previewSubscribe(planSlug, options)
     if (!freshPreview?.allowed) {
       throw new Error(freshPreview?.reason || t('subscription.subscribeFailed'))
     }
+
+    if (confirmedPreview?.proration_at) {
+      const isImmediateTransition = confirmedPreview.is_immediate
+      const amountChanged = isImmediateTransition
+        ? freshPreview.cost_today_cents > confirmedPreview.cost_today_cents
+        : freshPreview.cost_today_cents !== confirmedPreview.cost_today_cents
+      const materialChanged =
+        reactivationMaterialSnapshot(freshPreview, isImmediateTransition) !==
+        reactivationMaterialSnapshot(confirmedPreview, isImmediateTransition)
+      if (amountChanged || materialChanged) {
+        previewData.value = freshPreview
+        throw new ReactivationAmountChangedError(
+          t(
+            amountChanged
+              ? 'subscription.preview.reactivation.amountChanged'
+              : 'subscription.preview.reactivation.confirmationRequired'
+          )
+        )
+      }
+      return
+    }
+
     const amountChanged =
       freshPreview.cost_today_cents !==
-      (previewData.value?.cost_today_cents ?? 0)
+      (confirmedPreview?.cost_today_cents ?? 0)
+    const materialChanged =
+      !!confirmedPreview &&
+      reactivationMaterialSnapshot(freshPreview) !==
+        reactivationMaterialSnapshot(confirmedPreview)
     // Install regardless of outcome: on drift this is what makes the confirm
     // screen show the new amount and resets prior consent (via the
-    // component's own chargeCents watcher), so the next attempt compares
+    // component's own preview watcher), so the next attempt compares
     // against what's on screen instead of repeating this same failure.
     previewData.value = freshPreview
-    if (amountChanged) {
+    if (amountChanged || materialChanged) {
       throw new ReactivationAmountChangedError(
-        t('subscription.preview.reactivation.amountChanged')
+        t(
+          amountChanged
+            ? 'subscription.preview.reactivation.amountChanged'
+            : 'subscription.preview.reactivation.confirmationRequired'
+        )
       )
     }
+  }
+
+  function hasErrorCode(error: unknown, code: string): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === code
+    )
+  }
+
+  async function refreshExpiredProrationQuote(
+    error: unknown,
+    planSlug: string,
+    options?: PreviewSubscribeOptions
+  ): Promise<boolean> {
+    if (!hasErrorCode(error, 'PRORATION_QUOTE_EXPIRED')) return false
+
+    let freshPreview: PreviewSubscribeResponse | null
+    try {
+      freshPreview = await previewSubscribe(planSlug, options)
+    } catch (previewError) {
+      showSubscribeError(previewError)
+      return true
+    }
+    if (!isReactivationCapablePreview(freshPreview)) {
+      resetToPricing()
+      toast.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: t('subscription.preview.reactivation.unavailable')
+      })
+      return true
+    }
+
+    const amountChanged =
+      freshPreview.cost_today_cents !== previewData.value?.cost_today_cents
+    previewData.value = freshPreview
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t(
+        amountChanged
+          ? 'subscription.preview.reactivation.amountChanged'
+          : 'subscription.preview.reactivation.confirmationRequired'
+      )
+    })
+    return true
   }
 
   // The reactivation guard below reads cached `subscription.isCancelled`. If
@@ -218,10 +337,12 @@ export function useSubscriptionCheckout(
     }
     if (isReactivationCapablePreview(freshPreview)) {
       previewData.value = freshPreview
+      reactivationRequired.value = true
       notifyReactivationConfirmationRequired()
       return
     }
-    handleBackToPricing()
+    reactivationRequired.value = false
+    resetToPricing()
     toast.add({
       severity: 'error',
       summary: t('g.error'),
@@ -293,10 +414,17 @@ export function useSubscriptionCheckout(
     tierKey: CheckoutTierKey
     billingCycle: BillingCycle
   }) {
-    if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
+    if (
+      isSubscribing.value ||
+      !permissions.value.canManageSubscription ||
+      !canSelectTierPlan()
+    ) {
+      return
+    }
 
     const { tierKey, billingCycle } = payload
 
+    reactivationRequired.value = false
     isLoadingPreview.value = true
     loadingTier.value = tierKey
     selectedTierKey.value = tierKey
@@ -358,8 +486,10 @@ export function useSubscriptionCheckout(
     billingCycle: BillingCycle
     isChange?: boolean
   }) {
-    if (!permissions.value.canManageSubscription) return
+    if (isSubscribing.value || !permissions.value.canManageSubscription) return
 
+    const previewRequestId = ++teamPreviewRequestId
+    reactivationRequired.value = false
     selectedTeamCheckout.value = {
       stop: payload.stop,
       checkoutType: payload.isChange ? 'change' : 'new'
@@ -375,6 +505,7 @@ export function useSubscriptionCheckout(
     // collect confirm_reactivation, so it always needs a real,
     // reactivation-capable preview instead of the consent-less fallback.
     const needsPreview = payload.isChange || isCancelled.value
+    isLoadingPreview.value = needsPreview && !!payload.stop.id
     if (!needsPreview || !payload.stop.id) return
 
     let response: PreviewSubscribeResponse | null = null
@@ -387,9 +518,18 @@ export function useSubscriptionCheckout(
       })
     } catch (error) {
       previewError = error
+    } finally {
+      if (previewRequestId === teamPreviewRequestId) {
+        isLoadingPreview.value = false
+      }
     }
 
-    if (isReactivationCapablePreview(response)) {
+    if (previewRequestId !== teamPreviewRequestId) return
+
+    if (
+      (isCancelled.value && isReactivationCapablePreview(response)) ||
+      (!isCancelled.value && isExistingPlanPreview(response))
+    ) {
       previewData.value = response
       return
     }
@@ -411,12 +551,19 @@ export function useSubscriptionCheckout(
     selectedTeamCheckout.value = null
   }
 
-  function handleBackToPricing() {
-    if (isPolling.value) return
+  function resetToPricing() {
+    teamPreviewRequestId += 1
+    isLoadingPreview.value = false
+    reactivationRequired.value = false
     checkoutStep.value = 'pricing'
     previewData.value = null
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
+  }
+
+  function handleBackToPricing() {
+    if (isPolling.value || isSubscribing.value) return
+    resetToPricing()
   }
 
   function handleSuccessClose() {
@@ -430,6 +577,8 @@ export function useSubscriptionCheckout(
     if (!tierKey) return
 
     const billingCycle = selectedBillingCycle.value
+    const planSlug = getApiPlanSlug(tierKey, billingCycle)
+    if (!planSlug) return
     const checkoutType =
       previewData.value &&
       previewData.value.transition_type !== 'new_subscription'
@@ -438,21 +587,28 @@ export function useSubscriptionCheckout(
 
     isSubscribing.value = true
     try {
-      const planSlug = getApiPlanSlug(tierKey, billingCycle)
-      if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (
+        !confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await refreshPreviewOnReactivationBlock(planSlug)
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (
+        confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await assertReactivationAmountUnchanged(planSlug)
       }
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        prorationAt: previewData.value?.is_immediate
+          ? previewData.value.proration_at
+          : undefined
       })
 
       if (response) {
@@ -470,6 +626,23 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
+        trackSubscriptionFailure({
+          tier: tierKey,
+          cycle: billingCycle,
+          checkoutType
+        })
+        await refreshPreviewOnReactivationBlock(planSlug)
+        return
+      }
+      if (await refreshExpiredProrationQuote(error, planSlug)) {
+        trackSubscriptionFailure({
+          tier: tierKey,
+          cycle: billingCycle,
+          checkoutType
+        })
+        return
+      }
       trackSubscriptionFailure({
         tier: tierKey,
         cycle: billingCycle,
@@ -594,7 +767,13 @@ export function useSubscriptionCheckout(
   }
 
   async function handleTeamSubscription(confirmReactivation = false) {
-    if (!permissions.value.canManageSubscription) return
+    if (
+      isLoadingPreview.value ||
+      isSubscribing.value ||
+      !permissions.value.canManageSubscription
+    ) {
+      return
+    }
 
     const teamCheckout = selectedTeamCheckout.value
     if (!teamCheckout?.stop.id) {
@@ -613,14 +792,20 @@ export function useSubscriptionCheckout(
     isSubscribing.value = true
     try {
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (
+        !confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await refreshPreviewOnReactivationBlock(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
         })
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (
+        confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
@@ -631,7 +816,10 @@ export function useSubscriptionCheckout(
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        prorationAt: previewData.value?.is_immediate
+          ? previewData.value.proration_at
+          : undefined
       })
 
       if (response) {
@@ -649,6 +837,31 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
+        trackSubscriptionFailure({
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType
+        })
+        await refreshPreviewOnReactivationBlock(planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+        return
+      }
+      if (
+        await refreshExpiredProrationQuote(error, planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+      ) {
+        trackSubscriptionFailure({
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType
+        })
+        return
+      }
       trackSubscriptionFailure({
         tier: 'team',
         cycle: billingCycle,
@@ -715,6 +928,7 @@ export function useSubscriptionCheckout(
     isSubscribing,
     isResubscribing,
     previewData,
+    reactivationRequired,
     selectedTierKey,
     selectedTeamStop,
     selectedBillingCycle,

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -22,6 +22,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { trackWorkspaceCheckoutStarted } from '@/platform/workspace/utils/workspaceCheckoutTelemetry'
 
 type CheckoutStep = 'pricing' | 'preview' | 'success'
@@ -103,6 +104,7 @@ export function useSubscriptionCheckout(
   const { permissions } = useWorkspaceUI()
   const telemetry = useTelemetry()
   const billingOperationStore = useBillingOperationStore()
+  const workspaceStore = useTeamWorkspaceStore()
 
   const checkoutStep = ref<CheckoutStep>('pricing')
   const isLoadingPreview = ref(false)
@@ -113,7 +115,24 @@ export function useSubscriptionCheckout(
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
-  const isPolling = computed(() => billingOperationStore.hasPendingOperations)
+  const activeCheckoutOperationId = ref<string | null>(null)
+  const activeCheckoutOperation = computed(() => {
+    if (!activeCheckoutOperationId.value) {
+      return billingOperationStore.subscriptionActionOperation
+    }
+    const operation = billingOperationStore.getOperation(
+      activeCheckoutOperationId.value
+    )
+    return operation?.workspaceId === workspaceStore.activeWorkspaceId
+      ? operation
+      : undefined
+  })
+  const activeCheckoutActionUrl = computed(
+    () => activeCheckoutOperation.value?.actionUrl ?? null
+  )
+  const isPolling = computed(
+    () => activeCheckoutOperation.value?.status === 'pending'
+  )
   const selectedTeamStop = computed(
     () => selectedTeamCheckout.value?.stop ?? null
   )
@@ -393,9 +412,11 @@ export function useSubscriptionCheckout(
   }
 
   function handleBackToPricing() {
+    if (isPolling.value) return
     checkoutStep.value = 'pricing'
     previewData.value = null
     selectedTeamCheckout.value = null
+    activeCheckoutOperationId.value = null
   }
 
   function handleSuccessClose() {
@@ -552,6 +573,7 @@ export function useSubscriptionCheckout(
     opId: string,
     context: SubscriptionOutcomeContext
   ) {
+    activeCheckoutOperationId.value = opId
     const operation = await billingOperationStore.startOperation(
       opId,
       'subscription',
@@ -562,7 +584,13 @@ export function useSubscriptionCheckout(
         paymentIntentSource
       }
     )
-    if (operation.status === 'succeeded') checkoutStep.value = 'success'
+    if (
+      operation.status === 'succeeded' &&
+      activeCheckoutOperationId.value === opId &&
+      operation.workspaceId === workspaceStore.activeWorkspaceId
+    ) {
+      checkoutStep.value = 'success'
+    }
   }
 
   async function handleTeamSubscription(confirmReactivation = false) {
@@ -690,6 +718,7 @@ export function useSubscriptionCheckout(
     selectedTierKey,
     selectedTeamStop,
     selectedBillingCycle,
+    activeCheckoutActionUrl,
     isPolling,
     isTeamCheckout,
     previewVariant,

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -28,7 +28,9 @@ const mockBillingPlans = vi.hoisted(() => ({
 
 const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
+const mockGetOperation = vi.hoisted(() => vi.fn())
 const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
+const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
 // const is in its temporal dead zone when the hoisted factory runs under
@@ -67,13 +69,16 @@ vi.mock(
 
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
   useBillingOperationStore: () => ({
+    getOperation: mockGetOperation,
     startOperation: mockStartOperation
   })
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
-    activeWorkspace: { id: 'workspace-1' },
+    get activeWorkspace() {
+      return { id: mockActiveWorkspaceId.value }
+    },
     setWorkspaceBillingRail: mockSetWorkspaceBillingRail
   })
 }))
@@ -149,6 +154,7 @@ const subscribeResponses = [
 describe('useWorkspaceBilling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockActiveWorkspaceId.value = 'workspace-1'
     mockBillingPlans.plans.value = []
     mockBillingPlans.currentPlanSlug.value = null
     mockBillingPlans.error.value = null
@@ -253,6 +259,68 @@ describe('useWorkspaceBilling', () => {
         'workspace-1',
         'stripe'
       )
+    })
+
+    it('recovers a pending subscription operation from billing status', async () => {
+      const actionUrl = 'https://invoice.stripe.com/sensitive-token'
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-recovered',
+        action_url: actionUrl
+      } satisfies BillingStatusResponse)
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-recovered',
+        'subscription',
+        undefined,
+        actionUrl
+      )
+    })
+
+    it('does not restart an operation recovered by an earlier status read', async () => {
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-recovered'
+      } satisfies BillingStatusResponse)
+      mockGetOperation
+        .mockReturnValueOnce(undefined)
+        .mockReturnValue({ status: 'pending' })
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+      await billing.fetchStatus()
+
+      expect(mockStartOperation).toHaveBeenCalledOnce()
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-recovered',
+        'subscription',
+        undefined,
+        undefined
+      )
+    })
+
+    it('does not recover an operation from a stale workspace response', async () => {
+      const status = createDeferred<BillingStatusResponse>()
+      mockWorkspaceApi.getBillingStatus.mockReturnValue(status.promise)
+      const billing = setupBilling()
+
+      const fetch = billing.fetchStatus()
+      mockActiveWorkspaceId.value = 'workspace-2'
+      status.resolve({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-workspace-1',
+        action_url: 'https://invoice.stripe.com/sensitive-token'
+      })
+      await fetch
+
+      expect(mockStartOperation).not.toHaveBeenCalled()
+      expect(billing.subscription.value).toBeNull()
     })
 
     it("keeps a 'scheduled' subscription on the active treatment", async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -160,14 +160,27 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     error.value = null
     try {
       const status = await workspaceApi.getBillingStatus()
-      if (requestId === latestBillingReadIds.status) {
-        statusData.value = status
-        if (workspaceId && status.billing_rail) {
-          workspaceStore.setWorkspaceBillingRail(
-            workspaceId,
-            status.billing_rail
-          )
-        }
+      if (
+        requestId !== latestBillingReadIds.status ||
+        workspaceId !== workspaceStore.activeWorkspace?.id
+      ) {
+        return
+      }
+
+      statusData.value = status
+      if (workspaceId && status.billing_rail) {
+        workspaceStore.setWorkspaceBillingRail(workspaceId, status.billing_rail)
+      }
+      if (
+        status.pending_billing_op_id &&
+        !billingOperationStore.getOperation(status.pending_billing_op_id)
+      ) {
+        void billingOperationStore.startOperation(
+          status.pending_billing_op_id,
+          'subscription',
+          undefined,
+          status.action_url
+        )
       }
     } catch (err) {
       if (requestId === latestBillingReadIds.status) {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1,5 +1,6 @@
 import { setActivePinia, createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { ref } from 'vue'
 
 import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
@@ -62,9 +63,13 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 const mockUpdateActiveWorkspace = vi.fn()
+const mockActiveWorkspaceId = ref('workspace-1')
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
+    get activeWorkspaceId() {
+      return mockActiveWorkspaceId.value
+    },
     updateActiveWorkspace: mockUpdateActiveWorkspace
   })
 }))
@@ -78,6 +83,7 @@ describe('billingOperationStore', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.useFakeTimers()
+    mockActiveWorkspaceId.value = 'workspace-1'
   })
 
   afterEach(() => {
@@ -101,6 +107,46 @@ describe('billingOperationStore', () => {
       expect(operation?.status).toBe('pending')
       expect(operation?.type).toBe('subscription')
       expect(store.hasPendingOperations).toBe(true)
+    })
+
+    it('exposes a validated recovered action before the first poll completes', () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockReturnValue(
+        new Promise(() => {})
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation(
+        'op-recovered',
+        'subscription',
+        undefined,
+        'https://invoice.stripe.com/sensitive-token'
+      )
+
+      expect(store.subscriptionActionOperation).toMatchObject({
+        opId: 'op-recovered',
+        actionUrl: 'https://invoice.stripe.com/sensitive-token',
+        authenticationRequiredSeen: true
+      })
+    })
+
+    it('rejects an insecure recovered action URL', () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockReturnValue(
+        new Promise(() => {})
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation(
+        'op-recovered',
+        'subscription',
+        undefined,
+        'http://invoice.stripe.com/sensitive-token'
+      )
+
+      expect(store.getOperation('op-recovered')).toMatchObject({
+        actionUrl: null,
+        authenticationRequiredSeen: false
+      })
+      expect(store.subscriptionActionOperation).toBeUndefined()
     })
 
     it('does not create duplicate operations', () => {
@@ -412,7 +458,23 @@ describe('billingOperationStore', () => {
   })
 
   describe('polling timeout', () => {
-    it('times out after 2 minutes and shows error toast', async () => {
+    it('times out a subscription while its workspace is inactive', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      mockActiveWorkspaceId.value = 'workspace-2'
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 8001)
+
+      expect(store.getOperation('op-1')?.status).toBe('timeout')
+    })
+
+    it('allows five minutes to discover a subscription action', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'pending',
@@ -425,6 +487,9 @@ describe('billingOperationStore', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       await vi.advanceTimersByTimeAsync(121_000)
+      expect(store.getOperation('op-1')?.status).toBe('pending')
+
+      await vi.advanceTimersByTimeAsync(181_000)
       await vi.runAllTimersAsync()
 
       const operation = store.getOperation('op-1')
@@ -437,12 +502,180 @@ describe('billingOperationStore', () => {
       })
     })
 
-    it('shows topup timeout message for topup operations', async () => {
+    it('keeps a valid action URL pending past discovery and clears it on success', async () => {
+      const actionUrl = 'https://verify.example/sensitive-token'
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-1',
+          status: 'pending',
+          started_at: new Date().toISOString(),
+          action_url: actionUrl
+        })
+        .mockResolvedValue({
+          id: 'op-1',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.actionUrl).toBe(actionUrl)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(store.getOperation('op-1')).toMatchObject({
+        status: 'pending',
+        actionUrl: null,
+        authenticationRequiredSeen: true
+      })
+
+      await vi.advanceTimersByTimeAsync(4.5 * 60_000)
+      expect(store.getOperation('op-1')?.status).toBe('pending')
+
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValueOnce({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect((await terminal).status).toBe('succeeded')
+      expect(store.getOperation('op-1')?.actionUrl).toBeNull()
+      expect(JSON.stringify(mockToastAdd.mock.calls)).not.toContain(actionUrl)
+      expect(JSON.stringify(mockTrackBillingEvent.mock.calls)).not.toContain(
+        actionUrl
+      )
+    })
+
+    it('rejects an action URL received after the discovery deadline', async () => {
+      const actionUrl = 'https://verify.example/sensitive-token'
+      let resolveStatus!: (response: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1)
+
+      resolveStatus({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        action_url: actionUrl
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect((await terminal).status).toBe('timeout')
+      expect(store.getOperation('op-1')?.actionUrl).toBeNull()
+      expect(JSON.stringify([...store.operations.values()])).not.toContain(
+        actionUrl
+      )
+    })
+
+    it('accepts a terminal response received after the discovery deadline', async () => {
+      let resolveStatus!: (response: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1)
+
+      resolveStatus({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect((await terminal).status).toBe('succeeded')
+    })
+
+    it('ignores non-HTTPS action URLs', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
         status: 'pending',
-        started_at: new Date().toISOString()
+        started_at: new Date().toISOString(),
+        action_url: 'http://verify.example/sensitive-token'
       })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.actionUrl).toBeNull()
+    })
+
+    it('only exposes subscription actions for the active workspace', async () => {
+      const actionUrl = 'https://verify.example/sensitive-token'
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        action_url: actionUrl
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.subscriptionActionOperation?.actionUrl).toBe(actionUrl)
+      expect(store.isSettingUp).toBe(true)
+
+      mockActiveWorkspaceId.value = 'workspace-2'
+
+      expect(store.subscriptionActionOperation).toBeUndefined()
+      expect(store.isSettingUp).toBe(false)
+    })
+
+    it('ignores a response that completes after switching workspaces', async () => {
+      const actionUrl = 'https://verify.example/sensitive-token'
+      let resolveStatus!: (response: BillingOpStatusResponse) => void
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+      )
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      mockActiveWorkspaceId.value = 'workspace-2'
+
+      resolveStatus({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        action_url: actionUrl
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')).toMatchObject({
+        status: 'pending',
+        actionUrl: null
+      })
+      expect(store.subscriptionActionOperation).toBeUndefined()
+    })
+
+    it('shows topup timeout message for topup operations', async () => {
+      const startedAt = Date.now()
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementation(
+        async () => ({
+          id: 'op-1',
+          status:
+            Date.now() - startedAt > 120_000
+              ? ('succeeded' as const)
+              : ('pending' as const),
+          started_at: new Date().toISOString()
+        })
+      )
 
       const store = useBillingOperationStore()
       void store.startOperation('op-1', 'topup')
@@ -560,11 +793,17 @@ describe('billingOperationStore', () => {
     })
 
     it('resolves with a timeout operation after 2 minutes, no toast', async () => {
-      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
-        id: 'op-1',
-        status: 'pending',
-        started_at: new Date().toISOString()
-      })
+      const startedAt = Date.now()
+      vi.mocked(workspaceApi.getBillingOpStatus).mockImplementation(
+        async () => ({
+          id: 'op-1',
+          status:
+            Date.now() - startedAt > 120_000
+              ? ('succeeded' as const)
+              : ('pending' as const),
+          started_at: new Date().toISOString()
+        })
+      )
 
       const store = useBillingOperationStore()
       const terminal = store.startOperation('op-1', 'cancel')

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -20,8 +20,11 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 const INITIAL_INTERVAL_MS = 1000
 const MAX_INTERVAL_MS = 8000
+const ACTION_REQUIRED_INTERVAL_MS = 30_000
 const BACKOFF_MULTIPLIER = 1.5
-const TIMEOUT_MS = 120_000 // 2 minutes
+const TIMEOUT_MS = 120_000
+const SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS = 5 * 60_000
+const SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS = 23 * 60 * 60_000
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -44,6 +47,9 @@ interface BillingOperation {
   status: OperationStatus
   errorMessage: string | null
   startedAt: number
+  actionUrl: string | null
+  authenticationRequiredSeen: boolean
+  workspaceId: string | null
   tier?: SubscriptionCheckoutTier
   cycle?: BillingCycle
   checkoutType?: SubscriptionCheckoutType
@@ -54,6 +60,7 @@ interface BillingOperation {
 type TerminalResolver = (operation: BillingOperation) => void
 
 export const useBillingOperationStore = defineStore('billingOperation', () => {
+  const workspaceStore = useTeamWorkspaceStore()
   const operations = ref<Map<string, BillingOperation>>(new Map())
   const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
   const intervals = new Map<string, number>()
@@ -67,13 +74,26 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
 
   const isSettingUp = computed(() =>
     [...operations.value.values()].some(
-      (op) => op.status === 'pending' && op.type === 'subscription'
+      (op) =>
+        op.status === 'pending' &&
+        op.type === 'subscription' &&
+        op.workspaceId === workspaceStore.activeWorkspaceId
     )
   )
 
   const isAddingCredits = computed(() =>
     [...operations.value.values()].some(
       (op) => op.status === 'pending' && op.type === 'topup'
+    )
+  )
+
+  const subscriptionActionOperation = computed(() =>
+    [...operations.value.values()].find(
+      (op) =>
+        op.status === 'pending' &&
+        op.type === 'subscription' &&
+        op.workspaceId === workspaceStore.activeWorkspaceId &&
+        op.actionUrl !== null
     )
   )
 
@@ -84,19 +104,24 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   function startOperation(
     opId: string,
     type: OperationType,
-    metadata?: StartOperationMetadata
+    metadata?: StartOperationMetadata,
+    initialActionUrl?: string
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
     if (existing) {
       return terminalPromises.get(opId) ?? Promise.resolve(existing)
     }
 
+    const actionUrl = validateActionUrl(initialActionUrl)
     const operation: BillingOperation = {
       opId,
       type,
       status: 'pending',
       errorMessage: null,
       startedAt: Date.now(),
+      actionUrl,
+      authenticationRequiredSeen: actionUrl !== null,
+      workspaceId: workspaceStore.activeWorkspaceId,
       tier: metadata?.tier,
       cycle: metadata?.cycle,
       checkoutType: metadata?.checkoutType,
@@ -136,13 +161,22 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const operation = operations.value.get(opId)
     if (!operation || operation.status !== 'pending') return
 
-    if (Date.now() - operation.startedAt > TIMEOUT_MS) {
-      handleTimeout(opId)
+    if (stopIfTimedOut(opId, operation)) return
+
+    if (operation.workspaceId !== workspaceStore.activeWorkspaceId) {
+      scheduleNextPoll(opId)
       return
     }
 
     try {
       const response = await workspaceApi.getBillingOpStatus(opId)
+      const currentOperation = operations.value.get(opId)
+      if (currentOperation !== operation) return
+      if (operation.workspaceId !== workspaceStore.activeWorkspaceId) {
+        if (stopIfTimedOut(opId, operation)) return
+        scheduleNextPoll(opId)
+        return
+      }
 
       if (response.status === 'succeeded') {
         await handleSuccess(opId)
@@ -154,26 +188,66 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         return
       }
 
+      if (stopIfTimedOut(opId, operation)) return
+
+      updateOperationActionUrl(opId, validateActionUrl(response.action_url))
       scheduleNextPoll(opId)
     } catch {
-      if (Date.now() - operation.startedAt > TIMEOUT_MS) {
-        handleTimeout(opId)
-        return
-      }
+      const currentOperation = operations.value.get(opId)
+      if (currentOperation !== operation) return
+      if (stopIfTimedOut(opId, currentOperation)) return
       scheduleNextPoll(opId)
     }
   }
 
   function scheduleNextPoll(opId: string) {
-    const currentInterval = intervals.get(opId) ?? INITIAL_INTERVAL_MS
-    const nextInterval = Math.min(
-      currentInterval * BACKOFF_MULTIPLIER,
-      MAX_INTERVAL_MS
-    )
+    const operation = operations.value.get(opId)
+    if (!operation || operation.status !== 'pending') return
+    const nextInterval = operation.authenticationRequiredSeen
+      ? ACTION_REQUIRED_INTERVAL_MS
+      : Math.min(
+          (intervals.get(opId) ?? INITIAL_INTERVAL_MS) * BACKOFF_MULTIPLIER,
+          MAX_INTERVAL_MS
+        )
     intervals.set(opId, nextInterval)
 
     const timeoutId = setTimeout(() => void poll(opId), nextInterval)
     timeouts.set(opId, timeoutId)
+  }
+
+  function validateActionUrl(value: string | undefined): string | null {
+    if (!value) return null
+    try {
+      const url = new URL(value)
+      return url.protocol === 'https:' ? value : null
+    } catch {
+      return null
+    }
+  }
+
+  function hasTimedOut(operation: BillingOperation): boolean {
+    const elapsed = Date.now() - operation.startedAt
+    if (operation.type !== 'subscription') return elapsed > TIMEOUT_MS
+    return operation.authenticationRequiredSeen
+      ? elapsed > SUBSCRIPTION_AUTHENTICATION_TIMEOUT_MS
+      : elapsed > SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS
+  }
+
+  function stopIfTimedOut(opId: string, operation: BillingOperation): boolean {
+    if (!hasTimedOut(operation)) return false
+    handleTimeout(opId)
+    return true
+  }
+
+  function updateOperationActionUrl(opId: string, actionUrl: string | null) {
+    const operation = operations.value.get(opId)
+    if (!operation || operation.status !== 'pending') return
+    operations.value = new Map(operations.value).set(opId, {
+      ...operation,
+      actionUrl,
+      authenticationRequiredSeen:
+        operation.authenticationRequiredSeen || actionUrl !== null
+    })
   }
 
   async function handleSuccess(opId: string) {
@@ -384,7 +458,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const operation = operations.value.get(opId)
     if (!operation) return
 
-    const updated = { ...operation, status, errorMessage }
+    const updated = { ...operation, status, errorMessage, actionUrl: null }
     operations.value = new Map(operations.value).set(opId, updated)
   }
 
@@ -418,6 +492,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     hasPendingOperations,
     isSettingUp,
     isAddingCredits,
+    subscriptionActionOperation,
     getOperation,
     startOperation,
     clearOperation


### PR DESCRIPTION
Backport of #14344 to cloud/1.47.

Dependency: #14344 builds on the subscription 3DS support in #14303, which is still open. This branch includes that prerequisite commit so the backport can be reviewed and validated now; once #14303 lands, its diff will fall out.

Release compatibility: the older branch has no cloudAppFixture helper, so the recovered-3DS E2E wait is expressed inline. This also fixes the current browser typecheck and runtime failure carried by #14303.

Validation:
- 179 focused unit tests passed
- application and browser typechecks passed
- lint and formatting passed