### PR TITLE
[backport core/1.48] Fix cancelled plan changes using quoted previews

### DIFF
--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -453,14 +453,16 @@ describe('workspaceApi', () => {
       mockAxiosInstance.post.mockResolvedValue({ data })
 
       const result = await workspaceApi.subscribe('pro-monthly', {
-        confirmReactivation: true
+        confirmReactivation: true,
+        prorationAt: '2026-07-29T12:00:00Z'
       })
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/billing/subscribe',
         expect.objectContaining({
           plan_slug: 'pro-monthly',
-          confirm_reactivation: true
+          confirm_reactivation: true,
+          proration_at: '2026-07-29T12:00:00Z'
         }),
         { headers: AUTH_HEADER }
       )

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -170,6 +170,7 @@ interface SubscribeRequest {
   billing_cycle?: SubscribeBillingCycle
   /** Required to change plans while the current subscription is cancelled; server rejects the change without it. */
   confirm_reactivation?: boolean
+  proration_at?: string
 }
 
 export interface SubscribeOptions {
@@ -178,6 +179,7 @@ export interface SubscribeOptions {
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
   confirmReactivation?: boolean
+  prorationAt?: string
 }
 
 export interface PreviewSubscribeOptions {
@@ -223,7 +225,10 @@ interface PaymentPortalResponse {
 
 interface PreviewPlanInfo {
   slug: string
-  tier: SubscriptionTier
+  // The billing preview contract includes the workspace-level Team tier even
+  // though the registry subscription tier used by the personal plan catalog
+  // does not.
+  tier: SubscriptionTier | 'TEAM'
   duration: SubscriptionDuration
   price_cents: number
   credits_cents: number
@@ -244,6 +249,7 @@ export interface PreviewSubscribeResponse {
   credits_next_period_cents: number
   current_plan?: PreviewPlanInfo
   new_plan: PreviewPlanInfo
+  proration_at?: string
 }
 
 export type BillingSubscriptionStatus =
@@ -694,7 +700,8 @@ export const workspaceApi = {
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
-          confirm_reactivation: options.confirmReactivation
+          confirm_reactivation: options.confirmReactivation,
+          proration_at: options.prorationAt
         } satisfies SubscribeRequest,
         { headers }
       )

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -64,8 +64,9 @@
         v-if="previewVariant === 'team-change'"
         :preview-data="previewData!"
         :team-plan="selectedTeamStop!"
-        :is-loading="isSubscribing || isPolling"
+        :is-loading="isLoadingPreview || isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :force-reactivation="reactivationRequired"
         @confirm="handleTeamSubscribe"
         @back="handleBackToPricing"
       />
@@ -74,7 +75,7 @@
         v-else-if="previewVariant === 'team-new'"
         :team-plan="selectedTeamStop!"
         :billing-cycle="selectedBillingCycle"
-        :is-loading="isSubscribing || isPolling"
+        :is-loading="isLoadingPreview || isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
         @add-credit-card="handleTeamSubscribe"
         @back="handleBackToPricing"
@@ -96,6 +97,7 @@
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :force-reactivation="reactivationRequired"
         @confirm="handleConfirmTransition"
         @back="handleBackToPricing"
       />
@@ -146,6 +148,7 @@ const {
   isSubscribing,
   isResubscribing,
   previewData,
+  reactivationRequired,
   selectedTierKey,
   selectedTeamStop,
   selectedBillingCycle,

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -101,6 +101,7 @@
       :preview-data="previewData"
       :is-loading="isSubscribing || isPolling"
       :action-url="activeCheckoutActionUrl"
+      :force-reactivation="reactivationRequired"
       @confirm="handleConfirmTransition"
       @back="handleBackToPricing"
     />
@@ -152,6 +153,7 @@ const {
   isSubscribing,
   isResubscribing,
   previewData,
+  reactivationRequired,
   selectedTierKey,
   selectedBillingCycle,
   activeCheckoutActionUrl,

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -226,7 +226,8 @@ const {
   previewData,
   isLoading = false,
   teamPlan = null,
-  actionUrl = null
+  actionUrl = null,
+  forceReactivation = false
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
@@ -234,6 +235,9 @@ const {
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
   actionUrl?: string | null
+  /** Server-authoritative fallback for legacy status reads that omit a
+   * scheduled cancellation until subscribe enforces the consent gate. */
+  forceReactivation?: boolean
 }>()
 
 defineEmits<{
@@ -253,6 +257,10 @@ function openVerification() {
 
 function formatTierName(tier: string): string {
   return t(`subscription.tiers.${tier.toLowerCase()}.name`)
+}
+
+function isTeamTier(tier: string): boolean {
+  return tier.toUpperCase() === 'TEAM'
 }
 
 function formatDate(date: string | Date): string {
@@ -297,16 +305,22 @@ const newTierName = computed(() =>
     ? t('subscription.teamPlan.name')
     : formatTierName(previewData.new_plan.tier)
 )
-const currentTierName = computed(() =>
-  previewData.current_plan ? formatTierName(previewData.current_plan.tier) : ''
-)
+const currentTierName = computed(() => {
+  const tier = previewData.current_plan?.tier
+  if (!tier) return ''
+  return isTeamTier(tier)
+    ? t('subscription.teamPlan.name')
+    : formatTierName(tier)
+})
 const currentPlanLabel = computed(() =>
   currentIsYearly.value
     ? t('subscription.tierNameYearly', { name: currentTierName.value })
     : currentTierName.value
 )
 
-const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+const isCancelled = computed(
+  () => forceReactivation || (subscription.value?.isCancelled ?? false)
+)
 
 const reactivationVariant = computed<
   'upgrade' | 'downgrade' | 'duration_change' | null
@@ -326,16 +340,20 @@ const reactivationVariant = computed<
 // Requires the data the banner and threshold math actually read
 // (subscription.endDate, previewData.current_plan) — without it the banner
 // would render broken copy or force the checkbox on a bogus $0 threshold.
+const cancelAt = computed(
+  () => subscription.value?.endDate ?? previewData.current_plan?.period_end
+)
+
 const isReactivating = computed(
   () =>
     isCancelled.value &&
     reactivationVariant.value !== null &&
-    !!subscription.value?.endDate &&
+    !!cancelAt.value &&
     !!previewData.current_plan
 )
 
 const cancelDate = computed(() =>
-  subscription.value?.endDate ? formatDate(subscription.value.endDate) : ''
+  cancelAt.value ? formatDate(cancelAt.value) : ''
 )
 
 // seat_summary.total_cost_cents is the whole-subscription price; price_cents
@@ -363,11 +381,14 @@ const chargeDisplay = computed(
 )
 
 const reactivationConfirmed = ref(false)
-// A checked box is consent to *this* charge; a later charge change (e.g. a
-// different preview loads) must not carry that consent forward.
-watch(chargeCents, () => {
-  reactivationConfirmed.value = false
-})
+// A checked box is consent to this exact preview. A replacement preview must
+// not inherit that consent, even when its displayed charge is unchanged.
+watch(
+  () => previewData,
+  () => {
+    reactivationConfirmed.value = false
+  }
+)
 
 // isInitialized is aggregate (status + balance + plans); a balance or plans
 // failure must not permanently disable an otherwise-valid, already-loaded

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -37,6 +37,7 @@ const i18n = createI18n({
           standard: { name: 'Standard' },
           creator: { name: 'Creator' }
         },
+        teamPlan: { name: 'Team Plan' },
         preview: {
           switchesToday: 'Switches today',
           startsOn: 'Starts {date}',
@@ -124,9 +125,12 @@ function makePreview(
   }
 }
 
-function renderComponent(previewData: PreviewSubscribeResponse) {
+function renderComponent(
+  previewData: PreviewSubscribeResponse,
+  forceReactivation = false
+) {
   return render(SubscriptionTransitionPreviewWorkspace, {
-    props: { previewData },
+    props: { previewData, forceReactivation },
     global: { plugins: [i18n] }
   })
 }
@@ -149,6 +153,34 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(
         screen.queryByText('Reactivating your subscription')
       ).not.toBeInTheDocument()
+    })
+
+    it('uses a server-authoritative reactivation requirement when status omits the cancellation', () => {
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      const preview = makePreview({
+        transition_type: 'upgrade',
+        cost_today_cents: 2500
+      })
+      preview.current_plan!.tier = 'TEAM'
+      preview.current_plan!.period_end = '2026-08-29T00:00:00Z'
+
+      const { container } = renderComponent(preview, true)
+
+      expect(
+        screen.getByText('Reactivating your subscription')
+      ).toBeInTheDocument()
+      expect(container.textContent).toContain(
+        i18n.global.t('subscription.teamPlan.name')
+      )
+      expect(container.textContent).toContain('Aug 29, 2026')
+      expect(container.textContent).not.toContain(
+        'subscription.tiers.team.name'
+      )
+      expect(
+        screen.getByRole('button', {
+          name: 'Confirm & reactivate — $25.00 today'
+        })
+      ).toBeDisabled()
     })
   })
 
@@ -566,7 +598,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('reactivation consent lifetime', () => {
-    it('resets a ticked checkbox when the charge amount changes', async () => {
+    it('resets a ticked checkbox when a replacement preview keeps the same charge', async () => {
       const user = userEvent.setup()
       mockSubscription.value = {
         isCancelled: true,
@@ -598,22 +630,24 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
         })
       ).toBeEnabled()
 
-      // A different preview loads (e.g. user went back and re-previewed) with
-      // a higher charge; the earlier tick must not carry over as consent.
+      // A fresh quote can carry materially different billing state while
+      // displaying the same charge; the earlier tick must not carry over.
       await rerender({
         previewData: makePreview({
           transition_type: 'duration_change',
-          cost_today_cents: 50_000,
+          cost_today_cents: 33_600,
+          credits_next_period_cents: 1_000,
+          proration_at: '2026-08-01T00:01:00Z',
           new_plan: {
             slug: 'standard-annual',
             tier: 'STANDARD',
             duration: 'ANNUAL',
-            price_cents: 50_000,
+            price_cents: 33_600,
             credits_cents: 0,
             period_end: '2027-08-15T00:00:00Z',
             seat_summary: {
               seat_count: 1,
-              total_cost_cents: 50_000,
+              total_cost_cents: 33_600,
               total_credits_cents: 0
             }
           }
@@ -623,7 +657,7 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
       expect(screen.getByRole('checkbox')).not.toBeChecked()
       expect(
         screen.getByRole('button', {
-          name: 'Confirm & reactivate — $500.00 today'
+          name: 'Confirm & reactivate — $336.00 today'
         })
       ).toBeDisabled()
     })

--- a/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.test.ts
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 
-import { useDowngradeToPersonal } from './useDowngradeToPersonal'
+import {
+  ReactivationConfirmationRequiredError,
+  useDowngradeToPersonal
+} from './useDowngradeToPersonal'
 
 const mockMembers = ref<WorkspaceMember[]>([])
 const mockUserEmail = ref<string | null>(null)
@@ -219,7 +222,7 @@ describe('useDowngradeToPersonal', () => {
     })
 
     it('stops before submit when downgrade access is revoked during member removal', async () => {
-      mockMembers.value = teamWithOwnerAnd('m1')
+      mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation(async () => {
         mockPermissions.value.canDowngradeToPersonal = false
       })
@@ -330,6 +333,35 @@ describe('useDowngradeToPersonal', () => {
       expect(mockSubscribe).not.toHaveBeenCalled()
     })
 
+    it('surfaces a hidden cancellation after member cleanup and forwards the quote timestamp', async () => {
+      mockSubscription.value = { isCancelled: false }
+      mockMembers.value = teamWithOwnerAnd('m1')
+      mockPreviewSubscribe.mockResolvedValue({
+        allowed: true,
+        transition_type: 'downgrade',
+        cost_today_cents: 1500,
+        proration_at: '2026-07-30T00:00:00Z'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      const { downgradeToPersonal } = useDowngradeToPersonal()
+
+      await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
+        ReactivationConfirmationRequiredError
+      )
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'founder-monthly',
+        expect.objectContaining({
+          confirmReactivation: false,
+          prorationAt: '2026-07-30T00:00:00Z'
+        })
+      )
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
+    })
+
     it('requires reactivation confirmation when subscription state has not loaded yet', async () => {
       // isInitialized false means "cancelled or not" is unknown; must not
       // default to "not cancelled" and skip disclosure.
@@ -404,7 +436,7 @@ describe('useDowngradeToPersonal', () => {
       expect(mockSubscribe).toHaveBeenCalled()
     })
 
-    it('validates the transition before removing, then removes, then subscribes', async () => {
+    it('validates the transition before removing members, then subscribes', async () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       const calls: string[] = []
       mockPreviewSubscribe.mockImplementation(() => {
@@ -588,7 +620,7 @@ describe('useDowngradeToPersonal', () => {
       )
     })
 
-    it('reports members were already removed when subscribe fails after removal', async () => {
+    it('reports members were already removed when subscribe returns no response', async () => {
       mockMembers.value = teamWithOwnerAnd('m1')
       mockSubscribe.mockResolvedValue(undefined)
       const { downgradeToPersonal } = useDowngradeToPersonal()
@@ -596,9 +628,10 @@ describe('useDowngradeToPersonal', () => {
       await expect(downgradeToPersonal('founder-monthly')).rejects.toThrow(
         'subscription.downgrade.failedAfterMemberRemoval'
       )
+      expect(mockRemoveMember).toHaveBeenCalledWith('m1')
     })
 
-    it('surfaces which member failed and skips the plan change when removal throws', async () => {
+    it('surfaces which member failed and skips the plan change', async () => {
       mockMembers.value = teamWithOwnerAnd('m1', 'm2')
       mockRemoveMember.mockImplementation((id: string) =>
         id === 'm2' ? Promise.reject(new Error('network')) : Promise.resolve()

--- a/src/platform/workspace/composables/useDowngradeToPersonal.ts
+++ b/src/platform/workspace/composables/useDowngradeToPersonal.ts
@@ -30,9 +30,9 @@ export interface DowngradePreview {
   requiresReactivationConfirmation: boolean
 }
 
-/** Thrown by `downgradeToPersonal` before any member is removed, so a caller
- *  can collect consent and retry with `confirmReactivation: true` instead of
- *  losing team members on a request the BE was always going to reject. */
+/** Thrown by `downgradeToPersonal` when the billing authority requires
+ *  reactivation consent, so the still-open confirmation can collect it and
+ *  retry with `confirmReactivation: true`. */
 export class ReactivationConfirmationRequiredError extends Error {
   constructor(public readonly preview: PreviewSubscribeResponse) {
     super(t('subscription.downgrade.reactivationConfirmationRequired'))
@@ -51,6 +51,8 @@ export class ReactivationAmountChangedError extends Error {
 /**
  * Team-plan downgrade to personal: validate via `previewSubscribe`, remove
  * every member except the original owner, then initiate the tier change.
+ * Billing is not committed until member cleanup succeeds, so a removal failure
+ * cannot leave a personal plan with Team members still attached.
  * The removal-email and an atomic downgrade endpoint are backend-owned future
  * work; until then the frontend orchestrates the two steps non-atomically.
  */
@@ -79,6 +81,15 @@ export function useDowngradeToPersonal() {
     if (!permissions.value.canDowngradeToPersonal) {
       throw new Error(t('subscription.downgrade.notAllowed'))
     }
+  }
+
+  function hasErrorCode(error: unknown, code: string): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === code
+    )
   }
 
   async function refreshMembers(): Promise<void> {
@@ -171,20 +182,21 @@ export function useDowngradeToPersonal() {
         )
       }
       ensureCanDowngrade()
-      targetTier = preview.new_plan?.tier
-        ? TIER_TO_KEY[preview.new_plan.tier]
-        : undefined
+      targetTier =
+        preview.new_plan?.tier && preview.new_plan.tier !== 'TEAM'
+          ? TIER_TO_KEY[preview.new_plan.tier]
+          : undefined
       targetCycle = preview.new_plan
         ? preview.new_plan.duration === 'ANNUAL'
           ? 'yearly'
           : 'monthly'
         : undefined
 
-      // Guard before touching membership: the BE rejects this subscribe
-      // without confirm_reactivation, so members must never be removed for a
-      // transition that's going to fail on consent anyway. Refresh the
-      // cached subscription first — it can predate a cancellation that
-      // happened after the earlier previewDowngrade() call.
+      // Catch cancellations visible to billing status before touching
+      // membership. Refresh first because the cached value can predate a
+      // cancellation that happened after previewDowngrade(); legacy-rail
+      // cancellations omitted by status are recovered from the later
+      // authority rejection while the confirmation remains open.
       await fetchStatus()
       if (requiresReactivationConfirmation(preview)) {
         if (!confirmReactivation) {
@@ -223,11 +235,27 @@ export function useDowngradeToPersonal() {
       }
 
       ensureCanDowngrade()
-      const response = await subscribe(planSlug, {
-        returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
-        cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
-      })
+      let response: SubscribeResponse | void
+      try {
+        response = await subscribe(planSlug, {
+          returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
+          cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
+          confirmReactivation,
+          ...(preview.proration_at && { prorationAt: preview.proration_at })
+        })
+      } catch (error) {
+        if (
+          !confirmReactivation &&
+          hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')
+        ) {
+          telemetryFailure = {
+            failure_category: 'validation',
+            error_code: 'reactivation_not_confirmed'
+          }
+          throw new ReactivationConfirmationRequiredError(preview)
+        }
+        throw error
+      }
       if (!response) {
         telemetryFailure = {
           failure_category: 'unknown',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, reactive } from 'vue'
 
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
-import type { Plan } from '@/platform/workspace/api/workspaceApi'
+import type {
+  Plan,
+  PreviewSubscribeResponse
+} from '@/platform/workspace/api/workspaceApi'
 
 import { findPlanSlug } from './useSubscriptionCheckout'
 
@@ -44,6 +47,70 @@ function makeCreatorMonthly(): Plan {
 
 function allPlans(): Plan[] {
   return [makeStandardYearly(), makeCreatorMonthly()]
+}
+
+interface ReactivationPreviewPlanInput {
+  slug: string
+  tier: PreviewSubscribeResponse['new_plan']['tier']
+  duration: PreviewSubscribeResponse['new_plan']['duration']
+  priceCents: number
+  creditsCents: number
+  periodEnd: string
+}
+
+interface ReactivationPreviewInput {
+  effectiveAt: string
+  costTodayCents: number
+  costNextPeriodCents: number
+  creditsTodayCents: number
+  creditsNextPeriodCents: number
+  currentPlan: ReactivationPreviewPlanInput
+  newPlan: ReactivationPreviewPlanInput
+}
+
+function makeReactivationAuthorityPreview({
+  effectiveAt,
+  costTodayCents,
+  costNextPeriodCents,
+  creditsTodayCents,
+  creditsNextPeriodCents,
+  currentPlan,
+  newPlan
+}: ReactivationPreviewInput): PreviewSubscribeResponse {
+  const makePlan = ({
+    slug,
+    tier,
+    duration,
+    priceCents,
+    creditsCents,
+    periodEnd
+  }: ReactivationPreviewPlanInput): PreviewSubscribeResponse['new_plan'] => ({
+    slug,
+    tier,
+    duration,
+    price_cents: priceCents,
+    credits_cents: creditsCents,
+    period_end: periodEnd,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: priceCents,
+      total_credits_cents: creditsCents
+    }
+  })
+
+  return {
+    allowed: true,
+    transition_type: 'upgrade',
+    effective_at: effectiveAt,
+    is_immediate: true,
+    cost_today_cents: costTodayCents,
+    cost_next_period_cents: costNextPeriodCents,
+    credits_today_cents: creditsTodayCents,
+    credits_next_period_cents: creditsNextPeriodCents,
+    proration_at: '2026-07-30T00:00:00Z',
+    current_plan: makePlan(currentPlan),
+    new_plan: makePlan(newPlan)
+  }
 }
 
 describe('findPlanSlug', () => {
@@ -598,6 +665,101 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
 
+    it('blocks confirmation until the Team change preview resolves', async () => {
+      let resolvePreview!: (preview: Partial<PreviewSubscribeResponse>) => void
+      mockPreviewSubscribe.mockImplementationOnce(
+        () =>
+          new Promise<Partial<PreviewSubscribeResponse>>((resolve) => {
+            resolvePreview = resolve
+          })
+      )
+      const checkout = await setup()
+
+      const selectionPromise = checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.isLoadingPreview.value).toBe(true)
+      await checkout.handleTeamSubscribe()
+      expect(mockSubscribe).not.toHaveBeenCalled()
+
+      resolvePreview({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await selectionPromise
+
+      expect(checkout.isLoadingPreview.value).toBe(false)
+      expect(checkout.previewVariant.value).toBe('team-change')
+    })
+
+    it('discards a Team preview for a superseded stop and cycle', async () => {
+      let resolveStalePreview!: (
+        preview: Partial<PreviewSubscribeResponse>
+      ) => void
+      mockPreviewSubscribe
+        .mockImplementationOnce(
+          () =>
+            new Promise<Partial<PreviewSubscribeResponse>>((resolve) => {
+              resolveStalePreview = resolve
+            })
+        )
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'downgrade',
+          is_immediate: false,
+          cost_today_cents: 0
+        })
+      const checkout = await setup()
+
+      const staleSelection = checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 630
+        },
+        billingCycle: 'yearly',
+        isChange: true
+      })
+
+      resolveStalePreview({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000
+      })
+      await staleSelection
+
+      expect(checkout.selectedTeamStop.value?.id).toBe('team_700')
+      expect(checkout.selectedBillingCycle.value).toBe('yearly')
+      expect(checkout.previewData.value).toMatchObject({
+        transition_type: 'downgrade',
+        cost_today_cents: 0
+      })
+      expect(checkout.isLoadingPreview.value).toBe(false)
+    })
+
     it('falls back to the display-only confirm when the preview is a fresh subscription', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockResolvedValueOnce({
@@ -668,7 +830,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 70_000
+        cost_today_cents: 70_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       const checkout = await setup()
 
@@ -692,6 +855,53 @@ describe('useSubscriptionCheckout', () => {
       )
       expect(checkout.previewData.value).not.toBeNull()
       expect(checkout.previewVariant.value).toBe('team-change')
+    })
+
+    it('shows the reactivation preview for a cancelled Team downgrade scheduled at period end', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const preview = {
+        allowed: true,
+        transition_type: 'downgrade' as const,
+        is_immediate: false,
+        cost_today_cents: 0,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      }
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      const checkout = await setup()
+
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_700',
+          usd: 700,
+          credits: 147_700,
+          discountedUsd: 665
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      expect(checkout.previewData.value).toEqual(preview)
+      expect(checkout.previewVariant.value).toBe('team-change')
+      expect(mockToastAdd).not.toHaveBeenCalled()
+
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        ...preview,
+        proration_at: '2026-07-29T12:01:00Z'
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-scheduled-reactivation'
+      })
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: undefined
+        })
+      )
     })
 
     it('bounces a cancelled subscriber back to pricing when the preview does not qualify', async () => {
@@ -907,6 +1117,186 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('keeps the quoted Team charge when fresh material state is unchanged', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_today_cents: 221_550,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        credits_today_cents: 221_548,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-quoted-reactivation'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledTimes(2)
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:00:00Z'
+        })
+      )
+    })
+
+    it('blocks a quoted Team charge when material preview state changed', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_next_period_cents: 295_400,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        credits_next_period_cents: 300_000,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(checkout.previewData.value?.credits_next_period_cents).toBe(
+        300_000
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+    })
+
+    it('refreshes an expired Team quote and submits only after reconfirmation', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_1400',
+          usd: 1400,
+          credits: 295_400,
+          discountedUsd: 1295
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        proration_at: '2026-07-29T12:14:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 105_000,
+        proration_at: '2026-07-29T12:16:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1)
+      expect(checkout.previewData.value?.proration_at).toBe(
+        '2026-07-29T12:16:00Z'
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'team'
+        })
+      )
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-refreshed-quote'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 104_999,
+        proration_at: '2026-07-29T12:16:05Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:16:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
+
     // Regression guard: confirmReactivation must come from the disclosure
     // banner's own confirm action, never be re-derived from
     // subscription.isCancelled. A path with no banner (team-new fallback)
@@ -941,7 +1331,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 105_000
+        cost_today_cents: 105_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -957,7 +1348,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 120_000
+        cost_today_cents: 120_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleTeamSubscribe(true)
@@ -980,7 +1372,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 120_000
+        cost_today_cents: 120_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',
@@ -1037,9 +1430,9 @@ describe('useSubscriptionCheckout', () => {
 
     // Regression guard: drift recovery must reuse the same reactivation-
     // capable predicate as the initial cancelled-Team preview. A refreshed
-    // preview that comes back as a fresh subscribe can't feed the banner or
-    // emit confirm_reactivation, so installing it as a team-change would
-    // strand every retry; this must bounce back to pricing instead.
+    // preview without the current-plan date can't feed the banner or emit
+    // confirm_reactivation, so installing it as a team-change would strand
+    // every retry; this must bounce back to pricing instead.
     it('bounces to pricing when a status-drift refresh returns a preview that cannot collect reactivation consent', async () => {
       mockSubscription.value = { isCancelled: false }
       const checkout = await setup()
@@ -1063,11 +1456,12 @@ describe('useSubscriptionCheckout', () => {
 
       mockFetchStatus.mockImplementationOnce(() => {
         mockSubscription.value = { isCancelled: true }
+        checkout.reactivationRequired.value = true
         return Promise.resolve()
       })
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
-        transition_type: 'new_subscription',
+        transition_type: 'upgrade',
         is_immediate: true
       })
 
@@ -1079,6 +1473,87 @@ describe('useSubscriptionCheckout', () => {
       expect(mockToastAdd).toHaveBeenCalledWith(
         expect.objectContaining({ severity: 'error' })
       )
+    })
+
+    it('recovers when the subscribe authority sees a cancellation omitted by the status read', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      const preview = makeReactivationAuthorityPreview({
+        effectiveAt: '2026-08-30T00:00:00Z',
+        costTodayCents: 18_999,
+        costNextPeriodCents: 39_000,
+        creditsTodayCents: 42_200,
+        creditsNextPeriodCents: 84_400,
+        currentPlan: {
+          slug: 'team_per_credit_monthly',
+          tier: 'TEAM',
+          duration: 'MONTHLY',
+          priceCents: 20_000,
+          creditsCents: 42_200,
+          periodEnd: '2026-08-29T00:00:00Z'
+        },
+        newPlan: {
+          slug: 'team_per_credit_monthly',
+          tier: 'TEAM',
+          duration: 'MONTHLY',
+          priceCents: 39_000,
+          creditsCents: 84_400,
+          periodEnd: '2026-08-30T00:00:00Z'
+        }
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      await checkout.handleSubscribeTeamClick({
+        stop: {
+          id: 'team_400',
+          usd: 400,
+          credits: 84_400,
+          discountedUsd: 390
+        },
+        billingCycle: 'monthly',
+        isChange: true
+      })
+
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+
+      await checkout.handleTeamSubscribe()
+
+      expect(checkout.reactivationRequired.value).toBe(true)
+      expect(checkout.previewData.value).toStrictEqual(preview)
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'team'
+        })
+      )
+
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-team-authoritative-reactivation'
+      })
+
+      await checkout.handleTeamSubscribe(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'team_per_credit_monthly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-30T00:00:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
     })
 
     it('uses the annual plan slug for the yearly cycle', async () => {
@@ -1241,13 +1716,15 @@ describe('useSubscriptionCheckout', () => {
 
       mockFetchStatus.mockImplementationOnce(() => {
         mockSubscription.value = { isCancelled: true }
+        checkout.reactivationRequired.value = true
         return Promise.resolve()
       })
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 110_000
+        cost_today_cents: 110_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleTeamSubscribe()
@@ -1262,7 +1739,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 110_000
+        cost_today_cents: 110_000,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',
@@ -1348,6 +1826,16 @@ describe('useSubscriptionCheckout', () => {
 
       resolveOperation({ status: 'failed' })
       await payment
+    })
+
+    it('keeps the confirmation open while a submit is in flight', async () => {
+      const checkout = await setup()
+      checkout.checkoutStep.value = 'preview'
+      checkout.isSubscribing.value = true
+
+      checkout.handleBackToPricing()
+
+      expect(checkout.checkoutStep.value).toBe('preview')
     })
 
     it('does not apply an operation result after switching workspaces', async () => {
@@ -1722,6 +2210,242 @@ describe('useSubscriptionCheckout', () => {
       )
     })
 
+    it('recovers a personal transition when the subscribe authority requires reactivation consent', async () => {
+      mockSubscription.value = { isCancelled: false }
+      const checkout = await setup()
+      const preview = makeReactivationAuthorityPreview({
+        effectiveAt: '2026-08-29T00:00:00Z',
+        costTodayCents: 1500,
+        costNextPeriodCents: 1600,
+        creditsTodayCents: 3150,
+        creditsNextPeriodCents: 4200,
+        currentPlan: {
+          slug: 'creator-monthly',
+          tier: 'CREATOR',
+          duration: 'MONTHLY',
+          priceCents: 3500,
+          creditsCents: 7400,
+          periodEnd: '2026-08-29T00:00:00Z'
+        },
+        newPlan: {
+          slug: 'standard-yearly',
+          tier: 'STANDARD',
+          duration: 'ANNUAL',
+          priceCents: 1600,
+          creditsCents: 4200,
+          periodEnd: '2027-08-29T00:00:00Z'
+        }
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('reactivation confirmation required'), {
+          code: 'REACTIVATION_CONFIRMATION_REQUIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce(preview)
+
+      await checkout.handleConfirmTransition()
+
+      expect(checkout.reactivationRequired.value).toBe(true)
+      expect(checkout.previewData.value).toStrictEqual(preview)
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.confirmationRequired'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'standard'
+        })
+      )
+    })
+
+    it('keeps a pinned immediate duration-change quote when time-derived values drift', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      const currentPlan = {
+        slug: 'creator-monthly',
+        tier: 'CREATOR',
+        duration: 'MONTHLY',
+        price_cents: 3500,
+        credits_cents: 7400,
+        period_end: '2026-08-29T00:00:00Z'
+      }
+      const newPlan = {
+        slug: 'standard-yearly',
+        tier: 'STANDARD',
+        duration: 'ANNUAL',
+        price_cents: 1600,
+        credits_cents: 4200,
+        period_end: '2027-08-29T00:00:00Z'
+      }
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'duration_change',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        credits_today_cents: 3150,
+        proration_at: '2026-07-29T12:00:00Z',
+        current_plan: currentPlan,
+        new_plan: newPlan
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'duration_change',
+        is_immediate: true,
+        cost_today_cents: 1499,
+        credits_today_cents: 3148,
+        proration_at: '2026-07-29T12:05:00Z',
+        current_plan: currentPlan,
+        new_plan: newPlan
+      })
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-personal-quoted-reactivation'
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockPreviewSubscribe).toHaveBeenCalledTimes(2)
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:00:00Z'
+        })
+      )
+    })
+
+    it('refreshes an expired personal quote and submits only after reconfirmation', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        proration_at: '2026-07-29T12:00:00Z'
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1499,
+        proration_at: '2026-07-29T12:14:00Z'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1600,
+        proration_at: '2026-07-29T12:16:00Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenCalledTimes(1)
+      expect(checkout.previewData.value?.proration_at).toBe(
+        '2026-07-29T12:16:00Z'
+      )
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.amountChanged'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'subscription_checkout',
+          stage: 'failed',
+          outcome: 'failure',
+          tier: 'standard'
+        })
+      )
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-personal-refreshed-quote'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1599,
+        proration_at: '2026-07-29T12:16:05Z',
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
+      })
+      await checkout.handleConfirmTransition(true)
+
+      expect(mockSubscribe).toHaveBeenLastCalledWith(
+        'standard-yearly',
+        expect.objectContaining({
+          confirmReactivation: true,
+          prorationAt: '2026-07-29T12:16:00Z'
+        })
+      )
+      expect(checkout.checkoutStep.value).toBe('success')
+    })
+
+    it('keeps the confirmation open when an expired-quote refresh fails', async () => {
+      mockSubscription.value = { isCancelled: true }
+      const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1500,
+        proration_at: '2026-07-29T12:00:00Z'
+      })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'upgrade',
+        is_immediate: true,
+        cost_today_cents: 1499
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('Quote expired'), {
+          code: 'PRORATION_QUOTE_EXPIRED'
+        })
+      )
+      mockPreviewSubscribe.mockRejectedValueOnce(new Error('Preview offline'))
+
+      await checkout.handleConfirmTransition(true)
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: 'Preview offline' })
+      )
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.reactivation.unavailable'
+        })
+      )
+    })
+
     // Regression guard: confirmReactivation must come from the disclosure
     // banner's own confirm action, never be re-derived from
     // subscription.isCancelled. A path with no banner (add-payment preview)
@@ -1878,7 +2602,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 1600
+        cost_today_cents: 1600,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
 
       await checkout.handleConfirmTransition()
@@ -1898,7 +2623,8 @@ describe('useSubscriptionCheckout', () => {
         allowed: true,
         transition_type: 'upgrade',
         is_immediate: true,
-        cost_today_cents: 1600
+        cost_today_cents: 1600,
+        current_plan: { period_end: '2026-08-29T00:00:00Z' }
       })
       mockSubscribe.mockResolvedValueOnce({
         status: 'subscribed',

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -51,8 +51,7 @@ interface SubscriptionCheckoutOptions {
 
 /**
  * Which screen the `preview` step shows. Only a change prorates: a team change
- * carries `previewData` (handleSubscribeTeamClick sets it solely for an immediate
- * team transition), a personal change is anything other than `new_subscription`;
+ * carries `previewData`, a personal change is anything other than `new_subscription`;
  * the rest are display-only fresh-subscribe confirms.
  */
 type PreviewVariant =
@@ -62,10 +61,10 @@ type PreviewVariant =
   | 'personal-new'
   | null
 
-/** Thrown by `assertReactivationAmountUnchanged` when a fresh preview's
- *  `cost_today_cents` no longer matches what the reactivation banner showed
- *  and the user consented to. Caught by the surrounding try/catch and
- *  surfaced through the same toast as any other subscribe failure. */
+/** Thrown by `assertReactivationAmountUnchanged` when a fresh preview no
+ *  longer matches the billing state the reactivation banner showed and the
+ *  user consented to. Caught by the surrounding try/catch and surfaced
+ *  through the same toast as any other subscribe failure. */
 class ReactivationAmountChangedError extends Error {}
 
 export function findPlanSlug(
@@ -114,6 +113,12 @@ export function useSubscriptionCheckout(
   const previewData = ref<PreviewSubscribeResponse | null>(null)
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
+  let teamPreviewRequestId = 0
+  // Some legacy-rail status reads cannot expose a scheduled cancellation even
+  // though the subscribe authority can see it in Stripe. Once that authority
+  // rejects an unconfirmed change, keep the consent screen in reactivation
+  // mode until the user backs out or completes the change.
+  const reactivationRequired = ref(false)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
   const activeCheckoutOperationId = ref<string | null>(null)
   const activeCheckoutOperation = computed(() => {
@@ -153,47 +158,161 @@ export function useSubscriptionCheckout(
     })
   }
 
-  // Shared by the initial cancelled-Team preview (handleSubscribeTeamClick)
-  // and drift recovery (refreshPreviewOnReactivationBlock): a preview can
-  // only feed the reactivation banner if it's allowed, immediate, and an
-  // existing-plan change — new_subscription and scheduled changes route to
-  // screens that can't render the disclosure or emit confirm_reactivation.
+  function isExistingPlanPreview(
+    preview: PreviewSubscribeResponse | null | undefined
+  ): preview is PreviewSubscribeResponse & { allowed: true } {
+    return !!preview?.allowed && preview.transition_type !== 'new_subscription'
+  }
+
   function isReactivationCapablePreview(
     preview: PreviewSubscribeResponse | null | undefined
-  ): boolean {
+  ): preview is PreviewSubscribeResponse & { allowed: true } {
     return (
-      !!preview?.allowed &&
-      preview.is_immediate &&
-      preview.transition_type !== 'new_subscription'
+      isExistingPlanPreview(preview) &&
+      !!preview.current_plan &&
+      !!(subscription.value?.endDate ?? preview.current_plan.period_end)
     )
   }
 
-  // subscribe() recomputes the transaction independently of the preview the
-  // banner showed, so proration or team-seat state can drift while the
-  // screen is open. Re-preview right before billing and refuse if the
-  // amount moved — mirrors the guard useDowngradeToPersonal applies before
-  // a team-to-personal downgrade.
+  function reactivationMaterialSnapshot(
+    preview: PreviewSubscribeResponse,
+    ignoreTimeDerivedTodayValues = false
+  ): string {
+    const planSnapshot = (
+      plan: PreviewSubscribeResponse['new_plan'] | undefined
+    ) =>
+      plan
+        ? [
+            plan.slug,
+            plan.tier,
+            plan.duration,
+            plan.price_cents,
+            plan.credits_cents,
+            plan.seat_summary?.seat_count,
+            plan.seat_summary?.total_cost_cents,
+            plan.seat_summary?.total_credits_cents,
+            plan.period_start,
+            plan.period_end
+          ]
+        : null
+
+    return JSON.stringify([
+      preview.allowed,
+      preview.transition_type,
+      preview.is_immediate,
+      preview.is_immediate ? null : preview.effective_at,
+      preview.cost_next_period_cents,
+      ignoreTimeDerivedTodayValues ? null : preview.credits_today_cents,
+      preview.credits_next_period_cents,
+      planSnapshot(preview.current_plan),
+      planSnapshot(preview.new_plan)
+    ])
+  }
+
+  // Current backends return the exact proration instant used for the preview;
+  // subscribe() echoes it back so the charge cannot drift while the consent
+  // screen is open. A fresh preview still checks non-time-based plan, quantity,
+  // credit, and period state before the charge is submitted.
   async function assertReactivationAmountUnchanged(
     planSlug: string,
     options?: PreviewSubscribeOptions
   ): Promise<void> {
+    const confirmedPreview = previewData.value
     const freshPreview = await previewSubscribe(planSlug, options)
     if (!freshPreview?.allowed) {
       throw new Error(freshPreview?.reason || t('subscription.subscribeFailed'))
     }
+
+    if (confirmedPreview?.proration_at) {
+      const isImmediateTransition = confirmedPreview.is_immediate
+      const amountChanged = isImmediateTransition
+        ? freshPreview.cost_today_cents > confirmedPreview.cost_today_cents
+        : freshPreview.cost_today_cents !== confirmedPreview.cost_today_cents
+      const materialChanged =
+        reactivationMaterialSnapshot(freshPreview, isImmediateTransition) !==
+        reactivationMaterialSnapshot(confirmedPreview, isImmediateTransition)
+      if (amountChanged || materialChanged) {
+        previewData.value = freshPreview
+        throw new ReactivationAmountChangedError(
+          t(
+            amountChanged
+              ? 'subscription.preview.reactivation.amountChanged'
+              : 'subscription.preview.reactivation.confirmationRequired'
+          )
+        )
+      }
+      return
+    }
+
     const amountChanged =
       freshPreview.cost_today_cents !==
-      (previewData.value?.cost_today_cents ?? 0)
+      (confirmedPreview?.cost_today_cents ?? 0)
+    const materialChanged =
+      !!confirmedPreview &&
+      reactivationMaterialSnapshot(freshPreview) !==
+        reactivationMaterialSnapshot(confirmedPreview)
     // Install regardless of outcome: on drift this is what makes the confirm
     // screen show the new amount and resets prior consent (via the
-    // component's own chargeCents watcher), so the next attempt compares
+    // component's own preview watcher), so the next attempt compares
     // against what's on screen instead of repeating this same failure.
     previewData.value = freshPreview
-    if (amountChanged) {
+    if (amountChanged || materialChanged) {
       throw new ReactivationAmountChangedError(
-        t('subscription.preview.reactivation.amountChanged')
+        t(
+          amountChanged
+            ? 'subscription.preview.reactivation.amountChanged'
+            : 'subscription.preview.reactivation.confirmationRequired'
+        )
       )
     }
+  }
+
+  function hasErrorCode(error: unknown, code: string): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === code
+    )
+  }
+
+  async function refreshExpiredProrationQuote(
+    error: unknown,
+    planSlug: string,
+    options?: PreviewSubscribeOptions
+  ): Promise<boolean> {
+    if (!hasErrorCode(error, 'PRORATION_QUOTE_EXPIRED')) return false
+
+    let freshPreview: PreviewSubscribeResponse | null
+    try {
+      freshPreview = await previewSubscribe(planSlug, options)
+    } catch (previewError) {
+      showSubscribeError(previewError)
+      return true
+    }
+    if (!isReactivationCapablePreview(freshPreview)) {
+      resetToPricing()
+      toast.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: t('subscription.preview.reactivation.unavailable')
+      })
+      return true
+    }
+
+    const amountChanged =
+      freshPreview.cost_today_cents !== previewData.value?.cost_today_cents
+    previewData.value = freshPreview
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t(
+        amountChanged
+          ? 'subscription.preview.reactivation.amountChanged'
+          : 'subscription.preview.reactivation.confirmationRequired'
+      )
+    })
+    return true
   }
 
   // The reactivation guard below reads cached `subscription.isCancelled`. If
@@ -218,10 +337,12 @@ export function useSubscriptionCheckout(
     }
     if (isReactivationCapablePreview(freshPreview)) {
       previewData.value = freshPreview
+      reactivationRequired.value = true
       notifyReactivationConfirmationRequired()
       return
     }
-    handleBackToPricing()
+    reactivationRequired.value = false
+    resetToPricing()
     toast.add({
       severity: 'error',
       summary: t('g.error'),
@@ -293,10 +414,17 @@ export function useSubscriptionCheckout(
     tierKey: CheckoutTierKey
     billingCycle: BillingCycle
   }) {
-    if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
+    if (
+      isSubscribing.value ||
+      !permissions.value.canManageSubscription ||
+      !canSelectTierPlan()
+    ) {
+      return
+    }
 
     const { tierKey, billingCycle } = payload
 
+    reactivationRequired.value = false
     isLoadingPreview.value = true
     loadingTier.value = tierKey
     selectedTierKey.value = tierKey
@@ -358,8 +486,10 @@ export function useSubscriptionCheckout(
     billingCycle: BillingCycle
     isChange?: boolean
   }) {
-    if (!permissions.value.canManageSubscription) return
+    if (isSubscribing.value || !permissions.value.canManageSubscription) return
 
+    const previewRequestId = ++teamPreviewRequestId
+    reactivationRequired.value = false
     selectedTeamCheckout.value = {
       stop: payload.stop,
       checkoutType: payload.isChange ? 'change' : 'new'
@@ -375,6 +505,7 @@ export function useSubscriptionCheckout(
     // collect confirm_reactivation, so it always needs a real,
     // reactivation-capable preview instead of the consent-less fallback.
     const needsPreview = payload.isChange || isCancelled.value
+    isLoadingPreview.value = needsPreview && !!payload.stop.id
     if (!needsPreview || !payload.stop.id) return
 
     let response: PreviewSubscribeResponse | null = null
@@ -387,9 +518,18 @@ export function useSubscriptionCheckout(
       })
     } catch (error) {
       previewError = error
+    } finally {
+      if (previewRequestId === teamPreviewRequestId) {
+        isLoadingPreview.value = false
+      }
     }
 
-    if (isReactivationCapablePreview(response)) {
+    if (previewRequestId !== teamPreviewRequestId) return
+
+    if (
+      (isCancelled.value && isReactivationCapablePreview(response)) ||
+      (!isCancelled.value && isExistingPlanPreview(response))
+    ) {
       previewData.value = response
       return
     }
@@ -411,12 +551,19 @@ export function useSubscriptionCheckout(
     selectedTeamCheckout.value = null
   }
 
-  function handleBackToPricing() {
-    if (isPolling.value) return
+  function resetToPricing() {
+    teamPreviewRequestId += 1
+    isLoadingPreview.value = false
+    reactivationRequired.value = false
     checkoutStep.value = 'pricing'
     previewData.value = null
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
+  }
+
+  function handleBackToPricing() {
+    if (isPolling.value || isSubscribing.value) return
+    resetToPricing()
   }
 
   function handleSuccessClose() {
@@ -430,6 +577,8 @@ export function useSubscriptionCheckout(
     if (!tierKey) return
 
     const billingCycle = selectedBillingCycle.value
+    const planSlug = getApiPlanSlug(tierKey, billingCycle)
+    if (!planSlug) return
     const checkoutType =
       previewData.value &&
       previewData.value.transition_type !== 'new_subscription'
@@ -438,21 +587,28 @@ export function useSubscriptionCheckout(
 
     isSubscribing.value = true
     try {
-      const planSlug = getApiPlanSlug(tierKey, billingCycle)
-      if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (
+        !confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await refreshPreviewOnReactivationBlock(planSlug)
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (
+        confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await assertReactivationAmountUnchanged(planSlug)
       }
       const response = await subscribe(planSlug, {
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        prorationAt: previewData.value?.is_immediate
+          ? previewData.value.proration_at
+          : undefined
       })
 
       if (response) {
@@ -470,6 +626,23 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
+        trackSubscriptionFailure({
+          tier: tierKey,
+          cycle: billingCycle,
+          checkoutType
+        })
+        await refreshPreviewOnReactivationBlock(planSlug)
+        return
+      }
+      if (await refreshExpiredProrationQuote(error, planSlug)) {
+        trackSubscriptionFailure({
+          tier: tierKey,
+          cycle: billingCycle,
+          checkoutType
+        })
+        return
+      }
       trackSubscriptionFailure({
         tier: tierKey,
         cycle: billingCycle,
@@ -594,7 +767,13 @@ export function useSubscriptionCheckout(
   }
 
   async function handleTeamSubscription(confirmReactivation = false) {
-    if (!permissions.value.canManageSubscription) return
+    if (
+      isLoadingPreview.value ||
+      isSubscribing.value ||
+      !permissions.value.canManageSubscription
+    ) {
+      return
+    }
 
     const teamCheckout = selectedTeamCheckout.value
     if (!teamCheckout?.stop.id) {
@@ -613,14 +792,20 @@ export function useSubscriptionCheckout(
     isSubscribing.value = true
     try {
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (
+        !confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await refreshPreviewOnReactivationBlock(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
         })
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (
+        confirmReactivation &&
+        (isCancelled.value || reactivationRequired.value)
+      ) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
@@ -631,7 +816,10 @@ export function useSubscriptionCheckout(
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
-        confirmReactivation
+        confirmReactivation,
+        prorationAt: previewData.value?.is_immediate
+          ? previewData.value.proration_at
+          : undefined
       })
 
       if (response) {
@@ -649,6 +837,31 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (hasErrorCode(error, 'REACTIVATION_CONFIRMATION_REQUIRED')) {
+        trackSubscriptionFailure({
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType
+        })
+        await refreshPreviewOnReactivationBlock(planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+        return
+      }
+      if (
+        await refreshExpiredProrationQuote(error, planSlug, {
+          teamCreditStopId: stop.id,
+          billingCycle
+        })
+      ) {
+        trackSubscriptionFailure({
+          tier: 'team',
+          cycle: billingCycle,
+          checkoutType
+        })
+        return
+      }
       trackSubscriptionFailure({
         tier: 'team',
         cycle: billingCycle,
@@ -715,6 +928,7 @@ export function useSubscriptionCheckout(
     isSubscribing,
     isResubscribing,
     previewData,
+    reactivationRequired,
     selectedTierKey,
     selectedTeamStop,
     selectedBillingCycle,


### PR DESCRIPTION
Backport of #14344 to core/1.48.

Validation:
- 179 focused unit tests passed
- typecheck passed
- cherry-pick and diff checks passed