### PR TITLE
test: add failing regression test for subgraph resize loss (FE-853)

### DIFF
--- a/browser_tests/fixtures/components/SubgraphEditor.ts
+++ b/browser_tests/fixtures/components/SubgraphEditor.ts
@@ -9,12 +9,23 @@ import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 export class SubgraphEditor {
   public readonly root: Locator
   public readonly promotionItems: Locator
+  public readonly selectionToolboxButton: Locator
 
   constructor(protected readonly comfyPage: ComfyPage) {
     this.root = this.comfyPage.menu.propertiesPanel.root
     this.promotionItems = this.root.getByTestId(
       TestIds.subgraphEditor.widgetItem
     )
+    this.selectionToolboxButton = this.comfyPage.selectionToolbox.getByRole(
+      'button',
+      { name: 'Edit Subgraph Widgets' }
+    )
+  }
+
+  async openFromSelectionToolbox(subgraphNode: Locator) {
+    await new VueNodeFixture(subgraphNode).select()
+    await this.selectionToolboxButton.click()
+    await expect(this.root, 'Open Properties Panel').toBeVisible()
   }
 
   async ensureOpen(subgraphNode: Locator) {

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
 import type {
@@ -12,6 +13,7 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
 import type { Position, Size } from '@e2e/fixtures/types'
 import { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 
 export class NodeOperationsHelper {
   public readonly promptDialogInput: Locator
@@ -214,6 +216,37 @@ export class NodeOperationsHelper {
         bottomRight
       )
     }
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right Vue resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async fillPromptDialog(value: string): Promise<void> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,6 +15,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -496,6 +497,37 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,7 +15,6 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
-import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -497,37 +496,6 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
-  }
-
-  /**
-   * Enlarges the node titled `title` by dragging its bottom-right resize
-   * handle. The returned size is read from the graph model, not a DOM bounding
-   * box, so it stays comparable across zoom and side-panel layout changes.
-   */
-  async growNodeByDrag(
-    title: string,
-    delta: { x: number; y: number }
-  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
-    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
-    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
-
-    // Saved pans can leave the node too low for a downward drag to stay onscreen.
-    await nodeRef.centerOnNode()
-
-    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
-    const sizeBefore = await nodeRef.getSize()
-    await node.resizeFromCorner('SE', delta.x, delta.y)
-    await this.comfyPage.nextFrame()
-
-    const size = await nodeRef.getSize()
-    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
-      sizeBefore.width
-    )
-    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
-      sizeBefore.height
-    )
-
-    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -23,7 +23,7 @@ test.describe(
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, node, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )
@@ -39,7 +39,7 @@ test.describe(
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,4 +1,3 @@
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
@@ -12,90 +11,51 @@ import {
  *
  * https://linear.app/comfyorg/issue/FE-853
  */
-
-const SUBGRAPH_TITLE = 'New Subgraph'
-const RESIZE_DELTA = { x: 250, y: 250 }
-/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
-const INTERIOR_KSAMPLER_ID = '1'
-
-/**
- * Loads the subgraph fixture and grows the subgraph node by dragging its
- * bottom-right handle, the way a user would.
- *
- * Sizes are read from the graph model rather than from DOM bounding boxes so
- * that the assertions stay independent of canvas zoom and of the canvas
- * shrinking when the right side panel opens.
- */
-async function loadResizedSubgraph(comfyPage: ComfyPage) {
-  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
-
-  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
-  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
-
-  // The fixture is saved with a pan that leaves the node low in the viewport,
-  // so a downward resize drag would run off screen.
-  await nodeRef.centerOnNode()
-
-  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
-  const sizeBefore = await nodeRef.getSize()
-  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
-  await comfyPage.nextFrame()
-
-  const resizedSize = await nodeRef.getSize()
-  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
-    sizeBefore.width
-  )
-  expect(
-    resizedSize.height,
-    'manual resize heightened the node'
-  ).toBeGreaterThan(sizeBefore.height)
-
-  return { nodeRef, node, resizedSize }
-}
-
 test.describe(
   'Subgraph node size across widget editing',
   { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
     })
 
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, resizedSize } =
-        await loadResizedSubgraph(comfyPage)
+      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
-      await node.select()
-      await comfyPage.selectionToolbox
-        .getByRole('button', { name: 'Edit Subgraph Widgets' })
-        .click()
-      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.subgraph.editor.openFromSelectionToolbox(node.root)
       await comfyPage.nextFrame()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
-      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
+      expect(sizeAfter.height).toBeCloseTo(size.height, 0)
     })
 
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
       await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
       await comfyPage.subgraph.promoteWidget(
-        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        comfyPage.vueNodes.getNodeByTitle('KSampler'),
         'steps'
       )
       await comfyPage.subgraph.exitViaBreadcrumb()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
       // A newly promoted widget can legitimately raise the minimum height, so
       // only a shrink below the user's size is a regression.
-      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+      expect(sizeAfter.height).toBeGreaterThanOrEqual(size.height)
     })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,0 +1,101 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+/**
+ * FE-853: a subgraph node the user has manually resized snaps back to its
+ * computed minimum size as soon as the widget-editing UI is triggered — either
+ * by the "Edit Subgraph Widgets" selection-toolbox button or by promoting a
+ * widget from inside the subgraph — discarding the size the user set.
+ *
+ * https://linear.app/comfyorg/issue/FE-853
+ */
+
+const SUBGRAPH_TITLE = 'New Subgraph'
+const RESIZE_DELTA = { x: 250, y: 250 }
+/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
+const INTERIOR_KSAMPLER_ID = '1'
+
+/**
+ * Loads the subgraph fixture and grows the subgraph node by dragging its
+ * bottom-right handle, the way a user would.
+ *
+ * Sizes are read from the graph model rather than from DOM bounding boxes so
+ * that the assertions stay independent of canvas zoom and of the canvas
+ * shrinking when the right side panel opens.
+ */
+async function loadResizedSubgraph(comfyPage: ComfyPage) {
+  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
+  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
+
+  // The fixture is saved with a pan that leaves the node low in the viewport,
+  // so a downward resize drag would run off screen.
+  await nodeRef.centerOnNode()
+
+  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
+  const sizeBefore = await nodeRef.getSize()
+  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
+  await comfyPage.nextFrame()
+
+  const resizedSize = await nodeRef.getSize()
+  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
+    sizeBefore.width
+  )
+  expect(
+    resizedSize.height,
+    'manual resize heightened the node'
+  ).toBeGreaterThan(sizeBefore.height)
+
+  return { nodeRef, node, resizedSize }
+}
+
+test.describe(
+  'Subgraph node size across widget editing',
+  { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+    })
+
+    test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, node, resizedSize } =
+        await loadResizedSubgraph(comfyPage)
+
+      await node.select()
+      await comfyPage.selectionToolbox
+        .getByRole('button', { name: 'Edit Subgraph Widgets' })
+        .click()
+      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.nextFrame()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+    })
+
+    test('retains a manual resize when an interior widget is promoted', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+
+      await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
+      await comfyPage.subgraph.promoteWidget(
+        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        'steps'
+      )
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      // A newly promoted widget can legitimately raise the minimum height, so
+      // only a shrink below the user's size is a regression.
+      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+    })
+  }
+)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## ⚠️ These tests are expected to FAIL

This PR intentionally adds **no production fix**. It exists to pin down FE-853's exact behavior as a reference regression test before the real fix lands, so CI on this branch is red by design. Do not merge as-is.

- Tracked in [FE-853](https://linear.app/comfyorg/issue/FE-853/bug-promotingunpromoting-a-widget-collapses-subgraph-to-minimum-size)

## The bug

Manually resize a subgraph node, then trigger the widget-editing UI — the node snaps back to its computed minimum size and the manual resize is silently discarded. Reported in #bug-dump via the "Edit Subgraph Widgets" toolbox button; FE-853 tracks the same collapse on widget promotion.

Measured locally against `main`:

| Step | Node size (graph units) |
| --- | --- |
| After the user's resize drag | **506 × 339** |
| After clicking "Edit Subgraph Widgets" | **225 × 58** |
| After promoting an interior widget | **225 × 58** |

## Tests added

`browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts` covers both triggers:

1. **"Edit Subgraph Widgets" clicked** — the selection-toolbox button from the bug report, which is what the user's screen recording shows.
2. **Interior widget promoted** — the trigger named in FE-853's title.

Both resize the node by dragging its bottom-right handle, then assert the node keeps that size.

Sizes are read from the graph model rather than DOM bounding boxes, so the assertions are not confounded by canvas zoom or by the canvas shrinking when the right side panel opens.

The promotion test asserts width equality but only `>=` on height, since a newly promoted widget can legitimately raise the node's minimum height — only a shrink below the user's size is a regression.

## Fixture changes

Per `browser_tests/README.md` (setup routines and locator wiring belong in helpers/page objects, not free-standing in a spec):

- `SubgraphHelper.growNodeByDrag()` — performs the user-style resize drag and returns the resulting model size.
- `SubgraphEditor.openFromSelectionToolbox()` — opens the editor via the toolbox button, complementing the existing context-menu `ensureOpen()`.

Both are additive; the 5 existing `subgraphPromotedWidgetPanel.spec.ts` tests that consume `SubgraphEditor` still pass.

## Verification

- `pnpm typecheck:browser`, ESLint, oxlint, oxfmt, `pnpm knip` — all clean
- New spec: **2 failed**, both on the intended post-trigger width assertion (`expected 506.0625, received 225`) — the growth assertions before the trigger pass, confirming the resize itself works and the collapse is what fails
- `subgraphPromotedWidgetPanel.spec.ts`: **5 passed**

Note for the reviewer: if a red branch is undesirable, these can be annotated with `test.fail()` so CI stays green and flips once the fix lands — happy to do that, but left them genuinely failing as requested.


## Screenshots

![Subgraph node after the user manually resized it to 506x339, with the selection toolbox above it](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785443957785-25460967-06a7-4efb-b819-378829d9f20b.png)

![After clicking Edit Subgraph Widgets: the node has collapsed to 225x58 and the right side panel has opened](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785443958170-919080b0-2d85-4987-bf26-c6d3c42aeee5.png)