### PR TITLE
feat(website): use looping video for careers hero

### DIFF
--- a/apps/website/src/components/careers/HeroSection.vue
+++ b/apps/website/src/components/careers/HeroSection.vue
@@ -4,6 +4,7 @@ import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import GlassCard from '../common/GlassCard.vue'
 import SectionLabel from '../common/SectionLabel.vue'
+import SiteVideo from '../common/SiteVideo.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 </script>
@@ -15,19 +16,24 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
         {{ t('careers.hero.label', locale) }}
       </SectionLabel>
       <h1
-        class="text-primary-comfy-canvas mt-4 text-4xl font-light whitespace-pre-line md:text-6xl"
+        class="mt-4 text-4xl font-light whitespace-pre-line text-primary-comfy-canvas md:text-6xl"
       >
         {{ t('careers.hero.heading', locale) }}
       </h1>
     </div>
 
     <GlassCard class="mx-auto mt-12 max-w-3xl md:mt-16">
-      <img
-        src="https://media.comfy.org/website/careers/hero.webp"
+      <SiteVideo
+        name="hero"
+        base-url="https://media.comfy.org/website/careers"
+        poster="https://media.comfy.org/website/careers/hero-poster.jpg"
         alt="Comfy team"
-        class="w-full rounded-4xl object-cover"
+        autoplay
+        loop
+        muted
+        video-class="h-auto w-full rounded-4xl object-cover"
       />
-      <div class="text-primary-comfy-canvas space-y-6 p-8 text-base/relaxed">
+      <div class="space-y-6 p-8 text-base/relaxed text-primary-comfy-canvas">
         <p>{{ t('careers.hero.body1', locale) }}</p>
         <p>{{ t('careers.hero.body2', locale) }}</p>
         <p>{{ t('careers.hero.body3', locale) }}</p>

--- a/apps/website/src/components/careers/HeroSection.vue
+++ b/apps/website/src/components/careers/HeroSection.vue
@@ -31,6 +31,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
         autoplay
         loop
         muted
+        controls
         video-class="h-auto w-full rounded-4xl object-cover"
       />
       <div class="space-y-6 p-8 text-base/relaxed text-primary-comfy-canvas">

--- a/apps/website/src/components/common/SiteVideo.vue
+++ b/apps/website/src/components/common/SiteVideo.vue
@@ -14,9 +14,9 @@ const {
   alt,
   autoplay = false,
   loop = false,
-  muted = autoplay,
+  muted,
   controls = false,
-  preload = autoplay ? 'auto' : 'metadata',
+  preload,
   containerClass,
   videoClass
 } = defineProps<{
@@ -40,6 +40,10 @@ const sources = computed(() =>
 )
 const remountKey = computed(() => videoKey(sources.value))
 const decorative = computed(() => !alt && !controls)
+const resolvedMuted = computed(() => muted ?? autoplay)
+const resolvedPreload = computed(
+  () => preload ?? (autoplay ? 'auto' : 'metadata')
+)
 </script>
 
 <template>
@@ -48,10 +52,10 @@ const decorative = computed(() => !alt && !controls)
       :key="remountKey"
       :class="cn('size-full', videoClass)"
       :poster
-      :preload
+      :preload="resolvedPreload"
       :autoplay
       :loop
-      :muted
+      :muted="resolvedMuted"
       :controls
       :aria-label="alt"
       :aria-hidden="decorative ? true : undefined"

--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -1,4 +1,3 @@
-/** @knipIgnoreUsedByStackedPR */
 export type VideoFormat = 'webm' | 'mp4'
 
 type VideoSource = {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -53,7 +53,6 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     // Marketing media tooling — adopted by pages in a follow-up PR
-    'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',
     // Pending integration: consumed by the useWorkspaceInvoices seam once
     // #13591 (Plan & Credits tabs) lands — FE-1245


### PR DESCRIPTION
## Summary

Replace the static careers hero image with the new brand video, using the existing `SiteVideo` component.

## Changes

- **What**: Swap the `<img>` in `careers/HeroSection.vue` for `SiteVideo` (autoplay/loop/muted, `hero-poster.jpg` fallback). This covers both `/careers` and `/zh-CN/careers`, which share the component. Also drops the now-stale `@knipIgnoreUsedByStackedPR` marker on `video.ts`'s `VideoFormat` and removes `SiteVideo.vue` from the knip ignore list, since adopting the component makes both genuinely used.
- **Breaking**: None

## Review Focus

- Video assets are hosted on the CDN at `media.comfy.org/website/careers/` (`hero-1280.webm`, `hero-1280.mp4`, `hero-poster.jpg`), generated via `apps/website/scripts/process-videos.sh`. They are already uploaded and serving publicly, so the hero renders on merge.
- Source clip is ~70s with an audio track (muted in the hero). Can be trimmed to a shorter loop in a follow-up if preferred.

## Screenshots (if applicable)

Hero now plays the looping video in place of the previous still image.