### PR TITLE
fix: declare tailwindcss peer dep and add README for design-system package

### DIFF
--- a/.github/workflows/ci-design-system-pack.yaml
+++ b/.github/workflows/ci-design-system-pack.yaml
@@ -36,6 +36,7 @@ jobs:
                 | select(
                     . != "package.json"
                     and . != "LICENSE"
+                    and . != "README.md"
                     and (startswith("src/css/") | not)
                     and (startswith("src/icons/") | not)
                   )

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,0 +1,49 @@
+# @comfyorg/design-system
+
+Shared design tokens, theme, and icon set for Comfy Org frontends. Ships raw CSS
+and SVG so consumers compile them with their own Tailwind build.
+
+## Install
+
+```sh
+pnpm add @comfyorg/design-system tailwindcss
+```
+
+Tailwind v4 is a peer dependency — `style.css` imports `tailwindcss/theme` and
+`tailwindcss/utilities`, and the bundled plugins import `tailwindcss/plugin`.
+
+## Usage
+
+Import the full theme from your app's entry stylesheet:
+
+```css
+@import '@comfyorg/design-system/css/style.css';
+```
+
+This pulls in the fonts, the color palette, the Tailwind theme and utilities
+layers, `tw-animate-css`, the PrimeUI plugin, and the Comfy and Lucide icon
+plugins.
+
+For the palette and fonts without the Tailwind layers or icon plugins:
+
+```css
+@import '@comfyorg/design-system/css/base.css';
+```
+
+## Exports
+
+| Path                 | Contents                                                   |
+| -------------------- | ---------------------------------------------------------- |
+| `./css/style.css`    | Full theme — palette, fonts, Tailwind layers, icon plugins |
+| `./css/base.css`     | Palette and fonts only                                     |
+| `./css/_palette.css` | Color variables                                            |
+| `./css/fonts.css`    | Font faces                                                 |
+| `./icons/*.svg`      | Comfy icon set source SVGs                                 |
+
+Icons are exposed to Tailwind as `icon-[comfy--*]` and `icon-mask-[comfy--*]`
+utilities. Size them with `size-*`, not font-size classes.
+
+## Releasing
+
+Run the **Version Bump Design System** workflow to open a version PR, then merge
+it with the `Release` label. Publishing to npm happens automatically on merge.

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -39,5 +39,8 @@
   "devDependencies": {
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "tailwindcss": "^4.1.0"
   }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/design-system",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared design system for ComfyUI Frontend",
   "homepage": "https://comfy.org",
   "license": "MIT",


### PR DESCRIPTION
Follow-up to #14080. Two packaging gaps found while diagnosing the failed first publish of `@comfyorg/design-system` ([run 30579592610](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30579592610)).

- **No README in the tarball.** `pnpm pack` produced `package.json`, `LICENSE`, `src/css`, `src/icons` — nothing else. The npm page would render empty, which defeats the point of publishing this for platform.comfy.org to align on.
- **`tailwindcss` was only a devDependency.** `src/css/style.css` imports `tailwindcss/theme` and `tailwindcss/utilities`, and both `iconifyDynamicPlugin.ts` and `lucideStrokePlugin.js` import `tailwindcss/plugin`. Consumers must supply Tailwind, but nothing declared it. Now a peer dep at `^4.1.0` — `@source inline()` in `style.css` requires 4.1+.

Verified by packing the tarball: `README.md` is included and `peerDependencies` survives the `catalog:` rewrite.

Not included here: `id-token: write` for npm trusted publishing. That can only land after `@comfyorg/design-system` exists on the registry, since npm requires the package to exist before a trusted publisher can be configured ([npm/cli#8544](https://github.com/npm/cli/issues/8544)). Separate PR once the first version is up.

Also bumps to **1.0.1** and carries the `Release` label, so merging publishes via `publish-design-system-on-merge`. That doubles as the first end-to-end test of the rotated `NPM_TOKEN` — a manual dispatch would have been a no-op, since the workflow's `Check if version already on npm` step finds 1.0.0 and skips publishing entirely.