### PR TITLE
test: fold FE-853 Edit Subgraph Widgets regression test into the fix

### DIFF
--- a/browser_tests/fixtures/components/SubgraphEditor.ts
+++ b/browser_tests/fixtures/components/SubgraphEditor.ts
@@ -9,12 +9,23 @@ import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 export class SubgraphEditor {
   public readonly root: Locator
   public readonly promotionItems: Locator
+  public readonly selectionToolboxButton: Locator
 
   constructor(protected readonly comfyPage: ComfyPage) {
     this.root = this.comfyPage.menu.propertiesPanel.root
     this.promotionItems = this.root.getByTestId(
       TestIds.subgraphEditor.widgetItem
     )
+    this.selectionToolboxButton = this.comfyPage.selectionToolbox.getByRole(
+      'button',
+      { name: 'Edit Subgraph Widgets' }
+    )
+  }
+
+  async openFromSelectionToolbox(subgraphNode: Locator) {
+    await new VueNodeFixture(subgraphNode).select()
+    await this.selectionToolboxButton.click()
+    await expect(this.root, 'Open Properties Panel').toBeVisible()
   }
 
   async ensureOpen(subgraphNode: Locator) {

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
 import type {
@@ -12,6 +13,7 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
 import type { Position, Size } from '@e2e/fixtures/types'
 import { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 
 export class NodeOperationsHelper {
   public readonly promptDialogInput: Locator
@@ -214,6 +216,37 @@ export class NodeOperationsHelper {
         bottomRight
       )
     }
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right Vue resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async fillPromptDialog(value: string): Promise<void> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,6 +15,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -500,6 +501,37 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,7 +15,6 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
-import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -501,37 +500,6 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
-  }
-
-  /**
-   * Enlarges the node titled `title` by dragging its bottom-right resize
-   * handle. The returned size is read from the graph model, not a DOM bounding
-   * box, so it stays comparable across zoom and side-panel layout changes.
-   */
-  async growNodeByDrag(
-    title: string,
-    delta: { x: number; y: number }
-  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
-    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
-    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
-
-    // Saved pans can leave the node too low for a downward drag to stay onscreen.
-    await nodeRef.centerOnNode()
-
-    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
-    const sizeBefore = await nodeRef.getSize()
-    await node.resizeFromCorner('SE', delta.x, delta.y)
-    await this.comfyPage.nextFrame()
-
-    const size = await nodeRef.getSize()
-    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
-      sizeBefore.width
-    )
-    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
-      sizeBefore.height
-    )
-
-    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -51,6 +51,14 @@ test.describe(
       )
       await comfyPage.subgraph.exitViaBreadcrumb()
 
+      // Guards against a vacuous pass: if promotion silently became a no-op,
+      // the size assertions below would hold without exercising the bug.
+      await expect
+        .poll(() =>
+          comfyPage.subgraph.getPromotedWidgetOrder(String(nodeRef.id))
+        )
+        .toContain('steps')
+
       const sizeAfter = await nodeRef.getSize()
       expect(sizeAfter.width).toBeCloseTo(size.width, 0)
       // A newly promoted widget can legitimately raise the minimum height, so

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -23,7 +23,7 @@ test.describe(
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, node, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )
@@ -39,7 +39,7 @@ test.describe(
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,4 +1,3 @@
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
@@ -12,90 +11,51 @@ import {
  *
  * https://linear.app/comfyorg/issue/FE-853
  */
-
-const SUBGRAPH_TITLE = 'New Subgraph'
-const RESIZE_DELTA = { x: 250, y: 250 }
-/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
-const INTERIOR_KSAMPLER_ID = '1'
-
-/**
- * Loads the subgraph fixture and grows the subgraph node by dragging its
- * bottom-right handle, the way a user would.
- *
- * Sizes are read from the graph model rather than from DOM bounding boxes so
- * that the assertions stay independent of canvas zoom and of the canvas
- * shrinking when the right side panel opens.
- */
-async function loadResizedSubgraph(comfyPage: ComfyPage) {
-  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
-
-  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
-  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
-
-  // The fixture is saved with a pan that leaves the node low in the viewport,
-  // so a downward resize drag would run off screen.
-  await nodeRef.centerOnNode()
-
-  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
-  const sizeBefore = await nodeRef.getSize()
-  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
-  await comfyPage.nextFrame()
-
-  const resizedSize = await nodeRef.getSize()
-  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
-    sizeBefore.width
-  )
-  expect(
-    resizedSize.height,
-    'manual resize heightened the node'
-  ).toBeGreaterThan(sizeBefore.height)
-
-  return { nodeRef, node, resizedSize }
-}
-
 test.describe(
   'Subgraph node size across widget editing',
   { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
     })
 
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, resizedSize } =
-        await loadResizedSubgraph(comfyPage)
+      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
-      await node.select()
-      await comfyPage.selectionToolbox
-        .getByRole('button', { name: 'Edit Subgraph Widgets' })
-        .click()
-      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.subgraph.editor.openFromSelectionToolbox(node.root)
       await comfyPage.nextFrame()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
-      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
+      expect(sizeAfter.height).toBeCloseTo(size.height, 0)
     })
 
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
       await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
       await comfyPage.subgraph.promoteWidget(
-        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        comfyPage.vueNodes.getNodeByTitle('KSampler'),
         'steps'
       )
       await comfyPage.subgraph.exitViaBreadcrumb()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
       // A newly promoted widget can legitimately raise the minimum height, so
       // only a shrink below the user's size is a regression.
-      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+      expect(sizeAfter.height).toBeGreaterThanOrEqual(size.height)
     })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,0 +1,101 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+/**
+ * FE-853: a subgraph node the user has manually resized snaps back to its
+ * computed minimum size as soon as the widget-editing UI is triggered — either
+ * by the "Edit Subgraph Widgets" selection-toolbox button or by promoting a
+ * widget from inside the subgraph — discarding the size the user set.
+ *
+ * https://linear.app/comfyorg/issue/FE-853
+ */
+
+const SUBGRAPH_TITLE = 'New Subgraph'
+const RESIZE_DELTA = { x: 250, y: 250 }
+/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
+const INTERIOR_KSAMPLER_ID = '1'
+
+/**
+ * Loads the subgraph fixture and grows the subgraph node by dragging its
+ * bottom-right handle, the way a user would.
+ *
+ * Sizes are read from the graph model rather than from DOM bounding boxes so
+ * that the assertions stay independent of canvas zoom and of the canvas
+ * shrinking when the right side panel opens.
+ */
+async function loadResizedSubgraph(comfyPage: ComfyPage) {
+  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
+  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
+
+  // The fixture is saved with a pan that leaves the node low in the viewport,
+  // so a downward resize drag would run off screen.
+  await nodeRef.centerOnNode()
+
+  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
+  const sizeBefore = await nodeRef.getSize()
+  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
+  await comfyPage.nextFrame()
+
+  const resizedSize = await nodeRef.getSize()
+  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
+    sizeBefore.width
+  )
+  expect(
+    resizedSize.height,
+    'manual resize heightened the node'
+  ).toBeGreaterThan(sizeBefore.height)
+
+  return { nodeRef, node, resizedSize }
+}
+
+test.describe(
+  'Subgraph node size across widget editing',
+  { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+    })
+
+    test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, node, resizedSize } =
+        await loadResizedSubgraph(comfyPage)
+
+      await node.select()
+      await comfyPage.selectionToolbox
+        .getByRole('button', { name: 'Edit Subgraph Widgets' })
+        .click()
+      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.nextFrame()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+    })
+
+    test('retains a manual resize when an interior widget is promoted', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+
+      await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
+      await comfyPage.subgraph.promoteWidget(
+        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        'steps'
+      )
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      // A newly promoted widget can legitimately raise the minimum height, so
+      // only a shrink below the user's size is a regression.
+      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+    })
+  }
+)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Stacked on top of #14374 — **base is `fix/subgraph-resize-on-promote-demote`, not `main`.** Merging this folds the regression test from #14415 into #14374 so only one PR lands, per the request in the [bug-dump thread](https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1785406673029529).

Supersedes #14415 (which can be closed). Tracked in [FE-853](https://linear.app/comfyorg/issue/FE-853/bug-promotingunpromoting-a-widget-collapses-subgraph-to-minimum-size).

## What this adds

`browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts` — two tests approaching FE-853 from the user-reported entry point, complementing the six in #14374's `subgraphResizePreservation.spec.ts`:

1. **"Edit Subgraph Widgets" clicked** — the selection-toolbox button, which is what the screen recording in the bug report actually shows. #14374's closest case opens the panel via `actionbar.propertiesButton`; this drives the button on the node's toolbar instead, so the reported path is covered directly.
2. **Interior widget promoted** — the trigger in FE-853's title.

Plus two fixture additions:

- `NodeOperationsHelper.growNodeByDrag()` — user-style resize drag returning model-space size, next to the existing canvas-based `resizeNode`.
- `SubgraphEditor.openFromSelectionToolbox()` — the toolbox-button path, complementing the existing context-menu `ensureOpen()`.

Sizes are read from the graph model rather than DOM bounding boxes, so assertions aren't confounded by canvas zoom or by the canvas shrinking when the side panel opens.

## Verification

**The fix is what makes these pass** — established by reverting it in place:

| `src` state | Result |
| --- | --- |
| `expandToFitContent()` (this branch) | **2 passed** |
| reverted to `computeSize(node.size)` | **2 failed** — `expected 506.0625, received 225` |

In the reverted run the failure is the width assertion, not the promotion guard — so the tests detect the real regression rather than an incidental difference.

Everything else on the combined branch:

- `subgraphEditWidgetsResize.spec.ts` (new): **2 passed**
- `subgraphResizePreservation.spec.ts` (#14374's): **6 passed**
- `subgraphPromotedWidgetPanel.spec.ts` (existing consumers): **5 passed**
- `promotionUtils.test.ts` + `SubgraphEditor.test.ts` unit tests: **60 passed**
- `pnpm typecheck`, `pnpm typecheck:browser`, ESLint, oxlint, oxfmt `--check`, `pnpm knip`: clean

## Review feedback incorporated

CodeRabbit flagged that the promotion test could pass vacuously if `promoteWidget` became a no-op. Added an auto-retrying `getPromotedWidgetOrder()` assertion that `steps` actually landed on the host node before the size checks. The first test already had an equivalent guard — `openFromSelectionToolbox()` asserts the panel opened.

@DrJKL's earlier note on #14415 is also incorporated: `growNodeByDrag` lives in `NodeOperationsHelper`, not `SubgraphHelper`, since nothing about it is subgraph-specific.


## Screenshots

![Subgraph node manually resized to 506x339 with the selection toolbox above it](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785445508182-6533e000-0e02-4c9f-b761-2ba69083f05f.png)

![Pre-fix behavior: after clicking Edit Subgraph Widgets the node collapsed to 225x58](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785445508568-da9fc788-4016-4a16-a6a4-8943940905b6.png)