### PR TITLE
feat: support Datadog source map uploads

### DIFF
--- a/src/platform/telemetry/initDatadogRum.test.ts
+++ b/src/platform/telemetry/initDatadogRum.test.ts
@@ -60,7 +60,7 @@ describe('initDatadogRum', () => {
         site: 'us5.datadoghq.com',
         service: 'comfy-cloud-frontend',
         env,
-        version: __COMFYUI_FRONTEND_VERSION__,
+        version: __COMFYUI_FRONTEND_COMMIT__,
         beforeSend: rumBeforeSend,
         sessionSampleRate: 100,
         sessionReplaySampleRate: 0,

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -43,7 +43,7 @@ async function initializeDatadogRum(env: string): Promise<void> {
     site: 'us5.datadoghq.com',
     service: 'comfy-cloud-frontend',
     env,
-    version: __COMFYUI_FRONTEND_VERSION__,
+    version: __COMFYUI_FRONTEND_COMMIT__,
     beforeSend: rumBeforeSend,
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -518,22 +518,14 @@ export default defineConfig({
           sentryVitePlugin({
             org: process.env.SENTRY_ORG,
             project: process.env.SENTRY_PROJECT,
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            sourcemaps: {
-              filesToDeleteAfterUpload: process.env.SENTRY_PROJECT_PROD
-                ? []
-                : ['**/*.map']
-            }
+            authToken: process.env.SENTRY_AUTH_TOKEN
           }),
           ...(process.env.SENTRY_PROJECT_PROD
             ? [
                 sentryVitePlugin({
                   org: process.env.SENTRY_ORG,
                   project: process.env.SENTRY_PROJECT_PROD,
-                  authToken: process.env.SENTRY_AUTH_TOKEN,
-                  sourcemaps: {
-                    filesToDeleteAfterUpload: ['**/*.map']
-                  }
+                  authToken: process.env.SENTRY_AUTH_TOKEN
                 })
               ]
             : [])


### PR DESCRIPTION
## Summary

Keep hidden source maps after Sentry upload so Cloud can send them to Datadog. Use the frontend SHA for RUM `version` because it must match Datadog `--release-version` for symbolication.

## Verification

`vite.config.mts` retains the maps; Comfy-Org/cloud#5892 uploads with that SHA, deletes the maps, then publishes artifacts.

Created by Codex