### PR TITLE
fix: show annual credits for scheduled downgrades

### DIFF
--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { createI18n } from 'vue-i18n'
 import { describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -10,13 +11,6 @@ import type {
 
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({
-    t: (key: string) => key,
-    n: (value: number) => value.toLocaleString('en-US')
-  })
-}))
-
 // Not cancelled: keeps the reactivation banner out of these baseline scenarios.
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -25,8 +19,14 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
 const globalOptions = {
-  mocks: { $t: (key: string) => key },
+  plugins: [i18n],
   stubs: {
     SubscriptionTermsNote: { template: '<div />' },
     Button: { template: '<button @click="$emit(\'click\')"><slot /></button>' }
@@ -185,6 +185,35 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     expect(screen.queryByText('subscription.preview.switchesToday')).toBeNull()
     expect(
       screen.queryByText('subscription.preview.yearlySubscription')
+    ).toBeNull()
+  })
+
+  it('renders a scheduled annual downgrade with yearly refill and billing', () => {
+    render(SubscriptionTransitionPreviewWorkspace, {
+      props: {
+        previewData: preview({
+          transition_type: 'downgrade',
+          is_immediate: false,
+          cost_today_cents: 0,
+          effective_at: '2026-08-30T00:00:00Z',
+          current_plan: plan('CREATOR', 'MONTHLY', 3500),
+          new_plan: plan('STANDARD', 'ANNUAL', 19_200)
+        })
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$16')).toBeTruthy()
+    expect(
+      screen.getByText('subscription.preview.eachYearCreditsRefill')
+    ).toBeTruthy()
+    expect(screen.getByText('50,400')).toBeTruthy()
+    expect(screen.getByText('subscription.billedYearly')).toBeTruthy()
+    expect(
+      screen.queryByText('subscription.preview.creditsRefillMonthlyTo')
+    ).toBeNull()
+    expect(
+      screen.queryByText('subscription.preview.billedEachMonth')
     ).toBeNull()
   })
 

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -136,20 +136,30 @@
         </span>
         <div class="flex items-center justify-between">
           <span class="text-base-foreground">
-            {{ $t('subscription.preview.creditsRefillMonthlyTo') }}
+            {{
+              $t(
+                newIsYearly
+                  ? 'subscription.preview.eachYearCreditsRefill'
+                  : 'subscription.preview.creditsRefillMonthlyTo'
+              )
+            }}
           </span>
           <div class="flex items-center gap-1">
             <i class="icon-[comfy--credits] size-4 shrink-0 bg-credit" />
             <span class="font-bold text-base-foreground">{{
-              monthlyRefillCredits
+              refillCredits
             }}</span>
           </div>
         </div>
         <span class="text-sm text-muted-foreground">
           {{
-            $t('subscription.preview.billedEachMonth', {
-              amount: moneyShort(newMonthlyChargeUsd)
-            })
+            newIsYearly
+              ? $t('subscription.billedYearly', {
+                  total: annualTotalFormatted
+                })
+              : $t('subscription.preview.billedEachMonth', {
+                  amount: moneyShort(newMonthlyChargeUsd)
+                })
           }}
         </span>
       </div>
@@ -461,9 +471,6 @@ const refillCredits = computed(() => {
     : tierMonthlyCredits(previewData.new_plan.tier)
   return n(newIsYearly.value ? monthly * 12 : monthly)
 })
-const monthlyRefillCredits = computed(() =>
-  n(teamPlan ? teamPlan.credits : tierMonthlyCredits(previewData.new_plan.tier))
-)
 const refillLabel = computed(() =>
   newIsYearly.value
     ? t('subscription.preview.creditsYoullGetToday')


### PR DESCRIPTION
## Summary

Show annual refill credits and yearly billing copy when a lower-tier annual plan is scheduled for the current period end.

## Changes

- **Why**: Monthly Creator → Standard yearly is intentionally a scheduled downgrade with `$0.00` due today, but the confirmation showed a 4,200 monthly refill and monthly billing despite the annual target.
- **Root cause**: The scheduled-change block hardcoded monthly copy and `monthlyRefillCredits`; the preview already identifies the target as `ANNUAL`.
- **What**: Reuse the existing cadence-aware refill calculation and switch scheduled annual targets to the existing yearly refill/billing translations. Monthly scheduled changes remain unchanged.
- **Backend**: No backend change is required. The request preserves the annual plan slug, and the scheduled-downgrade path validates and persists the annual target cadence.

## Review Focus

- Annual scheduled targets show 50,400 credits and `$192 Billed yearly`.
- Monthly scheduled targets retain monthly refill and billing copy.
- Regression coverage uses a Creator monthly → Standard annual scheduled preview with no charge today.

Validation: 31 focused tests, Vue typecheck, ESLint, Stylelint, oxfmt, and knip pass.

## Screenshots

Captured from the actual cloud-distribution Vite app and its real subscription dialog flow, with billing APIs mocked only for deterministic state:

- **State**: authenticated personal workspace owner; active `creator-monthly`; selected `standard-annual`; period-end `downgrade` preview; `$0.00` due today.
- **AS IS URL**: `http://127.0.0.1:5174/?pricing=standard&cycle=yearly` at `origin/main` (`919d6ca4e`).
- **TO BE URL**: `http://127.0.0.1:5173/?pricing=standard&cycle=yearly` at this PR (`f5bd654e3`).

### AS IS

![Real app scheduled annual downgrade incorrectly shown as monthly](https://ampcode.com/user-content/attachments/d62ac0ed4984dbd46bcfb0316af3fda0342926d48778ba55d1a50cd41fecb67a-file.png)

### TO BE

![Real app scheduled annual downgrade shown with yearly credits and billing](https://ampcode.com/user-content/attachments/26fd1162e6f3f84d4a7c7b99c0a0b9eabed0fa75dcedaa4d1d1794bd099be401-file.png)
