### PR TITLE
docs: add publishing-a-new-package skill

### DIFF
--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -11,22 +11,25 @@ below happen after the "publish succeeded" line.
 
 ## The first publish is different
 
-**A brand-new package name cannot be published by CI on the first run**, and the
-error does not say so. npm returns:
+**A brand-new package name will fail the first CI publish unless the token was
+scoped for it**, and the error does not say so. npm returns:
 
 ```text
 [E404] 404 Not Found - PUT https://registry.npmjs.org/@comfyorg%2fyour-package
 ```
 
 A 404 on `PUT` means the token may publish _existing_ packages in the scope but
-may not _create_ a new name. It reads like "the package doesn't exist" — which
-is true and irrelevant — and sends you looking for a workflow bug that isn't
-there. `--access public` is already set; the registry URL is already right.
+may not _create_ a new name — a granular token whose write access is a
+hand-picked package list cannot include a package that does not exist yet. It
+reads like "the package doesn't exist" — which is true and irrelevant — and
+sends you looking for a workflow bug that isn't there. `--access public` is
+already set; the registry URL is already right.
 
 Two ways out, both fine:
 
-1. Widen the CI token to read+write over all packages (or the whole `@comfyorg`
-   scope) and re-run the workflow.
+1. Give the CI token read+write on the whole `@comfyorg` scope — the narrowest
+   grant that can create a new name, and preferable to all-packages access —
+   then re-run the workflow.
 2. Publish once by hand, then make sure the CI token covers the new name.
 
 Trusted publishing (OIDC) cannot bootstrap either — npm requires the package to

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -145,11 +145,15 @@ permissions:
   id-token: write
 ```
 
-Keep `NODE_AUTH_TOKEN` in place until an OIDC publish has actually succeeded —
-pnpm's OIDC path has open bugs ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513)),
-and `[WARN] Skipped OIDC` in the log means it silently fell back to the token.
-Only after a real OIDC publish should you tighten the org to require 2FA and
-disallow tokens; doing it earlier removes the only working path.
+Keep `NODE_AUTH_TOKEN` in place until an OIDC publish has actually succeeded.
+`[WARN] Skipped OIDC` in the log means it silently fell back to the token —
+treat that as a failure to chase down, not a warning to scroll past. Suspect
+`pnpm/action-setup` first: every workflow here still pins `v4.4.0`
+(`fc06bc1257f339d1d5d8b3a19a8cae5388b55320`), the version that broke pnpm's OIDC
+publish in [pnpm#11513](https://github.com/pnpm/pnpm/issues/11513) — closed once
+the reporter bumped the action, not by a pnpm release. Only after a real OIDC
+publish should you tighten the org to require 2FA and disallow tokens; doing it
+earlier removes the only working path.
 
 ## Announce it
 

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -18,8 +18,8 @@ error does not say so. npm returns:
 [E404] 404 Not Found - PUT https://registry.npmjs.org/@comfyorg%2fyour-package
 ```
 
-A 404 on `PUT` means the token may publish *existing* packages in the scope but
-may not *create* a new name. It reads like "the package doesn't exist" — which
+A 404 on `PUT` means the token may publish _existing_ packages in the scope but
+may not _create_ a new name. It reads like "the package doesn't exist" — which
 is true and irrelevant — and sends you looking for a workflow bug that isn't
 there. `--access public` is already set; the registry URL is already right.
 
@@ -61,12 +61,12 @@ Every value must be a real range. If you see `catalog:`, you used the wrong tool
 Copy the four-workflow set from an existing package — `design-system` and
 `desktop-ui` are the references:
 
-| Workflow | Role |
-| --- | --- |
-| `publish-<pkg>.yaml` | `workflow_call` + `workflow_dispatch`; does the publish |
-| `publish-<pkg>-on-merge.yaml` | fires on merged PR with the `Release` label |
-| `version-bump-<pkg>.yaml` | dispatch → opens a version PR labelled `Release` |
-| `ci-<pkg>-pack.yaml` | on PR — typecheck + assert tarball contents |
+| Workflow                      | Role                                                    |
+| ----------------------------- | ------------------------------------------------------- |
+| `publish-<pkg>.yaml`          | `workflow_call` + `workflow_dispatch`; does the publish |
+| `publish-<pkg>-on-merge.yaml` | fires on merged PR with the `Release` label             |
+| `version-bump-<pkg>.yaml`     | dispatch → opens a version PR labelled `Release`        |
+| `ci-<pkg>-pack.yaml`          | on PR — typecheck + assert tarball contents             |
 
 The pack check must allowlist `package.json`, `LICENSE`, **and `README.md`**.
 npm force-includes all three regardless of the `files` field, so a guard that
@@ -95,7 +95,7 @@ version number.
 ## Prove it is consumable
 
 This is the step people skip, and it is the only one that finds real problems.
-In a *different* repo — ideally one on npm rather than pnpm, since that is the
+In a _different_ repo — ideally one on npm rather than pnpm, since that is the
 path where `catalog:` would explode:
 
 ```sh

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -14,7 +14,7 @@ below happen after the "publish succeeded" line.
 **A brand-new package name cannot be published by CI on the first run**, and the
 error does not say so. npm returns:
 
-```
+```text
 [E404] 404 Not Found - PUT https://registry.npmjs.org/@comfyorg%2fyour-package
 ```
 

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -112,7 +112,8 @@ Then import it somewhere real, build, and grep the build output to confirm the
 thing you imported actually reached the bundle. Import **every** entry in the
 `exports` map while you are there — a subpath whose target never made it into
 the tarball fails only here. A green build proves the import resolved; it does
-not prove the values landed. For CSS:
+not prove the values landed. For CSS, pointed at the consumer's own build output
+— the path below is Nuxt's, so substitute whatever your consumer emits:
 
 ```sh
 grep -o -- "--your-token:[^;]*" .output/public/_nuxt/*.css

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -85,7 +85,10 @@ only permits the first two rejects any package that has a readme.
 - **Export `./package.json`.** Tooling reads it; an `exports` map that omits it
   throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
 - **Check `files` against the exports map.** Every path in `exports` must be
-  covered by `files` or consumers get a resolution error at install time.
+  covered by `files`, or the target is simply absent from the tarball. Nothing
+  catches this at install time — neither `npm pack` nor `npm install` resolves
+  export targets — so it surfaces as a consumer resolution error the first time
+  something imports that entry.
 
 ## Releasing after the first time
 
@@ -106,8 +109,10 @@ npm install @comfyorg/<name>
 ```
 
 Then import it somewhere real, build, and grep the build output to confirm the
-thing you imported actually reached the bundle. A green build proves the import
-resolved; it does not prove the values landed. For CSS:
+thing you imported actually reached the bundle. Import **every** entry in the
+`exports` map while you are there — a subpath whose target never made it into
+the tarball fails only here. A green build proves the import resolved; it does
+not prove the values landed. For CSS:
 
 ```sh
 grep -o -- "--your-token:[^;]*" .output/public/_nuxt/*.css

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -112,8 +112,9 @@ Then import it somewhere real, build, and grep the build output to confirm the
 thing you imported actually reached the bundle. Import **every** entry in the
 `exports` map while you are there — a subpath whose target never made it into
 the tarball fails only here. A green build proves the import resolved; it does
-not prove the values landed. For CSS, pointed at the consumer's own build output
-— the path below is Nuxt's, so substitute whatever your consumer emits:
+not prove the values landed. For CSS, point the check at the consumer's own
+build output — the path below is Nuxt's, so substitute whatever your consumer
+emits:
 
 ```sh
 grep -o -- "--your-token:[^;]*" .output/public/_nuxt/*.css

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: publishing-a-new-package
+description: 'Publishes a new package from this monorepo to npm under @comfyorg and proves it is consumable from another repo. Covers workflow scaffolding, the first-publish 404, catalog: rewriting, trusted publishing, and the consumer smoke test. Use when adding a package to packages/, publishing to npm for the first time, or when an npm publish workflow fails.'
+---
+
+# Publishing a New Package
+
+Getting a package onto npm is not done when the workflow goes green. It is done
+when someone in another repo can install it and it works. Most of the failures
+below happen after the "publish succeeded" line.
+
+## The first publish is different
+
+**A brand-new package name cannot be published by CI on the first run**, and the
+error does not say so. npm returns:
+
+```
+[E404] 404 Not Found - PUT https://registry.npmjs.org/@comfyorg%2fyour-package
+```
+
+A 404 on `PUT` means the token may publish *existing* packages in the scope but
+may not *create* a new name. It reads like "the package doesn't exist" — which
+is true and irrelevant — and sends you looking for a workflow bug that isn't
+there. `--access public` is already set; the registry URL is already right.
+
+Two ways out, both fine:
+
+1. Widen the CI token to read+write over all packages (or the whole `@comfyorg`
+   scope) and re-run the workflow.
+2. Publish once by hand, then make sure the CI token covers the new name.
+
+Trusted publishing (OIDC) cannot bootstrap either — npm requires the package to
+exist before a trusted publisher can be configured ([npm/cli#8544](https://github.com/npm/cli/issues/8544)).
+So the ordering is always: first publish by token → configure trusted publisher
+→ switch CI to OIDC.
+
+## Never `npm publish` from this repo
+
+Workspace packages use pnpm catalog specifiers:
+
+```json
+"dependencies": { "@iconify/utils": "catalog:" }
+```
+
+`pnpm publish` rewrites those to real ranges when it packs. `npm publish` ships
+the literal string `"catalog:"`, and every consumer install breaks. The tarball
+looks fine locally either way — the damage only shows up in the consumer.
+
+Check before you publish anything:
+
+```sh
+cd packages/<name>
+pnpm pack --pack-destination /tmp
+tar -xzOf /tmp/comfyorg-<name>-<version>.tgz package/package.json | jq .dependencies
+```
+
+Every value must be a real range. If you see `catalog:`, you used the wrong tool.
+
+## Scaffolding the workflows
+
+Copy the four-workflow set from an existing package — `design-system` and
+`desktop-ui` are the references:
+
+| Workflow | Role |
+| --- | --- |
+| `publish-<pkg>.yaml` | `workflow_call` + `workflow_dispatch`; does the publish |
+| `publish-<pkg>-on-merge.yaml` | fires on merged PR with the `Release` label |
+| `version-bump-<pkg>.yaml` | dispatch → opens a version PR labelled `Release` |
+| `ci-<pkg>-pack.yaml` | on PR — typecheck + assert tarball contents |
+
+The pack check must allowlist `package.json`, `LICENSE`, **and `README.md`**.
+npm force-includes all three regardless of the `files` field, so a guard that
+only permits the first two rejects any package that has a readme.
+
+## Before the first publish
+
+- **Write a README.** Without one the npm page renders empty, which defeats
+  publishing for another team to discover.
+- **Declare peer dependencies.** Anything the consumer must supply — Tailwind,
+  Vue — belongs in `peerDependencies`, not `devDependencies`. A devDependency
+  tells the consumer nothing.
+- **Export `./package.json`.** Tooling reads it; an `exports` map that omits it
+  throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- **Check `files` against the exports map.** Every path in `exports` must be
+  covered by `files` or consumers get a resolution error at install time.
+
+## Releasing after the first time
+
+Run the version-bump workflow → it opens a PR labelled `Release` → merge it →
+`publish-<pkg>-on-merge` publishes and posts to Slack. A manual dispatch at an
+already-published version is a **no-op**: the `Check if version already on npm`
+step finds it and skips. If you want to test the pipeline, you need a new
+version number.
+
+## Prove it is consumable
+
+This is the step people skip, and it is the only one that finds real problems.
+In a *different* repo — ideally one on npm rather than pnpm, since that is the
+path where `catalog:` would explode:
+
+```sh
+npm install @comfyorg/<name>
+```
+
+Then import it somewhere real, build, and grep the build output to confirm the
+thing you imported actually reached the bundle. A green build proves the import
+resolved; it does not prove the values landed. For CSS:
+
+```sh
+grep -o -- "--your-token:[^;]*" .output/public/_nuxt/*.css
+```
+
+Open that consumer change as a PR and keep the preview link — it is the
+evidence that the publish worked end to end.
+
+## Trusted publishing
+
+Once the package exists, configure it on npmjs.com under package settings:
+
+- Organization / repository / **workflow filename** — use the reusable workflow
+  that actually runs the publish (`publish-<pkg>.yaml`), not the on-merge wrapper.
+- **Environment name — leave blank** unless the publish job declares
+  `environment:`. A mismatch fails every publish.
+- **Allow `npm publish` only.** `npm stage publish` publishes unlisted pending
+  manual approval; we do not use it.
+
+Then add to the publish job:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Keep `NODE_AUTH_TOKEN` in place until an OIDC publish has actually succeeded —
+pnpm's OIDC path has open bugs ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513)),
+and `[WARN] Skipped OIDC` in the log means it silently fell back to the token.
+Only after a real OIDC publish should you tighten the org to require 2FA and
+disallow tokens; doing it earlier removes the only working path.
+
+## Announce it
+
+Post the npm link, the install line, and the consumer PR preview link. "It's
+published" is not actionable; "here is the import and here is it working" is.

--- a/.claude/skills/publishing-a-new-package/SKILL.md
+++ b/.claude/skills/publishing-a-new-package/SKILL.md
@@ -133,7 +133,11 @@ Once the package exists, configure it on npmjs.com under package settings:
 - **Allow `npm publish` only.** `npm stage publish` publishes unlisted pending
   manual approval; we do not use it.
 
-Then add to the publish job:
+Then grant OIDC at **both** workflow layers — the caller job that does
+`uses: ./.github/workflows/publish-<pkg>.yaml`, and the publish job inside the
+reusable workflow. A called workflow can never hold more than the calling job
+does, so setting this on the inner job alone leaves it with no token and the
+publish quietly falls back to `NPM_TOKEN`:
 
 ```yaml
 permissions:


### PR DESCRIPTION
Follow-up to #14080 / #14417. Writes down what the `@comfyorg/design-system` rollout actually cost, so the next package doesn't rediscover it.

The expensive parts, all of which happen *after* the workflow looks correct:

- **The first-publish 404.** npm returns `404 Not Found - PUT` when a token can publish existing packages in a scope but can't create a new name. It reads as "package doesn't exist" and sends you hunting for a workflow bug. Trusted publishing can't bootstrap either — npm needs the package to exist before you can configure a trusted publisher, so the ordering is fixed.
- **`pnpm publish`, never `npm publish`.** Workspace packages use `catalog:` specifiers. pnpm rewrites them at pack time; npm ships the literal string and every consumer install breaks. Includes the unpack-and-check command.
- **The pack guard needs `README.md`.** npm force-includes `package.json`, `LICENSE`, and `README.md` regardless of `files`. A guard allowlisting only the first two rejects any package with a readme — which is exactly what happened on #14417.
- **The consumer smoke test.** A green publish proves nothing. Install from a different repo, build, and grep the output to confirm the values landed.

Also documents the trusted-publisher form fields (blank environment name, `npm publish` only) and why the token has to stay until an OIDC publish actually succeeds.