### PR TITLE
test(zindex): regression guards for the templates dropdown stacking bug

### DIFF
--- a/browser_tests/tests/templateFilterDropdownStacking.spec.ts
+++ b/browser_tests/tests/templateFilterDropdownStacking.spec.ts
@@ -1,0 +1,65 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { makeTemplate } from '@e2e/fixtures/data/templateFixtures'
+import { withTemplates } from '@e2e/fixtures/helpers/TemplateHelper'
+import { templateApiFixture } from '@e2e/fixtures/templateApiFixture'
+
+const test = mergeTests(comfyPageFixture, templateApiFixture)
+
+/**
+ * End-to-end guard that the templates filter options are on top and clickable.
+ *
+ * This does NOT reproduce the 1.47.10 stacking bug (#14063, #14131, #14351,
+ * #14397): that needed the shared modal counter to have escalated past the
+ * dropdown's static z-3000 (reporters saw 7306), whereas a freshly opened
+ * dialog only reaches ~1702, so the broken build passes this test. The
+ * mechanism is pinned deterministically in useModalLiftedZIndex.test.ts; this
+ * covers the user-visible behaviour those unit tests cannot see.
+ */
+test.describe('Template filter dropdown stacking', () => {
+  test.beforeEach(async ({ comfyPage, templateApi }) => {
+    await comfyPage.settings.setSetting('Comfy.Templates.SelectedModels', [])
+    templateApi.configure(
+      withTemplates([
+        makeTemplate({ name: 'wan-1', title: 'Wan One', models: ['Wan 2.2'] }),
+        makeTemplate({ name: 'flux-1', title: 'Flux One', models: ['Flux'] })
+      ])
+    )
+    await templateApi.mock()
+    // The template index is fetched during app startup, so the routes have to be
+    // in place before the app loads or the store keeps its unmocked contents.
+    await comfyPage.setup()
+  })
+
+  test('renders filter options above the dialog and keeps them clickable', async ({
+    comfyPage
+  }) => {
+    await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
+    await expect(comfyPage.templates.content).toBeVisible()
+
+    await comfyPage.templatesDialog.openFilters()
+    await comfyPage.templatesDialog.modelFilter.click()
+
+    const option = comfyPage.page.getByRole('option', { name: 'Wan 2.2' })
+    await expect(option).toBeVisible()
+
+    // Visibility alone passes even when the dialog covers the option, so hit-test
+    // the option's centre: whatever paints there must belong to the option itself.
+    const optionIsOnTop = await option.evaluate((el) => {
+      const { left, top, width, height } = el.getBoundingClientRect()
+      const topMost = document.elementFromPoint(
+        left + width / 2,
+        top + height / 2
+      )
+      return !!topMost && el.contains(topMost)
+    })
+    expect(optionIsOnTop).toBe(true)
+
+    // The user-facing consequence: the click lands on the option, not the dialog.
+    await option.click()
+    await comfyPage.page.keyboard.press('Escape')
+
+    await expect(comfyPage.templates.allTemplateCards).toHaveCount(1)
+  })
+})

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -101,6 +101,23 @@ describe('MultiSelect', () => {
     unmount()
   })
 
+  it('opens above a dialog even when the caller passes its own contentStyle z-index', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const user = userEvent.setup()
+    const { unmount } = renderInParent({ contentStyle: { zIndex: 3000 } })
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
   it('keeps open-state border styling available while the dropdown is open', async () => {
     const user = userEvent.setup()
     const { unmount } = renderInParent()

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,5 +1,6 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import userEvent from '@testing-library/user-event'
 import { FocusScope } from 'reka-ui'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -31,7 +32,7 @@ const options = [
 ]
 
 function renderInParent(
-  multiSelectProps: Record<string, unknown> = {},
+  multiSelectProps: Partial<ComponentProps<typeof MultiSelect>> = {},
   modelValue: { name: string; value: string }[] = []
 ) {
   const parentEscapeCount = { value: 0 }

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -38,17 +38,21 @@ function findContentElement(): HTMLElement | null {
   return document.querySelector('[data-dismissable-layer]')
 }
 
-function renderInParent(modelValue?: string) {
+function renderInParent(
+  modelValue?: string,
+  singleSelectProps: Record<string, unknown> = {}
+) {
   const parentEscapeCount = { value: 0 }
 
   const Parent = {
     template:
-      '<div @keydown.escape="onEsc"><SingleSelect v-model="sel" :options="options" label="Pick" /></div>',
+      '<div @keydown.escape="onEsc"><SingleSelect v-model="sel" :options="options" label="Pick" v-bind="extraProps" /></div>',
     components: { SingleSelect },
     setup() {
       return {
         sel: ref(modelValue),
         options,
+        extraProps: singleSelectProps,
         onEsc: () => {
           parentEscapeCount.value++
         }
@@ -94,6 +98,23 @@ describe('SingleSelect', () => {
     ZIndex.set('modal', openModal, 3702)
     const dialogZIndex = Number(openModal.style.zIndex)
     const { unmount } = renderInParent()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('opens above a dialog even when the caller passes its own contentStyle z-index', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderInParent(undefined, {
+      contentStyle: { zIndex: 3000 }
+    })
 
     await openSelect(screen.getByRole('combobox'))
 

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -1,5 +1,6 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -40,7 +41,7 @@ function findContentElement(): HTMLElement | null {
 
 function renderInParent(
   modelValue?: string,
-  singleSelectProps: Record<string, unknown> = {}
+  singleSelectProps: Partial<ComponentProps<typeof SingleSelect>> = {}
 ) {
   const parentEscapeCount = { value: 0 }
 

--- a/src/composables/useModalLiftedZIndex.test.ts
+++ b/src/composables/useModalLiftedZIndex.test.ts
@@ -29,6 +29,22 @@ describe('useModalLiftedZIndex', () => {
     expect(style.value).toEqual({ zIndex: dialogZIndex + 1 })
   })
 
+  it('stays above a dialog stack that has escalated past the static z-3000 fallback', () => {
+    // PrimeVue's counter re-adds baseZIndex whenever the previous registration
+    // used a different key, so alternating dialogs with overlays/menus climbs by
+    // ~1800 a time. Reporters saw the dialog at 7306 while the dropdown sat at
+    // its static z-3000; a single fresh dialog only reaches ~1702 and hides this.
+    const other = document.createElement('div')
+    ZIndex.set('overlay', other, 1800)
+    registered.push(other)
+    const dialogZIndex = registerDialog()
+    expect(dialogZIndex).toBeGreaterThan(3000)
+
+    const style = useModalLiftedZIndex(ref(true))
+
+    expect(style.value).toEqual({ zIndex: dialogZIndex + 1 })
+  })
+
   it('re-reads the stack on every open rather than caching the first read', () => {
     registerDialog()
     const open = ref(true)

--- a/src/composables/useModalLiftedZIndex.test.ts
+++ b/src/composables/useModalLiftedZIndex.test.ts
@@ -1,0 +1,44 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { useModalLiftedZIndex } from './useModalLiftedZIndex'
+
+const registered: HTMLElement[] = []
+
+function registerDialog() {
+  const el = document.createElement('div')
+  ZIndex.set('modal', el, 1700)
+  registered.push(el)
+  return Number(el.style.zIndex)
+}
+
+afterEach(() => {
+  let el = registered.pop()
+  while (el) {
+    ZIndex.clear(el)
+    el = registered.pop()
+  }
+})
+
+describe('useModalLiftedZIndex', () => {
+  it('lifts past the current top of the modal stack', () => {
+    const dialogZIndex = registerDialog()
+    const style = useModalLiftedZIndex(ref(true))
+
+    expect(style.value).toEqual({ zIndex: dialogZIndex + 1 })
+  })
+
+  it('re-reads the stack on every open rather than caching the first read', () => {
+    registerDialog()
+    const open = ref(true)
+    const style = useModalLiftedZIndex(open)
+    expect(style.value).toBeDefined()
+
+    open.value = false
+    const laterDialogZIndex = registerDialog()
+    open.value = true
+
+    expect(style.value).toEqual({ zIndex: laterDialogZIndex + 1 })
+  })
+})


### PR DESCRIPTION
The dropdown-stacking fix (#14054) shipped with unit tests that only covered the
no-contentStyle case, so the shape of the original regression stayed uncovered.

## Root cause being guarded

`usePrimeVueOverlayChildStyle` took a one-shot, non-reactive z-index snapshot —
its only reactive dependency was the element ref, while `getComputedStyle(...).zIndex`
was untracked. The dialog's z-index is assigned after that snapshot, so the dropdown
kept its static `z-3000` while the dialog rose past it.

It only reproduces once the shared modal counter has escalated. `@primeuix/utils`
re-adds `baseZIndex` whenever the previously registered key differs:

```js
newZIndex = lastZIndex.value + (lastZIndex.key === key ? 0 : baseZIndex) + 1
```

Alternating `modal` with `overlay`/`menu`/`tooltip` (base 1800) climbs ~1800 a step:
1800 → 3601 → 5402 → 7203. Reporters saw 7306; a freshly opened dialog reaches ~1702,
which is *below* 3000 and hides the bug entirely.

## Tests

`useModalLiftedZIndex.test.ts`
- lifts past the current top of the modal stack
- **stays above an escalated stack** — fails if a static 3000 floor is reintroduced
- **re-reads on every open** — fails against a cached snapshot, replaying the original bug

`MultiSelect.test.ts` / `SingleSelect.test.ts`
- the lift wins over a caller-supplied `contentStyle` z-index, which is how the
  dialog originally defeated it

`browser_tests/tests/templateFilterDropdownStacking.spec.ts`
- options are hit-tested on top and the click lands on the option, not the dialog

## Verification

Every unit guard was mutation-checked — each fails against the specific defect it
describes while the others stay green.

The E2E test is deliberately documented as **not** reproducing the stacking bug: I
reverted the real fix (`25e74da75d`) and it still passed, because a fresh dialog never
escalates past 3000. The mechanism is pinned deterministically in the unit tests; the
E2E covers the user-visible behaviour they cannot see.

Refs #14063, #14131, #14351, #14397