### PR TITLE
fix(ci): stop cosmetic failures and slow merges from losing a release

### DIFF
--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -215,11 +215,18 @@ jobs:
           {
             echo "## Release stalled: tag \`v${TARGET_VERSION}\` never appeared"
             echo
-            echo "The \`Release\`-labelled bump PR for **${TARGET_VERSION}** on \`${TARGET_BRANCH}\` was not merged in time,"
-            echo "so \`publish-pypi\` failed and \`create-comfyui-pr\` was skipped — both the PyPI publish"
+            echo "Tag \`v${TARGET_VERSION}\` was not observed within the wait window, so"
+            echo "\`publish-pypi\` failed and \`create-comfyui-pr\` was skipped — both the PyPI publish"
             echo "and the ComfyUI pin PR are missing from this run."
             echo
-            echo "Recover by merging that PR, then re-running **only the failed jobs of this run**:"
+            echo "**Not observing the tag does not prove the bump PR is unmerged.** Check, in order:"
+            echo "1. Is the \`Release\`-labelled bump PR for **${TARGET_VERSION}** on \`${TARGET_BRANCH}\` merged?"
+            echo "   If not, merge it — that is what creates the tag."
+            echo "2. If it *is* merged, the tag-producing workflow (\`release-draft-create\`) failed or"
+            echo "   has not finished. Open its run and check the individual jobs before rerunning:"
+            echo "   a crashing summary-comment step can mark an otherwise successful run as failed."
+            echo
+            echo "Once the tag exists, re-run **only the failed jobs of this run**:"
             echo
             echo '```bash'
             echo "gh run rerun ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY} --failed"

--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -197,18 +197,37 @@ jobs:
           TARGET_BRANCH="${{ needs.resolve-version.outputs.target_branch }}"
           echo "Waiting for version bump PR for v${TARGET_VERSION} on ${TARGET_BRANCH} to be merged..."
 
-          # Poll for up to 30 minutes (a human or automation needs to merge the version bump PR)
-          for i in $(seq 1 60); do
+          # The tag only appears once a human merges the Release-labelled bump PR,
+          # so this window has to cover a human's response time, not a CI step's.
+          # At 30 minutes it timed out on both the 1.47.10 and the 2026-07-27 runs,
+          # taking the PyPI publish and the ComfyUI pin PR down with it each time.
+          for i in $(seq 1 480); do
             # Check if the tag exists (release-draft-create creates a tag on merge)
             if gh api "repos/Comfy-Org/ComfyUI_frontend/git/ref/tags/v${TARGET_VERSION}" --silent 2>/dev/null; then
               echo "✅ Tag v${TARGET_VERSION} found — release PR has been merged"
               exit 0
             fi
-            echo "Attempt $i/60: Tag v${TARGET_VERSION} not found yet, waiting 30s..."
+            echo "Attempt $i/480: Tag v${TARGET_VERSION} not found yet, waiting 30s..."
             sleep 30
           done
 
           echo "❌ Timed out waiting for tag v${TARGET_VERSION}"
+          {
+            echo "## Release stalled: tag \`v${TARGET_VERSION}\` never appeared"
+            echo
+            echo "The \`Release\`-labelled bump PR for **${TARGET_VERSION}** on \`${TARGET_BRANCH}\` was not merged in time,"
+            echo "so \`publish-pypi\` failed and \`create-comfyui-pr\` was skipped — both the PyPI publish"
+            echo "and the ComfyUI pin PR are missing from this run."
+            echo
+            echo "Recover by merging that PR, then re-running **only the failed jobs of this run**:"
+            echo
+            echo '```bash'
+            echo "gh run rerun ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY} --failed"
+            echo '```'
+            echo
+            echo "Use \`--failed\` on this run, not a fresh biweekly: it reuses the resolved"
+            echo "target_version so there is no re-resolve and no spurious next-patch bump."
+          } >> "$GITHUB_STEP_SUMMARY"
           exit 1
 
       - name: Checkout code at target version

--- a/.github/workflows/release-draft-create.yaml
+++ b/.github/workflows/release-draft-create.yaml
@@ -124,6 +124,10 @@ jobs:
           fetch-depth: 2
 
       - name: Post release summary comment
+        # A comment must never gate release success: this step crashing marked the
+        # whole v1.47.10 run as failed while the tag, GitHub release, and npm types
+        # had all published fine.
+        continue-on-error: true
         uses: ./.github/actions/comment-release-links
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Two of the three defects in #14033, both of which cost us real releases.

## 1. A crashing comment marked a successful release as failed (§2)

`release-draft-create.yaml`'s "Post release summary comment" step had no
`continue-on-error`, so a Node crash in the comment poster marked the entire
`v1.47.10` run `failure` — while `build`, `draft_release`, and `publish_types`
had all succeeded (tag cut, release created, npm types published). A cosmetic
step produced a false "release failed" signal.

## 2. A 30-minute tag-wait dropped both the publish and the pin PR (§1)

`publish-pypi` polled 30 minutes for the tag, which only appears once a human
merges the `Release`-labelled bump PR, then hard-failed. Because
`create-comfyui-pr` has `needs: publish-pypi`, the timeout **skipped the pin PR
too** — one run losing both the PyPI publish and the ComfyUI bump.

This fired twice: on the 1.47.10 run, and again on the scheduled 2026-07-27 run,
whose bump PR (#14150, 1.48.6) is still unmerged today.

Widened to four hours, since it is gated on a human's response time rather than
a CI step's. On timeout the job now writes the exact recovery into the job
summary — `gh run rerun <id> --failed` on the same run, which reuses the resolved
`target_version` instead of re-resolving and risking a spurious next-patch bump.

## Not fixed here

§1's preferred fix is to decouple the publish from the poll entirely and make it
release-triggered. That is the real cure and I did not attempt it in this PR — it
restructures a pipeline I cannot dry-run, and a mistake there breaks every
release. Left as a follow-up on #14033.

Refs #14033