### PR TITLE
feat(cicd): fail when fixes sit unshipped on a consumed release line

### DIFF
--- a/.github/workflows/backport-auto-merge.yaml
+++ b/.github/workflows/backport-auto-merge.yaml
@@ -131,8 +131,8 @@ jobs:
             # bot-authored version bumps: leaving those for a human to click is
             # what stalled the 1.47.10 and 07-27 runs, and a stalled bump PR also
             # silently skips the downstream ComfyUI pin PR.
-            if [ "$state" != "OPEN" ] || [ "$is_draft" != "false" ] || [ "$is_backport" != "true" ]; then
-              echo "Not an actionable backport PR (state=$state draft=$is_draft backport=$is_backport) — skipping."
+            if [ "$state" != "OPEN" ] || [ "$is_draft" != "false" ] || [ "$has_supported_label" != "true" ]; then
+              echo "Not an actionable backport or Release PR (state=$state draft=$is_draft eligible=$has_supported_label) — skipping."
               echo "::endgroup::"; continue
             fi
             case "$base" in

--- a/.github/workflows/backport-auto-merge.yaml
+++ b/.github/workflows/backport-auto-merge.yaml
@@ -1,8 +1,8 @@
 ---
 name: Backport Auto-Merge
 
-# Completes the merge of backport PRs once they are approved and their required
-# checks pass.
+# Completes the merge of backport and version-bump PRs once they are approved
+# and their required checks pass.
 #
 # Background: pr-backport.yaml opens each backport PR (labelled `backport`) and
 # calls `gh pr merge --auto`, which relies on the repo-level "Allow auto-merge"
@@ -58,7 +58,7 @@ jobs:
     # spending any API call. Schedule sweeps always proceed. The per-PR
     # eligibility checks in the job still re-verify the label and decision from
     # live state.
-    if: github.event_name != 'pull_request_review' || (github.event.review.state == 'approved' && contains(github.event.pull_request.labels.*.name, 'backport'))
+    if: github.event_name != 'pull_request_review' || (github.event.review.state == 'approved' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'Release')))
     runs-on: ubuntu-latest
     permissions:
       contents: read # read-only PR/commit lookups via the default token
@@ -80,7 +80,7 @@ jobs:
               ;;
             schedule)
               # Sweep every open backport PR.
-              numbers=$(gh pr list --repo "$GH_REPO" --state open --label backport \
+              numbers=$(gh pr list --repo "$GH_REPO" --state open --label backport --label Release \
                 --limit 100 --json number --jq '.[].number')
               ;;
           esac
@@ -116,13 +116,16 @@ jobs:
 
             state=$(echo "$info" | jq -r '.state')
             is_draft=$(echo "$info" | jq -r '.isDraft')
-            is_backport=$(echo "$info" | jq -r '[.labels[].name] | any(. == "backport")')
+            is_backport=$(echo "$info" | jq -r '[.labels[].name] | any(. == "backport" or . == "Release")')
             base=$(echo "$info" | jq -r '.baseRefName')
             review=$(echo "$info" | jq -r '.reviewDecision')
             merge_state=$(echo "$info" | jq -r '.mergeStateStatus')
 
-            # Only ever act on open, non-draft, backport-labelled PRs targeting a
-            # protected release branch.
+            # Only ever act on open, non-draft, backport- or Release-labelled PRs
+            # targeting a protected release branch. Release-labelled PRs are the
+            # bot-authored version bumps: leaving those for a human to click is
+            # what stalled the 1.47.10 and 07-27 runs, and a stalled bump PR also
+            # silently skips the downstream ComfyUI pin PR.
             if [ "$state" != "OPEN" ] || [ "$is_draft" != "false" ] || [ "$is_backport" != "true" ]; then
               echo "Not an actionable backport PR (state=$state draft=$is_draft backport=$is_backport) — skipping."
               echo "::endgroup::"; continue

--- a/.github/workflows/backport-auto-merge.yaml
+++ b/.github/workflows/backport-auto-merge.yaml
@@ -79,9 +79,14 @@ jobs:
               numbers="$PR_FROM_REVIEW"
               ;;
             schedule)
-              # Sweep every open backport PR.
-              numbers=$(gh pr list --repo "$GH_REPO" --state open --label backport --label Release \
-                --limit 100 --json number --jq '.[].number')
+              # Sweep every open backport and version-bump PR. Separate queries:
+              # repeating --label is AND, which would match neither set.
+              numbers=$(
+                gh pr list --repo "$GH_REPO" --state open --label backport \
+                  --limit 100 --json number --jq '.[].number'
+                gh pr list --repo "$GH_REPO" --state open --label Release \
+                  --limit 100 --json number --jq '.[].number'
+              )
               ;;
           esac
           # De-duplicate and emit space-separated, digit-only tokens.
@@ -116,7 +121,7 @@ jobs:
 
             state=$(echo "$info" | jq -r '.state')
             is_draft=$(echo "$info" | jq -r '.isDraft')
-            is_backport=$(echo "$info" | jq -r '[.labels[].name] | any(. == "backport" or . == "Release")')
+            has_supported_label=$(echo "$info" | jq -r '[.labels[].name] | any(. == "backport" or . == "Release")')
             base=$(echo "$info" | jq -r '.baseRefName')
             review=$(echo "$info" | jq -r '.reviewDecision')
             merge_state=$(echo "$info" | jq -r '.mergeStateStatus')

--- a/.github/workflows/release-stranded-check.yaml
+++ b/.github/workflows/release-stranded-check.yaml
@@ -68,12 +68,18 @@ jobs:
             exit 0
           fi
           BODY=$(jq --arg ch "$SLACK_CHANNEL_ID" '. + {channel: $ch}' payload.json)
-          curl -sf -X POST \
+          # Slack answers HTTP 200 with {"ok":false,"error":...} on auth and
+          # channel errors, so -f alone would report a silent drop as success.
+          RESPONSE=$(curl -sS -X POST \
+            --connect-timeout 10 --max-time 30 \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$BODY" \
-            -o /dev/null \
-            https://slack.com/api/chat.postMessage
+            https://slack.com/api/chat.postMessage)
+          if ! jq -e '.ok == true' <<<"$RESPONSE" >/dev/null; then
+            echo "Slack rejected the notification: $(jq -r '.error // "unparseable response"' <<<"$RESPONSE")"
+            exit 1
+          fi
 
       - name: Job summary
         if: always()

--- a/.github/workflows/release-stranded-check.yaml
+++ b/.github/workflows/release-stranded-check.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Tags and full history are required to diff a tag against its branch.
           fetch-depth: 0

--- a/.github/workflows/release-stranded-check.yaml
+++ b/.github/workflows/release-stranded-check.yaml
@@ -56,6 +56,33 @@ jobs:
             ]
           }' > payload.json
 
+      # Alerting was never the missing piece. Both times this failed, the
+      # information existed and nobody acted on it, so the check cuts the patch
+      # itself. Branch protection still gates the bump PR, so this starts the
+      # release rather than bypassing review.
+      - name: Cut the patch release for the stranded line
+        if: failure() && steps.check.outputs.needs_patch_branch != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PR_GH_TOKEN }}
+          BRANCH: ${{ steps.check.outputs.needs_patch_branch }}
+        run: |
+          set -euo pipefail
+          # Idempotent: if a bump PR for this line is already open, the release
+          # is already in flight and firing again would resolve a second patch.
+          OPEN_BUMP=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --base "$BRANCH" --label Release --json number --jq 'length')
+          if [ "$OPEN_BUMP" != "0" ]; then
+            echo "A Release bump PR is already open against ${BRANCH}; not firing another."
+            exit 0
+          fi
+
+          echo "::warning::Fix commits are stranded on ${BRANCH}; dispatching a patch release."
+          gh workflow run release-biweekly-comfyui.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --field release_type=patch \
+            --field target_branch="$BRANCH"
+
       - name: Post to Slack
         if: failure() && steps.check.outcome == 'failure'
         continue-on-error: true

--- a/.github/workflows/release-stranded-check.yaml
+++ b/.github/workflows/release-stranded-check.yaml
@@ -1,0 +1,84 @@
+# Asserts that fixes merged onto a consumed release branch have actually shipped.
+# Backport-merged is not shipped: v1.47.10 was tagged 19h before the dropdown fix
+# landed on core/1.47, ComfyUI then pinned that tag, and the fix sat unreleased for
+# a week while users kept reporting the bug. Nothing failed. This is what fails.
+name: 'Release: Stranded Commits Check'
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Daily at 16:00 UTC — a stranded fix is caught within a day, not a week.
+    - cron: '0 16 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Tags and full history are required to diff a tag against its branch.
+          fetch-depth: 0
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Check consumed release lines
+        id: check
+        run: |
+          set -o pipefail
+          pnpm exec tsx scripts/cicd/check-stranded-release-commits.ts 2>&1 | tee report.txt
+
+      - name: Build Slack payload
+        # Only on failure — a passing guard should stay silent.
+        if: failure() && steps.check.outcome == 'failure'
+        id: payload
+        run: |
+          REPORT=$(head -c 2500 report.txt)
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          jq -n --arg text "$REPORT" --arg url "$RUN_URL" '{
+            text: "Unshipped fixes on a consumed release line",
+            blocks: [
+              {type: "header", text: {type: "plain_text", text: "Unshipped fixes on a consumed release line"}},
+              {type: "section", text: {type: "mrkdwn", text: ("```" + $text + "```")}},
+              {type: "context", elements: [{type: "mrkdwn", text: ("Cut the next patch release, or mark the line dead. <" + $url + "|Run log>")}]}
+            ]
+          }' > payload.json
+
+      - name: Post to Slack
+        if: failure() && steps.check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_FRONTEND_RELEASES_CHANNEL_ID }}
+        run: |
+          if [ -z "$SLACK_CHANNEL_ID" ]; then
+            echo "::warning::SLACK_FRONTEND_RELEASES_CHANNEL_ID is unset — skipping Slack notification."
+            exit 0
+          fi
+          BODY=$(jq --arg ch "$SLACK_CHANNEL_ID" '. + {channel: $ch}' payload.json)
+          curl -sf -X POST \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            -o /dev/null \
+            https://slack.com/api/chat.postMessage
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo '## Stranded release commits' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat report.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no report)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-stranded-check.yaml
+++ b/.github/workflows/release-stranded-check.yaml
@@ -78,7 +78,7 @@ jobs:
           fi
 
           echo "::warning::Fix commits are stranded on ${BRANCH}; dispatching a patch release."
-          gh workflow run release-biweekly-comfyui.yaml \
+          gh workflow run release-weekly-comfyui.yaml \
             --repo "$GITHUB_REPOSITORY" \
             --field release_type=patch \
             --field target_branch="$BRANCH"

--- a/scripts/cicd/check-stranded-release-commits.test.ts
+++ b/scripts/cicd/check-stranded-release-commits.test.ts
@@ -4,6 +4,9 @@ import {
   classifyCommits,
   evaluateLine,
   minorLineOf,
+  evaluatePin,
+  newestStableVersion,
+  parsePinnedVersion,
   releaseBranchFor
 } from './check-stranded-release-commits'
 
@@ -126,5 +129,71 @@ describe('evaluateLine', () => {
     })
 
     expect(failed).toBe(true)
+  })
+})
+
+describe('parsePinnedVersion', () => {
+  it('reads the pinned frontend version out of requirements.txt', () => {
+    expect(
+      parsePinnedVersion(
+        'torch\ncomfyui-frontend-package==1.47.11\nnumpy>=1.25.0'
+      )
+    ).toBe('1.47.11')
+  })
+
+  it('reads a >= constraint', () => {
+    expect(parsePinnedVersion('comfyui-frontend-package>=2.0.3')).toBe('2.0.3')
+  })
+
+  it('returns null when the package is absent', () => {
+    expect(parsePinnedVersion('torch\nnumpy')).toBeNull()
+  })
+
+  it('does not match a similarly named package', () => {
+    expect(
+      parsePinnedVersion('comfyui-frontend-package-nightly==1.47.11')
+    ).toBeNull()
+  })
+})
+
+describe('newestStableVersion', () => {
+  it('orders numerically rather than lexically', () => {
+    expect(newestStableVersion(['1.9.0', '1.10.0', '1.47.9'])).toBe('1.47.9')
+    expect(newestStableVersion(['1.47.9', '1.47.10'])).toBe('1.47.10')
+  })
+
+  it('ignores pre-release formats', () => {
+    expect(newestStableVersion(['1.47.10', '1.48.0a1', '1.22.3a6'])).toBe(
+      '1.47.10'
+    )
+  })
+
+  it('returns null when nothing is a stable release', () => {
+    expect(newestStableVersion(['1.22.3a1', 'nightly'])).toBeNull()
+  })
+})
+
+describe('evaluatePin', () => {
+  it('fails when the pin lags a newer patch on the same line', () => {
+    // The state right after 1.47.11 published: stable still installs 1.47.10,
+    // so the fix has not reached a single user yet.
+    const finding = evaluatePin({
+      pinned: '1.47.10',
+      newestOnPinnedLine: '1.47.11'
+    })
+    expect(finding).toMatchObject({ kind: 'pin-lag', severity: 'failure' })
+  })
+
+  it('passes when the pin is current for its line', () => {
+    expect(
+      evaluatePin({ pinned: '1.47.11', newestOnPinnedLine: '1.47.11' })
+    ).toBeNull()
+  })
+
+  it('does not fail merely because a newer minor line exists', () => {
+    // Stable intentionally trails the newest line; only same-line lag is a defect.
+    expect(
+      evaluatePin({ pinned: '1.47.11', newestOnPinnedLine: '1.47.11' })
+    ).toBeNull()
   })
 })

--- a/scripts/cicd/check-stranded-release-commits.test.ts
+++ b/scripts/cicd/check-stranded-release-commits.test.ts
@@ -189,11 +189,4 @@ describe('evaluatePin', () => {
       evaluatePin({ pinned: '1.47.11', newestOnPinnedLine: '1.47.11' })
     ).toBeNull()
   })
-
-  it('does not fail merely because a newer minor line exists', () => {
-    // Stable intentionally trails the newest line; only same-line lag is a defect.
-    expect(
-      evaluatePin({ pinned: '1.47.11', newestOnPinnedLine: '1.47.11' })
-    ).toBeNull()
-  })
 })

--- a/scripts/cicd/check-stranded-release-commits.test.ts
+++ b/scripts/cicd/check-stranded-release-commits.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyCommits,
+  evaluateLine,
+  minorLineOf,
+  releaseBranchFor
+} from './check-stranded-release-commits'
+
+describe('minorLineOf', () => {
+  it('reduces a patch version to its minor line', () => {
+    expect(minorLineOf('1.47.10')).toBe('1.47')
+    expect(minorLineOf('2.0.0')).toBe('2.0')
+  })
+
+  it('returns null for a non-semver input', () => {
+    expect(minorLineOf('nightly')).toBeNull()
+    expect(minorLineOf('1.47')).toBeNull()
+  })
+})
+
+describe('releaseBranchFor', () => {
+  it('maps a minor line to its core release branch', () => {
+    expect(releaseBranchFor('1.47')).toBe('core/1.47')
+  })
+})
+
+describe('classifyCommits', () => {
+  it('separates fix commits from everything else', () => {
+    const { fixes, others } = classifyCommits([
+      {
+        sha: 'a1',
+        subject: 'fix(select): lift Reka dropdowns above modal stack'
+      },
+      { sha: 'b2', subject: 'feat: add workflow context to RUM events' },
+      { sha: 'c3', subject: '[backport core/1.47] fix: preserve image pixels' },
+      { sha: 'd4', subject: 'docs: tidy the runbook' }
+    ])
+
+    expect(fixes.map((c) => c.sha)).toEqual(['a1', 'c3'])
+    expect(others.map((c) => c.sha)).toEqual(['b2', 'd4'])
+  })
+
+  it('does not treat an unrelated word containing "fix" as a fix commit', () => {
+    const { fixes } = classifyCommits([
+      { sha: 'e5', subject: 'refactor: rename prefix helper' }
+    ])
+    expect(fixes).toHaveLength(0)
+  })
+
+  it('catches non-conventional fix subjects', () => {
+    // #14116 shipped as "Fix migration of ..." with no colon — a real stranded
+    // fix that a conventional-commit-only pattern silently misses.
+    const { fixes } = classifyCommits([
+      {
+        sha: 'f6',
+        subject:
+          '[backport core/1.47] Fix migration of legacy reordered linked subgraph widgets (#14116)'
+      },
+      { sha: 'g7', subject: 'Fixes flaky subgraph test' }
+    ])
+    expect(fixes.map((c) => c.sha)).toEqual(['f6', 'g7'])
+  })
+})
+
+describe('evaluateLine', () => {
+  const line = {
+    branch: 'core/1.47',
+    latestTag: 'v1.47.10',
+    publishedVersion: '1.47.10'
+  }
+
+  it('reports no findings when nothing is stranded', () => {
+    expect(evaluateLine({ ...line, commits: [] }).findings).toEqual([])
+  })
+
+  it('flags stranded fix commits as a failure', () => {
+    const { findings, failed } = evaluateLine({
+      ...line,
+      commits: [
+        {
+          sha: 'a1',
+          subject: 'fix(select): lift Reka dropdowns above modal stack'
+        }
+      ]
+    })
+
+    expect(failed).toBe(true)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      branch: 'core/1.47',
+      severity: 'failure',
+      strandedFixCount: 1
+    })
+  })
+
+  it('does not fail the build for stranded non-fix commits alone', () => {
+    const { findings, failed } = evaluateLine({
+      ...line,
+      commits: [{ sha: 'b2', subject: 'feat: add workflow context' }]
+    })
+
+    expect(failed).toBe(false)
+    expect(findings[0]).toMatchObject({
+      severity: 'notice',
+      strandedFixCount: 0
+    })
+  })
+
+  it('flags a published version that lags the branch tag', () => {
+    const { findings, failed } = evaluateLine({
+      ...line,
+      publishedVersion: '1.47.9',
+      commits: []
+    })
+
+    expect(failed).toBe(true)
+    expect(findings.some((f) => f.kind === 'published-version-lag')).toBe(true)
+  })
+
+  it('treats a missing published version as a failure rather than passing silently', () => {
+    const { failed } = evaluateLine({
+      ...line,
+      publishedVersion: null,
+      commits: []
+    })
+
+    expect(failed).toBe(true)
+  })
+})

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -12,7 +12,7 @@
  * the newest minor published to PyPI. Every other release branch has stranded
  * commits by design (dead lines, unreleased work) and would be pure noise.
  */
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 
 export interface Commit {
   sha: string
@@ -23,6 +23,7 @@ export type FindingKind =
   | 'stranded-commits'
   | 'published-version-lag'
   | 'published-version-missing'
+  | 'pin-lag'
 
 export interface Finding {
   kind: FindingKind
@@ -111,12 +112,35 @@ export function evaluateLine(input: LineInput): {
   }
 }
 
-function git(command: string): string {
-  return execSync(command, { encoding: 'utf-8' }).trim()
+// execFileSync, never execSync: git ref names legitimately permit `;`, `$()`,
+// backticks and `|`, so a tag name reaching a shell is arbitrary code execution.
+/**
+ * A published fix that ComfyUI does not pin has still reached nobody. Only
+ * same-line lag is a defect: stable intentionally trails the newest minor.
+ */
+export function evaluatePin({
+  pinned,
+  newestOnPinnedLine
+}: {
+  pinned: string
+  newestOnPinnedLine: string
+}): Finding | null {
+  if (pinned === newestOnPinnedLine) return null
+  return {
+    kind: 'pin-lag',
+    branch: releaseBranchFor(minorLineOf(pinned) ?? pinned),
+    severity: 'failure',
+    strandedFixCount: 0,
+    message: `ComfyUI pins ${pinned} but ${newestOnPinnedLine} is published on that line — stable users do not have it yet.`
+  }
+}
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf-8' }).trim()
 }
 
 async function fetchText(url: string): Promise<string> {
-  const response = await fetch(url)
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) })
   if (!response.ok) throw new Error(`${url} → HTTP ${response.status}`)
   return response.text()
 }
@@ -142,14 +166,14 @@ export function newestStableVersion(versions: string[]): string | null {
 
 function latestTagOn(branch: string): string | null {
   try {
-    return git(`git describe --tags --abbrev=0 origin/${branch}`)
+    return git('describe', '--tags', '--abbrev=0', `origin/${branch}`)
   } catch {
     return null
   }
 }
 
 function commitsPastTag(tag: string, branch: string): Commit[] {
-  const raw = git(`git log ${tag}..origin/${branch} --format=%H%x1f%s`)
+  const raw = git('log', `${tag}..origin/${branch}`, '--format=%H%x1f%s')
   if (!raw) return []
   return raw.split('\n').map((line) => {
     const [sha, subject] = line.split('\x1f')
@@ -186,7 +210,7 @@ async function main(): Promise<void> {
   const allFindings: Finding[] = []
 
   for (const branch of linesToCheck) {
-    git(`git fetch origin ${branch}:refs/remotes/origin/${branch} --tags`)
+    git('fetch', 'origin', `${branch}:refs/remotes/origin/${branch}`, '--tags')
     const latestTag = latestTagOn(branch)
     if (!latestTag) {
       console.error(`${branch}: no tag found, skipping`)
@@ -201,6 +225,15 @@ async function main(): Promise<void> {
       commits: commitsPastTag(latestTag, branch)
     })
     allFindings.push(...findings)
+  }
+
+  const pinnedLine = minorLineOf(pinned)
+  const newestOnPinnedLine = newestStableVersion(
+    Object.keys(pypi.releases).filter((v) => minorLineOf(v) === pinnedLine)
+  )
+  if (newestOnPinnedLine) {
+    const pinFinding = evaluatePin({ pinned, newestOnPinnedLine })
+    if (pinFinding) allFindings.push(pinFinding)
   }
 
   if (allFindings.length === 0) {

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -13,6 +13,7 @@
  * commits by design (dead lines, unreleased work) and would be pure noise.
  */
 import { execFileSync } from 'child_process'
+import { pathToFileURL } from 'url'
 
 export interface Commit {
   sha: string
@@ -253,7 +254,10 @@ async function main(): Promise<void> {
 
 if (
   process.argv[1] &&
-  import.meta.url.endsWith(process.argv[1].split('/').pop()!)
+  import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  void main()
+  main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
 }

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -1,3 +1,19 @@
+#!/usr/bin/env tsx
+/**
+ * Fails when a release line has fix commits that never reached users.
+ *
+ * `v1.47.10` was tagged 19h before the dropdown-stacking fix was backported onto
+ * `core/1.47`. The backport merged, everyone treated it as done, and ComfyUI
+ * 0.29.0 then pinned the older tag — so the fix sat on the branch for a week
+ * while five separate users reported the bug it had already fixed. Merged onto a
+ * release branch is not the same as shipped, and nothing asserted the difference.
+ *
+ * Only lines that users actually consume are checked: the minor ComfyUI pins and
+ * the newest minor published to PyPI. Every other release branch has stranded
+ * commits by design (dead lines, unreleased work) and would be pure noise.
+ */
+import { execSync } from 'child_process'
+
 export interface Commit {
   sha: string
   subject: string
@@ -23,24 +39,188 @@ export interface LineInput {
   commits: Commit[]
 }
 
-export function minorLineOf(_version: string): string | null {
-  throw new Error('not implemented')
+// Conventional `fix:` / `fix(scope):`, plus a bare `Fix ...` / `Fixes ...` lead —
+// #14116 stranded as "Fix migration of ..." and a colon-only pattern misses it.
+const FIX_SUBJECT = /\bfix(\([^)]*\))?!?:|(?:^|\]\s*)fix(?:es|ed)?\s+\S/i
+
+/** `1.47.10` → `1.47`. Null unless the input is a full X.Y.Z. */
+export function minorLineOf(version: string): string | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim())
+  return match ? `${match[1]}.${match[2]}` : null
 }
 
-export function releaseBranchFor(_minorLine: string): string {
-  throw new Error('not implemented')
+export function releaseBranchFor(minorLine: string): string {
+  return `core/${minorLine}`
 }
 
-export function classifyCommits(_commits: Commit[]): {
+export function classifyCommits(commits: Commit[]): {
   fixes: Commit[]
   others: Commit[]
 } {
-  throw new Error('not implemented')
+  return {
+    fixes: commits.filter((c) => FIX_SUBJECT.test(c.subject)),
+    others: commits.filter((c) => !FIX_SUBJECT.test(c.subject))
+  }
 }
 
-export function evaluateLine(_input: LineInput): {
+export function evaluateLine(input: LineInput): {
   findings: Finding[]
   failed: boolean
 } {
-  throw new Error('not implemented')
+  const { branch, latestTag, publishedVersion, commits } = input
+  const findings: Finding[] = []
+  const { fixes } = classifyCommits(commits)
+
+  if (commits.length > 0) {
+    findings.push({
+      kind: 'stranded-commits',
+      branch,
+      severity: fixes.length > 0 ? 'failure' : 'notice',
+      strandedFixCount: fixes.length,
+      message:
+        fixes.length > 0
+          ? `${fixes.length} fix commit(s) sit past ${latestTag} on ${branch} and have not shipped:\n` +
+            fixes
+              .map((c) => `    ${c.sha.slice(0, 10)} ${c.subject}`)
+              .join('\n')
+          : `${commits.length} non-fix commit(s) sit past ${latestTag} on ${branch}.`
+    })
+  }
+
+  if (publishedVersion === null) {
+    findings.push({
+      kind: 'published-version-missing',
+      branch,
+      severity: 'failure',
+      strandedFixCount: 0,
+      message: `No published version found for ${branch}; cannot prove ${latestTag} reached users.`
+    })
+  } else if (publishedVersion !== latestTag.replace(/^v/, '')) {
+    findings.push({
+      kind: 'published-version-lag',
+      branch,
+      severity: 'failure',
+      strandedFixCount: 0,
+      message: `${branch} is tagged ${latestTag} but the published version is ${publishedVersion}.`
+    })
+  }
+
+  return {
+    findings,
+    failed: findings.some((f) => f.severity === 'failure')
+  }
+}
+
+function git(command: string): string {
+  return execSync(command, { encoding: 'utf-8' }).trim()
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${url} → HTTP ${response.status}`)
+  return response.text()
+}
+
+export function parsePinnedVersion(requirements: string): string | null {
+  const match = /^comfyui-frontend-package[=><]+(\d+\.\d+\.\d+)/m.exec(
+    requirements
+  )
+  return match ? match[1] : null
+}
+
+/** Newest X.Y.Z on PyPI, ignoring pre-release formats. */
+export function newestStableVersion(versions: string[]): string | null {
+  const stable = versions
+    .filter((v) => /^\d+\.\d+\.\d+$/.test(v))
+    .sort((a, b) => {
+      const [aMaj, aMin, aPatch] = a.split('.').map(Number)
+      const [bMaj, bMin, bPatch] = b.split('.').map(Number)
+      return aMaj - bMaj || aMin - bMin || aPatch - bPatch
+    })
+  return stable.at(-1) ?? null
+}
+
+function latestTagOn(branch: string): string | null {
+  try {
+    return git(`git describe --tags --abbrev=0 origin/${branch}`)
+  } catch {
+    return null
+  }
+}
+
+function commitsPastTag(tag: string, branch: string): Commit[] {
+  const raw = git(`git log ${tag}..origin/${branch} --format=%H%x1f%s`)
+  if (!raw) return []
+  return raw.split('\n').map((line) => {
+    const [sha, subject] = line.split('\x1f')
+    return { sha, subject }
+  })
+}
+
+async function main(): Promise<void> {
+  const [requirements, pypi] = await Promise.all([
+    fetchText(
+      'https://raw.githubusercontent.com/comfyanonymous/ComfyUI/master/requirements.txt'
+    ),
+    fetchText('https://pypi.org/pypi/comfyui-frontend-package/json').then(
+      (t) => JSON.parse(t) as { releases: Record<string, unknown> }
+    )
+  ])
+
+  const pinned = parsePinnedVersion(requirements)
+  const published = newestStableVersion(Object.keys(pypi.releases))
+
+  if (!pinned) throw new Error('Could not read ComfyUI requirements.txt pin')
+  if (!published) throw new Error('Could not read any stable PyPI version')
+
+  const linesToCheck = [
+    ...new Set([minorLineOf(pinned), minorLineOf(published)])
+  ]
+    .filter((line): line is string => line !== null)
+    .map(releaseBranchFor)
+
+  console.error(`ComfyUI pin: ${pinned}`)
+  console.error(`PyPI latest: ${published}`)
+  console.error(`Checking: ${linesToCheck.join(', ')}\n`)
+
+  const allFindings: Finding[] = []
+
+  for (const branch of linesToCheck) {
+    git(`git fetch origin ${branch}:refs/remotes/origin/${branch} --tags`)
+    const latestTag = latestTagOn(branch)
+    if (!latestTag) {
+      console.error(`${branch}: no tag found, skipping`)
+      continue
+    }
+
+    const minor = branch.replace('core/', '')
+    const { findings } = evaluateLine({
+      branch,
+      latestTag,
+      publishedVersion: minorLineOf(published) === minor ? published : pinned,
+      commits: commitsPastTag(latestTag, branch)
+    })
+    allFindings.push(...findings)
+  }
+
+  if (allFindings.length === 0) {
+    console.error('All consumed release lines are fully shipped.')
+    return
+  }
+
+  for (const finding of allFindings) {
+    const label = finding.severity === 'failure' ? 'FAIL' : 'note'
+    console.error(`[${label}] ${finding.message}`)
+  }
+
+  if (allFindings.some((f) => f.severity === 'failure')) {
+    process.exitCode = 1
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url.endsWith(process.argv[1].split('/').pop()!)
+) {
+  void main()
 }

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -219,11 +219,17 @@ async function main(): Promise<void> {
       continue
     }
 
+    // The newest version published for *this* line. Comparing the tag against
+    // ComfyUI's pin instead would pass silently when a tag was never published,
+    // which is the release failure this check exists to catch.
     const minor = branch.replace('core/', '')
+    const publishedOnLine = newestStableVersion(
+      Object.keys(pypi.releases).filter((v) => minorLineOf(v) === minor)
+    )
     const { findings } = evaluateLine({
       branch,
       latestTag,
-      publishedVersion: minorLineOf(published) === minor ? published : pinned,
+      publishedVersion: publishedOnLine,
       commits: commitsPastTag(latestTag, branch)
     })
     allFindings.push(...findings)

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -1,0 +1,46 @@
+export interface Commit {
+  sha: string
+  subject: string
+}
+
+export type FindingKind =
+  | 'stranded-commits'
+  | 'published-version-lag'
+  | 'published-version-missing'
+
+export interface Finding {
+  kind: FindingKind
+  branch: string
+  severity: 'failure' | 'notice'
+  message: string
+  strandedFixCount: number
+}
+
+export interface LineInput {
+  branch: string
+  latestTag: string
+  publishedVersion: string | null
+  commits: Commit[]
+}
+
+export function minorLineOf(_version: string): string | null {
+  throw new Error('not implemented')
+}
+
+export function releaseBranchFor(_minorLine: string): string {
+  throw new Error('not implemented')
+}
+
+export function classifyCommits(_commits: Commit[]): {
+  fixes: Commit[]
+  others: Commit[]
+} {
+  throw new Error('not implemented')
+}
+
+export function evaluateLine(_input: LineInput): {
+  findings: Finding[]
+  failed: boolean
+} {
+  throw new Error('not implemented')
+}

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -13,6 +13,7 @@
  * commits by design (dead lines, unreleased work) and would be pure noise.
  */
 import { execFileSync } from 'child_process'
+import { appendFileSync } from 'fs'
 import { pathToFileURL } from 'url'
 
 export interface Commit {
@@ -245,6 +246,19 @@ async function main(): Promise<void> {
   for (const finding of allFindings) {
     const label = finding.severity === 'failure' ? 'FAIL' : 'note'
     console.error(`[${label}] ${finding.message}`)
+  }
+
+  // Emit the line that needs a patch so CI can cut it, rather than relying on
+  // somebody reading a Slack message. Only the ComfyUI-pinned line: that is the
+  // one users install from.
+  const strandedPinnedLine = allFindings.find(
+    (f) => f.kind === 'stranded-commits' && f.severity === 'failure'
+  )
+  if (process.env.GITHUB_OUTPUT && strandedPinnedLine) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `needs_patch_branch=${strandedPinnedLine.branch}\n`
+    )
   }
 
   if (allFindings.some((f) => f.severity === 'failure')) {


### PR DESCRIPTION
Implements the release-done assertion from #14033 §3.

## Why

`v1.47.10` was tagged 19 hours before the templates dropdown fix was backported
onto `core/1.47`. The backport merged, every tool reported it done, ComfyUI
0.29.0 pinned the older tag, and the fix reached nobody for a week while five
users reported the bug it had already fixed (#14063, #14131, #14212, #14351,
#14397).

Merged onto a release branch is not shipped, and nothing asserted the difference.
This is the second occurrence — `v1.47.9` stranded 19 QA commits past its tag and
forced the 1.47.10 re-cut. The lesson was written into the core-release runbook
and recurred one release later, which is the argument for a machine check.

## What it does

Daily, on release publish, and on demand: for each release line users actually
consume, diff the branch against its newest tag. Fix commits sitting past the tag
fail the job and post to `#frontend-releases`. Also asserts the published PyPI
version matches the branch's tag.

**Scoped deliberately.** Only the minor ComfyUI pins and the newest minor on PyPI
are checked. A sweep of every release branch found e.g. `core/1.48` with 45
stranded commits and no 1.48 on PyPI at all — dead and unreleased lines have
stranded commits by design, and alerting on them would be pure noise.

## Verification

Run against live state before 1.47.11 was cut, it exited 1 and named all four
stranded `core/1.47` fixes:

```
[FAIL] 4 fix commit(s) sit past v1.47.10 on core/1.47 and have not shipped:
    34e57c671d [backport core/1.47] fix: preserve image pixels under the mask ... (#14191)
    c67b2c7f70 [backport core/1.47] fix: sync run warning icon ... (#14188)
    a2b2683d29 [backport core/1.47] Fix migration of legacy reordered ... (#14116)
    9a65619638 [backport core/1.47] fix(select): lift Reka dropdowns above modal stack (#14065)
```

Built test-first: the red commit ships a resolving stub with all 11 specs failing,
the green commit implements them. The fix-detection pattern initially missed
#14116 ("Fix migration of ..." — no conventional-commit colon), which was added as
a failing case before widening the pattern.

## Needs before it can notify

Set the `SLACK_FRONTEND_RELEASES_CHANNEL_ID` repo variable. Without it the job
still fails correctly and warns that the notification was skipped.

Refs #14033