### PR TITLE
ci: grant id-token permission for npm trusted publishing

### DIFF
--- a/.github/workflows/publish-design-system-on-merge.yaml
+++ b/.github/workflows/publish-design-system-on-merge.yaml
@@ -48,6 +48,9 @@ jobs:
   publish:
     name: Publish Design System to npm
     needs: resolve
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-design-system.yaml
     with:
       version: ${{ needs.resolve.outputs.version }}

--- a/.github/workflows/publish-design-system.yaml
+++ b/.github/workflows/publish-design-system.yaml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Determine ref to checkout
         id: resolve_ref


### PR DESCRIPTION
The trusted publisher for `@comfyorg/design-system` is now configured on npmjs.com, but the job can't mint an OIDC token without `id-token: write`. Every run so far has logged:

```
[WARN] Skipped OIDC: ERR_PNPM_ID_TOKEN_GITHUB_WORKFLOW_INCORRECT_PERMISSIONS
```

and silently fallen back to `NODE_AUTH_TOKEN`.

**Two places need it, not one.** A reusable workflow cannot hold a permission its caller lacks. `publish-design-system-on-merge.yaml`'s `publish` job had no `permissions` block at all, so granting `id-token: write` only on the reusable job would still have produced a silent token fallback on the on-merge path — the one that actually ships releases. The `workflow_dispatch` path would have worked, which is exactly how this stays hidden.

**Deliberately not removing `NODE_AUTH_TOKEN` yet.** There is no dry run — the workflow refuses to republish an existing version, so proving OIDC costs a real version number. Keeping the token means a broken exchange degrades to the path verified by 1.0.1 in [run 30589514181](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30589514181) rather than failing a release.

How to know it worked: on the next publish, `Skipped OIDC` should be gone from the log. To prove it before a real release, dispatch `publish-design-system.yaml` against this branch with a prerelease version and `dist_tag: next`. Revert is two lines.

**Possible blocker worth knowing about.** [pnpm#11513](https://github.com/pnpm/pnpm/issues/11513) (pnpm publish + OIDC failing) was closed in May 2026 — but it was closed when the reporter moved off a specific `pnpm/action-setup` commit, not by a pnpm release. This repo pins that exact SHA (`fc06bc1257f3…`, v4.4.0) in every workflow; latest is v6.0.9. If OIDC still falls back after this merges, that pin is the first suspect, and it would affect `desktop-ui` publishing too. Bumping it repo-wide is a major-version jump and belongs in its own PR.

Context: follow-up to #14080 and #14417.