### PR TITLE
fix: prevent checkout dialog backdrop dismissal

### DIFF
--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -3,7 +3,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -16,7 +16,42 @@ import UiDialog from '@/components/ui/dialog/Dialog.vue'
 import UiDialogOverlay from '@/components/ui/dialog/DialogOverlay.vue'
 import UiDialogPortal from '@/components/ui/dialog/DialogPortal.vue'
 import SetMemberCreditLimitDialogContent from '@/platform/workspace/components/dialogs/SetMemberCreditLimitDialogContent.vue'
+import SubscriptionRequiredDialogContentUnified from '@/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue'
 import { useDialogStore } from '@/stores/dialogStore'
+
+vi.mock(
+  '@/platform/workspace/composables/useSubscriptionCheckout',
+  async () => {
+    const { computed, ref } = await import('vue')
+
+    return {
+      useSubscriptionCheckout: () => ({
+        checkoutStep: ref('pricing'),
+        isLoadingPreview: ref(false),
+        loadingTier: ref(null),
+        isSubscribing: ref(false),
+        isResubscribing: ref(false),
+        previewData: ref(null),
+        reactivationRequired: ref(false),
+        selectedTierKey: ref(null),
+        selectedTeamStop: ref(null),
+        selectedBillingCycle: ref('yearly'),
+        activeCheckoutActionUrl: ref(null),
+        isPolling: ref(false),
+        isTeamCheckout: computed(() => false),
+        previewVariant: computed(() => null),
+        handleSubscribeClick: vi.fn(),
+        handleSubscribeTeamClick: vi.fn(),
+        handleBackToPricing: vi.fn(),
+        handleSuccessClose: vi.fn(),
+        handleAddCreditCard: vi.fn(),
+        handleConfirmTransition: vi.fn(),
+        handleTeamSubscribe: vi.fn(),
+        handleResubscribe: vi.fn()
+      })
+    }
+  }
+)
 
 const i18n = createI18n({
   legacy: false,
@@ -404,23 +439,26 @@ describe('GlobalDialog Reka overlay scrim', () => {
   })
 
   it('keeps checkout open on the scrim while preserving explicit dismissal', async () => {
-    mountDialog()
+    render(GlobalDialog, {
+      global: {
+        plugins: [PrimeVue, i18n],
+        stubs: {
+          UnifiedPricingTable: true,
+          SubscriptionAddPaymentPreviewWorkspace: true,
+          SubscriptionTransitionPreviewWorkspace: true,
+          SubscriptionSuccessWorkspace: true
+        }
+      }
+    })
     const store = useDialogStore()
     const user = userEvent.setup()
     const key = 'subscription-required'
-    const CheckoutBody = defineComponent({
-      setup: () => () =>
-        h(
-          'button',
-          { onClick: () => store.closeDialog({ key }) },
-          'Close checkout'
-        )
-    })
 
     function openDialog() {
       store.showDialog({
         key,
-        component: CheckoutBody,
+        component: SubscriptionRequiredDialogContentUnified,
+        props: { onClose: () => store.closeDialog({ key }) },
         dialogComponentProps: {
           renderer: 'reka',
           headless: true,
@@ -430,9 +468,11 @@ describe('GlobalDialog Reka overlay scrim', () => {
     }
 
     openDialog()
-    await screen.findByRole('dialog')
+    const dialog = await screen.findByRole('dialog')
     await user.click(screen.getByTestId('dialog-overlay'))
+    await nextTick()
 
+    expect(dialog).toHaveAttribute('data-state', 'open')
     expect(store.isDialogOpen(key)).toBe(true)
 
     await user.keyboard('{Escape}')
@@ -440,7 +480,7 @@ describe('GlobalDialog Reka overlay scrim', () => {
 
     openDialog()
     await screen.findByRole('dialog')
-    await user.click(screen.getByRole('button', { name: 'Close checkout' }))
+    await user.click(screen.getByRole('button', { name: 'Close' }))
 
     await waitFor(() => expect(store.isDialogOpen(key)).toBe(false))
   })

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -402,6 +402,48 @@ describe('GlobalDialog Reka overlay scrim', () => {
       expect(store.isDialogOpen('reka-scrim-dismiss')).toBe(false)
     )
   })
+
+  it('keeps checkout open on the scrim while preserving explicit dismissal', async () => {
+    mountDialog()
+    const store = useDialogStore()
+    const user = userEvent.setup()
+    const key = 'subscription-required'
+    const CheckoutBody = defineComponent({
+      setup: () => () =>
+        h(
+          'button',
+          { onClick: () => store.closeDialog({ key }) },
+          'Close checkout'
+        )
+    })
+
+    function openDialog() {
+      store.showDialog({
+        key,
+        component: CheckoutBody,
+        dialogComponentProps: {
+          renderer: 'reka',
+          headless: true,
+          dismissableMask: false
+        }
+      })
+    }
+
+    openDialog()
+    await screen.findByRole('dialog')
+    await user.click(screen.getByTestId('dialog-overlay'))
+
+    expect(store.isDialogOpen(key)).toBe(true)
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(store.isDialogOpen(key)).toBe(false))
+
+    openDialog()
+    await screen.findByRole('dialog')
+    await user.click(screen.getByRole('button', { name: 'Close checkout' }))
+
+    await waitFor(() => expect(store.isDialogOpen(key)).toBe(false))
+  })
 })
 
 describe('shouldPreventRekaDismiss', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -98,7 +98,8 @@ function expectRekaPricingDialogProps(
 ) {
   expect(dialogComponentProps).toMatchObject({
     renderer: 'reka',
-    size: 'full'
+    size: 'full',
+    dismissableMask: false
   })
   expect(dialogComponentProps).not.toHaveProperty('style')
   expect(dialogComponentProps).not.toHaveProperty('pt')

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -90,6 +90,7 @@ export const useSubscriptionDialog = () => {
     const legacyPricingDialogProps = {
       renderer: 'reka',
       size: 'full',
+      dismissableMask: false,
       contentClass:
         'sm:max-w-7xl max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
     } as const
@@ -163,6 +164,7 @@ export const useSubscriptionDialog = () => {
           // steps shrink (the content root sets its own width per checkoutStep).
           renderer: 'reka',
           size: 'full',
+          dismissableMask: false,
           contentClass:
             'w-fit max-w-[min(1280px,95vw)] sm:max-w-[min(1280px,95vw)] max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
         }


### PR DESCRIPTION
## Summary

Keeps subscription checkout open when users click the dimmed backdrop, preventing accidental flow loss during payment verification.

## Changes

- **What**: Disable backdrop dismissal for unified and legacy subscription pricing dialogs while preserving the explicit close button and Escape behavior.
- **Root cause**: Subscription dialogs inherited the global `dismissableMask: true` default, so an outside click closed the entire checkout flow.
- **Tests**: Cover the non-dismissible pricing-dialog configuration and verify the shared Reka dialog behavior.

## Review Focus

Confirm outside-pointer dismissal is blocked for every subscription pricing variant without changing intentional close actions.

## Demo

![AS IS compared with TO BE](https://ampcode.com/user-content/artifacts/1dd846dbb9fd50c8e1b39131245976a553c8a14f3bfe9a72d6690a0c53091b52-file.gif)

- **AS IS**: Clicking the dimmed backdrop closes checkout and loses the in-progress flow ([QA report](https://comfy-organization.slack.com/archives/C0932CGKT5K/p1785442748396169?thread_ts=1785373105.971169&cid=C0932CGKT5K)).
- **TO BE**: The same backdrop click is ignored; users can still close checkout through an explicit close action or Escape.

