### PR TITLE
fix(workspace): show ended state after immediate cancellation

### DIFF
--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -9,6 +9,7 @@ import type { SubscriptionInfo } from '@/composables/billing/types'
 import enMessages from '@/locales/en/main.json'
 import * as tierPricing from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
+  BillingStatus,
   BillingSubscriptionStatus,
   CurrentTeamCreditStop,
   Plan,
@@ -56,6 +57,7 @@ const teamCreditStops: TeamCreditStops = {
 }
 
 const mockSubscriptionStatus = ref<BillingSubscriptionStatus>('active')
+const mockBillingStatus = ref<BillingStatus>('paid')
 const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockRenewalDate = ref<string | null>(RENEWAL_DATE_ISO)
 const mockEndDate = ref<string | null>(END_DATE_ISO)
@@ -155,6 +157,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
+    billingStatus: mockBillingStatus,
     isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     plans: mockPlans,
@@ -297,6 +300,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSubscriptionStatus.value = 'active'
+    mockBillingStatus.value = 'paid'
     mockRenewalDate.value = RENEWAL_DATE_ISO
     mockEndDate.value = END_DATE_ISO
     mockScheduledPlanSlug.value = null
@@ -514,13 +518,32 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('keeps an inactive paid Team plan visible in a Personal workspace', () => {
+  it('shows ended state for an inactive paid Personal workspace despite active status', () => {
     mockIsInPersonalWorkspace.value = true
     mockIsActiveSubscription.value = false
+    mockBillingStatus.value = 'inactive'
+    renderComponent()
+
+    expect(screen.getByText('Your subscription has ended')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Free' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Subscribe' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Team' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps a payment-failed personal plan visible until it is terminal', () => {
+    mockIsInPersonalWorkspace.value = true
+    mockIsActiveSubscription.value = false
+    mockBillingStatus.value = 'payment_failed'
     renderComponent()
 
     expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
-    expect(screen.queryByText('Free')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Your subscription has ended')
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Subscribe' })
     ).not.toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -534,20 +534,23 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('keeps a payment-failed personal plan visible until it is terminal', () => {
-    mockIsInPersonalWorkspace.value = true
-    mockIsActiveSubscription.value = false
-    mockBillingStatus.value = 'payment_failed'
-    renderComponent()
+  it.for(['paid', 'payment_failed', 'paused'] as BillingStatus[])(
+    'keeps a %s personal plan visible until it is terminal',
+    (billingStatus) => {
+      mockIsInPersonalWorkspace.value = true
+      mockIsActiveSubscription.value = false
+      mockBillingStatus.value = billingStatus
+      renderComponent()
 
-    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
-    expect(
-      screen.queryByText('Your subscription has ended')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: 'Subscribe' })
-    ).not.toBeInTheDocument()
-  })
+      expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+      expect(
+        screen.queryByText('Your subscription has ended')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Subscribe' })
+      ).not.toBeInTheDocument()
+    }
+  )
 
   it('shows dated cancellation copy while a cancelled plan remains active', async () => {
     const user = userEvent.setup()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -372,16 +372,18 @@ const { isResubscribing, handleResubscribe } = useResubscribe()
 const { displayPrice, priceUnitLabel } = useWorkspacePlanPricing()
 const { menuEntries } = useWorkspaceMenuItems()
 
+const isTerminalPersonalSubscription = computed(
+  () =>
+    isInPersonalWorkspace.value &&
+    !isActiveSubscription.value &&
+    billingStatus.value === 'inactive'
+)
+
 const isSubscriptionEnded = computed(
   () =>
     subscriptionStatus.value === 'ended' ||
     (isSubscriptionCancelled.value && !isActiveSubscription.value) ||
-    (isInPersonalWorkspace.value &&
-      subscription.value !== null &&
-      !isFreeTierPlan.value &&
-      !isActiveSubscription.value &&
-      (billingStatus.value === 'inactive' ||
-        subscriptionStatus.value === 'canceled'))
+    isTerminalPersonalSubscription.value
 )
 
 // Show subscribe prompt to owners without active subscription. A cancelled plan
@@ -390,15 +392,6 @@ const showSubscribePrompt = computed(() => {
   if (!permissions.value.canManageSubscription) return false
   if (isSubscriptionEnded.value && !isActiveSubscription.value) return true
   if (isSubscriptionCancelled.value) return false
-  // A terminal personal subscription can briefly retain an old/omitted
-  // subscription_status while is_active is already false. Treat it as ended
-  // instead of rendering the stale paid plan identity.
-  if (
-    isInPersonalWorkspace.value &&
-    !isActiveSubscription.value &&
-    billingStatus.value === 'inactive'
-  )
-    return true
   if (
     subscription.value &&
     !isFreeTierPlan.value &&

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -357,6 +357,7 @@ const {
   isTeamPlan,
   subscription,
   plans,
+  billingStatus,
   subscriptionStatus,
   isLoading,
   error,
@@ -374,7 +375,13 @@ const { menuEntries } = useWorkspaceMenuItems()
 const isSubscriptionEnded = computed(
   () =>
     subscriptionStatus.value === 'ended' ||
-    (isSubscriptionCancelled.value && !isActiveSubscription.value)
+    (isSubscriptionCancelled.value && !isActiveSubscription.value) ||
+    (isInPersonalWorkspace.value &&
+      subscription.value !== null &&
+      !isFreeTierPlan.value &&
+      !isActiveSubscription.value &&
+      (billingStatus.value === 'inactive' ||
+        subscriptionStatus.value === 'canceled'))
 )
 
 // Show subscribe prompt to owners without active subscription. A cancelled plan
@@ -383,6 +390,15 @@ const showSubscribePrompt = computed(() => {
   if (!permissions.value.canManageSubscription) return false
   if (isSubscriptionEnded.value && !isActiveSubscription.value) return true
   if (isSubscriptionCancelled.value) return false
+  // A terminal personal subscription can briefly retain an old/omitted
+  // subscription_status while is_active is already false. Treat it as ended
+  // instead of rendering the stale paid plan identity.
+  if (
+    isInPersonalWorkspace.value &&
+    !isActiveSubscription.value &&
+    billingStatus.value === 'inactive'
+  )
+    return true
   if (
     subscription.value &&
     !isFreeTierPlan.value &&


### PR DESCRIPTION
## Summary
- Render terminally inactive personal workspaces as the Free/ended state even when provider status is stale or omitted.
- Preserve paid-plan presentation for `payment_failed` and `paused` states.
- Add regression coverage for immediate cancellation and payment failure.

## Root cause
The workspace can receive `is_active=false` before or without a terminal `subscription_status`, while the panel still used the stale paid-plan identity.

## Validation
- `pnpm typecheck`
- `NODE_OPTIONS=--localstorage-file=/private/tmp/comfyui-vitest-local-storage.json ./node_modules/.bin/vitest run src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts` (39 passed)
- `git diff --cached --check`