### PR TITLE
feat(billing): visual pass for the embedded checkout

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,5 +1,14 @@
 @import '@comfyorg/design-system/css/style.css';
 
+/* Toasts teleport to <body>. Reka's modal mode sets pointer-events: none on
+   the body, which left toast close buttons painted above dialogs but
+   unclickable — clicks fell through to whatever sat beneath (including the
+   payment dialog's X, closing the checkout mid-payment). Keep toasts
+   interactive regardless of modal state. */
+.p-toast {
+  pointer-events: auto;
+}
+
 /* Use 0.001ms instead of 0s so transitionend/animationend events still fire
    and JS listeners aren't broken. */
 .disable-animations *,

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2893,10 +2893,10 @@
       "confirmChangeTitle": "Review your scheduled change",
       "paymentPopupBlocked": "Couldn't open the payment page — please allow popups and try again.",
       "paymentMethod": "Payment method",
-      "stripeMethodChoice": "Choose card or Alipay. Your payment details are handled securely by Stripe.",
+      "stripeMethodChoice": "Your payment details are handled securely by Stripe.",
       "planPrice": "Plan price",
       "promotionCode": "Promotion code",
-      "promotionCodePlaceholder": "Promotion code (optional)",
+      "promotionCodePlaceholder": "Promo code",
       "promotionCodeHelp": "Promotional discounts stack with eligible plan discounts.",
       "alipayRenewalNote": "Alipay authorization will also be used for automatic renewals and future purchases.",
       "payAndSubscribe": "Pay and subscribe",
@@ -2935,7 +2935,8 @@
         "confirmationRequired": "Your subscription is cancelled — please confirm the reactivation charge before continuing",
         "amountChanged": "The charge amount changed since you confirmed it — please review and try again",
         "unavailable": "We can't confirm this reactivation right now — please choose your plan again"
-      }
+      },
+      "addPromoCode": "Add promo code"
     },
     "success": {
       "allSet": "You're all set",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2914,7 +2914,7 @@
       "creditsRefillMonthlyTo": "Credits refill monthly to",
       "billedEachMonth": "{amount} billed each month. Cancel anytime.",
       "stayOnUntil": "You'll stay on {plan} until {date}.",
-      "termsAgreement": "By continuing, you agree to Comfy Org's {terms} and {privacy}.",
+      "termsAgreement": "By continuing, you agree to Comfy Org's {terms} and {privacy}, and authorize Comfy Org to charge your payment method each billing period until you cancel.",
       "terms": "Terms",
       "privacyPolicy": "Privacy Policy",
       "addCreditCard": "Add credit card",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2945,7 +2945,9 @@
       "inviteTitle": "Invite your team",
       "planUpdated": "Your plan has been successfully updated.",
       "receiptEmailed": "A receipt has been emailed to you.",
-      "sendInvites": "Send invites"
+      "sendInvites": "Send invites",
+      "promoApplied": "{code} applied.",
+      "promoRenews": "Renews at {amount} on {date}"
     }
   },
   "userSettings": {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -163,6 +163,9 @@ export const useSubscriptionDialog = () => {
           // steps shrink (the content root sets its own width per checkoutStep).
           renderer: 'reka',
           size: 'full',
+          // A scrim click mid-checkout would silently discard typed card
+          // details and any pending 3DS state; the X is the only close.
+          dismissableMask: false,
           contentClass:
             'w-fit max-w-[min(1280px,95vw)] sm:max-w-[min(1280px,95vw)] max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
         }

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -15,7 +15,11 @@
       :class="
         cn(
           usePaymentElement &&
-            'xl:w-[42%] xl:shrink-0 xl:border-r xl:border-border-subtle xl:bg-base-background xl:px-12 xl:py-10'
+            'xl:w-[42%] xl:shrink-0 xl:border-r xl:border-border-subtle xl:bg-base-background xl:px-12 xl:py-10',
+          // Below xl the same dual tone runs vertically: the summary bleeds
+          // dark to the dialog edges, payment continues on the shell below.
+          usePaymentElement &&
+            'max-xl:-mx-4 max-xl:-mt-6 max-xl:rounded-t-2xl max-xl:bg-base-background max-xl:px-6 max-xl:pt-4 max-xl:pb-6'
         )
       "
     >
@@ -47,6 +51,16 @@
         >
           {{ $t('subscription.preview.confirmPayment') }}
         </h2>
+        <Button
+          v-if="usePaymentElement"
+          size="icon"
+          variant="muted-textonly"
+          class="shrink-0 rounded-full xl:hidden"
+          :aria-label="$t('g.close')"
+          @click="$emit('close')"
+        >
+          <i class="pi pi-times text-base" />
+        </Button>
       </div>
       <!-- Plan Header -->
       <div class="flex flex-col gap-2">
@@ -55,23 +69,11 @@
         </span>
         <div class="flex items-baseline gap-2">
           <span
-            :class="
-              cn(
-                'text-4xl font-semibold text-base-foreground tabular-nums',
-                usePaymentElement && 'xl:text-2xl'
-              )
-            "
+            class="text-2xl font-semibold text-base-foreground tabular-nums"
           >
             ${{ displayPrice }}
           </span>
-          <span
-            :class="
-              cn(
-                'text-xl text-base-foreground',
-                usePaymentElement && 'xl:text-base'
-              )
-            "
-          >
+          <span class="text-base text-base-foreground">
             {{ $t('subscription.usdPerMonth') }}
           </span>
         </div>
@@ -167,7 +169,9 @@
         cn(
           'flex flex-col gap-2 pt-8',
           usePaymentElement &&
-            'xl:min-h-0 xl:min-w-0 xl:flex-1 xl:px-16 xl:py-10'
+            'xl:min-h-0 xl:min-w-0 xl:flex-1 xl:px-16 xl:py-10',
+          // Match the summary panel's 24px edge inset (root p-4 provides 16).
+          usePaymentElement && 'max-xl:px-2'
         )
       "
     >
@@ -256,6 +260,7 @@ const emit = defineEmits<{
   addCreditCard: []
   confirmPayment: [confirmationToken: string, promotionCode?: string]
   back: []
+  close: []
 }>()
 
 const { t, n } = useI18n()

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -1,47 +1,77 @@
 <template>
-  <h2
-    :class="
-      cn(
-        'm-0 mb-8 text-center text-xl font-semibold text-base-foreground lg:text-2xl',
-        usePaymentElement && 'xl:mb-4'
-      )
-    "
-  >
-    {{ $t('subscription.preview.confirmPayment') }}
-  </h2>
   <div
     :class="
       cn(
         'mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm',
-        // Stripe-checkout shape on desktop: order summary left, payment
-        // right, inside the pricing table's dialog footprint. Mobile keeps
-        // the stacked flow.
+        // Edge-to-edge Stripe-checkout split on desktop: the summary is a
+        // flush full-height sidebar on base-background, payment beside it on
+        // the shell. Mobile keeps the stacked flow.
         usePaymentElement &&
-          'xl:min-h-0 xl:max-w-none xl:flex-1 xl:flex-row xl:items-stretch xl:justify-center xl:gap-16'
+          'xl:min-h-0 xl:w-full xl:max-w-none xl:flex-1 xl:flex-row xl:items-stretch xl:gap-0'
       )
     "
   >
-    <!-- Dual-tone summary panel: same recipe as the pricing table's inner
-         box (rounded, bg-base-background, borderless) on the dialog's
-         secondary-background shell. -->
     <div
       :class="
         cn(
           usePaymentElement &&
-            'xl:w-[440px] xl:shrink-0 xl:rounded-2xl xl:bg-base-background xl:px-8 xl:py-6'
+            'xl:w-[42%] xl:shrink-0 xl:border-r xl:border-border-subtle xl:bg-base-background xl:px-12 xl:py-10'
         )
       "
     >
+      <div
+        :class="
+          cn('mb-8 flex items-center gap-3', usePaymentElement && 'xl:mb-10')
+        "
+      >
+        <Button
+          v-if="usePaymentElement"
+          size="icon"
+          variant="muted-textonly"
+          class="shrink-0 rounded-full"
+          :aria-label="$t('g.back')"
+          :disabled="isLoading"
+          @click="$emit('back')"
+        >
+          <i class="pi pi-arrow-left text-base" />
+        </Button>
+        <h2
+          :class="
+            cn(
+              'm-0 flex-1 text-center text-xl font-semibold text-base-foreground lg:text-2xl',
+              // In the sidebar the title goes quiet and the money block leads.
+              usePaymentElement &&
+                'xl:text-left xl:text-base xl:font-medium xl:text-muted-foreground'
+            )
+          "
+        >
+          {{ $t('subscription.preview.confirmPayment') }}
+        </h2>
+      </div>
       <!-- Plan Header -->
       <div class="flex flex-col gap-2">
         <span class="text-sm text-base-foreground">
           {{ tierName }}
         </span>
         <div class="flex items-baseline gap-2">
-          <span class="text-4xl font-semibold text-base-foreground">
+          <span
+            :class="
+              cn(
+                'text-4xl font-semibold text-base-foreground tabular-nums',
+                usePaymentElement && 'xl:text-2xl'
+              )
+            "
+          >
             ${{ displayPrice }}
           </span>
-          <span class="text-xl text-base-foreground">
+          <span
+            :class="
+              cn(
+                'text-xl text-base-foreground',
+                usePaymentElement && 'xl:text-base'
+              )
+            "
+          >
             {{ $t('subscription.usdPerMonth') }}
           </span>
         </div>
@@ -72,76 +102,10 @@
           </span>
           <div class="flex items-center gap-1">
             <i class="icon-[comfy--credits] size-4 shrink-0 bg-credit" />
-            <span class="font-bold text-base-foreground">
+            <span class="font-bold text-base-foreground tabular-nums">
               {{ refillCredits }}
             </span>
           </div>
-        </div>
-
-        <!-- Expandable Features -->
-        <button
-          class="flex cursor-pointer items-center justify-end gap-1 border-none bg-transparent p-0 font-inter text-sm text-muted-foreground hover:text-base-foreground"
-          @click="isFeaturesCollapsed = !isFeaturesCollapsed"
-        >
-          <span>
-            {{
-              isFeaturesCollapsed
-                ? $t('subscription.preview.showMoreFeatures')
-                : $t('subscription.preview.hideFeatures')
-            }}
-          </span>
-          <i
-            :class="
-              cn(
-                'pi text-xs',
-                isFeaturesCollapsed ? 'pi-chevron-down' : 'pi-chevron-up'
-              )
-            "
-          />
-        </button>
-        <div v-show="!isFeaturesCollapsed" class="flex flex-col gap-2 pt-2">
-          <template v-if="teamPlan">
-            <div
-              v-for="perk in teamPerks"
-              :key="perk"
-              class="flex items-center gap-2"
-            >
-              <i class="pi pi-check text-success-foreground text-xs" />
-              <span class="text-sm text-base-foreground">{{ perk }}</span>
-            </div>
-          </template>
-          <template v-else>
-            <div class="flex items-center justify-between">
-              <span class="text-sm text-base-foreground">
-                {{ $t('subscription.maxDurationLabel') }}
-              </span>
-              <span class="text-sm font-bold text-base-foreground">
-                {{ maxDuration }}
-              </span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-sm text-base-foreground">
-                {{ $t('subscription.gpuLabel') }}
-              </span>
-              <i class="pi pi-check text-success-foreground text-xs" />
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-sm text-base-foreground">
-                {{ $t('subscription.addCreditsLabel') }}
-              </span>
-              <i class="pi pi-check text-success-foreground text-xs" />
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-sm text-base-foreground">
-                {{ $t('subscription.customLoRAsLabel') }}
-              </span>
-              <i
-                v-if="hasCustomLoRAs"
-                class="pi pi-check text-success-foreground text-xs"
-              />
-              <i v-else class="pi pi-times text-xs text-muted-foreground" />
-            </div>
-          </template>
         </div>
       </div>
 
@@ -181,7 +145,7 @@
           <span class="text-base-foreground">
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
-          <span class="font-bold text-base-foreground">
+          <span class="font-bold text-base-foreground tabular-nums">
             ${{ totalDueToday }}
           </span>
         </div>
@@ -201,27 +165,31 @@
         cn(
           'flex flex-col gap-2 pt-8',
           usePaymentElement &&
-            'xl:min-h-0 xl:w-[480px] xl:min-w-0 xl:overflow-x-hidden xl:overflow-y-auto xl:pt-0 xl:pr-2'
+            'xl:min-h-0 xl:min-w-0 xl:flex-1 xl:overflow-x-hidden xl:overflow-y-auto xl:px-16 xl:py-10'
         )
       "
     >
-      <UnifiedStripePaymentSelector
-        v-if="usePaymentElement"
-        :amount-cents="amountDueCents"
-        :is-loading
-        :promotion-code="promotionCode"
-        @confirm="confirmPayment"
-      />
-
+      <!-- Pending 3DS verification is the only actionable step, so it takes
+           the top of the column; the pay button below it is demoted and
+           disabled while it shows. -->
       <Button
         v-if="actionUrl"
-        variant="primary"
+        variant="inverted"
         size="lg"
         class="w-full rounded-lg"
         @click="openVerification"
       >
         {{ $t('subscription.preview.completeVerification') }}
       </Button>
+
+      <UnifiedStripePaymentSelector
+        v-if="usePaymentElement"
+        :amount-cents="amountDueCents"
+        :is-loading
+        :promotion-code="promotionCode"
+        :verification-pending="Boolean(actionUrl)"
+        @confirm="confirmPayment"
+      />
 
       <Button
         v-if="!usePaymentElement"
@@ -235,17 +203,7 @@
       </Button>
 
       <!-- Terms Agreement (below the pay action, like Stripe checkout) -->
-      <SubscriptionTermsNote />
-
-      <!-- Back Link -->
-      <Button
-        variant="textonly"
-        class="cursor-pointer text-center text-xs text-muted-foreground transition-colors hover:bg-none hover:text-base-foreground"
-        :disabled="isLoading"
-        @click="$emit('back')"
-      >
-        {{ $t('subscription.preview.backToAllPlans') }}
-      </Button>
+      <SubscriptionTermsNote class="mt-2" />
     </div>
   </div>
 </template>
@@ -259,7 +217,6 @@ import Input from '@/components/ui/input/Input.vue'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import {
   getTierCredits,
-  getTierFeatures,
   getTierPrice
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
@@ -301,7 +258,6 @@ const emit = defineEmits<{
 
 const { t, n } = useI18n()
 
-const isFeaturesCollapsed = ref(true)
 const isPromoOpen = ref(false)
 const promotionCode = ref('')
 
@@ -354,18 +310,6 @@ const creditsRefillLabelKey = computed(() =>
     ? 'subscription.preview.eachYearCreditsRefill'
     : 'subscription.preview.eachMonthCreditsRefill'
 )
-
-const teamPerks = computed(() => [
-  t('subscription.teamPlan.perkInviteMembers'),
-  t('subscription.teamPlan.perkConcurrentRuns'),
-  t('subscription.teamPlan.perkSharedPool'),
-  t('subscription.teamPlan.perkRolePermissions')
-])
-
-const hasCustomLoRAs = computed(() =>
-  tierKey ? getTierFeatures(tierKey).customLoRAs : false
-)
-const maxDuration = computed(() => t(`subscription.maxDuration.${tierKey}`))
 
 const totalDueToday = computed(() => {
   if (teamPlan) {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -1,11 +1,37 @@
 <template>
-  <h2 class="m-0 mb-8 text-center text-xl text-muted-foreground lg:text-2xl">
+  <h2
+    :class="
+      cn(
+        'm-0 mb-8 text-center text-xl font-semibold text-base-foreground lg:text-2xl',
+        usePaymentElement && 'xl:mb-4'
+      )
+    "
+  >
     {{ $t('subscription.preview.confirmPayment') }}
   </h2>
   <div
-    class="mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm"
+    :class="
+      cn(
+        'mx-auto flex h-full max-w-[400px] flex-col items-stretch justify-between text-sm',
+        // Stripe-checkout shape on desktop: order summary left, payment
+        // right, inside the pricing table's dialog footprint. Mobile keeps
+        // the stacked flow.
+        usePaymentElement &&
+          'xl:min-h-0 xl:max-w-none xl:flex-1 xl:flex-row xl:items-stretch xl:justify-center xl:gap-16'
+      )
+    "
   >
-    <div class="">
+    <!-- Dual-tone summary panel: same recipe as the pricing table's inner
+         box (rounded, bg-base-background, borderless) on the dialog's
+         secondary-background shell. -->
+    <div
+      :class="
+        cn(
+          usePaymentElement &&
+            'xl:w-[440px] xl:shrink-0 xl:rounded-2xl xl:bg-base-background xl:px-8 xl:py-6'
+        )
+      "
+    >
       <!-- Plan Header -->
       <div class="flex flex-col gap-2">
         <span class="text-sm text-base-foreground">
@@ -32,7 +58,14 @@
       </div>
 
       <!-- Credits Section -->
-      <div class="flex flex-col gap-3 pt-16 pb-8">
+      <div
+        :class="
+          cn(
+            'flex flex-col gap-3 pt-16 pb-8',
+            usePaymentElement && 'xl:pt-6 xl:pb-4'
+          )
+        "
+      >
         <div class="flex items-center justify-between">
           <span class="text-base-foreground">
             {{ $t(creditsRefillLabelKey) }}
@@ -47,7 +80,7 @@
 
         <!-- Expandable Features -->
         <button
-          class="flex cursor-pointer items-center justify-end gap-1 border-none bg-transparent p-0 text-sm text-muted-foreground hover:text-base-foreground"
+          class="flex cursor-pointer items-center justify-end gap-1 border-none bg-transparent p-0 font-inter text-sm text-muted-foreground hover:text-base-foreground"
           @click="isFeaturesCollapsed = !isFeaturesCollapsed"
         >
           <span>
@@ -112,8 +145,38 @@
         </div>
       </div>
 
+      <!-- Promo code (Figma 5379-30077): below the money block, directly
+           above the divider — adjacent to the number it changes. Validation
+           and discount math need the BE preview endpoint; until then the
+           code rides along at confirm exactly as before. -->
+      <div v-if="usePaymentElement" class="pb-4">
+        <Button
+          v-if="!isPromoOpen"
+          variant="link"
+          size="lg"
+          class="self-start px-0"
+          @click="isPromoOpen = true"
+        >
+          {{ $t('subscription.preview.addPromoCode') }}
+        </Button>
+        <Input
+          v-else
+          v-model="promotionCode"
+          class="w-full"
+          :placeholder="$t('subscription.preview.promotionCodePlaceholder')"
+          autocomplete="off"
+        />
+      </div>
+
       <!-- Total Due Section -->
-      <div class="flex flex-col gap-2 border-t border-border-subtle pt-8">
+      <div
+        :class="
+          cn(
+            'flex flex-col gap-2 border-t border-border-subtle pt-8',
+            usePaymentElement && 'xl:pt-6'
+          )
+        "
+      >
         <div class="flex items-center justify-between text-base">
           <span class="text-base-foreground">
             {{ $t('subscription.preview.totalDueToday') }}
@@ -131,15 +194,22 @@
         </span>
       </div>
     </div>
-    <!-- Footer -->
-    <div class="flex flex-col gap-2 pt-8">
-      <!-- Terms Agreement -->
-      <SubscriptionTermsNote />
-
+    <!-- Footer (right column on desktop when the payment element is embedded;
+         scrolls independently so the summary panel stays put) -->
+    <div
+      :class="
+        cn(
+          'flex flex-col gap-2 pt-8',
+          usePaymentElement &&
+            'xl:min-h-0 xl:w-[480px] xl:min-w-0 xl:overflow-x-hidden xl:overflow-y-auto xl:pt-0 xl:pr-2'
+        )
+      "
+    >
       <UnifiedStripePaymentSelector
         v-if="usePaymentElement"
         :amount-cents="amountDueCents"
         :is-loading
+        :promotion-code="promotionCode"
         @confirm="confirmPayment"
       />
 
@@ -164,6 +234,9 @@
         {{ $t('subscription.preview.subscribeToPlan', { plan: tierName }) }}
       </Button>
 
+      <!-- Terms Agreement (below the pay action, like Stripe checkout) -->
+      <SubscriptionTermsNote />
+
       <!-- Back Link -->
       <Button
         variant="textonly"
@@ -182,6 +255,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
+import Input from '@/components/ui/input/Input.vue'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import {
   getTierCredits,
@@ -228,6 +302,8 @@ const emit = defineEmits<{
 const { t, n } = useI18n()
 
 const isFeaturesCollapsed = ref(true)
+const isPromoOpen = ref(false)
+const promotionCode = ref('')
 
 function openVerification() {
   if (!actionUrl) return

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -116,19 +116,21 @@
       <div v-if="usePaymentElement" class="pb-4">
         <Button
           v-if="!isPromoOpen"
-          variant="link"
+          variant="secondary"
           size="lg"
-          class="self-start px-0"
-          @click="isPromoOpen = true"
+          class="self-start"
+          @click="openPromo"
         >
           {{ $t('subscription.preview.addPromoCode') }}
         </Button>
         <Input
           v-else
+          ref="promoInput"
           v-model="promotionCode"
           class="w-full"
           :placeholder="$t('subscription.preview.promotionCodePlaceholder')"
           autocomplete="off"
+          @blur="onPromoBlur"
         />
       </div>
 
@@ -165,7 +167,7 @@
         cn(
           'flex flex-col gap-2 pt-8',
           usePaymentElement &&
-            'xl:min-h-0 xl:min-w-0 xl:flex-1 xl:overflow-x-hidden xl:overflow-y-auto xl:px-16 xl:py-10'
+            'xl:min-h-0 xl:min-w-0 xl:flex-1 xl:px-16 xl:py-10'
         )
       "
     >
@@ -209,7 +211,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
@@ -260,6 +262,21 @@ const { t, n } = useI18n()
 
 const isPromoOpen = ref(false)
 const promotionCode = ref('')
+const promoInput = ref<InstanceType<typeof Input>>()
+
+function openPromo() {
+  isPromoOpen.value = true
+  void nextTick(() => {
+    const el = promoInput.value?.$el
+    if (el instanceof HTMLInputElement) el.focus()
+  })
+}
+
+// An empty field collapses back to the button on blur; a typed code keeps
+// the field so the entered value stays visible.
+function onPromoBlur() {
+  if (!promotionCode.value.trim()) isPromoOpen.value = false
+}
 
 function openVerification() {
   if (!actionUrl) return

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="contentRoot"
     :class="
       cn(
         'relative flex h-full flex-col gap-4 overflow-y-auto p-4 pt-6',
@@ -12,13 +13,14 @@
         isEmbeddedPaymentStep &&
           'xl:h-[min(740px,90vh)] xl:gap-0 xl:overflow-hidden xl:rounded-2xl xl:p-0',
         isEmbeddedSuccessStep &&
-          'bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px] xl:rounded-2xl',
+          'overflow-hidden rounded-2xl bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px]',
         (isEmbeddedPaymentStep || isEmbeddedSuccessStep) &&
           'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out',
         // The w-fit shell hugs min-content on phones; give the embedded
         // steps a real width floor below xl.
         (isEmbeddedPaymentStep || isEmbeddedSuccessStep) &&
-          'max-xl:w-[min(430px,92vw)]'
+          'max-xl:w-[min(430px,92vw)]',
+        isEmbeddedPaymentStep && 'max-xl:h-[85vh]'
       )
     "
   >
@@ -148,7 +150,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { useEventListener } from '@vueuse/core'
-import { computed, onMounted } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
@@ -229,6 +231,29 @@ onMounted(() => {
     return
   }
   void handleSubscribeClick(initialCheckout)
+})
+
+// Height transitions with an `auto` endpoint never engage in Chromium (even
+// under interpolate-size), and CSS-transition FLIP gets eaten by the same
+// patch cycle that swaps the step content — so the height tween runs on the
+// Web Animations API instead, outside the CSS transition machinery. On
+// desktop both steps pin the same height, so this no-ops.
+const contentRoot = ref<HTMLElement>()
+watch(checkoutStep, async (next, prev) => {
+  const el = contentRoot.value
+  if (!el || !stripePaymentElementEnabled) return
+  const between = (a: string, b: string) =>
+    (prev === a && next === b) || (prev === b && next === a)
+  if (!between('preview', 'success')) return
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) return
+  const from = el.getBoundingClientRect().height
+  await nextTick()
+  const to = el.getBoundingClientRect().height
+  if (Math.abs(from - to) < 2) return
+  el.animate([{ height: `${from}px` }, { height: `${to}px` }], {
+    duration: 300,
+    easing: 'cubic-bezier(0.4, 0, 0.2, 1)'
+  })
 })
 
 // Backspace mirrors the back arrow on the confirm step, but never while an

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -10,7 +10,11 @@
         // mounted) and hand scrolling to the payment column so the summary
         // panel stays fixed; below xl the whole dialog scrolls as before.
         isEmbeddedPaymentStep &&
-          'xl:h-[min(740px,90vh)] xl:gap-0 xl:overflow-hidden xl:rounded-2xl xl:p-0'
+          'xl:h-[min(740px,90vh)] xl:gap-0 xl:overflow-hidden xl:rounded-2xl xl:p-0',
+        isEmbeddedSuccessStep &&
+          'bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px] xl:rounded-2xl',
+        (isEmbeddedPaymentStep || isEmbeddedSuccessStep) &&
+          'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out'
       )
     "
   >
@@ -39,7 +43,10 @@
     <!-- The embedded payment step titles itself ("Confirm your payment");
          stacking "Choose a Plan" above it doubled the header and made this
          step taller than the pricing table. -->
-    <div v-if="!isEmbeddedPaymentStep" class="flex flex-col items-center gap-3">
+    <div
+      v-if="!isEmbeddedPaymentStep && !isEmbeddedSuccessStep"
+      class="flex flex-col items-center gap-3"
+    >
       <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
         {{ $t('subscription.descriptionWorkspace') }}
       </h2>
@@ -121,6 +128,7 @@
       :team-plan="selectedTeamStop"
       :preview-data="previewData"
       :is-team="isTeamCheckout"
+      :dark-surface="isEmbeddedSuccessStep"
       @close="handleSuccessClose"
     />
   </div>
@@ -162,6 +170,16 @@ const stripePaymentElementEnabled = Boolean(
 const isEmbeddedPaymentStep = computed(
   () =>
     checkoutStep.value === 'preview' &&
+    stripePaymentElementEnabled &&
+    (previewVariant.value === 'team-new' ||
+      previewVariant.value === 'personal-new')
+)
+
+// Success after an embedded checkout: same pinned height, narrow width, and
+// the darker surface — the dialog collapses around the receipt.
+const isEmbeddedSuccessStep = computed(
+  () =>
+    checkoutStep.value === 'success' &&
     stripePaymentElementEnabled &&
     (previewVariant.value === 'team-new' ||
       previewVariant.value === 'personal-new')

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -9,12 +9,13 @@
         // alone is a floor — the Stripe iframe would stretch the dialog once
         // mounted) and hand scrolling to the payment column so the summary
         // panel stays fixed; below xl the whole dialog scrolls as before.
-        isEmbeddedPaymentStep && 'xl:h-[min(740px,90vh)] xl:overflow-hidden'
+        isEmbeddedPaymentStep &&
+          'xl:h-[min(740px,90vh)] xl:gap-0 xl:overflow-hidden xl:rounded-2xl xl:p-0'
       )
     "
   >
     <Button
-      v-if="checkoutStep === 'preview'"
+      v-if="checkoutStep === 'preview' && !isEmbeddedPaymentStep"
       size="icon"
       variant="muted-textonly"
       class="absolute top-2.5 left-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -14,7 +14,11 @@
         isEmbeddedSuccessStep &&
           'bg-base-background xl:h-[min(740px,90vh)] xl:w-[512px] xl:rounded-2xl',
         (isEmbeddedPaymentStep || isEmbeddedSuccessStep) &&
-          'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out'
+          'motion-safe:xl:transition-[width] motion-safe:xl:duration-300 motion-safe:xl:ease-in-out',
+        // The w-fit shell hugs min-content on phones; give the embedded
+        // steps a real width floor below xl.
+        (isEmbeddedPaymentStep || isEmbeddedSuccessStep) &&
+          'max-xl:w-[min(430px,92vw)]'
       )
     "
   >
@@ -33,7 +37,12 @@
     <Button
       size="icon"
       variant="muted-textonly"
-      class="absolute top-2.5 right-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
+      :class="
+        cn(
+          'absolute top-2.5 right-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10',
+          isEmbeddedPaymentStep && 'max-xl:hidden'
+        )
+      "
       :aria-label="$t('g.close')"
       @click="onClose"
     >
@@ -96,6 +105,7 @@
         @add-credit-card="handleTeamSubscribe"
         @confirm-payment="handleTeamSubscriptionPayment"
         @back="handleBackToPricing"
+        @close="onClose"
       />
 
       <SubscriptionAddPaymentPreviewWorkspace
@@ -109,6 +119,7 @@
         @add-credit-card="handleAddCreditCard"
         @confirm-payment="handleSubscriptionPayment"
         @back="handleBackToPricing"
+        @close="onClose"
       />
 
       <SubscriptionTransitionPreviewWorkspace

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -3,8 +3,13 @@
     :class="
       cn(
         'relative flex h-full flex-col gap-4 overflow-y-auto p-4 pt-6',
-        checkoutStep === 'pricing' &&
-          'xl:min-h-[min(740px,90vh)] xl:w-[min(1280px,95vw)]'
+        (checkoutStep === 'pricing' || isEmbeddedPaymentStep) &&
+          'xl:min-h-[min(740px,90vh)] xl:w-[min(1280px,95vw)]',
+        // Pin the embedded step to the pricing table's exact height (min-h
+        // alone is a floor — the Stripe iframe would stretch the dialog once
+        // mounted) and hand scrolling to the payment column so the summary
+        // panel stays fixed; below xl the whole dialog scrolls as before.
+        isEmbeddedPaymentStep && 'xl:h-[min(740px,90vh)] xl:overflow-hidden'
       )
     "
   >
@@ -30,7 +35,10 @@
       <i class="pi pi-times text-xl" />
     </Button>
 
-    <div class="flex flex-col items-center gap-3">
+    <!-- The embedded payment step titles itself ("Confirm your payment");
+         stacking "Choose a Plan" above it doubled the header and made this
+         step taller than the pricing table. -->
+    <div v-if="!isEmbeddedPaymentStep" class="flex flex-col items-center gap-3">
       <h2 class="m-0 font-inter text-2xl font-semibold text-base-foreground">
         {{ $t('subscription.descriptionWorkspace') }}
       </h2>
@@ -120,7 +128,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { useEventListener } from '@vueuse/core'
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { PaymentIntentSource } from '@/platform/telemetry/types'
@@ -145,6 +153,17 @@ const emit = defineEmits<{
 
 const stripePaymentElementEnabled = Boolean(
   import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+)
+
+// The embedded-payment confirm step keeps the pricing table's dialog
+// dimensions so stepping between them reads as one dialog changing content,
+// not two dialogs. Transition previews (no payment form) stay narrow.
+const isEmbeddedPaymentStep = computed(
+  () =>
+    checkoutStep.value === 'preview' &&
+    stripePaymentElementEnabled &&
+    (previewVariant.value === 'team-new' ||
+      previewVariant.value === 'personal-new')
 )
 
 const {

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
@@ -16,11 +16,18 @@
 
       <!-- Plan summary -->
       <div
-        class="mt-4 flex w-full flex-col gap-1 rounded-xl border border-border-default bg-base-background p-4"
+        :class="
+          cn(
+            'mt-4 flex w-full flex-col gap-1 rounded-xl border border-border-default bg-base-background p-4',
+            darkSurface && 'border-none bg-secondary-background'
+          )
+        "
       >
         <span class="text-sm text-base-foreground">{{ tierName }}</span>
         <div class="flex items-baseline gap-1">
-          <span class="text-2xl font-semibold text-base-foreground">
+          <span
+            class="text-2xl font-semibold text-base-foreground tabular-nums"
+          >
             ${{ displayPrice }}
           </span>
           <span class="text-sm text-base-foreground">
@@ -29,12 +36,31 @@
         </div>
         <div class="flex items-center gap-1 text-sm text-muted-foreground">
           <i class="icon-[comfy--credits] size-4 shrink-0 bg-credit" />
-          <span>{{ displayCredits }} {{ $t('subscription.perMonth') }}</span>
+          <span class="tabular-nums">
+            {{ displayCredits }} {{ $t('subscription.perMonth') }}
+          </span>
         </div>
       </div>
 
+      <p
+        v-if="promoApplied"
+        class="m-0 text-center text-sm text-muted-foreground tabular-nums"
+      >
+        <span class="font-medium text-base-foreground">
+          {{
+            $t('subscription.success.promoApplied', { code: promoApplied.code })
+          }}
+        </span>
+        {{
+          $t('subscription.success.promoRenews', {
+            amount: promoApplied.renewalAmount,
+            date: promoApplied.renewalDate
+          })
+        }}
+      </p>
+
       <div v-if="showInviteBlock" class="mt-4 flex w-full flex-col gap-2">
-        <h3 class="m-0 text-base font-semibold text-base-foreground">
+        <h3 class="m-0 text-base font-normal text-base-foreground">
           {{ $t('subscription.success.inviteTitle') }}
         </h3>
         <p class="m-0 text-sm text-muted-foreground">
@@ -59,6 +85,11 @@
             v-else
             ref="inviteForm"
             :show-submit="false"
+            :tags-input-class="
+              darkSurface
+                ? 'min-h-10 w-full bg-secondary-background px-3 focus-within:bg-secondary-background hover:bg-secondary-background-hover'
+                : undefined
+            "
             source="post_upgrade_success"
             :submit-label="$t('subscription.success.sendInvites')"
             :placeholder="$t('subscription.success.inviteEmailsPlaceholder')"
@@ -69,7 +100,7 @@
       </div>
     </div>
 
-    <div class="flex flex-col gap-2 pt-8">
+    <div class="flex flex-col gap-2 pt-8 pb-4">
       <Button
         v-if="showInviteBlock && invitedEmails.length === 0"
         variant="tertiary"
@@ -82,7 +113,11 @@
         {{ $t('subscription.success.sendInvites') }}
       </Button>
       <Button
-        variant="secondary"
+        :variant="
+          showInviteBlock && invitedEmails.length === 0
+            ? 'muted-textonly'
+            : 'secondary'
+        "
         size="lg"
         class="w-full rounded-lg"
         @click="$emit('close')"
@@ -95,6 +130,8 @@
 
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue'
+
+import { cn } from '@comfyorg/tailwind-utils'
 import { useI18n } from 'vue-i18n'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
@@ -115,12 +152,23 @@ const {
   tierKey,
   previewData = null,
   teamPlan = null,
-  isTeam = false
+  isTeam = false,
+  darkSurface = false,
+  promoApplied = null
 } = defineProps<{
   tierKey?: Exclude<TierKey, 'free' | 'founder'> | null
   previewData?: PreviewSubscribeResponse | null
   teamPlan?: TeamPlanSelection | null
   isTeam?: boolean
+  /** Dialog paints base-background; the plan card elevates to stay visible. */
+  darkSurface?: boolean
+  /** Applied promotion feedback (Figma 5379-30077 S3). Display-ready strings;
+   *  the backend does not supply this yet — see the promo validation ask. */
+  promoApplied?: {
+    code: string
+    renewalAmount: string
+    renewalDate: string
+  } | null
 }>()
 
 defineEmits<{

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -29,7 +29,7 @@
       </p>
     </div>
     <Button
-      variant="inverted"
+      :variant="verificationPending ? 'tertiary' : 'inverted'"
       size="lg"
       class="w-full rounded-lg"
       :disabled="!stripeElements"
@@ -56,12 +56,16 @@ import Button from '@/components/ui/button/Button.vue'
 const {
   amountCents,
   isLoading = false,
-  promotionCode = ''
+  promotionCode = '',
+  verificationPending = false
 } = defineProps<{
   amountCents: number
   isLoading?: boolean
   /** Entered in the order summary; rides along unchanged on confirm. */
   promotionCode?: string
+  /** A 3DS verification is pending: Complete verification (rendered by the
+   *  parent) is the primary action, so the pay button steps back. */
+  verificationPending?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -116,7 +120,10 @@ onMounted(async () => {
       },
       rules: {
         '.AccordionItem': {
-          border: `1px solid ${resolveThemeColor('--border-subtle')}`,
+          backgroundColor: resolveThemeColor('--base-background'),
+          // Transparent (not none) so rows keep their size when the
+          // selected item paints its outline.
+          border: '1px solid transparent',
           boxShadow: 'none'
         },
         '.AccordionItem--selected': {
@@ -144,7 +151,10 @@ onMounted(async () => {
       defaultCollapsed: false,
       radios: 'always',
       spacedAccordionItems: true
-    }
+    },
+    // Our terms note carries the recurring-charge authorization; Stripe's
+    // card mandate text would say it twice.
+    terms: { card: 'never' }
   })
   paymentElement.mount(paymentElementTarget.value)
   // Method-specific notes (e.g. the Alipay auto-renewal disclosure) key off

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-6">
+  <div class="flex min-h-0 flex-col gap-6 xl:flex-1">
     <div class="flex items-start justify-between gap-4">
       <div>
         <h3 class="m-0 text-base font-semibold text-base-foreground">
@@ -16,17 +16,23 @@
     >
       {{ configurationError }}
     </div>
-    <div ref="paymentElementTarget" />
+    <!-- Only the form region scrolls; the header above and the pay action
+         below hold their positions regardless of which method is expanded. -->
     <div
-      v-if="selectedMethodType === 'alipay'"
-      class="flex items-start gap-3 rounded-xl bg-base-background/60 px-4 py-3 text-xs text-muted-foreground"
+      class="flex flex-col gap-6 xl:min-h-0 xl:flex-1 xl:overflow-x-hidden xl:overflow-y-auto xl:pr-1"
     >
-      <i
-        class="text-success-foreground mt-0.5 icon-[lucide--shield-check] size-4 shrink-0"
-      />
-      <p class="m-0">
-        {{ $t('subscription.preview.alipayRenewalNote') }}
-      </p>
+      <div ref="paymentElementTarget" />
+      <div
+        v-if="selectedMethodType === 'alipay'"
+        class="flex items-start gap-3 rounded-xl bg-base-background/60 px-4 py-3 text-xs text-muted-foreground"
+      >
+        <i
+          class="text-success-foreground mt-0.5 icon-[lucide--shield-check] size-4 shrink-0"
+        />
+        <p class="m-0">
+          {{ $t('subscription.preview.alipayRenewalNote') }}
+        </p>
+      </div>
     </div>
     <Button
       :variant="verificationPending ? 'tertiary' : 'inverted'"

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -1,31 +1,12 @@
 <template>
-  <div
-    class="flex flex-col gap-6 rounded-2xl border border-border-default bg-secondary-background p-6 shadow-sm"
-  >
+  <div class="flex flex-col gap-6">
     <div class="flex items-start justify-between gap-4">
-      <div class="flex items-start gap-3">
-        <div
-          class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-background text-white"
-        >
-          <i class="icon-[lucide--credit-card] size-5" />
-        </div>
-        <div>
-          <h3 class="m-0 text-base font-semibold text-base-foreground">
-            {{ $t('subscription.preview.paymentMethod') }}
-          </h3>
-          <p class="m-0 mt-1 max-w-md text-sm text-muted-foreground">
-            {{ $t('subscription.preview.stripeMethodChoice') }}
-          </p>
-        </div>
-      </div>
-      <div
-        class="shrink-0 rounded-xl border border-border-subtle bg-base-background px-4 py-2 text-right"
-      >
-        <p class="m-0 text-xs text-muted-foreground">
-          {{ $t('subscription.preview.planPrice') }}
-        </p>
-        <p class="m-0 mt-1 font-semibold text-base-foreground">
-          {{ formattedAmount }}
+      <div>
+        <h3 class="m-0 text-base font-semibold text-base-foreground">
+          {{ $t('subscription.preview.paymentMethod') }}
+        </h3>
+        <p class="m-0 mt-1 max-w-md text-sm text-muted-foreground">
+          {{ $t('subscription.preview.stripeMethodChoice') }}
         </p>
       </div>
     </div>
@@ -35,35 +16,9 @@
     >
       {{ configurationError }}
     </div>
+    <div ref="paymentElementTarget" />
     <div
-      class="rounded-xl border border-border-subtle bg-base-background p-4 shadow-sm"
-    >
-      <div ref="paymentElementTarget" />
-    </div>
-    <div
-      class="flex flex-col gap-3 rounded-xl border border-border-subtle bg-base-background p-4"
-    >
-      <div class="flex items-center gap-2">
-        <i
-          class="icon-[lucide--badge-percent] size-4 text-primary-background"
-        />
-        <label class="text-sm font-medium text-base-foreground">
-          {{ $t('subscription.preview.promotionCode') }}
-        </label>
-      </div>
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <Input
-          v-model="promotionCode"
-          class="min-w-0 flex-1"
-          :placeholder="$t('subscription.preview.promotionCodePlaceholder')"
-          autocomplete="off"
-        />
-        <p class="m-0 text-xs text-muted-foreground sm:max-w-52">
-          {{ $t('subscription.preview.promotionCodeHelp') }}
-        </p>
-      </div>
-    </div>
-    <div
+      v-if="selectedMethodType === 'alipay'"
       class="flex items-start gap-3 rounded-xl bg-base-background/60 px-4 py-3 text-xs text-muted-foreground"
     >
       <i
@@ -74,6 +29,7 @@
       </p>
     </div>
     <Button
+      variant="inverted"
       size="lg"
       class="w-full rounded-lg"
       :disabled="!stripeElements"
@@ -92,15 +48,20 @@ import type {
   StripeElements,
   StripePaymentElement
 } from '@stripe/stripe-js'
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import Input from '@/components/ui/input/Input.vue'
 
-const { amountCents, isLoading = false } = defineProps<{
+const {
+  amountCents,
+  isLoading = false,
+  promotionCode = ''
+} = defineProps<{
   amountCents: number
   isLoading?: boolean
+  /** Entered in the order summary; rides along unchanged on confirm. */
+  promotionCode?: string
 }>()
 
 const emit = defineEmits<{
@@ -111,14 +72,8 @@ const { t } = useI18n()
 const paymentElementTarget = ref<HTMLDivElement>()
 const stripeElements = ref<StripeElements>()
 const configurationError = ref('')
-const promotionCode = ref('')
 const isSubmitting = ref(false)
-const formattedAmount = computed(() =>
-  new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: 'USD'
-  }).format(amountCents / 100)
-)
+const selectedMethodType = ref('')
 let stripe: Stripe | null = null
 let paymentElement: StripePaymentElement | undefined
 let isUnmounted = false
@@ -145,11 +100,16 @@ onMounted(async () => {
     setupFutureUsage: 'off_session',
     appearance: {
       variables: {
-        colorPrimary: resolveThemeColor('--primary-background'),
+        // Selection (radio, selected label, accordion highlight) uses the
+        // theme-aware foreground rather than brand blue.
+        colorPrimary: resolveThemeColor('--base-foreground'),
         colorBackground: resolveThemeColor('--base-background'),
         colorText: resolveThemeColor('--base-foreground'),
         colorTextSecondary: resolveThemeColor('--muted-foreground'),
         colorDanger: resolveThemeColor('--destructive-background'),
+        // Same token as the pricing table's "Save 20%" pill, so all
+        // deal/discount badges share one accent.
+        colorSuccess: resolveThemeColor('--primary-background'),
         fontFamily: getComputedStyle(document.body).fontFamily,
         borderRadius: '10px',
         spacingUnit: '5px'
@@ -160,7 +120,7 @@ onMounted(async () => {
           boxShadow: 'none'
         },
         '.AccordionItem--selected': {
-          borderColor: resolveThemeColor('--primary-background')
+          borderColor: resolveThemeColor('--base-foreground')
         },
         '.Input': {
           backgroundColor: resolveThemeColor('--input-surface'),
@@ -187,6 +147,11 @@ onMounted(async () => {
     }
   })
   paymentElement.mount(paymentElementTarget.value)
+  // Method-specific notes (e.g. the Alipay auto-renewal disclosure) key off
+  // whichever payment method the user has selected inside the element.
+  paymentElement.on('change', (event) => {
+    selectedMethodType.value = event.value?.type ?? ''
+  })
 })
 
 onBeforeUnmount(() => {
@@ -214,7 +179,7 @@ async function submit() {
     emit(
       'confirm',
       result.confirmationToken.id,
-      promotionCode.value.trim() || undefined
+      promotionCode.trim() || undefined
     )
   } catch {
     configurationError.value = t('g.error')


### PR DESCRIPTION
Visual pass over the embedded Stripe checkout (`proper-alipay-and-3ds-support`). Review commit-by-commit — each is a self-contained stage:

1. **Two-column payment step** — dual-tone summary panel, pinned dialog footprint
2. **Edge-to-edge split** — summary as flush sidebar, single title with inline back arrow, brand type scale, tabular numerals, one merged legal line, 3DS-aware CTA hierarchy (Complete verification inverted and first; Pay demotes to tertiary while a verification is pending)
3. **Success collapse** — same pinned height, width animates 1280→512 (300ms ease-in-out), darker surface, promo-applied feedback behind an optional prop, Close demotes while Send invites is primary
4. **Mobile pass** — width floor for the w-fit shell (was collapsing to ~190px), vertical dual tone, arrow/X aligned in one header row, 24px insets
5. **Mobile fixes** — 85vh cap (dialog exceeded the viewport), corner clipping, height tween via Web Animations API (height transitions with an auto endpoint never engage in Chromium; a CSS FLIP gets eaten by the step-content patch, so WAAPI owns mobile height and CSS keeps desktop width)

Intentional behavior changes to review as decisions, not side effects:

- **Scrim click no longer closes the dialog** (`dismissableMask: false`) — applies to every step including plan-change confirms; X is the only close (Esc still works)
- **One legal line**: Stripe's card mandate is suppressed (`terms.card: 'never'`); `subscription.preview.termsAgreement` now carries the recurring-charge authorization and is shared with the transition previews
- **Toasts stay clickable above modals** (`.p-toast` pointer-events) — global; also extracted to a standalone PR against main since it fixes all Reka modals

Known follow-ups (not in this PR):

- Promo validation/requote endpoint and success promo data (`promoApplied` prop ships dark until the backend supplies code/renewal fields)
- Expanding back to the payment step animates to a pre-Stripe-mount height, then grows when the iframe lands
- Yearly team pricing on the success card still displays monthly-normalized
- Planned next: customers with a saved payment method get a narrow (512px) confirm — summary + saved card + Pay — instead of the capture form; the wide split becomes first-capture-only, with "Change" expanding back into it. Needs the preview response to carry a default-payment-method summary. Open question for this branch: does the capture form currently show for customers who already have a saved method?

Plan-change flows (`SubscriptionTransitionPreviewWorkspace`, downgrade dialog) are untouched.

<img width="1353" height="810" alt="image" src="https://github.com/user-attachments/assets/59b74343-c0d7-4faf-8fa5-95912d047e73" />
<img width="1338" height="798" alt="Screenshot 2026-07-30 at 7 08 06 PM" src="https://github.com/user-attachments/assets/713527da-1041-4ae6-af21-0ff791d0b881" />

https://github.com/user-attachments/assets/a0b6a277-2480-4405-8df4-1fc6863a637d


