### PR TITLE
fix(ui): keep toasts clickable above Reka modal dialogs

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,5 +1,14 @@
 @import '@comfyorg/design-system/css/style.css';
 
+/* Toasts teleport to <body>. Reka's modal mode sets pointer-events: none on
+   the body, which left toast close buttons painted above dialogs but
+   unclickable — clicks fell through to whatever sat beneath (including any
+   dialog controls under the toast). Keep toasts interactive regardless of
+   modal state. */
+.p-toast {
+  pointer-events: auto;
+}
+
 /* Use 0.001ms instead of 0s so transitionend/animationend events still fire
    and JS listeners aren't broken. */
 .disable-animations *,


### PR DESCRIPTION
Reka's modal mode sets pointer-events: none on the body; toast containers
teleport to the body, so their close buttons rendered above dialogs but
could not be clicked - the click fell through to whatever sat beneath the
toast, including dialog controls. Re-enable pointer events on the toast
container.
