### PR TITLE
feat(billing): merge Manage billing and Invoice history into Billing & invoices

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2640,7 +2640,7 @@
     "endsOnDate": "Ends on {date}",
     "changesToPlanOnDate": "Changes to {plan} on {date}",
     "manageSubscription": "Manage subscription",
-    "manageBilling": "Manage billing",
+    "billingAndInvoices": "Billing & invoices",
     "changePlan": "Change plan",
     "cancelPlan": "Cancel plan",
     "canceled": "Canceled",
@@ -2743,7 +2743,6 @@
     "saveYearly": "Save 20%",
     "tierNameYearly": "{name} Yearly",
     "messageSupport": "Message support",
-    "invoiceHistory": "Invoice history",
     "refreshCredits": "Refresh credits",
     "benefits": {
       "benefit1": "Monthly credits for Partner Nodes — top up when needed",

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -79,6 +79,9 @@ describe('SubscriptionFooterLinks', () => {
       screen.getByRole('button', { name: 'Learn more' })
     ).toBeInTheDocument()
     expect(
+      screen.getByRole('button', { name: 'Partner Nodes pricing' })
+    ).toBeInTheDocument()
+    expect(
       screen.getByRole('button', { name: 'Message support' })
     ).toBeInTheDocument()
   })

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.test.ts
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -44,16 +43,14 @@ const i18n = createI18n({
       subscription: {
         learnMore: 'Learn more',
         partnerNodesPricingTable: 'Partner Nodes pricing',
-        messageSupport: 'Message support',
-        invoiceHistory: 'Invoice history'
+        messageSupport: 'Message support'
       }
     }
   }
 })
 
-function renderComponent(showInvoiceHistory?: boolean) {
+function renderComponent() {
   return render(SubscriptionFooterLinks, {
-    props: showInvoiceHistory === undefined ? {} : { showInvoiceHistory },
     global: {
       plugins: [i18n],
       stubs: {
@@ -72,17 +69,8 @@ describe('SubscriptionFooterLinks', () => {
     vi.clearAllMocks()
   })
 
-  it('keeps Invoice history visible by default for legacy billing', async () => {
-    const user = userEvent.setup()
+  it('renders only the support links (invoice history merged into Billing & Invoice)', () => {
     renderComponent()
-
-    await user.click(screen.getByRole('button', { name: 'Invoice history' }))
-
-    expect(state.manageSubscription).toHaveBeenCalledOnce()
-  })
-
-  it('hides Invoice history without opening the payment portal', () => {
-    renderComponent(false)
 
     expect(
       screen.queryByRole('button', { name: 'Invoice history' })
@@ -90,6 +78,8 @@ describe('SubscriptionFooterLinks', () => {
     expect(
       screen.getByRole('button', { name: 'Learn more' })
     ).toBeInTheDocument()
-    expect(state.manageSubscription).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Message support' })
+    ).toBeInTheDocument()
   })
 })

--- a/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionFooterLinks.vue
@@ -29,40 +29,18 @@
         {{ $t('subscription.messageSupport') }}
       </Button>
     </div>
-
-    <Button
-      v-if="showInvoiceHistory"
-      variant="muted-textonly"
-      class="text-xs text-text-secondary"
-      @click="handleInvoiceHistory"
-    >
-      {{ $t('subscription.invoiceHistory') }}
-      <i class="pi pi-external-link text-xs text-text-secondary" />
-    </Button>
   </div>
 </template>
 
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useSubscriptionActions } from '@/platform/cloud/subscription/composables/useSubscriptionActions'
 
-const { showInvoiceHistory = true } = defineProps<{
-  showInvoiceHistory?: boolean
-}>()
-
 const { buildDocsUrl, docsPaths } = useExternalLink()
-
-const { manageSubscription } = useBillingContext()
 
 const { isLoadingSupport, handleMessageSupport, handleLearnMoreClick } =
   useSubscriptionActions()
-
-async function handleInvoiceHistory() {
-  if (!showInvoiceHistory) return
-  await manageSubscription()
-}
 
 function handleOpenPartnerNodesInfo() {
   window.open(

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -265,9 +265,7 @@ const ButtonStub = {
 }
 
 const SubscriptionFooterLinksStub = {
-  props: ['showInvoiceHistory'],
-  template:
-    '<div data-testid="subscription-footer-links" :data-show-invoice-history="String(showInvoiceHistory)" />'
+  template: '<div data-testid="subscription-footer-links" />'
 }
 
 const DropdownMenuStub = {
@@ -374,10 +372,6 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByText(`Renews on ${formatPanelDate(RENEWAL_DATE_ISO)}`)
     ).toBeInTheDocument()
     expect(screen.getByTestId('subscription-footer-links')).toBeInTheDocument()
-    expect(screen.getByTestId('subscription-footer-links')).toHaveAttribute(
-      'data-show-invoice-history',
-      'true'
-    )
   })
 
   it('shows a scheduled plan change instead of the renewal date', () => {
@@ -466,11 +460,11 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(screen.getByText('$665.50')).toBeInTheDocument()
   })
 
-  it('wires Manage billing and Change plan actions for subscription managers', async () => {
+  it('wires Billing & invoices and Change plan actions for subscription managers', async () => {
     const user = userEvent.setup()
     renderComponent()
 
-    await user.click(screen.getByRole('button', { name: 'Manage billing' }))
+    await user.click(screen.getByRole('button', { name: 'Billing & invoices' }))
     expect(mockManageSubscription).toHaveBeenCalledOnce()
 
     await user.click(screen.getByRole('button', { name: 'Change plan' }))
@@ -488,7 +482,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
     expect(screen.getByTestId('credits-tile')).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Manage billing' })
+      screen.queryByRole('button', { name: 'Billing & invoices' })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Change plan' })
@@ -500,10 +494,6 @@ describe('SubscriptionPanelContentWorkspace', () => {
       screen.getByRole('button', { name: 'Leave Workspace' })
     ).toBeInTheDocument()
     expect(screen.getByText('Invite members')).toBeInTheDocument()
-    expect(screen.getByTestId('subscription-footer-links')).toHaveAttribute(
-      'data-show-invoice-history',
-      'false'
-    )
   })
 
   it('uses Team-plan change copy in a Personal workspace', () => {
@@ -592,7 +582,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).not.toBeInTheDocument()
     expect(screen.queryByText(/^Changes to/i)).not.toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Manage billing' })
+      screen.getByRole('button', { name: 'Billing & invoices' })
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Change plan' })
@@ -768,6 +758,9 @@ describe('SubscriptionPanelContentWorkspace', () => {
 
     await user.click(screen.getByRole('button', { name: 'Subscribe' }))
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
+
+    await user.click(screen.getByRole('button', { name: 'Billing & invoices' }))
+    expect(mockManageSubscription).toHaveBeenCalledOnce()
   })
 
   it('lets a Free personal workspace only rename itself (no Cancel or Delete)', async () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -628,6 +628,27 @@ describe('SubscriptionPanelContentWorkspace', () => {
     expect(screen.queryByText(/^Ends on/i)).not.toBeInTheDocument()
   })
 
+  it('keeps Billing & invoices portal access after a Team plan ends', async () => {
+    mockSubscriptionStatus.value = 'canceled'
+    mockIsActiveSubscription.value = false
+    mockIsWorkspaceSubscribed.value = false
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Billing & invoices' }))
+
+    expect(mockManageSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('keeps Billing & invoices while a cancellation is scheduled', () => {
+    mockSubscriptionStatus.value = 'canceled'
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Billing & invoices' })
+    ).toBeInTheDocument()
+  })
+
   it('does not show stale renewal copy for an explicitly ended active state', () => {
     mockSubscriptionStatus.value = 'ended'
     renderComponent()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -122,6 +122,15 @@
               </div>
               <div class="flex flex-wrap gap-2 md:ml-auto">
                 <Button
+                  v-if="permissions.canManageSubscription"
+                  size="lg"
+                  variant="secondary"
+                  class="rounded-lg bg-interface-menu-component-surface-selected px-4 text-sm font-normal text-text-primary"
+                  @click="manageSubscription"
+                >
+                  {{ $t('subscription.billingAndInvoices') }}
+                </Button>
+                <Button
                   variant="primary"
                   size="lg"
                   class="rounded-lg px-4 text-sm font-normal"
@@ -175,13 +184,13 @@
                 class="flex flex-wrap gap-2 md:ml-auto"
               >
                 <Button
-                  v-if="!isFreeTierPlan && permissions.canManageSubscription"
+                  v-if="permissions.canManageSubscription"
                   size="lg"
                   variant="secondary"
                   class="rounded-lg bg-interface-menu-component-surface-selected px-4 text-sm font-normal text-text-primary"
                   @click="manageSubscription"
                 >
-                  {{ $t('subscription.manageBilling') }}
+                  {{ $t('subscription.billingAndInvoices') }}
                 </Button>
                 <Button
                   v-if="
@@ -298,10 +307,7 @@
         </Button>
       </div>
 
-      <SubscriptionFooterLinks
-        class="mt-auto pt-6"
-        :show-invoice-history="permissions.canManageSubscription"
-      />
+      <SubscriptionFooterLinks class="mt-auto pt-6" />
     </template>
   </div>
 </template>

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -87,14 +87,24 @@
                   {{ $t('subscription.subscriptionRequiredMessage') }}
                 </div>
               </div>
-              <Button
-                variant="primary"
-                size="lg"
-                class="ml-auto rounded-lg px-4 py-2 text-sm font-normal"
-                @click="handleSubscribeWorkspace"
-              >
-                {{ $t('subscription.subscribeNow') }}
-              </Button>
+              <div class="flex flex-wrap gap-2 md:ml-auto">
+                <Button
+                  size="lg"
+                  variant="secondary"
+                  class="rounded-lg bg-interface-menu-component-surface-selected px-4 text-sm font-normal text-text-primary"
+                  @click="manageSubscription"
+                >
+                  {{ $t('subscription.billingAndInvoices') }}
+                </Button>
+                <Button
+                  variant="primary"
+                  size="lg"
+                  class="rounded-lg px-4 py-2 text-sm font-normal"
+                  @click="handleSubscribeWorkspace"
+                >
+                  {{ $t('subscription.subscribeNow') }}
+                </Button>
+              </div>
             </template>
 
             <!-- MEMBER View - read-only, workspace not subscribed -->


### PR DESCRIPTION
Both buttons opened the same Stripe billing portal (`accessBillingPortal()`), one from the plan header and one from the footer. One button now — **Billing & invoices** in the plan header actions — and the footer link is removed (component, prop plumbing, tests).

Free-tier and never-subscribed users get the button too: a local-account user who topped up credits already has a Stripe customer with saved payment methods and invoices, so the portal is reachable before any subscription exists. Gating is `canManageSubscription` only (role-based; members still never see it).

Fresh-account edge (no Stripe customer yet): verified safe against `Comfy-Org/cloud` — ingest's `GetPaymentPortal` lazily provisions via `EnsureProvisioned` (creates the Stripe customer under a per-workspace billing lock) before minting the portal session. Residual failure is a retryable `PROVISIONING_FAILED`, surfaced by the panel's existing error state.

The ended-team gap from FE-1435 is covered too: the unsubscribed-team prompt branch (where canceled/ended team workspaces land) now renders Billing & invoices beside Subscribe Now, per the inactive-team Figma state. State tests added for ended-team portal access and cancel-scheduled retention.

- Fixes DES-591
- Fixes FE-1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
