### PR TITLE
Track Desktop login browser arrival

### DIFF
--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -27,6 +27,13 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
   })
 }))
 
+const mockTrackDesktopLoginCodeCaptured = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackDesktopLoginCodeCaptured: mockTrackDesktopLoginCodeCaptured
+  })
+}))
+
 interface MockAuthStore {
   currentUser: {
     uid: string
@@ -159,9 +166,23 @@ describe('installDesktopLoginRedemption', () => {
 
     await trigger()
 
+    expect(mockTrackDesktopLoginCodeCaptured).not.toHaveBeenCalled()
     expect(mockConfirm).not.toHaveBeenCalled()
     expect(mockFetch).not.toHaveBeenCalled()
     expect(mockToastAdd).not.toHaveBeenCalled()
+  })
+
+  it('emits one code-free browser-arrival event when a valid code is captured', async () => {
+    const { trigger, seedStash } = await setup()
+    mockAuthStore.currentUser = null
+    seedStash(VALID_CODE)
+
+    await trigger()
+    await trigger()
+
+    expect(mockTrackDesktopLoginCodeCaptured).toHaveBeenCalledOnce()
+    expect(mockTrackDesktopLoginCodeCaptured).toHaveBeenCalledWith()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('redeems a stashed code once on navigation with the Firebase bearer token after approval', async () => {

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.ts
@@ -7,6 +7,7 @@ import {
   getPreservedQueryParam
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
 import { useDialogService } from '@/services/dialogService'
@@ -36,6 +37,7 @@ interface CodeRedemptionState {
   approvedUserUid: string | null
   settled: boolean
   forceTokenRefresh: boolean
+  pageArrivalTracked: boolean
 }
 
 // Keyed by code so a different code arriving later gets its own approval and
@@ -65,7 +67,8 @@ function getCodeState(code: string): CodeRedemptionState {
     attempts: 0,
     approvedUserUid: null,
     settled: false,
-    forceTokenRefresh: false
+    forceTokenRefresh: false,
+    pageArrivalTracked: false
   }
   codeStates.set(code, fresh)
   return fresh
@@ -82,6 +85,15 @@ function clearStashIfHolds(code: string): void {
 function settle(code: string, state: CodeRedemptionState): void {
   state.settled = true
   clearStashIfHolds(code)
+}
+
+function trackBrowserPageArrival(state: CodeRedemptionState): void {
+  if (state.pageArrivalTracked) return
+  const telemetry = useTelemetry()
+  if (!telemetry) return
+
+  state.pageArrivalTracked = true
+  telemetry.trackDesktopLoginCodeCaptured()
 }
 
 function handleTransientFailure(
@@ -233,6 +245,8 @@ async function redeemPendingDesktopLoginCode(): Promise<void> {
         clearPreservedQuery(NAMESPACE)
         continue
       }
+      const state = getCodeState(code)
+      trackBrowserPageArrival(state)
       await redeemCode(code)
       if (code !== getPreservedQueryParam(NAMESPACE, DESKTOP_LOGIN_CODE_KEY))
         retriggerRequested = true

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -90,6 +90,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackUserLoggedIn?.())
   }
 
+  trackDesktopLoginCodeCaptured(): void {
+    this.dispatch((provider) => provider.trackDesktopLoginCodeCaptured?.())
+  }
+
   trackSubscription(
     event: 'modal_opened' | 'subscribe_clicked',
     metadata?: SubscriptionMetadata

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -216,6 +216,18 @@ describe('PostHogTelemetryProvider', () => {
     })
   })
 
+  it('captures browser arrival for Desktop login without code properties', async () => {
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackDesktopLoginCodeCaptured()
+
+    expect(hoisted.mockCapture).toHaveBeenCalledWith(
+      TelemetryEvents.DESKTOP_LOGIN_CODE_CAPTURED,
+      {}
+    )
+  })
+
   describe('platform axes (client / deployment)', () => {
     afterEach(() => {
       delete window.__comfyDesktop2

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -380,6 +380,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.USER_LOGGED_IN)
   }
 
+  trackDesktopLoginCodeCaptured(): void {
+    this.trackEvent(TelemetryEvents.DESKTOP_LOGIN_CODE_CAPTURED)
+  }
+
   trackSubscription(
     event: 'modal_opened' | 'subscribe_clicked',
     metadata?: SubscriptionMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -787,6 +787,7 @@ export interface TelemetryProvider {
   trackAuth?(metadata: AuthMetadata): void
   trackAuthFailed?(metadata: AuthErrorMetadata): void
   trackUserLoggedIn?(): void
+  trackDesktopLoginCodeCaptured?(): void
 
   // Subscription flow events
   trackSubscription?(
@@ -913,6 +914,7 @@ export const TelemetryEvents = {
   USER_AUTH_COMPLETED: 'app:user_auth_completed',
   USER_AUTH_FAILED: 'app:user_auth_failed',
   USER_LOGGED_IN: 'app:user_logged_in',
+  DESKTOP_LOGIN_CODE_CAPTURED: 'app:desktop_login_code_captured',
 
   // Subscription Flow
   RUN_BUTTON_CLICKED: 'app:run_button_click',


### PR DESCRIPTION
Adds a once-per-code `app:desktop_login_code_captured` event after the browser page has captured and stripped a valid Desktop login code. The event carries no code or custom properties, separating confirmed page arrival from the OS-level handoff signal added in Comfy-Org/Comfy-Desktop#1358.

Validation: frontend oxfmt, type-aware oxlint, ESLint, and typecheck pre-commit gates; 101 focused redemption and PostHog tests.