### PR TITLE
fix: preserve subgraph node size when editing or promoting widgets (FE-853)

### DIFF
--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -55,8 +55,17 @@ export class ContextMenu {
     }
   }
 
-  async openFor(locator: Locator): Promise<this> {
-    await locator.click({ button: 'right' })
+  /**
+   * Right-clicks a locator to open its context menu.
+   *
+   * @param force Bypass Playwright's actionability checks. Needed for
+   * widgets that are disabled/readonly because they are driven by a
+   * promoted subgraph input — the app still opens a context menu for a
+   * real right-click on these, but Playwright refuses a plain click on a
+   * disabled element.
+   */
+  async openFor(locator: Locator, { force = false } = {}): Promise<this> {
+    await locator.click({ button: 'right', force })
     await expect(this.anyMenu).toBeVisible()
     return this
   }

--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -55,17 +55,14 @@ export class ContextMenu {
     }
   }
 
-  /**
-   * Right-clicks a locator to open its context menu.
-   *
-   * @param force Bypass Playwright's actionability checks. Needed for
-   * widgets that are disabled/readonly because they are driven by a
-   * promoted subgraph input — the app still opens a context menu for a
-   * real right-click on these, but Playwright refuses a plain click on a
-   * disabled element.
-   */
-  async openFor(locator: Locator, { force = false } = {}): Promise<this> {
-    await locator.click({ button: 'right', force })
+  async openFor(locator: Locator): Promise<this> {
+    await locator.click({ button: 'right' })
+    await expect(this.anyMenu).toBeVisible()
+    return this
+  }
+
+  async openForDisabledElement(locator: Locator): Promise<this> {
+    await locator.dispatchEvent('contextmenu', { button: 2 })
     await expect(this.anyMenu).toBeVisible()
     return this
   }

--- a/browser_tests/fixtures/components/SubgraphEditor.ts
+++ b/browser_tests/fixtures/components/SubgraphEditor.ts
@@ -9,12 +9,23 @@ import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 export class SubgraphEditor {
   public readonly root: Locator
   public readonly promotionItems: Locator
+  public readonly selectionToolboxButton: Locator
 
   constructor(protected readonly comfyPage: ComfyPage) {
     this.root = this.comfyPage.menu.propertiesPanel.root
     this.promotionItems = this.root.getByTestId(
       TestIds.subgraphEditor.widgetItem
     )
+    this.selectionToolboxButton = this.comfyPage.selectionToolbox.getByRole(
+      'button',
+      { name: 'Edit Subgraph Widgets' }
+    )
+  }
+
+  async openFromSelectionToolbox(subgraphNode: Locator) {
+    await new VueNodeFixture(subgraphNode).select()
+    await this.selectionToolboxButton.click()
+    await expect(this.root, 'Open Properties Panel').toBeVisible()
   }
 
   async ensureOpen(subgraphNode: Locator) {

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -195,13 +195,19 @@ export class NodeOperationsHelper {
     ratioY: number,
     revertAfter: boolean = false
   ): Promise<void> {
+    // nodePos is in screen space (NodeReference#getPosition already applies
+    // canvas pan/zoom) but nodeSize is raw graph-space size, so it must be
+    // scaled to match before combining the two into screen-space points.
+    const scale = await this.comfyPage.canvasOps.getScale()
+    const screenWidth = nodeSize.width * scale
+    const screenHeight = nodeSize.height * scale
     const bottomRight = {
-      x: nodePos.x + nodeSize.width,
-      y: nodePos.y + nodeSize.height
+      x: nodePos.x + screenWidth,
+      y: nodePos.y + screenHeight
     }
     const target = {
-      x: nodePos.x + nodeSize.width * ratioX,
-      y: nodePos.y + nodeSize.height * ratioY
+      x: nodePos.x + screenWidth * ratioX,
+      y: nodePos.y + screenHeight * ratioY
     }
     // -1 to be inside the node.  -2 because nodes currently get an arbitrary +1 to width.
     await this.comfyPage.canvasOps.dragAndDrop(

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
 import type {
@@ -228,7 +227,7 @@ export class NodeOperationsHelper {
     delta: { x: number; y: number }
   ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
     const [nodeRef] = await this.getNodeRefsByTitle(title)
-    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+    if (!nodeRef) throw new Error(`No node titled "${title}" on the canvas`)
 
     // Saved pans can leave the node too low for a downward drag to stay onscreen.
     await nodeRef.centerOnNode()
@@ -239,12 +238,11 @@ export class NodeOperationsHelper {
     await this.comfyPage.nextFrame()
 
     const size = await nodeRef.getSize()
-    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
-      sizeBefore.width
-    )
-    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
-      sizeBefore.height
-    )
+    if (size.width <= sizeBefore.width || size.height <= sizeBefore.height) {
+      throw new Error(
+        `Resize drag did not enlarge "${title}": ${sizeBefore.width}x${sizeBefore.height} -> ${size.width}x${size.height}`
+      )
+    }
 
     return { nodeRef, node, size }
   }

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -195,19 +195,13 @@ export class NodeOperationsHelper {
     ratioY: number,
     revertAfter: boolean = false
   ): Promise<void> {
-    // nodePos is in screen space (NodeReference#getPosition already applies
-    // canvas pan/zoom) but nodeSize is raw graph-space size, so it must be
-    // scaled to match before combining the two into screen-space points.
-    const scale = await this.comfyPage.canvasOps.getScale()
-    const screenWidth = nodeSize.width * scale
-    const screenHeight = nodeSize.height * scale
     const bottomRight = {
-      x: nodePos.x + screenWidth,
-      y: nodePos.y + screenHeight
+      x: nodePos.x + nodeSize.width,
+      y: nodePos.y + nodeSize.height
     }
     const target = {
-      x: nodePos.x + screenWidth * ratioX,
-      y: nodePos.y + screenHeight * ratioY
+      x: nodePos.x + nodeSize.width * ratioX,
+      y: nodePos.y + nodeSize.height * ratioY
     }
     // -1 to be inside the node.  -2 because nodes currently get an arbitrary +1 to width.
     await this.comfyPage.canvasOps.dragAndDrop(

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 
 import type {
@@ -12,6 +13,7 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
 import type { Position, Size } from '@e2e/fixtures/types'
 import { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 
 export class NodeOperationsHelper {
   public readonly promptDialogInput: Locator
@@ -214,6 +216,37 @@ export class NodeOperationsHelper {
         bottomRight
       )
     }
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right Vue resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async fillPromptDialog(value: string): Promise<void> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -359,8 +359,12 @@ export class SubgraphHelper {
     widgetName: string
   ): Promise<void> {
     const widget = nodeLocator.getByLabel(widgetName, { exact: true })
+    // A promoted widget's own display is disabled/readonly (its value comes
+    // from the subgraph input link), so the right-click must bypass
+    // Playwright's actionability check for disabled elements. The app still
+    // opens a context menu for a real right-click on these.
     await this.comfyPage.contextMenu
-      .openFor(widget)
+      .openFor(widget, { force: true })
       .then((m) => m.clickMenuItemExact(`Un-Promote Widget: ${widgetName}`))
   }
 

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,6 +15,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
+import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -500,6 +501,37 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
+  }
+
+  /**
+   * Enlarges the node titled `title` by dragging its bottom-right resize
+   * handle. The returned size is read from the graph model, not a DOM bounding
+   * box, so it stays comparable across zoom and side-panel layout changes.
+   */
+  async growNodeByDrag(
+    title: string,
+    delta: { x: number; y: number }
+  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
+    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
+    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
+
+    // Saved pans can leave the node too low for a downward drag to stay onscreen.
+    await nodeRef.centerOnNode()
+
+    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
+    const sizeBefore = await nodeRef.getSize()
+    await node.resizeFromCorner('SE', delta.x, delta.y)
+    await this.comfyPage.nextFrame()
+
+    const size = await nodeRef.getSize()
+    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
+      sizeBefore.width
+    )
+    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
+      sizeBefore.height
+    )
+
+    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -15,7 +15,6 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import type { Position, Size } from '@e2e/fixtures/types'
 import type { NodeReference } from '@e2e/fixtures/utils/litegraphUtils'
 import { SubgraphSlotReference } from '@e2e/fixtures/utils/litegraphUtils'
-import type { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import { getAllHostPromotedWidgets } from '@e2e/fixtures/utils/promotedWidgets'
 import type { PromotedWidgetEntry } from '@e2e/fixtures/utils/promotedWidgets'
 
@@ -501,37 +500,6 @@ export class SubgraphHelper {
       window.app!.graph!.serialize()
     )
     await this.comfyPage.workflow.loadGraphData(serialized as ComfyWorkflowJSON)
-  }
-
-  /**
-   * Enlarges the node titled `title` by dragging its bottom-right resize
-   * handle. The returned size is read from the graph model, not a DOM bounding
-   * box, so it stays comparable across zoom and side-panel layout changes.
-   */
-  async growNodeByDrag(
-    title: string,
-    delta: { x: number; y: number }
-  ): Promise<{ nodeRef: NodeReference; node: VueNodeFixture; size: Size }> {
-    const [nodeRef] = await this.comfyPage.nodeOps.getNodeRefsByTitle(title)
-    expect(nodeRef, `${title} node is on the canvas`).toBeDefined()
-
-    // Saved pans can leave the node too low for a downward drag to stay onscreen.
-    await nodeRef.centerOnNode()
-
-    const node = await this.comfyPage.vueNodes.getFixtureByTitle(title)
-    const sizeBefore = await nodeRef.getSize()
-    await node.resizeFromCorner('SE', delta.x, delta.y)
-    await this.comfyPage.nextFrame()
-
-    const size = await nodeRef.getSize()
-    expect(size.width, 'resize drag widened the node').toBeGreaterThan(
-      sizeBefore.width
-    )
-    expect(size.height, 'resize drag heightened the node').toBeGreaterThan(
-      sizeBefore.height
-    )
-
-    return { nodeRef, node, size }
   }
 
   async convertDefaultKSamplerToSubgraph(): Promise<NodeReference> {

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -359,12 +359,8 @@ export class SubgraphHelper {
     widgetName: string
   ): Promise<void> {
     const widget = nodeLocator.getByLabel(widgetName, { exact: true })
-    // A promoted widget's own display is disabled/readonly (its value comes
-    // from the subgraph input link), so the right-click must bypass
-    // Playwright's actionability check for disabled elements. The app still
-    // opens a context menu for a real right-click on these.
     await this.comfyPage.contextMenu
-      .openFor(widget, { force: true })
+      .openForDisabledElement(widget)
       .then((m) => m.clickMenuItemExact(`Un-Promote Widget: ${widgetName}`))
   }
 

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -3,17 +3,16 @@ import {
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
 
-/**
- * FE-853: a subgraph node the user has manually resized snaps back to its
- * computed minimum size as soon as the widget-editing UI is triggered — either
- * by the "Edit Subgraph Widgets" selection-toolbox button or by promoting a
- * widget from inside the subgraph — discarding the size the user set.
- *
- * https://linear.app/comfyorg/issue/FE-853
- */
 test.describe(
   'Subgraph node size across widget editing',
-  { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
+  {
+    tag: ['@subgraph', '@node', '@widget', '@vue-nodes'],
+    annotation: {
+      type: 'issue',
+      description:
+        'FE-853: widget editing collapsed a user-resized subgraph node to its minimum size'
+    }
+  },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -51,6 +51,14 @@ test.describe(
       )
       await comfyPage.subgraph.exitViaBreadcrumb()
 
+      // Guards against a vacuous pass: if promotion silently became a no-op,
+      // the size assertions below would hold without exercising the bug.
+      await expect
+        .poll(() =>
+          comfyPage.subgraph.getPromotedWidgetOrder(String(nodeRef.id))
+        )
+        .toContain('steps')
+
       const sizeAfter = await nodeRef.getSize()
       expect(sizeAfter.width).toBeCloseTo(size.width, 0)
       // A newly promoted widget can legitimately raise the minimum height, so

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -23,7 +23,7 @@ test.describe(
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, node, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )
@@ -39,7 +39,7 @@ test.describe(
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+      const { nodeRef, size } = await comfyPage.nodeOps.growNodeByDrag(
         'New Subgraph',
         { x: 250, y: 250 }
       )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,4 +1,3 @@
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
@@ -12,90 +11,51 @@ import {
  *
  * https://linear.app/comfyorg/issue/FE-853
  */
-
-const SUBGRAPH_TITLE = 'New Subgraph'
-const RESIZE_DELTA = { x: 250, y: 250 }
-/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
-const INTERIOR_KSAMPLER_ID = '1'
-
-/**
- * Loads the subgraph fixture and grows the subgraph node by dragging its
- * bottom-right handle, the way a user would.
- *
- * Sizes are read from the graph model rather than from DOM bounding boxes so
- * that the assertions stay independent of canvas zoom and of the canvas
- * shrinking when the right side panel opens.
- */
-async function loadResizedSubgraph(comfyPage: ComfyPage) {
-  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
-
-  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
-  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
-
-  // The fixture is saved with a pan that leaves the node low in the viewport,
-  // so a downward resize drag would run off screen.
-  await nodeRef.centerOnNode()
-
-  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
-  const sizeBefore = await nodeRef.getSize()
-  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
-  await comfyPage.nextFrame()
-
-  const resizedSize = await nodeRef.getSize()
-  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
-    sizeBefore.width
-  )
-  expect(
-    resizedSize.height,
-    'manual resize heightened the node'
-  ).toBeGreaterThan(sizeBefore.height)
-
-  return { nodeRef, node, resizedSize }
-}
-
 test.describe(
   'Subgraph node size across widget editing',
   { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
     })
 
     test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
       comfyPage
     }) => {
-      const { nodeRef, node, resizedSize } =
-        await loadResizedSubgraph(comfyPage)
+      const { nodeRef, node, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
-      await node.select()
-      await comfyPage.selectionToolbox
-        .getByRole('button', { name: 'Edit Subgraph Widgets' })
-        .click()
-      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.subgraph.editor.openFromSelectionToolbox(node.root)
       await comfyPage.nextFrame()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
-      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
+      expect(sizeAfter.height).toBeCloseTo(size.height, 0)
     })
 
     test('retains a manual resize when an interior widget is promoted', async ({
       comfyPage
     }) => {
-      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+      const { nodeRef, size } = await comfyPage.subgraph.growNodeByDrag(
+        'New Subgraph',
+        { x: 250, y: 250 }
+      )
 
       await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
       await comfyPage.subgraph.promoteWidget(
-        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        comfyPage.vueNodes.getNodeByTitle('KSampler'),
         'steps'
       )
       await comfyPage.subgraph.exitViaBreadcrumb()
 
-      const size = await nodeRef.getSize()
-      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      const sizeAfter = await nodeRef.getSize()
+      expect(sizeAfter.width).toBeCloseTo(size.width, 0)
       // A newly promoted widget can legitimately raise the minimum height, so
       // only a shrink below the user's size is a regression.
-      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+      expect(sizeAfter.height).toBeGreaterThanOrEqual(size.height)
     })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphEditWidgetsResize.spec.ts
@@ -1,0 +1,101 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+/**
+ * FE-853: a subgraph node the user has manually resized snaps back to its
+ * computed minimum size as soon as the widget-editing UI is triggered — either
+ * by the "Edit Subgraph Widgets" selection-toolbox button or by promoting a
+ * widget from inside the subgraph — discarding the size the user set.
+ *
+ * https://linear.app/comfyorg/issue/FE-853
+ */
+
+const SUBGRAPH_TITLE = 'New Subgraph'
+const RESIZE_DELTA = { x: 250, y: 250 }
+/** KSampler inside the `basic-subgraph` fixture's subgraph definition. */
+const INTERIOR_KSAMPLER_ID = '1'
+
+/**
+ * Loads the subgraph fixture and grows the subgraph node by dragging its
+ * bottom-right handle, the way a user would.
+ *
+ * Sizes are read from the graph model rather than from DOM bounding boxes so
+ * that the assertions stay independent of canvas zoom and of the canvas
+ * shrinking when the right side panel opens.
+ */
+async function loadResizedSubgraph(comfyPage: ComfyPage) {
+  await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+  const [nodeRef] = await comfyPage.nodeOps.getNodeRefsByTitle(SUBGRAPH_TITLE)
+  expect(nodeRef, `${SUBGRAPH_TITLE} node is on the canvas`).toBeDefined()
+
+  // The fixture is saved with a pan that leaves the node low in the viewport,
+  // so a downward resize drag would run off screen.
+  await nodeRef.centerOnNode()
+
+  const node = await comfyPage.vueNodes.getFixtureByTitle(SUBGRAPH_TITLE)
+  const sizeBefore = await nodeRef.getSize()
+  await node.resizeFromCorner('SE', RESIZE_DELTA.x, RESIZE_DELTA.y)
+  await comfyPage.nextFrame()
+
+  const resizedSize = await nodeRef.getSize()
+  expect(resizedSize.width, 'manual resize widened the node').toBeGreaterThan(
+    sizeBefore.width
+  )
+  expect(
+    resizedSize.height,
+    'manual resize heightened the node'
+  ).toBeGreaterThan(sizeBefore.height)
+
+  return { nodeRef, node, resizedSize }
+}
+
+test.describe(
+  'Subgraph node size across widget editing',
+  { tag: ['@subgraph', '@node', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
+    })
+
+    test('retains a manual resize when Edit Subgraph Widgets is clicked', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, node, resizedSize } =
+        await loadResizedSubgraph(comfyPage)
+
+      await node.select()
+      await comfyPage.selectionToolbox
+        .getByRole('button', { name: 'Edit Subgraph Widgets' })
+        .click()
+      await expect(comfyPage.subgraph.editor.root).toBeVisible()
+      await comfyPage.nextFrame()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      expect(size.height).toBeCloseTo(resizedSize.height, 0)
+    })
+
+    test('retains a manual resize when an interior widget is promoted', async ({
+      comfyPage
+    }) => {
+      const { nodeRef, resizedSize } = await loadResizedSubgraph(comfyPage)
+
+      await comfyPage.vueNodes.enterSubgraph(String(nodeRef.id))
+      await comfyPage.subgraph.promoteWidget(
+        comfyPage.vueNodes.getNodeLocator(INTERIOR_KSAMPLER_ID),
+        'steps'
+      )
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const size = await nodeRef.getSize()
+      expect(size.width).toBeCloseTo(resizedSize.width, 0)
+      // A newly promoted widget can legitimately raise the minimum height, so
+      // only a shrink below the user's size is a regression.
+      expect(size.height).toBeGreaterThanOrEqual(resizedSize.height)
+    })
+  }
+)

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -13,16 +13,31 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 /**
  * These fixture workflows carry a saved pan/zoom that was not authored
  * against the default 1280x720 Playwright viewport, so nodes can load
- * partially below the fold. Fitting the view keeps resize handles and the
- * subgraph-enter footer button on-screen for subsequent screen-space clicks
- * and drags.
+ * partially below the fold. Panning the nodes into view keeps resize
+ * handles and the subgraph-enter footer button on-screen for subsequent
+ * screen-space clicks and drags.
+ *
+ * This deliberately pans rather than using the app's zoom-to-fit command:
+ * these tests compute drag targets and pixel-space size deltas directly
+ * from node.pos/node.size, which only line up with on-screen pixels when
+ * the canvas scale is 1. Panning leaves scale untouched, so it also avoids
+ * the 'Top' menu bar's workflow tab strip, which renders above the canvas
+ * and would intercept a click at a fixed coordinate.
  */
 async function fitViewToNodes(comfyPage: ComfyPage): Promise<void> {
-  // Focus rather than click: the 'Top' menu bar's workflow tab strip
-  // renders above the canvas and clicking a fixed coordinate can hit it
-  // instead of the canvas underneath.
-  await comfyPage.canvas.focus()
-  await comfyPage.keyboard.press('Period')
+  await comfyPage.page.evaluate(() => {
+    const canvas = window.app!.canvas
+    const nodes = canvas.graph?.nodes ?? []
+    if (nodes.length === 0) return
+
+    const margin = 100
+    const left = Math.min(...nodes.map((node) => node.pos[0]))
+    const top = Math.min(...nodes.map((node) => node.pos[1]))
+
+    canvas.ds.scale = 1
+    canvas.ds.offset = [margin - left, margin - top]
+    canvas.setDirty(true, true)
+  })
   await comfyPage.nextFrame()
 }
 

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -18,7 +18,10 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
  * and drags.
  */
 async function fitViewToNodes(comfyPage: ComfyPage): Promise<void> {
-  await comfyPage.canvas.click({ position: { x: 10, y: 10 } })
+  // Focus rather than click: the 'Top' menu bar's workflow tab strip
+  // renders above the canvas and clicking a fixed coordinate can hit it
+  // instead of the canvas underneath.
+  await comfyPage.canvas.focus()
   await comfyPage.keyboard.press('Period')
   await comfyPage.nextFrame()
 }

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 /**
@@ -8,6 +9,20 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
  * collapse the node back to its computed minimum size, discarding whatever
  * size the user had explicitly set.
  */
+
+/**
+ * These fixture workflows carry a saved pan/zoom that was not authored
+ * against the default 1280x720 Playwright viewport, so nodes can load
+ * partially below the fold. Fitting the view keeps resize handles and the
+ * subgraph-enter footer button on-screen for subsequent screen-space clicks
+ * and drags.
+ */
+async function fitViewToNodes(comfyPage: ComfyPage): Promise<void> {
+  await comfyPage.canvas.click({ position: { x: 10, y: 10 } })
+  await comfyPage.keyboard.press('Period')
+  await comfyPage.nextFrame()
+}
+
 test.describe(
   'Subgraph node resize preservation',
   { tag: ['@subgraph', '@widget', '@vue-nodes'] },
@@ -20,6 +35,7 @@ test.describe(
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await fitViewToNodes(comfyPage)
 
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
@@ -41,6 +57,7 @@ test.describe(
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await fitViewToNodes(comfyPage)
 
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
@@ -66,6 +83,7 @@ test.describe(
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await fitViewToNodes(comfyPage)
 
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
@@ -85,6 +103,7 @@ test.describe(
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await fitViewToNodes(comfyPage)
 
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
@@ -119,6 +138,7 @@ test.describe(
       comfyPage
     }) => {
       await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+      await fitViewToNodes(comfyPage)
 
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
@@ -151,6 +171,7 @@ test.describe(
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-nested-promotion'
       )
+      await fitViewToNodes(comfyPage)
 
       const [outerHost] = await comfyPage.nodeOps.getNodeRefsByTitle('Sub 0')
       expect(outerHost).toBeDefined()

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -196,7 +196,12 @@ test.describe(
 
       const nodePos = await outerHost.getPosition()
       const nodeSize = await outerHost.getSize()
-      await comfyPage.nodeOps.resizeNode(nodePos, nodeSize, 2.5, 2.5)
+      // Keep the ratio modest: resizeNode scales the existing size (not an
+      // additive delta), and a larger ratio would push the resized node's
+      // bottom edge — and the subgraph-enter footer button below it — off
+      // the bottom of the viewport, since the top-left corner stays fixed
+      // during a resize-from-corner drag.
+      await comfyPage.nodeOps.resizeNode(nodePos, nodeSize, 1.4, 1.4)
       const resizedSize = await outerHost.getSize()
       expect(resizedSize.width).toBeGreaterThan(nodeSize.width)
       expect(resizedSize.height).toBeGreaterThan(nodeSize.height)

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -201,18 +201,16 @@ test.describe(
       expect(resizedSize.width).toBeGreaterThan(nodeSize.width)
       expect(resizedSize.height).toBeGreaterThan(nodeSize.height)
 
-      await outerHost.click('title')
-      await comfyPage.actionbar.propertiesButton.click()
-      const editorToggle = comfyPage.page.getByTestId('subgraph-editor-toggle')
-      if (await editorToggle.isVisible()) await editorToggle.click()
-
-      const shownSection = comfyPage.page.getByTestId(
-        'subgraph-editor-shown-section'
-      )
-      await expect(shownSection).toBeVisible()
-      const toggleButtons = shownSection.getByTestId('subgraph-widget-toggle')
-      await expect(toggleButtons.first()).toBeVisible()
-      await toggleButtons.first().click()
+      // Node 6 ('Sub 1' instance) exposes a 'value_1' widget that is itself a
+      // promotion chain three subgraphs deep (Inner 3 -> Sub 2 -> Sub 1),
+      // which Sub 0 re-promotes onto `outerHost`. The per-row toggle in the
+      // properties panel is disabled for widgets promoted this way, so
+      // demoting has to go through the same context-menu action a user would
+      // use: entering the host and un-promoting from the widget's own node.
+      await comfyPage.vueNodes.enterSubgraph(String(outerHost.id))
+      const sub1Instance = comfyPage.vueNodes.getNodeLocator('6')
+      await comfyPage.subgraph.unpromoteWidget(sub1Instance, 'value_1')
+      await comfyPage.subgraph.exitViaBreadcrumb()
 
       await expect
         .poll(async () => (await outerHost.getSize()).width)

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -24,6 +24,7 @@ test.describe(
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
       await subgraphNode.resizeFromCorner('SE', 250, 200)
+      await comfyPage.nextFrame()
       const resizedBox = (await subgraphNode.boundingBox())!
 
       const ksampler = comfyPage.vueNodes.getNodeLocator('1')
@@ -49,6 +50,7 @@ test.describe(
       await comfyPage.subgraph.exitViaBreadcrumb()
 
       await subgraphNode.resizeFromCorner('SE', 250, 200)
+      await comfyPage.nextFrame()
       const resizedBox = (await subgraphNode.boundingBox())!
 
       await comfyPage.vueNodes.enterSubgraph('2')
@@ -87,6 +89,7 @@ test.describe(
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
       await subgraphNode.resizeFromCorner('SE', 300, 250)
+      await comfyPage.nextFrame()
       const resizedBox = (await subgraphNode.boundingBox())!
       const ksampler = comfyPage.vueNodes.getNodeLocator('1')
 
@@ -136,8 +139,12 @@ test.describe(
 
 test.describe(
   'Subgraph node resize preservation — nested subgraphs',
-  { tag: ['@subgraph', '@widget'] },
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
   () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    })
+
     test('Demoting a nested promotion does not shrink a user-resized outer host', async ({
       comfyPage
     }) => {

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -1,0 +1,178 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+/**
+ * Regression coverage for FE-853: promoting/demoting a widget on a subgraph
+ * node — or merely opening the right-side properties panel for one — used to
+ * collapse the node back to its computed minimum size, discarding whatever
+ * size the user had explicitly set.
+ */
+test.describe(
+  'Subgraph node resize preservation',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    })
+
+    test('Promoting a widget preserves a user-resized subgraph node', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+      const subgraphNode =
+        await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+      await subgraphNode.resizeFromCorner('SE', 250, 200)
+      const resizedBox = (await subgraphNode.boundingBox())!
+
+      const ksampler = comfyPage.vueNodes.getNodeLocator('1')
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.promoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const box = await subgraphNode.boundingBox()
+      expect(box?.width).toBeCloseTo(resizedBox.width, 0)
+      expect(box?.height).toBeGreaterThanOrEqual(resizedBox.height - 1)
+    })
+
+    test('Un-promoting a widget preserves a user-resized subgraph node', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+      const subgraphNode =
+        await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+      const ksampler = comfyPage.vueNodes.getNodeLocator('1')
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.promoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      await subgraphNode.resizeFromCorner('SE', 250, 200)
+      const resizedBox = (await subgraphNode.boundingBox())!
+
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.unpromoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const box = await subgraphNode.boundingBox()
+      expect(box?.width).toBeCloseTo(resizedBox.width, 0)
+      expect(box?.height).toBeCloseTo(resizedBox.height, 0)
+    })
+
+    test('Opening the properties panel does not shrink a user-resized subgraph node', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+      const subgraphNode =
+        await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+      await subgraphNode.resizeFromCorner('SE', 250, 200)
+      const resizedBox = (await subgraphNode.boundingBox())!
+
+      await subgraphNode.select()
+      await comfyPage.actionbar.propertiesButton.click()
+      await expect(comfyPage.menu.propertiesPanel.root).toBeVisible()
+
+      const box = await subgraphNode.boundingBox()
+      expect(box?.width).toBeCloseTo(resizedBox.width, 0)
+      expect(box?.height).toBeCloseTo(resizedBox.height, 0)
+    })
+
+    test('Promoting and demoting multiple widgets in sequence preserves the resized size', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+      const subgraphNode =
+        await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+      await subgraphNode.resizeFromCorner('SE', 300, 250)
+      const resizedBox = (await subgraphNode.boundingBox())!
+      const ksampler = comfyPage.vueNodes.getNodeLocator('1')
+
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.promoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.promoteWidget(ksampler, 'cfg')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      await expect
+        .poll(async () => (await subgraphNode.boundingBox())?.width)
+        .toBeCloseTo(resizedBox.width, 0)
+
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.unpromoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.unpromoteWidget(ksampler, 'cfg')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const box = await subgraphNode.boundingBox()
+      expect(box?.width).toBeCloseTo(resizedBox.width, 0)
+      expect(box?.height).toBeCloseTo(resizedBox.height, 0)
+    })
+
+    test('Manually resizing still works normally after a promotion', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+
+      const subgraphNode =
+        await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
+      const ksampler = comfyPage.vueNodes.getNodeLocator('1')
+      await comfyPage.vueNodes.enterSubgraph('2')
+      await comfyPage.subgraph.promoteWidget(ksampler, 'steps')
+      await comfyPage.subgraph.exitViaBreadcrumb()
+
+      const boxBeforeResize = (await subgraphNode.boundingBox())!
+      await subgraphNode.resizeFromCorner('SE', 200, 150)
+
+      const box = await subgraphNode.boundingBox()
+      expect(box?.width).toBeGreaterThan(boxBeforeResize.width)
+      expect(box?.height).toBeGreaterThan(boxBeforeResize.height)
+    })
+  }
+)
+
+test.describe(
+  'Subgraph node resize preservation — nested subgraphs',
+  { tag: ['@subgraph', '@widget'] },
+  () => {
+    test('Demoting a nested promotion does not shrink a user-resized outer host', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-nested-promotion'
+      )
+
+      const [outerHost] = await comfyPage.nodeOps.getNodeRefsByTitle('Sub 0')
+      expect(outerHost).toBeDefined()
+
+      const nodePos = await outerHost.getPosition()
+      const nodeSize = await outerHost.getSize()
+      await comfyPage.nodeOps.resizeNode(nodePos, nodeSize, 2.5, 2.5)
+      const resizedSize = await outerHost.getSize()
+      expect(resizedSize.width).toBeGreaterThan(nodeSize.width)
+      expect(resizedSize.height).toBeGreaterThan(nodeSize.height)
+
+      await outerHost.click('title')
+      await comfyPage.actionbar.propertiesButton.click()
+      const editorToggle = comfyPage.page.getByTestId('subgraph-editor-toggle')
+      if (await editorToggle.isVisible()) await editorToggle.click()
+
+      const shownSection = comfyPage.page.getByTestId(
+        'subgraph-editor-shown-section'
+      )
+      await expect(shownSection).toBeVisible()
+      const toggleButtons = shownSection.getByTestId('subgraph-widget-toggle')
+      await expect(toggleButtons.first()).toBeVisible()
+      await toggleButtons.first().click()
+
+      await expect
+        .poll(async () => (await outerHost.getSize()).width)
+        .toBeCloseTo(resizedSize.width, 0)
+      const finalSize = await outerHost.getSize()
+      expect(finalSize.height).toBeCloseTo(resizedSize.height, 0)
+    })
+  }
+)

--- a/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphResizePreservation.spec.ts
@@ -106,6 +106,7 @@ test.describe(
       const subgraphNode =
         await comfyPage.vueNodes.getFixtureByTitle('New Subgraph')
       await subgraphNode.resizeFromCorner('SE', 250, 200)
+      await comfyPage.nextFrame()
       const resizedBox = (await subgraphNode.boundingBox())!
 
       await subgraphNode.select()
@@ -167,6 +168,7 @@ test.describe(
 
       const boxBeforeResize = (await subgraphNode.boundingBox())!
       await subgraphNode.resizeFromCorner('SE', 200, 150)
+      await comfyPage.nextFrame()
 
       const box = await subgraphNode.boundingBox()
       expect(box?.width).toBeGreaterThan(boxBeforeResize.width)

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.test.ts
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.test.ts
@@ -268,6 +268,64 @@ describe('SubgraphEditor', () => {
     expect(host.inputs.filter((input) => input.widgetId)).toHaveLength(0)
   })
 
+  it('does not shrink a user-resized subgraph node merely by mounting the panel (FE-853)', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [640, 480] })
+    const sourceNode = new LGraphNode('SourceNode')
+    subgraph.add(sourceNode)
+    const sourceInput = sourceNode.addInput('first', 'STRING')
+    const sourceWidget = sourceNode.addWidget('text', 'first', '', () => {})
+    sourceInput.widget = { name: sourceWidget.name }
+    promoteValueWidgetViaSubgraphInput(host, sourceNode, sourceWidget)
+    useCanvasStore().selectedItems = [host]
+
+    render(SubgraphEditor, {
+      container: document.body.appendChild(document.createElement('div')),
+      global: {
+        plugins: [i18n],
+        stubs: {
+          DraggableList: {
+            template:
+              '<div data-testid="draggable-list"><slot drag-class="draggable-item" /></div>'
+          }
+        }
+      }
+    })
+
+    expect(Array.from(host.size)).toEqual([640, 480])
+  })
+
+  it('does not shrink a user-resized subgraph node when promoting from the hidden section', async () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [640, 480] })
+    const sourceNode = new LGraphNode('SourceNode')
+    subgraph.add(sourceNode)
+
+    const sourceInput = sourceNode.addInput('first', 'STRING')
+    const sourceWidget = sourceNode.addWidget('text', 'first', '', () => {})
+    sourceInput.widget = { name: sourceWidget.name }
+    useCanvasStore().selectedItems = [host]
+
+    render(SubgraphEditor, {
+      container: document.body.appendChild(document.createElement('div')),
+      global: {
+        plugins: [i18n],
+        stubs: {
+          DraggableList: {
+            template:
+              '<div data-testid="draggable-list"><slot drag-class="draggable-item" /></div>'
+          }
+        }
+      }
+    })
+
+    const hidden = screen.getByTestId('subgraph-editor-hidden-section')
+    await userEvent.click(within(hidden).getByTestId('subgraph-widget-toggle'))
+    await nextTick()
+
+    expect(Array.from(host.size)).toEqual([640, 480])
+  })
+
   it('removes the exposure when a preview row without a real source widget is demoted', async () => {
     const subgraph = createTestSubgraph()
     const host = createTestSubgraphNode(subgraph)

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -14,7 +14,7 @@ import {
   isRecommendedWidget,
   promoteWidget,
   pruneDisconnected,
-  refreshPromotedWidgetRendering as refreshPromotedWidgetRenderingForNodes,
+  refreshPromotedWidgetRendering,
   reorderSubgraphInputsByWidgetOrder
 } from '@/core/graph/subgraph/promotionUtils'
 import {
@@ -150,7 +150,7 @@ function updateActivePromotedRows(
       value.map((row) => ({ widgetId: row.widget.widgetId }))
     )
   }
-  refreshPromotedWidgetRendering()
+  refreshActiveNodeRendering()
 }
 
 const interiorWidgets = computed<WidgetItem[]>(() => {
@@ -228,11 +228,11 @@ const filteredActivePreviews = computed<PreviewRow[]>(() =>
   )
 )
 
-function refreshPromotedWidgetRendering() {
+function refreshActiveNodeRendering() {
   const node = activeNode.value
   if (!node) return
 
-  refreshPromotedWidgetRenderingForNodes([node])
+  refreshPromotedWidgetRendering([node])
 }
 
 function rowDisplayName(row: ActiveRow): string {
@@ -282,7 +282,7 @@ function demoteRow(row: ActiveRow) {
         sourceWidgetName: source.widgetName
       })
     }
-    refreshPromotedWidgetRendering()
+    refreshActiveNodeRendering()
     return
   }
   if (row.realWidget) {
@@ -294,7 +294,7 @@ function demoteRow(row: ActiveRow) {
     String(subgraphNode.id),
     row.exposure.name
   )
-  refreshPromotedWidgetRendering()
+  refreshActiveNodeRendering()
 }
 
 function promotePromotedRow(row: PromotedRow) {

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -14,6 +14,7 @@ import {
   isRecommendedWidget,
   promoteWidget,
   pruneDisconnected,
+  refreshPromotedWidgetRendering as refreshPromotedWidgetRenderingForNodes,
   reorderSubgraphInputsByWidgetOrder
 } from '@/core/graph/subgraph/promotionUtils'
 import {
@@ -231,9 +232,7 @@ function refreshPromotedWidgetRendering() {
   const node = activeNode.value
   if (!node) return
 
-  node.expandToFitContent()
-  node.setDirtyCanvas(true, true)
-  canvasStore.canvas?.setDirty(true, true)
+  refreshPromotedWidgetRenderingForNodes([node])
 }
 
 function rowDisplayName(row: ActiveRow): string {

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -231,7 +231,7 @@ function refreshPromotedWidgetRendering() {
   const node = activeNode.value
   if (!node) return
 
-  node.computeSize(node.size)
+  node.expandToFitContent()
   node.setDirtyCanvas(true, true)
   canvasStore.canvas?.setDirty(true, true)
 }

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -62,6 +62,7 @@ import {
   isPreviewPseudoWidget,
   promoteValueWidgetViaSubgraphInput,
   promoteRecommendedWidgets,
+  promoteWidget,
   pruneDisconnected,
   reorderSubgraphInputsByName,
   reorderSubgraphInputsByWidgetOrder
@@ -935,6 +936,128 @@ describe('demoteWidget — axiomatic projection retraction', () => {
     expect(isLinkedPromotion(outerHost, String(innerHost.id), 'text')).toBe(
       true
     )
+  })
+})
+
+describe('size preservation across promotion (FE-853)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.restoreAllMocks()
+  })
+
+  function setupInteriorWidget(
+    subgraph: ReturnType<typeof createTestSubgraph>,
+    name = 'value'
+  ) {
+    const interiorNode = new LGraphNode('TestNode')
+    subgraph.add(interiorNode)
+    const interiorInput = interiorNode.addInput(name, 'STRING')
+    const interiorWidget = interiorNode.addWidget(
+      'text',
+      name,
+      'initial',
+      () => {}
+    )
+    interiorInput.widget = { name: interiorWidget.name }
+    return { interiorNode, interiorWidget }
+  }
+
+  it('promoteWidget does not shrink a host larger than the computed minimum', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [600, 400] })
+    const { interiorNode, interiorWidget } = setupInteriorWidget(subgraph)
+
+    promoteWidget(interiorNode, interiorWidget, [host])
+
+    expect(Array.from(host.size)).toEqual([600, 400])
+  })
+
+  it('demoteWidget does not shrink a host larger than the computed minimum', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph)
+    const { interiorNode, interiorWidget } = setupInteriorWidget(subgraph)
+    expect(
+      promoteValueWidgetViaSubgraphInput(host, interiorNode, interiorWidget).ok
+    ).toBe(true)
+    host.size = [600, 400]
+
+    demoteWidget(interiorNode, interiorWidget, [host])
+
+    expect(Array.from(host.size)).toEqual([600, 400])
+  })
+
+  it('preserves a user-resized host across a promote-then-demote cycle', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [500, 350] })
+    const { interiorNode, interiorWidget } = setupInteriorWidget(subgraph)
+
+    promoteWidget(interiorNode, interiorWidget, [host])
+    expect(Array.from(host.size)).toEqual([500, 350])
+
+    demoteWidget(interiorNode, interiorWidget, [host])
+    expect(Array.from(host.size)).toEqual([500, 350])
+  })
+
+  it('preserves a user-resized host across promoting and demoting multiple widgets', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [700, 450] })
+    const first = setupInteriorWidget(subgraph, 'first')
+    const second = setupInteriorWidget(subgraph, 'second')
+    const third = setupInteriorWidget(subgraph, 'third')
+
+    promoteWidget(first.interiorNode, first.interiorWidget, [host])
+    promoteWidget(second.interiorNode, second.interiorWidget, [host])
+    promoteWidget(third.interiorNode, third.interiorWidget, [host])
+    expect(Array.from(host.size)).toEqual([700, 450])
+
+    demoteWidget(second.interiorNode, second.interiorWidget, [host])
+    expect(Array.from(host.size)).toEqual([700, 450])
+
+    demoteWidget(first.interiorNode, first.interiorWidget, [host])
+    demoteWidget(third.interiorNode, third.interiorWidget, [host])
+    expect(Array.from(host.size)).toEqual([700, 450])
+  })
+
+  it('preserves a user-resized outer host when promoting through a nested subgraph', () => {
+    const { host: innerHost } = buildDuplicateNamePromotion()
+    const outerSubgraph = createTestSubgraph()
+    const outerHost = createTestSubgraphNode(outerSubgraph, {
+      size: [800, 500]
+    })
+    outerSubgraph.add(innerHost)
+
+    for (const input of innerHost.inputs) {
+      promoteWidget(innerHost, promotedWidgetRef(innerHost, input.name), [
+        outerHost
+      ])
+    }
+
+    expect(Array.from(outerHost.size)).toEqual([800, 500])
+  })
+
+  it('pruneDisconnected (run on right-side-panel mount) does not shrink a user-resized host', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [640, 480] })
+    const { interiorNode, interiorWidget } = setupInteriorWidget(subgraph)
+    expect(
+      promoteValueWidgetViaSubgraphInput(host, interiorNode, interiorWidget).ok
+    ).toBe(true)
+
+    pruneDisconnected(host)
+
+    expect(Array.from(host.size)).toEqual([640, 480])
+  })
+
+  it('still grows a host smaller than the computed minimum to fit its widgets', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph, { size: [1, 1] })
+    const { interiorNode, interiorWidget } = setupInteriorWidget(subgraph)
+    const minimumSize = host.computeSize()
+
+    promoteWidget(interiorNode, interiorWidget, [host])
+
+    expect(host.size[0]).toBeGreaterThanOrEqual(minimumSize[0])
+    expect(host.size[1]).toBeGreaterThanOrEqual(minimumSize[1])
   })
 })
 

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -259,7 +259,7 @@ function toPromotionSource(
 
 function refreshPromotedWidgetRendering(parents: SubgraphNode[]): void {
   for (const parent of parents) {
-    parent.computeSize(parent.size)
+    parent.expandToFitContent()
     parent.setDirtyCanvas(true, true)
   }
   useCanvasStore().canvas?.setDirty(true, true)
@@ -626,7 +626,7 @@ export function promoteRecommendedWidgets(subgraphNode: SubgraphNode) {
       })
     }
   }
-  subgraphNode.computeSize(subgraphNode.size)
+  subgraphNode.expandToFitContent()
 }
 
 export function pruneDisconnected(subgraphNode: SubgraphNode) {

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -257,7 +257,7 @@ function toPromotionSource(
   }
 }
 
-function refreshPromotedWidgetRendering(parents: SubgraphNode[]): void {
+export function refreshPromotedWidgetRendering(parents: SubgraphNode[]): void {
   for (const parent of parents) {
     parent.expandToFitContent()
     parent.setDirtyCanvas(true, true)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Single unified PR for FE-853 — the fix plus full regression coverage, targeting `main`.

**Supersedes #14374, #14415 and #14418, all of which can be closed.** This branch contains the fix originally proposed in #14374 (authorship preserved) with the regression test from #14415 folded in, rebased onto current `main`.

- Fixes [FE-853](https://linear.app/comfyorg/issue/FE-853/bug-promotingunpromoting-a-widget-collapses-subgraph-to-minimum-size)

## The bug

Resize a subgraph node, then touch the widget-editing UI, and the node snaps back to its computed minimum size — silently discarding the size you set. Reported in #bug-dump via the "Edit Subgraph Widgets" button; FE-853 tracks the same collapse when promoting or un-promoting a widget.

Measured against `main` before the fix:

| Step | Node size |
| --- | --- |
| After the user's resize drag | **506 × 339** |
| After clicking "Edit Subgraph Widgets" | **225 × 58** |
| After promoting an interior widget | **225 × 58** |

## The fix

Three call sites refreshed a subgraph host node's rendering with `computeSize(node.size)`. `computeSize` returns the *minimum* size for the node's content and those calls assigned it back, so every refresh clamped the node down and destroyed any larger user-set size.

Replaced with `expandToFitContent()`, which grows the node when content requires more room but never shrinks it:

- `src/components/rightSidePanel/subgraph/SubgraphEditor.vue` — `refreshPromotedWidgetRendering()`, the path the "Edit Subgraph Widgets" button hits
- `src/core/graph/subgraph/promotionUtils.ts` — `refreshPromotedWidgetRendering()` (promote/demote) and `promoteRecommendedWidgets()`

## Regression coverage

**`subgraphEditWidgetsResize.spec.ts`** (2 tests) — approaches the bug from the user-reported entry point:
1. Clicking the "Edit Subgraph Widgets" selection-toolbox button, which is what the screen recording shows
2. Promoting an interior widget, the trigger in FE-853's title

**`subgraphResizePreservation.spec.ts`** (6 tests) — promote, un-promote, panel open, multi-widget sequences, resize-still-works-after-promotion, and a nested-subgraph host.

**Unit tests** (60) across `promotionUtils.test.ts` and `SubgraphEditor.test.ts`.

Sizes are read from the graph model rather than DOM bounding boxes, so assertions aren't confounded by canvas zoom or by the canvas shrinking when the side panel opens. The promotion test asserts `steps` actually reached the host node before checking size, so it can't pass vacuously if promotion silently became a no-op.

Supporting fixtures: `NodeOperationsHelper.growNodeByDrag()` (user-style resize drag returning model-space size, beside the existing canvas-based `resizeNode`) and `SubgraphEditor.openFromSelectionToolbox()` (toolbox-button path, complementing the context-menu `ensureOpen()`).

## Verification

The tests were confirmed to detect the regression rather than pass incidentally, by reverting the fix in place on this branch:

| `src` state | `subgraphEditWidgetsResize` |
| --- | --- |
| `expandToFitContent()` | **2 passed** |
| reverted to `computeSize(node.size)` | **2 failed** — `expected 506.0625, received 225` |

In the reverted run the failing assertion is the width check, not the promotion guard.

Against current `main` after rebase: **8 e2e passed**, **60 unit passed**, and `pnpm typecheck`, `pnpm typecheck:browser`, ESLint, oxlint, oxfmt `--check` and `pnpm knip` all clean.

## Review history carried over

- @DrJKL (#14415): `growNodeByDrag` belongs outside `SubgraphHelper` → it lives in `NodeOperationsHelper`; `SubgraphHelper` is unchanged apart from #14374's own edit.
- CodeRabbit (#14415): promotion test could pass vacuously → added the `getPromotedWidgetOrder()` guard. CodeRabbit approved #14415 and #14418.


## Screenshots

![Subgraph node manually resized to 506x339 with the selection toolbox above it](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785469931216-f5c374cd-1f31-4814-8af7-8b324f6ab95f.png)

![Pre-fix behavior: after clicking Edit Subgraph Widgets the node collapsed to 225x58](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6ee0bca4776459e64f1aa10734090b387b188cbfe277699718f93639efeb8ea7/pr-images/1785469931526-e2eea7f3-aa47-455e-b4b0-9f99066bd46d.png)