### PR TITLE
[backport core/1.47] fix(workspace): show ended state after immediate cancellation

### DIFF
--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -8,6 +8,7 @@ import { createI18n } from 'vue-i18n'
 import type { SubscriptionInfo } from '@/composables/billing/types'
 import enMessages from '@/locales/en/main.json'
 import type {
+  BillingStatus,
   CurrentTeamCreditStop,
   TeamCreditStops
 } from '@/platform/workspace/api/workspaceApi'
@@ -46,6 +47,7 @@ const teamCreditStops: TeamCreditStops = {
 }
 
 const mockSubscriptionStatus = ref<'active' | 'canceled'>('active')
+const mockBillingStatus = ref<BillingStatus>('paid')
 const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockHasSubscription = ref(true)
 const mockIsActiveSubscription = ref(true)
@@ -128,6 +130,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
+    billingStatus: mockBillingStatus,
     subscription: mockSubscription,
     teamCreditStops: mockTeamCreditStops,
     currentTeamCreditStop: mockCurrentTeamCreditStop,
@@ -265,6 +268,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSubscriptionStatus.value = 'active'
+    mockBillingStatus.value = 'paid'
     mockHasSubscription.value = true
     mockIsActiveSubscription.value = true
     mockIsInPersonalWorkspace.value = false
@@ -485,6 +489,39 @@ describe('SubscriptionPanelContentWorkspace', () => {
       'true'
     )
   })
+
+  it('shows the Free plan for an inactive personal subscription with terminal billing', () => {
+    mockIsInPersonalWorkspace.value = true
+    mockIsActiveSubscription.value = false
+    mockBillingStatus.value = 'inactive'
+    renderComponent()
+
+    expect(screen.getByRole('heading', { name: 'Free' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Subscribe' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Pro' })
+    ).not.toBeInTheDocument()
+  })
+
+  it.for(['paid', 'payment_failed', 'paused'] as BillingStatus[])(
+    'keeps a %s personal plan visible until it is terminal',
+    (billingStatus) => {
+      mockIsInPersonalWorkspace.value = true
+      mockIsActiveSubscription.value = false
+      mockBillingStatus.value = billingStatus
+      renderComponent()
+
+      expect(screen.getByRole('heading', { name: 'Pro' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('heading', { name: 'Free' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Subscribe' })
+      ).not.toBeInTheDocument()
+    }
+  )
 
   it('renders the Free plan header with Subscribe CTA for unsubscribed personal workspaces', async () => {
     const user = userEvent.setup()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -345,6 +345,7 @@ const {
   isActiveSubscription,
   isFreeTier: isFreeTierPlan,
   subscription,
+  billingStatus,
   isLoading,
   error,
   showSubscriptionDialog,
@@ -358,12 +359,25 @@ const { isResubscribing, handleResubscribe } = useResubscribe()
 const { displayPrice, priceUnitLabel } = useWorkspacePlanPricing()
 const { menuEntries } = useWorkspaceMenuItems()
 
+const isTerminalPersonalSubscription = computed(
+  () =>
+    isInPersonalWorkspace.value &&
+    !isActiveSubscription.value &&
+    billingStatus.value === 'inactive'
+)
+
 // Show subscribe prompt to owners without active subscription. A cancelled plan
 // stays active until its end date, so it keeps the subscribed treatment.
 const showSubscribePrompt = computed(() => {
   if (!permissions.value.canManageSubscription) return false
+  if (isTerminalPersonalSubscription.value) return true
   if (isTeamPlanCancelled.value) return false
-  if (isInPersonalWorkspace.value) return !isActiveSubscription.value
+  if (isInPersonalWorkspace.value) {
+    if (!isActiveSubscription.value && subscription.value?.isCancelled) {
+      return true
+    }
+    return !isActiveSubscription.value && !subscription.value
+  }
   return !isWorkspaceSubscribed.value
 })
 


### PR DESCRIPTION
Backport of #14438 to `core/1.47`.

## Summary

Backports the immediate-cancellation billing-state fix without importing newer subscription-panel UI changes from `main`.

## Changes

- **What**: Show Free/Subscribe for terminally inactive personal subscriptions while preserving the paid plan for `paid`, `payment_failed`, and `paused` states.
- **Dependencies**: None.

## Review Focus

The conflict resolution preserves the 1.47 `Pro` plan presentation and its existing cancelled/unsubscribed behavior.

## Validation

- `NODE_OPTIONS=--localstorage-file=/private/tmp/comfyui-backport-14438-localstorage.json ./node_modules/.bin/vitest run src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts` (26 passed)
- `./node_modules/.bin/vue-tsc --noEmit`
- Focused oxfmt and ESLint checks
- Commit hooks, including type-aware lint and typecheck
- Push hook (`knip --cache`)