### PR TITLE
feat: wire quoted subscription checkout

### DIFF
--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -15,6 +15,7 @@ import type {
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type {
   Member,
+  PreviewSubscribeResponse as WorkspacePreviewSubscribeResponse,
   WorkspaceWithRole
 } from '@/platform/workspace/api/workspaceApi'
 
@@ -40,6 +41,20 @@ import {
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
 const SELF_EMAIL = 'e2e@test.comfy.org'
+
+type ExactQuotePreviewResponse = PreviewSubscribeResponse &
+  Required<
+    Pick<
+      WorkspacePreviewSubscribeResponse,
+      | 'quote_id'
+      | 'quote_version'
+      | 'discounts'
+      | 'amount_due_cents'
+      | 'currency'
+      | 'renewal_amount_cents'
+      | 'renewal_at'
+    >
+  >
 
 // consolidated_billing_enabled routes personal workspaces to the unified
 // pricing table asserted here; without it they fall back to the legacy table.
@@ -191,6 +206,66 @@ const TEAM_SUBSCRIBED_RESPONSE = {
   status: 'subscribed',
   effective_at: '2026-07-21T00:00:00Z'
 } satisfies SubscribeResponse
+
+const TEAM_YEARLY_SUBSCRIPTION_QUOTE = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: '2026-07-21T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 63_000,
+  cost_next_period_cents: 63_000,
+  credits_today_cents: 1_772_400,
+  credits_next_period_cents: 1_772_400,
+  new_plan: {
+    slug: 'team_per_credit_annual',
+    tier: 'TEAM',
+    duration: 'ANNUAL',
+    price_cents: 63_000,
+    credits_cents: 1_772_400,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 63_000,
+      total_credits_cents: 1_772_400
+    }
+  },
+  quote_id: 'team-yearly-quote',
+  quote_version: 1,
+  discounts: [{ kind: 'plan', code: 'team_volume_10' }],
+  amount_due_cents: 63_000,
+  currency: 'usd',
+  renewal_amount_cents: 63_000,
+  renewal_at: '2027-07-21T00:00:00Z'
+} satisfies ExactQuotePreviewResponse
+
+const TEAM_MONTHLY_SUBSCRIPTION_QUOTE = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: '2026-07-21T00:00:00Z',
+  is_immediate: true,
+  cost_today_cents: 39_000,
+  cost_next_period_cents: 39_000,
+  credits_today_cents: 84_400,
+  credits_next_period_cents: 84_400,
+  new_plan: {
+    slug: 'team_per_credit_monthly',
+    tier: 'TEAM',
+    duration: 'MONTHLY',
+    price_cents: 39_000,
+    credits_cents: 84_400,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 39_000,
+      total_credits_cents: 84_400
+    }
+  },
+  quote_id: 'team-monthly-quote',
+  quote_version: 1,
+  discounts: [{ kind: 'plan', code: 'team_volume_5' }],
+  amount_due_cents: 39_000,
+  currency: 'usd',
+  renewal_amount_cents: 39_000,
+  renewal_at: '2026-08-21T00:00:00Z'
+} satisfies ExactQuotePreviewResponse
 
 const NEW_CREATOR_SUBSCRIPTION = {
   allowed: true,
@@ -617,6 +692,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     await page.route('**/api/billing/plans', (route) =>
       route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
     )
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(TEAM_YEARLY_SUBSCRIPTION_QUOTE))
+    )
     await page.route('**/api/billing/subscribe', (route) => {
       subscribeRequests.push(route.request())
       return route.fulfill(jsonRoute(TEAM_SUBSCRIBED_RESPONSE))
@@ -646,7 +724,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     expect(subscribeRequests[0].postDataJSON()).toMatchObject({
       plan_slug: 'team_per_credit_annual',
       team_credit_stop_id: 'team_700',
-      billing_cycle: 'yearly'
+      billing_cycle: 'yearly',
+      quote_id: TEAM_YEARLY_SUBSCRIPTION_QUOTE.quote_id,
+      quote_version: TEAM_YEARLY_SUBSCRIPTION_QUOTE.quote_version
     })
   })
 
@@ -663,6 +743,9 @@ test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
     ])
     await page.route('**/api/billing/plans', (route) =>
       route.fulfill(jsonRoute(TEAM_CATALOG_PLANS))
+    )
+    await page.route('**/api/billing/preview-subscribe', (route) =>
+      route.fulfill(jsonRoute(TEAM_MONTHLY_SUBSCRIPTION_QUOTE))
     )
 
     await page.goto(`${APP_URL}/?pricing=team&stop=team_400&cycle=monthly`)

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2934,6 +2934,17 @@
         "unavailable": "We can't confirm this reactivation right now — please choose your plan again"
       },
       "addPromoCode": "Add promo code",
+      "promoCodePlaceholder": "Promo code",
+      "applyPromoCode": "Apply",
+      "applyQuoteBeforeContinuing": "Apply the promo code to refresh your quote before continuing.",
+      "quoteStale": "Your quote changed. Review the updated amount and try again.",
+      "quoteRefreshFailed": "Your quote expired and couldn't be refreshed. Choose your plan again.",
+      "renewsAt": "Renews at {amount} on {date}. Cancel anytime.",
+      "discountComposition": "Discounts",
+      "discount": {
+        "plan": "Plan discount",
+        "promotion": "Promo code"
+      },
       "changePaymentMethod": "Change",
       "savedPaymentMethod": "Payment method",
       "addNewPaymentMethod": "Add new payment method",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -388,6 +388,65 @@ describe('workspaceApi', () => {
   })
 
   describe('subscription', () => {
+    it('listSavedPaymentMethods() returns masked methods from GET', async () => {
+      const data = [
+        {
+          type: 'card',
+          id: 'pm_saved',
+          brand: 'visa',
+          last4: '4242',
+          isDefault: true
+        }
+      ]
+      mockAxiosInstance.get.mockResolvedValue({ data })
+
+      const result = await workspaceApi.listSavedPaymentMethods()
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/billing/payment-methods',
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(data)
+    })
+
+    it('previewSubscribe() sends the promotion code only when applied', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { allowed: true } })
+
+      await workspaceApi.previewSubscribe('pro-monthly', {
+        promotionCode: 'SAVE20'
+      })
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/billing/preview-subscribe',
+        expect.objectContaining({ promotion_code: 'SAVE20' }),
+        { headers: AUTH_HEADER }
+      )
+    })
+
+    it('subscribe() echoes the quote and selected saved method', async () => {
+      mockAxiosInstance.post.mockResolvedValue({
+        data: { billing_op_id: 'op-quote', status: 'subscribed' }
+      })
+
+      await workspaceApi.subscribe('pro-monthly', {
+        promotionCode: 'SAVE20',
+        quoteId: 'quote_123',
+        quoteVersion: 2,
+        savedPaymentMethodId: 'pm_saved'
+      })
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/billing/subscribe',
+        expect.objectContaining({
+          promotion_code: 'SAVE20',
+          quote_id: 'quote_123',
+          quote_version: 2,
+          saved_payment_method_id: 'pm_saved'
+        }),
+        { headers: AUTH_HEADER }
+      )
+    })
+
     it('previewSubscribe() sends POST with plan_slug', async () => {
       const data = { allowed: true, transition_type: 'new_subscription' }
       mockAxiosInstance.post.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -156,6 +156,7 @@ interface PreviewSubscribeRequest {
   plan_slug: string
   team_credit_stop_id?: string
   billing_cycle?: SubscribeBillingCycle
+  promotion_code?: string
 }
 
 type SubscribeBillingCycle = 'monthly' | 'yearly'
@@ -165,6 +166,9 @@ interface SubscribeRequest {
   idempotency_key?: string
   confirmation_token?: string
   promotion_code?: string
+  quote_id?: string
+  quote_version?: number
+  saved_payment_method_id?: string
   return_url?: string
   cancel_url?: string
   /** Required for the per-credit Team plan; selects the slider stop. */
@@ -177,6 +181,9 @@ interface SubscribeRequest {
 export interface SubscribeOptions {
   confirmationToken?: string
   promotionCode?: string
+  quoteId?: string
+  quoteVersion?: number
+  savedPaymentMethodId?: string
   returnUrl?: string
   cancelUrl?: string
   teamCreditStopId?: string
@@ -187,6 +194,7 @@ export interface SubscribeOptions {
 export interface PreviewSubscribeOptions {
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
+  promotionCode?: string
 }
 
 type SubscribeStatus = 'subscribed' | 'needs_payment_method' | 'pending_payment'
@@ -248,6 +256,28 @@ export interface PreviewSubscribeResponse {
   credits_next_period_cents: number
   current_plan?: PreviewPlanInfo
   new_plan: PreviewPlanInfo
+  proration_at?: string
+  quote_id?: string
+  quote_version?: number
+  promotion_code?: string
+  discounts?: SubscriptionDiscount[]
+  amount_due_cents?: number
+  currency?: string
+  renewal_amount_cents?: number
+  renewal_at?: string
+}
+
+interface SubscriptionDiscount {
+  kind: 'plan' | 'promotion'
+  code: string
+}
+
+export interface SavedPaymentMethod {
+  type: 'card' | 'alipay'
+  brand?: string
+  last4?: string
+  id: string
+  isDefault: boolean
 }
 
 export type BillingSubscriptionStatus =
@@ -656,6 +686,19 @@ export const workspaceApi = {
     }
   },
 
+  async listSavedPaymentMethods(): Promise<SavedPaymentMethod[]> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.get<SavedPaymentMethod[]>(
+        api.apiURL('/billing/payment-methods'),
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
   /**
    * Preview subscription change
    * POST /api/billing/preview-subscribe
@@ -671,7 +714,8 @@ export const workspaceApi = {
         {
           plan_slug: planSlug,
           team_credit_stop_id: options.teamCreditStopId,
-          billing_cycle: options.billingCycle
+          billing_cycle: options.billingCycle,
+          promotion_code: options.promotionCode
         } satisfies PreviewSubscribeRequest,
         { headers }
       )
@@ -697,6 +741,9 @@ export const workspaceApi = {
           plan_slug: planSlug,
           confirmation_token: options.confirmationToken,
           promotion_code: options.promotionCode,
+          quote_id: options.quoteId,
+          quote_version: options.quoteVersion,
+          saved_payment_method_id: options.savedPaymentMethodId,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -22,6 +22,12 @@ function previewFixture(
     cost_next_period_cents: priceCents,
     credits_today_cents: 0,
     credits_next_period_cents: 0,
+    quote_id: 'quote_123',
+    quote_version: 1,
+    amount_due_cents: priceCents,
+    currency: 'usd',
+    renewal_amount_cents: priceCents,
+    renewal_at: '2027-06-19T00:00:00Z',
     new_plan: {
       slug: 'creator',
       tier: 'CREATOR',
@@ -73,7 +79,7 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     expect(screen.getByText('subscription.teamPlan.name')).toBeTruthy()
     expect(screen.getByText('$380')).toBeTruthy()
     expect(screen.getAllByText('84,400').length).toBeGreaterThan(0)
-    expect(screen.getByText('$380.00')).toBeTruthy()
+    expect(screen.queryByText('$380.00')).toBeNull()
   })
 
   it('shows the monthly-equivalent price and annual total for a yearly preview', () => {
@@ -102,7 +108,7 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     })
     expect(screen.getByText('$28')).toBeTruthy()
     expect(screen.getByText('subscription.billedYearly')).toBeTruthy()
-    expect(screen.getByText('$336.00')).toBeTruthy()
+    expect(screen.queryByText('$336.00')).toBeNull()
   })
 
   it('omits the billed-yearly note for a monthly subscription', () => {
@@ -135,18 +141,84 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
     })
     expect(screen.getByText('$380')).toBeTruthy()
     expect(screen.getByText('subscription.billedYearly')).toBeTruthy()
-    expect(screen.getByText('$4,560.00')).toBeTruthy()
+    expect(screen.queryByText('$4,560.00')).toBeNull()
   })
 
   it('emits addCreditCard from the team confirm CTA', async () => {
     const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
-      props: { teamPlan: { usd: 400, credits: 84_400, discountedUsd: 380 } },
+      props: {
+        teamPlan: { usd: 400, credits: 84_400, discountedUsd: 380 },
+        previewData: previewFixture('MONTHLY', 38_000),
+        quoteIsCurrent: true
+      },
       global: globalOptions
     })
     await userEvent.click(
       screen.getByText('subscription.preview.subscribeToPlan')
     )
     expect(emitted().addCreditCard).toBeTruthy()
+  })
+
+  it('invalidates while editing a promo and applies only on button click', async () => {
+    const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        previewData: previewFixture('MONTHLY', 3500),
+        quoteIsCurrent: true
+      },
+      global: globalOptions
+    })
+    const input = screen.getByPlaceholderText(
+      'subscription.preview.promoCodePlaceholder'
+    )
+
+    await userEvent.type(input, 'SAVE20')
+    expect(emitted().invalidateQuote).toBeTruthy()
+    expect(emitted().applyPromotionCode).toBeUndefined()
+
+    await userEvent.click(
+      screen.getByText('subscription.preview.applyPromoCode')
+    )
+    expect(emitted().applyPromotionCode?.at(-1)).toEqual(['SAVE20'])
+  })
+
+  it('offers Add new payment method from the saved-method picker', async () => {
+    const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        previewData: previewFixture('MONTHLY', 3500),
+        quoteIsCurrent: true,
+        selectedSavedMethodId: 'pm_default',
+        savedMethods: [
+          {
+            type: 'card',
+            id: 'pm_default',
+            brand: 'visa',
+            last4: '4242',
+            isDefault: true
+          },
+          { type: 'alipay', id: 'pm_alipay', isDefault: false }
+        ]
+      },
+      global: {
+        ...globalOptions,
+        stubs: {
+          ...globalOptions.stubs,
+          SingleSelect: {
+            props: ['options'],
+            emits: ['update:modelValue'],
+            template:
+              '<button v-for="option in options" @click="$emit(\'update:modelValue\', option.value)">{{ option.name }}</button>'
+          }
+        }
+      }
+    })
+
+    await userEvent.click(
+      screen.getByText('subscription.preview.addNewPaymentMethod')
+    )
+    expect(emitted()['update:selectedSavedMethodId']).toEqual([[null]])
+    expect(emitted().changePaymentMethod).toBeTruthy()
   })
 
   it('opens verification only from its button without exposing the URL', async () => {

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -113,16 +113,43 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            ${{ totalDueToday }}
+            {{ totalDueToday }}
           </span>
         </div>
         <span class="text-sm text-muted-foreground">
-          {{
-            $t('subscription.preview.nextPaymentDue', {
-              date: nextPaymentDate
-            })
-          }}
+          {{ renewalTerms }}
         </span>
+      </div>
+      <div
+        v-if="previewData?.discounts?.length"
+        class="flex flex-col gap-2 pt-4 text-sm"
+      >
+        <div
+          v-for="discount in previewData.discounts"
+          :key="`${discount.kind}:${discount.code}`"
+          class="flex items-center justify-between text-muted-foreground"
+        >
+          <span>{{
+            $t(`subscription.preview.discount.${discount.kind}`)
+          }}</span>
+          <span class="text-base-foreground">{{ discount.code }}</span>
+        </div>
+      </div>
+      <div class="flex gap-2 pt-6">
+        <input
+          v-model="promotionCode"
+          class="h-10 min-w-0 flex-1 rounded-lg border border-interface-stroke bg-secondary-background px-3 text-base-foreground"
+          :placeholder="$t('subscription.preview.promoCodePlaceholder')"
+          @input="$emit('invalidateQuote')"
+        />
+        <Button
+          variant="secondary"
+          size="lg"
+          :disabled="isLoading"
+          @click="$emit('applyPromotionCode', promotionCode)"
+        >
+          {{ $t('subscription.preview.applyPromoCode') }}
+        </Button>
       </div>
       <!-- Saved method: no capture column; a card row with a change
            affordance stands in for the form. -->
@@ -138,11 +165,9 @@
             :class="
               cn(
                 'size-4 shrink-0',
-                savedMethods[0].type === 'bank'
-                  ? 'icon-[lucide--landmark]'
-                  : savedMethods[0].type === 'alipay'
-                    ? 'icon-[lucide--wallet]'
-                    : 'icon-[lucide--credit-card]'
+                savedMethods[0].type === 'alipay'
+                  ? 'icon-[lucide--wallet]'
+                  : 'icon-[lucide--credit-card]'
               )
             "
           />
@@ -195,8 +220,10 @@
       <UnifiedStripePaymentSelector
         v-if="captureMode"
         :amount-cents="amountDueCents"
+        :currency="previewData?.currency ?? ''"
         :is-loading
         :verification-pending="Boolean(actionUrl)"
+        :can-submit="quoteIsCurrent"
         @confirm="confirmPayment"
       />
 
@@ -206,6 +233,7 @@
         size="lg"
         class="w-full rounded-lg"
         :loading="isLoading"
+        :disabled="!quoteIsCurrent"
         @click="$emit('addCreditCard')"
       >
         {{ $t('subscription.preview.payAndSubscribe') }}
@@ -217,6 +245,7 @@
         size="lg"
         class="w-full rounded-lg"
         :loading="isLoading"
+        :disabled="!quoteIsCurrent"
         @click="$emit('addCreditCard')"
       >
         {{ $t('subscription.preview.subscribeToPlan', { plan: tierName }) }}
@@ -242,17 +271,14 @@ import {
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isYearlyCheckout } from '@/platform/cloud/subscription/utils/planDuration'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
-import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import type {
+  PreviewSubscribeResponse,
+  SavedPaymentMethod
+} from '@/platform/workspace/api/workspaceApi'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import SubscriptionTermsNote from './SubscriptionTermsNote.vue'
 import UnifiedStripePaymentSelector from './UnifiedStripePaymentSelector.vue'
-
-export interface SavedPaymentMethod {
-  type: 'card' | 'alipay' | 'bank'
-  brand?: string
-  last4?: string
-}
 
 interface Props {
   /** Personal-tier checkout. Required unless `teamPlan` is set. */
@@ -267,10 +293,11 @@ interface Props {
   /** Saved payment methods; when present the capture form is skipped and the
    *  confirm renders as a narrow summary. One method shows a Change
    *  affordance; two or more become a picker whose last option adds a new
-   *  method. Display varies by type: cards and banks carry brand + last4,
-   *  Alipay is a linked account with neither. The backend does not supply
-   *  this yet. */
+   *  method. Cards carry brand + last4; Alipay is a linked account with
+   *  neither. */
   savedMethods?: SavedPaymentMethod[] | null
+  selectedSavedMethodId?: string | null
+  quoteIsCurrent?: boolean
 }
 
 const {
@@ -281,7 +308,9 @@ const {
   teamPlan = null,
   actionUrl = null,
   usePaymentElement = false,
-  savedMethods = null
+  savedMethods = null,
+  selectedSavedMethodId = null,
+  quoteIsCurrent = false
 } = defineProps<Props>()
 
 const emit = defineEmits<{
@@ -289,6 +318,9 @@ const emit = defineEmits<{
   confirmPayment: [confirmationToken: string]
   back: []
   changePaymentMethod: []
+  'update:selectedSavedMethodId': [id: string | null]
+  applyPromotionCode: [code: string]
+  invalidateQuote: []
 }>()
 
 const { t, n } = useI18n()
@@ -303,21 +335,34 @@ function methodLabel(m: SavedPaymentMethod) {
 }
 
 const savedMethodOptions = computed(() => [
-  ...(savedMethods ?? []).map((m, i) => ({
+  ...(savedMethods ?? []).map((m) => ({
     name: methodLabel(m),
-    value: String(i)
+    value: m.id
   })),
   {
     name: t('subscription.preview.addNewPaymentMethod'),
     value: 'add-new'
   }
 ])
-const selectedMethod = ref('0')
-watch(selectedMethod, (value) => {
-  if (value !== 'add-new') return
-  selectedMethod.value = '0'
-  emit('changePaymentMethod')
+const selectedMethod = computed({
+  get: () => selectedSavedMethodId ?? '',
+  set: (value: string) => {
+    if (value === 'add-new') {
+      emit('update:selectedSavedMethodId', null)
+      emit('changePaymentMethod')
+      return
+    }
+    emit('update:selectedSavedMethodId', value)
+  }
 })
+
+const promotionCode = ref(previewData?.promotion_code ?? '')
+watch(
+  () => previewData?.promotion_code,
+  (code) => {
+    promotionCode.value = code ?? ''
+  }
+)
 
 function openVerification() {
   if (!actionUrl) return
@@ -370,45 +415,40 @@ const creditsRefillLabelKey = computed(() =>
 )
 
 const totalDueTodayUsd = computed(() => {
-  if (teamPlan) {
-    return isYearly.value ? teamPlan.discountedUsd * 12 : teamPlan.discountedUsd
-  }
-  if (previewData) return previewData.cost_today_cents / 100
-  if (!tierKey) return 0
-  const priceValue = getTierPrice(tierKey, isYearly.value)
-  return isYearly.value ? priceValue * 12 : priceValue
+  return (previewData?.amount_due_cents ?? 0) / 100
 })
 
+function formatQuoteMoney(cents: number): string {
+  if (!previewData?.currency) return ''
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: previewData.currency.toUpperCase()
+  }).format(cents / 100)
+}
+
 const totalDueToday = computed(() =>
-  totalDueTodayUsd.value.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  })
+  previewData?.amount_due_cents === undefined
+    ? ''
+    : formatQuoteMoney(previewData.amount_due_cents)
 )
 
 const amountDueCents = computed(() => Math.round(totalDueTodayUsd.value * 100))
 
-const nextPaymentDate = computed(() => {
-  if (previewData?.new_plan?.period_end) {
-    return new Date(previewData.new_plan.period_end).toLocaleDateString(
-      'en-US',
-      {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric'
-      }
-    )
+const renewalTerms = computed(() => {
+  if (
+    previewData?.renewal_amount_cents === undefined ||
+    !previewData.renewal_at
+  ) {
+    return ''
   }
-  const date = new Date()
-  if (billingCycle === 'yearly') {
-    date.setFullYear(date.getFullYear() + 1)
-  } else {
-    date.setMonth(date.getMonth() + 1)
-  }
-  return date.toLocaleDateString('en-US', {
+  const date = new Date(previewData.renewal_at).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric'
+  })
+  return t('subscription.preview.renewsAt', {
+    amount: formatQuoteMoney(previewData.renewal_amount_cents),
+    date
   })
 })
 </script>

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.test.ts
@@ -18,6 +18,9 @@ vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
     isSubscribing: ref(false),
     isResubscribing: ref(false),
     previewData: ref(null),
+    quoteIsCurrent: ref(false),
+    savedPaymentMethods: ref([]),
+    selectedSavedPaymentMethodId: ref(null),
     selectedTierKey: ref(null),
     selectedTeamStop: ref(null),
     selectedBillingCycle: ref('yearly'),
@@ -32,6 +35,10 @@ vi.mock('@/platform/workspace/composables/useSubscriptionCheckout', () => ({
     handleAddCreditCard: vi.fn(),
     handleConfirmTransition: vi.fn(),
     handleTeamSubscribe: vi.fn(),
+    handleSubscriptionPayment: vi.fn(),
+    handleTeamSubscriptionPayment: vi.fn(),
+    applyPromotionCode: vi.fn(),
+    invalidateQuote: vi.fn(),
     handleResubscribe: vi.fn()
   })
 }))

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -100,7 +100,10 @@
         :team-plan="selectedTeamStop!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :quote-is-current="quoteIsCurrent"
         @confirm="handleTeamSubscribe"
+        @apply-promotion-code="applyPromotionCode"
+        @invalidate-quote="invalidateQuote"
         @back="handleBackToPricing"
       />
 
@@ -112,9 +115,14 @@
         :action-url="activeCheckoutActionUrl"
         :use-payment-element="stripePaymentElementEnabled"
         :saved-methods="savedMethodsForConfirm"
+        :selected-saved-method-id="selectedSavedPaymentMethodId"
+        :quote-is-current="quoteIsCurrent"
+        @update:selected-saved-method-id="selectSavedPaymentMethod"
         @add-credit-card="handleTeamSubscribe"
-        @change-payment-method="savedMethodsForConfirm = null"
+        @change-payment-method="selectSavedPaymentMethod(null)"
         @confirm-payment="handleTeamSubscriptionPayment"
+        @apply-promotion-code="applyPromotionCode"
+        @invalidate-quote="invalidateQuote"
         @back="handleBackToPricing"
       />
 
@@ -127,9 +135,14 @@
         :action-url="activeCheckoutActionUrl"
         :use-payment-element="stripePaymentElementEnabled"
         :saved-methods="savedMethodsForConfirm"
+        :selected-saved-method-id="selectedSavedPaymentMethodId"
+        :quote-is-current="quoteIsCurrent"
+        @update:selected-saved-method-id="selectSavedPaymentMethod"
         @add-credit-card="handleAddCreditCard"
-        @change-payment-method="savedMethodsForConfirm = null"
+        @change-payment-method="selectSavedPaymentMethod(null)"
         @confirm-payment="handleSubscriptionPayment"
+        @apply-promotion-code="applyPromotionCode"
+        @invalidate-quote="invalidateQuote"
         @back="handleBackToPricing"
       />
 
@@ -138,7 +151,10 @@
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :quote-is-current="quoteIsCurrent"
         @confirm="handleConfirmTransition"
+        @apply-promotion-code="applyPromotionCode"
+        @invalidate-quote="invalidateQuote"
         @back="handleBackToPricing"
       />
     </template>
@@ -167,7 +183,6 @@ import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composa
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
-import type { SavedPaymentMethod } from './SubscriptionAddPaymentPreviewWorkspace.vue'
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
@@ -190,16 +205,16 @@ const stripePaymentElementEnabled = Boolean(
 // The embedded-payment confirm step keeps the pricing table's dialog
 // dimensions so stepping between them reads as one dialog changing content,
 // not two dialogs. Transition previews (no payment form) stay narrow.
-// Default payment method for the confirming workspace. The backend does not
-// expose this pre-confirm yet; once it does, populate from the preview
-// response and the capture form becomes first-subscribe-only.
-const savedMethodsForConfirm = ref<SavedPaymentMethod[] | null>(null)
+const collectingNewPaymentMethod = ref(false)
+const savedMethodsForConfirm = computed(() =>
+  collectingNewPaymentMethod.value ? [] : savedPaymentMethods.value
+)
 
 const isEmbeddedPaymentStep = computed(
   () =>
     checkoutStep.value === 'preview' &&
     stripePaymentElementEnabled &&
-    !savedMethodsForConfirm.value?.length &&
+    !savedMethodsForConfirm.value.length &&
     (previewVariant.value === 'team-new' ||
       previewVariant.value === 'personal-new')
 )
@@ -213,7 +228,7 @@ const isEmbeddedConfirmStep = computed(
     stripePaymentElementEnabled &&
     (previewVariant.value === 'team-change' ||
       previewVariant.value === 'personal-change' ||
-      (!!savedMethodsForConfirm.value?.length &&
+      (savedMethodsForConfirm.value.length > 0 &&
         (previewVariant.value === 'team-new' ||
           previewVariant.value === 'personal-new')))
 )
@@ -235,6 +250,9 @@ const {
   isSubscribing,
   isResubscribing,
   previewData,
+  quoteIsCurrent,
+  savedPaymentMethods,
+  selectedSavedPaymentMethodId,
   selectedTierKey,
   selectedTeamStop,
   selectedBillingCycle,
@@ -251,8 +269,21 @@ const {
   handleTeamSubscribe,
   handleSubscriptionPayment,
   handleTeamSubscriptionPayment,
+  applyPromotionCode,
+  invalidateQuote,
   handleResubscribe
 } = useSubscriptionCheckout(emit, reason)
+
+function selectSavedPaymentMethod(id: string | null) {
+  invalidateQuote()
+  if (id === null) {
+    collectingNewPaymentMethod.value = true
+    selectedSavedPaymentMethodId.value = null
+    return
+  }
+  collectingNewPaymentMethod.value = false
+  selectedSavedPaymentMethodId.value = id
+}
 
 onMounted(() => {
   if (!initialCheckout) return
@@ -270,7 +301,7 @@ onMounted(() => {
 // desktop both steps pin the same height, so this no-ops.
 const contentRoot = ref<HTMLElement>()
 watch(
-  [checkoutStep, () => !!savedMethodsForConfirm.value?.length] as const,
+  [checkoutStep, () => savedMethodsForConfirm.value.length > 0] as const,
   async ([next, nextSaved], [prev, prevSaved]) => {
     const el = contentRoot.value
     if (!el || !stripePaymentElementEnabled) return

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts
@@ -56,7 +56,7 @@ function plan(
 function preview(
   overrides: Partial<PreviewSubscribeResponse>
 ): PreviewSubscribeResponse {
-  return {
+  const result: PreviewSubscribeResponse = {
     allowed: true,
     transition_type: 'upgrade',
     effective_at: '2026-06-19T00:00:00Z',
@@ -67,6 +67,17 @@ function preview(
     credits_next_period_cents: 0,
     new_plan: plan('CREATOR', 'MONTHLY', 3500),
     ...overrides
+  }
+  return {
+    ...result,
+    quote_id: overrides.quote_id ?? 'quote_123',
+    quote_version: overrides.quote_version ?? 1,
+    amount_due_cents:
+      overrides.amount_due_cents ?? overrides.cost_today_cents ?? 0,
+    currency: overrides.currency ?? 'usd',
+    renewal_amount_cents:
+      overrides.renewal_amount_cents ?? result.new_plan.price_cents,
+    renewal_at: overrides.renewal_at ?? '2027-06-28T00:00:00Z'
   }
 }
 
@@ -90,11 +101,6 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     expect(screen.getByText('$28')).toBeTruthy()
     expect(screen.getByText('subscription.billedYearly')).toBeTruthy()
     expect(screen.getByText('subscription.preview.switchesToday')).toBeTruthy()
-    expect(
-      screen.getByText('subscription.preview.yearlySubscription')
-    ).toBeTruthy()
-    expect(screen.getByText('$336.00')).toBeTruthy()
-    expect(screen.getByText('− $17.50')).toBeTruthy()
     expect(
       screen.getByText('subscription.preview.creditsYoullGetToday')
     ).toBeTruthy()
@@ -121,9 +127,6 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     })
     expect(screen.getByText('$100')).toBeTruthy()
     expect(screen.getByText('subscription.billedMonthly')).toBeTruthy()
-    expect(
-      screen.getByText('subscription.preview.newMonthlySubscription')
-    ).toBeTruthy()
     expect(
       screen.getByText('subscription.preview.eachMonthCreditsRefill')
     ).toBeTruthy()
@@ -181,7 +184,6 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
       screen.getByText('subscription.preview.creditsRefillMonthlyTo')
     ).toBeTruthy()
     expect(screen.getByText('7,400')).toBeTruthy()
-    expect(screen.getByText('subscription.preview.stayOnUntil')).toBeTruthy()
     expect(screen.queryByText('subscription.preview.switchesToday')).toBeNull()
     expect(
       screen.queryByText('subscription.preview.yearlySubscription')
@@ -211,12 +213,6 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     // tier table (which would yield 0 credits for a team plan).
     expect(screen.getByText('subscription.teamPlan.name')).toBeTruthy()
     expect(screen.getByText('295,400')).toBeTruthy()
-    // Proration money stays driven by previewData.
-    expect(
-      screen.getByText('subscription.preview.newMonthlySubscription')
-    ).toBeTruthy()
-    expect(screen.getByText('$1,400.00')).toBeTruthy()
-    expect(screen.getByText('− $350.00')).toBeTruthy()
     expect(screen.getByText('$1,050.00')).toBeTruthy()
     expect(
       screen.getByText('subscription.preview.confirmUpgradeCta')
@@ -251,12 +247,6 @@ describe('SubscriptionTransitionPreviewWorkspace', () => {
     expect(
       screen.getByText('subscription.preview.refillReplacesNote')
     ).toBeTruthy()
-    // Yearly line label; proration money stays driven by previewData.
-    expect(
-      screen.getByText('subscription.preview.yearlySubscription')
-    ).toBeTruthy()
-    expect(screen.getByText('$16,800.00')).toBeTruthy()
-    expect(screen.getByText('− $4,200.00')).toBeTruthy()
     expect(screen.getByText('$12,600.00')).toBeTruthy()
   })
 })

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -159,23 +159,19 @@
           )
         "
       >
-        <template v-if="isImmediate">
+        <template v-if="isImmediate && previewData.discounts?.length">
           <div class="flex items-center justify-between text-muted-foreground">
-            <span>{{ subscriptionLineLabel }}</span>
-            <span class="tabular-nums">{{ money(newPlanPriceUsd) }}</span>
+            <span>{{ $t('subscription.preview.discountComposition') }}</span>
           </div>
           <div
-            v-if="prorationCreditUsd > 0"
+            v-for="discount in previewData.discounts"
+            :key="`${discount.kind}:${discount.code}`"
             class="flex items-center justify-between text-muted-foreground"
           >
-            <span>
-              {{
-                $t('subscription.preview.creditFromCurrent', {
-                  plan: creditFromPlanLabel
-                })
-              }}
-            </span>
-            <span class="tabular-nums">− {{ money(prorationCreditUsd) }}</span>
+            <span>{{
+              $t(`subscription.preview.discount.${discount.kind}`)
+            }}</span>
+            <span class="text-base-foreground">{{ discount.code }}</span>
           </div>
         </template>
         <div class="flex items-center justify-between text-base">
@@ -183,10 +179,26 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            {{ money(totalDueTodayUsd) }}
+            {{ exactAmountDue }}
           </span>
         </div>
-        <span class="text-sm text-muted-foreground">{{ totalNote }}</span>
+        <span class="text-sm text-muted-foreground">{{ renewalTerms }}</span>
+      </div>
+      <div class="flex gap-2 pt-6">
+        <input
+          v-model="promotionCode"
+          class="h-10 min-w-0 flex-1 rounded-lg border border-interface-stroke bg-secondary-background px-3 text-base-foreground"
+          :placeholder="$t('subscription.preview.promoCodePlaceholder')"
+          @input="$emit('invalidateQuote')"
+        />
+        <Button
+          variant="secondary"
+          size="lg"
+          :disabled="isLoading"
+          @click="$emit('applyPromotionCode', promotionCode)"
+        >
+          {{ $t('subscription.preview.applyPromoCode') }}
+        </Button>
       </div>
     </div>
 
@@ -207,7 +219,7 @@
         size="lg"
         class="w-full rounded-lg"
         :loading="isLoading"
-        :disabled="confirmDisabled"
+        :disabled="confirmDisabled || !quoteIsCurrent"
         @click="$emit('confirm', confirmReactivation)"
       >
         {{ confirmCta }}
@@ -239,7 +251,8 @@ const {
   previewData,
   isLoading = false,
   teamPlan = null,
-  actionUrl = null
+  actionUrl = null,
+  quoteIsCurrent = false
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
@@ -247,6 +260,7 @@ const {
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
   actionUrl?: string | null
+  quoteIsCurrent?: boolean
 }>()
 
 defineEmits<{
@@ -254,11 +268,20 @@ defineEmits<{
    *  ticked above the charge threshold, since confirmDisabled gates the button). */
   confirm: [confirmReactivation: boolean]
   back: []
+  applyPromotionCode: [code: string]
+  invalidateQuote: []
 }>()
 
 const { t, n } = useI18n()
 
 const { subscription } = useBillingContext()
+const promotionCode = ref(previewData.promotion_code ?? '')
+watch(
+  () => previewData.promotion_code,
+  (code) => {
+    promotionCode.value = code ?? ''
+  }
+)
 
 function openVerification() {
   if (!actionUrl) return
@@ -278,13 +301,6 @@ function formatDate(date: string | Date): string {
   }).format(typeof date === 'string' ? new Date(date) : date)
 }
 
-function money(usd: number): string {
-  return `$${usd.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  })}`
-}
-
 function moneyShort(usd: number): string {
   return `$${n(usd)}`
 }
@@ -300,12 +316,6 @@ const newIsYearly = computed(() =>
 const currentIsYearly = computed(() =>
   isAnnualDuration(previewData.current_plan?.duration)
 )
-const isCadenceChange = computed(
-  () =>
-    !!previewData.current_plan &&
-    previewData.current_plan.duration !== previewData.new_plan.duration
-)
-
 const newTierName = computed(() =>
   teamPlan
     ? t('subscription.teamPlan.name')
@@ -314,12 +324,6 @@ const newTierName = computed(() =>
 const currentTierName = computed(() =>
   previewData.current_plan ? formatTierName(previewData.current_plan.tier) : ''
 )
-const currentPlanLabel = computed(() =>
-  currentIsYearly.value
-    ? t('subscription.tierNameYearly', { name: currentTierName.value })
-    : currentTierName.value
-)
-
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 
 const reactivationVariant = computed<
@@ -362,7 +366,9 @@ const currentMonthlyPriceCents = computed(() => {
   const totalCents = plan.seat_summary.total_cost_cents
   return currentIsYearly.value ? totalCents / 12 : totalCents
 })
-const chargeCents = computed(() => previewData.cost_today_cents)
+const chargeCents = computed(
+  () => previewData.amount_due_cents ?? previewData.cost_today_cents
+)
 // The downgrade variant's copy always says "you won't be charged today" with
 // no amount shown, so it never gets the checkbox even if cost_today_cents is
 // unexpectedly positive.
@@ -428,25 +434,7 @@ const annualTotalFormatted = computed(
   () => `$${n(previewData.new_plan.price_cents / 100)}`
 )
 
-const newPlanPriceUsd = computed(() => previewData.new_plan.price_cents / 100)
-const prorationCreditUsd = computed(() => {
-  const credit = previewData.new_plan.price_cents - previewData.cost_today_cents
-  return credit > 0 ? credit / 100 : 0
-})
-const totalDueTodayUsd = computed(() => previewData.cost_today_cents / 100)
 const newMonthlyChargeUsd = computed(() => newMonthlyUsd.value)
-
-const subscriptionLineLabel = computed(() =>
-  newIsYearly.value
-    ? t('subscription.preview.yearlySubscription')
-    : t('subscription.preview.newMonthlySubscription')
-)
-const creditFromPlanLabel = computed(() => {
-  if (teamPlan) return t('subscription.preview.commitment')
-  return isCadenceChange.value
-    ? t('subscription.preview.currentMonthly')
-    : currentTierName.value
-})
 
 const refillCredits = computed(() => {
   const monthly = teamPlan
@@ -494,12 +482,6 @@ const nextPaymentDate = computed(() => {
   )
   return formatDate(fallback)
 })
-const currentPeriodEnd = computed(() =>
-  previewData.current_plan?.period_end
-    ? formatDate(previewData.current_plan.period_end)
-    : effectiveDateLabel.value
-)
-
 const confirmTitle = computed(() =>
   isImmediate.value
     ? t('subscription.preview.confirmUpgradeTitle')
@@ -521,12 +503,29 @@ const confirmCta = computed(() => {
     amount: chargeDisplay.value
   })
 })
-const totalNote = computed(() =>
-  isImmediate.value
-    ? t('subscription.preview.nextPaymentDue', { date: nextPaymentDate.value })
-    : t('subscription.preview.stayOnUntil', {
-        plan: currentPlanLabel.value,
-        date: currentPeriodEnd.value
-      })
+function formatQuoteMoney(cents: number): string {
+  if (!previewData.currency) return ''
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: previewData.currency.toUpperCase()
+  }).format(cents / 100)
+}
+
+const exactAmountDue = computed(() =>
+  previewData.amount_due_cents === undefined
+    ? ''
+    : formatQuoteMoney(previewData.amount_due_cents)
 )
+const renewalTerms = computed(() => {
+  if (
+    previewData.renewal_amount_cents === undefined ||
+    !previewData.renewal_at
+  ) {
+    return ''
+  }
+  return t('subscription.preview.renewsAt', {
+    amount: formatQuoteMoney(previewData.renewal_amount_cents),
+    date: formatDate(previewData.renewal_at)
+  })
+})
 </script>

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspaceReactivation.test.ts
@@ -86,7 +86,7 @@ const i18n = createI18n({
 function makePreview(
   overrides: Partial<PreviewSubscribeResponse>
 ): PreviewSubscribeResponse {
-  return {
+  const result: PreviewSubscribeResponse = {
     allowed: true,
     transition_type: 'upgrade',
     effective_at: '2026-08-01T00:00:00Z',
@@ -122,11 +122,24 @@ function makePreview(
     },
     ...overrides
   }
+  return {
+    ...result,
+    quote_id: 'quote_123',
+    quote_version: 1,
+    amount_due_cents: result.cost_today_cents,
+    currency: 'usd',
+    renewal_amount_cents: result.new_plan.price_cents,
+    renewal_at: result.new_plan.period_end ?? '2026-09-01T00:00:00Z',
+    ...overrides
+  }
 }
 
-function renderComponent(previewData: PreviewSubscribeResponse) {
+function renderComponent(
+  previewData: PreviewSubscribeResponse,
+  quoteIsCurrent = true
+) {
   return render(SubscriptionTransitionPreviewWorkspace, {
-    props: { previewData },
+    props: { previewData, quoteIsCurrent },
     global: { plugins: [i18n] }
   })
 }
@@ -502,6 +515,29 @@ describe('SubscriptionTransitionPreviewWorkspace reactivation disclosure', () =>
   })
 
   describe('confirm gating on load state', () => {
+    it('does not confirm without a current exact quote', async () => {
+      const user = userEvent.setup()
+      mockSubscription.value = { isCancelled: false, endDate: null }
+      const { emitted } = renderComponent(
+        makePreview({
+          quote_id: undefined,
+          quote_version: undefined,
+          amount_due_cents: undefined,
+          currency: undefined,
+          renewal_amount_cents: undefined,
+          renewal_at: undefined
+        }),
+        false
+      )
+      const confirmButton = screen.getByRole('button', {
+        name: 'Confirm upgrade'
+      })
+
+      expect(confirmButton).toBeDisabled()
+      await user.click(confirmButton)
+      expect(emitted().confirm).toBeUndefined()
+    })
+
     it('disables confirm while subscription status has not loaded yet, even below the charge threshold', () => {
       mockSubscription.value = null
       renderComponent(

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.test.ts
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.test.ts
@@ -55,7 +55,7 @@ const i18n = createI18n({
 
 function renderSelector(amountCents = 66500) {
   return render(UnifiedStripePaymentSelector, {
-    props: { amountCents },
+    props: { amountCents, currency: 'usd' },
     global: { plugins: [i18n] }
   })
 }

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -38,7 +38,7 @@
       :variant="verificationPending ? 'tertiary' : 'inverted'"
       size="lg"
       class="w-full rounded-lg"
-      :disabled="!stripeElements"
+      :disabled="!stripeElements || !canSubmit"
       :loading="isLoading || isSubmitting"
       @click="submit"
     >
@@ -61,14 +61,18 @@ import Button from '@/components/ui/button/Button.vue'
 
 const {
   amountCents,
+  currency,
   isLoading = false,
-  verificationPending = false
+  verificationPending = false,
+  canSubmit = true
 } = defineProps<{
   amountCents: number
+  currency: string
   isLoading?: boolean
   /** A 3DS verification is pending: Complete verification (rendered by the
    *  parent) is the primary action, so the pay button steps back. */
   verificationPending?: boolean
+  canSubmit?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -101,7 +105,7 @@ onMounted(async () => {
   stripeElements.value = stripe.elements({
     mode: 'subscription',
     amount: amountCents,
-    currency: 'usd',
+    currency: currency.toLowerCase(),
     setupFutureUsage: 'off_session',
     paymentMethodTypes: ['card', 'alipay'],
     appearance: {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -80,6 +80,7 @@ const {
   mockStartOperation,
   mockGetOperation,
   mockSubscriptionActionOperation,
+  mockListSavedPaymentMethods,
   mockTrackBeginCheckout,
   mockTrackBillingEvent,
   mockShowDowngradeToPersonalDialog,
@@ -109,6 +110,7 @@ const {
         }
       | undefined
   },
+  mockListSavedPaymentMethods: vi.fn(),
   mockTrackBeginCheckout: vi.fn(),
   mockTrackBillingEvent: vi.fn(),
   mockShowDowngradeToPersonalDialog: vi.fn(),
@@ -136,7 +138,11 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     fetchBalance: mockFetchBalance,
     isTeamPlan: computed(() => mockIsTeamPlan.value),
     resubscribe: mockResubscribe,
-    subscription: computed(() => mockSubscription.value)
+    subscription: {
+      get value() {
+        return mockSubscription.value
+      }
+    }
   })
 }))
 
@@ -166,7 +172,10 @@ vi.mock('@/services/dialogService', () => ({
 
 // Shields the test from the real workspaceApi → @/scripts/api → app.ts import chain
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
-  workspaceApi: { resubscribe: mockResubscribe }
+  workspaceApi: {
+    resubscribe: mockResubscribe,
+    listSavedPaymentMethods: mockListSavedPaymentMethods
+  }
 }))
 
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
@@ -243,13 +252,25 @@ describe('useSubscriptionCheckout', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
+    mockSubscribe.mockReset()
+    mockPreviewSubscribe.mockReset()
+    mockFetchPlans.mockReset()
+    mockFetchStatus.mockReset()
+    mockStartOperation.mockReset()
+    mockListSavedPaymentMethods.mockReset()
     mockSubscriptionActionOperation.value = undefined
     mockPlans.value = allPlans()
     mockFetchPlans.mockResolvedValue(undefined)
+    mockPreviewSubscribe.mockResolvedValue({
+      allowed: true,
+      transition_type: 'new_subscription',
+      is_immediate: true
+    })
     mockStartOperation.mockResolvedValue({
       status: 'succeeded',
       workspaceId: 'workspace-1'
     })
+    mockListSavedPaymentMethods.mockResolvedValue([])
     mockGetOperation.mockReturnValue(undefined)
     mockShowDowngradeToPersonalDialog.mockResolvedValue(null)
     mockUserId.value = 'user-1'
@@ -266,6 +287,131 @@ describe('useSubscriptionCheckout', () => {
   })
 
   describe('handleSubscribeClick', () => {
+    it('selects the backend default saved payment method', async () => {
+      const checkout = await setup()
+      mockListSavedPaymentMethods.mockResolvedValueOnce([
+        {
+          type: 'card',
+          id: 'pm_first',
+          brand: 'visa',
+          last4: '1111',
+          isDefault: false
+        },
+        {
+          type: 'alipay',
+          id: 'pm_default',
+          isDefault: true
+        }
+      ])
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+
+      expect(checkout.selectedSavedPaymentMethodId.value).toBe('pm_default')
+    })
+
+    it('previews a promotion only after Apply and submits the exact quote', async () => {
+      const checkout = await setup()
+      mockListSavedPaymentMethods.mockResolvedValueOnce([
+        {
+          type: 'card',
+          id: 'pm_saved',
+          brand: 'visa',
+          last4: '4242',
+          isDefault: true
+        }
+      ])
+      mockPreviewSubscribe
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'new_subscription'
+        })
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'new_subscription',
+          promotion_code: 'SAVE20',
+          quote_id: 'quote_123',
+          quote_version: 2,
+          amount_due_cents: 1280,
+          currency: 'usd',
+          renewal_amount_cents: 1600,
+          renewal_at: '2027-06-19T00:00:00Z'
+        })
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      expect(mockPreviewSubscribe).toHaveBeenCalledOnce()
+
+      await checkout.applyPromotionCode(' SAVE20 ')
+      expect(mockPreviewSubscribe).toHaveBeenLastCalledWith('standard-yearly', {
+        promotionCode: 'SAVE20'
+      })
+
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-quoted'
+      })
+      await checkout.handleConfirmTransition()
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'standard-yearly',
+        expect.objectContaining({
+          savedPaymentMethodId: 'pm_saved',
+          promotionCode: 'SAVE20',
+          quoteId: 'quote_123',
+          quoteVersion: 2
+        })
+      )
+    })
+
+    it('returns a stale quote to review with a refreshed quote', async () => {
+      const checkout = await setup()
+      mockPreviewSubscribe
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'new_subscription',
+          promotion_code: 'SAVE20',
+          quote_id: 'quote_old',
+          quote_version: 1,
+          amount_due_cents: 1280,
+          currency: 'usd',
+          renewal_amount_cents: 1600,
+          renewal_at: '2027-06-19T00:00:00Z'
+        })
+        .mockResolvedValueOnce({
+          allowed: true,
+          transition_type: 'new_subscription',
+          promotion_code: 'SAVE20',
+          quote_id: 'quote_new',
+          quote_version: 1,
+          amount_due_cents: 1280,
+          currency: 'usd',
+          renewal_amount_cents: 1600,
+          renewal_at: '2027-06-19T00:00:00Z'
+        })
+      await checkout.handleSubscribeClick({
+        tierKey: 'standard',
+        billingCycle: 'yearly'
+      })
+      mockSubscribe.mockRejectedValueOnce(
+        Object.assign(new Error('preview again'), {
+          code: 'SUBSCRIPTION_QUOTE_STALE'
+        })
+      )
+
+      await checkout.handleConfirmTransition()
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.previewData.value?.quote_id).toBe('quote_new')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: 'subscription.preview.quoteStale' })
+      )
+    })
+
     it('transitions to preview on successful preview', async () => {
       const checkout = await setup()
       const preview = {
@@ -566,7 +712,9 @@ describe('useSubscriptionCheckout', () => {
         discountedUsd: 380
       })
       expect(checkout.selectedBillingCycle.value).toBe('yearly')
-      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.previewData.value?.transition_type).toBe(
+        'new_subscription'
+      )
       expect(checkout.selectedTierKey.value).toBeNull()
     })
 
@@ -598,7 +746,7 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
 
-    it('falls back to the display-only confirm when the preview is a fresh subscription', async () => {
+    it('keeps the backend quote for a fresh subscription', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
@@ -617,10 +765,12 @@ describe('useSubscriptionCheckout', () => {
         isChange: true
       })
 
-      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.previewData.value?.transition_type).toBe(
+        'new_subscription'
+      )
     })
 
-    it('falls back to the display-only confirm when the preview request fails', async () => {
+    it('returns to pricing when the exact preview request fails', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockRejectedValueOnce(new Error('not supported'))
 
@@ -636,10 +786,10 @@ describe('useSubscriptionCheckout', () => {
       })
 
       expect(checkout.previewData.value).toBeNull()
-      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.checkoutStep.value).toBe('pricing')
     })
 
-    it('does not preview a fresh team subscribe (nothing to prorate)', async () => {
+    it('previews a fresh team subscribe for exact billing terms', async () => {
       const checkout = await setup()
 
       await checkout.handleSubscribeTeamClick({
@@ -653,8 +803,16 @@ describe('useSubscriptionCheckout', () => {
         isChange: false
       })
 
-      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
-      expect(checkout.previewData.value).toBeNull()
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        {
+          teamCreditStopId: 'team_700',
+          billingCycle: 'monthly'
+        }
+      )
+      expect(checkout.previewData.value?.transition_type).toBe(
+        'new_subscription'
+      )
     })
 
     // Regression guard: a cancelled personal subscriber picking Team has no
@@ -804,6 +962,11 @@ describe('useSubscriptionCheckout', () => {
 
     it('is team-new for a fresh team subscribe (nothing to prorate)', async () => {
       const checkout = await setup()
+      mockPreviewSubscribe.mockResolvedValueOnce({
+        allowed: true,
+        transition_type: 'new_subscription',
+        is_immediate: true
+      })
 
       await checkout.handleSubscribeTeamClick({
         stop: {
@@ -1186,7 +1349,7 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
-    it('keeps team checkout_type as change when the preview request fails', async () => {
+    it('does not submit a team change when the required quote fails', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockRejectedValueOnce(new Error('not supported'))
       await checkout.handleSubscribeTeamClick({
@@ -1199,22 +1362,12 @@ describe('useSubscriptionCheckout', () => {
         billingCycle: 'monthly',
         isChange: true
       })
-      mockSubscribe.mockResolvedValueOnce({
-        status: 'subscribed',
-        billing_op_id: 'op-team-change'
-      })
-      mockFetchStatus.mockResolvedValueOnce(undefined)
-      mockFetchBalance.mockResolvedValueOnce(undefined)
-
       await checkout.handleTeamSubscribe()
 
-      expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tier: 'team',
-          cycle: 'monthly',
-          checkout_type: 'change',
-          billing_op_id: 'op-team-change'
-        })
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(checkout.checkoutStep.value).toBe('pricing')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: 'not supported' })
       )
     })
 

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -18,8 +18,10 @@ import type {
   Plan,
   PreviewSubscribeOptions,
   PreviewSubscribeResponse,
+  SavedPaymentMethod,
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -112,6 +114,9 @@ export function useSubscriptionCheckout(
   const isSubscribing = ref(false)
   const isResubscribing = ref(false)
   const previewData = ref<PreviewSubscribeResponse | null>(null)
+  const quoteIsCurrent = ref(false)
+  const savedPaymentMethods = ref<SavedPaymentMethod[]>([])
+  const selectedSavedPaymentMethodId = ref<string | null>(null)
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
@@ -137,7 +142,53 @@ export function useSubscriptionCheckout(
     () => selectedTeamCheckout.value?.stop ?? null
   )
   const isTeamCheckout = computed(() => selectedTeamCheckout.value !== null)
-  const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+  function isSubscriptionCancelled(): boolean {
+    return subscription.value?.isCancelled ?? false
+  }
+
+  function hasExactQuote(
+    preview: PreviewSubscribeResponse
+  ): preview is PreviewSubscribeResponse & {
+    quote_id: string
+    quote_version: number
+    amount_due_cents: number
+    currency: string
+    renewal_amount_cents: number
+    renewal_at: string
+  } {
+    return (
+      Boolean(preview.quote_id) &&
+      preview.quote_version !== undefined &&
+      preview.amount_due_cents !== undefined &&
+      Boolean(preview.currency) &&
+      preview.renewal_amount_cents !== undefined &&
+      Boolean(preview.renewal_at)
+    )
+  }
+
+  function installPreview(preview: PreviewSubscribeResponse): boolean {
+    if (!preview.allowed) return false
+    previewData.value = preview
+    quoteIsCurrent.value = true
+    return true
+  }
+
+  async function loadSavedPaymentMethods(): Promise<void> {
+    if (!shouldUseWorkspaceBilling.value) return
+    try {
+      const methods = await workspaceApi.listSavedPaymentMethods()
+      savedPaymentMethods.value = methods
+      selectedSavedPaymentMethodId.value =
+        methods.find((method) => method.isDefault)?.id ?? methods[0]?.id ?? null
+    } catch {
+      savedPaymentMethods.value = []
+      selectedSavedPaymentMethodId.value = null
+    }
+  }
+
+  function invalidateQuote(): void {
+    quoteIsCurrent.value = false
+  }
 
   // A cancelled subscription needs confirm_reactivation, and the only place
   // that can honestly collect it is the reactivation banner. Paths with no
@@ -188,7 +239,7 @@ export function useSubscriptionCheckout(
     // screen show the new amount and resets prior consent (via the
     // component's own chargeCents watcher), so the next attempt compares
     // against what's on screen instead of repeating this same failure.
-    previewData.value = freshPreview
+    installPreview(freshPreview)
     if (amountChanged) {
       throw new ReactivationAmountChangedError(
         t('subscription.preview.reactivation.amountChanged')
@@ -216,8 +267,8 @@ export function useSubscriptionCheckout(
     } catch {
       // Treated the same as an incapable preview below.
     }
-    if (isReactivationCapablePreview(freshPreview)) {
-      previewData.value = freshPreview
+    if (freshPreview && isReactivationCapablePreview(freshPreview)) {
+      installPreview(freshPreview)
       notifyReactivationConfirmationRequired()
       return
     }
@@ -272,7 +323,11 @@ export function useSubscriptionCheckout(
 
   const previewVariant = computed<PreviewVariant>(() => {
     if (selectedTeamCheckout.value) {
-      return previewData.value ? 'team-change' : 'team-new'
+      return selectedTeamCheckout.value.checkoutType === 'change' ||
+        (previewData.value &&
+          previewData.value.transition_type !== 'new_subscription')
+        ? 'team-change'
+        : 'team-new'
     }
     if (previewData.value) {
       return previewData.value.transition_type === 'new_subscription'
@@ -317,7 +372,10 @@ export function useSubscriptionCheckout(
         return
       }
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
-      const response = await previewSubscribe(planSlug)
+      const [response] = await Promise.all([
+        previewSubscribe(planSlug),
+        loadSavedPaymentMethods()
+      ])
 
       if (!response || !response.allowed) {
         toast.add({
@@ -328,7 +386,7 @@ export function useSubscriptionCheckout(
         return
       }
 
-      previewData.value = response
+      installPreview(response)
       checkoutStep.value = 'preview'
     } catch (error) {
       const message =
@@ -367,38 +425,33 @@ export function useSubscriptionCheckout(
     selectedBillingCycle.value = payload.billingCycle
     selectedTierKey.value = null
     previewData.value = null
+    quoteIsCurrent.value = false
     checkoutStep.value = 'preview'
 
-    // A cancelled subscriber picking Team is a reactivation even when
-    // nothing existing is "changing" (isChange false, e.g. a first-time Team
-    // pick): the add-payment screen this would otherwise fall back to can't
-    // collect confirm_reactivation, so it always needs a real,
-    // reactivation-capable preview instead of the consent-less fallback.
-    const needsPreview = payload.isChange || isCancelled.value
-    if (!needsPreview || !payload.stop.id) return
+    if (!payload.stop.id) return
 
     let response: PreviewSubscribeResponse | null = null
     let previewError: unknown
     try {
       const planSlug = getTeamPlanSlug(payload.billingCycle)
-      response = await previewSubscribe(planSlug, {
-        teamCreditStopId: payload.stop.id,
-        billingCycle: payload.billingCycle
-      })
+      ;[response] = await Promise.all([
+        previewSubscribe(planSlug, {
+          teamCreditStopId: payload.stop.id,
+          billingCycle: payload.billingCycle
+        }),
+        loadSavedPaymentMethods()
+      ])
     } catch (error) {
       previewError = error
     }
 
-    if (isReactivationCapablePreview(response)) {
-      previewData.value = response
+    if (
+      response?.allowed &&
+      (!isSubscriptionCancelled() || isReactivationCapablePreview(response))
+    ) {
+      installPreview(response)
       return
     }
-    // Not cancelled: preview is best-effort, keep the display-only confirm.
-    if (!isCancelled.value) return
-
-    // Cancelled with no qualifying preview: the add-payment fallback has no
-    // way to collect confirm_reactivation, so every submit from it would be
-    // an unrecoverable dead end. Surface the failure instead.
     toast.add({
       severity: 'error',
       summary: t('subscription.teamPlan.name'),
@@ -415,6 +468,7 @@ export function useSubscriptionCheckout(
     if (isPolling.value) return
     checkoutStep.value = 'pricing'
     previewData.value = null
+    quoteIsCurrent.value = false
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
   }
@@ -446,16 +500,29 @@ export function useSubscriptionCheckout(
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (!confirmReactivation && isSubscriptionCancelled()) {
         await refreshPreviewOnReactivationBlock(planSlug)
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (confirmReactivation && isSubscriptionCancelled()) {
         await assertReactivationAmountUnchanged(planSlug)
+      }
+      const quote = previewData.value
+      if (quote && !quoteIsCurrent.value) {
+        throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
       }
       const response = await subscribe(planSlug, {
         ...(confirmationToken && { confirmationToken }),
-        ...(promotionCode && { promotionCode }),
+        ...(!confirmationToken &&
+          selectedSavedPaymentMethodId.value && {
+            savedPaymentMethodId: selectedSavedPaymentMethodId.value
+          }),
+        promotionCode: quote?.promotion_code ?? promotionCode,
+        ...(quote &&
+          hasExactQuote(quote) && {
+            quoteId: quote.quote_id,
+            quoteVersion: quote.quote_version
+          }),
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
         confirmReactivation
@@ -476,6 +543,7 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (await recoverStaleQuote(error)) return
       trackSubscriptionFailure({
         tier: tierKey,
         cycle: billingCycle,
@@ -496,6 +564,75 @@ export function useSubscriptionCheckout(
           ? error.message
           : t('subscription.subscribeFailed')
     })
+  }
+
+  async function recoverStaleQuote(error: unknown): Promise<boolean> {
+    if (
+      !(error instanceof Error) ||
+      !('code' in error) ||
+      error.code !== 'SUBSCRIPTION_QUOTE_STALE'
+    ) {
+      return false
+    }
+    quoteIsCurrent.value = false
+    try {
+      const refreshed = await applyPromotionCode(
+        previewData.value?.promotion_code ?? '',
+        false
+      )
+      if (!refreshed) throw new Error('quote refresh failed')
+      toast.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: t('subscription.preview.quoteStale')
+      })
+    } catch {
+      handleBackToPricing()
+      toast.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: t('subscription.preview.quoteRefreshFailed')
+      })
+    }
+    return true
+  }
+
+  async function applyPromotionCode(
+    promotionCode: string,
+    showFailure = true
+  ): Promise<boolean> {
+    const normalizedInput = promotionCode.trim()
+    let planSlug: string | null
+    let options: PreviewSubscribeOptions
+    if (selectedTeamCheckout.value?.stop.id) {
+      planSlug = getTeamPlanSlug(selectedBillingCycle.value)
+      options = {
+        teamCreditStopId: selectedTeamCheckout.value.stop.id,
+        billingCycle: selectedBillingCycle.value,
+        ...(normalizedInput && { promotionCode: normalizedInput })
+      }
+    } else if (selectedTierKey.value) {
+      planSlug = getApiPlanSlug(
+        selectedTierKey.value,
+        selectedBillingCycle.value
+      )
+      options = normalizedInput ? { promotionCode: normalizedInput } : {}
+    } else {
+      return false
+    }
+    if (!planSlug) return false
+    quoteIsCurrent.value = false
+    try {
+      const response = await previewSubscribe(planSlug, options)
+      if (!response?.allowed) {
+        throw new Error(response?.reason || t('subscription.subscribeFailed'))
+      }
+      installPreview(response)
+      return true
+    } catch (error) {
+      if (showFailure) showSubscribeError(error)
+      return false
+    }
   }
 
   interface SubscriptionOutcomeContext {
@@ -624,22 +761,35 @@ export function useSubscriptionCheckout(
     isSubscribing.value = true
     try {
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (!confirmReactivation && isSubscriptionCancelled()) {
         await refreshPreviewOnReactivationBlock(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
         })
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (confirmReactivation && isSubscriptionCancelled()) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
         })
       }
+      const quote = previewData.value
+      if (quote && !quoteIsCurrent.value) {
+        throw new Error(t('subscription.preview.applyQuoteBeforeContinuing'))
+      }
       const response = await subscribe(planSlug, {
         ...(confirmationToken && { confirmationToken }),
-        ...(promotionCode && { promotionCode }),
+        ...(!confirmationToken &&
+          selectedSavedPaymentMethodId.value && {
+            savedPaymentMethodId: selectedSavedPaymentMethodId.value
+          }),
+        promotionCode: quote?.promotion_code ?? promotionCode,
+        ...(quote &&
+          hasExactQuote(quote) && {
+            quoteId: quote.quote_id,
+            quoteVersion: quote.quote_version
+          }),
         teamCreditStopId: stop.id,
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
@@ -662,6 +812,7 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (await recoverStaleQuote(error)) return
       trackSubscriptionFailure({
         tier: 'team',
         cycle: billingCycle,
@@ -742,6 +893,9 @@ export function useSubscriptionCheckout(
     isSubscribing,
     isResubscribing,
     previewData,
+    quoteIsCurrent,
+    savedPaymentMethods,
+    selectedSavedPaymentMethodId,
     selectedTierKey,
     selectedTeamStop,
     selectedBillingCycle,
@@ -758,6 +912,8 @@ export function useSubscriptionCheckout(
     handleTeamSubscribe: handleTeamSubscription,
     handleSubscriptionPayment,
     handleTeamSubscriptionPayment,
+    applyPromotionCode,
+    invalidateQuote,
     handleResubscribe
   }
 }


### PR DESCRIPTION
## Summary

Wires the subscription checkout UI to the quote and saved-payment-method contracts from cloud PRs #5947 and #5949 so users review backend-authoritative totals before submitting.

## Changes

- **What**: Loads masked card/Alipay methods, defaults to the backend-selected method, supports switching or adding a new method, and submits `saved_payment_method_id`.
- **What**: Adds explicit promo Apply/preview, renders backend amount/currency/discounts/renewal terms, and echoes quote ID/version on subscribe.
- **What**: Invalidates changed checkout inputs and recovers stale quotes back to review with an actionable message.
- **Safety**: Keeps Stripe Payment Method Configuration disabled and the embedded Payment Element restricted to card/Alipay. No client secrets are persisted and 3DS recovery is unchanged.

## Review Focus

- Stacked on `fix/alex-embedded-checkout-safety`; cloud contract dependencies are Comfy-Org/cloud#5947 and #5949.
- Focused tests cover API payloads, default saved methods/Add new, explicit promo Apply, exact quote submission, and stale quote recovery.

## Tests

- `pnpm typecheck`
- `pnpm exec oxlint <touched TS/Vue files>`
- `pnpm test:unit src/platform/workspace/api/workspaceApi.test.ts src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.test.ts src/platform/workspace/components/UnifiedStripePaymentSelector.test.ts src/platform/workspace/composables/useSubscriptionCheckout.test.ts --reporter=dot` (130 passed)
- pre-push `knip --cache`

## Screenshots

Not included: this stacked UI requires the unmerged cloud quote/payment-method endpoints to exercise the AS IS / TO BE flow in the real app environment.
