### PR TITLE
feat: wire exact subscription checkout contracts

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2934,6 +2934,18 @@
         "unavailable": "We can't confirm this reactivation right now — please choose your plan again"
       },
       "addPromoCode": "Add promo code",
+      "applyPromoCode": "Apply",
+      "promotionCodePlaceholder": "Promo code",
+      "promotionCodeInvalid": "This promo code could not be applied.",
+      "quoteUnavailable": "An exact price is unavailable. Please choose the plan again.",
+      "quoteStale": "Your price changed or expired. Review the refreshed total and try again.",
+      "savedPaymentMethodUnavailable": "That saved payment method is no longer available. Choose another payment method and try again.",
+      "renewsOn": "Renews for {amount} on {date}. Cancel anytime.",
+      "discount": {
+        "plan": "Plan discount",
+        "promotion": "Promo discount"
+      },
+      "card": "Card",
       "changePaymentMethod": "Change",
       "savedPaymentMethod": "Payment method",
       "addNewPaymentMethod": "Add new payment method",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -388,6 +388,68 @@ describe('workspaceApi', () => {
   })
 
   describe('subscription', () => {
+    it('sends promotion input to preview and quote selection to subscribe', async () => {
+      mockAxiosInstance.post
+        .mockResolvedValueOnce({ data: { quote_id: 'quote-1' } })
+        .mockResolvedValueOnce({
+          data: { billing_op_id: 'op-1', status: 'subscribed' }
+        })
+
+      await workspaceApi.previewSubscribe('creator-monthly', {
+        promotionCode: 'SAVE20'
+      })
+      await workspaceApi.subscribe('creator-monthly', {
+        promotionCode: 'SAVE20',
+        quoteId: 'quote-1',
+        quoteVersion: 1,
+        savedPaymentMethodId: 'pm_owned'
+      })
+
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(
+        1,
+        '/api/billing/preview-subscribe',
+        expect.objectContaining({ promotion_code: 'SAVE20' }),
+        { headers: AUTH_HEADER }
+      )
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(
+        2,
+        '/api/billing/subscribe',
+        expect.objectContaining({
+          promotion_code: 'SAVE20',
+          quote_id: 'quote-1',
+          quote_version: 1,
+          saved_payment_method_id: 'pm_owned'
+        }),
+        { headers: AUTH_HEADER }
+      )
+    })
+
+    it('returns owner-authorized masked payment methods', async () => {
+      const methods = [
+        {
+          type: 'card',
+          brand: 'visa',
+          last4: '4242',
+          id: 'pm_owned',
+          isDefault: true
+        },
+        {
+          type: 'alipay',
+          id: 'pm_alipay',
+          isDefault: false
+        }
+      ]
+      mockAxiosInstance.get.mockResolvedValue({ data: methods })
+
+      await expect(workspaceApi.listSavedPaymentMethods()).resolves.toEqual(
+        methods
+      )
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/billing/payment-methods',
+        { headers: AUTH_HEADER }
+      )
+    })
+
     it('previewSubscribe() sends POST with plan_slug', async () => {
       const data = { allowed: true, transition_type: 'new_subscription' }
       mockAxiosInstance.post.mockResolvedValue({ data })

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -156,6 +156,7 @@ interface PreviewSubscribeRequest {
   plan_slug: string
   team_credit_stop_id?: string
   billing_cycle?: SubscribeBillingCycle
+  promotion_code?: string
 }
 
 type SubscribeBillingCycle = 'monthly' | 'yearly'
@@ -165,6 +166,9 @@ interface SubscribeRequest {
   idempotency_key?: string
   confirmation_token?: string
   promotion_code?: string
+  quote_id?: string
+  quote_version?: number
+  saved_payment_method_id?: string
   return_url?: string
   cancel_url?: string
   /** Required for the per-credit Team plan; selects the slider stop. */
@@ -177,6 +181,9 @@ interface SubscribeRequest {
 export interface SubscribeOptions {
   confirmationToken?: string
   promotionCode?: string
+  quoteId?: string
+  quoteVersion?: number
+  savedPaymentMethodId?: string
   returnUrl?: string
   cancelUrl?: string
   teamCreditStopId?: string
@@ -187,6 +194,20 @@ export interface SubscribeOptions {
 export interface PreviewSubscribeOptions {
   teamCreditStopId?: string
   billingCycle?: SubscribeBillingCycle
+  promotionCode?: string
+}
+
+export interface SavedPaymentMethod {
+  type: 'card' | 'alipay'
+  brand?: string
+  last4?: string
+  id: string
+  isDefault: boolean
+}
+
+interface SubscriptionDiscount {
+  kind: 'plan' | 'promotion'
+  code: string
 }
 
 type SubscribeStatus = 'subscribed' | 'needs_payment_method' | 'pending_payment'
@@ -248,6 +269,14 @@ export interface PreviewSubscribeResponse {
   credits_next_period_cents: number
   current_plan?: PreviewPlanInfo
   new_plan: PreviewPlanInfo
+  quote_id?: string
+  quote_version?: number
+  promotion_code?: string
+  discounts?: SubscriptionDiscount[]
+  amount_due_cents?: number
+  currency?: string
+  renewal_amount_cents?: number
+  renewal_at?: string
 }
 
 export type BillingSubscriptionStatus =
@@ -671,7 +700,8 @@ export const workspaceApi = {
         {
           plan_slug: planSlug,
           team_credit_stop_id: options.teamCreditStopId,
-          billing_cycle: options.billingCycle
+          billing_cycle: options.billingCycle,
+          promotion_code: options.promotionCode
         } satisfies PreviewSubscribeRequest,
         { headers }
       )
@@ -697,12 +727,28 @@ export const workspaceApi = {
           plan_slug: planSlug,
           confirmation_token: options.confirmationToken,
           promotion_code: options.promotionCode,
+          quote_id: options.quoteId,
+          quote_version: options.quoteVersion,
+          saved_payment_method_id: options.savedPaymentMethodId,
           return_url: options.returnUrl,
           cancel_url: options.cancelUrl,
           team_credit_stop_id: options.teamCreditStopId,
           billing_cycle: options.billingCycle,
           confirm_reactivation: options.confirmReactivation
         } satisfies SubscribeRequest,
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  async listSavedPaymentMethods(): Promise<SavedPaymentMethod[]> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.get<SavedPaymentMethod[]>(
+        api.apiURL('/billing/payment-methods'),
         { headers }
       )
       return response.data

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts
@@ -183,4 +183,59 @@ describe('SubscriptionAddPaymentPreviewWorkspace', () => {
       })
     ).toBeNull()
   })
+
+  it('renders the quoted amount, discount composition and renewal data', () => {
+    const preview = {
+      ...previewFixture('MONTHLY', 3_500),
+      amount_due_cents: 2_800,
+      currency: 'USD',
+      discounts: [
+        { kind: 'plan' as const, code: 'creator_monthly' },
+        { kind: 'promotion' as const, code: 'SAVE20' }
+      ],
+      renewal_amount_cents: 2_800,
+      renewal_at: '2026-07-19T00:00:00Z'
+    }
+    render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: { tierKey: 'creator', previewData: preview },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('$28.00')).toBeTruthy()
+    expect(screen.getByText('creator_monthly')).toBeTruthy()
+    expect(screen.getByText('SAVE20')).toBeTruthy()
+    expect(screen.getByText('subscription.preview.renewsOn')).toBeTruthy()
+  })
+
+  it('uses the default saved method and switches to capture on Change', async () => {
+    const { emitted } = render(SubscriptionAddPaymentPreviewWorkspace, {
+      props: {
+        tierKey: 'creator',
+        previewData: {
+          ...previewFixture('MONTHLY', 3_500),
+          amount_due_cents: 3_500,
+          currency: 'USD'
+        },
+        savedMethods: [
+          {
+            type: 'card',
+            brand: 'visa',
+            last4: '4242',
+            id: 'pm_owned',
+            isDefault: true
+          }
+        ],
+        selectedSavedPaymentMethodId: 'pm_owned'
+      },
+      global: globalOptions
+    })
+
+    expect(screen.getByText('visa •••• 4242')).toBeTruthy()
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.changePaymentMethod'
+      })
+    )
+    expect(emitted().selectPaymentMethod?.at(-1)).toEqual([null])
+  })
 })

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -99,6 +99,14 @@
         </div>
       </div>
 
+      <SubscriptionPromoCodeField
+        class="pt-4"
+        :applied-code="appliedPromotionCode"
+        :error="promotionCodeError"
+        :is-loading="isApplyingPromotionCode"
+        @apply="$emit('applyPromotionCode', $event)"
+      />
+
       <!-- Total Due Section -->
       <div
         :class="
@@ -113,13 +121,24 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            ${{ totalDueToday }}
+            {{ totalDueToday }}
           </span>
+        </div>
+        <div
+          v-for="discount in previewData?.discounts ?? []"
+          :key="`${discount.kind}-${discount.code}`"
+          class="flex items-center justify-between text-sm text-muted-foreground"
+        >
+          <span>{{
+            $t(`subscription.preview.discount.${discount.kind}`)
+          }}</span>
+          <span>{{ discount.code }}</span>
         </div>
         <span class="text-sm text-muted-foreground">
           {{
-            $t('subscription.preview.nextPaymentDue', {
-              date: nextPaymentDate
+            $t('subscription.preview.renewsOn', {
+              amount: renewalAmount,
+              date: renewalDate
             })
           }}
         </span>
@@ -138,11 +157,9 @@
             :class="
               cn(
                 'size-4 shrink-0',
-                savedMethods[0].type === 'bank'
-                  ? 'icon-[lucide--landmark]'
-                  : savedMethods[0].type === 'alipay'
-                    ? 'icon-[lucide--wallet]'
-                    : 'icon-[lucide--credit-card]'
+                savedMethods[0].type === 'alipay'
+                  ? 'icon-[lucide--wallet]'
+                  : 'icon-[lucide--credit-card]'
               )
             "
           />
@@ -153,7 +170,7 @@
             variant="link"
             size="lg"
             class="ml-auto px-0"
-            @click="$emit('changePaymentMethod')"
+            @click="$emit('selectPaymentMethod', null)"
           >
             {{ $t('subscription.preview.changePaymentMethod') }}
           </Button>
@@ -195,18 +212,19 @@
       <UnifiedStripePaymentSelector
         v-if="captureMode"
         :amount-cents="amountDueCents"
+        :currency="currency"
         :is-loading
         :verification-pending="Boolean(actionUrl)"
         @confirm="confirmPayment"
       />
 
       <Button
-        v-if="savedMethods?.length"
+        v-if="selectedSavedPaymentMethodId"
         variant="inverted"
         size="lg"
         class="w-full rounded-lg"
         :loading="isLoading"
-        @click="$emit('addCreditCard')"
+        @click="$emit('subscribeSavedMethod')"
       >
         {{ $t('subscription.preview.payAndSubscribe') }}
       </Button>
@@ -242,17 +260,15 @@ import {
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isYearlyCheckout } from '@/platform/cloud/subscription/utils/planDuration'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
-import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import type {
+  PreviewSubscribeResponse,
+  SavedPaymentMethod
+} from '@/platform/workspace/api/workspaceApi'
 import { cn } from '@comfyorg/tailwind-utils'
 
+import SubscriptionPromoCodeField from './SubscriptionPromoCodeField.vue'
 import SubscriptionTermsNote from './SubscriptionTermsNote.vue'
 import UnifiedStripePaymentSelector from './UnifiedStripePaymentSelector.vue'
-
-export interface SavedPaymentMethod {
-  type: 'card' | 'alipay' | 'bank'
-  brand?: string
-  last4?: string
-}
 
 interface Props {
   /** Personal-tier checkout. Required unless `teamPlan` is set. */
@@ -271,6 +287,10 @@ interface Props {
    *  Alipay is a linked account with neither. The backend does not supply
    *  this yet. */
   savedMethods?: SavedPaymentMethod[] | null
+  selectedSavedPaymentMethodId?: string | null
+  appliedPromotionCode?: string
+  promotionCodeError?: string | null
+  isApplyingPromotionCode?: boolean
 }
 
 const {
@@ -281,42 +301,54 @@ const {
   teamPlan = null,
   actionUrl = null,
   usePaymentElement = false,
-  savedMethods = null
+  savedMethods = null,
+  selectedSavedPaymentMethodId = null,
+  appliedPromotionCode = '',
+  promotionCodeError = null,
+  isApplyingPromotionCode = false
 } = defineProps<Props>()
 
 const emit = defineEmits<{
   addCreditCard: []
   confirmPayment: [confirmationToken: string]
   back: []
-  changePaymentMethod: []
+  selectPaymentMethod: [id: string | null]
+  subscribeSavedMethod: []
+  applyPromotionCode: [code: string]
 }>()
 
 const { t, n } = useI18n()
 
 // The wide capture split only applies while a payment method is being
 // collected; with a saved method the confirm is a single narrow column.
-const captureMode = computed(() => usePaymentElement && !savedMethods?.length)
+const captureMode = computed(
+  () => usePaymentElement && !selectedSavedPaymentMethodId
+)
 
 function methodLabel(m: SavedPaymentMethod) {
   if (m.type === 'alipay') return t('subscription.preview.alipay')
-  return `${m.brand} •••• ${m.last4}`
+  return `${m.brand ?? t('subscription.preview.card')} •••• ${m.last4 ?? ''}`
 }
 
 const savedMethodOptions = computed(() => [
-  ...(savedMethods ?? []).map((m, i) => ({
+  ...(savedMethods ?? []).map((m) => ({
     name: methodLabel(m),
-    value: String(i)
+    value: m.id
   })),
   {
     name: t('subscription.preview.addNewPaymentMethod'),
     value: 'add-new'
   }
 ])
-const selectedMethod = ref('0')
+const selectedMethod = ref(selectedSavedPaymentMethodId ?? 'add-new')
+watch(
+  () => selectedSavedPaymentMethodId,
+  (value) => {
+    selectedMethod.value = value ?? 'add-new'
+  }
+)
 watch(selectedMethod, (value) => {
-  if (value !== 'add-new') return
-  selectedMethod.value = '0'
-  emit('changePaymentMethod')
+  emit('selectPaymentMethod', value === 'add-new' ? null : value)
 })
 
 function openVerification() {
@@ -369,46 +401,36 @@ const creditsRefillLabelKey = computed(() =>
     : 'subscription.preview.eachMonthCreditsRefill'
 )
 
-const totalDueTodayUsd = computed(() => {
-  if (teamPlan) {
-    return isYearly.value ? teamPlan.discountedUsd * 12 : teamPlan.discountedUsd
-  }
-  if (previewData) return previewData.cost_today_cents / 100
-  if (!tierKey) return 0
-  const priceValue = getTierPrice(tierKey, isYearly.value)
-  return isYearly.value ? priceValue * 12 : priceValue
-})
-
-const totalDueToday = computed(() =>
-  totalDueTodayUsd.value.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  })
+const amountDueCents = computed(
+  () =>
+    previewData?.amount_due_cents ??
+    previewData?.cost_today_cents ??
+    (isYearly.value ? annualTotalUsd.value : Number(displayPrice.value)) * 100
 )
-
-const amountDueCents = computed(() => Math.round(totalDueTodayUsd.value * 100))
-
-const nextPaymentDate = computed(() => {
-  if (previewData?.new_plan?.period_end) {
-    return new Date(previewData.new_plan.period_end).toLocaleDateString(
-      'en-US',
-      {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric'
-      }
-    )
-  }
-  const date = new Date()
-  if (billingCycle === 'yearly') {
-    date.setFullYear(date.getFullYear() + 1)
-  } else {
-    date.setMonth(date.getMonth() + 1)
-  }
-  return date.toLocaleDateString('en-US', {
+const currency = computed(() => previewData?.currency ?? 'USD')
+const formatMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency.value
+  }).format(cents / 100)
+const totalDueToday = computed(() => formatMoney(amountDueCents.value))
+const renewalAmount = computed(() =>
+  formatMoney(
+    previewData?.renewal_amount_cents ??
+      previewData?.cost_next_period_cents ??
+      amountDueCents.value
+  )
+)
+const renewalDate = computed(() =>
+  new Date(
+    previewData?.renewal_at ??
+      previewData?.new_plan.period_end ??
+      previewData?.effective_at ??
+      0
+  ).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric'
   })
-})
+)
 </script>

--- a/src/platform/workspace/components/SubscriptionPromoCodeField.test.ts
+++ b/src/platform/workspace/components/SubscriptionPromoCodeField.test.ts
@@ -1,0 +1,47 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { createI18n } from 'vue-i18n'
+import { describe, expect, it } from 'vitest'
+
+import SubscriptionPromoCodeField from './SubscriptionPromoCodeField.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+describe('SubscriptionPromoCodeField', () => {
+  it('waits for explicit Apply before emitting a promotion code', async () => {
+    const user = userEvent.setup()
+    const { emitted } = render(SubscriptionPromoCodeField, {
+      global: { plugins: [i18n] }
+    })
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.addPromoCode'
+      })
+    )
+    await user.type(screen.getByRole('textbox'), ' SAVE20 ')
+    expect(emitted().apply).toBeUndefined()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.applyPromoCode'
+      })
+    )
+    expect(emitted().apply).toEqual([['SAVE20']])
+  })
+
+  it('renders backend validation feedback without marking the code applied', async () => {
+    const user = userEvent.setup()
+    render(SubscriptionPromoCodeField, {
+      props: { error: 'Promotion code is invalid' },
+      global: { plugins: [i18n] }
+    })
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'subscription.preview.addPromoCode'
+      })
+    )
+    expect(screen.getByText('Promotion code is invalid')).toBeTruthy()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionPromoCodeField.vue
+++ b/src/platform/workspace/components/SubscriptionPromoCodeField.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <Button
+      v-if="!isOpen"
+      variant="secondary"
+      size="lg"
+      class="self-start"
+      @click="open"
+    >
+      {{ $t('subscription.preview.addPromoCode') }}
+    </Button>
+    <div v-else class="flex gap-2">
+      <Input
+        ref="inputRef"
+        v-model="code"
+        class="min-w-0 flex-1"
+        :placeholder="$t('subscription.preview.promotionCodePlaceholder')"
+        autocomplete="off"
+        :disabled="isLoading"
+        @keydown.enter="apply"
+      />
+      <Button
+        variant="secondary"
+        :loading="isLoading"
+        :disabled="!code.trim()"
+        @click="apply"
+      >
+        {{ $t('subscription.preview.applyPromoCode') }}
+      </Button>
+    </div>
+    <span v-if="error" class="text-sm text-destructive-background">
+      {{ error }}
+    </span>
+    <span v-else-if="appliedCode" class="text-success-foreground text-sm">
+      {{ $t('subscription.success.promoApplied', { code: appliedCode }) }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+
+import Button from '@/components/ui/button/Button.vue'
+import Input from '@/components/ui/input/Input.vue'
+
+const {
+  appliedCode = '',
+  error = null,
+  isLoading = false
+} = defineProps<{
+  appliedCode?: string
+  error?: string | null
+  isLoading?: boolean
+}>()
+
+const emit = defineEmits<{
+  apply: [code: string]
+}>()
+
+const isOpen = ref(Boolean(appliedCode))
+const code = ref(appliedCode)
+const inputRef = ref<InstanceType<typeof Input>>()
+
+watch(
+  () => appliedCode,
+  (value) => {
+    code.value = value
+    if (value) isOpen.value = true
+  }
+)
+
+function open() {
+  isOpen.value = true
+  void nextTick(() => {
+    const el = inputRef.value?.$el
+    if (el instanceof HTMLInputElement) el.focus()
+  })
+}
+
+function apply() {
+  const normalized = code.value.trim()
+  if (normalized) emit('apply', normalized)
+}
+</script>

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -100,20 +100,31 @@
         :team-plan="selectedTeamStop!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :applied-promotion-code="appliedPromotionCode"
+        :promotion-code-error="promotionCodeError"
+        :is-applying-promotion-code="isApplyingPromotionCode"
+        @apply-promotion-code="applyPromotionCode"
         @confirm="handleTeamSubscribe"
         @back="handleBackToPricing"
       />
 
       <SubscriptionAddPaymentPreviewWorkspace
         v-else-if="previewVariant === 'team-new'"
+        :preview-data="previewData"
         :team-plan="selectedTeamStop!"
         :billing-cycle="selectedBillingCycle"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
         :use-payment-element="stripePaymentElementEnabled"
-        :saved-methods="savedMethodsForConfirm"
+        :saved-methods="savedPaymentMethods"
+        :selected-saved-payment-method-id="selectedSavedPaymentMethodId"
+        :applied-promotion-code="appliedPromotionCode"
+        :promotion-code-error="promotionCodeError"
+        :is-applying-promotion-code="isApplyingPromotionCode"
         @add-credit-card="handleTeamSubscribe"
-        @change-payment-method="savedMethodsForConfirm = null"
+        @select-payment-method="selectSavedPaymentMethod"
+        @subscribe-saved-method="handleTeamSubscribe"
+        @apply-promotion-code="applyPromotionCode"
         @confirm-payment="handleTeamSubscriptionPayment"
         @back="handleBackToPricing"
       />
@@ -126,9 +137,15 @@
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
         :use-payment-element="stripePaymentElementEnabled"
-        :saved-methods="savedMethodsForConfirm"
+        :saved-methods="savedPaymentMethods"
+        :selected-saved-payment-method-id="selectedSavedPaymentMethodId"
+        :applied-promotion-code="appliedPromotionCode"
+        :promotion-code-error="promotionCodeError"
+        :is-applying-promotion-code="isApplyingPromotionCode"
         @add-credit-card="handleAddCreditCard"
-        @change-payment-method="savedMethodsForConfirm = null"
+        @select-payment-method="selectSavedPaymentMethod"
+        @subscribe-saved-method="handleAddCreditCard"
+        @apply-promotion-code="applyPromotionCode"
         @confirm-payment="handleSubscriptionPayment"
         @back="handleBackToPricing"
       />
@@ -138,6 +155,10 @@
         :preview-data="previewData!"
         :is-loading="isSubscribing || isPolling"
         :action-url="activeCheckoutActionUrl"
+        :applied-promotion-code="appliedPromotionCode"
+        :promotion-code-error="promotionCodeError"
+        :is-applying-promotion-code="isApplyingPromotionCode"
+        @apply-promotion-code="applyPromotionCode"
         @confirm="handleConfirmTransition"
         @back="handleBackToPricing"
       />
@@ -167,7 +188,6 @@ import type { SubscriptionCheckoutSelection } from '@/platform/workspace/composa
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import SubscriptionAddPaymentPreviewWorkspace from './SubscriptionAddPaymentPreviewWorkspace.vue'
-import type { SavedPaymentMethod } from './SubscriptionAddPaymentPreviewWorkspace.vue'
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 import SubscriptionTransitionPreviewWorkspace from './SubscriptionTransitionPreviewWorkspace.vue'
 import UnifiedPricingTable from './UnifiedPricingTable.vue'
@@ -193,13 +213,11 @@ const stripePaymentElementEnabled = Boolean(
 // Default payment method for the confirming workspace. The backend does not
 // expose this pre-confirm yet; once it does, populate from the preview
 // response and the capture form becomes first-subscribe-only.
-const savedMethodsForConfirm = ref<SavedPaymentMethod[] | null>(null)
-
 const isEmbeddedPaymentStep = computed(
   () =>
     checkoutStep.value === 'preview' &&
     stripePaymentElementEnabled &&
-    !savedMethodsForConfirm.value?.length &&
+    !selectedSavedPaymentMethodId.value &&
     (previewVariant.value === 'team-new' ||
       previewVariant.value === 'personal-new')
 )
@@ -213,7 +231,7 @@ const isEmbeddedConfirmStep = computed(
     stripePaymentElementEnabled &&
     (previewVariant.value === 'team-change' ||
       previewVariant.value === 'personal-change' ||
-      (!!savedMethodsForConfirm.value?.length &&
+      (!!selectedSavedPaymentMethodId.value &&
         (previewVariant.value === 'team-new' ||
           previewVariant.value === 'personal-new')))
 )
@@ -238,6 +256,11 @@ const {
   selectedTierKey,
   selectedTeamStop,
   selectedBillingCycle,
+  savedPaymentMethods,
+  selectedSavedPaymentMethodId,
+  appliedPromotionCode,
+  promotionCodeError,
+  isApplyingPromotionCode,
   activeCheckoutActionUrl,
   isPolling,
   isTeamCheckout,
@@ -251,6 +274,8 @@ const {
   handleTeamSubscribe,
   handleSubscriptionPayment,
   handleTeamSubscriptionPayment,
+  applyPromotionCode,
+  selectSavedPaymentMethod,
   handleResubscribe
 } = useSubscriptionCheckout(emit, reason)
 
@@ -270,7 +295,7 @@ onMounted(() => {
 // desktop both steps pin the same height, so this no-ops.
 const contentRoot = ref<HTMLElement>()
 watch(
-  [checkoutStep, () => !!savedMethodsForConfirm.value?.length] as const,
+  [checkoutStep, () => !!selectedSavedPaymentMethodId.value] as const,
   async ([next, nextSaved], [prev, prevSaved]) => {
     const el = contentRoot.value
     if (!el || !stripePaymentElementEnabled) return

--- a/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionTransitionPreviewWorkspace.vue
@@ -149,6 +149,15 @@
         </span>
       </div>
 
+      <SubscriptionPromoCodeField
+        v-if="isImmediate"
+        class="pt-4"
+        :applied-code="appliedPromotionCode"
+        :error="promotionCodeError"
+        :is-loading="isApplyingPromotionCode"
+        @apply="$emit('applyPromotionCode', $event)"
+      />
+
       <!-- Total Due (immediate changes carry their addends: one sum under
            one divider, per Figma 5344-35724) -->
       <div
@@ -183,8 +192,18 @@
             {{ $t('subscription.preview.totalDueToday') }}
           </span>
           <span class="font-bold text-base-foreground tabular-nums">
-            {{ money(totalDueTodayUsd) }}
+            {{ exactAmountDue }}
           </span>
+        </div>
+        <div
+          v-for="discount in previewData.discounts ?? []"
+          :key="`${discount.kind}-${discount.code}`"
+          class="flex items-center justify-between text-sm text-muted-foreground"
+        >
+          <span>{{
+            $t(`subscription.preview.discount.${discount.kind}`)
+          }}</span>
+          <span>{{ discount.code }}</span>
         </div>
         <span class="text-sm text-muted-foreground">{{ totalNote }}</span>
       </div>
@@ -232,6 +251,7 @@ import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDurati
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 
 import SubscriptionTermsNote from './SubscriptionTermsNote.vue'
+import SubscriptionPromoCodeField from './SubscriptionPromoCodeField.vue'
 
 type PersonalTierKey = 'standard' | 'creator' | 'pro'
 
@@ -239,7 +259,10 @@ const {
   previewData,
   isLoading = false,
   teamPlan = null,
-  actionUrl = null
+  actionUrl = null,
+  appliedPromotionCode = '',
+  promotionCodeError = null,
+  isApplyingPromotionCode = false
 } = defineProps<{
   previewData: PreviewSubscribeResponse
   isLoading?: boolean
@@ -247,6 +270,9 @@ const {
    *  the selected slider stop; all proration money stays driven by previewData. */
   teamPlan?: TeamPlanSelection | null
   actionUrl?: string | null
+  appliedPromotionCode?: string
+  promotionCodeError?: string | null
+  isApplyingPromotionCode?: boolean
 }>()
 
 defineEmits<{
@@ -254,6 +280,7 @@ defineEmits<{
    *  ticked above the charge threshold, since confirmDisabled gates the button). */
   confirm: [confirmReactivation: boolean]
   back: []
+  applyPromotionCode: [code: string]
 }>()
 
 const { t, n } = useI18n()
@@ -319,7 +346,6 @@ const currentPlanLabel = computed(() =>
     ? t('subscription.tierNameYearly', { name: currentTierName.value })
     : currentTierName.value
 )
-
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 
 const reactivationVariant = computed<
@@ -433,8 +459,25 @@ const prorationCreditUsd = computed(() => {
   const credit = previewData.new_plan.price_cents - previewData.cost_today_cents
   return credit > 0 ? credit / 100 : 0
 })
-const totalDueTodayUsd = computed(() => previewData.cost_today_cents / 100)
 const newMonthlyChargeUsd = computed(() => newMonthlyUsd.value)
+
+const exactCurrency = computed(() => previewData.currency ?? 'USD')
+const formatExactMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: exactCurrency.value
+  }).format(cents / 100)
+const exactAmountDue = computed(() =>
+  formatExactMoney(previewData.amount_due_cents ?? previewData.cost_today_cents)
+)
+const exactRenewalAmount = computed(() =>
+  formatExactMoney(
+    previewData.renewal_amount_cents ?? previewData.cost_next_period_cents
+  )
+)
+const exactRenewalDate = computed(() =>
+  formatDate(previewData.renewal_at ?? previewData.effective_at)
+)
 
 const subscriptionLineLabel = computed(() =>
   newIsYearly.value
@@ -499,7 +542,6 @@ const currentPeriodEnd = computed(() =>
     ? formatDate(previewData.current_plan.period_end)
     : effectiveDateLabel.value
 )
-
 const confirmTitle = computed(() =>
   isImmediate.value
     ? t('subscription.preview.confirmUpgradeTitle')
@@ -523,7 +565,10 @@ const confirmCta = computed(() => {
 })
 const totalNote = computed(() =>
   isImmediate.value
-    ? t('subscription.preview.nextPaymentDue', { date: nextPaymentDate.value })
+    ? t('subscription.preview.renewsOn', {
+        amount: exactRenewalAmount.value,
+        date: exactRenewalDate.value
+      })
     : t('subscription.preview.stayOnUntil', {
         plan: currentPlanLabel.value,
         date: currentPeriodEnd.value

--- a/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
+++ b/src/platform/workspace/components/UnifiedStripePaymentSelector.vue
@@ -61,10 +61,12 @@ import Button from '@/components/ui/button/Button.vue'
 
 const {
   amountCents,
+  currency = 'USD',
   isLoading = false,
   verificationPending = false
 } = defineProps<{
   amountCents: number
+  currency?: string
   isLoading?: boolean
   /** A 3DS verification is pending: Complete verification (rendered by the
    *  parent) is the primary action, so the pay button steps back. */
@@ -101,7 +103,7 @@ onMounted(async () => {
   stripeElements.value = stripe.elements({
     mode: 'subscription',
     amount: amountCents,
-    currency: 'usd',
+    currency: currency.toLowerCase(),
     setupFutureUsage: 'off_session',
     paymentMethodTypes: ['card', 'alipay'],
     appearance: {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -87,6 +87,7 @@ const {
   mockIsTeamPlan,
   mockShouldUseWorkspaceBilling,
   mockSetActiveWorkspaceId,
+  mockListSavedPaymentMethods,
   mockPermissions,
   mockSubscription
 } = vi.hoisted(() => ({
@@ -116,6 +117,7 @@ const {
   mockIsTeamPlan: { value: false },
   mockShouldUseWorkspaceBilling: { value: true },
   mockSetActiveWorkspaceId: vi.fn<(workspaceId: string) => void>(),
+  mockListSavedPaymentMethods: vi.fn(),
   mockPermissions: {
     value: {
       canManageSubscription: true,
@@ -136,7 +138,11 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     fetchBalance: mockFetchBalance,
     isTeamPlan: computed(() => mockIsTeamPlan.value),
     resubscribe: mockResubscribe,
-    subscription: computed(() => mockSubscription.value)
+    subscription: {
+      get value() {
+        return mockSubscription.value
+      }
+    }
   })
 }))
 
@@ -166,7 +172,19 @@ vi.mock('@/services/dialogService', () => ({
 
 // Shields the test from the real workspaceApi → @/scripts/api → app.ts import chain
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
-  workspaceApi: { resubscribe: mockResubscribe }
+  WorkspaceApiError: class WorkspaceApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number,
+      public readonly code?: string
+    ) {
+      super(message)
+    }
+  },
+  workspaceApi: {
+    resubscribe: mockResubscribe,
+    listSavedPaymentMethods: mockListSavedPaymentMethods
+  }
 }))
 
 vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
@@ -243,9 +261,19 @@ describe('useSubscriptionCheckout', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
+    mockSubscribe.mockReset()
+    mockPreviewSubscribe.mockReset()
+    mockFetchPlans.mockReset()
+    mockFetchStatus.mockReset()
+    mockFetchBalance.mockReset()
+    mockListSavedPaymentMethods.mockReset()
+    mockStartOperation.mockReset()
+    mockGetOperation.mockReset()
     mockSubscriptionActionOperation.value = undefined
     mockPlans.value = allPlans()
     mockFetchPlans.mockResolvedValue(undefined)
+    mockPreviewSubscribe.mockResolvedValue(exactPreview())
+    mockListSavedPaymentMethods.mockResolvedValue([])
     mockStartOperation.mockResolvedValue({
       status: 'succeeded',
       workspaceId: 'workspace-1'
@@ -263,6 +291,180 @@ describe('useSubscriptionCheckout', () => {
     }
     mockSubscription.value = null
     emit = vi.fn()
+  })
+
+  function exactPreview(amountDueCents = 3_500, promotionCode?: string) {
+    return {
+      allowed: true,
+      transition_type: 'new_subscription' as const,
+      effective_at: '2026-08-01T00:00:00Z',
+      is_immediate: true,
+      cost_today_cents: amountDueCents,
+      cost_next_period_cents: amountDueCents,
+      credits_today_cents: 7_400,
+      credits_next_period_cents: 7_400,
+      new_plan: {
+        slug: 'creator-monthly',
+        tier: 'CREATOR' as const,
+        duration: 'MONTHLY' as const,
+        price_cents: 3_500,
+        credits_cents: 7_400,
+        seat_summary: {
+          seat_count: 1,
+          total_cost_cents: 3_500,
+          total_credits_cents: 7_400
+        }
+      },
+      quote_id: `quote-${amountDueCents}`,
+      quote_version: 1,
+      amount_due_cents: amountDueCents,
+      currency: 'USD',
+      renewal_amount_cents: amountDueCents,
+      renewal_at: '2026-09-01T00:00:00Z',
+      ...(promotionCode && {
+        promotion_code: promotionCode,
+        discounts: [{ kind: 'promotion' as const, code: promotionCode }]
+      })
+    }
+  }
+
+  describe('quoted saved-method checkout', () => {
+    it('selects the backend default from multiple masked methods', async () => {
+      mockPreviewSubscribe.mockResolvedValueOnce(exactPreview())
+      mockListSavedPaymentMethods.mockResolvedValueOnce([
+        {
+          type: 'card',
+          brand: 'mastercard',
+          last4: '4444',
+          id: 'pm_other',
+          isDefault: false
+        },
+        {
+          type: 'alipay',
+          id: 'pm_default',
+          isDefault: true
+        }
+      ])
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      expect(checkout.savedPaymentMethods.value).toHaveLength(2)
+      expect(checkout.selectedSavedPaymentMethodId.value).toBe('pm_default')
+    })
+
+    it('falls back to capture when payment methods are unavailable', async () => {
+      mockPreviewSubscribe.mockResolvedValueOnce(exactPreview())
+      mockListSavedPaymentMethods.mockRejectedValueOnce(new Error('Forbidden'))
+      const checkout = await setup()
+
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      expect(checkout.savedPaymentMethods.value).toEqual([])
+      expect(checkout.selectedSavedPaymentMethodId.value).toBeNull()
+    })
+
+    it('updates the amount only after a promotion preview succeeds', async () => {
+      mockPreviewSubscribe
+        .mockResolvedValueOnce(exactPreview())
+        .mockResolvedValueOnce(exactPreview(2_800, 'SAVE20'))
+      const checkout = await setup()
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      await expect(checkout.applyPromotionCode('SAVE20')).resolves.toBe(true)
+      expect(checkout.previewData.value?.amount_due_cents).toBe(2_800)
+      expect(checkout.appliedPromotionCode.value).toBe('SAVE20')
+    })
+
+    it('keeps the previous quote when promotion validation fails', async () => {
+      mockPreviewSubscribe
+        .mockResolvedValueOnce(exactPreview())
+        .mockRejectedValueOnce(new Error('Promotion code is invalid'))
+      const checkout = await setup()
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      await expect(checkout.applyPromotionCode('BAD')).resolves.toBe(false)
+      expect(checkout.previewData.value?.amount_due_cents).toBe(3_500)
+      expect(checkout.appliedPromotionCode.value).toBe('')
+      expect(checkout.promotionCodeError.value).toBe(
+        'Promotion code is invalid'
+      )
+    })
+
+    it('submits the quote with a capture token when Add new is selected', async () => {
+      mockPreviewSubscribe.mockResolvedValueOnce(exactPreview())
+      mockSubscribe.mockResolvedValueOnce({
+        status: 'subscribed',
+        billing_op_id: 'op-1'
+      })
+      const checkout = await setup()
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      await checkout.handleSubscriptionPayment('ctoken_new')
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'creator-monthly',
+        expect.objectContaining({
+          confirmationToken: 'ctoken_new',
+          quoteId: 'quote-3500',
+          quoteVersion: 1
+        })
+      )
+    })
+
+    it('requotes and returns to review when the backend rejects a stale quote', async () => {
+      const { WorkspaceApiError } =
+        await import('@/platform/workspace/api/workspaceApi')
+      mockPreviewSubscribe
+        .mockResolvedValueOnce(exactPreview())
+        .mockResolvedValueOnce(exactPreview(3_600))
+      mockListSavedPaymentMethods.mockResolvedValueOnce([
+        {
+          type: 'card',
+          brand: 'visa',
+          last4: '4242',
+          id: 'pm_owned',
+          isDefault: true
+        }
+      ])
+      mockSubscribe.mockRejectedValueOnce(
+        new WorkspaceApiError(
+          'subscription quote is stale',
+          422,
+          'SUBSCRIPTION_QUOTE_STALE'
+        )
+      )
+      const checkout = await setup()
+      await checkout.handleSubscribeClick({
+        tierKey: 'creator',
+        billingCycle: 'monthly'
+      })
+
+      await checkout.handleAddCreditCard()
+
+      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.previewData.value?.amount_due_cents).toBe(3_600)
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: 'subscription.preview.quoteStale'
+        })
+      )
+    })
   })
 
   describe('handleSubscribeClick', () => {
@@ -566,7 +768,7 @@ describe('useSubscriptionCheckout', () => {
         discountedUsd: 380
       })
       expect(checkout.selectedBillingCycle.value).toBe('yearly')
-      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.previewData.value).not.toBeNull()
       expect(checkout.selectedTierKey.value).toBeNull()
     })
 
@@ -598,7 +800,7 @@ describe('useSubscriptionCheckout', () => {
       expect(checkout.previewData.value).toStrictEqual(transition)
     })
 
-    it('falls back to the display-only confirm when the preview is a fresh subscription', async () => {
+    it('keeps the exact preview for a fresh subscription', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockResolvedValueOnce({
         allowed: true,
@@ -617,10 +819,10 @@ describe('useSubscriptionCheckout', () => {
         isChange: true
       })
 
-      expect(checkout.previewData.value).toBeNull()
+      expect(checkout.previewData.value).not.toBeNull()
     })
 
-    it('falls back to the display-only confirm when the preview request fails', async () => {
+    it('returns to pricing when the preview request fails', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockRejectedValueOnce(new Error('not supported'))
 
@@ -636,10 +838,10 @@ describe('useSubscriptionCheckout', () => {
       })
 
       expect(checkout.previewData.value).toBeNull()
-      expect(checkout.checkoutStep.value).toBe('preview')
+      expect(checkout.checkoutStep.value).toBe('pricing')
     })
 
-    it('does not preview a fresh team subscribe (nothing to prorate)', async () => {
+    it('previews a fresh team subscribe for an exact quote', async () => {
       const checkout = await setup()
 
       await checkout.handleSubscribeTeamClick({
@@ -653,8 +855,11 @@ describe('useSubscriptionCheckout', () => {
         isChange: false
       })
 
-      expect(mockPreviewSubscribe).not.toHaveBeenCalled()
-      expect(checkout.previewData.value).toBeNull()
+      expect(mockPreviewSubscribe).toHaveBeenCalledWith(
+        'team_per_credit_monthly',
+        { teamCreditStopId: 'team_700', billingCycle: 'monthly' }
+      )
+      expect(checkout.previewData.value).not.toBeNull()
     })
 
     // Regression guard: a cancelled personal subscriber picking Team has no
@@ -867,6 +1072,8 @@ describe('useSubscriptionCheckout', () => {
       expect(mockSubscribe).toHaveBeenCalledWith('team_per_credit_monthly', {
         teamCreditStopId: 'team_700',
         billingCycle: 'monthly',
+        quoteId: 'quote-3500',
+        quoteVersion: 1,
         returnUrl: 'https://platform.comfy.org/payment/success',
         cancelUrl: 'https://platform.comfy.org/payment/failed',
         confirmReactivation: false
@@ -1186,7 +1393,7 @@ describe('useSubscriptionCheckout', () => {
       })
     })
 
-    it('keeps team checkout_type as change when the preview request fails', async () => {
+    it('does not submit a team change when the preview request fails', async () => {
       const checkout = await setup()
       mockPreviewSubscribe.mockRejectedValueOnce(new Error('not supported'))
       await checkout.handleSubscribeTeamClick({
@@ -1208,14 +1415,8 @@ describe('useSubscriptionCheckout', () => {
 
       await checkout.handleTeamSubscribe()
 
-      expect(mockTrackBeginCheckout).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tier: 'team',
-          cycle: 'monthly',
-          checkout_type: 'change',
-          billing_op_id: 'op-team-change'
-        })
-      )
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(mockTrackBeginCheckout).not.toHaveBeenCalled()
     })
 
     it('refreshes stale cancellation state before a team submit and lets a retry succeed after the subscription is cancelled elsewhere', async () => {

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -18,7 +18,12 @@ import type {
   Plan,
   PreviewSubscribeOptions,
   PreviewSubscribeResponse,
+  SavedPaymentMethod,
   SubscribeResponse
+} from '@/platform/workspace/api/workspaceApi'
+import {
+  WorkspaceApiError,
+  workspaceApi
 } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
@@ -115,6 +120,12 @@ export function useSubscriptionCheckout(
   const selectedTierKey = ref<CheckoutTierKey | null>(null)
   const selectedTeamCheckout = ref<SelectedTeamCheckout | null>(null)
   const selectedBillingCycle = ref<BillingCycle>('yearly')
+  const savedPaymentMethods = ref<SavedPaymentMethod[]>([])
+  const selectedSavedPaymentMethodId = ref<string | null>(null)
+  const isLoadingPaymentMethods = ref(false)
+  const appliedPromotionCode = ref('')
+  const promotionCodeError = ref<string | null>(null)
+  const isApplyingPromotionCode = ref(false)
   const activeCheckoutOperationId = ref<string | null>(null)
   const activeCheckoutOperation = computed(() => {
     if (!activeCheckoutOperationId.value) {
@@ -137,7 +148,9 @@ export function useSubscriptionCheckout(
     () => selectedTeamCheckout.value?.stop ?? null
   )
   const isTeamCheckout = computed(() => selectedTeamCheckout.value !== null)
-  const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+  function isCancelled() {
+    return subscription.value?.isCancelled ?? false
+  }
 
   // A cancelled subscription needs confirm_reactivation, and the only place
   // that can honestly collect it is the reactivation banner. Paths with no
@@ -272,7 +285,9 @@ export function useSubscriptionCheckout(
 
   const previewVariant = computed<PreviewVariant>(() => {
     if (selectedTeamCheckout.value) {
-      return previewData.value ? 'team-change' : 'team-new'
+      return previewData.value?.transition_type === 'new_subscription'
+        ? 'team-new'
+        : 'team-change'
     }
     if (previewData.value) {
       return previewData.value.transition_type === 'new_subscription'
@@ -289,6 +304,112 @@ export function useSubscriptionCheckout(
     return findPlanSlug(plans.value, tierKey, billingCycle)
   }
 
+  function exactQuoteAvailable(preview: PreviewSubscribeResponse): boolean {
+    return (
+      typeof preview.quote_id === 'string' &&
+      typeof preview.quote_version === 'number' &&
+      typeof preview.amount_due_cents === 'number' &&
+      typeof preview.currency === 'string' &&
+      typeof preview.renewal_amount_cents === 'number' &&
+      typeof preview.renewal_at === 'string'
+    )
+  }
+
+  function previewCanBeReviewed(preview: PreviewSubscribeResponse): boolean {
+    const hasQuoteContract =
+      preview.quote_id !== undefined || preview.quote_version !== undefined
+    return (
+      preview.allowed && (!hasQuoteContract || exactQuoteAvailable(preview))
+    )
+  }
+
+  function selectedPlanSlug(): string | null {
+    if (selectedTeamCheckout.value) {
+      return getTeamPlanSlug(selectedBillingCycle.value)
+    }
+    return selectedTierKey.value
+      ? getApiPlanSlug(selectedTierKey.value, selectedBillingCycle.value)
+      : null
+  }
+
+  function selectedPreviewOptions(
+    promotionCode = appliedPromotionCode.value
+  ): PreviewSubscribeOptions {
+    return {
+      ...(selectedTeamCheckout.value?.stop.id && {
+        teamCreditStopId: selectedTeamCheckout.value.stop.id,
+        billingCycle: selectedBillingCycle.value
+      }),
+      ...(promotionCode && { promotionCode })
+    }
+  }
+
+  async function requote(promotionCode = appliedPromotionCode.value) {
+    const planSlug = selectedPlanSlug()
+    if (!planSlug) throw new Error(t('subscription.preview.quoteUnavailable'))
+    const response = await previewSubscribe(
+      planSlug,
+      selectedPreviewOptions(promotionCode)
+    )
+    if (!response?.allowed || !exactQuoteAvailable(response)) {
+      throw new Error(
+        response?.reason || t('subscription.preview.quoteUnavailable')
+      )
+    }
+    previewData.value = response
+    return response
+  }
+
+  async function loadSavedPaymentMethods() {
+    isLoadingPaymentMethods.value = true
+    try {
+      const methods = await workspaceApi.listSavedPaymentMethods()
+      savedPaymentMethods.value = methods.filter(
+        (method) => method.type === 'card' || method.type === 'alipay'
+      )
+      selectedSavedPaymentMethodId.value =
+        savedPaymentMethods.value.find((method) => method.isDefault)?.id ??
+        savedPaymentMethods.value[0]?.id ??
+        null
+    } catch {
+      savedPaymentMethods.value = []
+      selectedSavedPaymentMethodId.value = null
+    } finally {
+      isLoadingPaymentMethods.value = false
+    }
+  }
+
+  async function applyPromotionCode(code: string): Promise<boolean> {
+    isApplyingPromotionCode.value = true
+    promotionCodeError.value = null
+    try {
+      const normalized = code.trim()
+      const response = await requote(normalized)
+      appliedPromotionCode.value = response.promotion_code ?? normalized
+      return true
+    } catch (error) {
+      promotionCodeError.value =
+        error instanceof Error
+          ? error.message
+          : t('subscription.preview.promotionCodeInvalid')
+      return false
+    } finally {
+      isApplyingPromotionCode.value = false
+    }
+  }
+
+  async function selectSavedPaymentMethod(id: string | null) {
+    const previousId = selectedSavedPaymentMethodId.value
+    selectedSavedPaymentMethodId.value = id
+    promotionCodeError.value = null
+    try {
+      await requote()
+    } catch (error) {
+      selectedSavedPaymentMethodId.value = previousId
+      showSubscribeError(error)
+    }
+  }
+
   async function handleSubscribeClick(payload: {
     tierKey: CheckoutTierKey
     billingCycle: BillingCycle
@@ -301,6 +422,8 @@ export function useSubscriptionCheckout(
     loadingTier.value = tierKey
     selectedTierKey.value = tierKey
     selectedBillingCycle.value = billingCycle
+    savedPaymentMethods.value = []
+    selectedSavedPaymentMethodId.value = null
 
     try {
       let planSlug = getApiPlanSlug(tierKey, billingCycle)
@@ -319,7 +442,7 @@ export function useSubscriptionCheckout(
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       const response = await previewSubscribe(planSlug)
 
-      if (!response || !response.allowed) {
+      if (!response || !previewCanBeReviewed(response)) {
         toast.add({
           severity: 'error',
           summary: 'Unable to subscribe',
@@ -330,6 +453,10 @@ export function useSubscriptionCheckout(
 
       previewData.value = response
       checkoutStep.value = 'preview'
+      appliedPromotionCode.value = ''
+      if (response.transition_type === 'new_subscription') {
+        await loadSavedPaymentMethods()
+      }
     } catch (error) {
       const message =
         error instanceof Error
@@ -367,15 +494,10 @@ export function useSubscriptionCheckout(
     selectedBillingCycle.value = payload.billingCycle
     selectedTierKey.value = null
     previewData.value = null
-    checkoutStep.value = 'preview'
+    savedPaymentMethods.value = []
+    selectedSavedPaymentMethodId.value = null
 
-    // A cancelled subscriber picking Team is a reactivation even when
-    // nothing existing is "changing" (isChange false, e.g. a first-time Team
-    // pick): the add-payment screen this would otherwise fall back to can't
-    // collect confirm_reactivation, so it always needs a real,
-    // reactivation-capable preview instead of the consent-less fallback.
-    const needsPreview = payload.isChange || isCancelled.value
-    if (!needsPreview || !payload.stop.id) return
+    if (!payload.stop.id) return
 
     let response: PreviewSubscribeResponse | null = null
     let previewError: unknown
@@ -389,16 +511,19 @@ export function useSubscriptionCheckout(
       previewError = error
     }
 
-    if (isReactivationCapablePreview(response)) {
+    if (
+      response &&
+      previewCanBeReviewed(response) &&
+      (!isCancelled() || isReactivationCapablePreview(response))
+    ) {
       previewData.value = response
+      appliedPromotionCode.value = ''
+      checkoutStep.value = 'preview'
+      if (response.transition_type === 'new_subscription') {
+        await loadSavedPaymentMethods()
+      }
       return
     }
-    // Not cancelled: preview is best-effort, keep the display-only confirm.
-    if (!isCancelled.value) return
-
-    // Cancelled with no qualifying preview: the add-payment fallback has no
-    // way to collect confirm_reactivation, so every submit from it would be
-    // an unrecoverable dead end. Surface the failure instead.
     toast.add({
       severity: 'error',
       summary: t('subscription.teamPlan.name'),
@@ -409,6 +534,10 @@ export function useSubscriptionCheckout(
     })
     checkoutStep.value = 'pricing'
     selectedTeamCheckout.value = null
+    savedPaymentMethods.value = []
+    selectedSavedPaymentMethodId.value = null
+    appliedPromotionCode.value = ''
+    promotionCodeError.value = null
   }
 
   function handleBackToPricing() {
@@ -417,6 +546,10 @@ export function useSubscriptionCheckout(
     previewData.value = null
     selectedTeamCheckout.value = null
     activeCheckoutOperationId.value = null
+    savedPaymentMethods.value = []
+    selectedSavedPaymentMethodId.value = null
+    appliedPromotionCode.value = ''
+    promotionCodeError.value = null
   }
 
   function handleSuccessClose() {
@@ -425,8 +558,7 @@ export function useSubscriptionCheckout(
 
   async function handleSubscription(
     confirmReactivation = false,
-    confirmationToken?: string,
-    promotionCode?: string
+    confirmationToken?: string
   ) {
     if (!permissions.value.canManageSubscription || !canSelectTierPlan()) return
 
@@ -446,16 +578,30 @@ export function useSubscriptionCheckout(
       if (!planSlug) return
       if (await showTeamToPersonalDowngrade(planSlug, tierKey)) return
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (!confirmReactivation && isCancelled()) {
         await refreshPreviewOnReactivationBlock(planSlug)
         return
       }
-      if (confirmReactivation && isCancelled.value) {
-        await assertReactivationAmountUnchanged(planSlug)
+      if (confirmReactivation && isCancelled()) {
+        await assertReactivationAmountUnchanged(
+          planSlug,
+          selectedPreviewOptions()
+        )
       }
       const response = await subscribe(planSlug, {
         ...(confirmationToken && { confirmationToken }),
-        ...(promotionCode && { promotionCode }),
+        ...(selectedSavedPaymentMethodId.value && {
+          savedPaymentMethodId: selectedSavedPaymentMethodId.value
+        }),
+        ...(previewData.value?.promotion_code && {
+          promotionCode: previewData.value.promotion_code
+        }),
+        ...(previewData.value?.quote_id && {
+          quoteId: previewData.value.quote_id
+        }),
+        ...(previewData.value?.quote_version !== undefined && {
+          quoteVersion: previewData.value.quote_version
+        }),
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
         cancelUrl: `${getComfyPlatformBaseUrl()}/payment/failed`,
         confirmReactivation
@@ -476,6 +622,7 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (await recoverQuoteOrPaymentMethod(error)) return
       trackSubscriptionFailure({
         tier: tierKey,
         cycle: billingCycle,
@@ -496,6 +643,35 @@ export function useSubscriptionCheckout(
           ? error.message
           : t('subscription.subscribeFailed')
     })
+  }
+
+  async function recoverQuoteOrPaymentMethod(error: unknown): Promise<boolean> {
+    if (!(error instanceof WorkspaceApiError)) return false
+    if (error.code === 'INVALID_PAYMENT_METHOD') {
+      savedPaymentMethods.value = []
+      selectedSavedPaymentMethodId.value = null
+      try {
+        await requote()
+      } catch {
+        previewData.value = null
+        checkoutStep.value = 'pricing'
+      }
+      showSubscribeError(
+        new Error(t('subscription.preview.savedPaymentMethodUnavailable'))
+      )
+      return true
+    }
+    if (error.code === 'SUBSCRIPTION_QUOTE_STALE') {
+      try {
+        await requote()
+      } catch {
+        previewData.value = null
+        checkoutStep.value = 'pricing'
+      }
+      showSubscribeError(new Error(t('subscription.preview.quoteStale')))
+      return true
+    }
+    return false
   }
 
   interface SubscriptionOutcomeContext {
@@ -602,8 +778,7 @@ export function useSubscriptionCheckout(
 
   async function handleTeamSubscription(
     confirmReactivation = false,
-    confirmationToken?: string,
-    promotionCode?: string
+    confirmationToken?: string
   ) {
     if (!permissions.value.canManageSubscription) return
 
@@ -624,22 +799,36 @@ export function useSubscriptionCheckout(
     isSubscribing.value = true
     try {
       await fetchStatus()
-      if (!confirmReactivation && isCancelled.value) {
+      if (!confirmReactivation && isCancelled()) {
         await refreshPreviewOnReactivationBlock(planSlug, {
           teamCreditStopId: stop.id,
           billingCycle
         })
         return
       }
-      if (confirmReactivation && isCancelled.value) {
+      if (confirmReactivation && isCancelled()) {
         await assertReactivationAmountUnchanged(planSlug, {
           teamCreditStopId: stop.id,
-          billingCycle
+          billingCycle,
+          ...(appliedPromotionCode.value && {
+            promotionCode: appliedPromotionCode.value
+          })
         })
       }
       const response = await subscribe(planSlug, {
         ...(confirmationToken && { confirmationToken }),
-        ...(promotionCode && { promotionCode }),
+        ...(selectedSavedPaymentMethodId.value && {
+          savedPaymentMethodId: selectedSavedPaymentMethodId.value
+        }),
+        ...(previewData.value?.promotion_code && {
+          promotionCode: previewData.value.promotion_code
+        }),
+        ...(previewData.value?.quote_id && {
+          quoteId: previewData.value.quote_id
+        }),
+        ...(previewData.value?.quote_version !== undefined && {
+          quoteVersion: previewData.value.quote_version
+        }),
         teamCreditStopId: stop.id,
         billingCycle,
         returnUrl: `${getComfyPlatformBaseUrl()}/payment/success`,
@@ -662,6 +851,7 @@ export function useSubscriptionCheckout(
         checkoutType
       })
     } catch (error) {
+      if (await recoverQuoteOrPaymentMethod(error)) return
       trackSubscriptionFailure({
         tier: 'team',
         cycle: billingCycle,
@@ -721,18 +911,12 @@ export function useSubscriptionCheckout(
     }
   }
 
-  function handleSubscriptionPayment(
-    confirmationToken: string,
-    promotionCode?: string
-  ) {
-    return handleSubscription(false, confirmationToken, promotionCode)
+  function handleSubscriptionPayment(confirmationToken: string) {
+    return handleSubscription(false, confirmationToken)
   }
 
-  function handleTeamSubscriptionPayment(
-    confirmationToken: string,
-    promotionCode?: string
-  ) {
-    return handleTeamSubscription(false, confirmationToken, promotionCode)
+  function handleTeamSubscriptionPayment(confirmationToken: string) {
+    return handleTeamSubscription(false, confirmationToken)
   }
 
   return {
@@ -745,6 +929,12 @@ export function useSubscriptionCheckout(
     selectedTierKey,
     selectedTeamStop,
     selectedBillingCycle,
+    savedPaymentMethods,
+    selectedSavedPaymentMethodId,
+    isLoadingPaymentMethods,
+    appliedPromotionCode,
+    promotionCodeError,
+    isApplyingPromotionCode,
     activeCheckoutActionUrl,
     isPolling,
     isTeamCheckout,
@@ -758,6 +948,8 @@ export function useSubscriptionCheckout(
     handleTeamSubscribe: handleTeamSubscription,
     handleSubscriptionPayment,
     handleTeamSubscriptionPayment,
+    applyPromotionCode,
+    selectSavedPaymentMethod,
     handleResubscribe
   }
 }


### PR DESCRIPTION
## Summary

Integrates the embedded subscription checkout with the saved-payment-method and exact quote contracts from cloud PRs [#5947](https://github.com/Comfy-Org/cloud/pull/5947) and [#5949](https://github.com/Comfy-Org/cloud/pull/5949), preventing unquoted promotion totals and owner-unscoped payment-method selection.

## Changes

- **What**: Loads owner-authorized masked card/Alipay methods, supports saved-method confirmation and Add new capture fallback, and submits `saved_payment_method_id` only from in-memory checkout state.
- **What**: Adds explicit promo validation through preview, renders exact amount/currency/discount/renewal quote data, and submits `quote_id` + `quote_version`.
- **What**: Requotes on checkout selection changes, recovers stale quotes back to review, and clears method IDs when leaving checkout.

## Review Focus

- Saved-method ownership failures and stale quote recovery.
- Exact quote rendering for initial subscriptions and immediate plan changes.
- Existing Stripe Payment Element remains limited to card/Alipay with PMC disabled.

## Screenshots (if applicable)

Not included: the real app state requires an owner-authorized cloud workspace with attached Stripe methods and the stacked backend contracts.

## Verification

- `pnpm test:unit src/platform/workspace/api/workspaceApi.test.ts src/platform/workspace/composables/useSubscriptionCheckout.test.ts src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.test.ts src/platform/workspace/components/SubscriptionPromoCodeField.test.ts` (125 passed)
- `pnpm typecheck`
- focused ESLint and oxfmt checks on touched files
- pre-push `knip --cache`