### PR TITLE
fix(workspace): handle ended team subscription

### DIFF
--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,5 +1,6 @@
+import type { BillingStatusResponse as IngestBillingStatusResponse } from '@comfyorg/ingest-types'
+
 import type {
-  BillingStatusResponse,
   Member,
   Plan,
   WorkspaceWithRole
@@ -70,7 +71,7 @@ export const DEFAULT_TEAM_MEMBERS: Member[] = [
 
 const TEAM_PLAN_SLUG = 'team-pro-monthly'
 
-export const TEAM_BILLING_STATUS: BillingStatusResponse = {
+export const TEAM_BILLING_STATUS = {
   is_active: true,
   subscription_status: 'active',
   subscription_tier: 'PRO',
@@ -78,8 +79,21 @@ export const TEAM_BILLING_STATUS: BillingStatusResponse = {
   plan_slug: TEAM_PLAN_SLUG,
   billing_status: 'paid',
   has_funds: true,
-  renewal_date: '2099-02-20T00:00:00Z'
-}
+  renewal_date: '2099-02-20T00:00:00Z',
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse
+
+export const ENDED_STANDARD_BILLING_STATUS = {
+  billing_rail: 'stripe',
+  billing_status: 'inactive',
+  has_funds: true,
+  is_active: false,
+  plan_slug: 'standard-monthly',
+  subscription_duration: 'MONTHLY',
+  subscription_status: 'ended',
+  subscription_tier: 'STANDARD',
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse & { billing_rail: 'stripe' }
 
 export const TEAM_PRO_PLAN: Plan = {
   slug: TEAM_PLAN_SLUG,

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -1,4 +1,5 @@
 import type { Page, Route } from '@playwright/test'
+import type { BillingStatusResponse } from '@comfyorg/ingest-types'
 
 import type {
   Member,
@@ -45,9 +46,10 @@ export class CloudWorkspaceMockHelper {
 
   async setup(
     members: Member[] = DEFAULT_TEAM_MEMBERS,
-    activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE
+    activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE,
+    billingStatus: BillingStatusResponse = TEAM_BILLING_STATUS
   ): Promise<MemberMockState> {
-    const state = await this.mockBoot(members, activeWorkspace)
+    const state = await this.mockBoot(members, activeWorkspace, billingStatus)
     await new CloudAuthHelper(this.page).mockAuth()
     await this.page.addInitScript((workspaceId) => {
       localStorage.setItem('Comfy.userId', 'test-user-e2e')
@@ -58,7 +60,8 @@ export class CloudWorkspaceMockHelper {
 
   private async mockBoot(
     members: Member[],
-    activeWorkspace: WorkspaceWithRole
+    activeWorkspace: WorkspaceWithRole,
+    billingStatus: BillingStatusResponse
   ): Promise<MemberMockState> {
     const state: MemberMockState = {
       members: members.map((m) => ({ ...m })),
@@ -132,7 +135,7 @@ export class CloudWorkspaceMockHelper {
     )
 
     await page.route('**/api/billing/status', (r) =>
-      r.fulfill(jsonRoute(TEAM_BILLING_STATUS))
+      r.fulfill(jsonRoute(billingStatus))
     )
     await page.route('**/api/billing/balance', (r) =>
       r.fulfill(
@@ -148,7 +151,7 @@ export class CloudWorkspaceMockHelper {
     await page.route('**/api/billing/plans', (r) =>
       r.fulfill(
         jsonRoute({
-          current_plan_slug: TEAM_PRO_PLAN.slug,
+          current_plan_slug: billingStatus.plan_slug ?? TEAM_PRO_PLAN.slug,
           plans: [TEAM_PRO_PLAN]
         })
       )

--- a/browser_tests/tests/dialogs/endedSubscription.spec.ts
+++ b/browser_tests/tests/dialogs/endedSubscription.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from '@playwright/test'
+
+import {
+  cloudAppFixture as test,
+  waitForCloudApp
+} from '@e2e/fixtures/cloudAppFixture'
+import {
+  DEFAULT_TEAM_MEMBERS,
+  ENDED_STANDARD_BILLING_STATUS,
+  TEAM_WORKSPACE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+test.describe('Ended workspace subscription', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test.beforeEach(async ({ page }) => {
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      TEAM_WORKSPACE,
+      ENDED_STANDARD_BILLING_STATUS
+    )
+    await page.goto(process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188')
+    await waitForCloudApp(page)
+
+    await page
+      .getByRole('button', { name: /^Settings/ })
+      .first()
+      .click()
+    const dialog = page.getByTestId(TestIds.dialogs.settings)
+    await expect(dialog).toBeVisible()
+    await dialog
+      .locator('nav')
+      .getByRole('button', { name: 'Workspace', exact: true })
+      .click()
+  })
+
+  test('shows subscribe prompt instead of stale paid plan metadata', async ({
+    page
+  }) => {
+    const content = page.getByTestId(TestIds.dialogs.settings).getByRole('main')
+
+    await expect(
+      content.getByRole('heading', {
+        name: 'This workspace is not on a subscription'
+      })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('button', { name: 'Subscribe Now' })
+    ).toBeVisible()
+    await expect(
+      content.getByRole('heading', { name: 'Standard' })
+    ).toHaveCount(0)
+  })
+})

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -10,6 +10,7 @@ import enMessages from '@/locales/en/main.json'
 import * as tierPricing from '@/platform/cloud/subscription/constants/tierPricing'
 import type {
   BillingStatus,
+  BillingSubscriptionStatus,
   CurrentTeamCreditStop,
   TeamCreditStops
 } from '@/platform/workspace/api/workspaceApi'
@@ -54,7 +55,7 @@ const teamCreditStops: TeamCreditStops = {
   ]
 }
 
-const mockSubscriptionStatus = ref<'active' | 'canceled'>('active')
+const mockSubscriptionStatus = ref<BillingSubscriptionStatus>('active')
 const mockBillingStatus = ref<BillingStatus>('paid')
 const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockHasSubscription = ref(true)
@@ -134,6 +135,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isActiveSubscription: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
     billingStatus: mockBillingStatus,
+    subscriptionStatus: mockSubscriptionStatus,
     isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     teamCreditStops: mockTeamCreditStops,
@@ -469,6 +471,28 @@ describe('SubscriptionPanelContentWorkspace', () => {
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('heading', { name: 'Team' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows subscribe prompt for an ended Standard plan in a Team workspace', () => {
+    mockIsActiveSubscription.value = false
+    mockSubscriptionStatus.value = 'ended'
+    mockBillingStatus.value = 'inactive'
+    mockSubscriptionTier.value = 'STANDARD'
+    mockPlanSlug.value = 'standard-monthly'
+    mockHasTeamPlan.value = false
+    renderComponent()
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'This workspace is not on a subscription'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Subscribe Now' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Standard' })
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -377,6 +377,7 @@ const {
   isTeamPlan,
   subscription,
   billingStatus,
+  subscriptionStatus,
   isLoading,
   error,
   showSubscriptionDialog,
@@ -397,11 +398,18 @@ const isTerminalPersonalSubscription = computed(
     billingStatus.value === 'inactive'
 )
 
+const isSubscriptionEnded = computed(
+  () =>
+    subscriptionStatus.value === 'ended' ||
+    (isSubscriptionCancelled.value && !isActiveSubscription.value) ||
+    isTerminalPersonalSubscription.value
+)
+
 // Show subscribe prompt to owners without active subscription. A cancelled plan
 // stays active until its end date, so it keeps the subscribed treatment.
 const showSubscribePrompt = computed(() => {
   if (!permissions.value.canManageSubscription) return false
-  if (isTerminalPersonalSubscription.value) return true
+  if (isSubscriptionEnded.value && !isActiveSubscription.value) return true
   if (isSubscriptionCancelled.value) return false
   if (
     subscription.value &&


### PR DESCRIPTION
## Summary

- Treat an inactive `subscription_status: ended` as terminal for every workspace type before stale paid-plan metadata is considered.
- Show the workspace subscription prompt instead of a stale Standard plan after immediate cancellation.
- Add component and Playwright regression coverage for the full Settings → Workspace flow.

## Root cause

The cloud/1.48 backport only recognized terminal billing state for personal-typed workspaces. An ended subscription attached to a team-typed workspace retained paid-plan identity, which suppressed the subscribe prompt.

## Validation

- Component tests: 31 passed
- Playwright cloud regression: 1 passed
- oxfmt check
- type-aware oxlint
- git diff --check