### PR TITLE
feat: instrument unified auth retry outcomes

### DIFF
--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -7,9 +7,16 @@ import {
   fetchWithUnifiedRemint
 } from '@/platform/auth/unified/remintRetry'
 
-const { mockRemint, flagState } = vi.hoisted(() => ({
+const { mockRemint, mockTrackUnifiedAuthRetry, flagState } = vi.hoisted(() => ({
   mockRemint: vi.fn(),
+  mockTrackUnifiedAuthRetry: vi.fn(),
   flagState: { unifiedCloudAuthEnabled: true }
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackUnifiedAuthRetry: mockTrackUnifiedAuthRetry
+  })
 }))
 
 vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
@@ -37,6 +44,7 @@ describe('fetchWithUnifiedRemint', () => {
 
   beforeEach(() => {
     mockRemint.mockReset()
+    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
     mockFetch = vi.fn()
     vi.stubGlobal('fetch', mockFetch)
@@ -64,6 +72,11 @@ describe('fetchWithUnifiedRemint', () => {
     const retryHeaders = new Headers(mockFetch.mock.calls[1][1].headers)
     expect(retryHeaders.get('Authorization')).toBe('Bearer tokenB')
     expect(retryHeaders.get('Comfy-User')).toBe('u1')
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'succeeded',
+      final_status: 200
+    })
   })
 
   it('surfaces a persistent 401 after exactly one retry (AC2)', async () => {
@@ -82,6 +95,12 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(secondUnauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'retry_rejected'
+    })
   })
 
   it('does not re-mint or retry when the caller gate is false (AC3)', async () => {
@@ -96,6 +115,7 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(unauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRemint).not.toHaveBeenCalled()
+    expect(mockTrackUnifiedAuthRetry).not.toHaveBeenCalled()
   })
 
   it('does not retry a non-401 response', async () => {
@@ -126,6 +146,12 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(unauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'remint_failed'
+    })
   })
 
   it('uses the bearer from a Request when init does not override headers', async () => {
@@ -178,6 +204,12 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(unauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRemint).not.toHaveBeenCalled()
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'missing_bearer'
+    })
   })
 
   it('surfaces the original 401 when the re-mint throws a permanent auth error', async () => {
@@ -212,6 +244,12 @@ describe('fetchWithUnifiedRemint', () => {
     expect(result).toBe(unauthorized)
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRemint).not.toHaveBeenCalled()
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'non_replayable_body'
+    })
   })
 
   it.for([
@@ -259,6 +297,7 @@ describe('fetchWithUnifiedRemint', () => {
 describe('attachUnifiedRemintInterceptor', () => {
   beforeEach(() => {
     mockRemint.mockReset()
+    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
   })
 
@@ -312,6 +351,11 @@ describe('attachUnifiedRemintInterceptor', () => {
     expect(String(adapter.mock.calls[1][0].headers.Authorization)).toBe(
       'Bearer tokenB'
     )
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'axios',
+      outcome: 'succeeded',
+      final_status: 200
+    })
   })
 
   it('retries once then surfaces a persistent 401 (AC2)', async () => {
@@ -326,6 +370,12 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     expect(adapter).toHaveBeenCalledTimes(2)
     expect(mockRemint).toHaveBeenCalledTimes(1)
+    expect(mockTrackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'axios',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'retry_rejected'
+    })
   })
 
   it('does not re-mint when the flag is OFF (AC3)', async () => {
@@ -340,6 +390,7 @@ describe('attachUnifiedRemintInterceptor', () => {
 
     expect(adapter).toHaveBeenCalledTimes(1)
     expect(mockRemint).not.toHaveBeenCalled()
+    expect(mockTrackUnifiedAuthRetry).not.toHaveBeenCalled()
   })
 
   it('does not re-mint a request flagged __skipUnifiedRemint (acceptInvite)', async () => {

--- a/src/platform/auth/unified/remintRetry.ts
+++ b/src/platform/auth/unified/remintRetry.ts
@@ -6,6 +6,11 @@ import type {
 import axios, { AxiosHeaders } from 'axios'
 
 import { isCloud } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
+import type {
+  UnifiedAuthRetryFailureReason,
+  UnifiedAuthRetryMetadata
+} from '@/platform/telemetry/types'
 
 let cachedUnifiedFlags:
   | { readonly unifiedCloudAuthEnabled: boolean }
@@ -45,6 +50,32 @@ async function tryRemintToken(expectedToken: string): Promise<string | null> {
     console.warn('Unified re-mint primitive threw unexpectedly:', err)
     return null
   }
+}
+
+function trackRetry(
+  transport: UnifiedAuthRetryMetadata['transport'],
+  outcome: UnifiedAuthRetryMetadata['outcome'],
+  finalStatus?: number,
+  failureReason?: UnifiedAuthRetryFailureReason
+): void {
+  useTelemetry()?.trackUnifiedAuthRetry({
+    transport,
+    outcome,
+    ...(finalStatus !== undefined && { final_status: finalStatus }),
+    ...(failureReason !== undefined && { failure_reason: failureReason })
+  })
+}
+
+function trackRetryResponse(
+  transport: UnifiedAuthRetryMetadata['transport'],
+  status: number
+): void {
+  trackRetry(
+    transport,
+    status < 400 ? 'succeeded' : 'failed',
+    status,
+    status < 400 ? undefined : 'retry_rejected'
+  )
 }
 
 function bearerToken(authorization: unknown): string | undefined {
@@ -92,21 +123,33 @@ export async function fetchWithUnifiedRemint(
     console.warn(
       'fetchWithUnifiedRemint: a ReadableStream body is not replayable; surfacing the original 401'
     )
+    trackRetry('fetch', 'failed', response.status, 'non_replayable_body')
     return response
   }
 
   const requestHeaders = fetchRequestHeaders(input, init)
   const expectedToken = bearerToken(requestHeaders.get('Authorization'))
-  if (!expectedToken) return response
+  if (!expectedToken) {
+    trackRetry('fetch', 'failed', response.status, 'missing_bearer')
+    return response
+  }
 
   const token = await tryRemintToken(expectedToken)
   if (!token) {
+    trackRetry('fetch', 'failed', response.status, 'remint_failed')
     return response
   }
 
   const headers = requestHeaders
   headers.set('Authorization', `Bearer ${token}`)
-  return fetch(retryInput, { ...init, headers })
+  try {
+    const retryResponse = await fetch(retryInput, { ...init, headers })
+    trackRetryResponse('fetch', retryResponse.status)
+    return retryResponse
+  } catch (error) {
+    trackRetry('fetch', 'failed', undefined, 'retry_request_failed')
+    throw error
+  }
 }
 
 function isRetriableUnauthorized(
@@ -142,11 +185,13 @@ export function attachUnifiedRemintInterceptor(client: AxiosInstance): void {
         new AxiosHeaders(error.config.headers).get('Authorization')
       )
       if (!expectedToken) {
+        trackRetry('axios', 'failed', 401, 'missing_bearer')
         throw error
       }
 
       const token = await tryRemintToken(expectedToken)
       if (!token) {
+        trackRetry('axios', 'failed', 401, 'remint_failed')
         throw error
       }
 
@@ -155,7 +200,26 @@ export function attachUnifiedRemintInterceptor(client: AxiosInstance): void {
       const { config } = error
       const headers = new AxiosHeaders(config.headers)
       headers.set('Authorization', `Bearer ${token}`)
-      return client.request({ ...config, headers, __unifiedRetried: true })
+      try {
+        const retryResponse = await client.request({
+          ...config,
+          headers,
+          __unifiedRetried: true
+        })
+        trackRetryResponse('axios', retryResponse.status)
+        return retryResponse
+      } catch (retryError) {
+        const finalStatus = axios.isAxiosError(retryError)
+          ? retryError.response?.status
+          : undefined
+        trackRetry(
+          'axios',
+          'failed',
+          finalStatus,
+          finalStatus !== undefined ? 'retry_rejected' : 'retry_request_failed'
+        )
+        throw retryError
+      }
     }
   )
 }

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -66,6 +66,27 @@ describe('TelemetryRegistry', () => {
     expect(b.trackAuthFailed).toHaveBeenCalledExactlyOnceWith(payload)
   })
 
+  it('dispatches unified auth retry outcomes to supporting providers', () => {
+    const trackUnifiedAuthRetry = vi.fn()
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({ trackUnifiedAuthRetry })
+    registry.registerProvider({})
+
+    registry.trackUnifiedAuthRetry({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'retry_rejected'
+    })
+
+    expect(trackUnifiedAuthRetry).toHaveBeenCalledExactlyOnceWith({
+      transport: 'fetch',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'retry_rejected'
+    })
+  })
+
   it('dispatches trackAddApiCreditButtonClicked with its source', () => {
     const provider: TelemetryProvider = {
       trackAddApiCreditButtonClicked: vi.fn()

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -41,6 +41,7 @@ import type {
   TemplateLibraryMetadata,
   TemplateMetadata,
   UiButtonClickMetadata,
+  UnifiedAuthRetryMetadata,
   WidgetFavoriteToggledMetadata,
   WorkflowCreatedMetadata,
   WorkflowImportMetadata,
@@ -84,6 +85,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackAuthFailed(metadata: AuthErrorMetadata): void {
     this.dispatch((provider) => provider.trackAuthFailed?.(metadata))
+  }
+
+  trackUnifiedAuthRetry(metadata: UnifiedAuthRetryMetadata): void {
+    this.dispatch((provider) => provider.trackUnifiedAuthRetry?.(metadata))
   }
 
   trackUserLoggedIn(): void {

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -24,6 +24,25 @@ afterEach(() => {
 })
 
 describe('DatadogRumTelemetryProvider', () => {
+  it('records terminal unified auth retry outcomes without request data', () => {
+    new DatadogRumTelemetryProvider().trackUnifiedAuthRetry({
+      transport: 'axios',
+      outcome: 'failed',
+      final_status: 401,
+      failure_reason: 'retry_rejected'
+    })
+
+    expect(addAction).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.UNIFIED_AUTH_RETRY_FAILED,
+      {
+        transport: 'axios',
+        outcome: 'failed',
+        final_status: 401,
+        failure_reason: 'retry_rejected'
+      }
+    )
+  })
+
   it('records the same canonical billing name and context as PostHog', () => {
     const event: BillingTelemetryEvent = {
       operation: 'operation',

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.ts
@@ -3,14 +3,25 @@ import { datadogRum } from '@datadog/browser-rum'
 import type {
   BillingTelemetryEvent,
   ExecutionOutcomeMetadata,
-  TelemetryProvider
+  TelemetryProvider,
+  UnifiedAuthRetryMetadata
 } from '../../types'
 import {
   getBillingTelemetryEventName,
-  getBillingTelemetryEventPayload
+  getBillingTelemetryEventPayload,
+  TelemetryEvents
 } from '../../types'
 
 export class DatadogRumTelemetryProvider implements TelemetryProvider {
+  trackUnifiedAuthRetry(metadata: UnifiedAuthRetryMetadata): void {
+    datadogRum.addAction(
+      metadata.outcome === 'succeeded'
+        ? TelemetryEvents.UNIFIED_AUTH_RETRY_SUCCEEDED
+        : TelemetryEvents.UNIFIED_AUTH_RETRY_FAILED,
+      metadata
+    )
+  }
+
   trackBillingEvent(event: BillingTelemetryEvent): void {
     datadogRum.addAction(
       getBillingTelemetryEventName(event),

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -70,6 +70,20 @@ export interface AuthErrorMetadata {
   auth_action: AuthFlowAction
 }
 
+export type UnifiedAuthRetryFailureReason =
+  | 'missing_bearer'
+  | 'non_replayable_body'
+  | 'remint_failed'
+  | 'retry_rejected'
+  | 'retry_request_failed'
+
+export interface UnifiedAuthRetryMetadata {
+  transport: 'axios' | 'fetch'
+  outcome: 'succeeded' | 'failed'
+  final_status?: number
+  failure_reason?: UnifiedAuthRetryFailureReason
+}
+
 /**
  * Survey field ids mapped to answers. Fields are backend-overridable, so all
  * are optional.
@@ -786,6 +800,7 @@ export interface TelemetryProvider {
   trackSignupOpened?(): void
   trackAuth?(metadata: AuthMetadata): void
   trackAuthFailed?(metadata: AuthErrorMetadata): void
+  trackUnifiedAuthRetry?(metadata: UnifiedAuthRetryMetadata): void
   trackUserLoggedIn?(): void
 
   // Subscription flow events
@@ -913,6 +928,8 @@ export const TelemetryEvents = {
   USER_AUTH_COMPLETED: 'app:user_auth_completed',
   USER_AUTH_FAILED: 'app:user_auth_failed',
   USER_LOGGED_IN: 'app:user_logged_in',
+  UNIFIED_AUTH_RETRY_SUCCEEDED: 'auth.unified.request_retry.succeeded',
+  UNIFIED_AUTH_RETRY_FAILED: 'auth.unified.request_retry.failed',
 
   // Subscription Flow
   RUN_BUTTON_CLICKED: 'app:run_button_click',
@@ -1070,6 +1087,7 @@ export type TelemetryEventProperties =
   | AuthMetadata
   | OnboardingTourMetadata
   | AuthErrorMetadata
+  | UnifiedAuthRetryMetadata
   | SurveyResponses
   | TemplateMetadata
   | ExecutionContext


### PR DESCRIPTION
## Summary

Adds one terminal Datadog RUM action for each flag-enabled unified-auth 401 recovery attempt so rollout monitoring can distinguish successful recovery, persistent authorization failures, re-mint failures, and retry transport failures.

## Changes

- **What**: Emits `auth.unified.request_retry.succeeded` or `auth.unified.request_retry.failed` after fetch and Axios 401 recovery, with only low-cardinality `transport`, `outcome`, `final_status`, and `failure_reason` context.
- **Root cause**: Resource events show the treatment cohort but cannot identify whether a 401 was recovered or amplified by the retry path. Current production baselines include tens of thousands of repeated 401/403 events from fewer than 100 sessions, so raw resource counts cannot safely drive rollout decisions.
- **Privacy**: Does not emit tokens, authorization headers, request URLs, response bodies, or user identifiers.
- **Dependencies**: Related to #14273, which supplies `unified_cloud_auth` feature-flag attribution. This PR remains runtime-safe without it; cohort filtering becomes available after both changes deploy.

## Review Focus

- Exactly one lifecycle action is emitted per initial 401 that enters the unified retry path.
- Flag-off and non-401 traffic remain telemetry no-ops.
- Persistent 401s and transport failures preserve the existing response/error behavior.

## Verification

- `pnpm test:unit src/platform/auth/unified/remintRetry.test.ts src/platform/telemetry/TelemetryRegistry.test.ts src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts` (40 tests)
- `pnpm typecheck`
- Targeted ESLint on all changed files

## Screenshots (if applicable)

Not applicable; telemetry-only change with no UI impact.