### PR TITLE
fix: tolerate a missing /api/i18n endpoint during bootstrap

### DIFF
--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,9 +1,13 @@
 import { createTestingPinia } from '@pinia/testing'
+import type { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
+import { mergeCustomNodesI18n } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
 
 import { useBootstrapStore } from './bootstrapStore'
 
@@ -64,6 +68,12 @@ const mockDistributionTypes = vi.hoisted(() => ({
 }))
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
+function requestFailure(status: number) {
+  const error = new AxiosError(`Request failed with status code ${status}`)
+  error.response = { status } as AxiosResponse
+  return error
+}
+
 describe('bootstrapStore', () => {
   beforeEach(() => {
     mockIsSettingsReady.value = false
@@ -90,6 +100,35 @@ describe('bootstrapStore', () => {
     await vi.waitFor(() => {
       expect(settingStore.isReady).toBe(true)
       expect(store.isI18nReady).toBe(true)
+    })
+  })
+
+  describe('custom node translations', () => {
+    it('treats a missing /api/i18n endpoint as no translations', async () => {
+      vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
+        requestFailure(404)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
+
+      await vi.waitFor(() => {
+        expect(store.isI18nReady).toBe(true)
+      })
+      expect(store.i18nError).toBeUndefined()
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
+    })
+
+    it('surfaces failures other than a missing endpoint', async () => {
+      vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
+        requestFailure(500)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
+
+      await vi.waitFor(() => {
+        expect(store.i18nError).toBeDefined()
+      })
+      expect(store.isI18nReady).toBe(false)
     })
   })
 

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,12 +1,27 @@
 import { until, useAsyncState } from '@vueuse/core'
+import axios from 'axios'
 import { defineStore, storeToRefs } from 'pinia'
 
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
 import { useUserStore } from '@/stores/userStore'
+
+/**
+ * Backends that vendor no custom-node locale files do not implement
+ * `/api/i18n`, so a 404 means "no custom-node translations", not a failure.
+ */
+async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
+  try {
+    return await api.getCustomNodesI18n()
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) return
+    throw error
+  }
+}
 
 export const useBootstrapStore = defineStore('bootstrap', () => {
   const settingStore = useSettingStore()
@@ -19,8 +34,8 @@ export const useBootstrapStore = defineStore('bootstrap', () => {
   } = useAsyncState(
     async () => {
       const { mergeCustomNodesI18n } = await import('@/i18n')
-      const i18nData = await api.getCustomNodesI18n()
-      mergeCustomNodesI18n(i18nData)
+      const i18nData = await fetchCustomNodesI18n()
+      if (i18nData) mergeCustomNodesI18n(i18nData)
     },
     undefined,
     { immediate: false }


### PR DESCRIPTION
## ELI-5

Every time the app starts it asks the server "do any custom nodes ship translations?". Some backends deliberately don't have that endpoint at all, so the browser gets a 404 back — and because nobody was catching it, that 404 turned into a big red unhandled error in the console (and in error tracking) even though nothing was actually broken. Now we treat "endpoint isn't there" as "there are no custom-node translations", and carry on. Real failures still get reported.

## Summary

`bootstrapStore` called `api.getCustomNodesI18n()` unconditionally with no rejection handling. On a backend that does not implement `GET /api/i18n` (Cloud vendors no custom-node locale files, so the endpoint is intentionally absent), the request 404s and the resulting `AxiosError` reaches `useAsyncState`'s default `onError`, which is `globalThis.reportError` — i.e. it surfaces as an *unhandled* error to `window.onerror` and to RUM. In production this fires in ~1,300 distinct sessions/week (2,406 events over a rolling 7 days), mostly on the login view before the user has even signed in.

## Changes

- **What**: `bootstrapStore` now routes the fetch through a small `fetchCustomNodesI18n()` helper that swallows *only* an Axios 404 and returns `undefined`; everything else is rethrown unchanged and still lands in `i18nError`. When the endpoint is absent, `mergeCustomNodesI18n` is skipped and bootstrap proceeds.
- Tests: `src/stores/bootstrapStore.test.ts` gains a 404 case (asserts `isI18nReady` flips true, `i18nError` stays undefined, merge is skipped) and a 500 case (asserts the error is still surfaced). Confirmed the 404 test fails against the unpatched store and passes with the fix; the 500 test passes either way, which is the point — it is the guard against blanket-swallowing.

## Review Focus

- **Skip vs. empty map.** The 404 path skips `mergeCustomNodesI18n` rather than calling it with `{}`. That is deliberate: `mergeCustomNodesI18n` clears `customNodesI18nData` before assigning, so passing an empty map would *wipe* any previously merged custom-node translations on a re-run rather than being a no-op.
- **Where the tolerance lives.** I put it in the store (the consumer that owns "translations are optional") rather than in `ComfyApi.getCustomNodesI18n`, so the transport method stays faithful to the response and any future caller can still distinguish a 404. `getCustomNodesI18n` currently has exactly one call site.
- **Tradeoff worth naming.** On a backend that *does* implement the endpoint but 404s for some unrelated reason (a misconfigured proxy, say), custom-node translations now fail silently instead of loudly. The previous behaviour also failed to load them — it just additionally reported an error — so nothing regresses functionally, but diagnosability on that path is slightly reduced. Adding a warning log was considered and rejected: on Cloud it would fire on every session for a condition that is by design.
- Non-404 failures (5xx, network errors — `error.response` is undefined for the latter, so it rethrows) are unchanged and still reported.

## Verification

`vitest run src/stores/bootstrapStore.test.ts src/i18n.test.ts` (23 passed), `eslint` and `oxfmt` clean on both changed files. Full-repo `vue-tsc` was run but is not a usable signal in this worktree — it borrows the parent clone's `node_modules` via symlink, which breaks SFC type-reference resolution and produces ~1,400 pre-existing `.vue` diagnostics unrelated to this change. No diagnostics were reported for any file under `src/stores/`, including both changed files. Relying on CI for the whole-repo typecheck gate.

## Provenance

This came out of a goal run against the Cloud frontend error-free-sessions dashboard ("State of Dog", Datadog RUM, prod), measured over a rolling 7-day window: error-free sessions were sitting at 17–22% daily, with 8,662 of 10,790 sessions containing at least one error. The target is ≥90% daily, and this 404 was the single highest-session-count contributor. The endpoint's absence was confirmed server-side (it is tagged local-only and has no handler) before writing the fix, so this is deliberately a frontend-side tolerance rather than a request to implement the endpoint.
