### PR TITLE
feat(billing): update free workspace plan state

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2730,10 +2730,6 @@
       "sharedCreditPool": "Shared credit pool for all members",
       "rolePermissions": "Role-based permissions"
     },
-    "freePerks": {
-      "maxRuntime": "{duration} max runtime",
-      "freeRuns": "{count} free run | {count} free runs"
-    },
     "viewMoreDetails": "View more details",
     "learnMore": "Learn more",
     "billedMonthly": "Billed monthly",
@@ -2796,6 +2792,8 @@
     "subscribeToComfyCloud": "Subscribe to Comfy Cloud",
     "workspaceNotSubscribed": "This workspace is not on a subscription",
     "subscriptionRequiredMessage": "A subscription is required for members to run workflows on Cloud and invite members",
+    "noActivePlan": "This workspace has no active plan",
+    "noActivePlanDescription": "Subscribe to run more workflows on Cloud and invite members",
     "contactOwnerToSubscribe": "Contact the workspace owner to subscribe",
     "description": "Choose the best plan for you",
     "descriptionWorkspace": "Choose a Plan",

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -525,7 +525,11 @@ describe('SubscriptionPanelContentWorkspace', () => {
     renderComponent()
 
     expect(screen.getByText('Your subscription has ended')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Free' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'This workspace has no active plan'
+      })
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Subscribe' })
     ).toBeInTheDocument()
@@ -743,7 +747,7 @@ describe('SubscriptionPanelContentWorkspace', () => {
     )
   })
 
-  it('renders the Free plan header with Subscribe CTA for unsubscribed personal workspaces', async () => {
+  it('renders the no-plan state with subscription actions for personal workspaces', async () => {
     const user = userEvent.setup()
     mockIsInPersonalWorkspace.value = true
     mockIsActiveSubscription.value = false
@@ -753,11 +757,20 @@ describe('SubscriptionPanelContentWorkspace', () => {
     mockCanLeaveWorkspace.value = false
     renderComponent()
 
-    expect(screen.getByText('Free')).toBeInTheDocument()
-    expect(screen.getByText('$0')).toBeInTheDocument()
-    expect(screen.getByText('USD / mo')).toBeInTheDocument()
-    expect(screen.getByText("What's included:")).toBeInTheDocument()
-    expect(screen.getByText('10 min max runtime')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'This workspace has no active plan'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Subscribe to run more workflows on Cloud and invite members'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Free')).not.toBeInTheDocument()
+    expect(screen.queryByText('$0')).not.toBeInTheDocument()
+    expect(screen.queryByText("What's included:")).not.toBeInTheDocument()
+    expect(screen.queryByText('10 min max runtime')).not.toBeInTheDocument()
     expect(
       screen.queryByText('RTX 6000 Pro (96GB VRAM)')
     ).not.toBeInTheDocument()

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -113,11 +113,10 @@
             <template v-else-if="isPersonalFree">
               <div class="flex flex-col gap-2">
                 <h3 class="m-0 text-base font-bold text-text-primary">
-                  {{ $t('subscription.tiers.free.name') }}
+                  {{ $t('subscription.noActivePlan') }}
                 </h3>
-                <div class="flex items-baseline gap-1 font-inter">
-                  <span class="text-2xl font-semibold">{{ displayPrice }}</span>
-                  <span class="text-base">{{ priceUnitLabel }}</span>
+                <div class="text-sm text-text-secondary">
+                  {{ $t('subscription.noActivePlanDescription') }}
                 </div>
               </div>
               <div class="flex flex-wrap gap-2 md:ml-auto">
@@ -238,10 +237,7 @@
             <CreditsTile :zero-state="showZeroState" />
           </div>
 
-          <div
-            v-if="isActiveSubscription || isPersonalFree"
-            class="flex flex-col gap-2"
-          >
+          <div v-if="isActiveSubscription" class="flex flex-col gap-2">
             <i18n-t
               v-if="isTeamActive"
               keypath="subscription.teamPlanIncludes"
@@ -254,9 +250,6 @@
                 </span>
               </template>
             </i18n-t>
-            <div v-else-if="isPersonalFree" class="text-sm text-muted">
-              {{ $t('subscription.whatsIncluded') }}
-            </div>
             <div v-else class="text-sm text-text-primary">
               {{ $t('subscription.yourPlanIncludes') }}
             </div>
@@ -318,7 +311,6 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
-import { useFreeTierQuota } from '@/platform/cloud/subscription/composables/useFreeTierQuota'
 import type { TierBenefit } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { getCommonTierBenefits } from '@/platform/cloud/subscription/utils/tierBenefits'
 import { useResubscribe } from '@/platform/workspace/composables/useResubscribe'
@@ -336,8 +328,6 @@ const workspaceStore = useTeamWorkspaceStore()
 const { isWorkspaceSubscribed, isInPersonalWorkspace } =
   storeToRefs(workspaceStore)
 const { permissions, isSubscriptionCancelled } = useWorkspaceUI()
-const { maxAvailable: freeRunsAllowance, quotaEnabled: freeRunsQuotaEnabled } =
-  useFreeTierQuota()
 const { t, n, locale } = useI18n()
 
 const billingOperationStore = useBillingOperationStore()
@@ -548,29 +538,6 @@ const tierBenefits = computed((): TierBenefit[] => {
       type: 'feature',
       label: t(`subscription.teamPerks.${key}`)
     }))
-  }
-  if (isPersonalFree.value) {
-    return [
-      ...(freeRunsQuotaEnabled.value
-        ? [
-            {
-              key: 'freeRuns',
-              type: 'feature' as const,
-              label: t(
-                'subscription.freePerks.freeRuns',
-                freeRunsAllowance.value
-              )
-            }
-          ]
-        : []),
-      {
-        key: 'maxRuntime',
-        type: 'feature',
-        label: t('subscription.freePerks.maxRuntime', {
-          duration: t('subscription.maxDuration.free')
-        })
-      }
-    ]
   }
   return getCommonTierBenefits(tierKey.value, t, n)
 })


### PR DESCRIPTION
## Summary

Updates the personal free/no-subscription Plan & Credits view for the new free-run model. The previous UI described Free as a $0 monthly plan with plan benefits, which is no longer accurate.

## Changes

- **What**: Replaces the Free / $0 header with “This workspace has no active plan” and the new subscription guidance.
- **What**: Removes the free-plan benefits column and its now-unused quota coupling.
- **Preserved**: Existing subscription actions, the additional-credit zero state, pricing link, and footer actions.

## Review Focus

The personal owner no-plan branch changes; team-owner and member read-only branches remain unchanged. This PR is based directly on `main` and contains no prototype or unrelated billing implementation commits.

Fixes FE-1453

## Validation

- `pnpm test:unit src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts` — 42 passed
- `pnpm typecheck`
- Focused ESLint, Stylelint, oxfmt, oxlint, and knip through the commit hooks

## Screenshots

Figma reference: https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=5482-58299

Captured from the real cloud app at 1440×1000 in Chromium under the same mocked authenticated state: personal workspace, owner role, never subscribed/no active plan, zero credits, and consolidated billing enabled. No Storybook or prototype code was used, and the images are not committed to the repository.

### AS IS — current `main` (`7f3c594`)

![AS IS — Free workspace shown as a $0 monthly plan with free-plan benefits](https://ampcode.com/user-content/artifacts/07114f3d1e1efff06ac548a7dc3d82d285eb3a3c050695428d7bac790de0a10e-file.png)

### TO BE — PR head (`046a031`)

![TO BE — personal workspace shown with no active plan guidance](https://ampcode.com/user-content/artifacts/4ed37b3cfd4eace6b3fb1789964bda1deeb6fdb7474a35c92ccfe4126b0629e8-file.png)