### PR TITLE
fix: prevent Load3D menubar overflow at narrow node widths

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -288,6 +288,7 @@ export const TestIds = {
   },
   load3d: {
     categoryMenu: 'load3d-category-menu',
+    gizmoModeMenu: 'gizmo-mode-menu',
     recordingDuration: 'load3d-recording-duration'
   },
   load3dViewer: {

--- a/browser_tests/tests/load3d/Load3DHelper.ts
+++ b/browser_tests/tests/load3d/Load3DHelper.ts
@@ -86,20 +86,13 @@ export class Load3DHelper {
       .and(this.node.locator('[aria-pressed]'))
   }
 
-  get gizmoTranslateButton(): Locator {
-    return this.node.getByRole('button', { name: 'Translate' })
+  get gizmoModeMenuButton(): Locator {
+    return this.node.getByTestId(TestIds.load3d.gizmoModeMenu)
   }
 
-  get gizmoRotateButton(): Locator {
-    return this.node.getByRole('button', { name: 'Rotate' })
-  }
-
-  get gizmoScaleButton(): Locator {
-    return this.node.getByRole('button', { name: 'Scale' })
-  }
-
-  get gizmoResetButton(): Locator {
-    return this.node.getByRole('button', { name: 'Reset', exact: true })
+  async selectGizmoMode(name: string): Promise<void> {
+    await this.gizmoModeMenuButton.click()
+    await this.menuPanel.getByRole('button', { name, exact: true }).click()
   }
 
   async openMenu(): Promise<void> {

--- a/browser_tests/tests/load3d/gizmoControls.spec.ts
+++ b/browser_tests/tests/load3d/gizmoControls.spec.ts
@@ -31,31 +31,24 @@ test.describe('Load3D Gizmo Controls', () => {
       await load3d.openGizmoCategory()
 
       await expect(load3d.gizmoToggleButton).toBeVisible()
-      await expect(load3d.gizmoTranslateButton).toBeHidden()
-      await expect(load3d.gizmoRotateButton).toBeHidden()
-      await expect(load3d.gizmoScaleButton).toBeHidden()
-      await expect(load3d.gizmoResetButton).toBeHidden()
+      await expect(load3d.gizmoModeMenuButton).toBeHidden()
     }
   )
 
   test(
-    'Toggling gizmo reveals mode buttons and updates node state',
+    'Toggling gizmo reveals the mode menu and updates node state',
     { tag: '@smoke' },
     async ({ comfyPage, load3d }) => {
       await load3d.openGizmoCategory()
       await load3d.gizmoToggleButton.click()
 
-      await expect(load3d.gizmoTranslateButton).toBeVisible()
-      await expect(load3d.gizmoRotateButton).toBeVisible()
-      await expect(load3d.gizmoScaleButton).toBeVisible()
-      await expect(load3d.gizmoResetButton).toBeVisible()
-
+      await expect(load3d.gizmoModeMenuButton).toBeVisible()
       await expect
         .poll(() => getGizmoConfig(comfyPage.page).then((g) => g?.enabled))
         .toBe(true)
 
       await load3d.gizmoToggleButton.click()
-      await expect(load3d.gizmoTranslateButton).toBeHidden()
+      await expect(load3d.gizmoModeMenuButton).toBeHidden()
       await expect
         .poll(() => getGizmoConfig(comfyPage.page).then((g) => g?.enabled))
         .toBe(false)
@@ -69,17 +62,17 @@ test.describe('Load3D Gizmo Controls', () => {
       await load3d.openGizmoCategory()
       await load3d.gizmoToggleButton.click()
 
-      await load3d.gizmoRotateButton.click()
+      await load3d.selectGizmoMode('Rotate')
       await expect
         .poll(() => getGizmoConfig(comfyPage.page).then((g) => g?.mode))
         .toBe('rotate')
 
-      await load3d.gizmoScaleButton.click()
+      await load3d.selectGizmoMode('Scale')
       await expect
         .poll(() => getGizmoConfig(comfyPage.page).then((g) => g?.mode))
         .toBe('scale')
 
-      await load3d.gizmoTranslateButton.click()
+      await load3d.selectGizmoMode('Translate')
       await expect
         .poll(() => getGizmoConfig(comfyPage.page).then((g) => g?.mode))
         .toBe('translate')

--- a/src/components/load3d/Load3DMenuBar.test.ts
+++ b/src/components/load3d/Load3DMenuBar.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
+import { ref } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
@@ -12,6 +14,20 @@ import type {
   SceneConfig
 } from '@/extensions/core/load3d/interfaces'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+let mockedTopBarWidth: Ref<number>
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@vueuse/core')
+  return {
+    ...actual,
+    useElementSize: () => ({ width: mockedTopBarWidth, height: ref(40) })
+  }
+})
+
+beforeEach(() => {
+  mockedTopBarWidth = ref(0)
+})
 
 const i18n = createI18n({
   legacy: false,
@@ -230,6 +246,33 @@ describe('Load3DMenuBar', () => {
     expect(
       screen.queryByRole('button', { name: 'Light' })
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the category label as text when the bar is wide', () => {
+    mockedTopBarWidth = ref(600)
+    renderMenuBar()
+
+    expect(screen.getByTestId('load3d-category-menu')).toHaveTextContent(
+      'Scene'
+    )
+  })
+
+  it('collapses the category trigger to an icon when the bar is narrow', () => {
+    mockedTopBarWidth = ref(300)
+    renderMenuBar()
+
+    const trigger = screen.getByTestId('load3d-category-menu')
+    expect(trigger).not.toHaveTextContent('Scene')
+    expect(trigger).toHaveAccessibleName('Scene')
+  })
+
+  it('still lists labeled categories in the menu when the bar is narrow', async () => {
+    mockedTopBarWidth = ref(300)
+    const { user } = renderMenuBar()
+
+    await openCategoryMenu(user)
+
+    expect(screen.getByRole('button', { name: 'Gizmo' })).toBeInTheDocument()
   })
 
   it('hides scene controls when sceneConfig is undefined', () => {

--- a/src/components/load3d/Load3DMenuBar.vue
+++ b/src/components/load3d/Load3DMenuBar.vue
@@ -8,11 +8,14 @@
       <Popover v-model:open="categoryMenuOpen">
         <PopoverTrigger as-child>
           <button
+            v-tooltip.bottom="compact ? tip(activeLabel) : undefined"
             :class="chipClass"
             type="button"
+            :aria-label="compact ? activeLabel : undefined"
             data-testid="load3d-category-menu"
           >
-            {{ activeLabel }}
+            <i v-if="compact" :class="cn(activeIcon, 'size-4')" />
+            <template v-else>{{ activeLabel }}</template>
             <i class="icon-[lucide--chevron-down] size-4 opacity-70" />
           </button>
         </PopoverTrigger>
@@ -29,11 +32,13 @@
             :class="
               cn(
                 rowClass,
+                'gap-2',
                 activeCategory === c.key && 'bg-button-active-surface'
               )
             "
             @click="selectCategory(c.key)"
           >
+            <i :class="cn(c.icon, 'size-4')" />
             {{ c.label }}
           </button>
         </PopoverContent>
@@ -259,36 +264,51 @@ const { t } = useI18n()
 
 const categoryDefs = computed(() =>
   [
-    { key: 'scene', label: t('load3d.scene'), show: !!sceneConfig.value },
+    {
+      key: 'scene',
+      label: t('load3d.scene'),
+      icon: 'icon-[lucide--layers]',
+      show: !!sceneConfig.value
+    },
     {
       key: 'model',
       label: t('load3d.model3d'),
+      icon: 'icon-[lucide--box]',
       show: !!modelConfig.value
     },
-    { key: 'camera', label: t('load3d.camera'), show: !!cameraConfig.value },
+    {
+      key: 'camera',
+      label: t('load3d.camera'),
+      icon: 'icon-[lucide--camera]',
+      show: !!cameraConfig.value
+    },
     {
       key: 'light',
       label: t('load3d.light'),
+      icon: 'icon-[lucide--sun]',
       show: canUseLighting && !!lightConfig.value && !!modelConfig.value
     },
     {
       key: 'hdri',
       label: t('load3d.hdri.label'),
+      icon: 'icon-[lucide--globe]',
       show: canUseHdri && !!lightConfig.value
     },
     {
       key: 'gizmo',
       label: t('load3d.gizmo.label'),
+      icon: 'icon-[lucide--axis-3d]',
       show: canUseGizmo && !!modelConfig.value
     }
   ].filter((c) => c.show)
 )
 
 const activeCategory = ref('scene')
-const activeLabel = computed(
-  () =>
-    categoryDefs.value.find((c) => c.key === activeCategory.value)?.label ?? ''
+const activeDef = computed(() =>
+  categoryDefs.value.find((c) => c.key === activeCategory.value)
 )
+const activeLabel = computed(() => activeDef.value?.label ?? '')
+const activeIcon = computed(() => activeDef.value?.icon ?? '')
 watch(categoryDefs, (defs) => {
   if (!defs.some((c) => c.key === activeCategory.value)) {
     activeCategory.value = defs[0]?.key ?? 'scene'

--- a/src/components/load3d/menubar/GizmoMenuGroup.test.ts
+++ b/src/components/load3d/menubar/GizmoMenuGroup.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import GizmoMenuGroup from '@/components/load3d/menubar/GizmoMenuGroup.vue'
-import type { ModelConfig } from '@/extensions/core/load3d/interfaces'
+import type {
+  GizmoMode,
+  ModelConfig
+} from '@/extensions/core/load3d/interfaces'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 const i18n = createI18n({
@@ -30,8 +33,10 @@ function makeConfig(enabled: boolean): ModelConfig {
 
 type Props = {
   config: ModelConfig
+  compact?: boolean
   onToggleGizmo?: (enabled: boolean) => void
-  onSetGizmoMode?: (mode: string) => void
+  onSetGizmoMode?: (mode: GizmoMode) => void
+  onResetGizmoTransform?: () => void
 }
 
 function renderGroup(props: Props) {
@@ -68,5 +73,71 @@ describe('GizmoMenuGroup', () => {
 
     expect(onSetGizmoMode).toHaveBeenCalledWith('rotate')
     expect(config.gizmo?.mode).toBe('rotate')
+  })
+
+  it('collapses the mode controls into a dropdown when compact', async () => {
+    const config = makeConfig(true)
+    const onSetGizmoMode = vi.fn()
+    const { user } = renderGroup({ config, compact: true, onSetGizmoMode })
+
+    expect(
+      screen.queryByRole('button', { name: 'Rotate' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('gizmo-mode-menu'))
+
+    expect(
+      screen.getByRole('button', { name: 'Translate', pressed: true })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Rotate', pressed: false })
+    )
+
+    expect(onSetGizmoMode).toHaveBeenCalledWith('rotate')
+    expect(config.gizmo?.mode).toBe('rotate')
+    expect(
+      screen.queryByRole('button', { name: 'Scale' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('labels the compact dropdown trigger with the active mode', () => {
+    const config = makeConfig(true)
+    config.gizmo!.mode = 'scale'
+    renderGroup({ config, compact: true })
+
+    expect(screen.getByTestId('gizmo-mode-menu')).toHaveAccessibleName('Scale')
+  })
+
+  it('does not reopen the mode menu after the gizmo is disabled and re-enabled', async () => {
+    const { user, rerender } = renderGroup({
+      config: makeConfig(true),
+      compact: true
+    })
+
+    await user.click(screen.getByTestId('gizmo-mode-menu'))
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument()
+
+    await rerender({ config: makeConfig(false), compact: true })
+    await rerender({ config: makeConfig(true), compact: true })
+
+    expect(
+      screen.queryByRole('button', { name: 'Reset' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('forwards resetGizmoTransform from the compact dropdown', async () => {
+    const config = makeConfig(true)
+    const onResetGizmoTransform = vi.fn()
+    const { user } = renderGroup({
+      config,
+      compact: true,
+      onResetGizmoTransform
+    })
+
+    await user.click(screen.getByTestId('gizmo-mode-menu'))
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+
+    expect(onResetGizmoTransform).toHaveBeenCalledOnce()
   })
 })

--- a/src/components/load3d/menubar/GizmoMenuGroup.vue
+++ b/src/components/load3d/menubar/GizmoMenuGroup.vue
@@ -12,61 +12,97 @@
   </button>
 
   <template v-if="gizmoEnabled">
-    <button
-      v-tooltip.bottom="tip(t('load3d.gizmo.translate'))"
-      :class="actionClass(gizmoMode === 'translate')"
-      :aria-pressed="gizmoMode === 'translate'"
-      type="button"
-      :aria-label="compact ? t('load3d.gizmo.translate') : undefined"
-      @click="setGizmoMode('translate')"
-    >
-      <i class="icon-[lucide--move] size-4" />
-      <span v-if="!compact">{{ t('load3d.gizmo.translate') }}</span>
-    </button>
-    <button
-      v-tooltip.bottom="tip(t('load3d.gizmo.rotate'))"
-      :class="actionClass(gizmoMode === 'rotate')"
-      :aria-pressed="gizmoMode === 'rotate'"
-      type="button"
-      :aria-label="compact ? t('load3d.gizmo.rotate') : undefined"
-      @click="setGizmoMode('rotate')"
-    >
-      <i class="icon-[lucide--rotate-3d] size-4" />
-      <span v-if="!compact">{{ t('load3d.gizmo.rotate') }}</span>
-    </button>
-    <button
-      v-tooltip.bottom="tip(t('load3d.gizmo.scale'))"
-      :class="actionClass(gizmoMode === 'scale')"
-      :aria-pressed="gizmoMode === 'scale'"
-      type="button"
-      :aria-label="compact ? t('load3d.gizmo.scale') : undefined"
-      @click="setGizmoMode('scale')"
-    >
-      <i class="icon-[lucide--scale-3d] size-4" />
-      <span v-if="!compact">{{ t('load3d.gizmo.scale') }}</span>
-    </button>
-    <button
-      v-tooltip.bottom="tip(t('load3d.gizmo.reset'))"
-      :class="actionClass(false)"
-      type="button"
-      :aria-label="compact ? t('load3d.gizmo.reset') : undefined"
-      @click="resetGizmoTransform"
-    >
-      <i class="icon-[lucide--rotate-ccw] size-4" />
-      <span v-if="!compact">{{ t('load3d.gizmo.reset') }}</span>
-    </button>
+    <template v-if="!compact">
+      <button
+        v-for="m in modeDefs"
+        :key="m.mode"
+        v-tooltip.bottom="tip(t(m.labelKey))"
+        :class="actionClass(gizmoMode === m.mode)"
+        :aria-pressed="gizmoMode === m.mode"
+        type="button"
+        @click="setGizmoMode(m.mode)"
+      >
+        <i :class="cn(m.icon, 'size-4')" />
+        <span>{{ t(m.labelKey) }}</span>
+      </button>
+      <button
+        v-tooltip.bottom="tip(t('load3d.gizmo.reset'))"
+        :class="actionClass(false)"
+        type="button"
+        @click="resetGizmoTransform"
+      >
+        <i class="icon-[lucide--rotate-ccw] size-4" />
+        <span>{{ t('load3d.gizmo.reset') }}</span>
+      </button>
+    </template>
+    <Popover v-else v-model:open="modeMenuOpen">
+      <PopoverTrigger as-child>
+        <button
+          v-tooltip.bottom="tip(activeModeLabel)"
+          :class="actionClass(false)"
+          type="button"
+          :aria-label="activeModeLabel"
+          data-testid="gizmo-mode-menu"
+        >
+          <i :class="cn(activeModeDef.icon, 'size-4')" />
+          <i class="icon-[lucide--chevron-down] size-4 opacity-70" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        :side-offset="8"
+        :class="panelClass"
+      >
+        <button
+          v-for="m in modeDefs"
+          :key="m.mode"
+          type="button"
+          :aria-pressed="gizmoMode === m.mode"
+          :class="
+            cn(
+              rowClass,
+              'gap-2',
+              gizmoMode === m.mode && 'bg-button-active-surface'
+            )
+          "
+          @click="selectMode(m.mode)"
+        >
+          <i :class="cn(m.icon, 'size-4')" />
+          {{ t(m.labelKey) }}
+        </button>
+        <button
+          type="button"
+          :class="cn(rowClass, 'gap-2')"
+          @click="selectReset"
+        >
+          <i class="icon-[lucide--rotate-ccw] size-4" />
+          {{ t('load3d.gizmo.reset') }}
+        </button>
+      </PopoverContent>
+    </Popover>
   </template>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { actionClass, tip } from '@/components/load3d/menubar/menuBarStyles'
+import {
+  actionClass,
+  panelClass,
+  rowClass,
+  tip
+} from '@/components/load3d/menubar/menuBarStyles'
+import { usePopoverExclusivity } from '@/components/load3d/menubar/usePopoverExclusivity'
+import Popover from '@/components/ui/popover/Popover.vue'
+import PopoverContent from '@/components/ui/popover/PopoverContent.vue'
 import type {
   GizmoMode,
   ModelConfig
 } from '@/extensions/core/load3d/interfaces'
+import { cn } from '@comfyorg/tailwind-utils'
+import { PopoverTrigger } from 'reka-ui'
 
 const { compact = false } = defineProps<{
   compact?: boolean
@@ -82,8 +118,36 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+const modeDefs = [
+  {
+    mode: 'translate' as GizmoMode,
+    icon: 'icon-[lucide--move]',
+    labelKey: 'load3d.gizmo.translate'
+  },
+  {
+    mode: 'rotate' as GizmoMode,
+    icon: 'icon-[lucide--rotate-3d]',
+    labelKey: 'load3d.gizmo.rotate'
+  },
+  {
+    mode: 'scale' as GizmoMode,
+    icon: 'icon-[lucide--scale-3d]',
+    labelKey: 'load3d.gizmo.scale'
+  }
+]
+
 const gizmoEnabled = computed(() => config.value?.gizmo?.enabled ?? false)
 const gizmoMode = computed(() => config.value?.gizmo?.mode ?? 'translate')
+const activeModeDef = computed(
+  () => modeDefs.find((m) => m.mode === gizmoMode.value) ?? modeDefs[0]
+)
+const activeModeLabel = computed(() => t(activeModeDef.value.labelKey))
+
+const modeMenuOpen = usePopoverExclusivity()('gizmo-mode')
+const modeMenuAvailable = computed(() => compact && gizmoEnabled.value)
+watch(modeMenuAvailable, (available) => {
+  if (!available) modeMenuOpen.value = false
+})
 
 function toggleGizmo() {
   const gizmo = config.value?.gizmo
@@ -97,6 +161,16 @@ function setGizmoMode(mode: GizmoMode) {
   if (!gizmo) return
   gizmo.mode = mode
   emit('setGizmoMode', mode)
+}
+
+function selectMode(mode: GizmoMode) {
+  setGizmoMode(mode)
+  modeMenuOpen.value = false
+}
+
+function selectReset() {
+  resetGizmoTransform()
+  modeMenuOpen.value = false
 }
 
 function resetGizmoTransform() {


### PR DESCRIPTION
## Summary
Collapse the category dropdown trigger to an icon and the gizmo mode controls into a dropdown when the top bar is in compact mode.

## Screenshots (if applicable)
before
<img width="667" height="757" alt="image" src="https://github.com/user-attachments/assets/e17a7658-900d-4d30-8cf5-96c7731bc4be" />

after
<img width="505" height="566" alt="image" src="https://github.com/user-attachments/assets/df9bca7f-fb3b-48ef-849f-c33f64854236" />
