### PR TITLE
feat: retire team workspace rollout flags

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -13,6 +13,7 @@ import { TestIds } from '@e2e/fixtures/selectors'
 import { comfyExpect } from '@e2e/fixtures/utils/customMatchers'
 import { assetPath } from '@e2e/fixtures/utils/paths'
 import { nextFrame, sleep } from '@e2e/fixtures/utils/timing'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 import { VueNodeHelpers } from '@e2e/fixtures/VueNodeHelpers'
 import { BottomPanel } from '@e2e/fixtures/components/BottomPanel'
 import { ComfyNodeSearchBox } from '@e2e/fixtures/components/ComfyNodeSearchBox'
@@ -561,6 +562,7 @@ export const comfyPageFixture = base.extend<{
     }
 
     if (testInfo.tags.includes('@cloud')) {
+      await mockWorkspace(page.context(), workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()
     }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -6,6 +6,11 @@ import MCR from 'monocart-coverage-reports'
 import { COVERAGE_OUTPUT_DIR } from '@e2e/coverageConfig'
 import { TOURS, TOUR_SEEN_SETTING } from '@/platform/onboarding/onboardingTours'
 import { NodeBadgeMode } from '@/types/nodeSource'
+import {
+  EMPTY_BILLING_BALANCE,
+  EMPTY_BILLING_PLANS,
+  LEGACY_PERSONAL_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
 import { ComfyMouse } from '@e2e/fixtures/ComfyMouse'
@@ -565,6 +570,15 @@ export const comfyPageFixture = base.extend<{
       const context = page.context()
       await context.route('**/api/auth/session', (route) =>
         route.fulfill({ status: 204 })
+      )
+      await context.route('**/api/billing/status', (route) =>
+        route.fulfill({ json: LEGACY_PERSONAL_BILLING_STATUS })
+      )
+      await context.route('**/api/billing/balance', (route) =>
+        route.fulfill({ json: EMPTY_BILLING_BALANCE })
+      )
+      await context.route('**/api/billing/plans', (route) =>
+        route.fulfill({ json: EMPTY_BILLING_PLANS })
       )
       await mockWorkspace(context, workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -11,10 +11,7 @@ import {
   EMPTY_BILLING_PLANS,
   LEGACY_PERSONAL_BILLING_STATUS
 } from '@e2e/fixtures/data/cloudWorkspace'
-import {
-  UNSUBSCRIBED,
-  ZERO_BALANCE
-} from '@e2e/fixtures/data/subscriptionFixtures'
+import { ZERO_BALANCE } from '@e2e/fixtures/data/subscriptionFixtures'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
 import { ComfyMouse } from '@e2e/fixtures/ComfyMouse'
@@ -583,9 +580,6 @@ export const comfyPageFixture = base.extend<{
       )
       await context.route('**/api/billing/plans', (route) =>
         route.fulfill({ json: EMPTY_BILLING_PLANS })
-      )
-      await context.route('**/customers/cloud-subscription-status', (route) =>
-        route.fulfill({ json: UNSUBSCRIBED })
       )
       await context.route('**/customers/balance', (route) =>
         route.fulfill({ json: ZERO_BALANCE })

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -562,7 +562,11 @@ export const comfyPageFixture = base.extend<{
     }
 
     if (testInfo.tags.includes('@cloud')) {
-      await mockWorkspace(page.context(), workspace('personal', 'owner'), [])
+      const context = page.context()
+      await context.route('**/api/auth/session', (route) =>
+        route.fulfill({ status: 204 })
+      )
+      await mockWorkspace(context, workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()
     }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -11,6 +11,10 @@ import {
   EMPTY_BILLING_PLANS,
   LEGACY_PERSONAL_BILLING_STATUS
 } from '@e2e/fixtures/data/cloudWorkspace'
+import {
+  UNSUBSCRIBED,
+  ZERO_BALANCE
+} from '@e2e/fixtures/data/subscriptionFixtures'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
 import { ComfyMouse } from '@e2e/fixtures/ComfyMouse'
@@ -579,6 +583,12 @@ export const comfyPageFixture = base.extend<{
       )
       await context.route('**/api/billing/plans', (route) =>
         route.fulfill({ json: EMPTY_BILLING_PLANS })
+      )
+      await context.route('**/customers/cloud-subscription-status', (route) =>
+        route.fulfill({ json: UNSUBSCRIBED })
+      )
+      await context.route('**/customers/balance', (route) =>
+        route.fulfill({ json: ZERO_BALANCE })
       )
       await mockWorkspace(context, workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -7,12 +7,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-// `/api/features` is the remote-config source: production builds resolve the
-// workspaces flag from it (the `ff:` localStorage override is dev-only).
-export const WORKSPACE_FEATURE_FLAG: RemoteConfig = {
-  team_workspaces_enabled: true,
-  consolidated_billing_enabled: true
-}
+export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
 
 export const TEAM_WORKSPACE: WorkspaceWithRole = {
   id: 'ws-team',

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,4 +1,8 @@
-import type { BillingStatusResponse as IngestBillingStatusResponse } from '@comfyorg/ingest-types'
+import type {
+  BillingBalanceResponse,
+  BillingPlansResponse,
+  BillingStatusResponse as IngestBillingStatusResponse
+} from '@comfyorg/ingest-types'
 
 import type {
   Member,
@@ -8,6 +12,26 @@ import type {
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
+
+export const LEGACY_PERSONAL_BILLING_STATUS = {
+  billing_rail: 'legacy_stripe',
+  billing_status: 'inactive',
+  has_funds: true,
+  is_active: false,
+  subscription_status: 'ended',
+  subscription_tier: 'FREE',
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse
+
+export const EMPTY_BILLING_BALANCE = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0
+} satisfies BillingBalanceResponse
+
+export const EMPTY_BILLING_PLANS = {
+  plans: []
+} satisfies BillingPlansResponse
 
 export const TEAM_WORKSPACE: WorkspaceWithRole = {
   id: 'ws-team',

--- a/browser_tests/fixtures/data/subscriptionFixtures.ts
+++ b/browser_tests/fixtures/data/subscriptionFixtures.ts
@@ -1,22 +1,18 @@
 import type { operations } from '@comfyorg/registry-types'
 
-export type SubscriptionStatusResponse =
-  operations['GetCloudSubscriptionStatus']['responses']['200']['content']['application/json']
+import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
 export type BalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']
 
 export function createSubscriptionStatus(
-  overrides: Partial<SubscriptionStatusResponse> = {}
-): SubscriptionStatusResponse {
+  overrides: Partial<BillingStatusResponse> = {}
+): BillingStatusResponse {
   return {
     is_active: false,
-    subscription_id: null,
     subscription_tier: 'FREE',
-    subscription_duration: null,
-    has_fund: false,
-    renewal_date: null,
-    end_date: null,
+    has_funds: false,
+    billing_rail: 'legacy_stripe',
     ...overrides
   }
 }
@@ -35,13 +31,10 @@ export function createBalance(
   }
 }
 
-export const UNSUBSCRIBED: SubscriptionStatusResponse =
-  createSubscriptionStatus({
-    is_active: false,
-    subscription_id: null,
-    subscription_tier: 'FREE',
-    end_date: null
-  })
+export const UNSUBSCRIBED: BillingStatusResponse = createSubscriptionStatus({
+  is_active: false,
+  subscription_tier: 'FREE'
+})
 
 export const ZERO_BALANCE: BalanceResponse = createBalance({
   amount_micros: 0,

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -9,11 +9,11 @@ import type {
 
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import {
+  CLOUD_REMOTE_CONFIG,
   DEFAULT_TEAM_MEMBERS,
   TEAM_BILLING_STATUS,
   TEAM_PRO_PLAN,
-  TEAM_WORKSPACE,
-  WORKSPACE_FEATURE_FLAG
+  TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { mockWorkspaceTokenMint } from '@e2e/fixtures/utils/workspaceMocks'
@@ -71,7 +71,7 @@ export class CloudWorkspaceMockHelper {
     const { page } = this
 
     await page.route('**/api/features', (r) =>
-      r.fulfill(jsonRoute(WORKSPACE_FEATURE_FLAG))
+      r.fulfill(jsonRoute(CLOUD_REMOTE_CONFIG))
     )
     await page.route('**/api/system_stats', (r) =>
       r.fulfill(jsonRoute(mockSystemStats))

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -1,7 +1,10 @@
 import { expect } from '@playwright/test'
 import type { Page, Route } from '@playwright/test'
 
-import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
+import {
+  PENDING_SUBSCRIPTION_CHECKOUT_EVENT,
+  PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY
+} from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
 import {
   createBalance,
@@ -197,14 +200,14 @@ export class SubscriptionHelper {
   }
 
   /**
-   * Dispatch `visibilitychange` to simulate returning from Stripe checkout.
-   * The app re-fetches subscription status when a pending checkout attempt
-   * exists in localStorage (seeded via `seedPendingCheckout`).
+   * Notify the app that a pending checkout attempt needs to be recovered.
    */
   async triggerSubscriptionRefetch(): Promise<void> {
-    await this.page.evaluate(() => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    const eventName = PENDING_SUBSCRIPTION_CHECKOUT_EVENT
+    await this.page.evaluate(
+      (name) => window.dispatchEvent(new Event(name)),
+      eventName
+    )
   }
 
   /**

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -12,14 +12,11 @@ import {
   UNSUBSCRIBED,
   ZERO_BALANCE
 } from '@e2e/fixtures/data/subscriptionFixtures'
-import type {
-  BalanceResponse,
-  SubscriptionStatusResponse
-} from '@e2e/fixtures/data/subscriptionFixtures'
+import type { BalanceResponse } from '@e2e/fixtures/data/subscriptionFixtures'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 export interface SubscriptionConfig {
-  status: SubscriptionStatusResponse
+  status: BillingStatusResponse
   balance: BalanceResponse
 }
 
@@ -35,7 +32,7 @@ export type SubscriptionOperator = (
 ) => SubscriptionConfig
 
 function withSubscriptionStatus(
-  overrides: Partial<SubscriptionStatusResponse>
+  overrides: Partial<BillingStatusResponse>
 ): SubscriptionOperator {
   return (config) => ({
     ...config,
@@ -43,54 +40,32 @@ function withSubscriptionStatus(
   })
 }
 
-function toBillingStatus(
-  status: SubscriptionStatusResponse
-): BillingStatusResponse {
-  return {
-    is_active: status.is_active ?? false,
-    has_funds: status.has_fund ?? false,
-    billing_rail: 'legacy_stripe',
-    ...(status.subscription_tier
-      ? { subscription_tier: status.subscription_tier }
-      : {}),
-    ...(status.subscription_duration
-      ? { subscription_duration: status.subscription_duration }
-      : {}),
-    ...(status.renewal_date ? { renewal_date: status.renewal_date } : {}),
-    ...(status.end_date ? { cancel_at: status.end_date } : {})
-  }
-}
-
 export function withActiveSubscription(
-  tier: NonNullable<SubscriptionStatusResponse['subscription_tier']> = 'CREATOR'
+  tier: NonNullable<BillingStatusResponse['subscription_tier']> = 'CREATOR'
 ): SubscriptionOperator {
   return withSubscriptionStatus({
     is_active: true,
     subscription_tier: tier,
-    renewal_date: '2099-12-31T00:00:00.000Z',
-    end_date: null
+    renewal_date: '2099-12-31T00:00:00.000Z'
   })
 }
 
 export function withFreeTier(): SubscriptionOperator {
   return withSubscriptionStatus({
     is_active: true,
-    subscription_tier: 'FREE',
-    end_date: null
+    subscription_tier: 'FREE'
   })
 }
 
 export function withUnsubscribed(): SubscriptionOperator {
   return withSubscriptionStatus({
     is_active: false,
-    subscription_tier: 'FREE',
-    end_date: null,
-    renewal_date: null
+    subscription_tier: 'FREE'
   })
 }
 
 export class SubscriptionHelper {
-  private statusResponse: SubscriptionStatusResponse
+  private statusResponse: BillingStatusResponse
   private balanceResponse: BalanceResponse
   private routeHandlers: Array<{
     pattern: string
@@ -128,7 +103,7 @@ export class SubscriptionHelper {
 
     const statusPattern = '**/api/billing/status'
     const statusHandler = async (route: Route) => {
-      await route.fulfill({ json: toBillingStatus(this.statusResponse) })
+      await route.fulfill({ json: this.statusResponse })
     }
     this.routeHandlers.push({ pattern: statusPattern, handler: statusHandler })
     await this.page.route(statusPattern, statusHandler)
@@ -165,7 +140,7 @@ export class SubscriptionHelper {
     this.balanceResponse = { ...config.balance }
   }
 
-  setStatus(overrides: Partial<SubscriptionStatusResponse>): void {
+  setStatus(overrides: Partial<BillingStatusResponse>): void {
     this.statusResponse = { ...this.statusResponse, ...overrides }
   }
 

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test'
 import type { Page, Route } from '@playwright/test'
 
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
+import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
 import {
   createBalance,
   createSubscriptionStatus,
@@ -37,6 +38,23 @@ function withSubscriptionStatus(
     ...config,
     status: { ...config.status, ...overrides }
   })
+}
+
+function toBillingStatus(
+  status: SubscriptionStatusResponse
+): BillingStatusResponse {
+  return {
+    is_active: status.is_active ?? false,
+    has_funds: status.has_fund ?? false,
+    ...(status.subscription_tier
+      ? { subscription_tier: status.subscription_tier }
+      : {}),
+    ...(status.subscription_duration
+      ? { subscription_duration: status.subscription_duration }
+      : {}),
+    ...(status.renewal_date ? { renewal_date: status.renewal_date } : {}),
+    ...(status.end_date ? { cancel_at: status.end_date } : {})
+  }
 }
 
 export function withActiveSubscription(
@@ -104,9 +122,9 @@ export class SubscriptionHelper {
     })
     await this.page.route(featuresPattern, featuresHandler)
 
-    const statusPattern = '**/customers/cloud-subscription-status'
+    const statusPattern = '**/api/billing/status'
     const statusHandler = async (route: Route) => {
-      await route.fulfill({ json: this.statusResponse })
+      await route.fulfill({ json: toBillingStatus(this.statusResponse) })
     }
     this.routeHandlers.push({ pattern: statusPattern, handler: statusHandler })
     await this.page.route(statusPattern, statusHandler)

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -49,6 +49,7 @@ function toBillingStatus(
   return {
     is_active: status.is_active ?? false,
     has_funds: status.has_fund ?? false,
+    billing_rail: 'legacy_stripe',
     ...(status.subscription_tier
       ? { subscription_tier: status.subscription_tier }
       : {}),

--- a/browser_tests/fixtures/utils/cloudBillingMocks.ts
+++ b/browser_tests/fixtures/utils/cloudBillingMocks.ts
@@ -25,9 +25,6 @@ export async function mockBilling(page: Page) {
   await page.route('**/api/billing/plans', (r) =>
     r.fulfill(jsonRoute({ plans: [] }))
   )
-  await page.route('**/customers/cloud-subscription-status', (r) =>
-    r.fulfill(jsonRoute({ is_active: false }))
-  )
   await page.route('**/customers/balance', (r) =>
     r.fulfill(jsonRoute({ amount_micros: 0, currency: 'usd' }))
   )

--- a/browser_tests/fixtures/utils/cloudBootMocks.ts
+++ b/browser_tests/fixtures/utils/cloudBootMocks.ts
@@ -5,6 +5,7 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 interface CloudBootOptions {
   /** Remote-config payload for `/api/features` (enables the flags under test). */
@@ -47,6 +48,7 @@ export async function mockCloudBoot(
   await page.route('**/api/auth/session', (r) =>
     r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
   )
+  await mockWorkspace(page, workspace('personal', 'owner'), [])
   await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
 }
 

--- a/browser_tests/fixtures/utils/workspaceMocks.ts
+++ b/browser_tests/fixtures/utils/workspaceMocks.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { BrowserContext, Page } from '@playwright/test'
 
 import type {
   Member,
@@ -38,10 +38,10 @@ export function member(
  * this the mint fails and auth cannot resolve the active workspace.
  */
 export async function mockWorkspaceTokenMint(
-  page: Page,
+  routeTarget: Page | BrowserContext,
   ws: Pick<WorkspaceWithRole, 'id' | 'name' | 'type' | 'role'>
 ) {
-  await page.route('**/api/auth/token', (r) =>
+  await routeTarget.route('**/api/auth/token', (r) =>
     r.fulfill(
       jsonRoute({
         token: 'mock-workspace-token',
@@ -59,16 +59,16 @@ export async function mockWorkspaceTokenMint(
  * given workspace with the given roster (drives the original-owner gate).
  */
 export async function mockWorkspace(
-  page: Page,
+  routeTarget: Page | BrowserContext,
   ws: WorkspaceWithRole,
   members: Member[]
 ) {
-  await page.route('**/api/workspaces', async (route) => {
+  await routeTarget.route('**/api/workspaces', async (route) => {
     if (route.request().method() !== 'GET') return route.fallback()
     await route.fulfill(jsonRoute({ workspaces: [ws] }))
   })
-  await mockWorkspaceTokenMint(page, ws)
-  await page.route('**/api/workspace/members**', (r) =>
+  await mockWorkspaceTokenMint(routeTarget, ws)
+  await routeTarget.route('**/api/workspace/members**', (r) =>
     r.fulfill(
       jsonRoute({
         members,

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -6,9 +6,9 @@ import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspa
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { AssetsSidebarTab } from '@e2e/fixtures/components/SidebarTab'
 import {
+  CLOUD_REMOTE_CONFIG,
   DEFAULT_TEAM_MEMBERS,
-  TEAM_WORKSPACE,
-  WORKSPACE_FEATURE_FLAG
+  TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { AssetsHelper, createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
 import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
@@ -141,7 +141,7 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.unroute('**/securetoken.googleapis.com/**')
 
     const features = {
-      ...WORKSPACE_FEATURE_FLAG,
+      ...CLOUD_REMOTE_CONFIG,
       onboarding_survey_enabled: false,
       unified_cloud_auth: false
     } satisfies RemoteConfig

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -115,7 +115,8 @@ async function mockCloudBoot(
     )
   )
 
-  // Legacy endpoints remain mocked for consumers that explicitly use them.
+  // Keep the legacy status route observable so Cloud regressions cannot
+  // silently bypass the workspace-scoped billing authority.
   await page.route('**/customers/cloud-subscription-status', (r) => {
     billingRequests.legacyStatus++
     return r.fulfill(jsonRoute(subscriptionStatus))
@@ -186,7 +187,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
     await expect(popover.getByText('12,660')).toBeVisible()
     await expect(popover.getByTestId('add-credits-button')).toBeVisible()
     expect(billingRequests.workspaceStatus).toBeGreaterThan(0)
-    expect(billingRequests.legacyStatus).toBeGreaterThan(0)
+    expect(billingRequests.legacyStatus).toBe(0)
     expect(billingRequests.legacyBalance).toBeGreaterThan(0)
   })
 

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
-import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type {
   BillingBalanceResponse,
@@ -33,19 +32,6 @@ const jsonRoute = (body: unknown) => ({
   body: JSON.stringify(body)
 })
 
-// The workspace `/api/billing/status` shape mirrors the legacy subscription
-// status; map the fields so a single test fixture drives both backends.
-const toWorkspaceStatus = (
-  s: CloudSubscriptionStatusResponse
-): BillingStatusResponse => ({
-  is_active: s.is_active ?? false,
-  subscription_tier: s.subscription_tier ?? undefined,
-  subscription_duration: s.subscription_duration ?? undefined,
-  renewal_date: s.renewal_date ?? undefined,
-  cancel_at: s.end_date ?? undefined,
-  has_funds: s.has_fund ?? true
-})
-
 const mockBalance: BillingBalanceResponse = {
   amount_micros: 6000, // -> 12,660 credits
   currency: 'usd',
@@ -60,12 +46,11 @@ const mockWorkspaceBalance: BillingBalanceResponse = {
 
 async function mockCloudBoot(
   page: Page,
-  subscriptionStatus: CloudSubscriptionStatusResponse,
+  subscriptionStatus: BillingStatusResponse,
   remoteConfig: RemoteConfig = {},
   billingRail?: BillingStatusResponse['billing_rail']
 ) {
   const billingRequests = {
-    legacyStatus: 0,
     legacyBalance: 0,
     workspaceStatus: 0
   }
@@ -115,12 +100,6 @@ async function mockCloudBoot(
     )
   )
 
-  // Keep the legacy status route observable so Cloud regressions cannot
-  // silently bypass the workspace-scoped billing authority.
-  await page.route('**/customers/cloud-subscription-status', (r) => {
-    billingRequests.legacyStatus++
-    return r.fulfill(jsonRoute(subscriptionStatus))
-  })
   await page.route('**/customers/balance', (r) => {
     billingRequests.legacyBalance++
     return r.fulfill(jsonRoute(mockBalance))
@@ -131,7 +110,7 @@ async function mockCloudBoot(
     billingRequests.workspaceStatus++
     return r.fulfill(
       jsonRoute({
-        ...toWorkspaceStatus(subscriptionStatus),
+        ...subscriptionStatus,
         billing_rail: billingRail
       })
     )
@@ -173,7 +152,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         subscription_tier: 'PRO',
         subscription_duration: 'MONTHLY',
         renewal_date: '2099-02-20T10:00:00Z',
-        end_date: null
+        has_funds: true
       },
       {},
       'legacy_stripe'
@@ -187,7 +166,6 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
     await expect(popover.getByText('12,660')).toBeVisible()
     await expect(popover.getByTestId('add-credits-button')).toBeVisible()
     expect(billingRequests.workspaceStatus).toBeGreaterThan(0)
-    expect(billingRequests.legacyStatus).toBe(0)
     expect(billingRequests.legacyBalance).toBeGreaterThan(0)
   })
 
@@ -210,7 +188,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         subscription_duration: 'MONTHLY',
         // 10:00Z keeps the en-US calendar date stable across CI timezones.
         renewal_date: '2099-02-20T10:00:00Z',
-        end_date: null
+        has_funds: false
       },
       { subscription_required: true }
     )

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -19,11 +19,9 @@ import {
 /**
  * Billing facade consumers — FE-933 (B3) regression.
  *
- * The repointed surfaces (avatar popover tier badge / balance, free-tier
- * dialog renewal date) must keep rendering from `useBillingContext`. The facade
- * selects its backend by flag: `team_workspaces_enabled: false` routes through
- * the legacy `/customers/*` endpoints, while `true` routes a personal workspace
- * through the workspace `/api/billing/*` endpoints. Both shapes are mocked here.
+ * The repointed surfaces (avatar popover balance, free-tier dialog renewal
+ * date) must keep rendering from `useBillingContext`. Cloud
+ * personal workspaces route through the workspace `/api/billing/*` endpoints.
  * Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
  * against fully mocked endpoints — same pattern as creditsTile.spec.ts.
  */
@@ -54,11 +52,24 @@ const mockBalance: BillingBalanceResponse = {
   effective_balance_micros: 6000
 }
 
+const mockWorkspaceBalance: BillingBalanceResponse = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0
+}
+
 async function mockCloudBoot(
   page: Page,
   subscriptionStatus: CloudSubscriptionStatusResponse,
-  remoteConfig: RemoteConfig = { team_workspaces_enabled: false }
+  remoteConfig: RemoteConfig = {},
+  billingRail?: BillingStatusResponse['billing_rail']
 ) {
+  const billingRequests = {
+    legacyStatus: 0,
+    legacyBalance: 0,
+    workspaceStatus: 0
+  }
+
   await page.route('**/api/features', (r) => r.fulfill(jsonRoute(remoteConfig)))
   await page.route('**/api/system_stats', (r) =>
     r.fulfill(jsonRoute(mockSystemStats))
@@ -104,25 +115,34 @@ async function mockCloudBoot(
     )
   )
 
-  // Legacy backend (team_workspaces_enabled: false).
-  await page.route('**/customers/cloud-subscription-status', (r) =>
-    r.fulfill(jsonRoute(subscriptionStatus))
-  )
-  await page.route('**/customers/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  // Legacy endpoints remain mocked for consumers that explicitly use them.
+  await page.route('**/customers/cloud-subscription-status', (r) => {
+    billingRequests.legacyStatus++
+    return r.fulfill(jsonRoute(subscriptionStatus))
+  })
+  await page.route('**/customers/balance', (r) => {
+    billingRequests.legacyBalance++
+    return r.fulfill(jsonRoute(mockBalance))
+  })
 
-  // Workspace backend (team_workspaces_enabled: true) — a personal workspace
-  // now routes through `/api/billing/*`.
-  await page.route('**/api/billing/status', (r) =>
-    r.fulfill(jsonRoute(toWorkspaceStatus(subscriptionStatus)))
-  )
-  await page.route('**/api/billing/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  // Cloud personal workspaces route through `/api/billing/*`.
+  await page.route('**/api/billing/status', (r) => {
+    billingRequests.workspaceStatus++
+    return r.fulfill(
+      jsonRoute({
+        ...toWorkspaceStatus(subscriptionStatus),
+        billing_rail: billingRail
+      })
+    )
+  })
+  await page.route('**/api/billing/balance', (r) => {
+    return r.fulfill(jsonRoute(mockWorkspaceBalance))
+  })
   await page.route('**/api/billing/plans', (r) =>
     r.fulfill(jsonRoute({ plans: [] }))
   )
+
+  return billingRequests
 }
 
 async function bootApp(page: Page) {
@@ -140,27 +160,34 @@ async function bootApp(page: Page) {
 }
 
 test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
-  test('avatar popover renders tier badge and balance from the facade', async ({
+  test('avatar popover renders a legacy-rail balance from the facade', async ({
     page
   }) => {
     test.setTimeout(60_000)
 
-    await mockCloudBoot(page, {
-      is_active: true,
-      subscription_tier: 'PRO',
-      subscription_duration: 'MONTHLY',
-      renewal_date: '2099-02-20T10:00:00Z',
-      end_date: null
-    })
+    const billingRequests = await mockCloudBoot(
+      page,
+      {
+        is_active: true,
+        subscription_tier: 'PRO',
+        subscription_duration: 'MONTHLY',
+        renewal_date: '2099-02-20T10:00:00Z',
+        end_date: null
+      },
+      {},
+      'legacy_stripe'
+    )
     await bootApp(page)
 
     await page.getByRole('button', { name: 'Current user' }).click()
     const popover = page.locator('.current-user-popover')
     await expect(popover).toBeVisible()
 
-    await expect(popover.getByText('Pro', { exact: true })).toBeVisible()
     await expect(popover.getByText('12,660')).toBeVisible()
     await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    expect(billingRequests.workspaceStatus).toBeGreaterThan(0)
+    expect(billingRequests.legacyStatus).toBeGreaterThan(0)
+    expect(billingRequests.legacyBalance).toBeGreaterThan(0)
   })
 
   test('subscribe-to-run routes an inactive FREE user to the pricing table', async ({
@@ -168,8 +195,8 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
   }) => {
     test.setTimeout(60_000)
 
-    // Boots with team workspaces enabled (production shape); the facade routes a
-    // personal workspace through the workspace `/api/billing/*` endpoints. With
+    // The facade routes a personal workspace through the workspace
+    // `/api/billing/*` endpoints. With
     // subscription gating on, an inactive FREE user gets the "Subscribe to run"
     // button, which opens the pricing table on click. (refreshRemoteConfig
     // overwrites window.__CONFIG__ from /api/features, so the flags must come
@@ -184,12 +211,14 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         renewal_date: '2099-02-20T10:00:00Z',
         end_date: null
       },
-      { team_workspaces_enabled: true, subscription_required: true }
+      { subscription_required: true }
     )
     await bootApp(page)
 
     await page.getByTestId('subscribe-to-run-button').click()
 
-    await expect(page.getByRole('heading', { name: /Plans for/ })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toBeVisible()
   })
 })

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -17,7 +17,7 @@ type CustomerBalanceResponse = NonNullable<
 const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
 const FUTURE_DATE = '2099-01-01T00:00:00Z'
 
-const mockRemoteConfig: RemoteConfig = { team_workspaces_enabled: true }
+const mockRemoteConfig: RemoteConfig = {}
 
 const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
   workspaces: [
@@ -54,8 +54,8 @@ const mockSubscriptionStatus: CloudSubscriptionStatusResponse = {
   end_date: FUTURE_DATE
 }
 
-// With team workspaces enabled, the facade routes a personal workspace through
-// `/api/billing/*`. The cancelled-but-active state maps to `is_active: true`
+// The facade routes a Cloud personal workspace through `/api/billing/*`. The
+// cancelled-but-active state maps to `is_active: true`
 // with `subscription_status: 'canceled'`; a paid tier keeps "Add credits"
 // visible (free tier would swap it for "Upgrade to add credits").
 const mockBillingStatus: BillingStatusResponse = {
@@ -126,8 +126,7 @@ const test = comfyPageFixture.extend({
       })
     )
 
-    // Flag-on (team workspaces enabled) routes a personal workspace through the
-    // workspace billing endpoints, so the popover sources its data from here.
+    // The popover sources its data from the workspace billing endpoints.
     await page.route('**/api/billing/status', (route) =>
       route.fulfill({
         status: 200,

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test'
 
-import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type {
   BillingStatusResponse,
@@ -42,16 +41,6 @@ const mockTokenResponse: WorkspaceTokenResponse = {
   },
   role: 'owner',
   permissions: []
-}
-
-// Cancelled but still active: `end_date` set (cancelled) while `is_active` is
-// true. A personal owner in this state sees BOTH "Add credits" and "Resubscribe"
-// in the credits row.
-const mockSubscriptionStatus: CloudSubscriptionStatusResponse = {
-  is_active: true,
-  subscription_id: 'sub_e2e',
-  renewal_date: FUTURE_DATE,
-  end_date: FUTURE_DATE
 }
 
 // The facade routes a Cloud personal workspace through `/api/billing/*`. The
@@ -108,14 +97,6 @@ const test = comfyPageFixture.extend({
 
     await page.route('**/api/auth/session', (route) =>
       route.fulfill({ status: 204 })
-    )
-
-    await page.route('**/customers/cloud-subscription-status', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockSubscriptionStatus)
-      })
     )
 
     await page.route('**/customers/balance', (route) =>

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -125,24 +125,10 @@ async function mockCloudBoot(page: Page, billingControlEnabled = true) {
     )
   )
 
-  // Legacy billing (flag-off path, api.comfy.org/customers/*).
-  await page.route('**/customers/cloud-subscription-status', (r) =>
-    r.fulfill(
-      jsonRoute({
-        is_active: true,
-        subscription_tier: 'PRO',
-        subscription_duration: 'MONTHLY',
-        renewal_date: '2099-02-20T12:00:00Z',
-        end_date: null
-      })
-    )
-  )
   await page.route('**/customers/balance', (r) =>
     r.fulfill(balanceRoute(DEFAULT_BALANCE))
   )
 
-  // Workspace billing (flag-on path) — a personal workspace now routes through
-  // `/api/billing/*`.
   await page.route('**/api/billing/status', (r) =>
     r.fulfill(jsonRoute(mockBillingStatus))
   )

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -28,10 +28,9 @@ import {
  * The credits tile only lives inside the authenticated cloud app, which the
  * shared `comfyPage` fixture can't boot (it expects the OSS devtools backend).
  * Instead this drives a raw page: mock Firebase auth + every boot endpoint so
- * the cloud app initializes against fully stubbed data. With team workspaces
- * enabled the facade routes a personal workspace through the workspace
- * `/api/billing/*` endpoints (mocked with an active Pro subscription); the
- * legacy `/customers/*` shapes are mocked too for the flag-off path. The tile
+ * the cloud app initializes against fully stubbed data. The facade routes a
+ * personal workspace through the workspace `/api/billing/*` endpoints (mocked
+ * with an active Pro subscription). The tile
  * should then render its total / progress bar / monthly+additional breakdown /
  * add-credits.
  */
@@ -71,13 +70,10 @@ const mockBillingStatus: BillingStatusResponse = {
 
 async function mockCloudBoot(page: Page, billingControlEnabled = true) {
   // Frontend-origin boot endpoints (proxied to the backend in production).
-  // `/api/features` is the remote-config source: production builds resolve
-  // workspace availability and the billing UX rollout from it (the `ff:`
-  // localStorage override is dev-only).
+  // `/api/features` is the remote-config source for the billing UX rollout.
   await page.route('**/api/features', (r) =>
     r.fulfill(
       jsonRoute({
-        team_workspaces_enabled: true,
         billing_control_enabled: billingControlEnabled
       } satisfies RemoteConfig)
     )

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -41,11 +41,7 @@ const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
-// consolidated_billing_enabled routes personal workspaces to the unified
-// pricing table asserted here; without it they fall back to the legacy table.
 const BOOT_FEATURES = {
-  team_workspaces_enabled: true,
-  consolidated_billing_enabled: true,
   billing_control_enabled: true
 } satisfies RemoteConfig
 // Disable the experimental Asset API: with it on (cloud default) the unmocked

--- a/browser_tests/tests/freeTierQuota.spec.ts
+++ b/browser_tests/tests/freeTierQuota.spec.ts
@@ -15,8 +15,14 @@ test.describe('Free Tier Quota', { tag: ['@cloud', '@vue-nodes'] }, () => {
       free_tier_balance: { allowance: 5, remaining: 3, used: 0 }
     }
     await page.route('**/api/features', (r) => r.fulfill(jsonRoute(features)))
-    await page.route('**/customers/cloud-subscription-status', (r) =>
-      r.fulfill(jsonRoute({ is_active: true, subscription_tier: 'FREE' }))
+    await page.route('**/api/billing/status', (r) =>
+      r.fulfill(
+        jsonRoute({
+          is_active: true,
+          has_funds: true,
+          subscription_tier: 'FREE'
+        })
+      )
     )
   })
 

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -142,13 +142,6 @@ async function routeCloudBootstrapApis(page: Page) {
       body: JSON.stringify({})
     })
   })
-  await page.route('**/customers/cloud-subscription-status', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ is_active: true })
-    })
-  })
 }
 
 const cloudOutputTest = createCloudAssetsFixture([

--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -14,7 +14,6 @@ const TEAM_WORKSPACE_NAME = 'Team Workspace'
 const SINGLE_LINE_MAX_HEIGHT_PX = 28
 
 const mockRemoteConfig: RemoteConfig = {
-  team_workspaces_enabled: true,
   unified_cloud_auth: true
 }
 

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -8,10 +8,6 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import CurrentUserButton from './CurrentUserButton.vue'
 
-const mockFeatureFlags = vi.hoisted(() => ({
-  teamWorkspacesEnabled: false
-}))
-
 const mockTeamWorkspaceStore = vi.hoisted(() => ({
   workspaceName: { value: '' },
   initState: { value: 'idle' },
@@ -38,13 +34,6 @@ vi.mock('firebase/auth', () => ({
 // Mock pinia
 vi.mock('pinia', () => ({
   storeToRefs: vi.fn((store: Record<string, unknown>) => store)
-}))
-
-// Mock the useFeatureFlags composable
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: vi.fn(() => ({
-    flags: mockFeatureFlags
-  }))
 }))
 
 // Mock the useTeamWorkspaceStore
@@ -113,7 +102,6 @@ vi.mock('./CurrentUserPopoverLegacy.vue', () => ({
 describe('CurrentUserButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockTeamWorkspaceStore.workspaceName.value = ''
     mockTeamWorkspaceStore.initState.value = 'idle'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
@@ -183,7 +171,6 @@ describe('CurrentUserButton', () => {
 
   it('shows UserAvatar in personal workspace', () => {
     mockIsCloud.value = true
-    mockFeatureFlags.teamWorkspacesEnabled = true
     mockTeamWorkspaceStore.initState.value = 'ready'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = true
 
@@ -194,7 +181,6 @@ describe('CurrentUserButton', () => {
 
   it('shows WorkspaceProfilePic in team workspace', () => {
     mockIsCloud.value = true
-    mockFeatureFlags.teamWorkspacesEnabled = true
     mockTeamWorkspaceStore.initState.value = 'ready'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
     mockTeamWorkspaceStore.workspaceName.value = 'My Team'

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -77,6 +77,20 @@ vi.mock('@/platform/workspace/components/WorkspaceProfilePic.vue', () => ({
   }
 }))
 
+const CurrentUserPopoverWorkspaceStub = defineComponent({
+  name: 'CurrentUserPopoverWorkspace',
+  props: {
+    accountActionsOnly: Boolean
+  },
+  setup(props) {
+    return () =>
+      h('div', [
+        h('span', 'Workspace Popover Content'),
+        props.accountActionsOnly ? h('span', 'Account Actions Only') : ''
+      ])
+  }
+})
+
 // Mock the CurrentUserPopoverLegacy component
 vi.mock('./CurrentUserPopoverLegacy.vue', () => ({
   default: defineComponent({
@@ -85,7 +99,7 @@ vi.mock('./CurrentUserPopoverLegacy.vue', () => ({
     setup(_, { emit }) {
       return () =>
         h('div', [
-          'Popover Content',
+          h('span', 'Popover Content'),
           h(
             'button',
             {
@@ -120,6 +134,7 @@ describe('CurrentUserButton', () => {
       global: {
         plugins: [i18n],
         stubs: {
+          CurrentUserPopoverWorkspace: CurrentUserPopoverWorkspaceStub,
           Popover: defineComponent({
             setup(_, { slots, expose }) {
               const shown = ref(false)
@@ -157,6 +172,20 @@ describe('CurrentUserButton', () => {
 
     expect(screen.getByText('Popover Content')).toBeInTheDocument()
   })
+
+  it.for(['loading', 'error'])(
+    'shows account actions while Cloud workspace initialization is %s',
+    async (initState) => {
+      mockIsCloud.value = true
+      mockTeamWorkspaceStore.initState.value = initState
+      const { user } = renderComponent()
+
+      await user.click(screen.getByRole('button', { name: 'Current user' }))
+
+      expect(screen.getByText('Workspace Popover Content')).toBeInTheDocument()
+      expect(screen.getByText('Account Actions Only')).toBeInTheDocument()
+    }
+  )
 
   it('hides popover when closePopover is called', async () => {
     const { user } = renderComponent()

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -49,11 +49,12 @@
       @show="onPopoverShow"
     >
       <CurrentUserPopoverWorkspace
-        v-if="isCloud && initState === 'ready'"
+        v-if="isCloud"
         ref="workspacePopoverContent"
+        :account-actions-only="initState !== 'ready'"
         @close="closePopover"
       />
-      <CurrentUserPopoverLegacy v-else-if="!isCloud" @close="closePopover" />
+      <CurrentUserPopoverLegacy v-else @close="closePopover" />
     </Popover>
   </div>
 </template>

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -48,17 +48,12 @@
       }"
       @show="onPopoverShow"
     >
-      <!-- Workspace mode: workspace-aware popover (only when ready) -->
       <CurrentUserPopoverWorkspace
-        v-if="teamWorkspacesEnabled && initState === 'ready'"
+        v-if="isCloud && initState === 'ready'"
         ref="workspacePopoverContent"
         @close="closePopover"
       />
-      <!-- Legacy mode: original popover -->
-      <CurrentUserPopoverLegacy
-        v-else-if="!teamWorkspacesEnabled"
-        @close="closePopover"
-      />
+      <CurrentUserPopoverLegacy v-else-if="!isCloud" @close="closePopover" />
     </Popover>
   </div>
 </template>
@@ -73,7 +68,6 @@ import UserAvatar from '@/components/common/UserAvatar.vue'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -90,9 +84,6 @@ const { showArrow = true, compact = false } = defineProps<{
   compact?: boolean
 }>()
 
-const { flags } = useFeatureFlags()
-const teamWorkspacesEnabled = computed(() => flags.teamWorkspacesEnabled)
-
 const { isLoggedIn, userPhotoUrl } = useCurrentUser()
 
 const photoURL = computed<string | undefined>(
@@ -106,14 +97,10 @@ const {
 } = storeToRefs(useTeamWorkspaceStore())
 
 const showWorkspaceSkeleton = computed(
-  () => isCloud && teamWorkspacesEnabled.value && initState.value === 'loading'
+  () => isCloud && initState.value === 'loading'
 )
 const showWorkspaceIcon = computed(
-  () =>
-    isCloud &&
-    teamWorkspacesEnabled.value &&
-    initState.value === 'ready' &&
-    !isInPersonalWorkspace.value
+  () => isCloud && initState.value === 'ready' && !isInPersonalWorkspace.value
 )
 
 const workspaceName = computed(() => {

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -19,8 +19,6 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
-  mockTeamWorkspacesEnabled,
-  mockConsolidatedBillingEnabled,
   mockIsPersonal,
   mockBillingRail,
   mockPlans,
@@ -33,8 +31,6 @@ const {
   mockSetWorkspaceBillingRail,
   mockBillingStatus
 } = vi.hoisted(() => ({
-  mockTeamWorkspacesEnabled: { value: false },
-  mockConsolidatedBillingEnabled: { value: false },
   mockIsPersonal: { value: true },
   mockBillingRail: { value: undefined as BillingRail | undefined },
   mockPlans: { value: [] as Plan[] },
@@ -63,37 +59,7 @@ vi.mock('@vueuse/core', async (importOriginal) => {
   }
 })
 
-vi.mock('@/composables/useFeatureFlags', async () => {
-  const { ref } = await import('vue')
-  const teamWorkspacesEnabledRef = ref(mockTeamWorkspacesEnabled.value)
-  Object.defineProperty(mockTeamWorkspacesEnabled, 'value', {
-    get: () => teamWorkspacesEnabledRef.value,
-    set: (value: boolean) => {
-      teamWorkspacesEnabledRef.value = value
-    }
-  })
-  const consolidatedBillingEnabledRef = ref(
-    mockConsolidatedBillingEnabled.value
-  )
-  Object.defineProperty(mockConsolidatedBillingEnabled, 'value', {
-    get: () => consolidatedBillingEnabledRef.value,
-    set: (value: boolean) => {
-      consolidatedBillingEnabledRef.value = value
-    }
-  })
-  return {
-    useFeatureFlags: () => ({
-      flags: {
-        get teamWorkspacesEnabled() {
-          return mockTeamWorkspacesEnabled.value
-        },
-        get consolidatedBillingEnabled() {
-          return mockConsolidatedBillingEnabled.value
-        }
-      }
-    })
-  }
-})
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
   const { ref } = await import('vue')
@@ -191,8 +157,6 @@ describe('useBillingContext', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    mockTeamWorkspacesEnabled.value = false
-    mockConsolidatedBillingEnabled.value = false
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(
@@ -204,33 +168,14 @@ describe('useBillingContext', () => {
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
   })
 
-  it('selects legacy type when team workspaces are disabled', () => {
-    mockTeamWorkspacesEnabled.value = false
-    const { type } = useBillingContext()
-    expect(type.value).toBe('legacy')
-  })
-
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type } = useBillingContext()
-    expect(type.value).toBe('legacy')
-  })
-
-  it('selects workspace type for personal when consolidated billing is enabled', () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
+  it('selects workspace type for a Cloud personal workspace', () => {
     mockIsPersonal.value = true
 
     const { type } = useBillingContext()
     expect(type.value).toBe('workspace')
   })
 
-  it('selects workspace type for team regardless of consolidated billing', () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = false
+  it('selects workspace type for a Cloud team workspace', () => {
     mockIsPersonal.value = false
 
     const { type } = useBillingContext()
@@ -238,6 +183,7 @@ describe('useBillingContext', () => {
   })
 
   it('provides subscription info from legacy billing', () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { subscription } = useBillingContext()
 
     expect(subscription.value).toEqual({
@@ -253,6 +199,7 @@ describe('useBillingContext', () => {
   })
 
   it('provides balance info from legacy billing', () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { balance } = useBillingContext()
 
     expect(balance.value).toEqual({
@@ -281,15 +228,19 @@ describe('useBillingContext', () => {
 
   it('exposes subscribe action', async () => {
     const { subscribe } = useBillingContext()
-    await expect(subscribe('pro-monthly')).resolves.toBeUndefined()
+    await expect(subscribe('pro-monthly')).resolves.toEqual({
+      status: 'subscribed'
+    })
   })
 
   it('exposes manageSubscription action', async () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { manageSubscription } = useBillingContext()
     await expect(manageSubscription()).resolves.toBeUndefined()
   })
 
   it('converts topup cents to whole dollars for the legacy credit endpoint', async () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { topup } = useBillingContext()
     await topup(500)
 
@@ -297,8 +248,6 @@ describe('useBillingContext', () => {
   })
 
   it('uses workspace checkout while keeping legacy topups on legacy Stripe', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
     mockPlans.value = [
       {
@@ -327,7 +276,7 @@ describe('useBillingContext', () => {
     await context.fetchStatus()
 
     expect(mockFetchPlans).toHaveBeenCalledOnce()
-    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(mockLegacyFetchStatus).toHaveBeenCalled()
     expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
 
     await context.previewSubscribe('creator-annual')
@@ -347,8 +296,6 @@ describe('useBillingContext', () => {
   })
 
   it('switches billing adapters before refreshing a migrated balance', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
     mockBillingStatus.value = {
       ...DEFAULT_BILLING_STATUS,
@@ -356,6 +303,10 @@ describe('useBillingContext', () => {
     }
 
     const context = useBillingContext()
+    await vi.waitFor(() => {
+      expect(mockLegacyFetchStatus).toHaveBeenCalled()
+      expect(mockLegacyFetchBalance).toHaveBeenCalled()
+    })
     vi.clearAllMocks()
 
     await context.reconcileSubscriptionSuccess()
@@ -372,11 +323,13 @@ describe('useBillingContext', () => {
   })
 
   it('does not refresh a balance through a stale rail after discovery fails', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
 
     const context = useBillingContext()
+    await vi.waitFor(() => {
+      expect(mockLegacyFetchStatus).toHaveBeenCalled()
+      expect(mockLegacyFetchBalance).toHaveBeenCalled()
+    })
     vi.clearAllMocks()
     vi.mocked(workspaceApi.getBillingStatus).mockRejectedValueOnce(
       new Error('status unavailable')
@@ -399,6 +352,7 @@ describe('useBillingContext', () => {
   })
 
   it('provides isActiveSubscription convenience computed', () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { isActiveSubscription } = useBillingContext()
     expect(isActiveSubscription.value).toBe(true)
   })
@@ -413,48 +367,8 @@ describe('useBillingContext', () => {
     expect(() => showSubscriptionDialog()).not.toThrow()
   })
 
-  it('reinitializes workspace billing when the type flips on after legacy init', async () => {
-    mockTeamWorkspacesEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type, initialize } = useBillingContext()
-    await initialize()
-    await nextTick()
-
-    expect(type.value).toBe('legacy')
-    expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
-
-    // Authenticated remote config resolves the flag on for the same workspace
-    mockConsolidatedBillingEnabled.value = true
-    mockTeamWorkspacesEnabled.value = true
-
-    await vi.waitFor(() => {
-      expect(type.value).toBe('workspace')
-      expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
-    })
-  })
-
-  it('moves a personal workspace to workspace billing when consolidated billing flips on', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type } = useBillingContext()
-    await nextTick()
-    expect(type.value).toBe('legacy')
-
-    mockConsolidatedBillingEnabled.value = true
-
-    await vi.waitFor(() => {
-      expect(type.value).toBe('workspace')
-      expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
-    })
-  })
-
   describe('subscription mirror to workspace store', () => {
-    it('mirrors subscription for personal workspaces on the consolidated billing flow', async () => {
-      mockTeamWorkspacesEnabled.value = true
-      mockConsolidatedBillingEnabled.value = true
+    it('mirrors subscription for personal workspaces', async () => {
       mockIsPersonal.value = true
 
       const { initialize } = useBillingContext()
@@ -468,7 +382,6 @@ describe('useBillingContext', () => {
     })
 
     it('never clobbers the list-derived store when a subscription is absent', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
 
       const { initialize } = useBillingContext()
@@ -483,16 +396,15 @@ describe('useBillingContext', () => {
   })
 
   describe('getMaxSeats', () => {
-    it('returns 1 for personal workspaces regardless of tier', () => {
+    it('uses plan seat limits for Cloud personal workspaces', () => {
       const { getMaxSeats } = useBillingContext()
       expect(getMaxSeats('standard')).toBe(1)
-      expect(getMaxSeats('creator')).toBe(1)
-      expect(getMaxSeats('pro')).toBe(1)
+      expect(getMaxSeats('creator')).toBe(5)
+      expect(getMaxSeats('pro')).toBe(20)
       expect(getMaxSeats('founder')).toBe(1)
     })
 
     it('falls back to hardcoded values when no API plans available', () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
 
       const { getMaxSeats } = useBillingContext()
@@ -503,7 +415,6 @@ describe('useBillingContext', () => {
     })
 
     it('prefers API max_seats when plans are loaded', () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockPlans.value = [
         {
@@ -536,7 +447,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for an active team plan: team- slug and no credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -553,7 +463,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for any legacy team tier, not just standard', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -570,7 +479,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a new credit-slider team subscriber', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       // Real BE shape: underscore slug + populated credit stop. (subscription_tier
       // is 'TEAM' on the wire, not yet in the FE SubscriptionTier union, so it is
@@ -595,7 +503,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a new team sub even before its credit stop is populated', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       // Provisioning lag: credit stop not yet attached. The underscore slug
       // (team_per_credit, not team-) must still exclude it from the legacy table.
@@ -614,7 +521,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a team workspace on a personal-tier plan', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -631,7 +537,6 @@ describe('useBillingContext', () => {
     })
 
     it('stays true for a cancelled-but-still-active legacy team sub', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -650,7 +555,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a FREE-tier team even on a team- prefixed slug', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -666,7 +570,6 @@ describe('useBillingContext', () => {
     })
 
     it('matches the legacy slug case-insensitively', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -695,7 +598,6 @@ describe('useBillingContext', () => {
     // isTeamPlan reads the credit stop and the slug, never the tier — which is
     // what keeps it working despite that divergence.
     it('is true for a credit-slider team sub, which carries a credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -715,8 +617,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for a per-credit Team plan in a personal workspace before its credit stop is populated', async () => {
-      mockTeamWorkspacesEnabled.value = true
-      mockConsolidatedBillingEnabled.value = true
       mockIsPersonal.value = true
       mockBillingStatus.value = {
         is_active: true,
@@ -733,7 +633,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for a legacy team sub, identified by slug rather than credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -753,7 +652,6 @@ describe('useBillingContext', () => {
     // spend gate folds billing_status into it. Coupling isTeamPlan to an active
     // subscription would blank the banner precisely when it is needed.
     it('stays true for a paused team plan, which the backend reports inactive', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: false,
@@ -774,7 +672,6 @@ describe('useBillingContext', () => {
     })
 
     it('stays true for a legacy team plan whose payment failed', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: false,
@@ -791,7 +688,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a team workspace on a personal-tier plan', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -95,7 +95,11 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
     subscriptionTier: { value: 'PRO' },
     subscriptionDuration: { value: 'MONTHLY' },
     subscriptionStatus: {
-      value: { renewal_date: '2025-01-01T00:00:00Z', end_date: null }
+      value: {
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-01-01T00:00:00Z'
+      }
     },
     isCancelled: { value: false },
     fetchStatus: mockLegacyFetchStatus,

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -228,9 +228,7 @@ function useBillingContextInternal(): BillingContext {
     error.value = null
   }
 
-  // type flips when the team-workspaces or consolidated-billing flag resolves
-  // from authenticated config, swapping the active backend. Reset then reinit
-  // on every workspace-id or type change.
+  // Reset and reinitialize when the active workspace or billing backend changes.
   watch(
     [() => store.activeWorkspace?.id, () => type.value],
     async ([newWorkspaceId]) => {

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -4,12 +4,9 @@ import type { BillingRail } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const { mockFlags, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
+const { mockIsCloud, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
   vi.hoisted(() => ({
-    mockFlags: {
-      teamWorkspacesEnabled: false,
-      consolidatedBillingEnabled: false
-    },
+    mockIsCloud: { value: true },
     mockActiveWorkspace: {
       value: null as { id: string; type: 'personal' | 'team' } | null
     },
@@ -18,8 +15,10 @@ const { mockFlags, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
     }
   }))
 
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags })
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -38,14 +37,13 @@ const team = { id: 'w-team', type: 'team' as const }
 
 describe('useBillingRouting', () => {
   beforeEach(() => {
-    mockFlags.teamWorkspacesEnabled = false
-    mockFlags.consolidatedBillingEnabled = false
+    mockIsCloud.value = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = null
   })
 
-  it('uses legacy billing when team workspaces are disabled', () => {
-    mockFlags.teamWorkspacesEnabled = false
+  it('uses legacy billing off Cloud', () => {
+    mockIsCloud.value = false
     mockActiveWorkspace.value = team
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
@@ -54,19 +52,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(false)
   })
 
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = false
-    mockActiveWorkspace.value = personal
-
-    const { type } = useBillingRouting()
-
-    expect(type.value).toBe('legacy')
-  })
-
-  it('moves personal to workspace billing when consolidated billing is enabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
+  it('uses workspace billing for a Cloud personal workspace', () => {
     mockActiveWorkspace.value = personal
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
@@ -76,8 +62,6 @@ describe('useBillingRouting', () => {
   })
 
   it('uses unified pricing while keeping legacy Stripe top-ups on Checkout', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
@@ -90,8 +74,6 @@ describe('useBillingRouting', () => {
   })
 
   it('uses workspace billing for migrated Stripe personal workspaces', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'stripe'
 
@@ -101,9 +83,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
-  it('uses workspace billing for team workspaces regardless of consolidated billing', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = false
+  it('uses workspace billing for team workspaces', () => {
     mockActiveWorkspace.value = team
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
@@ -113,21 +93,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
-  it('uses workspace billing for team workspaces with consolidated billing enabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
-    mockActiveWorkspace.value = team
-    mockActiveWorkspaceBillingRail.value = 'stripe'
-
-    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
-
-    expect(type.value).toBe('workspace')
-    expect(shouldUseWorkspaceBilling.value).toBe(true)
-  })
-
   it('defaults to legacy while the workspace has not loaded', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = null
 
     const { type } = useBillingRouting()

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import type { BillingType } from './types'
@@ -8,27 +8,20 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * stay legacy until `consolidatedBillingEnabled`, and known legacy Stripe
- * workspaces remain legacy after it is enabled. An unknown rail keeps the
- * flag-based route so workspace status can load it. Team workspaces are always
- * workspace-scoped. Pricing follows feature availability independently of the
- * billing rail. The routing matrix is covered in useBillingRouting.test.ts.
+ * use workspace-scoped billing unless they are explicitly on the legacy Stripe
+ * rail. An unloaded workspace remains legacy during bootstrap. OSS always uses
+ * legacy billing. Pricing follows Cloud workspace availability independently
+ * of the billing rail.
  */
 export function useBillingRouting() {
-  const { flags } = useFeatureFlags()
   const workspaceStore = useTeamWorkspaceStore()
 
   const shouldUseUnifiedPricing = computed(() => {
-    if (!flags.teamWorkspacesEnabled) return false
-
-    const workspaceType = workspaceStore.activeWorkspace?.type
-    if (!workspaceType) return false
-
-    return workspaceType === 'team' || flags.consolidatedBillingEnabled
+    return isCloud && workspaceStore.activeWorkspace?.type !== undefined
   })
 
   const type = computed<BillingType>(() => {
-    if (!flags.teamWorkspacesEnabled) return 'legacy'
+    if (!isCloud) return 'legacy'
 
     // An unloaded workspace has no type yet; stay legacy so bootstrap never
     // eagerly routes to workspace billing.
@@ -37,8 +30,7 @@ export function useBillingRouting() {
 
     if (
       workspaceType === 'personal' &&
-      (!flags.consolidatedBillingEnabled ||
-        workspaceStore.activeWorkspaceBillingRail === 'legacy_stripe')
+      workspaceStore.activeWorkspaceBillingRail === 'legacy_stripe'
     ) {
       return 'legacy'
     }

--- a/src/composables/billing/useLegacyBilling.ts
+++ b/src/composables/billing/useLegacyBilling.ts
@@ -59,7 +59,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
       duration: subscriptionDuration.value,
       planSlug: null, // Legacy doesn't use plan slugs
       renewalDate: legacySubscriptionStatus.value?.renewal_date ?? null,
-      endDate: legacySubscriptionStatus.value?.end_date ?? null,
+      endDate: legacySubscriptionStatus.value?.cancel_at ?? null,
       isCancelled: isCancelled.value,
       hasFunds: (authStore.balance?.amount_micros ?? 0) > 0
     }

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -8,8 +8,6 @@ import {
 import * as distributionTypes from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   remoteConfig,
   remoteConfigState
 } from '@/platform/remoteConfig/remoteConfig'
@@ -243,14 +241,6 @@ describe('useFeatureFlags', () => {
       expect(flags.supportsPreviewMetadata).toBe('overridden')
     })
 
-    it('teamWorkspacesEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
-      vi.mocked(distributionTypes).isCloud = false
-      localStorage.setItem('ff:team_workspaces_enabled', 'true')
-
-      const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
-    })
-
     it('billingControlEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
       vi.mocked(distributionTypes).isCloud = false
       localStorage.setItem('ff:billing_control_enabled', 'true')
@@ -259,20 +249,11 @@ describe('useFeatureFlags', () => {
       expect(flags.billingControlEnabled).toBe(true)
     })
 
-    it('consolidatedBillingEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
-      vi.mocked(distributionTypes).isCloud = false
-      localStorage.setItem('ff:consolidated_billing_enabled', 'true')
-
-      const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(true)
-    })
-
     it('billingControlEnabled is false off-cloud even without an override', () => {
       vi.mocked(distributionTypes).isCloud = false
 
       const { flags } = useFeatureFlags()
       expect(flags.billingControlEnabled).toBe(false)
-      expect(flags.consolidatedBillingEnabled).toBe(false)
     })
   })
 
@@ -281,8 +262,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = true
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedTeamWorkspacesEnabled.value = undefined
-      cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       localStorage.clear()
     })
@@ -291,42 +270,30 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = false
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedTeamWorkspacesEnabled.value = undefined
-      cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       localStorage.clear()
     })
 
     it('returns the cached session value during the auth window', () => {
-      cachedTeamWorkspacesEnabled.value = false
-      cachedConsolidatedBillingEnabled.value = true
       cachedBillingControlEnabled.value = true
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(false)
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
     })
 
     it('defaults to false during the auth window when nothing is cached', () => {
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(false)
-      expect(flags.consolidatedBillingEnabled).toBe(false)
       expect(flags.billingControlEnabled).toBe(false)
     })
 
     it('prefers authenticated remoteConfig over the server feature fallback', () => {
       remoteConfigState.value = 'authenticated'
       remoteConfig.value = {
-        team_workspaces_enabled: true,
-        consolidated_billing_enabled: true,
         billing_control_enabled: false
       }
       vi.mocked(api.getServerFeature).mockReturnValue(false)
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(false)
     })
 
@@ -335,17 +302,12 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {}
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
-          if (path === ServerFeatureFlag.TEAM_WORKSPACES_ENABLED) return true
-          if (path === ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED)
-            return true
           if (path === ServerFeatureFlag.BILLING_CONTROL_ENABLED) return true
           return defaultValue
         }
       )
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
     })
   })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -4,8 +4,6 @@ import type { Ref } from 'vue'
 import { isCloud, isNightly } from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   isAuthenticatedConfigLoaded,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
@@ -24,7 +22,6 @@ export enum ServerFeatureFlag {
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
-  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
   PARTNER_NODE_GOVERNANCE_ENABLED = 'partner_node_governance_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
   NODE_REPLACEMENTS = 'node_replacements',
@@ -34,7 +31,6 @@ export enum ServerFeatureFlag {
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
-  CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
   FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
   CHURNKEY_APP_ID = 'churnkey_app_id',
@@ -126,19 +122,6 @@ export function useFeatureFlags() {
         false
       )
     },
-    /**
-     * Whether team workspaces feature is enabled.
-     * IMPORTANT: Returns false until authenticated remote config is loaded.
-     * This ensures we never use workspace tokens when the feature is disabled,
-     * and prevents race conditions during initialization.
-     */
-    get teamWorkspacesEnabled() {
-      return resolveAuthGatedFlag(
-        ServerFeatureFlag.TEAM_WORKSPACES_ENABLED,
-        remoteConfig.value.team_workspaces_enabled,
-        cachedTeamWorkspacesEnabled
-      )
-    },
     get partnerNodeGovernanceEnabled() {
       return resolveFlag(
         ServerFeatureFlag.PARTNER_NODE_GOVERNANCE_ENABLED,
@@ -201,18 +184,6 @@ export function useFeatureFlags() {
         ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
         remoteConfig.value.unified_cloud_auth,
         false
-      )
-    },
-    /**
-     * Whether personal workspaces use the consolidated (workspace-scoped)
-     * billing flow. While false (default), personal workspaces stay on the
-     * legacy per-user billing flow; team workspaces are unaffected.
-     */
-    get consolidatedBillingEnabled() {
-      return resolveAuthGatedFlag(
-        ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED,
-        remoteConfig.value.consolidated_billing_enabled,
-        cachedConsolidatedBillingEnabled
       )
     },
     get billingControlEnabled() {

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -9,11 +9,6 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-const mockFlags = vi.hoisted(() => ({ value: { teamWorkspacesEnabled: true } }))
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags.value })
-}))
-
 const mocks = vi.hoisted(() => ({
   loadInvite: vi.fn().mockResolvedValue(undefined),
   loadCreateWorkspace: vi.fn().mockResolvedValue(undefined),
@@ -47,7 +42,6 @@ describe('useUrlActionLoaders', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsCloud.value = true
-    mockFlags.value = { teamWorkspacesEnabled: true }
   })
 
   it('does not instantiate or run any loader off cloud', async () => {
@@ -64,23 +58,12 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.loadPricingTable).not.toHaveBeenCalled()
   })
 
-  it('runs all loaders on cloud when team workspaces are enabled', async () => {
+  it('runs all loaders on Cloud', async () => {
     const { runUrlActionLoaders } = useUrlActionLoaders()
     await runUrlActionLoaders()
 
     expect(mocks.loadInvite).toHaveBeenCalledOnce()
     expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
-    expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
-  })
-
-  it('runs the pricing loader but skips the flag-gated loaders when team workspaces are disabled', async () => {
-    mockFlags.value = { teamWorkspacesEnabled: false }
-
-    const { runUrlActionLoaders } = useUrlActionLoaders()
-    await runUrlActionLoaders()
-
-    expect(mocks.loadInvite).not.toHaveBeenCalled()
-    expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
   })
 

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
 import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
@@ -11,7 +10,6 @@ import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUr
  * from `onMounted` once the app is ready.
  */
 export function useUrlActionLoaders() {
-  const { flags } = useFeatureFlags()
   const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
   const createWorkspaceUrlLoader = isCloud
     ? useCreateWorkspaceUrlLoader()
@@ -20,13 +18,12 @@ export function useUrlActionLoaders() {
 
   async function runUrlActionLoaders() {
     // Accept workspace invite from URL if present (e.g., ?invite=TOKEN).
-    // WorkspaceAuthGate ensures flag state is resolved before the app mounts.
-    if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
+    if (inviteUrlLoader) {
       await inviteUrlLoader.loadInviteFromUrl()
     }
 
     // Open create workspace dialog from URL if present (e.g., ?create_workspace=1).
-    if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
+    if (createWorkspaceUrlLoader) {
       try {
         await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
       } catch (error) {
@@ -38,7 +35,6 @@ export function useUrlActionLoaders() {
     }
 
     // Open the pricing table from URL if present (e.g., ?pricing=1 / ?pricing=team).
-    // Not gated on the team-workspaces flag: it also drives personal/legacy users.
     if (pricingTableUrlLoader) {
       try {
         await pricingTableUrlLoader.loadPricingTableFromUrl()

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4606,6 +4606,9 @@
     "switchFailed": "Failed to switch workspace. Please try again."
   },
   "workspaceAuth": {
+    "initializationFailed": "Couldn't load your workspace",
+    "initializationFailedDetail": "Check your connection and try again.",
+    "retry": "Try again",
     "errors": {
       "notAuthenticated": "You must be logged in to access workspaces",
       "invalidFirebaseToken": "Authentication failed. Please try logging in again.",

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -5,17 +5,10 @@ const mockGetAuthHeader = vi.fn()
 const mockAuthState = vi.hoisted(() => ({
   currentUser: { uid: 'user-a' } as { uid: string } | null
 }))
-const mockFlags = vi.hoisted(() => ({ teamWorkspacesEnabled: true }))
 const originalFetch = globalThis.fetch
 
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: true
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: mockFlags
-  })
 }))
 
 vi.mock('@/stores/authStore', () => ({
@@ -41,7 +34,6 @@ describe('useSessionCookie', () => {
     mockGetIdToken.mockReset()
     mockGetAuthHeader.mockReset()
     mockAuthState.currentUser = { uid: 'user-a' }
-    mockFlags.teamWorkspacesEnabled = true
     globalThis.fetch = vi.fn()
   })
 
@@ -209,7 +201,6 @@ describe('useSessionCookie', () => {
   })
 
   it('does not let strict Firebase creation join a weaker request', async () => {
-    mockFlags.teamWorkspacesEnabled = false
     mockGetAuthHeader.mockResolvedValue(null)
     mockGetIdToken.mockResolvedValue('firebase-id-token')
     vi.mocked(globalThis.fetch).mockResolvedValue(

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
@@ -41,10 +40,9 @@ export const useSessionCookie = () => {
   const getSessionHeaderOrThrow = async (
     useFirebaseToken: boolean
   ): Promise<Record<string, string>> => {
-    const { flags } = useFeatureFlags()
     const authStore = useAuthStore()
 
-    if (useFirebaseToken || flags.teamWorkspacesEnabled) {
+    if (isCloud || useFirebaseToken) {
       const firebaseToken = await authStore.getIdToken()
       if (!firebaseToken) {
         throw new Error('No Firebase token available for session creation')
@@ -60,14 +58,7 @@ export const useSessionCookie = () => {
     return authHeader
   }
 
-  /**
-   * Creates or refreshes the session cookie.
-   * Called after login and on token refresh.
-   *
-   * When team_workspaces_enabled is true, uses Firebase token directly
-   * (since getAuthHeader() returns workspace token which shouldn't be used for session creation).
-   * When disabled, uses getAuthHeader() for backward compatibility.
-   */
+  /** Creates or refreshes the session cookie after login or token refresh. */
   const performCreateSession = async (
     expectedOwnerUid: string,
     useFirebaseToken: boolean
@@ -91,6 +82,7 @@ export const useSessionCookie = () => {
     forceRefresh: boolean,
     useFirebaseToken = false
   ): Promise<void> => {
+    const usesFirebaseToken = isCloud || useFirebaseToken
     if (
       !forceRefresh &&
       pendingSessionMutations === 0 &&
@@ -100,7 +92,7 @@ export const useSessionCookie = () => {
     }
     if (
       inFlightCreateSession?.ownerUid === ownerUid &&
-      (!useFirebaseToken || inFlightCreateSession.usesFirebaseToken)
+      (!usesFirebaseToken || inFlightCreateSession.usesFirebaseToken)
     ) {
       return inFlightCreateSession.promise
     }
@@ -108,13 +100,13 @@ export const useSessionCookie = () => {
     pendingSessionMutations++
     const request: InFlightCreateSession = {
       ownerUid,
-      usesFirebaseToken: useFirebaseToken,
+      usesFirebaseToken,
       promise: sessionMutationTail
         .then(async () => {
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed before creation')
           }
-          await performCreateSession(ownerUid, useFirebaseToken)
+          await performCreateSession(ownerUid, usesFirebaseToken)
           confirmedSessionOwnerUid = ownerUid
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed during creation')

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -614,21 +614,14 @@ describe('useSubscription', () => {
       expect(isActiveSubscription.value).toBe(true)
     })
 
-    it('keeps explicit local status reads on the Comfy API', async () => {
+    it('does not perform explicit subscription status reads outside Cloud', async () => {
       mockIsCloud.value = false
       const { fetchStatus } = useSubscriptionWithScope()
 
       await fetchStatus()
 
       expect(mockGetBillingStatus).not.toHaveBeenCalled()
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/customers/cloud-subscription-status'),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer test-token'
-          })
-        })
-      )
+      expect(global.fetch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -15,11 +15,13 @@ const {
   mockUserId,
   mockIsCloud,
   mockAuthStoreInitialized,
+  mockGetBillingStatus,
   mockLocalStorage
 } = vi.hoisted(() => ({
   mockIsLoggedIn: { value: false },
   mockIsCloud: { value: true },
   mockAuthStoreInitialized: { value: true },
+  mockGetBillingStatus: vi.fn(),
   mockReportError: vi.fn(),
   mockAccessBillingPortal: vi.fn(),
   mockShowSubscriptionRequiredDialog: vi.fn(),
@@ -134,6 +136,12 @@ vi.mock('@/platform/telemetry/utils/checkoutAttribution', () => ({
   getCheckoutAttribution: mockGetCheckoutAttribution
 }))
 
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getBillingStatus: mockGetBillingStatus
+  }
+}))
+
 vi.mock('@/services/dialogService', () => ({
   useDialogService: vi.fn(() => ({
     showSubscriptionRequiredDialog: mockShowSubscriptionRequiredDialog
@@ -181,6 +189,11 @@ describe('useSubscription', () => {
     mockUserId.value = 'user-123'
     mockIsCloud.value = true
     mockAuthStoreInitialized.value = true
+    mockGetBillingStatus.mockResolvedValue({
+      is_active: false,
+      has_funds: false,
+      team_credit_stop: null
+    })
     window.__CONFIG__ = {
       subscription_required: true
     } as typeof window.__CONFIG__
@@ -196,14 +209,11 @@ describe('useSubscription', () => {
 
   describe('computed properties', () => {
     it('should compute isActiveSubscription correctly when subscription is active', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16'
+      })
 
       mockIsLoggedIn.value = true
       const { isActiveSubscription, fetchStatus } = useSubscriptionWithScope()
@@ -213,14 +223,11 @@ describe('useSubscription', () => {
     })
 
     it('should compute isActiveSubscription as false when subscription is inactive', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: false,
-          subscription_id: 'sub_123',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: false,
+        has_funds: true,
+        renewal_date: '2025-11-16'
+      })
 
       mockIsLoggedIn.value = true
       const { isActiveSubscription, fetchStatus } = useSubscriptionWithScope()
@@ -230,14 +237,11 @@ describe('useSubscription', () => {
     })
 
     it('should format renewal date correctly', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          renewal_date: '2025-11-16T12:00:00Z'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16T12:00:00Z'
+      })
 
       mockIsLoggedIn.value = true
       const { formattedRenewalDate, fetchStatus } = useSubscriptionWithScope()
@@ -256,15 +260,12 @@ describe('useSubscription', () => {
     })
 
     it('should return subscription tier from status', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          subscription_tier: 'CREATOR',
-          renewal_date: '2025-11-16T12:00:00Z'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        subscription_tier: 'CREATOR',
+        renewal_date: '2025-11-16T12:00:00Z'
+      })
 
       mockIsLoggedIn.value = true
       const { subscriptionTier, fetchStatus } = useSubscriptionWithScope()
@@ -284,36 +285,25 @@ describe('useSubscription', () => {
     it('should fetch subscription status successfully', async () => {
       const mockStatus = {
         is_active: true,
-        subscription_id: 'sub_123',
-        renewal_date: '2025-11-16'
+        has_funds: true,
+        renewal_date: '2025-11-16',
+        team_credit_stop: null
       }
 
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => mockStatus
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue(mockStatus)
 
       mockIsLoggedIn.value = true
       const { fetchStatus } = useSubscriptionWithScope()
 
       await fetchStatus()
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/customers/cloud-subscription-status'),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer test-token',
-            'Content-Type': 'application/json'
-          })
-        })
-      )
+      expect(mockGetBillingStatus).toHaveBeenCalledOnce()
     })
 
     it('should handle fetch errors gracefully', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: false,
-        json: async () => ({ message: 'Subscription not found' })
-      } as Response)
+      mockGetBillingStatus.mockRejectedValue(
+        new Error('Subscription not found')
+      )
 
       const { fetchStatus } = useSubscriptionWithScope()
 
@@ -321,38 +311,35 @@ describe('useSubscription', () => {
     })
 
     it('coalesces concurrent callers into one fetch', async () => {
-      let resolveFetch: (value: Response) => void = () => {}
-      vi.mocked(global.fetch).mockReturnValue(
-        new Promise<Response>((resolve) => {
-          resolveFetch = resolve
+      let resolveStatus: (value: {
+        is_active: boolean
+        has_funds: boolean
+      }) => void = () => {}
+      mockGetBillingStatus.mockReturnValue(
+        new Promise((resolve) => {
+          resolveStatus = resolve
         })
       )
       const { fetchStatus } = useSubscriptionWithScope()
 
       const first = fetchStatus()
       const second = fetchStatus()
-      resolveFetch({
-        ok: true,
-        json: async () => ({ is_active: true })
-      } as Response)
+      resolveStatus({ is_active: true, has_funds: true })
       await Promise.all([first, second])
 
-      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(mockGetBillingStatus).toHaveBeenCalledTimes(1)
     })
 
     it('does not downgrade known-good status on a failed fetch', async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ is_active: true, subscription_id: 'sub_1' })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValueOnce({
+        is_active: true,
+        has_funds: true
+      })
       const { fetchStatus, isActiveSubscription } = useSubscriptionWithScope()
       await fetchStatus()
       expect(isActiveSubscription.value).toBe(true)
 
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ message: 'Invalid token' })
-      } as Response)
+      mockGetBillingStatus.mockRejectedValueOnce(new Error('Invalid token'))
       await fetchStatus().catch(() => {})
 
       expect(isActiveSubscription.value).toBe(true)
@@ -432,16 +419,13 @@ describe('useSubscription', () => {
         })
       )
 
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          subscription_tier: 'CREATOR',
-          subscription_duration: 'ANNUAL',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        subscription_tier: 'CREATOR',
+        subscription_duration: 'ANNUAL',
+        renewal_date: '2025-11-16'
+      })
 
       mockIsLoggedIn.value = true
       useSubscriptionWithScope()
@@ -480,16 +464,13 @@ describe('useSubscription', () => {
         })
       )
 
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          subscription_tier: 'PRO',
-          subscription_duration: 'MONTHLY',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        subscription_tier: 'PRO',
+        subscription_duration: 'MONTHLY',
+        renewal_date: '2025-11-16'
+      })
 
       mockIsLoggedIn.value = true
       useSubscriptionWithScope()
@@ -510,25 +491,14 @@ describe('useSubscription', () => {
       })
     })
 
-    it('rechecks pending checkout attempts when the document becomes visible', async () => {
-      mockIsLoggedIn.value = true
-
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: false,
-          subscription_id: '',
-          renewal_date: ''
-        })
-      } as Response)
-
-      useSubscriptionWithScope()
-
-      await vi.waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledTimes(1)
+    it('rechecks pending checkout attempts on status refresh', async () => {
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: false,
+        has_funds: false,
+        renewal_date: ''
       })
 
-      vi.mocked(global.fetch).mockClear()
+      const { fetchStatus } = useSubscriptionWithScope()
       localStorage.setItem(
         PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
         JSON.stringify({
@@ -540,10 +510,10 @@ describe('useSubscription', () => {
         })
       )
 
-      document.dispatchEvent(new Event('visibilitychange'))
+      await fetchStatus()
 
       await vi.waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledTimes(1)
+        expect(mockGetBillingStatus).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -596,14 +566,11 @@ describe('useSubscription', () => {
 
   describe('requireActiveSubscription', () => {
     it('should not show dialog when subscription is active', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_123',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16'
+      })
 
       const { requireActiveSubscription } = useSubscriptionWithScope()
 
@@ -613,14 +580,11 @@ describe('useSubscription', () => {
     })
 
     it('should show dialog when subscription is inactive', async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          is_active: false,
-          subscription_id: 'sub_123',
-          renewal_date: '2025-11-16'
-        })
-      } as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: false,
+        has_funds: true,
+        renewal_date: '2025-11-16'
+      })
 
       const { requireActiveSubscription } = useSubscriptionWithScope()
 
@@ -648,6 +612,23 @@ describe('useSubscription', () => {
       const { isActiveSubscription } = useSubscriptionWithScope()
 
       expect(isActiveSubscription.value).toBe(true)
+    })
+
+    it('keeps explicit local status reads on the Comfy API', async () => {
+      mockIsCloud.value = false
+      const { fetchStatus } = useSubscriptionWithScope()
+
+      await fetchStatus()
+
+      expect(mockGetBillingStatus).not.toHaveBeenCalled()
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers/cloud-subscription-status'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token'
+          })
+        })
+      )
     })
   })
 
@@ -705,27 +686,22 @@ describe('useSubscription', () => {
       mockIsLoggedIn.value = true
       mockAccessBillingPortal.mockResolvedValueOnce(false)
 
-      const activeResponse = {
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_active',
-          renewal_date: '2025-11-16'
-        })
-      }
-
-      vi.mocked(global.fetch).mockResolvedValue(activeResponse as Response)
+      mockGetBillingStatus.mockResolvedValue({
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16'
+      })
 
       try {
         const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
 
         await fetchStatus()
-        vi.mocked(global.fetch).mockClear()
+        mockGetBillingStatus.mockClear()
 
         await manageSubscription()
         await vi.advanceTimersByTimeAsync(5000)
 
-        expect(global.fetch).not.toHaveBeenCalled()
+        expect(mockGetBillingStatus).not.toHaveBeenCalled()
         expect(
           mockTelemetry.trackMonthlySubscriptionCancelled
         ).not.toHaveBeenCalled()
@@ -738,28 +714,22 @@ describe('useSubscription', () => {
       vi.useFakeTimers()
       mockIsLoggedIn.value = true
 
-      const activeResponse = {
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_active',
-          renewal_date: '2025-11-16'
-        })
+      const activeStatus = {
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16'
       }
 
-      const cancelledResponse = {
-        ok: true,
-        json: async () => ({
-          is_active: false,
-          subscription_id: 'sub_cancelled',
-          renewal_date: '2025-11-16',
-          end_date: '2025-12-01'
-        })
+      const cancelledStatus = {
+        is_active: false,
+        has_funds: true,
+        renewal_date: '2025-11-16',
+        cancel_at: '2025-12-01'
       }
 
-      vi.mocked(global.fetch)
-        .mockResolvedValueOnce(activeResponse as Response)
-        .mockResolvedValueOnce(cancelledResponse as Response)
+      mockGetBillingStatus
+        .mockResolvedValueOnce(activeStatus)
+        .mockResolvedValueOnce(cancelledStatus)
 
       try {
         const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
@@ -781,28 +751,22 @@ describe('useSubscription', () => {
       vi.useFakeTimers()
       mockIsLoggedIn.value = true
 
-      const activeResponse = {
-        ok: true,
-        json: async () => ({
-          is_active: true,
-          subscription_id: 'sub_active',
-          renewal_date: '2025-11-16'
-        })
+      const activeStatus = {
+        is_active: true,
+        has_funds: true,
+        renewal_date: '2025-11-16'
       }
 
-      const cancelledResponse = {
-        ok: true,
-        json: async () => ({
-          is_active: false,
-          subscription_id: 'sub_cancelled',
-          renewal_date: '2025-11-16',
-          end_date: '2025-12-01'
-        })
+      const cancelledStatus = {
+        is_active: false,
+        has_funds: true,
+        renewal_date: '2025-11-16',
+        cancel_at: '2025-12-01'
       }
 
-      vi.mocked(global.fetch)
-        .mockResolvedValueOnce(activeResponse as Response)
-        .mockResolvedValueOnce(cancelledResponse as Response)
+      mockGetBillingStatus
+        .mockResolvedValueOnce(activeStatus)
+        .mockResolvedValueOnce(cancelledStatus)
 
       try {
         const { fetchStatus, manageSubscription } = useSubscriptionWithScope()

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -17,6 +17,8 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { SubscriptionDialogOptions } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { CheckoutAttributionMetadata } from '@/platform/telemetry/types'
+import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import { useDialogService } from '@/services/dialogService'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
@@ -40,6 +42,19 @@ export type CloudSubscriptionStatusResponse = NonNullable<
 >
 
 const PENDING_SUBSCRIPTION_CHECKOUT_RETRY_DELAYS_MS = [3000, 10000, 30000]
+
+function toLegacySubscriptionStatus(
+  status: BillingStatusResponse
+): CloudSubscriptionStatusResponse {
+  return {
+    is_active: status.is_active,
+    has_fund: status.has_funds,
+    subscription_tier: status.subscription_tier,
+    subscription_duration: status.subscription_duration,
+    renewal_date: status.renewal_date,
+    end_date: status.cancel_at
+  }
+}
 
 function useSubscriptionInternal() {
   const subscriptionStatus = ref<CloudSubscriptionStatusResponse | null>(null)
@@ -326,6 +341,15 @@ function useSubscriptionInternal() {
   }
 
   async function performFetchSubscriptionStatus(): Promise<CloudSubscriptionStatusResponse | null> {
+    if (isCloud) {
+      const statusData = toLegacySubscriptionStatus(
+        await workspaceApi.getBillingStatus()
+      )
+      subscriptionStatus.value = statusData
+      syncPendingSubscriptionSuccess(statusData)
+      return statusData
+    }
+
     const headers = await buildAuthHeaders()
 
     const response = await fetchWithUnifiedRemint(

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -37,27 +37,10 @@ type CloudSubscriptionCheckoutResponse = NonNullable<
   operations['createCloudSubscriptionCheckout']['responses']['201']['content']['application/json']
 >
 
-export type CloudSubscriptionStatusResponse = NonNullable<
-  operations['GetCloudSubscriptionStatus']['responses']['200']['content']['application/json']
->
-
 const PENDING_SUBSCRIPTION_CHECKOUT_RETRY_DELAYS_MS = [3000, 10000, 30000]
 
-function toLegacySubscriptionStatus(
-  status: BillingStatusResponse
-): CloudSubscriptionStatusResponse {
-  return {
-    is_active: status.is_active,
-    has_fund: status.has_funds,
-    subscription_tier: status.subscription_tier,
-    subscription_duration: status.subscription_duration,
-    renewal_date: status.renewal_date,
-    end_date: status.cancel_at
-  }
-}
-
 function useSubscriptionInternal() {
-  const subscriptionStatus = ref<CloudSubscriptionStatusResponse | null>(null)
+  const subscriptionStatus = ref<BillingStatusResponse | null>(null)
   const telemetry = useTelemetry()
   const isInitialized = ref(false)
 
@@ -77,7 +60,7 @@ function useSubscriptionInternal() {
   const { isLoggedIn } = useCurrentUser()
 
   const isCancelled = computed(() => {
-    return !!subscriptionStatus.value?.end_date
+    return !!subscriptionStatus.value?.cancel_at
   })
 
   const formattedRenewalDate = computed(() => {
@@ -93,9 +76,9 @@ function useSubscriptionInternal() {
   })
 
   const formattedEndDate = computed(() => {
-    if (!subscriptionStatus.value?.end_date) return ''
+    if (!subscriptionStatus.value?.cancel_at) return ''
 
-    const endDate = new Date(subscriptionStatus.value.end_date)
+    const endDate = new Date(subscriptionStatus.value.cancel_at)
 
     return endDate.toLocaleDateString('en-US', {
       month: 'short',
@@ -184,7 +167,7 @@ function useSubscriptionInternal() {
   }
 
   const syncPendingSubscriptionSuccess = (
-    statusData: CloudSubscriptionStatusResponse
+    statusData: BillingStatusResponse
   ) => {
     const metadata = consumePendingSubscriptionCheckoutSuccess(statusData)
 
@@ -329,10 +312,9 @@ function useSubscriptionInternal() {
   }
 
   // Coalesce concurrent callers so an auth/session-rotation burst mints one fetch.
-  let inFlightStatusFetch: Promise<CloudSubscriptionStatusResponse | null> | null =
-    null
+  let inFlightStatusFetch: Promise<BillingStatusResponse | null> | null = null
 
-  async function fetchSubscriptionStatus(): Promise<CloudSubscriptionStatusResponse | null> {
+  async function fetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
     if (inFlightStatusFetch) return inFlightStatusFetch
     inFlightStatusFetch = performFetchSubscriptionStatus().finally(() => {
       inFlightStatusFetch = null
@@ -340,36 +322,10 @@ function useSubscriptionInternal() {
     return inFlightStatusFetch
   }
 
-  async function performFetchSubscriptionStatus(): Promise<CloudSubscriptionStatusResponse | null> {
-    if (isCloud) {
-      const statusData = toLegacySubscriptionStatus(
-        await workspaceApi.getBillingStatus()
-      )
-      subscriptionStatus.value = statusData
-      syncPendingSubscriptionSuccess(statusData)
-      return statusData
-    }
+  async function performFetchSubscriptionStatus(): Promise<BillingStatusResponse | null> {
+    if (!isCloud) return null
 
-    const headers = await buildAuthHeaders()
-
-    const response = await fetchWithUnifiedRemint(
-      buildApiUrl('/customers/cloud-subscription-status'),
-      {
-        headers
-      },
-      isCloud && flags.unifiedCloudAuthEnabled
-    )
-
-    if (!response.ok) {
-      const errorData = await response.json()
-      throw new AuthStoreError(
-        t('toastMessages.failedToFetchSubscription', {
-          error: errorData.message
-        })
-      )
-    }
-
-    const statusData = await response.json()
+    const statusData = await workspaceApi.getBillingStatus()
     subscriptionStatus.value = statusData
     syncPendingSubscriptionSuccess(statusData)
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, effectScope, ref } from 'vue'
 import type { EffectScope } from 'vue'
 
-import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
 import { useSubscriptionCancellationWatcher } from '@/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher'
 import type { TelemetryDispatcher } from '@/platform/telemetry/types'
+import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
 describe('useSubscriptionCancellationWatcher', () => {
   const trackMonthlySubscriptionCancelled = vi.fn()
@@ -15,15 +15,13 @@ describe('useSubscriptionCancellationWatcher', () => {
     trackMonthlySubscriptionCancelled
   }
 
-  const baseStatus: CloudSubscriptionStatusResponse = {
+  const baseStatus: BillingStatusResponse = {
     is_active: true,
-    subscription_id: 'sub_123',
+    has_funds: true,
     renewal_date: '2025-11-16'
   }
 
-  const subscriptionStatus = ref<CloudSubscriptionStatusResponse | null>(
-    baseStatus
-  )
+  const subscriptionStatus = ref<BillingStatusResponse | null>(baseStatus)
   const isActive = ref(true)
   const isActiveSubscription = computed(() => isActive.value)
 
@@ -68,9 +66,9 @@ describe('useSubscriptionCancellationWatcher', () => {
         isActive.value = false
         subscriptionStatus.value = {
           is_active: false,
-          subscription_id: 'sub_cancelled',
+          has_funds: true,
           renewal_date: '2025-11-16',
-          end_date: '2025-12-01'
+          cancel_at: '2025-12-01'
         }
       }
     })
@@ -101,7 +99,7 @@ describe('useSubscriptionCancellationWatcher', () => {
       subscriptionStatus.value = {
         ...baseStatus,
         is_active: false,
-        end_date: '2025-12-01'
+        cancel_at: '2025-12-01'
       }
     })
 

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
@@ -3,17 +3,16 @@ import type { ComputedRef, Ref } from 'vue'
 import { defaultWindow, useEventListener, useTimeoutFn } from '@vueuse/core'
 
 import type { TelemetryDispatcher } from '@/platform/telemetry/types'
-
-import type { CloudSubscriptionStatusResponse } from './useSubscription'
+import type { BillingStatusResponse } from '@/platform/workspace/api/workspaceApi'
 
 const MAX_CANCELLATION_ATTEMPTS = 4
 const CANCELLATION_BASE_DELAY_MS = 5000
 const CANCELLATION_BACKOFF_MULTIPLIER = 3 // 5s, 15s, 45s, 135s intervals
 
 type CancellationWatcherOptions = {
-  fetchStatus: () => Promise<CloudSubscriptionStatusResponse | null | void>
+  fetchStatus: () => Promise<BillingStatusResponse | null | void>
   isActiveSubscription: ComputedRef<boolean>
-  subscriptionStatus: Ref<CloudSubscriptionStatusResponse | null>
+  subscriptionStatus: Ref<BillingStatusResponse | null>
   telemetry: Pick<
     TelemetryDispatcher,
     'trackMonthlySubscriptionCancelled'

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -1,7 +1,5 @@
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   remoteConfig,
   remoteConfigState
 } from './remoteConfig'
@@ -58,12 +56,6 @@ export async function refreshRemoteConfig(
       remoteConfig.value = config
       remoteConfigState.value = useAuth ? 'authenticated' : 'anonymous'
       if (useAuth) {
-        cachedTeamWorkspacesEnabled.value = Boolean(
-          config.team_workspaces_enabled
-        )
-        cachedConsolidatedBillingEnabled.value = Boolean(
-          config.consolidated_billing_enabled
-        )
         cachedBillingControlEnabled.value = Boolean(
           config.billing_control_enabled
         )

--- a/src/platform/remoteConfig/remoteConfig.ts
+++ b/src/platform/remoteConfig/remoteConfig.ts
@@ -32,10 +32,7 @@ type RemoteConfigState = 'unloaded' | 'anonymous' | 'authenticated' | 'error'
  */
 export const remoteConfigState = ref<RemoteConfigState>('unloaded')
 
-/**
- * Whether the authenticated config has been loaded.
- * Use this to gate access to user-specific feature flags like teamWorkspacesEnabled.
- */
+/** Whether the authenticated config has been loaded. */
 export const isAuthenticatedConfigLoaded = computed(
   () => remoteConfigState.value === 'authenticated'
 )
@@ -54,16 +51,6 @@ export function configValueOrDefault<K extends keyof RemoteConfig>(
   const configValue = remoteConfig[key]
   return configValue || defaultValue
 }
-
-export const cachedTeamWorkspacesEnabled = useStorage<boolean | undefined>(
-  'team_workspaces_enabled' satisfies `${ServerFeatureFlag.TEAM_WORKSPACES_ENABLED}`,
-  undefined
-)
-
-export const cachedConsolidatedBillingEnabled = useStorage<boolean | undefined>(
-  'consolidated_billing_enabled' satisfies `${ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED}`,
-  undefined
-)
 
 export const cachedBillingControlEnabled = useStorage<boolean | undefined>(
   'billing_control_enabled' satisfies `${ServerFeatureFlag.BILLING_CONTROL_ENABLED}`,

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -106,7 +106,6 @@ export type RemoteConfig = {
   /** Full hosted (external) survey URL embedded in the Nodes Manager modal on Cloud. */
   manager_survey_url?: string
   linear_toggle_enabled?: boolean
-  team_workspaces_enabled?: boolean
   partner_node_governance_enabled?: boolean
   user_secrets_enabled?: boolean
   node_library_essentials_enabled?: boolean
@@ -121,7 +120,6 @@ export type RemoteConfig = {
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
   unified_cloud_auth?: boolean
-  consolidated_billing_enabled?: boolean
   billing_control_enabled?: boolean
   churnkey_app_id?: string
   sentry_dsn?: string

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -16,7 +16,6 @@ const env = vi.hoisted(() => {
     isCloud: false,
     isDesktop: false,
     isLoggedIn: false,
-    teamWorkspacesEnabled: false,
     billingControlEnabled: false,
     authenticatedConfigLoaded: false,
     partnerNodeGovernanceEnabled: false,
@@ -51,9 +50,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return env.state.teamWorkspacesEnabled
-      },
       get billingControlEnabled() {
         return env.state.billingControlEnabled
       },
@@ -133,7 +129,6 @@ describe('useSettingUI', () => {
       isCloud: false,
       isDesktop: false,
       isLoggedIn: false,
-      teamWorkspacesEnabled: false,
       billingControlEnabled: false,
       authenticatedConfigLoaded: false,
       partnerNodeGovernanceEnabled: false,
@@ -209,7 +204,6 @@ describe('useSettingUI', () => {
       Object.assign(env.state, {
         isCloud: true,
         isLoggedIn: true,
-        teamWorkspacesEnabled: true,
         authenticatedConfigLoaded: true,
         isActiveSubscription: true,
         billingType: 'workspace'
@@ -287,7 +281,6 @@ describe('useSettingUI', () => {
       Object.assign(env.state, {
         isCloud: true,
         isLoggedIn: true,
-        teamWorkspacesEnabled: true,
         billingControlEnabled: true,
         authenticatedConfigLoaded: true,
         partnerNodeGovernanceEnabled: true,
@@ -338,11 +331,11 @@ describe('useSettingUI', () => {
       expect(navKeys(navGroups.value)).not.toContain('workspace-allowlist')
     })
 
-    it('keeps the legacy plan panel in the legacy layout', () => {
-      env.state.teamWorkspacesEnabled = false
+    it('keeps OSS account navigation on the legacy layout', () => {
+      env.state.isCloud = false
       const { navGroups } = useSettingUI()
 
-      expect(navKeys(navGroups.value)).toContain('subscription')
+      expect(navKeys(navGroups.value)).toContain('credits')
       expect(navKeys(navGroups.value)).not.toContain('workspace')
     })
   })

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -194,6 +194,15 @@ describe('useSettingUI', () => {
     expect(defaultCategory.value).toBe(settingCategories.value[0])
   })
 
+  it('hides the empty Workspace navigation group for logged-out Cloud users', () => {
+    env.state.isCloud = true
+    env.state.isLoggedIn = false
+
+    const { navGroups } = useSettingUI()
+
+    expect(navGroups.value.map(({ title }) => title)).not.toContain('Workspace')
+  })
+
   it('gives defaultPanel precedence over scrollToSettingId', () => {
     const { defaultCategory } = useSettingUI('about', 'Comfy.Locale')
     expect(defaultCategory.value.key).toBe('about')

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -430,23 +430,25 @@ export function useSettingUI(
   )
 
   const navGroups = computed<NavGroupData[]>(() =>
-    groupedMenuTreeNodes.value.map((group) => ({
-      title:
-        (group as SettingTreeNode & { translatedLabel?: string })
-          .translatedLabel ?? group.label,
-      items: (group.children ?? []).map((child) => ({
-        id: child.key,
-        label:
-          (child as SettingTreeNode & { translatedLabel?: string })
-            .translatedLabel ?? child.label,
-        icon:
-          child.key === 'workspace' && billingControlsEnabled.value
-            ? CATEGORY_ICONS.PlanCredits
-            : (CATEGORY_ICONS[child.key] ??
-              CATEGORY_ICONS[child.label] ??
-              'icon-[lucide--plug]')
+    groupedMenuTreeNodes.value
+      .filter((group) => group.children?.length)
+      .map((group) => ({
+        title:
+          (group as SettingTreeNode & { translatedLabel?: string })
+            .translatedLabel ?? group.label,
+        items: (group.children ?? []).map((child) => ({
+          id: child.key,
+          label:
+            (child as SettingTreeNode & { translatedLabel?: string })
+              .translatedLabel ?? child.label,
+          icon:
+            child.key === 'workspace' && billingControlsEnabled.value
+              ? CATEGORY_ICONS.PlanCredits
+              : (CATEGORY_ICONS[child.key] ??
+                CATEGORY_ICONS[child.label] ??
+                'icon-[lucide--plug]')
+        }))
       }))
-    }))
   )
 
   function findCategoryByKey(key: string): SettingTreeNode | null {

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -61,10 +61,6 @@ export function useSettingUI(
   const { isActiveSubscription, type: billingType } = useBillingContext()
   const { workspaceRole } = useWorkspaceUI()
 
-  const teamWorkspacesEnabled = computed(
-    () => isCloud && flags.teamWorkspacesEnabled
-  )
-
   const settingRoot = computed<SettingTreeNode>(() => {
     const root = buildTree(
       Object.values(settingStore.settingsById).filter(
@@ -228,9 +224,7 @@ export function useSettingUI(
     props: { section: 'allowlist' }
   }
 
-  const shouldShowWorkspacePanel = computed(
-    () => teamWorkspacesEnabled.value && isLoggedIn.value
-  )
+  const shouldShowWorkspacePanel = computed(() => isCloud && isLoggedIn.value)
   const shouldShowWorkspaceAllowlist = computed(
     () =>
       shouldShowWorkspacePanel.value &&
@@ -348,7 +342,7 @@ export function useSettingUI(
     )
   })
 
-  // Sidebar structure when team workspaces is enabled
+  // Cloud workspace sidebar structure
   const workspaceMenuTreeNodes = computed<SettingTreeNode[]>(() => [
     // Workspace settings
     translateCategory({
@@ -394,7 +388,7 @@ export function useSettingUI(
       : [])
   ])
 
-  // Sidebar structure when team workspaces is disabled (legacy)
+  // OSS legacy sidebar structure
   const legacyMenuTreeNodes = computed<SettingTreeNode[]>(() => [
     // Account settings - show different panels based on distribution and auth state
     {
@@ -432,9 +426,7 @@ export function useSettingUI(
   ])
 
   const groupedMenuTreeNodes = computed<SettingTreeNode[]>(() =>
-    teamWorkspacesEnabled.value
-      ? workspaceMenuTreeNodes.value
-      : legacyMenuTreeNodes.value
+    isCloud ? workspaceMenuTreeNodes.value : legacyMenuTreeNodes.value
   )
 
   const navGroups = computed<NavGroupData[]>(() =>
@@ -480,7 +472,6 @@ export function useSettingUI(
     groupedMenuTreeNodes,
     settingCategories,
     navGroups,
-    teamWorkspacesEnabled,
     findCategoryByKey,
     findPanelByKey
   }

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -7,21 +7,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
-const teamWorkspacesFlag = vi.hoisted(() => ({ value: false }))
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({ showDialog, closeDialog: vi.fn() })
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: {
-      get teamWorkspacesEnabled() {
-        return teamWorkspacesFlag.value
-      }
-    }
-  })
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -49,7 +38,6 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 describe('useSettingsDialog', () => {
   beforeEach(() => {
     showDialog.mockReset()
-    teamWorkspacesFlag.value = false
     isCloudRef.value = false
   })
 
@@ -78,9 +66,8 @@ describe('useSettingsDialog', () => {
     expect(args.dialogComponentProps.overlayClass).toBeUndefined()
   })
 
-  it("show() sets overlayClass 'p-8' when isCloud && teamWorkspacesEnabled", () => {
+  it("show() sets overlayClass 'p-8' on Cloud", () => {
     isCloudRef.value = true
-    teamWorkspacesFlag.value = true
 
     useSettingsDialog().show()
     const [args] = showDialog.mock.calls[0]

--- a/src/platform/settings/composables/useSettingsDialog.ts
+++ b/src/platform/settings/composables/useSettingsDialog.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -15,14 +14,12 @@ const SETTINGS_CONTENT_CLASS =
 export function useSettingsDialog() {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
-  const { flags } = useFeatureFlags()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
   function show(panel?: SettingPanelType, settingId?: string) {
-    const isWorkspaceMode = isCloud && flags.teamWorkspacesEnabled
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component: SettingDialog,
@@ -46,7 +43,7 @@ export function useSettingsDialog() {
         dismissOnFocusOutside: false,
         size: 'full',
         contentClass: SETTINGS_CONTENT_CLASS,
-        overlayClass: isWorkspaceMode ? 'p-8' : undefined
+        overlayClass: isCloud ? 'p-8' : undefined
       }
     })
   }

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -40,14 +40,10 @@ vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
   remoteConfigState: mockRemoteConfigState
 }))
 
-const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: false }))
 const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return mockTeamWorkspacesEnabled.value
-      },
       get unifiedCloudAuthEnabled() {
         return mockUnifiedCloudAuthEnabled.value
       }
@@ -110,7 +106,6 @@ describe('WorkspaceAuthGate', () => {
     mockIsCloud.value = true
     mockIsInitialized.value = false
     mockCurrentUser.value = null
-    mockTeamWorkspacesEnabled.value = false
     mockUnifiedCloudAuthEnabled.value = false
     mockRemoteConfigState.value = 'authenticated'
     mockWorkspaceStoreInitState.value = 'uninitialized'
@@ -182,16 +177,6 @@ describe('WorkspaceAuthGate', () => {
       expect(mockRefreshRemoteConfig).toHaveBeenCalledWith({ useAuth: true })
     })
 
-    it('renders slot when teamWorkspacesEnabled is false', async () => {
-      mockTeamWorkspacesEnabled.value = false
-
-      mountComponent()
-      await flushPromises()
-
-      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
-    })
-
     it('mints unified auth after refreshing authenticated flags', async () => {
       mockRefreshRemoteConfig.mockImplementation(async () => {
         mockUnifiedCloudAuthEnabled.value = true
@@ -204,9 +189,7 @@ describe('WorkspaceAuthGate', () => {
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
 
-    it('initializes workspace store when teamWorkspacesEnabled is true', async () => {
-      mockTeamWorkspacesEnabled.value = true
-
+    it('initializes the workspace store', async () => {
       mountComponent()
       await flushPromises()
 
@@ -215,7 +198,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('calls resumePendingPricingFlow after successful workspace init', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'ready'
 
       mountComponent()
@@ -225,7 +207,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('skips workspace init when store is already initialized', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'ready'
 
       mountComponent()
@@ -299,7 +280,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('keeps the app gated when workspace store initialization fails', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitialize.mockRejectedValue(
         new Error('Workspace init failed')
       )
@@ -312,7 +292,6 @@ describe('WorkspaceAuthGate', () => {
 
     it('keeps the app gated when workspace setup clears unified auth', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockTeamWorkspacesEnabled.value = true
       mockGetUnifiedToken.mockReturnValue(undefined)
 
       mountComponent()
@@ -322,7 +301,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('keeps the app gated without a ready workspace context', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'loading'
 
       mountComponent()

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import WorkspaceAuthGate from './WorkspaceAuthGate.vue'
 
@@ -118,7 +121,11 @@ describe('WorkspaceAuthGate', () => {
     mockGetUnifiedToken.mockReturnValue('cloud-jwt')
   })
 
-  const i18n = createI18n({ legacy: false })
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
 
   const mountComponent = () =>
     render(WorkspaceAuthGate, {
@@ -223,14 +230,19 @@ describe('WorkspaceAuthGate', () => {
       mockCurrentUser.value = { uid: 'user-123' }
     })
 
-    it('keeps the app gated when remote config refresh fails', async () => {
+    it('shows a recoverable error when remote config refresh fails', async () => {
       const error = new Error('Network error')
       mockRefreshRemoteConfig.mockRejectedValue(error)
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Try again' })
+      ).toBeInTheDocument()
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         tags: {
           error_type: 'workspace_auth_gate_initialization_failure'
@@ -238,7 +250,7 @@ describe('WorkspaceAuthGate', () => {
       })
     })
 
-    it('keeps the app gated when remote config refresh times out', async () => {
+    it('shows a recoverable error when remote config refresh times out', async () => {
       vi.useFakeTimers()
       try {
         // Never-resolving promise simulates a hanging request
@@ -249,37 +261,46 @@ describe('WorkspaceAuthGate', () => {
 
         // Slot not yet rendered before timeout
         expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+        expect(
+          screen.queryByText("Couldn't load your workspace")
+        ).not.toBeInTheDocument()
 
         // Advance past the 10 second timeout
         await vi.advanceTimersByTimeAsync(10_001)
 
-        expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+        expect(
+          screen.getByText("Couldn't load your workspace")
+        ).toBeInTheDocument()
       } finally {
         vi.useRealTimers()
       }
     })
 
-    it('keeps the app gated when authenticated config is unavailable', async () => {
+    it('shows a recoverable error when authenticated config is unavailable', async () => {
       mockRemoteConfigState.value = 'error'
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
     })
 
-    it('keeps the app gated when unified auth initialization fails', async () => {
+    it('shows a recoverable error when unified auth initialization fails', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockMintAtLogin.mockResolvedValue(false)
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
       expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
     })
 
-    it('keeps the app gated when workspace store initialization fails', async () => {
+    it('shows a recoverable error when workspace store initialization fails', async () => {
       mockWorkspaceStoreInitialize.mockRejectedValue(
         new Error('Workspace init failed')
       )
@@ -287,26 +308,51 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
     })
 
-    it('keeps the app gated when workspace setup clears unified auth', async () => {
+    it('shows a recoverable error when workspace setup clears unified auth', async () => {
       mockUnifiedCloudAuthEnabled.value = true
       mockGetUnifiedToken.mockReturnValue(undefined)
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
     })
 
-    it('keeps the app gated without a ready workspace context', async () => {
+    it('shows a recoverable error without a ready workspace context', async () => {
       mockWorkspaceStoreInitState.value = 'loading'
 
       mountComponent()
       await flushPromises()
 
-      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
+    })
+
+    it('renders the app after retrying a failed initialization', async () => {
+      const user = userEvent.setup()
+      mockWorkspaceStoreInitialize
+        .mockImplementationOnce(async () => {
+          mockWorkspaceStoreInitState.value = 'error'
+          throw new Error('Workspace init failed')
+        })
+        .mockImplementationOnce(async () => {
+          mockWorkspaceStoreInitState.value = 'ready'
+        })
+
+      mountComponent()
+      await flushPromises()
+      await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
+      expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -350,6 +350,7 @@ describe('WorkspaceAuthGate', () => {
       mountComponent()
       await flushPromises()
       await user.click(screen.getByRole('button', { name: 'Try again' }))
+      await flushPromises()
 
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
       expect(mockWorkspaceStoreInitialize).toHaveBeenCalledTimes(2)

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -4,16 +4,15 @@
 
 <script setup lang="ts">
 /**
- * WorkspaceAuthGate - Conditional auth checkpoint for workspace mode.
+ * WorkspaceAuthGate - Cloud workspace auth checkpoint.
  *
  * This gate ensures proper initialization order for workspace-scoped auth:
  * 1. Wait for Firebase auth to resolve
- * 2. Check if teamWorkspacesEnabled feature flag is on
- * 3. If YES: Initialize workspace token and store before rendering
- * 4. If NO: Render immediately using existing Firebase auth
+ * 2. Load authenticated remote configuration
+ * 3. Initialize the workspace token and store before rendering
  *
  * This prevents race conditions where API calls use Firebase tokens
- * instead of workspace tokens when the workspace feature is enabled.
+ * instead of workspace tokens.
  *
  * The splash loader in index.html (z-9999) covers the screen during this
  * phase, so no separate loading indicator is needed here.
@@ -62,8 +61,6 @@ async function initialize(): Promise<void> {
     }
 
     // Step 3: Refresh feature flags with auth context
-    // This ensures teamWorkspacesEnabled reflects the authenticated user's state
-    // Timeout prevents hanging if server is slow/unresponsive
     await Promise.race([
       refreshRemoteConfig({ useAuth: true }),
       promiseTimeout(CONFIG_REFRESH_TIMEOUT_MS).then(() => {
@@ -74,7 +71,6 @@ async function initialize(): Promise<void> {
       throw new Error('Failed to load authenticated remote config')
     }
 
-    // Step 4: THE CHECKPOINT - Are we in workspace mode?
     const { flags } = useFeatureFlags()
     const workspaceAuthStore = useWorkspaceAuthStore()
     if (flags.unifiedCloudAuthEnabled) {
@@ -84,14 +80,6 @@ async function initialize(): Promise<void> {
       }
     }
 
-    if (!flags.teamWorkspacesEnabled) {
-      // Not in workspace mode - use existing Firebase auth flow
-      // No additional initialization needed
-      isReady.value = true
-      return
-    }
-
-    // Step 5: WORKSPACE MODE - Full initialization
     await initializeWorkspaceMode()
     if (
       flags.unifiedCloudAuthEnabled &&
@@ -100,7 +88,7 @@ async function initialize(): Promise<void> {
       throw new Error('Unified cloud auth was cleared during workspace setup')
     }
 
-    // Step 6: Resume any pending pricing flow from team workspace creation
+    // Resume any pending pricing flow from team workspace creation
     // Only safe after workspace store initialized successfully — the pricing
     // dialog reads workspace state to decide which variant to show.
     const workspaceStore = useTeamWorkspaceStore()

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -1,5 +1,27 @@
 <template>
-  <slot v-if="isReady" />
+  <slot v-if="initializationState === 'ready'" />
+  <div
+    v-else-if="initializationState !== 'initializing'"
+    class="flex size-full items-center justify-center bg-base-background p-8"
+  >
+    <div class="flex max-w-md flex-col items-center gap-4 text-center">
+      <i class="icon-[lucide--triangle-alert] size-8 text-error" />
+      <div>
+        <h1 class="m-0 text-lg font-semibold text-base-foreground">
+          {{ $t('workspaceAuth.initializationFailed') }}
+        </h1>
+        <p class="mt-2 mb-0 text-muted-foreground">
+          {{ $t('workspaceAuth.initializationFailedDetail') }}
+        </p>
+      </div>
+      <Button
+        :loading="initializationState === 'retrying'"
+        @click="retryInitialization"
+      >
+        {{ $t('workspaceAuth.retry') }}
+      </Button>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -22,6 +44,7 @@ import { promiseTimeout, until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { onMounted, ref } from 'vue'
 
+import Button from '@/components/ui/button/Button.vue'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -34,7 +57,9 @@ import { useAuthStore } from '@/stores/authStore'
 const FIREBASE_INIT_TIMEOUT_MS = 16_000
 const CONFIG_REFRESH_TIMEOUT_MS = 10_000
 
-const isReady = ref(!isCloud)
+const initializationState = ref<
+  'initializing' | 'retrying' | 'ready' | 'error'
+>(isCloud ? 'initializing' : 'ready')
 const subscriptionDialog = useSubscriptionDialog()
 
 async function initialize(): Promise<void> {
@@ -56,7 +81,7 @@ async function initialize(): Promise<void> {
     // Step 2: If not authenticated, nothing more to do
     // Unauthenticated users don't have workspace context
     if (!currentUser.value) {
-      isReady.value = true
+      initializationState.value = 'ready'
       return
     }
 
@@ -96,7 +121,7 @@ async function initialize(): Promise<void> {
       subscriptionDialog.resumePendingPricingFlow()
     }
 
-    isReady.value = true
+    initializationState.value = 'ready'
   } catch (error) {
     console.error('[WorkspaceAuthGate] Initialization failed:', error)
     captureException(error, {
@@ -104,7 +129,14 @@ async function initialize(): Promise<void> {
         error_type: 'workspace_auth_gate_initialization_failure'
       }
     })
+    initializationState.value = 'error'
+    document.getElementById('splash-loader')?.remove()
   }
+}
+
+async function retryInitialization(): Promise<void> {
+  initializationState.value = 'retrying'
+  await initialize()
 }
 
 async function initializeWorkspaceMode(): Promise<void> {
@@ -114,7 +146,10 @@ async function initializeWorkspaceMode(): Promise<void> {
   // - Switching to last used workspace if needed
   // - Setting active workspace
   const workspaceStore = useTeamWorkspaceStore()
-  if (workspaceStore.initState === 'uninitialized') {
+  if (
+    workspaceStore.initState === 'uninitialized' ||
+    workspaceStore.initState === 'error'
+  ) {
     await workspaceStore.initialize()
   }
   if (

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -121,9 +121,11 @@ function createWorkspaceState(
 
 function renderComponent(
   type: 'personal' | 'team' = 'personal',
-  role: 'owner' | 'member' = 'member'
+  role: 'owner' | 'member' = 'member',
+  accountActionsOnly = false
 ) {
   return render(CurrentUserPopoverWorkspace, {
+    props: { accountActionsOnly },
     global: {
       plugins: [
         createTestingPinia({
@@ -179,6 +181,20 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByTestId('workspace-switcher-trigger'))
     expect(
       screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps account actions available without workspace context', () => {
+    renderComponent('personal', 'member', true)
+
+    expect(screen.getByTestId('user-settings-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('logout-menu-item')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('workspace-switcher-trigger')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('add-credits-button')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('workspace-settings-menu-item')
     ).not.toBeInTheDocument()
   })
 

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -25,7 +25,7 @@
     </div>
 
     <!-- Workspace Selector -->
-    <div class="relative">
+    <div v-if="!accountActionsOnly" class="relative">
       <div
         ref="workspaceSwitcherTrigger"
         v-tooltip="{ value: workspaceName, showDelay: 300 }"
@@ -60,7 +60,7 @@
 
     <!-- Credits Section -->
 
-    <div class="flex items-center gap-2 px-4 py-2">
+    <div v-if="!accountActionsOnly" class="flex items-center gap-2 px-4 py-2">
       <i class="icon-[lucide--component] text-sm text-credit" />
       <Skeleton
         v-if="isLoadingBalance"
@@ -127,10 +127,10 @@
       </Button>
     </div>
 
-    <Divider class="mx-0 my-2" />
+    <Divider v-if="!accountActionsOnly" class="mx-0 my-2" />
 
     <div
-      v-if="showPlansAndPricing"
+      v-if="!accountActionsOnly && showPlansAndPricing"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="plans-pricing-menu-item"
       @click="handleOpenPlansAndPricing"
@@ -142,7 +142,7 @@
     </div>
 
     <div
-      v-if="showManagePlan"
+      v-if="!accountActionsOnly && showManagePlan"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="manage-plan-menu-item"
       @click="handleOpenPlanAndCreditsSettings"
@@ -155,6 +155,7 @@
 
     <!-- Partner Nodes Pricing (always shown) -->
     <div
+      v-if="!accountActionsOnly"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="partner-nodes-menu-item"
       @click="handleOpenPartnerNodesInfo"
@@ -165,10 +166,11 @@
       }}</span>
     </div>
 
-    <Divider class="mx-0 my-2" />
+    <Divider v-if="!accountActionsOnly" class="mx-0 my-2" />
 
     <!-- Workspace Settings (always shown) -->
     <div
+      v-if="!accountActionsOnly"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="workspace-settings-menu-item"
       @click="handleOpenWorkspaceSettings"
@@ -254,6 +256,10 @@ onClickOutside(
 
 const emit = defineEmits<{
   close: []
+}>()
+
+const { accountActionsOnly = false } = defineProps<{
+  accountActionsOnly?: boolean
 }>()
 
 const { buildDocsUrl, docsPaths } = useExternalLink()
@@ -365,7 +371,7 @@ const toggleWorkspaceSwitcher = () => {
 }
 
 const refreshBalance = () => {
-  void fetchBalance()
+  if (!accountActionsOnly) void fetchBalance()
 }
 
 defineExpose({ refreshBalance })

--- a/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
+++ b/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
@@ -208,7 +208,7 @@ export const SuccessAllSet: Story = {
 
 /**
  * Team success — "You're all set" with the inline "Invite your team" block
- * (FE-965 / DES-394). Team-only: gated on a team plan + teamWorkspacesEnabled.
+ * (FE-965 / DES-394).
  */
 export const TeamSuccessWithInvite: Story = {
   render: () => ({

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -29,14 +29,6 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   })
 }))
 
-const { mockFlags } = vi.hoisted(() => ({
-  mockFlags: { teamWorkspacesEnabled: true }
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags })
-}))
-
 vi.mock('./InviteMembersForm.vue', () => ({
   default: {
     name: 'InviteMembersForm',
@@ -114,7 +106,6 @@ function renderTeamCard(props: Record<string, unknown> = {}) {
 describe('SubscriptionSuccessWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFlags.teamWorkspacesEnabled = true
     mockMembers.length = 0
     mockPendingInvites.length = 0
   })
@@ -183,12 +174,6 @@ describe('SubscriptionSuccessWorkspace', () => {
   it('does not render the invite block for a personal upgrade', () => {
     renderCard({ isTeam: false })
     expect(screen.queryByText('subscription.success.inviteTitle')).toBeNull()
-    expect(screen.queryByTestId('invite-form')).toBeNull()
-  })
-
-  it('hides the invite block when team workspaces are disabled', () => {
-    mockFlags.teamWorkspacesEnabled = false
-    renderTeamCard()
     expect(screen.queryByTestId('invite-form')).toBeNull()
   })
 

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
@@ -97,7 +97,6 @@
 import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import Button from '@/components/ui/button/Button.vue'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
@@ -128,7 +127,6 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { flags } = useFeatureFlags()
 const workspaceStore = useTeamWorkspaceStore()
 
 const tierName = computed(() =>
@@ -161,7 +159,7 @@ const invitableSeats = computed(() =>
   Math.max(0, MAX_WORKSPACE_MEMBERS - occupiedSeats.value)
 )
 
-const showInviteBlock = computed(() => isTeam && flags.teamWorkspacesEnabled)
+const showInviteBlock = computed(() => isTeam)
 
 const invitedEmails = ref<string[]>([])
 const invitedMessage = ref<HTMLElement>()

--- a/src/platform/workspace/components/UnifiedPricingTable.stories.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.stories.ts
@@ -5,10 +5,7 @@ import UnifiedPricingTable from './UnifiedPricingTable.vue'
 /**
  * The unified pricing table (B4 / FE-934): one table for the new billing model,
  * with a personal/team **plan** toggle on a single workspace (Gamma-style).
- *
- * Note: the personal/team toggle itself only renders when `teamWorkspacesEnabled`
- * is on (a server flag, off in Storybook), so these stories drive the view via
- * `initialPlanMode` instead. Personal prices fall back to the static
+ * Personal prices fall back to the static
  * `TIER_PRICING` (no API in Storybook); the team column uses the locked DES-197
  * credit-slider stops.
  */

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -23,7 +23,6 @@ interface MockTeamStop {
 const mockSubscription = ref<MockSubscription | null>(null)
 const mockCurrentPlanSlug = ref<string | null>(null)
 const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
-const mockTeamFlag = ref(false)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
@@ -45,12 +44,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: mockCanManageSubscription.value,
       canDowngradeToPersonal: mockCanDowngradeToPersonal.value
     }))
-  })
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: { teamWorkspacesEnabled: mockTeamFlag.value }
   })
 }))
 
@@ -85,7 +78,6 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     mockSubscription.value = null
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
-    mockTeamFlag.value = false
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true
@@ -144,7 +136,6 @@ describe('UnifiedPricingTable plan CTA labels', () => {
       credits_monthly: 147_700,
       stop_usd: 700
     }
-    mockTeamFlag.value = true
     mockIsTeamPlan.value = true
     mockCanDowngradeToPersonal.value = false
 
@@ -168,7 +159,6 @@ describe('UnifiedPricingTable team plan CTA', () => {
     mockSubscription.value = null
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
-    mockTeamFlag.value = true
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="flex flex-col xl:h-full">
     <!-- Plan-scope toggle (personal vs team PLAN on one workspace): sits directly
-         on top of the content area — outside it, attached with no gap (DES QA).
-         Only shown when team plans are available (teamWorkspacesEnabled). -->
-    <div v-if="showTeam" class="flex justify-center">
+         on top of the content area — outside it, attached with no gap (DES QA). -->
+    <div class="flex justify-center">
       <SelectButton
         v-model="planMode"
         :options="planScopeOptions"
@@ -416,7 +415,6 @@ import { I18nT, useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import CreditSlider from '@/components/ui/credit-slider/CreditSlider.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   TIER_PRICING,
   TIER_TO_KEY
@@ -443,8 +441,7 @@ type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 interface Props {
   isLoading?: boolean
   loadingTier?: CheckoutTierKey | null
-  /** Initial plan scope. The toggle to switch is only shown when team plans
-   *  are available (`teamWorkspacesEnabled`). */
+  /** Initial plan scope. */
   initialPlanMode?: 'personal' | 'team'
 }
 
@@ -468,11 +465,7 @@ const emit = defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { flags } = useFeatureFlags()
 const { permissions } = useWorkspaceUI()
-
-/** Team plans only exist behind the flag (mirrors useBillingContext type). */
-const showTeam = computed(() => flags.teamWorkspacesEnabled)
 
 const planMode = ref<'personal' | 'team'>(initialPlanMode)
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -317,6 +317,20 @@ describe('useTeamWorkspaceStore', () => {
       expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(1)
     })
 
+    it('can retry after initialization fails', async () => {
+      mockWorkspaceApi.list.mockResolvedValueOnce({ workspaces: [] })
+      const store = useTeamWorkspaceStore()
+
+      await expect(store.initialize()).rejects.toThrow(
+        'No workspaces available'
+      )
+      await store.initialize()
+
+      expect(store.initState).toBe('ready')
+      expect(store.activeWorkspaceId).toBe(mockPersonalWorkspace.id)
+      expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(2)
+    })
+
     it('can initialize the next user after identity state is reset', async () => {
       const store = useTeamWorkspaceStore()
       await store.initialize()

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -270,7 +270,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
    * Call once on app boot.
    */
   async function initialize(): Promise<void> {
-    if (initState.value !== 'uninitialized') return
+    if (initState.value !== 'uninitialized' && initState.value !== 'error')
+      return
 
     const generation = identityGeneration
     initState.value = 'loading'

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -70,15 +70,11 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: true }))
 const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return mockTeamWorkspacesEnabled.value
-      },
       get unifiedCloudAuthEnabled() {
         return mockUnifiedCloudAuthEnabled.value
       }
@@ -115,7 +111,6 @@ describe('useWorkspaceAuthStore', () => {
     vi.resetAllMocks()
     vi.useFakeTimers()
     sessionStorage.clear()
-    mockTeamWorkspacesEnabled.value = true
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
     mockEnsureSessionCookie.mockResolvedValue(undefined)
@@ -958,19 +953,6 @@ describe('useWorkspaceAuthStore', () => {
       expect(header).toBeNull()
     })
 
-    it('is a no-op returning null when the feature flag is disabled', async () => {
-      mockTeamWorkspacesEnabled.value = false
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-
-      const header = await store.ensureWorkspaceAuthHeader('workspace-123')
-
-      expect(header).toBeNull()
-      expect(mockFetch).not.toHaveBeenCalled()
-    })
-
     it('tears down workspace context and surfaces a toast on a permanent recovery failure', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
       const mockFetch = vi
@@ -1303,54 +1285,6 @@ describe('useWorkspaceAuthStore', () => {
       workspaceToken.value = null
 
       expect(isAuthenticated.value).toBe(false)
-    })
-  })
-
-  describe('feature flag disabled', () => {
-    beforeEach(() => {
-      mockTeamWorkspacesEnabled.value = false
-    })
-
-    afterEach(() => {
-      mockTeamWorkspacesEnabled.value = true
-    })
-
-    it('initializeFromSession returns false when flag disabled', () => {
-      const futureExpiry = Date.now() + 3600 * 1000
-      sessionStorage.setItem(
-        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
-        JSON.stringify(mockWorkspaceWithRole)
-      )
-      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'valid-token')
-      sessionStorage.setItem(
-        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
-        futureExpiry.toString()
-      )
-
-      const store = useWorkspaceAuthStore()
-      const { currentWorkspace, workspaceToken } = storeToRefs(store)
-
-      const result = store.initializeFromSession()
-
-      expect(result).toBe(false)
-      expect(currentWorkspace.value).toBeNull()
-      expect(workspaceToken.value).toBeNull()
-    })
-
-    it('switchWorkspace is a no-op when flag disabled', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-      const { currentWorkspace, workspaceToken, isLoading } = storeToRefs(store)
-
-      await store.switchWorkspace('workspace-123')
-
-      expect(mockFetch).not.toHaveBeenCalled()
-      expect(currentWorkspace.value).toBeNull()
-      expect(workspaceToken.value).toBeNull()
-      expect(isLoading.value).toBe(false)
     })
   })
 
@@ -2565,23 +2499,6 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBeNull()
       expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
-    })
-
-    it('keeps the legacy refresh path gated: both flags OFF ⇒ no network from any timer', async () => {
-      mockTeamWorkspacesEnabled.value = false
-      mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-
-      await store.switchWorkspace('workspace-123')
-      await store.mintAtLogin()
-      await store.refreshToken()
-      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
-
-      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it.for([

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -93,8 +93,7 @@ function permanentAuthErrorMessageKey(code: string | undefined): string {
   }
 }
 
-// Flag-ON has no Firebase fallback, so surface permanent failures instead of
-// stranding every cloud request on a silently cleared token.
+// Workspace auth has no Firebase fallback, so surface permanent failures.
 function surfacePermanentAuthError(err: WorkspaceAuthError): void {
   console.error('Unified workspace auth revoked or invalid:', err)
   useToastStore().add({
@@ -282,10 +281,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   function initializeFromSession(): boolean {
-    if (!flags.teamWorkspacesEnabled) {
-      return false
-    }
-
     try {
       const workspaceJson = sessionStorage.getItem(
         WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
@@ -432,10 +427,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   async function performSwitchWorkspace(workspaceId: string): Promise<void> {
-    if (!flags.teamWorkspacesEnabled) {
-      return
-    }
-
     const capturedRequestId = refreshRequestId
     const capturedOwnerUid = currentUserUid()
 
@@ -566,10 +557,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   async function ensureWorkspaceToken(
     preferredWorkspaceId?: string
   ): Promise<string | null> {
-    if (!flags.teamWorkspacesEnabled) {
-      return null
-    }
-
     const ownerUid = currentUserUid()
     if (!ownerUid) return null
     const targetWorkspaceId = preferredWorkspaceId ?? currentWorkspace.value?.id

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -10,7 +10,6 @@ import { createTestingPinia } from '@pinia/testing'
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
-    teamWorkspacesEnabled: false,
     unifiedCloudAuthEnabled: false
   }
 }))
@@ -130,7 +129,6 @@ describe('auth token priority chain', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null
     mockActiveWorkspaceId = null
@@ -157,8 +155,7 @@ describe('auth token priority chain', () => {
   })
 
   describe('getAuthHeader priority', () => {
-    it('returns workspace auth header when workspace is active and feature enabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
+    it('returns workspace auth header when workspace is active', async () => {
       mockWorkspaceAuthHeader.mockReturnValue({
         Authorization: 'Bearer workspace-token'
       })
@@ -171,7 +168,6 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace is not active but user is authenticated', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockWorkspaceAuthHeader.mockReturnValue(null)
 
       const header = await store.getAuthHeader()
@@ -197,24 +193,10 @@ describe('auth token priority chain', () => {
 
       expect(header).toBeNull()
     })
-
-    it('skips workspace header when team_workspaces feature is disabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = false
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
-
-      const header = await store.getAuthHeader()
-
-      expect(header).toEqual({
-        Authorization: 'Bearer firebase-token'
-      })
-    })
   })
 
   describe('getAuthToken priority', () => {
-    it('returns workspace token when workspace is active and feature enabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
+    it('returns workspace token when workspace is active', async () => {
       mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
 
       const token = await store.getAuthToken()
@@ -223,7 +205,6 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace token is not available', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockGetWorkspaceToken.mockReturnValue(undefined)
 
       const token = await store.getAuthToken()
@@ -284,7 +265,6 @@ describe('auth token priority chain', () => {
     it('getAuthHeader returns only the unified Cloud JWT, never Firebase or API key', async () => {
       mockUnifiedToken = 'unified-jwt'
       // Even with the legacy sources available, the unified branch wins.
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockWorkspaceAuthHeader.mockReturnValue({
         Authorization: 'Bearer workspace-token'
       })

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -28,7 +28,6 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
-    teamWorkspacesEnabled: false,
     unifiedCloudAuthEnabled: false
   }
 }))
@@ -175,7 +174,6 @@ describe('useAuthStore', () => {
     sessionStorage.clear()
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockFeatureFlags.unifiedCloudAuthEnabled = false
 
     // Setup dialog service mock
@@ -688,10 +686,6 @@ describe('useAuthStore', () => {
   })
 
   describe('getAuthHeader workspace recovery', () => {
-    beforeEach(() => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
-    })
-
     it('uses the workspace header when a valid workspace token exists', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue({
@@ -750,10 +744,6 @@ describe('useAuthStore', () => {
   })
 
   describe('getAuthToken workspace recovery', () => {
-    beforeEach(() => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
-    })
-
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
       const teamStore = useTeamWorkspaceStore()

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -233,7 +233,7 @@ export const useAuthStore = defineStore('auth', () => {
    * When unified_cloud_auth is enabled, returns the single Cloud JWT for every
    * cloud request (no Firebase/API-key fallback) so one token is used end to end.
    * Otherwise checks for authentication in the following order:
-   * 1. Workspace token (if team_workspaces_enabled and user has active workspace context)
+   * 1. Workspace token on Cloud when the user has active workspace context
    * 2. Firebase authentication token (if user is logged in)
    * 3. API key (if stored in the browser's credential manager)
    *
@@ -248,7 +248,7 @@ export const useAuthStore = defineStore('auth', () => {
       return token ? { Authorization: `Bearer ${token}` } : null
     }
 
-    if (flags.teamWorkspacesEnabled) {
+    if (isCloud) {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 
@@ -292,7 +292,7 @@ export const useAuthStore = defineStore('auth', () => {
       return useWorkspaceAuthStore().getUnifiedToken()
     }
 
-    if (flags.teamWorkspacesEnabled) {
+    if (isCloud) {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 

--- a/src/storybook/mocks/useFeatureFlags.ts
+++ b/src/storybook/mocks/useFeatureFlags.ts
@@ -2,8 +2,7 @@
  * Storybook mock for `useFeatureFlags`.
  *
  * The real composable resolves flags from authenticated remote config, which is
- * unavailable in Storybook. This stub enables the workspace-facing flags so
- * team-plan billing components (e.g. the post-upgrade invite block) render.
+ * unavailable in Storybook. This stub enables billing controls.
  */
 // Inlined from `@/composables/useFeatureFlags` (the alias points here) so the
 // enum, consumed by modules like nodeReplacementStore, resolves without dragging
@@ -17,7 +16,6 @@ export enum ServerFeatureFlag {
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
-  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
   NODE_REPLACEMENTS = 'node_replacements',
   NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
@@ -26,15 +24,12 @@ export enum ServerFeatureFlag {
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
-  CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled'
 }
 
 export function useFeatureFlags() {
   return {
     flags: {
-      teamWorkspacesEnabled: true,
-      consolidatedBillingEnabled: true,
       billingControlEnabled: true
     }
   }

--- a/src/utils/devFeatureFlagOverride.ts
+++ b/src/utils/devFeatureFlagOverride.ts
@@ -10,8 +10,8 @@ const FF_PREFIX = 'ff:'
  * "override explicitly set to null".
  *
  * Usage in browser console:
- *   localStorage.setItem('ff:team_workspaces_enabled', 'true')
- *   localStorage.removeItem('ff:team_workspaces_enabled')
+ *   localStorage.setItem('ff:example_enabled', 'true')
+ *   localStorage.removeItem('ff:example_enabled')
  */
 export function getDevOverride<T>(flagKey: string): T | undefined {
   if (!import.meta.env.DEV) return undefined


### PR DESCRIPTION
## Summary

Permanently enable team workspaces and consolidated workspace billing in the frontend now that both rollouts are complete.

## Changes

- **What**: Removes `team_workspaces_enabled` and `consolidated_billing_enabled` from remote config, feature-flag consumers, cached overrides, mocks, stories, and tests. Cloud workspace auth and workspace billing are now the direct paths; personal workspaces explicitly marked `legacy_stripe` retain legacy account billing and top-ups.
- **Root cause**: These terminal flags already resolved to `true`, but retaining conditional branches left startup/auth races, stale false defaults, and two nominal billing modes around a rollout that had already completed.
- **Regression coverage**: Updates affected unit and browser coverage, including an end-to-end legacy-rail case that proves workspace discovery switches back to legacy status/balance without displaying the stale workspace balance.

## Review Focus

- Workspace auth initialization remains fail-closed after a workspace becomes active.
- `legacy_stripe` personal workspaces still use legacy status, balance, management, and top-up paths while checkout uses unified pricing.
- This PR must deploy before the companion Cloud cleanup removes the compatibility keys from `/api/features`.

## Testing

- 321 focused Vitest tests
- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm lint:unstaged`
- staged stylelint, oxfmt, oxlint, ESLint, source/browser typechecks, and knip hooks
- Playwright: `billingFacadeConsumers.spec.ts` cloud project (both cases; legacy case rerun after strengthening)

## Screenshots

AS IS / TO BE: no visual change. Both flags were already terminally enabled in production; this removes dead rollout branches while preserving the current Cloud UI.