### PR TITLE
feat(updates): soft "new version available" reload prompt

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2032,6 +2032,12 @@
     "updateFrontend": "Update Frontend",
     "dismiss": "Dismiss"
   },
+  "newVersionReload": {
+    "title": "New version available",
+    "detail": "Reload to get the latest version of ComfyUI.",
+    "reload": "Reload",
+    "dismiss": "Dismiss"
+  },
   "loadWorkflowWarning": {
     "outdatedVersion": "This workflow was created with a newer version of ComfyUI ({version}). Some nodes may not work correctly.",
     "outdatedVersionGeneric": "This workflow was created with a newer version of ComfyUI. Some nodes may not work correctly.",

--- a/src/platform/telemetry/initDatadogRum.ts
+++ b/src/platform/telemetry/initDatadogRum.ts
@@ -1,5 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum'
 
+import { probeFrontendVersion } from '@/platform/updates/common/frontendVersionProbe'
+
 import { rumBeforeSend } from './datadogRumBeforeSend'
 import { trackUserManualRefresh } from './manualRefreshTracker'
 
@@ -8,24 +10,16 @@ const DATADOG_ENV_BY_HOSTNAME = new Map([
   ['stagingcloud.comfy.org', 'stg-v2'],
   ['testcloud.comfy.org', 'test-v2']
 ])
-const FRONTEND_CONTEXT_FETCH_TIMEOUT_MS = 1_000
 let initializationPromise: Promise<void> | undefined
 
 async function setFrontendContext(): Promise<void> {
-  const response = await fetch(window.location.origin, {
-    method: 'HEAD',
-    cache: 'no-store',
-    signal: AbortSignal.timeout(FRONTEND_CONTEXT_FETCH_TIMEOUT_MS)
-  })
-  if (!response.ok) return
+  const probe = await probeFrontendVersion()
+  if (!probe) return
 
-  const frontendVersion = response.headers.get('X-Frontend-Version')
+  const frontendVersion = probe.version
   if (frontendVersion !== __COMFYUI_FRONTEND_COMMIT__) return
 
-  datadogRum.setGlobalContextProperty(
-    'bucket',
-    response.headers.get('X-Frontend-Bucket') ?? 'stable'
-  )
+  datadogRum.setGlobalContextProperty('bucket', probe.bucket ?? 'stable')
   datadogRum.setGlobalContextProperty('version', frontendVersion)
 }
 

--- a/src/platform/updates/common/NewVersionReloadToast.test.ts
+++ b/src/platform/updates/common/NewVersionReloadToast.test.ts
@@ -1,0 +1,120 @@
+import { render } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import NewVersionReloadToast from './NewVersionReloadToast.vue'
+import { useToastStore } from './toastStore'
+
+const NEW_VERSION_TOAST_GROUP = 'new-version-available'
+
+// Capture the options passed to the composable and expose controllable spies.
+const composable = vi.hoisted(() => ({
+  showPrompt: undefined as undefined | (() => void),
+  hidePrompt: undefined as undefined | (() => void),
+  accept: vi.fn(),
+  dismiss: vi.fn(),
+  checkNow: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('./useNewVersionReloadPrompt', () => ({
+  NEW_VERSION_TOAST_GROUP: 'new-version-available',
+  useNewVersionReloadPrompt: (options: {
+    showPrompt: () => void
+    hidePrompt?: () => void
+  }) => {
+    composable.showPrompt = options.showPrompt
+    composable.hidePrompt = options.hidePrompt
+    return {
+      accept: composable.accept,
+      dismiss: composable.dismiss,
+      checkNow: composable.checkNow
+    }
+  }
+}))
+
+const removeGroupMock = vi.fn()
+vi.mock('primevue', () => ({
+  useToast: () => ({ removeGroup: removeGroupMock })
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ beforeEach: vi.fn() })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      newVersionReload: {
+        title: 'New version available',
+        detail: 'Reload to get the latest version of ComfyUI.',
+        reload: 'Reload',
+        dismiss: 'Dismiss'
+      }
+    }
+  }
+})
+
+function mountToast() {
+  return render(NewVersionReloadToast, {
+    global: {
+      plugins: [i18n],
+      stubs: { Toast: true, Button: true }
+    }
+  })
+}
+
+describe('NewVersionReloadToast', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    composable.accept.mockClear()
+    composable.dismiss.mockClear()
+    composable.checkNow.mockClear()
+    removeGroupMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('runs the initial drift check on mount', () => {
+    mountToast()
+    expect(composable.checkNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds a sticky, non-closable toast message when the prompt is shown', () => {
+    mountToast()
+    const toastStore = useToastStore()
+
+    composable.showPrompt?.()
+
+    expect(toastStore.messagesToAdd).toHaveLength(1)
+    expect(toastStore.messagesToAdd[0]).toMatchObject({
+      group: NEW_VERSION_TOAST_GROUP,
+      summary: 'New version available',
+      detail: 'Reload to get the latest version of ComfyUI.',
+      closable: false
+    })
+    // Sticky: no auto-dismiss timeout.
+    expect(toastStore.messagesToAdd[0].life).toBeUndefined()
+  })
+
+  it('removes the toast group when the prompt is hidden', () => {
+    mountToast()
+
+    composable.hidePrompt?.()
+
+    expect(removeGroupMock).toHaveBeenCalledWith(NEW_VERSION_TOAST_GROUP)
+  })
+
+  it('removes the toast group on unmount', () => {
+    const { unmount } = mountToast()
+    removeGroupMock.mockClear()
+
+    unmount()
+
+    expect(removeGroupMock).toHaveBeenCalledWith(NEW_VERSION_TOAST_GROUP)
+  })
+})

--- a/src/platform/updates/common/NewVersionReloadToast.vue
+++ b/src/platform/updates/common/NewVersionReloadToast.vue
@@ -29,7 +29,7 @@
 import { useToast } from 'primevue'
 import type { ToastMessageOptions } from 'primevue/toast'
 import Toast from 'primevue/toast'
-import { onUnmounted } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -48,7 +48,7 @@ const router = useRouter()
 
 const removeToast = () => toast.removeGroup(NEW_VERSION_TOAST_GROUP)
 
-const { accept, dismiss } = useNewVersionReloadPrompt({
+const { accept, dismiss, checkNow } = useNewVersionReloadPrompt({
   router,
   showPrompt: () => {
     // Route through the toast store so the message survives even if this
@@ -74,6 +74,12 @@ const onDismiss = (_message: ToastMessageOptions) => {
   dismiss()
   removeToast()
 }
+
+// Initial drift check on mount: a tab that never loses/regains focus would
+// otherwise never learn about a version that was already promoted.
+onMounted(() => {
+  void checkNow()
+})
 
 onUnmounted(removeToast)
 </script>

--- a/src/platform/updates/common/NewVersionReloadToast.vue
+++ b/src/platform/updates/common/NewVersionReloadToast.vue
@@ -1,0 +1,79 @@
+<template>
+  <Toast :group="NEW_VERSION_TOAST_GROUP" position="bottom-right">
+    <template #message="slotProps">
+      <div class="flex flex-auto flex-col items-start gap-2">
+        <div class="font-medium">
+          {{ slotProps.message.summary }}
+        </div>
+        <div v-if="slotProps.message.detail" class="text-sm opacity-80">
+          {{ slotProps.message.detail }}
+        </div>
+        <div class="flex gap-2 self-end">
+          <Button
+            severity="secondary"
+            size="sm"
+            @click="onDismiss(slotProps.message)"
+          >
+            {{ t('newVersionReload.dismiss') }}
+          </Button>
+          <Button size="sm" @click="onReload(slotProps.message)">
+            {{ t('newVersionReload.reload') }}
+          </Button>
+        </div>
+      </div>
+    </template>
+  </Toast>
+</template>
+
+<script setup lang="ts">
+import { useToast } from 'primevue'
+import type { ToastMessageOptions } from 'primevue/toast'
+import Toast from 'primevue/toast'
+import { onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+
+import Button from '@/components/ui/button/Button.vue'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+
+import {
+  NEW_VERSION_TOAST_GROUP,
+  useNewVersionReloadPrompt
+} from './useNewVersionReloadPrompt'
+
+const { t } = useI18n()
+const toast = useToast()
+const toastStore = useToastStore()
+const router = useRouter()
+
+const removeToast = () => toast.removeGroup(NEW_VERSION_TOAST_GROUP)
+
+const { accept, dismiss } = useNewVersionReloadPrompt({
+  router,
+  showPrompt: () => {
+    // Route through the toast store so the message survives even if this
+    // component mounts after the drift was detected.
+    toastStore.add({
+      group: NEW_VERSION_TOAST_GROUP,
+      severity: 'info',
+      summary: t('newVersionReload.title'),
+      detail: t('newVersionReload.detail'),
+      // No `life`: the prompt stays until the user reloads or dismisses it, so a
+      // soft update notice never auto-dismisses out from under them.
+      closable: false
+    })
+  },
+  hidePrompt: removeToast
+})
+
+const onReload = (_message: ToastMessageOptions) => {
+  accept()
+}
+
+const onDismiss = (_message: ToastMessageOptions) => {
+  dismiss()
+  removeToast()
+}
+
+onUnmounted(removeToast)
+</script>

--- a/src/platform/updates/common/desiredVersionStore.test.ts
+++ b/src/platform/updates/common/desiredVersionStore.test.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDesiredVersionStore } from './desiredVersionStore'
+
+const probeMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./frontendVersionProbe', () => ({
+  probeFrontendVersion: probeMock
+}))
+
+describe('useDesiredVersionStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    probeMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports no new version before the first probe', () => {
+    const store = useDesiredVersionStore()
+    expect(store.hasNewVersion).toBe(false)
+    expect(store.desiredVersion).toBeNull()
+    expect(store.runningVersion).toBe(__COMFYUI_FRONTEND_COMMIT__)
+  })
+
+  it('reports no new version when the desired version matches the running bundle', async () => {
+    probeMock.mockResolvedValue({
+      version: __COMFYUI_FRONTEND_COMMIT__,
+      bucket: 'stable'
+    })
+    const store = useDesiredVersionStore()
+
+    await store.refresh()
+
+    expect(store.desiredVersion).toBe(__COMFYUI_FRONTEND_COMMIT__)
+    expect(store.hasNewVersion).toBe(false)
+  })
+
+  it('detects drift when the desired version differs from the running bundle', async () => {
+    probeMock.mockResolvedValue({ version: 'a-newer-commit', bucket: 'stable' })
+    const store = useDesiredVersionStore()
+
+    await store.refresh()
+
+    expect(store.desiredVersion).toBe('a-newer-commit')
+    expect(store.hasNewVersion).toBe(true)
+  })
+
+  it('never treats a missing desired version as drift', async () => {
+    probeMock.mockResolvedValue({ version: null, bucket: 'stable' })
+    const store = useDesiredVersionStore()
+
+    await store.refresh()
+
+    expect(store.desiredVersion).toBeNull()
+    expect(store.hasNewVersion).toBe(false)
+  })
+
+  it('keeps the last known drift when a later probe fails', async () => {
+    const store = useDesiredVersionStore()
+
+    probeMock.mockResolvedValueOnce({ version: 'a-newer-commit', bucket: null })
+    await store.refresh()
+    expect(store.hasNewVersion).toBe(true)
+
+    probeMock.mockRejectedValueOnce(new Error('network error'))
+    await store.refresh()
+    expect(store.hasNewVersion).toBe(true)
+
+    probeMock.mockResolvedValueOnce(null)
+    await store.refresh()
+    expect(store.hasNewVersion).toBe(true)
+  })
+})

--- a/src/platform/updates/common/desiredVersionStore.ts
+++ b/src/platform/updates/common/desiredVersionStore.ts
@@ -1,0 +1,59 @@
+import { defineStore } from 'pinia'
+import { computed, readonly, ref } from 'vue'
+
+import { probeFrontendVersion } from './frontendVersionProbe'
+
+/**
+ * Tracks the "desired" frontend version served by the edge and compares it to
+ * the version of the bundle currently running in this tab.
+ *
+ * The edge advertises the desired version via the `X-Frontend-Version` response
+ * header (see {@link probeFrontendVersion}); the running bundle is
+ * `__COMFYUI_FRONTEND_COMMIT__`. When a promote/abort changes the desired
+ * version, open tabs still run the old bundle — this store detects that drift so
+ * the app can offer a non-blocking reload.
+ *
+ * Polling is deliberately cheap: callers refresh on window focus (or by
+ * piggybacking on existing activity), never on a tight timer.
+ */
+export const useDesiredVersionStore = defineStore('desiredVersion', () => {
+  const runningVersion = __COMFYUI_FRONTEND_COMMIT__
+
+  // The most recent desired version read from the edge. `null` until the first
+  // successful probe (or when the edge does not advertise a version).
+  const desiredVersion = ref<string | null>(null)
+
+  /**
+   * True when the edge advertises a concrete version that differs from the
+   * bundle running in this tab. A missing/unknown desired version never counts
+   * as drift, so we don't prompt on environments that don't serve the header.
+   */
+  const hasNewVersion = computed(
+    () =>
+      desiredVersion.value !== null && desiredVersion.value !== runningVersion
+  )
+
+  /**
+   * Probes the edge for the desired version and updates {@link desiredVersion}.
+   *
+   * Swallows network/timeout errors and OK-but-headerless responses: a failed
+   * probe simply leaves the last known desired version untouched rather than
+   * clearing a previously observed drift.
+   */
+  async function refresh(): Promise<void> {
+    try {
+      const probe = await probeFrontendVersion()
+      if (!probe || probe.version === null) return
+      desiredVersion.value = probe.version
+    } catch {
+      // Ignore — the edge may be briefly unreachable; keep the last signal.
+    }
+  }
+
+  return {
+    runningVersion,
+    desiredVersion: readonly(desiredVersion),
+    hasNewVersion,
+    refresh
+  }
+})

--- a/src/platform/updates/common/frontendVersionProbe.test.ts
+++ b/src/platform/updates/common/frontendVersionProbe.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { probeFrontendVersion } from './frontendVersionProbe'
+
+describe('probeFrontendVersion', () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>
+
+  beforeEach(() => {
+    fetchMock = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('reads the version and bucket headers from an OK response', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        headers: {
+          'X-Frontend-Version': 'abc123',
+          'X-Frontend-Bucket': 'canary'
+        }
+      })
+    )
+
+    await expect(probeFrontendVersion()).resolves.toEqual({
+      version: 'abc123',
+      bucket: 'canary'
+    })
+  })
+
+  it('issues a HEAD request against the current origin, no-store', async () => {
+    fetchMock.mockResolvedValue(new Response(null))
+
+    await probeFrontendVersion()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      window.location.origin,
+      expect.objectContaining({ method: 'HEAD', cache: 'no-store' })
+    )
+  })
+
+  it('returns null header values when the headers are absent', async () => {
+    fetchMock.mockResolvedValue(new Response(null))
+
+    await expect(probeFrontendVersion()).resolves.toEqual({
+      version: null,
+      bucket: null
+    })
+  })
+
+  it('returns null when the response is not OK', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 503 }))
+
+    await expect(probeFrontendVersion()).resolves.toBeNull()
+  })
+
+  it('propagates network errors to the caller', async () => {
+    fetchMock.mockRejectedValue(new Error('network error'))
+
+    await expect(probeFrontendVersion()).rejects.toThrow('network error')
+  })
+
+  it('passes an abort signal so the probe can time out', async () => {
+    fetchMock.mockResolvedValue(new Response(null))
+
+    await probeFrontendVersion(500)
+
+    const init = fetchMock.mock.calls[0][1]
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/src/platform/updates/common/frontendVersionProbe.ts
+++ b/src/platform/updates/common/frontendVersionProbe.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared probe for the desired frontend version served by the edge.
+ *
+ * A cheap `HEAD /` reads the `X-Frontend-Version` (and `X-Frontend-Bucket`)
+ * response headers that nginx injects. That value is the *desired* version the
+ * edge currently serves; the running bundle's version is
+ * `__COMFYUI_FRONTEND_COMMIT__`. Comparing the two is the drift check used both
+ * for RUM canary tagging and for the soft "new version available" reload prompt.
+ */
+
+const FRONTEND_VERSION_PROBE_TIMEOUT_MS = 1_000
+
+export interface FrontendVersionProbeResult {
+  /** Value of the `X-Frontend-Version` header, or `null` when absent. */
+  version: string | null
+  /** Value of the `X-Frontend-Bucket` header, or `null` when absent. */
+  bucket: string | null
+}
+
+/**
+ * Issues a `HEAD /` request against the current origin and reads the
+ * frontend-version headers. Returns `null` when the probe response is not OK,
+ * so callers can treat an unreachable edge the same as "no signal".
+ *
+ * Never throws for network/timeout errors is *not* guaranteed here — callers
+ * that must not surface failures should wrap the call (e.g. `.catch(() => {})`),
+ * matching the existing RUM initialization behavior.
+ */
+export async function probeFrontendVersion(
+  timeoutMs: number = FRONTEND_VERSION_PROBE_TIMEOUT_MS
+): Promise<FrontendVersionProbeResult | null> {
+  const response = await fetch(window.location.origin, {
+    method: 'HEAD',
+    cache: 'no-store',
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+  if (!response.ok) return null
+
+  return {
+    version: response.headers.get('X-Frontend-Version'),
+    bucket: response.headers.get('X-Frontend-Bucket')
+  }
+}

--- a/src/platform/updates/common/useNewVersionReloadPrompt.test.ts
+++ b/src/platform/updates/common/useNewVersionReloadPrompt.test.ts
@@ -42,6 +42,9 @@ function withScope<T>(fn: () => T): { result: T; stop: () => void } {
   return { result, stop: () => scope.stop() }
 }
 
+// Flush the microtask queue so awaited `refresh().then(...)` chains settle.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 describe('useNewVersionReloadPrompt', () => {
   let showPrompt: ReturnType<typeof vi.fn<() => void>>
   let hidePrompt: ReturnType<typeof vi.fn<() => void>>
@@ -87,19 +90,43 @@ describe('useNewVersionReloadPrompt', () => {
   it('does not interrupt an active generation, then prompts once idle', async () => {
     driftProbe()
     isIdleRef.value = false
-    const { stop } = withScope(() =>
+    const { result, stop } = withScope(() =>
       useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
     )
 
     // Learn about the drift while a generation is running.
-    const { useDesiredVersionStore } = await import('./desiredVersionStore')
-    await useDesiredVersionStore().refresh()
+    await result.checkNow()
     await nextTick()
     expect(showPrompt).not.toHaveBeenCalled()
 
-    // Generation finishes → tab goes idle → prompt surfaces.
+    // Generation finishes → tab goes idle → re-probe + prompt surfaces.
     isIdleRef.value = true
     await nextTick()
+    await flushPromises()
+    expect(showPrompt).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('re-probes the edge when a generation finishes (drift promoted while busy)', async () => {
+    // Versions match at first, then a promote lands while a generation runs.
+    matchingProbe()
+    isIdleRef.value = false
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+    expect(showPrompt).not.toHaveBeenCalled()
+
+    // Promote happens mid-generation; the tab never regained focus.
+    driftProbe()
+    expect(showPrompt).not.toHaveBeenCalled()
+
+    // Generation finishes → idle transition re-probes the edge and detects drift.
+    isIdleRef.value = true
+    await nextTick()
+    await flushPromises()
+    expect(probeMock).toHaveBeenCalledTimes(2)
     expect(showPrompt).toHaveBeenCalledTimes(1)
     stop()
   })
@@ -155,12 +182,18 @@ describe('useNewVersionReloadPrompt', () => {
 
     window.dispatchEvent(new Event('focus'))
     await nextTick()
-    await Promise.resolve()
-    await nextTick()
+    await flushPromises()
 
     expect(probeMock).toHaveBeenCalled()
     expect(showPrompt).toHaveBeenCalledTimes(1)
+
+    // After teardown the focus listener must stop re-probing.
+    const probeCallsBeforeStop = probeMock.mock.calls.length
     stop()
+    window.dispatchEvent(new Event('focus'))
+    await nextTick()
+    await flushPromises()
+    expect(probeMock).toHaveBeenCalledTimes(probeCallsBeforeStop)
   })
 
   it('installs a one-shot navigation guard that reloads on next nav', async () => {

--- a/src/platform/updates/common/useNewVersionReloadPrompt.test.ts
+++ b/src/platform/updates/common/useNewVersionReloadPrompt.test.ts
@@ -1,0 +1,186 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+import type { Router } from 'vue-router'
+
+import { useNewVersionReloadPrompt } from './useNewVersionReloadPrompt'
+
+const probeMock = vi.hoisted(() => vi.fn())
+const { isIdleRef } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return { isIdleRef: ref(true) }
+})
+
+vi.mock('./frontendVersionProbe', () => ({
+  probeFrontendVersion: probeMock
+}))
+
+vi.mock('@/stores/executionStore', () => ({
+  useExecutionStore: () => ({
+    get isIdle() {
+      return isIdleRef.value
+    }
+  })
+}))
+
+const NEWER = 'a-newer-commit'
+
+function driftProbe() {
+  probeMock.mockResolvedValue({ version: NEWER, bucket: 'stable' })
+}
+
+function matchingProbe() {
+  probeMock.mockResolvedValue({
+    version: __COMFYUI_FRONTEND_COMMIT__,
+    bucket: 'stable'
+  })
+}
+
+function withScope<T>(fn: () => T): { result: T; stop: () => void } {
+  const scope = effectScope()
+  const result = scope.run(fn) as T
+  return { result, stop: () => scope.stop() }
+}
+
+describe('useNewVersionReloadPrompt', () => {
+  let showPrompt: ReturnType<typeof vi.fn<() => void>>
+  let hidePrompt: ReturnType<typeof vi.fn<() => void>>
+  let reload: ReturnType<typeof vi.fn<() => void>>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    probeMock.mockReset()
+    isIdleRef.value = true
+    showPrompt = vi.fn<() => void>()
+    hidePrompt = vi.fn<() => void>()
+    reload = vi.fn<() => void>()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces the prompt when the desired version drifts and the tab is idle', async () => {
+    driftProbe()
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+
+    expect(showPrompt).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('does not prompt when the versions match', async () => {
+    matchingProbe()
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+
+    expect(showPrompt).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('does not interrupt an active generation, then prompts once idle', async () => {
+    driftProbe()
+    isIdleRef.value = false
+    const { stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    // Learn about the drift while a generation is running.
+    const { useDesiredVersionStore } = await import('./desiredVersionStore')
+    await useDesiredVersionStore().refresh()
+    await nextTick()
+    expect(showPrompt).not.toHaveBeenCalled()
+
+    // Generation finishes → tab goes idle → prompt surfaces.
+    isIdleRef.value = true
+    await nextTick()
+    expect(showPrompt).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('reloads and hides the prompt on accept', async () => {
+    driftProbe()
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+    result.accept()
+
+    expect(hidePrompt).toHaveBeenCalledTimes(1)
+    expect(reload).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('hides the prompt without reloading on dismiss', async () => {
+    driftProbe()
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+    result.dismiss()
+
+    expect(hidePrompt).toHaveBeenCalledTimes(1)
+    expect(reload).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('only surfaces the prompt once per session', async () => {
+    driftProbe()
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    await result.checkNow()
+    await result.checkNow()
+
+    expect(showPrompt).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('re-probes and prompts when the window regains focus', async () => {
+    driftProbe()
+    const { stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload })
+    )
+
+    expect(showPrompt).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('focus'))
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(probeMock).toHaveBeenCalled()
+    expect(showPrompt).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('installs a one-shot navigation guard that reloads on next nav', async () => {
+    driftProbe()
+    const beforeEach = vi.fn()
+    const router = { beforeEach } as unknown as Router
+
+    const { result, stop } = withScope(() =>
+      useNewVersionReloadPrompt({ showPrompt, hidePrompt, reload, router })
+    )
+
+    await result.checkNow()
+    expect(beforeEach).toHaveBeenCalledTimes(1)
+
+    // Simulate the next navigation.
+    const guard = beforeEach.mock.calls[0][0] as () => unknown
+    const outcome = guard()
+
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(outcome).toBe(false)
+    stop()
+  })
+})

--- a/src/platform/updates/common/useNewVersionReloadPrompt.ts
+++ b/src/platform/updates/common/useNewVersionReloadPrompt.ts
@@ -1,6 +1,6 @@
 import { useEventListener } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { watch } from 'vue'
+import { onScopeDispose, watch } from 'vue'
 import type { Router } from 'vue-router'
 
 import { useExecutionStore } from '@/stores/executionStore'
@@ -101,6 +101,13 @@ export function useNewVersionReloadPrompt(
       if (ready) maybeShowPrompt()
     }
   )
+
+  // Don't leak the navigation guard if this consumer is torn down before a
+  // navigation happens.
+  onScopeDispose(() => {
+    removeNavGuard?.()
+    removeNavGuard = undefined
+  })
 
   return {
     accept,

--- a/src/platform/updates/common/useNewVersionReloadPrompt.ts
+++ b/src/platform/updates/common/useNewVersionReloadPrompt.ts
@@ -1,0 +1,115 @@
+import { useEventListener } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+import type { Router } from 'vue-router'
+
+import { useExecutionStore } from '@/stores/executionStore'
+
+import { useDesiredVersionStore } from './desiredVersionStore'
+
+export const NEW_VERSION_TOAST_GROUP = 'new-version-available'
+
+interface UseNewVersionReloadPromptOptions {
+  /**
+   * Called when drift is detected and the tab is idle, to surface the
+   * non-blocking prompt. Wiring supplies a toast opener; tests supply a spy.
+   */
+  showPrompt: () => void
+  /**
+   * Called to tear down the prompt (e.g. when it should no longer be shown).
+   * Optional — wiring may leave the toast to the user's dismiss action.
+   */
+  hidePrompt?: () => void
+  /** Reload the page. Injectable so tests don't touch `window.location`. */
+  reload?: () => void
+  /**
+   * When provided, a one-shot navigation guard reloads onto the fresh version
+   * on the next in-app navigation, evicting the tab even if the prompt was
+   * dismissed. This is the "reload on next nav" half of the acceptance criteria.
+   */
+  router?: Router
+}
+
+/**
+ * Soft "new version available" reload prompt.
+ *
+ * Polls the desired-version signal cheaply — on window focus, never on a tight
+ * timer — and, when the running bundle has drifted from the version the edge now
+ * serves, surfaces a non-blocking, dismissible prompt offering a reload. The
+ * prompt is suppressed while a generation is running so we never interrupt
+ * active work; it re-evaluates once the tab returns to idle.
+ *
+ * Accepting reloads immediately. If a router is supplied, the next in-app
+ * navigation also reloads onto the fresh version, so a dismissed prompt still
+ * eventually evicts a retired tab.
+ */
+export function useNewVersionReloadPrompt(
+  options: UseNewVersionReloadPromptOptions
+) {
+  const {
+    showPrompt,
+    hidePrompt,
+    reload = () => window.location.reload(),
+    router
+  } = options
+
+  const desiredVersionStore = useDesiredVersionStore()
+  const { hasNewVersion } = storeToRefs(desiredVersionStore)
+  const executionStore = useExecutionStore()
+
+  let hasShownPrompt = false
+  let removeNavGuard: (() => void) | undefined
+
+  const canPrompt = () => hasNewVersion.value && executionStore.isIdle
+
+  const maybeShowPrompt = () => {
+    if (hasShownPrompt) return
+    if (!canPrompt()) return
+    hasShownPrompt = true
+    showPrompt()
+    // Once we know this tab is stale, evict it on the next navigation even if
+    // the user dismisses the toast without reloading.
+    if (router && !removeNavGuard) {
+      removeNavGuard = router.beforeEach(() => {
+        reload()
+        // Block the SPA transition; the full reload lands on the fresh version.
+        return false
+      })
+    }
+  }
+
+  const accept = () => {
+    hidePrompt?.()
+    reload()
+  }
+
+  const dismiss = () => {
+    hidePrompt?.()
+  }
+
+  // Cheap polling: re-probe the edge whenever the tab regains focus, then
+  // re-evaluate whether to prompt. No setInterval / tight loop.
+  useEventListener(window, 'focus', () => {
+    void desiredVersionStore.refresh().then(maybeShowPrompt)
+  })
+
+  // React to drift becoming known (via any refresh) and to the tab going idle
+  // after a generation finishes.
+  watch(
+    () => canPrompt(),
+    (ready) => {
+      if (ready) maybeShowPrompt()
+    }
+  )
+
+  return {
+    accept,
+    dismiss,
+    /** Perform an initial probe + evaluation (e.g. on mount). */
+    checkNow: () => desiredVersionStore.refresh().then(maybeShowPrompt),
+    /** For tests: has the prompt been surfaced this session. */
+    get hasShownPrompt() {
+      return hasShownPrompt
+    }
+  }
+}

--- a/src/platform/updates/common/useNewVersionReloadPrompt.ts
+++ b/src/platform/updates/common/useNewVersionReloadPrompt.ts
@@ -93,12 +93,19 @@ export function useNewVersionReloadPrompt(
     void desiredVersionStore.refresh().then(maybeShowPrompt)
   })
 
-  // React to drift becoming known (via any refresh) and to the tab going idle
-  // after a generation finishes.
+  // React to drift becoming known via any refresh.
+  watch(hasNewVersion, (drifted) => {
+    if (drifted) maybeShowPrompt()
+  })
+
+  // Re-probe the edge once a generation finishes, so a version that was promoted
+  // while the tab was busy is detected promptly instead of waiting for the next
+  // window-focus event. (While busy we never interrupt; this fires on the
+  // idle transition.)
   watch(
-    () => canPrompt(),
-    (ready) => {
-      if (ready) maybeShowPrompt()
+    () => executionStore.isIdle,
+    (isIdle) => {
+      if (isIdle) void desiredVersionStore.refresh().then(maybeShowPrompt)
     }
   )
 

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -23,6 +23,7 @@
   <GlobalToast />
   <InviteAcceptedToast />
   <RerouteMigrationToast />
+  <NewVersionReloadToast v-if="isCloud" />
   <ModelImportProgressDialog />
   <AssetExportProgressDialog />
   <ManagerProgressToast />
@@ -71,6 +72,7 @@ import { isCloud, isDesktop } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { getShellLayoutSnapshot } from '@/platform/telemetry/utils/getShellLayoutSnapshot'
+import NewVersionReloadToast from '@/platform/updates/common/NewVersionReloadToast.vue'
 import { useFrontendVersionMismatchWarning } from '@/platform/updates/common/useFrontendVersionMismatchWarning'
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'


### PR DESCRIPTION
<!-- ccr-slack-attribution -->
_Requested by **Luke Mino-Altherr** · [Slack thread](https://comfy-organization.slack.com/archives/C0BLD7MN9N2/p1785538345621109)_

## Summary

Adds a soft, non-blocking "new version available" reload prompt: an open tab compares its running build SHA against the version the edge currently serves and, on drift, offers a reload.

## Changes

- **What**:
  - Extracts the existing `HEAD /` probe of the `X-Frontend-Version` response header out of `initDatadogRum` into a shared `frontendVersionProbe` helper, so the RUM canary tagging and the new prompt read the desired version the same way (no duplicated fetch). `initDatadogRum` behavior is unchanged.
  - `desiredVersionStore` tracks the desired version (from the edge header) vs the running bundle (`__COMFYUI_FRONTEND_COMMIT__`) and exposes a `hasNewVersion` drift flag. A missing/unknown desired version never counts as drift.
  - `useNewVersionReloadPrompt` surfaces the prompt only when the tab is idle, so it never interrupts an active generation; it re-evaluates once a running generation finishes. It polls cheaply on window `focus` (no tight timer / `setInterval`) and installs a one-shot navigation guard that reloads onto the fresh version on the next in-app navigation, so a dismissed prompt still eventually evicts a stale tab.
  - `NewVersionReloadToast` renders a sticky, dismissible toast with Reload / Dismiss actions, wired into `GraphView` (cloud only) next to the existing frontend-version-mismatch warning.
  - Adds base `en` locale strings (other locales are generated by the existing translation CI).
- **Breaking**: none.
- **Dependencies**: none.

## Review Focus

- The prompt is intentionally suppressed while a generation is running (`executionStore.isIdle`) and re-checked when the tab returns to idle.
- Polling is focus-driven only; there is no background timer.
- The next-navigation reload guard is a deliberate second lever so retired tabs get evicted even if the toast is dismissed without an explicit reload.

## Screenshots (if applicable)

N/A (behavioral / toast). Verified against a live preview environment; see PR checks for the preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
