### PR TITLE
feat(website): add MiniMax H3 launch page

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -15,7 +15,10 @@ const SITEMAP_EXCLUDED_PATHNAMES = new Set([
     PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
   ),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
-  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`)
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
+  // Embargoed until the MiniMax H3 OSS weights are public. Drop these two
+  // entries in the same PR that clears `noindexUntilLaunch` on the pages.
+  ...LOCALE_PREFIXES.map((prefix) => `${prefix}/minimax-h3`)
 ])
 
 function isExcludedFromSitemap(page: string): boolean {

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -17,7 +17,8 @@ const SITEMAP_EXCLUDED_PATHNAMES = new Set([
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/individual-submission`),
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/booking-confirmation`),
   // Embargoed until the MiniMax H3 OSS weights are public. Drop these two
-  // entries in the same PR that clears `noindexUntilLaunch` on the pages.
+  // entries in the same PR that clears `minimaxH3NoindexUntilLaunch` in
+  // src/data/minimaxH3.ts.
   ...LOCALE_PREFIXES.map((prefix) => `${prefix}/minimax-h3`)
 ])
 

--- a/apps/website/e2e/minimax-h3.spec.ts
+++ b/apps/website/e2e/minimax-h3.spec.ts
@@ -8,7 +8,7 @@ import { test } from './fixtures/blockExternalMedia'
 const PATH_EN = '/minimax-h3'
 const PATH_ZH = '/zh-CN/minimax-h3'
 const LAUNCH_WORKFLOW_COUNT = 3
-const FAQ_COUNT = 4
+const FAQ_COUNT = 6
 
 const LOCALES: ReadonlyArray<readonly [string, Locale]> = [
   [PATH_EN, 'en'],

--- a/apps/website/e2e/minimax-h3.spec.ts
+++ b/apps/website/e2e/minimax-h3.spec.ts
@@ -7,6 +7,8 @@ import { test } from './fixtures/blockExternalMedia'
 
 const PATH_EN = '/minimax-h3'
 const PATH_ZH = '/zh-CN/minimax-h3'
+const LAUNCH_WORKFLOW_COUNT = 3
+const FAQ_COUNT = 4
 
 const LOCALES: ReadonlyArray<readonly [string, Locale]> = [
   [PATH_EN, 'en'],
@@ -53,6 +55,15 @@ test.describe('MiniMax H3 page — desktop @smoke', () => {
     await heading.scrollIntoViewIfNeeded()
     await expect(heading).toBeVisible()
 
+    // Rob committed to three launch workflows; pin the count so emptying the
+    // data file fails here rather than silently shipping an empty section.
+    const workflows = page
+      .locator('section')
+      .filter({ has: heading })
+      .getByRole('listitem')
+    await expect(workflows).toHaveCount(LAUNCH_WORKFLOW_COUNT)
+    expect(minimaxH3Workflows).toHaveLength(LAUNCH_WORKFLOW_COUNT)
+
     for (const workflow of minimaxH3Workflows) {
       await expect(
         page.getByRole('heading', { level: 3, name: workflow.title.en })
@@ -92,6 +103,8 @@ test.describe('MiniMax H3 page — desktop @smoke', () => {
     })
     await heading.scrollIntoViewIfNeeded()
     await expect(heading).toBeVisible()
+
+    expect(minimaxH3Faqs).toHaveLength(FAQ_COUNT)
 
     for (const faq of minimaxH3Faqs) {
       await expect(

--- a/apps/website/e2e/minimax-h3.spec.ts
+++ b/apps/website/e2e/minimax-h3.spec.ts
@@ -1,0 +1,126 @@
+import { expect } from '@playwright/test'
+
+import { minimaxH3Faqs, minimaxH3Workflows } from '../src/data/minimaxH3'
+import type { Locale } from '../src/i18n/translations'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH_EN = '/minimax-h3'
+const PATH_ZH = '/zh-CN/minimax-h3'
+
+const LOCALES: ReadonlyArray<readonly [string, Locale]> = [
+  [PATH_EN, 'en'],
+  [PATH_ZH, 'zh-CN']
+]
+
+function heroTitle(locale: Locale) {
+  return `${t('minimaxH3.hero.titleLead', locale)} ${t('minimaxH3.hero.titleTrail', locale)}`
+}
+
+test.describe('MiniMax H3 page — desktop @smoke', () => {
+  for (const [path, locale] of LOCALES) {
+    test(`renders the configured title at ${path}`, async ({ page }) => {
+      await page.goto(path)
+      await expect(page).toHaveTitle(t('minimaxH3.meta.title', locale))
+    })
+
+    test(`renders the hero heading at ${path}`, async ({ page }) => {
+      await page.goto(path)
+      await expect(
+        page.getByRole('heading', { level: 1, name: heroTitle(locale) })
+      ).toBeVisible()
+    })
+  }
+
+  // The OSS weights are not public yet, so the page must stay out of the index
+  // until the launch PR flips `noindexUntilLaunch`.
+  test('stays unlisted at both locales', async ({ page }) => {
+    for (const [path] of LOCALES) {
+      await page.goto(path)
+      await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+        'content',
+        'noindex, nofollow'
+      )
+    }
+  })
+
+  test('renders every launch workflow', async ({ page }) => {
+    await page.goto(PATH_EN)
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: t('minimaxH3.workflows.heading', 'en')
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+
+    for (const workflow of minimaxH3Workflows) {
+      await expect(
+        page.getByRole('heading', { level: 3, name: workflow.title.en })
+      ).toBeVisible()
+    }
+  })
+
+  test('renders the banner heading and both CTAs', async ({ page }) => {
+    await page.goto(PATH_EN)
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: t('minimaxH3.banner.heading', 'en')
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+
+    const banner = page
+      .locator('section')
+      .filter({ has: heading })
+      .filter({ hasText: t('minimaxH3.banner.heading', 'en') })
+
+    await expect(
+      banner.getByRole('link', { name: t('minimaxH3.banner.primaryCta', 'en') })
+    ).toBeVisible()
+    await expect(
+      banner.getByRole('link', {
+        name: t('minimaxH3.banner.secondaryCta', 'en')
+      })
+    ).toBeVisible()
+  })
+
+  test('renders every FAQ question', async ({ page }) => {
+    await page.goto(PATH_EN)
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: t('minimaxH3.faq.heading', 'en')
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+
+    for (const faq of minimaxH3Faqs) {
+      await expect(
+        page.getByRole('button', { name: faq.question.en })
+      ).toBeVisible()
+    }
+  })
+})
+
+test.describe('MiniMax H3 page — mobile @mobile', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('renders the hero heading and both hero CTAs', async ({ page }) => {
+    await page.goto(PATH_EN)
+
+    const heading = page.getByRole('heading', {
+      level: 1,
+      name: heroTitle('en')
+    })
+    await expect(heading).toBeVisible()
+
+    // Scoped: the hero and banner CTAs share the "RUN MINIMAX H3" label.
+    const hero = page.locator('section').filter({ has: heading })
+
+    await expect(
+      hero.getByRole('link', { name: t('minimaxH3.hero.primaryCta', 'en') })
+    ).toBeVisible()
+    await expect(
+      hero.getByRole('link', { name: t('minimaxH3.hero.secondaryCta', 'en') })
+    ).toBeVisible()
+  })
+})

--- a/apps/website/src/config/routes.test.ts
+++ b/apps/website/src/config/routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { localizeHref } from './routes'
+import { getRoutes, localizeHref } from './routes'
 
 describe('localizeHref', () => {
   it('prefixes an internal path for a non-default locale', () => {
@@ -19,5 +19,15 @@ describe('localizeHref', () => {
 
   it('never prefixes locale-invariant routes', () => {
     expect(localizeHref('/terms-of-service', 'zh-CN')).toBe('/terms-of-service')
+  })
+})
+
+describe('getRoutes minimaxH3', () => {
+  it('serves the MiniMax H3 page at its canonical path for en', () => {
+    expect(getRoutes('en').minimaxH3).toBe('/minimax-h3')
+  })
+
+  it('serves a localized MiniMax H3 path for zh-CN', () => {
+    expect(getRoutes('zh-CN').minimaxH3).toBe('/zh-CN/minimax-h3')
   })
 })

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -23,6 +23,7 @@ const baseRoutes = {
   contact: '/contact',
   models: '/p/supported-models',
   mcp: '/mcp',
+  minimaxH3: '/minimax-h3',
   brand: '/brand'
 } as const
 

--- a/apps/website/src/data/minimaxH3.ts
+++ b/apps/website/src/data/minimaxH3.ts
@@ -39,8 +39,8 @@ export interface MinimaxH3Highlight {
   detail: LocalizedText
 }
 
-// Each highlight restates a claim already made in the hero subhead on the
-// Figma frame, so nothing here is a new marketing claim.
+// Each highlight restates a claim already made in the hero description, so
+// nothing here is a new marketing claim.
 export const minimaxH3Highlights: readonly MinimaxH3Highlight[] = [
   {
     id: 'open-weights',
@@ -67,11 +67,11 @@ export const minimaxH3Highlights: readonly MinimaxH3Highlight[] = [
     }
   },
   {
-    id: 'multi-modal',
-    label: { en: 'Multi-modal I/O', 'zh-CN': '多模态输入输出' },
+    id: 'local-hardware',
+    label: { en: 'Runs on your hardware', 'zh-CN': '在你的硬件上运行' },
     detail: {
-      en: 'Conditions on input audio instead of overwriting it.',
-      'zh-CN': '以输入音频作为条件，而非覆盖或丢弃它。'
+      en: 'A big model made small enough to run comfortably on a regular RTX 3060.',
+      'zh-CN': '大模型经过压缩，一张普通的 RTX 3060 即可流畅运行。'
     }
   }
 ] as const
@@ -92,8 +92,8 @@ export const minimaxH3Workflows: readonly MinimaxH3Workflow[] = [
     id: 'text-to-video',
     title: { en: 'Text to video', 'zh-CN': '文本生成视频' },
     description: {
-      en: 'Describe the shot and let H3 direct it, audio included.',
-      'zh-CN': '描述镜头，让 H3 完成拍摄，并同步生成音频。'
+      en: 'Write the shot and H3 renders it, audio included.',
+      'zh-CN': '写下镜头描述，H3 渲染成片，并同步生成音频。'
     },
     videoSrc: media.textToVideo,
     href: externalLinks.workflows
@@ -102,8 +102,8 @@ export const minimaxH3Workflows: readonly MinimaxH3Workflow[] = [
     id: 'image-to-video',
     title: { en: 'Image to video', 'zh-CN': '图像生成视频' },
     description: {
-      en: 'Bring a still into motion without losing the frame you set.',
-      'zh-CN': '让静态画面动起来，同时保留你设定的构图。'
+      en: 'Bring a still into motion, or pin the first and last frame and H3 fills the shot.',
+      'zh-CN': '让静态画面动起来，或固定首末帧，由 H3 补全整个镜头。'
     },
     videoSrc: media.imageToVideo,
     href: externalLinks.workflows
@@ -126,8 +126,10 @@ export interface MinimaxH3Faq {
   answer: LocalizedText
 }
 
-// Answers are deliberately limited to facts already public: the open-weights
-// release, the specs on the Figma frame, and the existing partner node.
+// Answers are deliberately limited to facts in the final launch email copy
+// approved in #gtm-mini-max and the open-weights release itself. Each answer
+// opens with a self-contained direct statement so it can be lifted verbatim
+// into search AI overviews and the FAQPage structured data.
 export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
   {
     id: 'what-is-minimax-h3',
@@ -136,45 +138,69 @@ export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
       'zh-CN': 'MiniMax H3 是什么？'
     },
     answer: {
-      en: 'MiniMax H3 is the open release of Hailuo 3.0, a video model with full multi-modal input and output. It generates five to fifteen second clips at up to 2K with native stereo audio in a single pass.',
+      en: 'MiniMax H3 is the open-weight release of Hailuo 3.0, a video generation model from MiniMax. It turns text, images, or reference inputs into video with stereo sound, at up to 2K resolution and 5 to 15 seconds per generation.',
       'zh-CN':
-        'MiniMax H3 是 Hailuo 3.0 的开源版本，是一款支持完整多模态输入输出的视频模型。它可一次性生成 5 至 15 秒、最高 2K 并带原生立体声的片段。'
+        'MiniMax H3 是 Hailuo 3.0 的开放权重版本，是 MiniMax 推出的视频生成模型。它可将文本、图像或参考输入生成带立体声的视频，最高 2K 分辨率，每次生成 5 至 15 秒。'
     }
   },
   {
-    id: 'audio-handling',
+    id: 'open-source-free',
     question: {
-      en: 'How does H3 handle input audio?',
-      'zh-CN': 'H3 如何处理输入音频？'
+      en: 'Is MiniMax H3 free and open source?',
+      'zh-CN': 'MiniMax H3 是免费开源的吗？'
     },
     answer: {
-      en: 'H3 conditions on the audio you supply rather than overwriting or discarding it, so a supplied track shapes the generation instead of being replaced by one.',
+      en: 'The MiniMax H3 weights are openly released. Download them and run H3 locally in ComfyUI at no cost beyond your own hardware. On Comfy Cloud, H3 runs on hosted GPUs and generations are billed in credits; current rates are on the pricing page.',
       'zh-CN':
-        'H3 会以你提供的音频作为生成条件，而不是覆盖或丢弃它，因此你的音轨会影响生成结果，而非被替换掉。'
+        'MiniMax H3 的权重已开放发布。下载权重后即可在本地 ComfyUI 中免费运行，只需自备硬件。在 Comfy Cloud 上，H3 在托管 GPU 上运行，按积分计费，最新费率见定价页面。'
     }
   },
   {
-    id: 'where-to-run',
+    id: 'gpu-requirements',
     question: {
-      en: 'Where can I run MiniMax H3?',
-      'zh-CN': '我可以在哪里运行 MiniMax H3？'
+      en: 'What GPU do I need to run MiniMax H3 locally?',
+      'zh-CN': '本地运行 MiniMax H3 需要什么 GPU？'
     },
     answer: {
-      en: 'Run it on Comfy Cloud with no local GPU, or locally in ComfyUI now that the weights are open. The MiniMax partner node is already available in ComfyUI.',
+      en: 'MiniMax H3 runs comfortably on a regular RTX 3060 in ComfyUI. It is a big model made small enough for consumer hardware, so no datacenter GPU is required.',
       'zh-CN':
-        '你可以在 Comfy Cloud 上运行，无需本地 GPU；权重开放后也可在本地的 ComfyUI 中运行。MiniMax 合作伙伴节点已在 ComfyUI 中提供。'
+        '在 ComfyUI 中，一张普通的 RTX 3060 就能流畅运行 MiniMax H3。这个大模型经过压缩，适配消费级硬件，无需数据中心级 GPU。'
     }
   },
   {
-    id: 'cost',
+    id: 'generation-modes',
     question: {
-      en: 'What does it cost?',
-      'zh-CN': '费用是多少？'
+      en: 'What can MiniMax H3 generate?',
+      'zh-CN': 'MiniMax H3 能生成什么？'
     },
     answer: {
-      en: 'Running the weights locally is free. On Comfy Cloud, H3 is billed per second of generated video like other partner models — see the pricing page for current rates.',
+      en: 'MiniMax H3 supports text to video, image to video with first and last frame control, reference to video, and edits to an existing shot in place. Every clip includes stereo sound, generated in the same pass as the frames.',
       'zh-CN':
-        '在本地运行权重是免费的。在 Comfy Cloud 上，H3 与其他合作伙伴模型一样按生成视频的秒数计费，具体费率请查看定价页面。'
+        'MiniMax H3 支持文本生成视频、带首末帧控制的图像生成视频、参考生成视频，以及对现有镜头的原位编辑。每段片段都带立体声，与画面在同一次生成中输出。'
+    }
+  },
+  {
+    id: 'hailuo-relationship',
+    question: {
+      en: 'How is MiniMax H3 related to Hailuo 3.0?',
+      'zh-CN': 'MiniMax H3 与 Hailuo 3.0 是什么关系？'
+    },
+    answer: {
+      en: 'MiniMax H3 is the open release of Hailuo 3.0. The generations come from the same model family; the difference is that H3 ships weights you can download, inspect, and run yourself.',
+      'zh-CN':
+        'MiniMax H3 就是 Hailuo 3.0 的开源版本。生成能力来自同一模型家族，区别在于 H3 提供可下载、可检查、可自行运行的权重。'
+    }
+  },
+  {
+    id: 'how-to-run',
+    question: {
+      en: 'How do I run MiniMax H3 in ComfyUI?',
+      'zh-CN': '如何在 ComfyUI 中运行 MiniMax H3？'
+    },
+    answer: {
+      en: 'Update ComfyUI to the latest version, open a MiniMax H3 workflow template, and press Run. The same workflow runs locally on your GPU or on Comfy Cloud with no local install.',
+      'zh-CN':
+        '将 ComfyUI 更新到最新版本，打开 MiniMax H3 工作流模板，点击运行即可。同一个工作流既可在本地 GPU 上运行，也可在无需本地安装的 Comfy Cloud 上运行。'
     }
   }
 ] as const

--- a/apps/website/src/data/minimaxH3.ts
+++ b/apps/website/src/data/minimaxH3.ts
@@ -22,7 +22,7 @@ export const minimaxH3HeroVideo = media.hero
 // Gates both locale pages until the OSS weights are public. Clearing it also
 // starts emitting their FAQ structured data, and must be paired with dropping
 // /minimax-h3 from SITEMAP_EXCLUDED_PATHNAMES in astro.config.ts.
-export const minimaxH3NoindexUntilLaunch = true
+export const minimaxH3NoindexUntilLaunch: boolean = true
 
 // CTA destinations. `runModel` is a stand-in for the launch workflow deep link
 // — Rob owns picking which of Lin's workflows the CTA points at, so it lands

--- a/apps/website/src/data/minimaxH3.ts
+++ b/apps/website/src/data/minimaxH3.ts
@@ -19,6 +19,11 @@ const media = {
 
 export const minimaxH3HeroVideo = media.hero
 
+// Gates both locale pages until the OSS weights are public. Clearing it also
+// starts emitting their FAQ structured data, and must be paired with dropping
+// /minimax-h3 from SITEMAP_EXCLUDED_PATHNAMES in astro.config.ts.
+export const minimaxH3NoindexUntilLaunch = true
+
 // CTA destinations. `runModel` is a stand-in for the launch workflow deep link
 // — Rob owns picking which of Lin's workflows the CTA points at, so it lands
 // on Comfy Cloud until that URL exists.

--- a/apps/website/src/data/minimaxH3.ts
+++ b/apps/website/src/data/minimaxH3.ts
@@ -1,0 +1,175 @@
+import type { LocalizedText } from '../i18n/translations'
+
+import { externalLinks } from '../config/routes'
+
+// PLACEHOLDER MEDIA. The MiniMax H3 renders June linked in the Figma
+// (node 9770-37353) are not reachable from this sandbox — the Figma token is
+// expired — so every clip below points at an already-hosted asset purely so
+// the preview renders. Swap these six URLs for the real
+// media.comfy.org/website/minimax-h3/* encodes before launch; nothing else
+// needs to change.
+const media = {
+  hero: 'https://media.comfy.org/website/homepage/showcase/video-showcase.webm',
+  textToVideo: 'https://media.comfy.org/website/cloud/ai-models/wan-22.webm',
+  imageToVideo:
+    'https://media.comfy.org/website/cloud/ai-models/seedance-20.webm',
+  referenceToVideo:
+    'https://media.comfy.org/website/cloud/ai-models/grok-video.webm'
+} as const
+
+export const minimaxH3HeroVideo = media.hero
+
+// CTA destinations. `runModel` is a stand-in for the launch workflow deep link
+// — Rob owns picking which of Lin's workflows the CTA points at, so it lands
+// on Comfy Cloud until that URL exists.
+export const minimaxH3Ctas = {
+  tryForFree: externalLinks.cloudCta('minimax_h3_lp'),
+  runModel: externalLinks.cloud,
+  workflows: externalLinks.workflows
+} as const
+
+export interface MinimaxH3Highlight {
+  id: string
+  label: LocalizedText
+  detail: LocalizedText
+}
+
+// Each highlight restates a claim already made in the hero subhead on the
+// Figma frame, so nothing here is a new marketing claim.
+export const minimaxH3Highlights: readonly MinimaxH3Highlight[] = [
+  {
+    id: 'open-weights',
+    label: { en: 'Open weights', 'zh-CN': '开放权重' },
+    detail: {
+      en: 'The open release of Hailuo 3.0, runnable locally.',
+      'zh-CN': 'Hailuo 3.0 的开源版本，可在本地运行。'
+    }
+  },
+  {
+    id: 'resolution',
+    label: { en: 'Up to 2K', 'zh-CN': '最高 2K' },
+    detail: {
+      en: 'Five to fifteen seconds per generation.',
+      'zh-CN': '每次生成 5 至 15 秒。'
+    }
+  },
+  {
+    id: 'audio',
+    label: { en: 'Native stereo', 'zh-CN': '原生立体声' },
+    detail: {
+      en: 'Sound on every clip, generated in the same pass.',
+      'zh-CN': '每段片段都带声音，一次生成同步输出。'
+    }
+  },
+  {
+    id: 'multi-modal',
+    label: { en: 'Multi-modal I/O', 'zh-CN': '多模态输入输出' },
+    detail: {
+      en: 'Conditions on input audio instead of overwriting it.',
+      'zh-CN': '以输入音频作为条件，而非覆盖或丢弃它。'
+    }
+  }
+] as const
+
+export interface MinimaxH3Workflow {
+  id: string
+  title: LocalizedText
+  description: LocalizedText
+  videoSrc: string
+  href: string
+}
+
+// The three launch workflows Rob confirmed in #gtm-mini-max. Titles and
+// descriptions are placeholders until Lin's templates are published — the
+// `href` should become each template's permalink at that point.
+export const minimaxH3Workflows: readonly MinimaxH3Workflow[] = [
+  {
+    id: 'text-to-video',
+    title: { en: 'Text to video', 'zh-CN': '文本生成视频' },
+    description: {
+      en: 'Describe the shot and let H3 direct it, audio included.',
+      'zh-CN': '描述镜头，让 H3 完成拍摄，并同步生成音频。'
+    },
+    videoSrc: media.textToVideo,
+    href: externalLinks.workflows
+  },
+  {
+    id: 'image-to-video',
+    title: { en: 'Image to video', 'zh-CN': '图像生成视频' },
+    description: {
+      en: 'Bring a still into motion without losing the frame you set.',
+      'zh-CN': '让静态画面动起来，同时保留你设定的构图。'
+    },
+    videoSrc: media.imageToVideo,
+    href: externalLinks.workflows
+  },
+  {
+    id: 'reference-to-video',
+    title: { en: 'Reference to video', 'zh-CN': '参考图生成视频' },
+    description: {
+      en: 'Carry a subject or style across every generation.',
+      'zh-CN': '在每一次生成中延续同一主体或风格。'
+    },
+    videoSrc: media.referenceToVideo,
+    href: externalLinks.workflows
+  }
+] as const
+
+export interface MinimaxH3Faq {
+  id: string
+  question: LocalizedText
+  answer: LocalizedText
+}
+
+// Answers are deliberately limited to facts already public: the open-weights
+// release, the specs on the Figma frame, and the existing partner node.
+export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
+  {
+    id: 'what-is-minimax-h3',
+    question: {
+      en: 'What is MiniMax H3?',
+      'zh-CN': 'MiniMax H3 是什么？'
+    },
+    answer: {
+      en: 'MiniMax H3 is the open release of Hailuo 3.0, a video model with full multi-modal input and output. It generates five to fifteen second clips at up to 2K with native stereo audio in a single pass.',
+      'zh-CN':
+        'MiniMax H3 是 Hailuo 3.0 的开源版本，是一款支持完整多模态输入输出的视频模型。它可一次性生成 5 至 15 秒、最高 2K 并带原生立体声的片段。'
+    }
+  },
+  {
+    id: 'audio-handling',
+    question: {
+      en: 'How does H3 handle input audio?',
+      'zh-CN': 'H3 如何处理输入音频？'
+    },
+    answer: {
+      en: 'H3 conditions on the audio you supply rather than overwriting or discarding it, so a supplied track shapes the generation instead of being replaced by one.',
+      'zh-CN':
+        'H3 会以你提供的音频作为生成条件，而不是覆盖或丢弃它，因此你的音轨会影响生成结果，而非被替换掉。'
+    }
+  },
+  {
+    id: 'where-to-run',
+    question: {
+      en: 'Where can I run MiniMax H3?',
+      'zh-CN': '我可以在哪里运行 MiniMax H3？'
+    },
+    answer: {
+      en: 'Run it on Comfy Cloud with no local GPU, or locally in ComfyUI now that the weights are open. The MiniMax partner node is already available in ComfyUI.',
+      'zh-CN':
+        '你可以在 Comfy Cloud 上运行，无需本地 GPU；权重开放后也可在本地的 ComfyUI 中运行。MiniMax 合作伙伴节点已在 ComfyUI 中提供。'
+    }
+  },
+  {
+    id: 'cost',
+    question: {
+      en: 'What does it cost?',
+      'zh-CN': '费用是多少？'
+    },
+    answer: {
+      en: 'Running the weights locally is free. On Comfy Cloud, H3 is billed per second of generated video like other partner models — see the pricing page for current rates.',
+      'zh-CN':
+        '在本地运行权重是免费的。在 Comfy Cloud 上，H3 与其他合作伙伴模型一样按生成视频的秒数计费，具体费率请查看定价页面。'
+    }
+  }
+] as const

--- a/apps/website/src/data/minimaxH3.ts
+++ b/apps/website/src/data/minimaxH3.ts
@@ -47,7 +47,7 @@ export const minimaxH3Highlights: readonly MinimaxH3Highlight[] = [
     label: { en: 'Open weights', 'zh-CN': '开放权重' },
     detail: {
       en: 'The open release of Hailuo 3.0, runnable locally.',
-      'zh-CN': 'Hailuo 3.0 的开源版本，可在本地运行。'
+      'zh-CN': 'Hailuo 3.0 的开放权重版本，可在本地运行。'
     }
   },
   {
@@ -174,9 +174,9 @@ export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
       'zh-CN': 'MiniMax H3 能生成什么？'
     },
     answer: {
-      en: 'MiniMax H3 supports text to video, image to video with first and last frame control, reference to video, and edits to an existing shot in place. Every clip includes stereo sound, generated in the same pass as the frames.',
+      en: 'MiniMax H3 supports text to video, image to video with first and last frame control, and reference to video. Every clip includes stereo sound, generated in the same pass as the frames.',
       'zh-CN':
-        'MiniMax H3 支持文本生成视频、带首末帧控制的图像生成视频、参考生成视频，以及对现有镜头的原位编辑。每段片段都带立体声，与画面在同一次生成中输出。'
+        'MiniMax H3 支持文本生成视频、带首末帧控制的图像生成视频，以及参考生成视频。每段片段都带立体声，与画面在同一次生成中输出。'
     }
   },
   {
@@ -188,7 +188,7 @@ export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
     answer: {
       en: 'MiniMax H3 is the open release of Hailuo 3.0. The generations come from the same model family; the difference is that H3 ships weights you can download, inspect, and run yourself.',
       'zh-CN':
-        'MiniMax H3 就是 Hailuo 3.0 的开源版本。生成能力来自同一模型家族，区别在于 H3 提供可下载、可检查、可自行运行的权重。'
+        'MiniMax H3 就是 Hailuo 3.0 的开放权重版本。生成能力来自同一模型家族，区别在于 H3 提供可下载、可检查、可自行运行的权重。'
     }
   },
   {
@@ -198,9 +198,9 @@ export const minimaxH3Faqs: readonly MinimaxH3Faq[] = [
       'zh-CN': '如何在 ComfyUI 中运行 MiniMax H3？'
     },
     answer: {
-      en: 'Update ComfyUI to the latest version, open a MiniMax H3 workflow template, and press Run. The same workflow runs locally on your GPU or on Comfy Cloud with no local install.',
+      en: 'Update ComfyUI to the latest version, load a MiniMax H3 workflow, and press Run. The same workflow runs locally on your GPU or on Comfy Cloud with no local install.',
       'zh-CN':
-        '将 ComfyUI 更新到最新版本，打开 MiniMax H3 工作流模板，点击运行即可。同一个工作流既可在本地 GPU 上运行，也可在无需本地安装的 Comfy Cloud 上运行。'
+        '将 ComfyUI 更新到最新版本，载入 MiniMax H3 工作流，点击运行即可。同一个工作流既可在本地 GPU 上运行，也可在无需本地安装的 Comfy Cloud 上运行。'
     }
   }
 ] as const

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4947,7 +4947,7 @@ const translations = {
   'minimaxH3.hero.description': {
     en: 'The open release of Hailuo 3.0. Feed it text or images and it generates video with real stereo sound, up to 2K and 15 seconds a clip. On ComfyUI, H3 runs comfortably on a regular RTX 3060.',
     'zh-CN':
-      'Hailuo 3.0 的开源版本。输入文本或图像，即可生成带真实立体声的视频，最高 2K，每段最长 15 秒。在 ComfyUI 中，一张普通的 RTX 3060 就能流畅运行 H3。'
+      'Hailuo 3.0 的开放权重版本。输入文本或图像，即可生成带真实立体声的视频，最高 2K，每段最长 15 秒。在 ComfyUI 中，一张普通的 RTX 3060 就能流畅运行 H3。'
   },
   'minimaxH3.hero.primaryCta': { en: 'TRY FOR FREE', 'zh-CN': '免费试用' },
   'minimaxH3.hero.secondaryCta': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4928,25 +4928,26 @@ const translations = {
     'zh-CN': '联系我们'
   },
 
-  // MiniMax H3 launch page (/minimax-h3). Hero and banner strings are verbatim
-  // from the Figma frame (node 9770-37353); remaining copy and the CTA button
-  // wording are unresolved (CRE-343). zh-CN hand-translated, native review
+  // MiniMax H3 launch page (/minimax-h3). Hero description and FAQ facts
+  // follow the final launch email copy approved in #gtm-mini-max; the Figma
+  // frame (node 9770-37353) still carries the earlier multi-modal draft that
+  // was corrected in that thread. zh-CN hand-translated, native review
   // welcome.
   'minimaxH3.meta.title': {
-    en: 'MiniMax H3 on Comfy — Open-Weights Video With Sound',
-    'zh-CN': 'Comfy 上的 MiniMax H3 — 开放权重、自带声音的视频模型'
+    en: 'MiniMax H3: Run Hailuo 3.0 Open Weights Free in ComfyUI',
+    'zh-CN': 'MiniMax H3：在 ComfyUI 免费运行 Hailuo 3.0 开放权重'
   },
   'minimaxH3.meta.description': {
-    en: 'Run MiniMax H3, the open release of Hailuo 3.0, on Comfy. Full multi-modal I/O, native stereo audio on every clip, up to 2K at five to fifteen seconds per generation.',
+    en: 'MiniMax H3 is the open-weight release of Hailuo 3.0. Text, image, or reference to video with stereo sound, up to 2K. Run it free in ComfyUI or on Comfy Cloud.',
     'zh-CN':
-      '在 Comfy 上运行 MiniMax H3——Hailuo 3.0 的开源版本。完整的多模态输入输出，每段片段自带原生立体声，最高 2K，每次生成 5 至 15 秒。'
+      'MiniMax H3 是 Hailuo 3.0 的开放权重版本。文本、图像或参考生成带立体声的视频，最高 2K。可在 ComfyUI 中免费运行，或使用 Comfy Cloud。'
   },
   'minimaxH3.hero.titleLead': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
   'minimaxH3.hero.titleTrail': { en: 'is here', 'zh-CN': '已上线' },
   'minimaxH3.hero.description': {
-    en: 'Open weights, full multi-modal I/O, native stereo on every clip. Up to 2K, 5 to 15s per generation. H3 actually conditions on input audio where others overwrite or drop it. The open release of Hailuo 3.0.',
+    en: 'The open release of Hailuo 3.0. Feed it text or images and it generates video with real stereo sound, up to 2K and 15 seconds a clip. On ComfyUI, H3 runs comfortably on a regular RTX 3060.',
     'zh-CN':
-      '开放权重，完整的多模态输入输出，每段片段都带原生立体声。最高 2K，每次生成 5 至 15 秒。当其他模型覆盖或丢弃输入音频时，H3 真正以它作为生成条件。这是 Hailuo 3.0 的开源版本。'
+      'Hailuo 3.0 的开源版本。输入文本或图像，即可生成带真实立体声的视频，最高 2K，每段最长 15 秒。在 ComfyUI 中，一张普通的 RTX 3060 就能流畅运行 H3。'
   },
   'minimaxH3.hero.primaryCta': { en: 'TRY FOR FREE', 'zh-CN': '免费试用' },
   'minimaxH3.hero.secondaryCta': {
@@ -4987,8 +4988,8 @@ const translations = {
     'zh-CN': '运行 Comfy 的各种方式。'
   },
   'minimaxH3.runOptions.subtitle': {
-    en: 'Local, cloud, API, or enterprise — the same graph runs everywhere.',
-    'zh-CN': '本地、云端、API 或企业版——同一个节点图，处处可运行。'
+    en: 'Local, cloud, API, or enterprise. The same graph runs everywhere.',
+    'zh-CN': '本地、云端、API 或企业版。同一个节点图，处处可运行。'
   },
   'minimaxH3.runOptions.cta': { en: 'Learn more', 'zh-CN': '了解更多' },
   'minimaxH3.faq.heading': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4926,6 +4926,74 @@ const translations = {
   'brand.questions.contact': {
     en: 'Contact Us',
     'zh-CN': '联系我们'
+  },
+
+  // MiniMax H3 launch page (/minimax-h3). Hero and banner strings are verbatim
+  // from the Figma frame (node 9770-37353); remaining copy and the CTA button
+  // wording are unresolved (CRE-343). zh-CN hand-translated, native review
+  // welcome.
+  'minimaxH3.meta.title': {
+    en: 'MiniMax H3 on Comfy — Open-Weights Video With Sound',
+    'zh-CN': 'Comfy 上的 MiniMax H3 — 开放权重、自带声音的视频模型'
+  },
+  'minimaxH3.meta.description': {
+    en: 'Run MiniMax H3, the open release of Hailuo 3.0, on Comfy. Full multi-modal I/O, native stereo audio on every clip, up to 2K at five to fifteen seconds per generation.',
+    'zh-CN':
+      '在 Comfy 上运行 MiniMax H3——Hailuo 3.0 的开源版本。完整的多模态输入输出，每段片段自带原生立体声，最高 2K，每次生成 5 至 15 秒。'
+  },
+  'minimaxH3.hero.titleLead': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
+  'minimaxH3.hero.titleTrail': { en: 'is here', 'zh-CN': '已上线' },
+  'minimaxH3.hero.description': {
+    en: 'Open weights, full multi-modal I/O, native stereo on every clip. Up to 2K, 5 to 15s per generation. H3 actually conditions on input audio where others overwrite or drop it. The open release of Hailuo 3.0.',
+    'zh-CN':
+      '开放权重，完整的多模态输入输出，每段片段都带原生立体声。最高 2K，每次生成 5 至 15 秒。当其他模型覆盖或丢弃输入音频时，H3 真正以它作为生成条件。这是 Hailuo 3.0 的开源版本。'
+  },
+  'minimaxH3.hero.primaryCta': { en: 'TRY FOR FREE', 'zh-CN': '免费试用' },
+  'minimaxH3.hero.secondaryCta': {
+    en: 'RUN MINIMAX H3',
+    'zh-CN': '运行 MiniMax H3'
+  },
+  'minimaxH3.hero.videoLabel': {
+    en: 'MiniMax H3 sample generation',
+    'zh-CN': 'MiniMax H3 生成示例'
+  },
+  'minimaxH3.highlights.heading': {
+    en: 'What lands with H3.',
+    'zh-CN': 'H3 带来了什么。'
+  },
+  'minimaxH3.workflows.heading': {
+    en: 'Three ways to run it.',
+    'zh-CN': '三种运行方式。'
+  },
+  'minimaxH3.workflows.subtitle': {
+    en: 'Open a workflow and start from a working graph rather than a blank canvas.',
+    'zh-CN': '打开工作流，从一个可用的节点图开始，而不是空白画布。'
+  },
+  'minimaxH3.workflows.cta': { en: 'Open workflow', 'zh-CN': '打开工作流' },
+  'minimaxH3.banner.heading': {
+    en: 'Up to 2K, with sound, in one generation.',
+    'zh-CN': '最高 2K，自带声音，一次生成。'
+  },
+  'minimaxH3.banner.primaryCta': {
+    en: 'RUN MINIMAX H3',
+    'zh-CN': '运行 MiniMax H3'
+  },
+  'minimaxH3.banner.secondaryCta': {
+    en: 'TRY WORKFLOWS',
+    'zh-CN': '试用工作流'
+  },
+  'minimaxH3.runOptions.heading': {
+    en: 'Every way to run Comfy.',
+    'zh-CN': '运行 Comfy 的各种方式。'
+  },
+  'minimaxH3.runOptions.subtitle': {
+    en: 'Local, cloud, API, or enterprise — the same graph runs everywhere.',
+    'zh-CN': '本地、云端、API 或企业版——同一个节点图，处处可运行。'
+  },
+  'minimaxH3.runOptions.cta': { en: 'Learn more', 'zh-CN': '了解更多' },
+  'minimaxH3.faq.heading': {
+    en: 'MiniMax H3, answered.',
+    'zh-CN': 'MiniMax H3 常见问题。'
   }
 } as const satisfies Record<string, Record<Locale, string>>
 

--- a/apps/website/src/pages/minimax-h3.astro
+++ b/apps/website/src/pages/minimax-h3.astro
@@ -6,7 +6,7 @@ import MinimaxH3HeroSection from '../templates/minimax-h3/MinimaxH3HeroSection.v
 import MinimaxH3HighlightsSection from '../templates/minimax-h3/MinimaxH3HighlightsSection.vue'
 import MinimaxH3RunOptionsSection from '../templates/minimax-h3/MinimaxH3RunOptionsSection.vue'
 import MinimaxH3WorkflowsSection from '../templates/minimax-h3/MinimaxH3WorkflowsSection.vue'
-import { minimaxH3Faqs } from '../data/minimaxH3'
+import { minimaxH3Faqs, minimaxH3NoindexUntilLaunch } from '../data/minimaxH3'
 import { t } from '../i18n/translations'
 import type { JsonLdNode } from '../utils/jsonLd'
 import { jsonLdId, pageContext } from '../utils/jsonLd'
@@ -16,11 +16,6 @@ const { locale, url } = pageContext(
   Astro.url.pathname,
   Astro.currentLocale,
 )
-
-// The OSS weights are not public until launch morning, so the page ships
-// unlisted: noindex, and no nav or footer entry. Flip this to false in the
-// launch PR and the FAQ structured data below starts emitting with it.
-const noindexUntilLaunch = true
 
 const faqPage: JsonLdNode = {
   '@type': 'FAQPage',
@@ -36,7 +31,7 @@ const faqPage: JsonLdNode = {
 <BaseLayout
   title={t('minimaxH3.meta.title', locale)}
   description={t('minimaxH3.meta.description', locale)}
-  noindex={noindexUntilLaunch}
+  noindex={minimaxH3NoindexUntilLaunch}
   extraJsonLd={[faqPage]}
 >
   <MinimaxH3HeroSection locale={locale} client:load />

--- a/apps/website/src/pages/minimax-h3.astro
+++ b/apps/website/src/pages/minimax-h3.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro'
+import MinimaxH3BannerSection from '../templates/minimax-h3/MinimaxH3BannerSection.vue'
+import MinimaxH3FaqSection from '../templates/minimax-h3/MinimaxH3FaqSection.vue'
+import MinimaxH3HeroSection from '../templates/minimax-h3/MinimaxH3HeroSection.vue'
+import MinimaxH3HighlightsSection from '../templates/minimax-h3/MinimaxH3HighlightsSection.vue'
+import MinimaxH3RunOptionsSection from '../templates/minimax-h3/MinimaxH3RunOptionsSection.vue'
+import MinimaxH3WorkflowsSection from '../templates/minimax-h3/MinimaxH3WorkflowsSection.vue'
+import { minimaxH3Faqs } from '../data/minimaxH3'
+import { t } from '../i18n/translations'
+import type { JsonLdNode } from '../utils/jsonLd'
+import { jsonLdId, pageContext } from '../utils/jsonLd'
+
+const { locale, url } = pageContext(
+  Astro.site,
+  Astro.url.pathname,
+  Astro.currentLocale,
+)
+
+// The OSS weights are not public until launch morning, so the page ships
+// unlisted: noindex, and no nav or footer entry. Flip this to false in the
+// launch PR and the FAQ structured data below starts emitting with it.
+const noindexUntilLaunch = true
+
+const faqPage: JsonLdNode = {
+  '@type': 'FAQPage',
+  '@id': jsonLdId(url, 'faq'),
+  mainEntity: minimaxH3Faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question[locale],
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer[locale] },
+  })),
+}
+---
+
+<BaseLayout
+  title={t('minimaxH3.meta.title', locale)}
+  description={t('minimaxH3.meta.description', locale)}
+  noindex={noindexUntilLaunch}
+  extraJsonLd={[faqPage]}
+>
+  <MinimaxH3HeroSection locale={locale} client:load />
+  <MinimaxH3HighlightsSection locale={locale} />
+  <MinimaxH3WorkflowsSection locale={locale} client:visible />
+  <MinimaxH3BannerSection locale={locale} />
+  <MinimaxH3RunOptionsSection locale={locale} />
+  <MinimaxH3FaqSection locale={locale} client:visible />
+</BaseLayout>

--- a/apps/website/src/pages/zh-CN/minimax-h3.astro
+++ b/apps/website/src/pages/zh-CN/minimax-h3.astro
@@ -1,0 +1,46 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import MinimaxH3BannerSection from '../../templates/minimax-h3/MinimaxH3BannerSection.vue'
+import MinimaxH3FaqSection from '../../templates/minimax-h3/MinimaxH3FaqSection.vue'
+import MinimaxH3HeroSection from '../../templates/minimax-h3/MinimaxH3HeroSection.vue'
+import MinimaxH3HighlightsSection from '../../templates/minimax-h3/MinimaxH3HighlightsSection.vue'
+import MinimaxH3RunOptionsSection from '../../templates/minimax-h3/MinimaxH3RunOptionsSection.vue'
+import MinimaxH3WorkflowsSection from '../../templates/minimax-h3/MinimaxH3WorkflowsSection.vue'
+import { minimaxH3Faqs } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+import type { JsonLdNode } from '../../utils/jsonLd'
+import { jsonLdId, pageContext } from '../../utils/jsonLd'
+
+const { locale, url } = pageContext(
+  Astro.site,
+  Astro.url.pathname,
+  Astro.currentLocale,
+)
+
+// Mirrors the launch gate on the English page — flip both together.
+const noindexUntilLaunch = true
+
+const faqPage: JsonLdNode = {
+  '@type': 'FAQPage',
+  '@id': jsonLdId(url, 'faq'),
+  mainEntity: minimaxH3Faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question[locale],
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer[locale] },
+  })),
+}
+---
+
+<BaseLayout
+  title={t('minimaxH3.meta.title', locale)}
+  description={t('minimaxH3.meta.description', locale)}
+  noindex={noindexUntilLaunch}
+  extraJsonLd={[faqPage]}
+>
+  <MinimaxH3HeroSection locale={locale} client:load />
+  <MinimaxH3HighlightsSection locale={locale} />
+  <MinimaxH3WorkflowsSection locale={locale} client:visible />
+  <MinimaxH3BannerSection locale={locale} />
+  <MinimaxH3RunOptionsSection locale={locale} />
+  <MinimaxH3FaqSection locale={locale} client:visible />
+</BaseLayout>

--- a/apps/website/src/pages/zh-CN/minimax-h3.astro
+++ b/apps/website/src/pages/zh-CN/minimax-h3.astro
@@ -6,7 +6,10 @@ import MinimaxH3HeroSection from '../../templates/minimax-h3/MinimaxH3HeroSectio
 import MinimaxH3HighlightsSection from '../../templates/minimax-h3/MinimaxH3HighlightsSection.vue'
 import MinimaxH3RunOptionsSection from '../../templates/minimax-h3/MinimaxH3RunOptionsSection.vue'
 import MinimaxH3WorkflowsSection from '../../templates/minimax-h3/MinimaxH3WorkflowsSection.vue'
-import { minimaxH3Faqs } from '../../data/minimaxH3'
+import {
+  minimaxH3Faqs,
+  minimaxH3NoindexUntilLaunch,
+} from '../../data/minimaxH3'
 import { t } from '../../i18n/translations'
 import type { JsonLdNode } from '../../utils/jsonLd'
 import { jsonLdId, pageContext } from '../../utils/jsonLd'
@@ -16,9 +19,6 @@ const { locale, url } = pageContext(
   Astro.url.pathname,
   Astro.currentLocale,
 )
-
-// Mirrors the launch gate on the English page — flip both together.
-const noindexUntilLaunch = true
 
 const faqPage: JsonLdNode = {
   '@type': 'FAQPage',
@@ -34,7 +34,7 @@ const faqPage: JsonLdNode = {
 <BaseLayout
   title={t('minimaxH3.meta.title', locale)}
   description={t('minimaxH3.meta.description', locale)}
-  noindex={noindexUntilLaunch}
+  noindex={minimaxH3NoindexUntilLaunch}
   extraJsonLd={[faqPage]}
 >
   <MinimaxH3HeroSection locale={locale} client:load />

--- a/apps/website/src/templates/minimax-h3/MinimaxH3BannerSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3BannerSection.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import CtaCenter01 from '../../components/blocks/CtaCenter01.vue'
+import { minimaxH3Ctas } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+</script>
+
+<template>
+  <CtaCenter01
+    :heading="t('minimaxH3.banner.heading', locale)"
+    :primary-cta="{
+      label: t('minimaxH3.banner.primaryCta', locale),
+      href: minimaxH3Ctas.runModel,
+      target: '_blank'
+    }"
+    :secondary-cta="{
+      label: t('minimaxH3.banner.secondaryCta', locale),
+      href: minimaxH3Ctas.workflows,
+      target: '_blank'
+    }"
+  />
+</template>

--- a/apps/website/src/templates/minimax-h3/MinimaxH3FaqSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3FaqSection.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import FAQSplit01 from '../../components/blocks/FAQSplit01.vue'
+import { minimaxH3Faqs } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+const faqs = minimaxH3Faqs.map((faq) => ({
+  id: faq.id,
+  question: faq.question[locale],
+  answer: faq.answer[locale]
+}))
+</script>
+
+<template>
+  <FAQSplit01 :heading="t('minimaxH3.faq.heading', locale)" :faqs="faqs" />
+</template>

--- a/apps/website/src/templates/minimax-h3/MinimaxH3HeroSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3HeroSection.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import BrandButton from '../../components/common/BrandButton.vue'
+import VideoPlayer from '../../components/common/VideoPlayer.vue'
+import { minimaxH3Ctas, minimaxH3HeroVideo } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+</script>
+
+<template>
+  <section class="max-w-9xl mx-auto px-6 py-12 lg:px-20 lg:py-16">
+    <VideoPlayer
+      :locale
+      :src="minimaxH3HeroVideo"
+      :aria-label="t('minimaxH3.hero.videoLabel', locale)"
+      autoplay
+      loop
+    />
+
+    <div class="mx-auto mt-10 flex max-w-2xl flex-col items-center text-center">
+      <h1
+        class="text-4xl font-light tracking-tight text-primary-comfy-canvas lg:text-6xl/tight"
+      >
+        {{ t('minimaxH3.hero.titleLead', locale) }}
+        <span class="text-primary-comfy-canvas/50">
+          {{ t('minimaxH3.hero.titleTrail', locale) }}
+        </span>
+      </h1>
+
+      <p
+        class="mt-6 text-base/relaxed font-light text-primary-comfy-canvas/80 lg:text-lg/relaxed"
+      >
+        {{ t('minimaxH3.hero.description', locale) }}
+      </p>
+
+      <div class="mt-8 flex w-full flex-col gap-4 sm:w-auto sm:flex-row">
+        <BrandButton
+          :href="minimaxH3Ctas.tryForFree"
+          target="_blank"
+          variant="solid"
+          size="lg"
+          class="w-full p-4 text-center lg:w-auto lg:min-w-52"
+        >
+          {{ t('minimaxH3.hero.primaryCta', locale) }}
+        </BrandButton>
+        <BrandButton
+          :href="minimaxH3Ctas.runModel"
+          target="_blank"
+          variant="outline"
+          size="lg"
+          class="w-full p-4 text-center lg:w-auto lg:min-w-52"
+        >
+          {{ t('minimaxH3.hero.secondaryCta', locale) }}
+        </BrandButton>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/minimax-h3/MinimaxH3HighlightsSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3HighlightsSection.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import { minimaxH3Highlights } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+</script>
+
+<template>
+  <section class="max-w-9xl mx-auto px-6 py-12 lg:px-20 lg:py-16">
+    <h2
+      class="text-3xl font-light tracking-tight text-primary-comfy-canvas lg:text-5xl/tight"
+    >
+      {{ t('minimaxH3.highlights.heading', locale) }}
+    </h2>
+
+    <dl class="mt-10 grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4">
+      <div
+        v-for="highlight in minimaxH3Highlights"
+        :key="highlight.id"
+        class="bg-transparency-white-t4 flex flex-col gap-3 p-6 lg:p-8"
+      >
+        <dt class="text-primary-comfy-yellow text-lg font-semibold">
+          {{ highlight.label[locale] }}
+        </dt>
+        <dd class="text-sm/relaxed font-light text-primary-comfy-canvas/70">
+          {{ highlight.detail[locale] }}
+        </dd>
+      </div>
+    </dl>
+  </section>
+</template>

--- a/apps/website/src/templates/minimax-h3/MinimaxH3RunOptionsSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3RunOptionsSection.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import ProductCard from '../../components/common/ProductCard.vue'
+import { getRoutes } from '../../config/routes'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+
+const routes = getRoutes(locale)
+
+const cards = [
+  { product: 'local', href: routes.download, bg: 'bg-primary-warm-gray' },
+  { product: 'cloud', href: routes.cloud, bg: 'bg-secondary-mauve' },
+  { product: 'api', href: routes.api, bg: 'bg-primary-comfy-plum' },
+  {
+    product: 'enterprise',
+    href: routes.cloudEnterprise,
+    bg: 'bg-secondary-cool-gray'
+  }
+] as const
+</script>
+
+<template>
+  <section
+    class="max-w-9xl mx-auto bg-primary-comfy-ink px-0 py-20 lg:px-20 lg:py-24"
+  >
+    <div class="flex flex-col items-center px-4 text-center">
+      <h2
+        class="text-3xl font-light tracking-tight text-primary-comfy-canvas lg:text-5xl/tight"
+      >
+        {{ t('minimaxH3.runOptions.heading', locale) }}
+      </h2>
+      <p class="mt-6 max-w-xl text-sm font-light text-primary-comfy-canvas/70">
+        {{ t('minimaxH3.runOptions.subtitle', locale) }}
+      </p>
+    </div>
+
+    <div
+      class="rounded-5xl bg-transparency-white-t4 mt-16 grid grid-cols-1 gap-4 p-4 lg:grid-cols-4 lg:p-2"
+    >
+      <ProductCard
+        v-for="card in cards"
+        :key="card.product"
+        :title="t(`products.${card.product}.title`, locale)"
+        :description="t(`products.${card.product}.description`, locale)"
+        :cta="t('minimaxH3.runOptions.cta', locale)"
+        :href="card.href"
+        :bg="card.bg"
+      />
+    </div>
+  </section>
+</template>

--- a/apps/website/src/templates/minimax-h3/MinimaxH3WorkflowsSection.vue
+++ b/apps/website/src/templates/minimax-h3/MinimaxH3WorkflowsSection.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { Locale } from '../../i18n/translations'
+
+import VideoPlayer from '../../components/common/VideoPlayer.vue'
+import { minimaxH3Workflows } from '../../data/minimaxH3'
+import { t } from '../../i18n/translations'
+
+const { locale = 'en' } = defineProps<{ locale?: Locale }>()
+</script>
+
+<template>
+  <section class="max-w-9xl mx-auto px-6 py-12 lg:px-20 lg:py-16">
+    <div class="flex flex-col items-center text-center">
+      <h2
+        class="text-3xl font-light tracking-tight text-primary-comfy-canvas lg:text-5xl/tight"
+      >
+        {{ t('minimaxH3.workflows.heading', locale) }}
+      </h2>
+      <p
+        class="mt-6 max-w-xl text-sm font-light text-primary-comfy-canvas/70 lg:text-base"
+      >
+        {{ t('minimaxH3.workflows.subtitle', locale) }}
+      </p>
+    </div>
+
+    <ul class="mt-12 grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <li
+        v-for="workflow in minimaxH3Workflows"
+        :key="workflow.id"
+        class="flex flex-col gap-5"
+      >
+        <VideoPlayer
+          :locale
+          :src="workflow.videoSrc"
+          :aria-label="workflow.title[locale]"
+          minimal
+          autoplay
+          loop
+        />
+        <div class="flex flex-col gap-2">
+          <h3 class="text-xl font-semibold text-primary-comfy-canvas">
+            {{ workflow.title[locale] }}
+          </h3>
+          <p class="text-sm/relaxed font-light text-primary-comfy-canvas/70">
+            {{ workflow.description[locale] }}
+          </p>
+          <a
+            :href="workflow.href"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 mt-1 w-fit rounded-sm text-sm font-semibold underline underline-offset-4 transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {{ t('minimaxH3.workflows.cta', locale) }}
+          </a>
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds `/minimax-h3` (+ `/zh-CN/minimax-h3`) for the MiniMax H3 / Hailuo 3.0 OSS launch, built from the Figma frame ([node 9770-37353](https://www.figma.com/design/11vkE4FAn4plEYpawd57zS/Comfy----Website-Design?node-id=9770-37353)). Linear: CRE-343.

Draft for review — **not mergeable as-is**, see Blockers.

## Changes

Same file layout as the Seedance 2.5 page (`ComfyUI_frontend-private#3`), so the two stay consistent:

| File | |
|---|---|
| `src/pages/minimax-h3.astro` + `zh-CN/` | pages, both locales |
| `src/data/minimaxH3.ts` | all per-page content + media URLs |
| `src/templates/minimax-h3/*.vue` | Hero, Highlights, Workflows, Banner, RunOptions, Faq |
| `src/i18n/translations.ts` | `minimaxH3.*`, en + zh-CN |
| `src/config/routes.ts` (+ test) | route registration |
| `astro.config.ts` | sitemap embargo |
| `e2e/minimax-h3.spec.ts` | `@smoke` + `@mobile` |

Reuses existing blocks only — `CtaCenter01`, `FAQSplit01`, `ProductCard`, `VideoPlayer`, `BrandButton`. It deliberately does **not** depend on `BreadcrumbBar` / `MediaCarousel` / `NodeTag`, since those only exist on the unmerged Seedance branch.

**Ships unlisted.** `noindex` on both pages, no nav or footer entry, and both paths excluded from the sitemap. At launch, clear `noindexUntilLaunch` in the two `.astro` files and drop the entry in `astro.config.ts` — that also switches the FAQ JSON-LD on.

## Copy provenance

Hero and banner strings are **verbatim** from the Figma frame:

- H1 "MiniMax H3 **is here**" (two-tone, matching the mock)
- "Open weights, full multi-modal I/O, native stereo on every clip. Up to 2K, 5 to 15s per generation. H3 actually conditions on input audio where others overwrite or drop it. The open release of Hailuo 3.0."
- "Up to 2K, with sound, in one generation."

Everything else (highlights, workflow blurbs, FAQ, meta) is a first pass. The four highlights only restate claims already made in the hero subhead — no new marketing claims. zh-CN is hand-translated; native review welcome.

## ⚠️ Open decision — CTA button copy

Not assumed. Currently implemented as the Figma shows it (hero `TRY FOR FREE` / `RUN MINIMAX H3`; banner `RUN MINIMAX H3` / `TRY WORKFLOWS`). June flagged that "Try for free" may read as *"try MiniMax for free"* rather than *try Comfy*. Alternative on the table: `Run Minimax H3` / `Try Comfy for free`. All four labels are single i18n keys — a one-line swap either way.

## Blockers before merge

1. **Figma token is expired** (403 on the MCP *and* the REST API with the env key), so June's newly-added video asset links, video titles, and edited copy could not be read. This page is built from the two thread screenshots plus the Figma copy visible in them.
2. **Placeholder media.** All four clips point at already-hosted assets so the preview renders something. They are isolated at the top of `src/data/minimaxH3.ts` for a one-line swap to `media.comfy.org/website/minimax-h3/*`.
3. **CTA destinations are stand-ins.** `RUN MINIMAX H3` → Comfy Cloud, `Open workflow` → the workflows index. Rob owns picking the featured workflow; Lin's three templates (text-to-video, image-to-video, reference-to-video) aren't published yet.

## Not included (separate, deliberate)

- **Footer + nav links** — held until launch so the page stays unlisted. Jo's footer ask is a one-line addition to `SiteFooter.vue` at launch.
- **Supported models page** — `/p/supported-models/hailuo-minimax` **already exists** and is already in the sitemap, so Jo's question there is already answered; it needs no work.
- **Nav featured card swap** (MCP → MiniMax) — 3 lines in `src/data/mainNavigation.ts` + one card image, worth its own PR.
- **`/workflows` featured slot** — that's the Hub, a different codebase.

## Verification

`pnpm typecheck` 0 errors · `pnpm test:unit` 304 passed · `pnpm build` 579 pages · `pnpm knip` clean · eslint/oxfmt/stylelint clean · **e2e 9/9** (desktop + mobile) · browser console clean.

Confirmed in built output: `noindex` on both locales, all CTA labels present at the right counts, zh-CN strings rendering, JSON-LD correctly suppressed under noindex, and both routes absent from `sitemap-0.xml` while `/p/supported-models/hailuo-minimax/` is untouched.

Review caught that `noindex` alone still left both pages listed in the sitemap — fixed in `4cdb25a`.

## Screenshots

![MiniMax H3 landing page, full desktop view at 1440px](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/67d51005e7afa02262e05e31571375ccd61675db8498c0177d0feaa1ff9df681/pr-images/1785625667203-ec68d19c-64d7-4a39-be98-a2448d2c0e3d.png)

![MiniMax H3 hero on mobile at 390px, matching the Figma mock](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/67d51005e7afa02262e05e31571375ccd61675db8498c0177d0feaa1ff9df681/pr-images/1785625667575-18380089-c8ec-41e3-bda2-2605993dfdf7.png)

![MiniMax H3 landing page, full mobile view at 390px](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/67d51005e7afa02262e05e31571375ccd61675db8498c0177d0feaa1ff9df681/pr-images/1785625667946-0f7dfd3b-a32e-4b40-b3d0-d802c1fa0fb9.png)