### PR TITLE
fix: restore ClipspaceDialog export so the comfyAPI clipspace shim is emitted

### DIFF
--- a/build/comfyAPISurface.test.ts
+++ b/build/comfyAPISurface.test.ts
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+import { isComfyAPISourceFile } from './comfyAPISurface'
+import { getPublishedExportNames } from './plugins/comfyAPIPlugin'
+
+describe('isComfyAPISourceFile', () => {
+  it.for([
+    'src/extensions/core/clipspace.ts',
+    'src/scripts/ui/imagePreview.ts'
+  ])('publishes %s', (id) => {
+    expect(isComfyAPISourceFile(id)).toBe(true)
+  })
+
+  it.for([
+    'src/services/load3dService.ts',
+    'src/stores/graphStore.ts',
+    'src/extensions/core/SomeComponent.vue'
+  ])('does not publish %s', (id) => {
+    expect(isComfyAPISourceFile(id)).toBe(false)
+  })
+})
+
+describe('getPublishedExportNames', () => {
+  it('publishes each top-level declaration export', () => {
+    const code = [
+      'export class Dialog {}',
+      'export const value = 1',
+      'export async function load() {}',
+      'class NotExported {}',
+      'export type Ignored = string'
+    ].join('\n')
+
+    expect(getPublishedExportNames(code)).toEqual(['Dialog', 'value', 'load'])
+  })
+
+  // Regression guard for #10348, which dropped the `export` keyword here and
+  // silently removed `window.comfyAPI.clipspace` and its generated shim.
+  it('publishes ClipspaceDialog, which custom nodes import via the shim', async () => {
+    const source = await readFile('src/extensions/core/clipspace.ts', 'utf8')
+
+    expect(getPublishedExportNames(source)).toContain('ClipspaceDialog')
+  })
+})

--- a/build/comfyAPISurface.ts
+++ b/build/comfyAPISurface.ts
@@ -1,0 +1,26 @@
+/**
+ * Directories whose top-level exports form the generated `window.comfyAPI`
+ * public API.
+ *
+ * `comfyAPIPlugin` rewrites every top-level export in these files into a
+ * `window.comfyAPI.<module>.<name>` assignment and emits a sibling `.js` shim
+ * that re-exports it, so third-party custom nodes can
+ * `import { ClipspaceDialog } from '.../extensions/core/clipspace.js'`.
+ *
+ * The `export` keyword in these files is therefore load-bearing: an export with
+ * no in-repo importer is still published API, not dead code. `knip.config.ts`
+ * reads the same list to treat these files as entry points, so the build's
+ * public surface and the dead-code analysis agree by construction instead of
+ * needing a per-symbol escape hatch on each published-but-unimported export.
+ */
+const COMFY_API_DIRS = ['src/extensions/core', 'src/scripts'] as const
+
+/** Knip `entry` patterns covering the generated public API surface. */
+export const COMFY_API_ENTRY_GLOBS = COMFY_API_DIRS.map(
+  (dir) => `${dir}/**/*.ts`
+)
+
+/** Whether a module id is transformed into `window.comfyAPI` public API. */
+export function isComfyAPISourceFile(id: string): boolean {
+  return id.endsWith('.ts') && COMFY_API_DIRS.some((dir) => id.includes(dir))
+}

--- a/build/plugins/comfyAPIPlugin.ts
+++ b/build/plugins/comfyAPIPlugin.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import type { Plugin } from 'vite'
 
+import { isComfyAPISourceFile } from '../comfyAPISurface'
+
 interface ShimResult {
   code: string
   exports: string[]
@@ -34,11 +36,11 @@ function getWarningMessage(
   return `[ComfyUI Notice] "${shimFileName}" is an internal module, not part of the public API. Future updates may break this import.`
 }
 
-function isLegacyFile(id: string): boolean {
-  return (
-    id.endsWith('.ts') &&
-    (id.includes('src/extensions/core') || id.includes('src/scripts'))
-  )
+/** Names this module publishes onto `window.comfyAPI`. */
+export function getPublishedExportNames(code: string): string[] {
+  const regex =
+    /export\s+(const|let|var|function|class|async function)\s+([a-zA-Z$_][a-zA-Z\d$_]*)(\s|\()/g
+  return Array.from(code.matchAll(regex), (match) => match[2])
 }
 
 function transformExports(code: string, id: string): ShimResult {
@@ -46,13 +48,7 @@ function transformExports(code: string, id: string): ShimResult {
   const exports: string[] = []
   let newCode = code
 
-  // Regex to match different types of exports
-  const regex =
-    /export\s+(const|let|var|function|class|async function)\s+([a-zA-Z$_][a-zA-Z\d$_]*)(\s|\()/g
-  let match
-
-  while ((match = regex.exec(code)) !== null) {
-    const name = match[2]
+  for (const name of getPublishedExportNames(code)) {
     // All exports should be bind to the window object as new API endpoint.
     if (exports.length == 0) {
       newCode += `\nwindow.comfyAPI = window.comfyAPI || {};`
@@ -84,7 +80,7 @@ export function comfyAPIPlugin(isDev: boolean): Plugin {
     transform(code: string, id: string) {
       if (isDev) return null
 
-      if (isLegacyFile(id)) {
+      if (isComfyAPISourceFile(id)) {
         const result = transformExports(code, id)
 
         if (result.exports.length > 0) {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,5 +1,7 @@
 import type { KnipConfig } from 'knip'
 
+import { COMFY_API_ENTRY_GLOBS } from './build/comfyAPISurface'
+
 const config: KnipConfig = {
   treatConfigHintsAsErrors: true,
   treatTagHintsAsErrors: true,
@@ -7,6 +9,7 @@ const config: KnipConfig = {
     '.': {
       entry: [
         '{build,scripts}/**/*.{js,ts}',
+        ...COMFY_API_ENTRY_GLOBS,
         'src/assets/css/style.css',
         'src/scripts/ui/menu/index.ts',
         'src/types/index.ts',

--- a/src/extensions/core/clipspace.ts
+++ b/src/extensions/core/clipspace.ts
@@ -2,7 +2,11 @@ import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'
 import { $el, ComfyDialog } from '../../scripts/ui'
 
-class ClipspaceDialog extends ComfyDialog {
+/**
+ * The export drives `comfyAPIPlugin`'s `window.comfyAPI.clipspace` shim.
+ * @knipIgnoreUnusedButUsedByCustomNodes
+ */
+export class ClipspaceDialog extends ComfyDialog {
   static items: Array<
     HTMLButtonElement & {
       contextPredicate?: () => boolean

--- a/src/extensions/core/clipspace.ts
+++ b/src/extensions/core/clipspace.ts
@@ -2,10 +2,6 @@ import { app } from '../../scripts/app'
 import { ComfyApp } from '../../scripts/app'
 import { $el, ComfyDialog } from '../../scripts/ui'
 
-/**
- * The export drives `comfyAPIPlugin`'s `window.comfyAPI.clipspace` shim.
- * @knipIgnoreUnusedButUsedByCustomNodes
- */
 export class ClipspaceDialog extends ComfyDialog {
   static items: Array<
     HTMLButtonElement & {

--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -815,8 +815,6 @@ export class GroupNodeConfig {
  * `configure`. The load-time migration unpacks each instance via
  * {@link convertToNodes} and {@link LGraph.convertToSubgraph} repackages the
  * result as a subgraph.
- *
- * @knipIgnoreUnusedButUsedByCustomNodes
  */
 export class GroupNodeHandler {
   node: LGraphNode

--- a/src/scripts/ui/imagePreview.ts
+++ b/src/scripts/ui/imagePreview.ts
@@ -50,7 +50,6 @@ export function calculateImageGrid(
   return { cellWidth, cellHeight, cols, rows, shiftX }
 }
 
-/** @knipIgnoreUnusedButUsedByCustomNodes */
 export function createImageHost(node: LGraphNode) {
   const el = $el('div.comfy-img-preview')
   // @ts-expect-error fixme ts strict error

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -734,7 +734,8 @@ export default defineConfig({
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'packages/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-      'scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
+      'scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'build/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## ELI-5

Custom nodes can `import { ClipspaceDialog } from ".../extensions/core/clipspace.js"`. That file isn't hand-written — the build generates it, but only for classes marked `export`. A cleanup PR quietly deleted that one keyword, so the build stopped generating the file and stopped attaching the class to `window.comfyAPI`. Nodes that import it now blow up.

This puts the keyword back, and declares the generated public API surface in one place so a mechanical cleanup can't silently delete it again.

## Summary

Restores `export` on `ClipspaceDialog` so `build/plugins/comfyAPIPlugin.ts` emits `window.comfyAPI.clipspace.ClipspaceDialog` and the `extensions/core/clipspace.js` shim asset again, and fixes the underlying reason it was removable.

## Changes

- **`export class ClipspaceDialog`** in `src/extensions/core/clipspace.ts`.
- **`build/comfyAPISurface.ts`** (new): single declaration of the directories whose top-level exports are published onto `window.comfyAPI`. Both `comfyAPIPlugin` (via `isComfyAPISourceFile`) and `knip.config.ts` (via `COMFY_API_ENTRY_GLOBS`) read it, so the published API and the dead-code analysis agree by construction.
- **Retires the per-symbol escape hatches** now subsumed by that declaration: `@knipIgnoreUnusedButUsedByCustomNodes` removed from `ClipspaceDialog`, `GroupNodeHandler` and `createImageHost`. The two remaining uses (`litegraph.ts`, `widgetMap.ts`) sit outside the shim surface and legitimately stay per-symbol.
- **`getPublishedExportNames`** extracted from `transformExports` so the contract is testable, plus `build/**` added to the vitest `include`.

### Root cause

`comfyAPIPlugin` transforms **top-level-exported** symbols under `src/extensions/core` and `src/scripts`, binding each to `window.comfyAPI` and emitting a re-export shim. That makes the `export` keyword in those files load-bearing public API rather than a statement about in-repo usage — but nothing in the repo said so. Dead-code analysis therefore saw published exports as unused, and the only defence was a per-symbol tag on each one.

#10348 (knip cleanup, 2026-03-21) changed `export class ClipspaceDialog` to `class ClipspaceDialog`: mechanically correct for knip, load-bearing for the build. Since that commit the plugin appends no `window.comfyAPI.clipspace.*` assignment and emits no shim asset. `git log -L` on the line confirms #10348 is the only change to it — the export existed from the file's introduction.

### Impact

`ComfyUI-Impact-Pack` does `import { ClipspaceDialog } from "../../extensions/core/clipspace.js"` in `js/impact-sam-editor.js`; GitHub code search shows ~119 files across the ecosystem referencing the path (`comfyui-photoshop`, `ComfyUI-Photopea`, `ComfyI2I`, `efficiency-nodes-ED`, `ComfyUI-Flow-Control`, …). Operators have independently written [compatibility shims](https://github.com/gavinmcfall/containers/blob/main/apps/lighthouse/web/clipspace-compat.js) that diagnose this exact breakage ("the frontend build emits no back-compat shim … the SAM mask editor never loads").

Sourced from production RUM error triage (7-day window measured 2026-07-31): ~7.4k error sessions/wk across Chrome, Safari and Firefox.

## Review Focus

- **Tradeoff in the central declaration**: adding the shim directories to knip's `entry` means knip no longer reports unused *exports* or orphaned *files* under `src/extensions/core` and `src/scripts`. That is semantically correct — those exports are published, not dead — but it is a real reduction in coverage over those two directories. Knip is clean before and after, so nothing currently-known is being masked. The narrower alternative is to keep per-symbol tags; this PR takes the central route per review feedback.
- **Scope**: the other two exports #10348 removed are untouched. `Load3dService` lives in `src/services/`, outside the transformed directories, so it is unaffected by this mechanism.

## Verification

`pnpm typecheck`, `pnpm lint` (0 errors), `pnpm knip`, `pnpm format:check` clean. `pnpm test:unit`: 14508 passed, 2 unrelated cold-cache timeouts (`GraphView`, `onboardingCloudRoutes`) that pass on isolated re-run and are retried in CI.

`pnpm build` before and after the refactor emits an identical surface — 73 shim assets, one `comfyAPI.clipspace.ClipspaceDialog` binding:

```
$ cat dist/extensions/core/clipspace.js
// Shim for extensions/core/clipspace.ts
console.warn('[ComfyUI Notice] "extensions/core/clipspace.js" is an internal module, not part of the public API. Future updates may break this import.');
export const ClipspaceDialog = window.comfyAPI.clipspace.ClipspaceDialog;
```

The new test is mutation-checked: reverting `export class ClipspaceDialog` to `class ClipspaceDialog` fails it, so it genuinely guards the #10348 regression.

## Provenance

**Authored by:** agent-work loop

**Verified:** `pnpm typecheck`, `pnpm lint`, `pnpm knip:no-cache`, `pnpm format:check`, `pnpm test:unit`, and `pnpm build` with the emitted `dist/extensions/core/clipspace.js` shim and shim-count diffed before/after the refactor. New contract test mutation-checked against the original regression.

**Deviations:** The central-declaration refactor (`build/comfyAPISurface.ts`, retired per-symbol tags, `build/**` test coverage) was added in response to review feedback and was not part of the original one-keyword fix.
