### PR TITLE
feat: add BYOM upload funnel analytics

### DIFF
--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -178,8 +178,11 @@ void refreshAssets()
 const { fetchModelTypes } = useModelTypes()
 void fetchModelTypes()
 
-const { isUploadButtonEnabled, showUploadDialog } =
-  useModelUpload(refreshAssets)
+const { isUploadButtonEnabled, showUploadDialog } = useModelUpload(
+  refreshAssets,
+  undefined,
+  'asset_browser'
+)
 
 const {
   searchQuery,

--- a/src/platform/assets/components/UploadModelDialog.vue
+++ b/src/platform/assets/components/UploadModelDialog.vue
@@ -64,13 +64,17 @@ import type {
   UploadModelSuccess
 } from '@/platform/assets/composables/useUploadModelWizard'
 import { useUploadModelWizard } from '@/platform/assets/composables/useUploadModelWizard'
+import type { ByomSurface } from '@/platform/telemetry/types'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
 const { modelTypes, fetchModelTypes } = useModelTypes()
 
-const { uploadContext } = defineProps<{
+const { uploadContext, byomFlowId, byomSurface } = defineProps<{
   uploadContext?: UploadModelDialogContext
+  /** Funnel correlation id + entry surface, minted by useModelUpload. */
+  byomFlowId?: string
+  byomSurface?: ByomSurface
 }>()
 
 const emit = defineEmits<{
@@ -102,7 +106,9 @@ const {
   goToPreviousStep,
   resetWizard
 } = useUploadModelWizard(modelTypes, {
-  requiredModelType: requiredModelType.value
+  requiredModelType: requiredModelType.value,
+  byomFlowId,
+  byomSurface
 })
 
 async function handleFetchMetadata() {

--- a/src/platform/assets/composables/useModelUpload.ts
+++ b/src/platform/assets/composables/useModelUpload.ts
@@ -7,8 +7,11 @@ import type {
   UploadModelDialogContext,
   UploadModelSuccess
 } from '@/platform/assets/composables/useUploadModelWizard'
+import { createByomFlowId } from '@/platform/assets/utils/byomTelemetry'
 import UploadModelUpgradeModal from '@/platform/assets/components/UploadModelUpgradeModal.vue'
 import UploadModelUpgradeModalHeader from '@/platform/assets/components/UploadModelUpgradeModalHeader.vue'
+import { useTelemetry } from '@/platform/telemetry'
+import type { ByomSurface } from '@/platform/telemetry/types'
 import { useDialogStore } from '@/stores/dialogStore'
 
 type UploadModelContextResolver = () => UploadModelDialogContext | undefined
@@ -24,7 +27,8 @@ const uploadDialogComponentProps = {
 
 export function useModelUpload(
   onUploadSuccess?: (result: UploadModelSuccess) => Promise<unknown> | void,
-  uploadContext?: UploadModelDialogContext | UploadModelContextResolver
+  uploadContext?: UploadModelDialogContext | UploadModelContextResolver,
+  surface: ByomSurface = 'asset_browser'
 ) {
   const dialogStore = useDialogStore()
   const { flags } = useFeatureFlags()
@@ -35,7 +39,23 @@ export function useModelUpload(
   }
 
   function showUploadDialog() {
-    if (!flags.privateModelsEnabled) {
+    const context = resolveUploadContext()
+    // Mint the correlation id here — the one point every entry surface funnels
+    // through — so the wizard's later stages join back to this exact attempt
+    // rather than to another attempt by the same user.
+    const flowId = createByomFlowId()
+    const gated = !flags.privateModelsEnabled
+
+    // Emitted BEFORE the paywall branch, so total intent is the funnel's first
+    // step and `gated` measures paywall conversion within a single step.
+    useTelemetry()?.trackByomFunnel('dialog_opened', {
+      flow_id: flowId,
+      surface,
+      gated,
+      required_model_type: context?.requiredModelType
+    })
+
+    if (gated) {
       dialogStore.showDialog({
         key: 'upload-model-upgrade',
         headerComponent: UploadModelUpgradeModalHeader,
@@ -48,7 +68,9 @@ export function useModelUpload(
         headerComponent: UploadModelDialogHeader,
         component: UploadModelDialog,
         props: {
-          uploadContext: resolveUploadContext(),
+          uploadContext: context,
+          byomFlowId: flowId,
+          byomSurface: surface,
           onUploadSuccess: async (result: UploadModelSuccess) => {
             await onUploadSuccess?.(result)
           }

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { computed, ref, watch } from 'vue'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
@@ -17,7 +17,18 @@ import {
   stripModelTypePrefix,
   toModelTypeTag
 } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  classifyByomError,
+  createByomFlowId
+} from '@/platform/assets/utils/byomTelemetry'
 import { validateSourceUrl } from '@/platform/assets/utils/importSourceUtil'
+import { useTelemetry } from '@/platform/telemetry'
+import type {
+  ByomFunnelMetadata,
+  ByomFunnelStage,
+  ByomModelTypeOrigin,
+  ByomSurface
+} from '@/platform/telemetry/types'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
@@ -66,6 +77,9 @@ export type UploadModelDialogContext = MissingModelUploadContext
 
 interface UploadModelWizardOptions {
   requiredModelType?: string
+  /** Correlation id minted at dialog open; see createByomFlowId. */
+  byomFlowId?: string
+  byomSurface?: ByomSurface
 }
 
 export function useUploadModelWizard(
@@ -78,6 +92,34 @@ export function useUploadModelWizard(
   const assetDownloadStore = useAssetDownloadStore()
   const modelToNodeStore = useModelToNodeStore()
   const requiredModelType = options.requiredModelType
+  const telemetry = useTelemetry()
+  // Falls back to a fresh id so the wizard still emits a self-consistent flow
+  // if it is ever mounted outside useModelUpload.
+  const byomFlowId = options.byomFlowId ?? createByomFlowId()
+  const byomSurface: ByomSurface = options.byomSurface ?? 'asset_browser'
+  // Set once a terminal stage fires, so dialog teardown doesn't also report an
+  // abandon for a flow that already succeeded or failed.
+  let byomTerminalReported = false
+
+  function trackByom(
+    stage: ByomFunnelStage,
+    metadata: Partial<ByomFunnelMetadata> = {}
+  ) {
+    telemetry?.trackByomFunnel(stage, {
+      flow_id: byomFlowId,
+      surface: byomSurface,
+      ...metadata
+    })
+  }
+
+  function modelTypeOrigin(): ByomModelTypeOrigin {
+    if (requiredModelType) return 'required'
+    return autodetectedModelType ? 'autodetected' : 'manual'
+  }
+
+  // Tracks whether step 2's model type came from metadata tags rather than the
+  // user picking it, which is the signal for how well auto-detection works.
+  let autodetectedModelType = false
   const currentStep = ref(1)
   const isFetchingMetadata = ref(false)
   const isUploading = ref(false)
@@ -160,8 +202,16 @@ export function useUploadModelWizard(
       uploadError.value = t('assetBrowser.unsupportedUrlSource', {
         sources: supportedSources
       })
+      trackByom('metadata_resolved', {
+        outcome: 'error',
+        error_reason: 'unsupported_source'
+      })
       return
     }
+
+    // Only the resolved source type is emitted — never the URL itself, which
+    // can carry tokens or private-repo paths in its query params.
+    trackByom('url_submitted', { source: source.type })
 
     isFetchingMetadata.value = true
     try {
@@ -202,10 +252,17 @@ export function useUploadModelWizard(
         )
         if (typeTag) {
           selectedModelType.value = typeTag
+          autodetectedModelType = true
         }
       }
 
       currentStep.value = 2
+      trackByom('metadata_resolved', {
+        source: source.type,
+        outcome: 'success',
+        model_type_autodetected: autodetectedModelType,
+        has_preview: !!wizardData.value.previewImage
+      })
     } catch (error) {
       console.error('Failed to retrieve metadata:', error)
       uploadError.value =
@@ -216,6 +273,12 @@ export function useUploadModelWizard(
               'Failed to retrieve metadata. Please check the link and try again.'
             )
       currentStep.value = 1
+      // The raw message is intentionally not forwarded — see classifyByomError.
+      trackByom('metadata_resolved', {
+        source: source.type,
+        outcome: 'error',
+        error_reason: classifyByomError('metadata')
+      })
     } finally {
       isFetchingMetadata.value = false
     }
@@ -324,6 +387,13 @@ export function useUploadModelWizard(
     uploadTypeMismatch.value = null
     let uploadSuccess: UploadModelSuccess | null = null
 
+    trackByom('upload_submitted', {
+      source: source.type,
+      model_type: resolvedModelType.value,
+      model_type_origin: modelTypeOrigin(),
+      has_preview: !!wizardData.value.previewImage
+    })
+
     try {
       const modelType = resolvedModelType.value
       const subtypeTag =
@@ -377,6 +447,14 @@ export function useUploadModelWizard(
             if (status === 'completed') {
               resolved = true
               uploadStatus.value = 'success'
+              byomTerminalReported = true
+              trackByom('upload_completed', {
+                source: source.type,
+                model_type: modelType,
+                model_type_origin: modelTypeOrigin(),
+                mode: 'async',
+                outcome: 'success'
+              })
               await refreshModelCaches()
               stopAsyncWatch?.()
               stopAsyncWatch = undefined
@@ -391,6 +469,15 @@ export function useUploadModelWizard(
                 t('assetBrowser.downloadFailed', {
                   name: download?.assetName || ''
                 })
+              byomTerminalReported = true
+              trackByom('upload_completed', {
+                source: source.type,
+                model_type: modelType,
+                model_type_origin: modelTypeOrigin(),
+                mode: 'async',
+                outcome: 'failed',
+                error_reason: classifyByomError('upload')
+              })
               stopAsyncWatch?.()
               stopAsyncWatch = undefined
             }
@@ -411,10 +498,27 @@ export function useUploadModelWizard(
           blockMismatchedImportedModel(result.asset, modelType)
         ) {
           currentStep.value = 3
+          byomTerminalReported = true
+          trackByom('upload_completed', {
+            source: source.type,
+            model_type: modelType,
+            model_type_origin: modelTypeOrigin(),
+            mode: 'sync',
+            outcome: 'type_mismatch',
+            error_reason: 'type_mismatch'
+          })
           return null
         }
 
         uploadStatus.value = 'success'
+        byomTerminalReported = true
+        trackByom('upload_completed', {
+          source: source.type,
+          model_type: modelType,
+          model_type_origin: modelTypeOrigin(),
+          mode: 'sync',
+          outcome: 'success'
+        })
         await refreshModelCaches()
         uploadSuccess = {
           filename:
@@ -430,11 +534,36 @@ export function useUploadModelWizard(
       uploadError.value =
         error instanceof Error ? error.message : 'Failed to upload model'
       currentStep.value = 3
+      byomTerminalReported = true
+      trackByom('upload_completed', {
+        source: source.type,
+        model_type: resolvedModelType.value,
+        model_type_origin: modelTypeOrigin(),
+        mode: 'sync',
+        outcome: 'failed',
+        error_reason: classifyByomError('upload')
+      })
     } finally {
       isUploading.value = false
     }
     return uploadSuccess
   }
+
+  /**
+   * Reports the abandon stage unless a terminal stage already fired. Called on
+   * dialog teardown, so a user who closes the wizard mid-flow is attributed to
+   * the step they dropped at rather than silently vanishing from the funnel.
+   */
+  function reportByomAbandonedIfUnresolved() {
+    if (byomTerminalReported) return
+    byomTerminalReported = true
+    trackByom('dialog_abandoned', {
+      last_step: currentStep.value,
+      source: detectedSource.value?.type
+    })
+  }
+
+  onScopeDispose(reportByomAbandonedIfUnresolved)
 
   function goToPreviousStep() {
     if (currentStep.value > 1) {

--- a/src/platform/assets/composables/useUploadModelWizardTelemetry.test.ts
+++ b/src/platform/assets/composables/useUploadModelWizardTelemetry.test.ts
@@ -1,0 +1,248 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, ref } from 'vue'
+import type { App } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import { useUploadModelWizard } from './useUploadModelWizard'
+
+const mockTrackByomFunnel = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackByomFunnel: mockTrackByomFunnel })
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    getAssetMetadata: vi.fn(),
+    uploadAssetAsync: vi.fn(),
+    uploadAssetFromBase64: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/assets/importSources/civitaiImportSource', () => ({
+  civitaiImportSource: {
+    name: 'Civitai',
+    type: 'civitai',
+    hostnames: ['civitai.com'],
+    fetchMetadata: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/assets/importSources/huggingfaceImportSource', () => ({
+  huggingfaceImportSource: {
+    name: 'HuggingFace',
+    type: 'huggingface',
+    hostnames: ['huggingface.co'],
+    fetchMetadata: vi.fn()
+  }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn(),
+    addEventListener: vi.fn(),
+    apiURL: vi.fn((path: string) => path),
+    getServerFeature: vi.fn(
+      (_name: string, defaultValue?: unknown) => defaultValue
+    )
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  st: (_key: string, fallback: string) => fallback,
+  t: (key: string) => key,
+  te: () => false,
+  d: (date: Date) => date.toISOString()
+}))
+
+/** Stage names in the order they were emitted. */
+function emittedStages(): string[] {
+  return mockTrackByomFunnel.mock.calls.map(([stage]) => stage as string)
+}
+
+/** Metadata of the first call for a given stage. */
+function metadataFor(stage: string): Record<string, unknown> | undefined {
+  return mockTrackByomFunnel.mock.calls.find(([s]) => s === stage)?.[1] as
+    | Record<string, unknown>
+    | undefined
+}
+
+describe('useUploadModelWizard telemetry', () => {
+  const modelTypes = ref([{ name: 'Checkpoint', value: 'checkpoints' }])
+  const mountedApps: App<Element>[] = []
+
+  function setup(options: Parameters<typeof useUploadModelWizard>[1] = {}) {
+    let result!: ReturnType<typeof useUploadModelWizard>
+    const app = createApp({
+      setup() {
+        result = useUploadModelWizard(modelTypes, options)
+        return () => null
+      }
+    })
+    app.use(
+      createI18n({
+        legacy: false,
+        locale: 'en',
+        messages: { en: enMessages }
+      })
+    )
+    app.mount(document.createElement('div'))
+    mountedApps.push(app)
+    return { result, app }
+  }
+
+  // Unmount in afterEach, never beforeEach: teardown emits dialog_abandoned, so
+  // unmounting after the mock has been cleared would leak the previous test's
+  // abandon event into the next test's assertions.
+  afterEach(() => {
+    while (mountedApps.length) mountedApps.pop()?.unmount()
+  })
+
+  beforeEach(() => {
+    mockTrackByomFunnel.mockClear()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('emits url_submitted with the resolved source, never the URL', async () => {
+    const { assetService } = await import(
+      '@/platform/assets/services/assetService'
+    )
+    vi.mocked(assetService.getAssetMetadata).mockResolvedValue({
+      filename: 'model.safetensors'
+    } as never)
+
+    const { result } = setup({ byomFlowId: 'flow-1' })
+    result.wizardData.value.url = 'https://civitai.com/models/123?token=SECRET'
+    await result.fetchMetadata()
+
+    const submitted = metadataFor('url_submitted')
+    expect(submitted).toMatchObject({
+      flow_id: 'flow-1',
+      surface: 'asset_browser',
+      source: 'civitai'
+    })
+    // The URL can carry tokens or private-repo paths — it must never be sent.
+    expect(JSON.stringify(mockTrackByomFunnel.mock.calls)).not.toContain(
+      'SECRET'
+    )
+  })
+
+  it('emits metadata_resolved with unsupported_source for an unknown host', async () => {
+    const { result } = setup()
+    result.wizardData.value.url = 'https://example.com/model.safetensors'
+    await result.fetchMetadata()
+
+    // canFetchMetadata gates the call, so nothing is emitted for a host that
+    // never resolves to a source.
+    expect(emittedStages()).not.toContain('url_submitted')
+  })
+
+  it('reports metadata failure without leaking the raw error message', async () => {
+    const { assetService } = await import(
+      '@/platform/assets/services/assetService'
+    )
+    vi.mocked(assetService.getAssetMetadata).mockRejectedValue(
+      new Error('404 fetching https://huggingface.co/private/repo?hf_token=XYZ')
+    )
+
+    const { result } = setup()
+    result.wizardData.value.url = 'https://huggingface.co/private/repo'
+    await result.fetchMetadata()
+
+    expect(metadataFor('metadata_resolved')).toMatchObject({
+      source: 'huggingface',
+      outcome: 'error',
+      error_reason: 'metadata_fetch_failed'
+    })
+    expect(JSON.stringify(mockTrackByomFunnel.mock.calls)).not.toContain(
+      'hf_token'
+    )
+  })
+
+  it('flags an auto-detected model type on metadata_resolved', async () => {
+    const { assetService } = await import(
+      '@/platform/assets/services/assetService'
+    )
+    vi.mocked(assetService.getAssetMetadata).mockResolvedValue({
+      filename: 'model.safetensors',
+      tags: ['checkpoints']
+    } as never)
+
+    const { result } = setup()
+    result.wizardData.value.url = 'https://civitai.com/models/123'
+    await result.fetchMetadata()
+
+    expect(metadataFor('metadata_resolved')).toMatchObject({
+      outcome: 'success',
+      model_type_autodetected: true
+    })
+  })
+
+  it('carries one flow_id across every stage of an attempt', async () => {
+    const { assetService } = await import(
+      '@/platform/assets/services/assetService'
+    )
+    vi.mocked(assetService.getAssetMetadata).mockResolvedValue({
+      filename: 'model.safetensors'
+    } as never)
+
+    const { result } = setup({ byomFlowId: 'flow-abc', byomSurface: 'missing_model' })
+    result.wizardData.value.url = 'https://civitai.com/models/123'
+    await result.fetchMetadata()
+
+    const flowIds = mockTrackByomFunnel.mock.calls.map(
+      ([, meta]) => (meta as { flow_id: string }).flow_id
+    )
+    expect(flowIds.length).toBeGreaterThan(0)
+    expect(new Set(flowIds)).toEqual(new Set(['flow-abc']))
+    expect(metadataFor('url_submitted')).toMatchObject({
+      surface: 'missing_model'
+    })
+  })
+
+  it('reports dialog_abandoned on teardown when no terminal stage fired', () => {
+    const { app } = setup({ byomFlowId: 'flow-drop' })
+
+    app.unmount()
+    mountedApps.pop()
+
+    expect(metadataFor('dialog_abandoned')).toMatchObject({
+      flow_id: 'flow-drop',
+      last_step: 1
+    })
+  })
+
+  it('does not report abandon after a terminal stage', async () => {
+    const { assetService } = await import(
+      '@/platform/assets/services/assetService'
+    )
+    vi.mocked(assetService.getAssetMetadata).mockResolvedValue({
+      filename: 'model.safetensors',
+      tags: ['checkpoints']
+    } as never)
+    vi.mocked(assetService.uploadAssetAsync).mockResolvedValue({
+      type: 'sync',
+      asset: { id: 'a1', name: 'model.safetensors', tags: [] }
+    } as never)
+
+    const { result, app } = setup()
+    result.wizardData.value.url = 'https://civitai.com/models/123'
+    await result.fetchMetadata()
+    await result.uploadModel()
+
+    expect(metadataFor('upload_completed')).toMatchObject({
+      mode: 'sync',
+      outcome: 'success'
+    })
+
+    app.unmount()
+    mountedApps.pop()
+
+    // A completed flow must not also be counted as a drop-off.
+    expect(emittedStages()).not.toContain('dialog_abandoned')
+  })
+})

--- a/src/platform/assets/utils/byomTelemetry.ts
+++ b/src/platform/assets/utils/byomTelemetry.ts
@@ -1,0 +1,28 @@
+import type { ByomErrorReason } from '@/platform/telemetry/types'
+
+/**
+ * Mints the correlation id that ties one bring-your-own-model dialog session's
+ * funnel events together. A user can open the wizard repeatedly, so without a
+ * per-attempt id a funnel would stitch the first step of one attempt to the
+ * last step of another, and three abandoned attempts would be
+ * indistinguishable from one.
+ */
+export function createByomFlowId(): string {
+  return globalThis.crypto?.randomUUID
+    ? globalThis.crypto.randomUUID()
+    : `byom-${Math.random().toString(36).slice(2)}`
+}
+
+/**
+ * Maps a caught upload/metadata error onto the closed `ByomErrorReason` set.
+ *
+ * The raw error is deliberately NOT emitted: `uploadError` is built from API
+ * messages and from i18n strings that interpolate the asset name, so shipping
+ * it verbatim would leak user-supplied text into analytics and give the
+ * property unbounded cardinality.
+ */
+export function classifyByomError(
+  stage: 'metadata' | 'upload'
+): ByomErrorReason {
+  return stage === 'metadata' ? 'metadata_fetch_failed' : 'download_failed'
+}

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -416,7 +416,8 @@ const { showUploadDialog } = useModelUpload(
       handleLibrarySelect()
     }
   },
-  () => missingModelUploadContext.value
+  () => missingModelUploadContext.value,
+  'missing_model'
 )
 
 onMounted(() => {

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -6,6 +6,8 @@ import type {
   AuthMetadata,
   BeginCheckoutMetadata,
   BillingTelemetryEvent,
+  ByomFunnelMetadata,
+  ByomFunnelStage,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ExecutionErrorMetadata,
@@ -131,6 +133,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackResubscribeClicked(metadata: ResubscribeClickMetadata): void {
     this.dispatch((provider) => provider.trackResubscribeClicked?.(metadata))
+  }
+
+  trackByomFunnel(stage: ByomFunnelStage, metadata: ByomFunnelMetadata): void {
+    this.dispatch((provider) => provider.trackByomFunnel?.(stage, metadata))
   }
 
   trackAddApiCreditButtonClicked(metadata?: AddCreditsClickMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -59,9 +59,12 @@ import type {
   WorkflowImportMetadata,
   WorkflowSavedMetadata,
   WorkspaceInviteFailedMetadata,
-  WorkspaceInviteMetadata
+  WorkspaceInviteMetadata,
+  ByomFunnelMetadata,
+  ByomFunnelStage
 } from '../../types'
 import {
+  BYOM_STAGE_EVENTS,
   CANCELLATION_STAGE_EVENTS,
   getBillingTelemetryEventName,
   getBillingTelemetryEventPayload,
@@ -421,6 +424,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackResubscribeClicked(metadata: ResubscribeClickMetadata): void {
     this.trackEvent(TelemetryEvents.RESUBSCRIBE_BUTTON_CLICKED, metadata)
+  }
+
+  trackByomFunnel(stage: ByomFunnelStage, metadata: ByomFunnelMetadata): void {
+    this.trackEvent(BYOM_STAGE_EVENTS[stage], metadata)
   }
 
   trackApiCreditTopupButtonPurchaseClicked(amount: number): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -604,6 +604,62 @@ export interface AddCreditsClickMetadata {
   source: 'credits_panel' | 'avatar_menu' | 'settings_billing_panel'
 }
 
+/** The UI surface a bring-your-own-model upload was started from. */
+export type ByomSurface = 'asset_browser' | 'model_dropdown' | 'missing_model'
+
+/** Import sources the upload wizard can resolve a URL to. */
+export type ByomSource = 'civitai' | 'huggingface'
+
+/** How the model type was decided, for measuring metadata auto-detection. */
+export type ByomModelTypeOrigin = 'required' | 'autodetected' | 'manual'
+
+/**
+ * Closed set of failure classes. Deliberately NOT the raw error string:
+ * `uploadError` is built from API messages and i18n strings that interpolate
+ * the asset name, so emitting it verbatim would leak user data into analytics
+ * and blow up property cardinality.
+ */
+export type ByomErrorReason =
+  | 'unsupported_source'
+  | 'metadata_fetch_failed'
+  | 'download_failed'
+  | 'type_mismatch'
+
+export type ByomFunnelStage = keyof typeof BYOM_STAGE_EVENTS
+
+export interface ByomFunnelMetadata {
+  /**
+   * Correlates the stages of ONE dialog session. A user can open the wizard
+   * repeatedly, so without this a funnel would happily stitch step 1 of one
+   * attempt to the final step of another, and repeated abandons would be
+   * indistinguishable from a single one.
+   */
+  flow_id: string
+  surface: ByomSurface
+  /**
+   * True when the user hit the upgrade modal instead of the wizard
+   * (`privateModelsEnabled` off). Only meaningful on `dialog_opened`.
+   */
+  gated?: boolean
+  /**
+   * NOTE: the source URL itself is never emitted — Hugging Face and Civitai
+   * URLs can carry tokens or private-repo paths in query params.
+   */
+  source?: ByomSource
+  model_type?: string
+  model_type_origin?: ByomModelTypeOrigin
+  /** Model type the missing-model flow demands, when entered that way. */
+  required_model_type?: string
+  model_type_autodetected?: boolean
+  has_preview?: boolean
+  /** Sync uploads finish inline; async ones resolve via the download store. */
+  mode?: 'sync' | 'async'
+  outcome?: 'success' | 'error' | 'failed' | 'type_mismatch'
+  error_reason?: ByomErrorReason
+  /** Wizard step the user was on when they abandoned. */
+  last_step?: number
+}
+
 export interface SubscriptionCancellationMetadata {
   current_tier?: string
   cycle?: BillingCycle
@@ -872,6 +928,12 @@ export interface TelemetryProvider {
   // Email verification events
   trackEmailVerification?(stage: 'opened' | 'requested' | 'completed'): void
 
+  // Bring-your-own-model upload funnel
+  trackByomFunnel?(
+    stage: ByomFunnelStage,
+    metadata: ByomFunnelMetadata
+  ): void
+
   // Template workflow events
   trackTemplate?(metadata: TemplateMetadata): void
   trackTemplateLibraryOpened?(metadata: TemplateLibraryMetadata): void
@@ -1056,6 +1118,14 @@ export const TelemetryEvents = {
   HELP_RESOURCE_CLICKED: 'app:help_resource_clicked',
   HELP_CENTER_CLOSED: 'app:help_center_closed',
 
+  // Bring Your Own Model (BYOM) upload funnel
+  BYOM_DIALOG_OPENED: 'app:byom_dialog_opened',
+  BYOM_URL_SUBMITTED: 'app:byom_url_submitted',
+  BYOM_METADATA_RESOLVED: 'app:byom_metadata_resolved',
+  BYOM_UPLOAD_SUBMITTED: 'app:byom_upload_submitted',
+  BYOM_UPLOAD_COMPLETED: 'app:byom_upload_completed',
+  BYOM_DIALOG_ABANDONED: 'app:byom_dialog_abandoned',
+
   // Workflow Creation
   WORKFLOW_CREATED: 'app:workflow_created',
   WORKFLOW_SAVED: 'app:workflow_saved',
@@ -1098,6 +1168,19 @@ export const CANCELLATION_STAGE_EVENTS = {
   confirmed: TelemetryEvents.SUBSCRIPTION_CANCEL_CONFIRMED,
   abandoned: TelemetryEvents.SUBSCRIPTION_CANCEL_ABANDONED,
   failed: TelemetryEvents.SUBSCRIPTION_CANCEL_FAILED
+} as const
+
+/**
+ * Bring-your-own-model funnel stages, one distinct event each so PostHog funnel
+ * steps work without per-step property filters.
+ */
+export const BYOM_STAGE_EVENTS = {
+  dialog_opened: TelemetryEvents.BYOM_DIALOG_OPENED,
+  url_submitted: TelemetryEvents.BYOM_URL_SUBMITTED,
+  metadata_resolved: TelemetryEvents.BYOM_METADATA_RESOLVED,
+  upload_submitted: TelemetryEvents.BYOM_UPLOAD_SUBMITTED,
+  upload_completed: TelemetryEvents.BYOM_UPLOAD_COMPLETED,
+  dialog_abandoned: TelemetryEvents.BYOM_DIALOG_ABANDONED
 } as const
 
 const executionTriggerSources = [

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.vue
@@ -16,7 +16,11 @@ const emit = defineEmits<{
 
 const filterSelected = defineModel<string>('filterSelected')
 
-const { isUploadButtonEnabled, showUploadDialog } = useModelUpload()
+const { isUploadButtonEnabled, showUploadDialog } = useModelUpload(
+  undefined,
+  undefined,
+  'model_dropdown'
+)
 
 const singleFilterOption = computed(() => filterOptions.length === 1)
 


### PR DESCRIPTION
Adds six `app:byom_*` events so the bring-your-own-model flow — discovery through a model actually being added — is measurable. The entire `src/platform/assets/` tree currently emits no analytics at all, so none of this flow is visible today.

| stage | event | fires |
|---|---|---|
| 1 | `app:byom_dialog_opened` | `showUploadDialog()`, before the paywall branch |
| 2 | `app:byom_url_submitted` | after source detection in `fetchMetadata()` |
| 3 | `app:byom_metadata_resolved` | both branches of `fetchMetadata()` |
| 4 | `app:byom_upload_submitted` | top of `uploadModel()` |
| 5 | `app:byom_upload_completed` | sync success, async watcher, type-mismatch |
| 6 | `app:byom_dialog_abandoned` | teardown, only if no terminal stage fired |

Wired as one `trackByomFunnel(stage, metadata)` mapping to six distinct event names via `BYOM_STAGE_EVENTS`, matching the existing `CANCELLATION_STAGE_EVENTS` pattern — distinct events so PostHog funnel steps work without per-step property filters.

Firing step 1 before the `privateModelsEnabled` branch with a `gated` property makes paywall conversion a single funnel step. All three entry surfaces are tagged: `asset_browser`, `model_dropdown`, `missing_model`.

A `flow_id` UUID is minted at dialog open and carried through every stage. Without it a funnel stitches step 1 of one attempt to the last step of another, and repeated abandons are indistinguishable from one.

**Privacy:** the source URL is never emitted — only the resolved `source` (`civitai`/`huggingface`), since HF and Civitai URLs can carry tokens. `error_reason` is a closed 4-value set rather than the raw message, which is built from API text and i18n strings that interpolate the asset name. There's a test asserting a `?token=SECRET` URL appears in no emitted payload.

**Known limitation:** `upload_completed` under-reports async uploads. The completion watcher lives in the composable's setup scope, so closing the dialog during a long download means no completion event (it reports `dialog_abandoned` instead). Steps 1–4 are reliable; a backend event at `CreateAssetDownload` is the fix if async success rate is needed.

**Testing:** 77 test files / 1086 tests pass across `src/platform/assets` and `src/platform/telemetry`, including 7 new funnel tests. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)