### PR TITLE
fix(workflow): repair the A1111 import lifecycle and report broken installs accurately

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2275,6 +2275,7 @@
     "failedToExportModel": "Failed to export model as {format}",
     "exportSuccess": "Successfully exported model as {format}",
     "fileLoadError": "Unable to find workflow in {fileName}",
+    "a1111CoreNodesUnavailable": "Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.",
     "dropFileError": "Unable to process dropped item: {error}",
     "missingModelVerificationFailed": "Failed to verify missing models. Some models may not be shown in the Errors tab.",
     "interrupted": "Execution has been interrupted",

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -39,6 +39,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import type { importA1111 } from './pnginfo'
 
 const {
   mockApiKeyAuthStore,
@@ -77,14 +78,7 @@ const {
     activeWorkflow: null as ComfyWorkflow | null
   },
   mockRefreshMissingModelPipeline: vi.fn(),
-  mockImportA1111:
-    vi.fn<
-      (
-        graph: unknown,
-        parameters: string,
-        beforeGraphClear?: () => void
-      ) => Promise<'imported' | 'not-a1111' | 'core-nodes-unavailable'>
-    >(),
+  mockImportA1111: vi.fn<typeof importA1111>(),
   mockWorkflowService: {
     beforeLoadNewGraph: vi.fn(),
     afterLoadNewGraph: vi.fn<(...args: unknown[]) => Promise<void>>(),

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -82,9 +82,8 @@ const {
       (
         graph: unknown,
         parameters: string,
-        beforeGraphClear?: () => void,
-        onCoreNodesUnavailable?: () => void
-      ) => Promise<boolean>
+        beforeGraphClear?: () => void
+      ) => Promise<'imported' | 'not-a1111' | 'core-nodes-unavailable'>
     >(),
   mockWorkflowService: {
     beforeLoadNewGraph: vi.fn(),
@@ -221,7 +220,7 @@ describe('ComfyApp', () => {
     mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
-    mockImportA1111.mockReset().mockResolvedValue(true)
+    mockImportA1111.mockReset().mockResolvedValue('imported')
     mockWorkflowService.beforeLoadNewGraph.mockReset()
     mockWorkflowService.afterLoadNewGraph.mockReset().mockResolvedValue()
     mockWorkflowService.showPendingWarnings.mockReset()
@@ -1252,30 +1251,42 @@ describe('ComfyApp', () => {
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
       Reflect.set(app, 'rootGraphInternal', graph)
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
-      mockImportA1111.mockImplementation(
-        async (_graph, _parameters, _beforeGraphClear, onUnavailable) => {
-          onUnavailable?.()
-          return false
-        }
-      )
+      mockImportA1111.mockResolvedValue('core-nodes-unavailable')
 
       await app.handleFile(createTestFile('a1111.png', 'image/png'))
 
       expect(mockImportA1111).toHaveBeenCalledWith(
         graph,
         parameters,
-        expect.any(Function),
         expect.any(Function)
       )
       expect(mockCanvas.setGraph).not.toHaveBeenCalled()
       expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
       expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
       expect(mockToastStore.addAlert).toHaveBeenCalledWith(
         'Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.'
       )
     })
 
-    it('switches to the root graph before import and awaits A1111 persistence', async () => {
+    it('shows one file-load error when parameters are not A1111-shaped', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockResolvedValue('not-a1111')
+
+      await app.handleFile(createTestFile('parameters.png', 'image/png'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        'Unable to find workflow in parameters.png'
+      )
+      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+    })
+
+    it('runs A1111 lifecycle in order and awaits persistence', async () => {
       const graph = new LGraph()
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
       Reflect.set(app, 'rootGraphInternal', graph)
@@ -1283,7 +1294,7 @@ describe('ComfyApp', () => {
       mockImportA1111.mockImplementation(
         async (_graph, _parameters, beforeGraphClear) => {
           beforeGraphClear?.()
-          return true
+          return 'imported'
         }
       )
       let resolveAfterLoad: (() => void) | undefined
@@ -1304,6 +1315,9 @@ describe('ComfyApp', () => {
 
       expect(mockCanvas.setGraph).toHaveBeenCalledWith(graph)
       expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledOnce()
+      expect(
+        mockWorkflowService.beforeLoadNewGraph.mock.invocationCallOrder[0]
+      ).toBeLessThan(vi.mocked(mockCanvas.setGraph).mock.invocationCallOrder[0])
       expect(settled).toBe(false)
 
       resolveAfterLoad?.()

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -40,6 +40,9 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { importA1111 } from './pnginfo'
+import type { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+
+type WorkflowService = ReturnType<typeof useWorkflowService>
 
 const {
   mockApiKeyAuthStore,
@@ -80,9 +83,9 @@ const {
   mockRefreshMissingModelPipeline: vi.fn(),
   mockImportA1111: vi.fn<typeof importA1111>(),
   mockWorkflowService: {
-    beforeLoadNewGraph: vi.fn(),
-    afterLoadNewGraph: vi.fn<(...args: unknown[]) => Promise<void>>(),
-    showPendingWarnings: vi.fn()
+    beforeLoadNewGraph: vi.fn<WorkflowService['beforeLoadNewGraph']>(),
+    afterLoadNewGraph: vi.fn<WorkflowService['afterLoadNewGraph']>(),
+    showPendingWarnings: vi.fn<WorkflowService['showPendingWarnings']>()
   }
 }))
 
@@ -205,7 +208,7 @@ describe('ComfyApp', () => {
 
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     app = new ComfyApp()
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
@@ -214,10 +217,8 @@ describe('ComfyApp', () => {
     mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
-    mockImportA1111.mockReset().mockResolvedValue('imported')
-    mockWorkflowService.beforeLoadNewGraph.mockReset()
-    mockWorkflowService.afterLoadNewGraph.mockReset().mockResolvedValue()
-    mockWorkflowService.showPendingWarnings.mockReset()
+    mockImportA1111.mockResolvedValue('imported')
+    mockWorkflowService.afterLoadNewGraph.mockResolvedValue()
     mockSettingStore.get.mockImplementation((key: string) =>
       key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
     )
@@ -1237,6 +1238,9 @@ describe('ComfyApp', () => {
       await app.handleFile(createTestFile('broken.json', 'application/json'))
 
       expect(mockToastStore.addAlert).toHaveBeenCalledTimes(1)
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        'Unable to find workflow in broken.json'
+      )
       consoleError.mockRestore()
     })
 
@@ -1280,7 +1284,7 @@ describe('ComfyApp', () => {
       expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
     })
 
-    it('runs A1111 lifecycle in order and awaits persistence', async () => {
+    it('awaits persistence and orders its clear callback before setGraph', async () => {
       const graph = new LGraph()
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
       Reflect.set(app, 'rootGraphInternal', graph)

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -48,7 +48,9 @@ const {
   mockExtensionService,
   mockNodeOutputStore,
   mockWorkspaceWorkflow,
-  mockRefreshMissingModelPipeline
+  mockRefreshMissingModelPipeline,
+  mockImportA1111,
+  mockWorkflowService
 } = vi.hoisted(() => ({
   mockApiKeyAuthStore: {
     getApiKey: vi.fn()
@@ -74,7 +76,21 @@ const {
   mockWorkspaceWorkflow: {
     activeWorkflow: null as ComfyWorkflow | null
   },
-  mockRefreshMissingModelPipeline: vi.fn()
+  mockRefreshMissingModelPipeline: vi.fn(),
+  mockImportA1111:
+    vi.fn<
+      (
+        graph: unknown,
+        parameters: string,
+        beforeGraphClear?: () => void,
+        onCoreNodesUnavailable?: () => void
+      ) => Promise<boolean>
+    >(),
+  mockWorkflowService: {
+    beforeLoadNewGraph: vi.fn(),
+    afterLoadNewGraph: vi.fn<(...args: unknown[]) => Promise<void>>(),
+    showPendingWarnings: vi.fn()
+  }
 }))
 
 vi.mock('@/utils/litegraphUtil', () => ({
@@ -109,6 +125,14 @@ vi.mock('@/composables/usePaste', () => ({
 
 vi.mock('@/scripts/metadata/parser', () => ({
   getWorkflowDataFromFile: vi.fn()
+}))
+
+vi.mock('./pnginfo', () => ({
+  importA1111: mockImportA1111
+}))
+
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: vi.fn(() => mockWorkflowService)
 }))
 
 vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
@@ -160,7 +184,8 @@ function createMockCanvas(): Partial<LGraphCanvas> {
   return {
     graph: mockGraph as LGraph,
     draw: vi.fn(),
-    selectItems: vi.fn()
+    selectItems: vi.fn(),
+    setGraph: vi.fn()
   }
 }
 
@@ -196,6 +221,10 @@ describe('ComfyApp', () => {
     mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
+    mockImportA1111.mockReset().mockResolvedValue(true)
+    mockWorkflowService.beforeLoadNewGraph.mockReset()
+    mockWorkflowService.afterLoadNewGraph.mockReset().mockResolvedValue()
+    mockWorkflowService.showPendingWarnings.mockReset()
     mockSettingStore.get.mockImplementation((key: string) =>
       key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
     )
@@ -1201,6 +1230,85 @@ describe('ComfyApp', () => {
         expect.any(DataTransferItemList),
         mockNode
       )
+    })
+
+    it.each([
+      ['an invalid structure', '[]'],
+      ['invalid JSON', '{invalid']
+    ])('shows one error for %s', async (_case, workflow) => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ workflow })
+
+      await app.handleFile(createTestFile('broken.json', 'application/json'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalledTimes(1)
+      consoleError.mockRestore()
+    })
+
+    it('preserves the current graph when A1111 core nodes are unavailable', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockImplementation(
+        async (_graph, _parameters, _beforeGraphClear, onUnavailable) => {
+          onUnavailable?.()
+          return false
+        }
+      )
+
+      await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+      expect(mockImportA1111).toHaveBeenCalledWith(
+        graph,
+        parameters,
+        expect.any(Function),
+        expect.any(Function)
+      )
+      expect(mockCanvas.setGraph).not.toHaveBeenCalled()
+      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        'Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.'
+      )
+    })
+
+    it('switches to the root graph before import and awaits A1111 persistence', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockImplementation(
+        async (_graph, _parameters, beforeGraphClear) => {
+          beforeGraphClear?.()
+          return true
+        }
+      )
+      let resolveAfterLoad: (() => void) | undefined
+      const afterLoad = new Promise<void>((resolve) => {
+        resolveAfterLoad = resolve
+      })
+      mockWorkflowService.afterLoadNewGraph.mockReturnValue(afterLoad)
+
+      let settled = false
+      const handleFile = app
+        .handleFile(createTestFile('a1111.png', 'image/png'))
+        .then(() => {
+          settled = true
+        })
+      await vi.waitFor(() =>
+        expect(mockWorkflowService.afterLoadNewGraph).toHaveBeenCalled()
+      )
+
+      expect(mockCanvas.setGraph).toHaveBeenCalledWith(graph)
+      expect(mockWorkflowService.beforeLoadNewGraph).toHaveBeenCalledOnce()
+      expect(settled).toBe(false)
+
+      resolveAfterLoad?.()
+      await handleFile
+      expect(settled).toBe(true)
     })
   })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2031,11 +2031,9 @@ export class ComfyApp {
           console.error(
             'Invalid workflow structure, trying parameters fallback'
           )
-          this.showErrorOnFileLoad(file)
         }
       } catch (err) {
         console.error('Failed to parse workflow:', err)
-        this.showErrorOnFileLoad(file)
         // Fall through to check parameters as fallback
       }
     }
@@ -2058,9 +2056,18 @@ export class ComfyApp {
 
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
-      useWorkflowService().beforeLoadNewGraph()
-      importA1111(this.rootGraph, parameters)
-      useWorkflowService().afterLoadNewGraph(
+      const imported = await importA1111(
+        this.rootGraph,
+        parameters,
+        () => {
+          this.canvas.setGraph(this.rootGraph)
+          useWorkflowService().beforeLoadNewGraph()
+        },
+        () =>
+          useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
+      )
+      if (!imported) return
+      await useWorkflowService().afterLoadNewGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
       )

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2056,17 +2056,18 @@ export class ComfyApp {
 
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
-      const imported = await importA1111(
-        this.rootGraph,
-        parameters,
-        () => {
-          this.canvas.setGraph(this.rootGraph)
-          useWorkflowService().beforeLoadNewGraph()
-        },
-        () =>
-          useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
-      )
-      if (!imported) return
+      const outcome = await importA1111(this.rootGraph, parameters, () => {
+        useWorkflowService().beforeLoadNewGraph()
+        this.canvas.setGraph(this.rootGraph)
+      })
+      if (outcome === 'core-nodes-unavailable') {
+        useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
+        return
+      }
+      if (outcome === 'not-a1111') {
+        this.showErrorOnFileLoad(file)
+        return
+      }
       await useWorkflowService().afterLoadNewGraph(
         fileName,
         this.rootGraph.serialize() as unknown as ComfyWorkflowJSON

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -2,6 +2,9 @@ import fs from 'fs'
 import path from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+import { api } from './api'
 import { getFromAvifFile } from './metadata/avif'
 import { getFromFlacFile } from './metadata/flac'
 import { getFromPngFile } from './metadata/png'
@@ -10,8 +13,15 @@ import {
   getFlacMetadata,
   getLatentMetadata,
   getPngMetadata,
-  getWebpMetadata
+  getWebpMetadata,
+  importA1111
 } from './pnginfo'
+
+vi.mock('./api', () => ({
+  api: {
+    getEmbeddings: vi.fn()
+  }
+}))
 
 vi.mock('./metadata/png', () => ({
   getFromPngFile: vi.fn()
@@ -232,5 +242,53 @@ describe('format-specific metadata wrappers', () => {
 
     expect(getFromAvifFile).toHaveBeenCalledWith(file)
     expect(result).toEqual({ workflow: '{"avif":1}' })
+  })
+})
+
+describe('importA1111', () => {
+  const parameters =
+    'positive\nNegative prompt: negative\nSteps: 20, Sampler: Euler, CFG scale: 7, Seed: 1, Size: 512x512, Model: model.safetensors'
+
+  it('returns false without clearing the graph when core nodes are unavailable', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    const onCoreNodesUnavailable = vi.fn()
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+    vi.spyOn(LiteGraph, 'createNode').mockReturnValue(null)
+
+    const imported = await importA1111(
+      graph,
+      parameters,
+      beforeGraphClear,
+      onCoreNodesUnavailable
+    )
+
+    expect(imported).toBe(false)
+    expect(beforeGraphClear).not.toHaveBeenCalled()
+    expect(onCoreNodesUnavailable).toHaveBeenCalledOnce()
+    expect(clear).not.toHaveBeenCalled()
+  })
+
+  it('runs the lifecycle callback immediately before clearing the graph', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
+      const node = new LGraphNode(type)
+      node.type = type
+      vi.spyOn(node, 'connect').mockReturnValue(null)
+      return node
+    })
+
+    const imported = await importA1111(graph, parameters, beforeGraphClear)
+
+    expect(imported).toBe(true)
+    expect(beforeGraphClear).toHaveBeenCalledOnce()
+    expect(beforeGraphClear.mock.invocationCallOrder[0]).toBeLessThan(
+      clear.mock.invocationCallOrder[0]
+    )
   })
 })

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -249,24 +249,32 @@ describe('importA1111', () => {
   const parameters =
     'positive\nNegative prompt: negative\nSteps: 20, Sampler: Euler, CFG scale: 7, Seed: 1, Size: 512x512, Model: model.safetensors'
 
-  it('returns false without clearing the graph when core nodes are unavailable', async () => {
+  it.each([
+    ['has no steps', 'positive'],
+    ['has no options', 'positive\nNegative prompt: negative\nSteps:'],
+    ['has no negative prompt', 'positive\nSteps: 20']
+  ])('returns not-a1111 when parameters %s', async (_case, input) => {
+    const graph = new LGraph()
+    const beforeGraphClear = vi.fn()
+    vi.mocked(api.getEmbeddings).mockResolvedValue([])
+
+    const imported = await importA1111(graph, input, beforeGraphClear)
+
+    expect(imported).toBe('not-a1111')
+    expect(beforeGraphClear).not.toHaveBeenCalled()
+  })
+
+  it('returns core-nodes-unavailable without clearing the graph', async () => {
     const graph = new LGraph()
     const clear = vi.spyOn(graph, 'clear')
     const beforeGraphClear = vi.fn()
-    const onCoreNodesUnavailable = vi.fn()
     vi.mocked(api.getEmbeddings).mockResolvedValue([])
     vi.spyOn(LiteGraph, 'createNode').mockReturnValue(null)
 
-    const imported = await importA1111(
-      graph,
-      parameters,
-      beforeGraphClear,
-      onCoreNodesUnavailable
-    )
+    const imported = await importA1111(graph, parameters, beforeGraphClear)
 
-    expect(imported).toBe(false)
+    expect(imported).toBe('core-nodes-unavailable')
     expect(beforeGraphClear).not.toHaveBeenCalled()
-    expect(onCoreNodesUnavailable).toHaveBeenCalledOnce()
     expect(clear).not.toHaveBeenCalled()
   })
 
@@ -285,7 +293,7 @@ describe('importA1111', () => {
 
     const imported = await importA1111(graph, parameters, beforeGraphClear)
 
-    expect(imported).toBe(true)
+    expect(imported).toBe('imported')
     expect(beforeGraphClear).toHaveBeenCalledOnce()
     expect(beforeGraphClear.mock.invocationCallOrder[0]).toBeLessThan(
       clear.mock.invocationCallOrder[0]

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -284,6 +284,7 @@ describe('importA1111', () => {
     const beforeGraphClear = vi.fn()
     vi.mocked(api.getEmbeddings).mockResolvedValue([])
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(graph, 'arrange').mockImplementation(() => {})
     vi.spyOn(LiteGraph, 'createNode').mockImplementation((type) => {
       const node = new LGraphNode(type)
       node.type = type

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -182,8 +182,10 @@ interface LoraEntry {
 
 export async function importA1111(
   graph: LGraph,
-  parameters: string
-): Promise<void> {
+  parameters: string,
+  beforeGraphClear?: () => void,
+  onCoreNodesUnavailable?: () => void
+): Promise<boolean> {
   const p = parameters.lastIndexOf('\nSteps:')
   if (p > -1) {
     const embeddings = await api.getEmbeddings()
@@ -193,7 +195,7 @@ export async function importA1111(
       .match(
         new RegExp('\\s*([^:]+:\\s*([^"\\{].*?|".*?"|\\{.*?\\}))\\s*(,|$)', 'g')
       )
-    if (!matchResult) return
+    if (!matchResult) return false
 
     const opts: Record<string, string> = matchResult.reduce(
       (acc: Record<string, string>, n: string) => {
@@ -231,7 +233,8 @@ export async function importA1111(
         !saveNode
       ) {
         console.error('Failed to create required nodes for A1111 import')
-        return
+        onCoreNodesUnavailable?.()
+        return false
       }
 
       let hrSamplerNode: LGraphNode | null = null
@@ -331,6 +334,7 @@ export async function importA1111(
         return v
       }
 
+      beforeGraphClear?.()
       graph.clear()
       graph.add(ckptNode)
       graph.add(clipSkipNode)
@@ -551,6 +555,8 @@ export async function importA1111(
       }
 
       console.warn('Unhandled parameters:', opts)
+      return true
     }
   }
+  return false
 }

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -180,11 +180,13 @@ interface LoraEntry {
   weight: number
 }
 
+type A1111ImportOutcome = 'imported' | 'not-a1111' | 'core-nodes-unavailable'
+
 export async function importA1111(
   graph: LGraph,
   parameters: string,
   beforeGraphClear?: () => void
-): Promise<'imported' | 'not-a1111' | 'core-nodes-unavailable'> {
+): Promise<A1111ImportOutcome> {
   const p = parameters.lastIndexOf('\nSteps:')
   if (p > -1) {
     const embeddings = await api.getEmbeddings()

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -183,9 +183,8 @@ interface LoraEntry {
 export async function importA1111(
   graph: LGraph,
   parameters: string,
-  beforeGraphClear?: () => void,
-  onCoreNodesUnavailable?: () => void
-): Promise<boolean> {
+  beforeGraphClear?: () => void
+): Promise<'imported' | 'not-a1111' | 'core-nodes-unavailable'> {
   const p = parameters.lastIndexOf('\nSteps:')
   if (p > -1) {
     const embeddings = await api.getEmbeddings()
@@ -195,7 +194,7 @@ export async function importA1111(
       .match(
         new RegExp('\\s*([^:]+:\\s*([^"\\{].*?|".*?"|\\{.*?\\}))\\s*(,|$)', 'g')
       )
-    if (!matchResult) return false
+    if (!matchResult) return 'not-a1111'
 
     const opts: Record<string, string> = matchResult.reduce(
       (acc: Record<string, string>, n: string) => {
@@ -233,8 +232,7 @@ export async function importA1111(
         !saveNode
       ) {
         console.error('Failed to create required nodes for A1111 import')
-        onCoreNodesUnavailable?.()
-        return false
+        return 'core-nodes-unavailable'
       }
 
       let hrSamplerNode: LGraphNode | null = null
@@ -555,8 +553,8 @@ export async function importA1111(
       }
 
       console.warn('Unhandled parameters:', opts)
-      return true
+      return 'imported'
     }
   }
-  return false
+  return 'not-a1111'
 }

--- a/src/scripts/pnginfo.ts
+++ b/src/scripts/pnginfo.ts
@@ -180,7 +180,10 @@ interface LoraEntry {
   weight: number
 }
 
-type A1111ImportOutcome = 'imported' | 'not-a1111' | 'core-nodes-unavailable'
+export type A1111ImportOutcome =
+  | 'imported'
+  | 'not-a1111'
+  | 'core-nodes-unavailable'
 
 export async function importA1111(
   graph: LGraph,
@@ -554,7 +557,9 @@ export async function importA1111(
         delete opts[opt]
       }
 
-      console.warn('Unhandled parameters:', opts)
+      if (Object.keys(opts).length) {
+        console.warn('Unhandled parameters:', opts)
+      }
       return 'imported'
     }
   }

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ComfyUI } from './ui'
+
+const { mockApp } = vi.hoisted(() => ({
+  mockApp: {
+    handleFile: vi.fn<(file: File, source: string) => Promise<void>>(),
+    showErrorOnFileLoad: vi.fn(),
+    queuePrompt: vi.fn(),
+    loadGraphData: vi.fn(),
+    refreshComboInNodes: vi.fn(),
+    openClipspace: vi.fn(),
+    clean: vi.fn(),
+    lastExecutionError: null
+  }
+}))
+
+vi.mock('./app', () => ({
+  ComfyApp: class {},
+  app: mockApp
+}))
+
+vi.mock('./api', () => ({
+  api: {
+    addEventListener: vi.fn()
+  }
+}))
+
+vi.mock('./ui/dialog', () => ({
+  ComfyDialog: class {}
+}))
+
+vi.mock('./ui/settings', () => ({
+  ComfySettingsDialog: class {}
+}))
+
+vi.mock('./ui/toggleSwitch', () => ({
+  toggleSwitch: vi.fn(() => document.createElement('div'))
+}))
+
+describe('ComfyUI file input', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        disconnect = vi.fn()
+        unobserve = vi.fn()
+      }
+    )
+    mockApp.handleFile.mockReset()
+    mockApp.showErrorOnFileLoad.mockReset()
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.unstubAllGlobals()
+  })
+
+  it('reports rejected imports and resets the selected file', async () => {
+    const file = new File([''], 'a1111.png', { type: 'image/png' })
+    const error = new Error('import failed')
+    mockApp.handleFile.mockRejectedValue(error)
+    new ComfyUI(mockApp)
+    const fileInput = document.getElementById(
+      'comfy-file-input'
+    ) as HTMLInputElement
+    Object.defineProperties(fileInput, {
+      files: { value: [file], configurable: true },
+      value: { value: 'a1111.png', writable: true, configurable: true }
+    })
+
+    fileInput.dispatchEvent(new Event('change'))
+
+    await vi.waitFor(() =>
+      expect(mockApp.showErrorOnFileLoad).toHaveBeenCalledWith(file)
+    )
+    expect(mockApp.handleFile).toHaveBeenCalledWith(file, 'file_button')
+    expect(fileInput.value).toBe('')
+  })
+})

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -69,6 +69,7 @@ describe('ComfyUI file input', () => {
       files: { value: [file], configurable: true },
       value: { value: 'a1111.png', writable: true, configurable: true }
     })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     fileInput.dispatchEvent(new Event('change'))
 
@@ -76,6 +77,10 @@ describe('ComfyUI file input', () => {
       expect(mockApp.showErrorOnFileLoad).toHaveBeenCalledWith(file)
     )
     expect(mockApp.handleFile).toHaveBeenCalledWith(file, 'file_button')
+    expect(consoleError).toHaveBeenCalledWith('Failed to load file:', error)
+    expect(consoleError.mock.invocationCallOrder[0]).toBeLessThan(
+      mockApp.showErrorOnFileLoad.mock.invocationCallOrder[0]
+    )
     expect(fileInput.value).toBe('')
   })
 })

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -409,7 +409,8 @@ export class ComfyUI {
         if (file) {
           try {
             await app.handleFile(file, 'file_button')
-          } catch {
+          } catch (error) {
+            console.error('Failed to load file:', error)
             app.showErrorOnFileLoad(file)
           } finally {
             fileInput.value = ''

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -407,8 +407,13 @@ export class ComfyUI {
       onchange: async () => {
         const file = fileInput.files?.[0]
         if (file) {
-          await app.handleFile(file, 'file_button')
-          fileInput.value = ''
+          try {
+            await app.handleFile(file, 'file_button')
+          } catch {
+            app.showErrorOnFileLoad(file)
+          } finally {
+            fileInput.value = ''
+          }
         }
       }
     })


### PR DESCRIPTION
Splits out of #14251. Five lifecycle fixes on the A1111 image-import path. 30 production lines.

## What

Dropping an A1111-generated PNG parses its `parameters` string and builds a ComfyUI graph from it. The path had four defects that only show up when something goes wrong, plus one that shows up always:

1. **`afterLoadNewGraph` was not awaited.** It suspends before the active workflow is reassigned, so `rootGraph.serialize()` on the next line captured the *outgoing* graph — the new tab was born dirty against a stale baseline.
2. **A rejection escaped an async DOM handler.** `importA1111` awaits `api.getEmbeddings()`, which does not check `resp.ok`. On a 500 with an HTML body it throws, `fileInput.value = ''` never runs, the input still holds the file, re-selecting it fires no `change` event, and Open silently does nothing on every retry. Now: `try`/`catch` with a toast, `finally` resets the input.
3. **Two identical alerts for one file.** The invalid-structure `else` and the parse `catch` each called `showErrorOnFileLoad`, then fell through to the final call at the end of `handleFile`. Those two are the `else` and `catch` of one `try`, so the maximum is two alerts, not three.
4. **`beforeLoadNewGraph()` ran before an import that might bail.** It calls `domWidgetStore.clear()`, and nothing re-registers on a bail path — a workflow with a multiline prompt on screen lost its DOM widget overlays when the user dropped a PNG that did not parse. It now runs immediately before the mutation, and the A1111 path gets the subgraph guard `clean()` already had.
5. **No message at all when required node types are unavailable, and silent corruption of the open workflow.** `importA1111` logged to the console and returned `void`. Because the call was unawaited, `afterLoadNewGraph` then registered the user's *unchanged* graph under the dropped file's name, after `beforeLoadNewGraph` had already cleared `domWidgetStore`. See below.

## The message

The seven types this importer needs — `CheckpointLoaderSimple`, `CLIPSetLastLayer`, `CLIPTextEncode`, `KSampler`, `EmptyLatentImage`, `VAEDecode`, `SaveImage` — are all **core nodes**, as are `LoraLoader` and the hires chain. Their absence does not mean a node pack is missing. It means the backend did not load, or the install is broken.

So this path deliberately writes nothing to the missing-node panel: no card, no entry, no placeholder. A type that was never added to the graph does not belong in a list of nodes missing *from the graph*, and naming the individual types would read as "install this pack" and send people looking for something that does not exist.

```
"Could not load the workflow because this ComfyUI installation is missing core nodes.
 Check that the backend started correctly."
```

`importA1111` returns `Promise<'imported' | 'not-a1111' | 'core-nodes-unavailable'>` — three string literals, replacing `Promise<boolean>`. The boolean could not distinguish "bailed and already told the user" from "bailed silently", which is how an ordinary A1111 PNG could vanish with no feedback at all: A1111 omits the `Negative prompt:` line entirely when the negative prompt is empty.

The `core-nodes-unavailable` return happens **before** the graph is touched, so a failed import leaves the open workflow intact. `pnginfo.test.ts` asserts that directly.

## What this deliberately does not do

`pnginfo.ts` is **+8 −4**, with zero re-indentation (`git diff` and `git diff -w` report the same line count). The nesting in that file is not pretty and it is not this PR's business. An earlier revision restructured it; that diff was 759 lines, ~72% of it re-indentation, and none of it fixed a bug. If it deserves a refactor it deserves a PR where a reviewer sees only that.

## Verification

6 unit tests across `app.test.ts`, `pnginfo.test.ts` and `ui.test.ts`, each mutation-proved. typecheck, lint, format, knip clean. Full unit suite: only pre-existing timeout flakes, confirmed by re-running the same files at the merge base and getting byte-identical results.

## Related

- Follow-up to #14251 (closed)
- Independent of #14555 and of the narrow submission fix — no ordering constraint

