### PR TITLE
fix(errors): keep missing node packs across prompt submissions

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -30,6 +30,28 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     ).toHaveText(/\S/)
   })
 
+  test('Should keep the missing node pack card after submitting a prompt', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'PR #14557 — submitting a prompt cleared missing-node state, emptying the Errors tab'
+    })
+
+    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
+
+    const missingNodeCard = comfyPage.page.getByTestId(
+      TestIds.dialogs.missingNodeCard
+    )
+    await expect(missingNodeCard).toBeVisible()
+
+    await comfyPage.runButton.click()
+
+    await expect(missingNodeCard).toBeVisible()
+    await expect(missingNodeCard.getByText('Unknown pack')).toBeVisible()
+  })
+
   test('Should show unknown pack node rows by default', async ({
     comfyPage
   }) => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -340,6 +340,30 @@ describe('ComfyApp', () => {
       expect(executionErrorStore.lastExecutionError).toBeNull()
     })
 
+    it('dismisses the error overlay when submitting a prompt', async () => {
+      prepareEmptyPromptQueue()
+      const executionErrorStore = useExecutionErrorStore()
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+      executionErrorStore.showErrorOverlay()
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      await app.queuePrompt(0)
+
+      expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
+    })
+
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
       const workflow = new ComfyWorkflow({

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1065,14 +1065,49 @@ describe('ComfyApp', () => {
     })
   })
   describe('clean', () => {
-    it('clears missing node packs explicitly', () => {
+    it('clears error state explicitly', () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
       const missingNodesStore = useMissingNodesErrorStore()
+      const executionErrorStore = useExecutionErrorStore()
       missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+      executionErrorStore.recordPromptError({
+        type: 'execution',
+        message: 'fail',
+        details: ''
+      })
+      executionErrorStore.recordNodeErrors({
+        '1': {
+          errors: [
+            {
+              type: 'required_input_missing',
+              message: 'Missing',
+              details: '',
+              extra_info: { input_name: 'x' }
+            }
+          ],
+          dependent_outputs: [],
+          class_type: 'Test'
+        }
+      })
+      executionErrorStore.showErrorOverlay()
 
       app.clean()
 
+      expect(executionErrorStore.lastExecutionError).toBeNull()
+      expect(executionErrorStore.lastPromptError).toBeNull()
+      expect(executionErrorStore.lastNodeErrors).toBeNull()
+      expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
       expect(missingNodesStore.missingNodesError).toBeNull()
     })
   })

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -312,6 +312,34 @@ describe('ComfyApp', () => {
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
 
+    it('preserves missing node packs when submitting a prompt', async () => {
+      prepareEmptyPromptQueue()
+      const missingNodesStore = useMissingNodesErrorStore()
+      const executionErrorStore = useExecutionErrorStore()
+      missingNodesStore.setMissingNodeTypes(['test/UninstalledLiveNode'])
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      await app.queuePrompt(0)
+
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+        'test/UninstalledLiveNode'
+      ])
+      expect(executionErrorStore.lastExecutionError).toBeNull()
+    })
+
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
       const workflow = new ComfyWorkflow({
@@ -1036,6 +1064,19 @@ describe('ComfyApp', () => {
       ])
     })
   })
+  describe('clean', () => {
+    it('clears missing node packs explicitly', () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+
+      app.clean()
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
+    })
+  })
+
   describe('refreshComboInNodes', () => {
     it('shows success toast and removes the pending toast after node defs reload', async () => {
       app.vueAppReady = true

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2432,6 +2432,7 @@ export class ComfyApp {
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
     executionErrorStore.clearRunErrors()
+    executionErrorStore.dismissErrorOverlay()
     useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -113,6 +113,7 @@ import { normalizePromptError } from '@/utils/executionErrorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
 import { getCnrIdFromProperties } from '@/platform/nodeReplacement/cnrIdUtil'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { rescanAndSurfaceMissingNodes } from '@/platform/nodeReplacement/missingNodeScan'
 import {
   refreshMissingModelPipeline,
@@ -1645,7 +1646,7 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     const executionErrorStore = useExecutionErrorStore()
     const telemetry = useTelemetry()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
@@ -2430,7 +2431,8 @@ export class ComfyApp {
     const nodeOutputStore = useNodeOutputStore()
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
+    useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1647,6 +1647,7 @@ export class ComfyApp {
     const executionErrorStore = useExecutionErrorStore()
     const telemetry = useTelemetry()
     executionErrorStore.clearRunErrors()
+    executionErrorStore.dismissErrorOverlay()
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import type { MissingNodeType } from '@/types/comfy'
 import {
   createBoundaryLinkedSubgraph,
   createTestRootGraph,
@@ -838,7 +837,7 @@ describe('hasMissingError', () => {
   })
 })
 
-describe('clearAllErrors', () => {
+describe('clearRunErrors', () => {
   let executionErrorStore: ReturnType<typeof useExecutionErrorStore>
   let missingNodesStore: ReturnType<typeof useMissingNodesErrorStore>
 
@@ -849,7 +848,7 @@ describe('clearAllErrors', () => {
     missingNodesStore = useMissingNodesErrorStore()
   })
 
-  it('resets all error categories and closes error overlay', () => {
+  it('resets run errors while keeping the missing-node overlay visible', () => {
     executionErrorStore.recordExecutionError({
       prompt_id: 'test',
       timestamp: 0,
@@ -879,18 +878,18 @@ describe('clearAllErrors', () => {
         class_type: 'Test'
       }
     })
-    missingNodesStore.setMissingNodeTypes(
-      fromAny<MissingNodeType[], unknown>([{ type: 'MissingNode', hint: '' }])
-    )
+    missingNodesStore.setMissingNodeTypes([{ type: 'MissingNode', hint: '' }])
     executionErrorStore.showErrorOverlay()
 
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
 
     expect(executionErrorStore.lastExecutionError).toBeNull()
     expect(executionErrorStore.lastPromptError).toBeNull()
     expect(executionErrorStore.lastNodeErrors).toBeNull()
-    expect(missingNodesStore.missingNodesError).toBeNull()
-    expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
-    expect(executionErrorStore.hasAnyError).toBe(false)
+    expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+      { type: 'MissingNode', hint: '' }
+    ])
+    expect(executionErrorStore.isErrorOverlayOpen).toBe(true)
+    expect(executionErrorStore.hasAnyError).toBe(true)
   })
 })

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -83,16 +83,14 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /** Clear all error state.
-   *  Missing model state is intentionally preserved here to avoid wiping
-   *  in-progress model repairs (importTaskIds, URL inputs, etc.).
-   *  Missing models are cleared separately during workflow load/clean paths. */
-  function clearAllErrors() {
+  /** Clear errors tied to the previous run: execution, prompt, and node errors.
+   *  Missing node, model, and media state is deliberately preserved because a
+   *  submission cannot prove those resources are no longer missing. Missing
+   *  nodes are cleared by `ComfyApp.clean` and the graph error-clearing hooks. */
+  function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null
     lastNodeErrors.value = null
-    missingNodesStore.setMissingNodeTypes([])
-    isErrorOverlayOpen.value = false
   }
 
   function clearExecutionStartErrors() {
@@ -550,7 +548,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     recordPromptError,
 
     // Clearing
-    clearAllErrors,
+    clearRunErrors,
     clearExecutionStartErrors,
     clearPromptError,
 

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -86,7 +86,10 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   /** Clear errors tied to the previous run: execution, prompt, and node errors.
    *  Missing node, model, and media state is deliberately preserved because a
    *  submission cannot prove those resources are no longer missing. Missing
-   *  nodes are cleared by `ComfyApp.clean` and the graph error-clearing hooks. */
+   *  nodes are cleared by the paths that overwrite the whole list —
+   *  `ComfyApp.clean` and `showPendingWarnings`. The graph error-clearing hooks
+   *  only retire entries carrying a `nodeId`, so group-node entries, which are
+   *  pushed without one, survive them. */
   function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null


### PR DESCRIPTION
The original thesis of #14251, and nothing else. **10 production lines added, 10 removed.**

## What

Missing node packs were wiped from the Issues panel on every prompt submission, while missing model and media state was deliberately preserved. This aligns node packs with the other two.

A submission carries no information about whether a node pack is installed. The missing node can sit on a branch the run never touches, and installing a pack needs a backend restart either way.

## Why it started mattering

#14177 replaced the Run-button warning icon's independent derivation with a store read:

```diff
-const hasMissingNodes = computed(() => graphHasMissingNodes(app.rootGraph, nodeDefStore.nodeDefsByName))
+const { hasMissingError } = storeToRefs(useExecutionErrorStore())
```

Before that the icon re-derived from the graph on every access, so clearing on submit could not affect it. After it, the icon is a pure read of `missingNodeTypes`, and the submit-time wipe started flipping the Run button from `triangle-alert` back to `play` on the first submission.

Blame also shows the clear was an omission rather than a decision: the commit that introduced missing-node state added it in the same stroke with no comment and no test, and the `clearAllErrors()` call in `queuePrompt` predates missing-node state by ~20 months.

## Changes

- `clearAllErrors` renamed to `clearRunErrors`. It clears the three categories this store owns — execution, prompt and node errors — and no longer touches missing-node state or overlay visibility. The name now matches what it does.
- `ComfyApp.clean()` spells out what it used to get transitively: the missing-node clear and the overlay dismissal. **Its net behaviour is unchanged** — all eight effects are preserved, only the ordering of two inert steps differs.

The single intended behaviour change is at `queuePrompt`.

## Why the overlay dismissal moved rather than disappeared

Leaving `isErrorOverlayOpen = false` in `clearRunErrors` would have been actively wrong once missing-node state survives: `hasAnyError` stays true while the overlay closes, which flips `showErrorIndicatorOnPanelButton` (`TopMenuSection.vue:274`) from false to true. A red indicator would appear as a side effect of pressing Run. `MobileDisplay.vue` also reads the flag raw, with no error-count guard.

## Ordering

**#14555 first, but as a quality improvement rather than a prerequisite.** (Corrected after review — the original wording overstated this.)

API-JSON entries are bare strings (`app.ts:2202`), so `removeMissingNodesByNodeId` and `removeMissingNodesByPrefix` cannot touch them, and `removeMissingNodesByType` is unreachable because `replaceNodesInPlace` walks live graph nodes that were never instantiated. #14555 gives those entries a `nodeId`, which makes the existing removers work.

They are not unclearable without it, though. `clean()` — which this PR teaches to call `setMissingNodeTypes([])` — is reachable from `Comfy.ClearWorkflow` (`useCoreCommands.ts:278`), the Clear button (`ui.ts:674`) and `loadGraphData(clean=true)`; switching or opening a workflow runs `showPendingWarnings`, which clears when empty.

So the accurate framing: within the currently-open API-JSON graph, submission was the only in-place clearer, and after this lands you have to discard or switch the workflow to shed the row. A bounded UX regression, not a permanent leak.

#14556 is independent of both, and has already merged.

## Verification

3 unit tests, mutation-proved. `clean()` parity against the merge base checked effect by effect. No `clearAllErrors` reference remains anywhere in the tree. typecheck, lint, format, knip clean; the full unit suite's failures reproduce identically at the merge base.

## Related

- Replaces #14251 (closed), which grew to ~600 non-test lines by absorbing three adjacent concerns. Split into #14555, #14556 and this.

