### PR TITLE
fix: reject on jobs-fetch failure instead of blanking the queue

### DIFF
--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -135,23 +135,38 @@ describe('fetchJobs', () => {
       expect(result[0].priority).toBe(999)
     })
 
-    it('returns empty array on error', async () => {
+    it('rejects on error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
-      const result = await fetchHistory(mockFetch)
-
-      expect(result).toEqual([])
+      await expect(fetchHistory(mockFetch)).rejects.toThrow('Network error')
+      errorSpy.mockRestore()
     })
 
-    it('returns empty array on non-ok response', async () => {
+    it('rejects on non-ok response', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 500
       })
 
-      const result = await fetchHistory(mockFetch)
+      await expect(fetchHistory(mockFetch)).rejects.toThrow(
+        '[Jobs API] Failed to fetch jobs: 500'
+      )
+      expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
+        '[Jobs API] Failed to fetch jobs: 500'
+      )
+      errorSpy.mockRestore()
+    })
 
-      expect(result).toEqual([])
+    it('rejects without logging when the request is aborted', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const abortError = new DOMException('Aborted', 'AbortError')
+      const mockFetch = vi.fn().mockRejectedValue(abortError)
+
+      await expect(fetchHistory(mockFetch)).rejects.toBe(abortError)
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
     })
 
     it('parses batch containing text-only preview outputs', async () => {
@@ -268,12 +283,22 @@ describe('fetchJobs', () => {
       )
     })
 
-    it('returns empty arrays on error', async () => {
+    it('rejects on error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
-      const result = await fetchQueue(mockFetch)
+      await expect(fetchQueue(mockFetch)).rejects.toThrow('Network error')
+      errorSpy.mockRestore()
+    })
 
-      expect(result).toEqual({ Running: [], Pending: [] })
+    it('rejects on non-ok response', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 })
+
+      await expect(fetchQueue(mockFetch)).rejects.toThrow(
+        '[Jobs API] Failed to fetch jobs: 503'
+      )
+      errorSpy.mockRestore()
     })
   })
 

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   extractWorkflow,
@@ -45,6 +45,10 @@ function createMockResponse(
 }
 
 describe('fetchJobs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   describe('fetchHistory', () => {
     it('fetches completed jobs', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
@@ -136,14 +140,12 @@ describe('fetchJobs', () => {
     })
 
     it('rejects on error', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
       await expect(fetchHistory(mockFetch)).rejects.toThrow('Network error')
-      errorSpy.mockRestore()
     })
 
-    it('rejects on non-ok response', async () => {
+    it('rejects on non-ok response without logging', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
@@ -153,20 +155,7 @@ describe('fetchJobs', () => {
       await expect(fetchHistory(mockFetch)).rejects.toThrow(
         '[Jobs API] Failed to fetch jobs: 500'
       )
-      expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
-        '[Jobs API] Failed to fetch jobs: 500'
-      )
-      errorSpy.mockRestore()
-    })
-
-    it('rejects without logging when the request is aborted', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      const abortError = new DOMException('Aborted', 'AbortError')
-      const mockFetch = vi.fn().mockRejectedValue(abortError)
-
-      await expect(fetchHistory(mockFetch)).rejects.toBe(abortError)
       expect(errorSpy).not.toHaveBeenCalled()
-      errorSpy.mockRestore()
     })
 
     it('parses batch containing text-only preview outputs', async () => {
@@ -284,21 +273,17 @@ describe('fetchJobs', () => {
     })
 
     it('rejects on error', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
       await expect(fetchQueue(mockFetch)).rejects.toThrow('Network error')
-      errorSpy.mockRestore()
     })
 
     it('rejects on non-ok response', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 })
 
       await expect(fetchQueue(mockFetch)).rejects.toThrow(
         '[Jobs API] Failed to fetch jobs: 503'
       )
-      errorSpy.mockRestore()
     })
   })
 

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -9,6 +9,7 @@
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { JobId } from '@/schemas/apiSchema'
+import { isAbortError } from '@/utils/typeGuardUtil'
 
 import type {
   JobDetail,
@@ -34,8 +35,15 @@ export interface FetchHistoryPageResult {
   hasMore: boolean
 }
 
+/** A failure already logged where it was detected. */
+class LoggedJobsFetchError extends Error {}
+
 /**
  * Fetches raw jobs from /jobs endpoint
+ *
+ * Rejects on any failure (network fault, non-ok response, parse error) so
+ * callers can preserve their last-known-good snapshot instead of treating a
+ * transient failure as an authoritative empty result.
  * @internal
  */
 async function fetchJobsRaw(
@@ -49,14 +57,9 @@ async function fetchJobsRaw(
   try {
     const res = await fetchApi(url)
     if (!res.ok) {
-      console.error(`[Jobs API] Failed to fetch jobs: ${res.status}`)
-      return {
-        jobs: [],
-        total: 0,
-        offset,
-        limit: maxItems,
-        hasMore: false
-      }
+      const message = `[Jobs API] Failed to fetch jobs: ${res.status}`
+      console.error(message)
+      throw new LoggedJobsFetchError(message)
     }
     const data = zJobsListResponse.parse(await res.json())
     return {
@@ -67,8 +70,10 @@ async function fetchJobsRaw(
       hasMore: data.pagination.has_more
     }
   } catch (error) {
-    console.error('[Jobs API] Error fetching jobs:', error)
-    return { jobs: [], total: 0, offset, limit: maxItems, hasMore: false }
+    if (!(error instanceof LoggedJobsFetchError) && !isAbortError(error)) {
+      console.error('[Jobs API] Error fetching jobs:', error)
+    }
+    throw error
   }
 }
 

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -9,7 +9,6 @@
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { JobId } from '@/schemas/apiSchema'
-import { isAbortError } from '@/utils/typeGuardUtil'
 
 import type {
   JobDetail,
@@ -35,15 +34,13 @@ export interface FetchHistoryPageResult {
   hasMore: boolean
 }
 
-/** A failure already logged where it was detected. */
-class LoggedJobsFetchError extends Error {}
-
 /**
  * Fetches raw jobs from /jobs endpoint
  *
  * Rejects on any failure (network fault, non-ok response, parse error) so
  * callers can preserve their last-known-good snapshot instead of treating a
- * transient failure as an authoritative empty result.
+ * transient failure as an authoritative empty result. Logging is left to the
+ * caller, which knows whether the failure is user-visible.
  * @internal
  */
 async function fetchJobsRaw(
@@ -54,26 +51,17 @@ async function fetchJobsRaw(
 ): Promise<FetchJobsRawResult> {
   const statusParam = statuses.join(',')
   const url = `/jobs?status=${statusParam}&limit=${maxItems}&offset=${offset}`
-  try {
-    const res = await fetchApi(url)
-    if (!res.ok) {
-      const message = `[Jobs API] Failed to fetch jobs: ${res.status}`
-      console.error(message)
-      throw new LoggedJobsFetchError(message)
-    }
-    const data = zJobsListResponse.parse(await res.json())
-    return {
-      jobs: data.jobs,
-      total: data.pagination.total,
-      offset: data.pagination.offset,
-      limit: data.pagination.limit,
-      hasMore: data.pagination.has_more
-    }
-  } catch (error) {
-    if (!(error instanceof LoggedJobsFetchError) && !isAbortError(error)) {
-      console.error('[Jobs API] Error fetching jobs:', error)
-    }
-    throw error
+  const res = await fetchApi(url)
+  if (!res.ok) {
+    throw new Error(`[Jobs API] Failed to fetch jobs: ${res.status}`)
+  }
+  const data = zJobsListResponse.parse(await res.json())
+  return {
+    jobs: data.jobs,
+    total: data.pagination.total,
+    offset: data.pagination.offset,
+    limit: data.pagination.limit,
+    hasMore: data.pagination.has_more
   }
 }
 

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -18,6 +18,16 @@ import type {
 } from './jobTypes'
 import { zJobDetail, zJobsListResponse, zWorkflowContainer } from './jobTypes'
 
+export class JobsApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number
+  ) {
+    super(message)
+    this.name = 'JobsApiError'
+  }
+}
+
 interface FetchJobsRawResult {
   jobs: RawJobListItem[]
   total: number
@@ -53,7 +63,10 @@ async function fetchJobsRaw(
   const url = `/jobs?status=${statusParam}&limit=${maxItems}&offset=${offset}`
   const res = await fetchApi(url)
   if (!res.ok) {
-    throw new Error(`[Jobs API] Failed to fetch jobs: ${res.status}`)
+    throw new JobsApiError(
+      `[Jobs API] Failed to fetch jobs: ${res.status}`,
+      res.status
+    )
   }
   const data = zJobsListResponse.parse(await res.json())
   return {

--- a/src/scripts/api.jobs.test.ts
+++ b/src/scripts/api.jobs.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+
+// Tests for api.getQueue and api.getHistory failure handling; fetchApi is stubbed.
+const serverError = () => ({ ok: false, status: 500 }) as Response
+
+describe('api jobs-namespace reads', () => {
+  let fetchApiSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchApiSpy = vi.spyOn(api, 'fetchApi').mockResolvedValue(serverError())
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getQueue', () => {
+    it('rejects when asked to throw', async () => {
+      await expect(api.getQueue({ throwOnError: true })).rejects.toThrow(
+        '[Jobs API] Failed to fetch jobs: 500'
+      )
+    })
+
+    it('returns an empty queue otherwise', async () => {
+      await expect(api.getQueue()).resolves.toEqual({
+        Running: [],
+        Pending: []
+      })
+    })
+
+    it('stays silent on an aborted request', async () => {
+      fetchApiSpy.mockRejectedValueOnce(
+        new DOMException('Aborted', 'AbortError')
+      )
+
+      await expect(api.getQueue()).resolves.toEqual({
+        Running: [],
+        Pending: []
+      })
+      expect(console.error).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getHistory', () => {
+    it('rejects when asked to throw', async () => {
+      await expect(api.getHistory(200, { throwOnError: true })).rejects.toThrow(
+        '[Jobs API] Failed to fetch jobs: 500'
+      )
+    })
+
+    it('returns an empty history otherwise', async () => {
+      await expect(api.getHistory()).resolves.toEqual([])
+    })
+
+    it('stays silent on an aborted request', async () => {
+      fetchApiSpy.mockRejectedValueOnce(
+        new DOMException('Aborted', 'AbortError')
+      )
+
+      await expect(api.getHistory()).resolves.toEqual([])
+      expect(console.error).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -70,6 +70,7 @@ import {
   fetchJobDetail,
   fetchQueue
 } from '@/platform/remote/comfyui/jobs/fetchJobs'
+import { isAbortError } from '@/utils/typeGuardUtil'
 
 interface QueuePromptRequestBody {
   client_id: string
@@ -1184,7 +1185,7 @@ export class ComfyApi extends EventTarget {
       return await fetchQueue(this.fetchApi.bind(this))
     } catch (error) {
       if (options?.throwOnError) throw error
-      console.error('Failed to fetch queue:', error)
+      if (!isAbortError(error)) console.error('Failed to fetch queue:', error)
       return { Running: [], Pending: [] }
     }
   }
@@ -1195,7 +1196,7 @@ export class ComfyApi extends EventTarget {
    */
   async getHistory(
     max_items: number = 200,
-    options?: { offset?: number }
+    options?: { offset?: number; throwOnError?: boolean }
   ): Promise<JobListItem[]> {
     try {
       return await fetchHistory(
@@ -1204,7 +1205,8 @@ export class ComfyApi extends EventTarget {
         options?.offset
       )
     } catch (error) {
-      console.error(error)
+      if (options?.throwOnError) throw error
+      if (!isAbortError(error)) console.error('Failed to fetch history:', error)
       return []
     }
   }

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -489,6 +489,53 @@ describe('assetsStore - Refactored (Option A)', () => {
       expect(store.historyAssets).toHaveLength(400)
     })
 
+    it('should keep loaded pages when a refresh fails mid-pagination', async () => {
+      const firstBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(firstBatch)
+      await store.updateHistory()
+
+      const secondBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(200 + i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(secondBatch)
+      await store.loadMoreHistory()
+      expect(store.historyAssets).toHaveLength(400)
+
+      vi.mocked(api.getHistory).mockRejectedValueOnce(new Error('Network'))
+      await store.updateHistory()
+      expect(store.historyAssets).toHaveLength(400)
+
+      const thirdBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(400 + i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(thirdBatch)
+      await store.loadMoreHistory()
+
+      expect(api.getHistory).toHaveBeenLastCalledWith(200, {
+        offset: 400,
+        throwOnError: true
+      })
+      expect(store.historyAssets).toHaveLength(600)
+    })
+
+    it('should not surface an error state when a fetch is aborted', async () => {
+      const firstBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(firstBatch)
+      await store.updateHistory()
+
+      vi.mocked(api.getHistory).mockRejectedValueOnce(
+        new DOMException('Aborted', 'AbortError')
+      )
+      await store.updateHistory()
+
+      expect(store.historyError).toBeNull()
+      expect(store.historyAssets).toHaveLength(200)
+    })
+
     it('should clear error state on successful retry', async () => {
       // First load succeeds
       const firstBatch = Array.from({ length: 200 }, (_, i) =>

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -217,7 +217,10 @@ describe('assetsStore - Refactored (Option A)', () => {
 
       await store.updateHistory()
 
-      expect(api.getHistory).toHaveBeenCalledWith(200, { offset: 0 })
+      expect(api.getHistory).toHaveBeenCalledWith(200, {
+        offset: 0,
+        throwOnError: true
+      })
       expect(store.historyAssets).toHaveLength(10)
       expect(store.hasMoreHistory).toBe(false) // Less than BATCH_SIZE
       expect(store.historyLoading).toBe(false)
@@ -295,7 +298,10 @@ describe('assetsStore - Refactored (Option A)', () => {
 
       await store.loadMoreHistory()
 
-      expect(api.getHistory).toHaveBeenCalledWith(200, { offset: 200 })
+      expect(api.getHistory).toHaveBeenCalledWith(200, {
+        offset: 200,
+        throwOnError: true
+      })
       expect(store.historyAssets).toHaveLength(400) // Accumulated
       expect(store.hasMoreHistory).toBe(true)
     })
@@ -455,6 +461,32 @@ describe('assetsStore - Refactored (Option A)', () => {
       expect(store.historyAssets).toHaveLength(200)
       expect(store.historyError).toBe(error)
       expect(store.isLoadingMore).toBe(false)
+    })
+
+    it('should re-request the same page after loadMore fails', async () => {
+      const firstBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(firstBatch)
+      await store.updateHistory()
+
+      vi.mocked(api.getHistory).mockRejectedValueOnce(new Error('Network'))
+      await store.loadMoreHistory()
+
+      expect(store.hasMoreHistory).toBe(true)
+      expect(store.historyAssets).toHaveLength(200)
+
+      const retriedBatch = Array.from({ length: 200 }, (_, i) =>
+        createMockJobItem(200 + i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValueOnce(retriedBatch)
+      await store.loadMoreHistory()
+
+      expect(api.getHistory).toHaveBeenLastCalledWith(200, {
+        offset: 200,
+        throwOnError: true
+      })
+      expect(store.historyAssets).toHaveLength(400)
     })
 
     it('should clear error state on successful retry', async () => {

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -153,19 +153,19 @@ export const useAssetsStore = defineStore('assets', () => {
    * @param loadMore - true for pagination (append), false for initial load (replace)
    */
   const fetchHistoryAssets = async (loadMore = false): Promise<AssetItem[]> => {
-    // Reset state for initial load
+    const offset = loadMore ? historyOffset.value : 0
+
+    // Fetch before touching accumulated state so a failed refresh leaves the
+    // last known good page set intact for the next load-more.
+    const history = await api.getHistory(BATCH_SIZE, {
+      offset,
+      throwOnError: true
+    })
+
     if (!loadMore) {
-      historyOffset.value = 0
-      hasMoreHistory.value = true
       allHistoryItems.value = []
       loadedIds.clear()
     }
-
-    // Fetch from server with offset
-    const history = await api.getHistory(BATCH_SIZE, {
-      offset: historyOffset.value,
-      throwOnError: true
-    })
 
     // Convert JobListItems to AssetItems
     const newAssets = mapHistoryToAssets(history)
@@ -199,7 +199,7 @@ export const useAssetsStore = defineStore('assets', () => {
     }
 
     // Update pagination state
-    historyOffset.value += BATCH_SIZE
+    historyOffset.value = offset + BATCH_SIZE
     hasMoreHistory.value = history.length === BATCH_SIZE
 
     if (allHistoryItems.value.length > MAX_HISTORY_ITEMS) {
@@ -227,9 +227,8 @@ export const useAssetsStore = defineStore('assets', () => {
       await fetchHistoryAssets(false)
       historyAssets.value = allHistoryItems.value
     } catch (err) {
-      if (!isAbortError(err)) {
-        console.error('Error fetching history assets:', err)
-      }
+      if (isAbortError(err)) return
+      console.error('Error fetching history assets:', err)
       historyError.value = err
       // Keep existing data when error occurs
       if (!historyAssets.value.length) {
@@ -254,9 +253,8 @@ export const useAssetsStore = defineStore('assets', () => {
       await fetchHistoryAssets(true)
       historyAssets.value = allHistoryItems.value
     } catch (err) {
-      if (!isAbortError(err)) {
-        console.error('Error loading more history:', err)
-      }
+      if (isAbortError(err)) return
+      console.error('Error loading more history:', err)
       historyError.value = err
       // Keep existing data when error occurs (consistent with updateHistory)
       if (!historyAssets.value.length) {

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -20,6 +20,7 @@ import type { AssetPaginationOptions } from '@/platform/assets/services/assetSer
 import { isCloud } from '@/platform/distribution/types'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { api } from '@/scripts/api'
+import { isAbortError } from '@/utils/typeGuardUtil'
 
 import { TaskItemImpl } from './queueStore'
 import { useAssetDownloadStore } from './assetDownloadStore'
@@ -162,7 +163,8 @@ export const useAssetsStore = defineStore('assets', () => {
 
     // Fetch from server with offset
     const history = await api.getHistory(BATCH_SIZE, {
-      offset: historyOffset.value
+      offset: historyOffset.value,
+      throwOnError: true
     })
 
     // Convert JobListItems to AssetItems
@@ -225,7 +227,9 @@ export const useAssetsStore = defineStore('assets', () => {
       await fetchHistoryAssets(false)
       historyAssets.value = allHistoryItems.value
     } catch (err) {
-      console.error('Error fetching history assets:', err)
+      if (!isAbortError(err)) {
+        console.error('Error fetching history assets:', err)
+      }
       historyError.value = err
       // Keep existing data when error occurs
       if (!historyAssets.value.length) {
@@ -250,7 +254,9 @@ export const useAssetsStore = defineStore('assets', () => {
       await fetchHistoryAssets(true)
       historyAssets.value = allHistoryItems.value
     } catch (err) {
-      console.error('Error loading more history:', err)
+      if (!isAbortError(err)) {
+        console.error('Error loading more history:', err)
+      }
       historyError.value = err
       // Keep existing data when error occurs (consistent with updateHistory)
       if (!historyAssets.value.length) {

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -373,6 +373,71 @@ describe('useQueueStore', () => {
     })
   })
 
+  describe('update() - failed fetches', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('should keep the existing queue when the queue fetch fails', async () => {
+      mockGetQueue.mockResolvedValue({
+        Running: [createRunningJob(1, 'run-1')],
+        Pending: [createPendingJob(2, 'pend-1')]
+      })
+      mockGetHistory.mockResolvedValue([])
+      await store.update()
+
+      mockGetQueue.mockRejectedValue(new Error('API error'))
+      await store.update()
+
+      expect(store.runningTasks).toHaveLength(1)
+      expect(store.pendingTasks).toHaveLength(1)
+      expect(store.activeJobsCount).toBe(2)
+    })
+
+    it('should keep the existing history when the history fetch fails', async () => {
+      mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
+      mockGetHistory.mockResolvedValue([createHistoryJob(5, 'hist-1')])
+      await store.update()
+
+      mockGetHistory.mockRejectedValue(new Error('API error'))
+      await store.update()
+
+      expect(store.historyTasks).toHaveLength(1)
+      expect(store.historyTasks[0].jobId).toBe('hist-1')
+    })
+
+    it('should ask both fetches to surface failures', async () => {
+      mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
+      mockGetHistory.mockResolvedValue([])
+
+      await store.update()
+
+      expect(mockGetQueue).toHaveBeenCalledWith({ throwOnError: true })
+      expect(mockGetHistory).toHaveBeenCalledWith(store.maxHistoryItems, {
+        throwOnError: true
+      })
+    })
+
+    it('should not mark the history snapshot as fetched when the history fetch fails', async () => {
+      mockGetQueue.mockResolvedValue({ Running: [], Pending: [] })
+      mockGetHistory.mockRejectedValue(new Error('API error'))
+
+      await store.update()
+
+      expect(store.hasFetchedHistorySnapshot).toBe(false)
+    })
+
+    it('should stay silent when a fetch is aborted', async () => {
+      const abortError = new DOMException('Aborted', 'AbortError')
+      mockGetQueue.mockRejectedValue(abortError)
+      mockGetHistory.mockRejectedValue(abortError)
+
+      await store.update()
+
+      expect(console.error).not.toHaveBeenCalled()
+    })
+  })
+
   describe('update() - single-flight coalescing', () => {
     it('should coalesce concurrent calls into one re-fetch', async () => {
       let resolveQueue!: QueueResolver

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -24,6 +24,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
+import { isAbortError } from '@/utils/typeGuardUtil'
 
 enum TaskItemDisplayStatus {
   Running = 'Running',
@@ -531,9 +532,11 @@ export const useQueueStore = defineStore('queue', () => {
     dirty = false
     isLoading.value = true
     try {
+      // Each snapshot is replaced only when its fetch succeeds; a rejected
+      // fetch leaves the last known good tasks in place.
       const [queueResult, historyResult] = await Promise.allSettled([
         api.getQueue({ throwOnError: true }),
-        api.getHistory(maxHistoryItems.value)
+        api.getHistory(maxHistoryItems.value, { throwOnError: true })
       ])
 
       if (queueResult.status === 'fulfilled') {
@@ -557,7 +560,7 @@ export const useQueueStore = defineStore('queue', () => {
           ...queue.Pending.map((j) => j.id)
         ])
         executionStore.reconcileInitializingJobs(activeJobIds)
-      } else {
+      } else if (!isAbortError(queueResult.reason)) {
         console.error('Failed to fetch queue:', queueResult.reason)
       }
 
@@ -596,7 +599,7 @@ export const useQueueStore = defineStore('queue', () => {
           historyTasks.value = nextHistoryTasks
         }
         hasFetchedHistorySnapshot.value = true
-      } else {
+      } else if (!isAbortError(historyResult.reason)) {
         console.error('Failed to fetch history:', historyResult.reason)
       }
     } finally {


### PR DESCRIPTION
## ELI-5

When the app asks the server "what jobs are running?" and the request fails, the answer used to come back as "nothing is running" — so the queue, the history list, and the running-job UI all went blank until the next successful poll. Now a failed request is reported as a failure, and every screen keeps showing the last thing it knew was true.

## Summary

`fetchJobsRaw` turned every failure — network fault, HTTP 5xx, malformed body, a fetch the browser cancels at page teardown — into a fulfilled, empty result, so callers could not distinguish "the queue is empty" from "the request failed". This makes it reject, and makes the two stores that consume it opt into the throwing behavior so their existing preserve-on-failure branches actually run.

## Changes

- **What**:
  - `fetchJobsRaw` rejects instead of returning an empty result. The non-ok branch logs the status and throws; the catch rethrows the original error and stays silent for aborts (`isAbortError`). `fetchQueue` / `fetchHistory` / `fetchHistoryPage` propagate the rejection; `fetchJobDetail` is unchanged (its `undefined` result is consumed as "not found").
  - `api.getHistory` gains `throwOnError` (same shape as `getQueue`); both wrappers now skip their `console.error` for aborted requests and still return an empty result on the non-throwing path, which is what the legacy `ui.ts` menu uses.
  - `queueStore.update()` asks both fetches to throw. The rejected branches were already write-free, so a failed poll now genuinely preserves `runningTasks` / `pendingTasks` / `historyTasks`, keeps `activeJobsCount` (and therefore polling) alive, and leaves `hasFetchedHistorySnapshot` at `false` so "never fetched" is no longer indistinguishable from "fetched empty".
  - `assetsStore.fetchHistoryAssets` opts in too, which also fixes a latent pagination bug: a failed page no longer advances `historyOffset` past a page that never loaded, nor sets `hasMoreHistory = false`. Both callers already keep existing data on error.
- **Breaking**: `fetchQueue` / `fetchHistory` / `fetchHistoryPage` now reject on failure. All in-tree callers handle it: the two stores catch, `missingMediaAssetResolver` is rejection-aware by design and its two boundaries (`app.ts` missing-media pipeline, `useErrorClearingHooks`) already catch. A mid-scan history failure now surfaces as a failed scan with the existing warning toast, instead of a silent partial result that could mark present media as missing.

## Review Focus

- `LoggedJobsFetchError` exists only so a non-ok response logs once: it is thrown from inside the `try`, and the catch skips re-logging it. Without the marker the same failure would print both the status line and the generic error line.
- Verified unchanged, as intended: `ui.ts` legacy `getItems` (still non-throwing), `useReconnectQueueRefresh` — its documented "previous snapshot survives a failed refresh" contract is now true, and its existing test for that (a still-running job is not cleared when the refresh fetch fails) passes.
- This composes with the open jobs-fetch logging PR (`matt/fe-1466-jobs-fetch-error-noise`), which touches the same catch block; the conflict resolution there is "classify the abort/teardown cases per that PR, then rethrow per this one".

Tests: targeted specs plus the full unit suite pass. Two suites (`GraphView.test.ts`, `onboardingCloudRoutes.test.ts`) time out locally on the base commit as well, i.e. pre-existing and unrelated.
