### PR TITLE
fix: stop logging expected jobs-poller auth failures as errors

### DIFF
--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -154,6 +154,33 @@ describe('fetchJobs', () => {
       expect(result).toEqual([])
     })
 
+    it.for([401, 403])(
+      'does not log expected auth status %i as an error',
+      async (status) => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const mockFetch = vi.fn().mockResolvedValue({ ok: false, status })
+
+        const result = await fetchHistory(mockFetch)
+
+        expect(result).toEqual([])
+        expect(errorSpy).not.toHaveBeenCalled()
+        errorSpy.mockRestore()
+      }
+    )
+
+    it('does not log a network failure as an error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValue(new TypeError('Failed to fetch'))
+
+      const result = await fetchHistory(mockFetch)
+
+      expect(result).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
     it('parses batch containing text-only preview outputs', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -154,17 +154,30 @@ describe('fetchJobs', () => {
       expect(result).toEqual([])
     })
 
-    it.for([401, 403])(
-      'does not log expected auth status %i as an error',
-      async (status) => {
+    it.for([
+      [401, 'workspace membership not found'],
+      [403, 'email not verified']
+    ] as const)(
+      'warns (not errors) with status %i and the response detail',
+      async ([status, message]) => {
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-        const mockFetch = vi.fn().mockResolvedValue({ ok: false, status })
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status,
+          text: () => Promise.resolve(JSON.stringify({ message }))
+        })
 
         const result = await fetchHistory(mockFetch)
 
         expect(result).toEqual([])
         expect(errorSpy).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(String(status))
+        )
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(message))
         errorSpy.mockRestore()
+        warnSpy.mockRestore()
       }
     )
 

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -34,6 +34,25 @@ export interface FetchHistoryPageResult {
   hasMore: boolean
 }
 
+async function readErrorDetail(res: Response): Promise<string> {
+  try {
+    const text = await res.text()
+    if (!text) return res.statusText
+    try {
+      const body = JSON.parse(text) as {
+        message?: string
+        error?: string
+        code?: string
+      }
+      return body.message ?? body.error ?? body.code ?? text.slice(0, 200)
+    } catch {
+      return text.slice(0, 200)
+    }
+  } catch {
+    return res.statusText
+  }
+}
+
 /**
  * Fetches raw jobs from /jobs endpoint
  * @internal
@@ -49,10 +68,9 @@ async function fetchJobsRaw(
   try {
     const res = await fetchApi(url)
     if (!res.ok) {
-      const isExpectedAuthStatus = res.status === 401 || res.status === 403
-      if (!isExpectedAuthStatus) {
-        console.warn(`[Jobs API] Failed to fetch jobs: ${res.status}`)
-      }
+      console.warn(
+        `[Jobs API] Failed to fetch jobs (${res.status}): ${await readErrorDetail(res)}`
+      )
       return {
         jobs: [],
         total: 0,

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -49,7 +49,10 @@ async function fetchJobsRaw(
   try {
     const res = await fetchApi(url)
     if (!res.ok) {
-      console.error(`[Jobs API] Failed to fetch jobs: ${res.status}`)
+      const isExpectedAuthStatus = res.status === 401 || res.status === 403
+      if (!isExpectedAuthStatus) {
+        console.warn(`[Jobs API] Failed to fetch jobs: ${res.status}`)
+      }
       return {
         jobs: [],
         total: 0,
@@ -67,7 +70,7 @@ async function fetchJobsRaw(
       hasMore: data.pagination.has_more
     }
   } catch (error) {
-    console.error('[Jobs API] Error fetching jobs:', error)
+    console.warn('[Jobs API] Error fetching jobs:', error)
     return { jobs: [], total: 0, offset, limit: maxItems, hasMore: false }
   }
 }


### PR DESCRIPTION
## Summary
The jobs poller logs `console.error` on any non-ok response, and Datadog RUM ingests `console.error` as an error. Expected auth states (401/403) during polling therefore flood RUM — ~123k errors/week, ~46% of all frontend RUM errors.

Backend context: `/jobs` is served on the ingest `Protected(requireEmailVerified)` group, so **401** = missing/expired token or unresolvable workspace/membership, and **403** = authenticated but email-not-verified (or account pending deletion) — not a token problem.

## Changes
- **What**: In `fetchJobsRaw`, downgrade non-ok responses from `console.error` to `console.warn` (RUM does not collect `warn`), and log each failure with its status **and** the backend error detail extracted from the response body (e.g. `workspace membership not found` vs the email-verification message). 401 and 403 now produce distinct, diagnosable log lines. Network failures also downgraded to `warn`. Control flow and return values unchanged.

## Review Focus
This is a noise-reduction + diagnosability stopgap. The real fixes (gate polling on email-verified; stop the poller / re-auth on permanent 401) are larger and tracked separately. Note: because RUM does not forward `console.warn`, the extracted detail is visible in the browser console but not in Datadog RUM.