### PR TITLE
fix: downgrade blocked analytics loader logs from error to warn

### DIFF
--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -195,6 +195,27 @@ describe('CustomerIoTelemetryProvider', () => {
     expect(hoisted.analytics.page).toHaveBeenCalledTimes(2)
   })
 
+  it('warns without erroring and disables tracking when the client fails to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const loadError = new Error('blocked by ad-blocker')
+    hoisted.load.mockImplementation(() => {
+      throw loadError
+    })
+    const provider = createProvider()
+
+    await vi.dynamicImportSettled()
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Failed to load Customer.io:',
+      loadError
+    )
+    expect(consoleError).not.toHaveBeenCalled()
+
+    provider.trackWorkflowExecution()
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+  })
+
   it('does not initialize without a write key', async () => {
     const provider = createProvider({ customer_io: { site_id: SITE_ID } })
     await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -130,7 +130,7 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
           })
       })
       .catch((error) => {
-        console.error('Failed to load Customer.io:', error)
+        console.warn('Failed to load Customer.io:', error)
         this.isEnabled = false
         this.eventQueue = []
       })

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -126,7 +126,7 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
             })
           })
           .catch((error) => {
-            console.error('Failed to load Mixpanel:', error)
+            console.warn('Failed to load Mixpanel:', error)
             this.isEnabled = false
           })
       } catch (error) {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -192,7 +192,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
             })
           })
           .catch((error) => {
-            console.error('Failed to load PostHog:', error)
+            console.warn('Failed to load PostHog:', error)
             this.isEnabled = false
           })
       } catch (error) {


### PR DESCRIPTION
## Summary
When ad-blockers/CSP block Mixpanel, PostHog, or Customer.io, their dynamic-import `.catch` handlers log `console.error` (ingested by RUM as errors) — ~4.7k errors/week — even though the failure is already handled gracefully (`isEnabled = false`).

## Changes
- **What**: Downgrade the three load-failure `.catch` logs from `console.error` to `console.warn`. No behavior change; only log level.

## Review Focus
The separate 'Failed to initialize' handlers are intentionally left as-is.