### PR TITLE
fix: guard against missing exec_info in setStatus

### DIFF
--- a/src/scripts/ui.setStatus.test.ts
+++ b/src/scripts/ui.setStatus.test.ts
@@ -46,21 +46,22 @@ describe('ComfyUI.setStatus', () => {
     expect(host.lastQueueSize).toBe(3)
   })
 
-  it('does not throw and shows ERR when exec_info is missing', () => {
+  it('does not throw or update when exec_info is missing', () => {
     const host = createHost({ lastQueueSize: 5 })
 
     expect(() => host.setStatus({} as StatusWsMessageStatus)).not.toThrow()
-    expect(host.queueSize.textContent).toBe('Queue size: ERR')
+    expect(host.queueSize.textContent).toBe('')
     expect(host.lastQueueSize).toBe(5)
     expect(app.queuePrompt).not.toHaveBeenCalled()
   })
 
-  it('shows ERR for a null status', () => {
-    const host = createHost({ lastQueueSize: 5 })
+  it('does not update or auto-queue on a null status (disconnect)', () => {
+    const host = createHost({ lastQueueSize: 2, autoQueueEnabled: true })
     host.setStatus(null)
 
-    expect(host.queueSize.textContent).toBe('Queue size: ERR')
-    expect(host.lastQueueSize).toBe(5)
+    expect(host.queueSize.textContent).toBe('')
+    expect(host.lastQueueSize).toBe(2)
+    expect(app.queuePrompt).not.toHaveBeenCalled()
   })
 
   it('auto-queues when the queue drains to zero', () => {

--- a/src/scripts/ui.setStatus.test.ts
+++ b/src/scripts/ui.setStatus.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { StatusWsMessageStatus } from '@/schemas/apiSchema'
+
+import { app } from './app'
+import { ComfyUI } from './ui'
+
+vi.mock('./app', () => ({
+  app: { lastExecutionError: null, queuePrompt: vi.fn() },
+  ComfyApp: class {}
+}))
+
+type SetStatusHost = {
+  queueSize: { textContent: string }
+  lastQueueSize: number
+  batchCount: number
+  autoQueueEnabled: boolean
+  autoQueueMode: string
+  graphHasChanged: boolean
+  setStatus: (status: StatusWsMessageStatus | null) => void
+}
+
+function createHost(overrides: Partial<SetStatusHost> = {}): SetStatusHost {
+  return {
+    queueSize: { textContent: '' },
+    lastQueueSize: 0,
+    batchCount: 1,
+    autoQueueEnabled: false,
+    autoQueueMode: 'instant',
+    graphHasChanged: false,
+    setStatus: ComfyUI.prototype.setStatus,
+    ...overrides
+  }
+}
+
+describe('ComfyUI.setStatus', () => {
+  beforeEach(() => {
+    vi.mocked(app.queuePrompt).mockClear()
+  })
+
+  it('renders the queue size when exec_info is present', () => {
+    const host = createHost()
+    host.setStatus({ exec_info: { queue_remaining: 3 } })
+
+    expect(host.queueSize.textContent).toBe('Queue size: 3')
+    expect(host.lastQueueSize).toBe(3)
+  })
+
+  it('does not throw and shows ERR when exec_info is missing', () => {
+    const host = createHost({ lastQueueSize: 5 })
+
+    expect(() => host.setStatus({} as StatusWsMessageStatus)).not.toThrow()
+    expect(host.queueSize.textContent).toBe('Queue size: ERR')
+    expect(host.lastQueueSize).toBe(5)
+    expect(app.queuePrompt).not.toHaveBeenCalled()
+  })
+
+  it('shows ERR for a null status', () => {
+    const host = createHost({ lastQueueSize: 5 })
+    host.setStatus(null)
+
+    expect(host.queueSize.textContent).toBe('Queue size: ERR')
+    expect(host.lastQueueSize).toBe(5)
+  })
+
+  it('auto-queues when the queue drains to zero', () => {
+    const host = createHost({
+      lastQueueSize: 2,
+      batchCount: 4,
+      autoQueueEnabled: true,
+      autoQueueMode: 'instant'
+    })
+    host.setStatus({ exec_info: { queue_remaining: 0 } })
+
+    expect(app.queuePrompt).toHaveBeenCalledWith(0, 4, {
+      intent: { trigger_source: 'auto_queue' }
+    })
+    expect(host.lastQueueSize).toBe(4)
+    expect(host.graphHasChanged).toBe(false)
+  })
+})

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -710,23 +710,23 @@ export class ComfyUI {
 
   setStatus(status: StatusWsMessageStatus | null) {
     const queueRemaining = status?.exec_info?.queue_remaining
-    this.queueSize.textContent = 'Queue size: ' + (queueRemaining ?? 'ERR')
-    if (queueRemaining != null) {
-      if (
-        this.lastQueueSize != 0 &&
-        queueRemaining == 0 &&
-        this.autoQueueEnabled &&
-        (this.autoQueueMode === 'instant' || this.graphHasChanged) &&
-        !app.lastExecutionError
-      ) {
-        app.queuePrompt(0, this.batchCount, {
-          intent: { trigger_source: 'auto_queue' }
-        })
-        this.graphHasChanged = false
-        this.lastQueueSize = queueRemaining + this.batchCount
-      } else {
-        this.lastQueueSize = queueRemaining
-      }
+    if (queueRemaining == null) return
+
+    this.queueSize.textContent = 'Queue size: ' + queueRemaining
+    if (
+      this.lastQueueSize != 0 &&
+      queueRemaining == 0 &&
+      this.autoQueueEnabled &&
+      (this.autoQueueMode === 'instant' || this.graphHasChanged) &&
+      !app.lastExecutionError
+    ) {
+      app.queuePrompt(0, this.batchCount, {
+        intent: { trigger_source: 'auto_queue' }
+      })
+      this.graphHasChanged = false
+      this.lastQueueSize = queueRemaining + this.batchCount
+    } else {
+      this.lastQueueSize = queueRemaining
     }
   }
 }

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -709,12 +709,12 @@ export class ComfyUI {
   }
 
   setStatus(status: StatusWsMessageStatus | null) {
-    this.queueSize.textContent =
-      'Queue size: ' + (status ? status.exec_info.queue_remaining : 'ERR')
-    if (status) {
+    const queueRemaining = status?.exec_info?.queue_remaining
+    this.queueSize.textContent = 'Queue size: ' + (queueRemaining ?? 'ERR')
+    if (queueRemaining != null) {
       if (
         this.lastQueueSize != 0 &&
-        status.exec_info.queue_remaining == 0 &&
+        queueRemaining == 0 &&
         this.autoQueueEnabled &&
         (this.autoQueueMode === 'instant' || this.graphHasChanged) &&
         !app.lastExecutionError
@@ -722,10 +722,11 @@ export class ComfyUI {
         app.queuePrompt(0, this.batchCount, {
           intent: { trigger_source: 'auto_queue' }
         })
-        status.exec_info.queue_remaining += this.batchCount
         this.graphHasChanged = false
+        this.lastQueueSize = queueRemaining + this.batchCount
+      } else {
+        this.lastQueueSize = queueRemaining
       }
-      this.lastQueueSize = status.exec_info.queue_remaining
     }
   }
 }


### PR DESCRIPTION
## Summary
`ui.ts` `setStatus` reads `status.exec_info.queue_remaining` guarding only `status`, not `exec_info`. A status message with `exec_info` absent throws `Cannot read properties of undefined (reading 'queue_remaining')` — ~721 RUM errors/week.

## Changes
- **What**: Read via `status?.exec_info?.queue_remaining` and fall back to `ERR`/skip the auto-queue branch when absent. Matches the defensive access already in `queueStore.ts`.

## Review Focus
Backend root cause is fixed in Comfy-Org/cloud#6082 (status message could omit `exec_info` on an error path); this is the defensive frontend guard and stands regardless.