### PR TITLE
fix: downgrade early rootGraph access log from error to warn

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -201,6 +201,32 @@ describe('ComfyApp', () => {
     )
   })
 
+  describe('rootGraph access before initialization', () => {
+    it('warns instead of erroring so RUM does not record an error', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(app.isGraphReady).toBe(false)
+      expect(app.rootGraph).toBeUndefined()
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        'ComfyApp graph accessed before initialization'
+      )
+    })
+
+    it('does not warn once the graph is initialized', () => {
+      Reflect.set(app, 'rootGraphInternal', new LGraph())
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(app.isGraphReady).toBe(true)
+      expect(app.rootGraph).toBeInstanceOf(LGraph)
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        'ComfyApp graph accessed before initialization'
+      )
+    })
+  })
+
   describe('queuePrompt', () => {
     function prepareEmptyPromptQueue() {
       const workflow = new ComfyWorkflow({

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -292,7 +292,7 @@ export class ComfyApp {
 
   get rootGraph(): LGraph {
     if (!this.rootGraphInternal) {
-      console.error('ComfyApp graph accessed before initialization')
+      console.warn('ComfyApp graph accessed before initialization')
     }
     return this.rootGraphInternal!
   }


### PR DESCRIPTION
## Summary
The `ComfyApp.rootGraph` getter logs `console.error` when accessed before init (RUM ingests it as an error) — ~3.9k errors/week. The early accesses are diffuse (~174 call sites, many reactive computeds evaluating during startup render), so guarding every caller isn't a small change.

## Changes
- **What**: Downgrade the getter's before-init log from `console.error` to `console.warn`. Return behavior and getter contract unchanged; `isGraphReady` remains available for callers that want to opt out.

## Review Focus
Chosen over per-caller guards because the accesses come from many reactive components (and extensions); this stops the RUM error noise without touching 77 files.