### PR TITLE
fix: back off jobs poller on permanent auth failure instead of erroring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ dist-ssr
 .claude/worktrees
 CLAUDE.local.md
 
+# Local git worktrees nested under the repo root (contaminate knip/lint scans)
+.worktrees
+
 # Editor directories and files
 .vscode/*
 *.code-workspace

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -85,20 +85,22 @@ describe('fetchJobs', () => {
       }
     )
 
-    it('logs the raw text when an auth-failure body is not JSON', async () => {
+    it('logs the raw text (truncated at 200 chars) when the body is not JSON', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const head = 'email not verified — '.padEnd(200, '.')
+      const sentinel = 'TRUNCATED_TAIL'
       const mockFetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 403,
         statusText: 'Forbidden',
-        text: () => Promise.resolve('upstream: email not verified')
+        text: () => Promise.resolve(head + sentinel)
       })
 
       await fetchHistory(mockFetch)
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('upstream: email not verified')
-      )
+      const logged = errorSpy.mock.calls[0]?.[0] as string
+      expect(logged).toContain(head)
+      expect(logged).not.toContain(sentinel)
     })
 
     it('falls back to statusText when an auth-failure body is empty', async () => {

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -85,6 +85,38 @@ describe('fetchJobs', () => {
       }
     )
 
+    it('logs the raw text when an auth-failure body is not JSON', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: () => Promise.resolve('upstream: email not verified')
+      })
+
+      await fetchHistory(mockFetch)
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('upstream: email not verified')
+      )
+    })
+
+    it('falls back to statusText when an auth-failure body is empty', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: () => Promise.resolve('')
+      })
+
+      await fetchHistory(mockFetch)
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unauthorized')
+      )
+    })
+
     it('recovers and polls normally once auth succeeds', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {})
       const failing = vi.fn().mockResolvedValue({

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -138,6 +138,51 @@ describe('fetchJobs', () => {
       expect(ok).toHaveBeenCalledTimes(1)
       expect(result).toHaveLength(1)
     })
+
+    it('ends the episode when a probe hits a non-auth 5xx, resuming polling', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve('')
+        })
+        .mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve('boom')
+        })
+
+      // First poll opens the auth episode; the next two are suppressed until a
+      // probe is allowed through on the fourth, which now hits a 500.
+      for (let i = 0; i < 4; i++) await fetchHistory(mockFetch)
+      const afterProbe = mockFetch.mock.calls.length
+
+      // The non-auth 500 ended the episode: polling is no longer suppressed.
+      await fetchHistory(mockFetch)
+      await fetchHistory(mockFetch)
+      expect(mockFetch.mock.calls.length).toBe(afterProbe + 2)
+    })
+
+    it('ends the episode when a probe hits a network error, resuming polling', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          text: () => Promise.resolve('')
+        })
+        .mockRejectedValue(new TypeError('Failed to fetch'))
+
+      for (let i = 0; i < 4; i++) await fetchHistory(mockFetch)
+      const afterProbe = mockFetch.mock.calls.length
+
+      await fetchHistory(mockFetch)
+      await fetchHistory(mockFetch)
+      expect(mockFetch.mock.calls.length).toBe(afterProbe + 2)
+    })
   })
 
   describe('non-auth failures', () => {

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  clearJobsAuthBackoff,
   extractWorkflow,
   fetchHistory,
   fetchHistoryPage,
@@ -46,6 +47,99 @@ function createMockResponse(
 }
 
 describe('fetchJobs', () => {
+  beforeEach(() => {
+    clearJobsAuthBackoff()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('auth failure backoff', () => {
+    it.for([401, 403] as const)(
+      'logs an auth %i once with detail and backs off further polls',
+      async (status) => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({ message: 'workspace membership not found' })
+            )
+        })
+
+        // Four consecutive poll-driven fetches while auth keeps failing.
+        for (let i = 0; i < 4; i++) await fetchHistory(mockFetch)
+
+        // Two of the four actually hit the network; the rest are suppressed.
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        // A failing episode logs exactly once, with the status and backend detail.
+        expect(errorSpy).toHaveBeenCalledTimes(1)
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(String(status))
+        )
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('workspace membership not found')
+        )
+      }
+    )
+
+    it('recovers and polls normally once auth succeeds', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const failing = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('')
+      })
+      await fetchHistory(failing)
+      clearJobsAuthBackoff() // e.g. token refresh / sign-in resolves auth
+
+      const ok = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(createMockResponse([createMockJob('job1')]))
+      })
+      const result = await fetchHistory(ok)
+
+      expect(ok).toHaveBeenCalledTimes(1)
+      expect(result).toHaveLength(1)
+    })
+  })
+
+  describe('non-auth failures', () => {
+    it('logs a server error with status and detail, without backing off', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('internal error')
+      })
+
+      const first = await fetchHistory(mockFetch)
+      const second = await fetchHistory(mockFetch)
+
+      expect(first).toEqual([])
+      expect(second).toEqual([])
+      expect(mockFetch).toHaveBeenCalledTimes(2) // no suppression for 5xx
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('500'))
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('internal error')
+      )
+    })
+
+    it('logs a network error and returns empty', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValue(new TypeError('Failed to fetch'))
+
+      const result = await fetchHistory(mockFetch)
+
+      expect(result).toEqual([])
+      expect(errorSpy).toHaveBeenCalled()
+    })
+  })
+
   describe('fetchHistory', () => {
     it('fetches completed jobs', async () => {
       const mockFetch = vi.fn().mockResolvedValue({

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -127,6 +127,7 @@ async function fetchJobsRaw(
           )
         }
       } else {
+        authBackoff.recordNonAuthFailure()
         console.error(
           `[Jobs API] Failed to fetch jobs (${res.status}): ${await readErrorDetail(res)}`
         )
@@ -143,6 +144,7 @@ async function fetchJobsRaw(
       hasMore: data.pagination.has_more
     }
   } catch (error) {
+    authBackoff.recordNonAuthFailure()
     console.error('[Jobs API] Error fetching jobs:', error)
     return EMPTY_RESULT(offset, maxItems)
   }

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -51,17 +51,34 @@ const EMPTY_RESULT = (
   hasMore: false
 })
 
+interface ErrorBody {
+  message?: string
+  error?: string
+  code?: string
+}
+
+function isErrorBody(value: unknown): value is ErrorBody {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  const isStringOrAbsent = (v: unknown) =>
+    v === undefined || typeof v === 'string'
+  return (
+    isStringOrAbsent(record.message) &&
+    isStringOrAbsent(record.error) &&
+    isStringOrAbsent(record.code)
+  )
+}
+
 async function readErrorDetail(res: Response): Promise<string> {
   try {
     const text = await res.text()
     if (!text) return res.statusText
     try {
-      const body = JSON.parse(text) as {
-        message?: string
-        error?: string
-        code?: string
+      const body: unknown = JSON.parse(text)
+      if (isErrorBody(body)) {
+        return body.message ?? body.error ?? body.code ?? text.slice(0, 200)
       }
-      return body.message ?? body.error ?? body.code ?? text.slice(0, 200)
+      return text.slice(0, 200)
     } catch {
       return text.slice(0, 200)
     }

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -18,12 +18,57 @@ import type {
   JobStatus,
   RawJobListItem
 } from './jobTypes'
+import { createJobsAuthBackoff } from './jobsAuthBackoff'
 import {
   zJobAssetsResponse,
   zJobDetail,
   zJobsListResponse,
   zWorkflowContainer
 } from './jobTypes'
+
+/** Backend statuses that mean "not authorized right now", not "server error". */
+const AUTH_FAILURE_STATUSES = new Set([401, 403])
+
+/**
+ * Shared across queue + history fetches, which poll the same `/jobs` endpoint
+ * under the same auth. A permanent auth failure on either backs off both.
+ */
+const authBackoff = createJobsAuthBackoff()
+
+/** Clears jobs-poller auth backoff (e.g. on sign-in/out, or between tests). */
+export function clearJobsAuthBackoff(): void {
+  authBackoff.recordSuccess()
+}
+
+const EMPTY_RESULT = (
+  offset: number,
+  maxItems: number
+): FetchJobsRawResult => ({
+  jobs: [],
+  total: 0,
+  offset,
+  limit: maxItems,
+  hasMore: false
+})
+
+async function readErrorDetail(res: Response): Promise<string> {
+  try {
+    const text = await res.text()
+    if (!text) return res.statusText
+    try {
+      const body = JSON.parse(text) as {
+        message?: string
+        error?: string
+        code?: string
+      }
+      return body.message ?? body.error ?? body.code ?? text.slice(0, 200)
+    } catch {
+      return text.slice(0, 200)
+    }
+  } catch {
+    return res.statusText
+  }
+}
 
 interface FetchJobsRawResult {
   jobs: RawJobListItem[]
@@ -51,20 +96,27 @@ async function fetchJobsRaw(
   maxItems: number = 200,
   offset: number = 0
 ): Promise<FetchJobsRawResult> {
+  if (authBackoff.shouldSkip()) return EMPTY_RESULT(offset, maxItems)
+
   const statusParam = statuses.join(',')
   const url = `/jobs?status=${statusParam}&limit=${maxItems}&offset=${offset}`
   try {
     const res = await fetchApi(url)
     if (!res.ok) {
-      console.error(`[Jobs API] Failed to fetch jobs: ${res.status}`)
-      return {
-        jobs: [],
-        total: 0,
-        offset,
-        limit: maxItems,
-        hasMore: false
+      if (AUTH_FAILURE_STATUSES.has(res.status)) {
+        if (authBackoff.recordAuthFailure()) {
+          console.error(
+            `[Jobs API] Auth failure fetching jobs (${res.status}); backing off polling: ${await readErrorDetail(res)}`
+          )
+        }
+      } else {
+        console.error(
+          `[Jobs API] Failed to fetch jobs (${res.status}): ${await readErrorDetail(res)}`
+        )
       }
+      return EMPTY_RESULT(offset, maxItems)
     }
+    authBackoff.recordSuccess()
     const data = zJobsListResponse.parse(await res.json())
     return {
       jobs: data.jobs,
@@ -75,7 +127,7 @@ async function fetchJobsRaw(
     }
   } catch (error) {
     console.error('[Jobs API] Error fetching jobs:', error)
-    return { jobs: [], total: 0, offset, limit: maxItems, hasMore: false }
+    return EMPTY_RESULT(offset, maxItems)
   }
 }
 

--- a/src/platform/remote/comfyui/jobs/jobsAuthBackoff.test.ts
+++ b/src/platform/remote/comfyui/jobs/jobsAuthBackoff.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { createJobsAuthBackoff } from './jobsAuthBackoff'
+
+describe('createJobsAuthBackoff', () => {
+  it('does not skip while healthy', () => {
+    const gate = createJobsAuthBackoff()
+    expect(gate.shouldSkip()).toBe(false)
+    expect(gate.shouldSkip()).toBe(false)
+  })
+
+  it('reports only the first failure of an episode', () => {
+    const gate = createJobsAuthBackoff()
+    expect(gate.recordAuthFailure()).toBe(true)
+    expect(gate.recordAuthFailure()).toBe(false)
+    expect(gate.recordAuthFailure()).toBe(false)
+  })
+
+  it('suppresses calls between probes and widens the window as failures persist', () => {
+    const gate = createJobsAuthBackoff()
+
+    // First failure → window of 2 skips before the next probe is allowed.
+    gate.recordAuthFailure()
+    expect(gate.shouldSkip()).toBe(true)
+    expect(gate.shouldSkip()).toBe(true)
+    expect(gate.shouldSkip()).toBe(false) // probe
+
+    // Probe also fails → window widens to 4 skips before the next probe.
+    gate.recordAuthFailure()
+    expect([1, 2, 3, 4, 5].map(() => gate.shouldSkip())).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false
+    ])
+  })
+
+  it('clears backoff immediately on success', () => {
+    const gate = createJobsAuthBackoff()
+    gate.recordAuthFailure()
+    expect(gate.shouldSkip()).toBe(true)
+
+    gate.recordSuccess()
+
+    expect(gate.shouldSkip()).toBe(false)
+    expect(gate.recordAuthFailure()).toBe(true) // next failure is a fresh episode
+  })
+})

--- a/src/platform/remote/comfyui/jobs/jobsAuthBackoff.test.ts
+++ b/src/platform/remote/comfyui/jobs/jobsAuthBackoff.test.ts
@@ -36,6 +36,23 @@ describe('createJobsAuthBackoff', () => {
     ])
   })
 
+  it('caps the suppression window at 32 skips and does not widen further', () => {
+    const gate = createJobsAuthBackoff()
+    const skipsBeforeProbe = () => {
+      let skips = 0
+      while (gate.shouldSkip()) skips++
+      return skips
+    }
+
+    // Five failures widen the window to its 2^5 = 32 maximum.
+    for (let i = 0; i < 5; i++) gate.recordAuthFailure()
+    expect(skipsBeforeProbe()).toBe(32)
+
+    // A sixth failure must not widen the window past the cap.
+    gate.recordAuthFailure()
+    expect(skipsBeforeProbe()).toBe(32)
+  })
+
   it('clears backoff immediately on success', () => {
     const gate = createJobsAuthBackoff()
     gate.recordAuthFailure()

--- a/src/platform/remote/comfyui/jobs/jobsAuthBackoff.ts
+++ b/src/platform/remote/comfyui/jobs/jobsAuthBackoff.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Client-side circuit breaker for the jobs poller.
+ * @module platform/remote/comfyui/jobs/jobsAuthBackoff
+ *
+ * The jobs poller re-fetches `/jobs` on every WebSocket `status` frame and on a
+ * timer. On sessions the backend never authorizes (401 = unresolved
+ * token/workspace membership, 403 = email-not-verified), this produced tens of
+ * thousands of rejected requests — and `console.error` logs ingested by RUM —
+ * per session, because nothing backed off after a permanent auth failure.
+ *
+ * This gate applies exponential backoff keyed on consecutive auth failures:
+ * after the first rejection it suppresses most poll-driven fetches, probing
+ * only occasionally, and clears instantly on the first successful response
+ * (e.g. once the user verifies their email or the workspace resolves). The
+ * backoff is counter-based (not wall-clock) so it is fully deterministic.
+ */
+
+/** Suppression window caps at 2^5 = 32 skipped calls between probes. */
+const MAX_BACKOFF_EXPONENT = 5
+
+export interface JobsAuthBackoff {
+  /**
+   * Whether the current fetch should skip the network while backing off.
+   * Advances the internal skip counter as a side effect.
+   */
+  shouldSkip: () => boolean
+  /**
+   * Records an auth failure (401/403) and widens the backoff window.
+   * @returns true if this failure starts a new failure episode (i.e. the
+   * caller should log), false while an episode is ongoing.
+   */
+  recordAuthFailure: () => boolean
+  /** Clears all backoff state after a successful response. */
+  recordSuccess: () => void
+}
+
+export function createJobsAuthBackoff(): JobsAuthBackoff {
+  let failureStreak = 0
+  let callsSinceProbe = 0
+
+  const suppressionWindow = () =>
+    1 << Math.min(failureStreak, MAX_BACKOFF_EXPONENT)
+
+  return {
+    shouldSkip() {
+      if (failureStreak === 0) return false
+      if (callsSinceProbe < suppressionWindow()) {
+        callsSinceProbe++
+        return true
+      }
+      callsSinceProbe = 0
+      return false
+    },
+    recordAuthFailure() {
+      const startsEpisode = failureStreak === 0
+      failureStreak++
+      return startsEpisode
+    },
+    recordSuccess() {
+      failureStreak = 0
+      callsSinceProbe = 0
+    }
+  }
+}

--- a/src/platform/remote/comfyui/jobs/jobsAuthBackoff.ts
+++ b/src/platform/remote/comfyui/jobs/jobsAuthBackoff.ts
@@ -32,6 +32,13 @@ export interface JobsAuthBackoff {
   recordAuthFailure: () => boolean
   /** Clears all backoff state after a successful response. */
   recordSuccess: () => void
+  /**
+   * Clears all backoff state after any non-auth outcome — a non-401/403 HTTP
+   * error or a thrown request. The episode only holds while auth keeps failing,
+   * so a probe that reaches the server (even to a 5xx) or fails the network
+   * ends it; those failures then log every poll as they did before the backoff.
+   */
+  recordNonAuthFailure: () => void
 }
 
 export function createJobsAuthBackoff(): JobsAuthBackoff {
@@ -40,6 +47,11 @@ export function createJobsAuthBackoff(): JobsAuthBackoff {
 
   const suppressionWindow = () =>
     1 << Math.min(failureStreak, MAX_BACKOFF_EXPONENT)
+
+  const reset = () => {
+    failureStreak = 0
+    callsSinceProbe = 0
+  }
 
   return {
     shouldSkip() {
@@ -56,9 +68,7 @@ export function createJobsAuthBackoff(): JobsAuthBackoff {
       failureStreak++
       return startsEpisode
     },
-    recordSuccess() {
-      failureStreak = 0
-      callsSinceProbe = 0
-    }
+    recordSuccess: reset,
+    recordNonAuthFailure: reset
   }
 }

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -4,8 +4,11 @@ import * as firebaseAuth from 'firebase/auth'
 import { setActivePinia } from 'pinia'
 import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import * as vuefire from 'vuefire'
 
+import type * as FetchJobsModule from '@/platform/remote/comfyui/jobs/fetchJobs'
+import { clearJobsAuthBackoff } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import {
   capturePreservedQuery,
   clearPreservedQuery
@@ -126,6 +129,13 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackAuth: mockTrackAuth
   })
+}))
+
+// Stub only the jobs-poller backoff reset so we can assert auth recovery clears
+// it, keeping the rest of the fetchers real.
+vi.mock('@/platform/remote/comfyui/jobs/fetchJobs', async (importOriginal) => ({
+  ...(await importOriginal<typeof FetchJobsModule>()),
+  clearJobsAuthBackoff: vi.fn()
 }))
 
 // Keep the real API singleton (other modules rely on its full surface) but
@@ -290,6 +300,28 @@ describe('useAuthStore', () => {
     it('notifyTokenRefreshed increments the rotation trigger (unified rotation driver)', () => {
       store.notifyTokenRefreshed()
       expect(store.tokenRefreshTrigger).toBe(1)
+    })
+  })
+
+  describe('jobs poller auth-backoff recovery', () => {
+    it('clears the jobs poller backoff on token refresh', async () => {
+      vi.mocked(clearJobsAuthBackoff).mockClear()
+
+      store.notifyTokenRefreshed()
+      await nextTick()
+
+      expect(clearJobsAuthBackoff).toHaveBeenCalled()
+    })
+
+    it('clears the jobs poller backoff when the user signs in', async () => {
+      authStateCallback?.(null)
+      await nextTick()
+      vi.mocked(clearJobsAuthBackoff).mockClear()
+
+      authStateCallback?.(mockUser)
+      await nextTick()
+
+      expect(clearJobsAuthBackoff).toHaveBeenCalled()
     })
   })
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -323,6 +323,18 @@ describe('useAuthStore', () => {
 
       expect(clearJobsAuthBackoff).toHaveBeenCalled()
     })
+
+    it('clears the jobs poller backoff on a direct account switch', async () => {
+      // A→B switch keeps isAuthenticated true and does not bump the token
+      // trigger, so the reset must key off the user identity itself.
+      vi.mocked(clearJobsAuthBackoff).mockClear()
+
+      const otherUser = { uid: 'other-user-id' } as Partial<User> as User
+      authStateCallback?.(otherUser)
+      await nextTick()
+
+      expect(clearJobsAuthBackoff).toHaveBeenCalled()
+    })
   })
 
   it('should initialize with the current user', () => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -17,7 +17,9 @@ import {
 } from 'firebase/auth'
 import type { Auth, User, UserCredential } from 'firebase/auth'
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
+
+import { clearJobsAuthBackoff } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import { useFirebaseAuth } from 'vuefire'
 
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
@@ -205,6 +207,14 @@ export const useAuthStore = defineStore('auth', () => {
   const notifyTokenRefreshed = (): void => {
     tokenRefreshTrigger.value++
   }
+
+  // A fresh sign-in or token refresh can resolve a permanent auth failure
+  // (email verified, workspace membership granted, JWT rotated). Clear the jobs
+  // poller's auth backoff so the next poll probes immediately instead of
+  // waiting out the suppression window.
+  watch([isAuthenticated, tokenRefreshTrigger], () => {
+    clearJobsAuthBackoff()
+  })
 
   const getIdToken = async (): Promise<string | undefined> => {
     const user = currentUser.value

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -208,11 +208,14 @@ export const useAuthStore = defineStore('auth', () => {
     tokenRefreshTrigger.value++
   }
 
-  // A fresh sign-in or token refresh can resolve a permanent auth failure
-  // (email verified, workspace membership granted, JWT rotated). Clear the jobs
-  // poller's auth backoff so the next poll probes immediately instead of
-  // waiting out the suppression window.
-  watch([isAuthenticated, tokenRefreshTrigger], () => {
+  // A user identity change (sign-in, sign-out, or a direct account switch) or a
+  // token refresh can resolve a permanent auth failure (email verified,
+  // workspace membership granted, JWT rotated). Clear the jobs poller's auth
+  // backoff so the next poll probes immediately instead of waiting out the
+  // suppression window. Watch currentUser rather than isAuthenticated so an
+  // A→B account switch — where isAuthenticated stays true and the new user's
+  // first token event doesn't bump tokenRefreshTrigger — still clears it.
+  watch([currentUser, tokenRefreshTrigger], () => {
     clearJobsAuthBackoff()
   })
 


### PR DESCRIPTION
## Summary
Root-cause fix for the single largest source of frontend RUM error noise — the jobs poller's `console.error` on rejected `/jobs` polls (~123k errors/week, ~46% of all frontend RUM errors). Replaces the blanket error→warn downgrade in #14562.

## Root cause (Datadog RUM + backend)
`/jobs` is served on the ingest `Protected(requireEmailVerified)` group. The poller re-fetches `/jobs` on **every WebSocket `status` frame** (via `GraphView.onStatus` → `queueStore.update()`, two `/jobs` calls each) plus a timer, and **never backs off** when the backend permanently rejects the session:
- **401** — unresolved token / workspace membership (41% of the volume)
- **403** — email-not-verified / pending deletion (59%)

RUM shows 131k errors from just ~263 sessions (100% with no resolved user). Individual left-open, unauthorized tabs emitted **>28k identical 401/403s over hours with zero successful polls**. This is a client-side retry storm, not a per-message logging-severity problem — so the fix is to add backoff, not to relabel the log.

## Changes
- **What**: New `jobsAuthBackoff.ts` — a counter-based circuit breaker keyed on consecutive auth failures. After the first 401/403, `fetchJobsRaw` suppresses most poll-driven fetches and probes only occasionally (exponential backoff, capped at 32 skipped calls between probes). The failure is logged **once per episode**, now including the backend error detail (`workspace membership not found` vs the email-verification message). Any successful response clears the backoff instantly.
- The log stays at `console.error` — a genuine auth failure is still a real signal; we fixed the *volume at the source* rather than hiding it. Non-auth failures (5xx, network) are unchanged and still log every time.
- Exported `clearJobsAuthBackoff()` so auth transitions (sign-in/out, token refresh) can reset the breaker.
- Counter-based (not wall-clock) so it is fully deterministic and unit-testable.

## Review Focus
- The breaker is a module singleton shared by the queue + history fetches (same endpoint, same auth) — a permanent failure on either backs off both. Safe for OSS: local `/jobs` returns 200 so the breaker never trips.
- Follow-up worth considering (not in this PR): call `clearJobsAuthBackoff()` on auth state changes, and gate the initial poll on auth-ready, to drop even the first-probe errors on known-ineligible sessions.

Closes #14562 (supersedes the error→warn downgrade with a source fix).

Note: includes a one-line `.gitignore` entry for nested `.worktrees/` so the local pre-push knip hook stops choking on developer worktrees.