### PR TITLE
feat(selection-toolbox): add Batch Selected Images button

### DIFF
--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -13,6 +13,7 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import { useExtensionService } from '@/services/extensionService'
 import {
   createMockCanvas,
+  createMockLGraphNode,
   createMockPositionable
 } from '@/utils/__tests__/litegraphTestUtils'
 import * as litegraphUtil from '@/utils/litegraphUtil'
@@ -90,7 +91,11 @@ vi.mock('@/services/extensionService', () => ({
 vi.mock('@/utils/litegraphUtil', () => ({
   isLGraphNode: vi.fn(() => true),
   isImageNode: vi.fn(() => false),
-  isLoad3dNode: vi.fn(() => false)
+  isLoad3dNode: vi.fn(() => false),
+  hasImageOutput: vi.fn(
+    (node: LGraphNode | undefined) =>
+      !!node?.outputs?.some((output) => output.type === 'IMAGE')
+  )
 }))
 
 vi.mock('@/utils/nodeFilterUtil', () => ({
@@ -115,9 +120,14 @@ let nodeDefMock = {
   title: 'Test Node'
 } as unknown
 
+let nodeDefsByNameMock: Record<string, unknown> = {}
+
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: () => ({
-    fromLGraphNode: vi.fn(() => nodeDefMock)
+    fromLGraphNode: vi.fn(() => nodeDefMock),
+    get nodeDefsByName() {
+      return nodeDefsByNameMock
+    }
   })
 }))
 
@@ -152,6 +162,9 @@ describe('SelectionToolbox', () => {
       type: 'TestNode',
       title: 'Test Node'
     } as unknown
+    nodeDefsByNameMock = {
+      BatchImagesNode: { name: 'BatchImagesNode' }
+    }
 
     // Mock the canvas to avoid "getCanvas: canvas is null" errors
     canvasStore.canvas = createMockCanvas()
@@ -181,6 +194,10 @@ describe('SelectionToolbox', () => {
               '<button data-testid="color-picker-button" class="color-picker-button" />'
           },
           FrameNodes: { template: '<div class="frame-nodes" />' },
+          BatchImagesButton: {
+            template:
+              '<button data-testid="batch-images-button" class="batch-images-button" />'
+          },
           PublishButton: {
             template:
               '<button data-testid="add-to-library" class="bookmark-button" />'
@@ -384,6 +401,52 @@ describe('SelectionToolbox', () => {
       canvasStore.selectedItems = [createMockPositionable()]
       const { container: container2 } = renderComponent()
       expect(container2.querySelector('.load-3d-viewer-button')).toBeFalsy()
+    })
+
+    it('should show batch images button only when multiple image-output nodes are selected', () => {
+      const createImageOutputNode = () =>
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] })
+      const createNonImageNode = () =>
+        createMockLGraphNode({ outputs: [{ name: 'LATENT', type: 'LATENT' }] })
+
+      // Multiple nodes with IMAGE outputs
+      canvasStore.selectedItems = [
+        createImageOutputNode(),
+        createImageOutputNode()
+      ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeTruthy()
+
+      // Single image-output node
+      canvasStore.selectedItems = [createImageOutputNode()]
+      const { container: container2 } = renderComponent()
+      expect(
+        container2.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
+
+      // Multiple nodes but only one has an IMAGE output
+      canvasStore.selectedItems = [
+        createImageOutputNode(),
+        createNonImageNode()
+      ]
+      const { container: container3 } = renderComponent()
+      expect(
+        container3.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
+    })
+
+    it('should not show batch images button when the Batch Images node def is unavailable', () => {
+      nodeDefsByNameMock = {}
+      canvasStore.selectedItems = [
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] }),
+        createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] })
+      ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
     })
 
     it('should show ExecuteButton only when output nodes are selected', () => {

--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -122,6 +122,16 @@ let nodeDefMock = {
 
 let nodeDefsByNameMock: Record<string, unknown> = {}
 
+const createMockBatchImagesNode = (feeding: LGraphNode[] = []) =>
+  createMockLGraphNode({
+    id: 'batch',
+    type: 'BatchImagesNode',
+    outputs: [{ name: 'IMAGE', type: 'IMAGE' }],
+    inputs: feeding.map(() => ({ name: 'image', type: 'IMAGE' })),
+    graph: {} as LGraphNode['graph'],
+    getInputNode: (slot: number) => feeding[slot] ?? null
+  })
+
 vi.mock('@/stores/nodeDefStore', () => ({
   useNodeDefStore: () => ({
     fromLGraphNode: vi.fn(() => nodeDefMock),
@@ -443,6 +453,33 @@ describe('SelectionToolbox', () => {
         createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] }),
         createMockLGraphNode({ outputs: [{ name: 'IMAGE', type: 'IMAGE' }] })
       ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeFalsy()
+    })
+
+    it('should show batch images button when a batch node and an unwired image node are selected', () => {
+      nodeDefsByNameMock = {}
+      canvasStore.selectedItems = [
+        createMockBatchImagesNode(),
+        createMockLGraphNode({
+          id: 'fresh',
+          outputs: [{ name: 'IMAGE', type: 'IMAGE' }]
+        })
+      ]
+      const { container } = renderComponent()
+      expect(
+        container.querySelector('[data-testid="batch-images-button"]')
+      ).toBeTruthy()
+    })
+
+    it('should hide batch images button when every selected image node already feeds the batch node', () => {
+      const wired = createMockLGraphNode({
+        id: 'wired',
+        outputs: [{ name: 'IMAGE', type: 'IMAGE' }]
+      })
+      canvasStore.selectedItems = [createMockBatchImagesNode([wired]), wired]
       const { container } = renderComponent()
       expect(
         container.querySelector('[data-testid="batch-images-button"]')

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -22,6 +22,7 @@
         <ColorPickerButton v-if="showColorPicker" />
         <ArrangeButton v-if="showArrange" />
         <FrameNodes v-if="showFrameNodes" />
+        <BatchImagesButton v-if="showBatchImages" />
         <ConvertToSubgraphButton v-if="showConvertToSubgraph" />
         <ConfigureSubgraph v-if="showSubgraphButtons" />
         <PublishSubgraphButton v-if="showSubgraphButtons" />
@@ -51,6 +52,7 @@ import Panel from 'primevue/panel'
 import { computed, ref } from 'vue'
 
 import ArrangeButton from '@/components/graph/selectionToolbox/ArrangeButton.vue'
+import BatchImagesButton from '@/components/graph/selectionToolbox/BatchImagesButton.vue'
 import BypassButton from '@/components/graph/selectionToolbox/BypassButton.vue'
 import ColorPickerButton from '@/components/graph/selectionToolbox/ColorPickerButton.vue'
 import ConfigureSubgraph from '@/components/graph/selectionToolbox/ConfigureSubgraph.vue'
@@ -70,6 +72,7 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import { useExtensionService } from '@/services/extensionService'
 import { useCommandStore } from '@/stores/commandStore'
 import type { ComfyCommandImpl } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import FrameNodes from './selectionToolbox/FrameNodes.vue'
 import NodeOptionsButton from './selectionToolbox/NodeOptionsButton.vue'
@@ -77,6 +80,7 @@ import VerticalDivider from './selectionToolbox/VerticalDivider.vue'
 
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
+const nodeDefStore = useNodeDefStore()
 const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
@@ -108,6 +112,7 @@ const {
   isSingleImageNode,
   hasAny3DNodeSelected,
   hasOutputNodesSelected,
+  hasMultipleImageOutputNodes,
   canOpenNodeInfo
 } = useSelectionState()
 
@@ -115,6 +120,11 @@ const showColorPicker = computed(() => hasAnySelection.value)
 const showConvertToSubgraph = computed(() => hasAnySelection.value)
 const showArrange = computed(() => hasMultipleSelection.value)
 const showFrameNodes = computed(() => hasMultipleSelection.value)
+const showBatchImages = computed(
+  () =>
+    hasMultipleImageOutputNodes.value &&
+    !!nodeDefStore.nodeDefsByName?.['BatchImagesNode']
+)
 const showSubgraphButtons = computed(() => isSingleSubgraph.value)
 
 const showBypass = computed(
@@ -137,6 +147,7 @@ const showAnyPrimaryActions = computed(
     showConvertToSubgraph.value ||
     showArrange.value ||
     showFrameNodes.value ||
+    showBatchImages.value ||
     showSubgraphButtons.value
 )
 

--- a/src/components/graph/SelectionToolbox.vue
+++ b/src/components/graph/SelectionToolbox.vue
@@ -72,7 +72,6 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import { useExtensionService } from '@/services/extensionService'
 import { useCommandStore } from '@/stores/commandStore'
 import type { ComfyCommandImpl } from '@/stores/commandStore'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
 
 import FrameNodes from './selectionToolbox/FrameNodes.vue'
 import NodeOptionsButton from './selectionToolbox/NodeOptionsButton.vue'
@@ -80,7 +79,6 @@ import VerticalDivider from './selectionToolbox/VerticalDivider.vue'
 
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
-const nodeDefStore = useNodeDefStore()
 const extensionService = useExtensionService()
 const canvasInteractions = useCanvasInteractions()
 
@@ -112,7 +110,8 @@ const {
   isSingleImageNode,
   hasAny3DNodeSelected,
   hasOutputNodesSelected,
-  hasMultipleImageOutputNodes,
+  canBatchSelectedImages,
+  canAddSelectedImagesToBatch,
   canOpenNodeInfo
 } = useSelectionState()
 
@@ -121,9 +120,7 @@ const showConvertToSubgraph = computed(() => hasAnySelection.value)
 const showArrange = computed(() => hasMultipleSelection.value)
 const showFrameNodes = computed(() => hasMultipleSelection.value)
 const showBatchImages = computed(
-  () =>
-    hasMultipleImageOutputNodes.value &&
-    !!nodeDefStore.nodeDefsByName?.['BatchImagesNode']
+  () => canBatchSelectedImages.value || canAddSelectedImagesToBatch.value
 )
 const showSubgraphButtons = computed(() => isSingleSubgraph.value)
 

--- a/src/components/graph/selectionToolbox/BatchImagesButton.vue
+++ b/src/components/graph/selectionToolbox/BatchImagesButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <Button
+    v-tooltip.top="{
+      value: $t('commands.Comfy_Graph_BatchSelectedImageNodes.label'),
+      showDelay: 1000
+    }"
+    variant="muted-textonly"
+    :aria-label="$t('commands.Comfy_Graph_BatchSelectedImageNodes.label')"
+    data-testid="batch-images-button"
+    @click="() => commandStore.execute('Comfy.Graph.BatchSelectedImageNodes')"
+  >
+    <i class="icon-[lucide--images]" />
+  </Button>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+import { useCommandStore } from '@/stores/commandStore'
+
+const commandStore = useCommandStore()
+</script>

--- a/src/components/graph/selectionToolbox/BatchImagesButton.vue
+++ b/src/components/graph/selectionToolbox/BatchImagesButton.vue
@@ -1,5 +1,19 @@
 <template>
   <Button
+    v-if="canAddSelectedImagesToBatch"
+    v-tooltip.top="{
+      value: $t('commands.Comfy_Graph_AddSelectedImagesToBatch.label'),
+      showDelay: 1000
+    }"
+    variant="muted-textonly"
+    :aria-label="$t('commands.Comfy_Graph_AddSelectedImagesToBatch.label')"
+    data-testid="add-to-batch-button"
+    @click="() => commandStore.execute('Comfy.Graph.AddSelectedImagesToBatch')"
+  >
+    <i class="icon-[lucide--image-plus]" />
+  </Button>
+  <Button
+    v-else
     v-tooltip.top="{
       value: $t('commands.Comfy_Graph_BatchSelectedImageNodes.label'),
       showDelay: 1000
@@ -15,7 +29,9 @@
 
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
+import { useSelectionState } from '@/composables/graph/useSelectionState'
 import { useCommandStore } from '@/stores/commandStore'
 
 const commandStore = useCommandStore()
+const { canAddSelectedImagesToBatch } = useSelectionState()
 </script>

--- a/src/composables/graph/useBatchImages.ts
+++ b/src/composables/graph/useBatchImages.ts
@@ -1,0 +1,99 @@
+import { t } from '@/i18n'
+import type { LGraphNode, Point } from '@/lib/litegraph/src/litegraph'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useLitegraphService } from '@/services/litegraphService'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import {
+  BATCH_IMAGES_NODE_TYPE,
+  resolveBatchImagesSelection
+} from '@/utils/batchImagesUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
+import { findNonOverlappingPosition } from '@/utils/mathUtil'
+
+const BATCH_NODE_GAP = 100
+const PLACEMENT_GAP = 20
+
+/**
+ * Wires image-producing nodes into a `BatchImagesNode`, either a freshly
+ * created one or the batch node the user included in their selection.
+ */
+export function useBatchImages() {
+  const canvasStore = useCanvasStore()
+
+  const selectionForBatching = () =>
+    resolveBatchImagesSelection(
+      [...canvasStore.getCanvas().selectedItems].filter(isLGraphNode)
+    )
+
+  const connectImages = (sources: LGraphNode[], batchNode: LGraphNode) => {
+    for (const source of sources) {
+      const outputIndex = source.outputs.findIndex(
+        (output) => output.type === 'IMAGE'
+      )
+      // Connecting the last free slot makes autogrow add the next one
+      const inputIndex = batchNode.inputs.findIndex(
+        (input) => input.link == null && input.type === 'IMAGE'
+      )
+      if (inputIndex === -1) break
+      source.connect(outputIndex, batchNode, inputIndex)
+    }
+  }
+
+  const clearOfOtherNodes = (node: LGraphNode, position: Point): Point => {
+    const others =
+      node.graph?.nodes.filter((other) => other.id !== node.id) ?? []
+    return findNonOverlappingPosition(others, position, node.size, [
+      0,
+      node.size[1] + PLACEMENT_GAP
+    ])
+  }
+
+  const selectOnly = (node: LGraphNode) => {
+    const canvas = canvasStore.getCanvas()
+    canvas.deselectAll()
+    canvas.select(node)
+    canvasStore.updateSelectedItems()
+  }
+
+  const batchSelectedImages = () => {
+    const { target, sources } = selectionForBatching()
+    if (target || sources.length < 2) return
+
+    const nodeDef = useNodeDefStore().nodeDefsByName[BATCH_IMAGES_NODE_TYPE]
+    if (!nodeDef) {
+      useToastStore().add({
+        severity: 'error',
+        summary: t('toastMessages.batchImagesNodeUnavailable')
+      })
+      return
+    }
+
+    const right = Math.max(...sources.map((node) => node.pos[0] + node.size[0]))
+    const centerY =
+      sources.reduce((sum, node) => sum + node.pos[1] + node.size[1] / 2, 0) /
+      sources.length
+
+    const batchNode = useLitegraphService().addNodeOnGraph(nodeDef, {
+      pos: [right + BATCH_NODE_GAP, centerY]
+    })
+    if (!batchNode) return
+
+    connectImages(sources, batchNode)
+    batchNode.pos = clearOfOtherNodes(batchNode, [
+      right + BATCH_NODE_GAP,
+      centerY - batchNode.size[1] / 2
+    ])
+    selectOnly(batchNode)
+  }
+
+  const addSelectedImagesToBatch = () => {
+    const { target, sources } = selectionForBatching()
+    if (!target || !sources.length) return
+
+    connectImages(sources, target)
+    selectOnly(target)
+  }
+
+  return { batchSelectedImages, addSelectedImagesToBatch }
+}

--- a/src/composables/graph/useSelectionState.ts
+++ b/src/composables/graph/useSelectionState.ts
@@ -8,6 +8,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import {
+  hasImageOutput,
   isImageNode,
   isLGraphGroup,
   isLGraphNode,
@@ -79,6 +80,9 @@ export function useSelectionState() {
   })
 
   const hasImageNode = computed(() => isSingleImageNode.value)
+  const hasMultipleImageOutputNodes = computed(
+    () => selectedNodes.value.filter((node) => hasImageOutput(node)).length > 1
+  )
   const hasOutputNodesSelected = computed(
     () => filterOutputNodes(selectedNodes.value).length > 0
   )
@@ -130,6 +134,7 @@ export function useSelectionState() {
     isSingleImageNode,
     hasSubgraphs,
     hasImageNode,
+    hasMultipleImageOutputNodes,
     hasOutputNodesSelected,
     selectedNodesStates,
     computeSelectionFlags

--- a/src/composables/graph/useSelectionState.ts
+++ b/src/composables/graph/useSelectionState.ts
@@ -8,7 +8,12 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import {
-  hasImageOutput,
+  BATCH_IMAGES_NODE_TYPE,
+  canAppendToBatch,
+  canCreateBatch,
+  resolveBatchImagesSelection
+} from '@/utils/batchImagesUtil'
+import {
   isImageNode,
   isLGraphGroup,
   isLGraphNode,
@@ -80,8 +85,16 @@ export function useSelectionState() {
   })
 
   const hasImageNode = computed(() => isSingleImageNode.value)
-  const hasMultipleImageOutputNodes = computed(
-    () => selectedNodes.value.filter((node) => hasImageOutput(node)).length > 1
+  const batchImagesSelection = computed(() =>
+    resolveBatchImagesSelection(selectedNodes.value)
+  )
+  const canBatchSelectedImages = computed(
+    () =>
+      canCreateBatch(batchImagesSelection.value) &&
+      !!nodeDefStore.nodeDefsByName?.[BATCH_IMAGES_NODE_TYPE]
+  )
+  const canAddSelectedImagesToBatch = computed(() =>
+    canAppendToBatch(batchImagesSelection.value)
   )
   const hasOutputNodesSelected = computed(
     () => filterOutputNodes(selectedNodes.value).length > 0
@@ -134,7 +147,8 @@ export function useSelectionState() {
     isSingleImageNode,
     hasSubgraphs,
     hasImageNode,
-    hasMultipleImageOutputNodes,
+    canBatchSelectedImages,
+    canAddSelectedImagesToBatch,
     hasOutputNodesSelected,
     selectedNodesStates,
     computeSelectionFlags

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -42,6 +42,7 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { ComfyCommand } from '@/stores/commandStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useHelpCenterStore } from '@/stores/helpCenterStore'
@@ -55,6 +56,7 @@ import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { ensureWorkflowSuffix, getWorkflowSuffix } from '@/utils/formatUtil'
+import { hasImageOutput, isLGraphNode } from '@/utils/litegraphUtil'
 import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
@@ -1060,6 +1062,60 @@ export function useCoreCommands(): ComfyCommand[] {
 
         const { node } = res
         canvas.select(node)
+        canvasStore.updateSelectedItems()
+      }
+    },
+    {
+      id: 'Comfy.Graph.BatchSelectedImageNodes',
+      icon: 'icon-[lucide--images]',
+      label: 'Batch Selected Images',
+      versionAdded: '1.49.3',
+      function: () => {
+        const canvas = canvasStore.getCanvas()
+        const imageNodes = [...canvas.selectedItems]
+          .filter(isLGraphNode)
+          .filter((node) => hasImageOutput(node))
+          .sort((a, b) => a.pos[1] - b.pos[1] || a.pos[0] - b.pos[0])
+        if (imageNodes.length < 2) return
+
+        const nodeDef = useNodeDefStore().nodeDefsByName['BatchImagesNode']
+        if (!nodeDef) {
+          toastStore.add({
+            severity: 'error',
+            summary: t('toastMessages.batchImagesNodeUnavailable')
+          })
+          return
+        }
+
+        const right = Math.max(
+          ...imageNodes.map((node) => node.pos[0] + node.size[0])
+        )
+        const centerY =
+          imageNodes.reduce(
+            (sum, node) => sum + node.pos[1] + node.size[1] / 2,
+            0
+          ) / imageNodes.length
+
+        const batchNode = useLitegraphService().addNodeOnGraph(nodeDef, {
+          pos: [right + 100, centerY]
+        })
+        if (!batchNode) return
+        batchNode.pos = [right + 100, centerY - batchNode.size[1] / 2]
+
+        for (const source of imageNodes) {
+          const outputIndex = source.outputs.findIndex(
+            (output) => output.type === 'IMAGE'
+          )
+          // Connecting the last free slot makes autogrow add the next one
+          const inputIndex = batchNode.inputs.findIndex(
+            (input) => input.link == null && input.type === 'IMAGE'
+          )
+          if (inputIndex === -1) break
+          source.connect(outputIndex, batchNode, inputIndex)
+        }
+
+        canvas.deselectAll()
+        canvas.select(batchNode)
         canvasStore.updateSelectedItems()
       }
     },

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1,6 +1,7 @@
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
+import { useBatchImages } from '@/composables/graph/useBatchImages'
 import { useSubgraphOperations } from '@/composables/graph/useSubgraphOperations'
 import { startModelNodeDragFromAsset } from '@/composables/node/startModelNodeDragFromAsset'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -42,7 +43,6 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { ComfyCommand } from '@/stores/commandStore'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useModelStore } from '@/stores/modelStore'
 import { useHelpCenterStore } from '@/stores/helpCenterStore'
@@ -56,7 +56,6 @@ import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { ensureWorkflowSuffix, getWorkflowSuffix } from '@/utils/formatUtil'
-import { hasImageOutput, isLGraphNode } from '@/utils/litegraphUtil'
 import {
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes
@@ -1071,52 +1070,16 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Batch Selected Images',
       versionAdded: '1.49.3',
       function: () => {
-        const canvas = canvasStore.getCanvas()
-        const imageNodes = [...canvas.selectedItems]
-          .filter(isLGraphNode)
-          .filter((node) => hasImageOutput(node))
-          .sort((a, b) => a.pos[1] - b.pos[1] || a.pos[0] - b.pos[0])
-        if (imageNodes.length < 2) return
-
-        const nodeDef = useNodeDefStore().nodeDefsByName['BatchImagesNode']
-        if (!nodeDef) {
-          toastStore.add({
-            severity: 'error',
-            summary: t('toastMessages.batchImagesNodeUnavailable')
-          })
-          return
-        }
-
-        const right = Math.max(
-          ...imageNodes.map((node) => node.pos[0] + node.size[0])
-        )
-        const centerY =
-          imageNodes.reduce(
-            (sum, node) => sum + node.pos[1] + node.size[1] / 2,
-            0
-          ) / imageNodes.length
-
-        const batchNode = useLitegraphService().addNodeOnGraph(nodeDef, {
-          pos: [right + 100, centerY]
-        })
-        if (!batchNode) return
-        batchNode.pos = [right + 100, centerY - batchNode.size[1] / 2]
-
-        for (const source of imageNodes) {
-          const outputIndex = source.outputs.findIndex(
-            (output) => output.type === 'IMAGE'
-          )
-          // Connecting the last free slot makes autogrow add the next one
-          const inputIndex = batchNode.inputs.findIndex(
-            (input) => input.link == null && input.type === 'IMAGE'
-          )
-          if (inputIndex === -1) break
-          source.connect(outputIndex, batchNode, inputIndex)
-        }
-
-        canvas.deselectAll()
-        canvas.select(batchNode)
-        canvasStore.updateSelectedItems()
+        useBatchImages().batchSelectedImages()
+      }
+    },
+    {
+      id: 'Comfy.Graph.AddSelectedImagesToBatch',
+      icon: 'icon-[lucide--image-plus]',
+      label: 'Add Selected Images to Batch',
+      versionAdded: '1.49.3',
+      function: () => {
+        useBatchImages().addSelectedImagesToBatch()
       }
     },
     {

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -137,6 +137,9 @@
   "Comfy_ExportWorkflowAPI": {
     "label": "Export Workflow (API Format)"
   },
+  "Comfy_Graph_BatchSelectedImageNodes": {
+    "label": "Batch Selected Images"
+  },
   "Comfy_Graph_ConvertToSubgraph": {
     "label": "Convert Selection to Subgraph"
   },

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -137,6 +137,9 @@
   "Comfy_ExportWorkflowAPI": {
     "label": "Export Workflow (API Format)"
   },
+  "Comfy_Graph_AddSelectedImagesToBatch": {
+    "label": "Add Selected Images to Batch"
+  },
   "Comfy_Graph_BatchSelectedImageNodes": {
     "label": "Batch Selected Images"
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2312,6 +2312,7 @@
     "nothingSelected": "Nothing selected",
     "cannotCreateSubgraph": "Cannot create subgraph",
     "failedToConvertToSubgraph": "Failed to convert items to subgraph",
+    "batchImagesNodeUnavailable": "The Batch Images node is not available on this server",
     "failedToInitializeLoad3dViewer": "Failed to initialize 3D Viewer",
     "failedToLoadBackgroundImage": "Failed to load background image",
     "failedToLoadModel": "Failed to load 3D model",

--- a/src/utils/batchImagesUtil.test.ts
+++ b/src/utils/batchImagesUtil.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+import {
+  BATCH_IMAGES_NODE_TYPE,
+  canAppendToBatch,
+  canCreateBatch,
+  resolveBatchImagesSelection
+} from '@/utils/batchImagesUtil'
+
+let nextNodeId = 0
+const uniqueId = () => toNodeId(++nextNodeId)
+
+const imageNode = (overrides: Record<string, unknown> = {}) =>
+  createMockLGraphNode({
+    id: uniqueId(),
+    type: 'LoadImage',
+    outputs: [{ name: 'IMAGE', type: 'IMAGE' }],
+    ...overrides
+  })
+
+const batchNode = (feeding: LGraphNode[] = []) =>
+  createMockLGraphNode({
+    id: uniqueId(),
+    type: BATCH_IMAGES_NODE_TYPE,
+    outputs: [{ name: 'IMAGE', type: 'IMAGE' }],
+    inputs: feeding.map(() => ({ name: 'image', type: 'IMAGE' })),
+    graph: {} as LGraphNode['graph'],
+    getInputNode: (slot: number) => feeding[slot] ?? null
+  })
+
+describe('resolveBatchImagesSelection', () => {
+  it('orders sources top-to-bottom then left-to-right', () => {
+    const bottom = imageNode({ pos: [0, 100] })
+    const topRight = imageNode({ pos: [50, 0] })
+    const topLeft = imageNode({ pos: [0, 0] })
+
+    const { target, sources } = resolveBatchImagesSelection([
+      bottom,
+      topRight,
+      topLeft
+    ])
+
+    expect(target).toBeUndefined()
+    expect(sources).toEqual([topLeft, topRight, bottom])
+  })
+
+  it('ignores nodes without an IMAGE output', () => {
+    const image = imageNode()
+    const latent = createMockLGraphNode({
+      id: uniqueId(),
+      outputs: [{ name: 'LATENT', type: 'LATENT' }]
+    })
+
+    expect(resolveBatchImagesSelection([image, latent]).sources).toEqual([
+      image
+    ])
+  })
+
+  it('appends into the batch node named by the selection', () => {
+    const batch = batchNode()
+    const image = imageNode()
+
+    const selection = resolveBatchImagesSelection([batch, image])
+
+    expect(selection.target).toBe(batch)
+    expect(selection.sources).toEqual([image])
+    expect(canAppendToBatch(selection)).toBe(true)
+    expect(canCreateBatch(selection)).toBe(false)
+  })
+
+  it('excludes sources already feeding the batch node', () => {
+    const connected = imageNode()
+    const fresh = imageNode()
+    const batch = batchNode([connected])
+
+    const selection = resolveBatchImagesSelection([batch, connected, fresh])
+
+    expect(selection.sources).toEqual([fresh])
+  })
+
+  it('cannot append when every selected source already feeds the batch node', () => {
+    const connected = imageNode()
+    const batch = batchNode([connected])
+
+    const selection = resolveBatchImagesSelection([batch, connected])
+
+    expect(selection.sources).toEqual([])
+    expect(canAppendToBatch(selection)).toBe(false)
+  })
+
+  it('creates a new batch when the selection names more than one batch node', () => {
+    const selection = resolveBatchImagesSelection([
+      batchNode(),
+      batchNode(),
+      imageNode()
+    ])
+
+    expect(selection.target).toBeUndefined()
+    expect(canCreateBatch(selection)).toBe(true)
+  })
+
+  it('cannot create a batch from a single image node', () => {
+    expect(canCreateBatch(resolveBatchImagesSelection([imageNode()]))).toBe(
+      false
+    )
+  })
+})

--- a/src/utils/batchImagesUtil.ts
+++ b/src/utils/batchImagesUtil.ts
@@ -1,0 +1,52 @@
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { NodeId } from '@/types/nodeId'
+import { hasImageOutput } from '@/utils/litegraphUtil'
+
+export const BATCH_IMAGES_NODE_TYPE = 'BatchImagesNode'
+
+export interface BatchImagesSelection {
+  /** The batch node to append to, when the selection names exactly one. */
+  target: LGraphNode | undefined
+  /** Image nodes to wire, ordered top-to-bottom, excluding those already feeding the target. */
+  sources: LGraphNode[]
+}
+
+const isBatchImagesNode = (node: LGraphNode) =>
+  node.type === BATCH_IMAGES_NODE_TYPE
+
+const byPosition = (a: LGraphNode, b: LGraphNode) =>
+  a.pos[1] - b.pos[1] || a.pos[0] - b.pos[0]
+
+const idsFeeding = (target: LGraphNode): Set<NodeId> => {
+  if (!target.graph) return new Set()
+  const origins = target.inputs.map((_, slot) => target.getInputNode(slot))
+  return new Set(origins.filter((node) => node !== null).map((node) => node.id))
+}
+
+/**
+ * Splits a selection into the batch node to append to and the image nodes to
+ * wire into it. The selection decides: exactly one batch node means append,
+ * anything else means a new batch node, so nothing is mutated implicitly.
+ */
+export function resolveBatchImagesSelection(
+  selection: Iterable<LGraphNode>
+): BatchImagesSelection {
+  const imageNodes = [...selection].filter(hasImageOutput).sort(byPosition)
+  const batchNodes = imageNodes.filter(isBatchImagesNode)
+  const target = batchNodes.length === 1 ? batchNodes[0] : undefined
+  if (!target) return { target: undefined, sources: imageNodes }
+
+  const alreadyFeeding = idsFeeding(target)
+  return {
+    target,
+    sources: imageNodes.filter(
+      (node) => node.id !== target.id && !alreadyFeeding.has(node.id)
+    )
+  }
+}
+
+export const canCreateBatch = ({ target, sources }: BatchImagesSelection) =>
+  !target && sources.length > 1
+
+export const canAppendToBatch = ({ target, sources }: BatchImagesSelection) =>
+  !!target && sources.length > 0

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -80,6 +80,11 @@ export function isImageNode(node: LGraphNode | undefined): node is ImageNode {
   )
 }
 
+export function hasImageOutput(node: LGraphNode | undefined): boolean {
+  if (!node) return false
+  return !!node.outputs?.some((output) => output.type === 'IMAGE')
+}
+
 export function isVideoNode(node: LGraphNode | undefined): node is VideoNode {
   if (!node) return false
   return node.previewMediaType === 'video' || !!node.videoContainer

--- a/src/utils/mathUtil.test.ts
+++ b/src/utils/mathUtil.test.ts
@@ -5,6 +5,7 @@ import {
   clipRectToBounds,
   computeUnionBounds,
   denormalize,
+  findNonOverlappingPosition,
   gcd,
   lcm,
   normalize
@@ -161,6 +162,34 @@ describe('mathUtil', () => {
       expect(
         clipRectToBounds({ left: 10, top: 10, right: 200, bottom: 40 }, bounds)
       ).toEqual({ left: 10, top: 10, right: 100, bottom: 40 })
+    })
+  })
+  describe('findNonOverlappingPosition', () => {
+    const size = [100, 50] as const
+    const offset = [0, 70] as const
+
+    it('keeps the requested position when it is already clear', () => {
+      const items = [{ pos: [500, 500], size: [100, 50] }] as const
+      expect(findNonOverlappingPosition(items, [0, 0], size, offset)).toEqual([
+        0, 0
+      ])
+    })
+
+    it('steps until the rect clears every item', () => {
+      const items = [
+        { pos: [0, 0], size: [100, 50] },
+        { pos: [0, 70], size: [100, 50] }
+      ] as const
+      expect(findNonOverlappingPosition(items, [0, 0], size, offset)).toEqual([
+        0, 140
+      ])
+    })
+
+    it('gives up after maxSteps so placement always resolves', () => {
+      const items = [{ pos: [0, 0], size: [100, 1000] }] as const
+      expect(
+        findNonOverlappingPosition(items, [0, 0], size, offset, 2)
+      ).toEqual([0, 140])
     })
   })
 })

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -162,3 +162,27 @@ export function anyItemOverlapsRect(
   }
   return false
 }
+
+/**
+ * Finds the first position at or after `position`, stepping by `offset`, where
+ * a rectangle of `size` clears every item. Returns the final candidate when
+ * nothing is free within `maxSteps` so placement always resolves.
+ */
+export function findNonOverlappingPosition(
+  items: Iterable<{ pos: Vec2; size: Vec2 }>,
+  position: Vec2,
+  size: Vec2,
+  offset: Vec2,
+  maxSteps = 20
+): [number, number] {
+  const obstacles = [...items]
+  let [x, y] = position
+
+  for (let step = 0; step < maxSteps; step++) {
+    if (!anyItemOverlapsRect(obstacles, [x, y, size[0], size[1]])) break
+    x += offset[0]
+    y += offset[1]
+  }
+
+  return [x, y]
+}


### PR DESCRIPTION
## Summary

Adds a selection toolbox button that batches all selected image-output nodes into a single Batch Images node with one click, instead of linking each image manually.

## Changes

- **What**: New `Comfy.Graph.BatchSelectedImageNodes` command and `BatchImagesButton` in the selection toolbox. When 2+ selected nodes have an IMAGE output, the button creates a `BatchImagesNode` to the right of the selection and connects each node's IMAGE output to it in top-to-bottom order, relying on the node's autogrow inputs to add a slot per connection. Only the new node is left selected afterwards, matching Convert to Subgraph behavior.

## Review Focus

- The button is hidden when the backend does not provide `BatchImagesNode` (older servers), and the command shows an error toast in that case.
- Connections stop gracefully if the autogrow max (50 inputs) is reached.
- Selected nodes are sorted by position (top-to-bottom, then left-to-right) so `image0..N` match the visual order.

## Screenshots

<img width="550" height="763" alt="image" src="https://github.com/user-attachments/assets/2e7fc1e5-081e-4225-8fe1-26fcfa85fb3d" />

Result:

<img width="551" height="714" alt="image" src="https://github.com/user-attachments/assets/c317f5d6-5eae-4967-9317-ad875320344d" />
