### PR TITLE
fix: escape node names in search results

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -200,8 +200,10 @@ describe('formatUtil', () => {
   })
 
   describe('highlightQuery', () => {
-    it('should return text unchanged when query is empty', () => {
-      expect(highlightQuery('Hello World', '')).toBe('Hello World')
+    it('should sanitize text when query is empty', () => {
+      expect(highlightQuery('<img src=x onerror=alert(1)>Hello', '')).toBe(
+        '&#60;img src=x onerror=alert(1)&#62;Hello'
+      )
     })
 
     it('should wrap matching text in highlight span', () => {
@@ -217,6 +219,17 @@ describe('formatUtil', () => {
     it('should sanitize text by default', () => {
       const result = highlightQuery('<script>alert("xss")</script>', 'alert')
       expect(result).not.toContain('<script>')
+    })
+
+    it('should escape markup while preserving highlights', () => {
+      const result = highlightQuery(
+        '<img src=x onerror=alert(1)>Script <b>name</b>',
+        'script'
+      )
+      expect(result).toContain('<span class="highlight">Script</span>')
+      expect(result).not.toContain('<img')
+      expect(result).not.toContain('<b>')
+      expect(result).toContain('img src=x onerror=alert(1)')
     })
 
     it('should skip sanitization when sanitize is false', () => {

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -64,15 +64,18 @@ export function ensureWorkflowSuffix(
   return name + '.' + suffix
 }
 
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (character) => {
+    return `&#${character.charCodeAt(0)};`
+  })
+}
+
 export function highlightQuery(
   text: string,
   query: string,
   sanitize: boolean = true
 ) {
-  if (!query) return text
-  if (sanitize) {
-    text = DOMPurify.sanitize(text)
-  }
+  if (!query) return sanitize ? escapeHtml(text) : text
 
   // Escape special regex characters, then join with an optional single
   // space so cross-word matches (e.g. "geto" → "imaGE TO") are
@@ -82,7 +85,23 @@ export function highlightQuery(
     .join('[ ]?')
 
   const regex = new RegExp(`(${pattern})`, 'gi')
-  return text.replace(regex, '<span class="highlight">$1</span>')
+  if (!sanitize) {
+    return text.replace(regex, '<span class="highlight">$1</span>')
+  }
+
+  const parts: string[] = []
+  let lastIndex = 0
+  for (const match of text.matchAll(regex)) {
+    parts.push(escapeHtml(text.slice(lastIndex, match.index)))
+    parts.push(`<span class="highlight">${escapeHtml(match[0])}</span>`)
+    lastIndex = match.index + match[0].length
+  }
+  parts.push(escapeHtml(text.slice(lastIndex)))
+
+  return DOMPurify.sanitize(parts.join(''), {
+    ALLOWED_TAGS: ['span'],
+    ALLOWED_ATTR: ['class']
+  })
 }
 
 export function formatNumberWithSuffix(

--- a/src/components/searchbox/v2/NodeSearchListItem.test.ts
+++ b/src/components/searchbox/v2/NodeSearchListItem.test.ts
@@ -34,6 +34,18 @@ describe('NodeSearchListItem', () => {
     vi.restoreAllMocks()
   })
 
+  it('does not render HTML from node names', () => {
+    const displayName = '<img src=x onerror=alert(1)>Node'
+    renderItem({
+      nodeDef: createMockNodeDef({
+        display_name: displayName
+      })
+    })
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText(displayName)).toBeInTheDocument()
+  })
+
   describe('id name badge', () => {
     it('shows id name when ShowIdName setting is enabled', () => {
       useSettingStore().settingValues['Comfy.NodeSearchBoxImpl.ShowIdName'] =


### PR DESCRIPTION
## Summary

Escapes node names before rendering search-highlight markup so workflow-provided group node names are always displayed as text.

## Changes

- **What**: Escape source text before adding the generated highlight span, including when the search query is empty.
- **What**: Restrict the final rendered markup to the generated `span.highlight` structure.
- **What**: Add utility and component regression coverage for markup in node names.

## Review Focus

Confirm highlighting remains unchanged while node display names and internal names cannot contribute rendered markup.

## Testing

- `pnpm test:unit packages/shared-frontend-utils/src/formatUtil.test.ts src/components/searchbox/v2/NodeSearchListItem.test.ts` (115 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format:check packages/shared-frontend-utils/src/formatUtil.ts packages/shared-frontend-utils/src/formatUtil.test.ts src/components/searchbox/v2/NodeSearchListItem.test.ts`
- targeted ESLint and Oxlint