### PR TITLE
fix: persist workflow drafts across page refresh

### DIFF
--- a/browser_tests/tests/workflowPersistence.spec.ts
+++ b/browser_tests/tests/workflowPersistence.spec.ts
@@ -534,6 +534,42 @@ test.describe('Workflow Persistence', () => {
     await expect(comfyPage.toast.toastErrors).toHaveCount(0)
   })
 
+  test('Flushes a pending draft edit before an immediate reload', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'FE-1484 — refreshing inside the persistence debounce window lost the latest workflow edit'
+    })
+
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    await fitToViewInstant(comfyPage)
+
+    const firstNode = await getRequiredFirstNodeRef(
+      comfyPage,
+      'First node should be available after loading single_ksampler'
+    )
+    await firstNode.centerOnNode()
+
+    const baselineSaveStartedAt = Date.now()
+    await firstNode.toggleCollapse()
+    await expect.poll(() => firstNode.isCollapsed()).toBe(true)
+    await comfyPage.workflow.waitForDraftIndexUpdatedSince(
+      baselineSaveStartedAt
+    )
+
+    await firstNode.toggleCollapse()
+    await comfyPage.workflow.reloadAndWaitForApp()
+
+    const restoredNode = await getRequiredFirstNodeRef(
+      comfyPage,
+      'First node should be restored after the immediate reload'
+    )
+    await expect.poll(() => restoredNode.isCollapsed()).toBe(false)
+  })
+
   test('Closing an inactive tab with save preserves its own content', async ({
     comfyPage
   }) => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -622,6 +622,31 @@ describe('useWorkflowPersistenceV2', () => {
     })
   })
 
+  it('flushes a pending workflow edit when the page is unloaded', async () => {
+    const workflowStore = useWorkflowStore()
+    const workflow = await workflowStore.createTemporary('Draft.json').load()
+    workflowStore.activeWorkflow = workflow
+    mountWorkflowPersistence()
+    await nextTick()
+
+    mocks.state.currentGraph = {
+      nodes: [],
+      extra: { marker: 'final-edit' }
+    }
+    mocks.state.graphChangedHandler?.()
+
+    const payloadKey = StorageKeys.draftPayload(workflow.path, 'personal')
+    expect(localStorage.getItem(payloadKey)).toBeNull()
+
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+
+    const payload = JSON.parse(localStorage.getItem(payloadKey)!)
+    expect(JSON.parse(payload.data)).toEqual({
+      nodes: [],
+      extra: { marker: 'final-edit' }
+    })
+  })
+
   it('flushes the final source-workspace edit before blocking transition writes', async () => {
     const sourceWorkspaceId = 'workspace-a'
     const destinationWorkspaceId = 'workspace-b'

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -654,7 +654,11 @@ describe('useWorkflowPersistenceV2', () => {
     mountWorkflowPersistence()
 
     mocks.state.currentGraph = { nodes: [] }
-    mocks.state.graphChangedHandler?.()
+    const graphChangedHandler = mocks.state.graphChangedHandler
+    if (!graphChangedHandler) {
+      throw new Error('Graph change handler was not registered')
+    }
+    graphChangedHandler()
 
     const mounted = mountedApps.pop()
     if (!mounted) throw new Error('Failed to find mounted persistence app')

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -647,6 +647,28 @@ describe('useWorkflowPersistenceV2', () => {
     })
   })
 
+  it('does not flush a pending workflow edit after disposal', async () => {
+    const workflowStore = useWorkflowStore()
+    const workflow = await workflowStore.createTemporary('Draft.json').load()
+    workflowStore.activeWorkflow = workflow
+    mountWorkflowPersistence()
+
+    mocks.state.currentGraph = { nodes: [] }
+    mocks.state.graphChangedHandler?.()
+
+    const mounted = mountedApps.pop()
+    if (!mounted) throw new Error('Failed to find mounted persistence app')
+    mounted.app.unmount()
+    mounted.container.remove()
+
+    window.dispatchEvent(new PageTransitionEvent('pagehide'))
+    await vi.runAllTimersAsync()
+
+    expect(
+      localStorage.getItem(StorageKeys.draftPayload(workflow.path, 'personal'))
+    ).toBeNull()
+  })
+
   it('flushes the final source-workspace edit before blocking transition writes', async () => {
     const sourceWorkspaceId = 'workspace-a'
     const destinationWorkspaceId = 'workspace-b'

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -134,9 +134,15 @@ export function useWorkflowPersistenceV2() {
 
   // Debounced version for graphChanged events
   const debouncedPersist = debounce(persistCurrentWorkflow, PERSIST_DEBOUNCE_MS)
-  const unregisterPersistenceFlush = registerWorkflowPersistenceFlush(() =>
+
+  function flushPendingPersistence() {
     debouncedPersist.flush()
+  }
+
+  const unregisterPersistenceFlush = registerWorkflowPersistenceFlush(
+    flushPendingPersistence
   )
+  window.addEventListener('pagehide', flushPendingPersistence)
 
   const loadPreviousWorkflowFromStorage = async () => {
     const sessionPath = tabState.getActivePath()
@@ -259,6 +265,7 @@ export function useWorkflowPersistenceV2() {
   // Clean up event listener when component unmounts
   tryOnScopeDispose(() => {
     api.removeEventListener('graphChanged', debouncedPersist)
+    window.removeEventListener('pagehide', flushPendingPersistence)
     unregisterPersistenceFlush()
     debouncedPersist.cancel()
   })


### PR DESCRIPTION
## Summary

Flush pending debounced workflow draft writes when the page unloads so recent edits survive refresh.

## Root cause

Workflow graph writes are debounced by 512 ms. If a user refreshed during that window, the page was destroyed before the pending write ran, so the next load restored the previous draft. The persistence composable already flushed pending writes during workspace transitions, but it had no browser lifecycle flush.

## How we handle it

- Reuse the existing guarded persistence flush for `window.pagehide` instead of adding a separate unload storage path.
- Preserve the existing workspace scoping and blocked-write behavior.
- Remove the `pagehide` listener during scope disposal before cancelling the debounce.

## Regression coverage

- Unit: a pending graph edit flushes on `pagehide`.
- Unit: disposing the composable removes the lifecycle listener and prevents stale writes.
- Playwright E2E: persist a baseline node state, reverse it, reload immediately without waiting for the 512 ms debounce, and verify the pending state is restored.

## Review Focus

The unload path uses the same persistence operation and guards as normal graph changes and workspace transitions.

## Verification

Personal workspace scenario: persist one node, add a second node, then refresh after **80 ms** (before the 512 ms debounce fires).

- **AS IS**: the last edit is lost; 1 of 2 nodes returns.
- **TO BE**: `pagehide` flushes the pending write; both nodes return.

![AS IS versus TO BE workflow draft refresh behavior](https://ampcode.com/user-content/artifacts/d3bb8aaad1aa2d2ee76d9f2c056f7375e0cb4a217ff6990d2f04524201e7680f-file.png)

- [FE-1484](https://linear.app/comfyorg/issue/FE-1484/workflow-drafts-do-not-persist-across-refresh-on-cloud)
- [Slack report](https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1785650948159379)
