### PR TITLE
test: cover model import processing scrollbar (FE-1480)

### DIFF
--- a/browser_tests/tests/browseModelAssets.spec.ts
+++ b/browser_tests/tests/browseModelAssets.spec.ts
@@ -110,7 +110,7 @@ cloudAppFixture.describe(
         const downloadTask = {
           task_id: 'download-task-001',
           status: 'created',
-          message: 'Download started'
+          message: 'Queued'
         } satisfies Extract<AsyncUploadResponse, { type: 'async' }>['task']
 
         await page.setViewportSize({ width: 1280, height: 420 })
@@ -122,7 +122,7 @@ cloudAppFixture.describe(
         await page.route('**/api/experiment/models', (route) =>
           route.fulfill(jsonRoute(modelFolders))
         )
-        await page.route('**/assets/remote-metadata?**', (route) =>
+        await page.route(/\/assets\/remote-metadata(?:\?.*)?$/, (route) =>
           route.fulfill(jsonRoute(metadata))
         )
         await page.route('**/assets/download', (route) =>
@@ -146,25 +146,25 @@ cloudAppFixture.describe(
         await expect(cancelButton).toBeVisible()
 
         const metrics = await dialog.evaluate((element) => {
-          const scrollRegions = Array.from(
-            element.querySelectorAll<HTMLElement>('*')
-          ).filter((candidate) => {
-            const style = getComputedStyle(candidate)
-            return [style.overflowX, style.overflowY].some(
-              (overflow) => overflow === 'auto' || overflow === 'scroll'
-            )
-          })
+          const panel = element.querySelector('.upload-model-dialog')
+          const body = panel?.parentElement
           const dialogRect = element.getBoundingClientRect()
+          const panelRect = panel?.getBoundingClientRect()
+          const bodyRect = body?.getBoundingClientRect()
 
           return {
-            scrollRegionCount: scrollRegions.length,
             dialogBottom: dialogRect.bottom,
+            panelLeft: panelRect?.left,
+            panelRight: panelRect?.right,
+            bodyLeft: bodyRect?.left,
+            bodyRight: bodyRect?.right,
             viewportHeight: window.innerHeight
           }
         })
 
-        expect(metrics.scrollRegionCount).toBe(1)
         expect(metrics.dialogBottom).toBeLessThanOrEqual(metrics.viewportHeight)
+        expect(metrics.panelLeft).toBeGreaterThanOrEqual(metrics.bodyLeft!)
+        expect(metrics.panelRight).toBeLessThanOrEqual(metrics.bodyRight!)
 
         const cancelButtonRect = await cancelButton.boundingBox()
         expect(cancelButtonRect).not.toBeNull()
@@ -184,17 +184,67 @@ cloudAppFixture.describe(
         await expect(dialog.getByText('Download started')).toBeVisible()
         await expect(dialog.getByText(filename)).toBeVisible()
 
-        const processingScrollRegions = await dialog.locator('*').evaluateAll(
-          (elements) =>
-            elements.filter((element) => {
-              const style = getComputedStyle(element)
-              return [style.overflowX, style.overflowY].some(
-                (overflow) => overflow === 'auto' || overflow === 'scroll'
+        const finishButton = dialog.locator(
+          '[data-attr="upload-model-step3-finish-button"]'
+        )
+        await expect(finishButton).toBeVisible()
+
+        const processingMetrics = await dialog.evaluate((element) => {
+          const candidates = new Set<Element>([
+            element,
+            ...element.querySelectorAll('*')
+          ])
+          let ancestor = element.parentElement
+          while (ancestor) {
+            candidates.add(ancestor)
+            ancestor = ancestor.parentElement
+          }
+          if (document.scrollingElement) {
+            candidates.add(document.scrollingElement)
+          }
+
+          const panel = element.querySelector('.upload-model-dialog')
+          const body = panel?.parentElement
+          const panelRect = panel?.getBoundingClientRect()
+          const bodyRect = body?.getBoundingClientRect()
+
+          return {
+            overflowingRegionCount: [...candidates].filter((candidate) => {
+              const style = getComputedStyle(candidate)
+              return (
+                ((style.overflowX === 'auto' || style.overflowX === 'scroll') &&
+                  candidate.scrollWidth > candidate.clientWidth) ||
+                ((style.overflowY === 'auto' || style.overflowY === 'scroll') &&
+                  candidate.scrollHeight > candidate.clientHeight)
               )
-            }).length
+            }).length,
+            panelLeft: panelRect?.left,
+            panelRight: panelRect?.right,
+            bodyLeft: bodyRect?.left,
+            bodyRight: bodyRect?.right
+          }
+        })
+
+        expect(processingMetrics.overflowingRegionCount).toBe(0)
+        expect(processingMetrics.panelLeft).toBeGreaterThanOrEqual(
+          processingMetrics.bodyLeft!
+        )
+        expect(processingMetrics.panelRight).toBeLessThanOrEqual(
+          processingMetrics.bodyRight!
         )
 
-        expect(processingScrollRegions).toBe(1)
+        const bodyRect = await dialog
+          .locator('.upload-model-dialog')
+          .evaluate((panel) => {
+            const rect = panel.parentElement!.getBoundingClientRect()
+            return { top: rect.top, bottom: rect.bottom }
+          })
+        const finishButtonRect = await finishButton.boundingBox()
+        expect(finishButtonRect).not.toBeNull()
+        expect(finishButtonRect!.y).toBeGreaterThanOrEqual(bodyRect.top)
+        expect(
+          finishButtonRect!.y + finishButtonRect!.height
+        ).toBeLessThanOrEqual(bodyRect.bottom)
       }
     )
   }

--- a/browser_tests/tests/browseModelAssets.spec.ts
+++ b/browser_tests/tests/browseModelAssets.spec.ts
@@ -11,6 +11,10 @@ import { STABLE_CHECKPOINT } from '@e2e/fixtures/data/assetFixtures'
 import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
 
+import type {
+  AssetMetadata,
+  AsyncUploadResponse
+} from '@/platform/assets/schemas/assetSchema'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 const CLOUD_ASSETS: Asset[] = [STABLE_CHECKPOINT]
@@ -75,8 +79,11 @@ cloudAppFixture.describe(
   { tag: '@cloud' },
   () => {
     cloudAppFixture(
-      'uses one scroll region on a short viewport',
+      'uses one scroll region throughout import on a short viewport',
       async ({ page }) => {
+        const filename =
+          'Alissonerdx__CharacterSheet__QuadView_krea2_v1.safetensors'
+        const sourceUrl = `https://huggingface.co/comfy/test/resolve/main/${filename}`
         const features = {
           model_upload_button_enabled: true,
           private_models_enabled: true
@@ -93,6 +100,18 @@ cloudAppFixture.describe(
         const modelFolders = [
           { name: 'checkpoints', folders: [] }
         ] satisfies GetModelFoldersResponse
+        const metadata = {
+          content_length: 1024,
+          final_url: sourceUrl,
+          content_type: 'application/octet-stream',
+          filename,
+          tags: ['checkpoints']
+        } satisfies AssetMetadata
+        const downloadTask = {
+          task_id: 'download-task-001',
+          status: 'created',
+          message: 'Download started'
+        } satisfies Extract<AsyncUploadResponse, { type: 'async' }>['task']
 
         await page.setViewportSize({ width: 1280, height: 420 })
         await mockCloudBoot(page, { features, settings })
@@ -102,6 +121,12 @@ cloudAppFixture.describe(
         )
         await page.route('**/api/experiment/models', (route) =>
           route.fulfill(jsonRoute(modelFolders))
+        )
+        await page.route('**/assets/remote-metadata?**', (route) =>
+          route.fulfill(jsonRoute(metadata))
+        )
+        await page.route('**/assets/download', (route) =>
+          route.fulfill({ ...jsonRoute(downloadTask), status: 202 })
         )
 
         await page.goto(APP_URL)
@@ -146,6 +171,30 @@ cloudAppFixture.describe(
         expect(
           cancelButtonRect!.y + cancelButtonRect!.height
         ).toBeLessThanOrEqual(metrics.viewportHeight)
+
+        await dialog
+          .locator('[data-attr="upload-model-step1-url-input"]')
+          .fill(sourceUrl)
+        await dialog
+          .locator('[data-attr="upload-model-step1-continue-button"]')
+          .click()
+        await dialog
+          .locator('[data-attr="upload-model-step2-confirm-button"]')
+          .click()
+        await expect(dialog.getByText('Download started')).toBeVisible()
+        await expect(dialog.getByText(filename)).toBeVisible()
+
+        const processingScrollRegions = await dialog.locator('*').evaluateAll(
+          (elements) =>
+            elements.filter((element) => {
+              const style = getComputedStyle(element)
+              return [style.overflowX, style.overflowY].some(
+                (overflow) => overflow === 'auto' || overflow === 'scroll'
+              )
+            }).length
+        )
+
+        expect(processingScrollRegions).toBe(1)
       }
     )
   }

--- a/src/platform/assets/composables/useModelUpload.ts
+++ b/src/platform/assets/composables/useModelUpload.ts
@@ -17,6 +17,7 @@ type UploadModelContextResolver = () => UploadModelDialogContext | undefined
 // zero the section padding (the PrimeVue `pt` overrides this replaces).
 const uploadDialogComponentProps = {
   renderer: 'reka',
+  size: 'lg',
   contentClass: 'w-fit max-w-[calc(100vw-1rem)]',
   headerClass: 'py-0 pl-0',
   bodyClass: 'min-h-0 overflow-hidden p-0'


### PR DESCRIPTION
## Summary

Fix the Import Model dialog dimensions and add regression coverage for the exact asynchronous “Download started” state reported in FE-1480.

## Root Cause

The Reka `DialogContent` defaults to `size: 'md'` (`sm:max-w-xl`, 576px), while `UploadModelDialog` has a 600px minimum width on desktop. After #14024 changed the outer body to `overflow-hidden`, its 574px content box no longer displayed a horizontal scrollbar, but the 600px panel still overflowed and was clipped by 13px on each side. The footer remained partially clipped even though `boundingBox()`-to-viewport assertions passed because those assertions do not account for ancestor clipping.

The `/assets/download` endpoint also returns the nested task for HTTP 202; `assetService.uploadAssetAsync()` adds the `type: 'async'` response discriminator before schema validation. The browser mock therefore intentionally returns the task payload rather than an already wrapped response.

## Changes

- Give the Import Model dialog the `lg` Reka size so its 600px panel fits without clipping.
- Extend the short-viewport test through the asynchronous import flow.
- Assert the panel and processing footer remain inside the body clip box.
- Check actual scroll dimensions across the dialog, ancestors, and document instead of counting overflow styles only.
- Use the exact reported long filename while keeping the HTTP 202 mock faithful to the backend contract.

## Review Focus

- The panel and footer are fully contained at 1280×420.
- Removing `size: 'lg'` makes the new geometry assertion fail (`panelLeft: 343`, `bodyLeft: 353`).
- The dialog has no unintended actively overflowing region during processing.

Linear: https://linear.app/comfyorg/issue/FE-1480/bug-import-a-model-modal-shows-unnecessary-scrollbar

## AS IS / TO BE

| AS IS | TO BE |
| --- | --- |
| ![AS IS — panel clipped into its body padding](https://ampcode.com/user-content/artifacts/ad2293d7c5487b7732150489e575c1122bc40470685e0a31c099dbc2c53741a8-file.png) | ![TO BE — right and bottom padding restored](https://ampcode.com/user-content/artifacts/14b3a3e27540a26b11b617bb1f2b12cb692b5cb74db1d9f09bd9a4be0cf2803d-file.png) |

## Comparison GIF

![AS IS / TO BE padding comparison at 1280×420](https://ampcode.com/user-content/artifacts/f0c410718a1c4925a2b7d94738408b78c01459589ab277fbce9282bb2100e4a1-file.gif)

## Validation

- Focused cloud Playwright test passed.
- Mutation run without `size: 'lg'` failed on the panel/body containment assertion.
- `pnpm lint:unstaged`
- `pnpm typecheck`
- `pnpm typecheck:browser`
- Targeted formatting check
- Push hook `knip`


