### PR TITLE
fix: render node search highlights as text

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -499,6 +499,12 @@ export default defineConfig([
       ]
     }
   },
+  {
+    files: ['src/components/searchbox/**/*.vue'],
+    rules: {
+      'vue/no-v-html': 'error'
+    }
+  },
   // Browser tests must use comfyPageFixture, not raw @playwright/test test
   {
     files: ['browser_tests/tests/**/*.spec.ts'],

--- a/packages/shared-frontend-utils/package.json
+++ b/packages/shared-frontend-utils/package.json
@@ -14,8 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "axios": "catalog:",
-    "dompurify": "catalog:"
+    "axios": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -200,62 +200,74 @@ describe('formatUtil', () => {
   })
 
   describe('highlightQuery', () => {
-    it('should return text unchanged when query is empty', () => {
-      expect(highlightQuery('Hello World', '')).toBe('Hello World')
+    it('should return one plain-text part when query is empty', () => {
+      expect(highlightQuery('Hello World', '')).toEqual([
+        { text: 'Hello World', highlighted: false }
+      ])
     })
 
-    it('should wrap matching text in highlight span', () => {
-      const result = highlightQuery('Hello World', 'World')
-      expect(result).toBe('Hello <span class="highlight">World</span>')
+    it('should mark matching text for highlighting', () => {
+      expect(highlightQuery('Hello World', 'World')).toEqual([
+        { text: 'Hello ', highlighted: false },
+        { text: 'World', highlighted: true }
+      ])
     })
 
     it('should be case-insensitive', () => {
-      const result = highlightQuery('Hello World', 'hello')
-      expect(result).toBe('<span class="highlight">Hello</span> World')
+      expect(highlightQuery('Hello World', 'hello')).toEqual([
+        { text: 'Hello', highlighted: true },
+        { text: ' World', highlighted: false }
+      ])
     })
 
-    it('should sanitize text by default', () => {
-      const result = highlightQuery('<script>alert("xss")</script>', 'alert')
-      expect(result).not.toContain('<script>')
-    })
-
-    it('should skip sanitization when sanitize is false', () => {
-      const result = highlightQuery('<b>bold</b>', 'bold', false)
-      expect(result).toContain('<b>')
+    it('should preserve markup as text parts', () => {
+      expect(highlightQuery('<script>alert("xss")</script>', 'alert')).toEqual([
+        { text: '<script>', highlighted: false },
+        { text: 'alert', highlighted: true },
+        { text: '("xss")</script>', highlighted: false }
+      ])
     })
 
     it('should escape special regex characters in query', () => {
-      const result = highlightQuery('price is $10.00', '$10')
-      expect(result).toContain('<span class="highlight">$10</span>')
+      expect(highlightQuery('price is $10.00', '$10')).toEqual([
+        { text: 'price is ', highlighted: false },
+        { text: '$10', highlighted: true },
+        { text: '.00', highlighted: false }
+      ])
     })
 
     it('should highlight multiple occurrences', () => {
-      const result = highlightQuery('foo bar foo', 'foo')
-      expect(result).toBe(
-        '<span class="highlight">foo</span> bar <span class="highlight">foo</span>'
-      )
+      expect(highlightQuery('foo bar foo', 'foo')).toEqual([
+        { text: 'foo', highlighted: true },
+        { text: ' bar ', highlighted: false },
+        { text: 'foo', highlighted: true }
+      ])
     })
 
     it('should highlight cross-word matches', () => {
-      const result = highlightQuery('convert image to mask', 'geto', false)
-      expect(result).toBe(
-        'convert ima<span class="highlight">ge to</span> mask'
-      )
+      expect(highlightQuery('convert image to mask', 'geto')).toEqual([
+        { text: 'convert ima', highlighted: false },
+        { text: 'ge to', highlighted: true },
+        { text: ' mask', highlighted: false }
+      ])
     })
 
     it('should not match across line breaks', () => {
-      const result = highlightQuery('ge\nto', 'geto', false)
-      expect(result).toBe('ge\nto')
+      expect(highlightQuery('ge\nto', 'geto')).toEqual([
+        { text: 'ge\nto', highlighted: false }
+      ])
     })
 
     it('should not match across tabs', () => {
-      const result = highlightQuery('ge\tto', 'geto', false)
-      expect(result).toBe('ge\tto')
+      expect(highlightQuery('ge\tto', 'geto')).toEqual([
+        { text: 'ge\tto', highlighted: false }
+      ])
     })
 
     it('should not match across multiple spaces', () => {
-      const result = highlightQuery('ge  to', 'geto', false)
-      expect(result).toBe('ge  to')
+      expect(highlightQuery('ge  to', 'geto')).toEqual([
+        { text: 'ge  to', highlighted: false }
+      ])
     })
   })
 

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -1,4 +1,3 @@
-import { default as DOMPurify } from 'dompurify'
 import type { operations } from '@comfyorg/registry-types'
 
 export function formatCamelCase(str: string): string {
@@ -64,15 +63,16 @@ export function ensureWorkflowSuffix(
   return name + '.' + suffix
 }
 
+interface HighlightQueryPart {
+  text: string
+  highlighted: boolean
+}
+
 export function highlightQuery(
   text: string,
-  query: string,
-  sanitize: boolean = true
-) {
-  if (!query) return text
-  if (sanitize) {
-    text = DOMPurify.sanitize(text)
-  }
+  query: string
+): HighlightQueryPart[] {
+  if (!query) return [{ text, highlighted: false }]
 
   // Escape special regex characters, then join with an optional single
   // space so cross-word matches (e.g. "geto" → "imaGE TO") are
@@ -81,8 +81,26 @@ export function highlightQuery(
     .map((ch) => ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     .join('[ ]?')
 
-  const regex = new RegExp(`(${pattern})`, 'gi')
-  return text.replace(regex, '<span class="highlight">$1</span>')
+  const regex = new RegExp(pattern, 'gi')
+  const parts: HighlightQueryPart[] = []
+  let lastIndex = 0
+
+  for (const match of text.matchAll(regex)) {
+    if (match.index > lastIndex) {
+      parts.push({
+        text: text.slice(lastIndex, match.index),
+        highlighted: false
+      })
+    }
+    parts.push({ text: match[0], highlighted: true })
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < text.length || parts.length === 0) {
+    parts.push({ text: text.slice(lastIndex), highlighted: false })
+  }
+
+  return parts
 }
 
 export function formatNumberWithSuffix(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,9 +1120,6 @@ importers:
       axios:
         specifier: 'catalog:'
         version: 1.18.1
-      dompurify:
-        specifier: 'catalog:'
-        version: 3.4.7
     devDependencies:
       typescript:
         specifier: 'catalog:'

--- a/src/components/searchbox/HighlightedText.vue
+++ b/src/components/searchbox/HighlightedText.vue
@@ -1,0 +1,15 @@
+<template>
+  <template v-for="(part, index) in highlightQuery(text, query)" :key="index">
+    <span v-if="part.highlighted" class="highlight">{{ part.text }}</span>
+    <template v-else>{{ part.text }}</template>
+  </template>
+</template>
+
+<script setup lang="ts">
+import { highlightQuery } from '@/utils/formatUtil'
+
+const { text, query } = defineProps<{
+  text: string
+  query: string
+}>()
+</script>

--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -7,10 +7,14 @@
         <span v-if="isBookmarked">
           <i class="pi pi-bookmark-fill mr-1 text-sm" />
         </span>
-        <span v-html="highlightQuery(nodeDef.display_name, currentQuery)" />
+        <span>
+          <HighlightedText :text="nodeDef.display_name" :query="currentQuery" />
+        </span>
         <span>&nbsp;</span>
         <Tag v-if="showIdName" severity="secondary">
-          <span v-html="highlightQuery(nodeDef.name, currentQuery)" />
+          <span>
+            <HighlightedText :text="nodeDef.name" :query="currentQuery" />
+          </span>
         </Tag>
       </div>
       <div
@@ -52,12 +56,13 @@ import Chip from 'primevue/chip'
 import Tag from 'primevue/tag'
 import { computed } from 'vue'
 
+import HighlightedText from '@/components/searchbox/HighlightedText.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { NodeSourceType } from '@/types/nodeSource'
-import { formatNumberWithSuffix, highlightQuery } from '@/utils/formatUtil'
+import { formatNumberWithSuffix } from '@/utils/formatUtil'
 
 const settingStore = useSettingStore()
 const showCategory = computed(() =>

--- a/src/components/searchbox/v2/NodeSearchListItem.test.ts
+++ b/src/components/searchbox/v2/NodeSearchListItem.test.ts
@@ -34,6 +34,16 @@ describe('NodeSearchListItem', () => {
     vi.restoreAllMocks()
   })
 
+  it('renders node names as text rather than HTML', () => {
+    const displayName = '<img src=x onerror=alert(1)>Node'
+    renderItem({
+      nodeDef: createMockNodeDef({ display_name: displayName })
+    })
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText(displayName)).toBeInTheDocument()
+  })
+
   describe('id name badge', () => {
     it('shows id name when ShowIdName setting is enabled', () => {
       useSettingStore().settingValues['Comfy.NodeSearchBoxImpl.ShowIdName'] =

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -12,16 +12,16 @@
         >
           <i aria-hidden="true" class="pi pi-bookmark-fill mr-1 text-sm" />
         </span>
-        <span
-          class="truncate"
-          v-html="highlightQuery(nodeDef.display_name, currentQuery)"
-        />
+        <span class="truncate">
+          <HighlightedText :text="nodeDef.display_name" :query="currentQuery" />
+        </span>
         <span
           v-if="showIdName"
           data-testid="node-id-badge"
           class="shrink-0 rounded-sm bg-secondary-background px-1.5 py-0.5 text-xs text-muted-foreground"
-          v-html="highlightQuery(nodeDef.name, currentQuery)"
-        />
+        >
+          <HighlightedText :text="nodeDef.name" :query="currentQuery" />
+        </span>
 
         <template v-if="showDescription">
           <div class="flex-1" />
@@ -124,6 +124,7 @@ import { computed } from 'vue'
 import TextTicker from '@/components/common/TextTicker.vue'
 import NodePricingBadge from '@/components/node/NodePricingBadge.vue'
 import NodeProviderBadge from '@/components/node/NodeProviderBadge.vue'
+import HighlightedText from '@/components/searchbox/HighlightedText.vue'
 import { NODE_TO_ESSENTIALS_CATEGORY } from '@/constants/essentialsNodes'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
@@ -131,7 +132,7 @@ import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { CORE_NODE_MODULES, NodeSourceType } from '@/types/nodeSource'
 import { getProviderIcon, getProviderName } from '@/utils/categoryUtil'
-import { formatNumberWithSuffix, highlightQuery } from '@/utils/formatUtil'
+import { formatNumberWithSuffix } from '@/utils/formatUtil'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -248,7 +248,7 @@
           <span class="underline">
             {{ t('subscription.videoEstimateTryTemplate') }}
           </span>
-          <span class="no-underline" v-html="'&rarr;'"></span>
+          <span class="no-underline">→</span>
         </a>
       </div>
     </Popover>

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -263,7 +263,7 @@
           <span class="underline">
             {{ t('subscription.videoEstimateTryTemplate') }}
           </span>
-          <span class="no-underline" v-html="'&rarr;'"></span>
+          <span class="no-underline">→</span>
         </a>
       </div>
     </Popover>


### PR DESCRIPTION
## Summary

Render node-search highlights as Vue text nodes instead of injecting generated HTML. This closes the workflow/custom-node-controlled HTML injection path in both the legacy and v2 search UIs.

Related to #14574. This version removes the raw HTML sink and the optional sanitizer bypass instead of relying on sanitization before later string interpolation.

## Changes

- **What**: `highlightQuery` now returns text/highlight segments; `HighlightedText` renders them through Vue interpolation in both search implementations.
- **Guardrail**: `vue/no-v-html` is an error for `src/components/searchbox/**/*.vue`.
- **Cleanup**: Two hard-coded arrow entities now render as text, and the now-unused shared-utils DOMPurify dependency is removed.
- **Breaking**: None outside the private workspace utility.
- **Dependencies**: Removes `dompurify` from `@comfyorg/shared-frontend-utils`; the application still retains DOMPurify for its audited markdown/content sinks.

## Security audit

`git grep -n 'v-html=' origin/main -- 'src/**/*.vue' 'apps/**/*.vue'` found **24 directives**:

| Risk | Count | Locations | Finding |
| --- | ---: | --- | --- |
| High | 4 | `NodeSearchItem.vue` (2), `NodeSearchListItem.vue` (2) | Node names can be workflow/custom-node controlled. An empty query returned the input unchanged and `v-html` parsed it as markup. Removed in this PR. |
| Sanitized | 7 | `WidgetTextPreview.vue`, `WidgetMarkdown.vue`, `NodeHelpContent.vue`, `NodePreview.vue`, `TextPreviewWidget.vue`, `ReleaseNotificationToast.vue`, `WhatsNewPopup.vue` | Each value reaches the sink after `DOMPurify.sanitize()` or `renderMarkdownToHtml()`, which sanitizes with DOMPurify. No bypass found. |
| Repository-owned content | 10 | Website `ContentSection` (1), `FAQSection` (2), customer/gallery `ContactSection` (2), `DemoTranscript` (1), `LegalContentSection` (2), `WhatsIncludedSection` (1), `ReasonSection` (1) | Values come from the checked-in translation table/demo config, not workflow, API, or CMS input. No runtime attacker-controlled source found. |
| Hard-coded constants | 3 | `ToolPanel.vue` SVG map (1), cloud/workspace pricing arrows (2) | No attacker-controlled source. The two unnecessary arrow sinks are removed here. |

Branch result: **18 remaining audited directives**, **0 in node search**. The six removed directives are all four unsafe search sinks plus both hard-coded arrow sinks.

Root cause: sanitizing a string before generating highlight markup creates a fragile trust boundary, and the empty-query branch skipped sanitization entirely. The new path never constructs HTML from node names; Vue escapes every text segment.

## Verification

- `pnpm test:unit packages/shared-frontend-utils/src/formatUtil.test.ts` — **84/84 passed**
- `pnpm test:unit src/components/searchbox/v2/NodeSearchListItem.test.ts` — **29/29 passed**, including `<img src=x onerror=alert(1)>` with an empty query
- `pnpm typecheck` — passed
- `pnpm lint` — passed with 0 errors (existing warnings only)
- `pnpm knip` — passed
- `pnpm build` — passed; 5,968 modules transformed
- Full `pnpm test:unit --reporter=dot` — **14,504 passed**, 1 unrelated timeout in unchanged `onboardingCloudRoutes.test.ts`; isolated rerun passed **7/7**
- `rg -n --glob '*.vue' 'v-html=' src/components/searchbox` — no matches

## GitHub CI

Required checks passed on commit `29a7e7207`:

- [Unit tests + coverage](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675210/job/91538588677) — passed in **13m22s**
- [Lint and format](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675238/job/91538569178) — passed in **4m24s**
- [Website E2E](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675270/job/91538595387) — passed in **7m59s**
- [Browser E2E aggregate](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675221/job/91539787107) — passed
- [Production build](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675212/job/91538596974) — passed in **52s**
- [Distribution telemetry scan](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30763675249/job/91538598718) — passed in **1m52s**
- Socket Project Report and Pull Request Alerts — passed
