### PR TITLE
fix(ci): don't fail PR report when size-data artifact is absent

### DIFF
--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -59,6 +59,7 @@ jobs:
           name: size-data
           run_id: ${{ steps.find-size.outputs.run-id }}
           path: temp/size
+          if_no_artifact_found: warn
 
       - name: Download size baseline
         if: steps.pr-meta.outputs.skip != 'true' && steps.find-size.outputs.status == 'ready'

--- a/scripts/unified-report.ts
+++ b/scripts/unified-report.ts
@@ -15,7 +15,9 @@ const coverageStatus = getArg('coverage-status') ?? 'skip'
 
 const lines: string[] = []
 
-if (sizeStatus === 'ready') {
+const hasSizeData = existsSync('temp/size')
+
+if (sizeStatus === 'ready' && hasSizeData) {
   try {
     const sizeReport = execFileSync('node', ['scripts/size-report.js'], {
       encoding: 'utf-8'
@@ -32,13 +34,13 @@ if (sizeStatus === 'ready') {
   lines.push('## 📦 Bundle Size')
   lines.push('')
   lines.push('> ⚠️ Size data collection failed. Check the CI workflow logs.')
-} else {
+} else if (sizeStatus !== 'ready') {
   lines.push('## 📦 Bundle Size')
   lines.push('')
   lines.push('> ⏳ Size data collection in progress…')
 }
 
-lines.push('')
+if (lines.length > 0) lines.push('')
 
 if (perfStatus === 'ready' && existsSync('test-results/perf-metrics.json')) {
   try {


### PR DESCRIPTION
## Summary

"PR: Unified Report" fails on website/docs-only PRs: `ci-size-data.yaml` gates its collect job behind `changes-filter`, so those PRs produce a successful "CI: Size Data" run with no `size-data` artifact, and the "Download size data (current)" step (default `if_no_artifact_found: fail`) kills the report job (e.g. run 30766674355 for #14566).

- Add `if_no_artifact_found: warn` to the current size-data download, matching the existing baseline download steps.
- In `scripts/unified-report.ts`, omit the Bundle Size section when the size run completed but `temp/size` doesn't exist (size collection was skipped for the PR), instead of rendering a failure notice.