### PR TITLE
security: 2/x centralize sanitized HTML rendering

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -499,6 +499,21 @@ export default defineConfig([
       ]
     }
   },
+  {
+    name: 'comfy/enforce-sanitized-html-boundary',
+    files: [
+      'src/components/graph/widgets/TextPreviewWidget.vue',
+      'src/components/node/NodeHelpContent.vue',
+      'src/components/node/NodePreview.vue',
+      'src/platform/updates/components/ReleaseNotificationToast.vue',
+      'src/platform/updates/components/WhatsNewPopup.vue',
+      'src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue',
+      'src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.vue'
+    ],
+    rules: {
+      'vue/no-v-html': 'error'
+    }
+  },
   // Browser tests must use comfyPageFixture, not raw @playwright/test test
   {
     files: ['browser_tests/tests/**/*.spec.ts'],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -681,7 +681,8 @@ export default defineConfig([
     }
   },
   {
-    files: ['src/components/searchbox/**/*.vue'],
+    name: 'comfy/enforce-sanitized-html-boundary',
+    files: ['src/**/*.vue'],
     rules: {
       'vue/no-v-html': 'error'
     }

--- a/src/components/common/SanitizedHtml.test.ts
+++ b/src/components/common/SanitizedHtml.test.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import SanitizedHtml from './SanitizedHtml.vue'
+
+describe('SanitizedHtml', () => {
+  it('preserves safe markup while removing executable content', () => {
+    render(SanitizedHtml, {
+      props: {
+        as: 'section',
+        html: [
+          '<strong>Safe content</strong>',
+          '<a id="safe-link" href="https://example.com" target="_blank">safe link</a>',
+          '<a id="unsafe-link" href="javascript:alert(1)">unsafe link</a>',
+          '<img src="x" alt="unsafe image" onerror="alert(1)">',
+          '<script>alert(1)</script>'
+        ].join('')
+      },
+      attrs: { 'data-testid': 'sanitized-html' }
+    })
+
+    expect(screen.getByTestId('sanitized-html')).toBeInTheDocument()
+    expect(
+      screen.getByText('Safe content', { selector: 'strong' })
+    ).toBeVisible()
+    expect(screen.getByText('unsafe link')).not.toHaveAttribute('href')
+    expect(screen.getByRole('link', { name: 'safe link' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+    expect(screen.getByRole('link', { name: 'safe link' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    )
+    expect(
+      screen.getByRole('img', { name: 'unsafe image' })
+    ).not.toHaveAttribute('onerror')
+    expect(screen.queryByText('alert(1)')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/common/SanitizedHtml.test.ts
+++ b/src/components/common/SanitizedHtml.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import SanitizedHtml from './SanitizedHtml.vue'
+
+describe('SanitizedHtml', () => {
+  it('preserves supported markup and removes executable content', () => {
+    render(SanitizedHtml, {
+      props: {
+        as: 'span',
+        html: [
+          '<strong>Safe</strong>',
+          '<a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>',
+          '<video controls><source src="video.mp4"></video>',
+          '<img src="x" onerror="alert(1)">',
+          '<script>alert(1)</script>'
+        ].join('')
+      },
+      attrs: { 'data-testid': 'content' }
+    })
+
+    const content = screen.getByTestId('content')
+    expect(content.tagName).toBe('SPAN')
+    expect(screen.getByText('Safe', { selector: 'strong' })).toBeVisible()
+    expect(screen.getByRole('link')).toHaveAttribute('target', '_blank')
+    expect(content.innerHTML).toContain('<video controls="">')
+    expect(content.innerHTML).not.toContain('onerror')
+    expect(content.innerHTML).not.toContain('<script')
+  })
+})

--- a/src/components/common/SanitizedHtml.vue
+++ b/src/components/common/SanitizedHtml.vue
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { default as DOMPurify } from 'dompurify'
+import { computed, defineComponent, h } from 'vue'
+
+export default defineComponent({
+  name: 'SanitizedHtml',
+  inheritAttrs: false,
+  props: {
+    html: { type: String, required: true },
+    as: { type: String, default: 'div' }
+  },
+  setup(props, { attrs }) {
+    const sanitizedHtml = computed(() => {
+      const fragment = DOMPurify.sanitize(props.html, {
+        ADD_ATTR: ['target', 'rel'],
+        RETURN_DOM_FRAGMENT: true
+      })
+
+      for (const anchor of fragment.querySelectorAll('a[target="_blank"]')) {
+        const rel = new Set((anchor.getAttribute('rel') ?? '').split(/\s+/))
+        rel.delete('')
+        rel.add('noopener')
+        rel.add('noreferrer')
+        anchor.setAttribute('rel', [...rel].join(' '))
+      }
+
+      const container = document.createElement('div')
+      container.append(fragment)
+      return container.innerHTML
+    })
+
+    return () => h(props.as, { ...attrs, innerHTML: sanitizedHtml.value })
+  }
+})
+</script>

--- a/src/components/common/SanitizedHtml.vue
+++ b/src/components/common/SanitizedHtml.vue
@@ -1,0 +1,36 @@
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <span v-if="as === 'span'" v-bind="$attrs" v-html="sanitizedHtml" />
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <div v-else v-bind="$attrs" v-html="sanitizedHtml" />
+</template>
+
+<script setup lang="ts">
+import { default as createDOMPurify } from 'dompurify'
+import { computed } from 'vue'
+
+const purifier = createDOMPurify(window)
+
+defineOptions({ inheritAttrs: false })
+
+const { html, as = 'div' } = defineProps<{
+  html: string
+  as?: 'div' | 'span'
+}>()
+
+const sanitizedHtml = computed(() =>
+  purifier.sanitize(html, {
+    ADD_TAGS: ['video', 'source'],
+    ADD_ATTR: [
+      'controls',
+      'autoplay',
+      'loop',
+      'muted',
+      'preload',
+      'poster',
+      'target',
+      'rel'
+    ]
+  })
+)
+</script>

--- a/src/components/graph/widgets/TextPreviewWidget.vue
+++ b/src/components/graph/widgets/TextPreviewWidget.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex items-center gap-2">
       <div class="flex flex-1 items-center gap-2 break-all">
-        <span v-html="formattedText"></span>
+        <SanitizedHtml as="span" :html="formattedText" />
         <Skeleton v-if="isParentNodeExecuting" class="h-4! flex-1!" />
       </div>
     </div>
@@ -16,6 +16,7 @@ import { default as DOMPurify } from 'dompurify'
 import Skeleton from 'primevue/skeleton'
 import { computed } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { useExecutionStore } from '@/stores/executionStore'
 import type { NodeId } from '@/types/nodeId'
 import { linkifyHtml, nl2br } from '@/utils/formatUtil'

--- a/src/components/node/NodeHelpContent.vue
+++ b/src/components/node/NodeHelpContent.vue
@@ -6,10 +6,10 @@
       :aria-label="$t('g.loading')"
     />
     <!-- Markdown fetched successfully -->
-    <div
+    <SanitizedHtml
       v-else-if="!error"
       class="markdown-content overflow-visible text-sm leading-(--text-sm--line-height)"
-      v-html="renderedHelpHtml"
+      :html="renderedHelpHtml"
     />
     <!-- Fallback: markdown not found or fetch error -->
     <div
@@ -80,6 +80,7 @@
 import ProgressSpinner from 'primevue/progressspinner'
 import { computed } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { useNodeHelpContent } from '@/composables/useNodeHelpContent'
 import { flattenInputSpecs } from '@/schemas/nodeDef/inputSpecUtil'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'

--- a/src/components/node/NodeHelpContent.vue
+++ b/src/components/node/NodeHelpContent.vue
@@ -6,10 +6,10 @@
       :aria-label="$t('g.loading')"
     />
     <!-- Markdown fetched successfully -->
-    <div
+    <SanitizedHtml
       v-else-if="!error"
       class="markdown-content overflow-visible text-sm leading-(--text-sm--line-height)"
-      v-html="renderedHelpHtml"
+      :html="renderedHelpHtml"
     />
     <!-- Fallback: markdown not found or fetch error -->
     <div
@@ -80,6 +80,7 @@
 import ProgressSpinner from 'primevue/progressspinner'
 import { computed } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { useNodeHelpContent } from '@/composables/useNodeHelpContent'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 

--- a/src/components/node/NodePreview.test.ts
+++ b/src/components/node/NodePreview.test.ts
@@ -243,7 +243,7 @@ describe('NodePreview', () => {
       expect(description).toBeInTheDocument()
     })
 
-    it('uses v-html directive for rendered content', () => {
+    it('renders markdown as HTML', () => {
       const htmlNodeDef: ComfyNodeDefV2 = {
         ...mockNodeDef,
         description: 'Content with **bold** text'

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -78,7 +78,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
     </div>
-    <div
+    <SanitizedHtml
       v-if="renderedDescription"
       class="_sb_description"
       data-testid="node-description"
@@ -86,7 +86,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
         backgroundColor: litegraphColors.WIDGET_BGCOLOR
       }"
-      v-html="renderedDescription"
+      :html="renderedDescription"
     />
   </div>
 </template>
@@ -95,6 +95,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 import { truncate, zip } from 'es-toolkit/compat'
 import { computed } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'

--- a/src/components/node/NodePreview.vue
+++ b/src/components/node/NodePreview.vue
@@ -78,7 +78,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         <div class="_sb_col _sb_arrow">&#x25B6;</div>
       </div>
     </div>
-    <div
+    <SanitizedHtml
       v-if="renderedDescription"
       class="_sb_description"
       data-testid="node-description"
@@ -86,7 +86,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
         color: litegraphColors.WIDGET_SECONDARY_TEXT_COLOR,
         backgroundColor: litegraphColors.WIDGET_BGCOLOR
       }"
-      v-html="renderedDescription"
+      :html="renderedDescription"
     />
   </div>
 </template>
@@ -95,6 +95,7 @@ https://github.com/Nuked88/ComfyUI-N-Sidebar/blob/7ae7da4a9761009fb6629bc04c6830
 import _ from 'es-toolkit/compat'
 import { computed } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import type { ComfyNodeDef as ComfyNodeDefV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'

--- a/src/platform/updates/components/ReleaseNotificationToast.vue
+++ b/src/platform/updates/components/ReleaseNotificationToast.vue
@@ -6,10 +6,10 @@
       :subtitle="latestRelease?.version"
       :position
     >
-      <div
+      <SanitizedHtml
         class="pl-14 text-sm leading-[1.21] font-normal text-muted-foreground"
-        v-html="formattedContent"
-      ></div>
+        :html="formattedContent"
+      />
 
       <template #footer-start>
         <a
@@ -52,6 +52,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import NotificationPopup from '@/components/common/NotificationPopup.vue'
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useExternalLink } from '@/composables/useExternalLink'

--- a/src/platform/updates/components/WhatsNewPopup.vue
+++ b/src/platform/updates/components/WhatsNewPopup.vue
@@ -15,10 +15,10 @@
       <!-- Modal Body -->
       <div class="modal-body flex flex-1 flex-col gap-4 px-0 pt-0 pb-2">
         <!-- Release Content -->
-        <div
+        <SanitizedHtml
           class="content-text max-h-96 overflow-y-auto"
-          v-html="formattedContent"
-        ></div>
+          :html="formattedContent"
+        />
       </div>
 
       <!-- Modal Footer -->
@@ -55,6 +55,7 @@ import { default as DOMPurify } from 'dompurify'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { formatVersionAnchor } from '@/utils/formatUtil'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 /* eslint-disable testing-library/no-container, testing-library/no-node-access */
 /* eslint-disable testing-library/prefer-user-event */
 import { fireEvent, render, screen } from '@testing-library/vue'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetMarkdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-markdown relative w-full" @dblclick="startEditing">
-    <div
+    <SanitizedHtml
       class="comfy-markdown-content size-full min-h-[60px] overflow-y-auto rounded-lg"
       :class="isEditing ? 'invisible' : 'visible'"
       tabindex="0"
@@ -8,7 +8,7 @@
       role="textarea"
       :aria-label="widget.name || $t('g.markdown')"
       aria-readonly="true"
-      v-html="renderedHtml"
+      :html="renderedHtml"
     />
 
     <Textarea
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import Textarea from '@/components/ui/textarea/Textarea.vue'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.vue
@@ -30,14 +30,14 @@
       </Button>
     </div>
 
-    <div
+    <SanitizedHtml
       v-if="showMarkdown"
       class="comfy-markdown-content size-full min-h-[60px] overflow-y-auto rounded-lg text-sm"
       data-capture-wheel="true"
       role="textarea"
       :aria-label="widget.name"
       aria-readonly="true"
-      v-html="renderedMarkdown"
+      :html="renderedMarkdown"
     />
     <Textarea
       v-else
@@ -66,6 +66,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import Button from '@/components/ui/button/Button.vue'
 import Textarea from '@/components/ui/textarea/Textarea.vue'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'

--- a/src/workbench/extensions/agent/components/agent/message/CodeBlock.vue
+++ b/src/workbench/extensions/agent/components/agent/message/CodeBlock.vue
@@ -6,6 +6,8 @@ import { useI18n } from 'vue-i18n'
 
 import { cn } from '@comfyorg/tailwind-utils'
 
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
+
 const { code, lang = 'text' } = defineProps<{
   code: string
   lang?: string
@@ -76,10 +78,10 @@ watchDebounced(
         {{ copied ? t('agent.copied') : t('agent.copy') }}
       </button>
     </div>
-    <div
+    <SanitizedHtml
       v-if="highlighted"
       class="overflow-x-auto p-4 font-mono text-sm [&_pre]:bg-transparent"
-      v-html="highlighted"
+      :html="highlighted"
     />
     <pre
       v-else

--- a/src/workbench/extensions/agent/components/agent/message/MarkdownStream.vue
+++ b/src/workbench/extensions/agent/components/agent/message/MarkdownStream.vue
@@ -3,6 +3,8 @@ import { marked } from 'marked'
 import { computed, defineAsyncComponent, ref } from 'vue'
 
 import { cn } from '@comfyorg/tailwind-utils'
+
+import SanitizedHtml from '@/components/common/SanitizedHtml.vue'
 import { api } from '@/scripts/api'
 import type { ResultItemImpl } from '@/stores/queueStore'
 import {
@@ -125,11 +127,11 @@ const proseClass = cn(
         v-else-if="segment.type === 'assets'"
         :assets="segment.assets"
       />
-      <div
+      <SanitizedHtml
         v-else
         :class="proseClass"
+        :html="segment.html"
         @click="onProseClick"
-        v-html="segment.html"
       />
     </template>
     <MediaLightbox


### PR DESCRIPTION
## Summary

Routes application rich HTML through one DOMPurify boundary so future producer changes cannot reach a raw HTML sink unsanitized.

## Changes

- **What**: Adds a thin `SanitizedHtml` component, migrates the existing application rich-content sinks, and applies `vue/no-v-html` across `src/`.
- **Dependencies**: None.

The rewrite intentionally keeps the existing DOMPurify behavior and upstream sanitization. It drops the custom tag/attribute policy, feature flag, remote-config schema, and speculative compatibility machinery from the previous stack.

Atomic commits:

1. `security: centralize text preview HTML rendering`
2. `security: centralize node rich text rendering`
3. `security: centralize release note rendering`
4. `security: centralize agent rich text rendering`
5. `chore: enforce sanitized HTML boundary`

## Review Focus

- The boundary preserves the media and link attributes already supported by `renderMarkdownToHtml`.
- Existing output structure and caller-owned attributes remain unchanged.
- The only remaining `v-html` is the reviewed sink inside `SanitizedHtml.vue`.

Verification: 12 focused test files / 128 tests, typecheck, ESLint, formatting, and knip pass.
