### PR TITLE
fix(billing): keep top-up working for local users on the free tier

### DIFF
--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -396,6 +396,12 @@ WebKit engine does not expose embedded-WKWebView globals such as
 context `userAgent`. See `browser_tests/tests/cloudLoginIosWebview.spec.ts` for the
 reference pattern.
 
+`@auth` is a behavioural tag rather than a routing one: it makes the
+`comfyPage` fixture seed the mocked Firebase user (`cloudAuth.mockAuth()`),
+which `@cloud` also does implicitly. Reach for it when a signed-in user is
+needed outside the cloud project — pair `['@oss', '@auth']` to exercise a
+logged-in account on the localhost/desktop bundle, where `isCloud` is false.
+
 Organizational tags are used for manual `--grep` filtering (not project
 routing). Common ones in the suite: `@smoke`, `@slow`, `@screenshot`, `@canvas`,
 `@node`, `@widget`, `@vue-nodes`, `@subgraph`, `@ui`. Apply them so a test is

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -560,7 +560,7 @@ export const comfyPageFixture = base.extend<{
       console.error(e)
     }
 
-    if (testInfo.tags.includes('@cloud')) {
+    if (testInfo.tags.includes('@cloud') || testInfo.tags.includes('@auth')) {
       await comfyPage.cloudAuth.mockAuth()
     }
 

--- a/browser_tests/tests/localCreditsGating.spec.ts
+++ b/browser_tests/tests/localCreditsGating.spec.ts
@@ -63,6 +63,7 @@ test.describe(
       const userButton = page.getByTestId(TestIds.user.currentUserButton)
 
       await expect(userButton).toBeVisible()
+      await comfyPage.toast.closeToasts()
 
       await userButton.click()
       await expect(

--- a/browser_tests/tests/localCreditsGating.spec.ts
+++ b/browser_tests/tests/localCreditsGating.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  createBalance,
+  createSubscriptionStatus
+} from '@e2e/fixtures/data/subscriptionFixtures'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+/**
+ * Local (non-Cloud) credits gating.
+ *
+ * Every other billing/credits spec is tagged `@cloud`, so the suite only ever
+ * runs against the `DISTRIBUTION=cloud` bundle. This one runs in the `chromium`
+ * project (localhost bundle, `isCloud === false`) as a signed-in desktop user
+ * with no Comfy Cloud subscription.
+ *
+ * Nothing fetches subscription status on a local boot until Settings ▸ Credits
+ * mounts the credits tile. That first fetch flips `isFreeTier` to true, which
+ * used to swap in an "Upgrade to add credits" CTA and reroute every later
+ * top-up into `showSubscriptionRequiredDialog`. Both are cloud-only, so off
+ * cloud they no-op silently and the purchase flow dies until app restart.
+ */
+const freeTierStatus = createSubscriptionStatus({
+  is_active: true,
+  subscription_id: 'sub_local_free',
+  subscription_tier: 'FREE',
+  subscription_duration: 'MONTHLY',
+  renewal_date: '2099-01-01T00:00:00Z',
+  end_date: null,
+  has_fund: true
+})
+
+const balance = createBalance({
+  amount_micros: 5000,
+  effective_balance_micros: 5000,
+  prepaid_balance_micros: 5000,
+  currency: 'usd'
+})
+
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/customers/cloud-subscription-status', (route) =>
+      route.fulfill({ json: freeTierStatus })
+    )
+    await page.route('**/customers/balance', (route) =>
+      route.fulfill({ json: balance })
+    )
+    await use(page)
+  }
+})
+
+test.describe(
+  'Credits on a local build without a Cloud subscription',
+  { tag: ['@oss', '@auth'] },
+  () => {
+    test('never offers a subscribe/upgrade path and keeps top-up working after Settings ▸ Credits', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      const topUpDialog = new TopUpCreditsDialog(page)
+      const userButton = page.getByTestId(TestIds.user.currentUserButton)
+
+      await expect(userButton).toBeVisible()
+
+      await userButton.click()
+      await expect(
+        page.getByTestId(TestIds.user.currentUserPopover)
+      ).toBeVisible()
+      await expect(
+        page.getByTestId('upgrade-to-add-credits-button')
+      ).toBeHidden()
+      await expect(page.getByTestId('plans-pricing-menu-item')).toBeHidden()
+
+      await page.getByTestId('add-credits-button').click()
+      await topUpDialog.waitForVisible()
+      await topUpDialog.close()
+
+      await comfyPage.settingDialog.open()
+      await comfyPage.settingDialog.category('Credits').click()
+      await expect(
+        comfyPage.settingDialog.contentArea.getByText('Total credits')
+      ).toBeVisible()
+      await expect(
+        page.getByTestId('upgrade-to-add-credits-button')
+      ).toBeHidden()
+      await expect(
+        comfyPage.settingDialog.contentArea.getByText('Upgrade to add credits')
+      ).toBeHidden()
+      await comfyPage.settingDialog.close()
+
+      await userButton.click()
+      await page.getByTestId('add-credits-button').click()
+      await topUpDialog.waitForVisible()
+    })
+  }
+)

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -18,6 +18,7 @@ type Subscription = Pick<SubscriptionInfo, 'duration' | 'renewalDate'> & {
 type TeamStop = CurrentTeamCreditStop
 
 const state = vi.hoisted(() => ({
+  isCloud: true,
   balance: null as Balance | null,
   subscription: null as Subscription | null,
   isActiveSubscription: false,
@@ -47,6 +48,12 @@ vi.mock('@/composables/useErrorHandling', () => ({
         }
       }
   })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return state.isCloud
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -159,6 +166,7 @@ function activeProSubscription() {
 
 describe('CreditsTile', () => {
   beforeEach(() => {
+    state.isCloud = true
     state.balance = null
     state.subscription = null
     state.isActiveSubscription = false
@@ -374,6 +382,17 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
     await userEvent.click(screen.getByText('Upgrade to add credits'))
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('keeps add-credits on the free tier off cloud, where there is no upgrade flow', async () => {
+    activeProSubscription()
+    state.isCloud = false
+    state.isFreeTier = true
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    await userEvent.click(screen.getByText('Add credits'))
+    expect(state.showPricingTable).not.toHaveBeenCalled()
+    expect(state.showTopUpCreditsDialog).toHaveBeenCalledOnce()
   })
 
   it('hides the action button when the user lacks the top-up permission', () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -188,10 +188,11 @@
 
     <div v-if="showActionButton" class="flex flex-col gap-3">
       <Button
-        v-if="isFreeTier"
+        v-if="isCloud && isFreeTier"
         variant="subscribe"
         size="lg"
         class="w-full font-normal"
+        data-testid="upgrade-to-add-credits-button"
         @click="handleUpgradeToAddCredits"
       >
         {{ $t('subscription.upgradeToAddCredits') }}
@@ -207,6 +208,7 @@
               'bg-interface-menu-component-surface-selected text-text-primary'
           )
         "
+        data-testid="add-credits-button"
         @click="handleAddCredits"
       >
         {{ $t('subscription.addCredits') }}
@@ -234,6 +236,7 @@ import {
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { consumePendingTopup } from '@/platform/telemetry/topupTracker'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -275,4 +275,17 @@ describe('CurrentUserPopoverWorkspace', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
   })
+
+  it('hides the resubscribe prompt off cloud', () => {
+    state.isCloud = false
+    state.isCancelled = true
+    state.canTopUp = true
+    state.canManageSubscription = true
+    state.canManageSubscriptionLifecycle = true
+    renderComponent('team', 'owner')
+
+    expect(
+      screen.queryByRole('button', { name: 'Resubscribe' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -12,6 +12,7 @@ import enMessages from '@/locales/en/main.json'
 import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
 
 const state = vi.hoisted(() => ({
+  isCloud: true,
   isActiveSubscription: true,
   isFreeTier: false,
   isCancelled: false,
@@ -30,6 +31,12 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
     userPhotoUrl: ref(null),
     handleSignOut: vi.fn()
   })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return state.isCloud
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -156,6 +163,7 @@ function renderComponent(
 
 describe('CurrentUserPopoverWorkspace', () => {
   beforeEach(() => {
+    state.isCloud = true
     state.isActiveSubscription = true
     state.isFreeTier = false
     state.isCancelled = false
@@ -250,5 +258,21 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
 
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('drops every subscribe reference off cloud and leaves top-up intact', () => {
+    state.isCloud = false
+    state.isFreeTier = true
+    state.canTopUp = true
+    state.canManageSubscription = true
+    renderComponent('personal', 'owner')
+
+    expect(
+      screen.queryByTestId('upgrade-to-add-credits-button')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('plans-pricing-menu-item')
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-credits-button')).toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -303,8 +303,9 @@ const showManagePlan = computed(
 )
 const showSubscribeAction = computed(
   () =>
-    (isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
-    (!isActiveSubscription.value && permissions.value.canManageSubscription)
+    isCloud &&
+    ((isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
+      (!isActiveSubscription.value && permissions.value.canManageSubscription))
 )
 
 const handleOpenUserSettings = () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -83,7 +83,9 @@
       </Button>
       <!-- Upgrade to add credits (free tier) -->
       <Button
-        v-if="isActiveSubscription && permissions.canTopUp && isFreeTier"
+        v-if="
+          isCloud && isActiveSubscription && permissions.canTopUp && isFreeTier
+        "
         variant="subscribe"
         size="sm"
         data-testid="upgrade-to-add-credits-button"
@@ -294,7 +296,7 @@ const displayedCredits = computed(() => {
 })
 
 const showPlansAndPricing = computed(
-  () => permissions.value.canManageSubscription
+  () => isCloud && permissions.value.canManageSubscription
 )
 const showManagePlan = computed(
   () => permissions.value.canManageSubscription && isActiveSubscription.value

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
 const state = vi.hoisted(() => ({
+  isCloud: true,
   isActiveSubscription: true,
   isFreeTier: false,
   type: 'workspace' as 'workspace' | 'legacy',
@@ -27,7 +28,9 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
-  isCloud: true
+  get isCloud() {
+    return state.isCloud
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -62,6 +65,7 @@ import { useDialogService } from '@/services/dialogService'
 describe('showTopUpCreditsDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    state.isCloud = true
     state.isActiveSubscription = true
     state.isFreeTier = false
     state.type = 'workspace'
@@ -119,5 +123,17 @@ describe('showTopUpCreditsDialog', () => {
       reason: 'out_of_credits'
     })
     expect(showDialog).not.toHaveBeenCalled()
+  })
+
+  it('opens the purchase dialog for a free-tier user off cloud, where the subscribe flow does not exist', async () => {
+    state.isCloud = false
+    state.isFreeTier = true
+    state.type = 'legacy'
+
+    await useDialogService().showTopUpCreditsDialog()
+
+    expect(showSubscriptionDialog).not.toHaveBeenCalled()
+    const [args] = showDialog.mock.calls[0]
+    expect(args.key).toBe('top-up-credits')
   })
 })

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -334,7 +334,7 @@ export const useDialogService = () => {
     isInsufficientCredits?: boolean
   }) {
     const { isActiveSubscription, isFreeTier, type } = useBillingContext()
-    if (!isActiveSubscription.value || isFreeTier.value) {
+    if (isCloud && (!isActiveSubscription.value || isFreeTier.value)) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits
           ? 'out_of_credits'


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Local (desktop/portable) users who are not Cloud subscribers lose the credit purchase flow after opening Settings ▸ Credits, and cannot recover without restarting the app. Reported in #bug-dump; related to BE-999 but frontend-only.

## Root cause

Clicking "Upgrade to add credits" does nothing *and* changes nothing. Merely **opening Settings ▸ Credits** is what breaks the flow.

On a non-cloud build `isActiveSubscription` is hardwired `true` (`isSubscribedOrIsNotCloud` returns `true` whenever `!isCloud`), so `isFreeTier` is the only live term in the top-up subscription gate.

Nothing fetches subscription status on a local boot — `useBillingContext`'s init watcher returns early because `activeWorkspace?.id` is undefined off cloud. `CreditsTile`'s `onMounted(handleRefresh)` is the first and only thing that ever calls `fetchStatus()`, so opening Settings ▸ Credits sets `tier: "FREE"` and latches `isFreeTier` true for the shared billing context.

From then on `showTopUpCreditsDialog()` routes into `showSubscriptionRequiredDialog()`, which returns immediately when `!isCloud` — a permanent silent no-op until restart. Independently, `CreditsTile` rendered `v-if="isFreeTier"` "Upgrade to add credits" with no distribution guard, whose handler `showPricingTable()` also returns on `!isCloud`.

Measured in a real `DISTRIBUTION=localhost` build, signed in, with `/customers/cloud-subscription-status` returning `{is_active: true, subscription_tier: "FREE"}`:

| step | `tier` | `isFreeTier` | click → `dialogStack` |
| --- | --- | --- | --- |
| popover, before Settings | `null` | false | `["top-up-credits"]` |
| Settings ▸ Credits mounted | `"FREE"` | true | — |
| popover, after Settings | `"FREE"` | true | `[]` — silent no-op |

## Changes

- `dialogService.showTopUpCreditsDialog` — apply the subscription gate only on cloud. Off cloud there is no subscribe flow, so diverting there strands the purchase dialog. This is the load-bearing fix.
- `CreditsTile.vue` — gate the "Upgrade to add credits" CTA on `isCloud`; local users keep "Add credits".
- `CurrentUserPopoverWorkspace.vue` — gate the upgrade CTA, "Plans & pricing", and the subscribe/resubscribe prompt on `isCloud`, matching guards `CurrentUserPopoverLegacy.vue` already has. Cloud-side hardening: this component never renders off cloud, since `teamWorkspacesEnabled` is hard-false there.

## Regression lineage

The **visible CTA** entered ungated in 026b2c479 (#12734, FE-964, 2026-06-25), which replaced `LegacyCreditsPanel.vue` with the facade-driven `CreditsTile`. The old panel had no free-tier branch and never called `fetchStatus`. First shipped in **v1.47.4**.

It became invisible again in **v1.48.4** via 51884bc96 (#13812), which added `hasActiveWorkspace` to `getPermissions` — off cloud `activeWorkspace` is null, so `canTopUp` is false and `showActionButton` suppresses the whole block. That was accidental masking, not a fix.

**Visible-CTA window: v1.47.4 → v1.48.3.** Reproduced empirically in a v1.47.4 build. The popover was never affected — `CurrentUserPopoverLegacy` has had its `isCloud` guard since #11463 (v1.44.7) — which is why the customer saw the button only in Settings ▸ Credits.

**The top-up dead-end still exists at HEAD**, independent of the CTA: v1.48.4 hid the button but left `onMounted(handleRefresh)` untouched. That is the part that needs to ship.

## Why the e2e suite missed it

Not a coverage-volume problem — a structural one. `ComfyPage` only mocked auth for `@cloud`-tagged tests:

```ts
if (testInfo.tags.includes('@cloud')) {
  await comfyPage.cloudAuth.mockAuth()
}
```

`@cloud` is a project-routing tag: it excludes a spec from the `chromium` project (`grepInvert: /…|@cloud/`) and routes it to the `cloud` project, which runs the `frontend-dist-cloud` artifact built with `pnpm build:cloud`. So getting a signed-in user *required* the tag that guarantees `isCloud === true`. Every credits/billing spec is `@cloud`-tagged, making local coverage impossible to write.

The unit layer had the mirror-image blind spot: `vitest.setup.ts` pins `__DISTRIBUTION__ = 'localhost'`, but `CreditsTile.vue` never read the distribution, and `dialogService.topUpCredits.test.ts` hard-stubbed `isCloud: true` — so those tests asserted cloud semantics while nominally running local.

Fixed by adding an `@auth` tag so auth mocking is independent of project routing, plus `browser_tests/tests/localCreditsGating.spec.ts` (`@oss @auth`) walking the reported journey on the localhost bundle. Unit specs now drive `isCloud` through a mockable getter and cover both distributions.

Each new test was verified to fail against the unfixed source and pass with the fix.

## Verification

- `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, `pnpm knip` clean; pre-commit gates green.
- 1817 unit tests pass across `subscription` / `billing` / `services` / `workspace` / `topbar` / `dialog`.
- Manual: real browser against a `DISTRIBUTION=localhost` dev server (`isCloud === false` read at runtime), signed in via the `CloudAuthHelper` Firebase-IndexedDB technique, billing endpoints mocked to a FREE tier. Walked the customer's exact steps with and without the fix, and against a v1.47.4 build.
- The new Playwright spec was not executed here (no CI backend in the sandbox); it is written against existing fixtures and typechecks under `typecheck:browser`.

## Notes

- No competing branch exists for this fix. `remove-team-ff` also edits `CurrentUserPopoverWorkspace.vue`, so expect a small conflict; it keeps that popover cloud-only (`v-if="isCloud"`), so there is no behavioural clash.
- Follow-up, not in this PR: `canRunWorkflows` folds `isFreeTier` into free-tier quota, so the same latch could swap the Run button for "Subscribe to run" on local. Currently inert only because `freeTierJobAllowanceEnabled` uses `resolveFlag` (default false) rather than being distribution-gated.


## Screenshots

![v1.47.4 local build, Settings > Credits: the gradient 'Upgrade to add credits' CTA the customer reported. Clicking it is a dead click.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/735354910a3082380956f585e104396a8acf177eeb4140778a32c8202919cf84/pr-images/1785723071924-a22962fa-78b9-44bd-9c0f-65ef914fa344.png)

![Before the fix: after visiting Settings > Credits, clicking 'Add credits' in the profile popover does nothing - no dialog opens.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/735354910a3082380956f585e104396a8acf177eeb4140778a32c8202919cf84/pr-images/1785723072643-ed9f195b-ee7b-4aa7-ad96-587a7f8c2cd8.png)

![After the fix: the same sequence opens the 'Add more credits' top-up dialog as expected.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/735354910a3082380956f585e104396a8acf177eeb4140778a32c8202919cf84/pr-images/1785723072994-e0542b7d-70b5-47bb-ac40-f41146e8cf56.png)

![After the fix: Settings > Credits on a local build shows the balance with no subscribe or upgrade references.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/735354910a3082380956f585e104396a8acf177eeb4140778a32c8202919cf84/pr-images/1785723073294-81f222d2-cc75-4f0e-aa2e-a3afd1c23b36.png)