### PR TITLE
[backport core/1.48] fix: hide subscribe/upgrade credits UI on non-cloud distributions

### DIFF
--- a/browser_tests/fixtures/components/BaseDialog.ts
+++ b/browser_tests/fixtures/components/BaseDialog.ts
@@ -4,11 +4,22 @@ export class BaseDialog {
   readonly root: Locator
   readonly closeButton: Locator
 
+  /**
+   * @param testIdOrRoot - A `data-testid` to scope the dialog root by, a
+   * pre-built `Locator` (e.g. for a dialog identified by content rather than
+   * a testid), or omitted to fall back to the generic `[role="dialog"]`.
+   * The generic fallback matches *every* open dialog when more than one is
+   * stacked (e.g. a dialog opened from within Settings) — prefer a specific
+   * testid or Locator whenever the dialog can be reached alongside another.
+   */
   constructor(
     public readonly page: Page,
-    testId?: string
+    testIdOrRoot?: string | Locator
   ) {
-    this.root = testId ? page.getByTestId(testId) : page.getByRole('dialog')
+    this.root =
+      typeof testIdOrRoot === 'string'
+        ? page.getByTestId(testIdOrRoot)
+        : (testIdOrRoot ?? page.getByRole('dialog'))
     this.closeButton = this.root.getByRole('button', { name: 'Close' })
   }
 

--- a/browser_tests/fixtures/components/TopUpCreditsDialog.ts
+++ b/browser_tests/fixtures/components/TopUpCreditsDialog.ts
@@ -14,7 +14,17 @@ export class TopUpCreditsDialog extends BaseDialog {
   readonly pricingLink: Locator
 
   constructor(page: Page) {
-    super(page)
+    // Scope to the dialog containing the top-up heading rather than the
+    // generic `[role="dialog"]` fallback: this dialog can be opened from
+    // within another already-open dialog (e.g. Settings > Credits), and
+    // Reka renders each stacked dialog as its own independent `role="dialog"`
+    // root, so the generic fallback would match both simultaneously.
+    super(
+      page,
+      page.getByRole('dialog').filter({
+        has: page.getByRole('heading', { name: 'Add more credits' })
+      })
+    )
     this.heading = this.root.getByRole('heading', { name: 'Add more credits' })
     this.insufficientHeading = this.root.getByRole('heading', {
       name: 'Add more credits to run'

--- a/browser_tests/fixtures/localAuthFixture.ts
+++ b/browser_tests/fixtures/localAuthFixture.ts
@@ -1,0 +1,52 @@
+import { test as base } from '@playwright/test'
+
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  createSubscriptionHelper,
+  withFreeTier
+} from '@e2e/fixtures/helpers/SubscriptionHelper'
+
+const LOCAL_AUTH_BOOT_TIMEOUT = 45_000
+
+/**
+ * Boots the local (non-Cloud) build as a logged-in, legacy Free-tier user.
+ *
+ * Firebase auth must be seeded via `ComfyPage.cloudAuth` *before* the app's
+ * first navigation: seeding it against an already-booted page races the
+ * app's own Firebase listener and can hang indefinitely. `comfyPageFixture`
+ * only seeds pre-boot for `@cloud`-tagged tests (which also run against the
+ * Cloud-distribution build), so specs that need an authenticated local user
+ * construct `ComfyPage` directly here and drive its setup themselves,
+ * mirroring `ComfyPage.setup()` but with auth mocked first.
+ */
+export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
+  comfyPage: async ({ page, request }, use, testInfo) => {
+    testInfo.setTimeout(LOCAL_AUTH_BOOT_TIMEOUT)
+
+    const comfyPage = new ComfyPage(page, request)
+    const userId = await comfyPage.setupUser(
+      `playwright-local-auth-${testInfo.parallelIndex}`
+    )
+    await comfyPage.setupSettings({
+      'Comfy.TutorialCompleted': true,
+      'Comfy.userId': userId
+    })
+
+    await comfyPage.cloudAuth.mockAuth()
+    const subscriptionHelper = createSubscriptionHelper(page, withFreeTier())
+    await subscriptionHelper.mock()
+
+    await page.evaluate((id) => {
+      localStorage.clear()
+      sessionStorage.clear()
+      localStorage.setItem('Comfy.userId', id)
+    }, userId)
+
+    await comfyPage.goto()
+    await page.waitForFunction(() => document.fonts.ready)
+    await comfyPage.waitForAppReady()
+
+    await use(comfyPage)
+    await subscriptionHelper.clearMocks()
+  }
+})

--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test'
+
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { localAuthFixture as test } from '@e2e/fixtures/localAuthFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+/**
+ * Regression coverage for a local/non-cloud dead-click: a logged-in Free-tier
+ * user on a local (non-Cloud) distribution must never see subscribe/upgrade
+ * UI in the credits surfaces, and the "Add credits" purchase flow must keep
+ * working no matter which of those surfaces was visited beforehand.
+ *
+ * Every other credits/billing e2e spec (creditsTile.spec.ts,
+ * currentUserPopoverCredits.spec.ts, billingFacadeConsumers.spec.ts,
+ * subscription.spec.ts) is tagged `@cloud` and only runs against the
+ * Cloud-distribution build with an always-active paid subscription fixture,
+ * so none of them ever exercise the OSS/local build (`isCloud === false`)
+ * with a logged-in Free-tier account — the exact combination that trips
+ * this bug. This spec intentionally carries no `@cloud` tag so it runs in
+ * the default (local) `chromium` project instead.
+ */
+test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
+  test('keeps "Add credits" working across the profile popover and Settings > Credits', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    const topUpDialog = new TopUpCreditsDialog(page)
+
+    // 1. Profile popover: a Free-tier local user gets "Add credits", never
+    //    "Upgrade to add credits" — subscribing is a Cloud-only concept.
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    let popover = page.getByTestId(TestIds.user.currentUserPopover)
+    await expect(popover).toBeVisible()
+    await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+
+    // Clicking it must open the purchase dialog, not silently no-op.
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    // 2. Settings > Credits, reached the same way the reported bug did: the
+    //    popover's "Manage Plan" entry, not a generic keyboard shortcut. This
+    //    must also hide the subscribe CTA and keep its own "Add credits"
+    //    button working, not just render a dead replacement for it.
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    popover = page.getByTestId(TestIds.user.currentUserPopover)
+    await popover.getByTestId('manage-plan-menu-item').click()
+
+    const settingsDialog = comfyPage.settingDialog
+    await settingsDialog.waitForVisible()
+    const creditsContent = settingsDialog.contentArea
+    await expect(
+      creditsContent.getByText('Upgrade to add credits')
+    ).toHaveCount(0)
+
+    const settingsAddCredits = creditsContent.getByRole('button', {
+      name: 'Add credits'
+    })
+    await expect(settingsAddCredits).toBeVisible()
+    await settingsAddCredits.click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    await settingsDialog.close()
+
+    // 3. Reopening the popover afterward must still work — regression check
+    //    for the stuck-trigger bug, where visiting Settings > Credits left
+    //    the popover's top-up button permanently dead.
+    await page.getByTestId(TestIds.user.currentUserButton).click()
+    popover = page.getByTestId(TestIds.user.currentUserPopover)
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+  })
+})

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -25,6 +25,7 @@ const state = vi.hoisted(() => ({
   currentTeamCreditStop: null as TeamStop | null,
   isLoading: false,
   canTopUp: true,
+  type: 'workspace' as 'workspace' | 'legacy',
   fetchBalance: vi.fn(),
   fetchStatus: vi.fn(),
   showPricingTable: vi.fn(),
@@ -57,6 +58,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     isFreeTier: computed(() => state.isFreeTier),
     currentTeamCreditStop: computed(() => state.currentTeamCreditStop),
     isLoading: computed(() => state.isLoading),
+    type: computed(() => state.type),
     fetchBalance: state.fetchBalance,
     fetchStatus: state.fetchStatus
   })
@@ -85,6 +87,13 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackAddApiCreditButtonClicked: state.trackAddApiCreditButtonClicked
   })
+}))
+
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
 }))
 
 const i18n = createI18n({
@@ -165,6 +174,8 @@ describe('CreditsTile', () => {
     state.currentTeamCreditStop = null
     state.isLoading = false
     state.canTopUp = true
+    state.type = 'workspace'
+    mockIsCloud.value = true
     vi.clearAllMocks()
   })
 
@@ -363,12 +374,29 @@ describe('CreditsTile', () => {
     expect(state.showPricingTable).toHaveBeenCalledOnce()
   })
 
-  it('hides the action button when the user lacks the top-up permission', () => {
+  it('keeps offering add-credits on the free tier for non-cloud distributions', () => {
+    mockIsCloud.value = false
+    activeProSubscription()
+    state.isFreeTier = true
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    expect(screen.getByText('Add credits')).toBeInTheDocument()
+  })
+
+  it('hides the action button when a team workspace member lacks the top-up permission', () => {
     activeProSubscription()
     state.canTopUp = false
     renderTile()
     expect(screen.queryByText('Add credits')).toBeNull()
     expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+  })
+
+  it('ignores the workspace top-up permission on legacy (personal) billing', () => {
+    activeProSubscription()
+    state.type = 'legacy'
+    state.canTopUp = false
+    renderTile()
+    expect(screen.getByText('Add credits')).toBeInTheDocument()
   })
 
   it('refreshes balance and status from the facade on mount and on demand', async () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -146,7 +146,7 @@
 
     <div v-if="showActionButton" class="flex flex-col gap-3">
       <Button
-        v-if="isFreeTier"
+        v-if="isCloud && isFreeTier"
         variant="subscribe"
         size="lg"
         class="w-full font-normal"
@@ -192,6 +192,7 @@ import {
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { consumePendingTopup } from '@/platform/telemetry/topupTracker'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
@@ -211,7 +212,8 @@ const {
   isFreeTier,
   currentTeamCreditStop,
   fetchBalance,
-  fetchStatus
+  fetchStatus,
+  type
 } = useBillingContext()
 const {
   monthlyBonusCredits,
@@ -311,8 +313,13 @@ const showBar = computed(
     creditPoolTotalCredits.value !== null &&
     creditPoolTotalCredits.value > 0
 )
+// Workspace-owner gating only applies to team billing; legacy (personal,
+// including local/desktop) accounts have no workspace concept to gate on.
 const showActionButton = computed(
-  () => isActiveSubscription.value && !zeroState && permissions.value.canTopUp
+  () =>
+    isActiveSubscription.value &&
+    !zeroState &&
+    (type.value !== 'workspace' || permissions.value.canTopUp)
 )
 
 const isMonthlyDepleted = computed(

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -26,8 +26,11 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({ trackEvent: vi.fn() })
 }))
 
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
 vi.mock('@/platform/distribution/types', () => ({
-  isCloud: true
+  get isCloud() {
+    return mockIsCloud.value
+  }
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -66,6 +69,7 @@ describe('showTopUpCreditsDialog', () => {
     state.isFreeTier = false
     state.type = 'workspace'
     state.canTopUp = true
+    mockIsCloud.value = true
   })
 
   it('shows the purchase dialog to users who can top up', async () => {
@@ -119,5 +123,32 @@ describe('showTopUpCreditsDialog', () => {
       reason: 'out_of_credits'
     })
     expect(showDialog).not.toHaveBeenCalled()
+  })
+
+  describe('non-cloud distribution', () => {
+    beforeEach(() => {
+      mockIsCloud.value = false
+      state.type = 'legacy'
+    })
+
+    it('opens the purchase dialog directly on the free tier instead of the subscription-required flow', async () => {
+      state.isFreeTier = true
+
+      await useDialogService().showTopUpCreditsDialog()
+
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      const [args] = showDialog.mock.calls[0]
+      expect(args.key).toBe('top-up-credits')
+    })
+
+    it('opens the purchase dialog even when the facade reports no active subscription', async () => {
+      state.isActiveSubscription = false
+
+      await useDialogService().showTopUpCreditsDialog()
+
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      const [args] = showDialog.mock.calls[0]
+      expect(args.key).toBe('top-up-credits')
+    })
   })
 })

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -334,7 +334,9 @@ export const useDialogService = () => {
     isInsufficientCredits?: boolean
   }) {
     const { isActiveSubscription, isFreeTier, type } = useBillingContext()
-    if (!isActiveSubscription.value || isFreeTier.value) {
+    // Subscribing to unlock top-ups is a Cloud-only concept; local/desktop
+    // users always keep the purchase flow regardless of tier.
+    if (isCloud && (!isActiveSubscription.value || isFreeTier.value)) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits
           ? 'out_of_credits'


### PR DESCRIPTION
## Summary

Manual backport of #14587 to `core/1.48`. Non-cloud distributions should not show Cloud-only subscribe/upgrade credits UI or route top-ups into a no-op subscription-required flow.

## Changes

- **What**: Gates the free-tier upgrade CTA and subscription-required top-up path on the Cloud distribution flag, preserving direct credit purchases for local/desktop users.
- **Conflict resolution**: The automatic backport conflicted in `CreditsTile.vue` because the source branch includes newer inactive-plan UI/state that is not present on `core/1.48`. The resolution preserves the target branch component structure and package/lockfile versions, applies the distribution gate, and uses the target branch's existing billing `type` API so workspace permissions only gate team billing.
- **Breaking**: None.

## Review Focus

- Non-cloud free-tier users see **Add credits**, never **Upgrade to add credits**.
- Cloud free-tier behavior remains unchanged.
- Team workspace top-up permissions remain enforced; legacy/personal billing is not incorrectly blocked by workspace permissions.

## Verification

- `pnpm test:unit src/platform/cloud/subscription/components/CreditsTile.test.ts src/services/dialogService.topUpCredits.test.ts` — 27 tests passed.
- `pnpm typecheck` — passed.
- `pnpm typecheck:browser` — passed.
- `pnpm exec eslint` on all eight changed TypeScript/Vue files — passed.
- `pnpm exec oxfmt --check` on all eight changed files — passed.
- Pre-push `pnpm knip --cache` — passed.

## Screenshots

Not applicable; this is a behavioral gating fix covered by unit and browser regression tests.