### PR TITLE
[backport core/1.47] fix: hide subscribe/upgrade credits UI on non-cloud distributions

### DIFF
--- a/browser_tests/fixtures/components/BaseDialog.ts
+++ b/browser_tests/fixtures/components/BaseDialog.ts
@@ -4,11 +4,22 @@ export class BaseDialog {
   readonly root: Locator
   readonly closeButton: Locator
 
+  /**
+   * @param testIdOrRoot - A `data-testid` to scope the dialog root by, a
+   * pre-built `Locator` (e.g. for a dialog identified by content rather than
+   * a testid), or omitted to fall back to the generic `[role="dialog"]`.
+   * The generic fallback matches *every* open dialog when more than one is
+   * stacked (e.g. a dialog opened from within Settings) — prefer a specific
+   * testid or Locator whenever the dialog can be reached alongside another.
+   */
   constructor(
     public readonly page: Page,
-    testId?: string
+    testIdOrRoot?: string | Locator
   ) {
-    this.root = testId ? page.getByTestId(testId) : page.getByRole('dialog')
+    this.root =
+      typeof testIdOrRoot === 'string'
+        ? page.getByTestId(testIdOrRoot)
+        : (testIdOrRoot ?? page.getByRole('dialog'))
     this.closeButton = this.root.getByRole('button', { name: 'Close' })
   }
 

--- a/browser_tests/fixtures/components/TopUpCreditsDialog.ts
+++ b/browser_tests/fixtures/components/TopUpCreditsDialog.ts
@@ -14,7 +14,17 @@ export class TopUpCreditsDialog extends BaseDialog {
   readonly pricingLink: Locator
 
   constructor(page: Page) {
-    super(page)
+    // Scope to the dialog containing the top-up heading rather than the
+    // generic `[role="dialog"]` fallback: this dialog can be opened from
+    // within another already-open dialog (e.g. Settings > Credits), and
+    // Reka renders each stacked dialog as its own independent `role="dialog"`
+    // root, so the generic fallback would match both simultaneously.
+    super(
+      page,
+      page.getByRole('dialog').filter({
+        has: page.getByRole('heading', { name: 'Add more credits' })
+      })
+    )
     this.heading = this.root.getByRole('heading', { name: 'Add more credits' })
     this.insufficientHeading = this.root.getByRole('heading', {
       name: 'Add more credits to run'

--- a/browser_tests/fixtures/localAuthFixture.ts
+++ b/browser_tests/fixtures/localAuthFixture.ts
@@ -1,0 +1,73 @@
+import { test as base } from '@playwright/test'
+
+import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
+import type { operations } from '@/types/comfyRegistryTypes'
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+
+type CustomerBalanceResponse = NonNullable<
+  operations['GetCustomerBalance']['responses']['200']['content']['application/json']
+>
+
+const LOCAL_AUTH_BOOT_TIMEOUT = 45_000
+
+/**
+ * Boots the local (non-Cloud) build as a logged-in, legacy Free-tier user.
+ *
+ * Firebase auth must be seeded via `ComfyPage.cloudAuth` *before* the app's
+ * first navigation: seeding it against an already-booted page races the
+ * app's own Firebase listener and can hang indefinitely. `comfyPageFixture`
+ * only seeds pre-boot for `@cloud`-tagged tests (which also run against the
+ * Cloud-distribution build), so specs that need an authenticated local user
+ * construct `ComfyPage` directly here and drive its setup themselves,
+ * mirroring `ComfyPage.setup()` but with auth mocked first.
+ */
+export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
+  comfyPage: async ({ page, request }, use, testInfo) => {
+    testInfo.setTimeout(LOCAL_AUTH_BOOT_TIMEOUT)
+
+    const comfyPage = new ComfyPage(page, request)
+    const userId = await comfyPage.setupUser(
+      `playwright-local-auth-${testInfo.parallelIndex}`
+    )
+    await comfyPage.setupSettings({
+      'Comfy.TutorialCompleted': true,
+      'Comfy.userId': userId
+    })
+
+    await comfyPage.cloudAuth.mockAuth()
+    const freeTierStatus: CloudSubscriptionStatusResponse = {
+      is_active: true,
+      subscription_id: null,
+      subscription_tier: 'FREE',
+      subscription_duration: null,
+      renewal_date: null,
+      end_date: null
+    }
+    const zeroBalance: CustomerBalanceResponse = {
+      amount_micros: 0,
+      effective_balance_micros: 0,
+      prepaid_balance_micros: 0,
+      cloud_credit_balance_micros: 0,
+      pending_charges_micros: 0,
+      currency: 'USD'
+    }
+    await page.route('**/customers/cloud-subscription-status', (route) =>
+      route.fulfill({ json: freeTierStatus })
+    )
+    await page.route('**/customers/balance', (route) =>
+      route.fulfill({ json: zeroBalance })
+    )
+
+    await page.evaluate((id) => {
+      localStorage.clear()
+      sessionStorage.clear()
+      localStorage.setItem('Comfy.userId', id)
+    }, userId)
+
+    await comfyPage.goto()
+    await page.waitForFunction(() => document.fonts.ready)
+    await comfyPage.waitForAppReady()
+
+    await use(comfyPage)
+  }
+})

--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test'
+
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import { localAuthFixture as test } from '@e2e/fixtures/localAuthFixture'
+
+/**
+ * Regression coverage for a local/non-cloud dead-click: a logged-in Free-tier
+ * user on a local (non-Cloud) distribution must never see subscribe/upgrade
+ * UI in the credits surfaces, and the "Add credits" purchase flow must keep
+ * working no matter which of those surfaces was visited beforehand.
+ *
+ * Every other credits/billing e2e spec (creditsTile.spec.ts,
+ * currentUserPopoverCredits.spec.ts, billingFacadeConsumers.spec.ts,
+ * subscription.spec.ts) is tagged `@cloud` and only runs against the
+ * Cloud-distribution build with an always-active paid subscription fixture,
+ * so none of them ever exercise the OSS/local build (`isCloud === false`)
+ * with a logged-in Free-tier account — the exact combination that trips
+ * this bug. This spec intentionally carries no `@cloud` tag so it runs in
+ * the default (local) `chromium` project instead.
+ */
+test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
+  test('keeps "Add credits" working across the profile popover and Settings > Credits', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+    const topUpDialog = new TopUpCreditsDialog(page)
+
+    // 1. Profile popover: a Free-tier local user gets "Add credits", never
+    //    "Upgrade to add credits" — subscribing is a Cloud-only concept.
+    await page.getByRole('button', { name: 'Current user' }).click()
+    let popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+
+    // Clicking it must open the purchase dialog, not silently no-op.
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    // 2. Settings > Credits, reached the same way the reported bug did: the
+    //    popover's "Manage Plan" entry, not a generic keyboard shortcut. This
+    //    must also hide the subscribe CTA and keep its own "Add credits"
+    //    button working, not just render a dead replacement for it.
+    await page.getByRole('button', { name: 'Current user' }).click()
+    popover = page.locator('.current-user-popover')
+    await popover.getByTestId('manage-plan-menu-item').click()
+
+    const settingsDialog = comfyPage.settingDialog
+    await settingsDialog.waitForVisible()
+    const creditsContent = settingsDialog.contentArea
+    await expect(
+      creditsContent.getByText('Upgrade to add credits')
+    ).toHaveCount(0)
+
+    const settingsAddCredits = creditsContent.getByRole('button', {
+      name: 'Add credits'
+    })
+    await expect(settingsAddCredits).toBeVisible()
+    await settingsAddCredits.click()
+    await expect(topUpDialog.heading).toBeVisible()
+    await topUpDialog.close()
+
+    await settingsDialog.close()
+
+    // 3. Reopening the popover afterward must still work — regression check
+    //    for the stuck-trigger bug, where visiting Settings > Credits left
+    //    the popover's top-up button permanently dead.
+    await page.getByRole('button', { name: 'Current user' }).click()
+    popover = page.locator('.current-user-popover')
+    await expect(
+      popover.getByTestId('upgrade-to-add-credits-button')
+    ).toHaveCount(0)
+    await popover.getByTestId('add-credits-button').click()
+    await expect(topUpDialog.heading).toBeVisible()
+  })
+})

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -87,6 +87,13 @@ vi.mock('@/platform/telemetry', () => ({
   })
 }))
 
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -165,6 +172,7 @@ describe('CreditsTile', () => {
     state.currentTeamCreditStop = null
     state.isLoading = false
     state.canTopUp = true
+    mockIsCloud.value = true
     vi.clearAllMocks()
   })
 
@@ -339,6 +347,15 @@ describe('CreditsTile', () => {
     expect(screen.queryByText('Add credits')).toBeNull()
     await userEvent.click(screen.getByText('Upgrade to add credits'))
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('keeps offering add-credits on the free tier for non-cloud distributions', () => {
+    mockIsCloud.value = false
+    activeProSubscription()
+    state.isFreeTier = true
+    renderTile()
+    expect(screen.queryByText('Upgrade to add credits')).toBeNull()
+    expect(screen.getByText('Add credits')).toBeInTheDocument()
   })
 
   it('hides the action button when the user lacks the top-up permission', () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -146,7 +146,7 @@
 
     <div v-if="showActionButton" class="flex flex-col gap-3">
       <Button
-        v-if="isFreeTier"
+        v-if="isCloud && isFreeTier"
         variant="gradient"
         size="lg"
         class="w-full font-normal"
@@ -192,6 +192,7 @@ import {
   getTierCredits
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
+import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { consumePendingTopup } from '@/platform/telemetry/topupTracker'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const showDialog = vi.hoisted(() => vi.fn())
+const state = vi.hoisted(() => ({
+  isActiveSubscription: true,
+  isFreeTier: false,
+  type: 'legacy' as 'workspace' | 'legacy'
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ showDialog })
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackEvent: vi.fn() })
+}))
+
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: { value: state.isActiveSubscription },
+    isFreeTier: { value: state.isFreeTier },
+    type: { value: state.type }
+  })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: vi.fn() })
+}))
+
+const showSubscriptionDialog = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({ show: showSubscriptionDialog })
+  })
+)
+
+import { useDialogService } from '@/services/dialogService'
+
+describe('showTopUpCreditsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.isActiveSubscription = true
+    state.isFreeTier = false
+    state.type = 'legacy'
+    mockIsCloud.value = true
+  })
+
+  it('shows the purchase dialog to users who can top up', async () => {
+    await useDialogService().showTopUpCreditsDialog({
+      isInsufficientCredits: true
+    })
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.key).toBe('top-up-credits')
+  })
+
+  it('routes an inactive cloud user to the subscription-required flow', async () => {
+    state.isActiveSubscription = false
+
+    await useDialogService().showTopUpCreditsDialog({
+      isInsufficientCredits: true
+    })
+
+    expect(showSubscriptionDialog).toHaveBeenCalledWith({
+      reason: 'out_of_credits'
+    })
+    expect(showDialog).not.toHaveBeenCalled()
+  })
+
+  describe('non-cloud distribution', () => {
+    beforeEach(() => {
+      mockIsCloud.value = false
+    })
+
+    it('opens the purchase dialog directly on the free tier instead of the subscription-required flow', async () => {
+      state.isFreeTier = true
+
+      await useDialogService().showTopUpCreditsDialog()
+
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      const [args] = showDialog.mock.calls[0]
+      expect(args.key).toBe('top-up-credits')
+    })
+
+    it('opens the purchase dialog even when the facade reports no active subscription', async () => {
+      state.isActiveSubscription = false
+
+      await useDialogService().showTopUpCreditsDialog()
+
+      expect(showSubscriptionDialog).not.toHaveBeenCalled()
+      const [args] = showDialog.mock.calls[0]
+      expect(args.key).toBe('top-up-credits')
+    })
+  })
+})

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -330,7 +330,7 @@ export const useDialogService = () => {
     isInsufficientCredits?: boolean
   }) {
     const { isActiveSubscription, isFreeTier, type } = useBillingContext()
-    if (!isActiveSubscription.value || isFreeTier.value) {
+    if (isCloud && (!isActiveSubscription.value || isFreeTier.value)) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits
           ? 'out_of_credits'


### PR DESCRIPTION
## Summary

Manual backport of #14587 to `core/1.47`. Non-cloud distributions now keep the Add credits purchase flow available and do not render Cloud-only subscribe/upgrade UI.

## Changes

- **What**: Gate the free-tier upgrade CTA and subscription-required top-up diversion on `isCloud`; carry over focused unit and local-browser regression coverage.
- **Manual backport**: The automatic cherry-pick conflicted because `core/1.47` has the older `CreditsTile` implementation and predates `dialogService.topUpCredits.test.ts`.
- **Conflict resolution**: Preserved the target branch's `gradient` button variant, monthly-credit calculations, workspace permission gating, package versions, and lockfile. Adapted the dialog regression test to the target service API and replaced source-only browser fixture/selectors with equivalent `core/1.47` APIs.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- Free-tier users on Cloud still see the upgrade path.
- Free-tier or inactive users on non-cloud distributions open the top-up dialog directly.
- The backport contains no package or lockfile changes.

## Verification

- `pnpm test:unit src/platform/cloud/subscription/components/CreditsTile.test.ts src/services/dialogService.topUpCredits.test.ts` — 23 tests passed.
- `pnpm typecheck` — passed via the commit hook.
- `pnpm typecheck:browser` — passed.
- ESLint, oxlint, oxfmt, stylelint, and knip — passed via commit/pre-push hooks.
- The focused Playwright spec was attempted locally but could not run because no test ComfyUI server was available at `127.0.0.1:5173`; it is included for CI execution.

## Screenshots

N/A — this is a distribution-gating behavior fix with unit and browser regression coverage; it does not introduce a visual design change.