### PR TITLE
fix(templates): make searchRank a real curator override in search ranking

### DIFF
--- a/docs/TEMPLATE_RANKING.md
+++ b/docs/TEMPLATE_RANKING.md
@@ -52,9 +52,10 @@ Set per template in the `workflow_templates` repo's `templates/index.json`. It i
 | `searchRank`   | Effect                                    |
 | -------------- | ----------------------------------------- |
 | absent, or `0` | Neutral. No influence on ordering         |
-| `1` … `1000`   | Promote, with rapidly diminishing returns |
+| `1` … `5`      | Neutral. Reserved, see below              |
+| `6` … `1000`   | Promote, with rapidly diminishing returns |
 | above `1000`   | Same as `1000`. Saturated, never larger   |
-| negative       | Demote, mirroring the positive curve      |
+| `-6` and below | Demote, mirroring the positive curve      |
 
 Magnitude follows `log1p(|searchRank|) / log1p(1000)`, capped at 1. The curve is logarithmic so the whole documented `0`–`1000` range from [`workflow_templates/docs/SPEC.md`](https://github.com/Comfy-Org/workflow_templates/blob/main/docs/SPEC.md) is usable, and saturating so an out-of-range value cannot swamp relevance:
 
@@ -66,6 +67,10 @@ Magnitude follows `log1p(|searchRank|) / log1p(1000)`, capped at 1. The curve is
 | `500`        | 0.90  | 1.27×             |
 | `1000`       | 1.00  | 1.30×             |
 | `1000000`    | 1.00  | 1.30×             |
+
+### Why `1`–`5` are inert
+
+`searchRank` previously used a 1–10 scale where 1–4 demoted and 5 was neutral. A handful of templates — the numbered starter workflows — still carry values from it. Reading those on the current scale would turn a demotion into a promotion, so magnitudes of 5 and below are ignored. Nothing is lost: on a 0–1000 dial a value that small is indistinguishable from noise.
 
 ### Why `0` is neutral rather than a demotion
 

--- a/docs/TEMPLATE_RANKING.md
+++ b/docs/TEMPLATE_RANKING.md
@@ -1,66 +1,83 @@
 # Template Ranking System
 
-Usage-based ordering for workflow templates with position bias normalization.
+How the template picker orders results, and how curators influence that order.
 
-Scores are pre-computed and normalized offline and shipped as static JSON (mirrors `sorted-custom-node-map.json` pattern for node search).
+There are two independent orderings: **search** (a query is active) and **browse** (no query). They use different code paths and different signals.
 
-## Sort Modes
+## Search ordering
 
-| Mode           | Formula                                          | Description            |
-| -------------- | ------------------------------------------------ | ---------------------- |
-| `recommended`  | `usage × 0.5 + internal × 0.3 + freshness × 0.2` | Curated recommendation |
-| `popular`      | `usage × 0.9 + freshness × 0.1`                  | Pure user-driven       |
-| `newest`       | Date sort                                        | Existing               |
-| `alphabetical` | Name sort                                        | Existing               |
+Implemented in [`src/composables/templateSearchConfig.ts`](../src/composables/templateSearchConfig.ts).
 
-Freshness computed at runtime from `template.date`: `1.0 / (1 + daysSinceAdded / 90)`, min 0.1.
+`searchTemplates()` runs MiniSearch (BM25) over `title`, `description`, `tags`, `models` and `name`, with field boosts `title ×3`, `models ×2`, `tags ×2`, `name ×1`, `description ×0.5`. It searches with `AND`, falls back to `OR` if that returns nothing, then repeats both for the abbreviation-expanded query (`i2v` → `image video`) and appends the deduplicated extras.
 
-## Data Files
+`rankByRelevanceThenUsage()` then orders the hits:
 
-**Usage scores** (generated from Mixpanel):
+1. Each hit's relevance score is scaled by its curation multiplier — `1 + searchRankBoost(searchRank) × 0.3`, so curation can move a hit by at most ±30%.
+2. Scores are bucketed into bands of 5% of the top score. Different band → higher score wins.
+3. Same band → higher `usage` wins, dampened with `log1p`.
+
+Bucketing keeps the result a stable total order; a pairwise "within X%" comparison is intransitive and would make the order depend on input order.
+
+The ±30% cap is the deliberate balance: it is roughly six tiebreak bands, enough for a curated launch template to clear near-equal matches, and never enough to drag a weak match to the top. Curation cannot introduce a template that does not match the query at all.
+
+## Browse ordering (sort dropdown)
+
+Implemented in [`src/composables/useTemplateFiltering.ts`](../src/composables/useTemplateFiltering.ts).
+
+| Mode                     | Ordering                                                        |
+| ------------------------ | --------------------------------------------------------------- |
+| `relevance`              | Search order, unmodified. Auto-selected while a query is active |
+| `default`                | The array order of `templates/index.json`                       |
+| `recommended`            | `usage × 0.5 + curation × 0.3 + freshness × 0.2`                |
+| `popular`                | Raw `usage`, descending                                         |
+| `newest`                 | `date`, descending                                              |
+| `alphabetical`           | Displayed title, A→Z, number-prefixed titles last               |
+| `model-size-low-to-high` | `size`, ascending                                               |
+
+`default` is a deliberate pass-through: the order of `templates/index.json` is the editorial lever owned by the `workflow_templates` repo. Reordering entries there is what changes the default browse order. See [#7062](https://github.com/Comfy-Org/ComfyUI_frontend/pull/7062) for why this is not a computed blend.
+
+`freshness` is computed at runtime from `template.date` as `max(0.1, 1 / (1 + daysSinceAdded / 90))`. `curation` is `searchRankBoost(searchRank)` shifted from `[-1, 1]` into `[0, 1]`, so an uncurated template sits at the 0.5 midpoint.
+
+## `searchRank`
+
+Set per template in the `workflow_templates` repo's `templates/index.json`. It is the manual override curators use to surface important templates — for example the templates accompanying a model launch.
 
 ```json
-// In templates/index.json, add to any template:
 {
-  "name": "some_template",
-  "usage": 1000,
-  ...
+  "name": "video_minimax_h3_i2v",
+  "searchRank": 1000
 }
 ```
 
-**Search rank** (set per-template in workflow_templates repo):
+| `searchRank`   | Effect                                    |
+| -------------- | ----------------------------------------- |
+| absent, or `0` | Neutral. No influence on ordering         |
+| `1` … `1000`   | Promote, with rapidly diminishing returns |
+| above `1000`   | Same as `1000`. Saturated, never larger   |
+| negative       | Demote, mirroring the positive curve      |
 
-```json
-// In templates/index.json, add to any template:
-{
-  "name": "some_template",
-  "searchRank": 8,  // Scale 1-10, default 5
-  ...
-}
-```
+Magnitude follows `log1p(|searchRank|) / log1p(1000)`, capped at 1. The curve is logarithmic so the whole documented `0`–`1000` range from [`workflow_templates/docs/SPEC.md`](https://github.com/Comfy-Org/workflow_templates/blob/main/docs/SPEC.md) is usable, and saturating so an out-of-range value cannot swamp relevance:
 
-| searchRank | Effect                       |
-| ---------- | ---------------------------- |
-| 1-4        | Demote (bury in results)     |
-| 5          | Neutral (default if not set) |
-| 6-10       | Promote (boost in results)   |
+| `searchRank` | Boost | Search multiplier |
+| ------------ | ----- | ----------------- |
+| `0`          | 0.00  | 1.00×             |
+| `8`          | 0.32  | 1.10×             |
+| `100`        | 0.67  | 1.20×             |
+| `500`        | 0.90  | 1.27×             |
+| `1000`       | 1.00  | 1.30×             |
+| `1000000`    | 1.00  | 1.30×             |
 
-## Position Bias Correction
+### Why `0` is neutral rather than a demotion
 
-Raw usage reflects true preference AND UI position bias. We use linear interpolation:
+`workflow_templates` documents the field as "0-1000, higher = better ranking", and its tooling writes an explicit `"searchRank": 0` onto templates that nobody has curated — the majority of the catalog. Treating `0` as a demotion would therefore bury most templates beneath the minority that simply omit the field. Explicit demotion uses negative values instead.
+
+## `usage`
+
+A per-template count shipped in `templates/index.json`, refreshed periodically from real usage data. It drives the `popular` sort, the `recommended` blend, and the search tiebreak within a score band.
+
+Raw usage reflects both genuine preference and UI position bias, so it is normalized offline before being committed. Position-bias correction uses linear interpolation, giving templates buried further down up to a 2× correction:
 
 ```
 correction = 1 + (position - 1) / (maxPosition - 1)
 normalizedUsage = rawUsage × correction
 ```
-
-| Position | Boost |
-| -------- | ----- |
-| 1        | 1.0×  |
-| 50       | 1.28× |
-| 100      | 1.57× |
-| 175      | 2.0×  |
-
-Templates buried at the bottom get up to 2× boost to compensate for reduced visibility.
-
----

--- a/docs/TEMPLATE_RANKING.md
+++ b/docs/TEMPLATE_RANKING.md
@@ -57,7 +57,7 @@ Set per template in the `workflow_templates` repo's `templates/index.json`. It i
 | above `1000`   | Same as `1000`. Saturated, never larger   |
 | `-6` and below | Demote, mirroring the positive curve      |
 
-Magnitude follows `log1p(|searchRank|) / log1p(1000)`, capped at 1. The curve is logarithmic so the whole documented `0`–`1000` range from [`workflow_templates/docs/SPEC.md`](https://github.com/Comfy-Org/workflow_templates/blob/main/docs/SPEC.md) is usable, and saturating so an out-of-range value cannot swamp relevance:
+`searchRankBoost()` in [`src/platform/workflow/templates/utils/templateRanking.ts`](../src/platform/workflow/templates/utils/templateRanking.ts) is the single definition of what the field means; both the search path and the `recommended` sort read it. Magnitude follows `log1p(|searchRank|) / log1p(1000)`, capped at 1. The curve is logarithmic so the whole documented `0`–`1000` range from [`workflow_templates/docs/SPEC.md`](https://github.com/Comfy-Org/workflow_templates/blob/main/docs/SPEC.md) is usable, and saturating so an out-of-range value cannot swamp relevance:
 
 | `searchRank` | Boost | Search multiplier |
 | ------------ | ----- | ----------------- |

--- a/src/composables/templateSearchConfig.test.ts
+++ b/src/composables/templateSearchConfig.test.ts
@@ -7,7 +7,6 @@ import {
   expandAbbreviation,
   expandQuery,
   rankByRelevanceThenUsage,
-  searchRankBoost,
   searchTemplates,
   termFuzziness,
   tokenize
@@ -279,38 +278,6 @@ describe('searchTemplates', () => {
       buildTemplate({ name: 'exact', title: 'ControlNet' })
     ])
     expect(searchTemplates(index, 'controlnet')[0]).toBe('exact')
-  })
-})
-
-describe('searchRankBoost', () => {
-  // Most of the catalog ships an explicit `"searchRank": 0` from tooling, so 0
-  // must mean the same thing as an absent field, not a demotion.
-  it('treats unset, zero and non-numeric ranks as the same neutral baseline', () => {
-    expect(searchRankBoost(undefined)).toBe(0)
-    expect(searchRankBoost(0)).toBe(0)
-    expect(searchRankBoost(Number.NaN)).toBe(0)
-  })
-
-  it('promotes on positive and demotes on negative, symmetrically', () => {
-    expect(searchRankBoost(8)).toBeGreaterThan(0)
-    expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
-  })
-
-  // The retired 1-10 scale read 1-4 as "demote" and 5 as "neutral"; the starter
-  // templates still ship searchRank 3. Reading those as a promotion would
-  // invert the only intent their authors could have had.
-  it('ignores magnitudes left over from the retired 1-10 scale', () => {
-    for (const legacyRank of [1, 2, 3, 4, 5]) {
-      expect(searchRankBoost(legacyRank)).toBe(0)
-    }
-    expect(searchRankBoost(6)).toBeGreaterThan(0)
-  })
-
-  it('increases with rank but saturates so out-of-range values stay bounded', () => {
-    expect(searchRankBoost(1000)).toBeGreaterThan(searchRankBoost(8))
-    expect(searchRankBoost(1_000_000)).toBe(1)
-    expect(searchRankBoost(Number.MAX_SAFE_INTEGER)).toBe(1)
-    expect(searchRankBoost(-1_000_000)).toBe(-1)
   })
 })
 

--- a/src/composables/templateSearchConfig.test.ts
+++ b/src/composables/templateSearchConfig.test.ts
@@ -7,6 +7,7 @@ import {
   expandAbbreviation,
   expandQuery,
   rankByRelevanceThenUsage,
+  searchRankBoost,
   searchTemplates,
   termFuzziness,
   tokenize
@@ -281,9 +282,39 @@ describe('searchTemplates', () => {
   })
 })
 
+describe('searchRankBoost', () => {
+  // Most of the catalog ships an explicit `"searchRank": 0` from tooling, so 0
+  // must mean the same thing as an absent field, not a demotion.
+  it('treats unset, zero and non-numeric ranks as the same neutral baseline', () => {
+    expect(searchRankBoost(undefined)).toBe(0)
+    expect(searchRankBoost(0)).toBe(0)
+    expect(searchRankBoost(Number.NaN)).toBe(0)
+  })
+
+  it('promotes on positive and demotes on negative, symmetrically', () => {
+    expect(searchRankBoost(8)).toBeGreaterThan(0)
+    expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
+  })
+
+  it('increases with rank but saturates so out-of-range values stay bounded', () => {
+    expect(searchRankBoost(1000)).toBeGreaterThan(searchRankBoost(8))
+    expect(searchRankBoost(1_000_000)).toBe(1)
+    expect(searchRankBoost(Number.MAX_SAFE_INTEGER)).toBe(1)
+    expect(searchRankBoost(-1_000_000)).toBe(-1)
+  })
+})
+
 describe('rankByRelevanceThenUsage', () => {
   const hit = (id: string, score: number, usage: number): SearchResult =>
     ({ id, score, usage }) as unknown as SearchResult
+
+  const curatedHit = (
+    id: string,
+    score: number,
+    usage: number,
+    searchRank: number
+  ): SearchResult =>
+    ({ id, score, usage, searchRank }) as unknown as SearchResult
 
   // Scores 0.93/0.965/1.0 with usages 100/50/1 form an intransitive cycle under
   // a pairwise relative-band compare (A>B, B>C, but A<C), which makes Array.sort
@@ -312,5 +343,46 @@ describe('rankByRelevanceThenUsage', () => {
     )
     // near (higher usage, same band as strong) leads; weak stays last on score.
     expect(ids).toEqual(['near', 'strong', 'weak'])
+  })
+
+  it('lets curation lift a near-equal match above a slightly better one', () => {
+    const best = hit('best', 1.0, 0)
+    const curated = curatedHit('curated', 0.94, 0, 1000)
+
+    expect(rankByRelevanceThenUsage([best, curated]).map((h) => h.id)).toEqual([
+      'curated',
+      'best'
+    ])
+  })
+
+  it('never lets curation drag a weak match over a strong one', () => {
+    const strong = hit('strong', 1.0, 0)
+    const weakButCurated = curatedHit('weak', 0.4, 0, 1_000_000)
+
+    expect(
+      rankByRelevanceThenUsage([weakButCurated, strong]).map((h) => h.id)
+    ).toEqual(['strong', 'weak'])
+  })
+
+  it('leaves ordering untouched when no hit is curated', () => {
+    const hits = [hit('a', 1.0, 5), hit('b', 0.5, 900), hit('c', 0.2, 1)]
+
+    expect(rankByRelevanceThenUsage(hits).map((h) => h.id)).toEqual([
+      'a',
+      'b',
+      'c'
+    ])
+  })
+
+  // A demoting zero would knock `zero` into a lower score bucket, so `unset`
+  // would win on score instead of losing on usage.
+  it('ranks an explicit zero the same as an absent searchRank', () => {
+    const zero = curatedHit('zero', 1.0, 900, 0)
+    const unset = hit('unset', 1.0, 1)
+
+    expect(rankByRelevanceThenUsage([unset, zero]).map((h) => h.id)).toEqual([
+      'zero',
+      'unset'
+    ])
   })
 })

--- a/src/composables/templateSearchConfig.test.ts
+++ b/src/composables/templateSearchConfig.test.ts
@@ -293,10 +293,9 @@ describe('rankByRelevanceThenUsage', () => {
   ): SearchResult =>
     ({ id, score, usage, searchRank }) as unknown as SearchResult
 
-  // Scores 0.93/0.965/1.0 with usages 100/50/1 form an intransitive cycle under
-  // a pairwise relative-band compare (A>B, B>C, but A<C), which makes Array.sort
-  // input-order-dependent. Bucketing must give one stable order for any input.
   it('produces a stable order for an intransitive cluster', () => {
+    // These scores and usages cycle under a pairwise relative-band compare
+    // (A>B, B>C, but A<C), which makes Array.sort input-order-dependent.
     const a = hit('a', 0.93, 100)
     const b = hit('b', 0.965, 50)
     const c = hit('c', 1.0, 1)
@@ -304,10 +303,11 @@ describe('rankByRelevanceThenUsage', () => {
     const order = (hits: SearchResult[]) =>
       rankByRelevanceThenUsage(hits).map((h) => h.id)
 
+    const stable = 'an intransitive score cluster must resolve to one order'
     const expected = order([a, b, c])
-    expect(order([c, b, a])).toEqual(expected)
-    expect(order([b, a, c])).toEqual(expected)
-    expect(order([c, a, b])).toEqual(expected)
+    expect(order([c, b, a]), stable).toEqual(expected)
+    expect(order([b, a, c]), stable).toEqual(expected)
+    expect(order([c, a, b]), stable).toEqual(expected)
   })
 
   it('breaks ties within a band by usage but not across bands', () => {
@@ -318,8 +318,10 @@ describe('rankByRelevanceThenUsage', () => {
     const ids = rankByRelevanceThenUsage([weak, strong, nearStrong]).map(
       (h) => h.id
     )
-    // near (higher usage, same band as strong) leads; weak stays last on score.
-    expect(ids).toEqual(['near', 'strong', 'weak'])
+    expect(
+      ids,
+      "near leads on usage inside strong's band; weak stays last on score"
+    ).toEqual(['near', 'strong', 'weak'])
   })
 
   it('lets curation lift a near-equal match above a slightly better one', () => {
@@ -351,15 +353,13 @@ describe('rankByRelevanceThenUsage', () => {
     ])
   })
 
-  // A demoting zero would knock `zero` into a lower score bucket, so `unset`
-  // would win on score instead of losing on usage.
   it('ranks an explicit zero the same as an absent searchRank', () => {
     const zero = curatedHit('zero', 1.0, 900, 0)
     const unset = hit('unset', 1.0, 1)
 
-    expect(rankByRelevanceThenUsage([unset, zero]).map((h) => h.id)).toEqual([
-      'zero',
-      'unset'
-    ])
+    expect(
+      rankByRelevanceThenUsage([unset, zero]).map((h) => h.id),
+      'a demoting zero would drop `zero` a bucket and let `unset` win on score'
+    ).toEqual(['zero', 'unset'])
   })
 })

--- a/src/composables/templateSearchConfig.test.ts
+++ b/src/composables/templateSearchConfig.test.ts
@@ -296,6 +296,16 @@ describe('searchRankBoost', () => {
     expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
   })
 
+  // The retired 1-10 scale read 1-4 as "demote" and 5 as "neutral"; the starter
+  // templates still ship searchRank 3. Reading those as a promotion would
+  // invert the only intent their authors could have had.
+  it('ignores magnitudes left over from the retired 1-10 scale', () => {
+    for (const legacyRank of [1, 2, 3, 4, 5]) {
+      expect(searchRankBoost(legacyRank)).toBe(0)
+    }
+    expect(searchRankBoost(6)).toBeGreaterThan(0)
+  })
+
   it('increases with rank but saturates so out-of-range values stay bounded', () => {
     expect(searchRankBoost(1000)).toBeGreaterThan(searchRankBoost(8))
     expect(searchRankBoost(1_000_000)).toBe(1)

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -19,9 +19,8 @@ const SEARCH_FIELDS = [
 // never overrides a clearly-better text match. 5% tuned empirically.
 const USAGE_TIEBREAK_BAND = 0.05
 
-// How far curation may move a hit relative to its text relevance. ±30% is ~6
-// tiebreak bands: enough to lift a launch template over near-equal matches,
-// never enough to drag a weak match to the top.
+// ~6 tiebreak bands of headroom: enough to lift a near-equal match, never
+// enough to surface a weak one.
 const SEARCH_RANK_RELEVANCE_WEIGHT = 0.3
 
 // Script-matched so spaced neighbors like Korean fall to the word tokenizer.

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -2,6 +2,7 @@ import MiniSearch from 'minisearch'
 import type { SearchResult } from 'minisearch'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
+import { searchRankBoost } from '@/platform/workflow/templates/utils/templateRanking'
 
 // MiniSearch serializes the index but not the search options, so the tokenizer
 // and field list live here and are used at both index and query time.
@@ -17,17 +18,6 @@ const SEARCH_FIELDS = [
 // Usage only reorders hits within this fraction of the top score, so popularity
 // never overrides a clearly-better text match. 5% tuned empirically.
 const USAGE_TIEBREAK_BAND = 0.05
-
-// `searchRank` is the curator dial authored in workflow_templates, specified
-// there as "0-1000, higher = better" (docs/SPEC.md). Magnitude saturates on a
-// log curve so the values curators actually write — 8, 500, 1000, 1_000_000 —
-// all land inside the cap instead of swamping relevance.
-const SEARCH_RANK_SATURATION = 1000
-
-// The retired 1-10 scale used 1-4 to demote and 5 as neutral. Those magnitudes
-// are noise on a 0-1000 dial, so ignoring them honours both contracts: no
-// legacy value ever flips from demotion to promotion.
-const SEARCH_RANK_DEAD_ZONE = 5
 
 // How far curation may move a hit relative to its text relevance. ±30% is ~6
 // tiebreak bands: enough to lift a launch template over near-equal matches,
@@ -171,22 +161,6 @@ export function createTemplateSearchIndex(
   })
   index.addAll(templates)
   return index
-}
-
-/**
- * Curator intent as a signed strength in [-1, 1]. Unset, non-numeric, and any
- * rank within the dead zone are the same neutral baseline — most of the catalog
- * ships an explicit `"searchRank": 0` meaning "not curated", so 0 must not
- * demote. Promotion starts once the rank exceeds the dead zone and demotion
- * once it falls below the negative of it, each saturating at the cap.
- */
-export function searchRankBoost(searchRank: number | undefined): number {
-  if (!searchRank || Math.abs(searchRank) <= SEARCH_RANK_DEAD_ZONE) return 0
-  const magnitude = Math.min(
-    1,
-    Math.log1p(Math.abs(searchRank)) / Math.log1p(SEARCH_RANK_SATURATION)
-  )
-  return Math.sign(searchRank) * magnitude
 }
 
 function searchRankMultiplier(searchRank: number | undefined): number {

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -18,6 +18,17 @@ const SEARCH_FIELDS = [
 // never overrides a clearly-better text match. 5% tuned empirically.
 const USAGE_TIEBREAK_BAND = 0.05
 
+// `searchRank` is the curator dial authored in workflow_templates, specified
+// there as "0-1000, higher = better" (docs/SPEC.md). Magnitude saturates on a
+// log curve so the values curators actually write — 8, 500, 1000, 1_000_000 —
+// all land inside the cap instead of swamping relevance.
+const SEARCH_RANK_SATURATION = 1000
+
+// How far curation may move a hit relative to its text relevance. ±30% is ~6
+// tiebreak bands: enough to lift a launch template over near-equal matches,
+// never enough to drag a weak match to the top.
+const SEARCH_RANK_RELEVANCE_WEIGHT = 0.3
+
 // Script-matched so spaced neighbors like Korean fall to the word tokenizer.
 const CJK = /[\p{scx=Han}\p{scx=Hiragana}\p{scx=Katakana}]/u
 const CJK_RUN = new RegExp(`${CJK.source}+`, 'gu')
@@ -137,8 +148,9 @@ export function createTemplateSearchIndex(
   const index = new MiniSearch<TemplateInfo>({
     idField: 'name',
     fields: [...SEARCH_FIELDS],
-    // Returned on each hit so the tiebreak can read usage without a second lookup.
-    storeFields: ['usage'],
+    // Returned on each hit so ranking can read usage and curation without a
+    // second lookup.
+    storeFields: ['usage', 'searchRank'],
     // Index the localized strings the card actually shows, so a match explains
     // a visible result.
     extractField: (template, field) => {
@@ -156,18 +168,47 @@ export function createTemplateSearchIndex(
   return index
 }
 
-// Rank by relevance, with usage breaking ties inside a score band. Scores are
-// bucketed so the ordering is a stable total order (a pairwise relative-band
-// compare is intransitive). log1p dampens heavy-tailed usage.
+/**
+ * Curator intent as a signed strength in [-1, 1]. Unset, `0` and non-numeric
+ * ranks are all the same neutral baseline — most of the catalog ships an
+ * explicit `"searchRank": 0` meaning "not curated", so 0 must not demote.
+ * Positive promotes, negative demotes, and magnitude saturates at the cap.
+ */
+export function searchRankBoost(searchRank: number | undefined): number {
+  if (!searchRank) return 0
+  const magnitude = Math.min(
+    1,
+    Math.log1p(Math.abs(searchRank)) / Math.log1p(SEARCH_RANK_SATURATION)
+  )
+  return Math.sign(searchRank) * magnitude
+}
+
+function searchRankMultiplier(searchRank: number | undefined): number {
+  return 1 + searchRankBoost(searchRank) * SEARCH_RANK_RELEVANCE_WEIGHT
+}
+
+// Rank by curated relevance, with usage breaking ties inside a score band.
+// Scores are bucketed so the ordering is a stable total order (a pairwise
+// relative-band compare is intransitive). log1p dampens heavy-tailed usage.
 export function rankByRelevanceThenUsage(hits: SearchResult[]): SearchResult[] {
+  const ranked = hits.map((hit) => ({
+    hit,
+    score: hit.score * searchRankMultiplier(Number(hit.searchRank ?? 0))
+  }))
   const bandSize =
-    hits.reduce((max, hit) => Math.max(max, hit.score), 0) * USAGE_TIEBREAK_BAND
+    ranked.reduce((max, entry) => Math.max(max, entry.score), 0) *
+    USAGE_TIEBREAK_BAND
   const bucket = (score: number) =>
     bandSize > 0 ? Math.round(score / bandSize) : 0
-  return [...hits].sort((a, b) => {
-    if (bucket(a.score) !== bucket(b.score)) return b.score - a.score
-    return Math.log1p(Number(b.usage ?? 0)) - Math.log1p(Number(a.usage ?? 0))
-  })
+  return ranked
+    .sort((a, b) => {
+      if (bucket(a.score) !== bucket(b.score)) return b.score - a.score
+      return (
+        Math.log1p(Number(b.hit.usage ?? 0)) -
+        Math.log1p(Number(a.hit.usage ?? 0))
+      )
+    })
+    .map((entry) => entry.hit)
 }
 
 /** Ordered template names for a query: literal matches first, then dedup'd expansion matches. */

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -174,10 +174,11 @@ export function createTemplateSearchIndex(
 }
 
 /**
- * Curator intent as a signed strength in [-1, 1]. Unset, `0`, non-numeric and
- * dead-zone ranks are all the same neutral baseline — most of the catalog ships
- * an explicit `"searchRank": 0` meaning "not curated", so 0 must not demote.
- * Positive promotes, negative demotes, and magnitude saturates at the cap.
+ * Curator intent as a signed strength in [-1, 1]. Unset, non-numeric, and any
+ * rank within the dead zone are the same neutral baseline — most of the catalog
+ * ships an explicit `"searchRank": 0` meaning "not curated", so 0 must not
+ * demote. Promotion starts once the rank exceeds the dead zone and demotion
+ * once it falls below the negative of it, each saturating at the cap.
  */
 export function searchRankBoost(searchRank: number | undefined): number {
   if (!searchRank || Math.abs(searchRank) <= SEARCH_RANK_DEAD_ZONE) return 0

--- a/src/composables/templateSearchConfig.ts
+++ b/src/composables/templateSearchConfig.ts
@@ -24,6 +24,11 @@ const USAGE_TIEBREAK_BAND = 0.05
 // all land inside the cap instead of swamping relevance.
 const SEARCH_RANK_SATURATION = 1000
 
+// The retired 1-10 scale used 1-4 to demote and 5 as neutral. Those magnitudes
+// are noise on a 0-1000 dial, so ignoring them honours both contracts: no
+// legacy value ever flips from demotion to promotion.
+const SEARCH_RANK_DEAD_ZONE = 5
+
 // How far curation may move a hit relative to its text relevance. ±30% is ~6
 // tiebreak bands: enough to lift a launch template over near-equal matches,
 // never enough to drag a weak match to the top.
@@ -169,13 +174,13 @@ export function createTemplateSearchIndex(
 }
 
 /**
- * Curator intent as a signed strength in [-1, 1]. Unset, `0` and non-numeric
- * ranks are all the same neutral baseline — most of the catalog ships an
- * explicit `"searchRank": 0` meaning "not curated", so 0 must not demote.
+ * Curator intent as a signed strength in [-1, 1]. Unset, `0`, non-numeric and
+ * dead-zone ranks are all the same neutral baseline — most of the catalog ships
+ * an explicit `"searchRank": 0` meaning "not curated", so 0 must not demote.
  * Positive promotes, negative demotes, and magnitude saturates at the cap.
  */
 export function searchRankBoost(searchRank: number | undefined): number {
-  if (!searchRank) return 0
+  if (!searchRank || Math.abs(searchRank) <= SEARCH_RANK_DEAD_ZONE) return 0
   const magnitude = Math.min(
     1,
     Math.log1p(Math.abs(searchRank)) / Math.log1p(SEARCH_RANK_SATURATION)

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -41,8 +41,9 @@ export interface TemplateInfo {
   requiresCustomNodes?: string[]
   /**
    * Curator override applied to search relevance and the "Recommended" sort.
-   * Absent or 0 is neutral, positive promotes, negative demotes; magnitude
-   * saturates at 1000. See docs/TEMPLATE_RANKING.md.
+   * Anything from -5 to 5, and an absent value, is neutral; promotion starts at
+   * 6 and demotion at -6, both saturating at a magnitude of 1000.
+   * See docs/TEMPLATE_RANKING.md.
    */
   searchRank?: number
   /**

--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -40,8 +40,9 @@ export interface TemplateInfo {
    */
   requiresCustomNodes?: string[]
   /**
-   * Manual ranking boost/demotion for "Recommended" sort. Scale 1-10, default 5.
-   * Higher values promote the template, lower values demote it.
+   * Curator override applied to search relevance and the "Recommended" sort.
+   * Absent or 0 is neutral, positive promotes, negative demotes; magnitude
+   * saturates at 1000. See docs/TEMPLATE_RANKING.md.
    */
   searchRank?: number
   /**

--- a/src/platform/workflow/templates/utils/templateRanking.test.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { searchRankBoost } from '@/platform/workflow/templates/utils/templateRanking'
 
 describe('searchRankBoost', () => {
-  // Most of the catalog ships an explicit `"searchRank": 0` from tooling, so 0
-  // must mean the same thing as an absent field, not a demotion.
   it('treats unset, zero and non-numeric ranks as the same neutral baseline', () => {
     expect(searchRankBoost(undefined)).toBe(0)
-    expect(searchRankBoost(0)).toBe(0)
+    expect(
+      searchRankBoost(0),
+      'tooling writes an explicit 0 for uncurated templates, so 0 must not demote'
+    ).toBe(0)
     expect(searchRankBoost(Number.NaN)).toBe(0)
   })
 
@@ -16,12 +17,11 @@ describe('searchRankBoost', () => {
     expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
   })
 
-  // The dead zone exists because the retired 1-10 scale read 1-4 as "demote"
-  // and 5 as "neutral", and the starter templates still ship searchRank 3.
-  // Reading those as a promotion would invert their authors' only intent.
   it('stays neutral inside the dead zone and engages just outside it', () => {
+    const inert =
+      "retired 1-10 ranks like the starter templates' 3 must stay inert"
     for (const insideDeadZone of [1, 2, 3, 4, 5, -1, -5]) {
-      expect(searchRankBoost(insideDeadZone)).toBe(0)
+      expect(searchRankBoost(insideDeadZone), inert).toBe(0)
     }
     expect(searchRankBoost(6)).toBeGreaterThan(0)
     expect(searchRankBoost(-6)).toBeLessThan(0)

--- a/src/platform/workflow/templates/utils/templateRanking.test.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.test.ts
@@ -16,14 +16,15 @@ describe('searchRankBoost', () => {
     expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
   })
 
-  // The retired 1-10 scale read 1-4 as "demote" and 5 as "neutral"; the starter
-  // templates still ship searchRank 3. Reading those as a promotion would
-  // invert the only intent their authors could have had.
-  it('ignores magnitudes left over from the retired 1-10 scale', () => {
-    for (const legacyRank of [1, 2, 3, 4, 5]) {
-      expect(searchRankBoost(legacyRank)).toBe(0)
+  // The dead zone exists because the retired 1-10 scale read 1-4 as "demote"
+  // and 5 as "neutral", and the starter templates still ship searchRank 3.
+  // Reading those as a promotion would invert their authors' only intent.
+  it('stays neutral inside the dead zone and engages just outside it', () => {
+    for (const insideDeadZone of [1, 2, 3, 4, 5, -1, -5]) {
+      expect(searchRankBoost(insideDeadZone)).toBe(0)
     }
     expect(searchRankBoost(6)).toBeGreaterThan(0)
+    expect(searchRankBoost(-6)).toBeLessThan(0)
   })
 
   it('increases with rank but saturates so out-of-range values stay bounded', () => {

--- a/src/platform/workflow/templates/utils/templateRanking.test.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { searchRankBoost } from '@/platform/workflow/templates/utils/templateRanking'
+
+describe('searchRankBoost', () => {
+  // Most of the catalog ships an explicit `"searchRank": 0` from tooling, so 0
+  // must mean the same thing as an absent field, not a demotion.
+  it('treats unset, zero and non-numeric ranks as the same neutral baseline', () => {
+    expect(searchRankBoost(undefined)).toBe(0)
+    expect(searchRankBoost(0)).toBe(0)
+    expect(searchRankBoost(Number.NaN)).toBe(0)
+  })
+
+  it('promotes on positive and demotes on negative, symmetrically', () => {
+    expect(searchRankBoost(8)).toBeGreaterThan(0)
+    expect(searchRankBoost(-8)).toBeCloseTo(-searchRankBoost(8), 10)
+  })
+
+  // The retired 1-10 scale read 1-4 as "demote" and 5 as "neutral"; the starter
+  // templates still ship searchRank 3. Reading those as a promotion would
+  // invert the only intent their authors could have had.
+  it('ignores magnitudes left over from the retired 1-10 scale', () => {
+    for (const legacyRank of [1, 2, 3, 4, 5]) {
+      expect(searchRankBoost(legacyRank)).toBe(0)
+    }
+    expect(searchRankBoost(6)).toBeGreaterThan(0)
+  })
+
+  it('increases with rank but saturates so out-of-range values stay bounded', () => {
+    expect(searchRankBoost(1000)).toBeGreaterThan(searchRankBoost(8))
+    expect(searchRankBoost(1_000_000)).toBe(1)
+    expect(searchRankBoost(Number.MAX_SAFE_INTEGER)).toBe(1)
+    expect(searchRankBoost(-1_000_000)).toBe(-1)
+  })
+})

--- a/src/platform/workflow/templates/utils/templateRanking.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.ts
@@ -1,12 +1,7 @@
-// `searchRank` is the curator dial authored in workflow_templates, specified
-// there as "0-1000, higher = better" (docs/SPEC.md). Magnitude saturates on a
-// log curve so the values curators actually write — 8, 500, 1000, 1_000_000 —
-// all land inside the cap instead of swamping whatever it is applied to.
+// Ceiling of the authored 0-1000 range (workflow_templates docs/SPEC.md).
 const SEARCH_RANK_SATURATION = 1000
 
-// The retired 1-10 scale used 1-4 to demote and 5 as neutral. Those magnitudes
-// are noise on a 0-1000 dial, so ignoring them honours both contracts: no
-// legacy value ever flips from demotion to promotion.
+// Spans the retired 1-10 scale's demote band; no legacy value flips to promote.
 const SEARCH_RANK_DEAD_ZONE = 5
 
 /**

--- a/src/platform/workflow/templates/utils/templateRanking.ts
+++ b/src/platform/workflow/templates/utils/templateRanking.ts
@@ -1,0 +1,26 @@
+// `searchRank` is the curator dial authored in workflow_templates, specified
+// there as "0-1000, higher = better" (docs/SPEC.md). Magnitude saturates on a
+// log curve so the values curators actually write — 8, 500, 1000, 1_000_000 —
+// all land inside the cap instead of swamping whatever it is applied to.
+const SEARCH_RANK_SATURATION = 1000
+
+// The retired 1-10 scale used 1-4 to demote and 5 as neutral. Those magnitudes
+// are noise on a 0-1000 dial, so ignoring them honours both contracts: no
+// legacy value ever flips from demotion to promotion.
+const SEARCH_RANK_DEAD_ZONE = 5
+
+/**
+ * Curator intent as a signed strength in [-1, 1]. Unset, non-numeric, and any
+ * rank within the dead zone are the same neutral baseline — most of the catalog
+ * ships an explicit `"searchRank": 0` meaning "not curated", so 0 must not
+ * demote. Promotion starts once the rank exceeds the dead zone and demotion
+ * once it falls below the negative of it, each saturating at the cap.
+ */
+export function searchRankBoost(searchRank: number | undefined): number {
+  if (!searchRank || Math.abs(searchRank) <= SEARCH_RANK_DEAD_ZONE) return 0
+  const magnitude = Math.min(
+    1,
+    Math.log1p(Math.abs(searchRank)) / Math.log1p(SEARCH_RANK_SATURATION)
+  )
+  return Math.sign(searchRank) * magnitude
+}

--- a/src/stores/templateRankingStore.test.ts
+++ b/src/stores/templateRankingStore.test.ts
@@ -52,65 +52,51 @@ describe('templateRankingStore', () => {
   })
 
   describe('computeDefaultScore', () => {
-    it('uses default searchRank of 5 when not provided', () => {
+    it('scores an uncurated template from usage and freshness alone', () => {
       const store = useTemplateRankingStore()
-      // Set largestUsageScore to avoid NaN when usage is 0
       store.largestUsageScore = 100
-      const score = store.computeDefaultScore('2024-01-01', undefined, 0)
-      // With no usage score loaded, usage = 0
-      // internal = 5/10 = 0.5, freshness ~0.1 (old date)
-      // score = 0 * 0.5 + 0.5 * 0.3 + 0.1 * 0.2 = 0.15 + 0.02 = 0.17
-      expect(score).toBeCloseTo(0.17, 1)
+      // curation = neutral 0.5, freshness = 0.1 (old date), usage = 0
+      // score = 0 * 0.5 + 0.5 * 0.3 + 0.1 * 0.2 = 0.17
+      expect(store.computeDefaultScore('2024-01-01', undefined, 0)).toBeCloseTo(
+        0.17,
+        2
+      )
     })
 
-    it('high searchRank (10) boosts score', () => {
+    it('ranks promoted above neutral above demoted', () => {
       const store = useTemplateRankingStore()
       store.largestUsageScore = 100
-      const lowRank = store.computeDefaultScore('2024-01-01', 1, 0)
-      const highRank = store.computeDefaultScore('2024-01-01', 10, 0)
-      expect(highRank).toBeGreaterThan(lowRank)
+      const promoted = store.computeDefaultScore('2024-01-01', 1000, 0)
+      const neutral = store.computeDefaultScore('2024-01-01', 0, 0)
+      const demoted = store.computeDefaultScore('2024-01-01', -1000, 0)
+
+      expect(promoted).toBeGreaterThan(neutral)
+      expect(neutral).toBeGreaterThan(demoted)
     })
 
-    it('low searchRank (1) demotes score', () => {
+    it('scores an explicit zero the same as an absent searchRank', () => {
       const store = useTemplateRankingStore()
       store.largestUsageScore = 100
-      const neutral = store.computeDefaultScore('2024-01-01', 5, 0)
-      const demoted = store.computeDefaultScore('2024-01-01', 1, 0)
-      expect(demoted).toBeLessThan(neutral)
+
+      expect(store.computeDefaultScore('2024-01-01', 0, 0)).toBe(
+        store.computeDefaultScore('2024-01-01', undefined, 0)
+      )
     })
 
-    it('searchRank difference is significant', () => {
+    it('saturates out-of-range ranks instead of returning runaway scores', () => {
       const store = useTemplateRankingStore()
       store.largestUsageScore = 100
-      const rank1 = store.computeDefaultScore('2024-01-01', 1, 0)
-      const rank10 = store.computeDefaultScore('2024-01-01', 10, 0)
-      // Difference should be 0.9 * 0.3 = 0.27 (30% weight, 0.9 range)
-      expect(rank10 - rank1).toBeCloseTo(0.27, 2)
-    })
-  })
+      const capped = store.computeDefaultScore('2024-01-01', 1000, 0)
 
-  describe('searchRank edge cases', () => {
-    it('handles searchRank of 0 (should still work, treated as very low)', () => {
-      const store = useTemplateRankingStore()
-      store.largestUsageScore = 100
-      const score = store.computeDefaultScore('2024-01-01', 0, 0)
-      expect(score).toBeGreaterThanOrEqual(0)
+      expect(store.computeDefaultScore('2024-01-01', 1_000_000, 0)).toBe(capped)
+      expect(capped).toBeLessThanOrEqual(1)
     })
 
-    it('handles searchRank above 10 (clamping not enforced, but works)', () => {
+    it('stays finite when nothing in the filtered set has usage', () => {
       const store = useTemplateRankingStore()
-      store.largestUsageScore = 100
-      const rank10 = store.computeDefaultScore('2024-01-01', 10, 0)
-      const rank15 = store.computeDefaultScore('2024-01-01', 15, 0)
-      expect(rank15).toBeGreaterThan(rank10)
-    })
+      store.largestUsageScore = 0
 
-    it('handles negative searchRank', () => {
-      const store = useTemplateRankingStore()
-      store.largestUsageScore = 100
-      const score = store.computeDefaultScore('2024-01-01', -5, 0)
-      // Should still compute, just negative contribution from searchRank
-      expect(typeof score).toBe('number')
+      expect(store.computeDefaultScore('2024-01-01', 8, 0)).toBeGreaterThan(0)
     })
   })
 })

--- a/src/stores/templateRankingStore.ts
+++ b/src/stores/templateRankingStore.ts
@@ -8,7 +8,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-import { searchRankBoost } from '@/composables/templateSearchConfig'
+import { searchRankBoost } from '@/platform/workflow/templates/utils/templateRanking'
 
 export const useTemplateRankingStore = defineStore('templateRanking', () => {
   const largestUsageScore = ref<number>()

--- a/src/stores/templateRankingStore.ts
+++ b/src/stores/templateRankingStore.ts
@@ -8,11 +8,14 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+import { searchRankBoost } from '@/composables/templateSearchConfig'
+
 export const useTemplateRankingStore = defineStore('templateRanking', () => {
   const largestUsageScore = ref<number>()
 
   const normalizeUsageScore = (usage: number): number => {
-    return usage / (largestUsageScore.value ?? usage)
+    const largest = largestUsageScore.value
+    return largest ? usage / largest : 0
   }
 
   /**
@@ -30,18 +33,19 @@ export const useTemplateRankingStore = defineStore('templateRanking', () => {
   }
 
   /**
-   * Compute composite score for "default" sort.
-   * Formula: usage × 0.5 + internal × 0.3 + freshness × 0.2
+   * Compute composite score for "recommended" sort.
+   * Formula: usage × 0.5 + curation × 0.3 + freshness × 0.2
    */
   const computeDefaultScore = (
     dateStr: string | undefined,
     searchRank: number | undefined,
     usage: number = 0
   ): number => {
-    const internal = (searchRank ?? 5) / 10 // Normalize 1-10 to 0-1
+    // searchRankBoost is [-1, 1]; shift to [0, 1] so neutral stays the midpoint.
+    const curation = (searchRankBoost(searchRank) + 1) / 2
     const freshness = computeFreshness(dateStr)
 
-    return normalizeUsageScore(usage) * 0.5 + internal * 0.3 + freshness * 0.2
+    return normalizeUsageScore(usage) * 0.5 + curation * 0.3 + freshness * 0.2
   }
 
   return {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

`searchRank` did nothing. It was read in exactly one place — the `recommended` sort — which neither the default browse view nor search ever selects, so setting it on a template had no observable effect anywhere. Bumping a template to `searchRank: 1000000` for the MiniMax H3 launch changed nothing, which is what surfaced this.

This applies it where curators expect it: the search relevance path, as a bounded multiplier that can lift a near-equal match but never surface a weak one.

### How it got that way

In #7062 `searchRank` *was* wired into the default sort — commit 95d7207 reads `"Recommended" (default): usage × 0.5 + searchRank × 0.3 + freshness × 0.2`. During review that PR was found to have replaced the plain "Default" sort option outright, removing the `index.json` ordering that `workflow_templates` owns. Commit 4f23735 fixed that by moving the curated blend onto a new opt-in `recommended` dropdown entry and restoring `default` as a pass-through. `searchRank` went along for the ride onto an option nobody selects, and was never revisited.

Browse-default ordering stays a pass-through of `index.json` here — deliberately. That is the editorial lever #7062 protected, and reordering entries there remains how you change the browse order.

## Changes

**Curation now affects search relevance.** `rankByRelevanceThenUsage` scales each hit's score by `1 + searchRankBoost(searchRank) × 0.3` before bucketing. The ±30% cap is ~6 tiebreak bands: enough to clear near-equal matches, never enough to drag a weak match up, and it cannot introduce a template that does not match the query at all. `searchRank` is added to `storeFields` so hits carry it.

**Scale reconciled across the two repos.** `workflow_templates/docs/SPEC.md` — what template authors actually read — specifies `searchRank` as "0-1000, higher = better ranking". The frontend documented 1–10 with 5 neutral. The data follows the former: of 463 templates with the field set, 435 use it that way (429 × `0`, plus `500`, `1000`, `1000000`). Adopting the authored contract:

| `searchRank` | Effect |
| --- | --- |
| absent, or `0` | Neutral |
| `1` … `5` | Neutral (retired-scale range, see below) |
| `6` … `1000` | Promote, diminishing returns |
| above `1000` | Saturates — `1000000` is identical to `1000` |
| `-6` and below | Demote, mirroring the positive curve |

**Polarity fixed.** `0` was previously the *harshest* demotion (`0/10 = 0`) while an absent field got neutral `5/10`. Since `workflow_templates` tooling writes an explicit `"searchRank": 0` onto uncurated templates, that buried 429 of 583 templates beneath the 120 that simply omit the field. Both are now neutral; explicit demotion uses negative values.

**Out-of-range values bounded.** Magnitude follows `log1p(|rank|) / log1p(1000)`, capped at 1, so `1000000` lands on the cap instead of producing a nonsense score.

**Retired-scale values left inert.** The old scale read 1–4 as demote and 5 as neutral, and the numbered starter templates still ship `searchRank: 3`. Reading those on the new scale would have flipped their only plausible intent into a promotion, so magnitudes ≤ 5 are ignored. This covers the entire retired 1–10 range without inverting anything and needs no data migration; on a 0–1000 dial a value that small is noise.

**`recommended` sort no longer silently no-ops.** `computeDefaultScore` returned `NaN` whenever nothing in the filtered set had usage (`0 / 0`), making the comparator return `NaN` and the sort a no-op. The existing test carried a `// Set largestUsageScore to avoid NaN` workaround.

**`docs/TEMPLATE_RANKING.md` rewritten.** It described a `popular` formula (`usage × 0.9 + freshness × 0.1`) and a `computePopularScore` function that no longer exist, and omitted the search path entirely.

## Verification

Ran the real ranking code against the live 583-template `index.json`:

```
query "minimax"                        before          after
1. MiniMax H3: Text to Video      rank=1000000    #2 -> #1
2. MiniMax H3: Image to Video     rank=1000000    #3 -> #2
3. MiniMax H3: Reference to Video rank=1000000    #4 -> #3
4. MiniMax H3: FLF2V              rank=0          #1 -> #4
```

Queries with no curated templates in range (`wan`, `upscale`, `flux upscale`, `img2img`) are byte-identical to before. `starter` confirms the rank-3 templates sort purely on relevance, with no promotion.

End-to-end in a browser against a running dev server (screenshot below) — the three curated templates lead, no new console errors.

`pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format` clean. 155 test files / 2637 tests pass, including new coverage for neutrality of `0`/unset/`NaN`, retired-scale inertness, saturation, symmetry, the curation cap not overriding a strong match, and uncurated result sets being untouched.

## Follow-up

`workflow_templates/docs/SPEC.md` and this doc now agree, but the three `gsc_starter_*` templates still carry retired-scale `3` values. They are inert rather than wrong, so no migration is required — worth cleaning up whenever those templates are next touched.


## Screenshots

![Template picker searching 'minimax' after the change: the three curated searchRank:1000000 MiniMax H3 templates (Text to Video, Image to Video, Reference to Video) occupy the first three result slots](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c3286213b7e8f0ec40b427de1aed5b9245738fd60925c6e3967dd179bb65594a/pr-images/1785732565706-1514ba78-9067-4e54-ae4b-a295532e7101.png)