### PR TITLE
fix: label account menu entry for the settings panel it opens

### DIFF
--- a/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
+++ b/browser_tests/tests/localCreditsNoSubscribeUi.spec.ts
@@ -42,7 +42,7 @@ test.describe('Local credits surfaces hide subscribe UI (non-cloud)', () => {
     await topUpDialog.close()
 
     // 2. Settings > Credits, reached the same way the reported bug did: the
-    //    popover's "Manage Plan" entry, not a generic keyboard shortcut. This
+    //    popover's plan & credits entry, not a generic keyboard shortcut. This
     //    must also hide the subscribe CTA and keep its own "Add credits"
     //    button working, not just render a dead replacement for it.
     await page.getByTestId(TestIds.user.currentUserButton).click()

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -338,6 +338,18 @@ describe('CurrentUserPopoverLegacy', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('offers plan management and opens the subscription panel when it is clicked', async () => {
+    const { user, onClose } = renderComponent()
+
+    const menuItem = screen.getByTestId('manage-plan-menu-item')
+    expect(menuItem).toHaveTextContent(enMessages.subscription.managePlan)
+
+    await user.click(menuItem)
+
+    expect(mockShowSettingsDialog).toHaveBeenCalledWith('subscription')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   describe('facade balance handling', () => {
     it('uses effectiveBalanceMicros when present (positive balance)', () => {
       mockBalance.value = {
@@ -497,9 +509,16 @@ describe('CurrentUserPopoverLegacy', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('still shows manage plan menu item', () => {
-      renderComponent()
-      expect(screen.getByTestId('manage-plan-menu-item')).toBeInTheDocument()
+    it('labels the plan & credits item for the credits panel it opens, since no plan management exists here', async () => {
+      const { user } = renderComponent()
+
+      const menuItem = screen.getByTestId('manage-plan-menu-item')
+      expect(menuItem).toHaveTextContent(enMessages.credits.credits)
+      expect(menuItem).not.toHaveTextContent(enMessages.subscription.managePlan)
+
+      await user.click(menuItem)
+
+      expect(mockShowSettingsDialog).toHaveBeenCalledWith('credits')
     })
 
     it('still shows user settings menu item', () => {

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -510,7 +510,7 @@ describe('CurrentUserPopoverLegacy', () => {
     })
 
     it('labels the plan & credits item for the credits panel it opens, since no plan management exists here', async () => {
-      const { user } = renderComponent()
+      const { user, onClose } = renderComponent()
 
       const menuItem = screen.getByTestId('manage-plan-menu-item')
       expect(menuItem).toHaveTextContent(enMessages.credits.credits)
@@ -519,6 +519,7 @@ describe('CurrentUserPopoverLegacy', () => {
       await user.click(menuItem)
 
       expect(mockShowSettingsDialog).toHaveBeenCalledWith('credits')
+      expect(onClose).toHaveBeenCalledTimes(1)
     })
 
     it('still shows user settings menu item', () => {

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -118,7 +118,7 @@
     >
       <i class="icon-[lucide--file-text] text-sm text-muted-foreground" />
       <span class="flex-1 text-sm text-base-foreground">{{
-        $t('subscription.managePlan')
+        planAndCreditsLabel
       }}</span>
     </div>
 
@@ -190,7 +190,7 @@ const {
 } = useBillingContext()
 const { formatTierName } = useWorkspaceTierLabel()
 const subscriptionDialog = useSubscriptionDialog()
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 
 const subscriptionTierName = computed(() =>
   formatTierName(tier.value, subscription.value?.duration === 'ANNUAL')
@@ -218,6 +218,12 @@ const canUpgrade = computed(() => {
     currentTier === 'CREATOR'
   )
 })
+
+// Settings only has a plan-management panel on Cloud; elsewhere this entry can
+// only open the Credits panel, so it is labeled for where it actually goes.
+const planAndCreditsLabel = computed(() =>
+  isCloud ? t('subscription.managePlan') : t('credits.credits')
+)
 
 const handleOpenUserSettings = () => {
   settingsDialog.show('user')

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -219,8 +219,6 @@ const canUpgrade = computed(() => {
   )
 })
 
-// Settings only has a plan-management panel on Cloud; elsewhere this entry can
-// only open the Credits panel, so it is labeled for where it actually goes.
 const planAndCreditsLabel = computed(() =>
   isCloud ? t('subscription.managePlan') : t('credits.credits')
 )

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -266,7 +266,7 @@ describe('CurrentUserPopoverWorkspace', () => {
   it('labels the plan & credits item for the panel it opens off cloud', async () => {
     const user = userEvent.setup()
     state.canManageSubscription = true
-    renderComponent('personal', 'owner')
+    const { emitted } = renderComponent('personal', 'owner')
 
     const menuItem = screen.getByTestId('manage-plan-menu-item')
     expect(menuItem).toHaveTextContent(enMessages.credits.credits)
@@ -275,13 +275,14 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(menuItem)
 
     expect(state.showSettingsDialog).toHaveBeenCalledWith('credits')
+    expect(emitted('close')).toHaveLength(1)
   })
 
   it('offers plan management pointing at the workspace panel on cloud', async () => {
     const user = userEvent.setup()
     mockIsCloud.value = true
     state.canManageSubscription = true
-    renderComponent('team', 'owner')
+    const { emitted } = renderComponent('team', 'owner')
 
     const menuItem = screen.getByTestId('manage-plan-menu-item')
     expect(menuItem).toHaveTextContent(enMessages.subscription.managePlan)
@@ -289,5 +290,6 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(menuItem)
 
     expect(state.showSettingsDialog).toHaveBeenCalledWith('workspace')
+    expect(emitted('close')).toHaveLength(1)
   })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -8,6 +8,7 @@ import { computed, defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
+import type * as DistributionTypes from '@/platform/distribution/types'
 
 import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
 
@@ -65,6 +66,14 @@ vi.mock(
 
 vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
   useSettingsDialog: () => ({ show: state.showSettingsDialog })
+}))
+
+const mockIsCloud = vi.hoisted(() => ({ value: false }))
+vi.mock('@/platform/distribution/types', async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionTypes>()),
+  get isCloud() {
+    return mockIsCloud.value
+  }
 }))
 
 vi.mock('@/services/dialogService', () => ({
@@ -157,6 +166,7 @@ function renderComponent(
 
 describe('CurrentUserPopoverWorkspace', () => {
   beforeEach(() => {
+    mockIsCloud.value = false
     state.isActiveSubscription = true
     state.isFreeTier = false
     state.isCancelled = false
@@ -265,5 +275,19 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(menuItem)
 
     expect(state.showSettingsDialog).toHaveBeenCalledWith('credits')
+  })
+
+  it('offers plan management pointing at the workspace panel on cloud', async () => {
+    const user = userEvent.setup()
+    mockIsCloud.value = true
+    state.canManageSubscription = true
+    renderComponent('team', 'owner')
+
+    const menuItem = screen.getByTestId('manage-plan-menu-item')
+    expect(menuItem).toHaveTextContent(enMessages.subscription.managePlan)
+
+    await user.click(menuItem)
+
+    expect(state.showSettingsDialog).toHaveBeenCalledWith('workspace')
   })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -20,7 +20,8 @@ const state = vi.hoisted(() => ({
   canManageSubscriptionLifecycle: false,
   showCreateWorkspaceDialog: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
-  showPricingTable: vi.fn()
+  showPricingTable: vi.fn(),
+  showSettingsDialog: vi.fn()
 }))
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
@@ -63,7 +64,7 @@ vi.mock(
 )
 
 vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
-  useSettingsDialog: () => ({ show: vi.fn() })
+  useSettingsDialog: () => ({ show: state.showSettingsDialog })
 }))
 
 vi.mock('@/services/dialogService', () => ({
@@ -250,5 +251,19 @@ describe('CurrentUserPopoverWorkspace', () => {
     await user.click(screen.getByRole('button', { name: 'Resubscribe' }))
 
     expect(state.showPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('labels the plan & credits item for the panel it opens off cloud', async () => {
+    const user = userEvent.setup()
+    state.canManageSubscription = true
+    renderComponent('personal', 'owner')
+
+    const menuItem = screen.getByTestId('manage-plan-menu-item')
+    expect(menuItem).toHaveTextContent(enMessages.credits.credits)
+    expect(menuItem).not.toHaveTextContent(enMessages.subscription.managePlan)
+
+    await user.click(menuItem)
+
+    expect(state.showSettingsDialog).toHaveBeenCalledWith('credits')
   })
 })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -149,7 +149,7 @@
     >
       <i class="icon-[lucide--file-text] text-sm text-muted-foreground" />
       <span class="flex-1 text-sm text-base-foreground">{{
-        $t('subscription.managePlan')
+        planAndCreditsLabel
       }}</span>
     </div>
 
@@ -274,8 +274,14 @@ const {
 const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
 const subscriptionDialog = useSubscriptionDialog()
 
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 const isLoadingBalance = isLoading
+
+// Settings only has a plan-management panel on Cloud; elsewhere this entry can
+// only open the Credits panel, so it is labeled for where it actually goes.
+const planAndCreditsLabel = computed(() =>
+  isCloud ? t('subscription.managePlan') : t('credits.credits')
+)
 
 const displayedCredits = computed(() => {
   if (initState.value !== 'ready') return ''

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -277,8 +277,6 @@ const subscriptionDialog = useSubscriptionDialog()
 const { locale, t } = useI18n()
 const isLoadingBalance = isLoading
 
-// Settings only has a plan-management panel on Cloud; elsewhere this entry can
-// only open the Credits panel, so it is labeled for where it actually goes.
 const planAndCreditsLabel = computed(() =>
   isCloud ? t('subscription.managePlan') : t('credits.credits')
 )


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The account popover entry read **"Manage plan"** on every distribution, but Settings only hosts a plan-management panel on Cloud. On local/desktop builds the entry opens Settings → **Credits** (balance + usage), which is what the user reported.

- Fixes FE-1485 ([Linear](https://linear.app/comfyorg/issue/FE-1485/bug-manage-plan-account-menu-item-opens-credits-page-instead-of-plan))

## Changes

- **What**: The entry's label is now derived from the panel it actually opens, in both `CurrentUserPopoverLegacy.vue` and `CurrentUserPopoverWorkspace.vue`:
  - Cloud → "Manage plan", opens the plan panel (`subscription` / `workspace`) — unchanged.
  - Off Cloud → "Credits", opens the `credits` panel, matching that panel's own title in the Settings sidebar.
- **Why relabel instead of reroute**: there is no plan-management view to route to off Cloud. `subscriptionPanel` in `src/platform/settings/composables/useSettingUI.ts` is `null` unless `isCloud && __CONFIG__.subscription_required`, and legacy billing has no plans at all (`useLegacyBilling` returns `plans: []`, `currentPlanSlug: null`). The entry still appears off Cloud because `isActiveSubscription` is hardcoded `true` there (`isSubscribedOrIsNotCloud`), which is what surfaced the mislabeled item.
- **Routing/behavior**: unchanged. No new i18n keys — reuses the existing `credits.credits`.
- **Breaking**: none. `data-testid="manage-plan-menu-item"` is kept, so existing e2e specs (`localCreditsNoSubscribeUi`, `pricingTableDeepLink`) are unaffected.

## Review Focus

- The label must track the destination, not the tier: off Cloud it reads "Credits" for every tier, since no plan panel exists to open.
- Unit coverage asserts label **and** destination per distribution in both popovers; both new label assertions fail against `main`.

## Verification

- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check`, `pnpm knip` — clean.
- `pnpm vitest run` on both popover suites — 39 passing.
- Manual: local (non-Cloud) build against a running ComfyUI backend, signed in via the repo's Firebase auth mock, driving the real popover in Chromium. Screenshots below reproduce the reported flow — the entry now reads "Credits" and lands on the Credits panel highlighted in the sidebar.

## Screenshots


## Screenshots

![Account menu on a local build: the entry now reads Credits instead of Manage plan](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/b042dc22c8c07a4cc589fcb8be6efb9a7b0faf563d443b6ce182c91d3f86e0f8/pr-images/1785749019381-d2042ea2-488e-49eb-94f1-09ff4cc0541c.png)

![Clicking the entry opens Settings with the Credits panel selected, matching the label](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/b042dc22c8c07a4cc589fcb8be6efb9a7b0faf563d443b6ce182c91d3f86e0f8/pr-images/1785749019698-378f909a-b4c7-4b51-bafa-ce5a65a6cf86.png)