### PR TITLE
feat(templates): default an active search to Popular instead of Relevance

### DIFF
--- a/browser_tests/fixtures/components/TemplatesDialog.ts
+++ b/browser_tests/fixtures/components/TemplatesDialog.ts
@@ -3,6 +3,8 @@ import type { Locator, Page } from '@playwright/test'
 export class TemplatesDialog {
   public readonly root: Locator
   public readonly modelFilter: Locator
+  public readonly sortSelect: Locator
+  public readonly searchInput: Locator
   public readonly resultsCount: Locator
   public readonly mobileFiltersToggle: Locator
   public readonly filterBar: Locator
@@ -13,9 +15,14 @@ export class TemplatesDialog {
     this.modelFilter = this.root
       .getByRole('button', { name: /Model Filter/ })
       .filter({ visible: true })
+    this.sortSelect = this.root
+      .getByRole('combobox', { name: /Sort by/ })
+      .filter({ visible: true })
+    this.searchInput = this.root.getByPlaceholder(/^Search/)
     this.resultsCount = this.root.getByText(/Showing.*of.*templates/i)
     this.mobileFiltersToggle = this.root.getByRole('button', {
-      name: 'Filters'
+      name: 'Filters',
+      exact: true
     })
     this.filterBar = this.root.getByTestId('template-filter-bar')
     this.clearFilters = this.filterBar.getByRole('button', {
@@ -52,5 +59,17 @@ export class TemplatesDialog {
     await this.modelFilter.click()
     await this.page.getByRole('option', { name }).click()
     await this.page.keyboard.press('Escape')
+  }
+
+  async selectSortOption(name: string): Promise<void> {
+    await this.openFilters()
+    await this.sortSelect.click()
+    await this.page.getByRole('option', { name, exact: true }).click()
+  }
+
+  navItem(name: string): Locator {
+    return this.root
+      .getByRole('navigation')
+      .getByRole('button', { name, exact: true })
   }
 }

--- a/browser_tests/tests/templateSearchSort.spec.ts
+++ b/browser_tests/tests/templateSearchSort.spec.ts
@@ -1,0 +1,86 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { makeTemplate } from '@e2e/fixtures/data/templateFixtures'
+import { withTemplates } from '@e2e/fixtures/helpers/TemplateHelper'
+import { templateApiFixture } from '@e2e/fixtures/templateApiFixture'
+
+const test = mergeTests(comfyPageFixture, templateApiFixture)
+
+/**
+ * `useTemplateFiltering.test.ts` owns the sort semantics; these cover the wiring
+ * it cannot reach, because `coordinateNavAndSort` and its two watchers live in
+ * `WorkflowTemplateSelectorDialog.vue`. Those watchers mirror nav and sort for
+ * browsing — the Popular category selects the Popular sort and moving off it
+ * restores Default — which, once a search also defaults to Popular, would
+ * discard the sort the user is looking at every time the category changed.
+ */
+test.describe('Template search sort', () => {
+  test.beforeEach(async ({ comfyPage, templateApi }) => {
+    await comfyPage.settings.setSetting('Comfy.Templates.SelectedModels', [])
+    await comfyPage.settings.setSetting('Comfy.Templates.SelectedUseCases', [])
+    await comfyPage.settings.setSetting('Comfy.Templates.SelectedRunsOn', [])
+    await comfyPage.settings.setSetting('Comfy.Templates.SortBy', 'default')
+
+    templateApi.configure(
+      withTemplates([
+        makeTemplate({ name: 'wan-rare', title: 'Wan Rare', usage: 1 }),
+        makeTemplate({ name: 'wan-common', title: 'Wan Common', usage: 9000 }),
+        makeTemplate({ name: 'flux-other', title: 'Flux Other', usage: 5 })
+      ])
+    )
+    await templateApi.mock()
+    await comfyPage.setup()
+
+    await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
+    await expect(comfyPage.templates.content).toBeVisible()
+    await comfyPage.templatesDialog.openFilters()
+  })
+
+  test('defaults an active search to Popular and ranks matches by usage', async ({
+    comfyPage
+  }) => {
+    const dialog = comfyPage.templatesDialog
+    await expect(dialog.sortSelect).toHaveText('Default')
+
+    await dialog.searchInput.fill('wan')
+    await expect(dialog.resultsCount).toHaveText(/Showing 2 of 3 templates/i)
+
+    await expect(dialog.sortSelect).toHaveText('Popular')
+    await expect(comfyPage.templates.allTemplateCards.first()).toContainText(
+      'Wan Common'
+    )
+  })
+
+  test('keeps the search sort when the category changes mid-search', async ({
+    comfyPage
+  }) => {
+    const dialog = comfyPage.templatesDialog
+
+    await dialog.searchInput.fill('wan')
+    await expect(dialog.sortSelect).toHaveText('Popular')
+
+    await dialog.navItem('Popular').click()
+    await dialog.navItem('All Templates').click()
+    await expect(dialog.sortSelect).toHaveText('Popular')
+
+    await dialog.selectSortOption('Relevance')
+    await expect(dialog.sortSelect).toHaveText('Relevance')
+
+    await dialog.navItem('Popular').click()
+    await expect(dialog.sortSelect).toHaveText('Relevance')
+  })
+
+  test('restores the persisted browse sort when the search is cleared', async ({
+    comfyPage
+  }) => {
+    const dialog = comfyPage.templatesDialog
+
+    await dialog.searchInput.fill('wan')
+    await expect(dialog.sortSelect).toHaveText('Popular')
+
+    await dialog.searchInput.fill('')
+    await expect(dialog.sortSelect).toHaveText('Default')
+    await expect(dialog.resultsCount).toHaveText(/Showing 3 of 3 templates/i)
+  })
+})

--- a/browser_tests/tests/templates/templateSearchSort.spec.ts
+++ b/browser_tests/tests/templates/templateSearchSort.spec.ts
@@ -30,7 +30,6 @@ test.describe('Template search sort', () => {
       ])
     )
     await templateApi.mock()
-    await comfyPage.setup()
 
     await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
     await expect(comfyPage.templates.content).toBeVisible()

--- a/browser_tests/tests/templates/templateSearchSort.spec.ts
+++ b/browser_tests/tests/templates/templateSearchSort.spec.ts
@@ -20,7 +20,7 @@ test.describe('Template search sort', () => {
     await comfyPage.settings.setSetting('Comfy.Templates.SelectedModels', [])
     await comfyPage.settings.setSetting('Comfy.Templates.SelectedUseCases', [])
     await comfyPage.settings.setSetting('Comfy.Templates.SelectedRunsOn', [])
-    await comfyPage.settings.setSetting('Comfy.Templates.SortBy', 'default')
+    await comfyPage.settings.setSetting('Comfy.Templates.SortBy', 'newest')
 
     templateApi.configure(
       withTemplates([
@@ -40,7 +40,7 @@ test.describe('Template search sort', () => {
     comfyPage
   }) => {
     const dialog = comfyPage.templatesDialog
-    await expect(dialog.sortSelect).toHaveText('Default')
+    await expect(dialog.sortSelect).toHaveText('Newest')
 
     await dialog.searchInput.fill('wan')
     await expect(dialog.resultsCount).toHaveText(/Showing 2 of 3 templates/i)
@@ -79,7 +79,7 @@ test.describe('Template search sort', () => {
     await expect(dialog.sortSelect).toHaveText('Popular')
 
     await dialog.searchInput.fill('')
-    await expect(dialog.sortSelect).toHaveText('Default')
+    await expect(dialog.sortSelect).toHaveText('Newest')
     await expect(dialog.resultsCount).toHaveText(/Showing 3 of 3 templates/i)
   })
 })

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -643,6 +643,11 @@ watch(searchQuery, (value) => {
  * @param source The origin of the change ('nav' or 'sort').
  */
 const coordinateNavAndSort = (source: 'nav' | 'sort') => {
+  // The nav/sort mirror is a browse concern. While a query is active the sort is
+  // ephemeral and the nav is only a scope filter, so coupling them would reset
+  // the search sort every time the category changed.
+  if (hasActiveQuery.value) return
+
   const isPopularNav = selectedNavItem.value === 'popular'
   const isPopularSort = sortSelection.value === 'popular'
 

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -643,9 +643,6 @@ watch(searchQuery, (value) => {
  * @param source The origin of the change ('nav' or 'sort').
  */
 const coordinateNavAndSort = (source: 'nav' | 'sort') => {
-  // The nav/sort mirror is a browse concern. While a query is active the sort is
-  // ephemeral and the nav is only a scope filter, so coupling them would reset
-  // the search sort every time the category changed.
   if (hasActiveQuery.value) return
 
   const isPopularNav = selectedNavItem.value === 'popular'

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -397,6 +397,15 @@ describe('useTemplateFiltering', () => {
       return composable
     }
 
+    // Search now defaults to Popular, so anything asserting the relevance
+    // pipeline must select Relevance or it silently measures usage instead.
+    async function searchByRelevance(templates: TemplateInfo[], query: string) {
+      const composable = await searchFor(templates, query)
+      composable.sortSelection.value = 'relevance'
+      await nextTick()
+      return composable
+    }
+
     it('matches "img2img" via abbreviation expansion', async () => {
       const templates = [
         buildTemplate({
@@ -433,7 +442,10 @@ describe('useTemplateFiltering', () => {
         })
       ]
 
-      const { filteredTemplates } = await searchFor(templates, 'flux upscale')
+      const { filteredTemplates } = await searchByRelevance(
+        templates,
+        'flux upscale'
+      )
 
       expect(names(filteredTemplates.value)[0]).toBe('flux_upscale')
     })
@@ -454,13 +466,16 @@ describe('useTemplateFiltering', () => {
         })
       ]
 
-      const { filteredTemplates } = await searchFor(templates, 'upscale')
+      const { filteredTemplates } = await searchByRelevance(
+        templates,
+        'upscale'
+      )
 
       // Near-identical text scores → the far more used template ranks first.
       expect(names(filteredTemplates.value)[0]).toBe('high_usage_upscale')
     })
 
-    it('keeps relevance order even when a usage sort is persisted', async () => {
+    it('defaults a search to Popular, ranking usage over match quality', async () => {
       const templates = [
         buildTemplate({
           name: 'exact_match',
@@ -477,17 +492,38 @@ describe('useTemplateFiltering', () => {
       ]
 
       const composable = useTemplateFiltering(ref(templates))
-      composable.sortBy.value = 'popular'
       composable.searchQuery.value = 'outpaint'
       await nextTick()
 
-      // Search defaults to relevance regardless of the persisted browse sort,
-      // so the exact title match wins over the high-usage weak match.
-      expect(composable.sortSelection.value).toBe('relevance')
+      expect(composable.sortSelection.value).toBe('popular')
+      expect(
+        names(composable.filteredTemplates.value)[0],
+        'the accepted cost of a Popular default: a weak high-usage match leads'
+      ).toBe('popular_weak_match')
+    })
+
+    it('still ranks by match quality once Relevance is selected', async () => {
+      const templates = [
+        buildTemplate({
+          name: 'exact_match',
+          title: 'Outpaint Studio',
+          tags: ['Outpaint'],
+          usage: 1
+        }),
+        buildTemplate({
+          name: 'popular_weak_match',
+          title: 'Portrait Generator',
+          description: 'supports outpaint as a minor feature',
+          usage: 9000
+        })
+      ]
+
+      const composable = await searchByRelevance(templates, 'outpaint')
+
       expect(names(composable.filteredTemplates.value)[0]).toBe('exact_match')
     })
 
-    it('lets the user override relevance with another sort while searching', async () => {
+    it('lets the user override the search default with another sort', async () => {
       const templates = [
         buildTemplate({
           name: 'exact_low_usage',
@@ -505,34 +541,36 @@ describe('useTemplateFiltering', () => {
       const composable = useTemplateFiltering(ref(templates))
       composable.searchQuery.value = 'outpaint'
       await nextTick()
-      expect(composable.sortSelection.value).toBe('relevance')
-      expect(names(composable.filteredTemplates.value)[0]).toBe(
-        'exact_low_usage'
-      )
-
-      composable.sortSelection.value = 'popular'
-      await nextTick()
       expect(composable.sortSelection.value).toBe('popular')
       expect(names(composable.filteredTemplates.value)[0]).toBe(
         'weak_high_usage'
       )
+
+      composable.sortSelection.value = 'relevance'
+      await nextTick()
+      expect(composable.sortSelection.value).toBe('relevance')
+      expect(names(composable.filteredTemplates.value)[0]).toBe(
+        'exact_low_usage'
+      )
     })
 
-    it('restores the browse sort when the search is cleared and keeps relevance ephemeral', async () => {
+    it('restores the browse sort when the search is cleared', async () => {
       const composable = useTemplateFiltering(
         ref([buildTemplate({ name: 'only', title: 'Only' })])
       )
-      composable.sortBy.value = 'popular'
+      composable.sortBy.value = 'newest'
 
       composable.searchQuery.value = 'only'
       await nextTick()
-      expect(composable.sortSelection.value).toBe('relevance')
+      expect(composable.sortSelection.value).toBe('popular')
 
       composable.searchQuery.value = ''
       await nextTick()
-      // Browse sort is untouched by the search; relevance is never persisted.
-      expect(composable.sortSelection.value).toBe('popular')
-      expect(composable.sortBy.value).toBe('popular')
+      expect(
+        composable.sortSelection.value,
+        'the search default must never overwrite the persisted browse sort'
+      ).toBe('newest')
+      expect(composable.sortBy.value).toBe('newest')
     })
 
     it('keeps a browse sort chosen mid-search ephemeral', async () => {
@@ -587,14 +625,16 @@ describe('useTemplateFiltering', () => {
         const composable = useTemplateFiltering(
           ref([buildTemplate({ name: 'only', title: 'Only' })])
         )
-        composable.sortBy.value = 'popular'
+        composable.sortBy.value = 'newest'
         composable.searchQuery.value = 'only'
         await nextTick()
         await vi.runOnlyPendingTimersAsync()
 
-        // Searching shows relevance, so telemetry must report relevance, not popular.
-        expect(trackTemplateFilterChanged).toHaveBeenLastCalledWith(
-          expect.objectContaining({ sort_by: 'relevance' })
+        expect(
+          trackTemplateFilterChanged,
+          'telemetry must report the search default, not the persisted browse sort'
+        ).toHaveBeenLastCalledWith(
+          expect.objectContaining({ sort_by: 'popular' })
         )
       } finally {
         vi.useRealTimers()
@@ -617,8 +657,7 @@ describe('useTemplateFiltering', () => {
         })
       ]
 
-      const composable = useTemplateFiltering(ref(templates))
-      composable.searchQuery.value = 'upscale'
+      const composable = await searchByRelevance(templates, 'upscale')
       composable.selectedModels.value = ['Flux']
       await nextTick()
 

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -26,6 +26,10 @@ type TemplateBrowseSort =
 
 export type TemplateSortMode = TemplateBrowseSort | 'relevance'
 
+// Sort applied when a query becomes active, before the user picks one. Flip to
+// 'relevance' to rank by text match instead of raw usage.
+const SEARCH_DEFAULT_SORT: TemplateSortMode = 'popular'
+
 /** The title shown on the card, trimmed for stable sorting. */
 function displayTitle(template: TemplateInfo): string {
   return (
@@ -168,9 +172,9 @@ export function useTemplateFiltering<T extends TemplateInfo>(
   )
 
   const hasActiveQuery = computed(() => searchQuery.value.trim().length > 0)
-  const searchSort = ref<TemplateSortMode>('relevance')
+  const searchSort = ref<TemplateSortMode>(SEARCH_DEFAULT_SORT)
   watch(hasActiveQuery, (searching) => {
-    if (searching) searchSort.value = 'relevance'
+    if (searching) searchSort.value = SEARCH_DEFAULT_SORT
   })
   const activeSort = computed(() =>
     hasActiveQuery.value ? searchSort.value : sortBy.value

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -26,8 +26,6 @@ type TemplateBrowseSort =
 
 export type TemplateSortMode = TemplateBrowseSort | 'relevance'
 
-// Sort applied when a query becomes active, before the user picks one. Flip to
-// 'relevance' to rank by text match instead of raw usage.
 const SEARCH_DEFAULT_SORT: TemplateSortMode = 'popular'
 
 /** The title shown on the card, trimmed for stable sorting. */

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -324,7 +324,7 @@ export function useTemplateFiltering<T extends TemplateInfo>(
     selectedUseCases.value = []
     selectedRunsOn.value = []
     sortBy.value = 'default'
-    searchSort.value = 'relevance'
+    searchSort.value = SEARCH_DEFAULT_SORT
   }
 
   const removeModelFilter = (model: string) => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Lin's proposal, built as the alternative to #14596 so the two approaches to the same goal can be measured side by side. Requested by @MaanilVerma.

**Stacked on `glary/searchrank-boost-in-relevance` (#14596)**, so the diff here is only the one variable under debate. Both branches produce a working build; #14596 should merge first, after which this retargets to `main` and the diff is unchanged.

## The goal

Get a high-usage launch template like MiniMax H3 to top a generic query such as "Image to Video". #14596 does it with curation (`searchRank`); this does it with usage.

## Changes

Typing a query now selects **Popular**, ranking the matched set by raw usage. Relevance stays selectable in the dropdown, and the persisted browse sort is still never overwritten. The default is now one constant, so concluding the experiment is a one-line revert:

```ts
// Sort applied when a query becomes active, before the user picks one. Flip to
// 'relevance' to rank by text match instead of raw usage.
const SEARCH_DEFAULT_SORT: TemplateSortMode = 'popular'
```

It was previously duplicated across the `ref` initializer and the `watch`, so "one line" wasn't quite true.

**One bug this flip exposed.** `coordinateNavAndSort` mirrors the Popular *category* onto the Popular *sort*. With Popular as the search default, `isPopularSort` is true for every search, so changing nav category mid-search hit the `!isPopularNav && isPopularSort` branch and silently reset the sort to Default. That branch never fires when the default is Relevance. Guarded — the nav/sort mirror is a browse concern and the search sort is ephemeral. Verified in a browser: category change mid-search now leaves the sort on Popular.

## A/B on the real 583-template catalog

**"image to video"** — Lin's case. Works:

| # | A: Relevance default (#14596) | B: Popular default (this PR) |
|---|---|---|
| 1 | Hunyuan Video 1.5 Image to Video · u=219 | **MiniMax H3: Image to Video · u=80000** |
| 2 | **MiniMax H3: Image to Video · u=80000** | MiniMax H3: Reference to Video · u=80000 |
| 3 | Vidu Q3 Image-to-Video with Audio · u=83 | Seedance 2.0: Reference to Video · u=40815 |
| 4 | Capybara: Image to Video · u=10 | Grok: Video generation · u=10919 |
| 5 | MiniMax H3: Reference to Video · u=80000 | Image to Video · u=1806 |

But note rows 4–5: "Grok: Video generation" outranks the template literally titled "Image to Video" on an *"image to video"* query. That's the relevance loss @MaanilVerma predicted, confirmed.

**"upscale"** — B is worse across the board:

| # | A | B |
|---|---|---|
| 1 | SeedVR2: Image Upscale · u=683 | SeedVR2: Image Upscale · u=683 |
| 2 | Wan2.2: Creative Video Upscale · u=91 | Skin Enhancer + Upscaler · u=450 |
| 3 | WaveSpeed: Image Upscale · u=208 | Generate Realistic Variations · u=256 |
| 4 | Magnific: Precise Image Upscale · u=104 | SeedVR2: Video Upscaling · u=250 |

"Generate Realistic Variations" has no "upscale" in its title at all.

**"minimax"** — identical top 3; B's 4–5 degrade (weak high-usage matches displace `MiniMax H3: FLF2V`).

## Option C, for the record

A third path gets Lin's result without changing what search means — raising the curation cap on #14596:

```
weight 0.30 -> #1 Hunyuan Video 1.5 Image to Video   | MiniMax H3 at #2
weight 0.50 -> #1 Hunyuan Video 1.5 Image to Video   | MiniMax H3 at #2
weight 0.60 -> #1 MiniMax H3: Image to Video         | MiniMax H3 at #1
```

`SEARCH_RANK_RELEVANCE_WEIGHT = 0.6` puts MiniMax H3 first on "image to video" while leaving intra-list relevance intact everywhere else. One constant, no semantic change.

## My recommendation

Still A, or A with `weight = 0.6`. B re-enables what #13386 set out to fix — its own description reads *"any active sort re-ordered results by usage — so the best textual match rarely landed on top"*, and its behaviour matrix lists `Query active, "Popular" selected → burying the best match` as the **old broken** column. B's failure mode is also unfixable per-template, whereas a curation miss is one JSON edit.

That said, this is a product call and the code is here to test with. Telemetry already reports `sort_by` on every filter change, so both builds will be distinguishable in analytics without further work.

## Verification

161 test files / 2697 tests pass; `typecheck`, `lint`, `knip`, `format` clean.

Relevance-pipeline tests now opt in through a `searchByRelevance` helper — without it they pass while silently measuring usage instead of match quality, which is the sort of false green this flip makes easy. Added coverage for the new default, for Relevance still overriding it, and for the browse sort surviving a search.


## Screenshots

![Template picker searching 'image to video' with the Popular default: sort dropdown reads Popular and MiniMax H3: Image to Video is the first result](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c3286213b7e8f0ec40b427de1aed5b9245738fd60925c6e3967dd179bb65594a/pr-images/1785758547076-90cb1490-6d0f-4ee9-bee9-45f20f406422.png)