### PR TITLE
feat(website): rewrite /minimax meta for MiniMax H3 (Hailuo 3.0) search intent

### DIFF
--- a/apps/website/src/data/minimax.ts
+++ b/apps/website/src/data/minimax.ts
@@ -324,9 +324,9 @@ export const minimaxFaqs: readonly MiniMaxFaq[] = [
       'zh-CN': 'MiniMax H3 每次生成需要多少费用？'
     },
     answer: {
-      en: 'It runs on pay-as-you-go or subscription credits. You can draft the same shot free on Wan 2.2 first, and spend credits only on the final render.',
+      en: 'It runs on pay-as-you-go or subscription credits, with no watermark and commercial use included. You can also run the open weights locally instead of spending credits.',
       'zh-CN':
-        '它采用按量付费或订阅积分。你可以先在 Wan 2.2 上免费打样同一个镜头，只在最终渲染时消耗积分。'
+        '它采用按量付费或订阅积分，无水印，并包含商业使用授权。你也可以在本地运行开源权重，无需消耗积分。'
     }
   },
   {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4929,13 +4929,13 @@ const translations = {
   },
 
   'minimax.meta.title': {
-    en: 'MiniMax H3 on Comfy — Open-Weight Video Model',
-    'zh-CN': 'Comfy 上的 MiniMax H3 — 开源权重视频模型'
+    en: 'MiniMax H3 (Hailuo 3.0) — Open-Weights Video in ComfyUI',
+    'zh-CN': 'MiniMax H3（Hailuo 3.0）— ComfyUI 开源权重视频模型'
   },
   'minimax.meta.description': {
-    en: 'Run MiniMax H3 on Comfy: available as Open Weights and through Partner Nodes, multi-modal in/out, native stereo audio on every clip, up to 2K and 5–15s per generation. Draft free on Wan 2.2 and spend credits only on the final render.',
+    en: 'Run MiniMax H3 (Hailuo 3.0) in ComfyUI: open-weights omni-modal video with native stereo audio, up to 2K, 5–15s clips. Text, image and reference to video.',
     'zh-CN':
-      '在 Comfy 上运行 MiniMax H3：以开源权重形式提供，也可通过合作伙伴节点使用，多模态输入/输出，每个片段都带原生立体声音频，最高 2K，每次生成 5–15 秒。先用 Wan 2.2 免费打样，只在最终渲染时消耗积分。'
+      '在 ComfyUI 中运行 MiniMax H3（Hailuo 3.0）：开源权重全模态视频，原生立体声，最高 2K，5–15 秒，支持文生、图生与参考生视频。'
   },
   'minimax.breadcrumb.model': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
   'minimax.breadcrumb.updated': {

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4933,9 +4933,9 @@ const translations = {
     'zh-CN': 'MiniMax H3（Hailuo 3.0）— ComfyUI 开源权重视频模型'
   },
   'minimax.meta.description': {
-    en: 'Run MiniMax H3 (Hailuo 3.0) in ComfyUI: open-weights omni-modal video with native stereo audio, up to 2K, 5–15s clips. Text, image and reference to video.',
+    en: 'Run MiniMax H3 (Hailuo 3.0) in ComfyUI: open-weights omni-modal video with native stereo audio. Text-to-video, image-to-video and reference-to-video.',
     'zh-CN':
-      '在 ComfyUI 中运行 MiniMax H3（Hailuo 3.0）：开源权重全模态视频，原生立体声，最高 2K，5–15 秒，支持文生、图生与参考生视频。'
+      '在 ComfyUI 中运行 MiniMax H3（Hailuo 3.0）：开源权重全模态视频生成，原生立体声音频，支持文生视频、图生视频与参考生视频。'
   },
   'minimax.breadcrumb.model': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
   'minimax.breadcrumb.updated': {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The `/minimax` meta tags were launch-announcement copy rather than search-intent copy, so aggregators and the ComfyUI Wiki are outranking us for MiniMax H3 / Hailuo 3.0 terms. This rewrites the title and description and removes the Wan 2.2 reference.

Refs [GTM-415](https://linear.app/comfyorg/issue/GTM-415/seo-comfyorgminimax-meta-titledescription-on-page-fixes-to-win-minimax).

## Changes

| | Before | After |
|---|---|---|
| **Title** (60 max) | `MiniMax H3 on Comfy — Open-Weight Video Model` (45) | `MiniMax H3 (Hailuo 3.0) — Open-Weights Video in ComfyUI` (55) |
| **Description** (160 max) | 233 chars — **truncated in SERPs** | 149 chars — renders in full |

New description: `Run MiniMax H3 (Hailuo 3.0) in ComfyUI: open-weights omni-modal video with native stereo audio. Text-to-video, image-to-video and reference-to-video.`

Rationale, in priority order:

- **The old description was 233 characters.** Google cut it off well before the end, so roughly a third of it never rendered — including the Wan 2.2 sentence this issue asks to remove.
- **Added the `Hailuo 3.0` alias.** GTM-415 notes aggregators rank for the branded term; the page never contained it, so we couldn't compete.
- **`ComfyUI`, not `Comfy`.** The former is the search term. The old title used the latter.
- **`omni-modal`** matches the vocabulary of the pages currently outranking us (Wiki: "open general-purpose omni-modal generation model"; blog: "open-weights omni-modal video model").
- **Named the three task modalities** — `text-to-video`, `image-to-video`, `reference-to-video` — for long-tail coverage, mirroring the docs tutorial.

Also dropped the "draft free on Wan 2.2" line from the **pricing FAQ answer**, which was carrying it into the `FAQPage` JSON-LD as well as the visible page. Replaced with the credits/no-watermark/commercial-use terms plus the local open-weights option.

Both locales updated; the zh-CN description is 75 chars, under the ~80-char CJK truncation point.

## Review Focus

- **Two Wan 2.2 references intentionally left alone:**
  1. `pricing.footnote` — "*Based on 5s videos created with the Wan 2.2 Image-to-Video template…" is a factual benchmark disclosure for the credit estimates and is **shared with `/cloud/pricing`**. Changing it would misstate how those numbers were derived and would touch another page.
  2. `src/data/minimax.ts` step `draft-on-wan` ("Draft free on Wan 2.2" / "Same workflow, zero credits") — currently dormant behind `showPlaceholderMediaSections: false`, so it does not render. **It will reintroduce the Wan 2.2 framing the moment that section is enabled.** I left it because rewriting it means redesigning a step in a flow whose artwork doesn't exist yet — flagging it for whoever lands the final step art.
- **Spec claims deliberately kept out of the meta.** My first draft said "up to 2K, 5–15s clips". Review flagged that as conflating capabilities: official H3 docs and the Wiki both describe `H3-Base` as 768p with 2K via in-context regeneration, and give the clip range as 4–15s. The page body currently says "Up to 2K, 5 to 15s per generation" unqualified, so **there may be a separate on-page accuracy fix needed** — that's a spec question for GTM/model folks, not something to settle in a meta tag, so the description now describes capability and leaves numbers to the body.
- **Only meta + the one FAQ answer are in scope here.** GTM-415 references further on-page fixes; its description was truncated by the Linear API and the issue body isn't readable via tooling, so I could not confirm that full scope.

## Verification

- Build — 579 pages; rendered `<title>`, `meta[name=description]`, `og:*` and `twitter:*` all confirmed on `/minimax` and `/zh-CN/minimax`.
- `Wan 2.2` occurrences on the built page: **1** (the shared pricing footnote), down from 2.
- `validate:jsonld` — passed across 582 pages, so the `FAQPage` graph is still valid after the answer edit.
- `typecheck` 0 errors / 0 warnings · `test:unit` 304 passed · `minimax` E2E 12/12 including "emits FAQPage structured data with one entry per FAQ".

cc @mobeenabdullah for review, same as #14604.
