### PR TITLE
refactor(workspace): retire team workspace rollout flag

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -14,6 +14,10 @@ import {
   EMPTY_BILLING_PLANS,
   LEGACY_PERSONAL_BILLING_STATUS
 } from '@e2e/fixtures/data/cloudWorkspace'
+import {
+  UNSUBSCRIBED,
+  ZERO_BALANCE
+} from '@e2e/fixtures/data/subscriptionFixtures'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
 import { ComfyMouse } from '@e2e/fixtures/ComfyMouse'
@@ -582,6 +586,12 @@ export const comfyPageFixture = base.extend<{
       )
       await context.route('**/api/billing/plans', (route) =>
         route.fulfill({ json: EMPTY_BILLING_PLANS })
+      )
+      await context.route('**/customers/cloud-subscription-status', (route) =>
+        route.fulfill({ json: UNSUBSCRIBED })
+      )
+      await context.route('**/customers/balance', (route) =>
+        route.fulfill({ json: ZERO_BALANCE })
       )
       await mockWorkspace(context, workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -9,6 +9,11 @@ import {
   TOUR_SEEN_SETTING
 } from '@/platform/onboarding/onboardingTours'
 import { NodeBadgeMode } from '@/types/nodeSource'
+import {
+  EMPTY_BILLING_BALANCE,
+  EMPTY_BILLING_PLANS,
+  LEGACY_PERSONAL_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
 import { ComfyActionbar } from '@e2e/fixtures/components/Actionbar'
 import { ComfyTemplates } from '@e2e/fixtures/components/Templates'
 import { ComfyMouse } from '@e2e/fixtures/ComfyMouse'
@@ -568,6 +573,15 @@ export const comfyPageFixture = base.extend<{
       const context = page.context()
       await context.route('**/api/auth/session', (route) =>
         route.fulfill({ status: 204 })
+      )
+      await context.route('**/api/billing/status', (route) =>
+        route.fulfill({ json: LEGACY_PERSONAL_BILLING_STATUS })
+      )
+      await context.route('**/api/billing/balance', (route) =>
+        route.fulfill({ json: EMPTY_BILLING_BALANCE })
+      )
+      await context.route('**/api/billing/plans', (route) =>
+        route.fulfill({ json: EMPTY_BILLING_PLANS })
       )
       await mockWorkspace(context, workspace('personal', 'owner'), [])
       await comfyPage.cloudAuth.mockAuth()

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -7,12 +7,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-// `/api/features` is the remote-config source: production builds resolve the
-// workspaces flag from it (the `ff:` localStorage override is dev-only).
-export const WORKSPACE_FEATURE_FLAG: RemoteConfig = {
-  team_workspaces_enabled: true,
-  consolidated_billing_enabled: true
-}
+export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
 
 export const TEAM_WORKSPACE: WorkspaceWithRole = {
   id: 'ws-team',

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -20,6 +20,8 @@ export const LEGACY_PERSONAL_BILLING_STATUS = {
   billing_status: 'inactive',
   has_funds: true,
   is_active: false,
+  max_seats: 1,
+  occupied_seats: 1,
   subscription_status: 'ended',
   subscription_tier: 'FREE',
   team_credit_stop: null

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,4 +1,8 @@
-import type { BillingStatusResponse as IngestBillingStatusResponse } from '@comfyorg/ingest-types'
+import type {
+  BillingBalanceResponse,
+  BillingPlansResponse,
+  BillingStatusResponse as IngestBillingStatusResponse
+} from '@comfyorg/ingest-types'
 
 import type {
   Member,
@@ -8,6 +12,26 @@ import type {
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
+
+export const LEGACY_PERSONAL_BILLING_STATUS = {
+  billing_rail: 'legacy_stripe',
+  billing_status: 'inactive',
+  has_funds: true,
+  is_active: false,
+  subscription_status: 'ended',
+  subscription_tier: 'FREE',
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse
+
+export const EMPTY_BILLING_BALANCE = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0
+} satisfies BillingBalanceResponse
+
+export const EMPTY_BILLING_PLANS = {
+  plans: []
+} satisfies BillingPlansResponse
 
 export const TEAM_WORKSPACE: WorkspaceWithRole = {
   id: 'ws-team',

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -11,7 +11,9 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
+export const CLOUD_REMOTE_CONFIG: RemoteConfig = {
+  consolidated_billing_enabled: true
+}
 
 export const LEGACY_PERSONAL_BILLING_STATUS = {
   billing_rail: 'legacy_stripe',

--- a/browser_tests/fixtures/data/workspaceSwitcher.ts
+++ b/browser_tests/fixtures/data/workspaceSwitcher.ts
@@ -8,7 +8,6 @@ export const TEAM_WORKSPACE_NAME = 'Team Workspace'
 export const OFF_SCREEN_WORKSPACE_NAME = 'Off-screen Team Workspace'
 
 export const WORKSPACE_SWITCHER_REMOTE_CONFIG: RemoteConfig = {
-  team_workspaces_enabled: true,
   unified_cloud_auth: true
 }
 

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -9,11 +9,11 @@ import type {
 
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import {
+  CLOUD_REMOTE_CONFIG,
   DEFAULT_TEAM_MEMBERS,
   TEAM_BILLING_STATUS,
   TEAM_PRO_PLAN,
-  TEAM_WORKSPACE,
-  WORKSPACE_FEATURE_FLAG
+  TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { mockWorkspaceTokenMint } from '@e2e/fixtures/utils/workspaceMocks'
@@ -71,7 +71,7 @@ export class CloudWorkspaceMockHelper {
     const { page } = this
 
     await page.route('**/api/features', (r) =>
-      r.fulfill(jsonRoute(WORKSPACE_FEATURE_FLAG))
+      r.fulfill(jsonRoute(CLOUD_REMOTE_CONFIG))
     )
     await page.route('**/api/system_stats', (r) =>
       r.fulfill(jsonRoute(mockSystemStats))

--- a/browser_tests/fixtures/utils/cloudAppSetup.ts
+++ b/browser_tests/fixtures/utils/cloudAppSetup.ts
@@ -18,7 +18,6 @@ export const APP_URL =
 // billing surfaces the cloud specs assert; without it they fall back to the
 // legacy variants.
 const DEFAULT_FEATURES = {
-  team_workspaces_enabled: true,
   consolidated_billing_enabled: true
 } satisfies RemoteConfig
 

--- a/browser_tests/fixtures/utils/cloudBootMocks.ts
+++ b/browser_tests/fixtures/utils/cloudBootMocks.ts
@@ -5,6 +5,7 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
 
 interface CloudBootOptions {
   /** Remote-config payload for `/api/features` (enables the flags under test). */
@@ -47,6 +48,7 @@ export async function mockCloudBoot(
   await page.route('**/api/auth/session', (r) =>
     r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
   )
+  await mockWorkspace(page, workspace('personal', 'owner'), [])
   await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
 }
 

--- a/browser_tests/tests/authAccountSwitch.spec.ts
+++ b/browser_tests/tests/authAccountSwitch.spec.ts
@@ -6,9 +6,9 @@ import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspa
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { AssetsSidebarTab } from '@e2e/fixtures/components/SidebarTab'
 import {
+  CLOUD_REMOTE_CONFIG,
   DEFAULT_TEAM_MEMBERS,
-  TEAM_WORKSPACE,
-  WORKSPACE_FEATURE_FLAG
+  TEAM_WORKSPACE
 } from '@e2e/fixtures/data/cloudWorkspace'
 import { AssetsHelper, createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
 import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
@@ -141,7 +141,7 @@ test.describe('Cloud account switch', { tag: '@cloud' }, () => {
     await page.unroute('**/securetoken.googleapis.com/**')
 
     const features = {
-      ...WORKSPACE_FEATURE_FLAG,
+      ...CLOUD_REMOTE_CONFIG,
       onboarding_survey_enabled: false,
       unified_cloud_auth: false
     } satisfies RemoteConfig

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -19,11 +19,9 @@ import {
 /**
  * Billing facade consumers — FE-933 (B3) regression.
  *
- * The repointed surfaces (avatar popover tier badge / balance, free-tier
- * dialog renewal date) must keep rendering from `useBillingContext`. The facade
- * selects its backend by flag: `team_workspaces_enabled: false` routes through
- * the legacy `/customers/*` endpoints, while `true` routes a personal workspace
- * through the workspace `/api/billing/*` endpoints. Both shapes are mocked here.
+ * The repointed surfaces (avatar popover balance, free-tier dialog renewal
+ * date) must keep rendering from `useBillingContext`. Cloud
+ * personal workspaces route through the workspace `/api/billing/*` endpoints.
  * Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
  * against fully mocked endpoints — same pattern as creditsTile.spec.ts.
  */
@@ -56,11 +54,24 @@ const mockBalance: BillingBalanceResponse = {
   effective_balance_micros: 6000
 }
 
+const mockWorkspaceBalance: BillingBalanceResponse = {
+  amount_micros: 0,
+  currency: 'usd',
+  effective_balance_micros: 0
+}
+
 async function mockCloudBoot(
   page: Page,
   subscriptionStatus: CloudSubscriptionStatusResponse,
-  remoteConfig: RemoteConfig = { team_workspaces_enabled: false }
+  remoteConfig: RemoteConfig = {},
+  billingRail?: BillingStatusResponse['billing_rail']
 ) {
+  const billingRequests = {
+    legacyStatus: 0,
+    legacyBalance: 0,
+    workspaceStatus: 0
+  }
+
   await page.route('**/api/features', (r) => r.fulfill(jsonRoute(remoteConfig)))
   await page.route('**/api/system_stats', (r) =>
     r.fulfill(jsonRoute(mockSystemStats))
@@ -106,25 +117,34 @@ async function mockCloudBoot(
     )
   )
 
-  // Legacy backend (team_workspaces_enabled: false).
-  await page.route('**/customers/cloud-subscription-status', (r) =>
-    r.fulfill(jsonRoute(subscriptionStatus))
-  )
-  await page.route('**/customers/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  // Legacy endpoints remain mocked for consumers that explicitly use them.
+  await page.route('**/customers/cloud-subscription-status', (r) => {
+    billingRequests.legacyStatus++
+    return r.fulfill(jsonRoute(subscriptionStatus))
+  })
+  await page.route('**/customers/balance', (r) => {
+    billingRequests.legacyBalance++
+    return r.fulfill(jsonRoute(mockBalance))
+  })
 
-  // Workspace backend (team_workspaces_enabled: true) — a personal workspace
-  // now routes through `/api/billing/*`.
-  await page.route('**/api/billing/status', (r) =>
-    r.fulfill(jsonRoute(toWorkspaceStatus(subscriptionStatus)))
-  )
-  await page.route('**/api/billing/balance', (r) =>
-    r.fulfill(jsonRoute(mockBalance))
-  )
+  // Cloud personal workspaces route through `/api/billing/*`.
+  await page.route('**/api/billing/status', (r) => {
+    billingRequests.workspaceStatus++
+    return r.fulfill(
+      jsonRoute({
+        ...toWorkspaceStatus(subscriptionStatus),
+        billing_rail: billingRail
+      })
+    )
+  })
+  await page.route('**/api/billing/balance', (r) => {
+    return r.fulfill(jsonRoute(mockWorkspaceBalance))
+  })
   await page.route('**/api/billing/plans', (r) =>
     r.fulfill(jsonRoute({ plans: [] }))
   )
+
+  return billingRequests
 }
 
 async function bootApp(page: Page) {
@@ -142,27 +162,34 @@ async function bootApp(page: Page) {
 }
 
 test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
-  test('avatar popover renders tier badge and balance from the facade', async ({
+  test('avatar popover renders a legacy-rail balance from the facade', async ({
     page
   }) => {
     test.setTimeout(60_000)
 
-    await mockCloudBoot(page, {
-      is_active: true,
-      subscription_tier: 'PRO',
-      subscription_duration: 'MONTHLY',
-      renewal_date: '2099-02-20T10:00:00Z',
-      end_date: null
-    })
+    const billingRequests = await mockCloudBoot(
+      page,
+      {
+        is_active: true,
+        subscription_tier: 'PRO',
+        subscription_duration: 'MONTHLY',
+        renewal_date: '2099-02-20T10:00:00Z',
+        end_date: null
+      },
+      {},
+      'legacy_stripe'
+    )
     await bootApp(page)
 
     await page.getByRole('button', { name: 'Current user' }).click()
     const popover = page.locator('.current-user-popover')
     await expect(popover).toBeVisible()
 
-    await expect(popover.getByText('Pro', { exact: true })).toBeVisible()
     await expect(popover.getByText('12,660')).toBeVisible()
     await expect(popover.getByTestId('add-credits-button')).toBeVisible()
+    expect(billingRequests.workspaceStatus).toBeGreaterThan(0)
+    expect(billingRequests.legacyStatus).toBeGreaterThan(0)
+    expect(billingRequests.legacyBalance).toBeGreaterThan(0)
   })
 
   test('subscribe-to-run routes an inactive FREE user to the pricing table', async ({
@@ -170,8 +197,8 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
   }) => {
     test.setTimeout(60_000)
 
-    // Boots with team workspaces enabled (production shape); the facade routes a
-    // personal workspace through the workspace `/api/billing/*` endpoints. With
+    // The facade routes a personal workspace through the workspace
+    // `/api/billing/*` endpoints. With
     // subscription gating on, an inactive FREE user gets the "Subscribe to run"
     // button, which opens the pricing table on click. (refreshRemoteConfig
     // overwrites window.__CONFIG__ from /api/features, so the flags must come
@@ -186,12 +213,14 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         renewal_date: '2099-02-20T10:00:00Z',
         end_date: null
       },
-      { team_workspaces_enabled: true, subscription_required: true }
+      { subscription_required: true }
     )
     await bootApp(page)
 
     await page.getByTestId('subscribe-to-run-button').click()
 
-    await expect(page.getByRole('heading', { name: /Plans for/ })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Choose a Plan' })
+    ).toBeVisible()
   })
 })

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -176,7 +176,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         renewal_date: '2099-02-20T10:00:00Z',
         end_date: null
       },
-      {},
+      { consolidated_billing_enabled: true },
       'legacy_stripe'
     )
     await bootApp(page)
@@ -213,7 +213,10 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         renewal_date: '2099-02-20T10:00:00Z',
         end_date: null
       },
-      { subscription_required: true }
+      {
+        subscription_required: true,
+        consolidated_billing_enabled: true
+      }
     )
     await bootApp(page)
 

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -2,10 +2,7 @@ import { expect } from '@playwright/test'
 
 import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
-import type {
-  BillingStatusResponse,
-  WorkspaceWithRole
-} from '@/platform/workspace/api/workspaceApi'
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { operations } from '@/types/comfyRegistryTypes'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
@@ -52,22 +49,6 @@ const mockSubscriptionStatus: CloudSubscriptionStatusResponse = {
   subscription_id: 'sub_e2e',
   renewal_date: FUTURE_DATE,
   end_date: FUTURE_DATE
-}
-
-// The facade routes a Cloud personal workspace through `/api/billing/*`. The
-// cancelled-but-active state maps to `is_active: true`
-// with `subscription_status: 'canceled'`; a paid tier keeps "Add credits"
-// visible (free tier would swap it for "Upgrade to add credits").
-const mockBillingStatus: BillingStatusResponse = {
-  is_active: true,
-  max_seats: 1,
-  occupied_seats: 1,
-  subscription_status: 'canceled',
-  subscription_tier: 'PRO',
-  subscription_duration: 'MONTHLY',
-  has_funds: true,
-  cancel_at: FUTURE_DATE,
-  renewal_date: FUTURE_DATE
 }
 
 // ~6.3M credits — a 7-digit balance is what pushes the second action button out
@@ -125,31 +106,6 @@ const test = comfyPageFixture.extend({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(mockBalance)
-      })
-    )
-
-    // The popover sources its data from the workspace billing endpoints.
-    await page.route('**/api/billing/status', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockBillingStatus)
-      })
-    )
-
-    await page.route('**/api/billing/balance', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockBalance)
-      })
-    )
-
-    await page.route('**/api/billing/plans', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ plans: [] })
       })
     )
 

--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -17,7 +17,7 @@ type CustomerBalanceResponse = NonNullable<
 const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
 const FUTURE_DATE = '2099-01-01T00:00:00Z'
 
-const mockRemoteConfig: RemoteConfig = { team_workspaces_enabled: true }
+const mockRemoteConfig: RemoteConfig = {}
 
 const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
   workspaces: [
@@ -54,8 +54,8 @@ const mockSubscriptionStatus: CloudSubscriptionStatusResponse = {
   end_date: FUTURE_DATE
 }
 
-// With team workspaces enabled, the facade routes a personal workspace through
-// `/api/billing/*`. The cancelled-but-active state maps to `is_active: true`
+// The facade routes a Cloud personal workspace through `/api/billing/*`. The
+// cancelled-but-active state maps to `is_active: true`
 // with `subscription_status: 'canceled'`; a paid tier keeps "Add credits"
 // visible (free tier would swap it for "Upgrade to add credits").
 const mockBillingStatus: BillingStatusResponse = {
@@ -128,8 +128,7 @@ const test = comfyPageFixture.extend({
       })
     )
 
-    // Flag-on (team workspaces enabled) routes a personal workspace through the
-    // workspace billing endpoints, so the popover sources its data from here.
+    // The popover sources its data from the workspace billing endpoints.
     await page.route('**/api/billing/status', (route) =>
       route.fulfill({
         status: 200,

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -27,10 +27,9 @@ import {
  * The credits tile only lives inside the authenticated cloud app, which the
  * shared `comfyPage` fixture can't boot (it expects the OSS devtools backend).
  * Instead this drives a raw page: mock Firebase auth + every boot endpoint so
- * the cloud app initializes against fully stubbed data. With team workspaces
- * enabled the facade routes a personal workspace through the workspace
- * `/api/billing/*` endpoints (mocked with an active Pro subscription); the
- * legacy `/customers/*` shapes are mocked too for the flag-off path. The tile
+ * the cloud app initializes against fully stubbed data. The facade routes a
+ * personal workspace through the workspace `/api/billing/*` endpoints (mocked
+ * with an active Pro subscription). The tile
  * should then render its total / progress bar / monthly+additional breakdown /
  * add-credits.
  */
@@ -72,13 +71,10 @@ const mockBillingStatus: BillingStatusResponse = {
 
 async function mockCloudBoot(page: Page, billingControlEnabled = true) {
   // Frontend-origin boot endpoints (proxied to the backend in production).
-  // `/api/features` is the remote-config source: production builds resolve
-  // workspace availability and the billing UX rollout from it (the `ff:`
-  // localStorage override is dev-only).
+  // `/api/features` is the remote-config source for the billing UX rollout.
   await page.route('**/api/features', (r) =>
     r.fulfill(
       jsonRoute({
-        team_workspaces_enabled: true,
         consolidated_billing_enabled: true,
         billing_control_enabled: billingControlEnabled
       } satisfies RemoteConfig)

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -42,7 +42,8 @@ const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
 const BOOT_FEATURES = {
-  billing_control_enabled: true
+  billing_control_enabled: true,
+  consolidated_billing_enabled: true
 } satisfies RemoteConfig
 // Disable the experimental Asset API: with it on (cloud default) the unmocked
 // asset endpoints 403 and workflow restore throws uncaught, aborting the

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -41,11 +41,7 @@ const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
-// consolidated_billing_enabled routes personal workspaces to the unified
-// pricing table asserted here; without it they fall back to the legacy table.
 const BOOT_FEATURES = {
-  team_workspaces_enabled: true,
-  consolidated_billing_enabled: true,
   billing_control_enabled: true
 } satisfies RemoteConfig
 // Disable the experimental Asset API: with it on (cloud default) the unmocked

--- a/src/components/topbar/CurrentUserButton.test.ts
+++ b/src/components/topbar/CurrentUserButton.test.ts
@@ -8,10 +8,6 @@ import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 import CurrentUserButton from './CurrentUserButton.vue'
 
-const mockFeatureFlags = vi.hoisted(() => ({
-  teamWorkspacesEnabled: false
-}))
-
 const mockTeamWorkspaceStore = vi.hoisted(() => ({
   workspaceName: { value: '' },
   initState: { value: 'idle' },
@@ -38,13 +34,6 @@ vi.mock('firebase/auth', () => ({
 // Mock pinia
 vi.mock('pinia', () => ({
   storeToRefs: vi.fn((store: Record<string, unknown>) => store)
-}))
-
-// Mock the useFeatureFlags composable
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: vi.fn(() => ({
-    flags: mockFeatureFlags
-  }))
 }))
 
 // Mock the useTeamWorkspaceStore
@@ -127,7 +116,6 @@ vi.mock('./CurrentUserPopoverLegacy.vue', () => ({
 describe('CurrentUserButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockTeamWorkspaceStore.workspaceName.value = ''
     mockTeamWorkspaceStore.initState.value = 'idle'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
@@ -189,7 +177,6 @@ describe('CurrentUserButton', () => {
     'shows account actions while Cloud workspace initialization is %s',
     async (initState) => {
       mockIsCloud.value = true
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockTeamWorkspaceStore.initState.value = initState
       const { user } = renderComponent()
 
@@ -213,7 +200,6 @@ describe('CurrentUserButton', () => {
 
   it('shows UserAvatar in personal workspace', () => {
     mockIsCloud.value = true
-    mockFeatureFlags.teamWorkspacesEnabled = true
     mockTeamWorkspaceStore.initState.value = 'ready'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = true
 
@@ -224,7 +210,6 @@ describe('CurrentUserButton', () => {
 
   it('shows WorkspaceProfilePic in team workspace', () => {
     mockIsCloud.value = true
-    mockFeatureFlags.teamWorkspacesEnabled = true
     mockTeamWorkspaceStore.initState.value = 'ready'
     mockTeamWorkspaceStore.isInPersonalWorkspace.value = false
     mockTeamWorkspaceStore.workspaceName.value = 'My Team'

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -49,7 +49,7 @@
       @show="onPopoverShow"
     >
       <CurrentUserPopoverWorkspace
-        v-if="teamWorkspacesEnabled"
+        v-if="isCloud"
         ref="workspacePopoverContent"
         :account-actions-only="initState !== 'ready'"
         @close="closePopover"
@@ -69,7 +69,6 @@ import UserAvatar from '@/components/common/UserAvatar.vue'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -86,9 +85,6 @@ const { showArrow = true, compact = false } = defineProps<{
   compact?: boolean
 }>()
 
-const { flags } = useFeatureFlags()
-const teamWorkspacesEnabled = computed(() => flags.teamWorkspacesEnabled)
-
 const { isLoggedIn, userPhotoUrl } = useCurrentUser()
 
 const photoURL = computed<string | undefined>(
@@ -102,14 +98,10 @@ const {
 } = storeToRefs(useTeamWorkspaceStore())
 
 const showWorkspaceSkeleton = computed(
-  () => isCloud && teamWorkspacesEnabled.value && initState.value === 'loading'
+  () => isCloud && initState.value === 'loading'
 )
 const showWorkspaceIcon = computed(
-  () =>
-    isCloud &&
-    teamWorkspacesEnabled.value &&
-    initState.value === 'ready' &&
-    !isInPersonalWorkspace.value
+  () => isCloud && initState.value === 'ready' && !isInPersonalWorkspace.value
 )
 
 const workspaceName = computed(() => {

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -21,7 +21,6 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
-  mockTeamWorkspacesEnabled,
   mockConsolidatedBillingEnabled,
   mockIsPersonal,
   mockBillingRail,
@@ -35,8 +34,7 @@ const {
   mockSetWorkspaceBillingRail,
   mockBillingStatus
 } = vi.hoisted(() => ({
-  mockTeamWorkspacesEnabled: { value: false },
-  mockConsolidatedBillingEnabled: { value: false },
+  mockConsolidatedBillingEnabled: { value: true },
   mockIsPersonal: { value: true },
   mockBillingRail: { value: undefined as BillingRail | undefined },
   mockPlans: { value: [] as Plan[] },
@@ -57,6 +55,16 @@ const {
   }
 }))
 
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get consolidatedBillingEnabled() {
+        return mockConsolidatedBillingEnabled.value
+      }
+    }
+  })
+}))
+
 vi.mock('@vueuse/core', async (importOriginal) => {
   const original = await importOriginal()
   return {
@@ -65,37 +73,7 @@ vi.mock('@vueuse/core', async (importOriginal) => {
   }
 })
 
-vi.mock('@/composables/useFeatureFlags', async () => {
-  const { ref } = await import('vue')
-  const teamWorkspacesEnabledRef = ref(mockTeamWorkspacesEnabled.value)
-  Object.defineProperty(mockTeamWorkspacesEnabled, 'value', {
-    get: () => teamWorkspacesEnabledRef.value,
-    set: (value: boolean) => {
-      teamWorkspacesEnabledRef.value = value
-    }
-  })
-  const consolidatedBillingEnabledRef = ref(
-    mockConsolidatedBillingEnabled.value
-  )
-  Object.defineProperty(mockConsolidatedBillingEnabled, 'value', {
-    get: () => consolidatedBillingEnabledRef.value,
-    set: (value: boolean) => {
-      consolidatedBillingEnabledRef.value = value
-    }
-  })
-  return {
-    useFeatureFlags: () => ({
-      flags: {
-        get teamWorkspacesEnabled() {
-          return mockTeamWorkspacesEnabled.value
-        },
-        get consolidatedBillingEnabled() {
-          return mockConsolidatedBillingEnabled.value
-        }
-      }
-    })
-  }
-})
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
   const { ref } = await import('vue')
@@ -195,8 +173,7 @@ describe('useBillingContext', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    mockTeamWorkspacesEnabled.value = false
-    mockConsolidatedBillingEnabled.value = false
+    mockConsolidatedBillingEnabled.value = true
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(
@@ -208,33 +185,22 @@ describe('useBillingContext', () => {
     mockBillingStatus.value = { ...DEFAULT_BILLING_STATUS }
   })
 
-  it('selects legacy type when team workspaces are disabled', () => {
-    mockTeamWorkspacesEnabled.value = false
-    const { type } = useBillingContext()
-    expect(type.value).toBe('legacy')
-  })
-
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type } = useBillingContext()
-    expect(type.value).toBe('legacy')
-  })
-
-  it('selects workspace type for personal when consolidated billing is enabled', () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
+  it('selects workspace type for a Cloud personal workspace', () => {
     mockIsPersonal.value = true
 
     const { type } = useBillingContext()
     expect(type.value).toBe('workspace')
   })
 
-  it('selects workspace type for team regardless of consolidated billing', () => {
-    mockTeamWorkspacesEnabled.value = true
+  it('keeps a Cloud personal workspace on legacy while consolidation is off', () => {
     mockConsolidatedBillingEnabled.value = false
+
+    const { type } = useBillingContext()
+
+    expect(type.value).toBe('legacy')
+  })
+
+  it('selects workspace type for a Cloud team workspace', () => {
     mockIsPersonal.value = false
 
     const { type } = useBillingContext()
@@ -242,6 +208,7 @@ describe('useBillingContext', () => {
   })
 
   it('provides subscription info from legacy billing', () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { subscription } = useBillingContext()
 
     expect(subscription.value).toEqual({
@@ -257,6 +224,7 @@ describe('useBillingContext', () => {
   })
 
   it('provides balance info from legacy billing', () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { balance } = useBillingContext()
 
     expect(balance.value).toEqual({
@@ -285,15 +253,19 @@ describe('useBillingContext', () => {
 
   it('exposes subscribe action', async () => {
     const { subscribe } = useBillingContext()
-    await expect(subscribe('pro-monthly')).resolves.toBeUndefined()
+    await expect(subscribe('pro-monthly')).resolves.toEqual({
+      status: 'subscribed'
+    })
   })
 
   it('exposes manageSubscription action', async () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { manageSubscription } = useBillingContext()
     await expect(manageSubscription()).resolves.toBeUndefined()
   })
 
   it('converts topup cents to whole dollars for the legacy credit endpoint', async () => {
+    mockBillingRail.value = 'legacy_stripe'
     const { topup } = useBillingContext()
     await topup(500)
 
@@ -301,8 +273,6 @@ describe('useBillingContext', () => {
   })
 
   it('uses workspace checkout while keeping legacy topups on legacy Stripe', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
     mockPlans.value = [
       {
@@ -331,7 +301,7 @@ describe('useBillingContext', () => {
     await context.fetchStatus()
 
     expect(mockFetchPlans).toHaveBeenCalledOnce()
-    expect(mockLegacyFetchStatus).toHaveBeenCalledOnce()
+    expect(mockLegacyFetchStatus).toHaveBeenCalled()
     expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
 
     await context.previewSubscribe('creator-annual')
@@ -351,8 +321,6 @@ describe('useBillingContext', () => {
   })
 
   it('switches billing adapters before refreshing a migrated balance', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
     mockBillingStatus.value = {
       ...DEFAULT_BILLING_STATUS,
@@ -360,6 +328,10 @@ describe('useBillingContext', () => {
     }
 
     const context = useBillingContext()
+    await vi.waitFor(() => {
+      expect(mockLegacyFetchStatus).toHaveBeenCalled()
+      expect(mockLegacyFetchBalance).toHaveBeenCalled()
+    })
     vi.clearAllMocks()
 
     await context.reconcileSubscriptionSuccess()
@@ -376,11 +348,13 @@ describe('useBillingContext', () => {
   })
 
   it('does not refresh a balance through a stale rail after discovery fails', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = true
     mockBillingRail.value = 'legacy_stripe'
 
     const context = useBillingContext()
+    await vi.waitFor(() => {
+      expect(mockLegacyFetchStatus).toHaveBeenCalled()
+      expect(mockLegacyFetchBalance).toHaveBeenCalled()
+    })
     vi.clearAllMocks()
     vi.mocked(workspaceApi.getBillingStatus).mockRejectedValueOnce(
       new Error('status unavailable')
@@ -407,6 +381,12 @@ describe('useBillingContext', () => {
     expect(canAccessSubscriptionFeatures.value).toBe(true)
   })
 
+  it('provides isActiveSubscription convenience computed', () => {
+    mockBillingRail.value = 'legacy_stripe'
+    const { isActiveSubscription } = useBillingContext()
+    expect(isActiveSubscription.value).toBe(true)
+  })
+
   it('exposes requireActiveSubscription action', async () => {
     const { requireActiveSubscription } = useBillingContext()
     await expect(requireActiveSubscription()).resolves.toBeUndefined()
@@ -417,48 +397,8 @@ describe('useBillingContext', () => {
     expect(() => showSubscriptionDialog()).not.toThrow()
   })
 
-  it('reinitializes workspace billing when the type flips on after legacy init', async () => {
-    mockTeamWorkspacesEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type, initialize } = useBillingContext()
-    await initialize()
-    await nextTick()
-
-    expect(type.value).toBe('legacy')
-    expect(workspaceApi.getBillingStatus).not.toHaveBeenCalled()
-
-    // Authenticated remote config resolves the flag on for the same workspace
-    mockConsolidatedBillingEnabled.value = true
-    mockTeamWorkspacesEnabled.value = true
-
-    await vi.waitFor(() => {
-      expect(type.value).toBe('workspace')
-      expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
-    })
-  })
-
-  it('moves a personal workspace to workspace billing when consolidated billing flips on', async () => {
-    mockTeamWorkspacesEnabled.value = true
-    mockConsolidatedBillingEnabled.value = false
-    mockIsPersonal.value = true
-
-    const { type } = useBillingContext()
-    await nextTick()
-    expect(type.value).toBe('legacy')
-
-    mockConsolidatedBillingEnabled.value = true
-
-    await vi.waitFor(() => {
-      expect(type.value).toBe('workspace')
-      expect(workspaceApi.getBillingStatus).toHaveBeenCalled()
-    })
-  })
-
   describe('subscription mirror to workspace store', () => {
-    it('mirrors subscription for personal workspaces on the consolidated billing flow', async () => {
-      mockTeamWorkspacesEnabled.value = true
-      mockConsolidatedBillingEnabled.value = true
+    it('mirrors subscription for personal workspaces', async () => {
       mockIsPersonal.value = true
 
       const { initialize } = useBillingContext()
@@ -472,7 +412,6 @@ describe('useBillingContext', () => {
     })
 
     it('never clobbers the list-derived store when a subscription is absent', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
 
       const { initialize } = useBillingContext()
@@ -487,16 +426,15 @@ describe('useBillingContext', () => {
   })
 
   describe('getMaxSeats', () => {
-    it('returns 1 for personal workspaces regardless of tier', () => {
+    it('uses plan seat limits for Cloud personal workspaces', () => {
       const { getMaxSeats } = useBillingContext()
       expect(getMaxSeats('standard')).toBe(1)
-      expect(getMaxSeats('creator')).toBe(1)
-      expect(getMaxSeats('pro')).toBe(1)
+      expect(getMaxSeats('creator')).toBe(5)
+      expect(getMaxSeats('pro')).toBe(20)
       expect(getMaxSeats('founder')).toBe(1)
     })
 
     it('falls back to hardcoded values when no API plans available', () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
 
       const { getMaxSeats } = useBillingContext()
@@ -507,7 +445,6 @@ describe('useBillingContext', () => {
     })
 
     it('prefers API max_seats when plans are loaded', () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockPlans.value = [
         {
@@ -540,7 +477,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for an active team plan: team- slug and no credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -557,7 +493,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for any legacy team tier, not just standard', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -574,7 +509,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a new credit-slider team subscriber', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       // Real BE shape: underscore slug + populated credit stop. (subscription_tier
       // is 'TEAM' on the wire, not yet in the FE SubscriptionTier union, so it is
@@ -599,7 +533,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a new team sub even before its credit stop is populated', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       // Provisioning lag: credit stop not yet attached. The underscore slug
       // (team_per_credit, not team-) must still exclude it from the legacy table.
@@ -618,7 +551,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a team workspace on a personal-tier plan', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -635,7 +567,6 @@ describe('useBillingContext', () => {
     })
 
     it('stays true for a cancelled-but-still-active legacy team sub', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -654,7 +585,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a FREE-tier team even on a team- prefixed slug', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -670,7 +600,6 @@ describe('useBillingContext', () => {
     })
 
     it('matches the legacy slug case-insensitively', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -699,7 +628,6 @@ describe('useBillingContext', () => {
     // isTeamPlan reads the credit stop and the slug, never the tier — which is
     // what keeps it working despite that divergence.
     it('is true for a credit-slider team sub, which carries a credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -719,8 +647,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for a per-credit Team plan in a personal workspace before its credit stop is populated', async () => {
-      mockTeamWorkspacesEnabled.value = true
-      mockConsolidatedBillingEnabled.value = true
       mockIsPersonal.value = true
       mockBillingStatus.value = {
         is_active: true,
@@ -737,7 +663,6 @@ describe('useBillingContext', () => {
     })
 
     it('is true for a legacy team sub, identified by slug rather than credit stop', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,
@@ -757,7 +682,6 @@ describe('useBillingContext', () => {
     // spend gate folds billing_status into it. Coupling isTeamPlan to an active
     // subscription would blank the banner precisely when it is needed.
     it('stays true for a paused team plan, which the backend reports inactive', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: false,
@@ -778,7 +702,6 @@ describe('useBillingContext', () => {
     })
 
     it('stays true for a legacy team plan whose payment failed', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: false,
@@ -795,7 +718,6 @@ describe('useBillingContext', () => {
     })
 
     it('is false for a team workspace on a personal-tier plan', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockIsPersonal.value = false
       mockBillingStatus.value = {
         is_active: true,

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -376,11 +376,6 @@ describe('useBillingContext', () => {
     await expect(topup(99.5)).rejects.toThrow()
   })
 
-  it('provides canAccessSubscriptionFeatures convenience computed', () => {
-    const { canAccessSubscriptionFeatures } = useBillingContext()
-    expect(canAccessSubscriptionFeatures.value).toBe(true)
-  })
-
   it('provides isActiveSubscription convenience computed', () => {
     mockBillingRail.value = 'legacy_stripe'
     const { isActiveSubscription } = useBillingContext()

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -236,9 +236,7 @@ function useBillingContextInternal(): BillingContext {
     error.value = null
   }
 
-  // type flips when the team-workspaces or consolidated-billing flag resolves
-  // from authenticated config, swapping the active backend. Reset then reinit
-  // on every workspace-id or type change.
+  // Reset and reinitialize when the active workspace or billing backend changes.
   watch(
     [() => store.activeWorkspace?.id, () => type.value],
     async ([newWorkspaceId]) => {

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -4,22 +4,36 @@ import type { BillingRail } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const { mockFlags, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
-  vi.hoisted(() => ({
-    mockFlags: {
-      teamWorkspacesEnabled: false,
-      consolidatedBillingEnabled: false
-    },
-    mockActiveWorkspace: {
-      value: null as { id: string; type: 'personal' | 'team' } | null
-    },
-    mockActiveWorkspaceBillingRail: {
-      value: null as BillingRail | null
-    }
-  }))
+const {
+  mockIsCloud,
+  mockConsolidatedBillingEnabled,
+  mockActiveWorkspace,
+  mockActiveWorkspaceBillingRail
+} = vi.hoisted(() => ({
+  mockIsCloud: { value: true },
+  mockConsolidatedBillingEnabled: { value: false },
+  mockActiveWorkspace: {
+    value: null as { id: string; type: 'personal' | 'team' } | null
+  },
+  mockActiveWorkspaceBillingRail: {
+    value: null as BillingRail | null
+  }
+}))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags })
+  useFeatureFlags: () => ({
+    flags: {
+      get consolidatedBillingEnabled() {
+        return mockConsolidatedBillingEnabled.value
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -38,14 +52,14 @@ const team = { id: 'w-team', type: 'team' as const }
 
 describe('useBillingRouting', () => {
   beforeEach(() => {
-    mockFlags.teamWorkspacesEnabled = false
-    mockFlags.consolidatedBillingEnabled = false
+    mockIsCloud.value = true
+    mockConsolidatedBillingEnabled.value = false
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = null
   })
 
-  it('uses legacy billing when team workspaces are disabled', () => {
-    mockFlags.teamWorkspacesEnabled = false
+  it('uses legacy billing off Cloud', () => {
+    mockIsCloud.value = false
     mockActiveWorkspace.value = team
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
@@ -54,20 +68,17 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(false)
   })
 
-  it('keeps personal on legacy when consolidated billing is disabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = false
+  it('keeps a Cloud personal workspace on legacy while consolidation is off', () => {
     mockActiveWorkspace.value = personal
 
-    const { type } = useBillingRouting()
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
     expect(type.value).toBe('legacy')
+    expect(shouldUseWorkspaceBilling.value).toBe(false)
   })
 
-  it('moves personal to workspace billing when consolidated billing is enabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
-    mockActiveWorkspace.value = personal
+  it('uses workspace billing for a Cloud personal workspace when consolidation is on', () => {
+    mockConsolidatedBillingEnabled.value = true
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
@@ -76,8 +87,7 @@ describe('useBillingRouting', () => {
   })
 
   it('uses unified pricing while keeping legacy Stripe top-ups on Checkout', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
+    mockConsolidatedBillingEnabled.value = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
@@ -90,8 +100,7 @@ describe('useBillingRouting', () => {
   })
 
   it('uses workspace billing for migrated Stripe personal workspaces', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
+    mockConsolidatedBillingEnabled.value = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'stripe'
 
@@ -101,9 +110,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
-  it('uses workspace billing for team workspaces regardless of consolidated billing', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = false
+  it('uses workspace billing for team workspaces', () => {
     mockActiveWorkspace.value = team
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
@@ -113,21 +120,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
-  it('uses workspace billing for team workspaces with consolidated billing enabled', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
-    mockActiveWorkspace.value = team
-    mockActiveWorkspaceBillingRail.value = 'stripe'
-
-    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
-
-    expect(type.value).toBe('workspace')
-    expect(shouldUseWorkspaceBilling.value).toBe(true)
-  })
-
   it('defaults to legacy while the workspace has not loaded', () => {
-    mockFlags.teamWorkspacesEnabled = true
-    mockFlags.consolidatedBillingEnabled = true
     mockActiveWorkspace.value = null
 
     const { type } = useBillingRouting()

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -1,6 +1,7 @@
 import { computed } from 'vue'
 
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import type { BillingType } from './types'
@@ -8,18 +9,16 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * stay legacy until `consolidatedBillingEnabled`, and known legacy Stripe
- * workspaces remain legacy after it is enabled. An unknown rail keeps the
- * flag-based route so workspace status can load it. Team workspaces are always
- * workspace-scoped. Pricing follows feature availability independently of the
- * billing rail. The routing matrix is covered in useBillingRouting.test.ts.
+ * stay legacy until consolidated billing is enabled; an explicit legacy Stripe
+ * rail continues to use legacy account operations after enablement. An unloaded
+ * workspace remains legacy during bootstrap, and OSS always uses legacy billing.
  */
 export function useBillingRouting() {
   const { flags } = useFeatureFlags()
   const workspaceStore = useTeamWorkspaceStore()
 
   const shouldUseUnifiedPricing = computed(() => {
-    if (!flags.teamWorkspacesEnabled) return false
+    if (!isCloud) return false
 
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return false
@@ -28,7 +27,7 @@ export function useBillingRouting() {
   })
 
   const type = computed<BillingType>(() => {
-    if (!flags.teamWorkspacesEnabled) return 'legacy'
+    if (!isCloud) return 'legacy'
 
     // An unloaded workspace has no type yet; stay legacy so bootstrap never
     // eagerly routes to workspace billing.

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -9,7 +9,6 @@ import * as distributionTypes from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigState
@@ -271,14 +270,6 @@ describe('useFeatureFlags', () => {
       expect(flags.supportsPreviewMetadata).toBe('overridden')
     })
 
-    it('teamWorkspacesEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
-      vi.mocked(distributionTypes).isCloud = false
-      localStorage.setItem('ff:team_workspaces_enabled', 'true')
-
-      const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
-    })
-
     it('billingControlEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
       vi.mocked(distributionTypes).isCloud = false
       localStorage.setItem('ff:billing_control_enabled', 'true')
@@ -308,7 +299,6 @@ describe('useFeatureFlags', () => {
 
       const { flags } = useFeatureFlags()
       expect(flags.billingControlEnabled).toBe(false)
-      expect(flags.consolidatedBillingEnabled).toBe(false)
     })
   })
 
@@ -317,7 +307,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = true
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedTeamWorkspacesEnabled.value = undefined
       cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
@@ -328,7 +317,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = false
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedTeamWorkspacesEnabled.value = undefined
       cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
@@ -336,13 +324,11 @@ describe('useFeatureFlags', () => {
     })
 
     it('returns the cached session value during the auth window', () => {
-      cachedTeamWorkspacesEnabled.value = false
       cachedConsolidatedBillingEnabled.value = true
       cachedBillingControlEnabled.value = true
       cachedV1PaymentRecovery.value = true
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(false)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
       expect(flags.v1PaymentRecovery).toBe(true)
@@ -350,7 +336,6 @@ describe('useFeatureFlags', () => {
 
     it('defaults to false during the auth window when nothing is cached', () => {
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(false)
       expect(flags.consolidatedBillingEnabled).toBe(false)
       expect(flags.billingControlEnabled).toBe(false)
       expect(flags.v1PaymentRecovery).toBe(false)
@@ -359,7 +344,6 @@ describe('useFeatureFlags', () => {
     it('prefers authenticated remoteConfig over the server feature fallback', () => {
       remoteConfigState.value = 'authenticated'
       remoteConfig.value = {
-        team_workspaces_enabled: true,
         consolidated_billing_enabled: true,
         billing_control_enabled: false,
         v1_payment_recovery: true
@@ -367,7 +351,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(api.getServerFeature).mockReturnValue(false)
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(false)
       expect(flags.v1PaymentRecovery).toBe(true)
@@ -378,7 +361,6 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {}
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
-          if (path === ServerFeatureFlag.TEAM_WORKSPACES_ENABLED) return true
           if (path === ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED)
             return true
           if (path === ServerFeatureFlag.BILLING_CONTROL_ENABLED) return true
@@ -388,7 +370,6 @@ describe('useFeatureFlags', () => {
       )
 
       const { flags } = useFeatureFlags()
-      expect(flags.teamWorkspacesEnabled).toBe(true)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
       expect(flags.v1PaymentRecovery).toBe(true)

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -5,7 +5,6 @@ import { isCloud, isNightly } from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   cachedV1PaymentRecovery,
   isAuthenticatedConfigLoaded,
   remoteConfig
@@ -25,7 +24,6 @@ export enum ServerFeatureFlag {
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
-  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
   PARTNER_NODE_GOVERNANCE_ENABLED = 'partner_node_governance_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
   NODE_REPLACEMENTS = 'node_replacements',
@@ -129,19 +127,6 @@ export function useFeatureFlags() {
         false
       )
     },
-    /**
-     * Whether team workspaces feature is enabled.
-     * IMPORTANT: Returns false until authenticated remote config is loaded.
-     * This ensures we never use workspace tokens when the feature is disabled,
-     * and prevents race conditions during initialization.
-     */
-    get teamWorkspacesEnabled() {
-      return resolveAuthGatedFlag(
-        ServerFeatureFlag.TEAM_WORKSPACES_ENABLED,
-        remoteConfig.value.team_workspaces_enabled,
-        cachedTeamWorkspacesEnabled
-      )
-    },
     get partnerNodeGovernanceEnabled() {
       return resolveFlag(
         ServerFeatureFlag.PARTNER_NODE_GOVERNANCE_ENABLED,
@@ -206,11 +191,6 @@ export function useFeatureFlags() {
         false
       )
     },
-    /**
-     * Whether personal workspaces use the consolidated (workspace-scoped)
-     * billing flow. While false (default), personal workspaces stay on the
-     * legacy per-user billing flow; team workspaces are unaffected.
-     */
     get consolidatedBillingEnabled() {
       return resolveAuthGatedFlag(
         ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED,

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -9,11 +9,6 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-const mockFlags = vi.hoisted(() => ({ value: { teamWorkspacesEnabled: true } }))
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags.value })
-}))
-
 const mocks = vi.hoisted(() => ({
   loadInvite: vi.fn().mockResolvedValue(undefined),
   loadCreateWorkspace: vi.fn().mockResolvedValue(undefined),
@@ -55,7 +50,6 @@ describe('useUrlActionLoaders', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsCloud.value = true
-    mockFlags.value = { teamWorkspacesEnabled: true }
   })
 
   it('does not instantiate or run any loader off cloud', async () => {
@@ -74,24 +68,12 @@ describe('useUrlActionLoaders', () => {
     expect(mocks.loadTopUp).not.toHaveBeenCalled()
   })
 
-  it('runs all loaders on cloud when team workspaces are enabled', async () => {
+  it('runs all loaders on Cloud', async () => {
     const { runUrlActionLoaders } = useUrlActionLoaders()
     await runUrlActionLoaders()
 
     expect(mocks.loadInvite).toHaveBeenCalledOnce()
     expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
-    expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
-    expect(mocks.loadTopUp).toHaveBeenCalledOnce()
-  })
-
-  it('runs the pricing and top-up loaders but skips the flag-gated loaders when team workspaces are disabled', async () => {
-    mockFlags.value = { teamWorkspacesEnabled: false }
-
-    const { runUrlActionLoaders } = useUrlActionLoaders()
-    await runUrlActionLoaders()
-
-    expect(mocks.loadInvite).not.toHaveBeenCalled()
-    expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
     expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
     expect(mocks.loadTopUp).toHaveBeenCalledOnce()
   })

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
 import { useTopUpUrlLoader } from '@/platform/cloud/subscription/composables/useTopUpUrlLoader'
 import { isCloud } from '@/platform/distribution/types'
@@ -12,7 +11,6 @@ import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUr
  * `runUrlActionLoaders()` from `onMounted` once the app is ready.
  */
 export function useUrlActionLoaders() {
-  const { flags } = useFeatureFlags()
   const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
   const createWorkspaceUrlLoader = isCloud
     ? useCreateWorkspaceUrlLoader()
@@ -22,13 +20,12 @@ export function useUrlActionLoaders() {
 
   async function runUrlActionLoaders() {
     // Accept workspace invite from URL if present (e.g., ?invite=TOKEN).
-    // WorkspaceAuthGate ensures flag state is resolved before the app mounts.
-    if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
+    if (inviteUrlLoader) {
       await inviteUrlLoader.loadInviteFromUrl()
     }
 
     // Open create workspace dialog from URL if present (e.g., ?create_workspace=1).
-    if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
+    if (createWorkspaceUrlLoader) {
       try {
         await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
       } catch (error) {
@@ -40,7 +37,6 @@ export function useUrlActionLoaders() {
     }
 
     // Open the pricing table from URL if present (e.g., ?pricing=1 / ?pricing=team).
-    // Not gated on the team-workspaces flag: it also drives personal/legacy users.
     if (pricingTableUrlLoader) {
       try {
         await pricingTableUrlLoader.loadPricingTableFromUrl()

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -5,17 +5,10 @@ const mockGetAuthHeader = vi.fn()
 const mockAuthState = vi.hoisted(() => ({
   currentUser: { uid: 'user-a' } as { uid: string } | null
 }))
-const mockFlags = vi.hoisted(() => ({ teamWorkspacesEnabled: true }))
 const originalFetch = globalThis.fetch
 
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: true
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: mockFlags
-  })
 }))
 
 vi.mock('@/stores/authStore', () => ({
@@ -41,7 +34,6 @@ describe('useSessionCookie', () => {
     mockGetIdToken.mockReset()
     mockGetAuthHeader.mockReset()
     mockAuthState.currentUser = { uid: 'user-a' }
-    mockFlags.teamWorkspacesEnabled = true
     globalThis.fetch = vi.fn()
   })
 
@@ -209,7 +201,6 @@ describe('useSessionCookie', () => {
   })
 
   it('does not let strict Firebase creation join a weaker request', async () => {
-    mockFlags.teamWorkspacesEnabled = false
     mockGetAuthHeader.mockResolvedValue(null)
     mockGetIdToken.mockResolvedValue('firebase-id-token')
     vi.mocked(globalThis.fetch).mockResolvedValue(

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -200,7 +200,7 @@ describe('useSessionCookie', () => {
     expect(finalHeaders.get('Authorization')).toBe('Bearer firebase-user-a')
   })
 
-  it('does not let strict Firebase creation join a weaker request', async () => {
+  it('lets strict creation join an in-flight Firebase request on Cloud', async () => {
     mockGetAuthHeader.mockResolvedValue(null)
     mockGetIdToken.mockResolvedValue('firebase-id-token')
     vi.mocked(globalThis.fetch).mockResolvedValue(
@@ -218,6 +218,7 @@ describe('useSessionCookie', () => {
       vi.mocked(globalThis.fetch).mock.calls[0][1]?.headers
     )
     expect(headers.get('Authorization')).toBe('Bearer firebase-id-token')
+    expect(mockGetAuthHeader).not.toHaveBeenCalled()
   })
 
   it('serializes session deletion after an in-flight creation', async () => {

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { useAuthStore } from '@/stores/authStore'
@@ -41,10 +40,9 @@ export const useSessionCookie = () => {
   const getSessionHeaderOrThrow = async (
     useFirebaseToken: boolean
   ): Promise<Record<string, string>> => {
-    const { flags } = useFeatureFlags()
     const authStore = useAuthStore()
 
-    if (useFirebaseToken || flags.teamWorkspacesEnabled) {
+    if (isCloud || useFirebaseToken) {
       const firebaseToken = await authStore.getIdToken()
       if (!firebaseToken) {
         throw new Error('No Firebase token available for session creation')
@@ -60,14 +58,7 @@ export const useSessionCookie = () => {
     return authHeader
   }
 
-  /**
-   * Creates or refreshes the session cookie.
-   * Called after login and on token refresh.
-   *
-   * When team_workspaces_enabled is true, uses Firebase token directly
-   * (since getAuthHeader() returns workspace token which shouldn't be used for session creation).
-   * When disabled, uses getAuthHeader() for backward compatibility.
-   */
+  /** Creates or refreshes the session cookie after login or token refresh. */
   const performCreateSession = async (
     expectedOwnerUid: string,
     useFirebaseToken: boolean
@@ -91,6 +82,7 @@ export const useSessionCookie = () => {
     forceRefresh: boolean,
     useFirebaseToken = false
   ): Promise<void> => {
+    const usesFirebaseToken = isCloud || useFirebaseToken
     if (
       !forceRefresh &&
       pendingSessionMutations === 0 &&
@@ -100,7 +92,7 @@ export const useSessionCookie = () => {
     }
     if (
       inFlightCreateSession?.ownerUid === ownerUid &&
-      (!useFirebaseToken || inFlightCreateSession.usesFirebaseToken)
+      (!usesFirebaseToken || inFlightCreateSession.usesFirebaseToken)
     ) {
       return inFlightCreateSession.promise
     }
@@ -108,13 +100,13 @@ export const useSessionCookie = () => {
     pendingSessionMutations++
     const request: InFlightCreateSession = {
       ownerUid,
-      usesFirebaseToken: useFirebaseToken,
+      usesFirebaseToken,
       promise: sessionMutationTail
         .then(async () => {
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed before creation')
           }
-          await performCreateSession(ownerUid, useFirebaseToken)
+          await performCreateSession(ownerUid, usesFirebaseToken)
           confirmedSessionOwnerUid = ownerUid
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed during creation')

--- a/src/platform/auth/session/useSessionCookie.ts
+++ b/src/platform/auth/session/useSessionCookie.ts
@@ -4,7 +4,6 @@ import { useAuthStore } from '@/stores/authStore'
 
 interface InFlightCreateSession {
   ownerUid: string | null
-  usesFirebaseToken: boolean
   promise: Promise<void>
 }
 
@@ -37,34 +36,22 @@ export const useSessionCookie = () => {
     return typeof message === 'string' ? message : response.statusText
   }
 
-  const getSessionHeaderOrThrow = async (
-    useFirebaseToken: boolean
-  ): Promise<Record<string, string>> => {
+  const getSessionHeaderOrThrow = async (): Promise<Record<string, string>> => {
     const authStore = useAuthStore()
-
-    if (isCloud || useFirebaseToken) {
-      const firebaseToken = await authStore.getIdToken()
-      if (!firebaseToken) {
-        throw new Error('No Firebase token available for session creation')
-      }
-
-      return { Authorization: `Bearer ${firebaseToken}` }
+    const firebaseToken = await authStore.getIdToken()
+    if (!firebaseToken) {
+      throw new Error('No Firebase token available for session creation')
     }
 
-    const authHeader = await authStore.getAuthHeader()
-    if (!authHeader) {
-      throw new Error('No auth header available for session creation')
-    }
-    return authHeader
+    return { Authorization: `Bearer ${firebaseToken}` }
   }
 
   /** Creates or refreshes the session cookie after login or token refresh. */
   const performCreateSession = async (
-    expectedOwnerUid: string,
-    useFirebaseToken: boolean
+    expectedOwnerUid: string
   ): Promise<void> => {
     const authStore = useAuthStore()
-    const authHeader = await getSessionHeaderOrThrow(useFirebaseToken)
+    const authHeader = await getSessionHeaderOrThrow()
 
     if ((authStore.currentUser?.uid ?? null) !== expectedOwnerUid) {
       throw new Error('Session identity changed during creation')
@@ -79,10 +66,8 @@ export const useSessionCookie = () => {
 
   const establishSession = (
     ownerUid: string,
-    forceRefresh: boolean,
-    useFirebaseToken = false
+    forceRefresh: boolean
   ): Promise<void> => {
-    const usesFirebaseToken = isCloud || useFirebaseToken
     if (
       !forceRefresh &&
       pendingSessionMutations === 0 &&
@@ -90,23 +75,19 @@ export const useSessionCookie = () => {
     ) {
       return Promise.resolve()
     }
-    if (
-      inFlightCreateSession?.ownerUid === ownerUid &&
-      (!usesFirebaseToken || inFlightCreateSession.usesFirebaseToken)
-    ) {
+    if (inFlightCreateSession?.ownerUid === ownerUid) {
       return inFlightCreateSession.promise
     }
 
     pendingSessionMutations++
     const request: InFlightCreateSession = {
       ownerUid,
-      usesFirebaseToken,
       promise: sessionMutationTail
         .then(async () => {
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed before creation')
           }
-          await performCreateSession(ownerUid, usesFirebaseToken)
+          await performCreateSession(ownerUid)
           confirmedSessionOwnerUid = ownerUid
           if ((useAuthStore().currentUser?.uid ?? null) !== ownerUid) {
             throw new Error('Session identity changed during creation')
@@ -148,7 +129,7 @@ export const useSessionCookie = () => {
 
   const createSessionOrThrow = async (): Promise<void> => {
     if (!isCloud) return
-    await establishSession(currentOwnerUidOrThrow(), true, true)
+    await establishSession(currentOwnerUidOrThrow(), true)
   }
 
   /**

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -1,7 +1,6 @@
 import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
-  cachedTeamWorkspacesEnabled,
   cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigErrorStatus,
@@ -73,9 +72,6 @@ export async function refreshRemoteConfig(
       remoteConfigErrorStatus.value = null
       remoteConfigState.value = useAuth ? 'authenticated' : 'anonymous'
       if (useAuth) {
-        cachedTeamWorkspacesEnabled.value = Boolean(
-          config.team_workspaces_enabled
-        )
         cachedConsolidatedBillingEnabled.value = Boolean(
           config.consolidated_billing_enabled
         )

--- a/src/platform/remoteConfig/remoteConfig.ts
+++ b/src/platform/remoteConfig/remoteConfig.ts
@@ -34,10 +34,7 @@ export const remoteConfigState = ref<RemoteConfigState>('unloaded')
 
 export const remoteConfigErrorStatus = ref<number | null>(null)
 
-/**
- * Whether the authenticated config has been loaded.
- * Use this to gate access to user-specific feature flags like teamWorkspacesEnabled.
- */
+/** Whether the authenticated config has been loaded. */
 export const isAuthenticatedConfigLoaded = computed(
   () => remoteConfigState.value === 'authenticated'
 )
@@ -56,11 +53,6 @@ export function configValueOrDefault<K extends keyof RemoteConfig>(
   const configValue = remoteConfig[key]
   return configValue || defaultValue
 }
-
-export const cachedTeamWorkspacesEnabled = useStorage<boolean | undefined>(
-  'team_workspaces_enabled' satisfies `${ServerFeatureFlag.TEAM_WORKSPACES_ENABLED}`,
-  undefined
-)
 
 export const cachedConsolidatedBillingEnabled = useStorage<boolean | undefined>(
   'consolidated_billing_enabled' satisfies `${ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED}`,

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -107,7 +107,6 @@ export type RemoteConfig = {
   /** Full hosted (external) survey URL embedded in the Nodes Manager modal on Cloud. */
   manager_survey_url?: string
   linear_toggle_enabled?: boolean
-  team_workspaces_enabled?: boolean
   partner_node_governance_enabled?: boolean
   user_secrets_enabled?: boolean
   node_library_essentials_enabled?: boolean

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -16,7 +16,6 @@ const env = vi.hoisted(() => {
     isCloud: false,
     isDesktop: false,
     isLoggedIn: false,
-    teamWorkspacesEnabled: false,
     billingControlEnabled: false,
     authenticatedConfigLoaded: false,
     partnerNodeGovernanceEnabled: false,
@@ -51,9 +50,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return env.state.teamWorkspacesEnabled
-      },
       get billingControlEnabled() {
         return env.state.billingControlEnabled
       },
@@ -133,7 +129,6 @@ describe('useSettingUI', () => {
       isCloud: false,
       isDesktop: false,
       isLoggedIn: false,
-      teamWorkspacesEnabled: false,
       billingControlEnabled: false,
       authenticatedConfigLoaded: false,
       partnerNodeGovernanceEnabled: false,
@@ -202,7 +197,6 @@ describe('useSettingUI', () => {
   it('hides the empty Workspace navigation group for logged-out Cloud users', () => {
     env.state.isCloud = true
     env.state.isLoggedIn = false
-    env.state.teamWorkspacesEnabled = true
 
     const { navGroups } = useSettingUI()
 
@@ -219,7 +213,6 @@ describe('useSettingUI', () => {
       Object.assign(env.state, {
         isCloud: true,
         isLoggedIn: true,
-        teamWorkspacesEnabled: true,
         authenticatedConfigLoaded: true,
         isActiveSubscription: true,
         billingType: 'workspace'
@@ -297,7 +290,6 @@ describe('useSettingUI', () => {
       Object.assign(env.state, {
         isCloud: true,
         isLoggedIn: true,
-        teamWorkspacesEnabled: true,
         billingControlEnabled: true,
         authenticatedConfigLoaded: true,
         partnerNodeGovernanceEnabled: true,
@@ -348,11 +340,11 @@ describe('useSettingUI', () => {
       expect(navKeys(navGroups.value)).not.toContain('workspace-allowlist')
     })
 
-    it('keeps the legacy plan panel in the legacy layout', () => {
-      env.state.teamWorkspacesEnabled = false
+    it('keeps OSS account navigation on the legacy layout', () => {
+      env.state.isCloud = false
       const { navGroups } = useSettingUI()
 
-      expect(navKeys(navGroups.value)).toContain('subscription')
+      expect(navKeys(navGroups.value)).toContain('credits')
       expect(navKeys(navGroups.value)).not.toContain('workspace')
     })
   })

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -3,7 +3,6 @@ import type { Component } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
@@ -58,8 +57,6 @@ export function useSettingUI(
 
   const { flags } = useFeatureFlags()
   const { shouldRenderVueNodes } = useVueFeatureFlags()
-  const { canAccessSubscriptionFeatures, type: billingType } =
-    useBillingContext()
   const { workspaceRole } = useWorkspaceUI()
 
   const settingRoot = computed<SettingTreeNode>(() => {
@@ -139,33 +136,6 @@ export function useSettingUI(
       () => import('@/components/dialog/content/setting/CreditsPanel.vue')
     )
   }
-
-  const subscriptionPanel: SettingPanelItem | null =
-    !isCloud || !window.__CONFIG__?.subscription_required
-      ? null
-      : {
-          node: {
-            key: 'subscription',
-            label: 'PlanCredits',
-            children: []
-          },
-          component: defineAsyncComponent(
-            () =>
-              import('@/platform/cloud/subscription/components/SubscriptionPanel.vue')
-          )
-        }
-
-  const shouldShowPlanCreditsPanel = computed(() => {
-    if (!subscriptionPanel) return false
-    return canAccessSubscriptionFeatures.value
-  })
-
-  const shouldShowLegacyPlanCreditsPanel = computed(
-    () =>
-      isLoggedIn.value &&
-      billingType.value === 'legacy' &&
-      shouldShowPlanCreditsPanel.value
-  )
 
   const userPanel: SettingPanelItem = {
     node: {
@@ -304,9 +274,6 @@ export function useSettingUI(
       keybindingPanel,
       extensionPanel,
       ...(isDesktop ? [serverConfigPanel] : []),
-      ...(shouldShowPlanCreditsPanel.value && subscriptionPanel
-        ? [subscriptionPanel]
-        : []),
       ...(shouldShowSecretsPanel.value ? [secretsPanel] : [])
     ].filter((panel) => panel !== null && panel.component)
   )
@@ -397,9 +364,6 @@ export function useSettingUI(
       label: 'Account',
       children: [
         userPanel.node,
-        ...(shouldShowLegacyPlanCreditsPanel.value && subscriptionPanel
-          ? [subscriptionPanel.node]
-          : []),
         ...(shouldShowSecretsPanel.value ? [secretsPanel.node] : []),
         ...(isLoggedIn.value &&
         !(isCloud && window.__CONFIG__?.subscription_required)

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -62,10 +62,6 @@ export function useSettingUI(
     useBillingContext()
   const { workspaceRole } = useWorkspaceUI()
 
-  const teamWorkspacesEnabled = computed(
-    () => isCloud && flags.teamWorkspacesEnabled
-  )
-
   const settingRoot = computed<SettingTreeNode>(() => {
     const root = buildTree(
       Object.values(settingStore.settingsById).filter(
@@ -229,9 +225,7 @@ export function useSettingUI(
     props: { section: 'allowlist' }
   }
 
-  const shouldShowWorkspacePanel = computed(
-    () => teamWorkspacesEnabled.value && isLoggedIn.value
-  )
+  const shouldShowWorkspacePanel = computed(() => isCloud && isLoggedIn.value)
   const shouldShowWorkspaceAllowlist = computed(
     () =>
       shouldShowWorkspacePanel.value &&
@@ -349,7 +343,7 @@ export function useSettingUI(
     )
   })
 
-  // Sidebar structure when team workspaces is enabled
+  // Cloud workspace sidebar structure
   const workspaceMenuTreeNodes = computed<SettingTreeNode[]>(() => [
     // Workspace settings
     translateCategory({
@@ -395,7 +389,7 @@ export function useSettingUI(
       : [])
   ])
 
-  // Sidebar structure when team workspaces is disabled (legacy)
+  // OSS legacy sidebar structure
   const legacyMenuTreeNodes = computed<SettingTreeNode[]>(() => [
     // Account settings - show different panels based on distribution and auth state
     {
@@ -433,9 +427,7 @@ export function useSettingUI(
   ])
 
   const groupedMenuTreeNodes = computed<SettingTreeNode[]>(() =>
-    teamWorkspacesEnabled.value
-      ? workspaceMenuTreeNodes.value
-      : legacyMenuTreeNodes.value
+    isCloud ? workspaceMenuTreeNodes.value : legacyMenuTreeNodes.value
   )
 
   const navGroups = computed<NavGroupData[]>(() =>
@@ -483,7 +475,6 @@ export function useSettingUI(
     groupedMenuTreeNodes,
     settingCategories,
     navGroups,
-    teamWorkspacesEnabled,
     findCategoryByKey,
     findPanelByKey
   }

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -7,21 +7,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
-const teamWorkspacesFlag = vi.hoisted(() => ({ value: false }))
 const isCloudRef = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({ showDialog, closeDialog: vi.fn() })
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: {
-      get teamWorkspacesEnabled() {
-        return teamWorkspacesFlag.value
-      }
-    }
-  })
 }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -49,7 +38,6 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 describe('useSettingsDialog', () => {
   beforeEach(() => {
     showDialog.mockReset()
-    teamWorkspacesFlag.value = false
     isCloudRef.value = false
   })
 
@@ -78,9 +66,8 @@ describe('useSettingsDialog', () => {
     expect(args.dialogComponentProps.overlayClass).toBeUndefined()
   })
 
-  it("show() sets overlayClass 'p-8' when isCloud && teamWorkspacesEnabled", () => {
+  it("show() sets overlayClass 'p-8' on Cloud", () => {
     isCloudRef.value = true
-    teamWorkspacesFlag.value = true
 
     useSettingsDialog().show()
     const [args] = showDialog.mock.calls[0]

--- a/src/platform/settings/composables/useSettingsDialog.ts
+++ b/src/platform/settings/composables/useSettingsDialog.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -15,14 +14,12 @@ const SETTINGS_CONTENT_CLASS =
 export function useSettingsDialog() {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
-  const { flags } = useFeatureFlags()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
   }
 
   function show(panel?: SettingPanelType, settingId?: string) {
-    const isWorkspaceMode = isCloud && flags.teamWorkspacesEnabled
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component: SettingDialog,
@@ -46,7 +43,7 @@ export function useSettingsDialog() {
         dismissOnFocusOutside: false,
         size: 'full',
         contentClass: SETTINGS_CONTENT_CLASS,
-        overlayClass: isWorkspaceMode ? 'p-8' : undefined
+        overlayClass: isCloud ? 'p-8' : undefined
       }
     })
   }

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -52,14 +52,10 @@ vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
   remoteConfigErrorStatus: mockRemoteConfigErrorStatus
 }))
 
-const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: false }))
 const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return mockTeamWorkspacesEnabled.value
-      },
       get unifiedCloudAuthEnabled() {
         return mockUnifiedCloudAuthEnabled.value
       }
@@ -122,7 +118,6 @@ describe('WorkspaceAuthGate', () => {
     mockIsCloud.value = true
     mockIsInitialized.value = false
     mockCurrentUser.value = null
-    mockTeamWorkspacesEnabled.value = false
     mockUnifiedCloudAuthEnabled.value = false
     mockRemoteConfigState.value = 'authenticated'
     mockRemoteConfigErrorStatus.value = null
@@ -218,16 +213,6 @@ describe('WorkspaceAuthGate', () => {
       })
     })
 
-    it('renders slot when teamWorkspacesEnabled is false', async () => {
-      mockTeamWorkspacesEnabled.value = false
-
-      mountComponent()
-      await flushPromises()
-
-      expect(screen.getByTestId('slot-content')).toBeInTheDocument()
-      expect(mockWorkspaceStoreInitialize).not.toHaveBeenCalled()
-    })
-
     it('mints unified auth after refreshing authenticated flags', async () => {
       mockRefreshRemoteConfig.mockImplementation(async () => {
         mockUnifiedCloudAuthEnabled.value = true
@@ -240,9 +225,7 @@ describe('WorkspaceAuthGate', () => {
       expect(screen.getByTestId('slot-content')).toBeInTheDocument()
     })
 
-    it('initializes workspace store when teamWorkspacesEnabled is true', async () => {
-      mockTeamWorkspacesEnabled.value = true
-
+    it('initializes the workspace store', async () => {
       mountComponent()
       await flushPromises()
 
@@ -252,7 +235,6 @@ describe('WorkspaceAuthGate', () => {
 
     it('stops initialization when unmounted', async () => {
       let resolveRefresh: (() => void) | undefined
-      mockTeamWorkspacesEnabled.value = true
       mockRefreshRemoteConfig.mockImplementation(
         () =>
           new Promise<void>((resolve) => {
@@ -276,7 +258,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('calls resumePendingPricingFlow after successful workspace init', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'ready'
 
       mountComponent()
@@ -286,7 +267,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('skips workspace init when store is already initialized', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'ready'
 
       mountComponent()
@@ -355,7 +335,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error when authenticated config is unavailable', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockRemoteConfigState.value = 'error'
 
       mountComponent()
@@ -400,7 +379,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error when workspace store initialization fails', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitialize.mockRejectedValue(
         new Error('Workspace init failed')
       )
@@ -414,7 +392,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('requires sign out when no workspace is available', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitialize.mockRejectedValue(
         new Error('No workspaces available')
       )
@@ -432,7 +409,6 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when workspace setup clears unified auth', async () => {
       mockUnifiedCloudAuthEnabled.value = true
-      mockTeamWorkspacesEnabled.value = true
       mockGetUnifiedToken.mockReturnValue(undefined)
 
       mountComponent()
@@ -444,7 +420,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error without a ready workspace context', async () => {
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitState.value = 'loading'
 
       mountComponent()
@@ -457,7 +432,6 @@ describe('WorkspaceAuthGate', () => {
 
     it('renders the app after retrying a failed initialization', async () => {
       const user = userEvent.setup()
-      mockTeamWorkspacesEnabled.value = true
       mockWorkspaceStoreInitialize
         .mockImplementationOnce(async () => {
           mockWorkspaceStoreInitState.value = 'error'
@@ -503,7 +477,6 @@ describe('WorkspaceAuthGate', () => {
     it('stops a pending retry before logging out', async () => {
       const user = userEvent.setup()
       let resolveRetry: (() => void) | undefined
-      mockTeamWorkspacesEnabled.value = true
       mockRefreshRemoteConfig
         .mockRejectedValueOnce(new Error('Network error'))
         .mockImplementationOnce(

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -43,16 +43,15 @@
 
 <script setup lang="ts">
 /**
- * WorkspaceAuthGate - Conditional auth checkpoint for workspace mode.
+ * WorkspaceAuthGate - Cloud workspace auth checkpoint.
  *
  * This gate ensures proper initialization order for workspace-scoped auth:
  * 1. Wait for Firebase auth to resolve
- * 2. Check if teamWorkspacesEnabled feature flag is on
- * 3. If YES: Initialize workspace token and store before rendering
- * 4. If NO: Render immediately using existing Firebase auth
+ * 2. Load authenticated remote configuration
+ * 3. Initialize the workspace token and store before rendering
  *
  * This prevents race conditions where API calls use Firebase tokens
- * instead of workspace tokens when the workspace feature is enabled.
+ * instead of workspace tokens.
  *
  * The splash loader in index.html (z-9999) covers the screen during this
  * phase, so no separate loading indicator is needed here.
@@ -125,7 +124,6 @@ async function initialize(): Promise<void> {
     }
 
     // Step 3: Refresh feature flags with auth context
-    // This ensures teamWorkspacesEnabled reflects the authenticated user's state
     // Timeout prevents hanging if server is slow/unresponsive
     let timeoutId: ReturnType<typeof setTimeout>
     await Promise.race([
@@ -142,7 +140,6 @@ async function initialize(): Promise<void> {
       throw new Error('Failed to load authenticated remote config')
     }
 
-    // Step 4: THE CHECKPOINT - Are we in workspace mode?
     const { flags } = useFeatureFlags()
     const workspaceAuthStore = useWorkspaceAuthStore()
     if (flags.unifiedCloudAuthEnabled) {
@@ -153,14 +150,6 @@ async function initialize(): Promise<void> {
       }
     }
 
-    if (!flags.teamWorkspacesEnabled) {
-      // Not in workspace mode - use existing Firebase auth flow
-      // No additional initialization needed
-      initializationState.value = 'ready'
-      return
-    }
-
-    // Step 5: WORKSPACE MODE - Full initialization
     await initializeWorkspaceMode()
     if (generation !== initializationGeneration) return
     if (
@@ -170,7 +159,7 @@ async function initialize(): Promise<void> {
       throw new Error('Unified cloud auth was cleared during workspace setup')
     }
 
-    // Step 6: Resume any pending pricing flow from team workspace creation
+    // Resume any pending pricing flow from team workspace creation
     // Only safe after workspace store initialized successfully — the pricing
     // dialog reads workspace state to decide which variant to show.
     const workspaceStore = useTeamWorkspaceStore()

--- a/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
+++ b/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
@@ -212,7 +212,7 @@ export const SuccessAllSet: Story = {
 
 /**
  * Team success — "You're all set" with the inline "Invite your team" block
- * (FE-965 / DES-394). Team-only: gated on a team plan + teamWorkspacesEnabled.
+ * (FE-965 / DES-394).
  */
 export const TeamSuccessWithInvite: Story = {
   render: () => {

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -34,14 +34,6 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   })
 }))
 
-const { mockFlags } = vi.hoisted(() => ({
-  mockFlags: { teamWorkspacesEnabled: true }
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({ flags: mockFlags })
-}))
-
 vi.mock('./InviteMembersForm.vue', () => ({
   default: {
     name: 'InviteMembersForm',
@@ -118,7 +110,6 @@ function renderTeamCard(props: Record<string, unknown> = {}) {
 describe('SubscriptionSuccessWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFlags.teamWorkspacesEnabled = true
     mockMembers.length = 0
     mockPendingInvites.length = 0
     mockMaxSeats.value = 73
@@ -196,12 +187,6 @@ describe('SubscriptionSuccessWorkspace', () => {
     mockMaxSeats.value = 5
     renderCard()
     expect(screen.getByText('seats:4', { exact: false })).toBeTruthy()
-  })
-
-  it('hides the invite block when team workspaces are disabled', () => {
-    mockFlags.teamWorkspacesEnabled = false
-    renderTeamCard()
-    expect(screen.queryByTestId('invite-form')).toBeNull()
   })
 
   it('subtracts existing members and pending invites from invitable seats', () => {

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
@@ -97,7 +97,6 @@
 import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import Button from '@/components/ui/button/Button.vue'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
@@ -123,7 +122,6 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { flags } = useFeatureFlags()
 const { maxSeats, occupiedSeats } = useBillingContext()
 
 const tierName = computed(() =>
@@ -153,9 +151,7 @@ const invitableSeats = computed(() => {
 })
 
 const showInviteBlock = computed(
-  () =>
-    flags.teamWorkspacesEnabled &&
-    (maxSeats.value === 0 || (maxSeats.value ?? 0) > 1)
+  () => maxSeats.value === 0 || (maxSeats.value ?? 0) > 1
 )
 
 const invitedEmails = ref<string[]>([])

--- a/src/platform/workspace/components/UnifiedPricingTable.stories.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.stories.ts
@@ -5,10 +5,7 @@ import UnifiedPricingTable from './UnifiedPricingTable.vue'
 /**
  * The unified pricing table (B4 / FE-934): one table for the new billing model,
  * with a personal/team **plan** toggle on a single workspace (Gamma-style).
- *
- * Note: the personal/team toggle itself only renders when `teamWorkspacesEnabled`
- * is on (a server flag, off in Storybook), so these stories drive the view via
- * `initialPlanMode` instead. Personal prices fall back to the static
+ * Personal prices fall back to the static
  * `TIER_PRICING` (no API in Storybook); the team column uses the locked DES-197
  * credit-slider stops.
  */

--- a/src/platform/workspace/components/UnifiedPricingTable.test.ts
+++ b/src/platform/workspace/components/UnifiedPricingTable.test.ts
@@ -25,7 +25,6 @@ const mockSubscription = ref<MockSubscription | null>(null)
 const mockSubscriptionStatus = ref<BillingSubscriptionStatus | null>(null)
 const mockCurrentPlanSlug = ref<string | null>(null)
 const mockCurrentTeamCreditStop = ref<MockTeamStop | null>(null)
-const mockTeamFlag = ref(false)
 const mockIsTeamPlan = ref(false)
 const mockCanManageSubscription = ref(true)
 const mockCanDowngradeToPersonal = ref(true)
@@ -48,12 +47,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
       canManageSubscription: mockCanManageSubscription.value,
       canDowngradeToPersonal: mockCanDowngradeToPersonal.value
     }))
-  })
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: { teamWorkspacesEnabled: mockTeamFlag.value }
   })
 }))
 
@@ -89,7 +82,6 @@ describe('UnifiedPricingTable plan CTA labels', () => {
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
-    mockTeamFlag.value = false
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true
@@ -178,7 +170,6 @@ describe('UnifiedPricingTable plan CTA labels', () => {
       credits_monthly: 147_700,
       stop_usd: 700
     }
-    mockTeamFlag.value = true
     mockIsTeamPlan.value = true
     mockCanDowngradeToPersonal.value = false
 
@@ -203,7 +194,6 @@ describe('UnifiedPricingTable team plan CTA', () => {
     mockSubscriptionStatus.value = null
     mockCurrentPlanSlug.value = null
     mockCurrentTeamCreditStop.value = null
-    mockTeamFlag.value = true
     mockIsTeamPlan.value = false
     mockCanManageSubscription.value = true
     mockCanDowngradeToPersonal.value = true

--- a/src/platform/workspace/components/UnifiedPricingTable.vue
+++ b/src/platform/workspace/components/UnifiedPricingTable.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="flex flex-col xl:h-full">
     <!-- Plan-scope toggle (personal vs team PLAN on one workspace): sits directly
-         on top of the content area — outside it, attached with no gap (DES QA).
-         Only shown when team plans are available (teamWorkspacesEnabled). -->
-    <div v-if="showTeam" class="flex justify-center">
+         on top of the content area — outside it, attached with no gap (DES QA). -->
+    <div class="flex justify-center">
       <SelectButton
         v-model="planMode"
         :options="planScopeOptions"
@@ -416,7 +415,6 @@ import { I18nT, useI18n } from 'vue-i18n'
 import Button from '@/components/ui/button/Button.vue'
 import CreditSlider from '@/components/ui/credit-slider/CreditSlider.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   TIER_PRICING,
   TIER_TO_KEY
@@ -443,8 +441,7 @@ type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 interface Props {
   isLoading?: boolean
   loadingTier?: CheckoutTierKey | null
-  /** Initial plan scope. The toggle to switch is only shown when team plans
-   *  are available (`teamWorkspacesEnabled`). */
+  /** Initial plan scope. */
   initialPlanMode?: 'personal' | 'team'
 }
 
@@ -468,11 +465,7 @@ const emit = defineEmits<{
 }>()
 
 const { t, n } = useI18n()
-const { flags } = useFeatureFlags()
 const { permissions } = useWorkspaceUI()
-
-/** Team plans only exist behind the flag (mirrors useBillingContext type). */
-const showTeam = computed(() => flags.teamWorkspacesEnabled)
 
 const planMode = ref<'personal' | 'team'>(initialPlanMode)
 

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -70,15 +70,11 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
-const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: true }))
 const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
-      get teamWorkspacesEnabled() {
-        return mockTeamWorkspacesEnabled.value
-      },
       get unifiedCloudAuthEnabled() {
         return mockUnifiedCloudAuthEnabled.value
       }
@@ -115,7 +111,6 @@ describe('useWorkspaceAuthStore', () => {
     vi.resetAllMocks()
     vi.useFakeTimers()
     sessionStorage.clear()
-    mockTeamWorkspacesEnabled.value = true
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
     mockEnsureSessionCookie.mockResolvedValue(undefined)
@@ -958,19 +953,6 @@ describe('useWorkspaceAuthStore', () => {
       expect(header).toBeNull()
     })
 
-    it('is a no-op returning null when the feature flag is disabled', async () => {
-      mockTeamWorkspacesEnabled.value = false
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-
-      const header = await store.ensureWorkspaceAuthHeader('workspace-123')
-
-      expect(header).toBeNull()
-      expect(mockFetch).not.toHaveBeenCalled()
-    })
-
     it('tears down workspace context and surfaces a toast on a permanent recovery failure', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
       const mockFetch = vi
@@ -1303,54 +1285,6 @@ describe('useWorkspaceAuthStore', () => {
       workspaceToken.value = null
 
       expect(isAuthenticated.value).toBe(false)
-    })
-  })
-
-  describe('feature flag disabled', () => {
-    beforeEach(() => {
-      mockTeamWorkspacesEnabled.value = false
-    })
-
-    afterEach(() => {
-      mockTeamWorkspacesEnabled.value = true
-    })
-
-    it('initializeFromSession returns false when flag disabled', () => {
-      const futureExpiry = Date.now() + 3600 * 1000
-      sessionStorage.setItem(
-        WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE,
-        JSON.stringify(mockWorkspaceWithRole)
-      )
-      sessionStorage.setItem(WORKSPACE_STORAGE_KEYS.TOKEN, 'valid-token')
-      sessionStorage.setItem(
-        WORKSPACE_STORAGE_KEYS.EXPIRES_AT,
-        futureExpiry.toString()
-      )
-
-      const store = useWorkspaceAuthStore()
-      const { currentWorkspace, workspaceToken } = storeToRefs(store)
-
-      const result = store.initializeFromSession()
-
-      expect(result).toBe(false)
-      expect(currentWorkspace.value).toBeNull()
-      expect(workspaceToken.value).toBeNull()
-    })
-
-    it('switchWorkspace is a no-op when flag disabled', async () => {
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-      const { currentWorkspace, workspaceToken, isLoading } = storeToRefs(store)
-
-      await store.switchWorkspace('workspace-123')
-
-      expect(mockFetch).not.toHaveBeenCalled()
-      expect(currentWorkspace.value).toBeNull()
-      expect(workspaceToken.value).toBeNull()
-      expect(isLoading.value).toBe(false)
     })
   })
 
@@ -2565,23 +2499,6 @@ describe('useWorkspaceAuthStore', () => {
       expect(mockFetch).not.toHaveBeenCalled()
       expect(unifiedToken.value).toBeNull()
       expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
-    })
-
-    it('keeps the legacy refresh path gated: both flags OFF ⇒ no network from any timer', async () => {
-      mockTeamWorkspacesEnabled.value = false
-      mockUnifiedCloudAuthEnabled.value = false
-      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
-      const mockFetch = vi.fn()
-      vi.stubGlobal('fetch', mockFetch)
-
-      const store = useWorkspaceAuthStore()
-
-      await store.switchWorkspace('workspace-123')
-      await store.mintAtLogin()
-      await store.refreshToken()
-      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
-
-      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it.for([

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -93,8 +93,7 @@ function permanentAuthErrorMessageKey(code: string | undefined): string {
   }
 }
 
-// Flag-ON has no Firebase fallback, so surface permanent failures instead of
-// stranding every cloud request on a silently cleared token.
+// Workspace auth has no Firebase fallback, so surface permanent failures.
 function surfacePermanentAuthError(err: WorkspaceAuthError): void {
   console.error('Unified workspace auth revoked or invalid:', err)
   useToastStore().add({
@@ -282,10 +281,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   function initializeFromSession(): boolean {
-    if (!flags.teamWorkspacesEnabled) {
-      return false
-    }
-
     try {
       const workspaceJson = sessionStorage.getItem(
         WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
@@ -432,10 +427,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   }
 
   async function performSwitchWorkspace(workspaceId: string): Promise<void> {
-    if (!flags.teamWorkspacesEnabled) {
-      return
-    }
-
     const capturedRequestId = refreshRequestId
     const capturedOwnerUid = currentUserUid()
 
@@ -566,10 +557,6 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   async function ensureWorkspaceToken(
     preferredWorkspaceId?: string
   ): Promise<string | null> {
-    if (!flags.teamWorkspacesEnabled) {
-      return null
-    }
-
     const ownerUid = currentUserUid()
     if (!ownerUid) return null
     const targetWorkspaceId = preferredWorkspaceId ?? currentWorkspace.value?.id

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -129,6 +129,7 @@ describe('auth token priority chain', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 
+    mockDistributionTypes.isCloud = true
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null
     mockActiveWorkspaceId = null
@@ -169,6 +170,19 @@ describe('auth token priority chain', () => {
 
     it('returns Firebase token when workspace is not active but user is authenticated', async () => {
       mockWorkspaceAuthHeader.mockReturnValue(null)
+
+      const header = await store.getAuthHeader()
+
+      expect(header).toEqual({
+        Authorization: 'Bearer firebase-token'
+      })
+    })
+
+    it('ignores workspace auth header outside Cloud', async () => {
+      mockDistributionTypes.isCloud = false
+      mockWorkspaceAuthHeader.mockReturnValue({
+        Authorization: 'Bearer workspace-token'
+      })
 
       const header = await store.getAuthHeader()
 

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -10,7 +10,6 @@ import { createTestingPinia } from '@pinia/testing'
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
-    teamWorkspacesEnabled: false,
     unifiedCloudAuthEnabled: false
   }
 }))
@@ -130,7 +129,6 @@ describe('auth token priority chain', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockUnifiedToken = null
     mockActiveWorkspaceId = null
@@ -157,8 +155,7 @@ describe('auth token priority chain', () => {
   })
 
   describe('getAuthHeader priority', () => {
-    it('returns workspace auth header when workspace is active and feature enabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
+    it('returns workspace auth header when workspace is active', async () => {
       mockWorkspaceAuthHeader.mockReturnValue({
         Authorization: 'Bearer workspace-token'
       })
@@ -171,7 +168,6 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace is not active but user is authenticated', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockWorkspaceAuthHeader.mockReturnValue(null)
 
       const header = await store.getAuthHeader()
@@ -197,24 +193,10 @@ describe('auth token priority chain', () => {
 
       expect(header).toBeNull()
     })
-
-    it('skips workspace header when team_workspaces feature is disabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = false
-      mockWorkspaceAuthHeader.mockReturnValue({
-        Authorization: 'Bearer workspace-token'
-      })
-
-      const header = await store.getAuthHeader()
-
-      expect(header).toEqual({
-        Authorization: 'Bearer firebase-token'
-      })
-    })
   })
 
   describe('getAuthToken priority', () => {
-    it('returns workspace token when workspace is active and feature enabled', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
+    it('returns workspace token when workspace is active', async () => {
       mockGetWorkspaceToken.mockReturnValue('workspace-raw-token')
 
       const token = await store.getAuthToken()
@@ -223,7 +205,6 @@ describe('auth token priority chain', () => {
     })
 
     it('returns Firebase token when workspace token is not available', async () => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockGetWorkspaceToken.mockReturnValue(undefined)
 
       const token = await store.getAuthToken()
@@ -284,7 +265,6 @@ describe('auth token priority chain', () => {
     it('getAuthHeader returns only the unified Cloud JWT, never Firebase or API key', async () => {
       mockUnifiedToken = 'unified-jwt'
       // Even with the legacy sources available, the unified branch wins.
-      mockFeatureFlags.teamWorkspacesEnabled = true
       mockWorkspaceAuthHeader.mockReturnValue({
         Authorization: 'Bearer workspace-token'
       })

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -29,7 +29,6 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
-    teamWorkspacesEnabled: false,
     unifiedCloudAuthEnabled: false
   }
 }))
@@ -186,7 +185,6 @@ describe('useAuthStore', () => {
     sessionStorage.clear()
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
-    mockFeatureFlags.teamWorkspacesEnabled = false
     mockFeatureFlags.unifiedCloudAuthEnabled = false
 
     // Setup dialog service mock
@@ -699,10 +697,6 @@ describe('useAuthStore', () => {
   })
 
   describe('getAuthHeader workspace recovery', () => {
-    beforeEach(() => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
-    })
-
     it('uses the workspace header when a valid workspace token exists', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
       vi.spyOn(workspaceAuth, 'getWorkspaceAuthHeader').mockReturnValue({
@@ -761,10 +755,6 @@ describe('useAuthStore', () => {
   })
 
   describe('getAuthToken workspace recovery', () => {
-    beforeEach(() => {
-      mockFeatureFlags.teamWorkspacesEnabled = true
-    })
-
     it('recovers the workspace token instead of downgrading to personal auth', async () => {
       const workspaceAuth = useWorkspaceAuthStore()
       const teamStore = useTeamWorkspaceStore()

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -250,7 +250,7 @@ export const useAuthStore = defineStore('auth', () => {
    * When unified_cloud_auth is enabled, returns the single Cloud JWT for every
    * cloud request (no Firebase/API-key fallback) so one token is used end to end.
    * Otherwise checks for authentication in the following order:
-   * 1. Workspace token (if team_workspaces_enabled and user has active workspace context)
+   * 1. Workspace token on Cloud when the user has active workspace context
    * 2. Firebase authentication token (if user is logged in)
    * 3. API key (if stored in the browser's credential manager)
    *
@@ -265,7 +265,7 @@ export const useAuthStore = defineStore('auth', () => {
       return token ? { Authorization: `Bearer ${token}` } : null
     }
 
-    if (flags.teamWorkspacesEnabled) {
+    if (isCloud) {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 
@@ -309,7 +309,7 @@ export const useAuthStore = defineStore('auth', () => {
       return useWorkspaceAuthStore().getUnifiedToken()
     }
 
-    if (flags.teamWorkspacesEnabled) {
+    if (isCloud) {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 

--- a/src/storybook/mocks/useFeatureFlags.ts
+++ b/src/storybook/mocks/useFeatureFlags.ts
@@ -2,8 +2,7 @@
  * Storybook mock for `useFeatureFlags`.
  *
  * The real composable resolves flags from authenticated remote config, which is
- * unavailable in Storybook. This stub enables the workspace-facing flags so
- * team-plan billing components (e.g. the post-upgrade invite block) render.
+ * unavailable in Storybook. This stub enables billing controls.
  */
 // Inlined from `@/composables/useFeatureFlags` (the alias points here) so the
 // enum, consumed by modules like nodeReplacementStore, resolves without dragging
@@ -17,7 +16,6 @@ export enum ServerFeatureFlag {
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
-  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
   USER_SECRETS_ENABLED = 'user_secrets_enabled',
   NODE_REPLACEMENTS = 'node_replacements',
   NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
@@ -34,7 +32,6 @@ export enum ServerFeatureFlag {
 export function useFeatureFlags() {
   return {
     flags: {
-      teamWorkspacesEnabled: true,
       consolidatedBillingEnabled: true,
       billingControlEnabled: true,
       v1PaymentRecovery: true

--- a/src/utils/devFeatureFlagOverride.ts
+++ b/src/utils/devFeatureFlagOverride.ts
@@ -10,8 +10,8 @@ const FF_PREFIX = 'ff:'
  * "override explicitly set to null".
  *
  * Usage in browser console:
- *   localStorage.setItem('ff:team_workspaces_enabled', 'true')
- *   localStorage.removeItem('ff:team_workspaces_enabled')
+ *   localStorage.setItem('ff:example_enabled', 'true')
+ *   localStorage.removeItem('ff:example_enabled')
  */
 export function getDevOverride<T>(flagKey: string): T | undefined {
   if (!import.meta.env.DEV) return undefined


### PR DESCRIPTION
## Summary
Part 2/4 of the workspace/billing rollout retirement stack. Removes `team_workspaces_enabled` atomically after the recovery foundation in [#14612](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14612).

Predecessor: [#14612](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14612). Successor: [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614).

## Root cause
Workspace mode was split across a long-lived rollout key in session cookies, token selection, auth restoration, workspace boot, account UI/settings, URL actions, and billing routing. Once Cloud workspace support is the default, keeping both branches creates divergent authentication and billing behavior and makes backend feature-key removal unsafe.

## Changes
- Remove the team workspace key from remote-config types, enum/getters/cache/refresh, local override, Storybook, browser payloads, and obsolete flag tests.
- Make Cloud workspace auth/session restoration/switch/recovery and workspace UI/loaders unconditional after the authenticated config checkpoint.
- Preserve OSS and unloaded-workspace legacy bootstrap behavior.
- Preserve `consolidated_billing_enabled` and the intermediate billing matrix, including explicit `legacy_stripe` account operations with unified pricing.
- Update Cloud fixtures and affected account, settings, subscription, pricing, and token-flow coverage.

## AS IS
Cloud workspace/auth/UI/billing paths can diverge depending on `team_workspaces_enabled`.

## TO BE
Cloud workspace mode is the single path after authenticated config loads; OSS and unloaded workspace bootstrap remain legacy. No intended visual change; this is rollout retirement, so no screenshot is required.

## Regression coverage
- Auth session cookie, API/WebSocket token priority, workspace restoration/switch/recovery.
- Workspace gate, account UI, settings/dialog layout, create/invite loaders, pricing, and subscription success behavior.
- Intermediate billing routing for OSS, unloaded Cloud, team, personal consolidated off/on, and `legacy_stripe`.
- Cloud browser fixtures omit the retired key.
- Exact source/browser scan confirms no `team_workspaces_enabled` or `teamWorkspacesEnabled` references.

## Validation
- 14 focused Vitest files: 453 tests passed.
- `pnpm typecheck` and `pnpm typecheck:browser` passed via commit hook.
- targeted formatting/lint passed via commit hook.
- `git diff --check dante/workspace-init-recovery...HEAD` passed.
- `pnpm knip --cache` passed via push hook.
- Focused Cloud Playwright: billing facade 2 passed; pricing owner flow 1 passed. The member-plan flow timed out during local app boot before assertions; the corrected full Cloud Playwright CI job passed.

## Review focus
Review only the atomic team-flag removal and intermediate routing matrix. Canonical billing status and consolidated-flag retirement are intentionally deferred.

## Stack/deployment order
1. [#14612](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14612) — recovery foundation
2. **This PR** — retire team workspace rollout flag
3. [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614) — canonical billing status and legacy rail preservation
4. [#14615](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14615) — retire consolidated billing rollout flag

Deploy the frontend stack before the backend removes `/api/features` compatibility keys. This is also a drain requirement: age out deployed frontend versions and open tabs that still read either retired key before removing backend compatibility keys. Confirm `team_workspaces_enabled` is at 100% and update `Comfy-Org/cloud#6040` to depend on the selected stack rather than competing PR #14530 before merge. After backend key removal, reverting this PR is not a behavioral restore because a reinstated read of the missing key resolves to the off branch.
