### PR TITLE
refactor(billing): retire consolidated billing rollout flag

### DIFF
--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -11,9 +11,7 @@ import type {
 } from '@/platform/workspace/api/workspaceApi'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
-export const CLOUD_REMOTE_CONFIG: RemoteConfig = {
-  consolidated_billing_enabled: true
-}
+export const CLOUD_REMOTE_CONFIG: RemoteConfig = {}
 
 export const LEGACY_PERSONAL_BILLING_STATUS = {
   billing_rail: 'legacy_stripe',

--- a/browser_tests/fixtures/utils/cloudAppSetup.ts
+++ b/browser_tests/fixtures/utils/cloudAppSetup.ts
@@ -14,13 +14,6 @@ import { mockWorkspace } from '@e2e/fixtures/utils/workspaceMocks'
 export const APP_URL =
   process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
-// consolidated_billing_enabled routes personal workspaces to the unified
-// billing surfaces the cloud specs assert; without it they fall back to the
-// legacy variants.
-const DEFAULT_FEATURES = {
-  consolidated_billing_enabled: true
-} satisfies RemoteConfig
-
 // Disable the experimental Asset API: with it on (cloud default) the unmocked
 // asset endpoints 403 and workflow restore throws uncaught, aborting the
 // GraphCanvas onMounted chain before the URL action loaders.
@@ -63,7 +56,7 @@ export async function setupCloudApp(
   { workspace, members = [], features }: CloudAppSetupOptions
 ) {
   await mockCloudBoot(page, {
-    features: { ...DEFAULT_FEATURES, ...features },
+    features: features ?? {},
     settings: DEFAULT_SETTINGS
   })
   await mockGraphBootExtras(page)

--- a/browser_tests/tests/billingFacadeConsumers.spec.ts
+++ b/browser_tests/tests/billingFacadeConsumers.spec.ts
@@ -163,7 +163,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         renewal_date: '2099-02-20T10:00:00Z',
         has_funds: true
       },
-      { consolidated_billing_enabled: true },
+      {},
       'legacy_stripe'
     )
     await bootApp(page)
@@ -222,8 +222,7 @@ test.describe('Billing facade consumers (FE-933)', { tag: '@cloud' }, () => {
         has_funds: false
       },
       {
-        subscription_required: true,
-        consolidated_billing_enabled: true
+        subscription_required: true
       },
       'stripe'
     )

--- a/browser_tests/tests/dialogs/creditsTile.spec.ts
+++ b/browser_tests/tests/dialogs/creditsTile.spec.ts
@@ -95,7 +95,6 @@ async function mockCloudBoot(
   await page.route('**/api/features', (r) =>
     r.fulfill(
       jsonRoute({
-        consolidated_billing_enabled: true,
         billing_control_enabled: billingControlEnabled
       } satisfies RemoteConfig)
     )

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -42,8 +42,7 @@ const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 const SELF_EMAIL = 'e2e@test.comfy.org'
 
 const BOOT_FEATURES = {
-  billing_control_enabled: true,
-  consolidated_billing_enabled: true
+  billing_control_enabled: true
 } satisfies RemoteConfig
 // Disable the experimental Asset API: with it on (cloud default) the unmocked
 // asset endpoints 403 and workflow restore throws uncaught, aborting the

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -21,7 +21,6 @@ const DEFAULT_BILLING_STATUS: BillingStatusResponse = {
 }
 
 const {
-  mockConsolidatedBillingEnabled,
   mockIsPersonal,
   mockBillingRail,
   mockPlans,
@@ -35,7 +34,6 @@ const {
   mockLegacyStatus,
   mockBillingStatus
 } = vi.hoisted(() => ({
-  mockConsolidatedBillingEnabled: { value: true },
   mockIsPersonal: { value: true },
   mockBillingRail: { value: undefined as BillingRail | undefined },
   mockPlans: { value: [] as Plan[] },
@@ -61,16 +59,6 @@ const {
       subscription_duration: 'MONTHLY'
     } as Partial<BillingStatusResponse>
   }
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: {
-      get consolidatedBillingEnabled() {
-        return mockConsolidatedBillingEnabled.value
-      }
-    }
-  })
 }))
 
 vi.mock('@vueuse/core', async (importOriginal) => {
@@ -187,7 +175,6 @@ describe('useBillingContext', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    mockConsolidatedBillingEnabled.value = true
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(
@@ -209,14 +196,6 @@ describe('useBillingContext', () => {
 
     const { type } = useBillingContext()
     expect(type.value).toBe('workspace')
-  })
-
-  it('keeps a Cloud personal workspace on legacy while consolidation is off', () => {
-    mockConsolidatedBillingEnabled.value = false
-
-    const { type } = useBillingContext()
-
-    expect(type.value).toBe('legacy')
   })
 
   it('selects workspace type for a Cloud team workspace', () => {

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -4,31 +4,16 @@ import type { BillingRail } from '@/platform/workspace/api/workspaceApi'
 
 import { useBillingRouting } from './useBillingRouting'
 
-const {
-  mockIsCloud,
-  mockConsolidatedBillingEnabled,
-  mockActiveWorkspace,
-  mockActiveWorkspaceBillingRail
-} = vi.hoisted(() => ({
-  mockIsCloud: { value: true },
-  mockConsolidatedBillingEnabled: { value: false },
-  mockActiveWorkspace: {
-    value: null as { id: string; type: 'personal' | 'team' } | null
-  },
-  mockActiveWorkspaceBillingRail: {
-    value: null as BillingRail | null
-  }
-}))
-
-vi.mock('@/composables/useFeatureFlags', () => ({
-  useFeatureFlags: () => ({
-    flags: {
-      get consolidatedBillingEnabled() {
-        return mockConsolidatedBillingEnabled.value
-      }
+const { mockIsCloud, mockActiveWorkspace, mockActiveWorkspaceBillingRail } =
+  vi.hoisted(() => ({
+    mockIsCloud: { value: true },
+    mockActiveWorkspace: {
+      value: null as { id: string; type: 'personal' | 'team' } | null
+    },
+    mockActiveWorkspaceBillingRail: {
+      value: null as BillingRail | null
     }
-  })
-}))
+  }))
 
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -53,7 +38,6 @@ const team = { id: 'w-team', type: 'team' as const }
 describe('useBillingRouting', () => {
   beforeEach(() => {
     mockIsCloud.value = true
-    mockConsolidatedBillingEnabled.value = false
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = null
   })
@@ -68,18 +52,7 @@ describe('useBillingRouting', () => {
     expect(shouldUseWorkspaceBilling.value).toBe(false)
   })
 
-  it('keeps a Cloud personal workspace on legacy while consolidation is off', () => {
-    mockActiveWorkspace.value = personal
-
-    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
-
-    expect(type.value).toBe('legacy')
-    expect(shouldUseWorkspaceBilling.value).toBe(false)
-  })
-
-  it('uses workspace billing for a Cloud personal workspace when consolidation is on', () => {
-    mockConsolidatedBillingEnabled.value = true
-
+  it('uses workspace billing for a Cloud personal workspace', () => {
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
     expect(type.value).toBe('workspace')
@@ -87,7 +60,6 @@ describe('useBillingRouting', () => {
   })
 
   it('uses unified pricing while keeping legacy Stripe top-ups on Checkout', () => {
-    mockConsolidatedBillingEnabled.value = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'legacy_stripe'
 
@@ -100,7 +72,6 @@ describe('useBillingRouting', () => {
   })
 
   it('uses workspace billing for migrated Stripe personal workspaces', () => {
-    mockConsolidatedBillingEnabled.value = true
     mockActiveWorkspace.value = personal
     mockActiveWorkspaceBillingRail.value = 'stripe'
 

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -1,6 +1,5 @@
 import { computed } from 'vue'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
@@ -9,21 +8,15 @@ import type { BillingType } from './types'
 /**
  * Selects the billing backend for the active workspace: legacy user-scoped
  * (`/customers/*`) or workspace-scoped (`/api/billing/*`). Personal workspaces
- * stay legacy until consolidated billing is enabled; an explicit legacy Stripe
- * rail continues to use legacy account operations after enablement. An unloaded
- * workspace remains legacy during bootstrap, and OSS always uses legacy billing.
+ * use workspace billing unless an explicit legacy Stripe rail selects legacy
+ * account operations. An unloaded workspace remains legacy during bootstrap,
+ * and OSS always uses legacy billing.
  */
 export function useBillingRouting() {
-  const { flags } = useFeatureFlags()
   const workspaceStore = useTeamWorkspaceStore()
 
   const shouldUseUnifiedPricing = computed(() => {
-    if (!isCloud) return false
-
-    const workspaceType = workspaceStore.activeWorkspace?.type
-    if (!workspaceType) return false
-
-    return workspaceType === 'team' || flags.consolidatedBillingEnabled
+    return isCloud && workspaceStore.activeWorkspace?.type !== undefined
   })
 
   const type = computed<BillingType>(() => {
@@ -36,8 +29,7 @@ export function useBillingRouting() {
 
     if (
       workspaceType === 'personal' &&
-      (!flags.consolidatedBillingEnabled ||
-        workspaceStore.activeWorkspaceBillingRail === 'legacy_stripe')
+      workspaceStore.activeWorkspaceBillingRail === 'legacy_stripe'
     ) {
       return 'legacy'
     }

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -8,7 +8,6 @@ import {
 import * as distributionTypes from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
   cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigState
@@ -286,14 +285,6 @@ describe('useFeatureFlags', () => {
       expect(flags.v1PaymentRecovery).toBe(true)
     })
 
-    it('consolidatedBillingEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
-      vi.mocked(distributionTypes).isCloud = false
-      localStorage.setItem('ff:consolidated_billing_enabled', 'true')
-
-      const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(true)
-    })
-
     it('billingControlEnabled is false off-cloud even without an override', () => {
       vi.mocked(distributionTypes).isCloud = false
 
@@ -307,7 +298,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = true
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
       localStorage.clear()
@@ -317,26 +307,22 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = false
       remoteConfigState.value = 'unloaded'
       remoteConfig.value = {}
-      cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
       localStorage.clear()
     })
 
     it('returns the cached session value during the auth window', () => {
-      cachedConsolidatedBillingEnabled.value = true
       cachedBillingControlEnabled.value = true
       cachedV1PaymentRecovery.value = true
 
       const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
       expect(flags.v1PaymentRecovery).toBe(true)
     })
 
     it('defaults to false during the auth window when nothing is cached', () => {
       const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(false)
       expect(flags.billingControlEnabled).toBe(false)
       expect(flags.v1PaymentRecovery).toBe(false)
     })
@@ -344,14 +330,12 @@ describe('useFeatureFlags', () => {
     it('prefers authenticated remoteConfig over the server feature fallback', () => {
       remoteConfigState.value = 'authenticated'
       remoteConfig.value = {
-        consolidated_billing_enabled: true,
         billing_control_enabled: false,
         v1_payment_recovery: true
       }
       vi.mocked(api.getServerFeature).mockReturnValue(false)
 
       const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(false)
       expect(flags.v1PaymentRecovery).toBe(true)
     })
@@ -361,8 +345,6 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {}
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
-          if (path === ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED)
-            return true
           if (path === ServerFeatureFlag.BILLING_CONTROL_ENABLED) return true
           if (path === ServerFeatureFlag.V1_PAYMENT_RECOVERY) return true
           return defaultValue
@@ -370,7 +352,6 @@ describe('useFeatureFlags', () => {
       )
 
       const { flags } = useFeatureFlags()
-      expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
       expect(flags.v1PaymentRecovery).toBe(true)
     })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -4,7 +4,6 @@ import type { Ref } from 'vue'
 import { isCloud, isNightly } from '@/platform/distribution/types'
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
   cachedV1PaymentRecovery,
   isAuthenticatedConfigLoaded,
   remoteConfig
@@ -33,7 +32,6 @@ export enum ServerFeatureFlag {
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
-  CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
   V1_PAYMENT_RECOVERY = 'v1_payment_recovery',
   FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
@@ -189,13 +187,6 @@ export function useFeatureFlags() {
         ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
         remoteConfig.value.unified_cloud_auth,
         false
-      )
-    },
-    get consolidatedBillingEnabled() {
-      return resolveAuthGatedFlag(
-        ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED,
-        remoteConfig.value.consolidated_billing_enabled,
-        cachedConsolidatedBillingEnabled
       )
     },
     get billingControlEnabled() {

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -1,6 +1,5 @@
 import {
   cachedBillingControlEnabled,
-  cachedConsolidatedBillingEnabled,
   cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigErrorStatus,
@@ -72,9 +71,6 @@ export async function refreshRemoteConfig(
       remoteConfigErrorStatus.value = null
       remoteConfigState.value = useAuth ? 'authenticated' : 'anonymous'
       if (useAuth) {
-        cachedConsolidatedBillingEnabled.value = Boolean(
-          config.consolidated_billing_enabled
-        )
         cachedBillingControlEnabled.value = Boolean(
           config.billing_control_enabled
         )

--- a/src/platform/remoteConfig/remoteConfig.ts
+++ b/src/platform/remoteConfig/remoteConfig.ts
@@ -54,11 +54,6 @@ export function configValueOrDefault<K extends keyof RemoteConfig>(
   return configValue || defaultValue
 }
 
-export const cachedConsolidatedBillingEnabled = useStorage<boolean | undefined>(
-  'consolidated_billing_enabled' satisfies `${ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED}`,
-  undefined
-)
-
 export const cachedBillingControlEnabled = useStorage<boolean | undefined>(
   'billing_control_enabled' satisfies `${ServerFeatureFlag.BILLING_CONTROL_ENABLED}`,
   undefined

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -122,7 +122,6 @@ export type RemoteConfig = {
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
   unified_cloud_auth?: boolean
-  consolidated_billing_enabled?: boolean
   billing_control_enabled?: boolean
   v1_payment_recovery?: boolean
   churnkey_app_id?: string

--- a/src/storybook/mocks/useFeatureFlags.ts
+++ b/src/storybook/mocks/useFeatureFlags.ts
@@ -24,7 +24,6 @@ export enum ServerFeatureFlag {
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
-  CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
   V1_PAYMENT_RECOVERY = 'v1_payment_recovery'
 }
@@ -32,7 +31,6 @@ export enum ServerFeatureFlag {
 export function useFeatureFlags() {
   return {
     flags: {
-      consolidatedBillingEnabled: true,
       billingControlEnabled: true,
       v1PaymentRecovery: true
     }


### PR DESCRIPTION
Part 4/4 of the workspace and billing rollout retirement stack.

Predecessor: [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614)
Successor: none (final stack PR)

## Summary

Retires `consolidated_billing_enabled` after canonical billing discovery and explicit rail preservation landed in [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614). Loaded Cloud workspaces now use unified pricing, while personal workspaces on `legacy_stripe` retain legacy account operations.

## Root cause

The final billing route still depended on a compatibility feature key even after the workspace billing contract and canonical rail status were available. Removing the backend key first would therefore change personal-workspace routing during bootstrap or strand legacy Stripe balance/top-up/management behavior. The frontend needs a deterministic route based on distribution, workspace readiness/type, and the canonical billing rail before backend compatibility keys disappear.

## Changes

- Removes the consolidated-billing key from remote-config types, enum/getter, authenticated cache/refresh, local override path, Storybook mocks, and browser payloads.
- Routes OSS and unloaded Cloud workspaces through legacy bootstrap.
- Routes loaded Cloud team workspaces and personal `unknown`/`stripe` rails through workspace billing.
- Preserves legacy account operations for personal `legacy_stripe` while keeping unified pricing for every loaded Cloud workspace.
- Keeps the legacy adapter, balance, top-up, management behavior, and meaningful regression coverage.
- Re-runs the canonical-status rail regression with both retired feature keys absent from `/api/features`.

## AS IS

A loaded Cloud personal workspace still consults `consolidated_billing_enabled` to decide its billing adapter and pricing route.

No intended visual change. This is rollout cleanup, so no screenshot is required.

## TO BE

Loaded Cloud workspaces use unified pricing without a rollout key. Canonical `billing_rail` determines whether personal account operations remain on `legacy_stripe`; team and migrated/unknown personal workspaces use workspace billing.

No intended visual change. The existing legacy rail UI remains available where the canonical status selects it.

## Regression coverage

- OSS and unloaded-workspace legacy bootstrap.
- Cloud team workspace billing.
- Cloud personal unknown/Stripe workspace billing.
- Cloud personal `legacy_stripe` legacy account operations plus unified pricing.
- Billing-context adapter switching and preserved legacy adapter behavior.
- Playwright avatar-popover rail selection with `/api/features` omitting both retired keys, canonical status discovery, legacy balance/credits, and no stale workspace zero balance.
- Repository search confirms no consolidated-flag symbol/string remains in `src` or `browser_tests`.

## Validation

- `pnpm test:unit src/composables/useFeatureFlags.test.ts src/composables/billing/useBillingRouting.test.ts src/composables/billing/useBillingContext.test.ts src/platform/remoteConfig/refreshRemoteConfig.test.ts` — 83 passed.
- `pnpm typecheck` — passed.
- `pnpm typecheck:browser` — passed.
- Targeted oxfmt/oxlint/ESLint commit checks — passed.
- `pnpm knip --cache` pre-push check — passed.
- `PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5174 pnpm test:browser browser_tests/tests/billingFacadeConsumers.spec.ts -g 'avatar popover'` — 1 passed.
- `git diff --check dante/canonical-billing-status...HEAD` — passed.

## Review focus

Please review only this PR's removal of the consolidated flag and the final routing matrix. Canonical endpoint migration and pending-checkout stabilization belong to [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614); workspace-flag retirement belongs to [#14613](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14613).

## Stack/deployment order

1. [#14612](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14612) — workspace initialization recovery
2. [#14613](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14613) — retire team workspace rollout flag
3. [#14614](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14614) — canonical billing status and legacy rail preservation
4. [#14615](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14615) — this PR; retire consolidated billing rollout flag

Deploy the frontend stack in this order before the backend removes the `/api/features` compatibility keys. Each branch remains independently deployable; do not deploy a later PR without its predecessor. This is also a drain requirement: age out deployed frontend versions and open tabs that still read either retired key before removing backend compatibility keys. Confirm `consolidated_billing_enabled` is at 100% and update `Comfy-Org/cloud#6040` to depend on this selected stack rather than competing PR #14530 before merge. After backend key removal, reverting this PR is not a behavioral restore because a reinstated read of the missing key resolves to the off branch.
