### PR TITLE
fix(manager): fail closed when a bulk registry lookup fails

### DIFF
--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -613,6 +613,12 @@ describe('useConflictDetection', () => {
         nodeVersions: components['schemas']['NodeVersionIdentifier'][]
       ) => nodeVersions.some(({ node_id }) => node_id === 'pack-0')
 
+      const bannedConflict = {
+        type: 'banned' as const,
+        current_value: 'installed',
+        required_value: 'not_banned'
+      }
+
       it.for([
         { outcome: 'resolves null', fail: () => Promise.resolve(null) },
         {
@@ -642,11 +648,6 @@ describe('useConflictDetection', () => {
 
       it('keeps a stored banned conflict for a pack whose lookup failed', async () => {
         installPacks(1)
-        const bannedConflict = {
-          type: 'banned' as const,
-          current_value: 'installed',
-          required_value: 'not_banned'
-        }
         mockConflictedPackages = [
           {
             package_id: 'pack-0',
@@ -673,15 +674,79 @@ describe('useConflictDetection', () => {
         ])
       })
 
+      it('keeps a stored compatibility conflict for a pack whose lookup failed', async () => {
+        installPacks(1)
+        const osConflict = {
+          type: 'os' as const,
+          current_value: 'Windows',
+          required_value: 'Linux'
+        }
+        mockConflictedPackages = [
+          {
+            package_id: 'pack-0',
+            package_name: 'pack-0',
+            has_conflict: true,
+            conflicts: [osConflict],
+            is_compatible: false
+          }
+        ]
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue(
+          null
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        await runFullConflictAnalysis()
+
+        expect(mockConflictStore.setConflictedPackages).toHaveBeenCalledWith([
+          expect.objectContaining({
+            package_id: 'pack-0',
+            conflicts: [osConflict],
+            registry_status_unknown: true
+          })
+        ])
+      })
+
+      it('drops a stored import failure rather than carrying it over', async () => {
+        installPacks(1)
+        mockConflictedPackages = [
+          {
+            package_id: 'pack-0',
+            package_name: 'pack-0',
+            has_conflict: true,
+            conflicts: [
+              bannedConflict,
+              {
+                type: 'import_failed' as const,
+                current_value: 'since-resolved error',
+                required_value: 'since-resolved error'
+              }
+            ],
+            is_compatible: false
+          }
+        ]
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue(
+          null
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        await runFullConflictAnalysis()
+
+        expect(mockConflictStore.setConflictedPackages).toHaveBeenCalledWith([
+          expect.objectContaining({
+            package_id: 'pack-0',
+            conflicts: [bannedConflict]
+          })
+        ])
+      })
+
       it.for([
         { answer: 'omits the pack', node_versions: [] },
         {
-          answer: 'reports an error for the pack',
+          answer: "reports the pack 'not_found'",
           node_versions: [
             {
-              status: 'error' as const,
-              identifier: { node_id: 'pack-0', version: '1.0.0' },
-              error_message: 'node version not found'
+              status: 'not_found' as const,
+              identifier: { node_id: 'pack-0', version: '1.0.0' }
             }
           ]
         }
@@ -700,6 +765,30 @@ describe('useConflictDetection', () => {
           expect(unknownPackIds(results)).toEqual([])
         }
       )
+
+      it("marks a pack unverified when its entry comes back 'error'", async () => {
+        installPacks(2)
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockImplementation(
+          (nodeVersions) =>
+            Promise.resolve({
+              node_versions: nodeVersions.map((identifier) =>
+                identifier.node_id === 'pack-0'
+                  ? {
+                      status: 'error' as const,
+                      identifier,
+                      error_message: 'internal error'
+                    }
+                  : activeResponse([identifier]).node_versions[0]
+              )
+            })
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        const { results } = await runFullConflictAnalysis()
+
+        expect(bulkCalls()).toHaveLength(1)
+        expect(unknownPackIds(results)).toEqual(['pack-0'])
+      })
 
       it('does not mark packs unverified when the retry succeeds', async () => {
         installPacks(50)
@@ -733,8 +822,17 @@ describe('useConflictDetection', () => {
         expect(unknownPackIds(results)).toEqual(packIds(50))
       })
 
-      it('neither retries nor marks packs unverified when the run is cancelled', async () => {
+      it('leaves the stored conflicts untouched when the run is cancelled', async () => {
         installPacks(50)
+        mockConflictedPackages = [
+          {
+            package_id: 'pack-0',
+            package_name: 'pack-0',
+            has_conflict: true,
+            conflicts: [bannedConflict],
+            is_compatible: false
+          }
+        ]
 
         const { runFullConflictAnalysis, cancelRequests } =
           useConflictDetection()
@@ -745,13 +843,15 @@ describe('useConflictDetection', () => {
           }
         )
 
-        const { results } = await runFullConflictAnalysis()
+        const { success } = await runFullConflictAnalysis()
 
+        expect(success).toBe(false)
         expect(bulkCalls()).toHaveLength(1)
-        expect(unknownPackIds(results)).toEqual([])
         expect(
           mockConflictStore.setRegistryUnknownPackIds
-        ).toHaveBeenCalledWith(new Set())
+        ).not.toHaveBeenCalled()
+        expect(mockConflictStore.setConflictedPackages).not.toHaveBeenCalled()
+        expect(mockConflictStore.clearConflicts).not.toHaveBeenCalled()
       })
 
       it('clears the unverified pack ids on a later successful run', async () => {

--- a/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.test.ts
@@ -178,8 +178,11 @@ describe('useConflictDetection', () => {
         p.conflicts?.some((c) => c.type === 'pending')
       )
     },
+    getConflictsForPackageByID: (packageId: string) =>
+      mockConflictedPackages.find((pkg) => pkg.package_id === packageId),
     setConflictedPackages: vi.fn(),
-    clearConflicts: vi.fn()
+    clearConflicts: vi.fn(),
+    setRegistryUnknownPackIds: vi.fn()
   } as Partial<ReturnType<typeof useConflictDetectionStore>> as ReturnType<
     typeof useConflictDetectionStore
   >
@@ -582,6 +585,197 @@ describe('useConflictDetection', () => {
 
       expect(bulkCalls()).toHaveLength(1)
       expect(bulkCalls()[0][0]).toHaveLength(50)
+    })
+
+    describe('unverified registry status', () => {
+      const activeResponse = (
+        nodeVersions: components['schemas']['NodeVersionIdentifier'][]
+      ) => ({
+        node_versions: nodeVersions.map((identifier) => ({
+          status: 'success' as const,
+          identifier,
+          node_version: {
+            status: 'NodeVersionStatusActive' as const,
+            version: identifier.version,
+            publisher_id: 'test-publisher',
+            node_id: identifier.node_id,
+            created_at: '2024-01-01T00:00:00Z'
+          } as components['schemas']['NodeVersion']
+        }))
+      })
+
+      const unknownPackIds = (results: ConflictDetectionResult[]) =>
+        results
+          .filter((result) => result.registry_status_unknown)
+          .map((result) => result.package_id)
+
+      const isFirstChunk = (
+        nodeVersions: components['schemas']['NodeVersionIdentifier'][]
+      ) => nodeVersions.some(({ node_id }) => node_id === 'pack-0')
+
+      it.for([
+        { outcome: 'resolves null', fail: () => Promise.resolve(null) },
+        {
+          outcome: 'rejects',
+          fail: () => Promise.reject(new Error('network down'))
+        }
+      ])(
+        'marks unverified only the packs in the failed chunk when its request $outcome',
+        async ({ fail }) => {
+          installPacks(250)
+          vi.mocked(mockRegistryService.getBulkNodeVersions).mockImplementation(
+            (nodeVersions) =>
+              isFirstChunk(nodeVersions)
+                ? fail()
+                : Promise.resolve(activeResponse(nodeVersions))
+          )
+
+          const { runFullConflictAnalysis } = useConflictDetection()
+          const { results } = await runFullConflictAnalysis()
+
+          expect(unknownPackIds(results)).toEqual(packIds(100))
+          expect(
+            mockConflictStore.setRegistryUnknownPackIds
+          ).toHaveBeenCalledWith(new Set(packIds(100)))
+        }
+      )
+
+      it('keeps a stored banned conflict for a pack whose lookup failed', async () => {
+        installPacks(1)
+        const bannedConflict = {
+          type: 'banned' as const,
+          current_value: 'installed',
+          required_value: 'not_banned'
+        }
+        mockConflictedPackages = [
+          {
+            package_id: 'pack-0',
+            package_name: 'pack-0',
+            has_conflict: true,
+            conflicts: [bannedConflict],
+            is_compatible: false
+          }
+        ]
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue(
+          null
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        await runFullConflictAnalysis()
+
+        expect(mockConflictStore.clearConflicts).not.toHaveBeenCalled()
+        expect(mockConflictStore.setConflictedPackages).toHaveBeenCalledWith([
+          expect.objectContaining({
+            package_id: 'pack-0',
+            conflicts: [bannedConflict],
+            registry_status_unknown: true
+          })
+        ])
+      })
+
+      it.for([
+        { answer: 'omits the pack', node_versions: [] },
+        {
+          answer: 'reports an error for the pack',
+          node_versions: [
+            {
+              status: 'error' as const,
+              identifier: { node_id: 'pack-0', version: '1.0.0' },
+              error_message: 'node version not found'
+            }
+          ]
+        }
+      ])(
+        'leaves the plain fallback when the response $answer',
+        async ({ node_versions }) => {
+          installPacks(1)
+          vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue({
+            node_versions
+          })
+
+          const { runFullConflictAnalysis } = useConflictDetection()
+          const { results } = await runFullConflictAnalysis()
+
+          expect(bulkCalls()).toHaveLength(1)
+          expect(unknownPackIds(results)).toEqual([])
+        }
+      )
+
+      it('does not mark packs unverified when the retry succeeds', async () => {
+        installPacks(50)
+        let attempts = 0
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockImplementation(
+          (nodeVersions) => {
+            attempts += 1
+            return Promise.resolve(
+              attempts === 1 ? null : activeResponse(nodeVersions)
+            )
+          }
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        const { results } = await runFullConflictAnalysis()
+
+        expect(bulkCalls()).toHaveLength(2)
+        expect(unknownPackIds(results)).toEqual([])
+      })
+
+      it('retries a chunk exactly once before marking its packs unverified', async () => {
+        installPacks(50)
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue(
+          null
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        const { results } = await runFullConflictAnalysis()
+
+        expect(bulkCalls()).toHaveLength(2)
+        expect(unknownPackIds(results)).toEqual(packIds(50))
+      })
+
+      it('neither retries nor marks packs unverified when the run is cancelled', async () => {
+        installPacks(50)
+
+        const { runFullConflictAnalysis, cancelRequests } =
+          useConflictDetection()
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockImplementation(
+          () => {
+            cancelRequests()
+            return Promise.resolve(null)
+          }
+        )
+
+        const { results } = await runFullConflictAnalysis()
+
+        expect(bulkCalls()).toHaveLength(1)
+        expect(unknownPackIds(results)).toEqual([])
+        expect(
+          mockConflictStore.setRegistryUnknownPackIds
+        ).toHaveBeenCalledWith(new Set())
+      })
+
+      it('clears the unverified pack ids on a later successful run', async () => {
+        installPacks(50)
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockResolvedValue(
+          null
+        )
+
+        const { runFullConflictAnalysis } = useConflictDetection()
+        await runFullConflictAnalysis()
+
+        expect(
+          mockConflictStore.setRegistryUnknownPackIds
+        ).toHaveBeenLastCalledWith(new Set(packIds(50)))
+
+        vi.mocked(mockRegistryService.getBulkNodeVersions).mockImplementation(
+          (nodeVersions) => Promise.resolve(activeResponse(nodeVersions))
+        )
+        await runFullConflictAnalysis()
+
+        expect(
+          mockConflictStore.setRegistryUnknownPackIds
+        ).toHaveBeenLastCalledWith(new Set())
+      })
     })
   })
 

--- a/src/workbench/extensions/manager/composables/useConflictDetection.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.ts
@@ -6,6 +6,7 @@ import { computed, getCurrentInstance, onUnmounted, readonly, ref } from 'vue'
 import { useComfyRegistryService } from '@/services/comfyRegistryService'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import type { components } from '@/types/comfyRegistryTypes'
+import { isAbortError } from '@/utils/typeGuardUtil'
 import { useInstalledPacks } from '@/workbench/extensions/manager/composables/nodePack/useInstalledPacks'
 import { useConflictAcknowledgment } from '@/workbench/extensions/manager/composables/useConflictAcknowledgment'
 import { useManagerState } from '@/workbench/extensions/manager/composables/useManagerState'
@@ -52,17 +53,68 @@ const BULK_NODE_VERSIONS_CHUNK_SIZE = 100
  */
 const BULK_NODE_VERSIONS_MAX_PARALLEL_REQUESTS = 4
 
+type BulkNodeVersionsResponse =
+  components['schemas']['BulkNodeVersionsResponse']
+
+interface BulkNodeVersionsResult {
+  versionDataMap: Map<string, components['schemas']['NodeVersion']>
+  /**
+   * Packs whose chunk request never produced an answer, so the Registry never
+   * said whether they are banned or pending. Packs an answered response merely
+   * omits (or reports a per-identifier error for) are NOT in here — that is how
+   * the Registry reports packs it doesn't know about.
+   */
+  failedNodeIds: Set<string>
+}
+
+function collectNodeVersions(
+  response: BulkNodeVersionsResponse,
+  versionDataMap: Map<string, components['schemas']['NodeVersion']>
+): void {
+  response.node_versions?.forEach((result) => {
+    if (result.status === 'success' && result.node_version) {
+      versionDataMap.set(result.identifier.node_id, result.node_version)
+    } else if (result.status === 'error') {
+      console.warn(
+        `[ConflictDetection] Failed to fetch version data for ${result.identifier.node_id}@${result.identifier.version}:`,
+        result.error_message
+      )
+    }
+  })
+}
+
+async function retryBulkNodeVersionsChunk(
+  registryService: ReturnType<typeof useComfyRegistryService>,
+  nodeVersions: components['schemas']['NodeVersionIdentifier'][],
+  signal?: AbortSignal
+): Promise<BulkNodeVersionsResponse | null> {
+  try {
+    return await registryService.getBulkNodeVersions(nodeVersions, signal)
+  } catch (error) {
+    if (!isAbortError(error)) {
+      console.warn(
+        '[ConflictDetection] Retry of bulk version data failed:',
+        error
+      )
+    }
+    return null
+  }
+}
+
 /**
  * Fetches version data for every installed pack in bounded batches of
- * `POST /bulk/nodes/versions` requests, keyed by node id. Chunks that fail are
- * skipped so the rest of the installed packs still get their Registry data.
+ * `POST /bulk/nodes/versions` requests, keyed by node id. A chunk that fails is
+ * retried once; if it still fails, its packs are reported as unknown rather
+ * than silently treated as having no Registry status.
  */
 async function fetchBulkNodeVersions(
   registryService: ReturnType<typeof useComfyRegistryService>,
   nodeVersions: components['schemas']['NodeVersionIdentifier'][],
   signal?: AbortSignal
-): Promise<Map<string, components['schemas']['NodeVersion']>> {
+): Promise<BulkNodeVersionsResult> {
   const versionDataMap = new Map<string, components['schemas']['NodeVersion']>()
+  const failedNodeIds = new Set<string>()
+  const result = { versionDataMap, failedNodeIds }
 
   const requestChunks = chunk(nodeVersions, BULK_NODE_VERSIONS_CHUNK_SIZE)
 
@@ -70,7 +122,7 @@ async function fetchBulkNodeVersions(
     requestChunks,
     BULK_NODE_VERSIONS_MAX_PARALLEL_REQUESTS
   )) {
-    if (signal?.aborted) break
+    if (signal?.aborted) return result
 
     const bulkResponses = await Promise.allSettled(
       parallelChunks.map((nodeVersionsChunk) =>
@@ -78,38 +130,45 @@ async function fetchBulkNodeVersions(
       )
     )
 
-    for (const bulkResponse of bulkResponses) {
-      if (signal?.aborted) break
+    for (const [index, bulkResponse] of bulkResponses.entries()) {
+      // A cancelled run is not a failed lookup: leave those packs unmarked.
+      if (signal?.aborted) return result
+
+      const nodeVersionsChunk = parallelChunks[index]
+      let response: BulkNodeVersionsResponse | null = null
 
       if (bulkResponse.status === 'rejected') {
+        if (isAbortError(bulkResponse.reason)) return result
         console.warn(
           '[ConflictDetection] Failed to fetch bulk version data:',
           bulkResponse.reason
         )
-        continue
+      } else {
+        response = bulkResponse.value
       }
 
-      if (!bulkResponse.value) {
+      if (!response) {
+        response = await retryBulkNodeVersionsChunk(
+          registryService,
+          nodeVersionsChunk,
+          signal
+        )
+        if (signal?.aborted) return result
+      }
+
+      if (!response) {
         console.warn(
           '[ConflictDetection] Failed to fetch bulk version data for one batch of installed packs'
         )
+        nodeVersionsChunk.forEach(({ node_id }) => failedNodeIds.add(node_id))
         continue
       }
 
-      bulkResponse.value.node_versions?.forEach((result) => {
-        if (result.status === 'success' && result.node_version) {
-          versionDataMap.set(result.identifier.node_id, result.node_version)
-        } else if (result.status === 'error') {
-          console.warn(
-            `[ConflictDetection] Failed to fetch version data for ${result.identifier.node_id}@${result.identifier.version}:`,
-            result.error_message
-          )
-        }
-      })
+      collectNodeVersions(response, versionDataMap)
     }
   }
 
-  return versionDataMap
+  return result
 }
 
 /**
@@ -234,7 +293,7 @@ export function useConflictDetection() {
         version: pack.version
       }))
 
-      const versionDataMap = await fetchBulkNodeVersions(
+      const { versionDataMap, failedNodeIds } = await fetchBulkNodeVersions(
         registryService,
         nodeVersions,
         abortController.value?.signal
@@ -284,14 +343,17 @@ export function useConflictDetection() {
             `[ConflictDetection] No Registry data found for ${installedPackVersion.id}, using fallback`
           )
 
-          // Create fallback requirement without Registry data
+          // Create fallback requirement without Registry data. A failed lookup
+          // is flagged rather than reported as not-banned, so an earlier known
+          // banned/pending status isn't erased.
           const fallbackRequirement: NodeRequirements = {
             id: installedPackVersion.id,
             name: packInfo?.name || installedPackVersion.id,
             installed_version: installedPackVersion.version,
             is_enabled: isEnabled,
             is_banned: false,
-            is_pending: false
+            is_pending: false,
+            registry_status_unknown: failedNodeIds.has(installedPackVersion.id)
           }
 
           requirements.push(fallbackRequirement)
@@ -371,7 +433,8 @@ export function useConflictDetection() {
       package_name: packageReq.name ?? '',
       has_conflict: hasConflict,
       conflicts,
-      is_compatible: !hasConflict
+      is_compatible: !hasConflict,
+      registry_status_unknown: packageReq.registry_status_unknown
     }
   }
 
@@ -471,6 +534,25 @@ export function useConflictDetection() {
   }
 
   /**
+   * Keeps the banned/pending conflicts an earlier run already established for
+   * packs whose Registry lookup failed this run, so a Registry outage can't
+   * quietly downgrade a known-banned pack to "compatible".
+   */
+  function carryOverUnverifiedConflicts(
+    unknownPackIds: Set<string>
+  ): ConflictDetectionResult[] {
+    return [...unknownPackIds].flatMap((packId) => {
+      const storedResult = conflictStore.getConflictsForPackageByID(packId)
+      const hasKnownStatusConflict = storedResult?.conflicts.some(
+        (conflict) => conflict.type === 'banned' || conflict.type === 'pending'
+      )
+      return hasKnownStatusConflict && storedResult
+        ? [{ ...storedResult, registry_status_unknown: true }]
+        : []
+    })
+  }
+
+  /**
    * Performs complete conflict detection.
    * @returns Promise that resolves to conflict detection response
    */
@@ -492,6 +574,18 @@ export function useConflictDetection() {
 
       // 2. Collect installed node requirement information
       const installedNodeRequirements = await buildNodeRequirements()
+
+      const registryUnknownPackIds = new Set(
+        installedNodeRequirements.flatMap((requirement) =>
+          requirement.registry_status_unknown && requirement.id
+            ? [requirement.id]
+            : []
+        )
+      )
+      // Read before the store is overwritten below
+      const carriedOverConflicts = carryOverUnverifiedConflicts(
+        registryUnknownPackIds
+      )
 
       // 3. Detect conflicts for each package (parallel processing)
       const conflictDetectionTasks = installedNodeRequirements.map(
@@ -524,14 +618,16 @@ export function useConflictDetection() {
       // 6. Update state
       detectionResults.value = allResults
       lastDetectionTime.value = new Date().toISOString()
+      conflictStore.setRegistryUnknownPackIds(registryUnknownPackIds)
 
       // Store conflict results for later UI display
       // Dialog will be shown based on specific events, not on app mount
-      if (allResults.some((result) => result.has_conflict)) {
-        const conflictedResults = allResults.filter(
-          (result) => result.has_conflict
-        )
+      const conflictedResults = [
+        ...allResults.filter((result) => result.has_conflict),
+        ...carriedOverConflicts
+      ]
 
+      if (conflictedResults.length > 0) {
         // Merge conflicts for packages with the same name
         const mergedConflicts = consolidateConflictsByPackage(conflictedResults)
 

--- a/src/workbench/extensions/manager/composables/useConflictDetection.ts
+++ b/src/workbench/extensions/manager/composables/useConflictDetection.ts
@@ -59,17 +59,18 @@ type BulkNodeVersionsResponse =
 interface BulkNodeVersionsResult {
   versionDataMap: Map<string, components['schemas']['NodeVersion']>
   /**
-   * Packs whose chunk request never produced an answer, so the Registry never
-   * said whether they are banned or pending. Packs an answered response merely
-   * omits (or reports a per-identifier error for) are NOT in here — that is how
-   * the Registry reports packs it doesn't know about.
+   * Packs the Registry never gave a banned/pending answer for, because their
+   * chunk request went unanswered or their entry came back `status: 'error'`.
+   * A `not_found` entry (or an omitted one) is NOT in here — that is how the
+   * Registry reports packs it doesn't know about.
    */
   failedNodeIds: Set<string>
 }
 
 function collectNodeVersions(
   response: BulkNodeVersionsResponse,
-  versionDataMap: Map<string, components['schemas']['NodeVersion']>
+  versionDataMap: Map<string, components['schemas']['NodeVersion']>,
+  failedNodeIds: Set<string>
 ): void {
   response.node_versions?.forEach((result) => {
     if (result.status === 'success' && result.node_version) {
@@ -79,6 +80,7 @@ function collectNodeVersions(
         `[ConflictDetection] Failed to fetch version data for ${result.identifier.node_id}@${result.identifier.version}:`,
         result.error_message
       )
+      failedNodeIds.add(result.identifier.node_id)
     }
   })
 }
@@ -138,7 +140,6 @@ async function fetchBulkNodeVersions(
       let response: BulkNodeVersionsResponse | null = null
 
       if (bulkResponse.status === 'rejected') {
-        if (isAbortError(bulkResponse.reason)) return result
         console.warn(
           '[ConflictDetection] Failed to fetch bulk version data:',
           bulkResponse.reason
@@ -164,7 +165,7 @@ async function fetchBulkNodeVersions(
         continue
       }
 
-      collectNodeVersions(response, versionDataMap)
+      collectNodeVersions(response, versionDataMap, failedNodeIds)
     }
   }
 
@@ -283,10 +284,7 @@ export function useConflictDetection() {
       // Step 2: Get Registry service for bulk API calls
       const registryService = useComfyRegistryService()
 
-      // Step 3: Setup abort controller for request cancellation
-      abortController.value = new AbortController()
-
-      // Step 4: Use bulk API to fetch all version data in chunked requests
+      // Step 3: Use bulk API to fetch all version data in chunked requests
       // Prepare bulk request with actual installed versions from Manager API
       const nodeVersions = installedPacksWithVersions.value.map((pack) => ({
         node_id: pack.id,
@@ -299,7 +297,7 @@ export function useConflictDetection() {
         abortController.value?.signal
       )
 
-      // Step 5: Combine local installation data with Registry version data
+      // Step 4: Combine local installation data with Registry version data
       const requirements: NodeRequirements[] = []
 
       // IMPORTANT: Use installedPacksWithVersions to check ALL installed packages
@@ -534,20 +532,30 @@ export function useConflictDetection() {
   }
 
   /**
-   * Keeps the banned/pending conflicts an earlier run already established for
-   * packs whose Registry lookup failed this run, so a Registry outage can't
-   * quietly downgrade a known-banned pack to "compatible".
+   * Keeps the Registry-derived conflicts an earlier run already established for
+   * packs whose Registry lookup failed this run, so an outage can't quietly
+   * downgrade a known-banned pack to "compatible". `import_failed` is excluded
+   * because it comes from the Manager, not the Registry, and is re-detected in
+   * full on every run — carrying it over would resurrect a resolved failure.
    */
   function carryOverUnverifiedConflicts(
     unknownPackIds: Set<string>
   ): ConflictDetectionResult[] {
     return [...unknownPackIds].flatMap((packId) => {
       const storedResult = conflictStore.getConflictsForPackageByID(packId)
-      const hasKnownStatusConflict = storedResult?.conflicts.some(
-        (conflict) => conflict.type === 'banned' || conflict.type === 'pending'
+      const conflicts = storedResult?.conflicts.filter(
+        (conflict) => conflict.type !== 'import_failed'
       )
-      return hasKnownStatusConflict && storedResult
-        ? [{ ...storedResult, registry_status_unknown: true }]
+      return storedResult && conflicts?.length
+        ? [
+            {
+              ...storedResult,
+              conflicts,
+              has_conflict: true,
+              is_compatible: false,
+              registry_status_unknown: true
+            }
+          ]
         : []
     })
   }
@@ -567,6 +575,10 @@ export function useConflictDetection() {
 
     isDetecting.value = true
     detectionError.value = null
+
+    // Held locally because `cancelRequests` drops the ref on abort
+    abortController.value = new AbortController()
+    const { signal } = abortController.value
 
     try {
       // 1. Collect system environment information
@@ -615,10 +627,19 @@ export function useConflictDetection() {
       // 5. Combine all results
       const allResults = [...packageResults, ...importFailResults]
 
+      // A cancelled run saw only partial Registry and Manager data; committing
+      // it would downgrade every pack it never got to re-verify.
+      if (signal.aborted) {
+        return {
+          success: false,
+          error_message: 'Conflict detection cancelled',
+          results: detectionResults.value
+        }
+      }
+
       // 6. Update state
       detectionResults.value = allResults
       lastDetectionTime.value = new Date().toISOString()
-      conflictStore.setRegistryUnknownPackIds(registryUnknownPackIds)
 
       // Store conflict results for later UI display
       // Dialog will be shown based on specific events, not on app mount
@@ -627,33 +648,31 @@ export function useConflictDetection() {
         ...carriedOverConflicts
       ]
 
-      if (conflictedResults.length > 0) {
-        // Merge conflicts for packages with the same name
-        const mergedConflicts = consolidateConflictsByPackage(conflictedResults)
+      // Merge conflicts for packages with the same name
+      const mergedConflicts =
+        conflictedResults.length > 0
+          ? consolidateConflictsByPackage(conflictedResults)
+          : null
 
+      if (mergedConflicts) {
         // Store merged conflicts in Pinia store for UI usage
         conflictStore.setConflictedPackages(mergedConflicts)
 
         // Also update local state for backward compatibility
         detectionResults.value = [...mergedConflicts]
         storedMergedConflicts.value = [...mergedConflicts]
-
-        // Use merged conflicts in response as well
-        const response: ConflictDetectionResponse = {
-          success: true,
-          results: mergedConflicts,
-          detected_system_environment: systemEnvInfo
-        }
-        return response
       } else {
         // No conflicts detected, clear the results
         conflictStore.clearConflicts()
         detectionResults.value = []
       }
 
+      // After clearConflicts(), which also resets the unknown-pack ids
+      conflictStore.setRegistryUnknownPackIds(registryUnknownPackIds)
+
       const response: ConflictDetectionResponse = {
         success: true,
-        results: allResults,
+        results: mergedConflicts ?? allResults,
         detected_system_environment: systemEnvInfo
       }
 

--- a/src/workbench/extensions/manager/stores/conflictDetectionStore.test.ts
+++ b/src/workbench/extensions/manager/stores/conflictDetectionStore.test.ts
@@ -155,6 +155,15 @@ describe('useConflictDetectionStore', () => {
       expect(store.conflictedPackages).toEqual([])
       expect(store.hasConflicts).toBe(false)
     })
+
+    it('should clear the unverified registry pack ids', () => {
+      const store = useConflictDetectionStore()
+      store.setRegistryUnknownPackIds(new Set(['ComfyUI-Manager']))
+
+      store.clearConflicts()
+
+      expect(store.registryUnknownPackIds).toEqual(new Set())
+    })
   })
 
   describe('detection state management', () => {

--- a/src/workbench/extensions/manager/stores/conflictDetectionStore.ts
+++ b/src/workbench/extensions/manager/stores/conflictDetectionStore.ts
@@ -45,6 +45,7 @@ export const useConflictDetectionStore = defineStore(
 
     function clearConflicts() {
       conflictedPackages.value = []
+      registryUnknownPackIds.value = new Set()
     }
 
     function setRegistryUnknownPackIds(packIds: Set<string>) {

--- a/src/workbench/extensions/manager/stores/conflictDetectionStore.ts
+++ b/src/workbench/extensions/manager/stores/conflictDetectionStore.ts
@@ -10,6 +10,11 @@ export const useConflictDetectionStore = defineStore(
     const conflictedPackages = ref<ConflictDetectionResult[]>([])
     const isDetecting = ref(false)
     const lastDetectionTime = ref<string | null>(null)
+    /**
+     * Packs whose Registry lookup failed during the last detection run, so
+     * their banned/pending status could not be verified either way.
+     */
+    const registryUnknownPackIds = ref<Set<string>>(new Set())
 
     // Getters
     const hasConflicts = computed(() =>
@@ -42,6 +47,10 @@ export const useConflictDetectionStore = defineStore(
       conflictedPackages.value = []
     }
 
+    function setRegistryUnknownPackIds(packIds: Set<string>) {
+      registryUnknownPackIds.value = new Set(packIds)
+    }
+
     function setDetecting(detecting: boolean) {
       isDetecting.value = detecting
     }
@@ -55,6 +64,7 @@ export const useConflictDetectionStore = defineStore(
       conflictedPackages,
       isDetecting,
       lastDetectionTime,
+      registryUnknownPackIds,
       // Getters
       hasConflicts,
       getConflictsForPackageByID,
@@ -63,6 +73,7 @@ export const useConflictDetectionStore = defineStore(
       // Actions
       setConflictedPackages,
       clearConflicts,
+      setRegistryUnknownPackIds,
       setDetecting,
       setLastDetectionTime
     }

--- a/src/workbench/extensions/manager/types/conflictDetectionTypes.ts
+++ b/src/workbench/extensions/manager/types/conflictDetectionTypes.ts
@@ -32,6 +32,11 @@ export interface NodeRequirements extends Node {
   is_enabled: boolean
   is_banned: boolean
   is_pending: boolean
+  /**
+   * True when the Registry lookup for this pack failed, so `is_banned` /
+   * `is_pending` are unknown rather than verified false.
+   */
+  registry_status_unknown?: boolean
   // Aliases for backwards compatibility with existing code
   version_status?: string
 }
@@ -58,6 +63,11 @@ export interface ConflictDetectionResult {
   has_conflict: boolean
   conflicts: ConflictDetail[]
   is_compatible: boolean
+  /**
+   * True when the Registry lookup for this pack failed, so the absence of a
+   * banned/pending conflict means "not verified", not "verified compatible".
+   */
+  registry_status_unknown?: boolean
 }
 
 /**

--- a/src/workbench/extensions/manager/utils/conflictUtils.test.ts
+++ b/src/workbench/extensions/manager/utils/conflictUtils.test.ts
@@ -143,6 +143,43 @@ describe('conflictUtils', () => {
       expect(result).toEqual([])
     })
 
+    it('keeps the unverified-registry marker when any grouped entry carries it', () => {
+      const conflicts: ConflictDetectionResult[] = [
+        {
+          package_name: 'pack',
+          package_id: 'pack',
+          conflicts: [
+            {
+              type: 'import_failed',
+              current_value: 'boom',
+              required_value: 'boom'
+            }
+          ],
+          has_conflict: true,
+          is_compatible: false
+        },
+        {
+          package_name: 'pack@1_0_0',
+          package_id: 'pack@1_0_0',
+          conflicts: [
+            {
+              type: 'banned',
+              current_value: 'installed',
+              required_value: 'not_banned'
+            }
+          ],
+          has_conflict: true,
+          is_compatible: false,
+          registry_status_unknown: true
+        }
+      ]
+
+      const result = consolidateConflictsByPackage(conflicts)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].registry_status_unknown).toBe(true)
+    })
+
     it('should merge conflicts from multiple versions of same package', () => {
       const conflicts: ConflictDetectionResult[] = [
         {

--- a/src/workbench/extensions/manager/utils/conflictUtils.ts
+++ b/src/workbench/extensions/manager/utils/conflictUtils.ts
@@ -77,7 +77,10 @@ export function consolidateConflictsByPackage(
       package_name: packageName, // Use normalized name
       conflicts: uniqueConflicts,
       has_conflict: uniqueConflicts.length > 0,
-      is_compatible: uniqueConflicts.length === 0
+      is_compatible: uniqueConflicts.length === 0,
+      registry_status_unknown: packageConflicts.some(
+        (pc) => pc.registry_status_unknown
+      )
     }
   })
 }


### PR DESCRIPTION
> **STACKED — merging lands on `matt/be-6088-chunk-bulk-node-versions` (owned by @mattmillerai, PR #14588), NOT `main`.** GitHub will retarget this PR to `main` once #14588 merges. Review the net diff (6 files, this PR's two commits only).

## ELI-5

When the Manager asks the registry "are any of my installed packs banned?", it used to treat "the request failed" the same as "the registry said nothing is wrong". So a network hiccup made a *banned* pack look perfectly fine — and worse, it then wiped out the banned warning a previous, successful check had already found. Now a failed lookup is retried once, and if it still fails those packs are marked "we couldn't check" instead of "all clear", and any warning we already knew about is kept.

## Summary

Fail closed when a bulk registry lookup fails, instead of silently downgrading the affected packs to compatible and clearing previously known conflicts.

## Changes

- **What**: `fetchBulkNodeVersions` now returns `{ versionDataMap, failedNodeIds }`. A chunk whose request rejects or resolves `null` is retried once (sequentially, same signal); if it still fails, every pack in that chunk lands in `failedNodeIds`, as does any pack whose per-identifier entry comes back `status: 'error'`. The fallback requirement for those packs sets a new `registry_status_unknown` flag (`is_banned` / `is_pending` stay `false` — an unverified pack must not fabricate a conflict), which propagates onto `ConflictDetectionResult`. `runFullConflictAnalysis` carries over the stored Registry-derived conflicts for every unverified pack before overwriting the store, and only takes the `clearConflicts()` path when there are neither fresh nor carried-over conflicts. The failed-pack ids are also published as `conflictDetectionStore.registryUnknownPackIds`.
- **Breaking**: none. Both new type fields are optional; no public API or wire contract changes.

## Review Focus

- **The one existing condition this changes**: `if (allResults.some(r => r.has_conflict))` became `if (conflictedResults.length > 0)` where `conflictedResults = [...allResults.filter(has_conflict), ...carriedOver]`. With no carried-over conflicts the two are exactly equivalent (`some(p)` ⟺ `filter(p).length > 0`), so the only new path is the intended one: a run that finds no fresh conflicts but has a known conflict on a pack it could not re-verify now keeps that entry instead of clearing it.
- **What counts as an unanswered lookup**: an unanswered chunk request, and a per-identifier `status: 'error'`. The Registry schema has a *separate* `not_found` status for packs it does not know (unregistered / git-cloned), and documents `error_message` as "Error message if retrieval failed" — so `error` is a retrieval failure, not a "no such pack" answer. `not_found` and omitted entries keep today's plain fallback.
- **What is carried over**: only Registry-derived conflicts. `import_failed` comes from the Manager, is re-detected in full on every run, and is unaffected by a Registry outage, so carrying it over would resurrect a since-resolved failure.
- **Cancellation**: a cancelled run commits nothing. `runFullConflictAnalysis` owns the `AbortController` and holds the signal in a local (`cancelRequests` nulls the ref), then returns `success: false` before the state update — otherwise an unmount mid-run would let the analysis finish against partial Registry *and* Manager data and overwrite the shared store, which is the exact regression this PR targets.
- **Ordering**: the carry-over reads `conflictStore` *before* `setConflictedPackages` overwrites it; `setRegistryUnknownPackIds` is written *after* the `clearConflicts()` branch, because `clearConflicts` also resets those ids.
- **Request volume**: worst case one extra sequential request per failed chunk (retries are not parallelized), so a total outage on a 1000-pack install adds 10 sequential requests, not 10 parallel ones.
- **`registryUnknownPackIds` has no consumer yet** — intentional. The user-visible "couldn't verify compatibility" state is a separate, design-gated change; this PR adds no UI, no i18n strings, and does not touch how `PackStatusMessage` or the summary counts render.

## Verification

- `vitest run src/workbench/extensions/manager` — 415 tests across 29 files pass.
- Every new test was mutation-checked: dropping the carry-over, dropping the retry, dropping the abort guard, dropping the failed-id tracking, dropping the per-identifier `error` tracking, dropping the `registry_status_unknown` recompute in `consolidateConflictsByPackage`, and dropping the `clearConflicts` reset each turn the relevant test red.
- `oxfmt`, `eslint`, `oxlint --type-aware`, `pnpm knip` clean. `vue-tsc --noEmit` reports zero errors repo-wide.
- Capability check: this change denies nothing — it adds an "unverified" state and *preserves* warnings that previously vanished. No deny/throw path, no "unsupported" messaging, and no user-facing surface is gated off by it.

## Review round 2

Addressed all 7 cursor-review panel threads. Fixed: the cancelled-run store overwrite (High), the per-identifier `error` fail-open (Medium, the PR's original premise was wrong — checked the schema), carry-over scope for `import_failed` and for `supported_*` conflicts (Medium + half of the second High), the `registry_status_unknown` marker lost in `consolidateConflictsByPackage` (Low), the `clearConflicts` / `registryUnknownPackIds` inconsistency (Low), and the unreachable `isAbortError` branch (Nit). Declined with rationale on the thread: making `is_compatible` false for an unverified pack, since `consolidateConflictsByPackage` re-derives it from the conflict count and `registry_status_unknown` already carries that signal.
