### PR TITLE
test(errors): stop TabErrors leaking a console.warn past teardown

### DIFF
--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -49,6 +49,17 @@ vi.mock('@/composables/canvas/useFocusNode', () => ({
   }))
 }))
 
+// Its pack lookup resolves after the test file ends, and the console.warn on a
+// rejection lands while the worker's rpc is closing - an unhandled error that
+// fails the whole run with every test green. Mocked as the sibling suites do.
+vi.mock('@/stores/comfyRegistryStore', () => ({
+  useComfyRegistryStore: () => ({
+    inferPackFromNodeName: vi.fn(),
+    // TabErrors mounts the node-pack tree, which cancels this on unmount.
+    getPacksByIds: { call: vi.fn().mockResolvedValue([]), cancel: vi.fn() }
+  })
+}))
+
 vi.mock('@/platform/missingModel/missingModelDownload', () => ({
   downloadModel: vi.fn(),
   fetchModelMetadata: vi.fn().mockResolvedValue({


### PR DESCRIPTION
`TabErrors.test.ts` is the only suite in `src/components/rightSidePanel/errors/` that does not mock `useComfyRegistryStore`, so the real `inferPackFromNodeName` runs. Its `Promise.allSettled` can settle *after* the test file has finished, and the `console.warn` on a rejection then lands while the vitest worker's rpc is closing:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
```

**Vitest exits non-zero on unhandled errors even when every test passes.** The run that triggered this was `1092 files passed | 14905 tests passed | 2 errors` — fully green, check failed. It silently evicted PRs from the merge queue while their own status checks still read green, which is what makes it hard to diagnose from the PR side.

## The fix

Mocks the store the way `swapNodeGroups.test.ts` and `useErrorGroups.test.ts` already do, plus `getPacksByIds`.

**First attempt broke 15 tests.** Copying the sibling mock verbatim wasn't enough — `TabErrors` mounts the node-pack tree, and `useNodePacks` calls `getPacksByIds.cancel()` on unmount, so the narrower mock produced `Cannot read properties of undefined (reading 'cancel')`. The mock needs both members.

## Coverage: unchanged

Measured rather than assumed, before and after:

| | with mock | without |
| --- | --- | --- |
| `TabErrors.vue` stmts | 72.72% | 72.72% |
| branch | 42.85% | 42.85% |
| funcs / lines | 40% / 70% | 40% / 70% |
| uncovered lines | 23, 33, 54 | 23, 33, 54 |

The reason it's unchanged is the point: **the unmocked call was never providing coverage.** It attempts a real network request — the run logs `ECONNREFUSED 127.0.0.1:3000` — so it only ever traversed the rejection path, and nothing in the suite asserts on a resolved pack id. The mock replaces a call that always failed with one that returns nothing.

One honest caveat: `getPacksByIds` now resolves `[]` where it previously rejected, so the node-pack tree takes an empty-success path rather than an error path. Coverage says nothing measurable changed, but that is a behavioural difference in the test rather than a pure no-op.

## What I could not verify

**Not reproducible locally.** This directory runs in ~10s against ~724s for the full CI suite, so the race never opens here — I ran it with and without the fix and both are clean. The change is justified by the mechanism, not by a demonstrated red-to-green.

If it recurs, the next step is unmounting explicitly in an `afterEach` so the composable's `cancelled` guard is set, rather than only removing the rejection source.

Closes #14646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
