### PR TITLE
fix: missing-media follow-ups from #14578 review

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -11,7 +11,7 @@ import {
   assetRequestIncludesTag,
   createCloudAssetsFixture
 } from '@e2e/fixtures/assetApiFixture'
-import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { WorkspaceStore } from '@e2e/types/globals'
 import {
@@ -32,7 +32,7 @@ import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPane
 import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { toNodeId } from '@/types/nodeId'
 
-const ossTest = mergeTests(comfyPageFixture, jobsRouteFixture)
+const ossTest = mergeTests(test, jobsRouteFixture)
 const outputHash =
   '147257c95a3e957e0deee73a077cfec89da2d906dd086ca70a2b0c897a9591d6e.png'
 const outputVideoHash = 'cloud-video-hash.mp4'
@@ -204,7 +204,7 @@ const cloudEmptyMediaInputsTest = createCloudAssetsFixture([]).extend({
   }
 })
 const cloudUploadAssetStateByPage = new WeakMap<Page, CloudUploadAssetState>()
-const cloudUploadRaceTest = comfyPageFixture.extend<{
+const cloudUploadRaceTest = test.extend<{
   markUploadedCloudAssetAvailable: () => void
 }>({
   page: async ({ page }, use) => {
@@ -513,105 +513,102 @@ ossTest.describe(
   }
 )
 
-comfyPageFixture.describe(
+test.describe(
   'Errors tab - promoted missing media',
   { tag: ['@ui', '@vue-nodes', '@widget', '@subgraph'] },
   () => {
-    comfyPageFixture.beforeEach(async ({ comfyPage }) => {
+    test.beforeEach(async ({ comfyPage }) => {
       await enableErrorsTab(comfyPage)
     })
 
-    comfyPageFixture(
-      'shows missing media on the promoted host and not the interior widget',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+    test('shows missing media on the promoted host and not the interior widget', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
 
-        const missingMediaRow = comfyPage.page.getByTestId(
-          TestIds.dialogs.missingMediaRow
-        )
-        await expect(missingMediaRow).toHaveCount(1)
-        await expect(missingMediaRow).toContainText(
-          `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
-        )
+      const missingMediaRow = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingMediaRow
+      )
+      await expect(missingMediaRow).toHaveCount(1)
+      await expect(missingMediaRow).toContainText(
+        `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
+      )
 
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.close()
-        await comfyPage.subgraph.enterSubgraphWithFallback(
-          String(promotedMediaHostNodeId)
-        )
-        await panel.open(comfyPage.actionbar.propertiesButton)
-        await expect(missingMediaRow).toHaveCount(1)
-        await expect(missingMediaRow).toContainText(
-          `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
-        )
-      }
-    )
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.close()
+      await comfyPage.subgraph.enterSubgraphWithFallback(
+        String(promotedMediaHostNodeId)
+      )
+      await panel.open(comfyPage.actionbar.propertiesButton)
+      await expect(missingMediaRow).toHaveCount(1)
+      await expect(missingMediaRow).toContainText(
+        `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
+      )
+    })
 
-    comfyPageFixture(
-      'clears promoted missing media after selecting a valid host image',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
-        const missingMediaRow = comfyPage.page.getByTestId(
-          TestIds.dialogs.missingMediaRow
-        )
-        await expect(missingMediaRow).toHaveCount(1)
+    test('clears promoted missing media after selecting a valid host image', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+      const missingMediaRow = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingMediaRow
+      )
+      await expect(missingMediaRow).toHaveCount(1)
 
-        await selectVuePromotedMediaByTitle(
-          comfyPage,
-          promotedMediaHostTitle,
-          promotedMediaHostWidgetName,
-          validPromotedMedia
-        )
+      await selectVuePromotedMediaByTitle(
+        comfyPage,
+        promotedMediaHostTitle,
+        promotedMediaHostWidgetName,
+        validPromotedMedia
+      )
 
-        await expectNoErrorsTab(comfyPage)
-        await expect(missingMediaRow).toHaveCount(0)
+      await expectNoErrorsTab(comfyPage)
+      await expect(missingMediaRow).toHaveCount(0)
 
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.close()
-        await comfyPage.subgraph.enterSubgraphWithFallback(
-          String(promotedMediaHostNodeId)
-        )
-        await expectNoErrorsTab(comfyPage)
-        await expect(missingMediaRow).toHaveCount(0)
-      }
-    )
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.close()
+      await comfyPage.subgraph.enterSubgraphWithFallback(
+        String(promotedMediaHostNodeId)
+      )
+      await expectNoErrorsTab(comfyPage)
+      await expect(missingMediaRow).toHaveCount(0)
+    })
 
-    comfyPageFixture(
-      'keeps a host-only option value resolved after a promoted media rescan',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+    test('keeps a host-only option value resolved after a promoted media rescan', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
 
-        const optionState = await setPromotedMediaHostOptionsAndValue(
-          comfyPage,
-          promotedMediaHostNodeId,
-          promotedMediaLeafNodeId,
-          promotedMediaHostWidgetName,
-          promotedMediaLeafWidgetName,
-          hostOnlyPromotedMedia
-        )
-        expect(
-          optionState,
-          'Expected the uploaded value only in the promoted host options'
-        ).toEqual({
-          hostValue: hostOnlyPromotedMedia,
-          leafIncludesValue: false
-        })
+      const optionState = await setPromotedMediaHostOptionsAndValue(
+        comfyPage,
+        promotedMediaHostNodeId,
+        promotedMediaLeafNodeId,
+        promotedMediaHostWidgetName,
+        promotedMediaLeafWidgetName,
+        hostOnlyPromotedMedia
+      )
+      expect(
+        optionState,
+        'Expected the uploaded value only in the promoted host options'
+      ).toEqual({
+        hostValue: hostOnlyPromotedMedia,
+        leafIncludesValue: false
+      })
 
-        await expectNoErrorsTab(comfyPage)
+      await expectNoErrorsTab(comfyPage)
 
-        const host = comfyPage.vueNodes.getNodeByTitle(promotedMediaHostTitle)
-        await comfyPage.vueNodes.selectNode(String(promotedMediaHostNodeId))
-        await comfyPage.keyboard.bypass()
-        await expect(host.getByText('Bypassed', { exact: true })).toBeVisible()
+      const host = comfyPage.vueNodes.getNodeByTitle(promotedMediaHostTitle)
+      await comfyPage.vueNodes.selectNode(String(promotedMediaHostNodeId))
+      await comfyPage.keyboard.bypass()
+      await expect(host.getByText('Bypassed', { exact: true })).toBeVisible()
 
-        await comfyPage.keyboard.bypass()
-        await expect(host.getByText('Bypassed', { exact: true })).toBeHidden()
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.open(comfyPage.actionbar.propertiesButton)
-        await expect(panel.errorsTab).toBeHidden()
-        await expect(getErrorOverlay(comfyPage)).toBeHidden()
-      }
-    )
+      await comfyPage.keyboard.bypass()
+      await expect(host.getByText('Bypassed', { exact: true })).toBeHidden()
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.open(comfyPage.actionbar.propertiesButton)
+      await expect(panel.errorsTab).toBeHidden()
+      await expect(getErrorOverlay(comfyPage)).toBeHidden()
+    })
   }
 )
 

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -11,7 +11,7 @@ import {
   assetRequestIncludesTag,
   createCloudAssetsFixture
 } from '@e2e/fixtures/assetApiFixture'
-import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { WorkspaceStore } from '@e2e/types/globals'
 import {
@@ -32,7 +32,7 @@ import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPane
 import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { toNodeId } from '@/types/nodeId'
 
-const ossTest = mergeTests(comfyPageFixture, jobsRouteFixture)
+const ossTest = mergeTests(test, jobsRouteFixture)
 const outputHash =
   '147257c95a3e957e0deee73a077cfec89da2d906dd086ca70a2b0c897a9591d6e.png'
 const outputVideoHash = 'cloud-video-hash.mp4'
@@ -197,7 +197,7 @@ const cloudEmptyMediaInputsTest = createCloudAssetsFixture([]).extend({
   }
 })
 const cloudUploadAssetStateByPage = new WeakMap<Page, CloudUploadAssetState>()
-const cloudUploadRaceTest = comfyPageFixture.extend<{
+const cloudUploadRaceTest = test.extend<{
   markUploadedCloudAssetAvailable: () => void
 }>({
   page: async ({ page }, use) => {
@@ -506,105 +506,102 @@ ossTest.describe(
   }
 )
 
-comfyPageFixture.describe(
+test.describe(
   'Errors tab - promoted missing media',
   { tag: ['@ui', '@vue-nodes', '@widget', '@subgraph'] },
   () => {
-    comfyPageFixture.beforeEach(async ({ comfyPage }) => {
+    test.beforeEach(async ({ comfyPage }) => {
       await enableErrorsTab(comfyPage)
     })
 
-    comfyPageFixture(
-      'shows missing media on the promoted host and not the interior widget',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+    test('shows missing media on the promoted host and not the interior widget', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
 
-        const missingMediaRow = comfyPage.page.getByTestId(
-          TestIds.dialogs.missingMediaRow
-        )
-        await expect(missingMediaRow).toHaveCount(1)
-        await expect(missingMediaRow).toContainText(
-          `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
-        )
+      const missingMediaRow = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingMediaRow
+      )
+      await expect(missingMediaRow).toHaveCount(1)
+      await expect(missingMediaRow).toContainText(
+        `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
+      )
 
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.close()
-        await comfyPage.subgraph.enterSubgraphWithFallback(
-          String(promotedMediaHostNodeId)
-        )
-        await panel.open(comfyPage.actionbar.propertiesButton)
-        await expect(missingMediaRow).toHaveCount(1)
-        await expect(missingMediaRow).toContainText(
-          `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
-        )
-      }
-    )
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.close()
+      await comfyPage.subgraph.enterSubgraphWithFallback(
+        String(promotedMediaHostNodeId)
+      )
+      await panel.open(comfyPage.actionbar.propertiesButton)
+      await expect(missingMediaRow).toHaveCount(1)
+      await expect(missingMediaRow).toContainText(
+        `${promotedMediaHostTitle} - ${promotedMediaHostWidgetName}`
+      )
+    })
 
-    comfyPageFixture(
-      'clears promoted missing media after selecting a valid host image',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
-        const missingMediaRow = comfyPage.page.getByTestId(
-          TestIds.dialogs.missingMediaRow
-        )
-        await expect(missingMediaRow).toHaveCount(1)
+    test('clears promoted missing media after selecting a valid host image', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+      const missingMediaRow = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingMediaRow
+      )
+      await expect(missingMediaRow).toHaveCount(1)
 
-        await selectVuePromotedMediaByTitle(
-          comfyPage,
-          promotedMediaHostTitle,
-          promotedMediaHostWidgetName,
-          validPromotedMedia
-        )
+      await selectVuePromotedMediaByTitle(
+        comfyPage,
+        promotedMediaHostTitle,
+        promotedMediaHostWidgetName,
+        validPromotedMedia
+      )
 
-        await expectNoErrorsTab(comfyPage)
-        await expect(missingMediaRow).toHaveCount(0)
+      await expectNoErrorsTab(comfyPage)
+      await expect(missingMediaRow).toHaveCount(0)
 
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.close()
-        await comfyPage.subgraph.enterSubgraphWithFallback(
-          String(promotedMediaHostNodeId)
-        )
-        await expectNoErrorsTab(comfyPage)
-        await expect(missingMediaRow).toHaveCount(0)
-      }
-    )
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.close()
+      await comfyPage.subgraph.enterSubgraphWithFallback(
+        String(promotedMediaHostNodeId)
+      )
+      await expectNoErrorsTab(comfyPage)
+      await expect(missingMediaRow).toHaveCount(0)
+    })
 
-    comfyPageFixture(
-      'keeps a host-only option value resolved after a promoted media rescan',
-      async ({ comfyPage }) => {
-        await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
+    test('keeps a host-only option value resolved after a promoted media rescan', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, promotedMediaWorkflow)
 
-        const optionState = await setPromotedMediaHostOptionsAndValue(
-          comfyPage,
-          promotedMediaHostNodeId,
-          promotedMediaLeafNodeId,
-          promotedMediaHostWidgetName,
-          promotedMediaLeafWidgetName,
-          hostOnlyPromotedMedia
-        )
-        expect(
-          optionState,
-          'Expected the uploaded value only in the promoted host options'
-        ).toEqual({
-          hostValue: hostOnlyPromotedMedia,
-          leafIncludesValue: false
-        })
+      const optionState = await setPromotedMediaHostOptionsAndValue(
+        comfyPage,
+        promotedMediaHostNodeId,
+        promotedMediaLeafNodeId,
+        promotedMediaHostWidgetName,
+        promotedMediaLeafWidgetName,
+        hostOnlyPromotedMedia
+      )
+      expect(
+        optionState,
+        'Expected the uploaded value only in the promoted host options'
+      ).toEqual({
+        hostValue: hostOnlyPromotedMedia,
+        leafIncludesValue: false
+      })
 
-        await expectNoErrorsTab(comfyPage)
+      await expectNoErrorsTab(comfyPage)
 
-        const host = comfyPage.vueNodes.getNodeByTitle(promotedMediaHostTitle)
-        await comfyPage.vueNodes.selectNode(String(promotedMediaHostNodeId))
-        await comfyPage.keyboard.bypass()
-        await expect(host.getByText('Bypassed', { exact: true })).toBeVisible()
+      const host = comfyPage.vueNodes.getNodeByTitle(promotedMediaHostTitle)
+      await comfyPage.vueNodes.selectNode(String(promotedMediaHostNodeId))
+      await comfyPage.keyboard.bypass()
+      await expect(host.getByText('Bypassed', { exact: true })).toBeVisible()
 
-        await comfyPage.keyboard.bypass()
-        await expect(host.getByText('Bypassed', { exact: true })).toBeHidden()
-        const panel = new PropertiesPanelHelper(comfyPage.page)
-        await panel.open(comfyPage.actionbar.propertiesButton)
-        await expect(panel.errorsTab).toBeHidden()
-        await expect(getErrorOverlay(comfyPage)).toBeHidden()
-      }
-    )
+      await comfyPage.keyboard.bypass()
+      await expect(host.getByText('Bypassed', { exact: true })).toBeHidden()
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+      await panel.open(comfyPage.actionbar.propertiesButton)
+      await expect(panel.errorsTab).toBeHidden()
+      await expect(getErrorOverlay(comfyPage)).toBeHidden()
+    })
   }
 )
 

--- a/src/composables/graph/useErrorClearingHooks.promotion.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.promotion.test.ts
@@ -152,6 +152,10 @@ describe('promotion listener lifecycle', () => {
     vi.spyOn(app, 'isGraphReady', 'get').mockReturnValue(false)
   })
 
+  /** Lets a removal's own deferred reconcile land before the test seeds. */
+  const flushRemovalReconcile = () =>
+    new Promise((resolve) => setTimeout(resolve, 0))
+
   /** A candidate for a node that does not exist, so any reconcile drops it. */
   function seedStaleCandidate() {
     const mediaStore = useMissingMediaStore()
@@ -181,6 +185,7 @@ describe('promotion listener lifecycle', () => {
     } = createSharedDefinitionGraph([65])
     installErrorClearingHooks(rootGraph)
     rootGraph.remove(host)
+    await flushRemovalReconcile()
 
     const mediaStore = seedStaleCandidate()
     subgraph.events.dispatch('widget-promoted', {
@@ -206,6 +211,7 @@ describe('promotion listener lifecycle', () => {
     // already in the graph, so hosts counted at install time arrive again.
     rootGraph.onNodeAdded?.(host)
     rootGraph.remove(host)
+    await flushRemovalReconcile()
 
     const mediaStore = seedStaleCandidate()
     subgraph.events.dispatch('widget-promoted', {
@@ -225,6 +231,7 @@ describe('promotion listener lifecycle', () => {
     } = createSharedDefinitionGraph([65, 66])
     installErrorClearingHooks(rootGraph)
     rootGraph.remove(first)
+    await flushRemovalReconcile()
 
     const mediaStore = seedStaleCandidate()
     subgraph.events.dispatch('widget-promoted', {

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -1704,14 +1704,8 @@ describe('scan skips interior of bypassed subgraph containers', () => {
     vi.spyOn(missingMediaScan, 'scanNodeMediaCandidates').mockReturnValue([])
     installErrorClearingHooks(outerSubgraph)
 
-    innerSubgraphNode.mode = LGraphEventMode.ALWAYS
-    outerSubgraph.onTrigger?.({
-      type: 'node:property:changed',
-      nodeId: innerSubgraphNode.id,
-      property: 'mode',
-      oldValue: LGraphEventMode.BYPASS,
-      newValue: LGraphEventMode.ALWAYS
-    })
+    innerSubgraphNode.mode = LGraphEventMode.BYPASS
+    setNodeMode(outerSubgraph, innerSubgraphNode, LGraphEventMode.ALWAYS)
 
     expect(useMissingModelStore().missingModelCandidates).toEqual([
       hostCandidate

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -1042,6 +1042,47 @@ describe('onNodeRemoved clears missing asset errors by execution ID', () => {
     expect(nodesStore.missingNodesError).toBeNull()
   })
 
+  it('reconciles missing media once for a burst of removals', async () => {
+    const subgraph = createTestSubgraph()
+    const addInteriorNode = (id: number) => {
+      const node = new LGraphNode('LoadImage')
+      node.id = toNodeId(id)
+      subgraph.add(node)
+      return node
+    }
+    const removedNodes = [1, 2, 3].map(addInteriorNode)
+    const survivingNodes = [4, 5].map(addInteriorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
+    const rootGraph = subgraphNode.graph as LGraph
+    rootGraph.add(subgraphNode)
+
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
+    installErrorClearingHooks(subgraph)
+
+    const mediaStore = useMissingMediaStore()
+    mediaStore.setMissingMedia(
+      survivingNodes.map((node) =>
+        createMissingMediaCandidate([toNodeId(65), node.id], {
+          name: `cat-${node.id}.png`
+        })
+      )
+    )
+
+    const scopeSpy = vi.spyOn(
+      missingMediaScan,
+      'isMissingMediaCandidateScopeActive'
+    )
+
+    for (const node of removedNodes) subgraph.remove(node)
+
+    expect.soft(scopeSpy).not.toHaveBeenCalled()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(scopeSpy).toHaveBeenCalledTimes(survivingNodes.length)
+  })
+
   it('removes host-keyed missing media when its sole promoted consumer is deleted', () => {
     const {
       rootGraph,

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -88,13 +88,7 @@ function installNodeHooks(node: LGraphNode): void {
       if (isConnected) {
         useExecutionErrorStore().clearSimpleNodeErrors(execId, slotName)
       }
-      // Linking hands value ownership to the upstream node and unlinking hands
-      // it back, so the media error surface follows the same way it follows
-      // promotion.
       queueMicrotask(() => {
-        // LGraphNode.configure fires this for every input slot while a
-        // workflow loads, so a load would prune candidates against a graph
-        // that is still being wired.
         if (!app.rootGraph || ChangeTracker.isLoadingGraph) return
         dropOutOfScopeMissingMedia()
         if (!isConnected) scanSingleNodeMedia(node)
@@ -405,9 +399,8 @@ function removeNodeErrors(node: LGraphNode, execId: string): void {
   dropOutOfScopeMissingMedia()
 }
 
+/** Removes candidates whose widget is no longer the editable value owner. */
 function dropOutOfScopeMissingMedia(): void {
-  // No root graph means every candidate reads out of scope, which would empty
-  // the store rather than no-op.
   if (!app.rootGraph || ChangeTracker.isLoadingGraph) return
 
   const mediaStore = useMissingMediaStore()
@@ -422,7 +415,7 @@ function dropOutOfScopeMissingMedia(): void {
 
 export function installErrorClearingHooks(graph: LGraph): () => void {
   const promotionErrors = createPromotionErrorReconciler({
-    pruneOutOfScope: dropOutOfScopeMissingMedia,
+    dropOutOfScope: dropOutOfScopeMissingMedia,
     rescanHost: (subgraphNode) =>
       scanNodeErrorTargets(subgraphNode, scanSingleNodeMedia),
     removeHostWidgetCandidate: (subgraphNode, widgetName) => {

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -88,13 +88,7 @@ function installNodeHooks(node: LGraphNode): void {
       if (isConnected) {
         useExecutionErrorStore().clearSimpleNodeErrors(execId, slotName)
       }
-      // Linking hands value ownership to the upstream node and unlinking hands
-      // it back, so the media error surface follows the same way it follows
-      // promotion.
       queueMicrotask(() => {
-        // LGraphNode.configure fires this for every input slot while a
-        // workflow loads, so a load would prune candidates against a graph
-        // that is still being wired.
         if (!app.rootGraph || ChangeTracker.isLoadingGraph) return
         dropOutOfScopeMissingMedia()
         if (!isConnected) scanSingleNodeMedia(node)
@@ -532,9 +526,8 @@ function removeNodeErrors(node: LGraphNode, execId: string): void {
   dropOutOfScopeMissingMedia()
 }
 
+/** Removes candidates whose widget is no longer the editable value owner. */
 function dropOutOfScopeMissingMedia(): void {
-  // No root graph means every candidate reads out of scope, which would empty
-  // the store rather than no-op.
   if (!app.rootGraph || ChangeTracker.isLoadingGraph) return
 
   const mediaStore = useMissingMediaStore()
@@ -551,7 +544,7 @@ export function installErrorClearingHooks(graph: LGraph): () => void {
   const pendingScans = new Map<LGraphNode, Set<PendingScanControl>>()
   let disposed = false
   const promotionErrors = createPromotionErrorReconciler({
-    pruneOutOfScope: dropOutOfScopeMissingMedia,
+    dropOutOfScope: dropOutOfScopeMissingMedia,
     rescanHost: (subgraphNode) =>
       scanNodeErrorTargets(subgraphNode, scanSingleNodeMedia),
     removeHostWidgetCandidate: (subgraphNode, widgetName) => {

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -482,6 +482,7 @@ function handleNodeModeChange(
 
   if (isNowInactive) {
     removeNodeErrors(node, execId)
+    dropOutOfScopeMissingMedia()
   } else {
     scanAndAddNodeErrors(node)
     scanAncestorSubgraphHosts(execId)
@@ -522,8 +523,6 @@ function removeNodeErrors(node: LGraphNode, execId: string): void {
     mediaStore.removeMissingMediaByPrefix(prefix)
     nodesStore.removeMissingNodesByPrefix(prefix)
   }
-
-  dropOutOfScopeMissingMedia()
 }
 
 /** Removes candidates whose widget is no longer the editable value owner. */
@@ -543,6 +542,22 @@ function dropOutOfScopeMissingMedia(): void {
 export function installErrorClearingHooks(graph: LGraph): () => void {
   const pendingScans = new Map<LGraphNode, Set<PendingScanControl>>()
   let disposed = false
+  let pendingOutOfScopeDrop = false
+
+  /**
+   * Coalesces `dropOutOfScopeMissingMedia` across a burst of removals, which
+   * would otherwise re-walk every candidate's topology once per removed node.
+   */
+  const scheduleDropOutOfScopeMissingMedia = (): void => {
+    if (pendingOutOfScopeDrop) return
+    pendingOutOfScopeDrop = true
+    queueMicrotask(() => {
+      pendingOutOfScopeDrop = false
+      if (disposed) return
+      dropOutOfScopeMissingMedia()
+    })
+  }
+
   const promotionErrors = createPromotionErrorReconciler({
     dropOutOfScope: dropOutOfScopeMissingMedia,
     rescanHost: (subgraphNode) =>
@@ -590,6 +605,7 @@ export function installErrorClearingHooks(graph: LGraph): () => void {
     // misses subgraph entries.
     const execId = getRemovedNodeExecutionId(graph, node.id)
     removeNodeErrors(node, execId)
+    scheduleDropOutOfScopeMissingMedia()
     restoreNodeHooksRecursive(node)
     promotionErrors.detachNode(node)
     originalOnNodeRemoved?.call(this, node)

--- a/src/core/graph/subgraph/createPromotionErrorReconciler.ts
+++ b/src/core/graph/subgraph/createPromotionErrorReconciler.ts
@@ -1,14 +1,6 @@
 /**
- * Keeps the missing-media error surface aligned with promotion.
- *
- * Promoting a widget moves value ownership from the interior widget to the
- * host, and demoting moves it back. The error has to travel with ownership,
- * otherwise it stays keyed to a widget the user can no longer edit.
- *
- * Attach and detach are recursive and symmetric: a subgraph host that is added
- * brings its nested definitions with it, and one that is removed takes them
- * away again. Subscriptions are counted because several hosts can share one
- * definition, and removing one of them must not silence the others.
+ * Moves the missing-media error surface between the interior widget and its
+ * host as promotion transfers value ownership.
  */
 import type {
   LGraphNode,
@@ -19,7 +11,7 @@ import type {
 
 interface PromotionErrorReconcilerHandlers {
   /** Drops candidates whose widget is no longer the editable value owner. */
-  pruneOutOfScope: () => void
+  dropOutOfScope: () => void
   /** Rescans a host and its interior nodes for missing media. */
   rescanHost: (subgraphNode: SubgraphNode) => void
   /** Removes the host-keyed candidate for a widget that is being demoted. */
@@ -46,22 +38,18 @@ interface Subscription {
 }
 
 export function createPromotionErrorReconciler({
-  pruneOutOfScope,
+  dropOutOfScope,
   rescanHost,
   removeHostWidgetCandidate
 }: PromotionErrorReconcilerHandlers): PromotionErrorReconciler {
   const subscriptions = new Map<Subgraph, Subscription>()
-  // useGraphNodeManager chains onNodeAdded and replays it for every node
-  // already in the graph, so the same host arrives twice. Count hosts, not
-  // arrivals, or the definition never drops to zero and is never released.
+  /** Hosts already counted, since onNodeAdded is replayed for existing nodes. */
   const attachedHosts = new WeakSet<LGraphNode>()
 
-  // Ownership has not settled when the event fires, so reconcile on the next
-  // microtask: the side that lost it fails the scope check and is dropped, the
-  // side that gained it is scanned fresh.
+  /** Re-derives both sides once ownership has settled. */
   const reconcile = (subgraphNode: SubgraphNode) => {
     queueMicrotask(() => {
-      pruneOutOfScope()
+      dropOutOfScope()
       rescanHost(subgraphNode)
     })
   }
@@ -71,8 +59,8 @@ export function createPromotionErrorReconciler({
       event: CustomEvent<SubgraphEventMap['widget-demoted']>
     ) => {
       const { subgraphNode, widget } = event.detail
-      // The host input still carries the widget at this point, so the scope
-      // filter cannot see it as gone yet.
+      // Fires before the widget leaves the host input, so the scope filter
+      // cannot see it gone yet.
       removeHostWidgetCandidate(subgraphNode, widget.name)
       reconcile(subgraphNode)
     }

--- a/src/platform/assets/utils/clearNodePreviewCacheForValues.ts
+++ b/src/platform/assets/utils/clearNodePreviewCacheForValues.ts
@@ -46,9 +46,6 @@ export function clearNodePreviewCacheForValues(
  * paths.
  *
  * Skips subgraph wrapper nodes — only their interior nodes are inspected.
- * `markDeletedAssetsAsMissingMedia` appends promoted hosts at its own call
- * site, because a host owns a widget value but not the outputs a preview
- * would clear.
  */
 export function findNodesReferencingValues(
   rootGraph: LGraph | Subgraph,

--- a/src/platform/missingMedia/missingMediaPipeline.test.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
@@ -11,12 +11,24 @@ import { runMissingMediaPipeline } from '@/platform/missingMedia/missingMediaPip
 import * as missingMediaScan from '@/platform/missingMedia/missingMediaScan'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+
+const { activeWorkflow } = vi.hoisted(() => {
+  const activeWorkflow: Pick<ComfyWorkflow, 'pendingWarnings'> = {
+    pendingWarnings: null
+  }
+  return { activeWorkflow }
+})
 
 // The real store reaches authStore -> firebase setPersistence, which has no
 // config under vitest. Mirrors missingModelPipeline.test.ts.
 vi.mock('@/stores/workspaceStore', () => ({
-  useWorkspaceStore: () => ({ workflow: { activeWorkflow: null } })
+  useWorkspaceStore: () => ({ workflow: { activeWorkflow } })
 }))
+
+beforeEach(() => {
+  activeWorkflow.pendingWarnings = null
+})
 
 async function startPendingWorkflowLoadMediaVerification(
   rootGraph: LGraph,
@@ -82,5 +94,29 @@ describe('runMissingMediaPipeline', () => {
 
     expect.soft(pendingCandidate.isMissing).toBe(true)
     expect(useMissingMediaStore().missingMediaCandidates).toBeNull()
+  })
+
+  it('neither surfaces nor caches workflow-load media when the promoted host value changed during verification', async () => {
+    const {
+      rootGraph,
+      hosts: [host]
+    } = createPromotedMediaRuntime()
+    const pendingCandidate = {
+      ...createPromotedMissingMediaCandidate(host),
+      isMissing: undefined
+    }
+    const resolveVerification = await startPendingWorkflowLoadMediaVerification(
+      rootGraph,
+      pendingCandidate
+    )
+
+    const hostWidget = host.widgets?.[0]
+    if (!hostWidget) throw new Error('Expected promoted image host widget')
+    hostWidget.value = 'user-picked-valid.png'
+    resolveVerification()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect.soft(useMissingMediaStore().missingMediaCandidates).toBeNull()
+    expect(activeWorkflow.pendingWarnings).toBeNull()
   })
 })

--- a/src/platform/missingMedia/missingMediaPipeline.ts
+++ b/src/platform/missingMedia/missingMediaPipeline.ts
@@ -16,7 +16,6 @@ import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 interface RunMissingMediaPipelineOptions {
-  /** Must be the root graph: candidates are keyed by root-relative execution id. */
   rootGraph: LGraph
   silent?: boolean
 }

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -41,11 +41,7 @@ function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
   return widget.type === 'combo'
 }
 
-/**
- * The widget a user can actually edit. A linked slot means the value comes
- * from upstream; a promoted host owns the value only while some interior
- * consumer is still live.
- */
+/** The widget a user can actually edit. */
 function isEditableValueOwner(node: LGraphNode, widget: IBaseWidget): boolean {
   const input = node.getSlotFromWidget(widget)
   if (input?.link != null) return false
@@ -111,10 +107,6 @@ export function scanNodeMediaCandidates(
   for (const widget of node.widgets) {
     if (!isComboWidget(widget)) continue
 
-    // getInputSpecForWidget projects a promoted host input to its interior
-    // spec itself, so the scan reads schema through the store rather than
-    // walking the subgraph. Media-ness is the cheaper question, so it runs
-    // before the ownership walk.
     const mediaType = mediaTypeFromSpec(
       nodeDefStore.getInputSpecForWidget(node, widget.name)
     )

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -41,11 +41,7 @@ function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
   return widget.type === 'combo'
 }
 
-/**
- * The widget a user can actually edit. A linked slot means the value comes
- * from upstream; a promoted host owns the value only while some interior
- * consumer is still live.
- */
+/** The widget a user can actually edit. */
 function isEditableValueOwner(node: LGraphNode, widget: IBaseWidget): boolean {
   const input = node.getSlotFromWidget(widget)
   if (input?.link != null) return false
@@ -111,10 +107,6 @@ export function scanNodeMediaCandidates(
   for (const widget of node.widgets) {
     if (!isComboWidget(widget)) continue
 
-    // getInputSpecForWidget projects a promoted host input to its interior
-    // spec itself, so the scan reads schema through the store rather than
-    // walking the subgraph. Media-ness is the cheaper question, so it runs
-    // before the ownership walk.
     const mediaType = mediaTypeFromSpec(
       nodeDefStore.getInputSpecForWidget(node, widget.name)
     )
@@ -173,7 +165,6 @@ export function isMissingMediaCandidateScopeActive(
   const widget = node.widgets?.find(
     (candidateWidget) => candidateWidget.name === candidate.widgetName
   )
-  // Removed or renamed while verification was pending: nothing owns the value.
   if (!widget) return false
 
   return widget.value === candidate.name && isEditableValueOwner(node, widget)

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -215,8 +215,6 @@ describe('useMissingMediaStore', () => {
       expect(store.missingMediaCandidates).toBeNull()
     })
 
-    // The sibling removeMissingMediaByPrefix matches on prefix, so exact
-    // matching here is easy to regress into.
     it('does not remove a node whose id only shares a numeric prefix', () => {
       const store = useMissingMediaStore()
       store.setMissingMedia([

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -210,8 +210,6 @@ describe('useMissingMediaStore', () => {
       expect(store.missingMediaCandidates).toBeNull()
     })
 
-    // The sibling removeMissingMediaByPrefix matches on prefix, so exact
-    // matching here is easy to regress into.
     it('does not remove a node whose id only shares a numeric prefix', () => {
       const store = useMissingMediaStore()
       store.setMissingMedia([


### PR DESCRIPTION
## Summary

Follow-up to [#14578](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14578): the comment/naming cleanup requested during its review, plus what remains of DrJKL's post-merge findings after [#14948](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14948) landed the stale-value guard. Rebased onto current `main`. Contained to files #14578 already touched — no new modules, exports, or store surfaces.

## Changes

**Reconciliation during multi-node deletion (`useErrorClearingHooks.ts`)** — deleting N nodes ran the global candidate walk N times. Targeted removal for the deleted node stays synchronous; only the global pass is coalesced into one microtask per burst, and it drops if the hooks were torn down meanwhile. The mode-change path keeps its synchronous semantics. The scheduler lives in the `installErrorClearingHooks` closure rather than at module scope, so it follows the per-installation `disposed` lifecycle #15012 introduced.

Two promotion lifecycle tests seeded their stale candidate after the removal and relied on the synchronous pass having already gone by; they now let the removal's own reconcile land first.

**Un-bypass transition test** — hand-rolled the mode event while leaving the node in its default mode, so it never established the BYPASS state its transition claimed. Driven through `setNodeMode`, which already sits in that file.

**Workflow-load coverage for the stale-value guard** — #14948 pinned the guard through the realtime path and through the predicate itself. The pipeline also writes confirmed candidates into the workflow's `pendingWarnings`, which `workflowService` restores without re-validating, so a stale candidate surviving there outlives the session. Asserting the cache needs a workflow stub, which is why the `workspaceStore` mock stops returning a null `activeWorkflow`.

**Comment and naming cleanup** — comments say what a thing *is* rather than narrating the situation around it: the reconciler's module doc keeps its first line and drops the essay; the notes above the `dropOutOfScope` guard, the scan's ordering, `isEditableValueOwner`, and `rootGraph` are gone because the code and the names already carry them. The unparseable `missingMediaStore.test.ts` comment is deleted. `findNodesReferencingValues` no longer explains a caller's behaviour. Settles on `drop` for the operation spelled both `prune` and `drop`. Aliases `comfyPageFixture` to `test` in `errorsTabMissingMediaRuntime.spec.ts`, matching the 213 other specs that do.

**Breaking**: none.

## Dropped on rebase

The stale-value hunk and its realtime regression test are identical to what #14948 shipped, so `main` already has them. The promoted-media harness also encoded an impossible fixture state — `createPromotedMissingMediaCandidate` derives `name` from `hostWidget.value`, but the harness overrode `name` while leaving the widget elsewhere. #14948 fixed that by seeding through `hostValue`, which keeps the two in sync rather than dropping the distinct name; that resolution is kept.

## Review focus

Both behavioural changes carry a mutation-proved regression test on this base: reverting the coalescing makes the burst test fail (2 calls instead of 0 before the microtask), and reverting the value guard makes the workflow-load test fail. Commits are split so each is independently reviewable and independently green.

Deliberately **not** included:

- Moving `isEditableValueOwner` into `src/core/graph/subgraph/`, raised on #14578. The point stands — nothing there combines link state, promotion and liveness into "is this widget the editable value owner", and the predicate isn't missing-media-specific. But the move creates a new shared surface in the area `feature/ecs-migration` is actively reworking, which is not worth it for a single-caller helper. Left where it is.
- `WidgetSelectDropdown`'s `root`/`trigger` semantics, and the reconciler's dependency on node add/remove — both scoped out by the reviewer, the latter to be handled in his refactor.
- The E2E-structure items — the conditional repair path in `enterSubgraphWithFallback`, driving promoted-widget setup through user behaviour instead of `page.evaluate`, the options argument, and the `_testNodes` mock branches. Those change how the suite is built, so they're tracked in [FE-1493](https://linear.app/comfyorg/issue/FE-1493/no-e2e-for-promotedemote-error-reconciliation-and-promoted-media).

## Test plan

Static gates clean on the rebased tree (`typecheck`, `lint`, `format:check`, `knip`). Unit run scoped to the affected areas — `composables/graph`, `platform/missingMedia` — 188 tests green, and each of the four commits verified green on its own. Full suite left to CI.
