### PR TITLE
fix(first-run-tour): read Anti-prompt as the negative prompt

### DIFF
--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -330,7 +330,12 @@ describe('heuristicRoles', () => {
     'negatives',
     'NEGATIVEPROMPT',
     'Undesired content',
-    'Things to avoid'
+    'Things to avoid',
+    'Anti-prompt',
+    'anti prompt',
+    'AntiPrompt',
+    'ANTIPROMPT',
+    'anti_prompts'
   ])('reads %s as a negative prompt rather than the prompt', (title) => {
     const graph = createTestRootGraph()
     addWiredSink(graph)
@@ -342,7 +347,24 @@ describe('heuristicRoles', () => {
     ).toBeNull()
   })
 
-  it.for(['Antique portrait', 'Negro', 'negate mask', 'anti_aliasing'])(
+  it('reads a widget named anti_prompt as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    addNode(graph, 'CustomEncode', { prompts: ['anti_prompt'] })
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the widget name names the box just as the node title does'
+    ).toBeNull()
+  })
+
+  it.for([
+    'Antique portrait',
+    'Negro',
+    'negate mask',
+    'anti_aliasing',
+    'antialiasing strength'
+  ])(
     'still offers %s as the prompt, since only its spelling looks negative',
     (title) => {
       const graph = createTestRootGraph()

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -358,6 +358,36 @@ describe('heuristicRoles', () => {
     ).toBeNull()
   })
 
+  it('reads the anti_prompt input a box feeds as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    const text = addNode(graph, 'CLIPTextEncode', {
+      prompts: ['text'],
+      outputs: ['CONDITIONING']
+    })
+    const sampler = addNode(graph, 'CustomSampler', {
+      inputs: ['anti_prompt'],
+      inputType: 'CONDITIONING'
+    })
+    text.connect(0, sampler, 0)
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the input a box feeds names it, the same as its own title would'
+    ).toBeNull()
+  })
+
+  it('reads a subgraph port named Anti-Prompt as a negative prompt', () => {
+    const graph = createTestRootGraph()
+    addWiredSink(graph)
+    addExposedPrompt(graph, 'Anti-Prompt')
+
+    expect(
+      heuristicRoles(graph)?.prompt,
+      'the exposed port is the only label on an interior node titled nothing useful'
+    ).toBeNull()
+  })
+
   it.for([
     'Antique portrait',
     'Negro',

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.ts
@@ -28,8 +28,18 @@ const MEDIA_KIND_BY_SLOT_TYPE: Partial<Record<string, TourMediaKind>> = {
  * `negate`, `negligible` and Spanish `negro` disqualify a real prompt. */
 const DISQUALIFYING = ['negative', 'neg', 'system', 'undesired', 'avoid']
 
+/** `anti` names the negative box only next to the noun — `Anti-prompt`,
+ * `AntiPrompt`, `ANTIPROMPT` — since `anti_aliasing` and `antique` are ordinary
+ * words a real prompt carries. Read off the normalised label, not its words, so
+ * the pair survives the separator and camelCase spellings alike. */
+const ANTI_PROMPT = /\banti ?prompts?\b/
+
 function disqualified(word: string): boolean {
   return DISQUALIFYING.includes(word) || word.startsWith('negative')
+}
+
+function readsAsAntiPrompt(label: string | undefined): boolean {
+  return ANTI_PROMPT.test(labelWords(label).join(' '))
 }
 
 /** Real templates ship nodes with no title and widgets with no name. */
@@ -95,6 +105,7 @@ function promptScore(labels: string[], fedInputNames: string[]): number {
   const fed = fedInputNames.flatMap(labelWords)
 
   if ([...words, ...fed].some(disqualified)) return -1
+  if ([...labels, ...fedInputNames].some(readsAsAntiPrompt)) return -1
   if (fed.includes('positive')) return 3
   if (words.includes('positive')) return 2
   if (words.includes('prompt')) return 1


### PR DESCRIPTION
## Summary

A workflow whose only multiline text box is titled `Anti-prompt` had the first-run tour's _"Describe what you want — your image gets built from this description"_ callout spotlit on its **negative** box. The user types "a cat" and gets everything except a cat.

Closes #14623

## Changes

- **What**: `heuristicRoles.ts` now disqualifies a prompt candidate whose label reads as an anti-prompt, alongside the existing `negative`/`neg`/`system`/`undesired`/`avoid` stems.

### Why not just add `anti` to the stem list

The issue suggests one more stem. That does not work as written: `DISQUALIFYING` is matched against **normalised label words**, and `labelWords('anti_aliasing')` is `['anti', 'aliasing']` — so a bare `anti` stem disqualifies `anti_aliasing`, which the existing carve-out test at `heuristicRoles.test.ts` explicitly requires to remain a valid prompt (its message already anticipates this: _"a prefix match on 'neg'/'anti' drops the prompt step for ordinary words"_). `startsWith('anti')` is worse — it also eats `antique`.

`anti` only names the negative box next to the noun, so the check matches the pair off the normalised label rather than its individual words:

```ts
const ANTI_PROMPT = /\banti ?prompts?\b/
```

Because it runs on the label after camelCase-splitting and separator normalisation, one expression covers `Anti-prompt`, `anti prompt`, `AntiPrompt`, `anti_prompts` and `ANTIPROMPT`, while `antique`, `anti_aliasing` and `antialiasing strength` still qualify. It is applied to the same label set as the existing check — node title, widget name, subgraph port name, and the input name the node feeds — so a widget named `anti_prompt` is caught too.

## Review Focus

- The regex is deliberately noun-adjacent rather than a stem. If you would rather lose `anti_aliasing` as a prompt than carry a regex, say so and I will swap it for the stem plus a deleted test case — but that trade seems clearly worse.
- Bare `anti` as an entire label (no noun) is _not_ disqualified. It is ambiguous and unattested; the existing `anti_aliasing` carve-out points the same way.

## Verification

- `pnpm test:unit src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts` — 47 passed.
- Red-green checked: with the new guard line deleted and the new cases kept, exactly the 6 new assertions fail (`Anti-prompt`, `anti prompt`, `AntiPrompt`, `ANTIPROMPT`, `anti_prompts`, and the `anti_prompt` widget); restoring it turns them green with no other test moving.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all clean.

Not verified: no browser run. This is pure label-matching logic with unit coverage on both the disqualifying and the must-not-disqualify side, so a live tour run would not add signal beyond what the tests assert.
