### PR TITLE
fix(first-run-tour): stop illustrating the nudge with the Open Graph card

### DIFF
--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -100,6 +100,21 @@ describe('FirstRunTourNudge', () => {
     })
   })
 
+  it('never illustrates itself with the Open Graph card', async () => {
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    const src = screen.getByTestId('first-run-nudge-image').getAttribute('src')
+    expect(src, 'the nudge renders an illustration').toBe(
+      '/assets/images/default-template.png'
+    )
+    expect(
+      src,
+      'og-image.png is the social preview: rotating it would silently redraw onboarding'
+    ).not.toContain('og-image')
+  })
+
   it('waits out a dialog that is already open', async () => {
     mocks.nudgeArmed.value = true
     mocks.openDialogs.value = ['some-dialog']

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -7,7 +7,12 @@
     class="fixed right-0 bottom-0 z-1000 flex w-80 animate-in flex-col overflow-hidden rounded-tl-xl border-t border-l border-border-default/50 bg-base-background shadow-lg duration-500 fade-in-0"
   >
     <div class="relative h-50 w-full bg-secondary-background">
-      <img :src="NUDGE_IMAGE" alt="" class="size-full object-cover" />
+      <img
+        :src="NUDGE_IMAGE"
+        alt=""
+        data-testid="first-run-nudge-image"
+        class="size-full object-cover"
+      />
       <Button
         class="absolute top-2 right-2 opacity-50 hover:opacity-100"
         variant="secondary"
@@ -64,7 +69,16 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 import { useFirstRunTourController } from '../tour/useFirstRunTourController'
 
-const NUDGE_IMAGE = '/assets/images/og-image.png'
+/**
+ * The card placeholder the template thumbnails already fall back to — sized and
+ * framed for a card, and owned by the UI.
+ *
+ * This must never point back at `og-image.png`: that file is the site's Open
+ * Graph card, so whoever rotates the social preview would silently redraw
+ * onboarding, and it is a Comfy Cloud ad besides. A dedicated illustration from
+ * design belongs here; a placeholder is the stopgap, not the OG banner.
+ */
+const NUDGE_IMAGE = '/assets/images/default-template.png'
 
 /** Delayed, so the finished workflow is seen before this fades in over it. */
 const APPEAR_DELAY_MS = 1500


### PR DESCRIPTION
## Summary

The first-run tour nudge illustrated itself with `/assets/images/og-image.png` — the site's Open Graph card. It was the only reference to that file outside the OG meta tags, so anyone rotating the social preview silently redrew onboarding UI with no reason to know they had.

Closes #14624

## Changes

- **What**: `FirstRunTourNudge.vue` now renders `/assets/images/default-template.png`, with a comment on the constant and a test both stating the asset must never be the OG card.

What was actually on screen: a 1200x630, 269 KB "Comfy Cloud — Run ComfyUI anywhere. No setup." marketing banner, `object-cover`-cropped into a 320x200 panel — so a local first-run user finished their first generation and got a cloud ad, mid-cropped, as their congratulation.

### Choosing the replacement

I inventoried every image under `public/` before picking:

| asset                  | size   | dimensions | verdict                                                                               |
| ---------------------- | ------ | ---------- | ------------------------------------------------------------------------------------- |
| `og-image.png`         | 269 KB | 1200x630   | the bug — coupled to the OG meta tags, and a Cloud ad                                 |
| `default-template.png` | 54 KB  | 224x224    | **chosen** — the placeholder `BaseThumbnail`/`LazyImage` already render in card slots |
| `app-mode-landing.png` | 288 KB | 768x865    | portrait app-mode screenshot; a landscape crop throws most of it away                 |
| `comfy-icon-512.png`   | 28 KB  | 512x512    | an icon, not card art                                                                 |

`default-template.png` is a soft blue-green gradient, so the upscale from 224 px to a 320 px-wide box costs nothing visible — I simulated the exact `object-cover` transform (cover-scale, center-crop to 320x200) and the result is a clean gradient, no artefacts or seams. It also cuts 215 KB off the panel.

**This is a stopgap, not the real fix.** `default-template.png` is a placeholder, not an illustration; the nudge deserves a designer-provided asset. What this PR guarantees is that whatever lands there, it is not the social preview. Per the issue I did not invent an asset, so the coupling is instead made explicit:

```ts
/**
 * The card placeholder the template thumbnails already fall back to — sized and
 * framed for a card, and owned by the UI.
 *
 * This must never point back at `og-image.png`: that file is the site's Open
 * Graph card, so whoever rotates the social preview would silently redraw
 * onboarding, and it is a Comfy Cloud ad besides. A dedicated illustration from
 * design belongs here; a placeholder is the stopgap, not the OG banner.
 */
```

A unit test asserts the same, because the failure mode is invisible from the side that causes it — someone editing OG metadata will never open this component.

## Review Focus

- Is a gradient placeholder acceptable interim art here, or would you rather hold this until design supplies an illustration? The decoupling is the load-bearing part; the asset choice is easy to change later, and the test pins the src so a swap is a one-line diff plus one string.
- The `img` gained `data-testid="first-run-nudge-image"` so the test can reach it — it has `alt=""` (decorative), so there is no Testing Library query for it otherwise.

## Verification

- `pnpm test:unit src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts` — 9 passed, including the new assertion.
- Rendered the `object-cover` crop offline (cover-scale + center-crop to the panel's 320x200) to confirm the replacement does not look degraded at the size it is displayed.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all clean.

**Not verified: I did not see this in a running browser.** The crop check was an offline simulation of the CSS, not a screenshot of the real panel, so the composition against the surrounding card (close button contrast over the gradient, in particular) is unconfirmed. Worth a glance from whoever has the tour running locally.

`browser_tests/tests/appMode.spec.ts` also references `og-image.png`, but as a drag-and-drop payload fixture — unrelated, and left alone.
