### PR TITLE
fix(onboarding): arm the first-run nudge on the tour's ending, not on a start

### DIFF
--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -247,6 +247,86 @@ describe('onboardingTourStore', () => {
     expect(skipped?.[1]).toMatchObject({ skip_reason: 'user' })
   })
 
+  describe('the ending it hands on', () => {
+    it('has none to report before a tour has ended', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      expect(
+        store.lastEnding,
+        'a running tour has not ended, so nothing may act on how it did'
+      ).toBeNull()
+    })
+
+    it('records a deliberate dismissal as the user’s own', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      store.skip()
+
+      expect(store.lastEnding).toEqual({
+        tour: 'appMode',
+        outcome: 'skipped',
+        skipReason: 'user'
+      })
+    })
+
+    it('records a tour torn down by a target that never mounted', async () => {
+      vi.useFakeTimers()
+      const store = mountStore()
+      store.replayTour('appMode')
+      await vi.advanceTimersByTimeAsync(0)
+      store.next()
+      // The deferred target (inputs list) is never registered; exhaust the wait.
+      await vi.advanceTimersByTimeAsync(8000)
+
+      expect(
+        store.lastEnding,
+        'whatever follows the tour has to be able to tell this apart from a finished one'
+      ).toEqual({
+        tour: 'appMode',
+        outcome: 'skipped',
+        skipReason: 'target_timeout'
+      })
+    })
+
+    it('records a walked-to-the-end tour with no skip reason', async () => {
+      registerAppModeTargets()
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      // Capped so a stuck tour fails instead of hanging.
+      for (let i = 0; i < 12 && !seenTours().includes('appMode'); i++) {
+        store.next()
+        await nextTick()
+      }
+
+      expect(store.lastEnding).toEqual({
+        tour: 'appMode',
+        outcome: 'completed'
+      })
+    })
+
+    it('drops the last ending as soon as a new run is requested', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+      store.skip()
+      expect(store.lastEnding).not.toBeNull()
+
+      store.replayTour('appMode')
+      await nextTick()
+
+      expect(
+        store.lastEnding,
+        'a run still going has no ending, and the last one does not speak for it'
+      ).toBeNull()
+    })
+  })
+
   it('holds the card on its step while a deferred target is awaited', async () => {
     vi.useFakeTimers()
     const store = mountStore()

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -33,12 +33,13 @@ const DEFER_TIMEOUT_MS = 8000
  * ending it is following: "a tour ran" cannot tell a walked-to-the-end tour
  * apart from one the user waved away, or one a missing target tore down.
  */
-export interface TourEnding {
-  tour: EntryPath
-  outcome: 'completed' | 'skipped'
-  /** Present only when `outcome` is `skipped`. */
-  skipReason?: OnboardingTourSkipReason
-}
+export type TourEnding =
+  | { tour: EntryPath; outcome: 'completed' }
+  | {
+      tour: EntryPath
+      outcome: 'skipped'
+      skipReason: OnboardingTourSkipReason
+    }
 
 /** Empty when a runtime resolver fails, so one bad graph costs only its own tour. */
 async function resolveDefinition(
@@ -297,11 +298,10 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     if (!dispatch({ type: 'ended', run })) return
 
     if (ending.tour)
-      lastEnding.value = {
-        tour: ending.tour,
-        outcome,
-        ...(outcome === 'skipped' && { skipReason })
-      }
+      lastEnding.value =
+        outcome === 'skipped'
+          ? { tour: ending.tour, outcome, skipReason }
+          : { tour: ending.tour, outcome }
     trackTour(
       outcome,
       outcome === 'skipped' ? skipReason : undefined,

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -28,6 +28,18 @@ import { useTourTriggers } from './useTourTriggers'
 
 const DEFER_TIMEOUT_MS = 8000
 
+/**
+ * How the last run of a tour ended. Whatever follows a tour has to know which
+ * ending it is following: "a tour ran" cannot tell a walked-to-the-end tour
+ * apart from one the user waved away, or one a missing target tore down.
+ */
+export interface TourEnding {
+  tour: EntryPath
+  outcome: 'completed' | 'skipped'
+  /** Present only when `outcome` is `skipped`. */
+  skipReason?: OnboardingTourSkipReason
+}
+
 /** Empty when a runtime resolver fails, so one bad graph costs only its own tour. */
 async function resolveDefinition(
   definition: TourDefinition
@@ -51,6 +63,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
   const telemetry = useTelemetry()
 
   const state = shallowRef<TourState>(IDLE)
+  const lastEnding = shallowRef<TourEnding | null>(null)
   let stepController: AbortController | null = null
   let lastRun = 0
 
@@ -283,6 +296,12 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
     if (!dispatch({ type: 'ended', run })) return
 
+    if (ending.tour)
+      lastEnding.value = {
+        tour: ending.tour,
+        outcome,
+        ...(outcome === 'skipped' && { skipReason })
+      }
     trackTour(
       outcome,
       outcome === 'skipped' ? skipReason : undefined,
@@ -330,6 +349,8 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     if (!definition) return false
     const run = nextRun()
     if (!dispatch({ type: 'requested', tour: entryPath, run })) return false
+    // A new run has no ending yet; the one before it must not speak for it.
+    lastEnding.value = null
     const built = await resolveDefinition(definition)
     const resolved = resolveSteps(built.steps, targetMounted)
     if (!resolved.length) {
@@ -373,6 +394,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
   return {
     activeTour: readonly(activeTour),
+    lastEnding: readonly(lastEnding),
     step,
     isLast,
     canGoBack,

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -153,9 +153,17 @@ export interface OnboardingTourStepMetadata {
   not_started_reason?: OnboardingTourNotStartedReason
 }
 
+/**
+ * How the tour the nudge follows ended. `not_started` is the population the
+ * tour never reached at all — it still gets a nudge, and the funnel has to be
+ * able to tell it apart from the users who saw a tour.
+ */
+export type OnboardingTourNudgeOutcome = 'completed' | 'skipped' | 'not_started'
+
 /** The nudge is post-tour, so it reports no step and no count. */
 export interface OnboardingTourNudgeMetadata {
   tour: string
+  tour_outcome: OnboardingTourNudgeOutcome
 }
 
 export type OnboardingTourMetadata =

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -15,7 +15,7 @@ const mocks = await vi.hoisted(async () => {
   const { ref } = await import('vue')
   return {
     nudgeArmed: ref(false),
-    tourWasShown: ref(true),
+    tourOutcome: ref<'completed' | 'skipped' | 'not_started'>('completed'),
     openDialogs: ref<string[]>([]),
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
@@ -28,7 +28,7 @@ const mocks = await vi.hoisted(async () => {
 vi.mock('../tour/useFirstRunTourController', () => ({
   useFirstRunTourController: () => ({
     nudgeArmed: mocks.nudgeArmed,
-    tourWasShown: mocks.tourWasShown,
+    tourOutcome: mocks.tourOutcome,
     dismissNudge: mocks.dismissNudge
   })
 }))
@@ -71,6 +71,7 @@ describe('FirstRunTourNudge', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     mocks.nudgeArmed.value = false
+    mocks.tourOutcome.value = 'completed'
     mocks.openDialogs.value = []
   })
 
@@ -96,7 +97,8 @@ describe('FirstRunTourNudge', () => {
       'a nudge armed before this mounted still has to appear'
     ).not.toBeNull()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith('nudge_shown', {
-      tour: 'firstRun'
+      tour: 'firstRun',
+      tour_outcome: 'completed'
     })
   })
 
@@ -157,8 +159,17 @@ describe('FirstRunTourNudge', () => {
     ).toHaveLength(1)
   })
 
+  it('congratulates a tour the user walked to the end', async () => {
+    mocks.tourOutcome.value = 'completed'
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    expect(screen.getByText(nudgeCopy.ran.title)).toBeTruthy()
+  })
+
   it('offers no congratulation for a tour that never appeared', async () => {
-    mocks.tourWasShown.value = false
+    mocks.tourOutcome.value = 'not_started'
     mocks.nudgeArmed.value = true
     renderNudge()
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
@@ -168,6 +179,34 @@ describe('FirstRunTourNudge', () => {
       'a user whose tour never ran made nothing to be congratulated for'
     ).toBeNull()
     expect(screen.getByText(nudgeCopy.noTour.title)).toBeTruthy()
+  })
+
+  it('offers no congratulation for a tour the user skipped', async () => {
+    mocks.tourOutcome.value = 'skipped'
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    expect(
+      screen.queryByText(nudgeCopy.ran.title),
+      'a user who waved the tour away made no first result to be congratulated for'
+    ).toBeNull()
+    expect(screen.getByText(nudgeCopy.noTour.title)).toBeTruthy()
+  })
+
+  it('says which population it was shown to', async () => {
+    mocks.tourOutcome.value = 'not_started'
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    expect(
+      mocks.trackOnboardingTour,
+      'a nudge_shown that cannot tell a tour-less user from a toured one counts two funnels as one'
+    ).toHaveBeenCalledWith('nudge_shown', {
+      tour: 'firstRun',
+      tour_outcome: 'not_started'
+    })
   })
 
   it('stays gone once the user closes it', async () => {
@@ -205,7 +244,7 @@ describe('FirstRunTourNudge', () => {
     expect(mocks.dismissNudge).toHaveBeenCalled()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',
-      { tour: 'firstRun' }
+      { tour: 'firstRun', tour_outcome: 'completed' }
     )
   })
 })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type { OnboardingTourNudgeOutcome } from '@/platform/telemetry/types'
 
 import FirstRunTourNudge from './FirstRunTourNudge.vue'
 
@@ -15,7 +16,7 @@ const mocks = await vi.hoisted(async () => {
   const { ref } = await import('vue')
   return {
     nudgeArmed: ref(false),
-    tourOutcome: ref<'completed' | 'skipped' | 'not_started'>('completed'),
+    tourOutcome: ref<OnboardingTourNudgeOutcome>('completed'),
     openDialogs: ref<string[]>([]),
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
@@ -194,8 +195,14 @@ describe('FirstRunTourNudge', () => {
     expect(screen.getByText(nudgeCopy.noTour.title)).toBeTruthy()
   })
 
-  it('says which population it was shown to', async () => {
-    mocks.tourOutcome.value = 'not_started'
+  const OUTCOMES: OnboardingTourNudgeOutcome[] = [
+    'completed',
+    'skipped',
+    'not_started'
+  ]
+
+  it.for(OUTCOMES)('says it was shown to a %s tour', async (outcome) => {
+    mocks.tourOutcome.value = outcome
     mocks.nudgeArmed.value = true
     renderNudge()
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
@@ -205,9 +212,30 @@ describe('FirstRunTourNudge', () => {
       'a nudge_shown that cannot tell a tour-less user from a toured one counts two funnels as one'
     ).toHaveBeenCalledWith('nudge_shown', {
       tour: 'firstRun',
-      tour_outcome: 'not_started'
+      tour_outcome: outcome
     })
   })
+
+  it.for(OUTCOMES)(
+    'carries the %s outcome through to the templates click',
+    async (outcome) => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      mocks.tourOutcome.value = outcome
+      mocks.nudgeArmed.value = true
+      renderNudge()
+      await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+      await user.click(screen.getByTestId('first-run-nudge-explore'))
+
+      expect(
+        mocks.trackOnboardingTour,
+        'conversion is only readable per population if both ends of the funnel carry it'
+      ).toHaveBeenCalledWith('explore_templates_clicked', {
+        tour: 'firstRun',
+        tour_outcome: outcome
+      })
+    }
+  )
 
   it('stays gone once the user closes it', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -70,15 +70,16 @@ const NUDGE_IMAGE = '/assets/images/og-image.png'
 const APPEAR_DELAY_MS = 1500
 
 const { t } = useI18n()
-const { nudgeArmed, tourWasShown, dismissNudge } = useFirstRunTourController()
+const { nudgeArmed, tourOutcome, dismissNudge } = useFirstRunTourController()
 const dialogStore = useDialogStore()
 const telemetry = useTelemetry()
 const titleId = useId()
 
-// A tour that never appeared made nothing to congratulate the user for.
+// Only a tour walked to the end made a first result to congratulate; every
+// other ending gets the same neutral pointer at the templates.
 const copyKey = computed(
   () =>
-    `onboardingCoachmarks.firstRun.nudge.${tourWasShown.value ? 'ran' : 'noTour'}`
+    `onboardingCoachmarks.firstRun.nudge.${tourOutcome.value === 'completed' ? 'ran' : 'noTour'}`
 )
 
 const onScreen = ref(false)
@@ -88,7 +89,12 @@ const { start: scheduleAppearance, stop: cancelAppearance } = useTimeoutFn(
     onScreen.value = true
     if (reported) return
     reported = true
-    telemetry?.trackOnboardingTour('nudge_shown', { tour: 'firstRun' })
+    // The nudge is shown to users the tour never reached as well as to users
+    // who saw one; the funnel can only read either if the event says which.
+    telemetry?.trackOnboardingTour('nudge_shown', {
+      tour: 'firstRun',
+      tour_outcome: tourOutcome.value
+    })
   },
   APPEAR_DELAY_MS,
   { immediate: false }
@@ -115,7 +121,8 @@ watch(
 function onExplore() {
   useWorkflowTemplateSelectorDialog().show('first_run_nudge')
   telemetry?.trackOnboardingTour('explore_templates_clicked', {
-    tour: 'firstRun'
+    tour: 'firstRun',
+    tour_outcome: tourOutcome.value
   })
   dismissNudge()
 }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -724,26 +724,28 @@ describe('useFirstRunTourController', () => {
       ).toBe(false)
     })
 
-    it('stays away from a tour the paywall parked', async () => {
+    it('still offers somewhere to go when the paywall parks the tour', async () => {
       const { controller } = await tourOnRunStep()
 
       await endTour(skippedBecause('postponed'))
 
       expect(
         controller.nudgeArmed.value,
-        'a postponed tour is left unseen and offered again, so it has not ended for the user yet'
-      ).toBe(false)
+        'a tour parked on a button that will never run leaves the templates as the only way on'
+      ).toBe(true)
+      expect(
+        controller.tourOutcome.value,
+        'the run never happened, so there is no first result to congratulate'
+      ).toBe('skipped')
     })
 
-    it('stays away from a tour whose context walked off', async () => {
+    it('still offers somewhere to go when the tour loses its context', async () => {
       const { controller } = await tourOnRunStep()
 
       await endTour(skippedBecause('trigger_lost'))
 
-      expect(
-        controller.nudgeArmed.value,
-        'the user moved on to something else; the nudge would land on top of it'
-      ).toBe(false)
+      expect(controller.nudgeArmed.value).toBe(true)
+      expect(controller.tourOutcome.value).toBe('skipped')
     })
 
     it('stops offering the nudge once it is waved away', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 import type { EffectScope, Ref } from 'vue'
 
+import type { TourEnding } from '@/platform/onboarding/onboardingTourStore'
+import type { OnboardingTourSkipReason } from '@/platform/telemetry/types'
 import type {
   CoachStep,
   SpotlightStep
@@ -28,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   releaseFirstRunTargets: vi.fn(),
   engine: {
     activeTour: null as string | null,
+    lastEnding: null as TourEnding | null,
     step: null as CoachStep | null,
     isLast: false,
     startTour: vi.fn(),
@@ -147,6 +150,8 @@ async function tourOnRunStep() {
   mocks.activeWorkflow.value = TOUR_WORKFLOW
   mocks.engine.startTour.mockImplementation(async () => {
     await resolveRegisteredTour()
+    // The store drops the previous run's ending as soon as one is requested.
+    mocks.engine.lastEnding = null
     mocks.engine.activeTour = 'firstRun'
     mocks.engine.step = runStep()
     return true
@@ -157,6 +162,20 @@ async function tourOnRunStep() {
   await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
 
   return { controller, started: await starting }
+}
+
+/** The engine ending the tour, recording how, the way `finish()` leaves it. */
+function endTour(ending: TourEnding | null) {
+  mocks.engine.lastEnding = ending
+  mocks.engine.activeTour = null
+  mocks.engine.step = null
+  return nextTick()
+}
+
+const COMPLETED: TourEnding = { tour: 'firstRun', outcome: 'completed' }
+
+function skippedBecause(skipReason: OnboardingTourSkipReason): TourEnding {
+  return { tour: 'firstRun', outcome: 'skipped', skipReason }
 }
 
 function finishRun(workflow: unknown, status: string) {
@@ -209,6 +228,7 @@ describe('useFirstRunTourController', () => {
     mocks.vueNodesEnabled = true
     mocks.steps = []
     mocks.engine.activeTour = null
+    mocks.engine.lastEnding = null
     mocks.engine.step = null
     mocks.engine.isLast = false
   })
@@ -608,8 +628,7 @@ describe('useFirstRunTourController', () => {
         'a nudge fighting a live tour for the screen helps nobody'
       ).toBe(false)
 
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
 
       expect(controller.nudgeArmed.value).toBe(true)
     })
@@ -619,8 +638,7 @@ describe('useFirstRunTourController', () => {
       mountRunButton('queue-button', () => {}).click()
       await finishRun(TOUR_WORKFLOW, 'failed')
 
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
 
       expect(
         controller.nudgeArmed.value,
@@ -630,8 +648,7 @@ describe('useFirstRunTourController', () => {
 
     it('takes an armed nudge off the screen when a second tour starts', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
       expect(controller.nudgeArmed.value).toBe(true)
 
       const starting = controller.beginTour('image_z_image_turbo')
@@ -644,11 +661,24 @@ describe('useFirstRunTourController', () => {
       ).toBe(false)
     })
 
+    it('congratulates a tour the user walked to the end', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(COMPLETED)
+
+      expect(controller.tourOutcome.value).toBe('completed')
+    })
+
     it('congratulates nobody when the tour never appeared', async () => {
       mocks.steps = []
       mocks.activeWorkflow.value = TOUR_WORKFLOW
       mocks.engine.startTour.mockImplementation(async () => {
         await resolveRegisteredTour()
+        // The store requests the run, resolves no steps and returns to idle,
+        // so nothing ever calls `finish()` and no ending is recorded.
+        mocks.engine.activeTour = 'firstRun'
+        await nextTick()
+        mocks.engine.activeTour = null
         return false
       })
       const controller = await freshController()
@@ -656,17 +686,69 @@ describe('useFirstRunTourController', () => {
       const starting = controller.beginTour('image_z_image_turbo')
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
       await starting
+      await nextTick()
 
       expect(
-        controller.tourWasShown.value,
+        controller.nudgeArmed.value,
+        'a user the tour declined still has templates worth pointing at'
+      ).toBe(true)
+      expect(
+        controller.tourOutcome.value,
         'a tour that resolved no steps made nothing for the nudge to celebrate'
+      ).toBe('not_started')
+    })
+
+    it('congratulates nobody for a tour the user skipped', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(skippedBecause('user'))
+
+      expect(
+        controller.nudgeArmed.value,
+        'someone who declined the guided path is exactly who the templates are for'
+      ).toBe(true)
+      expect(
+        controller.tourOutcome.value,
+        'skipping on step 1 makes no first result to be congratulated for'
+      ).toBe('skipped')
+    })
+
+    it('stays away from a tour a missing target tore down', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(skippedBecause('target_timeout'))
+
+      expect(
+        controller.nudgeArmed.value,
+        'the same event already raised an error toast; a panel beside it congratulates a failure'
+      ).toBe(false)
+    })
+
+    it('stays away from a tour the paywall parked', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(skippedBecause('postponed'))
+
+      expect(
+        controller.nudgeArmed.value,
+        'a postponed tour is left unseen and offered again, so it has not ended for the user yet'
+      ).toBe(false)
+    })
+
+    it('stays away from a tour whose context walked off', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(skippedBecause('trigger_lost'))
+
+      expect(
+        controller.nudgeArmed.value,
+        'the user moved on to something else; the nudge would land on top of it'
       ).toBe(false)
     })
 
     it('stops offering the nudge once it is waved away', async () => {
       const { controller } = await tourOnRunStep()
-      mocks.engine.activeTour = null
-      await nextTick()
+      await endTour(COMPLETED)
 
       controller.dismissNudge()
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -123,24 +123,25 @@ function useFirstRunTourControllerInternal() {
   )
 
   /**
-   * The nudge follows the ending, not the fact that a tour ran. Only an ending
-   * the user themselves reached earns one:
+   * The nudge follows the ending, not the fact that a tour ran. Every ending
+   * still leaves the user somewhere to go next, so the nudge keeps appearing —
+   * but only a tour walked to the end made a first result to congratulate, so
+   * `completed` is the only outcome that earns the `ran` copy.
    *
-   * - `completed` — the tour was walked to the end, so there is a first result
-   *   to congratulate.
-   * - `skipped` by the user — no congratulation, but somewhere to go next is
-   *   still the right offer for someone who declined the guided path.
-   * - any other skip (`target_timeout`, `postponed`, `trigger_lost`) — the tour
-   *   was cut short by circumstance, is left unseen and will be offered again.
-   *   A target that never mounted also raises an error toast, and a panel
-   *   celebrating the same event is the bug in #14622.
-   * - no ending at all — the tour never resolved a step, so nothing happened to
-   *   congratulate, but the templates are still worth pointing at.
+   * The one ending that gets no nudge at all is a tour abandoned because a
+   * target never mounted: that same ending raises the `loadError` toast, and a
+   * panel arriving beside an error to celebrate it is the bug in #14622.
+   *
+   * Every other skip keeps its nudge. A paywalled tour in particular is parked
+   * on a button that will never run, so the templates are the *only* place left
+   * to send that user — see `gettingStartedTour.spec.ts`, "leaves the nudge
+   * until the upgrade dialog closes".
    */
   function armNudge() {
     const ending = engine.lastEnding
     if (ending && ending.tour !== 'firstRun') return
-    if (ending?.outcome === 'skipped' && ending.skipReason !== 'user') return
+    if (ending?.outcome === 'skipped' && ending.skipReason === 'target_timeout')
+      return
     tourOutcome.value = ending?.outcome ?? 'not_started'
     nudgeArmed.value = true
   }

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -11,6 +11,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useOnboardingTourStore } from '@/platform/onboarding/onboardingTourStore'
 import { registerTour } from '@/platform/onboarding/onboardingTours'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import type { OnboardingTourNudgeOutcome } from '@/platform/telemetry/types'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -43,8 +44,8 @@ function useFirstRunTourControllerInternal() {
   const desktopLayout = useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
   const tourWorkflow = shallowRef<ComfyWorkflow | null>(null)
   const nudgeArmed = ref(false)
-  /** A tour that never appeared leaves the user nothing to be congratulated for. */
-  const tourWasShown = ref(false)
+  /** Which ending the nudge is following, which is what it may say about it. */
+  const tourOutcome = ref<OnboardingTourNudgeOutcome>('not_started')
 
   // The tour's node ids are graph-local, so they only describe the workflow it
   // resolved against: swapping workflows leaves it pointing at strangers.
@@ -121,11 +122,34 @@ function useFirstRunTourControllerInternal() {
     { capture: true }
   )
 
+  /**
+   * The nudge follows the ending, not the fact that a tour ran. Only an ending
+   * the user themselves reached earns one:
+   *
+   * - `completed` — the tour was walked to the end, so there is a first result
+   *   to congratulate.
+   * - `skipped` by the user — no congratulation, but somewhere to go next is
+   *   still the right offer for someone who declined the guided path.
+   * - any other skip (`target_timeout`, `postponed`, `trigger_lost`) — the tour
+   *   was cut short by circumstance, is left unseen and will be offered again.
+   *   A target that never mounted also raises an error toast, and a panel
+   *   celebrating the same event is the bug in #14622.
+   * - no ending at all — the tour never resolved a step, so nothing happened to
+   *   congratulate, but the templates are still worth pointing at.
+   */
+  function armNudge() {
+    const ending = engine.lastEnding
+    if (ending && ending.tour !== 'firstRun') return
+    if (ending?.outcome === 'skipped' && ending.skipReason !== 'user') return
+    tourOutcome.value = ending?.outcome ?? 'not_started'
+    nudgeArmed.value = true
+  }
+
   watch(
     () => engine.activeTour === 'firstRun',
     (active) => {
       if (active) return
-      nudgeArmed.value = true
+      armNudge()
       stopOfflineGrace()
       releaseFirstRunTargets()
       tourWorkflow.value = null
@@ -147,7 +171,7 @@ function useFirstRunTourControllerInternal() {
     tourWorkflow.value = workflowStore.activeWorkflow ?? null
     runState.value = 'idle'
     nudgeArmed.value = false
-    tourWasShown.value = false
+    tourOutcome.value = 'not_started'
     registerTour(
       'firstRun',
       () => firstRunTourSteps(templateId, runState),
@@ -155,7 +179,6 @@ function useFirstRunTourControllerInternal() {
     )
     await delay(INTRO_PREVIEW_MS)
     const started = await engine.startTour('firstRun')
-    tourWasShown.value = started
     if (!started) {
       releaseFirstRunTargets()
       tourWorkflow.value = null
@@ -168,7 +191,7 @@ function useFirstRunTourControllerInternal() {
   return {
     beginTour,
     nudgeArmed: readonly(nudgeArmed),
-    tourWasShown: readonly(tourWasShown),
+    tourOutcome: readonly(tourOutcome),
     dismissNudge
   }
 }


### PR DESCRIPTION
Closes #14622

## The failure

The post-tour nudge decided its copy from whether a tour **started**, not from how it **ended**. `useFirstRunTourController` set `tourWasShown = await engine.startTour('firstRun')`, and `FirstRunTourNudge.vue` rendered the congratulatory `ran` copy — *"That was one of hundreds — You just made your first."* — for any truthy value.

So every ending that followed a started tour was congratulated:

- a tour **abandoned** because a deferred target never mounted (`abandonStep` → `finish('skipped', { skipReason: 'target_timeout' })`) also raises the `onboardingCoachmarks.loadError` toast. The user got an error toast and a congratulation for the same event.
- a tour **skipped on step 1** was congratulated for a first result the user never made.
- a tour **postponed** by the paywall, or ended because its **trigger was lost**, likewise.

Separately, `nudge_shown` fired with only `{ tour: 'firstRun' }`, so the funnel could not tell the users the tour never reached from the users who saw one.

## The fix

`finish()` already computes `outcome` and `skipReason` but kept them to itself. The store now records them:

```ts
export interface TourEnding {
  tour: EntryPath
  outcome: 'completed' | 'skipped'
  skipReason?: OnboardingTourSkipReason
}
```

exposed as `lastEnding`, cleared when a new run is requested so a stale ending cannot speak for the run in progress. The controller arms the nudge off that instead of off `started`.

### What each ending shows, and why

| ending | nudge | copy |
| --- | --- | --- |
| `completed` | shown | `ran` — there is a first result to congratulate |
| `skipped`, `skip_reason: user` | shown | `noTour` |
| `skipped`, `postponed` (paywall) | shown | `noTour` |
| `skipped`, `trigger_lost` | shown | `noTour` |
| `skipped`, `target_timeout` | **not shown** | — |
| never resolved a step (no ending recorded) | shown | `noTour` (unchanged) |

Every ending still leaves the user somewhere to go next, so the nudge keeps appearing. What changes is that `ran` — *"You just made your first"* — is now reserved for the one ending that made a first result.

The single suppression is the case the issue reported: a tour abandoned because a target never mounted already raises the `loadError` toast, and a panel arriving beside an error to celebrate it is the sharp case.

**I got this wrong first and the cloud e2e caught it.** My initial rule suppressed the nudge for every ending `finish()` calls with `markSeen: false`, which swept in `postponed` and `trigger_lost` too. `gettingStartedTour.spec.ts` > *"leaves the nudge until the upgrade dialog closes"* failed, and it was right to: a paywalled tour is parked on a button that will never run, so the templates are the **only** place left to send that user. The rule is now narrowed to the one ending that raises an error toast of its own. Those two endings keep their nudge and lose only the congratulation.

**The judgement call — a deliberate skip.** Nudge kept, congratulation dropped. Waving the tour away rejects *guidance*, not the product; a pointer at the templates is still the right next offer, and it is the one thing the nudge exists to do. What was wrong was claiming the user made something. `noTour`'s copy — *"Hundreds more where that came from / Browse the templates and pick something to build"* — reads correctly for a skipper, so no new locale key was added (only `en` carries these keys today; a new one would sit untranslated in the other 11 locales).

### Second half — `nudge_shown` for a tour that never started

Handled. `OnboardingTourNudgeMetadata` gains a required `tour_outcome: 'completed' | 'skipped' | 'not_started'`, carried by both `nudge_shown` and `explore_templates_clicked`. The two populations are now separable downstream, and because both ends of the funnel carry it, conversion is readable per population rather than only in aggregate. I chose the outcome over a `ran`/`noTour` copy flag because the copy is derivable from it and the outcome is not derivable from the copy.

## Verified

- `pnpm test:unit src/renderer/extensions/firstRunTour/ src/platform/onboarding/` — 23 files, 368 tests, green.
- New tests gate each ending: five in `useFirstRunTourController.test.ts` (completed / user-skip / target_timeout / postponed / trigger_lost / never-resolved), three in `FirstRunTourNudge.test.ts` for the copy each outcome renders, one for the telemetry field, and five in `onboardingTourStore.test.ts` for `lastEnding` itself (including that a new run drops the previous ending).
- **Mutation-checked.** Reverting `armNudge()` to the pre-fix behaviour (arm unconditionally; outcome from `started`) turns 4 of the new controller tests red — `congratulates nobody for a tour the user skipped`, `stays away from a tour a missing target tore down`, and both `still offers somewhere to go ...` cases. Restored, green again.
- `playwright-tests (cloud)`: **red on the first attempt** (`leaves the nudge until the upgrade dialog closes`), which is what drove the narrowing above. Re-running on the fix.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm knip` all clean.

## Not verified

- The `target_timeout` suppression has no browser coverage — it needs an 8 s deferred-target timeout to reproduce, and the only e2e that touches the nudge is the paywall one. Unit-level only.
- CodeRabbit's review (discriminated `TourEnding`, typed mock ref, per-outcome telemetry matrix) is applied in follow-up commits.
- `tour_outcome` is a new property on two existing Mixpanel events. Nothing downstream is updated here; existing dashboards keep working on the untouched `tour` property, but a dashboard that wants the split needs the new field added.