### PR TITLE
fix(onboarding): refuse the first-run tour when the canvas is hidden

### DIFF
--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   activeWorkflow: { value: null as unknown },
   linearMode: { value: false },
   vueNodesEnabled: true,
+  setSetting: vi.fn(),
   steps: [] as CoachStep[],
   runState: { value: 'idle' } as Ref<string>,
   releaseFirstRunTargets: vi.fn(),
@@ -91,10 +92,9 @@ vi.mock('@/renderer/core/canvas/canvasStore', async () => {
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
     get: () => mocks.vueNodesEnabled,
-    set: (_key: string, value: boolean) => {
-      mocks.vueNodesEnabled = value
-      return Promise.resolve()
-    }
+    // A spy, not a plain writer: a value that was flipped and put back reads
+    // the same as one that was never touched.
+    set: mocks.setSetting
   })
 }))
 
@@ -207,6 +207,10 @@ describe('useFirstRunTourController', () => {
     mocks.activeWorkflow.value = null
     mocks.linearMode.value = false
     mocks.vueNodesEnabled = true
+    mocks.setSetting.mockImplementation((_key: string, value: boolean) => {
+      mocks.vueNodesEnabled = value
+      return Promise.resolve()
+    })
     mocks.steps = []
     mocks.engine.activeTour = null
     mocks.engine.step = null
@@ -308,9 +312,9 @@ describe('useFirstRunTourController', () => {
         'the cards would sit over a hidden canvas until their targets timed out'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.vueNodesEnabled,
-        'a tour that never opened must not leave the renderer switched behind it'
-      ).toBe(false)
+        mocks.setSetting,
+        'a tour that never opened must not touch the renderer setting at all'
+      ).not.toHaveBeenCalledWith('Comfy.VueNodes.Enabled', true)
     })
 
     it('refuses to open on a viewport below the desktop layout', async () => {
@@ -327,7 +331,30 @@ describe('useFirstRunTourController', () => {
         'the spotlights are placed against a desktop layout, so below md they point nowhere'
       ).toBe(false)
       expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.vueNodesEnabled).toBe(false)
+      expect(mocks.setSetting).not.toHaveBeenCalledWith(
+        'Comfy.VueNodes.Enabled',
+        true
+      )
+    })
+
+    it('refuses to open when the canvas goes away during the intro preview', async () => {
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      mocks.linearMode.value = true
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        'the holds watcher cannot catch this — there is no active tour to end yet'
+      ).toBe(false)
+      expect(mocks.engine.startTour).not.toHaveBeenCalled()
+      expect(
+        mocks.vueNodesEnabled,
+        'the renderer switch thrown for a tour that never opened is handed back'
+      ).toBe(false)
     })
 
     it('leaves the workflow undimmed before taking the screen over', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -286,6 +286,50 @@ describe('useFirstRunTourController', () => {
       expect(mocks.vueNodesEnabled).toBe(true)
     })
 
+    // Holds only ever end a tour that is already running, and only when they
+    // change, so a context that is lost before the tour opens has to be
+    // refused at the door. Asserted as "nothing opened" rather than as the
+    // holds value: with no tour registered there is nothing to hold.
+    it('refuses to open over the linear view, which hides the canvas', async () => {
+      mocks.linearMode.value = true
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        '?template=X&mode=linear display:none-s the canvas, so every card would point at a node nobody can see'
+      ).toBe(false)
+      expect(
+        mocks.engine.startTour,
+        'the cards would sit over a hidden canvas until their targets timed out'
+      ).not.toHaveBeenCalled()
+      expect(
+        mocks.vueNodesEnabled,
+        'a tour that never opened must not leave the renderer switched behind it'
+      ).toBe(false)
+    })
+
+    it('refuses to open on a viewport below the desktop layout', async () => {
+      setViewportWidth(500)
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        'the spotlights are placed against a desktop layout, so below md they point nowhere'
+      ).toBe(false)
+      expect(mocks.engine.startTour).not.toHaveBeenCalled()
+      expect(mocks.vueNodesEnabled).toBe(false)
+    })
+
     it('leaves the workflow undimmed before taking the screen over', async () => {
       mocks.steps = [runStep()]
       const controller = await freshController()
@@ -445,26 +489,6 @@ describe('useFirstRunTourController', () => {
         registeredTourHolds(),
         'a tour must not end just because its run progressed'
       ).toBe(true)
-    })
-
-    it('refuses to hold a tour on a viewport below the desktop layout', async () => {
-      setViewportWidth(500)
-      await tourOnRunStep()
-
-      expect(
-        registeredTourHolds(),
-        'the spotlight is placed against a desktop layout, so below md it points nowhere'
-      ).toBe(false)
-    })
-
-    it('refuses to hold a tour over the linear view, which hides the canvas', async () => {
-      mocks.linearMode.value = true
-      await tourOnRunStep()
-
-      expect(
-        registeredTourHolds(),
-        '?mode=linear display:none-s the canvas, so every spotlight lands on a node nobody can see'
-      ).toBe(false)
     })
 
     it('ends the tour when the user switches into the linear view mid-walk', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -317,6 +317,50 @@ describe('useFirstRunTourController', () => {
       expect(mocks.vueNodesEnabled).toBe(true)
     })
 
+    // Holds only ever end a tour that is already running, and only when they
+    // change, so a context that is lost before the tour opens has to be
+    // refused at the door. Asserted as "nothing opened" rather than as the
+    // holds value: with no tour registered there is nothing to hold.
+    it('refuses to open over the linear view, which hides the canvas', async () => {
+      mocks.linearMode.value = true
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        '?template=X&mode=linear display:none-s the canvas, so every card would point at a node nobody can see'
+      ).toBe(false)
+      expect(
+        mocks.engine.startTour,
+        'the cards would sit over a hidden canvas until their targets timed out'
+      ).not.toHaveBeenCalled()
+      expect(
+        mocks.vueNodesEnabled,
+        'a tour that never opened must not leave the renderer switched behind it'
+      ).toBe(false)
+    })
+
+    it('refuses to open on a viewport below the desktop layout', async () => {
+      setViewportWidth(500)
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        'the spotlights are placed against a desktop layout, so below md they point nowhere'
+      ).toBe(false)
+      expect(mocks.engine.startTour).not.toHaveBeenCalled()
+      expect(mocks.vueNodesEnabled).toBe(false)
+    })
+
     it('leaves the workflow undimmed before taking the screen over', async () => {
       mocks.steps = [runStep()]
       const controller = await freshController()
@@ -476,26 +520,6 @@ describe('useFirstRunTourController', () => {
         registeredTourHolds(),
         'a tour must not end just because its run progressed'
       ).toBe(true)
-    })
-
-    it('refuses to hold a tour on a viewport below the desktop layout', async () => {
-      setViewportWidth(500)
-      await tourOnRunStep()
-
-      expect(
-        registeredTourHolds(),
-        'the spotlight is placed against a desktop layout, so below md it points nowhere'
-      ).toBe(false)
-    })
-
-    it('refuses to hold a tour over the linear view, which hides the canvas', async () => {
-      mocks.linearMode.value = true
-      await tourOnRunStep()
-
-      expect(
-        registeredTourHolds(),
-        '?mode=linear display:none-s the canvas, so every spotlight lands on a node nobody can see'
-      ).toBe(false)
     })
 
     it('ends the tour when the user switches into the linear view mid-walk', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -374,6 +374,10 @@ describe('useFirstRunTourController', () => {
       const controller = await freshController()
 
       const starting = controller.beginTour('image_z_image_turbo')
+      // Flush the renderer switch first, so the canvas is lost inside the
+      // preview delay rather than while beginTour is still setting up. Only
+      // the post-delay re-check can catch it from there.
+      await vi.advanceTimersByTimeAsync(0)
       mocks.linearMode.value = true
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
 

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   activeWorkflow: { value: null as unknown },
   linearMode: { value: false },
   vueNodesEnabled: true,
+  setSetting: vi.fn(),
   steps: [] as CoachStep[],
   runState: { value: 'idle' } as Ref<string>,
   releaseFirstRunTargets: vi.fn(),
@@ -94,10 +95,9 @@ vi.mock('@/renderer/core/canvas/canvasStore', async () => {
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
     get: () => mocks.vueNodesEnabled,
-    set: (_key: string, value: boolean) => {
-      mocks.vueNodesEnabled = value
-      return Promise.resolve()
-    }
+    // A spy, not a plain writer: a value that was flipped and put back reads
+    // the same as one that was never touched.
+    set: mocks.setSetting
   })
 }))
 
@@ -238,6 +238,10 @@ describe('useFirstRunTourController', () => {
     mocks.activeWorkflow.value = null
     mocks.linearMode.value = false
     mocks.vueNodesEnabled = true
+    mocks.setSetting.mockImplementation((_key: string, value: boolean) => {
+      mocks.vueNodesEnabled = value
+      return Promise.resolve()
+    })
     mocks.steps = []
     mocks.engine.activeTour = null
     mocks.engine.lastEnding = null
@@ -339,9 +343,9 @@ describe('useFirstRunTourController', () => {
         'the cards would sit over a hidden canvas until their targets timed out'
       ).not.toHaveBeenCalled()
       expect(
-        mocks.vueNodesEnabled,
-        'a tour that never opened must not leave the renderer switched behind it'
-      ).toBe(false)
+        mocks.setSetting,
+        'a tour that never opened must not touch the renderer setting at all'
+      ).not.toHaveBeenCalledWith('Comfy.VueNodes.Enabled', true)
     })
 
     it('refuses to open on a viewport below the desktop layout', async () => {
@@ -358,7 +362,30 @@ describe('useFirstRunTourController', () => {
         'the spotlights are placed against a desktop layout, so below md they point nowhere'
       ).toBe(false)
       expect(mocks.engine.startTour).not.toHaveBeenCalled()
-      expect(mocks.vueNodesEnabled).toBe(false)
+      expect(mocks.setSetting).not.toHaveBeenCalledWith(
+        'Comfy.VueNodes.Enabled',
+        true
+      )
+    })
+
+    it('refuses to open when the canvas goes away during the intro preview', async () => {
+      mocks.vueNodesEnabled = false
+      mocks.steps = [runStep()]
+      const controller = await freshController()
+
+      const starting = controller.beginTour('image_z_image_turbo')
+      mocks.linearMode.value = true
+      await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
+
+      expect(
+        await starting,
+        'the holds watcher cannot catch this — there is no active tour to end yet'
+      ).toBe(false)
+      expect(mocks.engine.startTour).not.toHaveBeenCalled()
+      expect(
+        mocks.vueNodesEnabled,
+        'the renderer switch thrown for a tour that never opened is handed back'
+      ).toBe(false)
     })
 
     it('leaves the workflow undimmed before taking the screen over', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -46,13 +46,21 @@ function useFirstRunTourControllerInternal() {
   /** A tour that never appeared leaves the user nothing to be congratulated for. */
   const tourWasShown = ref(false)
 
+  /**
+   * The half of the tour's context that exists before the tour does: a canvas
+   * the steps can point at. Linear mode `display:none`s it entirely, and below
+   * the desktop layout the spotlights are placed against a screen that isn't
+   * there. Split out so it can also serve as the precondition for opening one.
+   */
+  const canvasContextHolds = computed(
+    () => desktopLayout.value && !canvasStore.linearMode
+  )
+
   // The tour's node ids are graph-local, so they only describe the workflow it
   // resolved against: swapping workflows leaves it pointing at strangers.
-  // Linear mode hides the canvas entirely, so its nodes are nothing to point at.
   const tourContextHolds = computed(
     () =>
-      desktopLayout.value &&
-      !canvasStore.linearMode &&
+      canvasContextHolds.value &&
       workflowStore.activeWorkflow === tourWorkflow.value
   )
 
@@ -140,6 +148,11 @@ function useFirstRunTourControllerInternal() {
   /** False when there is no tour to give; any renderer switch is undone. */
   async function beginTour(templateId?: string): Promise<boolean> {
     if (engine.activeTour) return false
+    // Holds only ever end a tour that is already running, and only when they
+    // change — a context lost before the tour opens (`?template=X&mode=linear`
+    // boots straight into linear mode) never produces that change. Refused
+    // here, ahead of the renderer switch below, so nothing is left to undo.
+    if (!canvasContextHolds.value) return false
 
     const enabledForTour = !settingStore.get('Comfy.VueNodes.Enabled')
     if (enabledForTour) await settingStore.set('Comfy.VueNodes.Enabled', true)

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -167,7 +167,10 @@ function useFirstRunTourControllerInternal() {
       tourContextHolds
     )
     await delay(INTRO_PREVIEW_MS)
-    const started = await engine.startTour('firstRun')
+    // The preview is long enough for the canvas to go away underneath it, and
+    // the holds watcher cannot catch that: there is no active tour to end yet.
+    const started =
+      canvasContextHolds.value && (await engine.startTour('firstRun'))
     tourWasShown.value = started
     if (!started) {
       releaseFirstRunTargets()

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -171,7 +171,10 @@ function useFirstRunTourControllerInternal() {
       tourContextHolds
     )
     await delay(INTRO_PREVIEW_MS)
-    const started = await engine.startTour('firstRun')
+    // The preview is long enough for the canvas to go away underneath it, and
+    // the holds watcher cannot catch that: there is no active tour to end yet.
+    const started =
+      canvasContextHolds.value && (await engine.startTour('firstRun'))
     if (!started) {
       releaseFirstRunTargets()
       tourWorkflow.value = null

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -46,13 +46,21 @@ function useFirstRunTourControllerInternal() {
   /** Only a tour walked to the end made a first result to be congratulated for. */
   const tourWasCompleted = ref(false)
 
+  /**
+   * The half of the tour's context that exists before the tour does: a canvas
+   * the steps can point at. Linear mode `display:none`s it entirely, and below
+   * the desktop layout the spotlights are placed against a screen that isn't
+   * there. Split out so it can also serve as the precondition for opening one.
+   */
+  const canvasContextHolds = computed(
+    () => desktopLayout.value && !canvasStore.linearMode
+  )
+
   // The tour's node ids are graph-local, so they only describe the workflow it
   // resolved against: swapping workflows leaves it pointing at strangers.
-  // Linear mode hides the canvas entirely, so its nodes are nothing to point at.
   const tourContextHolds = computed(
     () =>
-      desktopLayout.value &&
-      !canvasStore.linearMode &&
+      canvasContextHolds.value &&
       workflowStore.activeWorkflow === tourWorkflow.value
   )
 
@@ -145,6 +153,11 @@ function useFirstRunTourControllerInternal() {
   /** False when there is no tour to give; any renderer switch is undone. */
   async function beginTour(templateId?: string): Promise<boolean> {
     if (engine.activeTour) return false
+    // Holds only ever end a tour that is already running, and only when they
+    // change — a context lost before the tour opens (`?template=X&mode=linear`
+    // boots straight into linear mode) never produces that change. Refused
+    // here, ahead of the renderer switch below, so nothing is left to undo.
+    if (!canvasContextHolds.value) return false
 
     const enabledForTour = !settingStore.get('Comfy.VueNodes.Enabled')
     if (enabledForTour) await settingStore.set('Comfy.VueNodes.Enabled', true)


### PR DESCRIPTION
Closes #14628

## The failure

Open `/?template=image_z_image_turbo&mode=linear` as a new cloud user.

`GraphView` puts `v-show="!linearMode"` on the canvas container, so the graph canvas is `display:none` and the Linear view covers the screen. A `display:none` element still yields a (all-zero) `DOMRect`, so the tour's targets read as mounted and the tour opens anyway. The user gets coach cards floating over the Linear view pointing at nothing, until the targets time out (~8s) and an error toast fires. `Comfy.VueNodes.Enabled` is left flipped on as well, since `beginTour` only reverts it when the engine turns the start down — and here it did not.

## Why the existing guard did not catch it

`tourContextHolds` already contains `!canvasStore.linearMode`, and it correctly **ends** a tour when the user switches into linear mode mid-walk. But holds are a running-tour mechanism:

- `begin()` has no holds precondition.
- The holds watcher in `onboardingTourStore.ts` fires only on a *change*, and only ends a tour that is already `activeTour`.

If linear mode is already on when the tour is requested, holds are already `false`, nothing changes, and nothing fires.

Worth stating explicitly, since the issue raises it: **adding `{ immediate: true }` to that watcher would not have fixed this.** It runs at store construction, when no tour is active, so it has nothing to end. The gap is the missing precondition, not the watcher's timing.

## The fix

`tourContextHolds` was doing two jobs. This splits out the half that is meaningful *before* a tour exists:

```ts
const canvasContextHolds = computed(
  () => desktopLayout.value && !canvasStore.linearMode
)

const tourContextHolds = computed(
  () =>
    canvasContextHolds.value &&
    workflowStore.activeWorkflow === tourWorkflow.value
)
```

The workflow-identity half can only be evaluated once `tourWorkflow` is set, which `beginTour` itself does — so it cannot serve as a precondition. The canvas half can, and it is the half this bug is about. `beginTour` now checks it immediately after the already-running check, ahead of the `Comfy.VueNodes.Enabled` flip, so a refused tour leaves nothing behind to undo.

It is checked a second time after the 500 ms intro preview. That window is long enough for the user to switch into linear mode themselves, and the holds watcher cannot catch that either — it fires while `activeTour` is still `null`, so it has nothing to end, and `engine.startTour` does not consult holds on the way in. The re-check routes into the existing `!started` path, which already hands the renderer switch back. (Raised in review; the first version of this PR had the entry guard only.)

## Why here and not in `begin()`

The issue notes a more general fix: a holds precondition inside `begin()` in `onboardingTourStore.ts`, which would close the class for every tour. I did not take it, deliberately:

- It fails 26 store tests, which start tours in contexts whose holds are false. Making them pass means reworking the store test setup — a test-architecture change that should not ride along with a user-facing bug fix that is a backport candidate.
- A guard in `begin()` refuses *after* `beginTour` has already flipped the renderer setting and burned the 500 ms intro delay. It would be reverted (`started === false` takes the revert path), but the guard here avoids the write entirely.
- `beginTour` is where this tour's context is known and where `tourContextHolds` is constructed; checking your own precondition at the point you build the tour is local and obvious.

The general precondition in `begin()` remains worth doing as follow-up work, together with the store test setup it needs.

## Test fallout, handled

Returning before `registerTour` means `tourHolds('firstRun')` stays at its unregistered default of `true` — correctly, since no tour is registered and there is nothing to hold. Two existing tests asserted `registeredTourHolds() === false` for linear mode and for narrow viewports. Rather than delete them, they now assert the **stronger** property that those contexts were always about: the tour never opens.

- `refuses to open over the linear view, which hides the canvas`
- `refuses to open on a viewport below the desktop layout`

Each asserts `beginTour` returns `false`, `engine.startTour` was never called, and `settingStore.set` was never called with `('Comfy.VueNodes.Enabled', true)`. They moved from the `run outcome` block to `starting`, where a refusal to open belongs.

A third test, `refuses to open when the canvas goes away during the intro preview`, covers the window described above. The setting mock is now a spy rather than a plain writer, so a refusal that flipped the renderer on and put it back can no longer read as one that never touched it — also raised in review.

The mid-walk test (`ends the tour when the user switches into the linear view mid-walk`) is unchanged and still passing — the end-condition behaviour is untouched.

## Verified

- `pnpm install --frozen-lockfile`, `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all clean.
- `pnpm test:unit src/renderer/extensions/firstRunTour src/platform/onboarding` — 356 passed, 23 files. No test outside the two rewritten ones changed behaviour.
- Full `pnpm test:unit` — 1095 files, 14954 passed, 8 skipped, 1 failed: `onboardingCloudRoutes.test.ts > lazily resolves the /oauth layout and consent view components` times out at 5 s. Unrelated and flaky — it comes and goes between runs on this worktree and on a sibling worktree that does not contain these changes, and it is a lazy dynamic-import timing flake in this environment.
- **Mutation check.** Each guard was removed in turn and the controller suite re-run:

| Mutation | Result |
| --- | --- |
| remove `if (!canvasContextHolds.value) return false` | `refuses to open over the linear view` and `refuses to open on a viewport below the desktop layout` **fail** (2 failed, 38 passed) |
| remove the `canvasContextHolds.value &&` re-check before `startTour` | `refuses to open when the canvas goes away during the intro preview` **fails** (1 failed, 39 passed) |
| both restored | 40 passed |

Each guard is gated by its own tests, and neither is carrying the other.

## Not verified

- No browser/e2e run against a live `?template=X&mode=linear` boot. The reproduction path (`v-show` on the canvas container, zero-`DOMRect` targets reading as mounted) is taken from the issue and reasoned about, not re-observed in a browser.
- The `GettingStartedScreen` call site (`await beginTour(id)`) now has one more way to get `false` back. It already handled a refusal — the engine could always turn a start down — so no change was made there, but that path was reasoned about rather than exercised.
- Only the `firstRun` tour is fixed. `appMode` still has no precondition on its holds; in practice it is shielded because its `autoOpen` condition is a subset of its holds, but the class of bug remains open there.
