### PR TITLE
test(graph): cover the first-run tour's activation seam

### DIFF
--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -1,6 +1,7 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import type { RenderOptions } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -143,6 +144,11 @@ vi.mock(
 )
 
 async function mountGraphCanvas() {
+  // Handed to the component rather than left to the active-Pinia fallback, so
+  // the readiness gates below are set on the instance startup actually reads.
+  const pinia = createTestingPinia({ stubActions: false })
+  setActivePinia(pinia)
+
   // Startup waits on both readiness gates before it reaches the tour hand-off.
   useSettingStore().isReady = true
   useBootstrapStore().isI18nReady = true
@@ -153,7 +159,10 @@ async function mountGraphCanvas() {
     // which honours it — @testing-library/vue just omits it from its own type.
     shallow: true,
     global: {
-      plugins: [createI18n({ legacy: false, locale: 'en', missingWarn: false })]
+      plugins: [
+        pinia,
+        createI18n({ legacy: false, locale: 'en', missingWarn: false })
+      ]
     }
   } as RenderOptions<typeof GraphCanvas>)
 
@@ -166,7 +175,6 @@ async function mountGraphCanvas() {
 
 describe('GraphCanvas first-run tour wiring', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     vi.clearAllMocks()
     // Startup writes to the workspace store, and clearAllMocks does not undo
     // writes to a plain object.

--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -168,6 +168,13 @@ describe('GraphCanvas first-run tour wiring', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    // Startup writes to the workspace store, and clearAllMocks does not undo
+    // writes to a plain object.
+    Object.assign(mocks.workspaceStore, {
+      spinner: false,
+      focusMode: false,
+      sidebarTab: { activeSidebarTab: null }
+    })
     mocks.initializeWorkflow.mockResolvedValue('url-intent')
     mocks.loadTemplateFromUrlIfPresent.mockResolvedValue('image_to_image')
     mocks.loadSharedWorkflowFromUrlIfPresent.mockResolvedValue(undefined)

--- a/src/components/graph/GraphCanvas.firstRunEntry.test.ts
+++ b/src/components/graph/GraphCanvas.firstRunEntry.test.ts
@@ -1,0 +1,191 @@
+import { render } from '@testing-library/vue'
+import type { RenderOptions } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useBootstrapStore } from '@/stores/bootstrapStore'
+
+import GraphCanvas from './GraphCanvas.vue'
+
+/**
+ * GraphCanvas is the only place the first-run tour is wired into startup: it
+ * feeds the startup outcome to `handleStartupOutcome`, and the URL workflow
+ * results to `handleUrlWorkflow`. Both composables are unit-tested on their
+ * own; this file covers the seam, so deleting either call from the startup
+ * sequence fails a test instead of silently disconnecting the feature.
+ */
+const mocks = vi.hoisted(() => ({
+  handleStartupOutcome: vi.fn(),
+  handleUrlWorkflow: vi.fn(),
+  initializeWorkflow: vi.fn(),
+  loadTemplateFromUrlIfPresent: vi.fn(),
+  loadSharedWorkflowFromUrlIfPresent: vi.fn(),
+  workspaceStore: {
+    spinner: false,
+    focusMode: false,
+    sidebarTab: { activeSidebarTab: null }
+  }
+}))
+
+vi.mock(
+  '@/renderer/extensions/firstRunTour/gettingStarted/firstRunEntry',
+  () => ({
+    useFirstRunEntry: () => ({
+      gettingStartedVisible: { value: false },
+      handleStartupOutcome: mocks.handleStartupOutcome,
+      handleUrlWorkflow: mocks.handleUrlWorkflow,
+      dismissGettingStarted: vi.fn()
+    })
+  })
+)
+
+vi.mock(
+  '@/platform/workflow/persistence/composables/useWorkflowPersistenceV2',
+  () => ({
+    useWorkflowPersistenceV2: () => ({
+      initializeWorkflow: mocks.initializeWorkflow,
+      restoreWorkflowTabsState: vi.fn(),
+      loadTemplateFromUrlIfPresent: mocks.loadTemplateFromUrlIfPresent,
+      loadSharedWorkflowFromUrlIfPresent:
+        mocks.loadSharedWorkflowFromUrlIfPresent
+    })
+  })
+)
+
+vi.mock('@/scripts/app', () => {
+  const canvas = {
+    render_canvas_border: false,
+    graph: null,
+    onSelectionChange: null,
+    setDirty: vi.fn(),
+    canvas: document.createElement('canvas')
+  }
+  return {
+    app: {
+      vueAppReady: false,
+      canvas,
+      graph: null,
+      rootGraph: null,
+      ui: { settings: { dispatchChange: vi.fn() } },
+      setup: vi.fn()
+    }
+  }
+})
+
+vi.mock('@/scripts/changeTracker', () => ({
+  ChangeTracker: { init: vi.fn() }
+}))
+
+vi.mock('@/services/useNewUserService', () => ({
+  useNewUserService: () => ({
+    initializeIfNewUser: vi.fn(),
+    isNewUser: () => false
+  })
+}))
+
+vi.mock('@/composables/useUrlActionLoaders', () => ({
+  useUrlActionLoaders: () => ({ runUrlActionLoaders: vi.fn() })
+}))
+
+vi.mock('@/platform/updates/common/releaseStore', () => ({
+  useReleaseStore: () => ({ initialize: vi.fn() })
+}))
+
+vi.mock('@/composables/graph/useVueNodeLifecycle', () => ({
+  useVueNodeLifecycle: () => ({
+    nodeManager: { value: null },
+    setupEmptyGraphListener: vi.fn(),
+    initializeNodeManager: vi.fn(),
+    disposeNodeManagerAndSyncs: vi.fn(),
+    cleanup: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/graph/useErrorClearingHooks', () => ({
+  installErrorClearingHooks: () => vi.fn()
+}))
+
+vi.mock('@/services/colorPaletteService', () => ({
+  useColorPaletteService: () => ({ loadColorPalette: vi.fn() })
+}))
+
+vi.mock('@/renderer/core/canvas/useCanvasInteractions', () => ({
+  useCanvasInteractions: () => ({ forwardEventToCanvas: vi.fn() })
+}))
+
+vi.mock('@/composables/useCanvasDrop', () => ({ useCanvasDrop: vi.fn() }))
+vi.mock('@/platform/settings/composables/useLitegraphSettings', () => ({
+  useLitegraphSettings: vi.fn()
+}))
+vi.mock('@/composables/node/useNodeBadge', () => ({ useNodeBadge: vi.fn() }))
+vi.mock('@/composables/useGlobalLitegraph', () => ({
+  useGlobalLitegraph: vi.fn()
+}))
+vi.mock('@/composables/useContextMenuTranslation', () => ({
+  useContextMenuTranslation: vi.fn()
+}))
+vi.mock('@/composables/graph/useGroupContextMenu', () => ({
+  useGroupContextMenu: vi.fn()
+}))
+// Instantiating the real one pulls in the Firebase auth store.
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => mocks.workspaceStore
+}))
+
+vi.mock('@/composables/useCopy', () => ({ useCopy: vi.fn() }))
+vi.mock('@/composables/usePaste', () => ({ usePaste: vi.fn() }))
+vi.mock(
+  '@/platform/workflow/persistence/composables/useWorkflowAutoSave',
+  () => ({ useWorkflowAutoSave: vi.fn() })
+)
+
+async function mountGraphCanvas() {
+  // Startup waits on both readiness gates before it reaches the tour hand-off.
+  useSettingStore().isReady = true
+  useBootstrapStore().isI18nReady = true
+
+  render(GraphCanvas, {
+    // Child components are stubbed: this covers the startup sequence, not the
+    // canvas chrome. `shallow` is forwarded verbatim to Vue Test Utils' mount,
+    // which honours it — @testing-library/vue just omits it from its own type.
+    shallow: true,
+    global: {
+      plugins: [createI18n({ legacy: false, locale: 'en', missingWarn: false })]
+    }
+  } as RenderOptions<typeof GraphCanvas>)
+
+  // The startup sequence is a chain of awaits; flush until it settles.
+  for (let i = 0; i < 50; i++) {
+    await nextTick()
+    await Promise.resolve()
+  }
+}
+
+describe('GraphCanvas first-run tour wiring', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mocks.initializeWorkflow.mockResolvedValue('url-intent')
+    mocks.loadTemplateFromUrlIfPresent.mockResolvedValue('image_to_image')
+    mocks.loadSharedWorkflowFromUrlIfPresent.mockResolvedValue(undefined)
+  })
+
+  it('hands the startup outcome to the first-run entry point', async () => {
+    await mountGraphCanvas()
+
+    expect(mocks.handleStartupOutcome).toHaveBeenCalledWith('url-intent')
+  })
+
+  it('offers the tour over a workflow that arrived from the URL', async () => {
+    await mountGraphCanvas()
+
+    expect(mocks.handleUrlWorkflow).toHaveBeenCalledWith(
+      'url-intent',
+      'image_to_image',
+      undefined
+    )
+  })
+})


### PR DESCRIPTION
Partially addresses #14625

## The gap

`GraphCanvas.vue` is the only place the first-run tour is connected to startup. Its `onMounted` makes two calls:

```ts
startupOutcome = await workflowPersistence.initializeWorkflow()
await workflowPersistence.restoreWorkflowTabsState()
urlTemplateId = await workflowPersistence.loadTemplateFromUrlIfPresent()
await useFirstRunEntry().handleStartupOutcome(startupOutcome)   // :569
...
await useFirstRunEntry().handleUrlWorkflow(                     // :595
  startupOutcome, urlTemplateId, sharedStatus
)
```

There was no `GraphCanvas` test file. Deleting **either** call left the entire suite green. `useFirstRunEntry` and `useFirstRunTourController` are both well covered on their own — what was untested was the line joining them, so the whole feature could be disconnected in a refactor and CI would not notice.

Nothing user-visible is broken today. This closes a hole that would let it break silently: no Getting Started screen and no template-browser fallback for new users (first call), or a template/share link that silently never offers the tour (second call).

## What the test does

`src/components/graph/GraphCanvas.firstRunEntry.test.ts` mounts the real component and asserts both hand-offs happen with the values startup produced:

- `handleStartupOutcome` receives the outcome from `initializeWorkflow()`.
- `handleUrlWorkflow` receives that outcome, the template id from `loadTemplateFromUrlIfPresent()`, and the status from `loadSharedWorkflowFromUrlIfPresent()`.

Asserting the *arguments*, not just the calls, also pins the data flow — swapping the template id and the shared status, or passing a re-read outcome, fails.

### On mounting a 630-line component

I looked at cheaper options first and rejected them. A source-text or AST assertion over `GraphCanvas.vue` would go red on the mutation, but it would also pass if the calls were in dead code, and it gates the spelling of the call rather than the behaviour. Mounting turned out to be practical, so that is what this does.

The cost is a block of `vi.mock` calls, which is why it is a separate file rather than a general `GraphCanvas.test.ts`: children are stubbed via `shallow`, the startup dependencies (`@/scripts/app`, `useWorkflowPersistenceV2`, `ChangeTracker`, `useNewUserService`, the canvas/lifecycle composables) are faked, and the two readiness gates the sequence waits on — `settingStore.isReady` and `bootstrapStore.isI18nReady` — are set before mounting. The mocks are startup infrastructure only; the component's own `onMounted` runs for real. Two notes for future readers:

- `@/stores/workspaceStore` is mocked because instantiating the real one reaches the Firebase auth store.
- `shallow` is forwarded verbatim to Vue Test Utils' `mount`, which honours it; `@testing-library/vue` just omits it from its own option type, hence the cast.

Runtime is ~30 ms of test time (the rest is module import).

## Verified

- `pnpm install --frozen-lockfile`, `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all clean.
- `pnpm test:unit src/components/graph/GraphCanvas.firstRunEntry.test.ts` — 2 passed.
- Full `pnpm test:unit` — 14955 passed, 8 skipped, 1 failed: `onboardingCloudRoutes.test.ts > lazily resolves the /oauth layout and consent view components` times out at 5 s. Confirmed flaky and unrelated: it fails the same way when run alone on a sibling worktree that does not contain this file, and it passed in a subsequent full run (1095/1095 files). It is a lazy dynamic-import timing flake in this environment, not something this PR touches.

### Mutation results

Each call was deleted in turn, the suite run, then restored:

| Mutation | Result |
| --- | --- |
| remove `await useFirstRunEntry().handleStartupOutcome(startupOutcome)` | `hands the startup outcome to the first-run entry point` **fails** (1 failed, 1 passed) |
| remove `await useFirstRunEntry().handleUrlWorkflow(...)` | `offers the tour over a workflow that arrived from the URL` **fails** (1 failed, 1 passed) |
| both restored | 2 passed; `git diff` on `GraphCanvas.vue` empty |

Each mutation fails only its own test, so neither assertion is carrying the other.

## Not covered

- No production code changed; this PR is test-only.
- The issue lists two further surviving mutations that this PR does **not** close: `hasPromptError` in `useFirstRunTourController` (only the negative case is asserted) and the nudge's `show('first_run_nudge')` telemetry source. Both are single assertions in existing files and are worth a small follow-up; flagging them since this PR closes the issue that tracks them.
- `handleUrlWorkflow` is asserted with a template-id boot. The share-link path (`sharedStatus === 'loaded'`) is covered by `firstRunEntry.test.ts`, not here.


---

**⚠️ Do not let this auto-close #14625.** The issue lists **three** surviving mutations and this PR closes only the first — the activation seam. Two remain, both single assertions:

- **`hasPromptError` is asserted only in the negative**, so the test passes precisely when the term does nothing. Remove the term and the suite stays green, yet a prompt-level validation refusal then leaves the Result step spinning — the defect that term exists to prevent.
- **`show('first_run_nudge')` → `show('command')` stays green**, so the telemetry source can silently regress back to filing every nudge conversion under the command palette.

Reworded the close reference to `Partially addresses` so the issue survives this merge.