### PR TITLE
test: resolve two heavy dynamic imports out of the test body

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -17,6 +17,34 @@ vi.mock('@/platform/auth/session/useSessionCookie', () => ({
   useSessionCookie: () => ({ createSessionOrThrow })
 }))
 
+const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
+const consentRoute = oauthLayout?.children?.find(
+  (c) => c.name === 'cloud-oauth-consent'
+)
+const layoutLoader = oauthLayout?.component
+const consentLoader = consentRoute?.component
+
+/**
+ * Resolved here rather than inside the test.
+ *
+ * These are the real loaders, so calling them compiles `OAuthLayoutView.vue`,
+ * `OAuthConsentView.vue` and everything they import — seconds of work even on
+ * an idle machine. Awaited inside a test body that time is billed against the
+ * 5 s test timeout, which is what made this test fail under a loaded worker
+ * pool while passing in isolation (#14666). At module scope it is collection
+ * cost, which nothing times out, and the test itself becomes synchronous.
+ *
+ * The loaders are still the ones the router will call: a route pointing at a
+ * module that does not exist still fails here, at import time.
+ */
+const resolvedComponents = await Promise.all(
+  [layoutLoader, consentLoader].map(async (loader) =>
+    typeof loader === 'function'
+      ? await (loader as () => Promise<unknown>)()
+      : undefined
+  )
+)
+
 describe('cloudOnboardingRoutes', () => {
   it('consent route is not a child of the /cloud layout', () => {
     const cloudLayout = cloudOnboardingRoutes.find((r) => r.path === '/cloud')
@@ -25,34 +53,19 @@ describe('cloudOnboardingRoutes', () => {
   })
 
   it('consent route lives under a standalone /oauth layout', () => {
-    const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
-    const consentRoute = oauthLayout?.children?.find(
-      (c) => c.name === 'cloud-oauth-consent'
-    )
     expect(consentRoute).toBeDefined()
     expect(consentRoute?.path).toBe('consent')
   })
 
   it('consent route carries no requiresAuth meta', () => {
-    const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
-    const consentRoute = oauthLayout?.children?.find(
-      (c) => c.name === 'cloud-oauth-consent'
-    )
     expect(consentRoute?.meta?.requiresAuth).toBeFalsy()
   })
 
-  it('lazily resolves the /oauth layout and consent view components', async () => {
-    const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
-    const consentRoute = oauthLayout?.children?.find(
-      (c) => c.name === 'cloud-oauth-consent'
-    )
-    const layoutLoader = oauthLayout?.component
-    const consentLoader = consentRoute?.component
+  it('lazily resolves the /oauth layout and consent view components', () => {
     expect(typeof layoutLoader).toBe('function')
     expect(typeof consentLoader).toBe('function')
 
-    const layoutModule = await (layoutLoader as () => Promise<unknown>)()
-    const consentModule = await (consentLoader as () => Promise<unknown>)()
+    const [layoutModule, consentModule] = resolvedComponents
     expect(layoutModule).toHaveProperty('default')
     expect(consentModule).toHaveProperty('default')
   })

--- a/src/views/GraphView.test.ts
+++ b/src/views/GraphView.test.ts
@@ -193,23 +193,30 @@ vi.mock('@/components/MenuHamburger.vue', () => stubModule)
 vi.mock('@/components/dialog/UnloadWindowConfirmDialog.vue', () => stubModule)
 vi.mock('@/renderer/extensions/firstRunTour/FirstRunTour.vue', () => stubModule)
 
+// Imported at module scope, not inside the test. `vi.mock` is hoisted above
+// every import, so the stubs above still apply — but compiling GraphView.vue
+// and its import graph costs seconds, and awaited inside a test body that is
+// billed against the 5 s test timeout. That is what failed this test under a
+// loaded worker pool while it passed in isolation (#14666).
+const { default: GraphView } = await import('./GraphView.vue')
+
 describe('GraphView - reconnect wiring', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it('wires the reconnected event to the toast and queue refresh', async () => {
-    const GraphView = (await import('./GraphView.vue')).default
+  it('wires the reconnected event to the toast and queue refresh', () => {
     render(GraphView)
 
     apiMock.dispatchEvent(new Event('reconnected'))
 
+    // `handleReconnected` calls both before its first `await`, so dispatching
+    // the event is enough — there is nothing to wait for, and waiting for it
+    // only hid how long the import above was taking.
     const { onReconnected } = useReconnectingNotification()
     const refreshOnReconnect = useReconnectQueueRefresh()
-    await vi.waitFor(() => {
-      expect(onReconnected).toHaveBeenCalledTimes(1)
-      expect(refreshOnReconnect).toHaveBeenCalledTimes(1)
-    })
+    expect(onReconnected).toHaveBeenCalledTimes(1)
+    expect(refreshOnReconnect).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Closes #14666

## The failure

Both tests `await` a large module graph **inside the test body**, where the time is billed against the 5 s `testTimeout`. They were never close to safe. Measured on this branch's parent, in isolation, on an idle machine:

```
✓ GraphView - reconnect wiring > wires the reconnected event ...        3017ms
✓ cloudOnboardingRoutes > lazily resolves the /oauth layout ...         4097ms
```

60 % and 82 % of the budget with zero contention. Under a full 1091-file run the worker pool serialises transform work behind other files and both slide past 5000 ms — hence the 5005 ms / 5002 ms in the issue, and hence "passes in isolation".

The cost is transform, not the code under test:
- `onboardingCloudRoutes` calls the two real route loaders, compiling `OAuthLayoutView.vue`, `OAuthConsentView.vue` and their whole import graphs, to assert `toHaveProperty('default')`.
- `GraphView` did `await import('./GraphView.vue')` inside the test. Every heavy child is already `vi.mock`ed, but GraphView.vue's own graph is not.

**This is not a real regression.** Confirmed on parent `dad1b94ebd`: both pass, and the failure is duration alone — no assertion ever fails.

## The fix — deterministic, not a raised timeout

Neither test needed to await anything inside the body.

**`onboardingCloudRoutes.test.ts`** — resolve the lazy imports explicitly at module scope and assert on the results. The `typeof loader === 'function'` assertions (the actual laziness claim) stay in the test, and the loaders are the real ones, so the import cost is still paid and still meaningful. The test body is now synchronous.

**`GraphView.test.ts`** — import the component at module scope. `vi.mock` is hoisted above all imports, so every stub still applies. Then `vi.waitFor` goes: `handleReconnected` calls `onReconnected()` and `refreshOnReconnect()` before its first `await`, so dispatching the event is enough. The `waitFor` was waiting for something that had already happened — it only ever masked how long the import was taking.

```
✓ GraphView - reconnect wiring > wires the reconnected event ...          15ms
✓ cloudOnboardingRoutes > lazily resolves the /oauth layout ...            0ms
```

7.12 s of test time → 20 ms. The transform cost moves to collection, which no timeout guards.

## Why not `vi.mock` the two SFCs

That was the obvious way to make the cloud-routes test instant, and it is wrong. I checked: **`vi.mock` on a path that does not exist passes silently** (verified with a throwaway spec). Mocking the two views would have deleted the only thing that test catches — a route pointing at a module that isn't there.

## Verified

- Full `pnpm test:unit`: **1095 files, 14954 passed, 8 skipped**, exit 0.
- Both files, isolated: 8/8, timings above.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` clean.
- **Mutation-checked, both.** Deleting `useEventListener(api, 'reconnected', handleReconnected)` from `GraphView.vue` → *"expected vi.fn() to be called 1 times, but got 0 times"*. Pointing the consent route at `OAuthConsentViewGone.vue` → the file fails to load with a resolve error. Both reverted; green again.

## Not verified

- I could not reproduce the intermittent 5005/5002 ms failure locally — this machine ran the full suite green on the parent commit too. The claim rests on the measured headroom (3017/4097 ms of 5000 ms idle), which explains the reported numbers exactly, rather than on a local reproduction of the flake.
- I did not sweep the rest of the suite for the same shape (a heavy `await import` inside a test body). If #14666 recurs elsewhere, that sweep is the follow-up.
