### PR TITLE
test(firstRunTour): close the two remaining mutation gaps from #14625

### DIFF
--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -201,7 +201,10 @@ describe('FirstRunTourNudge', () => {
 
     await user.click(screen.getByTestId('first-run-nudge-explore'))
 
-    expect(mocks.showTemplates).toHaveBeenCalled()
+    expect(
+      mocks.showTemplates,
+      'the source is what separates a nudge conversion from a command-palette one, and it defaults to command'
+    ).toHaveBeenCalledWith('first_run_nudge')
     expect(mocks.dismissNudge).toHaveBeenCalled()
     expect(mocks.trackOnboardingTour).toHaveBeenCalledWith(
       'explore_templates_clicked',

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -587,6 +587,19 @@ describe('useFirstRunTourController', () => {
       ).toBe('failed')
     })
 
+    it('gives up on a run the validator refused before it reached a node', async () => {
+      await tourOnRunStep()
+      mountRunButton('queue-button', () => {}).click()
+
+      mocks.executionErrors.hasPromptError = true
+      await nextTick()
+
+      expect(
+        mocks.runState.value,
+        'a prompt refused whole never reaches a node, so no node error and no status will ever end the wait'
+      ).toBe('failed')
+    })
+
     it('leaves errors alone until the tour has run something', async () => {
       await tourOnRunStep()
 


### PR DESCRIPTION
Closes #14625.

#14625 found three mutations of the first-run tour stack that leave the suite green. The first — the `GraphCanvas` activation seam — is already fixed in #14674. This PR closes the other two, so **together with #14674** the issue is complete. On its own this PR does not cover gap 1.

Test-only: no source file is touched.

## Gap 2 — `hasPromptError` was asserted only in the negative

The run-state watcher in `useFirstRunTourController` sources `hasNodeError || hasPromptError`. The positive case was covered for `hasNodeError` alone; the only test naming `hasPromptError` asserted that errors already on screen *before* the tour runs anything are ignored — which passes precisely when the term does nothing.

Added `gives up on a run the validator refused before it reached a node`: a prompt-level refusal arriving while `runState` is `generating` must move the card to a terminal state. Without it, a prompt rejected whole never reaches a node and never gets a queue status, so the Result step spins forever.

**Mutation evidence** — delete `|| executionErrorStore.hasPromptError` from the watcher source:

| | before this PR | after |
|---|---|---|
| mutation applied | 39 passed, 0 failed (green — the gap) | 1 failed, 39 passed |
| mutation reverted | 39 passed | 40 passed |

## Gap 3 — the nudge telemetry source was ungated

`FirstRunTourNudge` calls `useWorkflowTemplateSelectorDialog().show('first_run_nudge')`. The existing test asserted only `toHaveBeenCalled()`, so the argument was free. Pinned it to `toHaveBeenCalledWith('first_run_nudge')`.

Worth noting: `'command'` is also the *default* value of that parameter, so dropping the argument entirely regresses identically — the pinned assertion catches both.

**Mutation evidence** — change the argument to `'command'`:

| | before this PR | after |
|---|---|---|
| mutation applied | 8 passed, 0 failed (green — the gap) | 1 failed, 7 passed |
| mutation reverted | 8 passed | 8 passed |

## Verification

- `pnpm install --frozen-lockfile`, `pnpm format:check`, `pnpm lint`, `pnpm typecheck` — all exit 0.
- `pnpm test:unit src/renderer/extensions/firstRunTour/` — 10 files, 174 passed.
- Both mutations were applied and reverted individually; source files confirmed restored (`git status` shows only the two `.test.ts` files changed).

## Unverified

- Gap 1 is out of scope here and is not re-verified in this branch — it is #14674's.
- Mutation testing was scoped to the two named mutations and the `firstRunTour` suites; this is not a full re-run of the 31-mutation sweep from #14625.
- No e2e/browser coverage was added; both gaps are unit-level assertions on existing behaviour.
- CI note: `playwright-tests-chromium-sharded (2, 16)` failed on the first run in `changeTracker.spec.ts › Does not restore invalid navigation stack` (subgraph undo `expect.poll` assertions, one of which is already annotated `Currently bugged:`). Unrelated to this diff, which touches no source and no `browser_tests`. It passed on re-run; all 51 non-skipped checks now pass.
