### PR TITLE
fix(onboarding): pick the first-run nudge's copy from how the tour ended

### DIFF
--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -247,6 +247,104 @@ describe('onboardingTourStore', () => {
     expect(skipped?.[1]).toMatchObject({ skip_reason: 'user' })
   })
 
+  describe('the ending it hands on', () => {
+    it('has none to report before a tour has ended', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      expect(
+        store.lastEnding,
+        'a running tour has not ended, so nothing may act on how it did'
+      ).toBeNull()
+    })
+
+    it('records a deliberate dismissal as the user’s own', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      store.skip()
+
+      expect(store.lastEnding).toEqual({
+        tour: 'appMode',
+        outcome: 'skipped',
+        skipReason: 'user'
+      })
+    })
+
+    it('records a tour torn down by a target that never mounted', async () => {
+      vi.useFakeTimers()
+      const store = mountStore()
+      store.replayTour('appMode')
+      await vi.advanceTimersByTimeAsync(0)
+      store.next()
+      // The deferred target (inputs list) is never registered; exhaust the wait.
+      await vi.advanceTimersByTimeAsync(8000)
+
+      expect(
+        store.lastEnding,
+        'whatever follows the tour has to tell this apart from a finished one'
+      ).toEqual({
+        tour: 'appMode',
+        outcome: 'skipped',
+        skipReason: 'target_timeout'
+      })
+    })
+
+    it('records a tour that lost the context its steps point at', async () => {
+      settings.store.set(TOUR_SEEN_SETTING, ['appMode'])
+      const store = mountStore()
+      enterApp('app', false)
+      await nextTick()
+      store.replayTour('appMode')
+      await nextTick()
+
+      enterApp('graph', false)
+      await nextTick()
+
+      expect(store.lastEnding).toEqual({
+        tour: 'appMode',
+        outcome: 'skipped',
+        skipReason: 'trigger_lost'
+      })
+    })
+
+    it('records a walked-to-the-end tour with no skip reason', async () => {
+      registerAppModeTargets()
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+
+      // Capped so a stuck tour fails instead of hanging.
+      for (let i = 0; i < 12 && !seenTours().includes('appMode'); i++) {
+        store.next()
+        await nextTick()
+      }
+
+      expect(store.lastEnding).toEqual({
+        tour: 'appMode',
+        outcome: 'completed'
+      })
+    })
+
+    it('drops the last ending as soon as a new run is requested', async () => {
+      const store = mountStore()
+      store.replayTour('appMode')
+      await nextTick()
+      store.skip()
+      expect(store.lastEnding).not.toBeNull()
+
+      store.replayTour('appMode')
+      await nextTick()
+
+      expect(
+        store.lastEnding,
+        'a run still going has no ending, and the last one does not speak for it'
+      ).toBeNull()
+    })
+  })
+
   it('holds the card on its step while a deferred target is awaited', async () => {
     vi.useFakeTimers()
     const store = mountStore()

--- a/src/platform/onboarding/onboardingTourStore.ts
+++ b/src/platform/onboarding/onboardingTourStore.ts
@@ -28,6 +28,20 @@ import { useTourTriggers } from './useTourTriggers'
 
 const DEFER_TIMEOUT_MS = 8000
 
+/**
+ * How the last run of a tour ended. Whatever follows a tour has to know which
+ * ending it is following: "a tour ran" cannot tell a tour walked to the end
+ * apart from one the user waved away on step 1, or one a missing target tore
+ * down.
+ */
+export type TourEnding =
+  | { tour: EntryPath; outcome: 'completed' }
+  | {
+      tour: EntryPath
+      outcome: 'skipped'
+      skipReason: OnboardingTourSkipReason
+    }
+
 /** Empty when a runtime resolver fails, so one bad graph costs only its own tour. */
 async function resolveDefinition(
   definition: TourDefinition
@@ -51,6 +65,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
   const telemetry = useTelemetry()
 
   const state = shallowRef<TourState>(IDLE)
+  const lastEnding = shallowRef<TourEnding | null>(null)
   let stepController: AbortController | null = null
   let lastRun = 0
 
@@ -283,6 +298,11 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
     if (!dispatch({ type: 'ended', run })) return
 
+    if (ending.tour)
+      lastEnding.value =
+        outcome === 'skipped'
+          ? { tour: ending.tour, outcome, skipReason }
+          : { tour: ending.tour, outcome }
     trackTour(
       outcome,
       outcome === 'skipped' ? skipReason : undefined,
@@ -330,6 +350,8 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
     if (!definition) return false
     const run = nextRun()
     if (!dispatch({ type: 'requested', tour: entryPath, run })) return false
+    // A new run has no ending yet; the one before it must not speak for it.
+    lastEnding.value = null
     const built = await resolveDefinition(definition)
     const resolved = resolveSteps(built.steps, targetMounted)
     if (!resolved.length) {
@@ -373,6 +395,7 @@ export const useOnboardingTourStore = defineStore('onboardingTour', () => {
 
   return {
     activeTour: readonly(activeTour),
+    lastEnding: readonly(lastEnding),
     step,
     isLast,
     canGoBack,

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -15,7 +15,7 @@ const mocks = await vi.hoisted(async () => {
   const { ref } = await import('vue')
   return {
     nudgeArmed: ref(false),
-    tourWasShown: ref(true),
+    tourWasCompleted: ref(true),
     openDialogs: ref<string[]>([]),
     dismissNudge: vi.fn(() => {
       mocks.nudgeArmed.value = false
@@ -28,7 +28,7 @@ const mocks = await vi.hoisted(async () => {
 vi.mock('../tour/useFirstRunTourController', () => ({
   useFirstRunTourController: () => ({
     nudgeArmed: mocks.nudgeArmed,
-    tourWasShown: mocks.tourWasShown,
+    tourWasCompleted: mocks.tourWasCompleted,
     dismissNudge: mocks.dismissNudge
   })
 }))
@@ -71,6 +71,7 @@ describe('FirstRunTourNudge', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     mocks.nudgeArmed.value = false
+    mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []
   })
 
@@ -157,18 +158,42 @@ describe('FirstRunTourNudge', () => {
     ).toHaveLength(1)
   })
 
-  it('offers no congratulation for a tour that never appeared', async () => {
-    mocks.tourWasShown.value = false
+  it('congratulates a tour the user walked to the end', async () => {
+    mocks.tourWasCompleted.value = true
+    mocks.nudgeArmed.value = true
+    renderNudge()
+    await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+    expect(screen.getByText(nudgeCopy.ran.title)).toBeTruthy()
+  })
+
+  it('offers no congratulation for a tour nobody finished', async () => {
+    mocks.tourWasCompleted.value = false
     mocks.nudgeArmed.value = true
     renderNudge()
     await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
 
     expect(
       screen.queryByText(nudgeCopy.ran.title),
-      'a user whose tour never ran made nothing to be congratulated for'
+      'a user who skipped, was cut off or saw no tour made no first result'
     ).toBeNull()
     expect(screen.getByText(nudgeCopy.noTour.title)).toBeTruthy()
   })
+
+  it.for([{ finished: true }, { finished: false }])(
+    'appears whether or not the tour finished ($finished)',
+    async ({ finished }) => {
+      mocks.tourWasCompleted.value = finished
+      mocks.nudgeArmed.value = true
+      renderNudge()
+      await vi.advanceTimersByTimeAsync(APPEAR_DELAY_MS)
+
+      expect(
+        nudge(),
+        'the copy is all that the ending changes; the way forward is offered either way'
+      ).not.toBeNull()
+    }
+  )
 
   it('stays gone once the user closes it', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.vue
@@ -70,15 +70,17 @@ const NUDGE_IMAGE = '/assets/images/og-image.png'
 const APPEAR_DELAY_MS = 1500
 
 const { t } = useI18n()
-const { nudgeArmed, tourWasShown, dismissNudge } = useFirstRunTourController()
+const { nudgeArmed, tourWasCompleted, dismissNudge } =
+  useFirstRunTourController()
 const dialogStore = useDialogStore()
 const telemetry = useTelemetry()
 const titleId = useId()
 
-// A tour that never appeared made nothing to congratulate the user for.
+// Only a tour walked to the end made a first result to congratulate; every
+// other ending still gets a nudge, pointing at the templates instead.
 const copyKey = computed(
   () =>
-    `onboardingCoachmarks.firstRun.nudge.${tourWasShown.value ? 'ran' : 'noTour'}`
+    `onboardingCoachmarks.firstRun.nudge.${tourWasCompleted.value ? 'ran' : 'noTour'}`
 )
 
 const onScreen = ref(false)

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -5,10 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 import type { EffectScope, Ref } from 'vue'
 
+import type { TourEnding } from '@/platform/onboarding/onboardingTourStore'
 import type {
   CoachStep,
   SpotlightStep
 } from '@/platform/onboarding/onboardingTours'
+import type { OnboardingTourSkipReason } from '@/platform/telemetry/types'
 
 const TOUR_WORKFLOW = { path: 'tour.json' }
 const OTHER_WORKFLOW = { path: 'other.json' }
@@ -28,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   releaseFirstRunTargets: vi.fn(),
   engine: {
     activeTour: null as string | null,
+    lastEnding: null as TourEnding | null,
     step: null as CoachStep | null,
     isLast: false,
     startTour: vi.fn(),
@@ -159,6 +162,36 @@ async function tourOnRunStep() {
   return { controller, started: await starting }
 }
 
+/** The engine ending the tour and recording how, the way `finish()` leaves it. */
+function endTour(ending: TourEnding) {
+  mocks.engine.lastEnding = ending
+  mocks.engine.activeTour = null
+  mocks.engine.step = null
+  return nextTick()
+}
+
+const COMPLETED: TourEnding = { tour: 'firstRun', outcome: 'completed' }
+
+function skippedBecause(skipReason: OnboardingTourSkipReason): TourEnding {
+  return { tour: 'firstRun', outcome: 'skipped', skipReason }
+}
+
+/** Every ending short of walking the tour to the end. */
+const UNFINISHED_ENDINGS: { named: string; ending: TourEnding }[] = [
+  { named: 'the user waved away on step 1', ending: skippedBecause('user') },
+  {
+    named: 'a missing target tore down',
+    ending: skippedBecause('target_timeout')
+  },
+  { named: 'the paywall parked', ending: skippedBecause('postponed') },
+  { named: 'a lost context ended', ending: skippedBecause('trigger_lost') }
+]
+
+const EVERY_ENDING: { named: string; ending: TourEnding }[] = [
+  { named: 'the user walked to the end', ending: COMPLETED },
+  ...UNFINISHED_ENDINGS
+]
+
 function finishRun(workflow: unknown, status: string) {
   mocks.workflowStatus.value = new Map(mocks.workflowStatus.value).set(
     workflow,
@@ -209,6 +242,7 @@ describe('useFirstRunTourController', () => {
     mocks.vueNodesEnabled = true
     mocks.steps = []
     mocks.engine.activeTour = null
+    mocks.engine.lastEnding = null
     mocks.engine.step = null
     mocks.engine.isLast = false
   })
@@ -644,11 +678,52 @@ describe('useFirstRunTourController', () => {
       ).toBe(false)
     })
 
+    it('congratulates a tour the user walked to the end', async () => {
+      const { controller } = await tourOnRunStep()
+
+      await endTour(COMPLETED)
+
+      expect(controller.tourWasCompleted.value).toBe(true)
+    })
+
+    it.for(UNFINISHED_ENDINGS)(
+      'congratulates nobody for a tour $named',
+      async ({ ending }) => {
+        const { controller } = await tourOnRunStep()
+
+        await endTour(ending)
+
+        expect(
+          controller.tourWasCompleted.value,
+          'a tour the user never walked to the end made no first result to congratulate'
+        ).toBe(false)
+      }
+    )
+
+    it.for(EVERY_ENDING)(
+      'still offers the nudge after a tour $named',
+      async ({ ending }) => {
+        const { controller } = await tourOnRunStep()
+
+        await endTour(ending)
+
+        expect(
+          controller.nudgeArmed.value,
+          'suppressing the nudge takes the way forward from the user who most needs it (#14144)'
+        ).toBe(true)
+      }
+    )
+
     it('congratulates nobody when the tour never appeared', async () => {
       mocks.steps = []
       mocks.activeWorkflow.value = TOUR_WORKFLOW
       mocks.engine.startTour.mockImplementation(async () => {
         await resolveRegisteredTour()
+        // The store requests the run, resolves no steps and returns to idle, so
+        // nothing ever calls `finish()` and no ending is recorded.
+        mocks.engine.activeTour = 'firstRun'
+        await nextTick()
+        mocks.engine.activeTour = null
         return false
       })
       const controller = await freshController()
@@ -656,11 +731,16 @@ describe('useFirstRunTourController', () => {
       const starting = controller.beginTour('image_z_image_turbo')
       await vi.advanceTimersByTimeAsync(INTRO_PREVIEW_MS)
       await starting
+      await nextTick()
 
       expect(
-        controller.tourWasShown.value,
+        controller.tourWasCompleted.value,
         'a tour that resolved no steps made nothing for the nudge to celebrate'
       ).toBe(false)
+      expect(
+        controller.nudgeArmed.value,
+        'a user who saw no tour is the one who most needs somewhere to go next'
+      ).toBe(true)
     })
 
     it('stops offering the nudge once it is waved away', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.ts
@@ -43,8 +43,8 @@ function useFirstRunTourControllerInternal() {
   const desktopLayout = useBreakpoints(breakpointsTailwind).greaterOrEqual('md')
   const tourWorkflow = shallowRef<ComfyWorkflow | null>(null)
   const nudgeArmed = ref(false)
-  /** A tour that never appeared leaves the user nothing to be congratulated for. */
-  const tourWasShown = ref(false)
+  /** Only a tour walked to the end made a first result to be congratulated for. */
+  const tourWasCompleted = ref(false)
 
   // The tour's node ids are graph-local, so they only describe the workflow it
   // resolved against: swapping workflows leaves it pointing at strangers.
@@ -125,6 +125,11 @@ function useFirstRunTourControllerInternal() {
     () => engine.activeTour === 'firstRun',
     (active) => {
       if (active) return
+      // Every ending leaves the user somewhere to go next, so every ending arms
+      // the nudge; only what it says depends on how the tour ended.
+      const ending = engine.lastEnding
+      tourWasCompleted.value =
+        ending?.tour === 'firstRun' && ending.outcome === 'completed'
       nudgeArmed.value = true
       stopOfflineGrace()
       releaseFirstRunTargets()
@@ -147,7 +152,6 @@ function useFirstRunTourControllerInternal() {
     tourWorkflow.value = workflowStore.activeWorkflow ?? null
     runState.value = 'idle'
     nudgeArmed.value = false
-    tourWasShown.value = false
     registerTour(
       'firstRun',
       () => firstRunTourSteps(templateId, runState),
@@ -155,7 +159,6 @@ function useFirstRunTourControllerInternal() {
     )
     await delay(INTRO_PREVIEW_MS)
     const started = await engine.startTour('firstRun')
-    tourWasShown.value = started
     if (!started) {
       releaseFirstRunTargets()
       tourWorkflow.value = null
@@ -168,7 +171,7 @@ function useFirstRunTourControllerInternal() {
   return {
     beginTour,
     nudgeArmed: readonly(nudgeArmed),
-    tourWasShown: readonly(tourWasShown),
+    tourWasCompleted: readonly(tourWasCompleted),
     dismissNudge
   }
 }


### PR DESCRIPTION
## Summary

The first-run nudge picked its copy from whether a tour _started_, so a user who skipped on step 1 — or one whose tour was torn down by a target that never mounted — was congratulated for a first result they never made. This makes the copy follow how the tour actually ended. **The nudge's visibility is unchanged: every ending still shows it.**

## The defect

`FirstRunTourNudge.vue` chose its copy with `` `…nudge.${tourWasShown ? 'ran' : 'noTour'}` ``, and `tourWasShown` was assigned from `started` — the return of `engine.startTour()` in `useFirstRunTourController.ts` — which means _a tour began_, not _the user completed one_:

| ending                           | copy before                                      | copy now |
| -------------------------------- | ------------------------------------------------ | -------- |
| completed                        | `ran`                                            | `ran`    |
| never appeared                   | `noTour` ✓                                       | `noTour` |
| **skipped on step 1**            | **`ran`** — "You just made your first"           | `noTour` |
| **abandoned (`target_timeout`)** | **`ran`**, shown alongside the `loadError` toast | `noTour` |
| postponed (paywall)              | `ran`                                            | `noTour` |
| `trigger_lost`                   | `ran`                                            | `noTour` |

The abandoned case is the sharp one: the same event raises an error toast and a congratulation.

## Changes

- **What**: `finish()` in `onboardingTourStore.ts` already computes `outcome` and `skipReason`; the store now hands that on as `lastEnding` (a discriminated union, cleared when a new run is requested so the previous ending cannot speak for it). `useFirstRunTourController` derives `tourWasCompleted` from it in place of `tourWasShown`, and the nudge reserves the `ran` copy for `completed`. Every other ending gets `noTour`, which reads as "here's where to go next" for a skipper or an abandoner.
- **Breaking**: none. `lastEnding` is additive; `tourWasShown` had exactly one consumer (the nudge).

## Visibility is deliberately unchanged

Every ending still arms the nudge, including the ones that now read as `noTour`. That is @MaanilVerma's product decision in #14144: _"a user who saw no tour is the one who most needs somewhere to go next, so suppressing it there removes the way forward."_ #14672 tried to suppress the nudge on the abandoned ending and was closed for exactly this reason — this PR treats the copy, not the visibility, as the defect.

The regression guard for that is `still offers the nudge after a tour $named` in `useFirstRunTourController.test.ts`, which asserts `nudgeArmed` for all five endings, plus a sixth test for the never-started case and a component-level check that the nudge renders whether or not the tour finished.

## Tests

New coverage, 19 tests:

- `onboardingTourStore.test.ts` (6) — the ending recorded for a user skip, a `target_timeout` teardown, a `trigger_lost` teardown, a walked-to-the-end tour; that a running tour has no ending; that a new run drops the last one.
- `useFirstRunTourController.test.ts` (10, plus an existing never-started test extended to assert visibility) — `completed` → congratulation; `user` / `target_timeout` / `postponed` / `trigger_lost` → none; **all five endings still arm the nudge**; never-started arms it too, with no congratulation.
- `FirstRunTourNudge.test.ts` (3) — completed → `ran`, unfinished → `noTour`, and the nudge appears either way.

### Mutation evidence

- Revert the rule to the old semantics (`tourWasCompleted = ending?.tour === 'firstRun'`, i.e. "a tour ran"): **4 failed | 45 passed**. The four are the skipped/abandoned/postponed/lost-context copy cases. The five visibility tests stayed green, confirming they are not coupled to the copy rule.
- Pin the component's copy key to `ran`: **1 failed | 10 passed**. Pin it to `noTour`: **1 failed | 10 passed**.
- Restored: **374 passed (23 files)** across `src/renderer/extensions/firstRunTour` and `src/platform/onboarding`.

`pnpm install --frozen-lockfile`, `format:check`, `lint`, `typecheck` and `knip` all clean.

## Review Focus

- `lastEnding` carries `skipReason` although no production code reads it today — the tests name each ending, so the reason has to be observable, and it is the shape `finish()` already computes. Say the word if you would rather it be trimmed to `{ tour, outcome }`.
- The controller latches `tourWasCompleted` when the nudge arms rather than deriving it live, so a later tour ending cannot rewrite the copy of a nudge already on screen.
- Not verified: no e2e run. `gettingStartedTour.spec.ts` → "leaves the nudge until the upgrade dialog closes" asserts visibility only (postponed still arms), and no e2e or unit test elsewhere asserts the nudge's copy strings — checked by grep, not by running Playwright.
- Telemetry is untouched: `nudge_shown` and `explore_templates_clicked` still report only `{ tour: 'firstRun' }`, so the funnel still cannot tell a toured user from a tour-less one. That is a real gap, and deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)