### PR TITLE
ci(backport): flag likely stacking conflicts in the failure comment

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -411,6 +411,8 @@ jobs:
             manually onto branch `${BACKPORT_BRANCH}` (from `origin/${target}`) and
             open a PR to `${target}`.
 
+            ${STACK_HINT}
+
             <details>
             <summary>📄 Conflicting files</summary>
 
@@ -489,8 +491,25 @@ jobs:
               CONFLICTS_BLOCK=$(echo "${conflicts}" | tr ',' '\n')
               MERGE_COMMIT_SHORT="${MERGE_COMMIT:0:7}"
 
-              export target MERGE_COMMIT_SHORT BACKPORT_BRANCH CONFLICTS_BLOCK AGENT_PROMPT PR_AUTHOR
-              COMMENT_BODY=$(envsubst '${target} ${MERGE_COMMIT_SHORT} ${BACKPORT_BRANCH} ${CONFLICTS_BLOCK} ${AGENT_PROMPT} ${PR_AUTHOR}' <<<"$COMMENT_BODY_TEMPLATE")
+              # Each labelled PR is cherry-picked onto the target independently,
+              # so a *stack* of PRs conflicts at every level above the first
+              # until the PR below it has actually merged into the target
+              # branch. Those conflicts are an artifact of picking in isolation,
+              # not a real incompatibility. If other backport PRs are still open
+              # against this target, say so rather than let the failure read as
+              # a genuine conflict. Best-effort only: never fail the comment.
+              STACK_HINT=""
+              OPEN_BACKPORTS=$(
+                gh pr list --repo "${GITHUB_REPOSITORY}" --state open \
+                  --base "${target}" --label backport --json number \
+                  --jq '[.[].number | "#\(.)"] | join(", ")' 2>/dev/null
+              ) || OPEN_BACKPORTS=""
+              if [ -n "${OPEN_BACKPORTS}" ]; then
+                STACK_HINT="> **This may be a stacking conflict rather than a real one.** ${OPEN_BACKPORTS} are still open against \`${target}\`. If this PR sits on top of any of them, the conflict will disappear once they merge — wait for that, then remove and re-add the \`needs-backport\` label to re-run this workflow."
+              fi
+
+              export target MERGE_COMMIT_SHORT BACKPORT_BRANCH CONFLICTS_BLOCK AGENT_PROMPT PR_AUTHOR STACK_HINT
+              COMMENT_BODY=$(envsubst '${target} ${MERGE_COMMIT_SHORT} ${BACKPORT_BRANCH} ${CONFLICTS_BLOCK} ${AGENT_PROMPT} ${PR_AUTHOR} ${STACK_HINT}' <<<"$COMMENT_BODY_TEMPLATE")
 
               post_comment "${COMMENT_BODY}" "cherry-pick conflict on ${target} (backport manually onto ${BACKPORT_BRANCH})"
             fi


### PR DESCRIPTION
Partial mitigation for #14679. **This does not make the backport workflow stack-aware** — it only stops the failure comment from being misleading.

## Why

`pr-backport.yaml` builds every backport branch straight off the target:

```bash
git checkout -B "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
```

so each labelled PR is cherry-picked **independently**. A _stack_ of PRs therefore conflicts at every level above the first, until the PR below it has actually merged into the target branch. Those conflicts are an artifact of picking each commit in isolation, not a real incompatibility.

Verified on #14142–#14145 → `core/1.49`, from the release branch tip immediately before any of the four landed:

- cherry-picking **#14144 alone** conflicts in 6 files — byte-for-byte the list the bot reported
- cherry-picking **all four in stack order** applies cleanly, **zero conflicts**

Live evidence: #14145's backport failed at `03:12Z`, failed _again_ at `04:41Z` — the moment #14144's backports were merely _created_ — and only succeeded at `05:00Z`, once #14144's backport had actually merged.

## What the author sees today

A bare **"⚠️ Backport to `core/1.49` failed — merge conflicts detected"** plus a six-file conflict list and an AI-agent prompt telling them to go resolve it by hand. Nothing indicates the conflict will evaporate on its own once the PR below merges, so the rational response is to do redundant manual conflict resolution.

## Change

When a cherry-pick conflicts, check whether other PRs labelled `backport` are still open against the same target branch. If so, add one blockquote to the existing failure comment:

> **This may be a stacking conflict rather than a real one.** #14662, #14664 are still open against `core/1.49`. If this PR sits on top of any of them, the conflict will disappear once they merge — wait for that, then remove and re-add the `needs-backport` label to re-run this workflow.

The `needs-backport` remove/re-add is the re-trigger that actually works — `workflow_dispatch` is broken today for an unrelated reason (its `gh pr view` calls run before `actions/checkout` and so have no repo context; fix pending in #13699).

## Safety

- Comment text only. No change to which commits are picked, which branches are created or pushed, or when the job fails.
- The lookup is best-effort: `2>/dev/null` plus `|| OPEN_BACKPORTS=""`, so a `gh` failure cannot abort the step (the default `bash -e` shell would otherwise) or suppress the existing comment.
- When nothing is open against the target, `STACK_HINT` is empty and the comment renders exactly as before.

## Verification

- YAML parses; `bash -n` clean on the step's `run` block. Remaining `shellcheck` findings in that block are pre-existing `${{ }}` templating noise.
- Rendered the comment through `envsubst` with the real template for both cases (hint present / absent) — output verified.
- Exercised the `gh pr list` query against this repo, including a nonexistent base branch: returns empty with exit 0 in both cases.

Cannot be end-to-end tested without merging, since the failure path only runs inside a real `pull_request_target` backport run.