### PR TITLE
fix(first-run-tour): replace a fallback template no backend serves

### DIFF
--- a/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
@@ -10,7 +10,7 @@ export const CURATED_TEMPLATE_IDS = [
 export const FALLBACK_TEMPLATE_IDS = [
   'templates-image_to_real',
   'image_qwen_image_edit_2509',
-  'templates-qwen_multiangle.app',
+  'flux_fill_inpaint_example',
   'video_ltx2_i2v_distilled'
 ] as const
 

--- a/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
+++ b/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
@@ -80,9 +80,10 @@ export const TOUR_ROLE_PINS: Record<SupportedTemplateId, RolePins> = {
     sink: { id: 60, type: 'SaveImage' },
     mediaKind: 'image'
   },
-  'templates-qwen_multiangle.app': {
-    source: { id: 1, type: 'LoadImage' },
-    sink: { id: 2, type: 'SaveImage' },
+  flux_fill_inpaint_example: {
+    source: { id: 17, type: 'LoadImage' },
+    prompt: { id: 23, type: 'CLIPTextEncode' },
+    sink: { id: 9, type: 'SaveImage' },
     mediaKind: 'image'
   },
   video_ltx2_i2v_distilled: {


### PR DESCRIPTION
## Summary

`templates-qwen_multiangle.app` is pinned as a Getting Started fallback card, and **no supported backend serves it.** It 404s on the templates package bundled with ComfyUI v0.19.3 (`0.9.57`) and on the one bundled with v0.30.0 (`0.11.27`) alike, so this is a live product bug rather than version drift: whenever the grid falls back to it, the card silently drops out and its tour role pins go unchecked.

I verified this against real backends rather than the repo, by querying both CI container images directly:

| backend | templates pkg | `/templates/templates-qwen_multiangle.app.json` |
| --- | --- | --- |
| `comfyui-ci-container:0.0.21` (ComfyUI v0.19.3) | `0.9.57` | ❌ 404 |
| `comfyui-ci-container:0.0.22` (ComfyUI v0.30.0) | `0.11.27` | ❌ 404, and absent from `/templates/index.json` |

### Why it was easy to miss

The id **is** present in `Comfy-Org/workflow_templates` under `templates/`. But the published package ships a **509-template subset** of that directory, so "exists on `workflow_templates@main`" never implied that a backend serves it. That inference is what hid this.

## The replacement

`flux_fill_inpaint_example`, picked on verified properties rather than on looking like a plausible successor:

| | `0.9.57` | `0.11.27` |
| --- | --- | --- |
| source `17` | `LoadImage` ×1 | `LoadImage` ×1 |
| prompt `23` | `CLIPTextEncode` ×1 | `CLIPTextEncode` ×1 |
| sink `9` | `SaveImage` ×1 | `SaveImage` ×1 |
| node count | 14 | 14 |

- **Pins are identical on both template versions**, so this does not re-create the drift it replaces. I scanned all 493 indexed templates for "exactly one `LoadImage`, exactly one image sink, ids unique across root + subgraphs" and then filtered to the ones stable across both versions.
- **Local models only.** Every other pinned template is local; the two smallest candidates (`templates_doc_workbox_poster_recreator`, `templates_graphic_design_recomposer`) are Gemini API templates, which would have made this the one first-run card that needs API credits to run. That seemed like the wrong default for a first-run experience, so I passed on them despite being simpler.
- It is an inpaint workflow, which lines up with the existing `inpaint` tutorial card.

`@MaanilVerma` — assigning you as the owner of `firstRunTour`; the template choice is the part worth a second opinion, the "it 404s everywhere" part is measured.

## Scope note

This deliberately does **not** touch `image_qwen_image_edit_2509`, which has a related but *version-dependent* problem: it was restructured upstream into a subgraph, and its sink is node `60` (`SaveImage`) on `0.9.57` but node `469` (`SaveImageAdvanced`) on `0.11.27`. **No single pin is correct for both**, so it cannot be fixed independently of the container bump — that fix rides in #14682.

This PR is version-independent by construction, which is why it can land on `main` on its own.

## Verification

- `firstRunTourRolePins.spec.ts` run against **both** containers locally: passes on `0.0.21` (which is what `main`'s CI uses, so this should be green here) and, on `0.0.22`, the only remaining failure is the `image_qwen_image_edit_2509` pin that #14682 fixes.
- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean; full unit suite passes.