### PR TITLE
fix(first-run-tour): let the upload step take the click it asks for

### DIFF
--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -186,14 +186,18 @@ describe('firstRunTourSteps', () => {
     expect(result?.name).toBe('result.image')
   })
 
-  it('lets only interactive steps take pointer input', async () => {
+  it('lets every step but the result take pointer input', async () => {
     loadTemplate(FROM_IMAGE)
 
     const interactive = (await buildSteps(FROM_IMAGE))
       .filter((step) => step.kind === 'spotlight' && step.interactive)
       .map((step) => step.name)
 
-    expect(interactive).toEqual(['prompt.image-edit', 'run'])
+    expect(interactive).toEqual([
+      'upload.image-edit',
+      'prompt.image-edit',
+      'run'
+    ])
   })
 
   it('registers each spotlit node so the engine can find it', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -189,15 +189,19 @@ describe('firstRunTourSteps', () => {
   it('lets every step but the result take pointer input', async () => {
     loadTemplate(FROM_IMAGE)
 
-    const interactive = (await buildSteps(FROM_IMAGE))
-      .filter((step) => step.kind === 'spotlight' && step.interactive)
-      .map((step) => step.name)
+    const byName = new Map(
+      (await buildSteps(FROM_IMAGE)).map((step) => [
+        step.name,
+        step.kind === 'spotlight' && step.interactive === true
+      ])
+    )
 
-    expect(interactive).toEqual([
-      'upload.image-edit',
-      'prompt.image-edit',
-      'run'
-    ])
+    expect(Object.fromEntries(byName)).toEqual({
+      'upload.image-edit': true,
+      'prompt.image-edit': true,
+      run: true,
+      'result.image': false
+    })
   })
 
   it('registers each spotlit node so the engine can find it', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
@@ -92,7 +92,7 @@ function toCoachStep(
     coachId: COACH_ID[step.kind],
     deferTarget: true,
     cursor: true,
-    interactive: step.kind === 'prompt' || step.kind === 'run'
+    interactive: step.kind !== 'result'
   }
 
   if (step.kind === 'run')


### PR DESCRIPTION
## Summary

The upload step tells the user to swap in their own image, then a full-screen blocker swallows every click on the node it is spotlighting.

## Changes

- **What**: `interactive` was an allowlist of `prompt` and `run`, so `upload` fell through to the non-interactive branch in `TourSpotlight.vue`, which renders a `pointer-events-auto` overlay across the whole viewport. Inverted to exclude only `result` — the one step with nothing to touch.

## Review Focus

Advancing is unaffected: only `run` is `selfAdvancing`, and `upload` and `prompt` both advance on Next, so `upload` now behaves exactly like `prompt` already did.

The existing test enumerated the old list with no rationale, so it went red. Rewritten to assert the rule rather than the list, and mutation-checked — reverting the one line turns it red again.

Found by hand against a real backend. The whole `interactive` cluster also drives the focus trap and `aria-modal`, none of which is observable in happy-dom, which is why the suite stayed green through this.

## What changed.

Before: clicking the spotlit LoadImage node on the upload step does nothing.
After: the node takes the click and the file picker opens.
