### PR TITLE
ci: stop snapshot regeneration laundering bad baselines and dead shards

### DIFF
--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -172,9 +172,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Run tests with snapshot updates (browsers pre-installed in container)
+      # continue-on-error is required: --update-snapshots reports a rewritten
+      # baseline as a test failure. It also swallows genuine breakage, so the
+      # JSON report is kept and checked by the next step.
       - name: Update snapshots (${{ matrix.shard == 'cloud' && 'cloud' || format('Shard {0}/4', matrix.shard) }})
         id: playwright-tests
-        run: pnpm exec playwright test --update-snapshots --grep @screenshot ${{ matrix.shard == 'cloud' && '--project=cloud' || format('--grep-invert @cloud --shard={0}/4', matrix.shard) }}
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: /tmp/playwright-results.json
+        run: pnpm exec playwright test --update-snapshots --reporter=json,html --grep @screenshot ${{ matrix.shard == 'cloud' && '--project=cloud' || format('--grep-invert @cloud --shard={0}/4', matrix.shard) }}
         continue-on-error: true
 
       - name: Stage changed snapshot files
@@ -211,6 +216,71 @@ jobs:
             mkdir -p "/tmp/changed_snapshots_shard/$(dirname "$file_without_prefix")"
             cp "$file" "/tmp/changed_snapshots_shard/$file_without_prefix"
           done <<< "$changed_files"
+
+      # A shard that reported test failures but rewrote nothing did not
+      # "find no drift" - it broke (server never came up, container wrong,
+      # Playwright died). Without this the shard is green, merge-and-commit
+      # logs "No changes to commit", and the whole run reports success having
+      # done nothing.
+      - name: Verify shard did the work it claims
+        shell: bash
+        env:
+          SHARD: ${{ matrix.shard }}
+          HAS_CHANGES: ${{ steps.changed-snapshots.outputs.has-changes }}
+        run: |
+          set -uo pipefail
+
+          results='/tmp/playwright-results.json'
+
+          # No JSON at all means the process died before reporting. Playwright
+          # still writes the report when zero tests match, so absence is fatal.
+          if [ ! -f "$results" ]; then
+            echo "::error::Shard ${SHARD}: Playwright wrote no JSON report, so it never completed a run. Refusing to report success."
+            exit 1
+          fi
+
+          # Parsed with node, not jq: this step runs inside the CI container,
+          # where node is guaranteed (it just ran pnpm/playwright) but jq is not.
+          if ! summary=$(node -e '
+            const fs = require("fs");
+            const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const s = r.stats;
+            if (!s) throw new Error("no stats in report");
+            const n = (v) => (typeof v === "number" ? v : 0);
+            const notPassing = n(s.unexpected) + n(s.flaky);
+            const ran = n(s.expected) + notPassing;
+            const errs = Array.isArray(r.errors) ? r.errors.length : 0;
+            console.log(ran + " " + notPassing + " " + errs);
+            console.log(JSON.stringify(s));
+          ' "$results" 2>&1); then
+            echo "::error::Shard ${SHARD}: Playwright JSON report is unreadable or has no stats. Refusing to report success."
+            echo "$summary"
+            exit 1
+          fi
+
+          read -r ran not_passing error_count <<< "$(printf '%s\n' "$summary" | head -1)"
+          echo "Shard ${SHARD} stats: $(printf '%s\n' "$summary" | tail -1)"
+
+          # Zero tests matched is legitimate for a leg whose grep selects
+          # nothing (Playwright exits non-zero AND records a top-level error
+          # for it, which is why neither signal can be trusted on its own).
+          if [ "$ran" -eq 0 ]; then
+            echo "::notice::Shard ${SHARD}: no tests matched this shard's filters; nothing to regenerate."
+            exit 0
+          fi
+
+          if [ "$error_count" -gt 0 ]; then
+            echo "::warning::Shard ${SHARD}: Playwright reported ${error_count} top-level error(s); the regenerated baselines for this shard may be incomplete."
+          fi
+
+          # A rewritten baseline surfaces as unexpected/flaky, so failures with
+          # zero rewritten files is the broken-run signature.
+          if [ "$not_passing" -gt 0 ] && [ "${HAS_CHANGES:-false}" != 'true' ]; then
+            echo "::error::Shard ${SHARD}: ${not_passing} test(s) did not pass yet no snapshot was rewritten. That is a broken run, not an absence of drift. Refusing to report success."
+            exit 1
+          fi
+
+          echo "Shard ${SHARD}: ${ran} test(s) ran, ${not_passing} not passing, snapshot changes=${HAS_CHANGES:-false}"
 
       # Upload ONLY the changed files from this shard
       - name: Upload changed snapshots
@@ -351,6 +421,7 @@ jobs:
           echo "has-changes=true" >> $GITHUB_OUTPUT
 
           git add browser_tests/
+
           git commit -m "[automated] Update test expectations"
 
           echo "Pushing to ${{ needs.setup.outputs.branch }}..."

--- a/.github/workflows/pr-update-playwright-expectations.yaml
+++ b/.github/workflows/pr-update-playwright-expectations.yaml
@@ -402,6 +402,88 @@ jobs:
             echo "$CHANGES" | wc -l
           fi
 
+      # Regeneration has no notion of *whether* a baseline drifted: it rewrites
+      # whatever it captured. Screenshot capture is not bit-deterministic (text
+      # glyph rasterization varies run to run), so a baseline that never
+      # actually changed can be rewritten, and a baseline failing from a real
+      # visual regression can be laundered into an accepted one. Reviewing that
+      # means eyeballing binary diffs, which is exactly the review binary files
+      # defeat. Publish a per-file magnitude so there is a number to review.
+      - name: Report snapshot diff magnitudes
+        id: diff-report
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          report='/tmp/diff-report.md'
+          : > "$report"
+
+          mapfile -t changed < <(
+            git status --porcelain=v1 --untracked-files=all -- browser_tests/ |
+              sed -e 's/^...//' -e 's/^"//' -e 's/"$//'
+          )
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No snapshot changes to measure"
+            exit 0
+          fi
+
+          if command -v compare >/dev/null 2>&1; then
+            echo "Measuring ${#changed[@]} rewritten snapshot(s) with ImageMagick"
+          else
+            echo "::warning::ImageMagick 'compare' unavailable; falling back to byte sizes, which cannot distinguish a real visual change from rasterization noise."
+          fi
+
+          small=0
+          {
+            echo "| snapshot | status | changed pixels |"
+            echo "| --- | --- | --- |"
+          } >> "$report"
+
+          tmp_old="$(mktemp)"
+          for f in "${changed[@]}"; do
+            [ -f "$f" ] || continue
+            name="${f#browser_tests/}"
+
+            if ! git show "HEAD:$f" > "$tmp_old" 2>/dev/null; then
+              echo "| \`${name}\` | new | n/a |" >> "$report"
+              continue
+            fi
+
+            px=''
+            if command -v compare >/dev/null 2>&1; then
+              px=$(compare -metric AE "$tmp_old" "$f" null: 2>&1 >/dev/null)
+              # Non-numeric means differing geometry or a decode failure.
+              case "$px" in
+                ''|*[!0-9]*) px='' ;;
+              esac
+            fi
+
+            if [ -n "$px" ]; then
+              echo "| \`${name}\` | modified | ${px} |" >> "$report"
+              # Sub-threshold rewrites match the glyph-rasterization signature
+              # rather than an intended visual change. Advisory only.
+              if [ "$px" -gt 0 ] && [ "$px" -le 2000 ]; then
+                small=$((small + 1))
+              fi
+            else
+              old_b=$(wc -c < "$tmp_old" | tr -d ' ')
+              new_b=$(wc -c < "$f" | tr -d ' ')
+              echo "| \`${name}\` | modified | ${old_b}B -> ${new_b}B |" >> "$report"
+            fi
+          done
+          rm -f "$tmp_old"
+
+          if [ "$small" -gt 0 ]; then
+            echo "::warning::${small} rewritten baseline(s) changed by <=2000 pixels. Screenshot capture is not bit-deterministic - small diffs are usually text rasterization noise, not an intended change. Confirm each rewrite corresponds to a test you expected to change before merging."
+          fi
+
+          cat "$report"
+          {
+            echo "### Rewritten snapshots (${#changed[@]})"
+            echo
+            cat "$report"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Commit updated expectations
         id: commit
         run: |
@@ -422,7 +504,23 @@ jobs:
 
           git add browser_tests/
 
-          git commit -m "[automated] Update test expectations"
+          # Carry the magnitude table into the commit body so the numbers live
+          # with the binary diff a reviewer would otherwise have to eyeball.
+          # Built with cat, never a heredoc: the table contains backticks and
+          # arbitrary file names that must not be evaluated by the shell.
+          {
+            echo '[automated] Update test expectations'
+            if [ -s /tmp/diff-report.md ]; then
+              echo
+              cat /tmp/diff-report.md
+              echo
+              echo 'Screenshot capture is not bit-deterministic; small pixel'
+              echo 'deltas are usually text rasterization noise. Confirm each'
+              echo 'rewrite corresponds to a test expected to change.'
+            fi
+          } > /tmp/commit-msg.txt
+
+          git commit -F /tmp/commit-msg.txt
 
           echo "Pushing to ${{ needs.setup.outputs.branch }}..."
           git push origin ${{ needs.setup.outputs.branch }}


### PR DESCRIPTION
Follow-up to #14684, **stacked on it** (base is `ci/fix-update-playwright-expectations-triggers`, so the diff here shows only these two fixes). It auto-retargets to `main` when #14684 merges. Merge #14684 first.

Two more fail-open paths in the same workflow. Same defect class as #14684's bug 1: the run reports success having not done the thing it claims. Neither is a trigger problem, which is why they are here and not there.

## A. Regeneration rewrites baselines that never drifted

Screenshot capture is not bit-deterministic. 12 runs of one mobile pan test against the same container and the same `dist` produced 2 distinct images, minority roughly 1-in-6, differing by 795 pixels — and those pixels are purely **text glyph rasterization**, with layout byte-identical.

Normal e2e absorbs this because the project sets `retries: 3` and re-captures until a comparison passes. Regeneration does not get that protection: `--update-snapshots` **writes** on mismatch, so the committed bytes are one unvalidated capture rather than a stable one.

The consequence that matters is not the noise. It is that this path has **no notion of whether a baseline drifted at all**. It rewrites whatever differs and commits it. So it will just as readily overwrite a baseline that is failing because of a genuine visual regression, laundering the regression into an accepted baseline. The only guard was a human eyeballing binary files — exactly the review that binary diffs defeat.

**Fix chosen: report per-file diff magnitude.** Each rewritten snapshot is measured against `HEAD` with ImageMagick `compare -metric AE`, and the table is published to the step summary *and* into the commit body, so the numbers travel with the binary diff. Rewrites under 2000 pixels raise a `::warning::` — that is the rasterization-noise signature, not an intended visual change.

This would have caught the reported instance outright: 33 of 34 rewritten files corresponded to failing tests; the lone outlier that did not was the bad one, and it is the one that shows up as a small-magnitude rewrite.

**Rejected for now: capture-twice-and-write-on-agreement.** It is the more thorough fix and it removes the noise rather than reporting it. I did not take it here because it roughly doubles a regeneration that already runs ~40 minutes across 5 legs, and because it is a behavioural change to what gets committed that I cannot exercise before merging. Reporting is additive, cannot change what is committed, and turns an unreviewable binary diff into a sortable number today. Capture-twice is the right next step if the noise persists.

Note this fix is deliberately advisory: it does not block the commit. Making a small-magnitude rewrite *fail* would reject legitimate 1-pixel intentional changes, and I would rather not add a false-failure mode to a workflow I cannot test end-to-end.

## B. A dead shard reports success

`continue-on-error: true` on the update-snapshots run is **required** — under `--update-snapshots` a rewritten baseline surfaces as a test failure, so without it every successful regeneration would fail. But it also swallowed genuine breakage. If a shard died (ComfyUI server never came up, wrong container, Playwright crashed), zero snapshots changed, `merge-and-commit` logged "No changes to commit", and the whole run went green having done nothing.

Now the JSON report is retained and checked per shard:

| situation | verdict |
| --- | --- |
| no JSON report written | **error** — the process never completed a run |
| JSON unreadable / no `stats` | **error** |
| tests ran, failures > 0, zero rewritten files | **error** — broken run, not absence of drift |
| tests ran, failures > 0, files rewritten | pass — the normal regeneration path |
| tests ran, all passed, nothing rewritten | pass — genuinely no drift |
| zero tests matched this leg's filters | pass, with a notice |

That last row is why the exit code alone cannot be used, and I only found this by running it: **`--grep` with no matches exits 1 and records a top-level Playwright error**, identical on both counts to a real failure. The `cloud` leg can legitimately match nothing. The discriminator that actually works is the combination of "did the report get written" and "did failures coincide with zero rewrites".

Parsed with `node`, not `jq`: this step runs **inside** the CI container, where node is guaranteed (it just ran pnpm and Playwright) but jq is not.

## Verification

The workflow itself cannot be exercised without merging, for the reason established in #14684. What I *could* execute, I did — against real Playwright output and real images, not mocks:

- **Playwright JSON shape confirmed empirically** by running Playwright locally: `.stats.{expected,unexpected,flaky,skipped}` plus `.errors`. The no-match exit code and the dead-run "no JSON file at all" behaviour were both observed, not assumed — and the first of those invalidated my original design.
- **Shard gate executed against all 6 rows of the table above**, using genuine Playwright report files. Each produced the intended verdict, including the two that must *not* fail.
- **Diff-magnitude step executed on real PNGs in a real git repo**: a 100-pixel change reported exactly `100` and raised the warning; a 3600-pixel change reported exactly `3600` and did not; an untracked file reported `new`; an unchanged file was correctly absent.
- **Commit-body assembly tested for injection**: a report containing `` `a$(touch /tmp/PWNED)b.png` `` and backtick-wrapped names produced the literal text with no evaluation. This is why it is built with `cat` and not a heredoc.
- `yamllint` (the repo's `CI: YAML Validation` gate) passes; `actionlint` v1.7.11 reports no expression or context errors and the same 6 pre-existing `SC2086:info` findings as `main` — zero new. `bash -n` passes on every inline script. Both commits were checked individually, so the intermediate commit is not broken.

**Unverifiable until merge:** that ImageMagick `compare` is present on the runner (documented in the ubuntu runner image; the step degrades to byte sizes and warns if absent, and never fails); that `node` is present in the CI container (it necessarily is, since the preceding steps run pnpm and Playwright); that `--reporter=json,html` alongside `PLAYWRIGHT_JSON_OUTPUT_NAME` behaves in the container as it does locally; and the real end-to-end regeneration.

**Threshold caveat:** 2000 pixels is a heuristic chosen against a single reported 795-pixel instance, not a measured distribution. It only gates an advisory warning, never the commit, so being wrong about it costs noise and not correctness — but it should be revisited once there is more data.
