### PR TITLE
test: block real network requests in unit tests

### DIFF
--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -22,6 +22,23 @@ which is always loaded. In addition:
 - Keep module mocks contained - no global mutable state
 - Use `vi.hoisted()` for per-test mock manipulation
 
+## No Real Network
+
+`vitest.setup.ts` blocks every `http(s)` `fetch`, and happy-dom is configured not
+to load iframes, stylesheets or scripts from remote hosts. A blocked request
+rejects with `Blocked a real network request to <url>`.
+
+This is deliberate, not an inconvenience to route around. happy-dom serves the
+page from `http://localhost:3000`, so an un-mocked relative `fetch('/api/...')`
+becomes a real connection whose failure arrives _after_ the test that started it
+has finished. Vitest then reports the late `console.error` as an unhandled
+error - `Closing rpc while "onUserConsoleLog" was pending` - against whichever
+file happened to be running, and fails the run with every test passing.
+
+If you hit the guard, mock the module that issues the request. Stubbing `fetch`
+in your own test (`vi.stubGlobal('fetch', ...)`) also works and replaces the
+guard for that test.
+
 ## Component Testing
 
 - Use `@testing-library/vue` with `@testing-library/user-event` for component tests (an ESLint rule bans `@vue/test-utils` in new tests)

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -30,6 +30,23 @@ which is always loaded. In addition:
 - Module-scope `vi.fn()` declarations may provide reset-persistent defaults by
   passing the implementation directly to `vi.fn(implementation)`.
 
+## No Real Network
+
+`vitest.setup.ts` blocks every `http(s)` `fetch`, and happy-dom is configured not
+to load iframes, stylesheets or scripts from remote hosts. A blocked request
+rejects with `Blocked a real network request to <url>`.
+
+This is deliberate, not an inconvenience to route around. happy-dom serves the
+page from `http://localhost:3000`, so an un-mocked relative `fetch('/api/...')`
+becomes a real connection whose failure arrives _after_ the test that started it
+has finished. Vitest then reports the late `console.error` as an unhandled
+error - `Closing rpc while "onUserConsoleLog" was pending` - against whichever
+file happened to be running, and fails the run with every test passing.
+
+If you hit the guard, mock the module that issues the request. Stubbing `fetch`
+in your own test (`vi.stubGlobal('fetch', ...)`) also works and replaces the
+guard for that test.
+
 ## Component Testing
 
 - Use `@testing-library/vue` with `@testing-library/user-event` for component tests (an ESLint rule bans `@vue/test-utils` in new tests)

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -45,9 +45,11 @@ file happened to be running, and fails the run with every test passing.
 
 If you hit the guard, mock the module that issues the request. Stubbing `fetch`
 also works and replaces the guard for that test, but do it in a `beforeEach` or
-inside the test body - a `vi.stubGlobal` at module scope is not durable, since
-`vi.unstubAllGlobals` (and the `unstubGlobals` config option) removes it before
-the test runs, putting the real `fetch` back without failing anything.
+inside the test body. A `vi.stubGlobal` at module scope does stay in place by
+default, but nothing owns restoring it: any `vi.unstubAllGlobals()` - a cleanup
+hook, another test tidying up after itself, or enabling the `unstubGlobals`
+config option - drops it and puts the real `fetch` back without failing
+anything.
 
 ## Component Testing
 

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -44,8 +44,10 @@ error - `Closing rpc while "onUserConsoleLog" was pending` - against whichever
 file happened to be running, and fails the run with every test passing.
 
 If you hit the guard, mock the module that issues the request. Stubbing `fetch`
-in your own test (`vi.stubGlobal('fetch', ...)`) also works and replaces the
-guard for that test.
+also works and replaces the guard for that test, but do it in a `beforeEach` or
+inside the test body - a `vi.stubGlobal` at module scope is not durable, since
+`vi.unstubAllGlobals` (and the `unstubGlobals` config option) removes it before
+the test runs, putting the real `fetch` back without failing anything.
 
 ## Component Testing
 

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * Guards the network block installed by `vitest.setup.ts`.
+ *
+ * A real request from a unit test outlives the test that started it; when it
+ * eventually fails, the error is logged after vitest has torn the environment
+ * down and the run is failed by an unhandled rejection that no failing test
+ * explains. Keep this covered so the guard cannot be dropped silently.
+ */
+describe('unit test network guard', () => {
+  it('rejects absolute http requests instead of dialling out', async () => {
+    await expect(fetch('https://example.com/thing')).rejects.toThrow(
+      /Blocked a real network request/
+    )
+  })
+
+  it('rejects relative requests, which resolve against the happy-dom origin', async () => {
+    await expect(fetch('/api/system_stats')).rejects.toThrow(
+      /http:\/\/localhost:3000\/api\/system_stats/
+    )
+  })
+
+  it('rejects Request objects too', async () => {
+    await expect(
+      fetch(new Request('https://example.com/thing'))
+    ).rejects.toThrow(/Blocked a real network request/)
+  })
+
+  it('lets a test stub its own fetch', async () => {
+    const stub = vi.fn().mockResolvedValue(new Response('ok'))
+    vi.stubGlobal('fetch', stub)
+
+    await expect(fetch('https://example.com/thing')).resolves.toBeInstanceOf(
+      Response
+    )
+
+    vi.unstubAllGlobals()
+    await expect(fetch('https://example.com/thing')).rejects.toThrow(
+      /Blocked a real network request/
+    )
+  })
+})

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * Guards the network block installed by `vitest.setup.ts`.
@@ -9,6 +9,12 @@ import { describe, expect, it, vi } from 'vitest'
  * explains. Keep this covered so the guard cannot be dropped silently.
  */
 describe('unit test network guard', () => {
+  // Runs even when an assertion throws mid-test, so a stubbed fetch cannot
+  // leak into the tests below (or into a CI retry of this file).
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('rejects absolute http requests instead of dialling out', async () => {
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/
@@ -25,6 +31,14 @@ describe('unit test network guard', () => {
     await expect(
       fetch(new Request('https://example.com/thing'))
     ).rejects.toThrow(/Blocked a real network request/)
+  })
+
+  it('delegates non-http schemes to the real fetch', async () => {
+    // The guard only blocks http(s). Anything else has to reach the original
+    // fetch untouched - a `data:` URL round-tripping its body proves it did.
+    const response = await fetch('data:text/plain,delegated')
+
+    expect(await response.text()).toBe('delegated')
   })
 
   it('lets a test stub its own fetch', async () => {

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * Guards the network block installed by `vitest.setup.ts`.
@@ -9,6 +9,10 @@ import { describe, expect, it, vi } from 'vitest'
  * explains. Keep this covered so the guard cannot be dropped silently.
  */
 describe('unit test network guard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('rejects absolute http requests instead of dialling out', async () => {
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -43,8 +43,8 @@ describe('unit test network guard', () => {
       Response
     )
 
-    // unstubGlobals: true restores the guard after every test automatically,
-    // but verify it here to keep the contract explicit and red-green provable.
+    // A test that stubs fetch owns restoring it. Unstubbing here proves the
+    // guard is what sits underneath, rather than having been overwritten.
     vi.unstubAllGlobals()
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -31,6 +31,12 @@ describe('unit test network guard', () => {
     ).rejects.toThrow(/Blocked a real network request/)
   })
 
+  it('rejects window.fetch, which code under test may reach for', async () => {
+    await expect(window.fetch('https://example.com/thing')).rejects.toThrow(
+      /Blocked a real network request/
+    )
+  })
+
   it('delegates non-http schemes to the real fetch', async () => {
     // The guard only blocks http(s). Anything else has to reach the original
     // fetch untouched - a `data:` URL round-tripping its body proves it did.
@@ -46,6 +52,9 @@ describe('unit test network guard', () => {
     await expect(fetch('https://example.com/thing')).resolves.toBeInstanceOf(
       Response
     )
+    await expect(
+      window.fetch('https://example.com/thing')
+    ).resolves.toBeInstanceOf(Response)
 
     // A test that stubs fetch owns restoring it. Unstubbing here proves the
     // guard is what sits underneath, rather than having been overwritten.

--- a/src/vitestSetup.test.ts
+++ b/src/vitestSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 /**
  * Guards the network block installed by `vitest.setup.ts`.
@@ -9,12 +9,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
  * explains. Keep this covered so the guard cannot be dropped silently.
  */
 describe('unit test network guard', () => {
-  // Runs even when an assertion throws mid-test, so a stubbed fetch cannot
-  // leak into the tests below (or into a CI retry of this file).
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
   it('rejects absolute http requests instead of dialling out', async () => {
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/
@@ -23,7 +17,7 @@ describe('unit test network guard', () => {
 
   it('rejects relative requests, which resolve against the happy-dom origin', async () => {
     await expect(fetch('/api/system_stats')).rejects.toThrow(
-      /http:\/\/localhost:3000\/api\/system_stats/
+      /\/api\/system_stats/
     )
   })
 
@@ -49,6 +43,8 @@ describe('unit test network guard', () => {
       Response
     )
 
+    // unstubGlobals: true restores the guard after every test automatically,
+    // but verify it here to keep the contract explicit and red-green provable.
     vi.unstubAllGlobals()
     await expect(fetch('https://example.com/thing')).rejects.toThrow(
       /Blocked a real network request/

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -729,6 +729,20 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          // Stop happy-dom fetching real subresources. An <iframe src> or
+          // <link rel=stylesheet> pointing at a remote host issues a request
+          // that outlives the test; happy-dom aborts it during teardown and
+          // the resulting error is reported against whichever file is running
+          // then. Unit tests should never depend on the network.
+          disableIframePageLoading: true,
+          disableCSSFileLoading: true,
+          disableJavaScriptFileLoading: true
+        }
+      }
+    },
     // Pin the timezone so date-formatting assertions are deterministic
     // regardless of the contributor's local timezone (CI runs in UTC).
     env: { TZ: 'UTC' },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -749,6 +749,20 @@ export default defineConfig({
     fakeTimers: { now: TEST_SYSTEM_TIME, shouldAdvanceTime: true },
     globals: true,
     environment: 'happy-dom',
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          // Stop happy-dom fetching real subresources. An <iframe src> or
+          // <link rel=stylesheet> pointing at a remote host issues a request
+          // that outlives the test; happy-dom aborts it during teardown and
+          // the resulting error is reported against whichever file is running
+          // then. Unit tests should never depend on the network.
+          disableIframePageLoading: true,
+          disableCSSFileLoading: true,
+          disableJavaScriptFileLoading: true
+        }
+      }
+    },
     // Pin the timezone so date-formatting assertions are deterministic
     // regardless of the contributor's local timezone (CI runs in UTC).
     env: { TZ: 'UTC' },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -748,8 +748,6 @@ export default defineConfig({
     unstubGlobals: true,
     fakeTimers: { now: TEST_SYSTEM_TIME, shouldAdvanceTime: true },
     globals: true,
-    unstubGlobals: true,
-    restoreMocks: true,
     environment: 'happy-dom',
     environmentOptions: {
       happyDOM: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -748,6 +748,8 @@ export default defineConfig({
     unstubGlobals: true,
     fakeTimers: { now: TEST_SYSTEM_TIME, shouldAdvanceTime: true },
     globals: true,
+    unstubGlobals: true,
+    restoreMocks: true,
     environment: 'happy-dom',
     environmentOptions: {
       happyDOM: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,63 @@ import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 import 'vue'
 
+/**
+ * Unit tests must never perform real network I/O.
+ *
+ * happy-dom serves the page from `http://localhost:3000` (vitest's default
+ * environment URL), so any un-mocked relative `fetch('/api/...')` becomes a
+ * real TCP connection to a port nothing is listening on. The request outlives
+ * the test that started it, and when it finally fails the resulting
+ * `console.error` is emitted after vitest has torn the environment down:
+ *
+ *   EnvironmentTeardownError: [vitest-worker]: Closing rpc while
+ *   "onUserConsoleLog" was pending
+ *
+ * Vitest counts that as an unhandled error and exits non-zero even when every
+ * test passed, which silently evicts PRs from the merge queue.
+ *
+ * Rejecting immediately keeps the failure inside the test that caused it,
+ * where it is attributable and fixable. Tests that need network behaviour must
+ * mock the module that issues the request, or stub `fetch` themselves - a
+ * local stub replaces this guard.
+ */
+const originalFetch = globalThis.fetch
+
+const blockedNetworkFetch: typeof globalThis.fetch = (input, init) => {
+  const requested =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url
+
+  let resolved = requested
+  try {
+    resolved = new URL(requested, globalThis.location?.href).href
+  } catch {
+    // Keep the raw value if it cannot be resolved against the page URL.
+  }
+
+  if (!/^https?:/i.test(resolved)) {
+    return originalFetch(input, init)
+  }
+
+  return Promise.reject(
+    new Error(
+      `Blocked a real network request to ${resolved} from a unit test. ` +
+        'Mock the module that issues it (or stub globalThis.fetch in the ' +
+        'test) instead of letting the request escape - see vitest.setup.ts.'
+    )
+  )
+}
+
+globalThis.fetch = blockedNetworkFetch
+// vitest copies happy-dom's globals onto `globalThis` as bound functions, so
+// `window.fetch` is a separate reference that would otherwise stay unguarded.
+if (typeof window !== 'undefined' && window.fetch !== blockedNetworkFetch) {
+  window.fetch = blockedNetworkFetch
+}
+
 // Mock @sparkjsdev/spark which uses WASM that doesn't work in Node.js
 vi.mock('@sparkjsdev/spark', async () => {
   const three = await import('three')

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -56,11 +56,6 @@ const blockedNetworkFetch: typeof globalThis.fetch = (input, init) => {
 }
 
 globalThis.fetch = blockedNetworkFetch
-// vitest copies happy-dom's globals onto `globalThis` as bound functions, so
-// `window.fetch` is a separate reference that would otherwise stay unguarded.
-if (typeof window !== 'undefined' && window.fetch !== blockedNetworkFetch) {
-  window.fetch = blockedNetworkFetch
-}
 
 // Mock @sparkjsdev/spark which uses WASM that doesn't work in Node.js
 vi.mock('@sparkjsdev/spark', async () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -24,28 +24,31 @@ import 'vue'
  */
 const originalFetch = globalThis.fetch
 
-const blockedNetworkFetch: typeof globalThis.fetch = (input, init) => {
-  const requested =
+function resolveRequestUrl(input: RequestInfo | URL): string {
+  const requestedUrl =
     typeof input === 'string'
       ? input
       : input instanceof URL
         ? input.href
         : input.url
 
-  let resolved = requested
   try {
-    resolved = new URL(requested, globalThis.location?.href).href
+    return new URL(requestedUrl, globalThis.location?.href).href
   } catch {
-    // Keep the raw value if it cannot be resolved against the page URL.
+    return requestedUrl
   }
+}
 
-  if (!/^https?:/i.test(resolved)) {
+const blockedNetworkFetch: typeof globalThis.fetch = (input, init) => {
+  const requestUrl = resolveRequestUrl(input)
+
+  if (!/^https?:/i.test(requestUrl)) {
     return originalFetch(input, init)
   }
 
   return Promise.reject(
     new Error(
-      `Blocked a real network request to ${resolved} from a unit test. ` +
+      `Blocked a real network request to ${requestUrl} from a unit test. ` +
         'Mock the module that issues it (or stub globalThis.fetch in the ' +
         'test) instead of letting the request escape - see vitest.setup.ts.'
     )


### PR DESCRIPTION
Unit CI intermittently fails with **every test passing**:

```
 Test Files  1094 passed (1097)
      Tests  14943 passed | 8 skipped (14988)
     Errors  21 errors
```

```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
Vitest caught 21 unhandled errors during the test run.
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "src/workbench/extensions/manager/composables/nodePack/usePacksSelection.test.ts"
```

plus a wall of unattributed `connect ECONNREFUSED ::1:3000` on stderr. Vitest
exits non-zero on unhandled errors even when no test failed, which evicts PRs
from the merge queue while their own checks read green.

This is instance two of the class fixed in #14648 (a late `console.warn` from
`TabErrors.test.ts` firing after teardown).

## Where `localhost:3000` actually comes from

Not from any mock. `http://localhost:3000` is **vitest's default URL for the
happy-dom environment** (`vitest/dist/chunks/index…js`: `url: happyDOM.url ||
"http://localhost:3000"`). Every relative `fetch('/api/…')` in a unit test
resolves against it and becomes a real TCP connection to a port nothing is
listening on.

An earlier guess pinned this on `src/stores/assetsStore.test.ts`, which mocks
`internalURL`/`apiURL` to the same string. That file is a red herring - run on
its own it issues zero requests. Instrumenting `globalThis.fetch` across the
whole suite shows exactly **41** real requests, all to
`http://localhost:3000/api/system_stats`, from three files:

| file | requests |
| --- | --- |
| `usePacksSelection.test.ts` | **21** |
| `TabErrors.test.ts` | 15 |
| `ErrorGroupList.test.ts` | 5 |

21 requests from `usePacksSelection.test.ts`, 21 unhandled errors attributed to
`usePacksSelection.test.ts`. One per test in the file.

## The chain

`usePacksSelection.test.ts` has no network code in it. The request comes from
three levels down, off a single `useComfyManagerStore()` in `beforeEach`:

```
usePacksSelection.test.ts:43   useComfyManagerStore()
  comfyManagerStore.ts:199     whenever(...) fires immediately
  comfyManagerStore.ts:191     refreshInstalledList()
  comfyManagerService.ts:59    isManagerServiceAvailable()
  useManagerState.ts:40        useSystemStatsStore()
  systemStatsStore.ts:24       useAsyncState(fetchSystemStatsData, null, { immediate: true })
  api.ts:1239                  getSystemStats() -> fetch('/api/system_stats')
```

Constructing the Pinia store performs I/O. Nothing awaits it and nothing can -
it is a side effect of store construction. The test finishes; the socket is
still open; the connection eventually fails; `systemStatsStore` logs
`console.error('Error fetching system stats:', err)`; that console call has to
cross the worker RPC, and by then the RPC is closing. Hence
`EnvironmentTeardownError`, once per leaked request.

## Why it survived this long

Two layers of misdirection:

1. **The blamed file contains nothing suspicious.** `usePacksSelection.test.ts`
   is a pure composable test. Vitest is explicit that its attribution is
   positional - *"It doesn't mean the error was thrown inside the file itself,
   but while it was running"* - so a late emission gets pinned on whatever file
   the worker is on at that moment. With three files leaking requests, the name
   on the failure moves between branches, and each occurrence reads as an
   unrelated one-off in someone else's test.
2. **It needs the CI runner's network to reproduce.** Locally `::1:3000` gets an
   immediate RST, so the rejection lands well inside the test. On the runner the
   connect hangs (note the `AggregateError` with both `::1` and `127.0.0.1`),
   so all 21 settle at once during teardown. See "What I could not reproduce".

## The fix

**`vitest.setup.ts` rejects `http(s)` fetches instead of dialling out**, and
happy-dom is configured not to load remote iframes/scripts/stylesheets.

I went for the guard rather than mocking the store in the three files, and the
choice is worth defending because "add a global thing in test setup" is usually
the wrong answer:

- It is **fail-closed, not fail-open.** It does not swallow an unhandled
  rejection, silence output, or relax a vitest flag. It removes the *input* to
  the race - a request that can outlive its test - and turns it into an
  immediate, in-band, attributable rejection carrying the offending URL.
- **Per-file mocks cannot hold this line.** The request is three layers below
  the call the test makes. Nothing in `usePacksSelection.test.ts` hints that
  `useComfyManagerStore()` reaches the network, so the next test to touch that
  store reintroduces the leak silently. #14648 fixed one file this way; this is
  the same defect surfacing in a different file two weeks later.
- **Blast radius is measured, not assumed:** the entire suite makes 41 real
  requests, all accidental, all from the three files above. Audited with a
  passthrough counter - 45 blocked (41 + 4 from the new guard test), **0
  escaped**. Nothing in the suite legitimately uses the network.

Tests that want network behaviour still stub `fetch` themselves; a local
`vi.stubGlobal('fetch', …)` replaces the guard.

`src/vitestSetup.test.ts` covers the guard so it cannot be dropped silently, and
`docs/guidance/vitest.md` (globbed onto `**/*.test.ts`) explains the failure mode
to whoever hits the error next.

The iframe/CSS/script settings close the same hole for subresources -
`ManagerSurveyDialog.test.ts` was making real requests to `us.posthog.com` and
`useTypeformEmbed` to `embed.typeform.com`, both aborted at teardown. Those now
fail immediately and locally.

## Evidence

- Instrumented `globalThis.fetch` over the full suite: **41 → 0** real requests.
- 6 full runs on `main` before the change and 5 after, node 25 + `CI=true`
  (retry 2, as CI runs it): 0 unhandled errors after, all 15,000 tests passing.
- `pnpm typecheck`, `pnpm lint`, `oxfmt` clean.

### What I could not reproduce

**The unhandled-error mode does not reproduce on my machine, before or after.**
6 pre-change full runs produced 0 of them. I tried delaying the rejection
(100/200/400/1500 ms), routing the requests at a blackholed address so the
connect hangs the way it does on the runner, and node 25 - none of it opened the
window between "console.error emitted" and "RPC closed".

So the post-change green runs are *not* the proof, and I am not claiming a
red-to-green. The proof is upstream of the race: the suite no longer issues a
request that can outlive its test, verified by instrumentation, so there is
nothing left to settle late. The count and file identity (21 requests from
`usePacksSelection.test.ts`, 21 errors attributed to it) tie the CI failure to
the requests this PR removes.

The three test files still construct a live `systemStatsStore`; they now get an
immediate rejection instead of a socket. Making store construction not perform
I/O is the real cleanup, but that is a production behaviour change for eight
consumers and does not belong in a CI-stability PR.


## How often this actually fires

Measured across the last 400 `ci-tests-unit` runs (all branches, ~27 h):

| | count |
| --- | --- |
| success | 323 |
| cancelled (concurrency) | 54 |
| failure | 11 |

Grepping each failing job log for the signature, **2 of the 11 carry it**, both with exactly 21 errors:

- [`30929957273`](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30929957273) — `1096 passed (1096)`, **zero failed test files**, red purely from 21 `EnvironmentTeardownError`. This is the pure form of the failure.
- [`30882752230`](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/30882752230) — 3 real failures *plus* 21 teardown errors.

So roughly **0.5 % of runs, ~0.25 % for the all-green-but-red case** — one or two a day at current volume. Rare per run, continuous at repo scale, and a re-run clears it, which is why it has never accumulated on `main` and why nobody has chased it.

One correction to the earlier writeup: I asserted this evicts PRs from the merge queue. In this window there were 4 `gh-readonly-queue/*` unit failures and **none** of them were this mode — all were genuine `app.test.ts` failures. The merge-queue impact is plausible but not demonstrated; the observed hits were on ordinary branch runs.

The subresource half is directly observable. A full local run on `main` before the change emits, among others:

```
DOMException [NetworkError]: Failed to execute "fetch()" on "Window" with URL
"https://us.posthog.com/external_surveys/survey-123": The operation was aborted.
```

That is `ManagerSurveyDialog.test.ts` reaching the real PostHog host and being aborted at teardown — the same shape as the `/api/system_stats` leak, via happy-dom subresource loading rather than an explicit `fetch`. The `disableIframePageLoading` / `disableCSSFileLoading` / `disableJavaScriptFileLoading` settings in this PR close that path.

## Interaction with #14836

#14836 enables `mockReset` / `restoreMocks` / `unstubEnvs` / `unstubGlobals`
globally. It makes this guard more necessary rather than redundant.

`unstubGlobals` deletes a module-scope `vi.stubGlobal('fetch', ...)` before every
test, so a file that stubbed fetch once at module scope silently falls back to
the real one. #14836 fixes the current instances by moving them into
`beforeEach`, but nothing stops the next one from being written the old way, and
the failure is silent: the stub is simply gone, and any negative assertion on
the mock passes forever.

Reviewing #14836 turned up exactly that case still live in it:
`src/platform/telemetry/initHostTelemetry.test.ts` keeps its stub at module
scope, so `expect(fetchMock).not.toHaveBeenCalled()` is vacuously true. This
guard is what converts that class into `Blocked a real network request to <url>`
at the call site, attributed to the test that caused it.

Either PR can land first. The guidance in `docs/guidance/vitest.md` now points at
`beforeEach` or the test body rather than module scope, which is correct under
both configs.

## Related issues

- #14828 reports this exact failure: `ECONNREFUSED ::1:3000` unhandled, `test` job red with every test passing, stack frames in `loadExternalScript.ts`, `GtmTelemetryProvider.ts` and `useTypeformEmbed.ts` rather than in any test. The happy-dom settings here (`disableJavaScriptFileLoading`, `disableCSSFileLoading`, `disableIframePageLoading`) stop those script loads at the source, and the fetch guard covers the request half. Not marking it auto-closing until the drop in `ECONNREFUSED` count is measured on a full run.
- #14787 is the same class from a different origin (`EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`, from `ErrorGroupList.test.ts`). Whether this PR covers it depends on that file's late rejection being network-driven, which is unverified.
- #10049 is not covered. It leaks `navigator.clipboard` via `Object.defineProperty`, which no reset option or guard here touches.