### PR TITLE
fix: preserve asset subfolder in the assets lightbox

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -226,7 +226,10 @@ import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadat
 import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { getAssetDisplayName } from '@/platform/assets/utils/assetMetadataUtils'
-import { getAssetUrl } from '@/platform/assets/utils/assetUrlUtil'
+import {
+  getAssetSubfolder,
+  getAssetUrl
+} from '@/platform/assets/utils/assetUrlUtil'
 import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import { isCloud } from '@/platform/distribution/types'
@@ -452,7 +455,7 @@ const galleryItems = computed(() => {
     const mediaType = getMediaTypeFromFilename(asset.name)
     const resultItem = new ResultItemImpl({
       filename: asset.name,
-      subfolder: '',
+      subfolder: getAssetSubfolder(asset),
       type: 'output',
       nodeId: '0',
       mediaType: mediaType === 'image' ? 'images' : mediaType

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
@@ -24,6 +24,8 @@ function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
 }
 
 describe('getAssetSubfolder', () => {
+  beforeEach(() => vi.clearAllMocks())
+
   it('reads the subfolder from preview_url', () => {
     const asset = createAsset({
       preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'
@@ -52,9 +54,20 @@ describe('getAssetSubfolder', () => {
 })
 
 describe('getAssetUrl', () => {
+  beforeEach(() => vi.clearAllMocks())
+
   it('includes the subfolder carried by preview_url', () => {
     const asset = createAsset({
       preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'
+    })
+
+    expect(getAssetUrl(asset)).toContain('subfolder=vid%2F2026')
+  })
+
+  it('includes the subfolder taken from the user_metadata fallback', () => {
+    const asset = createAsset({
+      preview_url: '/api/view?filename=clip.webm&type=output',
+      user_metadata: { subfolder: 'vid/2026' }
     })
 
     expect(getAssetUrl(asset)).toContain('subfolder=vid%2F2026')

--- a/src/platform/assets/utils/assetUrlUtil.test.ts
+++ b/src/platform/assets/utils/assetUrlUtil.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import {
+  getAssetSubfolder,
+  getAssetUrl
+} from '@/platform/assets/utils/assetUrlUtil'
+
+const mockApiURL = vi.hoisted(() =>
+  vi.fn((path: string) => `http://localhost:8188/api${path}`)
+)
+
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: mockApiURL }
+}))
+
+function createAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'asset-1',
+    name: 'clip.webm',
+    tags: ['output'],
+    ...overrides
+  } as AssetItem
+}
+
+describe('getAssetSubfolder', () => {
+  it('reads the subfolder from preview_url', () => {
+    const asset = createAsset({
+      preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'
+    })
+
+    expect(getAssetSubfolder(asset)).toBe('vid/2026')
+  })
+
+  it('falls back to user_metadata when preview_url carries no subfolder', () => {
+    const asset = createAsset({
+      preview_url: '/api/view?filename=clip.webm&type=output',
+      user_metadata: { subfolder: 'vid/2026' }
+    })
+
+    expect(getAssetSubfolder(asset)).toBe('vid/2026')
+  })
+
+  it('returns an empty string for an asset at the type root', () => {
+    expect(getAssetSubfolder(createAsset())).toBe('')
+    expect(
+      getAssetSubfolder(
+        createAsset({ user_metadata: { subfolder: undefined } })
+      )
+    ).toBe('')
+  })
+})
+
+describe('getAssetUrl', () => {
+  it('includes the subfolder carried by preview_url', () => {
+    const asset = createAsset({
+      preview_url: '/api/view?filename=clip.webm&type=output&subfolder=vid/2026'
+    })
+
+    expect(getAssetUrl(asset)).toContain('subfolder=vid%2F2026')
+  })
+
+  it('omits the subfolder param for an asset at the type root', () => {
+    expect(getAssetUrl(createAsset())).not.toContain('subfolder')
+  })
+})

--- a/src/platform/assets/utils/assetUrlUtil.ts
+++ b/src/platform/assets/utils/assetUrlUtil.ts
@@ -23,12 +23,31 @@ export function getAssetUrl(
   defaultType: 'input' | 'output' = 'output'
 ): string {
   const assetType = getAssetType(asset, defaultType)
-  const subfolder = asset.user_metadata?.subfolder
+  const subfolder = getAssetSubfolder(asset)
   const params = new URLSearchParams()
   params.set('filename', asset.name)
   params.set('type', assetType)
-  if (typeof subfolder === 'string' && subfolder) {
+  if (subfolder) {
     params.set('subfolder', subfolder)
   }
   return api.apiURL(`/view?${params}`)
+}
+
+/**
+ * Get the subfolder an asset lives in, relative to its type root
+ *
+ * Reads `preview_url` first and falls back to `user_metadata`, mirroring how
+ * {@link getAssetType} resolves the type.
+ *
+ * @param asset The asset to get the subfolder for
+ * @returns The subfolder, or an empty string when the asset is at the root
+ */
+export function getAssetSubfolder(asset: AssetItem): string {
+  const previewSubfolder = new URLSearchParams(
+    (asset.preview_url ?? '').split('?')[1] ?? ''
+  ).get('subfolder')
+  if (previewSubfolder) return previewSubfolder
+
+  const { subfolder } = asset.user_metadata ?? {}
+  return typeof subfolder === 'string' ? subfolder : ''
 }


### PR DESCRIPTION
## Summary

Inspecting a video saved under a subfolder shows an empty player, because the assets lightbox builds its media URL from a subfolder the sidebar discarded.

## Changes

- **What**: `AssetsSidebarTab` built every gallery `ResultItemImpl` with `subfolder: ''` and overrode only the `url` getter. Images resolve through `preview_url` and were unaffected; `ResultVideo` uses `vhsAdvancedPreviewUrl`, which is rebuilt from `urlParams` — i.e. from the discarded subfolder. Extracted `getAssetSubfolder` (reads `preview_url`, falls back to `user_metadata`, mirroring how `getAssetType` resolves the type) and used it when building gallery items and in `getAssetUrl`.

Measured against a local backend — same file, same name, only the address differs:

| Request | Response |
| --- | --- |
| `viewvideo?filename=clip.webm&type=output&subfolder=` (file at output root) | 200, 910017 b |
| `viewvideo?filename=clip.webm&type=output&subfolder=sub` (file in `sub/`) | 200, 910017 b |
| `viewvideo?filename=clip.webm&type=output&subfolder=` (file in `sub/`) | **204, 0 b** |

The endpoint handles subfolders correctly; only the URL the lightbox constructed failed. This also matches the 204 independently reported in #7192, and explains why the same videos play from Job History (which builds result items from real queue data) and why the bug only appears with a `filename_prefix` containing a directory.

## Review Focus

`getAssetSubfolder` prefers `preview_url` over `user_metadata` because `preview_url` is already the trusted source for the `url` getter and for `getAssetType`. `getAssetUrl` previously read `user_metadata` only; that path is preserved as the fallback, so its behaviour is unchanged when `preview_url` carries no subfolder.

Not addressed here, to keep this focused: the same constructor hard-codes `type: 'output'`, which is wrong for imported (input) videos. `ResultItem['type']` is a narrow union while `getAssetType` returns `string`, so that needs its own change. Every case reported in #7192 is an output.

Fixes #7192