### PR TITLE
FE-1251 feat: add flagged payment recovery UI

### DIFF
--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -5,17 +6,59 @@ import { nextTick, ref } from 'vue'
 import CloudRunButtonWrapper from './CloudRunButtonWrapper.vue'
 
 const mockCanRunWorkflows = ref(true)
+const mockBillingStatus = ref<string | null>('paid')
+const state = vi.hoisted(() => ({
+  v1PaymentRecovery: true,
+  canManageSubscription: true,
+  manageSubscription: vi.fn(),
+  showLayoutDialog: vi.fn(),
+  closeDialog: vi.fn()
+}))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    canRunWorkflows: mockCanRunWorkflows
+    canRunWorkflows: mockCanRunWorkflows,
+    billingStatus: mockBillingStatus,
+    manageSubscription: state.manageSubscription
   })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get v1PaymentRecovery() {
+        return state.v1PaymentRecovery
+      }
+    }
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', async () => {
+  const { computed } = await import('vue')
+  return {
+    useWorkspaceUI: () => ({
+      permissions: computed(() => ({
+        canManageSubscription: state.canManageSubscription
+      }))
+    })
+  }
+})
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ showLayoutDialog: state.showLayoutDialog })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ closeDialog: state.closeDialog })
 }))
 
 vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
   default: {
     name: 'ComfyQueueButton',
-    template: '<div data-testid="queue-button" />'
+    props: ['paymentRecoveryLock'],
+    emits: ['paymentRecoveryClick'],
+    template:
+      '<div data-testid="queue-group"><div data-testid="batch-count"/><button data-testid="queue-button" @click="$emit(\'paymentRecoveryClick\')">{{ paymentRecoveryLock ?? \'queue\' }}</button><div data-testid="queue-dropdown"/></div>'
   }
 }))
 
@@ -33,6 +76,10 @@ function renderWrapper() {
 describe('CloudRunButtonWrapper', () => {
   beforeEach(() => {
     mockCanRunWorkflows.value = true
+    mockBillingStatus.value = 'paid'
+    state.v1PaymentRecovery = true
+    state.canManageSubscription = true
+    vi.clearAllMocks()
   })
 
   it('renders the runnable queue button when the subscription is active', () => {
@@ -65,5 +112,65 @@ describe('CloudRunButtonWrapper', () => {
     expect(
       screen.queryByTestId('subscribe-to-run-button')
     ).not.toBeInTheDocument()
+  })
+
+  it('preserves queue controls and opens the owner recovery flow when paused', async () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    renderWrapper()
+
+    expect(screen.getByTestId('batch-count')).toBeInTheDocument()
+    expect(screen.getByTestId('queue-dropdown')).toBeInTheDocument()
+    expect(screen.getByTestId('queue-button')).toHaveTextContent('owner')
+    expect(
+      screen.queryByTestId('subscribe-to-run-button')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('queue-button'))
+    const dialogOptions = state.showLayoutDialog.mock.calls[0][0]
+    expect(dialogOptions.props.canManage).toBe(true)
+
+    dialogOptions.props.onUpdatePayment()
+    expect(state.closeDialog).toHaveBeenCalledWith({
+      key: 'subscription-paused'
+    })
+    expect(state.manageSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('opens member-safe recovery copy without a payment action', async () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    state.canManageSubscription = false
+    renderWrapper()
+
+    expect(screen.getByTestId('queue-button')).toHaveTextContent('member')
+    await userEvent.click(screen.getByTestId('queue-button'))
+
+    const dialogOptions = state.showLayoutDialog.mock.calls[0][0]
+    expect(dialogOptions.props.canManage).toBe(false)
+    dialogOptions.props.onClose()
+    expect(state.closeDialog).toHaveBeenCalledWith({
+      key: 'subscription-paused'
+    })
+    expect(state.manageSubscription).not.toHaveBeenCalled()
+  })
+
+  it('keeps generic inactive behavior when payment recovery is disabled', () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    state.v1PaymentRecovery = false
+    renderWrapper()
+
+    expect(screen.getByTestId('subscribe-to-run-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('queue-group')).not.toBeInTheDocument()
+  })
+
+  it('keeps generic inactive behavior for non-paused statuses', () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'inactive'
+    renderWrapper()
+
+    expect(screen.getByTestId('subscribe-to-run-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('queue-group')).not.toBeInTheDocument()
   })
 })

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -11,6 +11,8 @@ const state = vi.hoisted(() => ({
   v1PaymentRecovery: true,
   canManageSubscription: true,
   manageSubscription: vi.fn(),
+  fetchStatus: vi.fn(),
+  fetchBalance: vi.fn(),
   toastErrorHandler: vi.fn(),
   showLayoutDialog: vi.fn(),
   closeDialog: vi.fn(),
@@ -21,7 +23,9 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     canRunWorkflows: mockCanRunWorkflows,
     billingStatus: mockBillingStatus,
-    manageSubscription: state.manageSubscription
+    manageSubscription: state.manageSubscription,
+    fetchStatus: state.fetchStatus,
+    fetchBalance: state.fetchBalance
   })
 }))
 
@@ -163,6 +167,33 @@ describe('CloudRunButtonWrapper', () => {
 
     expect(state.toastErrorHandler).toHaveBeenCalledWith(error)
     expect(state.closeDialog).not.toHaveBeenCalled()
+  })
+
+  it('refreshes billing once on focus after returning from the portal', async () => {
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    state.fetchStatus.mockImplementationOnce(() => {
+      mockBillingStatus.value = 'paid'
+      mockCanRunWorkflows.value = true
+    })
+    renderWrapper()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment to run' })
+    )
+    const dialog = state.showLayoutDialog.mock.calls[0][0]
+    await dialog.props.onUpdatePayment()
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => {
+      expect(state.fetchStatus).toHaveBeenCalledOnce()
+      expect(state.fetchBalance).toHaveBeenCalledOnce()
+      expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument()
+    })
+
+    window.dispatchEvent(new Event('focus'))
+    expect(state.fetchStatus).toHaveBeenCalledOnce()
+    expect(state.fetchBalance).toHaveBeenCalledOnce()
   })
 
   it('reuses a pending portal request across rapid clicks and reopen', async () => {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -13,7 +13,8 @@ const state = vi.hoisted(() => ({
   manageSubscription: vi.fn(),
   toastErrorHandler: vi.fn(),
   showLayoutDialog: vi.fn(),
-  closeDialog: vi.fn()
+  closeDialog: vi.fn(),
+  updateDialog: vi.fn()
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
@@ -54,7 +55,10 @@ vi.mock('@/services/dialogService', () => ({
 }))
 
 vi.mock('@/stores/dialogStore', () => ({
-  useDialogStore: () => ({ closeDialog: state.closeDialog })
+  useDialogStore: () => ({
+    closeDialog: state.closeDialog,
+    updateDialog: state.updateDialog
+  })
 }))
 
 vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
@@ -63,7 +67,7 @@ vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
     props: ['paymentRecoveryLock'],
     emits: ['paymentRecoveryClick'],
     template:
-      '<div data-testid="queue-group"><div data-testid="batch-count"/><button data-testid="queue-button" @click="$emit(\'paymentRecoveryClick\')">{{ paymentRecoveryLock ?? \'queue\' }}</button><div data-testid="queue-dropdown"/></div>'
+      '<div data-testid="queue-group"><div data-testid="batch-count"/><button data-testid="queue-button" @click="$emit(\'paymentRecoveryClick\')">{{ paymentRecoveryLock === \'owner\' ? \'Update payment to run\' : \'Run\' }}</button><div data-testid="queue-dropdown"/></div>'
   }
 }))
 
@@ -126,12 +130,16 @@ describe('CloudRunButtonWrapper', () => {
 
     expect(screen.getByTestId('batch-count')).toBeInTheDocument()
     expect(screen.getByTestId('queue-dropdown')).toBeInTheDocument()
-    expect(screen.getByTestId('queue-button')).toHaveTextContent('owner')
+    expect(screen.getByTestId('queue-button')).toHaveTextContent(
+      'Update payment to run'
+    )
     expect(
       screen.queryByTestId('subscribe-to-run-button')
     ).not.toBeInTheDocument()
 
-    await userEvent.click(screen.getByTestId('queue-button'))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment to run' })
+    )
     const dialogOptions = state.showLayoutDialog.mock.calls[0][0]
     expect(dialogOptions.props.canManage).toBe(true)
 
@@ -157,13 +165,51 @@ describe('CloudRunButtonWrapper', () => {
     expect(state.closeDialog).not.toHaveBeenCalled()
   })
 
+  it('reuses a pending portal request across rapid clicks and reopen', async () => {
+    let resolvePortal!: () => void
+    state.manageSubscription.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePortal = resolve
+        })
+    )
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    renderWrapper()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment to run' })
+    )
+    const firstDialog = state.showLayoutDialog.mock.calls[0][0]
+    const firstRequest = firstDialog.props.onUpdatePayment()
+    const repeatedRequest = firstDialog.props.onUpdatePayment()
+    expect(state.manageSubscription).toHaveBeenCalledOnce()
+
+    firstDialog.props.onClose()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment to run' })
+    )
+    const reopenedDialog = state.showLayoutDialog.mock.calls.at(-1)?.[0]
+    expect(reopenedDialog.props.isUpdatingPayment).toBe(true)
+    expect(reopenedDialog.props.onUpdatePayment()).toBe(firstRequest)
+    expect(repeatedRequest).toBe(firstRequest)
+    expect(state.manageSubscription).toHaveBeenCalledOnce()
+
+    resolvePortal()
+    await firstRequest
+    expect(state.updateDialog).toHaveBeenLastCalledWith({
+      key: 'subscription-paused',
+      contentProps: { isUpdatingPayment: false }
+    })
+  })
+
   it('opens member-safe recovery copy without a payment action', async () => {
     mockCanRunWorkflows.value = false
     mockBillingStatus.value = 'paused'
     state.canManageSubscription = false
     renderWrapper()
 
-    expect(screen.getByTestId('queue-button')).toHaveTextContent('member')
+    expect(screen.getByTestId('queue-button')).toHaveTextContent('Run')
     await userEvent.click(screen.getByTestId('queue-button'))
 
     const dialogOptions = state.showLayoutDialog.mock.calls[0][0]

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -203,6 +203,35 @@ describe('CloudRunButtonWrapper', () => {
     })
   })
 
+  it('does not update a replacement dialog after unmount', async () => {
+    let resolvePortal!: () => void
+    state.manageSubscription.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePortal = resolve
+        })
+    )
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    const { unmount } = renderWrapper()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment to run' })
+    )
+    const dialog = state.showLayoutDialog.mock.calls[0][0]
+    const portalRequest = dialog.props.onUpdatePayment()
+    unmount()
+
+    resolvePortal()
+    await portalRequest
+    expect(state.closeDialog).not.toHaveBeenCalled()
+    expect(state.updateDialog).toHaveBeenCalledTimes(1)
+    expect(state.updateDialog).toHaveBeenCalledWith({
+      key: 'subscription-paused',
+      contentProps: { isUpdatingPayment: true }
+    })
+  })
+
   it('opens member-safe recovery copy without a payment action', async () => {
     mockCanRunWorkflows.value = false
     mockBillingStatus.value = 'paused'

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   v1PaymentRecovery: true,
   canManageSubscription: true,
   manageSubscription: vi.fn(),
+  toastErrorHandler: vi.fn(),
   showLayoutDialog: vi.fn(),
   closeDialog: vi.fn()
 }))
@@ -31,6 +32,10 @@ vi.mock('@/composables/useFeatureFlags', () => ({
       }
     }
   })
+}))
+
+vi.mock('@/composables/useErrorHandling', () => ({
+  useErrorHandling: () => ({ toastErrorHandler: state.toastErrorHandler })
 }))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', async () => {
@@ -130,11 +135,26 @@ describe('CloudRunButtonWrapper', () => {
     const dialogOptions = state.showLayoutDialog.mock.calls[0][0]
     expect(dialogOptions.props.canManage).toBe(true)
 
-    dialogOptions.props.onUpdatePayment()
+    await dialogOptions.props.onUpdatePayment()
     expect(state.closeDialog).toHaveBeenCalledWith({
       key: 'subscription-paused'
     })
     expect(state.manageSubscription).toHaveBeenCalledOnce()
+  })
+
+  it('keeps recovery open and surfaces portal failures', async () => {
+    const error = new Error('Portal unavailable')
+    state.manageSubscription.mockRejectedValueOnce(error)
+    mockCanRunWorkflows.value = false
+    mockBillingStatus.value = 'paused'
+    renderWrapper()
+
+    await userEvent.click(screen.getByTestId('queue-button'))
+    const dialogOptions = state.showLayoutDialog.mock.calls[0][0]
+    await dialogOptions.props.onUpdatePayment()
+
+    expect(state.toastErrorHandler).toHaveBeenCalledWith(error)
+    expect(state.closeDialog).not.toHaveBeenCalled()
   })
 
   it('opens member-safe recovery copy without a payment action', async () => {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -7,6 +7,7 @@
   <SubscribeToRunButton v-else />
 </template>
 <script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
 import { computed, onUnmounted, ref } from 'vue'
 
 import ComfyQueueButton from '@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'
@@ -20,8 +21,13 @@ import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const DIALOG_KEY = 'subscription-paused'
-const { canRunWorkflows, billingStatus, manageSubscription } =
-  useBillingContext()
+const {
+  canRunWorkflows,
+  billingStatus,
+  manageSubscription,
+  fetchStatus,
+  fetchBalance
+} = useBillingContext()
 const { flags } = useFeatureFlags()
 const { permissions } = useWorkspaceUI()
 const dialogService = useDialogService()
@@ -30,9 +36,16 @@ const { toastErrorHandler } = useErrorHandling()
 const isUpdatingPayment = ref(false)
 let paymentPortalRequest: Promise<void> | null = null
 let isUnmounted = false
+let refreshBillingOnFocus = false
 
 onUnmounted(() => {
   isUnmounted = true
+})
+
+useEventListener(window, 'focus', () => {
+  if (!refreshBillingOnFocus) return
+  refreshBillingOnFocus = false
+  void Promise.allSettled([fetchStatus(), fetchBalance()])
 })
 
 const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
@@ -58,7 +71,10 @@ function updatePayment(): Promise<void> {
     })
     try {
       await manageSubscription()
-      if (!isUnmounted) closePaymentRecoveryDialog()
+      if (!isUnmounted) {
+        refreshBillingOnFocus = true
+        closePaymentRecoveryDialog()
+      }
     } catch (error) {
       if (!isUnmounted) toastErrorHandler(error)
     } finally {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -11,6 +11,7 @@ import { computed } from 'vue'
 
 import ComfyQueueButton from '@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import SubscribeToRunButton from '@/platform/cloud/subscription/components/SubscribeToRun.vue'
 import SubscriptionPausedDialog from '@/platform/workspace/components/SubscriptionPausedDialog.vue'
@@ -25,6 +26,7 @@ const { flags } = useFeatureFlags()
 const { permissions } = useWorkspaceUI()
 const dialogService = useDialogService()
 const dialogStore = useDialogStore()
+const { toastErrorHandler } = useErrorHandling()
 
 const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
   flags.v1PaymentRecovery && billingStatus.value === 'paused'
@@ -38,9 +40,13 @@ function closePaymentRecoveryDialog() {
   dialogStore.closeDialog({ key: DIALOG_KEY })
 }
 
-function updatePayment() {
-  closePaymentRecoveryDialog()
-  void manageSubscription()
+async function updatePayment() {
+  try {
+    await manageSubscription()
+    closePaymentRecoveryDialog()
+  } catch (error) {
+    toastErrorHandler(error)
+  }
 }
 
 function showPaymentRecoveryDialog() {

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -7,7 +7,7 @@
   <SubscribeToRunButton v-else />
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onUnmounted, ref } from 'vue'
 
 import ComfyQueueButton from '@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
@@ -29,6 +29,11 @@ const dialogStore = useDialogStore()
 const { toastErrorHandler } = useErrorHandling()
 const isUpdatingPayment = ref(false)
 let paymentPortalRequest: Promise<void> | null = null
+let isUnmounted = false
+
+onUnmounted(() => {
+  isUnmounted = true
+})
 
 const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
   flags.v1PaymentRecovery && billingStatus.value === 'paused'
@@ -53,16 +58,18 @@ function updatePayment(): Promise<void> {
     })
     try {
       await manageSubscription()
-      closePaymentRecoveryDialog()
+      if (!isUnmounted) closePaymentRecoveryDialog()
     } catch (error) {
-      toastErrorHandler(error)
+      if (!isUnmounted) toastErrorHandler(error)
     } finally {
       isUpdatingPayment.value = false
       paymentPortalRequest = null
-      dialogStore.updateDialog({
-        key: DIALOG_KEY,
-        contentProps: { isUpdatingPayment: false }
-      })
+      if (!isUnmounted) {
+        dialogStore.updateDialog({
+          key: DIALOG_KEY,
+          contentProps: { isUpdatingPayment: false }
+        })
+      }
     }
   })()
 

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -1,19 +1,63 @@
 <template>
-  <component
-    :is="currentButton"
-    :key="canRunWorkflows ? 'queue' : 'subscribe'"
+  <ComfyQueueButton
+    v-if="canRunWorkflows || paymentRecoveryLock"
+    :payment-recovery-lock="paymentRecoveryLock"
+    @payment-recovery-click="showPaymentRecoveryDialog"
   />
+  <SubscribeToRunButton v-else />
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
 
 import ComfyQueueButton from '@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import SubscribeToRunButton from '@/platform/cloud/subscription/components/SubscribeToRun.vue'
+import SubscriptionPausedDialog from '@/platform/workspace/components/SubscriptionPausedDialog.vue'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useDialogService } from '@/services/dialogService'
+import { useDialogStore } from '@/stores/dialogStore'
 
-const { canRunWorkflows } = useBillingContext()
+const DIALOG_KEY = 'subscription-paused'
+const { canRunWorkflows, billingStatus, manageSubscription } =
+  useBillingContext()
+const { flags } = useFeatureFlags()
+const { permissions } = useWorkspaceUI()
+const dialogService = useDialogService()
+const dialogStore = useDialogStore()
 
-const currentButton = computed(() =>
-  canRunWorkflows.value ? ComfyQueueButton : SubscribeToRunButton
+const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
+  flags.v1PaymentRecovery && billingStatus.value === 'paused'
+    ? permissions.value.canManageSubscription
+      ? 'owner'
+      : 'member'
+    : null
 )
+
+function closePaymentRecoveryDialog() {
+  dialogStore.closeDialog({ key: DIALOG_KEY })
+}
+
+function updatePayment() {
+  closePaymentRecoveryDialog()
+  void manageSubscription()
+}
+
+function showPaymentRecoveryDialog() {
+  dialogService.showLayoutDialog({
+    key: DIALOG_KEY,
+    component: SubscriptionPausedDialog,
+    props: {
+      canManage: paymentRecoveryLock.value === 'owner',
+      onClose: closePaymentRecoveryDialog,
+      onUpdatePayment: updatePayment
+    },
+    dialogComponentProps: {
+      renderer: 'reka',
+      headless: true,
+      contentClass:
+        'w-[min(360px,95vw)] max-w-[min(360px,95vw)] sm:max-w-[min(360px,95vw)] border-0 bg-transparent shadow-none'
+    }
+  })
+}
 </script>

--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.vue
@@ -7,7 +7,7 @@
   <SubscribeToRunButton v-else />
 </template>
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import ComfyQueueButton from '@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
@@ -27,6 +27,8 @@ const { permissions } = useWorkspaceUI()
 const dialogService = useDialogService()
 const dialogStore = useDialogStore()
 const { toastErrorHandler } = useErrorHandling()
+const isUpdatingPayment = ref(false)
+let paymentPortalRequest: Promise<void> | null = null
 
 const paymentRecoveryLock = computed<'owner' | 'member' | null>(() =>
   flags.v1PaymentRecovery && billingStatus.value === 'paused'
@@ -40,13 +42,31 @@ function closePaymentRecoveryDialog() {
   dialogStore.closeDialog({ key: DIALOG_KEY })
 }
 
-async function updatePayment() {
-  try {
-    await manageSubscription()
-    closePaymentRecoveryDialog()
-  } catch (error) {
-    toastErrorHandler(error)
-  }
+function updatePayment(): Promise<void> {
+  if (paymentPortalRequest) return paymentPortalRequest
+
+  paymentPortalRequest = (async () => {
+    isUpdatingPayment.value = true
+    dialogStore.updateDialog({
+      key: DIALOG_KEY,
+      contentProps: { isUpdatingPayment: true }
+    })
+    try {
+      await manageSubscription()
+      closePaymentRecoveryDialog()
+    } catch (error) {
+      toastErrorHandler(error)
+    } finally {
+      isUpdatingPayment.value = false
+      paymentPortalRequest = null
+      dialogStore.updateDialog({
+        key: DIALOG_KEY,
+        contentProps: { isUpdatingPayment: false }
+      })
+    }
+  })()
+
+  return paymentPortalRequest
 }
 
 function showPaymentRecoveryDialog() {
@@ -55,6 +75,7 @@ function showPaymentRecoveryDialog() {
     component: SubscriptionPausedDialog,
     props: {
       canManage: paymentRecoveryLock.value === 'owner',
+      isUpdatingPayment: isUpdatingPayment.value,
       onClose: closePaymentRecoveryDialog,
       onUpdatePayment: updatePayment
     },

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.test.ts
@@ -56,6 +56,15 @@ const i18n = createI18n({
         runWorkflow: 'Run workflow',
         runWorkflowFront: 'Run workflow front',
         runWorkflowMissingResources: 'Workflow contains missing resources'
+      },
+      subscription: {
+        paymentRecovery: {
+          ownerRunLabel: 'Update payment to run',
+          memberRunLabel: 'Run',
+          ownerRunTooltip: 'Update payment to restore this subscription',
+          memberRunTooltip:
+            'Ask your workspace owner to restore this subscription'
+        }
       }
     }
   }
@@ -136,7 +145,9 @@ const stubs = {
   DropdownMenuItem: { template: '<div><slot /></div>' }
 }
 
-function renderQueueButton() {
+function renderQueueButton(
+  props: { paymentRecoveryLock?: 'owner' | 'member' } = {}
+) {
   const pinia = createTestingPinia({
     createSpy: vi.fn,
     stubActions: (actionName) => actionName !== 'recordPromptError'
@@ -144,6 +155,7 @@ function renderQueueButton() {
   const user = userEvent.setup()
 
   const result = render(ComfyQueueButton, {
+    props,
     global: {
       plugins: [pinia, i18n],
       directives: {
@@ -164,6 +176,34 @@ describe('ComfyQueueButton', () => {
     expect(controls[0]).toHaveAttribute('data-testid', 'batch-count-edit')
     expect(controls[1]).toHaveAttribute('data-testid', 'queue-button')
   })
+
+  it.for([
+    {
+      paymentRecoveryLock: 'owner',
+      label: 'Update payment to run',
+      variant: 'subscribe'
+    },
+    { paymentRecoveryLock: 'member', label: 'Run', variant: 'secondary' }
+  ] as const)(
+    'keeps the queue group mounted for a paused $paymentRecoveryLock and blocks execution',
+    async ({ paymentRecoveryLock, label, variant }) => {
+      useQueueSettingsStore().mode = 'change'
+      const { user, emitted } = renderQueueButton({ paymentRecoveryLock })
+      const commandStore = useCommandStore()
+
+      expect(screen.getByTestId('batch-count-edit')).toBeInTheDocument()
+      expect(screen.getByTestId('queue-mode-menu-trigger')).toBeDisabled()
+      expect(useQueueSettingsStore().mode).toBe('disabled')
+      const button = screen.getByTestId('queue-button')
+      expect(button).toHaveTextContent(label)
+      expect(button).toHaveAttribute('data-variant', variant)
+
+      await user.click(button)
+
+      expect(commandStore.execute).not.toHaveBeenCalled()
+      expect(emitted()).toHaveProperty('paymentRecoveryClick')
+    }
+  )
 
   it.for(missingResourceCases)(
     'clears the warning icon when missing $label are resolved',

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -24,6 +24,7 @@
         <Button
           variant="secondary"
           size="unset"
+          :disabled="Boolean(paymentRecoveryLock)"
           :class="queueMenuTriggerClass"
           :aria-label="t('menu.run')"
           data-testid="queue-mode-menu-trigger"
@@ -71,7 +72,7 @@ import {
   DropdownMenuTrigger
 } from 'reka-ui'
 import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import BatchCountEdit from '@/components/actionbar/BatchCountEdit.vue'
@@ -96,6 +97,22 @@ const { hasMissingError } = storeToRefs(useExecutionErrorStore())
 
 const { t } = useI18n()
 type QueueModeMenuKey = 'disabled' | 'change' | 'instant-idle'
+type PaymentRecoveryLock = 'owner' | 'member'
+
+const { paymentRecoveryLock = null } = defineProps<{
+  paymentRecoveryLock?: PaymentRecoveryLock | null
+}>()
+const emit = defineEmits<{
+  paymentRecoveryClick: []
+}>()
+
+watch(
+  () => paymentRecoveryLock,
+  (lock) => {
+    if (lock) queueMode.value = 'disabled'
+  },
+  { immediate: true }
+)
 
 interface QueueModeMenuItem {
   key: QueueModeMenuKey
@@ -167,13 +184,25 @@ const isStopInstantAction = computed(() =>
 )
 
 const queueButtonLabel = computed(() =>
-  isStopInstantAction.value
-    ? t('menu.stopRunInstant')
-    : String(activeQueueModeMenuItem.value?.label ?? '')
+  paymentRecoveryLock === 'owner'
+    ? t('subscription.paymentRecovery.ownerRunLabel')
+    : paymentRecoveryLock === 'member'
+      ? t('subscription.paymentRecovery.memberRunLabel')
+      : isStopInstantAction.value
+        ? t('menu.stopRunInstant')
+        : String(activeQueueModeMenuItem.value?.label ?? '')
 )
 
-const queueButtonVariant = computed<'destructive' | 'primary'>(() =>
-  isStopInstantAction.value ? 'destructive' : 'primary'
+const queueButtonVariant = computed<
+  'destructive' | 'primary' | 'secondary' | 'subscribe'
+>(() =>
+  paymentRecoveryLock === 'owner'
+    ? 'subscribe'
+    : paymentRecoveryLock === 'member'
+      ? 'secondary'
+      : isStopInstantAction.value
+        ? 'destructive'
+        : 'primary'
 )
 const queueActionButtonClass = 'h-full rounded-lg gap-1.5 px-4 font-light'
 const queueMenuTriggerClass =
@@ -181,6 +210,9 @@ const queueMenuTriggerClass =
 const queueMenuItemButtonClass = 'w-full justify-start font-normal'
 
 const iconClass = computed(() => {
+  if (paymentRecoveryLock) {
+    return 'icon-[lucide--lock]'
+  }
   if (isStopInstantAction.value) {
     return 'icon-[lucide--square]'
   }
@@ -203,6 +235,12 @@ const iconClass = computed(() => {
 })
 
 const queueButtonTooltip = computed(() => {
+  if (paymentRecoveryLock === 'owner') {
+    return t('subscription.paymentRecovery.ownerRunTooltip')
+  }
+  if (paymentRecoveryLock === 'member') {
+    return t('subscription.paymentRecovery.memberRunTooltip')
+  }
   if (isStopInstantAction.value) {
     return t('menu.stopRunInstantTooltip')
   }
@@ -217,6 +255,10 @@ const queueButtonTooltip = computed(() => {
 
 const commandStore = useCommandStore()
 const queuePrompt = async (e: Event) => {
+  if (paymentRecoveryLock) {
+    emit('paymentRecoveryClick')
+    return
+  }
   if (isStopInstantAction.value) {
     queueMode.value = 'instant-idle'
     return

--- a/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
+++ b/src/components/actionbar/ComfyRunButton/ComfyQueueButton.vue
@@ -10,7 +10,12 @@
       }"
       :variant="queueButtonVariant"
       size="unset"
-      :class="queueActionButtonClass"
+      :class="
+        cn(
+          'h-full gap-1.5 rounded-lg px-4',
+          paymentRecoveryLock ? 'font-medium' : 'font-light'
+        )
+      "
       data-testid="queue-button"
       :data-variant="queueButtonVariant"
       @click="queuePrompt"
@@ -204,7 +209,6 @@ const queueButtonVariant = computed<
         ? 'destructive'
         : 'primary'
 )
-const queueActionButtonClass = 'h-full rounded-lg gap-1.5 px-4 font-light'
 const queueMenuTriggerClass =
   'h-full w-6 rounded-l-none rounded-r-lg border-l border-border-subtle p-0 text-muted-foreground data-[state=open]:bg-secondary-background-hover'
 const queueMenuItemButtonClass = 'w-full justify-start font-normal'

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -10,6 +10,7 @@ import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
   cachedTeamWorkspacesEnabled,
+  cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigState
 } from '@/platform/remoteConfig/remoteConfig'
@@ -286,6 +287,14 @@ describe('useFeatureFlags', () => {
       expect(flags.billingControlEnabled).toBe(true)
     })
 
+    it('v1PaymentRecovery uses the normal local development override', () => {
+      vi.mocked(distributionTypes).isCloud = false
+      localStorage.setItem('ff:v1_payment_recovery', 'true')
+
+      const { flags } = useFeatureFlags()
+      expect(flags.v1PaymentRecovery).toBe(true)
+    })
+
     it('consolidatedBillingEnabled override bypasses isCloud and isAuthenticatedConfigLoaded guards', () => {
       vi.mocked(distributionTypes).isCloud = false
       localStorage.setItem('ff:consolidated_billing_enabled', 'true')
@@ -311,6 +320,7 @@ describe('useFeatureFlags', () => {
       cachedTeamWorkspacesEnabled.value = undefined
       cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
+      cachedV1PaymentRecovery.value = undefined
       localStorage.clear()
     })
 
@@ -321,6 +331,7 @@ describe('useFeatureFlags', () => {
       cachedTeamWorkspacesEnabled.value = undefined
       cachedConsolidatedBillingEnabled.value = undefined
       cachedBillingControlEnabled.value = undefined
+      cachedV1PaymentRecovery.value = undefined
       localStorage.clear()
     })
 
@@ -328,11 +339,13 @@ describe('useFeatureFlags', () => {
       cachedTeamWorkspacesEnabled.value = false
       cachedConsolidatedBillingEnabled.value = true
       cachedBillingControlEnabled.value = true
+      cachedV1PaymentRecovery.value = true
 
       const { flags } = useFeatureFlags()
       expect(flags.teamWorkspacesEnabled).toBe(false)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
+      expect(flags.v1PaymentRecovery).toBe(true)
     })
 
     it('defaults to false during the auth window when nothing is cached', () => {
@@ -340,6 +353,7 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(false)
       expect(flags.consolidatedBillingEnabled).toBe(false)
       expect(flags.billingControlEnabled).toBe(false)
+      expect(flags.v1PaymentRecovery).toBe(false)
     })
 
     it('prefers authenticated remoteConfig over the server feature fallback', () => {
@@ -347,7 +361,8 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {
         team_workspaces_enabled: true,
         consolidated_billing_enabled: true,
-        billing_control_enabled: false
+        billing_control_enabled: false,
+        v1_payment_recovery: true
       }
       vi.mocked(api.getServerFeature).mockReturnValue(false)
 
@@ -355,6 +370,7 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(true)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(false)
+      expect(flags.v1PaymentRecovery).toBe(true)
     })
 
     it('falls back to api.getServerFeature when authenticated config omits the flag', () => {
@@ -366,6 +382,7 @@ describe('useFeatureFlags', () => {
           if (path === ServerFeatureFlag.CONSOLIDATED_BILLING_ENABLED)
             return true
           if (path === ServerFeatureFlag.BILLING_CONTROL_ENABLED) return true
+          if (path === ServerFeatureFlag.V1_PAYMENT_RECOVERY) return true
           return defaultValue
         }
       )
@@ -374,6 +391,7 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(true)
       expect(flags.consolidatedBillingEnabled).toBe(true)
       expect(flags.billingControlEnabled).toBe(true)
+      expect(flags.v1PaymentRecovery).toBe(true)
     })
   })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -6,6 +6,7 @@ import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
   cachedTeamWorkspacesEnabled,
+  cachedV1PaymentRecovery,
   isAuthenticatedConfigLoaded,
   remoteConfig
 } from '@/platform/remoteConfig/remoteConfig'
@@ -36,6 +37,7 @@ export enum ServerFeatureFlag {
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
   CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
+  V1_PAYMENT_RECOVERY = 'v1_payment_recovery',
   FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
   CHURNKEY_APP_ID = 'churnkey_app_id',
   SIGNUP_TURNSTILE = 'signup_turnstile',
@@ -221,6 +223,13 @@ export function useFeatureFlags() {
         ServerFeatureFlag.BILLING_CONTROL_ENABLED,
         remoteConfig.value.billing_control_enabled,
         cachedBillingControlEnabled
+      )
+    },
+    get v1PaymentRecovery() {
+      return resolveAuthGatedFlag(
+        ServerFeatureFlag.V1_PAYMENT_RECOVERY,
+        remoteConfig.value.v1_payment_recovery,
+        cachedV1PaymentRecovery
       )
     },
     get freeTierJobAllowanceEnabled() {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3005,7 +3005,6 @@
     "billingStatus": {
       "warning": {
         "title": "Payment failed",
-        "body": "Your payment failed to process. Your subscription will pause on {date} unless payment is updated.",
         "bodyNoDate": "Your payment failed to process. Update payment to avoid a pause."
       },
       "paused": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2803,6 +2803,17 @@
       "memberRunTooltip": "Contact your workspace owner to resubscribe",
       "runLabel": "Run"
     },
+    "paymentRecovery": {
+      "title": "Subscription paused",
+      "ownerDescription": "Update your payment method to restore the workspace's subscription and run workflows.",
+      "memberDescription": "Ask your workspace owner to restore the workspace's subscription.",
+      "ownerCta": "Update payment",
+      "memberCta": "Ok, got it",
+      "ownerRunLabel": "Update payment to run",
+      "memberRunLabel": "Run",
+      "ownerRunTooltip": "Update payment to restore this subscription",
+      "memberRunTooltip": "Ask your workspace owner to restore this subscription"
+    },
     "subscribeToRun": "Subscribe",
     "subscribeToRunFull": "Subscribe to Run",
     "subscribeForMore": "Upgrade",
@@ -2993,14 +3004,14 @@
     },
     "billingStatus": {
       "warning": {
-        "title": "Payment declined",
-        "body": "Your last payment didn't go through. Your subscription will pause on {date} unless payment is updated.",
-        "bodyNoDate": "Your last payment didn't go through. Update payment to avoid a pause."
+        "title": "Payment failed",
+        "body": "Your payment failed to process. Your subscription will pause on {date} unless payment is updated.",
+        "bodyNoDate": "Your payment failed to process. Update payment to avoid a pause."
       },
       "paused": {
         "title": "Subscription paused",
         "body": "This workspace's subscription is paused. Update payment to resume.",
-        "memberBody": "This workspace's subscription is paused. Your workspace admins need to update the payment method."
+        "memberBody": "Ask your workspace owner to restore the workspace's subscription."
       },
       "outOfCredits": {
         "title": "Out of credits",

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -2,6 +2,7 @@ import {
   cachedBillingControlEnabled,
   cachedConsolidatedBillingEnabled,
   cachedTeamWorkspacesEnabled,
+  cachedV1PaymentRecovery,
   remoteConfig,
   remoteConfigState
 } from './remoteConfig'
@@ -67,6 +68,7 @@ export async function refreshRemoteConfig(
         cachedBillingControlEnabled.value = Boolean(
           config.billing_control_enabled
         )
+        cachedV1PaymentRecovery.value = Boolean(config.v1_payment_recovery)
       }
       return
     }

--- a/src/platform/remoteConfig/remoteConfig.ts
+++ b/src/platform/remoteConfig/remoteConfig.ts
@@ -69,3 +69,8 @@ export const cachedBillingControlEnabled = useStorage<boolean | undefined>(
   'billing_control_enabled' satisfies `${ServerFeatureFlag.BILLING_CONTROL_ENABLED}`,
   undefined
 )
+
+export const cachedV1PaymentRecovery = useStorage<boolean | undefined>(
+  'v1_payment_recovery' satisfies `${ServerFeatureFlag.V1_PAYMENT_RECOVERY}`,
+  undefined
+)

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -124,6 +124,7 @@ export type RemoteConfig = {
   unified_cloud_auth?: boolean
   consolidated_billing_enabled?: boolean
   billing_control_enabled?: boolean
+  v1_payment_recovery?: boolean
   churnkey_app_id?: string
   sentry_dsn?: string
   turnstile_sitekey?: string

--- a/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
@@ -26,11 +26,11 @@ const i18n = createI18n({
   }
 })
 
-function renderDialog(canManage: boolean) {
+function renderDialog(canManage: boolean, isUpdatingPayment = false) {
   const onClose = vi.fn()
   const onUpdatePayment = vi.fn()
   render(SubscriptionPausedDialog, {
-    props: { canManage, onClose, onUpdatePayment },
+    props: { canManage, isUpdatingPayment, onClose, onUpdatePayment },
     global: { plugins: [i18n] }
   })
   return { onClose, onUpdatePayment }
@@ -72,5 +72,13 @@ describe('SubscriptionPausedDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('disables the owner action while payment recovery is pending', () => {
+    renderDialog(true, true)
+
+    expect(
+      screen.getByRole('button', { name: 'Update payment' })
+    ).toBeDisabled()
   })
 })

--- a/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
@@ -65,4 +65,12 @@ describe('SubscriptionPausedDialog', () => {
     expect(onClose).toHaveBeenCalledOnce()
     expect(onUpdatePayment).not.toHaveBeenCalled()
   })
+
+  it('closes from the visible close button', async () => {
+    const { onClose } = renderDialog(true)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
 })

--- a/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.test.ts
@@ -1,0 +1,68 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SubscriptionPausedDialog from './SubscriptionPausedDialog.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { close: 'Close' },
+      subscription: {
+        paymentRecovery: {
+          title: 'Subscription paused',
+          ownerDescription:
+            "Update your payment method to restore the workspace's subscription and run workflows.",
+          memberDescription:
+            "Ask your workspace owner to restore the workspace's subscription.",
+          ownerCta: 'Update payment',
+          memberCta: 'Ok, got it'
+        }
+      }
+    }
+  }
+})
+
+function renderDialog(canManage: boolean) {
+  const onClose = vi.fn()
+  const onUpdatePayment = vi.fn()
+  render(SubscriptionPausedDialog, {
+    props: { canManage, onClose, onUpdatePayment },
+    global: { plugins: [i18n] }
+  })
+  return { onClose, onUpdatePayment }
+}
+
+describe('SubscriptionPausedDialog', () => {
+  it('gives owners a payment recovery action', async () => {
+    const { onUpdatePayment } = renderDialog(true)
+
+    expect(screen.getByText('Subscription paused')).toBeInTheDocument()
+    expect(screen.getByText(/Update your payment method/)).toBeInTheDocument()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update payment' })
+    )
+
+    expect(onUpdatePayment).toHaveBeenCalledOnce()
+  })
+
+  it('gives members privacy-safe copy and no payment action', async () => {
+    const { onClose, onUpdatePayment } = renderDialog(false)
+
+    expect(
+      screen.getByText(
+        "Ask your workspace owner to restore the workspace's subscription."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Update payment' })
+    ).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Ok, got it' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onUpdatePayment).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionPausedDialog.vue
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.vue
@@ -32,7 +32,7 @@
 
     <div class="flex items-center justify-end p-4">
       <Button
-        :variant="canManage ? 'subscribe' : 'secondary'"
+        :variant="canManage ? 'inverted' : 'secondary'"
         size="lg"
         :disabled="canManage && isUpdatingPayment"
         @click="canManage ? onUpdatePayment() : onClose()"

--- a/src/platform/workspace/components/SubscriptionPausedDialog.vue
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.vue
@@ -1,0 +1,59 @@
+<template>
+  <div
+    class="flex flex-col overflow-hidden rounded-2xl border border-border-default bg-base-background"
+  >
+    <div
+      class="flex h-12 items-center gap-2 border-b border-border-default p-4"
+    >
+      <p class="m-0 min-w-0 flex-1 font-inter text-sm text-base-foreground">
+        {{ $t('subscription.paymentRecovery.title') }}
+      </p>
+      <button
+        type="button"
+        :aria-label="$t('g.close')"
+        class="flex size-4 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent text-base-foreground hover:text-muted-foreground"
+        @click="onClose"
+      >
+        <i class="pi pi-times text-xs" />
+      </button>
+    </div>
+
+    <div class="p-4">
+      <p class="m-0 font-inter text-sm text-muted-foreground">
+        {{
+          $t(
+            canManage
+              ? 'subscription.paymentRecovery.ownerDescription'
+              : 'subscription.paymentRecovery.memberDescription'
+          )
+        }}
+      </p>
+    </div>
+
+    <div class="flex items-center justify-end p-4">
+      <Button
+        :variant="canManage ? 'subscribe' : 'secondary'"
+        size="lg"
+        @click="canManage ? onUpdatePayment() : onClose()"
+      >
+        {{
+          $t(
+            canManage
+              ? 'subscription.paymentRecovery.ownerCta'
+              : 'subscription.paymentRecovery.memberCta'
+          )
+        }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+const { canManage, onClose, onUpdatePayment } = defineProps<{
+  canManage: boolean
+  onClose: () => void
+  onUpdatePayment: () => void
+}>()
+</script>

--- a/src/platform/workspace/components/SubscriptionPausedDialog.vue
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.vue
@@ -34,17 +34,13 @@
       <Button
         :variant="canManage ? 'subscribe' : 'secondary'"
         size="lg"
-        :loading="canManage && isUpdatingPayment"
         :disabled="canManage && isUpdatingPayment"
-        :aria-label="
-          $t(
-            canManage
-              ? 'subscription.paymentRecovery.ownerCta'
-              : 'subscription.paymentRecovery.memberCta'
-          )
-        "
         @click="canManage ? onUpdatePayment() : onClose()"
       >
+        <i
+          v-if="canManage && isUpdatingPayment"
+          class="pi pi-spin pi-spinner"
+        />
         {{
           $t(
             canManage

--- a/src/platform/workspace/components/SubscriptionPausedDialog.vue
+++ b/src/platform/workspace/components/SubscriptionPausedDialog.vue
@@ -34,6 +34,15 @@
       <Button
         :variant="canManage ? 'subscribe' : 'secondary'"
         size="lg"
+        :loading="canManage && isUpdatingPayment"
+        :disabled="canManage && isUpdatingPayment"
+        :aria-label="
+          $t(
+            canManage
+              ? 'subscription.paymentRecovery.ownerCta'
+              : 'subscription.paymentRecovery.memberCta'
+          )
+        "
         @click="canManage ? onUpdatePayment() : onClose()"
       >
         {{
@@ -51,8 +60,14 @@
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
 
-const { canManage, onClose, onUpdatePayment } = defineProps<{
+const {
+  canManage,
+  isUpdatingPayment = false,
+  onClose,
+  onUpdatePayment
+} = defineProps<{
   canManage: boolean
+  isUpdatingPayment?: boolean
   onClose: () => void
   onUpdatePayment: () => void
 }>()

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -18,6 +18,7 @@ interface Subscription {
 
 const state = vi.hoisted(() => ({
   billingControlEnabled: true,
+  v1PaymentRecovery: true,
   isActiveSubscription: true,
   isTeamPlan: true,
   billingStatus: 'paid' as string | null,
@@ -43,6 +44,9 @@ vi.mock('@/composables/useFeatureFlags', () => ({
     flags: {
       get billingControlEnabled() {
         return state.billingControlEnabled
+      },
+      get v1PaymentRecovery() {
+        return state.v1PaymentRecovery
       }
     }
   })
@@ -55,7 +59,9 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     billingStatus: computed(() => state.billingStatus as BillingStatus | null),
     subscription: computed(() => state.subscription),
     renewalDate: computed(() => state.renewalDate),
-    manageSubscription: state.manageSubscription
+    manageSubscription: state.manageSubscription,
+    fetchStatus: vi.fn(),
+    fetchBalance: vi.fn()
   })
 }))
 
@@ -91,16 +97,16 @@ const i18n = createI18n({
       workspacePanel: {
         billingStatus: {
           warning: {
-            title: 'Payment declined',
-            body: "Your last payment didn't go through. Your subscription will pause on {date} unless payment is updated.",
+            title: 'Payment failed',
+            body: 'Your payment failed to process. Your subscription will pause on {date} unless payment is updated.',
             bodyNoDate:
-              "Your last payment didn't go through. Update payment to avoid a pause."
+              'Your payment failed to process. Update payment to avoid a pause.'
           },
           paused: {
             title: 'Subscription paused',
             body: "This workspace's subscription is paused. Update payment to resume.",
             memberBody:
-              "This workspace's subscription is paused. Your workspace admins need to update the payment method."
+              "Ask your workspace owner to restore the workspace's subscription."
           },
           outOfCredits: {
             title: 'Out of credits',
@@ -159,6 +165,7 @@ function paymentFailedState() {
 describe('BillingStatusBanner', () => {
   beforeEach(() => {
     state.billingControlEnabled = true
+    state.v1PaymentRecovery = true
     state.isActiveSubscription = true
     state.isTeamPlan = true
     state.billingStatus = 'paid'
@@ -251,17 +258,17 @@ describe('BillingStatusBanner', () => {
     renderBanner()
 
     expect(screen.getByRole('status')).toHaveTextContent(
-      'Your workspace admins need to update the payment method'
+      "Ask your workspace owner to restore the workspace's subscription"
     )
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('shows the payment-declined banner with Update payment for owners', () => {
+  it('shows the payment-failed banner with Update payment for owners', () => {
     paymentFailedState()
     state.renewalDate = '2026-08-01T00:00:00Z'
     renderBanner()
 
-    expect(screen.getByRole('status')).toHaveTextContent('Payment declined')
+    expect(screen.getByRole('status')).toHaveTextContent('Payment failed')
     expect(screen.getByRole('status')).toHaveTextContent(/will pause on \S+/)
     expect(screen.getByRole('status')).not.toHaveTextContent('{date}')
     expect(
@@ -279,6 +286,20 @@ describe('BillingStatusBanner', () => {
       screen.queryByRole('button', { name: 'Update payment' })
     ).not.toBeInTheDocument()
     expect(state.manageSubscription).not.toHaveBeenCalled()
+  })
+
+  it('hides payment recovery states while preserving existing notices when the new flag is off', () => {
+    state.v1PaymentRecovery = false
+    paymentFailedState()
+    const { unmount } = renderBanner()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    unmount()
+
+    state.isActiveSubscription = true
+    state.billingStatus = 'paid'
+    exhausted()
+    renderBanner()
+    expect(screen.getByRole('status')).toHaveTextContent('Out of credits')
   })
 
   it('falls back to the no-date payment-declined copy when there is no renewal date', () => {

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -98,7 +98,6 @@ const i18n = createI18n({
         billingStatus: {
           warning: {
             title: 'Payment failed',
-            body: 'Your payment failed to process. Your subscription will pause on {date} unless payment is updated.',
             bodyNoDate:
               'Your payment failed to process. Update payment to avoid a pause.'
           },
@@ -263,14 +262,16 @@ describe('BillingStatusBanner', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  it('shows the payment-failed banner with Update payment for owners', () => {
+  it('shows immediate payment-failed copy with Update payment for owners', () => {
     paymentFailedState()
     state.renewalDate = '2026-08-01T00:00:00Z'
     renderBanner()
 
     expect(screen.getByRole('status')).toHaveTextContent('Payment failed')
-    expect(screen.getByRole('status')).toHaveTextContent(/will pause on \S+/)
-    expect(screen.getByRole('status')).not.toHaveTextContent('{date}')
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Update payment to avoid a pause'
+    )
+    expect(screen.getByRole('status')).not.toHaveTextContent('will pause on')
     expect(
       screen.getByRole('button', { name: 'Update payment' })
     ).toBeInTheDocument()
@@ -300,18 +301,6 @@ describe('BillingStatusBanner', () => {
     exhausted()
     renderBanner()
     expect(screen.getByRole('status')).toHaveTextContent('Out of credits')
-  })
-
-  it('falls back to the no-date payment-declined copy when there is no renewal date', () => {
-    paymentFailedState()
-    state.renewalDate = null
-    renderBanner()
-
-    expect(screen.getByRole('status')).toHaveTextContent(
-      'Update payment to avoid a pause'
-    )
-    expect(screen.getByRole('status')).not.toHaveTextContent('will pause on')
-    expect(screen.getByRole('status')).not.toHaveTextContent('{date}')
   })
 
   it('lets a promoted owner reactivate an ending plan', async () => {

--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.vue
@@ -125,9 +125,7 @@ const banner = computed<BannerView | null>(() => {
       return {
         muted: false,
         title: t(`${bs}.warning.title`),
-        body: cycleResetDate.value
-          ? t(`${bs}.warning.body`, { date: cycleResetDate.value })
-          : t(`${bs}.warning.bodyNoDate`),
+        body: t(`${bs}.warning.bodyNoDate`),
         action: 'updatePayment',
         dismissible: false
       }

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -5,6 +5,7 @@ import { deriveBillingBanner } from './useBillingBanner'
 
 const funded: BillingBannerInputs = {
   billingControlEnabled: true,
+  v1PaymentRecovery: true,
   isTeamPlan: true,
   isLoaded: true,
   isActiveSubscription: true,
@@ -43,8 +44,25 @@ describe('deriveBillingBanner', () => {
     expect(derive({ isTeamPlan: false, hasFunds: false })).toBeNull()
   })
 
-  it('shows no banner when billing control is rolled back, even out of credits', () => {
+  it('hides existing notices when billing control is rolled back', () => {
     expect(derive({ billingControlEnabled: false, hasFunds: false })).toBeNull()
+  })
+
+  it('keeps payment recovery independent from billing control', () => {
+    expect(derive({ ...paymentFailed, billingControlEnabled: false })).toBe(
+      'paymentFailed'
+    )
+  })
+
+  it('hides payment recovery states when their flag is off', () => {
+    expect(derive({ ...paymentFailed, v1PaymentRecovery: false })).toBeNull()
+    expect(derive({ ...paused, v1PaymentRecovery: false })).toBeNull()
+  })
+
+  it('does not move existing notices onto the payment recovery flag', () => {
+    expect(derive({ hasFunds: false, v1PaymentRecovery: false })).toBe(
+      'outOfCredits'
+    )
   })
 
   it('shows no banner until the subscription snapshot has loaded', () => {

--- a/src/platform/workspace/composables/useBillingBanner.test.ts
+++ b/src/platform/workspace/composables/useBillingBanner.test.ts
@@ -7,8 +7,11 @@ const mocks = vi.hoisted(() => ({
     isTeamPlan: { value: boolean }
     billingStatus: { value: string | null }
     subscription: { value: { hasFunds: boolean } | null }
+    fetchStatus: ReturnType<typeof vi.fn>
+    fetchBalance: ReturnType<typeof vi.fn>
   } | null,
-  billingControlEnabled: null as { value: boolean } | null
+  billingControlEnabled: null as { value: boolean } | null,
+  v1PaymentRecovery: null as { value: boolean } | null
 }))
 
 vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
@@ -16,12 +19,17 @@ vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 vi.mock('@/composables/useFeatureFlags', async () => {
   const { ref } = await import('vue')
   const billingControlEnabled = ref(true)
+  const v1PaymentRecovery = ref(true)
   mocks.billingControlEnabled = billingControlEnabled
+  mocks.v1PaymentRecovery = v1PaymentRecovery
   return {
     useFeatureFlags: () => ({
       flags: {
         get billingControlEnabled() {
           return billingControlEnabled.value
+        },
+        get v1PaymentRecovery() {
+          return v1PaymentRecovery.value
         }
       }
     })
@@ -34,7 +42,9 @@ vi.mock('@/composables/billing/useBillingContext', async () => {
     isActiveSubscription: ref(true),
     isTeamPlan: ref(true),
     billingStatus: ref<string | null>('paid'),
-    subscription: ref<{ hasFunds: boolean } | null>({ hasFunds: true })
+    subscription: ref<{ hasFunds: boolean } | null>({ hasFunds: true }),
+    fetchStatus: vi.fn(),
+    fetchBalance: vi.fn()
   }
   mocks.billing = billing
   return { useBillingContext: () => billing }
@@ -63,6 +73,9 @@ describe('useBillingBanner', () => {
     b.billingStatus.value = 'paid'
     b.subscription.value = { hasFunds: true }
     mocks.billingControlEnabled!.value = true
+    mocks.v1PaymentRecovery!.value = true
+    b.fetchStatus.mockClear()
+    b.fetchBalance.mockClear()
   })
 
   it('suppresses the banner entirely when billing control is rolled back', async () => {
@@ -95,5 +108,30 @@ describe('useBillingBanner', () => {
     b.subscription.value = { hasFunds: false }
     await nextTick()
     expect(kind.value).toBe('outOfCredits')
+  })
+
+  it('refreshes status and balance on focus while payment recovery is visible', async () => {
+    const b = mocks.billing!
+    useBillingBanner()
+    b.billingStatus.value = 'payment_failed'
+
+    window.dispatchEvent(new Event('focus'))
+    await nextTick()
+
+    expect(b.fetchStatus).toHaveBeenCalledOnce()
+    expect(b.fetchBalance).toHaveBeenCalledOnce()
+  })
+
+  it('does not refresh payment recovery on focus when the flag is off', async () => {
+    const b = mocks.billing!
+    useBillingBanner()
+    b.billingStatus.value = 'payment_failed'
+    mocks.v1PaymentRecovery!.value = false
+
+    window.dispatchEvent(new Event('focus'))
+    await nextTick()
+
+    expect(b.fetchStatus).not.toHaveBeenCalled()
+    expect(b.fetchBalance).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -1,4 +1,4 @@
-import { createSharedComposable } from '@vueuse/core'
+import { createSharedComposable, useEventListener } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
@@ -15,6 +15,7 @@ export type BillingBannerKind =
 
 export interface BillingBannerInputs {
   billingControlEnabled: boolean
+  v1PaymentRecovery: boolean
   isTeamPlan: boolean
   isLoaded: boolean
   isActiveSubscription: boolean
@@ -27,29 +28,24 @@ export interface BillingBannerInputs {
 }
 
 // The single billing banner slot, in priority order: paused > paymentFailed >
-// outOfCredits > ending. billingControlEnabled is the FE-1246 kill switch: the
-// whole banner is behind it so a PostHog rollback hides it for everyone. Then
-// gated on the team PLAN rather than the workspace type, because personal
-// workspaces are due to gain team plans (BE-1526) — a workspace-type gate would
-// then hide the banner from real team subscribers.
+// outOfCredits > ending. Payment recovery and the existing billing-control
+// notices have independent rollout gates.
 export function deriveBillingBanner(
   inputs: BillingBannerInputs
 ): BillingBannerKind | null {
-  if (!inputs.billingControlEnabled || !inputs.isTeamPlan || !inputs.isLoaded) {
+  if (!inputs.isTeamPlan || !inputs.isLoaded) {
     return null
   }
 
-  // Both sit above the isActiveSubscription gate because the backend folds
-  // billing_status into is_active: paused and payment_failed each report
-  // is_active=false, so either check would be dead code below it.
-  if (inputs.billingStatus === 'paused') return 'paused'
-  if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
-    return 'paymentFailed'
+  if (inputs.v1PaymentRecovery) {
+    if (inputs.billingStatus === 'paused') return 'paused'
+    if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
+      return 'paymentFailed'
+    }
   }
 
-  // Inactive workspaces surface a run-lock modal, not this banner. Members hit
-  // this on payment_failed, which is per design — only billing managers see it.
   if (!inputs.isActiveSubscription) return null
+  if (!inputs.billingControlEnabled) return null
 
   if (inputs.hasFunds === false && !inputs.outOfCreditsDismissed) {
     return 'outOfCredits'
@@ -62,8 +58,14 @@ export function deriveBillingBanner(
 }
 
 function useBillingBannerInternal() {
-  const { isActiveSubscription, billingStatus, subscription, isTeamPlan } =
-    useBillingContext()
+  const {
+    isActiveSubscription,
+    billingStatus,
+    subscription,
+    isTeamPlan,
+    fetchStatus,
+    fetchBalance
+  } = useBillingContext()
   const { permissions } = useWorkspaceUI()
   const { flags } = useFeatureFlags()
 
@@ -73,6 +75,7 @@ function useBillingBannerInternal() {
     if (!isCloud) return null
     return deriveBillingBanner({
       billingControlEnabled: flags.billingControlEnabled,
+      v1PaymentRecovery: flags.v1PaymentRecovery,
       isTeamPlan: isTeamPlan.value,
       isLoaded: subscription.value !== null,
       isActiveSubscription: isActiveSubscription.value,
@@ -94,6 +97,11 @@ function useBillingBannerInternal() {
   )
   watch(hasExhaustedFunds, (exhausted) => {
     if (!exhausted) dismissed.value = false
+  })
+
+  useEventListener(window, 'focus', () => {
+    if (kind.value !== 'paymentFailed') return
+    void Promise.allSettled([fetchStatus(), fetchBalance()])
   })
 
   function dismiss() {

--- a/src/storybook/mocks/useFeatureFlags.ts
+++ b/src/storybook/mocks/useFeatureFlags.ts
@@ -27,7 +27,8 @@ export enum ServerFeatureFlag {
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
   UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
   CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
-  BILLING_CONTROL_ENABLED = 'billing_control_enabled'
+  BILLING_CONTROL_ENABLED = 'billing_control_enabled',
+  V1_PAYMENT_RECOVERY = 'v1_payment_recovery'
 }
 
 export function useFeatureFlags() {
@@ -35,7 +36,8 @@ export function useFeatureFlags() {
     flags: {
       teamWorkspacesEnabled: true,
       consolidatedBillingEnabled: true,
-      billingControlEnabled: true
+      billingControlEnabled: true,
+      v1PaymentRecovery: true
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the independently flagged frontend slice for Payment Recovery US1 and US3: unattended renewal-failure visibility and role-safe paused-workspace run recovery, without depending on #14091.

### Root cause and why this is needed

Payment recovery states were coupled to `billing_control_enabled`, which is the rollout control for existing out-of-credits and subscription-ending notices. Paused workspaces also fell through the generic inactive path, replacing the entire queue group with `Subscribe to Run`. This hid batch/queue controls and exposed generic subscription/payment language to members instead of the required role-safe recovery UX.

### How this changes

- Adds the authenticated server flag key `v1_payment_recovery`, exposed as `flags.v1PaymentRecovery` with the normal `ff:v1_payment_recovery` local override.
- Gates only `payment_failed` and `paused` banners/run-lock behavior with the new flag; existing out-of-credits, ending, and generic inactive behavior remain on their existing paths.
- Shows billing managers a non-dismissible `Payment failed` banner with `Update payment`; returning focus refetches status/balance while that banner is visible.
- Keeps the queue group mounted when paused. Existing auto-run mode is reset and the visible dropdown is locked so no queued execution bypasses recovery.
- Gives owners a gold `Update payment to run` action and portal recovery dialog; members see a gray locked `Run` action and a billing-private `Subscription paused` explainer with `Ok, got it`.
- Uses the existing billing portal action, which opens Stripe Billing Portal in a new tab.

### API / backend boundary

This PR consumes existing `billing_status` values (`payment_failed`, `paused`) and the existing payment-portal endpoint. Backend/remote config must deliver `v1_payment_recovery`. It does not implement dunning, recovery state transitions, or server mechanics. PR #14091 remains separate transactional-decline work; this PR has no dependency on its dialog or implementation.

## Changes

- **What**: Flag wiring, payment recovery banner derivation/focus refresh, paused queue lock, owner/member recovery dialog, focused unit/component coverage.

## Review Focus

- Recovery states are independent from `billing_control_enabled` while unrelated states preserve existing gates.
- Paused owner/member flows cannot submit via primary action or Run-on-Change, but batch/dropdown controls stay mounted.
- Members receive no payment-declined, card, or payment-method details.

## Screenshots

Captured in the real cloud application with billing/workspace endpoints mocked through the repository's Playwright fixtures; no Storybook state was used.

### AS IS — paused owner uses generic inactive replacement

![AS IS - Subscribe to Run replaces queue controls](https://ampcode.com/user-content/artifacts/0155ae74ced7c0007eea1a6abc671182050e09385e5a9202c6f9dbba7cff5949-file.png)

### TO BE — paused owner queue lock and recovery

![TO BE - owner queue lock](https://ampcode.com/user-content/artifacts/2c012c3fe5cd3a59baccac620c00fc86439f3bd98453a974d77af94ca3339ffe-file.png)

![TO BE - owner payment recovery dialog](https://ampcode.com/user-content/artifacts/30fbef1ba90077c83cb9a84cba857953082efe391b4836e8cf4b20eba9247631-file.png)

### TO BE — paused member privacy-safe explainer

![TO BE - member paused explainer](https://ampcode.com/user-content/artifacts/fd523269fa8472b7d79cf32cf6abc34f25ab4075c488246b64d65d42905cc316-file.png)

## Validation

- `pnpm typecheck`
- `pnpm lint:unstaged`
- 101 focused unit/component tests
- 2 real-app Playwright cloud scenarios (paused owner/member)
- `pnpm exec oxfmt --check` on touched files
- `git diff --check`

`pnpm typecheck:browser` is currently blocked by pre-existing `BillingStatusResponse` fixture drift on `main` (existing fixtures are missing newly required seat fields); the added Playwright fixture itself was exercised successfully before being kept out of this focused diff.
