### PR TITLE
feat(website): swap MiniMax hero to launch sizzle, still image on mobile

### DIFF
--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -86,7 +86,7 @@ jobs:
           GIT_PR_ID: ${{ github.event.pull_request.number }}
           GIT_REPO: ${{ github.repository }}
         run: |
-          URL=$(vercel deploy --prebuilt \
+          URL=$(vercel deploy --prebuilt --archive=tgz \
             --meta githubCommitRef="$GIT_COMMIT_REF" \
             --meta githubCommitSha="$GIT_COMMIT_SHA" \
             --meta githubCommitAuthorLogin="$GIT_AUTHOR_LOGIN" \

--- a/apps/website/e2e/minimax.spec.ts
+++ b/apps/website/e2e/minimax.spec.ts
@@ -17,7 +17,9 @@ const CTA_HEADING = t('minimax.cta.heading', 'en')
 const CTA_PRIMARY = t('minimax.cta.primaryCta', 'en')
 const CLOUD_URL = externalLinks.cloud
 const CLOUD_RUN_URL = minimaxLinks.cloudRun
-const FAQS = minimaxPage.faq.items
+const { faq } = minimaxPage
+if (!faq) throw new Error('minimax page is expected to define an FAQ section')
+const FAQS = faq.items
 const FAQ_COUNT = FAQS.length
 const FIRST_FAQ = FAQS[0]
 const PRICING_HEADING = t('pricing.title', 'en')

--- a/apps/website/src/data/minimax.ts
+++ b/apps/website/src/data/minimax.ts
@@ -5,7 +5,8 @@ import { externalLinks } from '../config/routes'
 // MiniMax H3 renders, encoded to the site's web video profile and served from
 // media.comfy.org.
 const media = {
-  hero: 'https://media.comfy.org/website/minimax/hero.mp4',
+  hero: 'https://media.comfy.org/website/minimax/hero-sizzle.mp4',
+  heroFallback: 'https://media.comfy.org/website/minimax/hero-fallback.jpg',
   iceRider: 'https://media.comfy.org/website/minimax/ice-rider.webm',
   sunkenTemple: 'https://media.comfy.org/website/minimax/sunken-temple.webm',
   nightAscent: 'https://media.comfy.org/website/minimax/night-ascent.webm',
@@ -31,6 +32,7 @@ export const minimaxPage: ModelLaunchPage = {
   breadcrumbUpdatedKey: 'minimax.breadcrumb.updated',
   hero: {
     videoSrc: media.hero,
+    placeholderImageSrc: media.heroFallback,
     logoSrc: '/icons/ai-models/minimax.svg',
     titleKey: 'minimax.hero.titleModel',
     titleRestKey: 'minimax.hero.titleRest',

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+import { computed, onMounted, shallowRef } from 'vue'
+
 import type { Locale } from '../../i18n/translations'
 import type { ModelLaunchHero } from './types'
 
@@ -11,22 +14,45 @@ const { locale = 'en', hero } = defineProps<{
   hero: ModelLaunchHero
   locale?: Locale
 }>()
+
+// Hero clips run to tens of megabytes, so phones get the still instead. A
+// CSS-hidden <video> would still download during SSR hydration; withholding
+// the element until the query matches is what actually skips the transfer.
+const isDesktop = useMediaQuery('(min-width: 768px)')
+
+// The still is what SSR emits, so hold it through the first client render too;
+// swapping in the video before hydration settles would count as a mismatch.
+const mounted = shallowRef(false)
+onMounted(() => {
+  mounted.value = true
+})
+
+const showVideo = computed(
+  () =>
+    Boolean(hero.videoSrc) &&
+    (!hero.placeholderImageSrc || (mounted.value && isDesktop.value))
+)
 </script>
 
 <template>
   <section class="max-w-9xl mx-auto px-6 py-12 lg:px-20 lg:py-16">
-    <img
-      v-if="!hero.videoSrc && hero.placeholderImageSrc"
-      :src="hero.placeholderImageSrc"
-      alt=""
-      aria-hidden="true"
-      width="1440"
-      height="810"
-      class="aspect-21/9 w-full rounded-4xl border border-white/10 object-cover"
-    />
-
-    <div v-if="hero.videoSrc" class="relative">
-      <VideoPlayer :locale :src="hero.videoSrc" autoplay loop />
+    <div v-if="showVideo || hero.placeholderImageSrc" class="relative">
+      <VideoPlayer
+        v-if="showVideo"
+        :locale
+        :src="hero.videoSrc"
+        autoplay
+        loop
+      />
+      <img
+        v-else
+        :src="hero.placeholderImageSrc"
+        alt=""
+        aria-hidden="true"
+        width="1280"
+        height="720"
+        class="aspect-video w-full rounded-4xl border border-white/10 object-cover"
+      />
       <div
         v-if="hero.logoSrc"
         aria-hidden="true"

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -18,8 +18,9 @@ interface ModelLaunchCta {
 
 export interface ModelLaunchHero {
   videoSrc?: string
-  // Still stand-in for the hero frame, for pages announcing a model whose
-  // launch footage does not exist yet. Ignored once videoSrc is set.
+  // Still stand-in for the hero frame, used below 768px so phones skip the
+  // video download, and at every width for pages announcing a model whose
+  // launch footage does not exist yet.
   placeholderImageSrc?: string
   // Small label above the heading, e.g. NEW.
   eyebrowKey?: TranslationKey


### PR DESCRIPTION
## Summary

Swaps the `/minimax` hero from the 8s clip to the launch sizzle, and serves a still image instead of the video below 768px.

## Changes

- **What**: `hero-sizzle.mp4` (66s, 1280w, 19MB) replaces `hero.mp4`. Phones get `hero-fallback.jpg` — a frame from the previous hero — and never request the video. Both assets are already live at `media.comfy.org/website/minimax/`.
- Also fixes an unrelated `astro check` failure on `main` (`ts(18048)` at `e2e/minimax.spec.ts:20`) in its own commit; without it the pre-commit hook rejects any website commit.

## Review Focus

The hero island is `client:load`, so a CSS-hidden `<video>` would still SSR with its `src` and phones would pull all 19MB before hydration ran. `showVideo` therefore withholds the element itself until `useMediaQuery('(min-width: 768px)')` matches, with a `mounted` flag holding the still through the first client render so hydration doesn't mismatch. Pages with a video and no `placeholderImageSrc` keep today's behavior at every width, so `/flux3` is unaffected.

Verified against the production asset URLs:

- **375px** — only `hero-fallback.jpg` is requested; the mp4 appears nowhere in the network log.
- **1440px** — video only, 66.13s, no decode error, no image element.

Worth a second opinion: the sizzle has a burned-in "NOW ON Comfy" chip in the top-right that sits under the page's own MiniMax logo overlay on desktop. Left as-is for now; easy to drop the overlay or move it left.
