### PR TITLE
fix(billing): don't show an error when a checkout is superseded

### DIFF
--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -488,6 +488,13 @@ describe('billingOperationStore', () => {
       // an unexplained billing failure in either event stream.
       expect(mockTrackBillingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
+          operation: 'operation',
+          stage: 'failed',
+          failure_category: 'stale_operation'
+        })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
           operation: 'downgrade_to_personal',
           stage: 'failed',
           failure_category: 'stale_operation'

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1,4 +1,5 @@
-import { setActivePinia, createPinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
 import { ref } from 'vue'
 
@@ -80,7 +81,7 @@ import { useBillingOperationStore } from './billingOperationStore'
 
 describe('billingOperationStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     vi.useFakeTimers()
     mockActiveWorkspaceId.value = 'workspace-1'

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -438,6 +438,32 @@ describe('billingOperationStore', () => {
       })
     })
 
+    it('stays silent when a checkout was superseded by a new plan choice', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'checkout_superseded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(store.getOperation('op-1')?.status).toBe('failed')
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: 'failed',
+          billing_op_id: 'op-1',
+          failure_category: 'stale_operation'
+        })
+      )
+    })
+
     it('uses default message when no error_message in response', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -465,6 +465,39 @@ describe('billingOperationStore', () => {
       )
     })
 
+    it('categorises both events when a superseded op was a downgrade', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        error_message: 'checkout_superseded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription', {
+        downgradeToPersonal: {
+          memberRemovalCount: 2,
+          memberRemovalFailures: 0,
+          targetTier: 'free'
+        }
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Both emissions must agree: a downgrade that was merely replaced is not
+      // an unexplained billing failure in either event stream.
+      expect(mockTrackBillingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'downgrade_to_personal',
+          stage: 'failed',
+          failure_category: 'stale_operation'
+        })
+      )
+      expect(mockTrackBillingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ failure_category: 'unknown' })
+      )
+    })
+
     it('uses default message when no error_message in response', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -361,6 +361,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     if (!operation) return
 
     const superseded = errorMessage === CHECKOUT_SUPERSEDED_REASON
+    const failureCategory = superseded ? 'stale_operation' : 'unknown'
     const defaultMessage = failureMessage(operation.type)
     const detail =
       operation.type === 'subscription'
@@ -381,7 +382,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       cycle: operation.cycle,
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
-      failure_category: superseded ? 'stale_operation' : 'unknown'
+      failure_category: failureCategory
     })
     if (operation.downgradeToPersonal) {
       telemetry?.trackBillingEvent({
@@ -392,7 +393,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
         member_removal_failures:
           operation.downgradeToPersonal.memberRemovalFailures,
         target_tier: operation.downgradeToPersonal.targetTier,
-        failure_category: 'unknown'
+        failure_category: failureCategory
       })
     }
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -25,6 +25,10 @@ const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000
 const SUBSCRIPTION_ACTION_DISCOVERY_TIMEOUT_MS = 5 * 60_000
 const AUTHENTICATION_TIMEOUT_MS = 23 * 60 * 60_000
+// Failure reason for a checkout the user replaced by picking a different plan
+// mid-flow. The operation is terminal-failed only because it never completed —
+// its replacement is proceeding normally, so there is nothing to report.
+const CHECKOUT_SUPERSEDED_REASON = 'checkout_superseded'
 
 type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
@@ -356,6 +360,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const operation = operations.value.get(opId)
     if (!operation) return
 
+    const superseded = errorMessage === CHECKOUT_SUPERSEDED_REASON
     const defaultMessage = failureMessage(operation.type)
     const detail =
       operation.type === 'subscription'
@@ -376,7 +381,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       cycle: operation.cycle,
       checkout_type: operation.checkoutType,
       payment_intent_source: operation.paymentIntentSource,
-      failure_category: 'unknown'
+      failure_category: superseded ? 'stale_operation' : 'unknown'
     })
     if (operation.downgradeToPersonal) {
       telemetry?.trackBillingEvent({
@@ -391,7 +396,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       })
     }
 
-    if (operation.type !== 'cancel') {
+    if (operation.type !== 'cancel' && !superseded) {
       useToastStore().add({
         severity: 'error',
         summary: defaultMessage,


### PR DESCRIPTION
## What and why

Picking a different plan part-way through checkout makes the API replace the pending subscription operation with a new one. The replaced operation terminates as `failed` — it never completed — even though nothing actually went wrong. The store treated that like any other failure and showed **"We couldn't update your subscription. Please try again."** while the replacement checkout was still running and about to succeed.

Users hit this by starting a subscription, changing their mind, and picking a different plan: an error toast, immediately followed by a working subscription.

## The change

`handleFailure` now recognises the API's `checkout_superseded` failure reason and skips the error toast for it. The operation is still recorded as failed and still resolves normally — only the user-facing alarm goes away.

The failure is also reported as `stale_operation` instead of `unknown`, so a routine plan switch stops inflating the count of unexplained billing failures. `stale_operation` is an existing category; no telemetry types changed.

Takes effect once the API returns `checkout_superseded` for a replaced checkout.

## Scope

One `if` and one telemetry value. Deliberately narrow:

- Genuine subscription failures still toast exactly as before.
- Top-up and cancel paths are untouched.
- The success path already ignores stale operations (it checks the active checkout id before advancing), so it needed no change.

## Verification

- `vitest run src/platform/workspace/stores/billingOperationStore.test.ts src/platform/workspace/composables/useSubscriptionCheckout.test.ts --coverage` — 144 passed, run **with** coverage to match CI.
- New regression test: a superseded operation raises no error toast and reports `stale_operation`.
- `pnpm typecheck`, `oxfmt --check`, `eslint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)