### PR TITLE
[backport cloud/1.49] fix(first-run-tour): let the upload step take the click it asks for (#14685)

### DIFF
--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -186,14 +186,22 @@ describe('firstRunTourSteps', () => {
     expect(result?.name).toBe('result.image')
   })
 
-  it('lets only interactive steps take pointer input', async () => {
+  it('lets every step but the result take pointer input', async () => {
     loadTemplate(FROM_IMAGE)
 
-    const interactive = (await buildSteps(FROM_IMAGE))
-      .filter((step) => step.kind === 'spotlight' && step.interactive)
-      .map((step) => step.name)
+    const byName = new Map(
+      (await buildSteps(FROM_IMAGE)).map((step) => [
+        step.name,
+        step.kind === 'spotlight' && step.interactive === true
+      ])
+    )
 
-    expect(interactive).toEqual(['prompt.image-edit', 'run'])
+    expect(Object.fromEntries(byName)).toEqual({
+      'upload.image-edit': true,
+      'prompt.image-edit': true,
+      run: true,
+      'result.image': false
+    })
   })
 
   it('registers each spotlit node so the engine can find it', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.ts
@@ -92,7 +92,7 @@ function toCoachStep(
     coachId: COACH_ID[step.kind],
     deferTarget: true,
     cursor: true,
-    interactive: step.kind === 'prompt' || step.kind === 'run'
+    interactive: step.kind !== 'result'
   }
 
   if (step.kind === 'run')


### PR DESCRIPTION
Backport of #14685 to `cloud/1.49`.

The backport bot cherry-picked this cleanly and pushed the branch, but failed to open the PR ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/14685#issuecomment-5183644208)). Opening it manually — no conflicts, no manual resolution.

## Summary

The upload step tells the user to swap in their own image, then a full-screen blocker swallows every click on the node it is spotlighting.

## Changes

`interactive` was an allowlist of `prompt` and `run`, so `upload` fell through to the non-interactive branch in `TourSpotlight.vue`, which renders a `pointer-events-auto` overlay across the whole viewport. Inverted to exclude only `result` — the one step with nothing to touch.

## Review Focus

The cherry-picked diff is byte-identical to what landed on `main`, so review is about whether it holds up on this branch rather than what changed.

Verified on `cloud/1.49`:
- `pnpm typecheck` clean
- `pnpm exec vitest run src/renderer/extensions/firstRunTour/` — 173 passed across 10 files
- Mutation-checked on this branch: reverting the one-line change turns the rewritten test red, so the test guards the fix here too and did not come along as a no-op