### PR TITLE
hotfix: custom nodes adding widgets on subgraph nodes

### DIFF
--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -187,7 +187,7 @@ test.describe(
       ).toBeTruthy()
       await expect(
         comfyPage.page.getByTestId('custom-node-widget')
-      ).toBeVisible()
+      ).toBeAttached()
     })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -165,5 +165,25 @@ test.describe(
         })
       }
     )
+
+    test('Can add DOMWidget directly onto node', async ({ comfyPage }) => {
+      const ksampler = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+      await comfyPage.contextMenu.openForVueNode(ksampler.header)
+      await comfyPage.contextMenu.clickMenuItem('Convert to Subgraph')
+
+      expect(
+        await comfyPage.page.evaluate(() => {
+          const subgraphNode = graph?.nodes.find(
+            (n) => n.title === 'New Subgraph'
+          )
+          if (!subgraphNode) throw new Error('Failed to find subgraph node')
+
+          const el = document.createElement('div')
+          subgraphNode.addDOMWidget('testwidget', 'testwidget', el)
+          return !!subgraphNode.widgets?.find((w) => w.type === 'testwidget')
+        }),
+        'widget exists on node'
+      ).toBeTruthy()
+    })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -179,11 +179,15 @@ test.describe(
           if (!subgraphNode) throw new Error('Failed to find subgraph node')
 
           const el = document.createElement('div')
+          el.dataset.testid = 'custom-node-widget'
           subgraphNode.addDOMWidget('testwidget', 'testwidget', el)
           return !!subgraphNode.widgets?.find((w) => w.type === 'testwidget')
         }),
         'widget exists on node'
       ).toBeTruthy()
+      await expect(
+        comfyPage.page.getByTestId('custom-node-widget')
+      ).toBeVisible()
     })
   }
 )

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -7,7 +7,6 @@ import cloneDeep from 'es-toolkit/compat/cloneDeep'
 import { reactive, shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import { promotedInputWidgets } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
 import type {
   INodeInputSlot,
@@ -436,9 +435,7 @@ export function extractVueNodeData(node: LGraphNode): VueNodeData {
       slotMetadata.set(key, value)
     }
 
-    const widgets = node.isSubgraphNode()
-      ? promotedInputWidgets(node)
-      : (node.widgets ?? [])
+    const widgets = node.widgets ?? []
     return widgets.map(safeWidgetMapper(node, slotMetadata))
   })
 

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -34,6 +34,7 @@ import type {
 import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import { isNodeBindable } from '@/lib/litegraph/src/utils/type'
 import { toConcreteWidget } from '@/lib/litegraph/src/widgets/widgetMap'
+import type { WidgetTypeMap } from '@/lib/litegraph/src/widgets/widgetMap'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolveSubgraphInputTarget } from '@/core/graph/subgraph/resolveSubgraphInputTarget'
 import { parsePreviewExposures } from '@/core/schemas/previewExposureSchema'
@@ -842,7 +843,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override addCustomWidget<TPlainWidget extends IBaseWidget>(
     customWidget: TPlainWidget
-  ): TPlainWidget {
+  ): TPlainWidget | WidgetTypeMap[TPlainWidget['type']] {
     const widget = toConcreteWidget(customWidget, this, false) ?? customWidget
     this._extraWidgets.push(widget)
     this._widgetSlotsDirty = true
@@ -851,7 +852,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       widget.setNodeId(this.id)
     }
 
-    return widget as TPlainWidget
+    return widget
   }
 
   override removeWidget(widget: IBaseWidget): void {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -886,6 +886,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       }
       this._clearPromotedWidget(input)
     }
+    for (const widget of this._extraWidgets) widget.onRemove?.()
   }
   override drawTitleBox(
     ctx: CanvasRenderingContext2D,

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -16,7 +16,7 @@ import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { INodeInputSlot, ISlotType } from '@/lib/litegraph/src/litegraph'
 import { NodeInputSlot } from '@/lib/litegraph/src/node/NodeInputSlot'
 import { NodeOutputSlot } from '@/lib/litegraph/src/node/NodeOutputSlot'
-import { toNodeId } from '@/types/nodeId'
+import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type {
   GraphOrSubgraph,
@@ -32,6 +32,8 @@ import type {
   TWidgetValue
 } from '@/lib/litegraph/src/types/widgets'
 import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { isNodeBindable } from '@/lib/litegraph/src/utils/type'
+import { toConcreteWidget } from '@/lib/litegraph/src/widgets/widgetMap'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolveSubgraphInputTarget } from '@/core/graph/subgraph/resolveSubgraphInputTarget'
 import { parsePreviewExposures } from '@/core/schemas/previewExposureSchema'
@@ -80,6 +82,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   declare widgets: IBaseWidget[]
 
+  /** Widgets added programmatically (e.g. addDOMWidget) outside the promotion system. */
+  private readonly _extraWidgets: IBaseWidget[] = []
+
   /**
    * Retained as a no-op for extension compatibility: promoted host widgets are
    * now store-backed and addressed by widgetId, so there is no view cache to
@@ -98,11 +103,13 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     this.graph = graph
 
     Object.defineProperty(this, 'widgets', {
-      get: () =>
-        this.inputs.flatMap((input) => {
+      get: () => [
+        ...this.inputs.flatMap((input) => {
           const widget = this._projectPromotedWidget(input)
           return widget ? [widget] : []
         }),
+        ...this._extraWidgets
+      ],
       set: () => {
         if (import.meta.env.DEV)
           console.warn(
@@ -833,12 +840,34 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     return nodes
   }
 
+  override addCustomWidget<TPlainWidget extends IBaseWidget>(
+    customWidget: TPlainWidget
+  ): TPlainWidget {
+    const widget = toConcreteWidget(customWidget, this, false) ?? customWidget
+    this._extraWidgets.push(widget)
+    this._widgetSlotsDirty = true
+
+    if (this.id !== UNASSIGNED_NODE_ID && isNodeBindable(widget)) {
+      widget.setNodeId(this.id)
+    }
+
+    return widget as TPlainWidget
+  }
+
   override removeWidget(widget: IBaseWidget): void {
     this.ensureWidgetRemoved(widget)
   }
 
   override ensureWidgetRemoved(widget: IBaseWidget): void {
     widget.onRemove?.()
+
+    const index = this._extraWidgets.indexOf(widget)
+    if (index !== -1) {
+      this._extraWidgets.splice(index, 1)
+      this._widgetSlotsDirty = true
+      return
+    }
+
     this.subgraph.events.dispatch('widget-demoted', {
       widget,
       subgraphNode: this


### PR DESCRIPTION
VHS directly adds sampling previews onto parent subgraphs (partially to merge lifecycle across multiple ksamplers in multi-stage workflows), but this conflicts with requiring that all widgets on a subgraphNode have associated promoted inputs.

This PR adds a minimal reproduction test, and a proposed fix. Of note, this change necessitates custom nodes go through the appropriate api methods and still disallows blindly muting `node.widgets`

Resolves kosinkadink/ComfyUI-VideoHelperSuite#695