### PR TITLE
fix: block canvas undo while modal is open

### DIFF
--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -2,19 +2,12 @@ import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
+import { isModalOpen } from '@/utils/modalUtil'
 
 import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import { useKeybindingStore } from './keybindingStore'
-
-function hasOpenRekaDialog(): boolean {
-  return Array.from(
-    document.querySelectorAll('[role="dialog"][data-state="open"]')
-  ).some(
-    (dialog) => dialog.closest('[data-reka-popper-content-wrapper]') === null
-  )
-}
 
 export function useKeybindingService() {
   const keybindingStore = useKeybindingStore()
@@ -57,11 +50,7 @@ export function useKeybindingService() {
           return
         }
       }
-      if (
-        dialogStore.dialogStack.length > 0 ||
-        document.querySelector('[role="dialog"][aria-modal="true"]') ||
-        hasOpenRekaDialog()
-      ) {
+      if (isModalOpen(dialogStore.dialogStack.length)) {
         return
       }
 

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1239,15 +1239,37 @@ describe('ChangeTracker', () => {
   })
 
   describe('keyboard shortcuts', () => {
-    it('does not undo while a modal is open', async () => {
+    function createRekaDialog() {
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      return dialog
+    }
+
+    function createNativeDialog() {
+      const dialog = document.createElement('dialog')
+      dialog.setAttribute('open', '')
+      return dialog
+    }
+
+    function createLegacyComfyModal() {
+      const modal = document.createElement('div')
+      modal.className = 'comfy-modal'
+      modal.style.display = 'flex'
+      return modal
+    }
+
+    it.each([
+      ['a reka dialog', createRekaDialog],
+      ['a native dialog', createNativeDialog],
+      ['a legacy comfy modal', createLegacyComfyModal]
+    ])('does not undo while %s is open', async (_kind, createModal) => {
       const previousState = createState(1)
       const currentState = createState(2)
       const tracker = createTracker(currentState)
       tracker.undoQueue.push(previousState)
-      const dialog = document.createElement('div')
-      dialog.setAttribute('role', 'dialog')
-      dialog.setAttribute('data-state', 'open')
-      document.body.appendChild(dialog)
+      const modal = createModal()
+      document.body.appendChild(modal)
 
       try {
         ChangeTracker.init()
@@ -1260,7 +1282,7 @@ describe('ChangeTracker', () => {
         expect(tracker.activeState).toEqual(currentState)
         expect(tracker.undoQueue).toEqual([previousState])
       } finally {
-        document.body.removeChild(dialog)
+        document.body.removeChild(modal)
       }
     })
   })

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1237,4 +1237,31 @@ describe('ChangeTracker', () => {
       expect(tracker.activeState).toEqual(changed)
     })
   })
+
+  describe('keyboard shortcuts', () => {
+    it('does not undo while a modal is open', async () => {
+      const previousState = createState(1)
+      const currentState = createState(2)
+      const tracker = createTracker(currentState)
+      tracker.undoQueue.push(previousState)
+      const dialog = document.createElement('div')
+      dialog.setAttribute('role', 'dialog')
+      dialog.setAttribute('data-state', 'open')
+      document.body.appendChild(dialog)
+
+      try {
+        ChangeTracker.init()
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'z', ctrlKey: true })
+        )
+        await vi.runAllTimersAsync()
+
+        expect(app.loadGraphData).not.toHaveBeenCalled()
+        expect(tracker.activeState).toEqual(currentState)
+        expect(tracker.undoQueue).toEqual([previousState])
+      } finally {
+        document.body.removeChild(dialog)
+      }
+    })
+  })
 })

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -8,11 +8,13 @@ import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workfl
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
+import { useDialogStore } from '@/stores/dialogStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useQueueSettingsStore } from '@/stores/queueSettingsStore'
 import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { serializeNodeId } from '@/types/nodeId'
+import { isModalOpen } from '@/utils/modalUtil'
 
 import { api } from './api'
 import type { ComfyApp } from './app'
@@ -515,6 +517,7 @@ export class ChangeTracker {
     const getCurrentChangeTracker = () =>
       useWorkflowStore().activeWorkflow?.changeTracker
     const captureState = () => getCurrentChangeTracker()?.captureCanvasState()
+    const dialogStore = useDialogStore()
 
     let keyIgnored = false
     window.addEventListener(
@@ -527,6 +530,7 @@ export class ChangeTracker {
         // If the mask editor is opened, we don't want to trigger on key events
         const comfyApp = app.constructor as typeof ComfyApp
         if (comfyApp.maskeditor_is_opended?.()) return
+        if (isModalOpen(dialogStore.dialogStack.length)) return
 
         const activeEl = document.activeElement
         requestAnimationFrame(async () => {

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -6,10 +6,25 @@ function hasOpenRekaDialog(): boolean {
   )
 }
 
+function hasOpenNativeDialog(): boolean {
+  return document.querySelector('dialog[open]') !== null
+}
+
+/** ComfyDialog toggles visibility via inline display ('flex' / 'none'). */
+function hasVisibleLegacyModal(): boolean {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('.comfy-modal')
+  ).some(
+    (modal) => modal.style.display !== '' && modal.style.display !== 'none'
+  )
+}
+
 export function isModalOpen(managedDialogCount: number): boolean {
   return (
     managedDialogCount > 0 ||
     document.querySelector('[role="dialog"][aria-modal="true"]') !== null ||
-    hasOpenRekaDialog()
+    hasOpenRekaDialog() ||
+    hasOpenNativeDialog() ||
+    hasVisibleLegacyModal()
   )
 }

--- a/src/utils/modalUtil.ts
+++ b/src/utils/modalUtil.ts
@@ -1,0 +1,15 @@
+function hasOpenRekaDialog(): boolean {
+  return Array.from(
+    document.querySelectorAll('[role="dialog"][data-state="open"]')
+  ).some(
+    (dialog) => dialog.closest('[data-reka-popper-content-wrapper]') === null
+  )
+}
+
+export function isModalOpen(managedDialogCount: number): boolean {
+  return (
+    managedDialogCount > 0 ||
+    document.querySelector('[role="dialog"][aria-modal="true"]') !== null ||
+    hasOpenRekaDialog()
+  )
+}


### PR DESCRIPTION
I will refactor the entire keybinding system later, this is a hotfix for the cloud/1.49 release

## Summary

Block legacy canvas undo/redo shortcuts while a modal is open. This follows up on #14024: command keybindings were guarded there, but `ChangeTracker` handles Ctrl/Cmd+Z independently in a capture-phase listener and could still restore workflow state behind a dialog.

## Changes

- **What**: Share the existing modal predicate with `ChangeTracker` and add focused unit regression coverage for the real window shortcut path.

## Review Focus

Confirm the modal check runs synchronously before `ChangeTracker` schedules undo/redo work, while popover content remains excluded from modal detection.

## Validation

- `pnpm test:unit src/scripts/changeTracker.test.ts src/platform/keybindings/keybindingService.dialog.test.ts` (65 passed)
- Pre-commit: oxfmt, type-aware oxlint, ESLint, and `pnpm typecheck`
- Pre-push: `pnpm knip`
