### PR TITLE
fix: export temp history outputs by job ID

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -953,6 +953,33 @@ describe('useMediaAssetActions', () => {
       })
     })
 
+    it('should export inputs with output-shaped metadata through their asset IDs', async () => {
+      mockGetAssetType
+        .mockReturnValueOnce('input')
+        .mockReturnValueOnce('output')
+      const inputWithJobMetadata = createMockAsset({
+        id: 'input-asset',
+        name: 'reference.png',
+        tags: ['input'],
+        user_metadata: { jobId: 'unrelated-job', nodeId: '1' }
+      })
+      const savedOutput = createOutputAsset('output-job', 'out.png', 'job1', 1)
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets([inputWithJobMetadata, savedOutput])
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      expect(mockCreateAssetExport).toHaveBeenCalledWith({
+        job_ids: ['job1'],
+        asset_ids: ['input-asset'],
+        naming_strategy: 'preserve',
+        include_previews: true
+      })
+    })
+
     it('should include name filters when outputCount is unknown', async () => {
       const asset1 = createOutputAsset('a1', 'img1.png', 'job1')
       const asset2 = createOutputAsset('a2', 'img2.png', 'job2')

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -924,6 +924,35 @@ describe('useMediaAssetActions', () => {
       expect(payload.naming_strategy).toBe('group_by_job_time')
     })
 
+    it('should export temp history outputs through their job IDs', async () => {
+      mockGetAssetType.mockReturnValueOnce('temp').mockReturnValueOnce('output')
+      const tempOutput = createOutputAsset(
+        'temp-job',
+        'ComfyUI_temp_audio.flac',
+        'temp-job',
+        1
+      )
+      const savedOutput = createOutputAsset(
+        'output-job',
+        'ComfyUI_output.png',
+        'output-job',
+        1
+      )
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets([tempOutput, savedOutput])
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      expect(mockCreateAssetExport).toHaveBeenCalledWith({
+        job_ids: ['temp-job', 'output-job'],
+        naming_strategy: 'group_by_job_time',
+        include_previews: true
+      })
+    })
+
     it('should include name filters when outputCount is unknown', async () => {
       const asset1 = createOutputAsset('a1', 'img1.png', 'job1')
       const asset2 = createOutputAsset('a2', 'img2.png', 'job2')

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -238,8 +238,8 @@ export function useMediaAssetActions() {
       let fileCount = 0
 
       for (const asset of assets) {
-        if (getAssetType(asset) === 'output') {
-          const metadata = getOutputAssetMetadata(asset.user_metadata)
+        const metadata = getOutputAssetMetadata(asset.user_metadata)
+        if (metadata || getAssetType(asset) === 'output') {
           const jobId = metadata?.jobId || asset.id
           if (!jobIds.includes(jobId)) {
             jobIds.push(jobId)

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -238,8 +238,9 @@ export function useMediaAssetActions() {
       let fileCount = 0
 
       for (const asset of assets) {
+        const assetType = getAssetType(asset)
         const metadata = getOutputAssetMetadata(asset.user_metadata)
-        if (metadata || getAssetType(asset) === 'output') {
+        if (assetType === 'output' || (assetType === 'temp' && metadata)) {
           const jobId = metadata?.jobId || asset.id
           if (!jobIds.includes(jobId)) {
             jobIds.push(jobId)


### PR DESCRIPTION
## Summary

Fix bulk asset exports silently omitting temp-backed history outputs such as preview-node audio and images.

## Changes

- **What**: Treat output metadata as authoritative when routing history assets into `job_ids`, allowing the existing `include_previews` behavior to resolve temp outputs.
- **Root cause**: Export routing preferred `preview_url?type=temp` and submitted the history card's job ID as an `asset_id`; the backend could not resolve it and built a smaller ZIP.
- **Tests**: Add regression coverage for exporting a mixed temp and saved-output selection.

## Review Focus

Confirm that job-backed output metadata is the correct discriminator for ZIP request routing, independent of whether the underlying output is stored as `temp` or `output`.

## Validation

- `pnpm test:unit src/platform/assets/composables/useMediaAssetActions.test.ts`
- Scoped oxfmt and ESLint checks
- Commit hooks: type-aware lint and `pnpm typecheck`
- Pre-push `knip`

## Screenshots (if applicable)

Not applicable; behavior-only export request fix.