### PR TITLE
[backport core/1.47] test(zindex): regression guards for the templates dropdown stacking bug

### DIFF
--- a/browser_tests/tests/templateFilterDropdownStacking.spec.ts
+++ b/browser_tests/tests/templateFilterDropdownStacking.spec.ts
@@ -1,0 +1,65 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { makeTemplate } from '@e2e/fixtures/data/templateFixtures'
+import { withTemplates } from '@e2e/fixtures/helpers/TemplateHelper'
+import { templateApiFixture } from '@e2e/fixtures/templateApiFixture'
+
+const test = mergeTests(comfyPageFixture, templateApiFixture)
+
+/**
+ * End-to-end guard that the templates filter options are on top and clickable.
+ *
+ * This does NOT reproduce the 1.47.10 stacking bug (#14063, #14131, #14351,
+ * #14397): that needed the shared modal counter to have escalated past the
+ * dropdown's static z-3000 (reporters saw 7306), whereas a freshly opened
+ * dialog only reaches ~1702, so the broken build passes this test. The
+ * mechanism is pinned deterministically in useModalLiftedZIndex.test.ts; this
+ * covers the user-visible behaviour those unit tests cannot see.
+ */
+test.describe('Template filter dropdown stacking', () => {
+  test.beforeEach(async ({ comfyPage, templateApi }) => {
+    await comfyPage.settings.setSetting('Comfy.Templates.SelectedModels', [])
+    templateApi.configure(
+      withTemplates([
+        makeTemplate({ name: 'wan-1', title: 'Wan One', models: ['Wan 2.2'] }),
+        makeTemplate({ name: 'flux-1', title: 'Flux One', models: ['Flux'] })
+      ])
+    )
+    await templateApi.mock()
+    // The template index is fetched during app startup, so the routes have to be
+    // in place before the app loads or the store keeps its unmocked contents.
+    await comfyPage.setup()
+  })
+
+  test('renders filter options above the dialog and keeps them clickable', async ({
+    comfyPage
+  }) => {
+    await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
+    await expect(comfyPage.templates.content).toBeVisible()
+
+    await comfyPage.templatesDialog.openFilters()
+    await comfyPage.templatesDialog.modelFilter.click()
+
+    const option = comfyPage.page.getByRole('option', { name: 'Wan 2.2' })
+    await expect(option).toBeVisible()
+
+    // Visibility alone passes even when the dialog covers the option, so hit-test
+    // the option's centre: whatever paints there must belong to the option itself.
+    const optionIsOnTop = await option.evaluate((el) => {
+      const { left, top, width, height } = el.getBoundingClientRect()
+      const topMost = document.elementFromPoint(
+        left + width / 2,
+        top + height / 2
+      )
+      return !!topMost && el.contains(topMost)
+    })
+    expect(optionIsOnTop).toBe(true)
+
+    // The user-facing consequence: the click lands on the option, not the dialog.
+    await option.click()
+    await comfyPage.page.keyboard.press('Escape')
+
+    await expect(comfyPage.templates.allTemplateCards).toHaveCount(1)
+  })
+})

--- a/src/components/ui/multi-select/MultiSelect.test.ts
+++ b/src/components/ui/multi-select/MultiSelect.test.ts
@@ -1,5 +1,6 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -30,7 +31,7 @@ const options = [
 ]
 
 function renderInParent(
-  multiSelectProps: Record<string, unknown> = {},
+  multiSelectProps: Partial<ComponentProps<typeof MultiSelect>> = {},
   modelValue: { name: string; value: string }[] = []
 ) {
   const parentEscapeCount = { value: 0 }
@@ -89,6 +90,23 @@ describe('MultiSelect', () => {
     const dialogZIndex = Number(openModal.style.zIndex)
     const user = userEvent.setup()
     const { unmount } = renderInParent()
+
+    await user.click(screen.getByRole('button'))
+    await nextTick()
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('opens above a dialog even when the caller passes its own contentStyle z-index', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const user = userEvent.setup()
+    const { unmount } = renderInParent({ contentStyle: { zIndex: 3000 } })
 
     await user.click(screen.getByRole('button'))
     await nextTick()

--- a/src/components/ui/single-select/SingleSelect.test.ts
+++ b/src/components/ui/single-select/SingleSelect.test.ts
@@ -1,5 +1,6 @@
 import { ZIndex } from '@primeuix/utils/zindex'
 import { render, screen } from '@testing-library/vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -38,17 +39,21 @@ function findContentElement(): HTMLElement | null {
   return document.querySelector('[data-dismissable-layer]')
 }
 
-function renderInParent(modelValue?: string) {
+function renderInParent(
+  modelValue?: string,
+  singleSelectProps: Partial<ComponentProps<typeof SingleSelect>> = {}
+) {
   const parentEscapeCount = { value: 0 }
 
   const Parent = {
     template:
-      '<div @keydown.escape="onEsc"><SingleSelect v-model="sel" :options="options" label="Pick" /></div>',
+      '<div @keydown.escape="onEsc"><SingleSelect v-model="sel" :options="options" label="Pick" v-bind="extraProps" /></div>',
     components: { SingleSelect },
     setup() {
       return {
         sel: ref(modelValue),
         options,
+        extraProps: singleSelectProps,
         onEsc: () => {
           parentEscapeCount.value++
         }
@@ -94,6 +99,23 @@ describe('SingleSelect', () => {
     ZIndex.set('modal', openModal, 3702)
     const dialogZIndex = Number(openModal.style.zIndex)
     const { unmount } = renderInParent()
+
+    await openSelect(screen.getByRole('combobox'))
+
+    const content = findContentElement()
+    expect(content).not.toBeNull()
+    expect(Number(content!.style.zIndex)).toBeGreaterThan(dialogZIndex)
+
+    unmount()
+  })
+
+  it('opens above a dialog even when the caller passes its own contentStyle z-index', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 3702)
+    const dialogZIndex = Number(openModal.style.zIndex)
+    const { unmount } = renderInParent(undefined, {
+      contentStyle: { zIndex: 3000 }
+    })
 
     await openSelect(screen.getByRole('combobox'))
 

--- a/src/composables/useModalLiftedZIndex.test.ts
+++ b/src/composables/useModalLiftedZIndex.test.ts
@@ -1,0 +1,60 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { useModalLiftedZIndex } from './useModalLiftedZIndex'
+
+const registered: HTMLElement[] = []
+
+function registerDialog() {
+  const el = document.createElement('div')
+  ZIndex.set('modal', el, 1700)
+  registered.push(el)
+  return Number(el.style.zIndex)
+}
+
+afterEach(() => {
+  let el = registered.pop()
+  while (el) {
+    ZIndex.clear(el)
+    el = registered.pop()
+  }
+})
+
+describe('useModalLiftedZIndex', () => {
+  it('lifts past the current top of the modal stack', () => {
+    const dialogZIndex = registerDialog()
+    const style = useModalLiftedZIndex(ref(true))
+
+    expect(style.value).toEqual({ zIndex: dialogZIndex + 1 })
+  })
+
+  it('stays above a dialog stack that has escalated past the static z-3000 fallback', () => {
+    // PrimeVue's counter re-adds baseZIndex whenever the previous registration
+    // used a different key, so alternating dialogs with overlays/menus climbs by
+    // ~1800 a time. Reporters saw the dialog at 7306 while the dropdown sat at
+    // its static z-3000; a single fresh dialog only reaches ~1702 and hides this.
+    const other = document.createElement('div')
+    ZIndex.set('overlay', other, 1800)
+    registered.push(other)
+    const dialogZIndex = registerDialog()
+    expect(dialogZIndex).toBeGreaterThan(3000)
+
+    const style = useModalLiftedZIndex(ref(true))
+
+    expect(style.value).toEqual({ zIndex: dialogZIndex + 1 })
+  })
+
+  it('re-reads the stack on every open rather than caching the first read', () => {
+    registerDialog()
+    const open = ref(true)
+    const style = useModalLiftedZIndex(open)
+    expect(style.value).toBeDefined()
+
+    open.value = false
+    const laterDialogZIndex = registerDialog()
+    open.value = true
+
+    expect(style.value).toEqual({ zIndex: laterDialogZIndex + 1 })
+  })
+})


### PR DESCRIPTION
Backport of #14427 onto the release line that shipped the bug.

`ci-tests-unit.yaml` runs on push to `core/*`, so these guards are live here and protect future backports onto 1.47 from reintroducing the stacking regression that shipped in 1.47.10 and reached users for a week.

Covers the three properties the fix depends on: the lift tracks the live modal counter, it re-reads on every open rather than caching a snapshot, and it survives a caller-supplied `contentStyle` z-index. Each was mutation-verified on main against the specific defect it describes.

One test from the original is intentionally excluded. `lets a consumer class override the trigger variant it conflicts with` covers SingleSelect class merging that only exists on main, and it fails on this branch. It is unrelated to the z-index regression.

All 14 tests in the three affected files pass on this branch.