### PR TITLE
fix(assets): reveal card controls on keyboard focus

### DIFF
--- a/src/platform/assets/components/MediaAssetCard.test.ts
+++ b/src/platform/assets/components/MediaAssetCard.test.ts
@@ -208,6 +208,34 @@ describe('MediaAssetCard', () => {
     )
   })
 
+  it('keeps card actions visible while keyboard focus is within the card', async () => {
+    const user = userEvent.setup()
+    renderCard({ loading: false })
+
+    expect(
+      screen.queryByRole('button', { name: 'mediaAsset.actions.download' })
+    ).not.toBeInTheDocument()
+
+    const selectionControl = screen.getByRole('button', {
+      name: 'assetBrowser.ariaLabel.assetCard'
+    })
+    await user.tab()
+
+    expect(selectionControl).toHaveFocus()
+
+    const downloadButton = screen.getByRole('button', {
+      name: 'mediaAsset.actions.download'
+    })
+    expect(downloadButton).toBeInTheDocument()
+
+    await user.tab()
+
+    expect(downloadButton).toHaveFocus()
+    expect(
+      screen.getByRole('button', { name: 'mediaAsset.actions.moreOptions' })
+    ).toBeInTheDocument()
+  })
+
   it('shows image format and dimensions without file size', () => {
     renderCard({
       loading: false,

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -156,7 +156,7 @@
 
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { useElementHover } from '@vueuse/core'
+import { useElementHover, useFocusWithin } from '@vueuse/core'
 import { computed, defineAsyncComponent, provide, ref, toRef } from 'vue'
 
 import IconGroup from '@/components/button/IconGroup.vue'
@@ -235,6 +235,7 @@ const showVideoControls = ref(false)
 const imageDimensions = ref<{ width: number; height: number } | undefined>()
 
 const isHovered = useElementHover(cardContainerRef)
+const { focused: isFocusedWithin } = useFocusWithin(cardContainerRef)
 
 const actions = useMediaAssetActions()
 
@@ -330,7 +331,9 @@ const metaInfo = computed(() => {
 
 const showActionsOverlay = computed(() => {
   if (loading || !asset || isDeleting.value) return false
-  return isHovered.value || selected || isVideoPlaying.value
+  return (
+    isHovered.value || isFocusedWithin.value || selected || isVideoPlaying.value
+  )
 })
 
 const handleZoomClick = () => {


### PR DESCRIPTION
## Summary

Reveal Media Asset card controls when keyboard focus enters the card so keyboard-only users can see the selection and action controls they are operating.

## Changes

- **What**: Include focus-within state in the existing hover/selected/video action reveal logic.
- **What**: Add a component regression test that tabs from the selection toggle into Download and verifies the action group remains available.

## Review Focus

Tab through an unselected Media Asset card without hovering it. The selection toggle should reveal the action group, and Download and More should remain visible as focus advances.

## Testing

- `pnpm exec vitest run src/platform/assets/components/MediaAssetCard.test.ts`
- `pnpm exec eslint src/platform/assets/components/MediaAssetCard.vue src/platform/assets/components/MediaAssetCard.test.ts`
- `pnpm exec oxfmt --check src/platform/assets/components/MediaAssetCard.vue src/platform/assets/components/MediaAssetCard.test.ts`
- Commit hooks: staged checks, typecheck, and knip
