### PR TITLE
feat: alert #frontend-releases when the sheriff run degrades

### DIFF
--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -43,9 +43,35 @@ jobs:
         uses: ./.github/actions/setup-frontend
 
       - name: Assign release sheriff
+        id: sheriff
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
         run: pnpm exec tsx scripts/release-sheriff/release-sheriff.ts
+
+      # A failed scheduled run only notifies whoever last pushed to main, which
+      # in practice is nobody — the reason the placeholder config went unnoticed
+      # for weeks. Post where the rotation actually watches instead.
+      - name: Report a degraded run to Slack
+        if: failure()
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: 'C09K9TPU2G7' # #frontend-releases
+          REASON: ${{ steps.sheriff.outputs.degraded }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          DETAIL="${REASON:-The job failed before it could resolve a sheriff.}"
+          TEXT=":rotating_light: *Release sheriff assignment degraded.* ${DETAIL} <${RUN_URL}|View run>"
+          BODY=$(jq -n --arg ch "$SLACK_CHANNEL_ID" --arg text "$TEXT" '{channel: $ch, text: $text}')
+          RESPONSE=$(curl -sS -X POST \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            https://slack.com/api/chat.postMessage)
+          echo "$RESPONSE" | jq -e '.ok == true' >/dev/null

--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -68,15 +68,29 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          PREVIOUS=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/pr-assign-release-sheriff.yaml/runs?status=completed&per_page=40" \
-            --jq "[.workflow_runs[]
-                   | select(.id != ($RUN_ID|tonumber))
-                   | select(.conclusion == \"success\" or .conclusion == \"failure\")]
-                  | first.conclusion // \"none\"")
+          # The run's conclusion is the wrong signal: a run that died in
+          # checkout failed without ever reaching the sheriff, and counting it
+          # as "already alerted" would swallow the next real one. Read the
+          # step's own conclusion. Only scheduled runs are considered — the
+          # pull_request_target gate skips most others, so they are the ones
+          # dense in runs that actually decided something.
+          PREVIOUS=none
+          RUNS=$(gh api \
+            "repos/$REPO/actions/workflows/pr-assign-release-sheriff.yaml/runs?event=schedule&status=completed&per_page=15" \
+            --jq "[.workflow_runs[] | select(.id != ($RUN_ID|tonumber))] | .[].id")
+          for RUN in $RUNS; do
+            STEP=$(gh api "repos/$REPO/actions/runs/$RUN/jobs" \
+              --jq '[.jobs[].steps[]? | select(.name == "Assign release sheriff")]
+                    | first.conclusion // ""')
+            if [ "$STEP" = "success" ] || [ "$STEP" = "failure" ]; then
+              PREVIOUS=$STEP
+              break
+            fi
+          done
           echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
 
       # Scoped to this step, not the job: a checkout or pnpm blip is CI noise

--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -33,6 +33,9 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      # Reading this workflow's own run history, to alert only on the
+      # transition into failure rather than once an hour forever.
+      actions: read
 
     steps:
       # pull_request_target checks out the base branch, never PR head code.
@@ -54,11 +57,35 @@ jobs:
       # A failed scheduled run only notifies whoever last pushed to main, which
       # in practice is nobody — the reason the placeholder config went unnoticed
       # for weeks. Post where the rotation actually watches instead.
+      # This job runs hourly, so a lasting breakage would otherwise post ~24
+      # times a day until someone fixed it — and a channel that cries wolf gets
+      # muted, which is the failure this alert exists to prevent. Alert on the
+      # transition into failure: skip if the previous decisive run already did.
+      # Skipped runs (the pull_request_target gate) are not decisive.
+      - name: Check whether this failure is already known
+        id: known
+        if: failure() && steps.sheriff.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          PREVIOUS=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/pr-assign-release-sheriff.yaml/runs?status=completed&per_page=40" \
+            --jq "[.workflow_runs[]
+                   | select(.id != ($RUN_ID|tonumber))
+                   | select(.conclusion == \"success\" or .conclusion == \"failure\")]
+                  | first.conclusion // \"none\"")
+          echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
+
       # Scoped to this step, not the job: a checkout or pnpm blip is CI noise
       # that is already visible elsewhere, and paging the rotation for it is
       # how an alert channel gets muted.
       - name: Report a degraded run to Slack
-        if: failure() && steps.sheriff.outcome == 'failure'
+        if: >-
+          failure() && steps.sheriff.outcome == 'failure' &&
+          steps.known.outputs.previous != 'failure'
         continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -54,8 +54,11 @@ jobs:
       # A failed scheduled run only notifies whoever last pushed to main, which
       # in practice is nobody — the reason the placeholder config went unnoticed
       # for weeks. Post where the rotation actually watches instead.
+      # Scoped to this step, not the job: a checkout or pnpm blip is CI noise
+      # that is already visible elsewhere, and paging the rotation for it is
+      # how an alert channel gets muted.
       - name: Report a degraded run to Slack
-        if: failure()
+        if: failure() && steps.sheriff.outcome == 'failure'
         continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -95,6 +95,14 @@ failing scheduled workflow otherwise only notifies whoever last pushed to
 weeks. Needs the `SLACK_BOT_TOKEN` secret; the post is `continue-on-error`, so
 Slack being down never masks the underlying result.
 
+It alerts on the **transition** into failure, not on every failing run: the job
+runs hourly, so a lasting breakage would otherwise post around the clock until
+someone fixed it, and a channel that cries wolf gets muted. The check reads this
+workflow's own run history for the last run that actually decided something —
+`skipped` runs, which the `pull_request_target` gate produces in bulk, are
+ignored, and without that filter nothing would ever be throttled. If the check
+itself cannot run it fails open and alerts, since a duplicate beats a silence.
+
 ## Publishing
 
 Merged PRs with the `Release` label trigger `release-draft-create.yaml`,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -89,6 +89,12 @@ unreachable Datadog — the job still assigns `fallbackGithubLogin` so PRs are
 never left unowned, but **exits non-zero** so the degradation is visible. A
 green run means a real sheriff was resolved from Datadog.
 
+A failed run also posts to **#frontend-releases** with the reason, because a
+failing scheduled workflow otherwise only notifies whoever last pushed to
+`main` — in practice nobody, which is how the placeholder config survived for
+weeks. Needs the `SLACK_BOT_TOKEN` secret; the post is `continue-on-error`, so
+Slack being down never masks the underlying result.
+
 ## Publishing
 
 Merged PRs with the `Release` label trigger `release-draft-create.yaml`,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -97,11 +97,15 @@ Slack being down never masks the underlying result.
 
 It alerts on the **transition** into failure, not on every failing run: the job
 runs hourly, so a lasting breakage would otherwise post around the clock until
-someone fixed it, and a channel that cries wolf gets muted. The check reads this
-workflow's own run history for the last run that actually decided something —
-`skipped` runs, which the `pull_request_target` gate produces in bulk, are
-ignored, and without that filter nothing would ever be throttled. If the check
-itself cannot run it fails open and alerts, since a duplicate beats a silence.
+someone fixed it, and a channel that cries wolf gets muted.
+
+The check walks recent **scheduled** runs and reads the conclusion of the
+`Assign release sheriff` **step**, not of the run. A run that died in checkout
+failed without ever reaching the sheriff, and treating that as "already
+alerted" would swallow the next real failure. Scheduled runs are used because
+the `pull_request_target` gate skips most other runs, so they are the ones
+dense in runs that decided anything. If the check itself cannot run it fails
+open and alerts, since a duplicate beats a silence.
 
 ## Publishing
 

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -9,7 +9,8 @@ import {
   parseGithubLogins,
   parseOnCallEmails,
   planActions,
-  resolveSheriff
+  resolveSheriff,
+  singleLine
 } from './release-sheriff'
 
 const config = {
@@ -87,6 +88,16 @@ describe('parseGithubLogins', () => {
     expect(parseGithubLogins({ data: { attributes: { tags: 'no' } } })).toEqual(
       {}
     )
+  })
+})
+
+describe('singleLine', () => {
+  it('cannot emit a line that closes a GITHUB_OUTPUT heredoc early', () => {
+    expect(singleLine('before\n__EOF__\nafter')).toBe('before __EOF__ after')
+  })
+
+  it('collapses incidental whitespace', () => {
+    expect(singleLine('  a\t\tb \n c  ')).toBe('a b c')
   })
 })
 

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -288,11 +288,21 @@ function summary(line: string) {
   if (file) appendFileSync(file, `${line}\n`)
 }
 
+// A heredoc output ends at the first line equal to its delimiter, so a value
+// carrying that line would close the record early and let the rest parse as
+// further outputs. These messages are one line by construction; enforcing that
+// removes the possibility rather than picking a delimiter and hoping.
+export function singleLine(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 // Read by the workflow's failure step to say why in Slack, so the alert is
 // actionable without opening the run.
 function output(key: string, value: string) {
   const file = process.env.GITHUB_OUTPUT
-  if (file) appendFileSync(file, `${key}<<__EOF__\n${value}\n__EOF__\n`)
+  if (file) {
+    appendFileSync(file, `${key}<<__EOF__\n${singleLine(value)}\n__EOF__\n`)
+  }
 }
 
 function ghPost(path: string, field: string): boolean {
@@ -326,10 +336,12 @@ async function main() {
     ...CONFIG,
     githubLoginByUser: directory.githubLoginByUser
   })
+  // Keyed, not the full address: this repo is public, so the warning lands in
+  // public Actions logs and in Slack. The key is what the tag needs anyway.
   for (const email of unmappedEmails) {
     problems.push(
-      `Datadog on-call user ${email} has no GitHub login. Add the tag ` +
-        `"github:${emailKey(email)}:<github-login>" to the Datadog schedule.`
+      `Datadog on-call user "${emailKey(email)}" has no GitHub login. Add ` +
+        `the tag "github:${emailKey(email)}:<github-login>" to the schedule.`
     )
   }
   for (const problem of problems) warn(problem)

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -288,6 +288,13 @@ function summary(line: string) {
   if (file) appendFileSync(file, `${line}\n`)
 }
 
+// Read by the workflow's failure step to say why in Slack, so the alert is
+// actionable without opening the run.
+function output(key: string, value: string) {
+  const file = process.env.GITHUB_OUTPUT
+  if (file) appendFileSync(file, `${key}<<__EOF__\n${value}\n__EOF__\n`)
+}
+
 function ghPost(path: string, field: string): boolean {
   try {
     gh(['api', '--method', 'POST', path, '-f', field, '--silent'])
@@ -309,22 +316,27 @@ async function main() {
     fetchOnCallEmails(CONFIG, credentials),
     fetchGithubLogins(CONFIG, credentials)
   ])
-  for (const warning of [oncall.warning, directory.warning]) {
-    if (warning) warn(warning)
-  }
+  // Both lookups hit the same API, so a credentials or outage failure arrives
+  // twice; the Slack alert should say it once.
+  const problems = [
+    ...new Set([oncall.warning, directory.warning].filter((w) => w !== null))
+  ]
 
   const { login, source, unmappedEmails } = resolveSheriff(oncall.emails, {
     ...CONFIG,
     githubLoginByUser: directory.githubLoginByUser
   })
   for (const email of unmappedEmails) {
-    warn(
+    problems.push(
       `Datadog on-call user ${email} has no GitHub login. Add the tag ` +
         `"github:${emailKey(email)}:<github-login>" to the Datadog schedule.`
     )
   }
+  for (const problem of problems) warn(problem)
   if (!login) {
-    warn('No release sheriff could be resolved — nothing will be assigned.')
+    const message = 'No release sheriff could be resolved — nothing assigned.'
+    warn(message)
+    output('degraded', [message, ...problems].join(' '))
     process.exitCode = 1
     return
   }
@@ -333,6 +345,11 @@ async function main() {
   // green: this job warned "No Datadog On-Call schedule configured" on every
   // run for weeks and nobody noticed, because a warning alone reports success.
   if (source !== 'datadog') {
+    output(
+      'degraded',
+      `Fell back to \`${login}\` instead of the Datadog on-call user. ` +
+        problems.join(' ')
+    )
     process.exitCode = 1
   }
 


### PR DESCRIPTION
Follow-up to #14626.

That PR made the sheriff job exit non-zero when it cannot resolve the on-call user. But a failing **scheduled** workflow only notifies whoever last pushed to `main` — in practice nobody. That is exactly how the placeholder Datadog config survived for weeks: every run warned, and every run still reported success.

This posts the failure to **#frontend-releases** (`C09K9TPU2G7`), whose channel purpose is literally "Current Release Sheriff".

The script writes *why* it degraded to a step output, so the alert is actionable without opening the run:

> :rotating_light: **Release sheriff assignment degraded.** Fell back to `christian-byrne` instead of the Datadog on-call user. DATADOG_API_KEY / DATADOG_APP_KEY unavailable — using the fallback. [View run]

Both lookups hit the same API, so an outage or credentials failure produced the same warning twice; deduped so the alert reads once.

The post is `continue-on-error` and follows the existing pattern in `publish-design-system-on-merge.yaml` (same `SLACK_BOT_TOKEN` secret, same `chat.postMessage` + `jq -e '.ok == true'` shape), so Slack being unreachable never masks the underlying result.

## Verification

Ran the real script both ways:

- no credentials → exit 1, single-sentence reason written to `GITHUB_OUTPUT`, no PRs mutated
- real credentials → exit 0

Tests 24/24; lint, format, typecheck clean.
