### PR TITLE
test: stub /object_info display names so node-title goldens stop tracking the CI container

### DIFF
--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -153,7 +153,25 @@ export async function routeObjectInfoFromSetupApi(
       return
     }
 
-    await customize?.(objectInfo)
+    try {
+      await customize?.(objectInfo)
+    } catch (error) {
+      // A throwing mutator (e.g. a node type that disappeared from a newer
+      // ComfyUI build) must still fulfill the route. An unfulfilled request
+      // hangs the page, so the test dies on an opaque Playwright timeout
+      // instead of reporting the reason.
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`Failed to customize object_info: ${message}`)
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: `Failed to customize object_info from ${objectInfoUrl}: ${message}`
+        })
+      })
+      return
+    }
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -46,6 +46,19 @@ function getRequiredInput(
   return input
 }
 
+export function setNodeDisplayName(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  displayName: string
+): void {
+  const nodeInfo = objectInfo[nodeType]
+  if (!nodeInfo) {
+    throw new Error(`Missing object_info entry for ${nodeType}`)
+  }
+
+  nodeInfo.display_name = displayName
+}
+
 export function setStringInputTooltip(
   objectInfo: ObjectInfoResponse,
   nodeType: string,

--- a/browser_tests/tests/imageCompare.spec.ts
+++ b/browser_tests/tests/imageCompare.spec.ts
@@ -2,11 +2,39 @@ import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
+import {
+  routeObjectInfoFromSetupApi,
+  setNodeDisplayName
+} from '@e2e/fixtures/utils/objectInfo'
 import { toNodeId } from '@/types/nodeId'
 
 const IMAGE_COMPARE_NODE_ID = toNodeId(1)
+const IMAGE_COMPARE_NODE_TYPE = 'ImageCompare'
+const IMAGE_COMPARE_DISPLAY_NAME = 'Image Compare'
+
+// English node titles come from the backend, so any golden containing a node
+// header would otherwise track whatever ComfyUI build the CI container ships.
+// Pinning the name before the app boots keeps those baselines stable.
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      page,
+      (objectInfo) =>
+        setNodeDisplayName(
+          objectInfo,
+          IMAGE_COMPARE_NODE_TYPE,
+          IMAGE_COMPARE_DISPLAY_NAME
+        )
+    )
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
 
 test.describe('Image Compare', { tag: ['@widget', '@vue-nodes'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/nodeBadge.spec.ts
+++ b/browser_tests/tests/nodeBadge.spec.ts
@@ -2,14 +2,41 @@ import { expect } from '@playwright/test'
 
 import type { ComfyApp } from '@/scripts/app'
 import { NodeBadgeMode } from '@/types/nodeSource'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import {
+  routeObjectInfoFromSetupApi,
+  setNodeDisplayName
+} from '@e2e/fixtures/utils/objectInfo'
+
+const DEPRECATED_NODE_TYPE = 'ImageBatch'
+const DEPRECATED_NODE_DISPLAY_NAME = 'Batch Images'
+const API_NODE_TYPE = 'FluxProUltraImageNode'
+
+// English node titles come from the backend, so any golden containing a node
+// header would otherwise track whatever ComfyUI build the CI container ships.
+// Pinning the name before the app boots keeps those baselines stable.
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      page,
+      (objectInfo) =>
+        setNodeDisplayName(
+          objectInfo,
+          DEPRECATED_NODE_TYPE,
+          DEPRECATED_NODE_DISPLAY_NAME
+        )
+    )
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
 })
-
-const DEPRECATED_NODE_TYPE = 'ImageBatch'
-const API_NODE_TYPE = 'FluxProUltraImageNode'
 
 test.describe('Node Badge', { tag: ['@screenshot', '@smoke', '@node'] }, () => {
   test('Can add badge', async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary

Pin the node display names that Playwright goldens capture, so screenshots stop tracking whatever ComfyUI build the CI container happens to ship — and make the failure mode legible when a pinned node type goes missing.

## Changes

- **What**:
  - New `setNodeDisplayName(objectInfo, nodeType, displayName)` mutator in `browser_tests/fixtures/utils/objectInfo.ts`, alongside `setStringInputTooltip` / `setComboInputOptions`.
  - `imageCompare.spec.ts` pins `ImageCompare` -> `Image Compare`; `nodeBadge.spec.ts` pins `ImageBatch` -> `Batch Images`.
  - Both install the stub by extending the `page` fixture, so the route is live before `comfyPage.setup()` boots the node-definition store. That is the same pattern as `propertiesPanel/errorsTabModeAware.spec.ts` and avoids the extra `reloadAndWaitForApp()` that `widgetTooltip.spec.ts` needs when routing mid-test.
  - **Pre-existing bug fix:** `routeObjectInfoFromSetupApi` only wrapped the fetch and JSON parse in a `try`. A throwing `customize` callback rejected the route handler, so `route.fulfill` never ran and the request hung — the test then died on an opaque Playwright timeout rather than reporting the cause. The mutators throw precisely when a node type is missing from `/object_info`, which is what a container bump triggers, so shipping the pins without this would turn "node was renamed upstream" into a mystery hang. `customize` is now guarded and fulfills a 500 naming the failure, with the message logged to test output.

No baselines were regenerated. The pinned strings are the ones the committed PNGs already encode, so the images are byte-identical to `main`.

## Review Focus

Since #14541, English node titles resolve from the backend `/object_info` rather than from a bundled file. That makes every golden containing a node header a function of the CI container image, which is pinned to `ghcr.io/comfy-org/comfyui-ci-container:0.0.21` (ComfyUI v0.19.3) in four workflows: `ci-tests-e2e.yaml:57` and `:115`, `pr-update-playwright-expectations.yaml:84`, `ci-perf-report.yaml:34`. `0.0.22` (ComfyUI v0.30.0) already exists in the registry, and whoever bumps the pin currently gets unrelated node-title screenshot diffs with nothing in-repo explaining them. This makes that bump safe.

The chosen strings are not guesses. #14541 itself re-baselined these goldens, so they encode the container's names, and the rename is visible in the diff of that commit: in `image-compare-default-50`, the title descenders move from `p` at x=60 / `g` at x=112 (bundled `Compare Images`) to `g` at x=56 / `p` at x=98 (container `Image Compare`). `Batch Images` is legible directly in `node-lifecycle-*`.

No unit test covers the hang fix: `browser_tests/**` is outside vitest's `include` globs (`src/`, `packages/`, `scripts/`), and widening them would sweep the Playwright `.spec.ts` files into `pnpm test:unit`. Exercising the path for real needs a running ComfyUI backend.

Still coupled to the container, deliberately out of scope here: the `api-pricing-*` goldens (title `Flux 1.1 [pro] Ultra Image`, from `FluxProUltraImageNode`) and `node-badge-*` (titles from the `nodes/execution_error` workflow). Same fix applies if we want them covered.

Fixes #14630
