### PR TITLE
fix(subgraph): mirror promoted image widget previews

### DIFF
--- a/browser_tests/assets/subgraphs/subgraph-with-nested-promoted-image-widget.json
+++ b/browser_tests/assets/subgraphs/subgraph-with-nested-promoted-image-widget.json
@@ -1,0 +1,252 @@
+{
+  "id": "aaaaaaaa-bbbb-4ccc-8ddd-ffffffffffff",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 11,
+      "type": "44444444-5555-4666-8777-888888888888",
+      "pos": [200, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": null },
+        { "name": "MASK", "type": "MASK", "links": null }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    },
+    {
+      "id": 12,
+      "type": "44444444-5555-4666-8777-888888888888",
+      "pos": [700, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": null },
+        { "name": "MASK", "type": "MASK", "links": null }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "44444444-5555-4666-8777-888888888888",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 77,
+          "lastLinkId": 3,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Outer Promoted Image Widget",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 300, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [700, 300, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "55555555-6666-4777-8888-999999999999",
+            "name": "image",
+            "type": "COMBO",
+            "linkIds": [1],
+            "pos": [200, 320]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "66666666-7777-4888-8999-aaaaaaaaaaaa",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [2],
+            "pos": [720, 320]
+          },
+          {
+            "id": "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [3],
+            "pos": [720, 340]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 77,
+            "type": "11111111-2222-4333-8444-555555555555",
+            "pos": [300, 200],
+            "size": [315, 360],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "COMBO",
+                "widget": { "name": "image" },
+                "link": 1
+              }
+            ],
+            "outputs": [
+              { "name": "IMAGE", "type": "IMAGE", "links": [2] },
+              { "name": "MASK", "type": "MASK", "links": [3] }
+            ],
+            "properties": {},
+            "widgets_values": []
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 77,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 2,
+            "origin_id": 77,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 3,
+            "origin_id": 77,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "11111111-2222-4333-8444-555555555555",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 1,
+          "lastLinkId": 3,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Inner Promoted Image Widget",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 300, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [700, 300, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "99999999-8888-4777-8666-555555555555",
+            "name": "image",
+            "type": "COMBO",
+            "linkIds": [1],
+            "pos": [200, 320]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "22222222-3333-4444-8555-666666666666",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [2],
+            "pos": [720, 320]
+          },
+          {
+            "id": "33333333-4444-4555-8666-777777777777",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [3],
+            "pos": [720, 340]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "LoadImage",
+            "pos": [300, 200],
+            "size": [315, 360],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "COMBO",
+                "widget": { "name": "image" },
+                "link": 1
+              }
+            ],
+            "outputs": [
+              { "name": "IMAGE", "type": "IMAGE", "links": [2] },
+              { "name": "MASK", "type": "MASK", "links": [3] }
+            ],
+            "properties": { "Node name for S&R": "LoadImage" },
+            "widgets_values": ["interior.png", "image"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 2,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 3,
+            "origin_id": 1,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/subgraphs/subgraph-with-promoted-image-widget.json
+++ b/browser_tests/assets/subgraphs/subgraph-with-promoted-image-widget.json
@@ -1,0 +1,183 @@
+{
+  "id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 11,
+      "type": "11111111-2222-4333-8444-555555555555",
+      "pos": [200, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    },
+    {
+      "id": 12,
+      "type": "11111111-2222-4333-8444-555555555555",
+      "pos": [700, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "11111111-2222-4333-8444-555555555555",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 1,
+          "lastLinkId": 1,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Promoted Image Widget",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 300, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [700, 300, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "99999999-8888-4777-8666-555555555555",
+            "name": "image",
+            "type": "COMBO",
+            "linkIds": [1],
+            "pos": [200, 320]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "22222222-3333-4444-8555-666666666666",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [2],
+            "pos": [720, 320]
+          },
+          {
+            "id": "33333333-4444-4555-8666-777777777777",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [3],
+            "pos": [720, 340]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "LoadImage",
+            "pos": [300, 200],
+            "size": [315, 360],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "COMBO",
+                "widget": {
+                  "name": "image"
+                },
+                "link": 1
+              }
+            ],
+            "outputs": [
+              {
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [2]
+              },
+              {
+                "name": "MASK",
+                "type": "MASK",
+                "links": [3]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoadImage"
+            },
+            "widgets_values": ["interior.png", "image"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 2,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 3,
+            "origin_id": 1,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/subgraph/subgraphPromotedImageWidget.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotedImageWidget.spec.ts
@@ -1,0 +1,203 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+async function uploadImageToHost(
+  comfyPage: ComfyPage,
+  nodeId: string,
+  filename: string
+) {
+  const node = comfyPage.vueNodes.getNodeLocator(nodeId)
+  const uploadResponse = comfyPage.page.waitForResponse(
+    (response) =>
+      response.url().includes('/upload/') && response.status() === 200
+  )
+
+  await node
+    .locator('input[type="file"][aria-label="Upload"]')
+    .setInputFiles(assetPath(filename))
+  await uploadResponse
+}
+
+test.describe(
+  'Promoted image widget projection',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.page.route('**/api/view?*', (route) =>
+        route.fulfill({
+          contentType: 'image/webp',
+          path: assetPath('image64x64.webp')
+        })
+      )
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-with-promoted-image-widget'
+      )
+      await uploadImageToHost(comfyPage, '11', 'image64x64.webp')
+      await uploadImageToHost(comfyPage, '12', 'image32x32.webp')
+    })
+
+    test('shows the entered host value and preview without changing the definition value', async ({
+      comfyPage
+    }) => {
+      const firstHost = comfyPage.vueNodes.getNodeLocator('11')
+      const secondHost = comfyPage.vueNodes.getNodeLocator('12')
+      await expect(
+        firstHost.getByRole('button', {
+          name: 'image64x64.webp',
+          exact: true
+        })
+      ).toBeVisible()
+      await expect(
+        secondHost.getByRole('button', {
+          name: 'image32x32.webp',
+          exact: true
+        })
+      ).toBeVisible()
+
+      await comfyPage.vueNodes.enterSubgraph('12')
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+      const interiorNode = comfyPage.vueNodes.getNodeLocator('1')
+      const projectedValue = interiorNode.getByRole('button', {
+        name: 'image32x32.webp',
+        exact: true
+      })
+      const previewImage = interiorNode.locator('.image-preview img')
+
+      await expect(projectedValue).toBeVisible()
+      await expect(projectedValue).toBeDisabled()
+      await expect(previewImage).toBeVisible()
+      await expect(
+        interiorNode.getByRole('button', { name: 'Edit or mask image' })
+      ).toHaveCount(0)
+      await expect
+        .poll(async () => {
+          const src = await previewImage.getAttribute('src')
+          if (!src) return null
+          const params = new URL(src, 'http://localhost').searchParams
+          return {
+            filename: params.get('filename'),
+            subfolder: params.get('subfolder'),
+            type: params.get('type')
+          }
+        })
+        .toEqual({
+          filename: 'image32x32.webp',
+          subfolder: '',
+          type: 'input'
+        })
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(() => {
+            const node = window.app!.canvas.graph?.nodes.find(
+              (candidate) => String(candidate.id) === '1'
+            )
+            return node?.widgets?.find((widget) => widget.name === 'image')
+              ?.value
+          })
+        )
+        .toBe('interior.png')
+
+      const goToParent = interiorNode.getByRole('button', {
+        name: 'Go to parent node'
+      })
+      await expect(goToParent).toBeVisible()
+      await goToParent.click()
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
+      await expect(secondHost).toBeVisible()
+    })
+
+    test('keeps the interior fallback read-only when the shared host is ambiguous', async ({
+      comfyPage
+    }) => {
+      await comfyPage.page.evaluate(() => {
+        window.location.hash = '#11111111-2222-4333-8444-555555555555'
+      })
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+
+      const interiorNode = comfyPage.vueNodes.getNodeLocator('1')
+      const fallbackValue = interiorNode.getByRole('button', {
+        name: 'interior.png',
+        exact: true
+      })
+
+      await expect(fallbackValue).toBeVisible()
+      await expect(fallbackValue).toBeDisabled()
+      await expect(
+        interiorNode.getByRole('button', { name: 'Go to parent node' })
+      ).toHaveCount(0)
+    })
+  }
+)
+
+test.describe(
+  'Nested promoted image widget projection',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.page.route('**/api/view?*', (route) =>
+        route.fulfill({
+          contentType: 'image/webp',
+          path: assetPath('image32x32.webp')
+        })
+      )
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-with-nested-promoted-image-widget'
+      )
+      await uploadImageToHost(comfyPage, '12', 'image32x32.webp')
+    })
+
+    test('preserves the selected root host through nested entry and return', async ({
+      comfyPage
+    }) => {
+      await comfyPage.vueNodes.enterSubgraph('12')
+
+      const intermediateHost = comfyPage.vueNodes.getNodeLocator('77')
+      await expect(
+        intermediateHost.getByRole('button', {
+          name: 'image32x32.webp',
+          exact: true
+        })
+      ).toBeVisible()
+      await expect(intermediateHost.locator('.image-preview img')).toBeVisible()
+
+      await comfyPage.vueNodes.enterSubgraph('77')
+
+      const interiorNode = comfyPage.vueNodes.getNodeLocator('1')
+      await expect(
+        interiorNode.getByRole('button', {
+          name: 'image32x32.webp',
+          exact: true
+        })
+      ).toBeVisible()
+      await expect(interiorNode.locator('.image-preview img')).toBeVisible()
+
+      await comfyPage.page.getByTestId('subgraph-breadcrumb-back').click()
+
+      await expect(
+        intermediateHost.getByRole('button', {
+          name: 'image32x32.webp',
+          exact: true
+        })
+      ).toBeVisible()
+      await expect(intermediateHost.locator('.image-preview img')).toBeVisible()
+
+      await comfyPage.vueNodes.enterSubgraph('77')
+      await interiorNode
+        .getByRole('button', { name: 'Go to parent node' })
+        .click()
+
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
+      await expect(
+        comfyPage.vueNodes.getNodeLocator('12').getByRole('button', {
+          name: 'image32x32.webp',
+          exact: true
+        })
+      ).toBeVisible()
+    })
+  }
+)

--- a/src/core/graph/subgraph/liftNodeErrorsToBoundary.ts
+++ b/src/core/graph/subgraph/liftNodeErrorsToBoundary.ts
@@ -2,22 +2,16 @@ import { groupBy, partition } from 'es-toolkit'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import type { NodeError } from '@/schemas/apiSchema'
-import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
-import type { NodeExecutionId } from '@/types/nodeIdentification'
 import { isNodeLevelValidationError } from '@/utils/executionErrorUtil'
 import type { NodeValidationError } from '@/utils/executionErrorUtil'
 import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
-import { isSubgraph } from '@/utils/typeGuardUtil'
+
+import { resolvePromotedInputBoundaryChain } from './promotedInputBoundary'
 
 export interface LiftedErrorExtraInfo {
   input_name: string
   source_execution_id: string
   source_input_name: string
-}
-
-export interface LiftedSurface {
-  hostExecId: NodeExecutionId
-  hostInputName: string
 }
 
 interface ErrorPlacement {
@@ -42,50 +36,6 @@ export function getLiftedErrorSource(
   }
 
   return { input_name, source_execution_id, source_input_name }
-}
-
-function getHostExecutionId(executionId: string): NodeExecutionId | null {
-  const separatorIndex = executionId.lastIndexOf(':')
-  if (separatorIndex <= 0) return null
-  return tryNormalizeNodeExecutionId(executionId.slice(0, separatorIndex))
-}
-
-/**
- * Boundary surfaces that expose `(executionId, inputName)`, innermost first.
- * Walks one host per level and stops at the last resolvable surface, so an
- * unresolvable deeper host falls back to the shallower one (fail-open).
- */
-export function resolveLiftChain(
-  rootGraph: LGraph,
-  executionId: string,
-  inputName: string
-): LiftedSurface[] {
-  const chain: LiftedSurface[] = []
-  let currentExecId = executionId
-  let currentInputName = inputName
-
-  for (;;) {
-    const node = getNodeByExecutionId(rootGraph, currentExecId)
-    const graph = node?.graph
-    if (!node || !graph || !isSubgraph(graph)) break
-
-    const slot = node.inputs?.find((input) => input.name === currentInputName)
-    if (slot?.link == null) break
-
-    const subgraphInput = graph
-      .getLink(slot.link)
-      ?.resolve(graph)?.subgraphInput
-    if (!subgraphInput) break
-
-    const hostExecId = getHostExecutionId(currentExecId)
-    if (!hostExecId || !getNodeByExecutionId(rootGraph, hostExecId)) break
-
-    chain.push({ hostExecId, hostInputName: subgraphInput.name })
-    currentExecId = hostExecId
-    currentInputName = subgraphInput.name
-  }
-
-  return chain
 }
 
 function createEmptyNodeError(nodeError: NodeError): NodeError {
@@ -116,7 +66,9 @@ function toErrorPlacement(
   const inputName = error.extra_info?.input_name
   const surface =
     inputName && !isNodeLevelValidationError(error)
-      ? resolveLiftChain(rootGraph, executionId, inputName).at(-1)
+      ? resolvePromotedInputBoundaryChain(rootGraph, executionId, inputName).at(
+          -1
+        )
       : undefined
 
   if (!inputName || !surface) {
@@ -128,14 +80,14 @@ function toErrorPlacement(
   }
 
   const liftedExtraInfo: LiftedErrorExtraInfo = {
-    input_name: surface.hostInputName,
+    input_name: surface.inputName,
     source_execution_id: executionId,
     source_input_name: inputName
   }
 
   return {
     kind: 'lifted',
-    targetExecId: surface.hostExecId,
+    targetExecId: surface.hostExecutionId,
     error: {
       ...error,
       extra_info: {

--- a/src/core/graph/subgraph/promotedInputBoundary.ts
+++ b/src/core/graph/subgraph/promotedInputBoundary.ts
@@ -1,0 +1,52 @@
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+import { isSubgraph } from '@/utils/typeGuardUtil'
+
+interface PromotedInputBoundary {
+  hostExecutionId: NodeExecutionId
+  inputName: string
+}
+
+function getHostExecutionId(executionId: string): NodeExecutionId | null {
+  const separatorIndex = executionId.lastIndexOf(':')
+  if (separatorIndex <= 0) return null
+  return tryNormalizeNodeExecutionId(executionId.slice(0, separatorIndex))
+}
+
+/** Resolves promoted input boundaries from the innermost host outward. */
+export function resolvePromotedInputBoundaryChain(
+  rootGraph: LGraph,
+  executionId: string,
+  inputName: string
+): PromotedInputBoundary[] {
+  const chain: PromotedInputBoundary[] = []
+  let currentExecutionId = executionId
+  let currentInputName = inputName
+
+  for (;;) {
+    const node = getNodeByExecutionId(rootGraph, currentExecutionId)
+    const graph = node?.graph
+    if (!node || !graph || !isSubgraph(graph)) break
+
+    const slot = node.inputs?.find((input) => input.name === currentInputName)
+    if (slot?.link == null) break
+
+    const subgraphInput = graph
+      .getLink(slot.link)
+      ?.resolve(graph)?.subgraphInput
+    if (!subgraphInput) break
+
+    const hostExecutionId = getHostExecutionId(currentExecutionId)
+    if (!hostExecutionId || !getNodeByExecutionId(rootGraph, hostExecutionId)) {
+      break
+    }
+
+    chain.push({ hostExecutionId, inputName: subgraphInput.name })
+    currentExecutionId = hostExecutionId
+    currentInputName = subgraphInput.name
+  }
+
+  return chain
+}

--- a/src/core/graph/subgraph/subgraphHostExecution.test.ts
+++ b/src/core/graph/subgraph/subgraphHostExecution.test.ts
@@ -1,0 +1,128 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+
+import {
+  findSubgraphHostAncestorExecutionId,
+  findUniqueSubgraphHostExecutionId,
+  resolveEnteredSubgraphHostExecutionId
+} from './subgraphHostExecution'
+
+describe('subgraph host execution context', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('resolves a definition with one host instance', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    const host = createTestSubgraphNode(subgraph, { id: 11 })
+    rootGraph.add(host)
+
+    expect(findUniqueSubgraphHostExecutionId(rootGraph, subgraph)).toBe('11')
+  })
+
+  it('does not choose between two host instances of one definition', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    rootGraph.add(createTestSubgraphNode(subgraph, { id: 11 }))
+    rootGraph.add(createTestSubgraphNode(subgraph, { id: 12 }))
+
+    expect(
+      findUniqueSubgraphHostExecutionId(rootGraph, subgraph)
+    ).toBeUndefined()
+  })
+
+  it('treats a nested host under two shared outer instances as ambiguous', () => {
+    const rootGraph = createTestRootGraph()
+    const outerSubgraph = createTestSubgraph({ rootGraph })
+    const innerSubgraph = createTestSubgraph({ rootGraph })
+    outerSubgraph.add(
+      createTestSubgraphNode(innerSubgraph, {
+        parentGraph: outerSubgraph,
+        id: 22
+      })
+    )
+    rootGraph.add(createTestSubgraphNode(outerSubgraph, { id: 11 }))
+    rootGraph.add(createTestSubgraphNode(outerSubgraph, { id: 12 }))
+
+    expect(
+      findUniqueSubgraphHostExecutionId(rootGraph, innerSubgraph)
+    ).toBeUndefined()
+  })
+
+  it('preserves an exact ancestor when navigating back outward', () => {
+    const rootGraph = createTestRootGraph()
+    const outerSubgraph = createTestSubgraph({ rootGraph })
+    const innerSubgraph = createTestSubgraph({ rootGraph })
+    outerSubgraph.add(
+      createTestSubgraphNode(innerSubgraph, {
+        parentGraph: outerSubgraph,
+        id: 22
+      })
+    )
+    rootGraph.add(createTestSubgraphNode(outerSubgraph, { id: 11 }))
+    rootGraph.add(createTestSubgraphNode(outerSubgraph, { id: 12 }))
+
+    expect(
+      findSubgraphHostAncestorExecutionId(
+        rootGraph,
+        createNodeExecutionId([12, 22]),
+        outerSubgraph
+      )
+    ).toBe('12')
+  })
+
+  it('uses the selected host when entering from the root graph', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    rootGraph.add(createTestSubgraphNode(subgraph, { id: 11 }))
+    const selectedHost = createTestSubgraphNode(subgraph, { id: 12 })
+    rootGraph.add(selectedHost)
+
+    expect(
+      resolveEnteredSubgraphHostExecutionId(
+        rootGraph,
+        undefined,
+        rootGraph,
+        selectedHost
+      )
+    ).toBe('12')
+  })
+
+  it('extends the exact path when entering a nested subgraph', () => {
+    const rootGraph = createTestRootGraph()
+    const outerSubgraph = createTestSubgraph({ rootGraph })
+    const innerSubgraph = createTestSubgraph({ rootGraph })
+    const innerHost = createTestSubgraphNode(innerSubgraph, {
+      parentGraph: outerSubgraph,
+      id: 22
+    })
+    outerSubgraph.add(innerHost)
+    rootGraph.add(createTestSubgraphNode(outerSubgraph, { id: 12 }))
+
+    expect(
+      resolveEnteredSubgraphHostExecutionId(
+        rootGraph,
+        createNodeExecutionId([12]),
+        outerSubgraph,
+        innerHost
+      )
+    ).toBe('12:22')
+    expect(
+      resolveEnteredSubgraphHostExecutionId(
+        rootGraph,
+        undefined,
+        outerSubgraph,
+        innerHost
+      )
+    ).toBeUndefined()
+  })
+})

--- a/src/core/graph/subgraph/subgraphHostExecution.ts
+++ b/src/core/graph/subgraph/subgraphHostExecution.ts
@@ -1,0 +1,87 @@
+import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
+import {
+  appendNodeExecutionId,
+  createNodeExecutionId,
+  getAncestorExecutionIds
+} from '@/types/nodeIdentification'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+
+export function findUniqueSubgraphHostExecutionId(
+  rootGraph: LGraph,
+  targetSubgraph: Subgraph
+): NodeExecutionId | undefined {
+  let match: NodeExecutionId | undefined
+  let isAmbiguous = false
+
+  function visit(
+    graph: LGraph | Subgraph,
+    parentExecutionId: NodeExecutionId | undefined,
+    ancestorSubgraphIds: ReadonlySet<string>
+  ): void {
+    for (const node of graph.nodes) {
+      if (!node.isSubgraphNode()) continue
+      if (ancestorSubgraphIds.has(node.subgraph.id)) continue
+
+      const executionId = parentExecutionId
+        ? appendNodeExecutionId(parentExecutionId, node.id)
+        : createNodeExecutionId([node.id])
+
+      if (node.subgraph === targetSubgraph) {
+        if (match) {
+          isAmbiguous = true
+          return
+        }
+        match = executionId
+      }
+
+      const nextAncestorIds = new Set(ancestorSubgraphIds)
+      nextAncestorIds.add(node.subgraph.id)
+      visit(node.subgraph, executionId, nextAncestorIds)
+      if (isAmbiguous) return
+    }
+  }
+
+  visit(rootGraph, undefined, new Set())
+  return isAmbiguous ? undefined : match
+}
+
+export function findSubgraphHostAncestorExecutionId(
+  rootGraph: LGraph,
+  currentHostExecutionId: NodeExecutionId | undefined,
+  targetSubgraph: Subgraph
+): NodeExecutionId | undefined {
+  if (!currentHostExecutionId) return undefined
+
+  for (const executionId of getAncestorExecutionIds(
+    currentHostExecutionId
+  ).reverse()) {
+    const node = getNodeByExecutionId(rootGraph, executionId)
+    if (node?.isSubgraphNode() && node.subgraph === targetSubgraph) {
+      return executionId
+    }
+  }
+
+  return undefined
+}
+
+export function resolveEnteredSubgraphHostExecutionId(
+  rootGraph: LGraph,
+  currentHostExecutionId: NodeExecutionId | undefined,
+  closingGraph: LGraph | Subgraph,
+  fromNode: SubgraphNode
+): NodeExecutionId | undefined {
+  if (fromNode.graph !== closingGraph) return undefined
+  if (closingGraph === rootGraph) {
+    return createNodeExecutionId([fromNode.id])
+  }
+  if (!currentHostExecutionId) return undefined
+
+  const currentHost = getNodeByExecutionId(rootGraph, currentHostExecutionId)
+  if (!currentHost?.isSubgraphNode() || currentHost.subgraph !== closingGraph) {
+    return undefined
+  }
+
+  return appendNodeExecutionId(currentHostExecutionId, fromNode.id)
+}

--- a/src/lib/litegraph/src/infrastructure/LGraphCanvasEventMap.ts
+++ b/src/lib/litegraph/src/infrastructure/LGraphCanvasEventMap.ts
@@ -16,6 +16,11 @@ export interface LGraphCanvasEventMap {
     /** The old active graph, or `null` if there was no active graph. */
     oldGraph: LGraph | Subgraph | null | undefined
   }
+  'subgraph-opening': {
+    subgraph: Subgraph
+    closingGraph: LGraph
+    fromNode: SubgraphNode
+  }
   'subgraph-opened': {
     subgraph: Subgraph
     closingGraph: LGraph

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -176,6 +176,8 @@
     "devOnly": "DEV",
     "loadWorkflow": "Load Workflow",
     "goToNode": "Go to Node",
+    "goToParentNode": "Go to parent node",
+    "parentNode": "Parent node",
     "setAsBackground": "Set as Background",
     "customBackground": "Custom Background",
     "settings": "Settings",

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -151,6 +151,19 @@ describe('ImagePreview', () => {
     screen.getByRole('button', { name: 'Edit or mask image' })
   })
 
+  it('hides mask/edit while preserving view and download actions when read-only', () => {
+    renderImagePreview({
+      imageUrls: [defaultProps.imageUrls[0]],
+      readOnly: true
+    })
+
+    expect(screen.getByRole('img')).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: 'Edit or mask image' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Download image' })).toBeVisible()
+  })
+
   it('hides mask and download buttons when image fails to load', async () => {
     renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -108,7 +108,9 @@
       >
         <!-- Mask/Edit Button -->
         <button
-          v-if="!hasMultipleImages && !imageError && !currentImageIsHdr"
+          v-if="
+            !readOnly && !hasMultipleImages && !imageError && !currentImageIsHdr
+          "
           :class="actionButtonClass"
           :title="$t('g.editOrMaskImage')"
           :aria-label="$t('g.editOrMaskImage')"
@@ -217,9 +219,10 @@ interface ImagePreviewProps {
   readonly imageUrls: readonly string[]
   /** Optional node ID for context-aware actions */
   readonly nodeId?: NodeId
+  readonly readOnly?: boolean
 }
 
-const { imageUrls, nodeId } = defineProps<ImagePreviewProps>()
+const { imageUrls, nodeId, readOnly = false } = defineProps<ImagePreviewProps>()
 
 const { t } = useI18n()
 const maskEditor = useMaskEditor()

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.subgraph.test.ts
@@ -23,6 +23,12 @@ vi.mock('@/scripts/app', () => ({
   app: mockApp
 }))
 
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: () => ({
+    activeSubgraphHostExecutionId: undefined
+  })
+}))
+
 vi.mock('@/utils/graphTraversalUtil', () => ({
   getNodeByLocatorId: vi.fn(),
   getLocatorIdFromNodeData: vi.fn((nodeData) =>

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -65,6 +65,12 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: () => ({
+    activeSubgraphHostExecutionId: undefined
+  })
+}))
+
 vi.mock('@/composables/useErrorHandling', () => ({
   useErrorHandling: () => ({
     toastErrorHandler: vi.fn()

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -155,9 +155,31 @@
 
           <NodeWidgets v-if="nodeData.widgets?.length" :node-data="nodeData" />
 
+          <Button
+            v-if="linkedImageWidgetProjection"
+            variant="link"
+            size="sm"
+            data-testid="linked-image-parent-button"
+            :aria-label="t('g.goToParentNode')"
+            class="mr-3 gap-1 self-end rounded-sm px-1.5 font-normal"
+            @pointerdown.stop
+            @click.stop="handleGoToLinkedImageHost"
+          >
+            <i
+              class="icon-[lucide--arrow-up-left] size-3.5"
+              aria-hidden="true"
+            />
+            <span>{{ t('g.parentNode') }}</span>
+          </Button>
+
           <div v-if="hasCustomContent" class="flex min-h-0 flex-1 flex-col">
             <NodeContent
-              v-if="nodeMedia"
+              v-if="linkedImageWidgetMedia"
+              :media="linkedImageWidgetMedia"
+              read-only
+            />
+            <NodeContent
+              v-else-if="nodeMedia"
               :node-data="nodeData"
               :media="nodeMedia"
             />
@@ -254,6 +276,8 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import Button from '@/components/ui/button/Button.vue'
+import { useFocusNode } from '@/composables/canvas/useFocusNode'
 import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
 import { useAppMode } from '@/composables/useAppMode'
 import { useErrorHandling } from '@/composables/useErrorHandling'
@@ -284,6 +308,11 @@ import { useNodeEventHandlers } from '@/renderer/extensions/vueNodes/composables
 import { useNodePointerInteractions } from '@/renderer/extensions/vueNodes/composables/useNodePointerInteractions'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
 import { usePartitionedBadges } from '@/renderer/extensions/vueNodes/composables/usePartitionedBadges'
+import {
+  getImageWidgetPreviewUrls,
+  isLinkedImageWidget,
+  resolveLinkedImageWidgetValue
+} from '@/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue'
 import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
 import { useNodeExecutionState } from '@/renderer/extensions/vueNodes/execution/useNodeExecutionState'
 import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
@@ -296,6 +325,7 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { isVideoOutput } from '@/utils/litegraphUtil'
@@ -561,7 +591,8 @@ watch(isCollapsed, (collapsed) => {
 // Check if node has custom content (like image/video outputs)
 const hasCustomContent = computed(() => {
   if (promotedPreviews.value.length > 0) return true
-  return !!nodeMedia.value && nodeMedia.value.urls.length > 0
+  const media = linkedImageWidgetMedia.value ?? nodeMedia.value
+  return !!media?.urls.length
 })
 
 // Computed classes and conditions for better reusability
@@ -701,6 +732,8 @@ const handleEnterSubgraph = () => {
 }
 
 const nodeOutputs = useNodeOutputStore()
+const subgraphNavigationStore = useSubgraphNavigationStore()
+const { focusNode } = useFocusNode()
 
 const nodeOutputLocatorId = computed(() =>
   nodeData.subgraphId ? `${nodeData.subgraphId}:${nodeData.id}` : nodeData.id
@@ -716,6 +749,40 @@ const lgraphNode = computed(() => {
 // TODO: Surface subgraph info more cleanly in VueNodeData instead of
 // reaching through lgraphNode for promoted preview resolution.
 const { promotedPreviews } = usePromotedPreviews(lgraphNode)
+
+const linkedImageWidget = computed(() =>
+  nodeData.widgets?.find(isLinkedImageWidget)
+)
+
+const linkedImageWidgetProjection = computed(() => {
+  const hostExecutionId = subgraphNavigationStore.activeSubgraphHostExecutionId
+  const imageWidget = linkedImageWidget.value
+  if (!hostExecutionId || !imageWidget || !app.isGraphReady) return undefined
+
+  const projection = resolveLinkedImageWidgetValue(
+    app.rootGraph,
+    hostExecutionId,
+    nodeData.id,
+    imageWidget.name
+  )
+  if (!projection) return undefined
+
+  return {
+    hostExecutionId: projection.hostExecutionId,
+    type: 'image',
+    urls: getImageWidgetPreviewUrls(projection.value)
+  } as const
+})
+
+const linkedImageWidgetMedia = computed(() => {
+  if (!linkedImageWidget.value) return undefined
+  return linkedImageWidgetProjection.value ?? nodeMedia.value
+})
+
+function handleGoToLinkedImageHost() {
+  const hostExecutionId = linkedImageWidgetProjection.value?.hostExecutionId
+  if (hostExecutionId) void focusNode(hostExecutionId)
+}
 
 const { hideExecutedOutput } = useGLSLPreview(lgraphNode)
 

--- a/src/renderer/extensions/vueNodes/components/NodeContent.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeContent.vue
@@ -23,6 +23,7 @@
         v-else-if="hasMedia && media?.type === 'image'"
         :image-urls="media.urls"
         :node-id="nodeId"
+        :read-only="readOnly"
         class="mt-2 flex-auto"
       />
     </slot>
@@ -42,6 +43,7 @@ import ImagePreview from './ImagePreview.vue'
 
 interface NodeContentProps {
   nodeData?: VueNodeData
+  readOnly?: boolean
   media?: {
     type: 'image' | 'video' | 'audio'
     urls: string[]

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -32,6 +32,12 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   })
 }))
 
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: () => ({
+    activeSubgraphHostExecutionId: undefined
+  })
+}))
+
 const WidgetStub = {
   name: 'WidgetStub',
   props: ['widget', 'nodeId', 'nodeType', 'modelValue'],

--- a/src/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue.test.ts
@@ -1,0 +1,153 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { createNodeExecutionId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
+
+import {
+  getImageWidgetPreviewUrls,
+  resolveLinkedImageWidgetValue
+} from './resolveLinkedImageWidgetValue'
+
+describe('resolveLinkedImageWidgetValue', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('reads the selected host value without changing the shared interior value', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'image', type: 'COMBO' }]
+    })
+    const interiorNode = new LGraphNode('LoadImage')
+    interiorNode.id = toNodeId(5)
+    const interiorInput = interiorNode.addInput('image', 'COMBO')
+    interiorInput.widget = { name: 'image' }
+    const interiorWidget = interiorNode.addWidget(
+      'combo',
+      'image',
+      'interior.png',
+      () => undefined,
+      { values: ['interior.png', 'first.png', 'second.png'] }
+    )
+    subgraph.add(interiorNode)
+    subgraph.inputNode.slots[0].connect(interiorInput, interiorNode)
+
+    const firstHost = createTestSubgraphNode(subgraph, { id: 11 })
+    const secondHost = createTestSubgraphNode(subgraph, { id: 12 })
+    rootGraph.add(firstHost)
+    rootGraph.add(secondHost)
+
+    const firstWidgetId = firstHost.inputs[0].widgetId
+    const secondWidgetId = secondHost.inputs[0].widgetId
+    expect(firstWidgetId).toBeDefined()
+    expect(secondWidgetId).toBeDefined()
+    if (!firstWidgetId || !secondWidgetId) return
+
+    const widgetValueStore = useWidgetValueStore()
+    widgetValueStore.setValue(firstWidgetId, 'first.png')
+    widgetValueStore.setValue(secondWidgetId, 'second.png')
+
+    expect(
+      resolveLinkedImageWidgetValue(
+        rootGraph,
+        createNodeExecutionId([12]),
+        interiorNode.id,
+        interiorInput.name
+      )
+    ).toEqual({ hostExecutionId: '12', value: 'second.png' })
+    expect(interiorWidget.value).toBe('interior.png')
+  })
+
+  it('resolves the outermost host through a nested promoted input chain', () => {
+    const rootGraph = createTestRootGraph()
+    const outerSubgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'outer_image', type: 'COMBO' }]
+    })
+    const innerSubgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'middle_image', type: 'COMBO' }]
+    })
+    const imageNode = new LGraphNode('LoadImage')
+    imageNode.id = toNodeId(42)
+    const imageInput = imageNode.addInput('image', 'COMBO')
+    imageInput.widget = { name: 'image' }
+    imageNode.addWidget('combo', 'image', 'interior.png', () => undefined, {
+      values: ['interior.png', 'middle.png', 'outer.png']
+    })
+    innerSubgraph.add(imageNode)
+    innerSubgraph.inputNode.slots[0].connect(imageInput, imageNode)
+
+    const intermediateHost = createTestSubgraphNode(innerSubgraph, {
+      parentGraph: outerSubgraph,
+      id: 77
+    })
+    outerSubgraph.add(intermediateHost)
+    outerSubgraph.inputNode.slots[0].connect(
+      intermediateHost.inputs[0],
+      intermediateHost
+    )
+
+    const outerHost = createTestSubgraphNode(outerSubgraph, { id: 65 })
+    rootGraph.add(outerHost)
+
+    const intermediateWidgetId = intermediateHost.inputs[0].widgetId
+    const outerWidgetId = outerHost.inputs[0].widgetId
+    expect(intermediateWidgetId).toBeDefined()
+    expect(outerWidgetId).toBeDefined()
+    if (!intermediateWidgetId || !outerWidgetId) return
+
+    const widgetValueStore = useWidgetValueStore()
+    widgetValueStore.setValue(intermediateWidgetId, 'middle.png')
+    widgetValueStore.setValue(outerWidgetId, 'outer.png')
+
+    expect(
+      resolveLinkedImageWidgetValue(
+        rootGraph,
+        createNodeExecutionId([65, 77]),
+        imageNode.id,
+        imageInput.name
+      )
+    ).toEqual({ hostExecutionId: '65', value: 'outer.png' })
+  })
+
+  it('returns no projection for a linked input that does not reach a boundary', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({ rootGraph })
+    const interiorNode = new LGraphNode('LoadImage')
+    interiorNode.id = toNodeId(5)
+    interiorNode.addInput('image', 'COMBO')
+    subgraph.add(interiorNode)
+    const host = createTestSubgraphNode(subgraph, { id: 11 })
+    rootGraph.add(host)
+
+    expect(
+      resolveLinkedImageWidgetValue(
+        rootGraph,
+        createNodeExecutionId([11]),
+        interiorNode.id,
+        'image'
+      )
+    ).toBeUndefined()
+  })
+
+  it('builds display-only preview URLs from annotated image values', () => {
+    const [url] = getImageWidgetPreviewUrls('nested/selected.png [output]')
+    const parsed = new URL(url, 'http://localhost')
+
+    expect(parsed.pathname).toBe('/api/view')
+    expect(parsed.searchParams.get('filename')).toBe('selected.png')
+    expect(parsed.searchParams.get('subfolder')).toBe('nested')
+    expect(parsed.searchParams.get('type')).toBe('output')
+  })
+})

--- a/src/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue.ts
+++ b/src/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue.ts
@@ -1,0 +1,82 @@
+import { resolvePromotedInputBoundaryChain } from '@/core/graph/subgraph/promotedInputBoundary'
+import type { SafeWidgetData } from '@/composables/graph/useGraphNodeManager'
+import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
+import { isComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { api } from '@/scripts/api'
+import { app } from '@/scripts/app'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { appendNodeExecutionId } from '@/types/nodeIdentification'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+import { parseImageWidgetValue } from '@/utils/imageUtil'
+
+interface ResolvedLinkedImageWidgetValue {
+  hostExecutionId: NodeExecutionId
+  value: WidgetValue
+}
+
+export function isLinkedImageWidget(
+  widget: Pick<SafeWidgetData, 'slotMetadata' | 'spec'>
+): boolean {
+  if (!widget.slotMetadata?.linked || !widget.spec) return false
+  if (!isComboInputSpec(widget.spec)) return false
+  return widget.spec.image_upload || widget.spec.animated_image_upload || false
+}
+
+export function getImageWidgetPreviewUrls(value: WidgetValue): string[] {
+  const values =
+    typeof value === 'string'
+      ? [value]
+      : Array.isArray(value) && value.every((item) => typeof item === 'string')
+        ? value
+        : []
+
+  return values.flatMap((rawValue) => {
+    const { filename, subfolder, type } = parseImageWidgetValue(rawValue)
+    if (!filename) return []
+
+    const params = new URLSearchParams({ filename, subfolder, type })
+    appendCloudResParam(params, filename)
+    return [
+      api.apiURL(
+        `/view?${params}${app.getPreviewFormatParam()}${app.getRandParam()}`
+      )
+    ]
+  })
+}
+
+export function resolveLinkedImageWidgetValue(
+  rootGraph: LGraph,
+  activeSubgraphHostExecutionId: NodeExecutionId,
+  sourceNodeId: NodeId,
+  sourceInputName: string
+): ResolvedLinkedImageWidgetValue | undefined {
+  const sourceExecutionId = appendNodeExecutionId(
+    activeSubgraphHostExecutionId,
+    sourceNodeId
+  )
+
+  const surface = resolvePromotedInputBoundaryChain(
+    rootGraph,
+    sourceExecutionId,
+    sourceInputName
+  ).at(-1)
+  if (!surface) return undefined
+
+  const hostNode = getNodeByExecutionId(rootGraph, surface.hostExecutionId)
+  if (!hostNode?.isSubgraphNode()) return undefined
+
+  const widgetId = hostNode.inputs.find(
+    (input) => input.name === surface.inputName
+  )?.widgetId
+  if (!widgetId) return undefined
+
+  const value = useWidgetValueStore().getWidget(widgetId)?.value
+  return isWidgetValue(value)
+    ? { hostExecutionId: surface.hostExecutionId, value }
+    : undefined
+}

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -4,7 +4,13 @@ import { setActivePinia } from 'pinia'
 import { fromAny } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestRootGraph,
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -560,6 +566,100 @@ describe('computeProcessedWidgets borderStyle', () => {
         options: { values: ['state value'] }
       }
     })
+  })
+
+  it('projects an exact host image value and keeps the interior fallback when context is ambiguous', () => {
+    const rootGraph = createTestRootGraph()
+    const subgraph = createTestSubgraph({
+      rootGraph,
+      inputs: [{ name: 'image', type: 'COMBO' }]
+    })
+    const interiorNode = new LGraphNode('LoadImage')
+    interiorNode.id = toNodeId(5)
+    const interiorInput = interiorNode.addInput('image', 'COMBO')
+    interiorInput.widget = { name: 'image' }
+    interiorNode.addWidget('combo', 'image', 'interior.png', () => undefined, {
+      values: ['interior.png', 'first.png', 'second.png']
+    })
+    subgraph.add(interiorNode)
+    subgraph.inputNode.slots[0].connect(interiorInput, interiorNode)
+
+    const firstHost = createTestSubgraphNode(subgraph, { id: 11 })
+    const secondHost = createTestSubgraphNode(subgraph, { id: 12 })
+    rootGraph.add(firstHost)
+    rootGraph.add(secondHost)
+
+    const firstWidgetId = firstHost.inputs[0].widgetId
+    const secondWidgetId = secondHost.inputs[0].widgetId
+    expect(firstWidgetId).toBeDefined()
+    expect(secondWidgetId).toBeDefined()
+    if (!firstWidgetId || !secondWidgetId) return
+
+    const widgetValueStore = useWidgetValueStore()
+    widgetValueStore.registerWidget(
+      widgetId(rootGraph.id, interiorNode.id, 'image'),
+      {
+        type: 'combo',
+        value: 'interior.png',
+        options: {}
+      }
+    )
+    widgetValueStore.setValue(firstWidgetId, 'first.png')
+    widgetValueStore.setValue(secondWidgetId, 'second.png')
+
+    const imageWidget = createMockWidget({
+      name: 'image',
+      nodeId: interiorNode.id,
+      slotMetadata: { index: 0, linked: true, type: 'COMBO' },
+      spec: { type: 'COMBO', name: 'image', image_upload: true }
+    })
+    const nodeData = {
+      id: interiorNode.id,
+      type: 'LoadImage',
+      widgets: [imageWidget],
+      title: 'Load Image',
+      mode: 0,
+      selected: false,
+      executing: false,
+      inputs: [],
+      outputs: []
+    }
+    const baseOptions = {
+      nodeData,
+      graphId: rootGraph.id,
+      showAdvanced: false,
+      isGraphReady: false,
+      rootGraph,
+      ui: noopUi
+    }
+
+    const exactResult = computeProcessedWidgets({
+      ...baseOptions,
+      activeSubgraphHostExecutionId: createNodeExecutionId([12])
+    })
+    const ambiguousResult = computeProcessedWidgets(baseOptions)
+
+    expect(exactResult[0]).toMatchObject({
+      value: 'second.png',
+      simplified: {
+        value: 'second.png',
+        options: { disabled: true, read_only: true }
+      }
+    })
+    expect(ambiguousResult[0]).toMatchObject({
+      value: 'interior.png',
+      simplified: {
+        value: 'interior.png',
+        options: { disabled: true, read_only: true }
+      }
+    })
+
+    ambiguousResult[0].updateHandler('changed.png')
+    expect(
+      widgetValueStore.getWidget(
+        widgetId(rootGraph.id, interiorNode.id, 'image')
+      )?.value
+    ).toBe('interior.png')
   })
 
   it('uses widget nodeId for simplified widget locator when present', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -32,6 +32,7 @@ import {
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import {
   createNodeExecutionId,
   createNodeLocatorId
@@ -52,6 +53,10 @@ import type {
   SimplifiedWidget,
   WidgetValue
 } from '@/types/simplifiedWidget'
+import {
+  isLinkedImageWidget,
+  resolveLinkedImageWidgetValue
+} from '@/renderer/extensions/vueNodes/composables/resolveLinkedImageWidgetValue'
 
 const TOOLTIP_VALUE_TYPES = ['asset', 'combo', 'number', 'text'] as const
 type TooltipValueType = (typeof TOOLTIP_VALUE_TYPES)[number]
@@ -90,6 +95,7 @@ interface ComputeProcessedWidgetsOptions {
   showAdvanced: boolean
   isGraphReady: boolean
   rootGraph: LGraph | null
+  activeSubgraphHostExecutionId?: NodeExecutionId
   ui: WidgetUiCallbacks
 }
 
@@ -226,6 +232,7 @@ export function computeProcessedWidgets({
   showAdvanced,
   isGraphReady,
   rootGraph,
+  activeSubgraphHostExecutionId,
   ui
 }: ComputeProcessedWidgetsOptions): ProcessedWidget[] {
   if (!nodeData?.widgets) return []
@@ -327,13 +334,27 @@ export function computeProcessedWidgets({
       (widget.isDOMWidget ? WidgetDOM : WidgetLegacy)
 
     const { slotMetadata } = widget
+    const linkedImage = isLinkedImageWidget(widget)
 
-    const value = widgetState?.value as WidgetValue
+    const mirroredValue =
+      rootGraph && activeSubgraphHostExecutionId && nodeId && linkedImage
+        ? resolveLinkedImageWidgetValue(
+            rootGraph,
+            activeSubgraphHostExecutionId,
+            nodeId,
+            widget.name
+          )
+        : undefined
+    const value = mirroredValue
+      ? mirroredValue.value
+      : (widgetState?.value as WidgetValue)
 
     const isDisabled = slotMetadata?.linked || widgetState?.disabled
-    const widgetOptions = isDisabled
-      ? { ...mergedOptions, disabled: true }
-      : mergedOptions
+    const widgetOptions = linkedImage
+      ? { ...mergedOptions, disabled: true, read_only: true }
+      : isDisabled
+        ? { ...mergedOptions, disabled: true }
+        : mergedOptions
 
     const borderStyle = mergedOptions.advanced
       ? 'ring ring-component-node-widget-advanced'
@@ -368,13 +389,15 @@ export function computeProcessedWidgets({
       spec: widget.spec
     }
 
-    const updateHandler = createWidgetUpdateHandler(
-      widgetState,
-      widget,
-      nodeExecId,
-      widgetOptions,
-      executionErrorStore
-    )
+    const updateHandler = linkedImage
+      ? () => undefined
+      : createWidgetUpdateHandler(
+          widgetState,
+          widget,
+          nodeExecId,
+          widgetOptions,
+          executionErrorStore
+        )
 
     const valueTooltip =
       isTooltipValueType(widget.type) && String(value).length > 10
@@ -429,6 +452,7 @@ export function useProcessedWidgets(
   nodeDataGetter: () => VueNodeData | undefined
 ) {
   const canvasStore = useCanvasStore()
+  const subgraphNavigationStore = useSubgraphNavigationStore()
   const settingStore = useSettingStore()
   const { isSelectInputsMode } = useAppMode()
   const { handleNodeRightClick } = useNodeEventHandlers()
@@ -467,6 +491,8 @@ export function useProcessedWidgets(
       showAdvanced: showAdvanced.value,
       isGraphReady: app.isGraphReady,
       rootGraph: app.isGraphReady ? app.rootGraph : null,
+      activeSubgraphHostExecutionId:
+        subgraphNavigationStore.activeSubgraphHostExecutionId,
       ui
     })
   )

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.test.ts
@@ -85,6 +85,12 @@ describe('FormDropdownInput', () => {
       await user.click(screen.getByRole('button'))
       expect(onSelectClick).toHaveBeenCalledTimes(1)
     })
+
+    it('disables selection when the disabled prop is true', () => {
+      renderInput({ disabled: true })
+
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
   })
 
   describe('Upload affordance', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownInput.vue
@@ -78,6 +78,7 @@ defineExpose({ focus, showPicker })
   >
     <button
       ref="buttonRef"
+      :disabled="disabled"
       :class="
         cn(
           theButtonStyle,

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -4,9 +4,9 @@ import { computed, ref } from 'vue'
 import { useNodeErrorFlagSync } from '@/composables/graph/useNodeErrorFlagSync'
 import {
   getLiftedErrorSource,
-  liftNodeErrorsToBoundary,
-  resolveLiftChain
+  liftNodeErrorsToBoundary
 } from '@/core/graph/subgraph/liftNodeErrorsToBoundary'
+import { resolvePromotedInputBoundaryChain } from '@/core/graph/subgraph/promotedInputBoundary'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
@@ -169,13 +169,14 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
         )
         if (!sourceExecutionId) return []
 
-        const clearsThisError = resolveLiftChain(
+        const clearsThisError = resolvePromotedInputBoundaryChain(
           app.rootGraph,
           sourceExecutionId,
           source.source_input_name
         ).some(
           (level) =>
-            level.hostExecId === executionId && level.hostInputName === slotName
+            level.hostExecutionId === executionId &&
+            level.inputName === slotName
         )
         return clearsThisError
           ? [

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -1,4 +1,5 @@
 import QuickLRU from '@alloc/quick-lru'
+import { useEventListener } from '@vueuse/core'
 import { useRouteHash } from '@vueuse/router'
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef, watch } from 'vue'
@@ -9,9 +10,15 @@ import {
 } from 'vue-router'
 
 import type { DragAndScaleState } from '@/lib/litegraph/src/DragAndScale'
+import type { LGraphCanvasEventMap } from '@/lib/litegraph/src/infrastructure/LGraphCanvasEventMap'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import {
+  findSubgraphHostAncestorExecutionId,
+  findUniqueSubgraphHostExecutionId,
+  resolveEnteredSubgraphHostExecutionId
+} from '@/core/graph/subgraph/subgraphHostExecution'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { requestSlotLayoutSyncForAllNodes } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
 import { isUuidShapedSubgraphId } from '@/schemas/subgraphIdSchema'
@@ -19,6 +26,7 @@ import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 import { findSubgraphPathById } from '@/utils/graphTraversalUtil'
 import { isNonNullish, isSubgraph } from '@/utils/typeGuardUtil'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
 
 export const VIEWPORT_CACHE_MAX_SIZE = 32
 
@@ -40,6 +48,15 @@ export const useSubgraphNavigationStore = defineStore(
 
     /** The stack of subgraph IDs from the root graph to the currently opened subgraph. */
     const idStack = ref<string[]>([])
+
+    const activeSubgraphHostExecutionId = ref<NodeExecutionId>()
+
+    let pendingSubgraphEntry:
+      | {
+          detail: LGraphCanvasEventMap['subgraph-opening']
+          hostExecutionId: NodeExecutionId | undefined
+        }
+      | undefined
 
     /** LRU cache for viewport states. Key: `workflowPath:graphId` */
     const viewportCache = new QuickLRU<string, DragAndScaleState>({
@@ -95,6 +112,8 @@ export const useSubgraphNavigationStore = defineStore(
      */
     const restoreState = (subgraphIds: string[]) => {
       idStack.value.length = 0
+      activeSubgraphHostExecutionId.value = undefined
+      pendingSubgraphEntry = undefined
       for (const id of subgraphIds) idStack.value.push(id)
     }
 
@@ -178,9 +197,18 @@ export const useSubgraphNavigationStore = defineStore(
       const isInRootGraph = !subgraph
       if (isInRootGraph) {
         idStack.value.length = 0
+        activeSubgraphHostExecutionId.value = undefined
+        pendingSubgraphEntry = undefined
         restoreViewport(getCurrentRootGraphId())
         return
       }
+
+      activeSubgraphHostExecutionId.value =
+        findSubgraphHostAncestorExecutionId(
+          subgraph.rootGraph,
+          activeSubgraphHostExecutionId.value,
+          subgraph
+        ) ?? findUniqueSubgraphHostExecutionId(subgraph.rootGraph, subgraph)
 
       const path = findSubgraphPathById(subgraph.rootGraph, subgraph.id)
       const isInReachableSubgraph = !!path
@@ -192,6 +220,50 @@ export const useSubgraphNavigationStore = defineStore(
 
       restoreViewport(subgraph.id)
     }
+
+    useEventListener(
+      () => canvasStore.canvas?.canvas,
+      'subgraph-opening',
+      (event: CustomEvent<LGraphCanvasEventMap['subgraph-opening']>) => {
+        const { closingGraph, fromNode, subgraph } = event.detail
+        pendingSubgraphEntry = {
+          detail: event.detail,
+          hostExecutionId: resolveEnteredSubgraphHostExecutionId(
+            subgraph.rootGraph,
+            activeSubgraphHostExecutionId.value,
+            closingGraph,
+            fromNode
+          )
+        }
+      }
+    )
+
+    useEventListener(
+      () => canvasStore.canvas?.canvas,
+      'subgraph-opened',
+      (event: CustomEvent<LGraphCanvasEventMap['subgraph-opened']>) => {
+        const { closingGraph, fromNode, subgraph } = event.detail
+        const capturedEntry = pendingSubgraphEntry
+        pendingSubgraphEntry = undefined
+
+        if (
+          capturedEntry?.detail.closingGraph === closingGraph &&
+          capturedEntry.detail.fromNode === fromNode &&
+          capturedEntry.detail.subgraph === subgraph
+        ) {
+          activeSubgraphHostExecutionId.value = capturedEntry.hostExecutionId
+          return
+        }
+
+        activeSubgraphHostExecutionId.value =
+          resolveEnteredSubgraphHostExecutionId(
+            subgraph.rootGraph,
+            activeSubgraphHostExecutionId.value,
+            closingGraph,
+            fromNode
+          )
+      }
+    )
 
     // ── Watchers ─────────────────────────────────────────────────────
 
@@ -352,6 +424,7 @@ export const useSubgraphNavigationStore = defineStore(
 
     return {
       activeSubgraph,
+      activeSubgraphHostExecutionId,
       navigationStack,
       restoreState,
       exportState,


### PR DESCRIPTION
## ELI5

A subgraph is like a reusable box: when an image is selected on the outside, looking inside should still show that same image. This PR mirrors the active outer node's image value and preview into the inner image widget, keeps the inner control read-only, and provides a small path back to the source node.

## Motivation

Promoted image inputs are edited on the containing subgraph node, but opening the subgraph previously left the inner Load Image widget showing its definition-local value and no matching preview. That makes inspection misleading, especially in nested subgraphs where the same definition may be instantiated more than once. The image-widget case is the first priority because its value and visual preview can disagree at the same time. This change keeps the subgraph definition read-only from the inside while reflecting the active host instance when that runtime context is known.

## Provenance

- **Authored by:** `interactive session`
- **Verified:** `pnpm lint`; `pnpm typecheck`; `pnpm knip`; targeted `pnpm test:unit` (193 passed); promoted image widget Playwright spec (3 passed on retry after one cold-start setup timeout)
- **Deviations:** Direct hash or draft restoration of a shared definition with multiple possible host instances remains ambiguous; in that case the inner widget stays read-only, uses its definition-local value, and omits parent navigation.

## Reviewer context

- **Type:** feature — project promoted image values and previews through the active subgraph host context
- **Slots into:** subgraph promoted-widget behavior; no project or epic provided
- **Not in scope:** persisting host execution paths in workflow JSON or route hashes; generic mirroring for every widget type

## Summary

- Mirror the selected host instance's promoted image value and preview inside a subgraph without mutating the shared definition.
- Preserve the root host execution context through nested subgraph entry and return.
- Keep linked inner image widgets and previews read-only, with a compact Parent node navigation action when the host is known.

## Changes

- **Host context:** Capture the selected subgraph host at navigation time and retain its execution path across nested navigation.
- **Boundary resolution:** Share promoted-input boundary lookup between error lifting and image projection.
- **Widget rendering:** Resolve linked image values from the active host, render the matching preview, suppress edit and upload actions, and focus the outermost host on navigation.
- **Coverage:** Add unit coverage for traversal and rendering plus Playwright fixtures for multiple hosts, ambiguous direct entry, and nested subgraphs.
- **Dependencies:** None.

## Review Focus

- Confirm that runtime navigation context belongs in `subgraphNavigationStore` and remains compatible with shared subgraph definitions.
- Confirm the ambiguous direct-entry fallback: read-only definition value, no mirrored preview, and no Parent node action.
- Confirm that the image-only scope is appropriate before generalizing projection to other promoted widget types.

## Test plan

This behavior is intentionally ungated because it corrects the existing subgraph image inspection path without introducing a new workflow mode or persisted data format.

- [ ] Load a workflow with two hosts sharing one subgraph definition and select different images on each host.
- [ ] Enter each host and verify that the inner Load Image value and preview match the selected host and remain read-only.
- [ ] Enter a nested subgraph, navigate back, re-enter, and verify that Parent node focuses the outermost host.
- [ ] Open an ambiguous shared definition directly by hash and verify the read-only definition fallback without parent navigation.
