### PR TITLE
fix: resolve widget labels, output names and tooltips from the backend

### DIFF
--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -137,6 +137,14 @@ function mergeOutputTooltipMessage(tooltip: string | null) {
   })
 }
 
+function mergeInputTooltipMessage(tooltip: string | null) {
+  i18n.global.mergeLocaleMessage('en', {
+    nodeDefs: {
+      SAM3_Detect: { inputs: { positive_coords: { tooltip } } }
+    }
+  })
+}
+
 async function renderAndHoverCanvas() {
   const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
 
@@ -218,5 +226,48 @@ describe('NodeTooltip', () => {
     expect(te(positiveCoordsTooltipKey)).toBe(true)
     expect(screen.getByText(jsonTooltip)).toBeInTheDocument()
     expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  describe('when the bundled snapshot has gone stale', () => {
+    const staleInputTooltip = 'stale bundled input tooltip'
+    const staleOutputTooltip = 'stale bundled output tooltip'
+
+    beforeEach(() => {
+      mergeInputTooltipMessage(staleInputTooltip)
+      mergeOutputTooltipMessage(staleOutputTooltip)
+    })
+
+    afterEach(() => {
+      mergeInputTooltipMessage(jsonTooltip)
+    })
+
+    it('shows the live backend input slot tooltip', async () => {
+      vi.mocked(mockIsOverNodeInput).mockReturnValue(0)
+
+      await renderAndHoverCanvas()
+
+      expect(screen.getByText(jsonTooltip)).toBeInTheDocument()
+      expect(screen.queryByText(staleInputTooltip)).not.toBeInTheDocument()
+    })
+
+    it('shows the live backend output slot tooltip', async () => {
+      vi.mocked(mockIsOverNodeOutput).mockReturnValue(0)
+
+      await renderAndHoverCanvas()
+
+      expect(screen.getByText(jsonTooltip)).toBeInTheDocument()
+      expect(screen.queryByText(staleOutputTooltip)).not.toBeInTheDocument()
+    })
+
+    it('shows the live backend widget tooltip', async () => {
+      vi.mocked(mockCanvas.getWidgetAtCursor).mockReturnValue({
+        name: 'positive_coords'
+      })
+
+      await renderAndHoverCanvas()
+
+      expect(screen.getByText(jsonTooltip)).toBeInTheDocument()
+      expect(screen.queryByText(staleInputTooltip)).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/graph/NodeTooltip.vue
+++ b/src/components/graph/NodeTooltip.vue
@@ -13,7 +13,7 @@
 import { useEventListener } from '@vueuse/core'
 import { nextTick, ref } from 'vue'
 
-import { stRaw } from '@/i18n'
+import { resolveNodeDefInputText, resolveNodeDefOutputText } from '@/i18n'
 import {
   LiteGraph,
   isOverNodeInput,
@@ -23,7 +23,6 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { app as comfyApp } from '@/scripts/app'
 import { isDOMWidget } from '@/scripts/domWidget'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-import { normalizeI18nKey } from '@/utils/formatUtil'
 
 let idleTimeout: number
 const nodeDefStore = useNodeDefStore()
@@ -65,7 +64,8 @@ function onIdle() {
   if (!node || node.flags?.ghost) return
 
   const ctor = node.constructor as { title_mode?: 0 | 1 | 2 | 3 }
-  const nodeDef = nodeDefStore.nodeDefsByName[node.type ?? '']
+  const nodeType = node.type ?? ''
+  const nodeDef = nodeDefStore.nodeDefsByName[nodeType]
 
   if (
     ctor.title_mode !== LiteGraph.NO_TITLE &&
@@ -84,11 +84,14 @@ function onIdle() {
   )
   if (inputSlot !== -1) {
     const inputName = node.inputs[inputSlot].name
-    const translatedTooltip = stRaw(
-      `nodeDefs.${normalizeI18nKey(node.type ?? '')}.inputs.${normalizeI18nKey(inputName)}.tooltip`,
-      nodeDef?.inputs[inputName]?.tooltip ?? ''
+    return showTooltip(
+      resolveNodeDefInputText(
+        'tooltip',
+        nodeType,
+        inputName,
+        nodeDef?.inputs[inputName]?.tooltip
+      )
     )
-    return showTooltip(translatedTooltip)
   }
 
   const outputSlot = isOverNodeOutput(
@@ -98,19 +101,24 @@ function onIdle() {
     [0, 0]
   )
   if (outputSlot !== -1) {
-    const translatedTooltip = stRaw(
-      `nodeDefs.${normalizeI18nKey(node.type ?? '')}.outputs.${outputSlot}.tooltip`,
-      nodeDef?.outputs[outputSlot]?.tooltip ?? ''
+    return showTooltip(
+      resolveNodeDefOutputText(
+        'tooltip',
+        nodeType,
+        outputSlot,
+        nodeDef?.outputs[outputSlot]?.tooltip
+      )
     )
-    return showTooltip(translatedTooltip)
   }
 
   const widget = comfyApp.canvas.getWidgetAtCursor()
   // Dont show for DOM widgets, these use native browser tooltips as we dont get proper mouse events on these
   if (widget && !isDOMWidget(widget)) {
-    const translatedTooltip = stRaw(
-      `nodeDefs.${normalizeI18nKey(node.type ?? '')}.inputs.${normalizeI18nKey(widget.name)}.tooltip`,
-      nodeDef?.inputs[widget.name]?.tooltip ?? ''
+    const translatedTooltip = resolveNodeDefInputText(
+      'tooltip',
+      nodeType,
+      widget.name,
+      nodeDef?.inputs[widget.name]?.tooltip
     )
     // Widget tooltip can be set dynamically, current translation collection does not support this.
     return showTooltip(widget.tooltip ?? translatedTooltip)

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -5,6 +5,8 @@ import type * as I18nModule from './i18n'
 let i18n: typeof I18nModule.i18n
 let loadLocale: typeof I18nModule.loadLocale
 let resolveNodeDefText: typeof I18nModule.resolveNodeDefText
+let resolveNodeDefInputText: typeof I18nModule.resolveNodeDefInputText
+let resolveNodeDefOutputText: typeof I18nModule.resolveNodeDefOutputText
 let setBackendNodeText: typeof I18nModule.setBackendNodeText
 let mergeCustomNodesI18n: typeof I18nModule.mergeCustomNodesI18n
 let resolveSupportedLocale: typeof I18nModule.resolveSupportedLocale
@@ -16,6 +18,8 @@ async function importI18nModule() {
   i18n = i18nModule.i18n
   loadLocale = i18nModule.loadLocale
   resolveNodeDefText = i18nModule.resolveNodeDefText
+  resolveNodeDefInputText = i18nModule.resolveNodeDefInputText
+  resolveNodeDefOutputText = i18nModule.resolveNodeDefOutputText
   setBackendNodeText = i18nModule.setBackendNodeText
   mergeCustomNodesI18n = i18nModule.mergeCustomNodesI18n
   resolveSupportedLocale = i18nModule.resolveSupportedLocale
@@ -37,7 +41,18 @@ function restoreEnNodeDefsMock() {
   }
   Object.assign(enNodeDefsMock, {
     testNode: 'Test Node',
-    KSampler: { display_name: 'KSampler (bundled)' }
+    KSampler: {
+      display_name: 'KSampler (bundled)',
+      inputs: {
+        seed: { name: 'seed (bundled)', tooltip: 'Seed tooltip (bundled)' },
+        // The serializer escapes `name` and leaves `tooltip` verbatim, so the
+        // same source text is stored differently per field.
+        syntax: { name: "50{'%'} {'@'}", tooltip: "50{'%'} {'@'}" }
+      },
+      outputs: {
+        0: { name: 'LATENT (bundled)', tooltip: 'Latent tooltip (bundled)' }
+      }
+    }
   })
 }
 
@@ -54,7 +69,12 @@ vi.mock('./locales/en/settings.json', () => ({
 // Mock lazy-loaded locales
 vi.mock('./locales/zh/main.json', () => ({ default: { welcome: '欢迎' } }))
 vi.mock('./locales/zh/nodeDefs.json', () => ({
-  default: { testNode: '测试节点' }
+  default: {
+    testNode: '测试节点',
+    KSampler: {
+      inputs: { seed: { name: '种子', tooltip: '种子提示' } }
+    }
+  }
 }))
 vi.mock('./locales/zh/commands.json', () => ({ default: { save: '保存' } }))
 vi.mock('./locales/zh/settings.json', () => ({ default: { theme: '主题' } }))
@@ -154,7 +174,9 @@ describe('i18n', () => {
 
       // 4. Also verify base locale data is present
       expect(zhMessages.welcome).toBe('欢迎')
-      expect(zhMessages.nodeDefs).toEqual({ testNode: '测试节点' })
+      expect(zhMessages.nodeDefs).toEqual(
+        expect.objectContaining({ testNode: '测试节点' })
+      )
     })
 
     it('should handle multiple locales in custom nodes i18n data', async () => {
@@ -362,6 +384,129 @@ describe('i18n', () => {
         setBackendNodeText([])
 
         expect(resolveNodeDefText('description', 'Unknown')).toBe('')
+      })
+    })
+  })
+
+  describe('slot text', () => {
+    describe('precedence', () => {
+      it('en: the live backend value beats the bundled snapshot', () => {
+        expect(
+          resolveNodeDefInputText('name', 'KSampler', 'seed', 'Live Seed')
+        ).toBe('Live Seed')
+        expect(
+          resolveNodeDefInputText('tooltip', 'KSampler', 'seed', 'Live tooltip')
+        ).toBe('Live tooltip')
+        expect(
+          resolveNodeDefOutputText('name', 'KSampler', 0, 'Live Latent')
+        ).toBe('Live Latent')
+        expect(
+          resolveNodeDefOutputText('tooltip', 'KSampler', 0, 'Live tooltip')
+        ).toBe('Live tooltip')
+      })
+
+      it('en: the bundled snapshot is used when the backend sends nothing', () => {
+        expect(resolveNodeDefInputText('name', 'KSampler', 'seed')).toBe(
+          'seed (bundled)'
+        )
+        expect(resolveNodeDefInputText('tooltip', 'KSampler', 'seed')).toBe(
+          'Seed tooltip (bundled)'
+        )
+        expect(resolveNodeDefOutputText('tooltip', 'KSampler', 0)).toBe(
+          'Latent tooltip (bundled)'
+        )
+      })
+
+      it('en: falls back to the caller fallback when nothing supplies text', () => {
+        expect(
+          resolveNodeDefInputText('name', 'Unknown', 'seed', undefined, 'seed')
+        ).toBe('seed')
+        expect(resolveNodeDefOutputText('tooltip', 'Unknown', 0)).toBe('')
+      })
+
+      it('en: a custom-node translation beats the backend', () => {
+        mergeCustomNodesI18n({
+          en: {
+            nodeDefs: {
+              KSampler: { inputs: { seed: { name: 'Custom Seed' } } }
+            }
+          }
+        })
+
+        expect(
+          resolveNodeDefInputText('name', 'KSampler', 'seed', 'Live Seed')
+        ).toBe('Custom Seed')
+      })
+
+      it('non-en: the translation stays authoritative over the backend', async () => {
+        await setActiveLocale('zh')
+
+        expect(
+          resolveNodeDefInputText('name', 'KSampler', 'seed', 'Live Seed')
+        ).toBe('种子')
+        expect(
+          resolveNodeDefInputText('tooltip', 'KSampler', 'seed', 'Live tooltip')
+        ).toBe('种子提示')
+      })
+
+      it('non-en: falls back to the live backend value, not the en snapshot', async () => {
+        await setActiveLocale('zh')
+
+        expect(
+          resolveNodeDefOutputText('name', 'KSampler', 0, 'Live Latent')
+        ).toBe('Live Latent')
+      })
+    })
+
+    describe('raw / compiled split', () => {
+      it('compiles a bundled name but returns a bundled tooltip uncompiled', () => {
+        expect(resolveNodeDefInputText('name', 'KSampler', 'syntax')).toBe(
+          '50% @'
+        )
+        expect(resolveNodeDefInputText('tooltip', 'KSampler', 'syntax')).toBe(
+          "50{'%'} {'@'}"
+        )
+      })
+
+      it('returns backend slot text verbatim, never through the compiler', () => {
+        const raw = "Mask {'@'} 100% | D:\\output"
+
+        expect(
+          resolveNodeDefInputText('tooltip', 'KSampler', 'seed', raw)
+        ).toBe(raw)
+        expect(resolveNodeDefInputText('name', 'KSampler', 'seed', raw)).toBe(
+          raw
+        )
+      })
+    })
+
+    describe('key resolution', () => {
+      it('normalizes dotted input names', () => {
+        mergeCustomNodesI18n({
+          en: {
+            nodeDefs: {
+              KSampler: { inputs: { a_b: { name: 'Dotted Input' } } }
+            }
+          }
+        })
+
+        expect(resolveNodeDefInputText('name', 'KSampler', 'a.b', 'Live')).toBe(
+          'Dotted Input'
+        )
+      })
+
+      it('resolves the legacy nested shape hand-written locales use', () => {
+        mergeCustomNodesI18n({
+          en: {
+            nodeDefs: {
+              my: { node: { inputs: { seed: { name: 'Nested Seed' } } } }
+            }
+          }
+        })
+
+        expect(resolveNodeDefInputText('name', 'my.node', 'seed', 'Live')).toBe(
+          'Nested Seed'
+        )
       })
     })
   })

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -167,25 +167,22 @@ export function setBackendNodeText(
   }
 }
 
-function customNodesProvide(
-  nodeName: string,
-  field: NodeDefTextField
-): boolean {
+function customNodesProvide(nodeName: string, path: string): boolean {
   const data = customNodesI18nData[i18n.global.locale.value]
   if (typeof data !== 'object' || data === null) return false
   const nodeDefs = (data as Record<string, unknown>)['nodeDefs']
   if (typeof nodeDefs !== 'object' || nodeDefs === null) return false
 
-  for (const path of nodeDefKeyCandidates(nodeName)) {
+  for (const candidate of nodeDefKeyCandidates(nodeName)) {
     let cursor: unknown = nodeDefs
-    for (const segment of path.split('.')) {
-      if (typeof cursor !== 'object' || cursor === null) break
+    for (const segment of `${candidate}.${path}`.split('.')) {
+      if (typeof cursor !== 'object' || cursor === null) {
+        cursor = undefined
+        break
+      }
       cursor = (cursor as Record<string, unknown>)[segment]
     }
-    if (typeof cursor === 'object' && cursor !== null) {
-      if (typeof (cursor as Record<string, unknown>)[field] === 'string')
-        return true
-    }
+    if (typeof cursor === 'string') return true
   }
   return false
 }
@@ -200,14 +197,20 @@ function nodeDefKeyCandidates(nodeName: string): string[] {
   return normalized === nodeName ? [normalized] : [normalized, nodeName]
 }
 
+/**
+ * Reads a resolved locale message. `st` compiles it; `stRaw` does not.
+ */
+type MessageReader = (key: string, fallbackMessage: string) => string
+
 function translateNodeDefText(
   nodeName: string,
-  field: NodeDefTextField,
-  fallback: string
+  path: string,
+  fallback: string,
+  read: MessageReader
 ): string {
-  for (const path of nodeDefKeyCandidates(nodeName)) {
-    const key = `nodeDefs.${path}.${field}`
-    if (te(key)) return st(key, fallback)
+  for (const candidate of nodeDefKeyCandidates(nodeName)) {
+    const key = `nodeDefs.${candidate}.${path}`
+    if (te(key)) return read(key, fallback)
   }
   return fallback
 }
@@ -222,6 +225,21 @@ function translateNodeDefText(
  * Other locales: translations stay authoritative, falling back to the live
  * backend value rather than the stale English snapshot.
  */
+function resolveNodeDefPath(
+  nodeName: string,
+  path: string,
+  backend: string | undefined,
+  fallback: string,
+  read: MessageReader
+): string {
+  if (customNodesProvide(nodeName, path)) {
+    return translateNodeDefText(nodeName, path, fallback, read)
+  }
+  if (i18n.global.locale.value === 'en' && backend !== undefined) return backend
+
+  return translateNodeDefText(nodeName, path, fallback, read)
+}
+
 export function resolveNodeDefText(
   field: NodeDefTextField,
   nodeName: string,
@@ -230,12 +248,69 @@ export function resolveNodeDefText(
   const backend = backendValue ?? backendNodeText.get(nodeName)?.[field]
   const fallback = backend ?? (field === 'display_name' ? nodeName : '')
 
-  if (customNodesProvide(nodeName, field)) {
-    return translateNodeDefText(nodeName, field, fallback)
-  }
-  if (i18n.global.locale.value === 'en' && backend !== undefined) return backend
+  return resolveNodeDefPath(nodeName, field, backend, fallback, st)
+}
 
-  return translateNodeDefText(nodeName, field, fallback)
+/** Slot fields the generated locales carry text for. */
+export type NodeDefSlotTextField = 'name' | 'tooltip'
+
+/**
+ * `name` is escaped by `scripts/nodeDefLocaleSerializer.ts` and has to be
+ * compiled back; `tooltip` is stored verbatim and must never reach the message
+ * compiler, or a literal `{'@'}` would render to the user.
+ */
+function slotMessageReader(field: NodeDefSlotTextField): MessageReader {
+  return field === 'tooltip' ? stRaw : st
+}
+
+function resolveNodeDefSlotText(
+  field: NodeDefSlotTextField,
+  nodeName: string,
+  slotPath: string,
+  backendValue: string | undefined,
+  fallbackValue: string
+): string {
+  return resolveNodeDefPath(
+    nodeName,
+    `${slotPath}.${field}`,
+    backendValue,
+    backendValue ?? fallbackValue,
+    slotMessageReader(field)
+  )
+}
+
+/** Resolves an input slot's label or tooltip, same precedence as node text. */
+export function resolveNodeDefInputText(
+  field: NodeDefSlotTextField,
+  nodeName: string,
+  inputName: string,
+  backendValue?: string,
+  fallbackValue = ''
+): string {
+  return resolveNodeDefSlotText(
+    field,
+    nodeName,
+    `inputs.${normalizeI18nKey(inputName)}`,
+    backendValue,
+    fallbackValue
+  )
+}
+
+/** Resolves an output slot's label or tooltip, same precedence as node text. */
+export function resolveNodeDefOutputText(
+  field: NodeDefSlotTextField,
+  nodeName: string,
+  outputIndex: number,
+  backendValue?: string,
+  fallbackValue = ''
+): string {
+  return resolveNodeDefSlotText(
+    field,
+    nodeName,
+    `outputs.${outputIndex}`,
+    backendValue,
+    fallbackValue
+  )
 }
 
 // Only include English in the initial bundle; other locales lazy-load.

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.test.ts
@@ -38,12 +38,28 @@ function mergeOutputTooltipMessage(tooltip: string | null) {
   })
 }
 
+function mergeBundledMessages(messages: {
+  description: string | null
+  inputTooltip: string | null
+  outputTooltip: string | null
+}) {
+  i18n.global.mergeLocaleMessage('en', {
+    nodeDefs: {
+      SAM3_Detect: {
+        description: messages.description,
+        inputs: { positive_coords: { tooltip: messages.inputTooltip } },
+        outputs: { 0: { tooltip: messages.outputTooltip } }
+      }
+    }
+  })
+}
+
 const sam3DetectNodeDef: ComfyNodeDef = {
   name: 'SAM3_Detect',
   display_name: 'SAM3 Detect',
   category: 'detection/',
   python_module: 'comfy_extras.nodes_sam3',
-  description: '',
+  description: 'Live SAM3 description',
   input: {
     required: {},
     optional: {
@@ -129,5 +145,37 @@ describe('useNodeTooltips', () => {
     const textClass = pt?.text?.class ?? ''
     expect(textClass).toContain('whitespace-pre-line')
     expect(config.value).toContain('\n\n')
+  })
+
+  describe('when the bundled snapshot has gone stale', () => {
+    beforeEach(() => {
+      mergeBundledMessages({
+        description: 'stale bundled description',
+        inputTooltip: 'stale bundled input tooltip',
+        outputTooltip: 'stale bundled output tooltip'
+      })
+    })
+
+    afterEach(() => {
+      mergeBundledMessages({
+        description: null,
+        inputTooltip: jsonTooltip,
+        outputTooltip: null
+      })
+    })
+
+    it('prefers the live backend text over the snapshot', () => {
+      const {
+        getNodeDescription,
+        getInputSlotTooltip,
+        getOutputSlotTooltip,
+        getWidgetTooltip
+      } = useNodeTooltips('SAM3_Detect')
+
+      expect(getNodeDescription.value).toBe('Live SAM3 description')
+      expect(getInputSlotTooltip('positive_coords')).toBe(jsonTooltip)
+      expect(getOutputSlotTooltip(0)).toBe(jsonTooltip)
+      expect(getWidgetTooltip(positiveCoordsWidget)).toBe(jsonTooltip)
+    })
   })
 })

--- a/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodeTooltips.ts
@@ -6,10 +6,9 @@ import { computed, ref, unref } from 'vue'
 import type { MaybeRef } from 'vue'
 
 import type { SafeWidgetData } from '@/composables/graph/useGraphNodeManager'
-import { st, stRaw } from '@/i18n'
+import { resolveNodeDefInputText, resolveNodeDefOutputText } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-import { normalizeI18nKey } from '@/utils/formatUtil'
 import { cn } from '@comfyorg/tailwind-utils'
 
 // PrimeVue adds this internal property to elements with tooltips
@@ -107,8 +106,8 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
   const getNodeDescription = computed(() => {
     if (!tooltipsEnabled.value || !nodeDef.value) return ''
 
-    const key = `nodeDefs.${normalizeI18nKey(unref(nodeType))}.description`
-    return st(key, nodeDef.value.description || '')
+    // Already resolved against the backend and the locale by `getNodeDefs()`.
+    return nodeDef.value.description || ''
   })
 
   /**
@@ -117,9 +116,12 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
   const getInputSlotTooltip = (slotName: string) => {
     if (!tooltipsEnabled.value || !nodeDef.value) return ''
 
-    const key = `nodeDefs.${normalizeI18nKey(unref(nodeType))}.inputs.${normalizeI18nKey(slotName)}.tooltip`
-    const inputTooltip = nodeDef.value.inputs?.[slotName]?.tooltip ?? ''
-    return stRaw(key, inputTooltip)
+    return resolveNodeDefInputText(
+      'tooltip',
+      unref(nodeType),
+      slotName,
+      nodeDef.value.inputs?.[slotName]?.tooltip
+    )
   }
 
   /**
@@ -128,9 +130,12 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
   const getOutputSlotTooltip = (slotIndex: number) => {
     if (!tooltipsEnabled.value || !nodeDef.value) return ''
 
-    const key = `nodeDefs.${normalizeI18nKey(unref(nodeType))}.outputs.${slotIndex}.tooltip`
-    const outputTooltip = nodeDef.value.outputs?.[slotIndex]?.tooltip ?? ''
-    return stRaw(key, outputTooltip)
+    return resolveNodeDefOutputText(
+      'tooltip',
+      unref(nodeType),
+      slotIndex,
+      nodeDef.value.outputs?.[slotIndex]?.tooltip
+    )
   }
 
   /**
@@ -144,9 +149,12 @@ export function useNodeTooltips(nodeType: MaybeRef<string>) {
     if (widgetTooltip) return widgetTooltip
 
     // Then try input-based tooltip lookup
-    const key = `nodeDefs.${normalizeI18nKey(unref(nodeType))}.inputs.${normalizeI18nKey(widget.name)}.tooltip`
-    const inputTooltip = nodeDef.value.inputs?.[widget.name]?.tooltip ?? ''
-    return stRaw(key, inputTooltip)
+    return resolveNodeDefInputText(
+      'tooltip',
+      unref(nodeType),
+      widget.name,
+      nodeDef.value.inputs?.[widget.name]?.tooltip
+    )
   }
 
   /**

--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -1,12 +1,15 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/scripts/app', () => ({
   app: { canvas: undefined },
   ComfyApp: class {}
 }))
 
+import { i18n } from '@/i18n'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 
@@ -39,5 +42,58 @@ describe('useLitegraphService().getCanvasCenter', () => {
     const center = useLitegraphService().getCanvasCenter()
 
     expect(center).toEqual([110, 70])
+  })
+})
+
+describe('useLitegraphService().registerNodeDef slot text', () => {
+  const nodeName = 'TestBackendSlotText'
+
+  const nodeDef: ComfyNodeDefV1 = {
+    name: nodeName,
+    display_name: 'Test Backend Slot Text',
+    category: 'testing',
+    python_module: 'nodes',
+    description: '',
+    input: {
+      required: {
+        seed: ['INT', { display_name: 'Live Seed Label', default: 0 }],
+        mask: ['MASK', { display_name: 'Live Mask Label' }]
+      }
+    },
+    output: ['LATENT'],
+    output_name: ['Live Latent Name'],
+    output_node: false
+  }
+
+  function mergeBundledSlotText(text: string | null) {
+    i18n.global.mergeLocaleMessage('en', {
+      nodeDefs: {
+        [nodeName]: {
+          inputs: { seed: { name: text }, mask: { name: text } },
+          outputs: { 0: { name: text } }
+        }
+      }
+    })
+  }
+
+  beforeEach(async () => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    mergeBundledSlotText('stale bundled label')
+    await useLitegraphService().registerNodeDef(nodeName, nodeDef)
+  })
+
+  afterEach(() => {
+    mergeBundledSlotText(null)
+  })
+
+  it('labels widgets, sockets and outputs from the live backend', () => {
+    const node = LiteGraph.createNode(nodeName)
+    const localizedName = (name: string) =>
+      node?.inputs.find((input) => input.name === name)?.localized_name
+
+    expect(node?.widgets?.[0]?.label).toBe('Live Seed Label')
+    expect(localizedName('seed')).toBe('Live Seed Label')
+    expect(localizedName('mask')).toBe('Live Mask Label')
+    expect(node?.outputs[0]?.localized_name).toBe('Live Latent Name')
   })
 })

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -11,7 +11,12 @@ import {
   isPreviewPseudoWidget
 } from '@/core/graph/subgraph/promotionUtils'
 import { applyDynamicInputs } from '@/core/graph/widgets/dynamicWidgets'
-import { st, t } from '@/i18n'
+import {
+  resolveNodeDefInputText,
+  resolveNodeDefOutputText,
+  st,
+  t
+} from '@/i18n'
 import {
   LGraphCanvas,
   LGraphEventMode,
@@ -207,17 +212,16 @@ export const useLitegraphService = () => {
   }
 
   /**
-   * @internal The key for the node definition in the i18n file.
+   * @internal The node definition name used to resolve the node's i18n text.
    */
-  function nodeKey(node: LGraphNode): string {
-    return `nodeDefs.${normalizeI18nKey(node.constructor.nodeData?.name ?? '')}`
+  function nodeDefName(node: LGraphNode): string {
+    return node.constructor.nodeData?.name ?? ''
   }
   /**
    * @internal Add input sockets to the node. (No widget)
    */
   function addInputSocket(node: LGraphNode, inputSpec: InputSpec) {
     const inputName = inputSpec.name
-    const nameKey = `${nodeKey(node)}.inputs.${normalizeI18nKey(inputName)}.name`
     const widgetConstructor = widgetStore.widgets.get(
       inputSpec.widgetType ?? inputSpec.type
     )
@@ -229,7 +233,13 @@ export const useLitegraphService = () => {
 
     const input = node.addInput(inputName, inputSpec.type, {
       shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,
-      localized_name: st(nameKey, inputName)
+      localized_name: resolveNodeDefInputText(
+        'name',
+        nodeDefName(node),
+        inputName,
+        inputSpec.display_name,
+        inputName
+      )
     })
     input.label ??= inputSpec.display_name
   }
@@ -279,7 +289,14 @@ export const useLitegraphService = () => {
       widgetInputSpec.type = inputSpec.widgetType
     }
     const inputName = inputSpec.name
-    const nameKey = `${nodeKey(node)}.inputs.${normalizeI18nKey(inputName)}.name`
+    const resolveLabel = (fallback: string) =>
+      resolveNodeDefInputText(
+        'name',
+        nodeDefName(node),
+        inputName,
+        widgetInputSpec.display_name,
+        fallback
+      )
     const widgetConstructor = widgetStore.widgets.get(widgetInputSpec.type)
     if (!widgetConstructor || inputSpec.forceInput) return
 
@@ -295,8 +312,7 @@ export const useLitegraphService = () => {
     ) ?? {}
 
     if (widget) {
-      widget.label = st(
-        nameKey,
+      widget.label = resolveLabel(
         widget.label ?? widgetInputSpec.display_name ?? inputName
       )
       widget.options ??= {}
@@ -312,7 +328,7 @@ export const useLitegraphService = () => {
       const inputSpecV1 = transformInputSpecV2ToV1(widgetInputSpec)
       node.addInput(inputName, inputSpec.type, {
         shape: inputSpec.isOptional ? RenderShape.HollowCircle : undefined,
-        localized_name: st(nameKey, inputName),
+        localized_name: resolveLabel(inputName),
         widget: { name: inputName, [GET_CONFIG]: () => inputSpecV1 }
       })
     }
@@ -344,7 +360,6 @@ export const useLitegraphService = () => {
       // TODO: Fix the typing at the node spec level
       const type = output.type === 'COMFY_MATCHTYPE_V3' ? '*' : output.type
       const shapeOptions = is_list ? { shape: LiteGraph.GRID_SHAPE } : {}
-      const nameKey = `${nodeKey(node)}.outputs.${output.index}.name`
       const typeKey = `dataTypes.${normalizeI18nKey(type)}`
       const outputOptions = {
         ...shapeOptions,
@@ -352,7 +367,15 @@ export const useLitegraphService = () => {
         // e.g.
         // - type ("INT"); name ("Positive") => translate name
         // - type ("FLOAT"); name ("FLOAT") => translate type
-        localized_name: type !== name ? st(nameKey, name) : st(typeKey, name)
+        localized_name:
+          type !== name
+            ? resolveNodeDefOutputText(
+                'name',
+                nodeDefName(node),
+                output.index,
+                name
+              )
+            : st(typeKey, name)
       }
       node.addOutput(name, type, outputOptions)
     }


### PR DESCRIPTION
## Summary

Widget labels, socket labels, output names, node descriptions and tooltips now resolve from the live `/object_info` response instead of the bundled `en/nodeDefs.json` snapshot, so a backend rename no longer leaves a new node title beside old widget labels and old tooltips.

## Changes

- **What**: `resolveNodeDefInputText()` / `resolveNodeDefOutputText()` (`src/i18n.ts`) extend the precedence introduced in #14541 to slot text. They own all `nodeDefs.*.inputs|outputs.*` key construction and apply the same per-locale order:

  | locale | order                                                                                    |
  | ------ | ---------------------------------------------------------------------------------------- |
  | `en`   | custom-node `/api/i18n` -> backend `/object_info` -> bundled snapshot -> caller fallback |
  | other  | custom-node `/api/i18n` -> bundled snapshot -> backend -> caller fallback                |

  The existing `resolveNodeDefText` and the new slot resolvers share one core (`resolveNodeDefPath`), which now takes the message reader as a parameter — the only behavioural difference between a name and a tooltip.

- **What**: Call sites moved onto the resolvers:
  - `litegraphService.addInputWidget` — `widget.label` and the widget's socket `localized_name`
  - `litegraphService.addInputSocket` — socket `localized_name`
  - `litegraphService.addOutputs` — output `localized_name` (the `dataTypes.*` branch, used when the output name equals its type, is unchanged)
  - `NodeTooltip.vue` — input slot, output slot and widget tooltips
  - `useNodeTooltips.ts` — input slot, output slot and widget tooltips

- **What**: `useNodeTooltips.getNodeDescription` no longer re-resolves the description against the snapshot. `getNodeDefs()` has already resolved it, so wrapping it in `st()` let the stale bundled value win.

- **Breaking**: None.

## Review Focus

- **The raw/compiled split is the risk in this PR.** `scripts/nodeDefLocaleSerializer.ts` escapes `name` and leaves `tooltip` verbatim, because tooltips are read through `stRaw`/`tm()` uncompiled — an escaped `{'@'}` would render literally to the user. `slotMessageReader()` is the single place that picks `st` vs `stRaw`, keyed on the field. Nothing new is escaped at runtime, and no backend value is merged into the vue-i18n message tree.

- Widget labels previously always came from the snapshot, whose `inputs.*.name` is the raw input name rather than `display_name` — so a backend `display_name` on an input was never shown. It now is. Where the backend sends no `display_name` the snapshot still applies, which is the existing behaviour.

- Tests are verified by mutation, not by inspection, because `st()` swallows a vue-i18n `SyntaxError` and falls back to the raw stored message — a fixture with a throwing character passes either way. The `raw / compiled split` fixture uses `50{'%'} {'@'}`, which compiles cleanly, so `name` -> `50% @` and `tooltip` -> `50{'%'} {'@'}` genuinely diverge. Forcing either reader in both directions fails that test; dropping the `en` backend bypass, the custom-node precedence, or the backend fallback each fails a distinct test; passing `undefined` for the backend value at each of the seven call sites fails the test covering it.

Fixes #14631
