### PR TITLE
fix(billing): surface an unknown billing op type instead of defaulting silently

### DIFF
--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -30,6 +30,7 @@ const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockGetOperation = vi.hoisted(() => vi.fn())
 const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
+const mockCaptureException = vi.hoisted(() => vi.fn())
 const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
@@ -72,6 +73,10 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
     getOperation: mockGetOperation,
     startOperation: mockStartOperation
   })
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -291,6 +296,30 @@ describe('useWorkspaceBilling', () => {
       )
     })
 
+    it('recovers a pending subscription reported explicitly', async () => {
+      // What the server sends today for an initial subscription or a plan
+      // change — distinct from the older servers that send no type at all.
+      const actionUrl = 'https://invoice.stripe.com/sensitive-token'
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-sub',
+        pending_billing_op_type: 'subscription',
+        action_url: actionUrl
+      } satisfies BillingStatusResponse)
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-sub',
+        'subscription',
+        undefined,
+        actionUrl
+      )
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
     it('recovers a pending top-up as a top-up, not a subscription', async () => {
       const actionUrl = 'https://invoice.stripe.com/sensitive-token'
       mockWorkspaceApi.getBillingStatus.mockResolvedValue({
@@ -309,6 +338,35 @@ describe('useWorkspaceBilling', () => {
         'topup',
         undefined,
         actionUrl
+      )
+    })
+
+    it('reports a resume mode it does not recognize', async () => {
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-future',
+        // A server ahead of this bundle. Unrepresentable in the current union,
+        // which is why the branch cannot be left to the type system alone.
+        pending_billing_op_type: 'seat_change'
+      } as unknown as BillingStatusResponse)
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('seat_change')
+        }),
+        { tags: { error_type: 'billing_unknown_resume_mode' } }
+      )
+      // Recovery is preserved deliberately: without it the customer has no way
+      // back to the payment page, while a wrong panel clears on reload.
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-future',
+        'subscription',
+        undefined,
+        undefined
       )
     })
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/vue'
 import { computed, ref, shallowRef, watch } from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
@@ -25,6 +26,43 @@ import type {
   BillingState,
   SubscriptionInfo
 } from '../../../composables/billing/types'
+
+/**
+ * Which client path resumes a recovered operation. Exhaustive on purpose: the
+ * two-way check this replaces sent anything that was not `topup` down the
+ * subscription path, which covers the customer's real plan with a "setting up
+ * your subscription" spinner until the operation settles.
+ */
+function resumeModeFor(
+  type: BillingStatusResponse['pending_billing_op_type']
+): 'subscription' | 'topup' {
+  switch (type) {
+    case 'topup':
+      return 'topup'
+    case 'subscription':
+      return 'subscription'
+    // A server predating the field only ever had subscriptions to hand back.
+    case undefined:
+      return 'subscription'
+    default: {
+      const unexpected: never = type
+      // JSON.stringify, not String: the latter throws on a value with no
+      // callable toString/valueOf, and throwing out of the branch that exists
+      // to absorb a bad value would abort recovery entirely. The value came
+      // from a parsed response, so it cannot be circular.
+      captureException(
+        new Error(
+          `Unknown pending billing op type: ${JSON.stringify(unexpected)}`
+        ),
+        { tags: { error_type: 'billing_unknown_resume_mode' } }
+      )
+      // Reachable only against a newer server. Dropping recovery strands a
+      // customer who cannot reach the payment page; a wrong panel clears on
+      // reload, so recovery wins.
+      return 'subscription'
+    }
+  }
+}
 
 /**
  * Whether a rejection means the subscription already holds the state the caller
@@ -210,7 +248,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       ) {
         void billingOperationStore.startOperation(
           status.pending_billing_op_id,
-          status.pending_billing_op_type === 'topup' ? 'topup' : 'subscription',
+          resumeModeFor(status.pending_billing_op_type),
           undefined,
           status.action_url
         )


### PR DESCRIPTION
Follow-up to #14715. No behavior change against any value the API sends today — this is about what happens to the next one.

Recovering a pending billing operation picked its client path with a two-way check, so anything that was not `topup` became `subscription` — including a value this client has never heard of.

```ts
status.pending_billing_op_type === 'topup' ? 'topup' : 'subscription'
```

### Before

```mermaid
flowchart LR
    A["'subscription'"] --> S[subscription path]
    B["'topup'"] --> T[topup path]
    U[undefined] --> S
    N["any new value"] -.silently.-> S
    style N fill:#f8d7da,stroke:#b02a37,stroke-dasharray: 4
```

### After

```mermaid
flowchart LR
    A["'subscription'"] --> S[subscription path]
    B["'topup'"] --> T[topup path]
    U[undefined] --> S
    N["any new value"] --> R["subscription path<br/>+ Sentry report"]
    style N fill:#d1e7dd,stroke:#0f5132
    style R fill:#d1e7dd,stroke:#0f5132
```

## Why it matters

`subscription` is the worst branch to default into. A mislabelled operation flips `isSettingUp`, so the panel covers the user's real plan with a "setting up your subscription" spinner for as long as the operation is pending; `topupActionOperation` never matches; and `handleSuccess` reconciles the subscription instead of refetching the balance. Same failure #14715 fixed, waiting for the next value.

## The change

An exhaustive `switch`:

- `undefined` still resolves to `subscription` — the compatibility path for a server that does not send the field, and why #14715 was safe to land alone.
- An unknown value reports to Sentry (`billing_unknown_resume_mode`).
- `const unexpected: never = type` in `default` means a widened union fails to compile.

**The unknown case still resumes as a subscription, deliberately.** It is reachable only when this bundle is older than the server. In that window, dropping recovery strands a customer who cannot reach the payment page, while a wrong panel clears on reload — so recovery wins, and the report is what makes the skew visible.

`JSON.stringify` rather than `String` in the report: `String` throws on a value with no callable `toString`/`valueOf`, and throwing out of the branch that exists to absorb a bad value would abort the whole status read. The value came from a parsed response, so it cannot be circular.

## Tests

Three paths, all through `fetchStatus`:

| Test | Covers |
|---|---|
| `recovers a pending subscription reported explicitly` | what the server sends today for an initial subscription or plan change |
| `recovers a pending top-up as a top-up, not a subscription` | the `topup` path |
| `reports a resume mode it does not recognize` | the unknown value — **verified red** against the old ternary |

The absent-field compatibility path is already covered by the existing `recovers a pending subscription operation from billing status`.

`vitest run --coverage` (76 passed, matching how CI runs unit tests), `pnpm typecheck`, `pnpm lint`, `pnpm format`.

## Scope note

`BillingStatusResponse` is hand-written in `workspaceApi.ts` rather than taken from `@comfyorg/ingest-types`, so the `never` check is exhaustive over a hand-maintained union: it catches an edit to that union that misses this switch, but cannot widen on its own when the API changes. Single-sourcing it means regenerating the types package, which rewrites the whole generated surface and belongs in its own PR. Until then the Sentry report is the signal that matters here.

The server-side counterpart is tracked separately and does not gate this PR.