### PR TITLE
feat(subgraph): hide linked widget content

### DIFF
--- a/browser_tests/assets/subgraphs/subgraph-with-promoted-image-widget.json
+++ b/browser_tests/assets/subgraphs/subgraph-with-promoted-image-widget.json
@@ -1,0 +1,183 @@
+{
+  "id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 11,
+      "type": "11111111-2222-4333-8444-555555555555",
+      "pos": [200, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    },
+    {
+      "id": 12,
+      "type": "11111111-2222-4333-8444-555555555555",
+      "pos": [700, 300],
+      "size": [400, 300],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {},
+      "widgets_values": [""]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "11111111-2222-4333-8444-555555555555",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 1,
+          "lastLinkId": 3,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Promoted Image Widget",
+        "inputNode": {
+          "id": -10,
+          "bounding": [100, 300, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [700, 300, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "99999999-8888-4777-8666-555555555555",
+            "name": "image",
+            "type": "COMBO",
+            "linkIds": [1],
+            "pos": [200, 320]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "22222222-3333-4444-8555-666666666666",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [2],
+            "pos": [720, 320]
+          },
+          {
+            "id": "33333333-4444-4555-8666-777777777777",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [3],
+            "pos": [720, 340]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "LoadImage",
+            "pos": [300, 200],
+            "size": [315, 360],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "COMBO",
+                "widget": {
+                  "name": "image"
+                },
+                "link": 1
+              }
+            ],
+            "outputs": [
+              {
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [2]
+              },
+              {
+                "name": "MASK",
+                "type": "MASK",
+                "links": [3]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoadImage"
+            },
+            "widgets_values": ["interior.png", "image"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 2,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 3,
+            "origin_id": 1,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -79,6 +79,14 @@ export class ContextMenu {
     return this
   }
 
+  async dismissPrimeVueMenu(): Promise<void> {
+    await expect(this.primeVueMenu).not.toHaveClass(
+      /p-contextmenu-enter-active/
+    )
+    await this.page.keyboard.press('Tab')
+    await this.waitForHidden()
+  }
+
   async waitForHidden(): Promise<void> {
     await Promise.all([
       this.primeVueMenu.waitFor({ state: 'hidden' }),

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -165,6 +165,8 @@ export const TestIds = {
     container: 'node-widgets',
     widget: 'node-widget',
     layoutFieldLabel: 'widget-layout-field-label',
+    linkedPlaceholder: 'linked-widget-placeholder',
+    linkedIndicator: 'linked-widget-indicator',
     formDropdownMenu: 'form-dropdown-menu',
     decrement: 'decrement',
     increment: 'increment',

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -362,10 +362,10 @@ test.describe(
     })
 
     test.describe(
-      'Nested Promoted Widget Disabled State',
+      'Nested Promoted Widget Linked State',
       { tag: ['@vue-nodes'] },
       () => {
-        test('Externally linked promotions stay disabled while unlinked textareas remain editable', async ({
+        test('Externally linked promotions hide their controls while unlinked textareas remain editable', async ({
           comfyPage
         }) => {
           await comfyPage.workflow.loadWorkflow(
@@ -377,12 +377,16 @@ test.describe(
             .toEqual(expect.arrayContaining(['string_a', 'value']))
 
           const subgraphNode = comfyPage.vueNodes.getNodeLocator('5')
-          const linkedTextarea = subgraphNode.getByRole('textbox', {
-            name: 'string_a',
-            exact: true
-          })
-          await expect(linkedTextarea).toBeVisible()
-          await expect(linkedTextarea).toBeDisabled()
+          const linkedWidgetRow = subgraphNode
+            .getByTestId(TestIds.widgets.widget)
+            .filter({ hasText: 'string_a' })
+          await expect(linkedWidgetRow).toBeVisible()
+          await expect(
+            subgraphNode.getByRole('textbox', {
+              name: 'string_a',
+              exact: true
+            })
+          ).toHaveCount(0)
 
           const allTextareas = subgraphNode.getByRole('textbox')
           await expect(allTextareas.first()).toBeVisible()

--- a/browser_tests/tests/vueNodes/widgets/linkedWidgetContent.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/linkedWidgetContent.spec.ts
@@ -1,0 +1,122 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+test.describe(
+  'Linked widget content',
+  { tag: ['@subgraph', '@widget', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.page.route('**/api/view?*', (route) =>
+        route.fulfill({
+          contentType: 'image/webp',
+          path: assetPath('image64x64.webp')
+        })
+      )
+      await comfyPage.workflow.loadWorkflow(
+        'subgraphs/subgraph-with-promoted-image-widget'
+      )
+      await comfyPage.vueNodes.enterSubgraph('11')
+    })
+
+    test('hides linked image controls, preview, and contextual actions until disconnect', async ({
+      comfyPage
+    }) => {
+      const loadImage = await comfyPage.vueNodes.getFixtureByTitle('Load Image')
+      const linkedBounds = await loadImage.boundingBox()
+      if (!linkedBounds) throw new Error('Load Image node has no bounds')
+
+      const linkedPlaceholder = loadImage.root.getByTestId(
+        TestIds.widgets.linkedPlaceholder
+      )
+      const linkedIndicator = loadImage.root.getByTestId(
+        TestIds.widgets.linkedIndicator
+      )
+      await expect(linkedPlaceholder).toBeVisible()
+      await expect(linkedIndicator).toBeVisible()
+      for (const scale of [0.5, 2, 1]) {
+        await comfyPage.canvasOps.setScale(scale)
+        await expect
+          .poll(async () => {
+            const controlBounds = await linkedPlaceholder
+              .locator('.widget-input-base')
+              .boundingBox()
+            const indicatorBounds = await linkedIndicator.boundingBox()
+            if (!controlBounds || !indicatorBounds) return false
+
+            return (
+              indicatorBounds.x >= controlBounds.x &&
+              indicatorBounds.y >= controlBounds.y &&
+              indicatorBounds.x + indicatorBounds.width <=
+                controlBounds.x + controlBounds.width &&
+              indicatorBounds.y + indicatorBounds.height <=
+                controlBounds.y + controlBounds.height
+            )
+          })
+          .toBe(true)
+      }
+      await expect(
+        loadImage.root.getByRole('button', {
+          name: 'interior.png',
+          exact: true
+        })
+      ).toHaveCount(0)
+      await expect(loadImage.imagePreview).toHaveCount(0)
+      expect(linkedBounds.height).toBeLessThan(240)
+
+      await comfyPage.contextMenu.openForVueNode(loadImage.header)
+      for (const name of [
+        'Open Image',
+        'Open in Mask Editor',
+        'Copy Image',
+        'Paste Image',
+        'Save Image'
+      ]) {
+        await expect(comfyPage.contextMenu.menuItem(name)).toHaveCount(0)
+      }
+      await expect(comfyPage.contextMenu.menuItem('Bypass')).toBeVisible()
+      await comfyPage.contextMenu.dismissPrimeVueMenu()
+
+      const linkedWidgetRow = loadImage.root
+        .getByTestId(TestIds.widgets.widget)
+        .filter({
+          has: comfyPage.page.getByTestId(TestIds.widgets.linkedPlaceholder)
+        })
+      await comfyPage.contextMenu.openFor(linkedWidgetRow)
+      await expect(
+        comfyPage.page.getByRole('menuitem', { name: /Favorite Widget/ })
+      ).toHaveCount(0)
+      await comfyPage.contextMenu.dismissPrimeVueMenu()
+
+      const loadImageNode = await comfyPage.nodeOps.getNodeRefById('1')
+      await (await loadImageNode.getInput(0)).removeLinks()
+      await comfyPage.nextFrame()
+
+      await expect(linkedPlaceholder).toHaveCount(0)
+      await expect(linkedIndicator).toHaveCount(0)
+      await expect(
+        loadImage.root.getByRole('button', {
+          name: 'Select image...',
+          exact: true
+        })
+      ).toBeVisible()
+      await expect(loadImage.imagePreview.locator('img')).toBeVisible()
+
+      await comfyPage.contextMenu.openFor(
+        loadImage.root.getByRole('button', {
+          name: 'Select image...',
+          exact: true
+        })
+      )
+      await expect(comfyPage.contextMenu.menuItem('Paste Image')).toBeVisible()
+      await expect(
+        comfyPage.page.getByRole('menuitem', { name: /Favorite Widget/ })
+      ).toBeVisible()
+      await expect
+        .poll(async () => (await loadImage.boundingBox())?.height ?? 0)
+        .toBeGreaterThan(linkedBounds.height)
+    })
+  }
+)

--- a/src/composables/graph/useMoreOptionsMenu.ts
+++ b/src/composables/graph/useMoreOptionsMenu.ts
@@ -47,13 +47,30 @@ export enum BadgeVariant {
 // Global singleton for NodeOptions component reference
 let nodeOptionsInstance: null | NodeOptionsInstance = null
 
-const hoveredWidget = ref<[string, SerializedNodeId | undefined]>()
+interface NodeMenuContext {
+  widgetName?: string
+  widgetNodeId?: SerializedNodeId
+  contextualActionsDisabled: boolean
+}
+
+const nodeMenuContext = ref<NodeMenuContext>()
+
+const LEGACY_IMAGE_MENU_LABELS = new Set([
+  'Open Image',
+  'Copy Image',
+  'Paste Image',
+  'Paste (Clipspace)',
+  'Save Image',
+  'Open in Mask Editor',
+  'Open in MaskEditor | Image Canvas'
+])
 
 /**
  * Toggle the node options popover
  * @param event - The trigger event
  */
 export function toggleNodeOptions(event: Event) {
+  nodeMenuContext.value = undefined
   if (nodeOptionsInstance?.toggle) {
     nodeOptionsInstance.toggle(event)
   }
@@ -67,9 +84,13 @@ export function toggleNodeOptions(event: Event) {
 export function showNodeOptions(
   event: MouseEvent,
   widgetName?: string,
-  nodeId?: SerializedNodeId
+  widgetNodeId?: SerializedNodeId,
+  contextualActionsDisabled = false
 ) {
-  hoveredWidget.value = widgetName ? [widgetName, nodeId] : undefined
+  nodeMenuContext.value =
+    widgetName || contextualActionsDisabled
+      ? { widgetName, widgetNodeId, contextualActionsDisabled }
+      : undefined
   if (nodeOptionsInstance?.show) {
     nodeOptionsInstance.show(event)
   }
@@ -177,6 +198,10 @@ export function useMoreOptionsMenu() {
     // For single node selection, also get LiteGraph menu items to merge
     const litegraphOptions: MenuOption[] = []
     const node: LGraphNode | undefined = selectedNodes.value[0]
+    const menuContext = nodeMenuContext.value
+    const widget = menuContext?.widgetName
+      ? node?.widgets?.find((item) => item.name === menuContext.widgetName)
+      : undefined
     if (
       selectedNodes.value.length === 1 &&
       !groupContext &&
@@ -257,13 +282,15 @@ export function useMoreOptionsMenu() {
     options.push({ type: 'divider' })
 
     // Section 5: Image operations (if image node)
-    if (hasImageNode.value && selectedNodes.value.length > 0) {
+    if (
+      !menuContext?.contextualActionsDisabled &&
+      hasImageNode.value &&
+      selectedNodes.value.length > 0
+    ) {
       options.push(...getImageMenuOptions(selectedNodes.value[0]))
       options.push({ type: 'divider' })
     }
-    const [widgetName] = hoveredWidget.value ?? []
-    const widget = node?.widgets?.find((w) => w.name === widgetName)
-    if (widget) {
+    if (widget && !menuContext?.contextualActionsDisabled) {
       const widgetOptions = convertContextMenuToOptions(
         getExtraOptionsForWidget(node, widget)
       )
@@ -278,9 +305,21 @@ export function useMoreOptionsMenu() {
     // Mark all Vue options with source
     const markedVueOptions = markAsVueOptions(options)
 
-    if (litegraphOptions.length > 0) {
+    const suppressedLabels = new Set(LEGACY_IMAGE_MENU_LABELS)
+    if (menuContext?.contextualActionsDisabled && node && widget) {
+      for (const option of getExtraOptionsForWidget(node, widget)) {
+        if (option.content) suppressedLabels.add(option.content)
+      }
+    }
+    const visibleLitegraphOptions = menuContext?.contextualActionsDisabled
+      ? litegraphOptions.filter(
+          (option) => !option.label || !suppressedLabels.has(option.label)
+        )
+      : litegraphOptions
+
+    if (visibleLitegraphOptions.length > 0) {
       // Merge: LiteGraph options first, then Vue options (Vue will win in dedup)
-      const merged = [...litegraphOptions, ...markedVueOptions]
+      const merged = [...visibleLitegraphOptions, ...markedVueOptions]
       return buildStructuredMenu(merged)
     }
     // For other cases, structure the Vue options

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -15,6 +15,7 @@ import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composable
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
 const mockData = vi.hoisted(() => ({
   mockExecuting: false,
@@ -147,7 +148,9 @@ function renderLGraphNode(props: ComponentProps<typeof LGraphNode>) {
         NodeHeader: true,
         NodeSlots: true,
         NodeWidgets: true,
-        NodeContent: true,
+        NodeContent: {
+          template: '<div data-testid="node-content" />'
+        },
         SlotConnectionDot: true
       }
     }
@@ -178,6 +181,7 @@ describe('LGraphNode', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockData.mockExecuting = false
+    mockData.mockLgraphNode = null
 
     setActivePinia(pinia)
     const canvasStore = useCanvasStore()
@@ -245,6 +249,44 @@ describe('LGraphNode', () => {
 
     const overlay = screen.getByTestId('node-state-outline-overlay')
     expect(overlay).toHaveClass('border-node-stroke-executing')
+  })
+
+  it('hides a load media preview while its selector is linked', () => {
+    mockData.mockLgraphNode = {
+      constructor: {
+        nodeData: {
+          input: {
+            required: {
+              upload: ['IMAGEUPLOAD', { imageInputName: 'image' }]
+            }
+          },
+          isCoreNode: true
+        }
+      },
+      isSubgraphNode: () => false
+    }
+    const nodeOutputStore = useNodeOutputStore()
+    nodeOutputStore.nodeOutputs['test-node-123'] = {
+      images: [{ filename: 'input.png', type: 'input', subfolder: '' }]
+    }
+    vi.mocked(nodeOutputStore.getNodeImageUrls).mockReturnValue(['/input.png'])
+
+    renderLGraphNode({
+      nodeData: {
+        ...mockNodeData,
+        type: 'LoadImage',
+        widgets: [
+          {
+            name: 'image',
+            type: 'combo',
+            spec: { type: 'COMBO', name: 'image', image_upload: true },
+            slotMetadata: { index: 0, linked: true, type: 'IMAGE' }
+          }
+        ]
+      }
+    })
+
+    expect(screen.queryByTestId('node-content')).not.toBeInTheDocument()
   })
 
   it('should initialize height CSS vars for collapsed nodes', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -290,7 +290,12 @@ import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 import { useNodeLayout } from '@/renderer/extensions/vueNodes/layout/useNodeLayout'
 import { useNodePreviewState } from '@/renderer/extensions/vueNodes/preview/useNodePreviewState'
 import { nonWidgetedInputs } from '@/renderer/extensions/vueNodes/utils/nodeDataUtils'
+import {
+  hasLinkedInputPreviewWidget,
+  isInputMediaPreview
+} from '@/renderer/extensions/vueNodes/utils/linkedWidgetUtils'
 import { applyLightThemeColor } from '@/renderer/extensions/vueNodes/utils/nodeStyleUtils'
+import { getComponent } from '@/renderer/extensions/vueNodes/widgets/registry/widgetRegistry'
 import { app } from '@/scripts/app'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -411,6 +416,21 @@ const nodeOpacity = computed(() => {
 
 const hasInputs = computed(() => nonWidgetedInputs(nodeData).length > 0)
 const hasOutputs = computed((): boolean => !!nodeData.outputs?.length)
+const linkedWidgetKey = computed(() =>
+  (nodeData.widgets ?? [])
+    .filter(
+      (widget) => widget.slotMetadata?.linked && getComponent(widget.type)
+    )
+    .map(
+      (widget) =>
+        `${widget.widgetId ?? `${widget.name}:${widget.type}`}:${widget.slotMetadata?.index}`
+    )
+    .join('|')
+)
+const hasLinkedInputPreview = computed(() => {
+  const node = lgraphNode.value
+  return !!node && hasLinkedInputPreviewWidget(node, nodeData.widgets ?? [])
+})
 
 // Use canvas interactions for proper wheel event handling and pointer event capture control
 const { handleWheel, shouldHandleNodePointerEvents } = useCanvasInteractions()
@@ -457,7 +477,7 @@ const handleContextMenu = (event: MouseEvent) => {
   handleNodeRightClick(event as PointerEvent, nodeData.id)
 
   // Show the node options menu at the cursor position
-  showNodeOptions(event)
+  showNodeOptions(event, undefined, undefined, hasLinkedInputPreview.value)
 }
 
 /**
@@ -502,6 +522,7 @@ let unsubscribeLayoutChange: (() => void) | null = null
 
 onMounted(() => {
   initSizeStyles()
+  if (linkedWidgetKey.value) void fitNodeToVisibleContent()
   unsubscribeLayoutChange = layoutStore.onNodeChange(
     nodeData.id,
     handleLayoutChange
@@ -556,7 +577,22 @@ watch(isCollapsed, (collapsed) => {
   const currentHeight = element.style.getPropertyValue(`--node-height${from}`)
   element.style.setProperty(`--node-height${to}`, currentHeight)
   element.style.setProperty(`--node-height${from}`, '')
+
+  if (!collapsed && linkedWidgetKey.value) void fitNodeToVisibleContent()
 })
+
+watch(linkedWidgetKey, (key) => {
+  if (key) void fitNodeToVisibleContent()
+})
+
+async function fitNodeToVisibleContent() {
+  await nextTick()
+  const element = nodeContainerRef.value
+  if (!element || isCollapsed.value) return
+
+  element.style.setProperty('--node-height', '0px')
+  element.style.setProperty('--node-height', `${element.offsetHeight}px`)
+}
 
 // Check if node has custom content (like image/video outputs)
 const hasCustomContent = computed(() => {
@@ -793,6 +829,8 @@ const nodeMedia = computed(() => {
     return undefined
 
   if (node instanceof SubgraphNode) return undefined
+  if (hasLinkedInputPreview.value && isInputMediaPreview(newOutputs))
+    return undefined
 
   const urls = nodeOutputs.getNodeImageUrls(node)
   if (!urls?.length) return undefined

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
 import { createTestingPinia } from '@pinia/testing'
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
@@ -130,6 +130,45 @@ describe('NodeWidgets', () => {
       expect(stub).not.toBeNull()
       expect(stub!.getAttribute('data-node-type')).toBe('')
     })
+  })
+
+  it('keeps a linked simple widget mounted behind its empty display', () => {
+    const widget = createMockWidget({
+      slotMetadata: { index: 0, linked: true, type: 'IMAGE' }
+    })
+    const nodeData = createMockNodeData('LoadImage', [widget])
+
+    const { container } = renderComponent(nodeData)
+
+    expect(screen.getByTestId('linked-widget-placeholder')).toHaveAttribute(
+      'inert'
+    )
+    expect(screen.getByTestId('linked-widget-placeholder')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+    expect(screen.getByTestId('linked-widget-indicator')).toBeInTheDocument()
+    expect(container.querySelector('.widget-stub')).not.toBeNull()
+  })
+
+  it('hides the full control for a linked expanding widget', () => {
+    const widget = createMockWidget({
+      name: 'curve',
+      type: 'curve',
+      slotMetadata: { index: 0, linked: true, type: 'CURVE' }
+    })
+    const nodeData = createMockNodeData('ColorCurve', [widget])
+
+    const { container } = renderComponent(nodeData)
+
+    expect(
+      screen.queryByTestId('linked-widget-placeholder')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('linked-widget-indicator')
+    ).not.toBeInTheDocument()
+    expect(container.querySelector('.widget-stub')).toBeNull()
+    expect(container.querySelector('input-slot-stub')).not.toBeNull()
   })
 
   it('deduplicates widgets with identical render identity while keeping distinct promoted sources', () => {

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -26,13 +26,22 @@
       <div
         v-if="widget.visible"
         data-testid="node-widget"
-        class="lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch pr-3"
+        :class="
+          cn(
+            'lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch pr-3',
+            widget.linkedDisplay === 'placeholder' && 'relative'
+          )
+        "
+        @contextmenu="widget.linkedDisplay && widget.handleContextMenu($event)"
       >
         <!-- Widget Input Slot Dot -->
         <div
           :class="
             cn(
-              'z-10 flex w-3 items-stretch opacity-0 transition-opacity duration-150 group-hover:opacity-100',
+              'z-10 flex items-stretch transition-opacity duration-150',
+              widget.linkedDisplay === 'slot'
+                ? 'col-span-2 w-auto opacity-100'
+                : 'w-3 opacity-0 group-hover:opacity-100',
               widget.slotMetadata?.linked && 'opacity-100'
             )
           "
@@ -49,11 +58,12 @@
             :has-error="widget.hasError"
             :index="widget.slotMetadata.index"
             :socketless="widget.simplified.spec?.socketless"
-            dot-only
+            :dot-only="widget.linkedDisplay !== 'slot'"
           />
         </div>
         <!-- Widget Component -->
         <AppInput
+          v-if="widget.linkedDisplay !== 'slot'"
           :widget-id="widget.widgetId"
           :name="widget.name"
           :enable="canSelectInputs && !widget.simplified.options?.disabled"
@@ -65,14 +75,31 @@
             :widget="widget.simplified"
             :node-id="nodeData?.id"
             :node-type="nodeType"
+            :inert="widget.linkedDisplay === 'placeholder' ? true : undefined"
+            :aria-hidden="
+              widget.linkedDisplay === 'placeholder' ? 'true' : undefined
+            "
+            :data-testid="
+              widget.linkedDisplay === 'placeholder'
+                ? 'linked-widget-placeholder'
+                : undefined
+            "
             :class="
               cn(
                 'col-span-2',
+                widget.linkedDisplay === 'placeholder' &&
+                  LINKED_WIDGET_DISPLAY_CLASS,
                 widget.hasError && 'font-bold text-node-stroke-error'
               )
             "
             @update:model-value="widget.updateHandler"
             @contextmenu="widget.handleContextMenu"
+          />
+          <i
+            v-if="widget.linkedDisplay === 'placeholder'"
+            data-testid="linked-widget-indicator"
+            aria-hidden="true"
+            class="pointer-events-none absolute z-10 col-start-3 row-start-1 ml-2 icon-[lucide--link] size-4 self-center justify-self-start text-component-node-foreground-secondary opacity-40"
           />
         </AppInput>
       </div>
@@ -98,6 +125,16 @@ import InputSlot from './InputSlot.vue'
 interface NodeWidgetsProps {
   nodeData?: VueNodeData
 }
+
+const LINKED_WIDGET_DISPLAY_CLASS = cn(
+  'pointer-events-none',
+  '[&_.widget-input-base]:relative',
+  '[&_.widget-input-base]:bg-component-node-widget-background/40',
+  '[&_.widget-input-base]:text-transparent',
+  '[&_.widget-input-base]:opacity-100',
+  '[&_.widget-input-base]:ring-0',
+  '[&_.widget-input-base>*]:invisible'
+)
 
 const { nodeData } = defineProps<NodeWidgetsProps>()
 

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -745,6 +745,20 @@ describe('computeProcessedWidgets borderStyle', () => {
   })
 })
 
+describe('computeProcessedWidgets linked display', () => {
+  it('leaves fallback widgets on their existing disabled rendering path', () => {
+    const [processed] = processWidgets([
+      createMockWidget({
+        type: 'custom-fallback',
+        slotMetadata: { index: 0, linked: true, type: 'CUSTOM' }
+      })
+    ])
+
+    expect(processed.linkedDisplay).toBeUndefined()
+    expect(processed.simplified.options?.disabled).toBe(true)
+  })
+})
+
 describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -77,6 +77,7 @@ interface ProcessedWidget {
   visible: boolean
   vueComponent: Component
   slotMetadata?: WidgetSlotMetadata
+  linkedDisplay?: 'placeholder' | 'slot'
 }
 
 interface WidgetUiCallbacks {
@@ -322,11 +323,17 @@ export function computeProcessedWidgets({
   } of uniqueWidgets) {
     const bareWidgetId = stripGraphPrefix(widget.nodeId ?? nodeId)
 
+    const registeredComponent = getComponent(widget.type)
     const vueComponent =
-      getComponent(widget.type) ||
-      (widget.isDOMWidget ? WidgetDOM : WidgetLegacy)
+      registeredComponent ?? (widget.isDOMWidget ? WidgetDOM : WidgetLegacy)
 
     const { slotMetadata } = widget
+    const linkedDisplay =
+      slotMetadata?.linked && registeredComponent
+        ? shouldExpand(widget.type) || widget.hasLayoutSize
+          ? 'slot'
+          : 'placeholder'
+        : undefined
 
     const value = widgetState?.value as WidgetValue
 
@@ -390,7 +397,8 @@ export function computeProcessedWidgets({
         widget.name,
         widget.nodeId !== undefined
           ? (stripGraphPrefix(widget.nodeId) ?? undefined)
-          : undefined
+          : undefined,
+        Boolean(linkedDisplay)
       )
     }
 
@@ -418,6 +426,7 @@ export function computeProcessedWidgets({
       updateHandler,
       tooltipConfig,
       slotMetadata,
+      linkedDisplay,
       ...(bareWidgetId === null ? {} : { id: bareWidgetId })
     })
   }
@@ -478,7 +487,9 @@ export function useProcessedWidgets(
   const gridTemplateRows = computed((): string =>
     visibleWidgets.value
       .map((w) =>
-        shouldExpand(w.type) || w.hasLayoutSize ? 'auto' : 'min-content'
+        !w.linkedDisplay && (shouldExpand(w.type) || w.hasLayoutSize)
+          ? 'auto'
+          : 'min-content'
       )
       .join(' ')
   )

--- a/src/renderer/extensions/vueNodes/utils/linkedWidgetUtils.test.ts
+++ b/src/renderer/extensions/vueNodes/utils/linkedWidgetUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+import {
+  hasLinkedInputPreviewWidget,
+  isInputMediaPreview
+} from './linkedWidgetUtils'
+
+function mediaNode(imageInputName: string, isCoreNode = true): LGraphNode {
+  return {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            upload: ['IMAGEUPLOAD', { imageInputName }]
+          }
+        },
+        isCoreNode
+      }
+    }
+  } as unknown as LGraphNode
+}
+
+describe(hasLinkedInputPreviewWidget, () => {
+  it('uses the explicit IMAGEUPLOAD source widget', () => {
+    const node = mediaNode('image')
+
+    expect(
+      hasLinkedInputPreviewWidget(node, [
+        {
+          name: 'mask',
+          slotMetadata: { index: 0, linked: true, type: 'IMAGE' }
+        },
+        {
+          name: 'image',
+          slotMetadata: { index: 1, linked: true, type: 'IMAGE' }
+        }
+      ])
+    ).toBe(true)
+  })
+
+  it('ignores a linked widget that is not the IMAGEUPLOAD source', () => {
+    const node = mediaNode('image')
+
+    expect(
+      hasLinkedInputPreviewWidget(node, [
+        {
+          name: 'mask',
+          slotMetadata: { index: 0, linked: true, type: 'IMAGE' }
+        },
+        {
+          name: 'image',
+          slotMetadata: { index: 1, linked: false, type: 'IMAGE' }
+        }
+      ])
+    ).toBe(false)
+  })
+
+  it('leaves custom node previews unchanged', () => {
+    const node = mediaNode('image', false)
+
+    expect(
+      hasLinkedInputPreviewWidget(node, [
+        {
+          name: 'image',
+          slotMetadata: { index: 0, linked: true, type: 'IMAGE' }
+        }
+      ])
+    ).toBe(false)
+  })
+})
+
+describe(isInputMediaPreview, () => {
+  it('accepts only local input media', () => {
+    expect(
+      isInputMediaPreview({ images: [{ type: 'input' }, { type: 'input' }] })
+    ).toBe(true)
+    expect(isInputMediaPreview({ images: [{ type: 'output' }] })).toBe(false)
+    expect(
+      isInputMediaPreview({ images: [{ type: 'input' }, { type: 'output' }] })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/extensions/vueNodes/utils/linkedWidgetUtils.ts
+++ b/src/renderer/extensions/vueNodes/utils/linkedWidgetUtils.ts
@@ -1,0 +1,47 @@
+import type { SafeWidgetData } from '@/composables/graph/useGraphNodeManager'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { InputSpec } from '@/schemas/nodeDefSchema'
+import { isImageUploadInput } from '@/types/nodeDefAugmentation'
+
+interface MediaUploadNodeDef {
+  input?: {
+    required?: Record<string, InputSpec>
+  }
+  isCoreNode?: boolean
+}
+
+function getMediaInputName(node: LGraphNode): string | undefined {
+  const nodeDef = node.constructor.nodeData as MediaUploadNodeDef | undefined
+  if (!nodeDef?.isCoreNode) return undefined
+
+  const uploadInput = nodeDef.input?.required?.upload
+  if (!uploadInput || !isImageUploadInput(uploadInput)) return undefined
+
+  return uploadInput[1].imageInputName
+}
+
+export function hasLinkedInputPreviewWidget(
+  node: LGraphNode,
+  widgets: readonly Pick<SafeWidgetData, 'name' | 'slotMetadata'>[]
+): boolean {
+  const mediaInputName = getMediaInputName(node)
+  if (!mediaInputName) return false
+
+  return widgets.some(
+    (widget) =>
+      widget.name === mediaInputName && widget.slotMetadata?.linked === true
+  )
+}
+
+export function isInputMediaPreview(
+  output:
+    | {
+        images?: Array<{ type?: string } | null>
+      }
+    | undefined
+): boolean {
+  return Boolean(
+    output?.images?.length &&
+    output.images.every((image) => image?.type === 'input')
+  )
+}

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetColorPicker.vue
@@ -1,6 +1,10 @@
 <template>
   <WidgetLayoutField :widget="widget">
-    <ColorPicker v-model="localValue" @update:model-value="onUpdate" />
+    <ColorPicker
+      v-model="localValue"
+      class="widget-input-base"
+      @update:model-value="onUpdate"
+    />
   </WidgetLayoutField>
 </template>
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetToggleSwitch.vue
@@ -33,6 +33,7 @@
     >
       <Switch
         v-model="modelValue"
+        class="widget-input-base"
         :disabled="Boolean(widget.options?.disabled)"
         :readonly="Boolean(widget.options?.read_only)"
         :aria-label="widget.name"

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -1,6 +1,7 @@
 import { cn } from '@comfyorg/tailwind-utils'
 
 export const WidgetInputBaseClass = cn([
+  'widget-input-base',
   // Background
   'not-disabled:bg-component-node-widget-background',
   'not-disabled:text-component-node-foreground',


### PR DESCRIPTION
## Summary

Hide the contents of linked Vue widgets so the graph shows that their values come from connections rather than editable local controls.

## Changes

- **What**: Preserve each compact Vue widget's footprint with a muted linked-state surface, collapse linked expanding widgets to their input slot, suppress contextual actions that target hidden controls, and restore the original UI after disconnection.
- **Media scope**: Hide only a core image or video loader's local input preview when its explicit `IMAGEUPLOAD.imageInputName` widget is linked and its stored media is marked as `input`.
- **Unchanged**: Legacy and custom fallback widget rendering, server live previews, executed-output previews, preview nodes, and promoted previews.
- **Dependencies**: None.

## ELI5

Once a cable is connected to a widget, the cable supplies the value. Keeping the old control visible makes it look editable even though it no longer owns the value.

This change keeps the control's familiar size and shape but removes its stale contents and shows a small link indicator. Disconnecting the cable restores the control and its actions.

For media loaders, only the local file preview associated with the explicitly declared upload input is hidden. Other preview systems keep their existing behavior.

## Review Focus

- Whether compact linked widgets retain the expected dimensions and visual weight.
- Whether expanding widgets should collapse to their input slot when linked.
- Whether the explicit local-input preview boundary is appropriately narrow.
- Whether generic node actions remain available while actions targeting hidden controls are suppressed.

## Screenshots

The current prototype follows the linked-state treatment shared in the design discussion.

## Verification

- 66 focused Vitest tests passed.
- 2 focused Chromium Playwright tests passed.
- Commit hooks passed formatting, Stylelint, Oxlint, ESLint, `pnpm typecheck`, and `pnpm typecheck:browser`.
- Push hook passed `pnpm knip`.
