### PR TITLE
fix(assets): remove broken sam2 model-node mapping

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -25,8 +25,8 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   // LLM/Llama-3.2-3B-Instruct, LLM/Florence-2-large-PromptGen-v2.0
   // (id widgets); sam3, sharp, BEN, BiRefNet/pth (node/widget names don't
   // exist); depthanything, CogVideo/GGUF, checkpoints/dynamicrafter/*,
-  // transparent-background (asset names not accepted by the node's enum);
-  // interpolation, clip, onnx (empty or unreachable dirs).
+  // transparent-background, sam2 (asset names not accepted by the node's
+  // enum); interpolation, clip, onnx (empty or unreachable dirs).
 
   // ---- ComfyUI core loaders ----
   ['checkpoints', 'CheckpointLoaderSimple', 'ckpt_name'],
@@ -55,8 +55,7 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['chatterbox/chatterbox_multilingual', 'FL_ChatterboxMultilingualTTS', ''],
   ['chatterbox/chatterbox_vc', 'FL_ChatterboxVC', ''],
 
-  // ---- SAM / SAM2 (comfyui-segment-anything-2, comfyui-impact-pack) ----
-  ['sam2', 'DownloadAndLoadSAM2Model', 'model'],
+  // ---- SAM (comfyui-impact-pack) ----
   ['sams', 'SAMLoader', 'model_name'],
 
   // ---- DepthAnything (comfyui-depthanythingv3) ----

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -29,7 +29,6 @@ const EXPECTED_DEFAULT_TYPES = [
   'chatterbox/chatterbox_multilingual',
   'chatterbox/chatterbox_vc',
   'latent_upscale_models',
-  'sam2',
   'sams',
   'ipadapter',
   'nlf',
@@ -249,7 +248,6 @@ describe('useModelToNodeStore', () => {
     })
 
     it.for([
-      ['sam2', 'DownloadAndLoadSAM2Model', 'model'],
       ['sams', 'SAMLoader', 'model_name'],
       ['ipadapter', 'IPAdapterModelLoader', 'ipadapter_file'],
       ['FlashVSR', 'FlashVSRNode', ''],
@@ -275,6 +273,16 @@ describe('useModelToNodeStore', () => {
         expect(modelToNodeStore.getNodeProvider(modelType)).toBeUndefined()
       }
     )
+
+    it('should not register DownloadAndLoadSAM2Model against sam2, so the node falls back to its static combo', () => {
+      const modelToNodeStore = useModelToNodeStore()
+      modelToNodeStore.registerDefaults()
+
+      expect(modelToNodeStore.getNodeProvider('sam2')).toBeUndefined()
+      expect(
+        modelToNodeStore.getCategoryForNodeType('DownloadAndLoadSAM2Model')
+      ).toBeUndefined()
+    })
   })
 
   describe('getAllNodeProviders', () => {

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -76,7 +76,6 @@ const MOCK_NODE_NAMES = [
   'FL_ChatterboxMultilingualTTS',
   'FL_ChatterboxVC',
   'LatentUpscaleModelLoader',
-  'DownloadAndLoadSAM2Model',
   'SAMLoader',
   'IPAdapterModelLoader',
   'LoadNLFModel',
@@ -273,16 +272,6 @@ describe('useModelToNodeStore', () => {
         expect(modelToNodeStore.getNodeProvider(modelType)).toBeUndefined()
       }
     )
-
-    it('should not register DownloadAndLoadSAM2Model against sam2, so the node falls back to its static combo', () => {
-      const modelToNodeStore = useModelToNodeStore()
-      modelToNodeStore.registerDefaults()
-
-      expect(modelToNodeStore.getNodeProvider('sam2')).toBeUndefined()
-      expect(
-        modelToNodeStore.getCategoryForNodeType('DownloadAndLoadSAM2Model')
-      ).toBeUndefined()
-    })
   })
 
   describe('getAllNodeProviders', () => {


### PR DESCRIPTION
## TL;DR

**Reviewer attention**: *Do not merge as-is — back in draft.* The premise below is wrong; see Status.

**PR Justification**: On Cloud, the `sam2` asset picker offers four `-fp16` files that `DownloadAndLoadSAM2Model` rejects, so selecting one fails prompt validation with `value not in list`.

**Stakes**: Low. The node falls back to its own `object_info` combo, which is correct by construction; worst case is losing the asset-picker UI on one node it was mis-serving anyway.

**Changes**: Delete the `sam2` row from `MODEL_NODE_MAPPINGS`, document it in the intentionally-unmapped note, update tests.

## Status: blocked on a design decision

`MODEL_NODE_MAPPINGS` serves two purposes at once, and this PR only accounted for one of them:

1. it replaces the node's `object_info` combo with the Cloud asset picker, and
2. it lets a model create its loader node from the model-library sidebar or a canvas drop — `ModelLibrarySidebarTab.vue:222`, `useCanvasDrop.ts:62`, and `resolveModelNodeFromAsset.ts:112` all resolve through `getNodeProvider(directory)`, returning `NO_PROVIDER` and a generic creation-failed toast when it is missing.

So deleting the row hides 4 picker entries the node rejects, but breaks click/drag-to-create for **all 12** `sam2` assets — including the 8 the node accepts. That is plausibly a net loss.

This is what makes `sam2` unlike the rows removed in #14489/#14529: those directories were empty or the node rejected every filename, so losing click-to-create cost nothing. Here most of the files are genuinely loadable.

Viable fixes, none of which is this diff:

- **Cloud-side data fix** — stop serving `-fp16` variants for a node whose enum rejects them. Same class as the known `sams` loader issue, which is tracked separately and already deferred for a data-side fix. This leaves the mapping (and both flows) intact. Preferred.
- **Decouple loader-provider registration from asset-widget eligibility**, so a directory can create loader nodes without its widget being replaced by the picker. The real structural fix; larger than a one-row removal.
- **Constrain the picker's options to the node's accepted enum** — but the picker deliberately surfaces importable assets that are not yet in `object_info`, so this changes its semantics and needs a design call.

The reproduction and evidence below stand and are worth keeping for whoever picks this up.

**Review provenance** — the bot results do not all cover the current head, so check the reviewed sha rather than the check status before relying on any of them. Cursor's panel reviewed `6712d0b908` and genuinely ran (8/8 reviewers contributed, no findings); its label predates the follow-up commit and Cursor re-runs only on label change, not on push, so the current head has no Cursor coverage. Codex reviewed `e6c2f6c0b7`, the current head. CodeRabbit approved.

## Summary

Removes the broken `sam2` → `DownloadAndLoadSAM2Model` mapping left behind by #14489/#14529, so the node's `model` widget falls back to its own `object_info` dropdown instead of an asset picker that offers files the node rejects.

## Changes

- **What**: Deletes `['sam2', 'DownloadAndLoadSAM2Model', 'model']` from `MODEL_NODE_MAPPINGS`, adds `sam2` to the intentionally-unmapped note, and drops the now-dead `sam2` fixture entries from `modelToNodeStore.test.ts` (the `EXPECTED_DEFAULT_TYPES` entry, the provider-table row, and the orphaned `DownloadAndLoadSAM2Model` mock node def). No test is added, matching #14529, which removed four rows the same way; asserting on lookups derived from `MODEL_NODE_MAPPINGS` would be a change-detector test (AGENTS.md:183).

## Review Focus

Verified against prod (cloud.comfy.org, 2026-08-04): the mapped directory serves 12 files, the node's enum accepts 8 — the four extras are offered by the picker but rejected at validation.

| Source | Options |
|---|---|
| `GET /api/experiment/models/sam2` (asset picker) | 12 files: the 8 enum values below plus `sam2.1_hiera_{base_plus,large,small,tiny}-fp16.safetensors` |
| `DownloadAndLoadSAM2Model.model` in `object_info` | 8 files: `sam2_hiera_{base_plus,large,small,tiny}.safetensors`, `sam2.1_hiera_{base_plus,large,small,tiny}.safetensors` |

The neighbouring `sams` and `SEEDVR2` rows are deliberately untouched — for both, the node's own combo on Cloud matches the asset list (equally unfiltered), so removing the mapping would change nothing; their fixes are data-side and tracked separately.

## Screenshots

Reproduced for `sam2` on this PR's preview env (frontend 1.50.1). The only variable between the two states is this PR's mapping row, re-registered at runtime with `modelToNodeStore.quickRegister('sam2', 'DownloadAndLoadSAM2Model', 'model')` to reproduce the pre-fix behaviour in the same session.

| | Widget type | Options offered | `-fp16` offered |
|---|---|---|---|
| Before (mapping present) | `asset` — asset picker dialog | 12 | 4: `sam2.1_hiera_{tiny,small,large,base_plus}-fp16` |
| After (this PR) | `combo` — node's own `object_info` enum | 8 | 0 |

Before: the asset picker replaces the node's own combo and lists all 12 files in the directory.
<img width="1440" height="900" alt="before-asset-picker-full-list" src="https://github.com/user-attachments/assets/0fece4b2-9f5c-4188-806f-336c070e92ce" />

Before, filtered to `fp16`: the four models the picker offers and the node's enum rejects.
<img width="1440" height="900" alt="before-asset-picker-fp16-filtered" src="https://github.com/user-attachments/assets/0e70a02d-3058-40c3-98ba-bf81de647d90" />

After: the node's own dropdown, 8 entries, every one accepted by its enum.
<img width="1440" height="900" alt="after-node-own-combo-8-entries" src="https://github.com/user-attachments/assets/e44c8d58-0af2-497c-b89a-4942f0b46dbc" />

On this build `getNodeProvider('sam2')` is `undefined` while `sams` remains mapped to `SAMLoader`, confirming the diff moved only the intended row.





