### PR TITLE
feat: give the release sheriff every automation-authored PR

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -48,14 +48,25 @@ later ship as v1.40.2). Same commits, no divergence — the branch just prevents
 ## Release Sheriff Assignment
 
 `pr-assign-release-sheriff.yaml` assigns the on-call release sheriff to any
-open backport PR (label `backport`, or a `[backport ...]` title) and any
-release version-bump PR (label `Release`, or a `version-bump-<version>`
-branch) that has no assignee. It also requests their review, since backport merges are
-gated on an approval. Existing assignees and review requests are never
-overwritten.
+open PR that has no assignee and is either:
 
-It runs on PR events and hourly — the hourly sweep is what catches strays that
-were opened while nobody was looking.
+- a backport (label `backport`, or a `[backport ...]` title);
+- a release version bump (label `Release`, or a `version-bump-<version>`
+  branch);
+- opened by automation — `dependabot`, `comfy-pr-bot`, or `cloud-code-bot`.
+
+It also requests their review, since backport merges are gated on an approval.
+Existing assignees and review requests are never overwritten.
+
+Automation-authored PRs are included because nobody feels addressed by what a
+robot opens: they accumulated unassigned for weeks. Note these are matched by
+author rather than by content, so a dependency bump counts as sheriff work.
+
+It runs on PR events and hourly. Bot PRs are picked up by the hourly sweep
+rather than on open — the `pull_request_target` gate matches labels, titles and
+branches, and teaching it about bot logins would duplicate the author list in a
+second syntax (the webhook says `dependabot[bot]` where `gh` says
+`app/dependabot`), which would drift.
 
 The rotation itself lives in Datadog On-Call ("Frontend Team – Oncall
 Schedule", layer "Release Sheriff") and is read at execution time, so handovers
@@ -103,12 +114,12 @@ branch has unreleased commits, it triggers a patch bump and drafts a PR to
 
 ## Workflows
 
-| Workflow                         | Purpose                                          |
-| -------------------------------- | ------------------------------------------------ |
-| `release-version-bump.yaml`      | Bump version, create Release PR                  |
-| `release-draft-create.yaml`      | Build + publish to GitHub/PyPI/npm               |
-| `release-branch-create.yaml`     | Create `core/` + `cloud/` branches (minor/major) |
-| `release-weekly-comfyui.yaml`    | Weekly auto-patch + ComfyUI requirements PR      |
-| `pr-backport.yaml`               | Cherry-pick fixes to stable branches             |
-| `cloud-backport-tag.yaml`        | Tag cloud branch merges                          |
-| `pr-assign-release-sheriff.yaml` | Assign on-call sheriff to backport/release PRs   |
+| Workflow                         | Purpose                                            |
+| -------------------------------- | -------------------------------------------------- |
+| `release-version-bump.yaml`      | Bump version, create Release PR                    |
+| `release-draft-create.yaml`      | Build + publish to GitHub/PyPI/npm                 |
+| `release-branch-create.yaml`     | Create `core/` + `cloud/` branches (minor/major)   |
+| `release-weekly-comfyui.yaml`    | Weekly auto-patch + ComfyUI requirements PR        |
+| `pr-backport.yaml`               | Cherry-pick fixes to stable branches               |
+| `cloud-backport-tag.yaml`        | Tag cloud branch merges                            |
+| `pr-assign-release-sheriff.yaml` | Assign on-call sheriff to backport/release/bot PRs |

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -262,6 +262,20 @@ describe('isSheriffPr', () => {
     )
   })
 
+  it('matches anything opened by automation, whatever it is about', () => {
+    for (const login of [
+      'app/dependabot',
+      'app/cloud-code-bot',
+      'comfy-pr-bot'
+    ])
+      expect(isSheriffPr(pr({ author: { login } }))).toBe(true)
+  })
+
+  it('ignores humans whose login merely resembles a bot', () => {
+    expect(isSheriffPr(pr({ author: { login: 'dependabot-fan' } }))).toBe(false)
+    expect(isSheriffPr(pr({ author: null }))).toBe(false)
+  })
+
   it('ignores feature branches that merely start with version-bump-', () => {
     expect(isSheriffPr(pr())).toBe(false)
     expect(isSheriffPr(pr({ headRefName: 'feat/version-bump-ui' }))).toBe(false)

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -1,5 +1,6 @@
-// Assigns the on-call release sheriff to backport and release version-bump
-// PRs. Run by pr-assign-release-sheriff.yaml; details in docs/release-process.md.
+// Assigns the on-call release sheriff to backport, release version-bump and
+// automation-authored PRs. Run by pr-assign-release-sheriff.yaml; details in
+// docs/release-process.md.
 import { execFileSync } from 'node:child_process'
 import { appendFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -197,13 +198,23 @@ const VERSION_BUMP_BRANCH = /^version-bump-\d+\.\d+\.\d+/
 // matching would also catch PRs that are merely about backports.
 const BACKPORT_TITLE = '[backport'
 
+// Nobody owns what a robot opens: these sat unassigned for weeks, the oldest
+// weeks old, because no human felt addressed by them. The sheriff owns them.
+// gh reports GitHub Apps as "app/<slug>" and plain accounts by login.
+const AUTOMATION_AUTHORS = [
+  'app/dependabot',
+  'app/cloud-code-bot',
+  'comfy-pr-bot'
+]
+
 export function isSheriffPr(pr: PullRequestSummary): boolean {
   const labels = pr.labels.map((label) => label.name.toLowerCase())
   return (
     labels.includes('backport') ||
     pr.title.toLowerCase().startsWith(BACKPORT_TITLE) ||
     labels.includes('release') ||
-    VERSION_BUMP_BRANCH.test(pr.headRefName)
+    VERSION_BUMP_BRANCH.test(pr.headRefName) ||
+    AUTOMATION_AUTHORS.includes(pr.author?.login ?? '')
   )
 }
 
@@ -277,7 +288,10 @@ function collectCandidatePrs(): PullRequestSummary[] {
     ...ghPrList(['--label', 'backport']),
     ...ghPrList(['--label', 'Release']),
     ...ghPrList(['--search', 'backport in:title']),
-    ...ghPrList(['--search', 'head:version-bump-'])
+    ...ghPrList(['--search', 'head:version-bump-']),
+    ...AUTOMATION_AUTHORS.flatMap((author) =>
+      ghPrList(['--search', `author:${author}`])
+    )
   ]
   const byNumber = new Map(found.map((pr) => [pr.number, pr]))
   return [...byNumber.values()]


### PR DESCRIPTION
Follow-up to #14626.

Nobody feels addressed by what a robot opens. A sweep of open PRs found **12 automation-authored PRs sitting unassigned**, the oldest for nearly two weeks:

- 9 from `dependabot` (oldest #13997, Jul 23)
- 2 from `comfy-pr-bot` — API-type syncs (#14700, #14728)
- 1 from `cloud-code-bot` (#14224)

None were reachable by the existing criteria, which match labels, `[backport ...]` titles and `version-bump-` branches — a dependency bump has none of those. So the sweep could never have found them, no matter how often it ran.

This treats the **author** as sufficient grounds for sheriff ownership, and adds the matching search selectors so `collectCandidatePrs` actually returns them.

## Trade-off worth naming

Matching is by author, not content, so a dependency bump is now sheriff work. That is the point — these need *an owner*, not necessarily deep review — but it does mean the sheriff's queue grows by whatever automation files that week.

## Why bot PRs are caught by the sweep, not on open

The `pull_request_target` gate matches labels, titles and branches. Teaching it about bot logins would mean maintaining the same author list in a second syntax — the webhook payload says `dependabot[bot]` where `gh` says `app/dependabot` — and the two would drift silently. The hourly sweep already exists for exactly this ("strays opened while nobody was looking"), so bot PRs are picked up within the hour instead.

## Verification

Confirmed against the live repo that `gh` reports these authors as `app/dependabot`, `app/cloud-code-bot` and `comfy-pr-bot`, and that `author:app/<slug>` search syntax returns them (8, 1 and 15 open PRs respectively).

Tests 26/26 — including that a human login merely resembling a bot (`dependabot-fan`) and a null author are both rejected. Lint, knip, typecheck, format clean.

All 12 have already been assigned to the current sheriff manually; this stops it recurring.
