### PR TITLE
docs: link tracking issues for the fallow follow-ups in ADR 0011

### DIFF
--- a/docs/adr/0011-adopt-fallow.md
+++ b/docs/adr/0011-adopt-fallow.md
@@ -63,6 +63,11 @@ the cleanup and stop backsliding.
 
 ## Notes
 
-- Open follow-ups: declare the hoisted deps in `apps/desktop-ui/package.json`
-  and drop those `ignoreDependencies` exceptions; decide whether `fallow audit`
-  should run in CI or pre-push, and whether it replaces knip there.
+Open follow-ups, each with a tracking issue:
+
+- Declare the hoisted deps in `apps/desktop-ui/package.json` and drop those
+  `ignoreDependencies` exceptions:
+  [#14768](https://github.com/Comfy-Org/ComfyUI_frontend/issues/14768).
+- Decide whether `fallow audit` should run in CI or pre-push, and whether it
+  replaces knip there:
+  [#14769](https://github.com/Comfy-Org/ComfyUI_frontend/issues/14769).


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Addresses https://github.com/Comfy-Org/ComfyUI_frontend/pull/13284#discussion_r3717508971 on #13284.

The ADR's Notes section deferred two items in prose with no tracking issues. Both are now filed and linked from the ADR (the #13284 description has been updated with the same links):

- #14768 — declare the 9 pnpm-hoisted deps in `apps/desktop-ui/package.json`, then drop their `ignoreDependencies` exceptions. Enumerates all 9 with their importing files, split into runtime (`@xterm/xterm`, `@xterm/addon-fit`, `@xterm/addon-serialize`, `es-toolkit`) vs dev (`@testing-library/*`, `@pinia/testing`, `@storybook/vue3-vite`), and notes that 5 have catalog entries while the 4 runtime ones do not.
- #14769 — decide whether `fallow audit` runs in CI or pre-push and whether it replaces knip. Records the current gates (`pnpm knip` in `ci-lint-format.yaml` via `lint-format-verify`, plus `.husky/pre-push`) and the open decisions, including keeping the `ci-lint-format-queue.yaml` mirror in sync for branch protection.

Both issues are assigned to @DrJKL and note they are blocked on #13284 landing.

Base is `drjkl/fallow-compliant` so this can be merged into the PR branch (or cherry-picked) before #13284 merges.

Docs-only change: one file, +8/-3.

Unrelated, spotted while editing: `0011` is already taken on `main` by `0011-derived-credential-lifecycle.md` (and 0012–0014 exist), so this ADR and the `docs/adr/README.md` row will need renumbering before #13284 merges. Not touched here.


## Screenshots

![Rendered ADR 0011 Notes section showing two bullets, each ending in a linked tracking issue (#14768, #14769)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ed5b73ee4fc971a378a9e12ed55b70bd82bee51ede45f9e58426348ba58d80b2/pr-images/1785915955875-30a2254f-fc28-4588-95bd-e6548e29b669.png)

![GitHub issue #14768 - declare the 9 pnpm-hoisted dependencies in apps/desktop-ui/package.json](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ed5b73ee4fc971a378a9e12ed55b70bd82bee51ede45f9e58426348ba58d80b2/pr-images/1785915956186-9b93e6c4-51cc-4dbb-b9f9-7af0a1ae24b5.png)

![GitHub issue #14769 - decide fallow gating in CI / pre-push and knip's fate](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ed5b73ee4fc971a378a9e12ed55b70bd82bee51ede45f9e58426348ba58d80b2/pr-images/1785915956557-b8bd647d-f0fb-483f-98be-e583cde53d0e.png)