### PR TITLE
fix: do not inherit fetched Content-Type when opening media in a new tab

### DIFF
--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -374,8 +374,9 @@ describe('downloadUtil', () => {
 
       await openFileInNewTab('https://storage.googleapis.com/bucket/evil.png')
 
-      const [created] = createObjectURLSpy.mock.calls[0] as unknown as [Blob]
-      expect(created.type).toBe('application/octet-stream')
+      expect(createObjectURLSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'application/octet-stream' })
+      )
     })
 
     it('preserves a media type carrying codec parameters', async () => {

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -378,6 +378,23 @@ describe('downloadUtil', () => {
       expect(created.type).toBe('application/octet-stream')
     })
 
+    it('preserves a media type carrying codec parameters', async () => {
+      mockIsCloud.value = true
+      const audioBlob = new Blob(['test'], { type: 'audio/ogg; codecs=opus' })
+      const mockTab = { location: { href: '' }, closed: false, close: vi.fn() }
+      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      fetchMock.mockResolvedValue(
+        fromPartial<Response>({
+          ok: true,
+          blob: vi.fn().mockResolvedValue(audioBlob)
+        })
+      )
+
+      await openFileInNewTab('https://storage.googleapis.com/bucket/clip.ogg')
+
+      expect(createObjectURLSpy).toHaveBeenCalledWith(audioBlob)
+    })
+
     it('revokes blob URL after timeout in cloud mode', async () => {
       mockIsCloud.value = true
       const blob = new Blob(['test'], { type: 'image/png' })

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -355,6 +355,29 @@ describe('downloadUtil', () => {
       expect(mockTab.location.href).toBe('blob:mock-url')
     })
 
+    it('neutralizes non-media content types before creating the blob URL', async () => {
+      mockIsCloud.value = true
+      const htmlBlob = new Blob(
+        ['<script>globalThis.__pwned = true</script>'],
+        {
+          type: 'text/html'
+        }
+      )
+      const mockTab = { location: { href: '' }, closed: false, close: vi.fn() }
+      windowOpenSpy.mockReturnValue(fromAny<Window, unknown>(mockTab))
+      fetchMock.mockResolvedValue(
+        fromPartial<Response>({
+          ok: true,
+          blob: vi.fn().mockResolvedValue(htmlBlob)
+        })
+      )
+
+      await openFileInNewTab('https://storage.googleapis.com/bucket/evil.png')
+
+      const [created] = createObjectURLSpy.mock.calls[0] as unknown as [Blob]
+      expect(created.type).toBe('application/octet-stream')
+    })
+
     it('revokes blob URL after timeout in cloud mode', async () => {
       mockIsCloud.value = true
       const blob = new Blob(['test'], { type: 'image/png' })

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -169,6 +169,10 @@ const RENDERABLE_MEDIA_TYPES = new Set([
   'video/webm'
 ])
 
+function isRenderableMediaType(blobType: string): boolean {
+  return RENDERABLE_MEDIA_TYPES.has(blobType.split(';')[0].trim().toLowerCase())
+}
+
 export async function openFileInNewTab(url: string): Promise<void> {
   if (!isCloud) {
     window.open(url, '_blank')
@@ -181,7 +185,7 @@ export async function openFileInNewTab(url: string): Promise<void> {
   try {
     const response = await fetchAsBlob(url)
     const fetched = await response.blob()
-    const blob = RENDERABLE_MEDIA_TYPES.has(fetched.type)
+    const blob = isRenderableMediaType(fetched.type)
       ? fetched
       : new Blob([fetched], { type: 'application/octet-stream' })
     const blobUrl = URL.createObjectURL(blob)

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -152,6 +152,23 @@ async function downloadViaBlobFetch(
  * (browsers block window.open after an await), then navigates it to
  * the blob URL once the fetch completes.
  */
+const RENDERABLE_MEDIA_TYPES = new Set([
+  'image/apng',
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/wav',
+  'audio/webm',
+  'video/mp4',
+  'video/ogg',
+  'video/webm'
+])
+
 export async function openFileInNewTab(url: string): Promise<void> {
   if (!isCloud) {
     window.open(url, '_blank')
@@ -163,7 +180,10 @@ export async function openFileInNewTab(url: string): Promise<void> {
 
   try {
     const response = await fetchAsBlob(url)
-    const blob = await response.blob()
+    const fetched = await response.blob()
+    const blob = RENDERABLE_MEDIA_TYPES.has(fetched.type)
+      ? fetched
+      : new Blob([fetched], { type: 'application/octet-stream' })
     const blobUrl = URL.createObjectURL(blob)
 
     if (tab && !tab.closed) {


### PR DESCRIPTION
Scope reduced 2026-08-08: the property-name `innerHTML` fix originally in this PR was superseded by #14928, which landed the same fix plus a subgraph-type sink in the properties panel that this PR did not cover. That commit has been dropped; only the Open Image change remains.

## Problem

`openFileInNewTab` fetches the target and re-hosts it as a `blob:` URL on the cloud path. Blob URLs inherit the creating page's origin, and `blob.type` is taken from the fetched `Content-Type`, so a response typed `text/html` renders as a document on the app origin rather than as an image.

Upload MIME is caller-supplied with no allowlist, so the content type on a stored asset is attacker-controlled.

## Change

Carry the fetched type through only for media types the tab is meant to display; anything else becomes `application/octet-stream`. Comparison ignores parameters, so `audio/ogg;codecs=opus` still displays.

## Testing

31 tests pass in `downloadUtil.test.ts`, including new cases for a `text/html` response being neutralised and a parameterised media type being preserved. eslint and oxfmt clean.

## Note

This is a mitigation, not the root fix. Serving assets same-origin (BE-501) would let the blob path be deleted outright, and an upload MIME allowlist would remove the enabling condition. Relates to GHSA-8xxc-66vh-2pf3.