### PR TITLE
fix: name the malformed node definitions dropped from object_info

### DIFF
--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -153,9 +153,11 @@ describe('ComfyApp.getNodeDefs', () => {
 
     await comfyApp.getNodeDefs()
 
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('NullEntry, NamelessEntry')
-    )
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [message] = warn.mock.calls[0]
+    expect(message).toContain('NullEntry')
+    expect(message).toContain('NamelessEntry')
+    expect(message).not.toContain('TestNode')
     warn.mockRestore()
   })
 

--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -143,6 +143,32 @@ describe('ComfyApp.getNodeDefs', () => {
     expect(result.TestNode.category).toBe('')
   })
 
+  test('names the malformed entries it discards', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(api.getNodeDefs).mockResolvedValue({
+      TestNode: nodeDef({}),
+      NullEntry: null,
+      NamelessEntry: { category: 'test' }
+    } as unknown as Record<string, ComfyNodeDefV1>)
+
+    await comfyApp.getNodeDefs()
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('NullEntry, NamelessEntry')
+    )
+    warn.mockRestore()
+  })
+
+  test('stays silent when every entry is well formed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockDefs(nodeDef({}))
+
+    await comfyApp.getNodeDefs()
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
   test('discards malformed entries inside an otherwise valid response', async () => {
     vi.mocked(api.getNodeDefs).mockResolvedValue({
       TestNode: nodeDef({ display_name: 'Good Node' }),

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1127,6 +1127,15 @@ export class ComfyApp {
       !Array.isArray(response)
         ? Object.entries(response)
         : []
+    const droppedNames = entries
+      .filter(([, value]) => !isNodeDef(value))
+      .map(([name]) => name)
+    if (droppedNames.length > 0) {
+      console.warn(
+        `Ignored ${droppedNames.length} malformed node definition(s) from /object_info: ${droppedNames.join(', ')}`
+      )
+    }
+
     const defs: Record<string, ComfyNodeDefV1> = Object.fromEntries(
       entries.filter((entry): entry is [string, ComfyNodeDefV1] =>
         isNodeDef(entry[1])


### PR DESCRIPTION
## Summary

`ComfyApp.getNodeDefs()` discards `/object_info` entries that are not objects with a string `name`, so a single malformed def cannot abort node registration for every node. It did so silently, which makes a node vanishing from the UI undiagnosable.

Warn once per fetch, naming the discarded keys.

## Why this shape

This is the decision half of #14644, which asks whether node definitions should be structurally validated at the API boundary and what should happen to ones that fail.

Validation was removed deliberately: #1190 disabled it by default and #4038 removed it outright along with its setting. `/object_info` carries definitions from arbitrary custom nodes whose shapes vary in ways `ComfyNodeDefV1` does not fully capture, so tightening the contract risks silently dropping a node the user installed and expects to see. That posture is kept here.

What was actually wrong was not the permissiveness, it was the silence. Naming the dropped keys keeps the permissive behaviour while making the data loss visible, and it is the cheapest way to learn whether real payloads ever reach this path. If telemetry later shows they do, #14644 can be decided with evidence rather than speculation.

- **Breaking**: none. Same defs are dropped as before; only the logging changes.

## Review Focus

Verified by mutation: removing the warning fails the suite. A second test pins that a well-formed response stays silent, so the warning cannot become unconditional noise.

Related: #14644, #14541