### PR TITLE
test: pin the remaining container-coupled node titles

### DIFF
--- a/browser_tests/tests/nodeBadge.spec.ts
+++ b/browser_tests/tests/nodeBadge.spec.ts
@@ -9,22 +9,31 @@ import {
 } from '@e2e/fixtures/utils/objectInfo'
 
 const DEPRECATED_NODE_TYPE = 'ImageBatch'
-const DEPRECATED_NODE_DISPLAY_NAME = 'Batch Images'
 const API_NODE_TYPE = 'FluxProUltraImageNode'
 
 // English node titles come from the backend, so any golden containing a node
 // header would otherwise track whatever ComfyUI build the CI container ships.
 // Pinning the name before the app boots keeps those baselines stable.
+// `nodes/execution_error` also renders `DevToolsErrorRaiseNode`, which is not
+// pinned: it ships from this repo's `tools/devtools/`, so a rename there is a
+// deliberate in-repo change that its goldens should keep tracking.
+const PINNED_DISPLAY_NAMES: Record<string, string> = {
+  [DEPRECATED_NODE_TYPE]: 'Batch Images',
+  [API_NODE_TYPE]: 'Flux 1.1 [pro] Ultra Image',
+  PreviewImage: 'Preview Image'
+}
+
 const test = comfyPageFixture.extend({
   page: async ({ page }, use) => {
     const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
       page,
-      (objectInfo) =>
-        setNodeDisplayName(
-          objectInfo,
-          DEPRECATED_NODE_TYPE,
-          DEPRECATED_NODE_DISPLAY_NAME
-        )
+      (objectInfo) => {
+        for (const [nodeType, displayName] of Object.entries(
+          PINNED_DISPLAY_NAMES
+        )) {
+          setNodeDisplayName(objectInfo, nodeType, displayName)
+        }
+      }
     )
     try {
       await use(page)


### PR DESCRIPTION
## Summary

Finishes what #14744 started: the last two node-title goldens that still track the CI container image are now pinned. No baselines regenerated.

## Changes

`browser_tests/tests/nodeBadge.spec.ts` already extended the `page` fixture to stub `/object_info` for `ImageBatch`. That map now also carries:

| golden | node type | pinned title |
| --- | --- | --- |
| `api-pricing-{on,off}-{classic,vue}` | `FluxProUltraImageNode` | `Flux 1.1 [pro] Ultra Image` |
| `node-badge-{Show-all,Hide-built-in,None}` | `PreviewImage` | `Preview Image` |

The route shape, the `try`/`finally` unroute and the pre-boot install are unchanged — only the mutator body generalises to a loop.

`nodes/execution_error` also renders `DevToolsErrorRaiseNode` (`Raise Error`), which is **deliberately not pinned**. That name is defined in this repo at `tools/devtools/nodes/errors.py:76` and copied into `custom_nodes` during CI, so it is not a function of the container image. Pinning it would mask a deliberate in-repo rename.

## Review Focus

**Motivation.** Since #14541 English node display names resolve from the backend `/object_info`, so every golden containing a node header is a function of `ghcr.io/comfy-org/comfyui-ci-container`. #14682 moves that pin from `0.0.21` (ComfyUI v0.19.3) to `0.0.22` (v0.30.0) — eleven minors. The goal is that after this lands, a node-title golden that moves on that bump means a real structural change, not an upstream rename.

**How the strings were established.** Both are read off the committed PNGs, not guessed:

- `Flux 1.1 [pro] Ultra Image` is legible in the title band of `api-pricing-on-classic` and `api-pricing-on-vue`, and matches `src/locales/en/nodeDefs.json`.
- `Preview Image` is legible in the title band of all three `node-badge-*` goldens, likewise matching the bundled snapshot.

Two independent corroborations that these strings hold on both sides of the bump:

1. #14541 re-baselined only `image-compare-*` and `node-lifecycle-*`. It left `api-pricing-*` and `node-badge-*` byte-identical, so at `0.0.21` the container name already equalled the bundled name.
2. Diffing every golden #14682 regenerates against its committed counterpart, the changed pixels in `node-badge-*` sit at x 454–509 / y 69–81 — an `images` output slot appearing on `PreviewImage`. The title band is byte-identical, and `api-pricing-*` is not regenerated at all. So neither title moves at `0.0.22` either.

**Sweep.** All 26 goldens #14682 regenerates were diffed old-vs-new and classified. **None move because of a node display name:**

| cause | goldens |
| --- | --- |
| `SaveImage`/`PreviewImage` gained an `images` output | `colorPalette` ×9, `node-badge-*` ×3, `loadWorkflowInMedia` ×4, `save-image-and-webm-preview`, `lod-comparison-high-quality` |
| `control after generate` default `randomize` -> `fixed` | `static-primitive-connected` |
| 3D render differences | `load3d-*` ×3 |
| sub-5px antialiasing | `interaction` ×3, `lod-comparison-low-quality` |

So there is no evidence-backed third site. The remaining exposure is the default-workflow titles (`KSampler`, `CLIP Text Encode (Prompt)`, `Load Checkpoint`, `Save Image`, …), which appear across roughly 37 spec files and 257 goldens. Pinning those would touch most of the screenshot suite for a rename that has not happened, so it is left out; the fixture pattern applies unchanged if one ever does.

## Testing

`typecheck`, `lint`, `format`, `knip` pass locally. The stub itself needs a running ComfyUI backend, so CI is the verifier — the proof is that the `nodeBadge` and `imageCompare` screenshot tests stay green with the goldens unmodified, which also exercises the route-install ordering.

Related: #14630 (closed by #14744; this is the follow-through)
