### PR TITLE
refactor(i18n): resolve node display_name and description on read

### DIFF
--- a/src/locales/CONTRIBUTING.md
+++ b/src/locales/CONTRIBUTING.md
@@ -115,6 +115,29 @@ Each language has 4 translation files:
 - `settings.json` - Settings panel (~400+ entries)
 - `nodeDefs.json` - Node definitions (~varies based on installed nodes)
 
+### What `en/nodeDefs.json` is (and is not)
+
+It is **not** the source of English node text. The backend is: `/object_info`
+ships each node's `display_name` and `description`, and those are the English
+strings users see.
+
+`en/nodeDefs.json` is a point-in-time snapshot of that backend text, serving two
+purposes:
+
+1. **An extraction basis** for the lobe-i18n pipeline, which translates it into
+   the other locales.
+2. **An offline fallback** for nodes the connected backend does not describe.
+
+Treating it as authoritative is what produced the bug where a renamed or
+custom-built node showed a stale name: the snapshot outranked the live backend.
+So `resolveNodeDefText` in `src/i18n.ts` prefers, in order, a custom node's
+`/api/i18n` translation, then the live backend value, then this snapshot — and
+in English it returns the backend value uncompiled, because English is source
+text rather than a translation.
+
+Because the snapshot lags whatever nodes are actually installed, a missing entry
+here is normal and is not a bug to fix by hand-editing the file.
+
 ## Translation Quality
 
 - **Auto-translations are high quality** but may need refinement

--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -49,12 +49,12 @@ describe('ComfyApp.getNodeDefs', () => {
     expect(result.TestNode.display_name).toBe('Custom Display Name')
   })
 
-  test('falls back to the node name when display_name is empty', async () => {
+  test('leaves an empty display_name unresolved for the store to fill in', async () => {
     mockDefs(nodeDef({ display_name: '' }))
 
     const result = await comfyApp.getNodeDefs()
 
-    expect(result.TestNode.display_name).toBe('TestNode')
+    expect(result.TestNode.display_name).toBe('')
   })
 
   test('renders backend names containing i18n syntax verbatim', async () => {
@@ -65,7 +65,10 @@ describe('ComfyApp.getNodeDefs', () => {
     expect(result.TestNode.display_name).toBe('Load Image {batch} | v2')
   })
 
-  test('lets custom-node translations win over the backend name', async () => {
+  // Resolution happens on read, in ComfyNodeDefImpl — see
+  // nodeDefStore.nodeText.test.ts. Baking it in here is what froze the text to
+  // the fetch-time locale, so the raw value has to survive this layer intact.
+  test('hands the store raw text rather than a translation', async () => {
     mergeCustomNodesI18n({
       en: { nodeDefs: { TestNode: { display_name: 'Translated Name' } } }
     })
@@ -73,18 +76,7 @@ describe('ComfyApp.getNodeDefs', () => {
 
     const result = await comfyApp.getNodeDefs()
 
-    expect(result.TestNode.display_name).toBe('Translated Name')
-  })
-
-  test('resolves dotted node names against the normalized key', async () => {
-    mergeCustomNodesI18n({
-      en: { nodeDefs: { my_node: { display_name: 'Dotted Translated' } } }
-    })
-    mockDefs(nodeDef({ name: 'my.node', display_name: 'My Node' }))
-
-    const result = await comfyApp.getNodeDefs()
-
-    expect(result['my.node'].display_name).toBe('Dotted Translated')
+    expect(result.TestNode.display_name).toBe('Object Info Display Name')
   })
 
   test('publishes backend text for consumers that only know the node name', async () => {
@@ -111,7 +103,7 @@ describe('ComfyApp.getNodeDefs', () => {
     }
   )
 
-  test('falls back to the bundled name when the backend omits display_name', async () => {
+  test('does not substitute the bundled snapshot for an omitted field', async () => {
     mockDefs(
       nodeDef({
         name: 'CLIPTextEncode',
@@ -122,17 +114,8 @@ describe('ComfyApp.getNodeDefs', () => {
 
     const result = await comfyApp.getNodeDefs()
 
-    expect(result.CLIPTextEncode.display_name).toBe('CLIP Text Encode (Prompt)')
-  })
-
-  test('falls back to the bundled description when the backend omits one', async () => {
-    mockDefs(
-      nodeDef({ name: 'CLIPTextEncode', display_name: 'x', description: '' })
-    )
-
-    const result = await comfyApp.getNodeDefs()
-
-    expect(result.CLIPTextEncode.description).toMatch(/^Encodes a text prompt/)
+    expect(result.CLIPTextEncode.display_name).toBeUndefined()
+    expect(result.CLIPTextEncode.description).toBe('')
   })
 
   test('resolves a def without a category to an empty category', async () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -11,7 +11,7 @@ import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/com
 
 import { promotedInputSource } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
-import { resolveNodeDefText, setBackendNodeText, st, t } from '@/i18n'
+import { setBackendNodeText, st, t } from '@/i18n'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
@@ -1096,16 +1096,6 @@ export class ComfyApp {
     const translateNodeDef = (def: ComfyNodeDefV1): ComfyNodeDefV1 => {
       return {
         ...def,
-        display_name: resolveNodeDefText(
-          'display_name',
-          def.name,
-          def.display_name || undefined
-        ),
-        description: resolveNodeDefText(
-          'description',
-          def.name,
-          def.description || undefined
-        ),
         category: (typeof def.category === 'string' ? def.category : '')
           .split('/')
           .map((category: string) =>

--- a/src/stores/nodeDefStore.nodeText.test.ts
+++ b/src/stores/nodeDefStore.nodeText.test.ts
@@ -1,0 +1,170 @@
+import { createTestingPinia } from '@pinia/testing'
+import { clone } from 'es-toolkit/compat'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { mergeCustomNodesI18n, setActiveLocale } from '@/i18n'
+import type { ComfyNodeDef as ComfyNodeDefV1 } from '@/schemas/nodeDefSchema'
+import { ComfyNodeDefImpl, useNodeDefStore } from '@/stores/nodeDefStore'
+
+function def(overrides: Partial<ComfyNodeDefV1>): ComfyNodeDefV1 {
+  return {
+    name: 'TestNode',
+    display_name: 'Test Node',
+    category: 'test',
+    description: '',
+    input: {},
+    output: [],
+    output_node: false,
+    python_module: 'test.module',
+    ...overrides
+  } as ComfyNodeDefV1
+}
+
+// `KSampler` is chosen because the shipped zh bundle translates both fields and
+// neither translation contains vue-i18n syntax, so a compile failure cannot be
+// mistaken for a passing assertion.
+const KSAMPLER_EN = 'KSampler'
+const KSAMPLER_ZH = 'K采样器'
+
+describe('ComfyNodeDefImpl node text', () => {
+  afterEach(async () => {
+    await setActiveLocale('en')
+    mergeCustomNodesI18n({})
+  })
+
+  it('resolves display_name and description against the active locale on every read', async () => {
+    const nodeDef = new ComfyNodeDefImpl(
+      def({
+        name: 'KSampler',
+        display_name: KSAMPLER_EN,
+        description: 'Backend description'
+      })
+    )
+
+    expect(nodeDef.display_name).toBe(KSAMPLER_EN)
+    expect(nodeDef.description).toBe('Backend description')
+
+    await setActiveLocale('zh')
+
+    // Same instance, never rebuilt from a fresh /object_info fetch.
+    expect(nodeDef.display_name).toBe(KSAMPLER_ZH)
+    expect(nodeDef.description).toMatch(/^使用提供的模型/)
+  })
+
+  // `mergeCustomNodesI18n` merges into the vue-i18n message tree, which clearing
+  // the side map does not undo, so this uses a name no other test resolves.
+  it('keeps custom-node translations ahead of the backend value', () => {
+    mergeCustomNodesI18n({
+      en: { nodeDefs: { CustomNode: { display_name: 'Translated Name' } } }
+    })
+
+    const nodeDef = new ComfyNodeDefImpl(
+      def({ name: 'CustomNode', display_name: 'Object Info Display Name' })
+    )
+
+    expect(nodeDef.display_name).toBe('Translated Name')
+  })
+
+  it('resolves dotted node names against the normalized key', () => {
+    mergeCustomNodesI18n({
+      en: { nodeDefs: { my_node: { display_name: 'Dotted Translated' } } }
+    })
+
+    const nodeDef = new ComfyNodeDefImpl(
+      def({ name: 'my.node', display_name: 'My Node' })
+    )
+
+    expect(nodeDef.display_name).toBe('Dotted Translated')
+  })
+
+  it('returns an English backend value verbatim rather than compiling it', () => {
+    const nodeDef = new ComfyNodeDefImpl(
+      def({ display_name: 'Load Image {batch} | v2' })
+    )
+
+    expect(nodeDef.display_name).toBe('Load Image {batch} | v2')
+  })
+
+  it('falls back to the node name when the backend sends no display_name', () => {
+    expect(new ComfyNodeDefImpl(def({ display_name: '' })).display_name).toBe(
+      'TestNode'
+    )
+    expect(new ComfyNodeDefImpl(def({ description: '' })).description).toBe('')
+  })
+
+  it('prefers the bundled snapshot when the backend omits the field', () => {
+    const nodeDef = new ComfyNodeDefImpl(
+      def({ name: 'CLIPTextEncode', display_name: '', description: '' })
+    )
+
+    expect(nodeDef.display_name).toBe('CLIP Text Encode (Prompt)')
+    expect(nodeDef.description).toMatch(/^Encodes a text prompt/)
+  })
+
+  it('constructs from a def carrying display_name without assigning the accessor', () => {
+    const build = () =>
+      new ComfyNodeDefImpl(
+        def({ display_name: 'Assignable?', search_aliases: ['alias'] })
+      )
+
+    expect(build).not.toThrow()
+    expect(build().search_aliases).toEqual(['alias'])
+  })
+
+  // `nodeBookmarkStore.buildBookmarkTree` re-categorises defs via es-toolkit's
+  // `clone`. That keeps the prototype, so the accessors survive; a copy that
+  // drops it (spread, structuredClone) would blank every bookmark label.
+  it('still resolves text after a prototype-preserving clone', () => {
+    const nodeDef = new ComfyNodeDefImpl(
+      def({ name: 'KSampler', display_name: KSAMPLER_EN })
+    )
+
+    const copy = clone(nodeDef)
+    copy.category = 'bookmarks'
+
+    expect(copy.display_name).toBe(KSAMPLER_EN)
+    expect(copy.nodePath).toBe('bookmarks/KSampler')
+  })
+})
+
+describe('useNodeDefStore locale reactivity', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  afterEach(async () => {
+    await setActiveLocale('en')
+  })
+
+  it('re-resolves the search index when the locale changes', async () => {
+    const store = useNodeDefStore()
+    store.updateNodeDefs([def({ name: 'KSampler', display_name: KSAMPLER_EN })])
+
+    expect(store.nodeSearchService.searchNode(KSAMPLER_EN)).toHaveLength(1)
+    expect(store.nodeSearchService.searchNode(KSAMPLER_ZH)).toHaveLength(0)
+
+    await setActiveLocale('zh')
+
+    expect(store.nodeSearchService.searchNode(KSAMPLER_ZH)).toHaveLength(1)
+  })
+
+  it('keys nodeDefsByDisplayName by the resolved name', async () => {
+    const store = useNodeDefStore()
+    await setActiveLocale('zh')
+    store.updateNodeDefs([def({ name: 'KSampler', display_name: KSAMPLER_EN })])
+
+    expect(Object.keys(store.nodeDefsByDisplayName)).toEqual([KSAMPLER_ZH])
+  })
+
+  it('re-keys allNodeDefsByDisplayName when the locale changes', async () => {
+    const store = useNodeDefStore()
+    store.updateNodeDefs([def({ name: 'KSampler', display_name: KSAMPLER_EN })])
+
+    expect(store.allNodeDefsByDisplayName[KSAMPLER_EN]?.name).toBe('KSampler')
+
+    await setActiveLocale('zh')
+
+    expect(store.allNodeDefsByDisplayName[KSAMPLER_ZH]?.name).toBe('KSampler')
+  })
+})

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -3,7 +3,7 @@ import { cloneDeep, uniq } from 'es-toolkit/compat'
 import { defineStore } from 'pinia'
 import { computed, ref, watchEffect } from 'vue'
 
-import { t } from '@/i18n'
+import { resolveNodeDefText, t } from '@/i18n'
 import { promotedInputSource } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
 import { resolveInputType } from '@/core/graph/widgets/dynamicTypes'
@@ -36,7 +36,6 @@ export class ComfyNodeDefImpl
 {
   // ComfyNodeDef fields (V1)
   readonly name: string
-  readonly display_name: string
   /**
    * Category is not marked as readonly as the bookmark system
    * needs to write to it to assign a node to a custom folder.
@@ -44,7 +43,6 @@ export class ComfyNodeDefImpl
   category: string
   readonly main_category?: string
   readonly python_module: string
-  readonly description: string
   readonly help: string
   readonly deprecated: boolean
   readonly experimental: boolean
@@ -102,6 +100,15 @@ export class ComfyNodeDefImpl
   readonly inputTypes: string[]
 
   /**
+   * Raw `/object_info` text, kept unresolved so `display_name` and
+   * `description` can be resolved against the active locale on every read.
+   * Declared with TypeScript `private` rather than `#private`: Vue wraps store
+   * instances in a Proxy, and `#private` reads throw through one.
+   */
+  private readonly backendDisplayName?: string
+  private readonly backendDescription?: string
+
+  /**
    * @internal
    * Migrate default input options to forceInput.
    */
@@ -139,16 +146,19 @@ export class ComfyNodeDefImpl
     /**
      * Copy fields that are declared on this class but not explicitly assigned
      * below (e.g. `search_aliases`) straight from the source definition.
+     * `display_name` and `description` are held out: they are accessors with no
+     * setter, so assigning them here would throw.
      */
-    Object.assign(this, obj)
+    const { display_name, description, ...assignable } = obj
+    Object.assign(this, assignable)
 
     // Initialize V1 fields
     this.name = obj.name
-    this.display_name = obj.display_name
+    this.backendDisplayName = display_name || undefined
+    this.backendDescription = description || undefined
     this.category = obj.category
     this.main_category = obj.main_category
     this.python_module = obj.python_module
-    this.description = obj.description
     this.help = obj.help ?? ''
     this.deprecated = obj.deprecated ?? obj.category === ''
     this.experimental =
@@ -179,6 +189,22 @@ export class ComfyNodeDefImpl
     // Initialize node source
     this.nodeSource = getNodeSource(obj.python_module, this.essentials_category)
     this.inputTypes = uniq(Object.values(this.inputs).flatMap(resolveInputType))
+  }
+
+  /**
+   * Resolved against the active locale on read, so a locale switch retitles
+   * every def without refetching `/object_info`.
+   */
+  get display_name(): string {
+    return resolveNodeDefText(
+      'display_name',
+      this.name,
+      this.backendDisplayName
+    )
+  }
+
+  get description(): string {
+    return resolveNodeDefText('description', this.name, this.backendDescription)
   }
 
   get nodePath(): string {
@@ -397,7 +423,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
           : new ComfyNodeDefImpl(nodeDef)
 
       newNodeDefsByName[nodeDef.name] = nodeDefImpl
-      newNodeDefsByDisplayName[nodeDef.display_name] = nodeDefImpl
+      newNodeDefsByDisplayName[nodeDefImpl.display_name] = nodeDefImpl
     }
 
     nodeDefsByName.value = newNodeDefsByName
@@ -406,7 +432,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   function addNodeDef(nodeDef: ComfyNodeDefV1) {
     const nodeDefImpl = new ComfyNodeDefImpl(nodeDef)
     nodeDefsByName.value[nodeDef.name] = nodeDefImpl
-    nodeDefsByDisplayName.value[nodeDef.display_name] = nodeDefImpl
+    nodeDefsByDisplayName.value[nodeDefImpl.display_name] = nodeDefImpl
   }
   function fromLGraphNode(node: LGraphNode): ComfyNodeDefImpl | null {
     const nodeTypeName = node.constructor?.nodeData?.name ?? node.type


### PR DESCRIPTION
## Summary

`ComfyNodeDefImpl.display_name` and `.description` become getters that resolve against the active locale on read, instead of `ComfyApp.getNodeDefs()` baking resolved text into every def at fetch time.

## Changes

- **What**: `getNodeDefs()` no longer resolves `display_name`/`description` (it still resolves `category`), so `nodeDefStore` holds the raw `/object_info` text and resolves it per read via `resolveNodeDefText`. Precedence is unchanged — that logic still lives solely in `src/i18n.ts`. `setBackendNodeText` stays, because consumers like `nodeTitleUtil` only have a node type string.
- **Breaking**: extensions receiving defs through `beforeRegisterNodeDef`, `addCustomNodeDefs` and `beforeRegisterVueAppNodeDefs` now see raw backend `display_name`/`description` rather than pre-translated text. Anything reading those fields off a `ComfyNodeDefImpl` is unaffected.

Property-access shape is preserved deliberately, so the ~96 files reading `display_name` needed no changes.

Consequences that fall out: `allNodeDefsByDisplayName`, `nodeTree` and the Fuse search index are `computed`, and the getters read `i18n.global.locale.value`, so all three now re-resolve on a locale change with no refetch.

## Review Focus

A getter is not an own enumerable property, so the two constructor details are load-bearing:

- The raw values are held in TypeScript `private` fields, **not** `#private`. Vue wraps store instances in a Proxy and `#private` reads throw through one (`TypeError: Cannot read private member`).
- The constructor destructures `display_name`/`description` out before `Object.assign(this, obj)`. Assigning to a setter-less accessor throws in strict mode, which would have broken every construction.

Audited for silent loss of the accessors: object spread, `JSON.stringify`, `structuredClone`, `Object.keys/values/entries`, `Object.assign`, `toRaw`, and `cloneDeep`. The only place a `ComfyNodeDefImpl` instance is structurally copied is `nodeBookmarkStore.buildBookmarkTree`, which uses es-toolkit's `clone` — that preserves the prototype, so the accessors survive. Covered by a regression test, since swapping it for a spread would blank every bookmark label.

Two things left alone, noted for follow-up:

- `nodeDefsByDisplayName` (the plain `ref`, not the `computed`) still snapshots its keys at write time, so they go stale after a locale switch. It has no consumer in `src/`.
- `litegraphService` still assigns `node.title` once at registration, so existing canvas nodes keep their old title until reload — the pre-existing behaviour this refactor makes fixable, but does not fix.

Fixes #14629
