### PR TITLE
feat: ask the next rotation member to review the sheriff's own PRs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -107,6 +107,12 @@ unreachable Datadog — the job still assigns `fallbackGithubLogin` so PRs are
 never left unowned, but **exits non-zero** so the degradation is visible. A
 green run means a real sheriff was resolved from Datadog.
 
+Tag coverage is checked for the **whole rotation**, not just whoever is on call,
+and a member without one fails the run. Someone added to the layer without a tag
+otherwise works fine until their own shift begins — the breakage surfaces weeks
+after the cause, on whoever happens to be sheriff. This is a configuration
+check, so it fails even when today's assignment succeeded.
+
 A failed run also posts to **#frontend-releases** with the reason, because a
 failing scheduled workflow otherwise only notifies whoever last pushed to
 `main` — in practice nobody, which is how the placeholder config survived for

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -58,6 +58,13 @@ open PR that has no assignee and is either:
 It also requests their review, since backport merges are gated on an approval.
 Existing assignees and review requests are never overwritten.
 
+When the sheriff wrote the PR themselves, the review is requested from the
+**next person in the rotation** instead — GitHub rejects a self-review request,
+so previously those PRs were assigned to their own author with nobody asked to
+review, and then waited on an approval that had never been requested. The order
+comes from the Datadog layer's member list, so it needs no separate config. If
+nobody in the rotation can stand in, the run says so rather than staying quiet.
+
 Automation-authored PRs are included because nobody feels addressed by what a
 robot opens: they accumulated unassigned for weeks. Note these are matched by
 author rather than by content, so a dependency bump counts as sheriff work.

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -6,8 +6,10 @@ import {
   fetchGithubLogins,
   fetchOnCallEmails,
   isSheriffPr,
+  nextInRotation,
   parseGithubLogins,
   parseOnCallEmails,
+  parseRotation,
   planActions,
   resolveSheriff,
   singleLine
@@ -88,6 +90,57 @@ describe('parseGithubLogins', () => {
     expect(parseGithubLogins({ data: { attributes: { tags: 'no' } } })).toEqual(
       {}
     )
+  })
+})
+
+describe('nextInRotation', () => {
+  const rotation = ['a', 'b', 'c']
+
+  it('wraps around and ignores case', () => {
+    expect(nextInRotation(rotation, 'B')).toBe('c')
+    expect(nextInRotation(rotation, 'c')).toBe('a')
+  })
+
+  it('has no answer when the sheriff is alone or absent', () => {
+    expect(nextInRotation(['solo'], 'solo')).toBeNull()
+    expect(nextInRotation(rotation, 'stranger')).toBeNull()
+    expect(nextInRotation([], 'a')).toBeNull()
+  })
+})
+
+describe('parseRotation', () => {
+  const payload = {
+    included: [
+      {
+        type: 'layers',
+        id: 'l1',
+        relationships: { members: { data: [{ id: 'm2' }, { id: 'm1' }] } }
+      },
+      {
+        type: 'members',
+        id: 'm1',
+        relationships: { user: { data: { id: 'u1' } } }
+      },
+      {
+        type: 'members',
+        id: 'm2',
+        relationships: { user: { data: { id: 'u2' } } }
+      },
+      { type: 'users', id: 'u1', attributes: { email: 'ann@comfy.org' } },
+      { type: 'users', id: 'u2', attributes: { email: 'bo@comfy.org' } }
+    ]
+  }
+
+  it('preserves member order, which is what makes "next" meaningful', () => {
+    expect(parseRotation(payload, { ann: 'ann-gh', bo: 'bo-gh' })).toEqual([
+      'bo-gh',
+      'ann-gh'
+    ])
+  })
+
+  it('drops members with no github tag rather than inventing one', () => {
+    expect(parseRotation(payload, { ann: 'ann-gh' })).toEqual(['ann-gh'])
+    expect(parseRotation(null, { ann: 'ann-gh' })).toEqual([])
   })
 })
 
@@ -211,10 +264,12 @@ describe('fetchOnCallEmails', () => {
 
     expect(result).toEqual({
       githubLoginByUser: { sheriff: 'sheriff-dev' },
+      rotation: [],
       warning: null
     })
     expect(String(fetchSpy.mock.calls[0][0])).toBe(
-      'https://api.datadoghq.com/api/v2/on-call/schedules/sched-1'
+      'https://api.datadoghq.com/api/v2/on-call/schedules/sched-1' +
+        '?include=layers.members.user'
     )
   })
 
@@ -312,7 +367,9 @@ describe('planActions', () => {
         [pr({ number: 7, labels: [{ name: 'backport' }] })],
         'sheriff'
       )
-    ).toEqual([{ number: 7, assign: true, requestReview: true }])
+    ).toEqual([
+      { number: 7, assign: true, requestReview: true, reviewer: 'sheriff' }
+    ])
   })
 
   it('never overwrites an existing assignee or review request', () => {
@@ -330,12 +387,12 @@ describe('planActions', () => {
     ]
 
     expect(planActions(prs, 'sheriff')).toEqual([
-      { number: 1, assign: false, requestReview: true },
-      { number: 2, assign: true, requestReview: false }
+      { number: 1, assign: false, requestReview: true, reviewer: 'sheriff' },
+      { number: 2, assign: true, requestReview: false, reviewer: 'sheriff' }
     ])
   })
 
-  it('does not request review on approved PRs or the sheriff’s own PRs', () => {
+  it('does not request review on approved PRs, nor from the sheriff on their own', () => {
     const prs = [
       pr({
         number: 1,
@@ -350,8 +407,20 @@ describe('planActions', () => {
     ]
 
     expect(planActions(prs, 'sheriff')).toEqual([
-      { number: 1, assign: true, requestReview: false },
-      { number: 2, assign: true, requestReview: false }
+      { number: 1, assign: true, requestReview: false, reviewer: 'sheriff' },
+      { number: 2, assign: true, requestReview: false, reviewer: null }
+    ])
+  })
+
+  it('asks the next person in the rotation to review the sheriff’s own PR', () => {
+    const own = pr({
+      number: 3,
+      labels: [{ name: 'backport' }],
+      author: { login: 'Sheriff' }
+    })
+
+    expect(planActions([own], 'sheriff', ['a', 'sheriff', 'b'])).toEqual([
+      { number: 3, assign: true, requestReview: true, reviewer: 'b' }
     ])
   })
 
@@ -372,7 +441,7 @@ describe('planActions', () => {
     ]
 
     expect(planActions(prs, 'sheriff')).toEqual([
-      { number: 2, assign: true, requestReview: true }
+      { number: 2, assign: true, requestReview: true, reviewer: 'sheriff' }
     ])
   })
 

--- a/scripts/release-sheriff/release-sheriff.test.ts
+++ b/scripts/release-sheriff/release-sheriff.test.ts
@@ -9,7 +9,7 @@ import {
   nextInRotation,
   parseGithubLogins,
   parseOnCallEmails,
-  parseRotation,
+  parseRotationKeys,
   planActions,
   resolveSheriff,
   singleLine
@@ -108,7 +108,7 @@ describe('nextInRotation', () => {
   })
 })
 
-describe('parseRotation', () => {
+describe('parseRotationKeys', () => {
   const payload = {
     included: [
       {
@@ -132,15 +132,12 @@ describe('parseRotation', () => {
   }
 
   it('preserves member order, which is what makes "next" meaningful', () => {
-    expect(parseRotation(payload, { ann: 'ann-gh', bo: 'bo-gh' })).toEqual([
-      'bo-gh',
-      'ann-gh'
-    ])
+    expect(parseRotationKeys(payload)).toEqual(['bo', 'ann'])
   })
 
-  it('drops members with no github tag rather than inventing one', () => {
-    expect(parseRotation(payload, { ann: 'ann-gh' })).toEqual(['ann-gh'])
-    expect(parseRotation(null, { ann: 'ann-gh' })).toEqual([])
+  it('reads nothing from a payload without a member graph', () => {
+    expect(parseRotationKeys(null)).toEqual([])
+    expect(parseRotationKeys({ included: 'nope' })).toEqual([])
   })
 })
 
@@ -265,6 +262,7 @@ describe('fetchOnCallEmails', () => {
     expect(result).toEqual({
       githubLoginByUser: { sheriff: 'sheriff-dev' },
       rotation: [],
+      unmappedMembers: [],
       warning: null
     })
     expect(String(fetchSpy.mock.calls[0][0])).toBe(
@@ -273,12 +271,56 @@ describe('fetchOnCallEmails', () => {
     )
   })
 
+  it('separates tagged members from those still missing a login', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { attributes: { tags: ['github:ann:ann-gh'] } },
+            included: [
+              {
+                type: 'layers',
+                id: 'l1',
+                relationships: {
+                  members: { data: [{ id: 'm1' }, { id: 'm2' }] }
+                }
+              },
+              {
+                type: 'members',
+                id: 'm1',
+                relationships: { user: { data: { id: 'u1' } } }
+              },
+              {
+                type: 'members',
+                id: 'm2',
+                relationships: { user: { data: { id: 'u2' } } }
+              },
+              {
+                type: 'users',
+                id: 'u1',
+                attributes: { email: 'ann@comfy.org' }
+              },
+              { type: 'users', id: 'u2', attributes: { email: 'bo@comfy.org' } }
+            ]
+          })
+      })
+    )
+
+    const result = await fetchGithubLogins(datadog, creds)
+
+    expect(result.rotation).toEqual(['ann-gh'])
+    expect(result.unmappedMembers).toEqual(['bo'])
+  })
+
   it('degrades the directory to empty when Datadog is unreachable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')))
 
     const result = await fetchGithubLogins(datadog, creds)
 
     expect(result.githubLoginByUser).toEqual({})
+    expect(result.unmappedMembers).toEqual([])
     expect(result.warning).toMatch(/lookup failed/)
   })
 })

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -81,10 +81,7 @@ export interface OnCallLookup {
 
 // Layer members carry the rotation order, which is what makes "next" well
 // defined. The graph is members -> user -> email, all in `included`.
-export function parseRotation(
-  payload: unknown,
-  githubLoginByUser: Record<string, string>
-): string[] {
+export function parseRotationKeys(payload: unknown): string[] {
   if (!isRecord(payload) || !Array.isArray(payload.included)) return []
 
   const resources = payload.included.filter(isRecord)
@@ -99,7 +96,7 @@ export function parseRotation(
     return members.data.filter(isRecord).map((member) => member.id)
   })
 
-  const logins = memberIds.flatMap((id) => {
+  const keys = memberIds.flatMap((id) => {
     const member = find('members', id)
     if (!member || !isRecord(member.relationships)) return []
     const { user } = member.relationships
@@ -107,17 +104,18 @@ export function parseRotation(
     const record = find('users', user.data.id)
     if (!record || !isRecord(record.attributes)) return []
     const { email } = record.attributes
-    if (typeof email !== 'string') return []
-    const login = githubLoginByUser[emailKey(email)]
-    return login ? [login] : []
+    return typeof email === 'string' && email.trim() ? [emailKey(email)] : []
   })
 
-  return [...new Set(logins)]
+  return [...new Set(keys)]
 }
 
 export interface DirectoryLookup {
   githubLoginByUser: Record<string, string>
   rotation: string[]
+  // Rotation members with no github: tag. They break silently when their own
+  // shift starts, weeks after the tag was forgotten, so surface them now.
+  unmappedMembers: string[]
   warning: string | null
 }
 
@@ -203,9 +201,14 @@ export async function fetchGithubLogins(
     include: 'layers.members.user'
   })
   const githubLoginByUser = parseGithubLogins(payload)
+  const keys = parseRotationKeys(payload)
   return {
     githubLoginByUser,
-    rotation: parseRotation(payload, githubLoginByUser),
+    rotation: keys.flatMap((key) => {
+      const login = githubLoginByUser[key]
+      return login ? [login] : []
+    }),
+    unmappedMembers: keys.filter((key) => !githubLoginByUser[key]),
     warning
   }
 }
@@ -428,6 +431,15 @@ async function main() {
         `the tag "github:${emailKey(email)}:<github-login>" to the schedule.`
     )
   }
+  // Checked for the whole rotation, not just whoever is on call: a member
+  // added without a tag works fine until their own shift begins, then falls
+  // back silently. Fail now, while it is still someone else's week.
+  for (const key of directory.unmappedMembers) {
+    problems.push(
+      `Rotation member "${key}" has no GitHub login and will fall back when ` +
+        `their shift starts. Add "github:${key}:<github-login>" to the schedule.`
+    )
+  }
   for (const problem of problems) warn(problem)
   if (!login) {
     const message = 'No release sheriff could be resolved — nothing assigned.'
@@ -435,6 +447,11 @@ async function main() {
     output('degraded', [message, ...problems].join(' '))
     process.exitCode = 1
     return
+  }
+
+  if (directory.unmappedMembers.length > 0) {
+    output('degraded', problems.join(' '))
+    process.exitCode = 1
   }
 
   // Falling back still assigns, so PRs stay owned, but the run must not go

--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -79,8 +79,45 @@ export interface OnCallLookup {
   warning: string | null
 }
 
+// Layer members carry the rotation order, which is what makes "next" well
+// defined. The graph is members -> user -> email, all in `included`.
+export function parseRotation(
+  payload: unknown,
+  githubLoginByUser: Record<string, string>
+): string[] {
+  if (!isRecord(payload) || !Array.isArray(payload.included)) return []
+
+  const resources = payload.included.filter(isRecord)
+  const find = (type: string, id: unknown) =>
+    resources.find((r) => r.type === type && r.id === id)
+
+  const memberIds = resources.flatMap((resource) => {
+    if (resource.type !== 'layers' || !isRecord(resource.relationships))
+      return []
+    const { members } = resource.relationships
+    if (!isRecord(members) || !Array.isArray(members.data)) return []
+    return members.data.filter(isRecord).map((member) => member.id)
+  })
+
+  const logins = memberIds.flatMap((id) => {
+    const member = find('members', id)
+    if (!member || !isRecord(member.relationships)) return []
+    const { user } = member.relationships
+    if (!isRecord(user) || !isRecord(user.data)) return []
+    const record = find('users', user.data.id)
+    if (!record || !isRecord(record.attributes)) return []
+    const { email } = record.attributes
+    if (typeof email !== 'string') return []
+    const login = githubLoginByUser[emailKey(email)]
+    return login ? [login] : []
+  })
+
+  return [...new Set(logins)]
+}
+
 export interface DirectoryLookup {
   githubLoginByUser: Record<string, string>
+  rotation: string[]
   warning: string | null
 }
 
@@ -162,8 +199,15 @@ export async function fetchGithubLogins(
   config: Pick<typeof CONFIG, 'datadogSite' | 'scheduleId'>,
   credentials: { apiKey?: string; appKey?: string }
 ): Promise<DirectoryLookup> {
-  const { payload, warning } = await datadogGet(config, credentials, '')
-  return { githubLoginByUser: parseGithubLogins(payload), warning }
+  const { payload, warning } = await datadogGet(config, credentials, '', {
+    include: 'layers.members.user'
+  })
+  const githubLoginByUser = parseGithubLogins(payload)
+  return {
+    githubLoginByUser,
+    rotation: parseRotation(payload, githubLoginByUser),
+    warning
+  }
 }
 
 export interface SheriffResolution {
@@ -222,31 +266,57 @@ export interface SheriffAction {
   number: number
   assign: boolean
   requestReview: boolean
+  reviewer: string | null
+}
+
+// Who reviews the sheriff's own PRs. GitHub rejects a self-review request, so
+// without a standby the sheriff's backports were assigned to themselves with
+// nobody asked to review — and backport merges are gated on an approval, so
+// they waited on a review that had not been requested.
+export function nextInRotation(
+  rotation: string[],
+  current: string
+): string | null {
+  const isCurrent = (login: string) =>
+    login.toLowerCase() === current.toLowerCase()
+  const start = rotation.findIndex(isCurrent)
+  if (start === -1) return null
+
+  for (let step = 1; step < rotation.length; step++) {
+    const candidate = rotation[(start + step) % rotation.length]
+    if (!isCurrent(candidate)) return candidate
+  }
+  return null
 }
 
 // Existing assignees and review requests are never overwritten, so a rotation
 // handover does not churn open PRs and a human who picked one up keeps it.
 export function planActions(
   prs: PullRequestSummary[],
-  sheriffLogin: string
+  sheriffLogin: string,
+  rotation: string[] = []
 ): SheriffAction[] {
-  const normalizedSheriffLogin = sheriffLogin.toLowerCase()
+  const normalized = sheriffLogin.toLowerCase()
+  const standby = nextInRotation(rotation, sheriffLogin)
 
   return prs.flatMap((pr) => {
     if (pr.isDraft || !isSheriffPr(pr)) return []
 
     const assign = pr.assignees.length === 0
+    const reviewer =
+      pr.author?.login.toLowerCase() === normalized ? standby : sheriffLogin
+    const normalizedReviewer = reviewer?.toLowerCase()
     const requestReview =
+      reviewer !== null &&
       pr.reviewRequests.length === 0 &&
       pr.reviewDecision !== 'APPROVED' &&
-      pr.author?.login.toLowerCase() !== normalizedSheriffLogin &&
+      pr.author?.login.toLowerCase() !== normalizedReviewer &&
       !pr.latestReviews.some(
-        (review) =>
-          review.author?.login.toLowerCase() === normalizedSheriffLogin
+        (review) => review.author?.login.toLowerCase() === normalizedReviewer
       )
 
     return assign || requestReview
-      ? [{ number: pr.number, assign, requestReview }]
+      ? [{ number: pr.number, assign, requestReview, reviewer }]
       : []
   })
 }
@@ -379,14 +449,20 @@ async function main() {
     process.exitCode = 1
   }
 
-  const actions = planActions(collectCandidatePrs(), login)
+  const actions = planActions(collectCandidatePrs(), login, directory.rotation)
   summary(`### Release sheriff: \`${login}\` (via ${source})`)
   if (actions.length === 0) {
     summary('Nothing to do — every candidate PR already has an owner.')
     return
   }
+  if (actions.some((action) => action.reviewer === null)) {
+    warn(
+      `${login} authored some of these PRs and the rotation offered no ` +
+        'standby, so those still need a reviewer picked by hand.'
+    )
+  }
 
-  for (const { number, assign, requestReview } of actions) {
+  for (const { number, assign, requestReview, reviewer } of actions) {
     if (assign) {
       const path = `repos/${repo}/issues/${number}/assignees`
       if (ghPost(path, `assignees[]=${login}`)) summary(`- Assigned #${number}`)
@@ -394,12 +470,12 @@ async function main() {
     }
 
     // A failed review request (e.g. fork PRs) must not undo the assignment.
-    if (requestReview) {
+    if (requestReview && reviewer) {
       const path = `repos/${repo}/pulls/${number}/requested_reviewers`
-      if (ghPost(path, `reviewers[]=${login}`)) {
-        summary(`- Requested review on #${number}`)
+      if (ghPost(path, `reviewers[]=${reviewer}`)) {
+        summary(`- Requested review from \`${reviewer}\` on #${number}`)
       } else {
-        warn(`Could not request review from ${login} on #${number}`)
+        warn(`Could not request review from ${reviewer} on #${number}`)
       }
     }
   }


### PR DESCRIPTION
Follow-up to #14626. Third in the series with #14735 and #14766.

`planActions` skipped the review request when the sheriff had authored the PR:

```ts
pr.author?.login.toLowerCase() !== normalizedSheriffLogin &&
```

The guard is necessary — GitHub 422s a self-review request — but the job still *assigned* them, so the PR ended up owned by its own author with **nobody asked to review**. Backport merges are gated on an approval, so it then waited indefinitely on a review that had never been requested. Silent, and shaped exactly like the bug this script was fixed for.

## Fix

Request the **next person in the rotation** instead. The order comes from the Datadog layer's member list, which the schedule call already returns for the tags — one extra `include` parameter, no new config, no second source of truth to drift.

Verified against the live schedule:

```
rotation: dante01yoon → benceruleanlu → drjkl → austinmroz → huang47 → codejuggernaut → christian-byrne
sheriff : benceruleanlu   standby: drjkl
```

Wrap-around confirmed: `christian-byrne` → `dante01yoon`.

## Notes

- Members with no `github:` tag are dropped from the rotation rather than guessed at, so an unmapped person is skipped as a standby instead of producing a bad request.
- If nobody can stand in — a one-person rotation, or a sheriff resolved via `fallbackGithubLogin` and so absent from it — the run warns rather than staying quiet. It does not fail: a sheriff was still resolved and the PR still has an owner.
- `SheriffAction` gains a `reviewer` field, so the assignee and the reviewer are no longer assumed to be the same person.
- I did **not** add a random fallback. It only becomes reachable when the rotation cannot be read, which means Datadog is degraded — and that path already falls back and exits non-zero.

## Verification

29 tests, including rotation order preservation, wrap-around, case-insensitivity, unmapped members dropped, and the sheriff's-own-PR path. Lint, knip, typecheck, format clean.

Note the pre-existing behaviour this does not change: drafts are still skipped, and existing assignees and review requests are still never overwritten.
