### PR TITLE
[backport cloud/1.49] fix(first-run-tour): replace a fallback template no backend serves (#14683)

### DIFF
--- a/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/tutorialCards.ts
@@ -10,7 +10,7 @@ export const CURATED_TEMPLATE_IDS = [
 export const FALLBACK_TEMPLATE_IDS = [
   'templates-image_to_real',
   'image_qwen_image_edit_2509',
-  'templates-qwen_multiangle.app',
+  'flux_fill_inpaint_example',
   'video_ltx2_i2v_distilled'
 ] as const
 

--- a/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
+++ b/src/renderer/extensions/firstRunTour/roles/tourRolePins.ts
@@ -80,9 +80,10 @@ export const TOUR_ROLE_PINS: Record<SupportedTemplateId, RolePins> = {
     sink: { id: 60, type: 'SaveImage' },
     mediaKind: 'image'
   },
-  'templates-qwen_multiangle.app': {
-    source: { id: 1, type: 'LoadImage' },
-    sink: { id: 2, type: 'SaveImage' },
+  flux_fill_inpaint_example: {
+    source: { id: 17, type: 'LoadImage' },
+    prompt: { id: 23, type: 'CLIPTextEncode' },
+    sink: { id: 9, type: 'SaveImage' },
     mediaKind: 'image'
   },
   video_ltx2_i2v_distilled: {


### PR DESCRIPTION
Backport of #14683 to `cloud/1.49`.

`templates-qwen_multiangle.app` is pinned as a Getting Started fallback card and **no supported backend serves it** — it 404s on the templates package bundled with ComfyUI v0.19.3 (`0.9.57`) and on v0.30.0 (`0.11.27`) alike. Whenever the grid falls back to it the card silently drops out and its tour role pins go unchecked.

**Why this needs a manual backport:** #14683 was merged *before* the `cloud/1.49` label was applied, and the backport workflow triggers on the merge event — so adding the label afterwards fired nothing. Verified the bug is live on this branch: `qwen_multiangle` is still present in `tutorialCards.ts` here and gone from `main`.

Clean cherry-pick, no conflicts (2 files, +5/-4).