### PR TITLE
fix: render node search highlights as text instead of generated HTML

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -516,6 +516,12 @@ export default defineConfig([
       ]
     }
   },
+  {
+    files: ['src/components/searchbox/**/*.vue'],
+    rules: {
+      'vue/no-v-html': 'error'
+    }
+  },
   // Browser tests must use comfyPageFixture, not raw @playwright/test test
   {
     files: ['browser_tests/tests/**/*.spec.ts'],

--- a/packages/shared-frontend-utils/package.json
+++ b/packages/shared-frontend-utils/package.json
@@ -14,8 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "axios": "catalog:",
-    "dompurify": "catalog:"
+    "axios": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -4,6 +4,7 @@ import {
   appendWorkflowJsonExt,
   downloadUrlToHfRepoUrl,
   ensureWorkflowSuffix,
+  escapeI18nMessage,
   formatLocalizedMediumDate,
   formatLocalizedNumber,
   getFilePathSeparatorVariants,
@@ -510,6 +511,36 @@ describe('formatUtil', () => {
     it('returns an em-dash for undefined or unparseable input', () => {
       expect(formatLocalizedMediumDate(undefined, 'en')).toBe('—')
       expect(formatLocalizedMediumDate('not a date', 'en')).toBe('—')
+    })
+  })
+
+  describe('escapeI18nMessage', () => {
+    it('wraps message-syntax characters in literal interpolations', () => {
+      expect(escapeI18nMessage('a@b')).toBe("a{'@'}b")
+      expect(escapeI18nMessage('{x}')).toBe("{'{'}x{'}'}")
+      expect(escapeI18nMessage('a|b')).toBe("a{'|'}b")
+      expect(escapeI18nMessage('50%')).toBe("50{'%'}")
+      expect(escapeI18nMessage('$5')).toBe("{'$'}5")
+    })
+
+    it('doubles backslashes rather than interpolating them', () => {
+      expect(escapeI18nMessage('\\')).toBe('\\\\')
+      expect(escapeI18nMessage('C:\\@home')).toBe("C:\\\\{'@'}home")
+    })
+
+    it('leaves text without message syntax untouched', () => {
+      expect(escapeI18nMessage('plain name')).toBe('plain name')
+      expect(escapeI18nMessage('')).toBe('')
+    })
+
+    it('is not idempotent, so it must be applied exactly once', () => {
+      const once = escapeI18nMessage('a@b')
+      expect(escapeI18nMessage(once)).not.toBe(once)
+    })
+
+    it('returns an empty string for non-string input', () => {
+      expect(escapeI18nMessage(42 as unknown as string)).toBe('')
+      expect(escapeI18nMessage(null as unknown as string)).toBe('')
     })
   })
 })

--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -11,7 +11,6 @@ import {
   getMediaTypeFromFilename,
   getPathDetails,
   highlightQuery,
-  escapeI18nMessage,
   isCivitaiModelUrl,
   isCivitaiUrl,
   isPreviewableMediaType,
@@ -201,75 +200,74 @@ describe('formatUtil', () => {
   })
 
   describe('highlightQuery', () => {
-    it('should sanitize text when query is empty', () => {
-      expect(highlightQuery('<img src=x onerror=alert(1)>Hello', '')).toBe(
-        '&#60;img src=x onerror=alert(1)&#62;Hello'
-      )
+    it('should return one plain-text part when query is empty', () => {
+      expect(highlightQuery('Hello World', '')).toEqual([
+        { text: 'Hello World', highlighted: false }
+      ])
     })
 
-    it('should wrap matching text in highlight span', () => {
-      const result = highlightQuery('Hello World', 'World')
-      expect(result).toBe('Hello <span class="highlight">World</span>')
+    it('should mark matching text for highlighting', () => {
+      expect(highlightQuery('Hello World', 'World')).toEqual([
+        { text: 'Hello ', highlighted: false },
+        { text: 'World', highlighted: true }
+      ])
     })
 
     it('should be case-insensitive', () => {
-      const result = highlightQuery('Hello World', 'hello')
-      expect(result).toBe('<span class="highlight">Hello</span> World')
+      expect(highlightQuery('Hello World', 'hello')).toEqual([
+        { text: 'Hello', highlighted: true },
+        { text: ' World', highlighted: false }
+      ])
     })
 
-    it('should sanitize text by default', () => {
-      const result = highlightQuery('<script>alert("xss")</script>', 'alert')
-      expect(result).not.toContain('<script>')
-    })
-
-    it('should escape markup while preserving highlights', () => {
-      const result = highlightQuery(
-        '<img src=x onerror=alert(1)>Script <b>name</b>',
-        'script'
-      )
-      expect(result).toContain('<span class="highlight">Script</span>')
-      expect(result).not.toContain('<img')
-      expect(result).not.toContain('<b>')
-      expect(result).toContain('img src=x onerror=alert(1)')
-    })
-
-    it('should skip sanitization when sanitize is false', () => {
-      const result = highlightQuery('<b>bold</b>', 'bold', false)
-      expect(result).toContain('<b>')
+    it('should preserve markup as text parts', () => {
+      expect(highlightQuery('<script>alert("xss")</script>', 'alert')).toEqual([
+        { text: '<script>', highlighted: false },
+        { text: 'alert', highlighted: true },
+        { text: '("xss")</script>', highlighted: false }
+      ])
     })
 
     it('should escape special regex characters in query', () => {
-      const result = highlightQuery('price is $10.00', '$10')
-      expect(result).toContain('<span class="highlight">$10</span>')
+      expect(highlightQuery('price is $10.00', '$10')).toEqual([
+        { text: 'price is ', highlighted: false },
+        { text: '$10', highlighted: true },
+        { text: '.00', highlighted: false }
+      ])
     })
 
     it('should highlight multiple occurrences', () => {
-      const result = highlightQuery('foo bar foo', 'foo')
-      expect(result).toBe(
-        '<span class="highlight">foo</span> bar <span class="highlight">foo</span>'
-      )
+      expect(highlightQuery('foo bar foo', 'foo')).toEqual([
+        { text: 'foo', highlighted: true },
+        { text: ' bar ', highlighted: false },
+        { text: 'foo', highlighted: true }
+      ])
     })
 
     it('should highlight cross-word matches', () => {
-      const result = highlightQuery('convert image to mask', 'geto', false)
-      expect(result).toBe(
-        'convert ima<span class="highlight">ge to</span> mask'
-      )
+      expect(highlightQuery('convert image to mask', 'geto')).toEqual([
+        { text: 'convert ima', highlighted: false },
+        { text: 'ge to', highlighted: true },
+        { text: ' mask', highlighted: false }
+      ])
     })
 
     it('should not match across line breaks', () => {
-      const result = highlightQuery('ge\nto', 'geto', false)
-      expect(result).toBe('ge\nto')
+      expect(highlightQuery('ge\nto', 'geto')).toEqual([
+        { text: 'ge\nto', highlighted: false }
+      ])
     })
 
     it('should not match across tabs', () => {
-      const result = highlightQuery('ge\tto', 'geto', false)
-      expect(result).toBe('ge\tto')
+      expect(highlightQuery('ge\tto', 'geto')).toEqual([
+        { text: 'ge\tto', highlighted: false }
+      ])
     })
 
     it('should not match across multiple spaces', () => {
-      const result = highlightQuery('ge  to', 'geto', false)
-      expect(result).toBe('ge  to')
+      expect(highlightQuery('ge  to', 'geto')).toEqual([
+        { text: 'ge  to', highlighted: false }
+      ])
     })
   })
 
@@ -512,36 +510,6 @@ describe('formatUtil', () => {
     it('returns an em-dash for undefined or unparseable input', () => {
       expect(formatLocalizedMediumDate(undefined, 'en')).toBe('—')
       expect(formatLocalizedMediumDate('not a date', 'en')).toBe('—')
-    })
-  })
-
-  describe('escapeI18nMessage', () => {
-    it('wraps message-syntax characters in literal interpolations', () => {
-      expect(escapeI18nMessage('a@b')).toBe("a{'@'}b")
-      expect(escapeI18nMessage('{x}')).toBe("{'{'}x{'}'}")
-      expect(escapeI18nMessage('a|b')).toBe("a{'|'}b")
-      expect(escapeI18nMessage('50%')).toBe("50{'%'}")
-      expect(escapeI18nMessage('$5')).toBe("{'$'}5")
-    })
-
-    it('doubles backslashes rather than interpolating them', () => {
-      expect(escapeI18nMessage('\\')).toBe('\\\\')
-      expect(escapeI18nMessage('C:\\@home')).toBe("C:\\\\{'@'}home")
-    })
-
-    it('leaves text without message syntax untouched', () => {
-      expect(escapeI18nMessage('plain name')).toBe('plain name')
-      expect(escapeI18nMessage('')).toBe('')
-    })
-
-    it('is not idempotent, so it must be applied exactly once', () => {
-      const once = escapeI18nMessage('a@b')
-      expect(escapeI18nMessage(once)).not.toBe(once)
-    })
-
-    it('returns an empty string for non-string input', () => {
-      expect(escapeI18nMessage(42 as unknown as string)).toBe('')
-      expect(escapeI18nMessage(null as unknown as string)).toBe('')
     })
   })
 })

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -196,6 +196,33 @@ export function normalizeI18nKey(key: string) {
   return typeof key === 'string' ? key.replace(/\./g, '_') : ''
 }
 
+const VUE_I18N_BACKSLASH = /\\/g
+const VUE_I18N_SYNTAX_CHARS = /[@${}|%]/g
+
+/**
+ * Escapes vue-i18n message syntax so arbitrary text can be stored as a locale
+ * message and rendered verbatim by `t()`.
+ *
+ * Backslash is doubled rather than wrapped in a literal interpolation: since
+ * vue-i18n 11 the message compiler reads `\` as an escape introducer, so a
+ * backslash before an escaped character would swallow the `{` this emits, and
+ * `{'\'}` would escape its own closing quote. Doubling must therefore run
+ * first; the literal interpolations it emits contain no backslashes.
+ *
+ * Apply exactly once. This is NOT idempotent, because the escape output itself
+ * contains `{`/`}`.
+ *
+ * Apply only to values read back through `t()`/`st()`. Values read through
+ * `tm()`/`stRaw()` are never compiled, so escaping them renders the escape
+ * syntax literally.
+ */
+export function escapeI18nMessage(text: string): string {
+  if (typeof text !== 'string') return ''
+  return text
+    .replace(VUE_I18N_BACKSLASH, '\\\\')
+    .replace(VUE_I18N_SYNTAX_CHARS, (char) => `{'${char}'}`)
+}
+
 /**
  * Takes a dynamic prompt in the format {opt1|opt2|{optA|optB}|} and randomly replaces groups. Supports C style comments.
  * @param input The dynamic prompt to process

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -1,4 +1,3 @@
-import { default as DOMPurify } from 'dompurify'
 import type { operations } from '@comfyorg/registry-types'
 
 export function formatCamelCase(str: string): string {
@@ -64,18 +63,16 @@ export function ensureWorkflowSuffix(
   return name + '.' + suffix
 }
 
-function escapeHtml(text: string): string {
-  return text.replace(/[&<>"']/g, (character) => {
-    return `&#${character.charCodeAt(0)};`
-  })
+interface HighlightQueryPart {
+  text: string
+  highlighted: boolean
 }
 
 export function highlightQuery(
   text: string,
-  query: string,
-  sanitize: boolean = true
-) {
-  if (!query) return sanitize ? escapeHtml(text) : text
+  query: string
+): HighlightQueryPart[] {
+  if (!query) return [{ text, highlighted: false }]
 
   // Escape special regex characters, then join with an optional single
   // space so cross-word matches (e.g. "geto" → "imaGE TO") are
@@ -84,24 +81,26 @@ export function highlightQuery(
     .map((ch) => ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     .join('[ ]?')
 
-  const regex = new RegExp(`(${pattern})`, 'gi')
-  if (!sanitize) {
-    return text.replace(regex, '<span class="highlight">$1</span>')
-  }
-
-  const parts: string[] = []
+  const regex = new RegExp(pattern, 'gi')
+  const parts: HighlightQueryPart[] = []
   let lastIndex = 0
+
   for (const match of text.matchAll(regex)) {
-    parts.push(escapeHtml(text.slice(lastIndex, match.index)))
-    parts.push(`<span class="highlight">${escapeHtml(match[0])}</span>`)
+    if (match.index > lastIndex) {
+      parts.push({
+        text: text.slice(lastIndex, match.index),
+        highlighted: false
+      })
+    }
+    parts.push({ text: match[0], highlighted: true })
     lastIndex = match.index + match[0].length
   }
-  parts.push(escapeHtml(text.slice(lastIndex)))
 
-  return DOMPurify.sanitize(parts.join(''), {
-    ALLOWED_TAGS: ['span'],
-    ALLOWED_ATTR: ['class']
-  })
+  if (lastIndex < text.length || parts.length === 0) {
+    parts.push({ text: text.slice(lastIndex), highlighted: false })
+  }
+
+  return parts
 }
 
 export function formatNumberWithSuffix(
@@ -195,33 +194,6 @@ export function getPathDetails(path: string) {
  */
 export function normalizeI18nKey(key: string) {
   return typeof key === 'string' ? key.replace(/\./g, '_') : ''
-}
-
-const VUE_I18N_BACKSLASH = /\\/g
-const VUE_I18N_SYNTAX_CHARS = /[@${}|%]/g
-
-/**
- * Escapes vue-i18n message syntax so arbitrary text can be stored as a locale
- * message and rendered verbatim by `t()`.
- *
- * Backslash is doubled rather than wrapped in a literal interpolation: since
- * vue-i18n 11 the message compiler reads `\` as an escape introducer, so a
- * backslash before an escaped character would swallow the `{` this emits, and
- * `{'\'}` would escape its own closing quote. Doubling must therefore run
- * first; the literal interpolations it emits contain no backslashes.
- *
- * Apply exactly once. This is NOT idempotent, because the escape output itself
- * contains `{`/`}`.
- *
- * Apply only to values read back through `t()`/`st()`. Values read through
- * `tm()`/`stRaw()` are never compiled, so escaping them renders the escape
- * syntax literally.
- */
-export function escapeI18nMessage(text: string): string {
-  if (typeof text !== 'string') return ''
-  return text
-    .replace(VUE_I18N_BACKSLASH, '\\\\')
-    .replace(VUE_I18N_SYNTAX_CHARS, (char) => `{'${char}'}`)
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1119,9 +1119,6 @@ importers:
       axios:
         specifier: 'catalog:'
         version: 1.18.1
-      dompurify:
-        specifier: 'catalog:'
-        version: 3.4.7
     devDependencies:
       typescript:
         specifier: 'catalog:'

--- a/src/components/searchbox/HighlightedText.vue
+++ b/src/components/searchbox/HighlightedText.vue
@@ -1,0 +1,15 @@
+<template>
+  <template v-for="(part, index) in highlightQuery(text, query)" :key="index">
+    <span v-if="part.highlighted" class="highlight">{{ part.text }}</span>
+    <template v-else>{{ part.text }}</template>
+  </template>
+</template>
+
+<script setup lang="ts">
+import { highlightQuery } from '@/utils/formatUtil'
+
+const { text, query } = defineProps<{
+  text: string
+  query: string
+}>()
+</script>

--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -7,10 +7,14 @@
         <span v-if="isBookmarked">
           <i class="pi pi-bookmark-fill mr-1 text-sm" />
         </span>
-        <span v-html="highlightQuery(nodeDef.display_name, currentQuery)" />
+        <span>
+          <HighlightedText :text="nodeDef.display_name" :query="currentQuery" />
+        </span>
         <span>&nbsp;</span>
         <Tag v-if="showIdName" severity="secondary">
-          <span v-html="highlightQuery(nodeDef.name, currentQuery)" />
+          <span>
+            <HighlightedText :text="nodeDef.name" :query="currentQuery" />
+          </span>
         </Tag>
       </div>
       <div
@@ -52,12 +56,13 @@ import Chip from 'primevue/chip'
 import Tag from 'primevue/tag'
 import { computed } from 'vue'
 
+import HighlightedText from '@/components/searchbox/HighlightedText.vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { NodeSourceType } from '@/types/nodeSource'
-import { formatNumberWithSuffix, highlightQuery } from '@/utils/formatUtil'
+import { formatNumberWithSuffix } from '@/utils/formatUtil'
 
 const settingStore = useSettingStore()
 const showCategory = computed(() =>

--- a/src/components/searchbox/v2/NodeSearchListItem.test.ts
+++ b/src/components/searchbox/v2/NodeSearchListItem.test.ts
@@ -34,12 +34,10 @@ describe('NodeSearchListItem', () => {
     vi.restoreAllMocks()
   })
 
-  it('does not render HTML from node names', () => {
+  it('renders node names as text rather than HTML', () => {
     const displayName = '<img src=x onerror=alert(1)>Node'
     renderItem({
-      nodeDef: createMockNodeDef({
-        display_name: displayName
-      })
+      nodeDef: createMockNodeDef({ display_name: displayName })
     })
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument()

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -12,16 +12,16 @@
         >
           <i aria-hidden="true" class="pi pi-bookmark-fill mr-1 text-sm" />
         </span>
-        <span
-          class="truncate"
-          v-html="highlightQuery(nodeDef.display_name, currentQuery)"
-        />
+        <span class="truncate">
+          <HighlightedText :text="nodeDef.display_name" :query="currentQuery" />
+        </span>
         <span
           v-if="showIdName"
           data-testid="node-id-badge"
           class="shrink-0 rounded-sm bg-secondary-background px-1.5 py-0.5 text-xs text-muted-foreground"
-          v-html="highlightQuery(nodeDef.name, currentQuery)"
-        />
+        >
+          <HighlightedText :text="nodeDef.name" :query="currentQuery" />
+        </span>
 
         <template v-if="showDescription">
           <div class="flex-1" />
@@ -124,6 +124,7 @@ import { computed } from 'vue'
 import TextTicker from '@/components/common/TextTicker.vue'
 import NodePricingBadge from '@/components/node/NodePricingBadge.vue'
 import NodeProviderBadge from '@/components/node/NodeProviderBadge.vue'
+import HighlightedText from '@/components/searchbox/HighlightedText.vue'
 import { NODE_TO_ESSENTIALS_CATEGORY } from '@/constants/essentialsNodes'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
@@ -131,7 +132,7 @@ import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { CORE_NODE_MODULES, NodeSourceType } from '@/types/nodeSource'
 import { getProviderIcon, getProviderName } from '@/utils/categoryUtil'
-import { formatNumberWithSuffix, highlightQuery } from '@/utils/formatUtil'
+import { formatNumberWithSuffix } from '@/utils/formatUtil'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -248,7 +248,7 @@
           <span class="underline">
             {{ t('subscription.videoEstimateTryTemplate') }}
           </span>
-          <span class="no-underline" v-html="'&rarr;'"></span>
+          <span class="no-underline">→</span>
         </a>
       </div>
     </Popover>

--- a/src/platform/workspace/components/PricingTableWorkspace.vue
+++ b/src/platform/workspace/components/PricingTableWorkspace.vue
@@ -263,7 +263,7 @@
           <span class="underline">
             {{ t('subscription.videoEstimateTryTemplate') }}
           </span>
-          <span class="no-underline" v-html="'&rarr;'"></span>
+          <span class="no-underline">→</span>
         </a>
       </div>
     </Popover>


### PR DESCRIPTION
Follow-up to #14574, reviving the work from the closed #14580 rebased onto current main.

#14574 landed the escape-then-sanitize fix so Cloud could be patched without waiting. It left three things behind, all of which lived in #14580 and are in no other open PR:

- the `v-html` sink in both search components
- the `sanitize` parameter, which is a complete bypass when false
- a lint guardrail to stop the sink coming back

## Changes

`highlightQuery` now returns `{ text, highlighted }[]` instead of an HTML string, and the new `HighlightedText.vue` renders those segments as Vue text nodes. There is no markup to escape, no sanitizer to bypass, and no `v-html` in either the legacy or v2 search UI.

`vue/no-v-html` is set to `error` for `src/components/searchbox/**`. Verified it fires: a probe file with `v-html` produces `'v-html' directive can lead to XSS attack`.

Removing the string API also drops the `dompurify` dependency from `shared-frontend-utils`.

## Why this rather than keeping the escaping

The original defect was not a missing sanitizer — `highlightQuery` already called DOMPurify. It was an early return above the call. Escaping correctly is a property that has to hold at every future edit; not building HTML is a property that holds structurally.

## Testing

- 204 tests pass across `formatUtil` and `src/components/searchbox`
- eslint clean, oxfmt clean
- rebase conflict in `formatUtil.ts` resolved in favour of the segment API, which supersedes the escape-and-sanitize string it replaces

## Note on scope

This closes the searchbox sink. Two sibling sinks of the same class are handled in #14772 (property-name `innerHTML`, and Open Image blob typing) — neither is Vue, so this lint rule does not cover them.

Original work by @huang47 in #14580.