### PR TITLE
test: decouple node-title goldens from the CI container

### DIFF
--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -153,7 +153,25 @@ export async function routeObjectInfoFromSetupApi(
       return
     }
 
-    await customize?.(objectInfo)
+    try {
+      await customize?.(objectInfo)
+    } catch (error) {
+      // A throwing mutator (e.g. a node type that disappeared from a newer
+      // ComfyUI build) must still fulfill the route. An unfulfilled request
+      // hangs the page, so the test dies on an opaque Playwright timeout
+      // instead of reporting the reason.
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`Failed to customize object_info: ${message}`)
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: `Failed to customize object_info from ${objectInfoUrl}: ${message}`
+        })
+      })
+      return
+    }
+
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -46,6 +46,19 @@ function getRequiredInput(
   return input
 }
 
+export function setNodeDisplayName(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  displayName: string
+): void {
+  const nodeInfo = objectInfo[nodeType]
+  if (!nodeInfo) {
+    throw new Error(`Missing object_info entry for ${nodeType}`)
+  }
+
+  nodeInfo.display_name = displayName
+}
+
 export function setStringInputTooltip(
   objectInfo: ObjectInfoResponse,
   nodeType: string,

--- a/browser_tests/tests/imageCompare.spec.ts
+++ b/browser_tests/tests/imageCompare.spec.ts
@@ -2,11 +2,39 @@ import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
+import {
+  routeObjectInfoFromSetupApi,
+  setNodeDisplayName
+} from '@e2e/fixtures/utils/objectInfo'
 import { toNodeId } from '@/types/nodeId'
 
 const IMAGE_COMPARE_NODE_ID = toNodeId(1)
+const IMAGE_COMPARE_NODE_TYPE = 'ImageCompare'
+const IMAGE_COMPARE_DISPLAY_NAME = 'Image Compare'
+
+// English node titles come from the backend, so any golden containing a node
+// header would otherwise track whatever ComfyUI build the CI container ships.
+// Pinning the name before the app boots keeps those baselines stable.
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      page,
+      (objectInfo) =>
+        setNodeDisplayName(
+          objectInfo,
+          IMAGE_COMPARE_NODE_TYPE,
+          IMAGE_COMPARE_DISPLAY_NAME
+        )
+    )
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
 
 test.describe('Image Compare', { tag: ['@widget', '@vue-nodes'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/nodeBadge.spec.ts
+++ b/browser_tests/tests/nodeBadge.spec.ts
@@ -2,14 +2,41 @@ import { expect } from '@playwright/test'
 
 import type { ComfyApp } from '@/scripts/app'
 import { NodeBadgeMode } from '@/types/nodeSource'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import {
+  routeObjectInfoFromSetupApi,
+  setNodeDisplayName
+} from '@e2e/fixtures/utils/objectInfo'
+
+const DEPRECATED_NODE_TYPE = 'ImageBatch'
+const DEPRECATED_NODE_DISPLAY_NAME = 'Batch Images'
+const API_NODE_TYPE = 'FluxProUltraImageNode'
+
+// English node titles come from the backend, so any golden containing a node
+// header would otherwise track whatever ComfyUI build the CI container ships.
+// Pinning the name before the app boots keeps those baselines stable.
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      page,
+      (objectInfo) =>
+        setNodeDisplayName(
+          objectInfo,
+          DEPRECATED_NODE_TYPE,
+          DEPRECATED_NODE_DISPLAY_NAME
+        )
+    )
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
 
 test.beforeEach(async ({ comfyPage }) => {
   await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
 })
-
-const DEPRECATED_NODE_TYPE = 'ImageBatch'
-const API_NODE_TYPE = 'FluxProUltraImageNode'
 
 test.describe('Node Badge', { tag: ['@screenshot', '@smoke', '@node'] }, () => {
   test('Can add badge', async ({ comfyPage }) => {


### PR DESCRIPTION
Since English node display names come from the backend `/object_info`, any Playwright golden containing a node header tracks whatever ComfyUI build the CI container ships. The container is pinned at `0.0.21` (ComfyUI v0.19.3) while `0.0.22` (v0.30.0) already exists, so a bump would move node-title screenshots for reasons unrelated to the change making it.

Adds `setNodeDisplayName` to `browser_tests/fixtures/utils/objectInfo.ts` and pins `ImageCompare` and `ImageBatch` via `routeObjectInfoFromSetupApi` at the `page` fixture level, so the stub is installed before the app boots and no reload is needed near the screenshot assertions.

**Goldens are unchanged.** The pinned strings were read off the committed PNGs, so the existing images stay valid.

Also fixes a pre-existing hang: `customize` sat outside the try/catch in `routeObjectInfoFromSetupApi`, so a throwing mutator left the route unfulfilled and the test died on an opaque Playwright timeout instead of naming the missing node type.

Fixes #14630

---
Previously merged without review and backed out by https://github.com/Comfy-Org/ComfyUI_frontend/pull/14791. Re-submitting for normal review. Rebased onto post-revert `main`; content unchanged.