### PR TITLE
test: pin the remaining container-coupled node titles

### DIFF
--- a/browser_tests/tests/nodeBadge.spec.ts
+++ b/browser_tests/tests/nodeBadge.spec.ts
@@ -9,22 +9,31 @@ import {
 } from '@e2e/fixtures/utils/objectInfo'
 
 const DEPRECATED_NODE_TYPE = 'ImageBatch'
-const DEPRECATED_NODE_DISPLAY_NAME = 'Batch Images'
 const API_NODE_TYPE = 'FluxProUltraImageNode'
 
 // English node titles come from the backend, so any golden containing a node
 // header would otherwise track whatever ComfyUI build the CI container ships.
 // Pinning the name before the app boots keeps those baselines stable.
+// `nodes/execution_error` also renders `DevToolsErrorRaiseNode`, which is not
+// pinned: it ships from this repo's `tools/devtools/`, so a rename there is a
+// deliberate in-repo change that its goldens should keep tracking.
+const PINNED_DISPLAY_NAMES: Record<string, string> = {
+  [DEPRECATED_NODE_TYPE]: 'Batch Images',
+  [API_NODE_TYPE]: 'Flux 1.1 [pro] Ultra Image',
+  PreviewImage: 'Preview Image'
+}
+
 const test = comfyPageFixture.extend({
   page: async ({ page }, use) => {
     const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
       page,
-      (objectInfo) =>
-        setNodeDisplayName(
-          objectInfo,
-          DEPRECATED_NODE_TYPE,
-          DEPRECATED_NODE_DISPLAY_NAME
-        )
+      (objectInfo) => {
+        for (const [nodeType, displayName] of Object.entries(
+          PINNED_DISPLAY_NAMES
+        )) {
+          setNodeDisplayName(objectInfo, nodeType, displayName)
+        }
+      }
     )
     try {
       await use(page)


### PR DESCRIPTION
**Stacked on https://github.com/Comfy-Org/ComfyUI_frontend/pull/14794** — review that one first; this targets its branch and will retarget `main` once it lands.

Extends the same stubbing to the goldens 14794 left out:

| golden | node type | pinned title |
|---|---|---|
| `api-pricing-{on,off}-{classic,vue}` | `FluxProUltraImageNode` | `Flux 1.1 [pro] Ultra Image` |
| `node-badge-{Show-all,Hide-built-in,None}` | `PreviewImage` | `Preview Image` |

Goldens unchanged; both strings match `src/locales/en/nodeDefs.json` and are legible in the committed PNGs.

Deliberately **not** pinned: `DevToolsErrorRaiseNode` (`Raise Error`). It is defined in this repo at `tools/devtools/nodes/errors.py:76` and copied into `custom_nodes` during CI, so pinning it would mask a deliberate in-repo rename rather than container drift.

Related: #14630

---
Previously merged without review and backed out by https://github.com/Comfy-Org/ComfyUI_frontend/pull/14791. Re-submitting for normal review. Rebased onto post-revert `main`; content unchanged.