### PR TITLE
fix: name the malformed node definitions dropped from object_info

### DIFF
--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -142,6 +142,32 @@ describe('ComfyApp.getNodeDefs', () => {
     expect(result.TestNode.category).toBe('')
   })
 
+  test('names the malformed entries it discards', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(api.getNodeDefs).mockResolvedValue({
+      TestNode: nodeDef({}),
+      NullEntry: null,
+      NamelessEntry: { category: 'test' }
+    } as unknown as Record<string, ComfyNodeDefV1>)
+
+    await comfyApp.getNodeDefs()
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('NullEntry, NamelessEntry')
+    )
+    warn.mockRestore()
+  })
+
+  test('stays silent when every entry is well formed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockDefs(nodeDef({}))
+
+    await comfyApp.getNodeDefs()
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
   test('discards malformed entries inside an otherwise valid response', async () => {
     vi.mocked(api.getNodeDefs).mockResolvedValue({
       TestNode: nodeDef({ display_name: 'Good Node' }),

--- a/src/scripts/app.getNodeDefs.test.ts
+++ b/src/scripts/app.getNodeDefs.test.ts
@@ -152,9 +152,11 @@ describe('ComfyApp.getNodeDefs', () => {
 
     await comfyApp.getNodeDefs()
 
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('NullEntry, NamelessEntry')
-    )
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [message] = warn.mock.calls[0]
+    expect(message).toContain('NullEntry')
+    expect(message).toContain('NamelessEntry')
+    expect(message).not.toContain('TestNode')
     warn.mockRestore()
   })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1132,6 +1132,15 @@ export class ComfyApp {
       !Array.isArray(response)
         ? Object.entries(response)
         : []
+    const droppedNames = entries
+      .filter(([, value]) => !isNodeDef(value))
+      .map(([name]) => name)
+    if (droppedNames.length > 0) {
+      console.warn(
+        `Ignored ${droppedNames.length} malformed node definition(s) from /object_info: ${droppedNames.join(', ')}`
+      )
+    }
+
     const defs: Record<string, ComfyNodeDefV1> = Object.fromEntries(
       entries.filter((entry): entry is [string, ComfyNodeDefV1] =>
         isNodeDef(entry[1])


### PR DESCRIPTION
`ComfyApp.getNodeDefs()` discards `/object_info` entries that are not objects with a string `name`, so a single malformed def cannot abort node registration for every node. It did so silently, which makes a node vanishing from the UI undiagnosable. Warn once per fetch, naming the discarded keys.

This is the decision half of #14644: keep the permissive posture (#1190 disabled node-def validation by default, #4038 removed it), because tightening the contract risks silently dropping custom nodes users have installed. What was wrong was the silence, not the permissiveness. It also generates the evidence to revisit #14644 with data rather than speculation.

- **Breaking**: none. Same defs dropped as before; only logging changes.

Related: #14644

---
Previously merged without review and backed out by https://github.com/Comfy-Org/ComfyUI_frontend/pull/14791. Re-submitting for normal review. Rebased onto post-revert `main`; content unchanged.