### PR TITLE
feat: add gold-700 color primitive

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -51,6 +51,7 @@
   --color-gold-400: #fcbf64;
   --color-gold-500: #fdab34;
   --color-gold-600: #fd9903;
+  --color-gold-700: #c77700;
 
   --color-credit: #ddbd31;
 


### PR DESCRIPTION
## ELI5
Our warning color (gold) is bright enough to read on dark backgrounds, but on the light theme it's like yellow chalk on a whiteboard — technically there, hard to see. This adds one darker shade of the same gold to the palette so light-theme warnings can meet contrast guidelines.

## Summary
- Adds `--color-gold-700: #c77700` to the design-system primitives, extending the existing gold ramp (400/500/600).
- Same hue family as the current golds; measured for the light-theme `--warning-background` slot, where gold-400 sits at 1.48:1 against the hero band (WCAG wants 3:1 at that size).

## Context
Identified during the mixed-severity errors panel review (#14252): dark theme measures 7.28:1 but light theme fails contrast. Agreed there that the token lands via the design-system side and #14252's follow-up points `--warning-background` at it for light theme, so this PR intentionally adds the primitive only — no consumers change and there is no visual change yet. Note Tailwind v4 may tree-shake the unused variable from built CSS until it's referenced; the source token is what the follow-up wires up.

Part of DES-588.

## Test plan
- [ ] `pnpm format:check` and stylelint pass (pre-commit)
- [ ] No visual change expected until `--warning-background` (light) is repointed in the #14252 follow-up
- [ ] Not user-visible on its own, so no feature flag needed