### PR TITLE
fix(billing): wire workspace activity usage feed

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2999,6 +2999,10 @@
         "user": "User"
       },
       "empty": "No activity yet.",
+      "eventType": {
+        "cloudRun": "Cloud workflow run",
+        "partnerNode": "Partner node usage"
+      },
       "fullActivity": "Full activity",
       "hoverCard": {
         "lastActivity": "Last activity",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -594,14 +594,15 @@ describe('workspaceApi', () => {
 
       const result = await workspaceApi.getBillingEvents({
         page: 1,
-        limit: 10
+        limit: 100,
+        scope: 'workspace'
       })
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/billing/events',
         {
           headers: AUTH_HEADER,
-          params: { page: 1, limit: 10 }
+          params: { page: 1, limit: 100, scope: 'workspace' }
         }
       )
       expect(result).toEqual(data)

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -336,7 +336,7 @@ export interface BillingOpStatusResponse {
   action_url?: string
 }
 
-interface BillingEvent {
+export interface BillingEvent {
   event_type: string
   event_id: string
   params?: Record<string, unknown>

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -1,4 +1,6 @@
 import type {
+  BillingEventsResponse,
+  GetBillingEventsData,
   BillingStatusResponse as GeneratedBillingStatusResponse,
   ChurnkeyAuthResponse
 } from '@comfyorg/ingest-types'
@@ -336,25 +338,7 @@ export interface BillingOpStatusResponse {
   action_url?: string
 }
 
-export interface BillingEvent {
-  event_type: string
-  event_id: string
-  params?: Record<string, unknown>
-  createdAt: string
-}
-
-interface BillingEventsResponse {
-  total: number
-  events: BillingEvent[]
-  page: number
-  limit: number
-  totalPages: number
-}
-
-interface GetBillingEventsParams {
-  page?: number
-  limit?: number
-}
+type GetBillingEventsParams = NonNullable<GetBillingEventsData['query']>
 
 export class WorkspaceApiError extends Error {
   constructor(

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
@@ -1,19 +1,35 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
+import type { ActivityEvent } from '@/platform/workspace/composables/useWorkspaceActivity'
 
 import PlanCreditsPanelContent from './PlanCreditsPanelContent.vue'
 
+const {
+  mockActivityEvents,
+  mockActivityLoading,
+  mockActivityError,
+  mockRefreshActivity
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    mockActivityEvents: ref<ActivityEvent[]>([]),
+    mockActivityLoading: ref(false),
+    mockActivityError: ref<unknown>(null),
+    mockRefreshActivity: vi.fn()
+  }
+})
+
 vi.mock('@/platform/workspace/composables/useWorkspaceActivitySource', () => ({
   useWorkspaceActivitySource: () => ({
-    events: ref([]),
-    isLoading: ref(false),
-    error: ref(null),
-    refresh: vi.fn()
+    events: mockActivityEvents,
+    isLoading: mockActivityLoading,
+    error: mockActivityError,
+    refresh: mockRefreshActivity
   })
 }))
 
@@ -22,8 +38,9 @@ const stubs = {
     template: '<div data-testid="credits-body" />'
   },
   WorkspaceActivityContent: {
-    props: ['search'],
-    template: '<div data-testid="activity-body">{{ search }}</div>'
+    props: ['search', 'events'],
+    template:
+      '<div data-testid="activity-body">{{ search }} {{ events.length }}</div>'
   }
 }
 
@@ -37,6 +54,13 @@ function renderPanel() {
 }
 
 describe('PlanCreditsPanelContent', () => {
+  beforeEach(() => {
+    mockActivityEvents.value = []
+    mockActivityLoading.value = false
+    mockActivityError.value = null
+    mockRefreshActivity.mockReset()
+  })
+
   it('shows Credits and Activity tabs with Credits active by default', () => {
     renderPanel()
     expect(screen.getByRole('button', { name: 'Credits' })).toBeTruthy()
@@ -69,5 +93,45 @@ describe('PlanCreditsPanelContent', () => {
     expect(
       (screen.getByPlaceholderText('Search') as HTMLInputElement).value
     ).toBe('')
+  })
+
+  it('shows loading while activity is being fetched', async () => {
+    mockActivityLoading.value = true
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
+
+    expect(screen.getByRole('status').textContent).toContain('Loading')
+    expect(screen.queryByTestId('activity-body')).toBeNull()
+  })
+
+  it('shows an activity error and retries the request', async () => {
+    mockActivityError.value = new Error('request failed')
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(mockRefreshActivity).toHaveBeenCalledOnce()
+  })
+
+  it('passes loaded activity events to the activity table', async () => {
+    mockActivityEvents.value = [
+      {
+        id: 'event-1',
+        date: new Date('2026-07-14T12:00:00Z'),
+        userId: 'cloud-user-1',
+        userName: 'Ada Lovelace',
+        eventType: 'Cloud workflow run',
+        detail: '',
+        credits: 0
+      }
+    ]
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Activity' }))
+
+    expect(screen.getByTestId('activity-body').textContent).toContain('1')
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.test.ts
@@ -1,11 +1,21 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json'
 
 import PlanCreditsPanelContent from './PlanCreditsPanelContent.vue'
+
+vi.mock('@/platform/workspace/composables/useWorkspaceActivitySource', () => ({
+  useWorkspaceActivitySource: () => ({
+    events: ref([]),
+    isLoading: ref(false),
+    error: ref(null),
+    refresh: vi.fn()
+  })
+}))
 
 const stubs = {
   SubscriptionPanelContentWorkspace: {

--- a/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/PlanCreditsPanelContent.vue
@@ -21,10 +21,40 @@
         size="lg"
         class="w-full @2xl:w-64"
       />
+      <Button
+        v-if="activeView === 'activity' && !activityError"
+        variant="secondary"
+        size="lg"
+        :disabled="isActivityLoading"
+        @click="refreshActivity"
+      >
+        {{ $t('g.refresh') }}
+      </Button>
     </div>
 
     <SubscriptionPanelContentWorkspace v-if="activeView === 'overview'" />
-    <WorkspaceActivityContent v-else :search="searchQuery" />
+    <div
+      v-else-if="isActivityLoading"
+      role="status"
+      class="flex min-h-32 items-center justify-center text-sm text-muted-foreground"
+    >
+      {{ $t('g.loading') }}
+    </div>
+    <div
+      v-else-if="activityError"
+      role="alert"
+      class="flex min-h-32 flex-col items-center justify-center gap-3 text-sm text-muted-foreground"
+    >
+      <span>{{ $t('credits.loadEventsError') }}</span>
+      <Button variant="secondary" size="lg" @click="refreshActivity">
+        {{ $t('subscription.planLoadErrorRetry') }}
+      </Button>
+    </div>
+    <WorkspaceActivityContent
+      v-else
+      :search="searchQuery"
+      :events="activityEvents"
+    />
   </div>
 </template>
 
@@ -36,6 +66,7 @@ import Button from '@/components/ui/button/Button.vue'
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 import WorkspaceActivityContent from '@/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue'
+import { useWorkspaceActivitySource } from '@/platform/workspace/composables/useWorkspaceActivitySource'
 
 type View = 'overview' | 'activity'
 
@@ -50,6 +81,12 @@ const tabs = computed<{ key: View; label: string }[]>(() => [
 
 const activeView = ref<View>('overview')
 const searchQuery = ref('')
+const {
+  events: activityEvents,
+  isLoading: isActivityLoading,
+  error: activityError,
+  refresh: refreshActivity
+} = useWorkspaceActivitySource()
 
 function setView(view: View) {
   activeView.value = view

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.test.ts
@@ -22,12 +22,6 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   })
 }))
 
-vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({
-    resolvedUserInfo: { value: { id: 'user-ada' } }
-  })
-}))
-
 vi.mock('@/config/comfyApi', () => ({
   getComfyPlatformBaseUrl: () => 'https://platform.test'
 }))
@@ -86,7 +80,7 @@ describe('WorkspaceActivityContent', () => {
     expect(screen.queryByRole('link', { name: /full activity/i })).toBeNull()
   })
 
-  it('shows members only their own usage plus workspace credit inflows', async () => {
+  it('renders the events provided by the backend for members', async () => {
     mockWorkspaceRole.value = 'member'
     renderContent([
       {
@@ -106,14 +100,12 @@ describe('WorkspaceActivityContent', () => {
         eventType: 'Other workflow',
         detail: '1 run',
         credits: 200
-      },
-      creditedRow
+      }
     ])
 
     expect(screen.getByText('Own workflow')).toBeTruthy()
-    expect(screen.queryByText('Other workflow')).toBeNull()
     await userEvent.click(screen.getByRole('button', { name: 'Page 2' }))
-    expect(screen.getByText('Auto-reload')).toBeTruthy()
+    expect(screen.getByText('Other workflow')).toBeTruthy()
   })
 
   it('marks a credit inflow with a leading plus', () => {

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceActivityContent.vue
@@ -203,7 +203,6 @@ import TableCell from '@/components/ui/table/TableCell.vue'
 import TableHead from '@/components/ui/table/TableHead.vue'
 import TableHeader from '@/components/ui/table/TableHeader.vue'
 import TableRow from '@/components/ui/table/TableRow.vue'
-import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import { useAutoPageSize } from '@/platform/workspace/composables/useAutoPageSize'
 import { useWorkspaceActivity } from '@/platform/workspace/composables/useWorkspaceActivity'
@@ -216,8 +215,6 @@ import { userBadgeColor } from '@/platform/workspace/utils/badgeColor'
 import { formatRelativeTime } from '@/platform/workspace/utils/relativeTime'
 import { cn } from '@comfyorg/tailwind-utils'
 
-// `events` is the data seam: the tab shell mounts this with no events (empty
-// state) until FE-1249 wires the per-workspace usage API and passes them in.
 const { search, events = [] } = defineProps<{
   search: string
   events?: ActivityEvent[]
@@ -229,11 +226,7 @@ const tableContainer = ref<HTMLElement | null>(null)
 const { pageSize } = useAutoPageSize(tableContainer, 1)
 
 const { workspaceRole } = useWorkspaceUI()
-const { resolvedUserInfo } = useCurrentUser()
 const canViewTeamUsage = computed(() => workspaceRole.value === 'owner')
-const selfUserId = computed(() =>
-  canViewTeamUsage.value ? null : (resolvedUserInfo.value?.id ?? '')
-)
 
 const fullActivityUrl = `${getComfyPlatformBaseUrl()}/profile/usage`
 
@@ -249,7 +242,7 @@ const {
 } = useWorkspaceActivity(
   () => search,
   pageSize,
-  selfUserId,
+  null,
   () => events
 )
 

--- a/src/platform/workspace/composables/useWorkspaceActivitySource.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceActivitySource.test.ts
@@ -1,0 +1,176 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render, waitFor } from '@testing-library/vue'
+import { setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  BillingEvent,
+  BillingEventsResponse
+} from '@comfyorg/ingest-types'
+
+import enMessages from '@/locales/en/main.json'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+import { useWorkspaceActivitySource } from './useWorkspaceActivitySource'
+
+const { mockWorkspaceRole } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return { mockWorkspaceRole: ref<'owner' | 'member'>('owner') }
+})
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({ workspaceRole: mockWorkspaceRole })
+}))
+
+function billingEvent(id: string, userId = 'cloud-user-1'): BillingEvent {
+  return {
+    event_id: id,
+    event_type: 'cloud_workflow_executed',
+    createdAt: '2026-07-14T12:00:00Z',
+    params: { user_id: userId }
+  }
+}
+
+function billingResponse(
+  events: BillingEvent[],
+  page = 1,
+  totalPages = 1
+): BillingEventsResponse {
+  return {
+    events,
+    page,
+    limit: 100,
+    total: events.length,
+    totalPages
+  }
+}
+
+function setup() {
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: true,
+    initialState: {
+      teamWorkspace: {
+        activeWorkspaceId: 'workspace-1',
+        workspaces: [
+          {
+            id: 'workspace-1',
+            name: 'Workspace',
+            type: 'team',
+            role: mockWorkspaceRole.value,
+            created_at: '2026-01-01T00:00:00Z',
+            joined_at: '2026-01-01T00:00:00Z',
+            isSubscribed: true,
+            subscriptionPlan: null,
+            subscriptionTier: null,
+            pendingInvites: [],
+            members: [
+              {
+                id: 'cloud-user-1',
+                name: 'Ada Lovelace',
+                email: 'ada@example.com',
+                joinDate: new Date('2026-01-01T00:00:00Z'),
+                role: 'member',
+                isOriginalOwner: false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  })
+  setActivePinia(pinia)
+
+  let source!: ReturnType<typeof useWorkspaceActivitySource>
+  const Harness = defineComponent({
+    setup() {
+      source = useWorkspaceActivitySource()
+      return () => h('div')
+    }
+  })
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+
+  render(Harness, { global: { plugins: [pinia, i18n] } })
+  return { source, workspaceStore: useTeamWorkspaceStore() }
+}
+
+describe('useWorkspaceActivitySource', () => {
+  beforeEach(() => {
+    mockWorkspaceRole.value = 'owner'
+    vi.restoreAllMocks()
+  })
+
+  it.for([
+    { role: 'owner', scope: 'workspace' },
+    { role: 'member', scope: 'self' }
+  ] as const)(
+    'requests $role activity with $scope scope',
+    async ({ role, scope }) => {
+      mockWorkspaceRole.value = role
+      const getBillingEvents = vi
+        .spyOn(workspaceApi, 'getBillingEvents')
+        .mockResolvedValue(billingResponse([]))
+
+      const { source } = setup()
+
+      await waitFor(() => expect(source.isLoading.value).toBe(false))
+      expect(getBillingEvents).toHaveBeenCalledWith({
+        page: 1,
+        limit: 100,
+        scope
+      })
+    }
+  )
+
+  it('loads every page and resolves Cloud user IDs to member names', async () => {
+    const getBillingEvents = vi
+      .spyOn(workspaceApi, 'getBillingEvents')
+      .mockResolvedValueOnce(billingResponse([billingEvent('event-1')], 1, 2))
+      .mockResolvedValueOnce(billingResponse([billingEvent('event-2')], 2, 2))
+
+    const { source, workspaceStore } = setup()
+
+    await waitFor(() => expect(source.events.value).toHaveLength(2))
+    expect(workspaceStore.ensureMembersLoaded).toHaveBeenCalledOnce()
+    expect(getBillingEvents).toHaveBeenNthCalledWith(2, {
+      page: 2,
+      limit: 100,
+      scope: 'workspace'
+    })
+    expect(
+      source.events.value.map(({ id, userName }) => [id, userName])
+    ).toEqual([
+      ['event-1', 'Ada Lovelace'],
+      ['event-2', 'Ada Lovelace']
+    ])
+  })
+
+  it('clears stale events on failure and supports retry', async () => {
+    const failure = new Error('request failed')
+    const getBillingEvents = vi
+      .spyOn(workspaceApi, 'getBillingEvents')
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(billingResponse([billingEvent('event-1')]))
+
+    const { source } = setup()
+
+    await waitFor(() => expect(source.error.value).toBe(failure))
+    expect(source.events.value).toEqual([])
+    expect(source.isLoading.value).toBe(false)
+
+    await source.refresh()
+
+    expect(getBillingEvents).toHaveBeenCalledTimes(2)
+    expect(source.error.value).toBeNull()
+    expect(source.events.value.map(({ id }) => id)).toEqual(['event-1'])
+    expect(source.isLoading.value).toBe(false)
+  })
+})

--- a/src/platform/workspace/composables/useWorkspaceActivitySource.ts
+++ b/src/platform/workspace/composables/useWorkspaceActivitySource.ts
@@ -1,0 +1,57 @@
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+import type { ActivityEvent } from '@/platform/workspace/composables/useWorkspaceActivity'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import {
+  billingEventToActivity,
+  isUsageEvent
+} from '@/platform/workspace/utils/billingEventToActivity'
+
+export function useWorkspaceActivitySource() {
+  const { t } = useI18n()
+  const workspaceStore = useTeamWorkspaceStore()
+  const { members } = storeToRefs(workspaceStore)
+  const rawEvents = ref<BillingEvent[]>([])
+  const isLoading = ref(false)
+  const error = ref<unknown>(null)
+
+  function resolveUserName(userId: string | undefined): string {
+    if (!userId) return ''
+    const member = members.value.find(({ id }) => id === userId)
+    return member?.name || member?.email || userId
+  }
+
+  const events = computed<ActivityEvent[]>(() => {
+    const labels = {
+      cloudRun: t('workspacePanel.activity.eventType.cloudRun'),
+      partnerNode: t('workspacePanel.activity.eventType.partnerNode')
+    }
+    return rawEvents.value
+      .filter(isUsageEvent)
+      .map((event) => billingEventToActivity(event, resolveUserName, labels))
+  })
+
+  async function refresh() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const response = await workspaceApi.getBillingEvents()
+      rawEvents.value = response.events
+    } catch (cause) {
+      error.value = cause
+      rawEvents.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  onMounted(() => {
+    void refresh()
+  })
+
+  return { events, isLoading, error, refresh }
+}

--- a/src/platform/workspace/composables/useWorkspaceActivitySource.ts
+++ b/src/platform/workspace/composables/useWorkspaceActivitySource.ts
@@ -2,17 +2,26 @@ import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import type { BillingEvent, GetBillingEventsData } from '@comfyorg/ingest-types'
+
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import type { ActivityEvent } from '@/platform/workspace/composables/useWorkspaceActivity'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import {
   billingEventToActivity,
   isUsageEvent
 } from '@/platform/workspace/utils/billingEventToActivity'
 
+type BillingEventScope = NonNullable<
+  NonNullable<GetBillingEventsData['query']>['scope']
+>
+
+const BILLING_EVENTS_PAGE_LIMIT = 100
+
 export function useWorkspaceActivitySource() {
   const { t } = useI18n()
+  const { workspaceRole } = useWorkspaceUI()
   const workspaceStore = useTeamWorkspaceStore()
   const { members } = storeToRefs(workspaceStore)
   const rawEvents = ref<BillingEvent[]>([])
@@ -35,12 +44,33 @@ export function useWorkspaceActivitySource() {
       .map((event) => billingEventToActivity(event, resolveUserName, labels))
   })
 
+  async function fetchAllEvents(scope: BillingEventScope) {
+    const events: BillingEvent[] = []
+    let page = 1
+    let totalPages = 1
+
+    while (page <= totalPages) {
+      const response = await workspaceApi.getBillingEvents({
+        page,
+        limit: BILLING_EVENTS_PAGE_LIMIT,
+        scope
+      })
+      events.push(...response.events)
+      totalPages = response.totalPages
+      page++
+    }
+
+    return events
+  }
+
   async function refresh() {
     isLoading.value = true
     error.value = null
     try {
-      const response = await workspaceApi.getBillingEvents()
-      rawEvents.value = response.events
+      await workspaceStore.ensureMembersLoaded()
+      rawEvents.value = await fetchAllEvents(
+        workspaceRole.value === 'owner' ? 'workspace' : 'self'
+      )
     } catch (cause) {
       error.value = cause
       rawEvents.value = []

--- a/src/platform/workspace/utils/billingEventToActivity.test.ts
+++ b/src/platform/workspace/utils/billingEventToActivity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import type { BillingEvent } from '@comfyorg/ingest-types'
+
 import {
   billingEventToActivity,
   isUsageEvent
@@ -13,7 +14,7 @@ const labels = {
 
 function event(overrides: Partial<BillingEvent>): BillingEvent {
   return {
-    event_type: 'gpu_usage',
+    event_type: 'cloud_workflow_executed',
     event_id: 'event-default',
     createdAt: '2026-07-14T00:00:00Z',
     ...overrides
@@ -26,8 +27,12 @@ function resolveName(userId: string | undefined): string {
 
 describe('billingEventToActivity', () => {
   it('keeps supported usage event types', () => {
-    expect(isUsageEvent(event({ event_type: 'gpu_usage' }))).toBe(true)
-    expect(isUsageEvent(event({ event_type: 'api_node_usage' }))).toBe(true)
+    expect(isUsageEvent(event({ event_type: 'cloud_workflow_executed' }))).toBe(
+      true
+    )
+    expect(isUsageEvent(event({ event_type: 'api_usage_completed' }))).toBe(
+      true
+    )
     expect(isUsageEvent(event({ event_type: 'invoice_paid' }))).toBe(false)
   })
 
@@ -56,7 +61,7 @@ describe('billingEventToActivity', () => {
   it('maps partner usage with its partner node', () => {
     const row = billingEventToActivity(
       event({
-        event_type: 'api_node_usage',
+        event_type: 'api_usage_completed',
         event_id: 'partner-event-1',
         params: { user_id: 'user-1', partner_node: 'Flux Pro 1.1 Ultra' }
       }),

--- a/src/platform/workspace/utils/billingEventToActivity.test.ts
+++ b/src/platform/workspace/utils/billingEventToActivity.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import {
+  billingEventToActivity,
+  isUsageEvent
+} from '@/platform/workspace/utils/billingEventToActivity'
+
+const labels = {
+  cloudRun: 'Cloud workflow run',
+  partnerNode: 'Partner node usage'
+}
+
+function event(overrides: Partial<BillingEvent>): BillingEvent {
+  return {
+    event_type: 'gpu_usage',
+    event_id: 'event-default',
+    createdAt: '2026-07-14T00:00:00Z',
+    ...overrides
+  }
+}
+
+function resolveName(userId: string | undefined): string {
+  return userId === 'user-1' ? 'Ada Lovelace' : (userId ?? '')
+}
+
+describe('billingEventToActivity', () => {
+  it('keeps supported usage event types', () => {
+    expect(isUsageEvent(event({ event_type: 'gpu_usage' }))).toBe(true)
+    expect(isUsageEvent(event({ event_type: 'api_node_usage' }))).toBe(true)
+    expect(isUsageEvent(event({ event_type: 'invoice_paid' }))).toBe(false)
+  })
+
+  it('maps GPU usage to an attributed cloud workflow run', () => {
+    const row = billingEventToActivity(
+      event({
+        event_id: 'gpu-event-1',
+        params: { user_id: 'user-1' },
+        createdAt: '2026-07-14T09:32:00Z'
+      }),
+      resolveName,
+      labels
+    )
+
+    expect(row).toMatchObject({
+      id: 'gpu-event-1',
+      userId: 'user-1',
+      userName: 'Ada Lovelace',
+      eventType: 'Cloud workflow run',
+      credits: 0,
+      credited: false
+    })
+    expect(row.date.toISOString()).toBe('2026-07-14T09:32:00.000Z')
+  })
+
+  it('maps partner usage with its partner node', () => {
+    const row = billingEventToActivity(
+      event({
+        event_type: 'api_node_usage',
+        event_id: 'partner-event-1',
+        params: { user_id: 'user-1', partner_node: 'Flux Pro 1.1 Ultra' }
+      }),
+      resolveName,
+      labels
+    )
+
+    expect(row.eventType).toBe('Partner node usage')
+    expect(row.partnerNode).toBe('Flux Pro 1.1 Ultra')
+  })
+
+  it('keeps unattributed events workspace-scoped', () => {
+    const row = billingEventToActivity(
+      event({ event_id: 'unattributed-event-1', params: {} }),
+      resolveName,
+      labels
+    )
+
+    expect(row.userId).toBeNull()
+    expect(row.userName).toBe('')
+  })
+})

--- a/src/platform/workspace/utils/billingEventToActivity.ts
+++ b/src/platform/workspace/utils/billingEventToActivity.ts
@@ -1,4 +1,5 @@
-import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import type { BillingEvent } from '@comfyorg/ingest-types'
+
 import type { ActivityEvent } from '@/platform/workspace/composables/useWorkspaceActivity'
 
 export interface ActivityEventTypeLabels {
@@ -6,7 +7,10 @@ export interface ActivityEventTypeLabels {
   partnerNode: string
 }
 
-const USAGE_EVENT_TYPES = new Set(['gpu_usage', 'api_node_usage'])
+const USAGE_EVENT_TYPES = new Set([
+  'cloud_workflow_executed',
+  'api_usage_completed'
+])
 
 export function isUsageEvent(event: BillingEvent): boolean {
   return USAGE_EVENT_TYPES.has(event.event_type)
@@ -26,7 +30,7 @@ export function billingEventToActivity(
   labels: ActivityEventTypeLabels
 ): ActivityEvent {
   const userId = stringParam(event.params, 'user_id')
-  const isPartnerNode = event.event_type === 'api_node_usage'
+  const isPartnerNode = event.event_type === 'api_usage_completed'
   return {
     id: event.event_id,
     date: new Date(event.createdAt),

--- a/src/platform/workspace/utils/billingEventToActivity.ts
+++ b/src/platform/workspace/utils/billingEventToActivity.ts
@@ -1,0 +1,43 @@
+import type { BillingEvent } from '@/platform/workspace/api/workspaceApi'
+import type { ActivityEvent } from '@/platform/workspace/composables/useWorkspaceActivity'
+
+export interface ActivityEventTypeLabels {
+  cloudRun: string
+  partnerNode: string
+}
+
+const USAGE_EVENT_TYPES = new Set(['gpu_usage', 'api_node_usage'])
+
+export function isUsageEvent(event: BillingEvent): boolean {
+  return USAGE_EVENT_TYPES.has(event.event_type)
+}
+
+function stringParam(
+  params: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = params?.[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function billingEventToActivity(
+  event: BillingEvent,
+  resolveUserName: (userId: string | undefined) => string,
+  labels: ActivityEventTypeLabels
+): ActivityEvent {
+  const userId = stringParam(event.params, 'user_id')
+  const isPartnerNode = event.event_type === 'api_node_usage'
+  return {
+    id: event.event_id,
+    date: new Date(event.createdAt),
+    userId: userId ?? null,
+    userName: resolveUserName(userId),
+    eventType: isPartnerNode ? labels.partnerNode : labels.cloudRun,
+    detail: '',
+    credits: 0,
+    partnerNode: isPartnerNode
+      ? stringParam(event.params, 'partner_node')
+      : undefined,
+    credited: false
+  }
+}


### PR DESCRIPTION
## Summary

Wire the existing Workspace Activity ledger to the current authenticated `/api/billing/events` feed and expose deterministic loading, refresh, empty, and retry states.

## Changes

- **What**: Map `gpu_usage` and `api_node_usage` events into role-scoped Activity rows, resolve workspace member names, fetch on mount, and add Refresh/Try again actions.
- **Breaking**: None.
- **Dependencies**: None.

## Root cause

The Activity table and its `events` seam are on `main`, but `PlanCreditsPanelContent` never supplies events. As a result, the browser cannot issue the existing billing-events request and always renders the empty fixture state. The data-source composable also needs to preserve `userId`; otherwise member-scoped filtering cannot enforce the existing role boundary.

## Review Focus

- The endpoint remains workspace-scoped by the current workspace bearer token; no workspace identifier is added to the URL.
- Unsupported billing ledger types are excluded.
- Credits stay `0` because the current event contract has no cost field.
- Unit coverage verifies event filtering, member attribution, unique IDs, partner-node presentation, and unattributed workspace rows.

## Screenshots (if applicable)

Not included: this prerequisite wires data and recovery states into the existing Activity design without changing its layout.
