### PR TITLE
fix(billing): show enterprise guidance at top-up cap

### DIFF
--- a/browser_tests/fixtures/cloudBillingApiFixture.ts
+++ b/browser_tests/fixtures/cloudBillingApiFixture.ts
@@ -1,0 +1,473 @@
+import { test as base } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
+
+import type {
+  BillingBalanceResponse,
+  BillingOpStatusResponse,
+  BillingPlansResponse,
+  BillingStatusResponse,
+  CancelSubscriptionRequest,
+  CancelSubscriptionResponse,
+  CreateTopupRequest,
+  CreateTopupResponse,
+  ErrorResponse,
+  PreviewSubscribeRequest as GeneratedPreviewSubscribeRequest,
+  PreviewSubscribeResponse,
+  ResubscribeRequest,
+  ResubscribeResponse,
+  SubscribeRequest,
+  SubscribeResponse
+} from '@comfyorg/ingest-types'
+
+import {
+  BILLING_RENEWAL_DATE,
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_BILLING_STATUS,
+  DEFAULT_CANCEL_RESPONSE,
+  DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+  DEFAULT_RESUBSCRIBE_RESPONSE,
+  DEFAULT_SUBSCRIBE_RESPONSE,
+  DEFAULT_TOPUP_RESPONSE,
+  SUCCEEDED_BILLING_OPERATION
+} from '@e2e/fixtures/data/cloudWorkspace'
+
+const BILLING_ROUTE_PATTERN = '**/api/billing/**'
+
+type PreviewSubscribeRequest = GeneratedPreviewSubscribeRequest &
+  Pick<SubscribeRequest, 'team_credit_stop_id' | 'billing_cycle'>
+
+export interface BillingMutationRequests {
+  previewSubscribe: PreviewSubscribeRequest[]
+  subscribe: SubscribeRequest[]
+  topup: CreateTopupRequest[]
+  cancel: CancelSubscriptionRequest[]
+  resubscribe: ResubscribeRequest[]
+}
+
+export type BillingQuery = 'status' | 'balance' | 'plans'
+
+export interface CloudBillingState {
+  status: BillingStatusResponse
+  balance: BillingBalanceResponse
+  plans: BillingPlansResponse
+}
+
+export interface BillingHttpFailure {
+  status: number
+  message: string
+  code?: string
+}
+
+export interface CloudBillingSetupOptions {
+  status?: BillingStatusResponse
+  balance?: BillingBalanceResponse
+  plans?: BillingPlansResponse
+  previewResponse?: PreviewSubscribeResponse
+  subscribeResponse?: SubscribeResponse
+  topupResponse?: CreateTopupResponse
+  cancelResponse?: CancelSubscriptionResponse
+  resubscribeResponse?: ResubscribeResponse
+  postSubscribeBalance?: BillingBalanceResponse
+  operationResponses?: Record<string, readonly BillingOpStatusResponse[]>
+  failures?: Partial<Record<keyof BillingMutationRequests, BillingHttpFailure>>
+  queryFailures?: Partial<Record<BillingQuery, BillingHttpFailure>>
+}
+
+type PendingMutation =
+  | { type: 'subscribe'; request: SubscribeRequest }
+  | { type: 'topup'; amountCents: number }
+  | { type: 'cancel'; cancelAt: string }
+  | { type: 'resubscribe' }
+
+export class CloudBillingApiMock {
+  readonly requests: BillingMutationRequests = {
+    previewSubscribe: [],
+    subscribe: [],
+    topup: [],
+    cancel: [],
+    resubscribe: []
+  }
+  private _state: CloudBillingState | null = null
+  private previewResponse = structuredClone(DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE)
+  private subscribeResponse = structuredClone(DEFAULT_SUBSCRIBE_RESPONSE)
+  private topupResponse = structuredClone(DEFAULT_TOPUP_RESPONSE)
+  private cancelResponse = structuredClone(DEFAULT_CANCEL_RESPONSE)
+  private resubscribeResponse = structuredClone(DEFAULT_RESUBSCRIBE_RESPONSE)
+  private postSubscribeBalance: BillingBalanceResponse | null = null
+  private failures: CloudBillingSetupOptions['failures'] = {}
+  private readonly queryFailures = new Map<BillingQuery, BillingHttpFailure>()
+  private readonly operationResponses = new Map<
+    string,
+    readonly BillingOpStatusResponse[]
+  >()
+  private readonly operationPolls = new Map<string, number>()
+  private readonly pendingMutations = new Map<string, PendingMutation>()
+  private readonly appliedOperations = new Set<string>()
+  private readonly routeHandler: (route: Route) => Promise<void>
+
+  constructor(private readonly page: Page) {
+    this.routeHandler = this.handleRoute.bind(this)
+  }
+
+  get state(): CloudBillingState {
+    if (!this._state) {
+      throw new Error('Call billingApi.setup() before reading billing state')
+    }
+    return this._state
+  }
+
+  async setup(
+    options: CloudBillingSetupOptions = {}
+  ): Promise<CloudBillingState> {
+    if (this._state) {
+      throw new Error('billingApi.setup() can only be called once per test')
+    }
+
+    this._state = {
+      status: structuredClone(options.status ?? DEFAULT_BILLING_STATUS),
+      balance: structuredClone(options.balance ?? DEFAULT_BILLING_BALANCE),
+      plans: structuredClone(options.plans ?? DEFAULT_BILLING_PLANS)
+    }
+    this.previewResponse = structuredClone(
+      options.previewResponse ?? DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE
+    )
+    this.subscribeResponse = structuredClone(
+      options.subscribeResponse ?? DEFAULT_SUBSCRIBE_RESPONSE
+    )
+    this.topupResponse = structuredClone(
+      options.topupResponse ?? DEFAULT_TOPUP_RESPONSE
+    )
+    this.cancelResponse = structuredClone(
+      options.cancelResponse ?? DEFAULT_CANCEL_RESPONSE
+    )
+    this.resubscribeResponse = structuredClone(
+      options.resubscribeResponse ?? DEFAULT_RESUBSCRIBE_RESPONSE
+    )
+    this.postSubscribeBalance = options.postSubscribeBalance
+      ? structuredClone(options.postSubscribeBalance)
+      : null
+    this.failures = structuredClone(options.failures ?? {})
+
+    for (const [query, failure] of Object.entries(
+      options.queryFailures ?? {}
+    )) {
+      this.queryFailures.set(query as BillingQuery, structuredClone(failure))
+    }
+
+    for (const [operationId, responses] of Object.entries(
+      options.operationResponses ?? {}
+    )) {
+      this.operationResponses.set(operationId, structuredClone(responses))
+    }
+
+    await this.page.route(BILLING_ROUTE_PATTERN, this.routeHandler)
+    return this._state
+  }
+
+  setBalance(balance: BillingBalanceResponse): void {
+    this.state.balance = structuredClone(balance)
+  }
+
+  setQueryFailure(
+    query: BillingQuery,
+    failure: BillingHttpFailure | null
+  ): void {
+    if (failure) {
+      this.queryFailures.set(query, structuredClone(failure))
+      return
+    }
+    this.queryFailures.delete(query)
+  }
+
+  setMutationFailure(
+    mutation: keyof BillingMutationRequests,
+    failure: BillingHttpFailure | null
+  ): void {
+    if (failure) {
+      this.failures = { ...this.failures, [mutation]: structuredClone(failure) }
+      return
+    }
+    const failures = { ...this.failures }
+    delete failures[mutation]
+    this.failures = failures
+  }
+
+  setOperationResponses(
+    operationId: string,
+    responses: readonly BillingOpStatusResponse[]
+  ): void {
+    this.operationResponses.set(operationId, structuredClone(responses))
+  }
+
+  async dispose(): Promise<void> {
+    if (!this._state) return
+    await this.page.unroute(BILLING_ROUTE_PATTERN, this.routeHandler)
+  }
+
+  private async handleRoute(route: Route): Promise<void> {
+    const request = route.request()
+    const method = request.method().toUpperCase()
+    const pathname = new URL(request.url()).pathname
+
+    if (method === 'GET' && pathname.endsWith('/api/billing/status')) {
+      await this.handleQuery(route, 'status', this.state.status)
+      return
+    }
+    if (method === 'GET' && pathname.endsWith('/api/billing/balance')) {
+      await this.handleQuery(route, 'balance', this.state.balance)
+      return
+    }
+    if (method === 'GET' && pathname.endsWith('/api/billing/plans')) {
+      await this.handleQuery(route, 'plans', this.state.plans)
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/preview-subscribe')
+    ) {
+      await this.handlePreviewSubscribe(route)
+      return
+    }
+    if (method === 'POST' && pathname.endsWith('/api/billing/subscribe')) {
+      await this.handleSubscribe(route)
+      return
+    }
+    if (method === 'POST' && pathname.endsWith('/api/billing/topup')) {
+      await this.handleTopup(route)
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/subscription/cancel')
+    ) {
+      await this.handleCancel(route)
+      return
+    }
+    if (
+      method === 'POST' &&
+      pathname.endsWith('/api/billing/subscription/resubscribe')
+    ) {
+      await this.handleResubscribe(route)
+      return
+    }
+    if (method === 'GET' && pathname.includes('/api/billing/ops/')) {
+      await this.handleOperation(route, pathname)
+      return
+    }
+
+    await route.fallback()
+  }
+
+  private async handleQuery(
+    route: Route,
+    query: BillingQuery,
+    response:
+      | BillingStatusResponse
+      | BillingBalanceResponse
+      | BillingPlansResponse
+  ): Promise<void> {
+    const failure = this.queryFailures.get(query)
+    if (failure) {
+      const body: ErrorResponse = {
+        code: failure.code ?? 'billing_mock_error',
+        message: failure.message
+      }
+      await route.fulfill({ status: failure.status, json: body })
+      return
+    }
+    await route.fulfill({ json: response })
+  }
+
+  private async handlePreviewSubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as PreviewSubscribeRequest
+    this.requests.previewSubscribe.push(request)
+    if (await this.failIfConfigured(route, 'previewSubscribe')) return
+    await route.fulfill({ json: this.previewResponse })
+  }
+
+  private async handleSubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as SubscribeRequest
+    this.requests.subscribe.push(request)
+    if (await this.failIfConfigured(route, 'subscribe')) return
+
+    if (this.subscribeResponse.status === 'subscribed') {
+      this.applySubscribe(request)
+    } else {
+      this.pendingMutations.set(this.subscribeResponse.billing_op_id, {
+        type: 'subscribe',
+        request
+      })
+    }
+    await route.fulfill({ json: this.subscribeResponse })
+  }
+
+  private async handleTopup(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as CreateTopupRequest
+    this.requests.topup.push(request)
+    if (await this.failIfConfigured(route, 'topup')) return
+
+    const response: CreateTopupResponse = {
+      ...this.topupResponse,
+      amount_cents: request.amount_cents
+    }
+    if (response.status === 'completed') {
+      this.applyTopup(request.amount_cents)
+    } else if (response.status === 'pending') {
+      this.pendingMutations.set(response.billing_op_id, {
+        type: 'topup',
+        amountCents: request.amount_cents
+      })
+    }
+    await route.fulfill({ json: response })
+  }
+
+  private async handleCancel(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as CancelSubscriptionRequest
+    this.requests.cancel.push(request)
+    if (await this.failIfConfigured(route, 'cancel')) return
+
+    this.pendingMutations.set(this.cancelResponse.billing_op_id, {
+      type: 'cancel',
+      cancelAt: this.cancelResponse.cancel_at
+    })
+    await route.fulfill({ json: this.cancelResponse })
+  }
+
+  private async handleResubscribe(route: Route): Promise<void> {
+    const request = route.request().postDataJSON() as ResubscribeRequest
+    this.requests.resubscribe.push(request)
+    if (await this.failIfConfigured(route, 'resubscribe')) return
+
+    if (this.resubscribeResponse.status === 'active') {
+      this.applyResubscribe()
+    } else {
+      this.pendingMutations.set(this.resubscribeResponse.billing_op_id, {
+        type: 'resubscribe'
+      })
+    }
+    await route.fulfill({ json: this.resubscribeResponse })
+  }
+
+  private async handleOperation(route: Route, pathname: string): Promise<void> {
+    const operationId = decodeURIComponent(pathname.split('/').at(-1) ?? '')
+    const responses = this.operationResponses.get(operationId)
+    const poll = this.operationPolls.get(operationId) ?? 0
+    const configuredResponse = responses?.at(
+      Math.min(poll, responses.length - 1)
+    )
+    const response: BillingOpStatusResponse = {
+      ...(configuredResponse ?? SUCCEEDED_BILLING_OPERATION),
+      id: operationId
+    }
+    this.operationPolls.set(operationId, poll + 1)
+
+    if (response.status === 'succeeded') {
+      this.applyPendingMutation(operationId)
+    }
+    await route.fulfill({ json: response })
+  }
+
+  private async failIfConfigured(
+    route: Route,
+    mutation: keyof BillingMutationRequests
+  ): Promise<boolean> {
+    const failure = this.failures?.[mutation]
+    if (!failure) return false
+
+    const body: ErrorResponse = {
+      code: failure.code ?? 'billing_mock_error',
+      message: failure.message
+    }
+    await route.fulfill({ status: failure.status, json: body })
+    return true
+  }
+
+  private applyPendingMutation(operationId: string): void {
+    if (this.appliedOperations.has(operationId)) return
+    const mutation = this.pendingMutations.get(operationId)
+    if (!mutation) return
+
+    if (mutation.type === 'subscribe') this.applySubscribe(mutation.request)
+    if (mutation.type === 'topup') this.applyTopup(mutation.amountCents)
+    if (mutation.type === 'cancel') this.applyCancel(mutation.cancelAt)
+    if (mutation.type === 'resubscribe') this.applyResubscribe()
+    this.appliedOperations.add(operationId)
+  }
+
+  private applySubscribe(request: SubscribeRequest): void {
+    const plan = this.state.plans.plans.find(
+      ({ slug }) => slug === request.plan_slug
+    )
+    const stop = this.state.plans.team_credit_stops?.stops.find(
+      ({ id }) => id === request.team_credit_stop_id
+    )
+
+    this.state.status = {
+      ...this.state.status,
+      is_active: true,
+      subscription_status: 'active',
+      subscription_tier: plan?.tier ?? this.state.status.subscription_tier,
+      subscription_duration:
+        plan?.duration ?? this.state.status.subscription_duration,
+      plan_slug: request.plan_slug,
+      billing_status: 'paid',
+      renewal_date: this.state.status.renewal_date ?? BILLING_RENEWAL_DATE,
+      team_credit_stop:
+        plan?.tier === 'TEAM' && stop
+          ? {
+              id: stop.id,
+              credits_monthly: stop.credits,
+              stop_usd: stop.yearly.list_price_cents / 100
+            }
+          : null
+    }
+    this.state.plans.current_plan_slug = request.plan_slug
+    if (this.postSubscribeBalance) {
+      this.state.balance = structuredClone(this.postSubscribeBalance)
+    }
+  }
+
+  private applyTopup(amountCents: number): void {
+    const balance = this.state.balance
+    this.state.balance = {
+      ...balance,
+      amount_micros: balance.amount_micros + amountCents,
+      effective_balance_micros:
+        (balance.effective_balance_micros ?? balance.amount_micros) +
+        amountCents,
+      prepaid_balance_micros:
+        (balance.prepaid_balance_micros ?? 0) + amountCents
+    }
+    this.state.status = { ...this.state.status, has_funds: true }
+  }
+
+  private applyCancel(cancelAt: string): void {
+    this.state.status = {
+      ...this.state.status,
+      is_active: true,
+      subscription_status: 'canceled',
+      cancel_at: cancelAt
+    }
+  }
+
+  private applyResubscribe(): void {
+    const status = { ...this.state.status }
+    delete status.cancel_at
+    this.state.status = {
+      ...status,
+      is_active: true,
+      subscription_status: 'active'
+    }
+  }
+}
+
+export const cloudBillingApiFixture = base.extend<{
+  billingApi: CloudBillingApiMock
+}>({
+  billingApi: async ({ page }, use) => {
+    const billingApi = new CloudBillingApiMock(page)
+    await use(billingApi)
+    await billingApi.dispose()
+  }
+})

--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,4 +1,15 @@
-import type { BillingStatusResponse as IngestBillingStatusResponse } from '@comfyorg/ingest-types'
+import type {
+  BillingBalanceResponse,
+  BillingOpStatusResponse,
+  BillingPlansResponse,
+  BillingStatusResponse as IngestBillingStatusResponse,
+  CancelSubscriptionResponse,
+  CreateTopupResponse,
+  PreviewSubscribeResponse,
+  ResubscribeResponse,
+  SubscribeResponse,
+  TeamCreditStops
+} from '@comfyorg/ingest-types'
 
 import type {
   Member,
@@ -124,4 +135,178 @@ export const TEAM_PRO_PLAN: Plan = {
     total_cost_cents: 40000,
     total_credits_cents: 0
   }
+}
+
+export const BILLING_RENEWAL_DATE = '2099-02-20T00:00:00Z'
+const BILLING_OPERATION_STARTED_AT = '2099-01-20T00:00:00Z'
+const BILLING_OPERATION_COMPLETED_AT = '2099-01-20T00:00:01Z'
+
+function billingPlan(
+  slug: string,
+  tier: Plan['tier'],
+  duration: Plan['duration'],
+  priceCents: number,
+  creditsCents: number,
+  maxSeats: number,
+  seatCount: number
+): Plan {
+  return {
+    slug,
+    tier,
+    duration,
+    price_cents: priceCents,
+    credits_cents: creditsCents,
+    max_seats: maxSeats,
+    availability: { available: true },
+    seat_summary: {
+      seat_count: seatCount,
+      total_cost_cents: priceCents * seatCount,
+      total_credits_cents: creditsCents * seatCount
+    }
+  }
+}
+
+export const DEFAULT_BILLING_STATUS = {
+  is_active: false,
+  max_seats: 1,
+  occupied_seats: 1,
+  subscription_tier: 'FREE',
+  billing_status: 'inactive',
+  has_funds: true,
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse
+
+export const PERSONAL_BILLING_STATUS = {
+  is_active: true,
+  max_seats: 1,
+  occupied_seats: 1,
+  subscription_status: 'active',
+  subscription_tier: 'STANDARD',
+  subscription_duration: 'ANNUAL',
+  plan_slug: 'standard-annual',
+  billing_status: 'paid',
+  has_funds: true,
+  renewal_date: BILLING_RENEWAL_DATE,
+  team_credit_stop: null
+} satisfies IngestBillingStatusResponse
+
+export const TEAM_CREDIT_BILLING_STATUS = {
+  is_active: true,
+  max_seats: 30,
+  occupied_seats: DEFAULT_TEAM_MEMBERS.length,
+  subscription_status: 'active',
+  subscription_tier: 'TEAM',
+  subscription_duration: 'ANNUAL',
+  plan_slug: 'team_per_credit_annual',
+  billing_status: 'paid',
+  has_funds: true,
+  renewal_date: BILLING_RENEWAL_DATE,
+  team_credit_stop: {
+    id: 'team_700',
+    credits_monthly: 147_700,
+    stop_usd: 700
+  }
+} satisfies IngestBillingStatusResponse
+
+export const DEFAULT_BILLING_BALANCE: BillingBalanceResponse = {
+  amount_micros: 2_500,
+  currency: 'usd',
+  effective_balance_micros: 2_500,
+  cloud_credit_balance_micros: 2_000,
+  prepaid_balance_micros: 500
+}
+
+const PERSONAL_STANDARD_ANNUAL_PLAN = billingPlan(
+  'standard-annual',
+  'STANDARD',
+  'ANNUAL',
+  19_200,
+  4_200,
+  1,
+  1
+)
+
+const PERSONAL_PLANS: Plan[] = [
+  billingPlan('standard-monthly', 'STANDARD', 'MONTHLY', 2_000, 4_200, 1, 1),
+  PERSONAL_STANDARD_ANNUAL_PLAN,
+  billingPlan('creator-monthly', 'CREATOR', 'MONTHLY', 3_500, 7_400, 5, 1),
+  billingPlan('creator-annual', 'CREATOR', 'ANNUAL', 33_600, 7_400, 5, 1),
+  billingPlan('pro-monthly', 'PRO', 'MONTHLY', 10_000, 21_100, 20, 1),
+  billingPlan('pro-annual', 'PRO', 'ANNUAL', 96_000, 21_100, 20, 1)
+]
+
+const DEFAULT_TEAM_CREDIT_STOPS: TeamCreditStops = {
+  default_stop_index: 0,
+  stops: [
+    {
+      id: 'team_700',
+      credits: 147_700,
+      monthly: { list_price_cents: 70_000, price_cents: 66_500 },
+      yearly: { list_price_cents: 70_000, price_cents: 63_000 }
+    }
+  ]
+}
+
+export const DEFAULT_BILLING_PLANS: BillingPlansResponse = {
+  plans: PERSONAL_PLANS,
+  team_credit_stops: DEFAULT_TEAM_CREDIT_STOPS
+}
+
+export const DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE: PreviewSubscribeResponse = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  effective_at: BILLING_OPERATION_COMPLETED_AT,
+  is_immediate: true,
+  cost_today_cents: PERSONAL_STANDARD_ANNUAL_PLAN.price_cents,
+  cost_next_period_cents: PERSONAL_STANDARD_ANNUAL_PLAN.price_cents,
+  credits_today_cents: PERSONAL_STANDARD_ANNUAL_PLAN.credits_cents,
+  credits_next_period_cents: PERSONAL_STANDARD_ANNUAL_PLAN.credits_cents,
+  new_plan: PERSONAL_STANDARD_ANNUAL_PLAN
+}
+
+export const DEFAULT_SUBSCRIBE_RESPONSE: SubscribeResponse = {
+  billing_op_id: 'billing-op-subscribe',
+  status: 'subscribed',
+  effective_at: BILLING_OPERATION_COMPLETED_AT
+}
+
+export const DEFAULT_TOPUP_RESPONSE: CreateTopupResponse = {
+  billing_op_id: 'billing-op-topup',
+  topup_id: 'topup-1',
+  status: 'completed',
+  amount_cents: 2_500
+}
+
+export const PENDING_TOPUP_RESPONSE: CreateTopupResponse = {
+  ...DEFAULT_TOPUP_RESPONSE,
+  status: 'pending'
+}
+
+export const DEFAULT_CANCEL_RESPONSE: CancelSubscriptionResponse = {
+  billing_op_id: 'billing-op-cancel',
+  cancel_at: BILLING_RENEWAL_DATE
+}
+
+export const DEFAULT_RESUBSCRIBE_RESPONSE: ResubscribeResponse = {
+  billing_op_id: 'billing-op-resubscribe',
+  status: 'active'
+}
+
+export const PENDING_BILLING_OPERATION: BillingOpStatusResponse = {
+  id: 'billing-op',
+  status: 'pending',
+  started_at: BILLING_OPERATION_STARTED_AT
+}
+
+export const SUCCEEDED_BILLING_OPERATION: BillingOpStatusResponse = {
+  ...PENDING_BILLING_OPERATION,
+  status: 'succeeded',
+  completed_at: BILLING_OPERATION_COMPLETED_AT
+}
+
+export const FAILED_BILLING_OPERATION: BillingOpStatusResponse = {
+  ...PENDING_BILLING_OPERATION,
+  status: 'failed',
+  error_message: 'Mock billing operation failed',
+  completed_at: BILLING_OPERATION_COMPLETED_AT
 }

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -28,6 +28,10 @@ interface MemberMockState {
   patches: RoleChangeRequest[]
 }
 
+interface CloudWorkspaceMockOptions {
+  mockBilling?: boolean
+}
+
 const jsonRoute = (body: unknown) => ({
   status: 200,
   contentType: 'application/json',
@@ -48,9 +52,15 @@ export class CloudWorkspaceMockHelper {
   async setup(
     members: Member[] = DEFAULT_TEAM_MEMBERS,
     activeWorkspace: WorkspaceWithRole = TEAM_WORKSPACE,
-    billingStatus: BillingStatusResponse = TEAM_BILLING_STATUS
+    billingStatus: BillingStatusResponse = TEAM_BILLING_STATUS,
+    { mockBilling = true }: CloudWorkspaceMockOptions = {}
   ): Promise<MemberMockState> {
-    const state = await this.mockBoot(members, activeWorkspace, billingStatus)
+    const state = await this.mockBoot(
+      members,
+      activeWorkspace,
+      billingStatus,
+      mockBilling
+    )
     await new CloudAuthHelper(this.page).mockAuth()
     await this.page.addInitScript((workspaceId) => {
       localStorage.setItem('Comfy.userId', 'test-user-e2e')
@@ -62,7 +72,8 @@ export class CloudWorkspaceMockHelper {
   private async mockBoot(
     members: Member[],
     activeWorkspace: WorkspaceWithRole,
-    billingStatus: BillingStatusResponse
+    billingStatus: BillingStatusResponse,
+    mockBilling: boolean
   ): Promise<MemberMockState> {
     const state: MemberMockState = {
       members: members.map((m) => ({ ...m })),
@@ -135,41 +146,44 @@ export class CloudWorkspaceMockHelper {
       r.fulfill(jsonRoute({ invites: [] }))
     )
 
-    await page.route('**/api/billing/status', (r) =>
-      r.fulfill(jsonRoute(billingStatus))
-    )
-    await page.route('**/api/billing/balance', (r) =>
-      r.fulfill(
-        jsonRoute({
-          amount_micros: 6000,
-          currency: 'usd',
-          effective_balance_micros: 6000,
-          cloud_credit_balance_micros: 5000,
-          prepaid_balance_micros: 1000
-        })
+    if (mockBilling) {
+      await page.route('**/api/billing/status', (r) =>
+        r.fulfill(jsonRoute(billingStatus))
       )
-    )
-    const currentPlan: Plan =
-      billingStatus.plan_slug && billingStatus.plan_slug !== TEAM_PRO_PLAN.slug
-        ? {
-            ...TEAM_PRO_PLAN,
-            slug: billingStatus.plan_slug,
-            tier:
-              billingStatus.subscription_tier === 'TEAM'
-                ? TEAM_PRO_PLAN.tier
-                : (billingStatus.subscription_tier ?? TEAM_PRO_PLAN.tier),
-            duration:
-              billingStatus.subscription_duration ?? TEAM_PRO_PLAN.duration
-          }
-        : TEAM_PRO_PLAN
-    await page.route('**/api/billing/plans', (r) =>
-      r.fulfill(
-        jsonRoute({
-          current_plan_slug: currentPlan.slug,
-          plans: [currentPlan]
-        })
+      await page.route('**/api/billing/balance', (r) =>
+        r.fulfill(
+          jsonRoute({
+            amount_micros: 6000,
+            currency: 'usd',
+            effective_balance_micros: 6000,
+            cloud_credit_balance_micros: 5000,
+            prepaid_balance_micros: 1000
+          })
+        )
       )
-    )
+      const currentPlan: Plan =
+        billingStatus.plan_slug &&
+        billingStatus.plan_slug !== TEAM_PRO_PLAN.slug
+          ? {
+              ...TEAM_PRO_PLAN,
+              slug: billingStatus.plan_slug,
+              tier:
+                billingStatus.subscription_tier === 'TEAM'
+                  ? TEAM_PRO_PLAN.tier
+                  : (billingStatus.subscription_tier ?? TEAM_PRO_PLAN.tier),
+              duration:
+                billingStatus.subscription_duration ?? TEAM_PRO_PLAN.duration
+            }
+          : TEAM_PRO_PLAN
+      await page.route('**/api/billing/plans', (r) =>
+        r.fulfill(
+          jsonRoute({
+            current_plan_slug: currentPlan.slug,
+            plans: [currentPlan]
+          })
+        )
+      )
+    }
 
     return state
   }

--- a/browser_tests/tests/billingPartnerNodeLifecycle.spec.ts
+++ b/browser_tests/tests/billingPartnerNodeLifecycle.spec.ts
@@ -1,0 +1,390 @@
+import { expect } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
+import type {
+  BillingBalanceResponse,
+  ListWorkspaceInvitesResponse,
+  PromptRequest
+} from '@comfyorg/ingest-types'
+
+import type { PromptResponse } from '@/schemas/apiSchema'
+import { zJobsListResponse } from '@/platform/remote/comfyui/jobs/jobTypes'
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import type { NodeId } from '@/types/nodeId'
+
+import { cloudBillingApiFixture } from '@e2e/fixtures/cloudBillingApiFixture'
+import { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_TEAM_MEMBERS,
+  PERSONAL_BILLING_STATUS,
+  TEAM_CREDIT_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const API_NODE_TYPE = 'DevToolsNodeWithPriceBadge'
+const JOB_ID = 'partner-run-job'
+const PROMPT_ROUTE_PATTERN = /\/api\/prompt$/
+const PERSONAL_WORKSPACE = workspace('personal', 'owner')
+const TEAM_MEMBER_WORKSPACE = workspace('team', 'member')
+
+const POST_RUN_BALANCE: BillingBalanceResponse = {
+  ...DEFAULT_BILLING_BALANCE,
+  amount_micros: 2_000,
+  effective_balance_micros: 2_000,
+  cloud_credit_balance_micros: 1_500
+}
+
+const EMPTY_INVITES: ListWorkspaceInvitesResponse = { invites: [] }
+
+const API_NODE_DEFS: Record<string, ComfyNodeDef> = {
+  [API_NODE_TYPE]: {
+    name: API_NODE_TYPE,
+    display_name: 'Node With Price Badge',
+    description: 'An API node with a price badge',
+    category: 'api node',
+    python_module: 'comfy_api_nodes',
+    input: {
+      required: {
+        price: [['1x', '2x', '3x'], { default: '1x' }]
+      }
+    },
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    output_node: true,
+    api_node: true,
+    price_badge: {
+      engine: 'jsonata',
+      depends_on: {
+        widgets: [{ name: 'price', type: 'COMBO' }],
+        inputs: [],
+        input_groups: []
+      },
+      expr: "{'type':'text','text':'1 credit/Run'}"
+    }
+  }
+}
+
+const EMPTY_JOBS = zJobsListResponse.parse({
+  jobs: [],
+  pagination: {
+    offset: 0,
+    limit: 200,
+    total: 0,
+    has_more: false
+  }
+})
+
+interface PartnerApp {
+  comfyPage: ComfyPage
+  partnerNodeId: NodeId
+}
+
+async function mockGraphApi(page: Page): Promise<void> {
+  const promptStatus: PromptResponse = {
+    exec_info: { queue_remaining: 0 },
+    error: ''
+  }
+
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute(promptStatus))
+  })
+  await page.route('**/api/object_info', (route) =>
+    route.fulfill(jsonRoute(API_NODE_DEFS))
+  )
+  await page.route('**/api/jobs**', (route) =>
+    route.fulfill(jsonRoute(EMPTY_JOBS))
+  )
+  await page.route('**/api/workspace/invites', (route) =>
+    route.fulfill(jsonRoute(EMPTY_INVITES))
+  )
+}
+
+async function mockPromptPost(
+  page: Page,
+  response: PromptResponse,
+  status = 200
+) {
+  const handler = async (route: Route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback()
+      return
+    }
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+  }
+  await page.route(PROMPT_ROUTE_PATTERN, handler)
+  return handler
+}
+
+const test = cloudBillingApiFixture.extend<{
+  partnerApp: PartnerApp
+  partnerWorkspace: WorkspaceWithRole
+}>({
+  partnerWorkspace: [PERSONAL_WORKSPACE, { option: true }],
+  partnerApp: async ({ billingApi, page, partnerWorkspace, request }, use) => {
+    await billingApi.setup({
+      status:
+        partnerWorkspace.type === 'team'
+          ? TEAM_CREDIT_BILLING_STATUS
+          : PERSONAL_BILLING_STATUS,
+      balance: DEFAULT_BILLING_BALANCE
+    })
+    await new CloudWorkspaceMockHelper(page).setup(
+      DEFAULT_TEAM_MEMBERS,
+      partnerWorkspace,
+      undefined,
+      { mockBilling: false }
+    )
+    await page.route('**/api/settings/**', (route) =>
+      route.fulfill(jsonRoute({}))
+    )
+    await mockGraphApi(page)
+
+    await page.goto(APP_URL)
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+
+    const comfyPage = new ComfyPage(page, request)
+    await comfyPage.workflow.waitForActiveWorkflow()
+    await comfyPage.workflow.waitForWorkflowIdle()
+    await comfyPage.settings.setSetting('Comfy.NodeBadge.ShowApiPricing', true)
+    const partnerNode = await comfyPage.nodeOps.addNode(
+      API_NODE_TYPE,
+      undefined,
+      { x: 100, y: 100 }
+    )
+
+    await use({
+      comfyPage,
+      partnerNodeId: partnerNode.id
+    })
+  }
+})
+
+test.describe('Billing partner-node lifecycle', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('BILL-N01 presents the price, queues the node, and renders the refreshed balance', async ({
+    billingApi,
+    page,
+    partnerApp
+  }) => {
+    const { comfyPage, partnerNodeId } = partnerApp
+    const currentUserButton = page.getByRole('button', {
+      name: 'Current user'
+    })
+    const popover = page.locator('.current-user-popover')
+
+    const displayedPrices = await page.evaluate((nodeId) => {
+      const node = window.app!.graph.getNodeById(nodeId)
+      return (
+        node?.badges.map((badge) =>
+          typeof badge === 'function' ? badge().text : badge.text
+        ) ?? []
+      )
+    }, partnerNodeId)
+    expect(displayedPrices).toContain('1 credit/Run')
+
+    await currentUserButton.click()
+    await expect(popover.getByText('5,275', { exact: true })).toBeVisible()
+    await currentUserButton.click()
+    await expect(popover).toBeHidden()
+
+    const response: PromptResponse = {
+      prompt_id: JOB_ID,
+      node_errors: {},
+      error: ''
+    }
+    const promptPostHandler = await mockPromptPost(page, response)
+
+    const promptRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' && PROMPT_ROUTE_PATTERN.test(request.url())
+    )
+    const promptResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        PROMPT_ROUTE_PATTERN.test(response.url())
+    )
+    await comfyPage.actionbar.queueButton.primaryButton.click()
+
+    const promptRequest = (await promptRequestPromise).postDataJSON() as
+      | PromptRequest
+      | undefined
+    await promptResponsePromise
+    await page.unroute(PROMPT_ROUTE_PATTERN, promptPostHandler)
+    expect(promptRequest?.prompt).toBeDefined()
+    expect(Object.values(promptRequest?.prompt ?? {})).toContainEqual(
+      expect.objectContaining({
+        class_type: API_NODE_TYPE,
+        inputs: expect.objectContaining({ price: '1x' })
+      })
+    )
+    expect(promptRequest?.extra_data).toEqual(
+      expect.objectContaining({
+        comfy_usage_source: 'comfyui-frontend',
+        extra_pnginfo: expect.objectContaining({
+          workflow: expect.any(Object)
+        })
+      })
+    )
+
+    await comfyPage.nextFrame()
+    const cancelRunButton = page.getByRole('button', {
+      name: 'Cancel current run'
+    })
+    await page.evaluate(
+      ({ jobId, nodeId }) => {
+        window.app!.api.dispatchCustomEvent('execution_start', {
+          prompt_id: jobId,
+          timestamp: Date.now()
+        })
+        window.app!.api.dispatchCustomEvent('executing', nodeId)
+      },
+      { jobId: JOB_ID, nodeId: partnerNodeId }
+    )
+    await expect(cancelRunButton).toBeEnabled()
+    await page.evaluate(
+      ({ jobId, nodeId }) => {
+        window.app!.api.dispatchCustomEvent('executed', {
+          prompt_id: jobId,
+          node: nodeId,
+          display_node: nodeId,
+          output: {}
+        })
+        window.app!.api.dispatchCustomEvent('execution_success', {
+          prompt_id: jobId,
+          timestamp: Date.now()
+        })
+      },
+      { jobId: JOB_ID, nodeId: partnerNodeId }
+    )
+    await expect(cancelRunButton).toBeDisabled()
+    billingApi.setBalance(POST_RUN_BALANCE)
+
+    const balanceRefresh = page.waitForResponse((response) => {
+      const request = response.request()
+      return (
+        request.method() === 'GET' &&
+        new URL(response.url()).pathname.endsWith('/api/billing/balance') &&
+        response.status() === 200
+      )
+    })
+    await currentUserButton.click()
+    await balanceRefresh
+    await expect(popover.getByText('4,220', { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Plans for Personal Workspace' })
+    ).toBeHidden()
+    await expect(page.getByTestId(TestIds.dialogs.errorOverlay)).toBeHidden()
+  })
+
+  test('BILL-N02 keeps insufficient-credit recovery visible when billing refresh fails', async ({
+    billingApi,
+    page,
+    partnerApp
+  }) => {
+    const { comfyPage } = partnerApp
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => pageErrors.push(error))
+    billingApi.setQueryFailure('status', {
+      status: 503,
+      message: 'Billing status unavailable'
+    })
+    billingApi.setQueryFailure('balance', {
+      status: 503,
+      message: 'Billing balance unavailable'
+    })
+
+    const response: PromptResponse = {
+      node_errors: {},
+      error: {
+        type: 'PAYMENT_REQUIRED',
+        message: 'Insufficient credits to queue workflows',
+        details: ''
+      }
+    }
+    const promptPostHandler = await mockPromptPost(page, response, 429)
+
+    const promptResponsePromise = page.waitForResponse(
+      (promptResponse) =>
+        promptResponse.request().method() === 'POST' &&
+        PROMPT_ROUTE_PATTERN.test(promptResponse.url())
+    )
+    const statusFailure = page.waitForResponse(
+      (billingResponse) =>
+        billingResponse.request().method() === 'GET' &&
+        new URL(billingResponse.url()).pathname.endsWith(
+          '/api/billing/status'
+        ) &&
+        billingResponse.status() === 503
+    )
+    const balanceFailure = page.waitForResponse(
+      (billingResponse) =>
+        billingResponse.request().method() === 'GET' &&
+        new URL(billingResponse.url()).pathname.endsWith(
+          '/api/billing/balance'
+        ) &&
+        billingResponse.status() === 503
+    )
+    await comfyPage.actionbar.queueButton.primaryButton.click()
+    await Promise.all([promptResponsePromise, statusFailure, balanceFailure])
+    await page.unroute(PROMPT_ROUTE_PATTERN, promptPostHandler)
+
+    const topUpDialog = new TopUpCreditsDialog(page)
+    await expect(topUpDialog.insufficientHeading).toBeVisible()
+    await expect(topUpDialog.root).toContainText(
+      "You don't have enough credits to run this workflow"
+    )
+    await expect(page.getByTestId(TestIds.dialogs.errorOverlay)).toBeHidden()
+    await expect(page.getByTestId(TestIds.dialogs.errorDialog)).toBeHidden()
+    expect(pageErrors).toEqual([])
+  })
+
+  test.describe('team member', () => {
+    test.use({ partnerWorkspace: TEAM_MEMBER_WORKSPACE })
+
+    test('BILL-N03 keeps insufficient-credit recovery private from members', async ({
+      page,
+      partnerApp
+    }) => {
+      const response: PromptResponse = {
+        node_errors: {},
+        error: {
+          type: 'PAYMENT_REQUIRED',
+          message: 'Insufficient credits to queue workflows',
+          details: ''
+        }
+      }
+      const promptPostHandler = await mockPromptPost(page, response, 429)
+
+      const promptResponsePromise = page.waitForResponse(
+        (promptResponse) =>
+          promptResponse.request().method() === 'POST' &&
+          PROMPT_ROUTE_PATTERN.test(promptResponse.url())
+      )
+      await partnerApp.comfyPage.actionbar.queueButton.primaryButton.click()
+      await promptResponsePromise
+      await page.unroute(PROMPT_ROUTE_PATTERN, promptPostHandler)
+
+      await expect(
+        page.getByTestId('insufficient-credits-member-message')
+      ).toBeVisible()
+      await expect(
+        page.getByRole('button', { name: 'Add credits' })
+      ).toBeHidden()
+    })
+  })
+})

--- a/browser_tests/tests/dialogs/billingTopUp.spec.ts
+++ b/browser_tests/tests/dialogs/billingTopUp.spec.ts
@@ -1,0 +1,331 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page, Request } from '@playwright/test'
+
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { TopUpCreditsDialog } from '@e2e/fixtures/components/TopUpCreditsDialog'
+import {
+  DEFAULT_BILLING_BALANCE,
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_TEAM_MEMBERS,
+  FAILED_BILLING_OPERATION,
+  PERSONAL_BILLING_STATUS,
+  PENDING_BILLING_OPERATION,
+  PENDING_TOPUP_RESPONSE,
+  TEAM_CREDIT_BILLING_STATUS,
+  TEAM_WORKSPACE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const PERSONAL_WORKSPACE = workspace('personal', 'owner')
+
+interface BillingRequestCounts {
+  balance: number
+  status: number
+  operations: number
+}
+
+function trackBillingRequests(page: Page): BillingRequestCounts {
+  const counts: BillingRequestCounts = {
+    balance: 0,
+    status: 0,
+    operations: 0
+  }
+
+  page.on('request', (request: Request) => {
+    if (request.method() !== 'GET') return
+
+    const pathname = new URL(request.url()).pathname
+    if (pathname.endsWith('/api/billing/balance')) counts.balance += 1
+    if (pathname.endsWith('/api/billing/status')) counts.status += 1
+    if (pathname.includes('/api/billing/ops/')) counts.operations += 1
+  })
+
+  return counts
+}
+
+async function bootTopUpDialog(
+  page: Page,
+  activeWorkspace: WorkspaceWithRole = PERSONAL_WORKSPACE
+): Promise<TopUpCreditsDialog> {
+  await new CloudWorkspaceMockHelper(page).setup(
+    DEFAULT_TEAM_MEMBERS,
+    activeWorkspace,
+    undefined,
+    { mockBilling: false }
+  )
+
+  const initialBillingResponses = ['status', 'balance', 'plans'].map(
+    (endpoint) =>
+      page.waitForResponse((response) => {
+        const request = response.request()
+        return (
+          request.method() === 'GET' &&
+          new URL(request.url()).pathname.endsWith(`/api/billing/${endpoint}`)
+        )
+      })
+  )
+
+  await page.goto(APP_URL)
+  await Promise.all(initialBillingResponses)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  const dialog = new TopUpCreditsDialog(page)
+  await dialog.open()
+  await expect(dialog.heading).toBeVisible()
+  return dialog
+}
+
+async function expectWorkspaceCredits(
+  page: Page,
+  workspaceName: string
+): Promise<Locator> {
+  const settings = page.getByTestId('settings-dialog')
+  await expect(settings).toBeVisible()
+
+  const content = settings.getByRole('main')
+  await expect(
+    content.getByRole('heading', { name: workspaceName })
+  ).toBeVisible()
+  await expect(
+    content.getByRole('tab', { name: 'Plan & Credits' })
+  ).toHaveAttribute('data-state', 'active')
+  await expect(content.getByText('Total credits')).toBeVisible()
+  return content
+}
+
+async function submitTopUp(dialog: TopUpCreditsDialog, amount: string) {
+  await dialog.root.getByRole('button', { name: 'Add credits' }).click()
+  await expect(
+    dialog.root.getByRole('heading', { name: 'Confirm' })
+  ).toBeVisible()
+  await dialog.root.getByRole('button', { name: `Pay $${amount}` }).click()
+}
+
+test.describe('Billing top-up flows', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('BILL-T01 personal preset posts exact cents', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const dialog = await bootTopUpDialog(page)
+
+    await dialog.preset10.click()
+    await submitTopUp(dialog, '10.00')
+
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 1_000 }])
+  })
+
+  test('BILL-T02 personal custom amount posts exact cents', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const dialog = await bootTopUpDialog(page)
+
+    await dialog.payAmountInput.click()
+    await dialog.payAmountInput.press('ControlOrMeta+A')
+    await dialog.payAmountInput.pressSequentially('37')
+    await expect(dialog.payAmountInput).toHaveValue('37')
+    await submitTopUp(dialog, '37.00')
+
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 3_700 }])
+  })
+
+  test('BILL-T07 caps custom top-ups and links enterprise billing', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({ status: PERSONAL_BILLING_STATUS })
+    const dialog = await bootTopUpDialog(page)
+
+    await dialog.payAmountInput.click()
+    await dialog.payAmountInput.press('ControlOrMeta+A')
+    await dialog.payAmountInput.pressSequentially('9999')
+    await dialog.root
+      .getByTestId('top-up-pay-amount')
+      .getByRole('button', { name: 'Increment' })
+      .click()
+
+    await expect(dialog.payAmountInput).toHaveValue('10,000')
+    const enterpriseLink = dialog.root.getByRole('link', { name: 'Contact us' })
+    await expect(enterpriseLink).toHaveAttribute(
+      'href',
+      'https://www.comfy.org/cloud/enterprise'
+    )
+    await expect(enterpriseLink).toHaveAttribute('target', '_blank')
+  })
+
+  test('BILL-T03 team owner top-up returns to the active workspace credit pool', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: TEAM_CREDIT_BILLING_STATUS,
+      plans: {
+        ...DEFAULT_BILLING_PLANS,
+        current_plan_slug: TEAM_CREDIT_BILLING_STATUS.plan_slug
+      }
+    })
+    const dialog = await bootTopUpDialog(page, TEAM_WORKSPACE)
+
+    await dialog.preset100.click()
+    await submitTopUp(dialog, '100.00')
+
+    const content = await expectWorkspaceCredits(page, TEAM_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 10_000 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 12_500,
+      effective_balance_micros: 12_500,
+      prepaid_balance_micros: 10_500
+    })
+    await expect(content.getByText('26,375', { exact: true })).toBeVisible()
+  })
+
+  test('BILL-T04 pending top-up polls to success and applies one balance increment', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      topupResponse: PENDING_TOPUP_RESPONSE,
+      operationResponses: {
+        'billing-op-topup': [PENDING_BILLING_OPERATION]
+      }
+    })
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+    counts.operations = 0
+
+    await dialog.preset25.click()
+    await submitTopUp(dialog, '25.00')
+
+    await expect(
+      page.getByText('Processing payment — adding credits...')
+    ).toBeVisible()
+    billingApi.setOperationResponses('billing-op-topup', [
+      {
+        ...PENDING_BILLING_OPERATION,
+        status: 'succeeded',
+        completed_at: '2099-01-20T00:00:01Z'
+      }
+    ])
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    await expect(page.getByText('Credits added successfully')).toBeVisible()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 2_500 }])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 5_000,
+      effective_balance_micros: 5_000,
+      prepaid_balance_micros: 3_000
+    })
+    expect(counts.operations).toBeGreaterThanOrEqual(2)
+    expect(counts.balance).toBeGreaterThanOrEqual(1)
+    expect(counts.status).toBeGreaterThanOrEqual(1)
+  })
+
+  test('BILL-T05 HTTP rejection keeps the balance unchanged and supports retry', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      failures: {
+        topup: { status: 402, message: 'Card declined' }
+      }
+    })
+    const initialBalance = structuredClone(billingApi.state.balance)
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+
+    await dialog.preset25.click()
+    await submitTopUp(dialog, '25.00')
+
+    const errorToast = page
+      .locator('.p-toast-message.p-toast-message-error')
+      .filter({
+        hasText: 'Purchase Failed'
+      })
+    await expect(errorToast).toContainText('Purchase Failed')
+    await expect(errorToast).toContainText('An unknown error occurred')
+    await expect(
+      dialog.root.getByRole('heading', { name: 'Confirm' })
+    ).toBeVisible()
+    await expect(
+      dialog.root.getByRole('button', { name: 'Pay $25.00' })
+    ).toBeEnabled()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 2_500 }])
+    expect(billingApi.state.balance).toEqual(initialBalance)
+    expect(counts.balance).toBe(0)
+    expect(counts.status).toBe(0)
+
+    billingApi.setMutationFailure('topup', null)
+    await dialog.root.getByRole('button', { name: 'Pay $25.00' }).click()
+
+    await expectWorkspaceCredits(page, PERSONAL_WORKSPACE.name)
+    expect(billingApi.requests.topup).toEqual([
+      { amount_cents: 2_500 },
+      { amount_cents: 2_500 }
+    ])
+    expect(billingApi.state.balance).toEqual({
+      ...DEFAULT_BILLING_BALANCE,
+      amount_micros: 5_000,
+      effective_balance_micros: 5_000,
+      prepaid_balance_micros: 3_000
+    })
+  })
+
+  test('BILL-T06 failed operation keeps the balance unchanged and surfaces the operation error', async ({
+    billingApi,
+    page
+  }) => {
+    await billingApi.setup({
+      status: PERSONAL_BILLING_STATUS,
+      topupResponse: PENDING_TOPUP_RESPONSE,
+      operationResponses: {
+        'billing-op-topup': [FAILED_BILLING_OPERATION]
+      }
+    })
+    const initialBalance = structuredClone(billingApi.state.balance)
+    const counts = trackBillingRequests(page)
+    const dialog = await bootTopUpDialog(page)
+    counts.balance = 0
+    counts.status = 0
+    counts.operations = 0
+
+    await submitTopUp(dialog, '50.00')
+
+    const errorToast = page
+      .locator('.p-toast-message.p-toast-message-error')
+      .filter({
+        hasText: 'Top-up failed'
+      })
+    await expect(errorToast).toContainText('Top-up failed')
+    await expect(errorToast).toContainText('Mock billing operation failed')
+    await expect(
+      dialog.root.getByRole('heading', { name: 'Confirm' })
+    ).toBeVisible()
+    await expect(
+      dialog.root.getByRole('button', { name: 'Pay $50.00' })
+    ).toBeEnabled()
+    expect(billingApi.requests.topup).toEqual([{ amount_cents: 5_000 }])
+    expect(billingApi.state.balance).toEqual(initialBalance)
+    expect(counts.operations).toBe(1)
+    expect(counts.balance).toBe(0)
+    expect(counts.status).toBe(0)
+  })
+})

--- a/browser_tests/tests/dialogs/pricingTableBillingCycle.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableBillingCycle.spec.ts
@@ -1,0 +1,124 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { cloudBillingApiFixture as test } from '@e2e/fixtures/cloudBillingApiFixture'
+import { waitForCloudApp } from '@e2e/fixtures/cloudAppFixture'
+import {
+  DEFAULT_BILLING_PLANS,
+  DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { mockWorkspace, workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const BOOT_FEATURES = {
+  team_workspaces_enabled: true,
+  consolidated_billing_enabled: true,
+  billing_control_enabled: true
+} satisfies RemoteConfig
+const BOOT_SETTINGS = {
+  'Comfy.Assets.UseAssetAPI': false,
+  'Comfy.TutorialCompleted': true,
+  'Comfy.RightSidePanel.ShowErrorsTab': false
+}
+
+async function setupCloudPricing(page: Page) {
+  await mockCloudBoot(page, {
+    features: BOOT_FEATURES,
+    settings: BOOT_SETTINGS
+  })
+  await page.route('**/api/settings/**', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({}))
+  })
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+  })
+  await page.route('**/api/queue', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ queue_running: [], queue_pending: [] }))
+  })
+  await mockWorkspace(page, workspace('personal', 'owner'), [])
+  await bootCloud(page)
+}
+
+test.describe('Pricing table billing cycle', () => {
+  for (const { viewport, tag } of [
+    { viewport: 'desktop', tag: '@cloud' },
+    { viewport: 'mobile', tag: '@mobile-ios' }
+  ] as const) {
+    test(
+      `BILL-P01 switches Creator pricing from monthly to yearly on ${viewport}`,
+      { tag },
+      async ({ billingApi, page }) => {
+        test.slow()
+        const annualPlan = DEFAULT_BILLING_PLANS.plans.find(
+          ({ slug }) => slug === 'creator-annual'
+        )
+        if (!annualPlan) throw new Error('Missing creator-annual plan')
+
+        await billingApi.setup({
+          previewResponse: {
+            ...DEFAULT_PREVIEW_SUBSCRIBE_RESPONSE,
+            cost_today_cents: annualPlan.price_cents,
+            cost_next_period_cents: annualPlan.price_cents,
+            credits_today_cents: annualPlan.credits_cents,
+            credits_next_period_cents: annualPlan.credits_cents,
+            new_plan: annualPlan
+          }
+        })
+        await setupCloudPricing(page)
+        await page.goto(APP_URL)
+        await waitForCloudApp(page)
+        await page.getByTestId('current-user-button').click()
+        const userPopover = page.getByTestId('current-user-popover')
+        await expect(userPopover).toBeVisible()
+        await userPopover.getByTestId('plans-pricing-menu-item').click()
+
+        const dialog = page.getByRole('dialog').filter({
+          has: page.getByRole('heading', { name: 'Choose a Plan' })
+        })
+        await expect(dialog).toBeVisible({ timeout: 45_000 })
+
+        await dialog
+          .getByRole('button', { name: 'Monthly', exact: true })
+          .click()
+        const monthlyPlan = dialog.getByRole('button', {
+          name: 'Subscribe to Creator',
+          exact: true
+        })
+        await expect(monthlyPlan).toBeVisible()
+        expect(await monthlyPlan.locator('../..').innerText()).toContain('$35')
+
+        const yearlyToggle = dialog.getByRole('button', {
+          name: 'Yearly Save 20%',
+          exact: true
+        })
+        await expect(
+          yearlyToggle.getByText('Save 20%', { exact: true })
+        ).toBeVisible()
+        await yearlyToggle.click()
+
+        const yearlyPlan = dialog.getByRole('button', {
+          name: 'Subscribe to Creator Yearly',
+          exact: true
+        })
+        await expect(yearlyPlan).toBeVisible()
+        const yearlyPlanText = await yearlyPlan.locator('../..').innerText()
+        expect(yearlyPlanText).toContain('$28')
+        expect(yearlyPlanText).toContain('$336 Billed yearly')
+        await yearlyPlan.click()
+
+        await expect(
+          page.getByRole('heading', { name: 'Confirm your payment' })
+        ).toBeVisible()
+        expect(billingApi.requests.previewSubscribe).toEqual([
+          expect.objectContaining({ plan_slug: 'creator-annual' })
+        ])
+      }
+    )
+  }
+})

--- a/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/TopUpCreditsDialogContentWorkspace.vue
@@ -367,7 +367,7 @@ function getCreditsStepAmount(currentCredits: number): number {
 function handlePayAmountChange(value: number) {
   payAmount.value = value
   selectedPreset.value = null
-  showCeilingWarning.value = false
+  showCeilingWarning.value = value >= MAX_AMOUNT
 }
 
 function handlePresetClick(amount: number) {


### PR DESCRIPTION
## Summary

Makes the existing maximum top-up guidance reachable when a custom amount is clamped to $10,000. This is the isolated production prerequisite for the deterministic maximum-contract coverage in the follow-up billing E2E PR.

## Root cause

`handlePayAmountChange` always cleared `showCeilingWarning`. Since the number stepper clamps values to `MAX_AMOUNT`, the UI can never retain a value above $10,000, so the previous greater-than path could not expose the enterprise Contact us guidance.

## Change

Set the warning when the normalized custom value is equal to the maximum. Preset selection remains unchanged.

### AS IS

A custom value at or above $10,000 is clamped but hides enterprise guidance.

[AS IS screenshot](https://ampcode.com/user-content/artifacts/6f5bcdc4d255307bdaed598273b88977160cebe70cc89f89baa56c5330e79c0f-file.png)

### TO BE

The same clamped value shows the existing Maximum allowed and Contact us guidance.

[TO BE screenshot](https://ampcode.com/user-content/artifacts/4ef8548ce8b54dee264330d27bcef202cc5633667fecacd04c46d170a3a4b44b-file.png)

## Validation

- `pnpm typecheck`
- oxfmt, ESLint, oxlint, Stylelint
- knip push hook
- Browser regression coverage is stacked immediately after this PR in #14810.

## Stacking

- Base: #14713
- Follow-up deterministic browser coverage: #14810
