### PR TITLE
[backport core/1.49] fix(billing): surface an unknown billing op type instead of defaulting silently

### DIFF
--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -30,6 +30,7 @@ const mockShow = vi.hoisted(() => vi.fn())
 const mockStartOperation = vi.hoisted(() => vi.fn())
 const mockGetOperation = vi.hoisted(() => vi.fn())
 const mockSetWorkspaceBillingRail = vi.hoisted(() => vi.fn())
+const mockCaptureException = vi.hoisted(() => vi.fn())
 const mockActiveWorkspaceId = vi.hoisted(() => ({ value: 'workspace-1' }))
 
 // Hoisted so the vi.mock factory below can reference it: a plain top-level
@@ -72,6 +73,10 @@ vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
     getOperation: mockGetOperation,
     startOperation: mockStartOperation
   })
+}))
+
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
 }))
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
@@ -285,6 +290,30 @@ describe('useWorkspaceBilling', () => {
       )
     })
 
+    it('recovers a pending subscription reported explicitly', async () => {
+      // What the server sends today for an initial subscription or a plan
+      // change — distinct from the older servers that send no type at all.
+      const actionUrl = 'https://invoice.stripe.com/sensitive-token'
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-sub',
+        pending_billing_op_type: 'subscription',
+        action_url: actionUrl
+      } satisfies BillingStatusResponse)
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-sub',
+        'subscription',
+        undefined,
+        actionUrl
+      )
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
     it('recovers a pending top-up as a top-up, not a subscription', async () => {
       const actionUrl = 'https://invoice.stripe.com/sensitive-token'
       mockWorkspaceApi.getBillingStatus.mockResolvedValue({
@@ -303,6 +332,35 @@ describe('useWorkspaceBilling', () => {
         'topup',
         undefined,
         actionUrl
+      )
+    })
+
+    it('reports a resume mode it does not recognize', async () => {
+      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
+        ...activeStatus,
+        billing_status: 'pending_payment',
+        pending_billing_op_id: 'op-future',
+        // A server ahead of this bundle. Unrepresentable in the current union,
+        // which is why the branch cannot be left to the type system alone.
+        pending_billing_op_type: 'seat_change'
+      } as unknown as BillingStatusResponse)
+
+      const billing = setupBilling()
+      await billing.fetchStatus()
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('seat_change')
+        }),
+        { tags: { error_type: 'billing_unknown_resume_mode' } }
+      )
+      // Recovery is preserved deliberately: without it the customer has no way
+      // back to the payment page, while a wrong panel clears on reload.
+      expect(mockStartOperation).toHaveBeenCalledWith(
+        'op-future',
+        'subscription',
+        undefined,
+        undefined
       )
     })
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/vue'
 import { computed, ref, shallowRef } from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
@@ -25,6 +26,43 @@ import type {
   BillingState,
   SubscriptionInfo
 } from '../../../composables/billing/types'
+
+/**
+ * Which client path resumes a recovered operation. Exhaustive on purpose: the
+ * two-way check this replaces sent anything that was not `topup` down the
+ * subscription path, which covers the customer's real plan with a "setting up
+ * your subscription" spinner until the operation settles.
+ */
+function resumeModeFor(
+  type: BillingStatusResponse['pending_billing_op_type']
+): 'subscription' | 'topup' {
+  switch (type) {
+    case 'topup':
+      return 'topup'
+    case 'subscription':
+      return 'subscription'
+    // A server predating the field only ever had subscriptions to hand back.
+    case undefined:
+      return 'subscription'
+    default: {
+      const unexpected: never = type
+      // JSON.stringify, not String: the latter throws on a value with no
+      // callable toString/valueOf, and throwing out of the branch that exists
+      // to absorb a bad value would abort recovery entirely. The value came
+      // from a parsed response, so it cannot be circular.
+      captureException(
+        new Error(
+          `Unknown pending billing op type: ${JSON.stringify(unexpected)}`
+        ),
+        { tags: { error_type: 'billing_unknown_resume_mode' } }
+      )
+      // Reachable only against a newer server. Dropping recovery strands a
+      // customer who cannot reach the payment page; a wrong panel clears on
+      // reload, so recovery wins.
+      return 'subscription'
+    }
+  }
+}
 
 /**
  * Whether a rejection means the subscription already holds the state the caller
@@ -179,7 +217,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
       ) {
         void billingOperationStore.startOperation(
           status.pending_billing_op_id,
-          status.pending_billing_op_type === 'topup' ? 'topup' : 'subscription',
+          resumeModeFor(status.pending_billing_op_type),
           undefined,
           status.action_url
         )


### PR DESCRIPTION
Manual backport of #14759 — the automatic cherry-pick of `994d92a` hit a conflict.

Recovering a pending billing operation picked its client path with a two-way check, so anything that was not `topup` became `subscription` — including a value this client has never heard of. `subscription` is the worst branch to default into: a mislabelled operation flips `isSettingUp`, covering the user's real plan with a "setting up your subscription" spinner until the operation settles. This replaces the ternary with an exhaustive `switch` that reports an unrecognized value to Sentry (`billing_unknown_resume_mode`) and still resumes recovery.

No behavior change against any value the API sends today.

## Conflict resolution

One conflict, in the import block of `src/platform/workspace/composables/useWorkspaceBilling.ts`:

```
<<<<<<< HEAD
import { computed, ref, shallowRef } from 'vue'
=======
import { captureException } from '@sentry/vue'
import { computed, ref, shallowRef, watch } from 'vue'
>>>>>>>
```

`main` imports `watch` from an unrelated change that is not on this branch. Kept this branch's vue import and added the `@sentry/vue` import the cherry-pick needs. `watch` appears nowhere else in the file on this branch, so importing it would have been an unused-import error.

The rest of the commit — `resumeModeFor`, the call site, and all three tests — applied unchanged. The `pending_billing_op_type` union in `workspaceApi.ts` is identical here to `main`, so the `never` exhaustiveness check compiles as written.

## Verified on this branch

`vitest run --coverage` on `useWorkspaceBilling.test.ts` (74 passed), `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check`.
