### PR TITLE
feat(website): announce Seedance 2.5 at /seedance-2.5

### DIFF
--- a/apps/website/e2e/seedance-2.5.spec.ts
+++ b/apps/website/e2e/seedance-2.5.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from '@playwright/test'
+
+import { externalLinks, getRoutes } from '../src/config/routes'
+import { seedancePage } from '../src/data/seedance'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH = '/seedance-2.5'
+const HERO_TITLE = t('seedance.hero.title', 'en')
+const HERO_EYEBROW = t('seedance.hero.eyebrow', 'en')
+const HERO_CTA = t('seedance.hero.primaryCta', 'en')
+const RUN_OPTIONS_HEADING = t('seedance.runOptions.heading', 'en')
+const REVIEWS_HEADING = t('seedance.reviews.heading', 'en')
+const MODELS_ROUTE = getRoutes('en').models
+
+test.describe('Seedance 2.5 announcement page @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero over its backdrop and is indexable', async ({
+    page
+  }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+    await expect(hero.getByText(HERO_EYEBROW)).toBeVisible()
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+    await expect(hero.locator('img')).toHaveAttribute(
+      'src',
+      seedancePage.hero.placeholderImageSrc ?? ''
+    )
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+  })
+
+  test('hero CTA sends visitors to the cloud in a new tab', async ({
+    page
+  }) => {
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      })
+      .getByRole('link', { name: HERO_CTA })
+    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+    await expect(cta).toHaveAttribute('target', '_blank')
+  })
+
+  test('breadcrumb trail links to the models catalog', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: 'Breadcrumb' })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
+    await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
+  })
+
+  test('renders run options and reviews', async ({ page }) => {
+    const runOptions = page.getByRole('heading', {
+      level: 2,
+      name: RUN_OPTIONS_HEADING
+    })
+    await runOptions.scrollIntoViewIfNeeded()
+    await expect(runOptions).toBeVisible()
+
+    const reviews = page.getByRole('heading', {
+      level: 2,
+      name: REVIEWS_HEADING
+    })
+    await reviews.scrollIntoViewIfNeeded()
+    await expect(reviews).toBeVisible()
+  })
+
+  // The announcement page omits everything the model cannot back yet. If a
+  // future edit reintroduces one of these, it should be deliberate.
+  test('omits the sections that need a shipped model', async ({ page }) => {
+    await expect(page.locator('[id^="faq-trigger-"]')).toHaveCount(0)
+    await expect(
+      page.getByRole('heading', { level: 2, name: t('pricing.title', 'en') })
+    ).toHaveCount(0)
+    await expect(page.locator('video')).toHaveCount(0)
+  })
+})

--- a/apps/website/e2e/seedance-2.5.spec.ts
+++ b/apps/website/e2e/seedance-2.5.spec.ts
@@ -129,13 +129,21 @@ test.describe('Seedance 2.5 announcement page — mobile @mobile', () => {
       })
       .getByRole('link', { name: HERO_CTA })
 
+    await cta.scrollIntoViewIfNeeded()
     await expect(cta).toBeVisible()
     await expect(cta).toHaveAttribute('href', externalLinks.cloud)
 
     const box = await cta.boundingBox()
-    expect(box, 'hero CTA bounding box').not.toBeNull()
-    expect(box!.x + box!.width).toBeLessThanOrEqual(
-      page.viewportSize()!.width + 1
-    )
+    const viewport = page.viewportSize()
+    if (!box || !viewport) {
+      throw new Error('hero CTA has no layout box to measure')
+    }
+
+    // toBeVisible() does not imply the element sits inside the viewport, so
+    // check all four edges. One pixel of tolerance for subpixel rounding.
+    expect(box.x).toBeGreaterThanOrEqual(-1)
+    expect(box.y).toBeGreaterThanOrEqual(-1)
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height + 1)
   })
 })

--- a/apps/website/e2e/seedance-2.5.spec.ts
+++ b/apps/website/e2e/seedance-2.5.spec.ts
@@ -6,6 +6,7 @@ import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
 
 const PATH = '/seedance-2.5'
+const ZH_PATH = '/zh-CN/seedance-2.5'
 const HERO_TITLE = t('seedance.hero.title', 'en')
 const HERO_EYEBROW = t('seedance.hero.eyebrow', 'en')
 const HERO_CTA = t('seedance.hero.primaryCta', 'en')
@@ -50,7 +51,7 @@ test.describe('Seedance 2.5 announcement page @smoke', () => {
 
   test('breadcrumb trail links to the models catalog', async ({ page }) => {
     const modelsCrumb = page
-      .getByRole('navigation', { name: 'Breadcrumb' })
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
       .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
   })
@@ -71,13 +72,70 @@ test.describe('Seedance 2.5 announcement page @smoke', () => {
     await expect(reviews).toBeVisible()
   })
 
-  // The announcement page omits everything the model cannot back yet. If a
-  // future edit reintroduces one of these, it should be deliberate.
-  test('omits the sections that need a shipped model', async ({ page }) => {
-    await expect(page.locator('[id^="faq-trigger-"]')).toHaveCount(0)
-    await expect(
-      page.getByRole('heading', { level: 2, name: t('pricing.title', 'en') })
-    ).toHaveCount(0)
+  // The announcement omits gallery, pricing, FAQ and closing CTA, so these two
+  // are the only sections it should show. Asserting the whole set means
+  // reintroducing any of them has to be deliberate.
+  test('shows only the sections the announcement configures', async ({
+    page
+  }) => {
+    await expect(page.getByRole('heading', { level: 2 })).toHaveText([
+      RUN_OPTIONS_HEADING,
+      REVIEWS_HEADING
+    ])
     await expect(page.locator('video')).toHaveCount(0)
+  })
+})
+
+test.describe('Seedance 2.5 announcement page — zh-CN', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ZH_PATH)
+  })
+
+  test('renders the localized hero and run options', async ({ page }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+    await expect(
+      hero.getByText(t('seedance.hero.eyebrow', 'zh-CN'))
+    ).toBeVisible()
+    await expect(hero.getByRole('link')).toContainText(/[一-鿿]/)
+
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: t('seedance.runOptions.heading', 'zh-CN')
+      })
+    ).toBeVisible()
+  })
+
+  test('breadcrumb keeps visitors inside the locale', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'zh-CN') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'zh-CN') })
+    await expect(modelsCrumb).toHaveAttribute('href', getRoutes('zh-CN').models)
+  })
+})
+
+test.describe('Seedance 2.5 announcement page — mobile @mobile', () => {
+  test('hero CTA stays visible and linked at narrow viewports', async ({
+    page
+  }) => {
+    await page.goto(PATH)
+
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      })
+      .getByRole('link', { name: HERO_CTA })
+
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+
+    const box = await cta.boundingBox()
+    expect(box, 'hero CTA bounding box').not.toBeNull()
+    expect(box!.x + box!.width).toBeLessThanOrEqual(
+      page.viewportSize()!.width + 1
+    )
   })
 })

--- a/apps/website/e2e/seedance-2.5.spec.ts
+++ b/apps/website/e2e/seedance-2.5.spec.ts
@@ -7,11 +7,11 @@ import { test } from './fixtures/blockExternalMedia'
 
 const PATH = '/seedance-2.5'
 const ZH_PATH = '/zh-CN/seedance-2.5'
-const HERO_TITLE = t('seedance.hero.title', 'en')
-const HERO_EYEBROW = t('seedance.hero.eyebrow', 'en')
-const HERO_CTA = t('seedance.hero.primaryCta', 'en')
-const RUN_OPTIONS_HEADING = t('seedance.runOptions.heading', 'en')
-const REVIEWS_HEADING = t('seedance.reviews.heading', 'en')
+const HERO_TITLE = t('seedance.hero.title')
+const HERO_EYEBROW = t('seedance.hero.eyebrow')
+const HERO_CTA = t('seedance.hero.primaryCta')
+const RUN_OPTIONS_HEADING = t('seedance.runOptions.heading')
+const REVIEWS_HEADING = t('seedance.reviews.heading')
 const MODELS_ROUTE = getRoutes('en').models
 
 test.describe('Seedance 2.5 announcement page @smoke', () => {
@@ -51,8 +51,8 @@ test.describe('Seedance 2.5 announcement page @smoke', () => {
 
   test('breadcrumb trail links to the models catalog', async ({ page }) => {
     const modelsCrumb = page
-      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
-      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
+      .getByRole('navigation', { name: t('ui.breadcrumb') })
+      .getByRole('link', { name: t('models.breadcrumb.models') })
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
   })
 

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -40,7 +40,8 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('nav.comfyEnterprise', locale), href: routes.cloudEnterprise },
       { label: t('nav.mcpServer', locale), href: routes.mcp },
       { label: t('nav.supportedModels', locale), href: routes.models },
-      { label: t('footer.minimaxH3', locale), href: routes.minimax }
+      { label: t('footer.minimaxH3', locale), href: routes.minimax },
+      { label: t('footer.seedance', locale), href: routes.seedance }
     ]
   },
   {

--- a/apps/website/src/components/common/brandButton.variants.ts
+++ b/apps/website/src/components/common/brandButton.variants.ts
@@ -12,7 +12,9 @@ export const brandButtonVariants = cva({
       'outline-dark':
         'hover:text-primary-comfy-yellow border-2 border-primary-comfy-ink text-primary-comfy-ink uppercase hover:bg-primary-comfy-ink',
       inverse:
-        'text-primary-comfy-yellow bg-primary-comfy-ink transition-opacity hover:opacity-90'
+        'text-primary-comfy-yellow bg-primary-comfy-ink transition-opacity hover:opacity-90',
+      canvas:
+        'bg-primary-comfy-canvas text-primary-comfy-ink transition-opacity hover:opacity-90'
     },
     size: {
       xs: 'rounded-2xl px-6 py-3 text-xs font-bold',

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -25,6 +25,7 @@ const baseRoutes = {
   mcp: '/mcp',
   minimax: '/minimax',
   flux3: '/flux-3',
+  seedance: '/seedance-2.5',
   brand: '/brand'
 } as const
 

--- a/apps/website/src/data/seedance.ts
+++ b/apps/website/src/data/seedance.ts
@@ -1,0 +1,42 @@
+import type { ModelLaunchPage } from '../templates/model-launch/types'
+
+import { externalLinks } from '../config/routes'
+
+// Seedance 2.5 has not shipped yet, so this page announces it and holds the
+// URL. On launch day, replace this config with the full one the way /flux-3
+// did; the page stubs and the template stay as they are.
+const media = {
+  comingSoonHero:
+    'https://media.comfy.org/website/seedance-2.5/coming-soon-hero.webp'
+} as const
+
+export const seedancePage: ModelLaunchPage = {
+  metaTitleKey: 'seedance.meta.title',
+  metaDescriptionKey: 'seedance.meta.description',
+  breadcrumbLabelKey: 'seedance.breadcrumb.model',
+  breadcrumbUpdatedKey: 'seedance.breadcrumb.updated',
+  hero: {
+    layout: 'overlay',
+    placeholderImageSrc: media.comingSoonHero,
+    eyebrowKey: 'seedance.hero.eyebrow',
+    titleKey: 'seedance.hero.title',
+    primaryCta: {
+      labelKey: 'seedance.hero.primaryCta',
+      href: externalLinks.cloud,
+      target: '_blank'
+    }
+  },
+  runOptions: {
+    headingKey: 'seedance.runOptions.heading',
+    subtitleKey: 'seedance.runOptions.subtitle',
+    ctaKey: 'seedance.runOptions.cta'
+  },
+  reviews: {
+    headingKey: 'seedance.reviews.heading',
+    highlight: {
+      titleKey: 'seedance.reviews.highlightTitle',
+      descriptionKey: 'seedance.reviews.highlightDescription',
+      ctaKey: 'seedance.reviews.highlightCta'
+    }
+  }
+}

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5065,6 +5065,59 @@ const translations = {
       '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
   },
   'flux3.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
+  // Seedance 2.5 model page (/seedance-2.5) — announcement until the model ships
+  'seedance.meta.title': {
+    en: 'Seedance 2.5 on Comfy — Coming Soon',
+    'zh-CN': 'Comfy 上的 Seedance 2.5 — 即将推出'
+  },
+  'seedance.meta.description': {
+    en: 'Seedance 2.5 is coming to Comfy. Run it on Comfy Cloud the day it lands, or start building workflows for free now with every other model Comfy supports.',
+    'zh-CN':
+      'Seedance 2.5 即将登陆 Comfy。上线当天即可在 Comfy Cloud 上运行；现在就可以用 Comfy 支持的其他模型免费开始搭建工作流。'
+  },
+  'seedance.breadcrumb.model': {
+    en: 'Seedance 2.5',
+    'zh-CN': 'Seedance 2.5'
+  },
+  'seedance.breadcrumb.updated': {
+    en: 'Updated August 2026',
+    'zh-CN': '更新于 2026 年 8 月'
+  },
+  'seedance.hero.eyebrow': { en: 'Coming soon', 'zh-CN': '即将推出' },
+  'seedance.hero.title': {
+    en: 'Seedance 2.5',
+    'zh-CN': 'Seedance 2.5'
+  },
+  'seedance.hero.primaryCta': {
+    en: 'RUN COMFY FOR FREE',
+    'zh-CN': '免费使用 Comfy'
+  },
+  'seedance.runOptions.heading': {
+    en: 'One engine, every way to run it',
+    'zh-CN': '同一引擎，多种运行方式'
+  },
+  'seedance.runOptions.subtitle': {
+    en: 'Build workflows in the browser today. Batch campaigns with the API, or bring it in-house.',
+    'zh-CN': '今天就在浏览器中搭建工作流。用 API 批量制作，或部署到自有环境。'
+  },
+  'seedance.runOptions.cta': {
+    en: 'LEARN MORE',
+    'zh-CN': '了解更多'
+  },
+  'seedance.reviews.heading': {
+    en: '4+ million Comfy creators say',
+    'zh-CN': '超过 400 万 Comfy 创作者这样说'
+  },
+  'seedance.reviews.highlightTitle': {
+    en: 'Comfy MCP: now turn your agent into a creative technologist.',
+    'zh-CN': 'Comfy MCP：让你的智能体成为创意技术专家。'
+  },
+  'seedance.reviews.highlightDescription': {
+    en: 'Your AI assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D.',
+    'zh-CN':
+      '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
+  },
+  'seedance.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
   'minimax.meta.title': {
     en: 'MiniMax H3 on Comfy — Open-Weight Video Model',
     'zh-CN': 'Comfy 上的 MiniMax H3 — 开源权重视频模型'

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -2557,6 +2557,7 @@ const translations = {
   'footer.company': { en: 'Company', 'zh-CN': '公司' },
   'footer.contact': { en: 'Contact', 'zh-CN': '联系我们' },
   'footer.minimaxH3': { en: 'MiniMax H3', 'zh-CN': 'MiniMax H3' },
+  'footer.seedance': { en: 'Seedance 2.5', 'zh-CN': 'Seedance 2.5' },
   'footer.about': { en: 'About', 'zh-CN': '关于' },
   'footer.termsOfService': { en: 'Terms of Service', 'zh-CN': '服务条款' },
   'footer.privacyPolicy': { en: 'Privacy Policy', 'zh-CN': '隐私政策' },

--- a/apps/website/src/pages/seedance-2.5.astro
+++ b/apps/website/src/pages/seedance-2.5.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../templates/model-launch/ModelLaunchPage.astro'
+import { seedancePage } from '../data/seedance'
+---
+
+<ModelLaunchPage page={seedancePage} />

--- a/apps/website/src/pages/zh-CN/seedance-2.5.astro
+++ b/apps/website/src/pages/zh-CN/seedance-2.5.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../../templates/model-launch/ModelLaunchPage.astro'
+import { seedancePage } from '../../data/seedance'
+---
+
+<ModelLaunchPage page={seedancePage} />

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -40,7 +40,10 @@ const OVERLAY_CELL = 'col-start-1 row-start-1'
         "
       />
 
-      <div v-if="hero.videoSrc" class="relative">
+      <div
+        v-if="hero.videoSrc"
+        :class="cn('relative', isOverlay && OVERLAY_CELL)"
+      >
         <VideoPlayer :locale :src="hero.videoSrc" autoplay loop />
         <div
           v-if="hero.logoSrc"

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
 import type { Locale } from '../../i18n/translations'
 import type { ModelLaunchHero } from './types'
 
@@ -11,101 +13,167 @@ const { locale = 'en', hero } = defineProps<{
   hero: ModelLaunchHero
   locale?: Locale
 }>()
+
+// Both layouts render one content block. 'overlay' stacks the media, the scrim
+// and that block in a single grid cell instead of letting them flow.
+const isOverlay = hero.layout === 'overlay'
+const OVERLAY_CELL = 'col-start-1 row-start-1'
 </script>
 
 <template>
   <section class="max-w-9xl mx-auto px-6 py-12 lg:px-20 lg:py-16">
-    <img
-      v-if="!hero.videoSrc && hero.placeholderImageSrc"
-      :src="hero.placeholderImageSrc"
-      alt=""
-      aria-hidden="true"
-      width="1440"
-      height="810"
-      class="aspect-21/9 w-full rounded-4xl border border-white/10 object-cover"
-    />
-
-    <div v-if="hero.videoSrc" class="relative">
-      <VideoPlayer :locale :src="hero.videoSrc" autoplay loop />
-      <div
-        v-if="hero.logoSrc"
+    <div :class="cn(isOverlay && 'rounded-4.5xl grid overflow-hidden')">
+      <img
+        v-if="!hero.videoSrc && hero.placeholderImageSrc"
+        :src="hero.placeholderImageSrc"
+        alt=""
         aria-hidden="true"
-        class="bg-transparency-white-t4 pointer-events-none absolute top-6 right-6 flex size-12 items-center justify-center rounded-2xl backdrop-blur-sm lg:top-10 lg:right-10 lg:size-[70px] lg:rounded-3xl"
-      >
-        <span
-          class="inline-block size-6 bg-current text-primary-warm-white lg:size-[35px]"
-          :style="{
-            maskImage: `url(${hero.logoSrc})`,
-            maskSize: 'contain',
-            maskRepeat: 'no-repeat',
-            maskPosition: 'center'
-          }"
-        />
-      </div>
-    </div>
+        width="1440"
+        height="810"
+        :class="
+          cn(
+            'w-full object-cover',
+            isOverlay
+              ? `${OVERLAY_CELL} size-full`
+              : 'aspect-21/9 rounded-4xl border border-white/10'
+          )
+        "
+      />
 
-    <div class="mx-auto mt-10 flex max-w-2xl flex-col items-center text-center">
-      <p
-        v-if="hero.eyebrowKey"
-        class="text-primary-comfy-yellow mb-4 text-sm font-extrabold tracking-wider uppercase"
-      >
-        {{ t(hero.eyebrowKey, locale) }}
-      </p>
-
-      <h1
-        class="text-4xl font-light tracking-tight text-primary-comfy-canvas lg:text-6xl/tight"
-      >
-        {{ t(hero.titleKey, locale)
-        }}<span v-if="hero.titleRestKey" class="text-primary-comfy-canvas/80">{{
-          t(hero.titleRestKey, locale)
-        }}</span>
-      </h1>
-
-      <p
-        v-if="hero.descriptionKey"
-        class="mt-6 text-base/relaxed font-light text-primary-comfy-canvas lg:text-lg/relaxed"
-      >
-        {{ t(hero.descriptionKey, locale) }}
-      </p>
-
-      <div class="mt-8 flex w-full flex-col gap-4 sm:w-auto sm:flex-row">
-        <BrandButton
-          :href="hero.primaryCta.href"
-          :target="hero.primaryCta.target"
-          variant="solid"
-          size="lg"
-          class="w-full p-4 text-center lg:w-auto lg:min-w-52"
+      <div v-if="hero.videoSrc" class="relative">
+        <VideoPlayer :locale :src="hero.videoSrc" autoplay loop />
+        <div
+          v-if="hero.logoSrc"
+          aria-hidden="true"
+          class="bg-transparency-white-t4 pointer-events-none absolute top-6 right-6 flex size-12 items-center justify-center rounded-2xl backdrop-blur-sm lg:top-10 lg:right-10 lg:size-[70px] lg:rounded-3xl"
         >
-          {{ t(hero.primaryCta.labelKey, locale) }}
-        </BrandButton>
-        <BrandButton
-          v-if="hero.secondaryCta"
-          :href="hero.secondaryCta.href"
-          :target="hero.secondaryCta.target"
-          variant="outline"
-          size="lg"
-          class="w-full p-4 text-center lg:w-auto lg:min-w-52"
-        >
-          {{ t(hero.secondaryCta.labelKey, locale) }}
-        </BrandButton>
+          <span
+            class="inline-block size-6 bg-current text-primary-warm-white lg:size-[35px]"
+            :style="{
+              maskImage: `url(${hero.logoSrc})`,
+              maskSize: 'contain',
+              maskRepeat: 'no-repeat',
+              maskPosition: 'center'
+            }"
+          />
+        </div>
       </div>
 
       <div
-        v-if="hero.badgeKeys?.length"
-        class="mt-6 flex flex-wrap items-center justify-center gap-3"
-      >
-        <Badge
-          v-for="badgeKey in hero.badgeKeys"
-          :key="badgeKey"
-          variant="subtle"
-        >
-          {{ t(badgeKey, locale) }}
-        </Badge>
-      </div>
+        v-if="isOverlay"
+        aria-hidden="true"
+        :class="cn(OVERLAY_CELL, 'bg-black/30')"
+      />
 
-      <p v-if="hero.footnoteKey" class="mt-6 text-xs text-primary-warm-gray">
-        {{ t(hero.footnoteKey, locale) }}
-      </p>
+      <div
+        :class="
+          cn(
+            'flex flex-col items-center text-center',
+            isOverlay
+              ? `${OVERLAY_CELL} min-h-96 justify-center px-6 py-12 lg:aspect-21/9`
+              : 'mx-auto mt-10 max-w-2xl'
+          )
+        "
+      >
+        <p
+          v-if="hero.eyebrowKey"
+          :class="
+            cn(
+              'mb-4',
+              isOverlay
+                ? 'text-lg font-medium text-primary-warm-white uppercase lg:text-3xl'
+                : 'text-primary-comfy-yellow text-sm font-extrabold tracking-wider uppercase'
+            )
+          "
+        >
+          {{ t(hero.eyebrowKey, locale) }}
+        </p>
+
+        <h1
+          :class="
+            cn(
+              'font-light tracking-tight',
+              isOverlay
+                ? 'text-4xl text-primary-warm-white sm:text-6xl lg:text-8xl/none'
+                : 'text-4xl text-primary-comfy-canvas lg:text-6xl/tight'
+            )
+          "
+        >
+          {{ t(hero.titleKey, locale)
+          }}<span
+            v-if="hero.titleRestKey"
+            :class="
+              isOverlay
+                ? 'text-primary-warm-white/80'
+                : 'text-primary-comfy-canvas/80'
+            "
+            >{{ t(hero.titleRestKey, locale) }}</span
+          >
+        </h1>
+
+        <p
+          v-if="hero.descriptionKey"
+          :class="
+            cn(
+              'mt-6 text-base/relaxed font-light lg:text-lg/relaxed',
+              isOverlay
+                ? 'max-w-2xl text-primary-warm-white'
+                : 'text-primary-comfy-canvas'
+            )
+          "
+        >
+          {{ t(hero.descriptionKey, locale) }}
+        </p>
+
+        <div class="mt-8 flex w-full flex-col gap-4 sm:w-auto sm:flex-row">
+          <BrandButton
+            :href="hero.primaryCta.href"
+            :target="hero.primaryCta.target"
+            :variant="isOverlay ? 'canvas' : 'solid'"
+            size="lg"
+            class="w-full p-4 text-center lg:w-auto lg:min-w-52"
+          >
+            {{ t(hero.primaryCta.labelKey, locale) }}
+          </BrandButton>
+          <BrandButton
+            v-if="hero.secondaryCta"
+            :href="hero.secondaryCta.href"
+            :target="hero.secondaryCta.target"
+            variant="outline"
+            size="lg"
+            class="w-full p-4 text-center lg:w-auto lg:min-w-52"
+          >
+            {{ t(hero.secondaryCta.labelKey, locale) }}
+          </BrandButton>
+        </div>
+
+        <div
+          v-if="hero.badgeKeys?.length"
+          class="mt-6 flex flex-wrap items-center justify-center gap-3"
+        >
+          <Badge
+            v-for="badgeKey in hero.badgeKeys"
+            :key="badgeKey"
+            variant="subtle"
+          >
+            {{ t(badgeKey, locale) }}
+          </Badge>
+        </div>
+
+        <p
+          v-if="hero.footnoteKey"
+          :class="
+            cn(
+              'mt-6 text-xs',
+              isOverlay
+                ? 'text-primary-warm-white/80'
+                : 'text-primary-warm-gray'
+            )
+          "
+        >
+          {{ t(hero.footnoteKey, locale) }}
+        </p>
+      </div>
     </div>
   </section>
 </template>

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { flux3Page } from '../../data/flux3'
 import { minimaxPage } from '../../data/minimax'
+import { seedancePage } from '../../data/seedance'
 import type { TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import type { ModelLaunchPage } from './types'
@@ -9,7 +10,8 @@ import type { ModelLaunchPage } from './types'
 // Add every new launch-page config here so it inherits these checks.
 const pages: { name: string; page: ModelLaunchPage }[] = [
   { name: 'minimax', page: minimaxPage },
-  { name: 'flux3', page: flux3Page }
+  { name: 'flux3', page: flux3Page },
+  { name: 'seedance', page: seedancePage }
 ]
 
 describe.for(pages)('$name launch page config', ({ page }) => {

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -9,6 +9,11 @@ import type { LocalizedText, TranslationKey } from '../../i18n/translations'
 // add the `<model>.*` translation keys it points at, and add two page stubs
 // (`pages/<model>.astro` + `pages/zh-CN/<model>.astro`) that hand the config to
 // ModelLaunchPage.astro. No new components should be needed.
+//
+// An announcement page for a model that has not shipped is the same config with
+// less in it: give the hero `layout: 'overlay'` and a `placeholderImageSrc`,
+// omit gallery/pricing/faq/closingCta, and swap in the full config on launch
+// day. `src/data/seedance.ts` is the worked example.
 
 interface ModelLaunchCta {
   labelKey: TranslationKey
@@ -21,6 +26,10 @@ export interface ModelLaunchHero {
   // Still stand-in for the hero frame, for pages announcing a model whose
   // launch footage does not exist yet. Ignored once videoSrc is set.
   placeholderImageSrc?: string
+  // 'overlay' centres the eyebrow, heading and CTAs on top of the media behind
+  // a scrim, which is how the announcement pages are designed. Launch pages
+  // keep 'stacked', where the media sits above the text.
+  layout?: 'stacked' | 'overlay'
   // Small label above the heading, e.g. NEW.
   eyebrowKey?: TranslationKey
   // Brand mark drawn as a CSS mask over the top-right corner of the video.


### PR DESCRIPTION
## Summary

Adds the Seedance 2.5 announcement page from Figma `10086-7291`, and makes that shape reusable so the next model we tease is data rather than code.

## Changes

- **What**: New `/seedance-2.5` (en + zh-CN) rendered by the existing model-launch template. Everything below the hero was already optional in the contract, so the page is a config with no gallery, pricing, FAQ or closing CTA.
- The one thing the template could not express was this hero: the design centres the eyebrow, heading and CTA over the media instead of stacking them beneath it. That is now `hero.layout: 'overlay'`. Adding the next announcement page needs no new code: one config, its `<model>.*` keys, two page stubs, one line in the registry test. The recipe is documented next to the launch recipe in `types.ts`.
- Adds a `canvas` `BrandButton` variant for the light pill CTA in the design instead of hand-rolling a button.
- Hero backdrop is 44KB of webp on media.comfy.org, re-cut from the Figma layer's own transform. The scrim stays in CSS rather than baked into the image, so a future announcement image gets legible text without re-exporting.

## Review Focus

Both layouts still render **one** shared content block: the overlay stacks media, scrim and content in a single grid cell (`col-start-1 row-start-1`) rather than duplicating the markup per layout.

The design is desktop-only and a 21/9 card cannot hold a title plus a button at 390px, so the overlay takes `min-h-96` and only applies `lg:aspect-21/9`. Desktop matches the design; mobile grows to fit.

Three deviations from the Figma, all deliberate:

- The CTA in the design reads `RUN COMY FOR FREE`, missing the F. Shipped correctly.
- The breadcrumb in the design reads `SEEDANCE 2.0` against a `Seedance 2.5` title. Shipped as 2.5.
- The run-option cards in the design read `SEE LOCAL FEATURES` etc, but those were already shortened to `Learn more` in 93dea82e4. Kept the shipped shared copy.

Worth a designer eye on the first two in case they appear elsewhere in the file.

Key names match the full Seedance config, so launch day is the same file swap /flux-3 just went through.

Gates: `astro check` 0 errors, unused-i18n clean, unit 25/25, build 583 pages, `validate:jsonld` 586 pages, oxlint/knip/format/eslint clean. E2E 29/29, which includes re-running the minimax and flux-3 specs since a shared component changed. The new spec also asserts the page omits pricing, FAQ and video, so reintroducing one has to be deliberate.