### PR TITLE
feat: improve compositor layer editing

### DIFF
--- a/src/components/layerEditor/LayerEditorContent.test.ts
+++ b/src/components/layerEditor/LayerEditorContent.test.ts
@@ -1,0 +1,96 @@
+import { render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import LayerEditorContent from '@/components/layerEditor/LayerEditorContent.vue'
+import TopBarHeader from '@/components/layerEditor/dialog/TopBarHeader.vue'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { toNodeId } from '@/types/nodeId'
+
+const { saveComposite, session } = vi.hoisted(() => ({
+  saveComposite: vi.fn().mockResolvedValue(undefined),
+  session: {
+    dispose: vi.fn(),
+    editor: { history: { clear: vi.fn() } },
+    imageLayers: { value: [] },
+    loadImages: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('@/composables/layerEditor/useLayerEditorSession', () => ({
+  useLayerEditorSession: () => session
+}))
+vi.mock('@/composables/compositor/useCompositorSaver', () => ({
+  useCompositorSaver: () => ({ saveComposite })
+}))
+vi.mock('@/composables/compositor/useCompositorLayers', () => ({
+  getCompositorBBoxes: () => [],
+  getCompositorInputsFingerprint: () => [],
+  getCompositorLayers: () => []
+}))
+vi.mock('@/composables/compositor/compositorLayerState', () => ({
+  applyLayerState: vi.fn(),
+  parseLayerState: () => null,
+  resolveInitialLayerState: () => null
+}))
+vi.mock('@/composables/compositor/compositorWidgets', () => ({
+  getCompositorWidgetValue: () => ''
+}))
+vi.mock('@/scripts/api', () => ({
+  api: { apiURL: (url: string) => url }
+}))
+vi.mock('@/scripts/app', () => ({
+  app: { getRandParam: () => '' }
+}))
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({ getNodeImageUrls: () => [] })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { cancel: 'Cancel', save: 'Save' },
+      layerEditor: { title: 'Layer Editor' }
+    }
+  }
+})
+
+describe('LayerEditorContent', () => {
+  const node = { id: toNodeId(1) } as unknown as LGraphNode
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('places Save in the header and saves the composite', async () => {
+    const user = userEvent.setup()
+    render(TopBarHeader, { global: { plugins: [i18n] } })
+    render(LayerEditorContent, {
+      props: { node, mode: 'compositor' },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          LayerEditorCanvas: true,
+          LayerEditorToolbar: true,
+          LayerPanel: true,
+          LayerPropertiesPanel: true
+        }
+      }
+    })
+
+    const saveButton = await within(screen.getByRole('group')).findByRole(
+      'button',
+      {
+        name: 'Save'
+      }
+    )
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull()
+
+    await user.click(saveButton)
+
+    expect(saveComposite).toHaveBeenCalledWith(session, node)
+  })
+})

--- a/src/components/layerEditor/LayerEditorContent.vue
+++ b/src/components/layerEditor/LayerEditorContent.vue
@@ -1,19 +1,6 @@
 <template>
   <div class="flex min-h-0 flex-1 flex-col">
-    <div class="flex min-h-0 flex-1">
-      <LayerPanel :session="session" />
-      <div class="relative flex min-h-0 min-w-0 flex-1">
-        <LayerEditorCanvas :session="session" />
-        <LayerEditorToolbar :session="session" />
-      </div>
-      <LayerPropertiesPanel :session="session" />
-    </div>
-    <div
-      class="flex items-center justify-end gap-2 border-t border-border-default bg-base-background px-4 py-3"
-    >
-      <Button variant="destructive" size="md" @click="onCancel">
-        {{ t('g.cancel') }}
-      </Button>
+    <Teleport defer to="#layer-editor-header-actions">
       <Button
         variant="primary"
         size="md"
@@ -22,6 +9,14 @@
       >
         {{ t('g.save') }}
       </Button>
+    </Teleport>
+    <div class="flex min-h-0 flex-1">
+      <LayerPanel :session="session" />
+      <div class="relative flex min-h-0 min-w-0 flex-1">
+        <LayerEditorCanvas :session="session" />
+        <LayerEditorToolbar :session="session" />
+      </div>
+      <LayerPropertiesPanel :session="session" />
     </div>
   </div>
 </template>
@@ -52,7 +47,6 @@ import { useLayerEditorSession } from '@/composables/layerEditor/useLayerEditorS
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
-import { useDialogStore } from '@/stores/dialogStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
 const { node, mode = 'images' } = defineProps<{
@@ -75,10 +69,6 @@ function layerName(url: string, index: number): string {
     void 0
   }
   return t('layerEditor.layerN', { n: index + 1 })
-}
-
-function onCancel(): void {
-  useDialogStore().closeDialog({ key: 'global-layer-editor' })
 }
 
 async function onSave(): Promise<void> {

--- a/src/components/layerEditor/dialog/TopBarHeader.vue
+++ b/src/components/layerEditor/dialog/TopBarHeader.vue
@@ -1,7 +1,14 @@
 <template>
-  <div class="flex w-full items-center gap-2">
-    <i class="icon-[lucide--layers-2] size-4" />
-    <h3 class="m-0 text-sm font-semibold">{{ t('layerEditor.title') }}</h3>
+  <div class="flex w-full items-center justify-between gap-2">
+    <div class="flex items-center gap-2">
+      <i class="icon-[lucide--layers-2] size-4" />
+      <h3 class="m-0 text-sm font-semibold">{{ t('layerEditor.title') }}</h3>
+    </div>
+    <div
+      id="layer-editor-header-actions"
+      class="flex items-center gap-2"
+      role="group"
+    />
   </div>
 </template>
 

--- a/src/composables/compositor/useCompositorEditor.ts
+++ b/src/composables/compositor/useCompositorEditor.ts
@@ -32,7 +32,7 @@ export function useCompositorEditor() {
         renderer: 'reka',
         size: 'full',
         contentClass: 'layer-editor-dialog w-[90vw] h-[90vh] max-h-[90vh]',
-        headerClass: 'p-2',
+        headerClass: 'border-b border-border-default p-2',
         bodyClass: 'flex min-h-0 flex-col p-0',
         modal: true,
         maximizable: true,

--- a/src/composables/layerEditor/useLayerEditor.ts
+++ b/src/composables/layerEditor/useLayerEditor.ts
@@ -28,7 +28,7 @@ export function useLayerEditor() {
         renderer: 'reka',
         size: 'full',
         contentClass: 'layer-editor-dialog w-[90vw] h-[90vh] max-h-[90vh]',
-        headerClass: 'p-2',
+        headerClass: 'border-b border-border-default p-2',
         bodyClass: 'flex min-h-0 flex-col p-0',
         modal: true,
         maximizable: true,

--- a/src/composables/layerEditor/useLayerEditorSession.test.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.test.ts
@@ -60,6 +60,7 @@ class FakeCompositor implements Compositor {
 }
 
 const scaleCalls: Array<[number, number]> = []
+const drawImageCalls: unknown[][] = []
 
 function stub2d(): () => void {
   const orig = HTMLCanvasElement.prototype.getContext
@@ -84,7 +85,7 @@ function stub2d(): () => void {
         scaleCalls.push([x, y])
       },
       setTransform: () => {},
-      drawImage: () => {},
+      drawImage: (...args: unknown[]) => drawImageCalls.push(args),
       fillRect: () => {},
       strokeRect: () => {},
       clearRect: () => {},
@@ -127,6 +128,7 @@ afterAll(() => {
 
 beforeEach(() => {
   scaleCalls.length = 0
+  drawImageCalls.length = 0
   const pending = new Map<number, FrameRequestCallback>()
   let nextId = 1
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
@@ -828,6 +830,29 @@ describe('useLayerEditorSession', () => {
       session.selectBackground()
       expect(session.activeNodeId.value).toBe(session.backgroundLayer.value?.id)
       expect(session.selectedContext.value).toBe('background')
+    })
+  })
+
+  describe('outside canvas preview', () => {
+    it('previews only selected layers that cross the canvas edge', async () => {
+      const { session } = await loadedSession()
+      const [inside, clipped] = session.imageLayers.value
+      session.setLayerPosition(clipped.id, 60, 10)
+      session.setElements(makeElements())
+      await flushFrames()
+
+      session.selectBackground()
+      await flushFrames()
+      drawImageCalls.length = 0
+
+      session.setSelectedNodes([clipped.id])
+      await flushFrames()
+      expect(drawImageCalls).toHaveLength(1)
+
+      drawImageCalls.length = 0
+      session.setSelectedNodes([inside.id])
+      await flushFrames()
+      expect(drawImageCalls).toHaveLength(0)
     })
   })
 

--- a/src/composables/layerEditor/useLayerEditorSession.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.ts
@@ -29,6 +29,8 @@ import type {
   Vec2
 } from '@/core/layerEditor/engine/node'
 import { placedBounds } from '@/core/layerEditor/engine/render/bake'
+import type { OutsideCanvasPreviewLayer } from '@/core/layerEditor/engine/render/outsideCanvasPreview'
+import { drawOutsideCanvasPreview } from '@/core/layerEditor/engine/render/outsideCanvasPreview'
 import type { CanvasItem } from '@/core/layerEditor/engine/tool'
 import {
   canTransformNode,
@@ -312,6 +314,23 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     }
   }
 
+  function selectedOutsideCanvasPreviewLayers(): OutsideCanvasPreviewLayer[] {
+    const selectedIds = new Set(editor.selectedNodeIds())
+    const previewLayers: OutsideCanvasPreviewLayer[] = []
+    for (const node of editor.document().root.children) {
+      if (!selectedIds.has(node.id) || node.kind !== 'raster' || !node.visible)
+        continue
+      const bitmap = content.get(node.contentId)?.canvas
+      if (bitmap)
+        previewLayers.push({
+          bitmap,
+          opacity: node.opacity,
+          transform: node.transform
+        })
+    }
+    return previewLayers
+  }
+
   function drawOverlayCanvas(): void {
     if (!overlayCanvas || !viewportEl || !containerEl) return
     const dpr = window.devicePixelRatio || 1
@@ -332,6 +351,12 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
       z * dpr,
       containerEl.offsetLeft * dpr,
       containerEl.offsetTop * dpr
+    )
+    const { width, height } = editor.document()
+    drawOutsideCanvasPreview(
+      ctx,
+      { w: width, h: height },
+      selectedOutsideCanvasPreviewLayers()
     )
     ctx.lineWidth = 1 / z
     ctx.strokeStyle = '#3b82f6'

--- a/src/core/layerEditor/engine/render/bake.ts
+++ b/src/core/layerEditor/engine/render/bake.ts
@@ -55,10 +55,13 @@ export function drawPlacedInto(
   originY: number
 ): void {
   ctx.save()
-  ctx.translate(t.x + t.w / 2 - originX, t.y + t.h / 2 - originY)
-  ctx.rotate(t.rotation)
-  ctx.drawImage(bitmap, -t.w / 2, -t.h / 2, t.w, t.h)
-  ctx.restore()
+  try {
+    ctx.translate(t.x + t.w / 2 - originX, t.y + t.h / 2 - originY)
+    ctx.rotate(t.rotation)
+    ctx.drawImage(bitmap, -t.w / 2, -t.h / 2, t.w, t.h)
+  } finally {
+    ctx.restore()
+  }
 }
 
 export function bakePlaced(

--- a/src/core/layerEditor/engine/render/outsideCanvasPreview.test.ts
+++ b/src/core/layerEditor/engine/render/outsideCanvasPreview.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Transform } from '../node'
+import type { OutsideCanvasPreviewLayer } from './outsideCanvasPreview'
+import { drawOutsideCanvasPreview } from './outsideCanvasPreview'
+
+function layer(transform: Transform, opacity = 1): OutsideCanvasPreviewLayer {
+  const bitmap = document.createElement('canvas')
+  bitmap.width = 20
+  bitmap.height = 20
+  return {
+    bitmap,
+    opacity,
+    transform
+  }
+}
+
+function context(drawImageError?: Error) {
+  const drawImage = vi.fn()
+  const clearRect = vi.fn()
+  const alphaAtDraw: number[] = []
+  const alphaStack: number[] = []
+  let globalAlpha = 1
+  const restore = vi.fn(() => {
+    globalAlpha = alphaStack.pop() ?? 1
+  })
+  const ctx = {
+    get globalAlpha() {
+      return globalAlpha
+    },
+    set globalAlpha(value: number) {
+      globalAlpha = value
+    },
+    save: () => alphaStack.push(globalAlpha),
+    restore,
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    drawImage: (...args: unknown[]) => {
+      alphaAtDraw.push(globalAlpha)
+      drawImage(...args)
+      if (drawImageError) throw drawImageError
+    },
+    clearRect
+  } as unknown as CanvasRenderingContext2D
+  return { ctx, drawImage, clearRect, alphaAtDraw }
+}
+
+describe('drawOutsideCanvasPreview', () => {
+  const canvas = { w: 100, h: 80 }
+
+  it('does not draw layers contained by the canvas', () => {
+    const { ctx, drawImage, clearRect } = context()
+
+    drawOutsideCanvasPreview(ctx, canvas, [
+      layer({ x: 10, y: 10, w: 20, h: 20, rotation: 0 })
+    ])
+
+    expect(drawImage).not.toHaveBeenCalled()
+    expect(clearRect).not.toHaveBeenCalled()
+  })
+
+  it('does not draw transparent clipped layers', () => {
+    const { ctx, drawImage, clearRect } = context()
+
+    drawOutsideCanvasPreview(ctx, canvas, [
+      layer({ x: 90, y: 10, w: 20, h: 20, rotation: 0 }, 0)
+    ])
+
+    expect(drawImage).not.toHaveBeenCalled()
+    expect(clearRect).not.toHaveBeenCalled()
+  })
+
+  it('draws clipped layers at reduced opacity and removes the in-canvas part', () => {
+    const { ctx, drawImage, clearRect, alphaAtDraw } = context()
+
+    drawOutsideCanvasPreview(ctx, canvas, [
+      layer({ x: 90, y: 10, w: 20, h: 20, rotation: 0 }, 0.5)
+    ])
+
+    expect(drawImage).toHaveBeenCalledOnce()
+    expect(alphaAtDraw).toEqual([0.2])
+    expect(ctx.globalAlpha).toBe(1)
+    expect(clearRect).toHaveBeenCalledWith(0, 0, 100, 80)
+  })
+
+  it('restores canvas state when drawing fails', () => {
+    const drawError = new Error('draw failed')
+    const { ctx, clearRect } = context(drawError)
+
+    expect(() =>
+      drawOutsideCanvasPreview(ctx, canvas, [
+        layer({ x: 90, y: 10, w: 20, h: 20, rotation: 0 })
+      ])
+    ).toThrow(drawError)
+    expect(ctx.globalAlpha).toBe(1)
+    expect(clearRect).toHaveBeenCalledWith(0, 0, 100, 80)
+  })
+})

--- a/src/core/layerEditor/engine/render/outsideCanvasPreview.ts
+++ b/src/core/layerEditor/engine/render/outsideCanvasPreview.ts
@@ -1,0 +1,58 @@
+import { clamp } from 'es-toolkit'
+
+import type { Transform } from '../node'
+import { drawPlacedInto, placedBounds } from './bake'
+import type { Bitmap } from './place'
+
+const CLIPPED_LAYER_PREVIEW_OPACITY = 0.4
+
+export interface OutsideCanvasPreviewLayer {
+  bitmap: Bitmap
+  opacity: number
+  transform: Transform
+}
+
+interface CanvasSize {
+  w: number
+  h: number
+}
+
+function extendsOutsideCanvas(
+  transform: Transform,
+  canvas: CanvasSize
+): boolean {
+  const bounds = placedBounds(transform)
+  return (
+    bounds.x < 0 ||
+    bounds.y < 0 ||
+    bounds.x + bounds.w > canvas.w ||
+    bounds.y + bounds.h > canvas.h
+  )
+}
+
+export function drawOutsideCanvasPreview(
+  ctx: CanvasRenderingContext2D,
+  canvas: CanvasSize,
+  layers: OutsideCanvasPreviewLayer[]
+): void {
+  const clippedLayers = layers.filter(
+    (layer) =>
+      layer.opacity > 0 && extendsOutsideCanvas(layer.transform, canvas)
+  )
+  if (!clippedLayers.length) return
+
+  try {
+    for (const layer of clippedLayers) {
+      ctx.save()
+      try {
+        ctx.globalAlpha =
+          CLIPPED_LAYER_PREVIEW_OPACITY * clamp(layer.opacity, 0, 1)
+        drawPlacedInto(ctx, layer.bitmap, layer.transform, 0, 0)
+      } finally {
+        ctx.restore()
+      }
+    }
+  } finally {
+    ctx.clearRect(0, 0, canvas.w, canvas.h)
+  }
+}


### PR DESCRIPTION
## Summary

Improves compositor editing by previewing clipped layer content and moving Save into the dialog header.

## Changes

- **What**: Shows selected raster content outside the canvas at reduced opacity while keeping the saved composite clipped; removes the inactive Cancel button and footer; moves Save beside the dialog controls; adds a header divider.

## Review Focus

- Overflow preview behavior for transformed and transparent layers.
- Save placement and behavior in compositor mode.

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm knip`
- 66 focused layer-editor and compositor tests
