### PR TITLE
fix: canvas resize in layer editor stretches and shifts layers

### DIFF
--- a/src/components/layerEditor/LayerEditorContent.vue
+++ b/src/components/layerEditor/LayerEditorContent.vue
@@ -112,6 +112,7 @@ async function loadCompositorLayers(): Promise<void> {
   if (initialState) {
     applyLayerState(initialState, session.imageLayers.value, session)
     session.editor.history.clear()
+    session.fitView()
   }
 }
 

--- a/src/composables/layerEditor/useLayerEditorSession.test.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.test.ts
@@ -604,30 +604,40 @@ describe('useLayerEditorSession', () => {
       expect(session.canvasSize.value).toEqual({ w: 64, h: 8192 })
     })
 
-    it('grows the artboard in place without refitting the view', async () => {
+    it('grows the canvas around its center, keeping layers visually fixed', async () => {
       const { session } = await loadedSession()
       const els = makeElements()
       session.setElements(els)
       const zoom = session.zoomRatio.value
-      const { left, top } = els.container.style
+      const layer = rasterLayer(session, 0)
+      const screenX = (x: number) =>
+        parseFloat(els.container.style.left) + x * zoom
+      const screenY = (y: number) =>
+        parseFloat(els.container.style.top) + y * zoom
+      const beforeX = screenX(layer.transform.x)
+      const beforeY = screenY(layer.transform.y)
 
       session.setCanvasSize(128, 96)
       expect(session.zoomRatio.value).toBe(zoom)
-      expect(els.container.style.left).toBe(left)
-      expect(els.container.style.top).toBe(top)
+      expect(layer.transform).toMatchObject({ x: 32, y: 24 })
       expect(parseFloat(els.container.style.width)).toBeCloseTo(128 * zoom)
       expect(parseFloat(els.container.style.height)).toBeCloseTo(96 * zoom)
+      expect(screenX(layer.transform.x)).toBeCloseTo(beforeX)
+      expect(screenY(layer.transform.y)).toBeCloseTo(beforeY)
     })
 
-    it('keeps the container in sync with the document across undo/redo', async () => {
+    it('keeps the container and layer positions in sync across undo/redo', async () => {
       const { session } = await loadedSession()
       const els = makeElements()
       session.setElements(els)
       const zoom = session.zoomRatio.value
-      session.setCanvasSize(128, 96)
+      const layer = rasterLayer(session, 0)
+      session.setCanvasSize(129, 97)
+      expect(layer.transform).toMatchObject({ x: 32, y: 24 })
 
       session.undo()
       await flushFrames()
+      expect(layer.transform).toMatchObject({ x: 0, y: 0 })
       expect(parseFloat(els.container.style.width)).toBeCloseTo(64 * zoom)
       expect(parseFloat(els.container.style.height)).toBeCloseTo(48 * zoom)
       expect(els.main.width).toBe(64)
@@ -635,8 +645,9 @@ describe('useLayerEditorSession', () => {
 
       session.redo()
       await flushFrames()
-      expect(parseFloat(els.container.style.width)).toBeCloseTo(128 * zoom)
-      expect(els.main.width).toBe(128)
+      expect(layer.transform).toMatchObject({ x: 32, y: 24 })
+      expect(parseFloat(els.container.style.width)).toBeCloseTo(129 * zoom)
+      expect(els.main.width).toBe(129)
     })
   })
 

--- a/src/composables/layerEditor/useLayerEditorSession.test.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.test.ts
@@ -603,6 +603,41 @@ describe('useLayerEditorSession', () => {
       session.setCanvasSize(1, 99999)
       expect(session.canvasSize.value).toEqual({ w: 64, h: 8192 })
     })
+
+    it('grows the artboard in place without refitting the view', async () => {
+      const { session } = await loadedSession()
+      const els = makeElements()
+      session.setElements(els)
+      const zoom = session.zoomRatio.value
+      const { left, top } = els.container.style
+
+      session.setCanvasSize(128, 96)
+      expect(session.zoomRatio.value).toBe(zoom)
+      expect(els.container.style.left).toBe(left)
+      expect(els.container.style.top).toBe(top)
+      expect(parseFloat(els.container.style.width)).toBeCloseTo(128 * zoom)
+      expect(parseFloat(els.container.style.height)).toBeCloseTo(96 * zoom)
+    })
+
+    it('keeps the container in sync with the document across undo/redo', async () => {
+      const { session } = await loadedSession()
+      const els = makeElements()
+      session.setElements(els)
+      const zoom = session.zoomRatio.value
+      session.setCanvasSize(128, 96)
+
+      session.undo()
+      await flushFrames()
+      expect(parseFloat(els.container.style.width)).toBeCloseTo(64 * zoom)
+      expect(parseFloat(els.container.style.height)).toBeCloseTo(48 * zoom)
+      expect(els.main.width).toBe(64)
+      expect(els.main.height).toBe(48)
+
+      session.redo()
+      await flushFrames()
+      expect(parseFloat(els.container.style.width)).toBeCloseTo(128 * zoom)
+      expect(els.main.width).toBe(128)
+    })
   })
 
   describe('layer transform edits', () => {

--- a/src/composables/layerEditor/useLayerEditorSession.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.ts
@@ -601,6 +601,7 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
       doc.width = v.w
       doc.height = v.h
       if (glOk.value) compositor.resize(v.w, v.h)
+      panZoom.setArtboardSize(v.w, v.h)
     }
     apply({ w: width, h: height })
     editor.history.push(
@@ -614,7 +615,6 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
       )
     )
     editor.invalidate()
-    fitView()
   }
 
   function pushLayerTransform(

--- a/src/composables/layerEditor/useLayerEditorSession.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.ts
@@ -23,6 +23,7 @@ import type { BlendFn } from '@/core/layerEditor/engine/mode'
 import { LAYER_MODES, defaultMode } from '@/core/layerEditor/engine/mode'
 import type {
   FillData,
+  GroupData,
   Rect,
   SceneNode,
   Transform,
@@ -591,6 +592,18 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     pointerMode.value = mode
   }
 
+  function shiftLayers(nodes: SceneNode[], dx: number, dy: number): void {
+    for (const n of nodes) {
+      if (n.kind === 'fill') continue
+      n.transform = {
+        ...n.transform,
+        x: n.transform.x + dx,
+        y: n.transform.y + dy
+      }
+      if (n.kind === 'group') shiftLayers((n as GroupData).children, dx, dy)
+    }
+  }
+
   function setCanvasSize(w: number, h: number): void {
     const doc = editor.document()
     const width = clamp(Math.round(w), CANVAS_SIZE_MIN, CANVAS_SIZE_MAX)
@@ -598,10 +611,14 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     const before = { w: doc.width, h: doc.height }
     if (before.w === width && before.h === height) return
     const apply = (v: { w: number; h: number }): void => {
+      const dx = Math.trunc((v.w - doc.width) / 2)
+      const dy = Math.trunc((v.h - doc.height) / 2)
       doc.width = v.w
       doc.height = v.h
       if (glOk.value) compositor.resize(v.w, v.h)
+      shiftLayers(doc.root.children, dx, dy)
       panZoom.setArtboardSize(v.w, v.h)
+      panZoom.panBy(-dx * panZoom.zoom(), -dy * panZoom.zoom())
     }
     apply({ w: width, h: height })
     editor.history.push(

--- a/src/composables/layerEditor/useLayerEditorSession.ts
+++ b/src/composables/layerEditor/useLayerEditorSession.ts
@@ -23,7 +23,6 @@ import type { BlendFn } from '@/core/layerEditor/engine/mode'
 import { LAYER_MODES, defaultMode } from '@/core/layerEditor/engine/mode'
 import type {
   FillData,
-  GroupData,
   Rect,
   SceneNode,
   Transform,
@@ -593,6 +592,7 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
   }
 
   function shiftLayers(nodes: SceneNode[], dx: number, dy: number): void {
+    if (dx === 0 && dy === 0) return
     for (const n of nodes) {
       if (n.kind === 'fill') continue
       n.transform = {
@@ -600,7 +600,7 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
         x: n.transform.x + dx,
         y: n.transform.y + dy
       }
-      if (n.kind === 'group') shiftLayers((n as GroupData).children, dx, dy)
+      if (n.kind === 'group') shiftLayers(n.children, dx, dy)
     }
   }
 

--- a/src/core/layerEditor/panZoom.test.ts
+++ b/src/core/layerEditor/panZoom.test.ts
@@ -79,6 +79,34 @@ describe('createPanZoom', () => {
     })
   })
 
+  describe('setArtboardSize', () => {
+    it('resizes the container while keeping zoom and pan fixed', () => {
+      const els = makeEls(800, 600)
+      const pz = createPanZoom(() => els)
+      pz.fit(1024, 1024)
+      const zoom = pz.zoom()
+      const before = styleNumbers(els.container)
+      pz.setArtboardSize(2048, 1024)
+      expect(pz.zoom()).toBe(zoom)
+      const st = styleNumbers(els.container)
+      expect(st.left).toBeCloseTo(before.left)
+      expect(st.top).toBeCloseTo(before.top)
+      expect(st.width).toBeCloseTo(2048 * zoom)
+      expect(st.height).toBeCloseTo(1024 * zoom)
+    })
+
+    it('remembers the size while elements are unavailable', () => {
+      let els: PanZoomEls | null = null
+      const pz = createPanZoom(() => els)
+      expect(() => pz.setArtboardSize(500, 400)).not.toThrow()
+      els = makeEls()
+      pz.invalidate()
+      const st = styleNumbers(els.container)
+      expect(st.width).toBeCloseTo(500)
+      expect(st.height).toBeCloseTo(400)
+    })
+  })
+
   it('accumulates pan offsets into left/top and notifies listeners', () => {
     const els = makeEls()
     const pz = createPanZoom(() => els)

--- a/src/core/layerEditor/panZoom.ts
+++ b/src/core/layerEditor/panZoom.ts
@@ -8,6 +8,7 @@ export interface PanZoom {
   setZoom: (ratio: number) => void
   invalidate: () => void
   fit: (artW: number, artH: number) => void
+  setArtboardSize: (artW: number, artH: number) => void
   panBy: (dx: number, dy: number) => void
   handleWheel: (e: WheelEvent) => void
   screenToArtboard: (
@@ -49,6 +50,13 @@ export function createPanZoom(getEls: () => PanZoomEls | null): PanZoom {
     zoomRatio = Math.max(0.01, zoom)
     panX = (availW - artW * zoomRatio) / 2
     panY = (availH - artH * zoomRatio) / 2
+    invalidate()
+  }
+
+  function setArtboardSize(w: number, h: number): void {
+    if (w === artW && h === artH) return
+    artW = w
+    artH = h
     invalidate()
   }
 
@@ -106,6 +114,7 @@ export function createPanZoom(getEls: () => PanZoomEls | null): PanZoom {
     setZoom,
     invalidate,
     fit,
+    setArtboardSize,
     panBy,
     handleWheel,
     screenToArtboard,


### PR DESCRIPTION
## Summary

Canvas resize in the compositor's layer editor now grows/shrinks the canvas around its center, and undo/redo no longer leaves the rendered composite stretched or the view desynced.

## Changes

- **What**:
  - `setCanvasSize` syncs the pan/zoom container from inside its undoable `apply` closure via a new `panZoom.setArtboardSize` (updates artboard dims without refitting) instead of a one-shot `fitView()` that never re-ran on undo/redo — the stale container CSS stretched the canvas backing store by exactly oldW/newW and corrupted pointer mapping
  - Resizes are center-anchored: layers shift by half the size delta (inside the same undo command) and the view pans to compensate, so the canvas grows evenly on both sides while layers stay visually fixed
  - Restoring saved compositor state still fits the view once on dialog open

## Review Focus

- Undo/redo replays `apply`, so layer shifts and view sizing must stay side effects of the command, not of the interactive call site
- `Math.trunc` on the half-delta keeps layer positions integral and undo exactly reversible for odd deltas (the extra pixel lands right/bottom)