### PR TITLE
demo: cloud canary build banner (for canary rollout demo)

### DIFF
--- a/src/platform/cloud/components/CanaryDemoBanner.vue
+++ b/src/platform/cloud/components/CanaryDemoBanner.vue
@@ -1,0 +1,92 @@
+<!--
+  Temporary demo banner for showcasing the Comfy Cloud frontend canary
+  rollout. Renders a highly visible "canary build" ribbon at the top of the
+  authenticated app, along with the served frontend version + commit so you
+  can confirm which build a canary cohort is seeing.
+
+  This is intentionally cloud-only and meant for demos — remove before GA.
+-->
+<template>
+  <div v-if="isCloud" class="canary-demo-banner" role="status">
+    <!-- Inline canary bird so no binary asset is needed -->
+    <svg
+      class="canary-demo-banner__bird"
+      viewBox="0 0 64 64"
+      aria-hidden="true"
+    >
+      <ellipse cx="32" cy="38" rx="18" ry="16" fill="#ffd21e" />
+      <circle cx="32" cy="20" r="12" fill="#ffdf4d" />
+      <circle cx="37" cy="18" r="2.4" fill="#2b2b2b" />
+      <path d="M44 20 l9 -3 -6 6 z" fill="#ff8a3d" />
+      <path d="M20 44 q-10 2 -14 -4 q10 3 14 -2 z" fill="#ffb800" />
+      <path d="M24 52 l-2 6 m8 -5 l0 6 m8 -7 l3 6" stroke="#ff8a3d" stroke-width="2.5" stroke-linecap="round" fill="none" />
+    </svg>
+
+    <span class="canary-demo-banner__text">
+      🐤 CANARY BUILD — you are on a canary frontend release
+    </span>
+
+    <span class="canary-demo-banner__version">
+      v{{ version }}<template v-if="commit"> · {{ commit }}</template>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import config from '@/config'
+import { isCloud } from '@/platform/distribution/types'
+
+const version = config.app_version
+
+// __COMFYUI_FRONTEND_COMMIT__ is injected at build time by vite.config.mts.
+declare const __COMFYUI_FRONTEND_COMMIT__: string
+const commit =
+  typeof __COMFYUI_FRONTEND_COMMIT__ === 'string'
+    ? __COMFYUI_FRONTEND_COMMIT__.slice(0, 8)
+    : ''
+</script>
+
+<style scoped>
+.canary-demo-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 34px;
+  padding: 0 16px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #3a2c00;
+  background: repeating-linear-gradient(
+    45deg,
+    #ffd21e,
+    #ffd21e 16px,
+    #ffe066 16px,
+    #ffe066 32px
+  );
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  user-select: none;
+}
+
+.canary-demo-banner__bird {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.2));
+}
+
+.canary-demo-banner__version {
+  font-family: monospace;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.12);
+}
+</style>

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -20,6 +20,7 @@
     </template>
   </div>
 
+  <CanaryDemoBanner />
   <GlobalToast />
   <InviteAcceptedToast />
   <RerouteMigrationToast />
@@ -68,6 +69,7 @@ import type { ServerConfig, ServerConfigValue } from '@/constants/serverConfig'
 import { setActiveLocale } from '@/i18n'
 import AssetExportProgressDialog from '@/platform/assets/components/AssetExportProgressDialog.vue'
 import ModelImportProgressDialog from '@/platform/assets/components/ModelImportProgressDialog.vue'
+import CanaryDemoBanner from '@/platform/cloud/components/CanaryDemoBanner.vue'
 import DesktopCloudNotificationController from '@/platform/cloud/notification/components/DesktopCloudNotificationController.vue'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'


### PR DESCRIPTION
## Purpose
Temporary **demo** branch to visually showcase the frontend **canary rollout**. Adds a cloud-only banner pinned to the top of the authenticated app that reads **🐤 CANARY BUILD** and shows the served frontend version + commit hash — so during a canary you can see at a glance which build a cohort is being served.

## What it does
- New `CanaryDemoBanner.vue` (`src/platform/cloud/components/`), gated on `isCloud`.
- Mounted in `GraphView.vue` alongside the other always-present components.
- Self-contained: inline SVG canary, no binary asset. Shows `config.app_version` + `__COMFYUI_FRONTEND_COMMIT__`.

## Testing
- `vue-tsc --noEmit` passes clean (0 errors).

## Notes
- **Not for merge / GA** — this is a throwaway demo branch. It carries the `preview` label so the cloud CI builds it and uploads assets to GCS (`versions/<sha>/`) for the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)