### PR TITLE
feat: add persistent generated asset media tabs

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -14,6 +14,7 @@ import AssetsSidebarTab from './AssetsSidebarTab.vue'
 const flatOutputMocks = vi.hoisted(() => ({
   media: undefined as unknown as Ref<AssetItem[]>,
   hasMore: undefined as unknown as Ref<boolean>,
+  isLoadingMore: undefined as unknown as Ref<boolean>,
   loadMore: vi.fn()
 }))
 
@@ -42,6 +43,16 @@ const videoAsset = vi.hoisted(
     }) satisfies AssetItem
 )
 
+const audioAsset = vi.hoisted(
+  () =>
+    ({
+      id: 'audio-output',
+      name: 'audio-output.mp3',
+      mime_type: 'audio/mpeg',
+      tags: ['output']
+    }) satisfies AssetItem
+)
+
 vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
 
 vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
@@ -64,6 +75,7 @@ vi.mock('@/platform/assets/composables/media/useFlatOutputAssets', async () => {
   const { ref } = await import('vue')
   flatOutputMocks.media = ref([folderAsset, videoAsset])
   flatOutputMocks.hasMore = ref(false)
+  flatOutputMocks.isLoadingMore = ref(false)
 
   return {
     useFlatOutputAssets: () => ({
@@ -73,7 +85,7 @@ vi.mock('@/platform/assets/composables/media/useFlatOutputAssets', async () => {
       fetchMediaList: vi.fn().mockResolvedValue(flatOutputMocks.media.value),
       loadMore: flatOutputMocks.loadMore,
       hasMore: flatOutputMocks.hasMore,
-      isLoadingMore: ref(false)
+      isLoadingMore: flatOutputMocks.isLoadingMore
     })
   }
 })
@@ -207,6 +219,7 @@ describe('AssetsSidebarTab folder navigation', () => {
     vi.spyOn(api, 'getServerFeature').mockReturnValue(true)
     flatOutputMocks.media.value = [folderAsset, videoAsset]
     flatOutputMocks.hasMore.value = false
+    flatOutputMocks.isLoadingMore.value = false
     flatOutputMocks.loadMore.mockReset()
   })
 
@@ -266,6 +279,44 @@ describe('AssetsSidebarTab folder navigation', () => {
 
     expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
     expect(screen.getByText('video-output.mp4')).toBeVisible()
+  })
+
+  it('waits for active pagination before loading a newly selected media type', async () => {
+    let resolveFirstLoad!: () => void
+    const firstLoad = new Promise<void>((resolve) => {
+      resolveFirstLoad = resolve
+    })
+    flatOutputMocks.media.value = [folderAsset]
+    flatOutputMocks.hasMore.value = true
+    flatOutputMocks.loadMore
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.isLoadingMore.value = true
+        await firstLoad
+        flatOutputMocks.media.value = [folderAsset, videoAsset]
+        flatOutputMocks.isLoadingMore.value = false
+      })
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.isLoadingMore.value = true
+        flatOutputMocks.media.value = [folderAsset, videoAsset, audioAsset]
+        flatOutputMocks.hasMore.value = false
+        flatOutputMocks.isLoadingMore.value = false
+      })
+    renderTab()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await vi.waitFor(() => {
+      expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
+    })
+
+    await userEvent.click(screen.getByText('Audio'))
+    await nextTick()
+    expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
+
+    resolveFirstLoad()
+    await vi.waitFor(() => {
+      expect(flatOutputMocks.loadMore).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText('audio-output.mp3')).toBeVisible()
   })
 
   it('keeps history-backed generated assets when the asset API is disabled', () => {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -7,6 +7,7 @@ import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import { api } from '@/scripts/api'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
@@ -23,6 +24,8 @@ const folderAsset = vi.hoisted(
     ({
       id: 'multi-output',
       name: 'multi-output.png',
+      created_at: '2026-08-25T00:00:00.000Z',
+      updated_at: '2026-08-25T00:00:00.000Z',
       tags: ['output'],
       user_metadata: {
         jobId: 'multi-output-job',
@@ -38,6 +41,8 @@ const videoAsset = vi.hoisted(
     ({
       id: 'video-output',
       name: 'video-output.mp4',
+      created_at: '2026-08-25T00:00:00.000Z',
+      updated_at: '2026-08-25T00:00:00.000Z',
       mime_type: 'video/mp4',
       tags: ['output']
     }) satisfies AssetItem
@@ -48,8 +53,28 @@ const audioAsset = vi.hoisted(
     ({
       id: 'audio-output',
       name: 'audio-output.mp3',
+      created_at: '2026-08-25T00:00:00.000Z',
+      updated_at: '2026-08-25T00:00:00.000Z',
       mime_type: 'audio/mpeg',
       tags: ['output']
+    }) satisfies AssetItem
+)
+
+const folderVideoAsset = vi.hoisted(
+  () =>
+    ({
+      id: 'folder-video-output',
+      name: 'folder-video-output.mp4',
+      created_at: '2026-08-25T00:00:00.000Z',
+      updated_at: '2026-08-25T00:00:00.000Z',
+      mime_type: 'video/mp4',
+      tags: ['output'],
+      user_metadata: {
+        jobId: 'folder-video-job',
+        nodeId: '2',
+        subfolder: 'nested',
+        outputCount: 2
+      }
     }) satisfies AssetItem
 )
 
@@ -59,11 +84,13 @@ vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
   const { ref } = await import('vue')
 
   return {
-    useAssetsApi: () => ({
-      media: ref([folderAsset]),
+    useAssetsApi: (directory: 'input' | 'output') => ({
+      media: ref(directory === 'input' ? [] : [folderAsset]),
       loading: ref(false),
       error: ref(null),
-      fetchMediaList: vi.fn(async () => [folderAsset]),
+      fetchMediaList: vi.fn(async () =>
+        directory === 'input' ? [] : [folderAsset]
+      ),
       loadMore: vi.fn(),
       hasMore: ref(false),
       isLoadingMore: ref(false)
@@ -265,6 +292,33 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(screen.getByText('video-output.mp4')).toBeVisible()
   })
 
+  it('renders one persisted output card in each matching media tab', async () => {
+    flatOutputMocks.media.value = [
+      { ...folderAsset, job_id: 'multi-output-job' },
+      {
+        ...folderAsset,
+        id: 'multi-output-sibling',
+        name: 'multi-output-sibling.mp4',
+        mime_type: 'video/mp4',
+        job_id: 'multi-output-job'
+      }
+    ]
+    renderTab()
+
+    expect(screen.getByText('multi-output.png')).toBeVisible()
+    expect(
+      screen.queryByText('multi-output-sibling.mp4')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await nextTick()
+
+    expect(screen.getByText('multi-output.png')).toBeVisible()
+    expect(
+      screen.queryByText('multi-output-sibling.mp4')
+    ).not.toBeInTheDocument()
+  })
+
   it('loads more persisted assets when the selected media type is absent', async () => {
     flatOutputMocks.media.value = [folderAsset]
     flatOutputMocks.hasMore.value = true
@@ -279,6 +333,32 @@ describe('AssetsSidebarTab folder navigation', () => {
 
     expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
     expect(screen.getByText('video-output.mp4')).toBeVisible()
+  })
+
+  it('keeps paginating when an existing job gains non-matching outputs', async () => {
+    const first = { ...folderAsset, job_id: 'mixed-output-job' }
+    const second = { ...audioAsset, job_id: 'mixed-output-job' }
+    const third = { ...videoAsset, job_id: 'mixed-output-job' }
+    flatOutputMocks.media.value = [first]
+    flatOutputMocks.hasMore.value = true
+    flatOutputMocks.loadMore
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.media.value = [first, second]
+      })
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.media.value = [first, second, third]
+        flatOutputMocks.hasMore.value = false
+      })
+    renderTab()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await vi.waitFor(() => {
+      expect(flatOutputMocks.loadMore).toHaveBeenCalledTimes(2)
+    })
+    await nextTick()
+
+    expect(screen.getByText('multi-output.png')).toBeVisible()
+    expect(screen.queryByText('video-output.mp4')).not.toBeInTheDocument()
   })
 
   it('waits for active pagination before loading a newly selected media type', async () => {
@@ -318,6 +398,69 @@ describe('AssetsSidebarTab folder navigation', () => {
     })
     await nextTick()
     expect(screen.getByText('audio-output.mp3')).toBeVisible()
+  })
+
+  it('stops generated pagination after switching to Imported', async () => {
+    let resolveLoad!: () => void
+    const pendingLoad = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    flatOutputMocks.media.value = [folderAsset]
+    flatOutputMocks.hasMore.value = true
+    flatOutputMocks.loadMore.mockImplementation(async () => {
+      flatOutputMocks.isLoadingMore.value = true
+      await pendingLoad
+      flatOutputMocks.isLoadingMore.value = false
+    })
+    renderTab()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await vi.waitFor(() => {
+      expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
+    })
+
+    await userEvent.click(screen.getByText('Imported'))
+    resolveLoad()
+    await flatOutputMocks.loadMore.mock.results[0].value
+    await nextTick()
+
+    expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
+  })
+
+  it('stops generated pagination after entering a folder', async () => {
+    let resolveLoad!: () => void
+    const pendingLoad = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    flatOutputMocks.media.value = [folderAsset]
+    flatOutputMocks.hasMore.value = true
+    vi.mocked(resolveOutputAssetItems).mockResolvedValueOnce([])
+    flatOutputMocks.loadMore
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.isLoadingMore.value = true
+        flatOutputMocks.media.value = [folderAsset, folderVideoAsset]
+        await pendingLoad
+        flatOutputMocks.isLoadingMore.value = false
+      })
+      .mockImplementationOnce(async () => {
+        flatOutputMocks.hasMore.value = false
+      })
+    renderTab()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('folder-video-output.mp4')).toBeVisible()
+    })
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enter output folder' })
+    )
+
+    resolveLoad()
+    await flatOutputMocks.loadMore.mock.results[0].value
+    await nextTick()
+
+    expect(screen.getByText('folder-video-job')).toBeVisible()
+    expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
   })
 
   it('keeps history-backed generated assets when the asset API is disabled', () => {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -11,8 +11,6 @@ import { api } from '@/scripts/api'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
 
-const mockGetServerFeature = vi.spyOn(api, 'getServerFeature')
-
 const flatOutputMocks = vi.hoisted(() => ({
   media: undefined as unknown as Ref<AssetItem[]>,
   hasMore: undefined as unknown as Ref<boolean>,
@@ -206,7 +204,7 @@ function renderTab() {
 
 describe('AssetsSidebarTab folder navigation', () => {
   beforeEach(() => {
-    mockGetServerFeature.mockReturnValue(true)
+    vi.spyOn(api, 'getServerFeature').mockReturnValue(true)
     flatOutputMocks.media.value = [folderAsset, videoAsset]
     flatOutputMocks.hasMore.value = false
     flatOutputMocks.loadMore.mockReset()
@@ -271,7 +269,7 @@ describe('AssetsSidebarTab folder navigation', () => {
   })
 
   it('keeps history-backed generated assets when the asset API is disabled', () => {
-    mockGetServerFeature.mockReturnValue(false)
+    vi.mocked(api.getServerFeature).mockReturnValue(false)
 
     renderTab()
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,22 +1,42 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia } from 'pinia'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { api } from '@/scripts/api'
 
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
 
-const folderAsset = vi.hoisted(() => ({
-  id: 'multi-output',
-  name: 'multi-output.png',
-  tags: ['output'],
-  user_metadata: {
-    jobId: 'multi-output-job',
-    nodeId: '1',
-    subfolder: '',
-    outputCount: 2
-  }
-}))
+const mockGetServerFeature = vi.spyOn(api, 'getServerFeature')
+
+const folderAsset = vi.hoisted(
+  () =>
+    ({
+      id: 'multi-output',
+      name: 'multi-output.png',
+      tags: ['output'],
+      user_metadata: {
+        jobId: 'multi-output-job',
+        nodeId: '1',
+        subfolder: '',
+        outputCount: 2
+      }
+    }) satisfies AssetItem
+)
+
+const videoAsset = vi.hoisted(
+  () =>
+    ({
+      id: 'video-output',
+      name: 'video-output.mp4',
+      mime_type: 'video/mp4',
+      tags: ['output']
+    }) satisfies AssetItem
+)
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: false }))
 
 vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
   const { ref } = await import('vue')
@@ -27,6 +47,23 @@ vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
       loading: ref(false),
       error: ref(null),
       fetchMediaList: vi.fn(async () => [folderAsset]),
+      loadMore: vi.fn(),
+      hasMore: ref(false),
+      isLoadingMore: ref(false)
+    })
+  }
+})
+
+vi.mock('@/platform/assets/composables/media/useFlatOutputAssets', async () => {
+  const { ref } = await import('vue')
+  const media = ref([folderAsset, videoAsset])
+
+  return {
+    useFlatOutputAssets: () => ({
+      media,
+      loading: ref(false),
+      error: ref(null),
+      fetchMediaList: vi.fn().mockResolvedValue(media.value),
       loadMore: vi.fn(),
       hasMore: ref(false),
       isLoadingMore: ref(false)
@@ -93,6 +130,14 @@ const i18n = createI18n({
         backToAssets: 'Back to all assets',
         mediaAssets: { title: 'Media Assets' },
         labels: { generated: 'Generated', imported: 'Imported' }
+      },
+      mediaAsset: {
+        generatedMediaTabs: {
+          all: 'All',
+          images: 'Images',
+          videos: 'Videos',
+          audio: 'Audio'
+        }
       }
     }
   }
@@ -115,9 +160,11 @@ const assetsGridStub = {
   emits: ['output-count-click'],
   template: `
     <button
+      v-if="assets.length"
       aria-label="Enter output folder"
       @click="$emit('output-count-click', assets[0])"
     />
+    <span v-for="asset in assets" :key="asset.id">{{ asset.name }}</span>
   `
 }
 
@@ -149,6 +196,10 @@ function renderTab() {
 }
 
 describe('AssetsSidebarTab folder navigation', () => {
+  beforeEach(() => {
+    mockGetServerFeature.mockReturnValue(true)
+  })
+
   it('places accessible folder actions beside the job ID', async () => {
     renderTab()
     await userEvent.click(
@@ -176,5 +227,26 @@ describe('AssetsSidebarTab folder navigation', () => {
       screen.queryByRole('button', { name: 'Back to all assets' })
     ).not.toBeInTheDocument()
     expect(screen.queryByText('multi-output-job')).not.toBeInTheDocument()
+  })
+
+  it('filters persisted generated assets by media type', async () => {
+    renderTab()
+
+    expect(screen.getByText('multi-output.png')).toBeVisible()
+    expect(screen.getByText('video-output.mp4')).toBeVisible()
+
+    await userEvent.click(screen.getByText('Videos'))
+
+    expect(screen.queryByText('multi-output.png')).not.toBeInTheDocument()
+    expect(screen.getByText('video-output.mp4')).toBeVisible()
+  })
+
+  it('keeps history-backed generated assets when the asset API is disabled', () => {
+    mockGetServerFeature.mockReturnValue(false)
+
+    renderTab()
+
+    expect(screen.getByText('multi-output.png')).toBeVisible()
+    expect(screen.queryByText('video-output.mp4')).not.toBeInTheDocument()
   })
 })

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -2,6 +2,8 @@ import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
@@ -10,6 +12,12 @@ import { api } from '@/scripts/api'
 import AssetsSidebarTab from './AssetsSidebarTab.vue'
 
 const mockGetServerFeature = vi.spyOn(api, 'getServerFeature')
+
+const flatOutputMocks = vi.hoisted(() => ({
+  media: undefined as unknown as Ref<AssetItem[]>,
+  hasMore: undefined as unknown as Ref<boolean>,
+  loadMore: vi.fn()
+}))
 
 const folderAsset = vi.hoisted(
   () =>
@@ -56,16 +64,17 @@ vi.mock('@/platform/assets/composables/media/useAssetsApi', async () => {
 
 vi.mock('@/platform/assets/composables/media/useFlatOutputAssets', async () => {
   const { ref } = await import('vue')
-  const media = ref([folderAsset, videoAsset])
+  flatOutputMocks.media = ref([folderAsset, videoAsset])
+  flatOutputMocks.hasMore = ref(false)
 
   return {
     useFlatOutputAssets: () => ({
-      media,
+      media: flatOutputMocks.media,
       loading: ref(false),
       error: ref(null),
-      fetchMediaList: vi.fn().mockResolvedValue(media.value),
-      loadMore: vi.fn(),
-      hasMore: ref(false),
+      fetchMediaList: vi.fn().mockResolvedValue(flatOutputMocks.media.value),
+      loadMore: flatOutputMocks.loadMore,
+      hasMore: flatOutputMocks.hasMore,
       isLoadingMore: ref(false)
     })
   }
@@ -198,6 +207,9 @@ function renderTab() {
 describe('AssetsSidebarTab folder navigation', () => {
   beforeEach(() => {
     mockGetServerFeature.mockReturnValue(true)
+    flatOutputMocks.media.value = [folderAsset, videoAsset]
+    flatOutputMocks.hasMore.value = false
+    flatOutputMocks.loadMore.mockReset()
   })
 
   it('places accessible folder actions beside the job ID', async () => {
@@ -236,8 +248,25 @@ describe('AssetsSidebarTab folder navigation', () => {
     expect(screen.getByText('video-output.mp4')).toBeVisible()
 
     await userEvent.click(screen.getByText('Videos'))
+    await nextTick()
 
     expect(screen.queryByText('multi-output.png')).not.toBeInTheDocument()
+    expect(screen.getByText('video-output.mp4')).toBeVisible()
+  })
+
+  it('loads more persisted assets when the selected media type is absent', async () => {
+    flatOutputMocks.media.value = [folderAsset]
+    flatOutputMocks.hasMore.value = true
+    flatOutputMocks.loadMore.mockImplementation(async () => {
+      flatOutputMocks.media.value = [folderAsset, videoAsset]
+      flatOutputMocks.hasMore.value = false
+    })
+    renderTab()
+
+    await userEvent.click(screen.getByText('Videos'))
+    await nextTick()
+
+    expect(flatOutputMocks.loadMore).toHaveBeenCalledOnce()
     expect(screen.getByText('video-output.mp4')).toBeVisible()
   })
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -316,6 +316,7 @@ describe('AssetsSidebarTab folder navigation', () => {
     await vi.waitFor(() => {
       expect(flatOutputMocks.loadMore).toHaveBeenCalledTimes(2)
     })
+    await nextTick()
     expect(screen.getByText('audio-output.mp3')).toBeVisible()
   })
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -239,7 +239,7 @@ import type {
 } from '@/platform/assets/components/mediaAssetViewOptions'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'
 import { useAssetsApi } from '@/platform/assets/composables/media/useAssetsApi'
-import { useFlatOutputAssets } from '@/platform/assets/composables/media/useFlatOutputAssets'
+import { useFlatOutputAssetsGrouped } from '@/platform/assets/composables/media/useFlatOutputAssetsGrouped'
 import { useAssetGridSelection } from '@/platform/assets/composables/useAssetGridSelection'
 import { useAssetSelection } from '@/platform/assets/composables/useAssetSelection'
 import { useMediaAssetActions } from '@/platform/assets/composables/useMediaAssetActions'
@@ -257,7 +257,10 @@ import {
   getAssetUrl
 } from '@/platform/assets/utils/assetUrlUtil'
 import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
-import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
+import {
+  getTotalAssetOutputCount,
+  resolveOutputAssetItems
+} from '@/platform/assets/utils/outputAssetUtil'
 import { isCloud } from '@/platform/distribution/types'
 import { api } from '@/scripts/api'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -328,7 +331,7 @@ const toast = useToast()
 const inputAssets = useAssetsApi('input')
 const outputAssets =
   !isCloud && api.getServerFeature('assets', false)
-    ? useFlatOutputAssets()
+    ? useFlatOutputAssetsGrouped()
     : useAssetsApi('output')
 
 // Asset selection
@@ -392,14 +395,30 @@ const {
   { immediate: false, resetOnExecute: true }
 )
 
+function matchesGeneratedMediaKind(
+  asset: AssetItem,
+  mediaKind: Exclude<GeneratedMediaKind, 'all'>
+): boolean {
+  if (getAssetMediaKind(asset) === mediaKind) return true
+  const outputs = getOutputAssetMetadata(asset.user_metadata)?.allOutputs
+  return (
+    outputs?.some(
+      (output) =>
+        output.mediaType === mediaKind ||
+        (mediaKind === 'image' && output.mediaType === 'images')
+    ) ?? false
+  )
+}
+
 // Base assets before search filtering
 const baseAssets = computed(() => {
   if (isInFolderView.value) {
     return folderAssets.value
   }
-  if (activeTab.value === 'output' && generatedMediaKind.value !== 'all') {
-    return mediaAssets.value.filter(
-      (asset) => getAssetMediaKind(asset) === generatedMediaKind.value
+  const mediaKind = generatedMediaKind.value
+  if (activeTab.value === 'output' && mediaKind !== 'all') {
+    return mediaAssets.value.filter((asset) =>
+      matchesGeneratedMediaKind(asset, mediaKind)
     )
   }
   return mediaAssets.value
@@ -532,6 +551,15 @@ watch(
   { immediate: true }
 )
 
+let generatedMediaContextVersion = 0
+watch(
+  [activeTab, isInFolderView, generatedMediaKind],
+  () => {
+    generatedMediaContextVersion += 1
+  },
+  { flush: 'sync' }
+)
+
 async function ensureGeneratedMediaResults() {
   if (
     activeTab.value !== 'output' ||
@@ -543,10 +571,21 @@ async function ensureGeneratedMediaResults() {
     return
   }
 
-  while (baseAssets.value.length === 0 && outputAssets.hasMore.value) {
-    const previousCount = mediaAssets.value.length
+  const contextVersion = generatedMediaContextVersion
+  while (
+    contextVersion === generatedMediaContextVersion &&
+    baseAssets.value.length === 0 &&
+    outputAssets.hasMore.value
+  ) {
+    const previousCount = getTotalAssetOutputCount(mediaAssets.value)
     await outputAssets.loadMore()
-    if (error.value || mediaAssets.value.length === previousCount) break
+    if (
+      contextVersion !== generatedMediaContextVersion ||
+      error.value ||
+      getTotalAssetOutputCount(mediaAssets.value) === previousCount
+    ) {
+      break
+    }
   }
 }
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -537,7 +537,8 @@ async function ensureGeneratedMediaResults() {
     activeTab.value !== 'output' ||
     isInFolderView.value ||
     generatedMediaKind.value === 'all' ||
-    loading.value
+    loading.value ||
+    outputAssets.isLoadingMore.value
   ) {
     return
   }

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -69,6 +69,25 @@
           <Tab value="input">{{ $t('sideToolbar.labels.imported') }}</Tab>
         </TabList>
       </div>
+      <div
+        v-if="activeTab === 'output' && !isInFolderView"
+        class="border-b border-comfy-input px-2 py-1 2xl:px-4"
+      >
+        <TabList v-model="generatedMediaKind">
+          <Tab value="all" class="flex-1">{{
+            $t('mediaAsset.generatedMediaTabs.all')
+          }}</Tab>
+          <Tab value="image" class="flex-1">{{
+            $t('mediaAsset.generatedMediaTabs.images')
+          }}</Tab>
+          <Tab value="video" class="flex-1">{{
+            $t('mediaAsset.generatedMediaTabs.videos')
+          }}</Tab>
+          <Tab value="audio" class="flex-1">{{
+            $t('mediaAsset.generatedMediaTabs.audio')
+          }}</Tab>
+        </TabList>
+      </div>
     </template>
     <template #body>
       <div
@@ -220,6 +239,7 @@ import type {
 } from '@/platform/assets/components/mediaAssetViewOptions'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'
 import { useAssetsApi } from '@/platform/assets/composables/media/useAssetsApi'
+import { useFlatOutputAssets } from '@/platform/assets/composables/media/useFlatOutputAssets'
 import { useAssetGridSelection } from '@/platform/assets/composables/useAssetGridSelection'
 import { useAssetSelection } from '@/platform/assets/composables/useAssetSelection'
 import { useMediaAssetActions } from '@/platform/assets/composables/useMediaAssetActions'
@@ -228,7 +248,10 @@ import { useOutputStacks } from '@/platform/assets/composables/useOutputStacks'
 import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { getAssetDisplayName } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  getAssetDisplayName,
+  getAssetMediaKind
+} from '@/platform/assets/utils/assetMetadataUtils'
 import {
   getAssetSubfolder,
   getAssetUrl
@@ -236,13 +259,10 @@ import {
 import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import { isCloud } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
 import { useDialogStore } from '@/stores/dialogStore'
 import { ResultItemImpl } from '@/stores/queueStore'
-import {
-  formatDuration,
-  getMediaTypeFromFilename,
-  isPreviewableMediaType
-} from '@/utils/formatUtil'
+import { formatDuration, isPreviewableMediaType } from '@/utils/formatUtil'
 
 const Load3dViewerContent = defineAsyncComponent(
   () => import('@/components/load3d/Load3dViewerContent.vue')
@@ -253,6 +273,8 @@ const { t } = useI18n()
 const emit = defineEmits<{ assetSelected: [asset: AssetItem] }>()
 
 const activeTab = ref<'input' | 'output'>('output')
+type GeneratedMediaKind = 'all' | 'image' | 'video' | 'audio'
+const generatedMediaKind = ref<GeneratedMediaKind>('all')
 const folderJobId = ref<string | null>(null)
 const folderExecutionTime = ref<number | undefined>(undefined)
 const expectedFolderCount = ref(0)
@@ -286,7 +308,7 @@ const contextMenuAssetType = computed(() =>
 )
 
 const contextMenuFileKind = computed<MediaKind>(() =>
-  getMediaTypeFromFilename(contextMenuAsset.value?.name ?? '')
+  contextMenuAsset.value ? getAssetMediaKind(contextMenuAsset.value) : 'other'
 )
 
 const showOutputCount = (item: AssetItem): boolean => {
@@ -304,7 +326,10 @@ const formattedExecutionTime = computed(() => {
 const toast = useToast()
 
 const inputAssets = useAssetsApi('input')
-const outputAssets = useAssetsApi('output')
+const outputAssets =
+  !isCloud && api.getServerFeature('assets', false)
+    ? useFlatOutputAssets()
+    : useAssetsApi('output')
 
 // Asset selection
 const {
@@ -372,6 +397,11 @@ const baseAssets = computed(() => {
   if (isInFolderView.value) {
     return folderAssets.value
   }
+  if (activeTab.value === 'output' && generatedMediaKind.value !== 'all') {
+    return mediaAssets.value.filter(
+      (asset) => getAssetMediaKind(asset) === generatedMediaKind.value
+    )
+  }
   return mediaAssets.value
 })
 
@@ -409,7 +439,7 @@ const { marqueeStyle } = useAssetGridSelection({
 
 const previewableVisibleAssets = computed(() =>
   visibleAssets.value.filter((asset) =>
-    isPreviewableMediaType(getMediaTypeFromFilename(asset.name))
+    isPreviewableMediaType(getAssetMediaKind(asset))
   )
 )
 
@@ -429,12 +459,18 @@ const isFolderLoading = computed(
 
 const showLoadingState = computed(
   () =>
-    (loading.value || isFolderLoading.value) && displayAssets.value.length === 0
+    (loading.value ||
+      isFolderLoading.value ||
+      (activeTab.value === 'output' && outputAssets.isLoadingMore.value)) &&
+    displayAssets.value.length === 0
 )
 
 const showEmptyState = computed(
   () =>
-    !loading.value && !isFolderLoading.value && displayAssets.value.length === 0
+    !loading.value &&
+    !isFolderLoading.value &&
+    !outputAssets.isLoadingMore.value &&
+    displayAssets.value.length === 0
 )
 
 watch(visibleAssets, (newAssets) => {
@@ -457,7 +493,7 @@ watch(galleryActiveIndex, (index) => {
 
 const galleryItems = computed(() => {
   return previewableVisibleAssets.value.map((asset) => {
-    const mediaType = getMediaTypeFromFilename(asset.name)
+    const mediaType = getAssetMediaKind(asset)
     const resultItem = new ResultItemImpl({
       filename: asset.name,
       subfolder: getAssetSubfolder(asset),
@@ -494,6 +530,35 @@ watch(
     void refreshAssets()
   },
   { immediate: true }
+)
+
+async function ensureGeneratedMediaResults() {
+  if (
+    activeTab.value !== 'output' ||
+    isInFolderView.value ||
+    generatedMediaKind.value === 'all' ||
+    loading.value
+  ) {
+    return
+  }
+
+  while (baseAssets.value.length === 0 && outputAssets.hasMore.value) {
+    const previousCount = mediaAssets.value.length
+    await outputAssets.loadMore()
+    if (error.value || mediaAssets.value.length === previousCount) break
+  }
+}
+
+watch(generatedMediaKind, () => {
+  clearSelection()
+  void ensureGeneratedMediaResults()
+})
+
+watch(
+  [loading, () => outputAssets.isLoadingMore.value],
+  ([isLoading, loadingMore]) => {
+    if (!isLoading && !loadingMore) void ensureGeneratedMediaResults()
+  }
 )
 
 function handleAssetSelect(asset: AssetItem, assets?: AssetItem[]) {
@@ -567,7 +632,7 @@ const handleDeleteSelected = async () => {
 }
 
 const handleZoomClick = (asset: AssetItem) => {
-  const mediaType = getMediaTypeFromFilename(asset.name)
+  const mediaType = getAssetMediaKind(asset)
   if (!isPreviewableMediaType(mediaType)) {
     return
   }

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -469,7 +469,7 @@ const showEmptyState = computed(
   () =>
     !loading.value &&
     !isFolderLoading.value &&
-    !outputAssets.isLoadingMore.value &&
+    !(activeTab.value === 'output' && outputAssets.isLoadingMore.value) &&
     displayAssets.value.length === 0
 )
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3826,6 +3826,12 @@
     }
   },
   "mediaAsset": {
+    "generatedMediaTabs": {
+      "all": "All",
+      "images": "Images",
+      "videos": "Videos",
+      "audio": "Audio"
+    },
     "deleteAssetTitle": "Delete this asset?",
     "deleteAssetDescription": "This asset will be permanently removed.",
     "deleteSelectedTitle": "Delete selected assets?",

--- a/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.test.ts
+++ b/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
+import { ref } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+
+import { useFlatOutputAssetsGrouped } from './useFlatOutputAssetsGrouped'
+
+const media: Ref<AssetItem[]> = ref([])
+
+vi.mock('./useFlatOutputAssets', () => ({
+  useFlatOutputAssets: () => ({
+    media,
+    loading: ref(false),
+    error: ref(null),
+    hasMore: ref(false),
+    isLoadingMore: ref(false),
+    fetchMediaList: vi.fn(),
+    refresh: vi.fn(),
+    loadMore: vi.fn()
+  })
+}))
+
+function asset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    ...overrides,
+    id: overrides.id ?? 'asset-id',
+    name: overrides.name ?? 'output.png',
+    created_at: overrides.created_at ?? '2026-08-25T00:00:00.000Z',
+    updated_at: overrides.updated_at ?? '2026-08-25T00:00:00.000Z',
+    tags: overrides.tags ?? ['output']
+  }
+}
+
+describe('useFlatOutputAssetsGrouped', () => {
+  it('preserves one output card per job with the full loaded output group', () => {
+    const first = asset({
+      id: 'first',
+      name: 'first.png',
+      job_id: 'job-1',
+      preview_url: '/view?filename=first.png&type=output&subfolder=nested',
+      user_metadata: { nodeId: '7' }
+    })
+    const second = asset({
+      id: 'second',
+      name: 'second.mp4',
+      mime_type: 'video/mp4',
+      job_id: 'job-1'
+    })
+    media.value = [first, second, asset({ id: 'ungrouped' })]
+
+    const grouped = useFlatOutputAssetsGrouped().media.value
+    const metadata = getOutputAssetMetadata(grouped[0].user_metadata)
+
+    expect(grouped.map((item) => item.id)).toEqual(['first', 'ungrouped'])
+    expect(metadata).toMatchObject({
+      jobId: 'job-1',
+      nodeId: '7',
+      subfolder: 'nested',
+      outputCount: 2
+    })
+    expect(metadata?.allOutputs?.map((output) => output.filename)).toEqual([
+      'first.png',
+      'second.mp4'
+    ])
+    expect(metadata?.allOutputs?.map((output) => output.mediaType)).toEqual([
+      'images',
+      'video'
+    ])
+    expect(first.user_metadata).toEqual({ nodeId: '7' })
+  })
+
+  it('keeps distinct jobs in first-occurrence order', () => {
+    media.value = [
+      asset({ id: 'a', job_id: 'job-a' }),
+      asset({ id: 'b', job_id: 'job-b' }),
+      asset({ id: 'a-sibling', job_id: 'job-a' })
+    ]
+
+    expect(
+      useFlatOutputAssetsGrouped().media.value.map((item) => item.id)
+    ).toEqual(['a', 'b'])
+  })
+})

--- a/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.ts
+++ b/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.ts
@@ -1,0 +1,71 @@
+import { computed } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { getAssetMediaKind } from '@/platform/assets/utils/assetMetadataUtils'
+import { getAssetSubfolder } from '@/platform/assets/utils/assetUrlUtil'
+import { ResultItemImpl } from '@/stores/queueStore'
+
+import type { IAssetsProvider } from './IAssetsProvider'
+import { useFlatOutputAssets } from './useFlatOutputAssets'
+
+function getAssetNodeId(asset: AssetItem): string | number {
+  const nodeId = asset.user_metadata?.nodeId ?? asset.metadata?.node_id
+  return typeof nodeId === 'string' || typeof nodeId === 'number' ? nodeId : '0'
+}
+
+function toResultItem(asset: AssetItem): ResultItemImpl {
+  const mediaKind = getAssetMediaKind(asset)
+  return new ResultItemImpl({
+    filename: asset.name,
+    subfolder: getAssetSubfolder(asset),
+    type: 'output',
+    nodeId: getAssetNodeId(asset),
+    mediaType: mediaKind === 'image' ? 'images' : mediaKind,
+    display_name: asset.display_name ?? undefined
+  })
+}
+
+function groupByJobId(assets: AssetItem[]): AssetItem[] {
+  const assetsByJobId = new Map<string, AssetItem[]>()
+  for (const asset of assets) {
+    if (!asset.job_id) continue
+    const groupedAssets = assetsByJobId.get(asset.job_id)
+    if (groupedAssets) {
+      groupedAssets.push(asset)
+    } else {
+      assetsByJobId.set(asset.job_id, [asset])
+    }
+  }
+
+  const seenJobIds = new Set<string>()
+  return assets.flatMap((asset) => {
+    const jobId = asset.job_id
+    if (!jobId) return [asset]
+    if (seenJobIds.has(jobId)) return []
+    seenJobIds.add(jobId)
+
+    const allOutputs = (assetsByJobId.get(jobId) ?? [asset]).map(toResultItem)
+    const representativeOutput = allOutputs[0]
+    return [
+      {
+        ...asset,
+        user_metadata: {
+          ...asset.user_metadata,
+          jobId,
+          nodeId: representativeOutput.nodeId,
+          subfolder: representativeOutput.subfolder,
+          outputCount: allOutputs.length,
+          allOutputs
+        }
+      }
+    ]
+  })
+}
+
+export function useFlatOutputAssetsGrouped(): IAssetsProvider {
+  const inner = useFlatOutputAssets()
+  return {
+    ...inner,
+    media: computed(() => groupByJobId(inner.media.value))
+  }
+}

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -162,6 +162,17 @@ describe('assetMetadataUtils', () => {
       ).toBe('video')
     })
 
+    it('falls back to filename metadata', () => {
+      expect(
+        getAssetMediaKind({
+          ...mockAsset,
+          name: 'blake3:abc',
+          metadata: { filename: 'render.mp4' },
+          mime_type: 'application/octet-stream'
+        })
+      ).toBe('video')
+    })
+
     it('falls back to the asset name for generic MIME metadata', () => {
       expect(
         getAssetMediaKind({

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -19,6 +19,7 @@ import {
   getAssetDisplayName,
   getAssetFilename,
   getAssetMetadataDimensions,
+  getAssetMediaKind,
   getAssetModelType,
   getAssetNodeCategoryCandidates,
   getAssetSourceUrl,
@@ -132,6 +133,43 @@ describe('assetMetadataUtils', () => {
     ])('$name', ({ user_metadata, display_name, expected }) => {
       const asset = { ...mockAsset, user_metadata, display_name }
       expect(getAssetDisplayName(asset)).toBe(expected)
+    })
+  })
+
+  describe('getAssetMediaKind', () => {
+    it.for([
+      { mime_type: 'image/png', expected: 'image' },
+      { mime_type: 'video/mp4', expected: 'video' },
+      { mime_type: 'audio/wav', expected: 'audio' }
+    ])('prefers $mime_type MIME metadata', ({ mime_type, expected }) => {
+      expect(
+        getAssetMediaKind({
+          ...mockAsset,
+          name: 'content-without-extension',
+          mime_type
+        })
+      ).toBe(expected)
+    })
+
+    it('falls back to the display filename', () => {
+      expect(
+        getAssetMediaKind({
+          ...mockAsset,
+          name: 'blake3:abc',
+          display_name: 'render.mp4',
+          mime_type: null
+        })
+      ).toBe('video')
+    })
+
+    it('falls back to the asset name for generic MIME metadata', () => {
+      expect(
+        getAssetMediaKind({
+          ...mockAsset,
+          name: 'voice.flac',
+          mime_type: 'application/octet-stream'
+        })
+      ).toBe('audio')
     })
   })
 

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -157,7 +157,7 @@ describe('assetMetadataUtils', () => {
           ...mockAsset,
           name: 'blake3:abc',
           display_name: 'render.mp4',
-          mime_type: null
+          mime_type: undefined
         })
       ).toBe('video')
     })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -1,6 +1,7 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import type { MediaKind } from '@/platform/assets/schemas/mediaAssetSchema'
 import { isCloud } from '@/platform/distribution/types'
-import { isCivitaiUrl } from '@/utils/formatUtil'
+import { getMediaTypeFromFilename, isCivitaiUrl } from '@/utils/formatUtil'
 
 // Reserved tag literals (mirror assetService's MODELS_TAG/MISSING_TAG). Kept
 // local so this leaf util doesn't pull the heavier assetService -> i18n chain.
@@ -71,6 +72,17 @@ export function getAssetBaseModels(asset: AssetItem): string[] {
  */
 export function getAssetDisplayName(asset: AssetItem): string {
   return getStringProperty(asset, 'name') || asset.display_name || asset.name
+}
+
+export function getAssetMediaKind(asset: AssetItem): MediaKind {
+  const mimeKind = asset.mime_type?.split('/', 1)[0]?.trim().toLowerCase()
+  if (mimeKind === 'image' || mimeKind === 'video' || mimeKind === 'audio') {
+    return mimeKind
+  }
+
+  const filename =
+    getStringProperty(asset, 'filename') ?? asset.display_name ?? asset.name
+  return getMediaTypeFromFilename(filename)
 }
 
 /**


### PR DESCRIPTION
## Summary

Use the persistent local output asset index for the Generated gallery when the server advertises asset support, while preserving one card per job and adding All, Images, Videos, and Audio filters.

## Changes

- Groups persisted outputs by `job_id` and preserves `outputCount` / `allOutputs`; assets without a job remain independent.
- Keeps current `main` subfolder handling and history-backed behavior when the asset API is unavailable.
- Filters mixed-output jobs by every grouped output, not only the representative card.
- Loads additional pages when the selected media type is absent, serializes requests, and stops stale pagination after tab, folder, or media-context changes.
- Aligns the grouping contract with the overlapping work in #12464 and has no dependency on the closed #14831.

## Review Focus

- One-card-per-job behavior across pages, including mixed media and output counts.
- Pagination cancellation when switching Generated/Imported, entering a folder, or changing media filters.
- Existing Generated subfolder behavior and the asset-API-disabled fallback.

## Tests

- 263 tests across 11 related Vitest files
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm knip`
- Commit and pre-push hooks
