### PR TITLE
[backport core/1.49] fix(workflow): build nodes for uninstalled types on API JSON import (#14555)

### DIFF
--- a/browser_tests/tests/workflowPersistence.spec.ts
+++ b/browser_tests/tests/workflowPersistence.spec.ts
@@ -307,20 +307,26 @@ test.describe('Workflow Persistence', () => {
     }, apiWorkflow)
     await comfyPage.nextFrame()
 
-    // Known nodes (KSampler, EmptyLatentImage) should load; unknown node skipped
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBeGreaterThanOrEqual(2)
+    // Known nodes and an error-marked placeholder for the unknown node load.
+    await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(3)
 
-    const getNodeTypes = () =>
+    const getNodes = () =>
       comfyPage.page.evaluate(() =>
-        window.app!.graph.nodes.map((n: { type: string }) => n.type)
+        window.app!.graph.nodes.map((node) => ({
+          type: node.type,
+          hasErrors: node.has_errors
+        }))
       )
-    await expect.poll(getNodeTypes).toContain('KSampler')
-    await expect.poll(getNodeTypes).toContain('EmptyLatentImage')
     await expect
-      .poll(getNodeTypes)
-      .not.toContain('NonExistentCustomNode_XYZ_12345')
+      .poll(getNodes)
+      .toContainEqual(expect.objectContaining({ type: 'KSampler' }))
+    await expect
+      .poll(getNodes)
+      .toContainEqual(expect.objectContaining({ type: 'EmptyLatentImage' }))
+    await expect.poll(getNodes).toContainEqual({
+      type: 'NonExistentCustomNode_XYZ_12345',
+      hasErrors: true
+    })
   })
 
   test('Canvas has auxclick handler to prevent middle-click paste', async ({

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -2,13 +2,21 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
 } from '@/platform/workflow/validation/schemas/workflowSchema'
-import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import {
+  ComfyWorkflow,
+  useWorkflowStore
+} from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
+import { useNodeReplacementStore } from '@/platform/nodeReplacement/nodeReplacementStore'
+import type { NodeReplacement } from '@/platform/nodeReplacement/types'
 import { ComfyApp, app as singletonApp } from './app'
 import { createNode } from '@/utils/litegraphUtil'
 import {
@@ -22,6 +30,8 @@ import {
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
+import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import { setTelemetryRegistry } from '@/platform/telemetry'
 import { TelemetryRegistry } from '@/platform/telemetry/TelemetryRegistry'
 import * as executionContextUtils from '@/platform/telemetry/utils/getExecutionContext'
@@ -33,14 +43,15 @@ import { useDialogStore } from '@/stores/dialogStore'
 import type { NodeError } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { createNodeExecutionId } from '@/types/nodeIdentification'
+import { toNodeId } from '@/types/nodeId'
 import {
   createTestRootGraph,
   createTestSubgraph,
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { extractFilesFromDragEvent } from '@/utils/eventUtils'
 import type { importA1111 } from './pnginfo'
-import type { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 
 type WorkflowService = ReturnType<typeof useWorkflowService>
 
@@ -75,10 +86,14 @@ const {
     invokeExtensionsAsync: vi.fn()
   },
   mockNodeOutputStore: {
-    refreshNodeOutputs: vi.fn()
+    refreshNodeOutputs: vi.fn(),
+    resetAllOutputsAndPreviews: vi.fn()
   },
   mockWorkspaceWorkflow: {
-    activeWorkflow: null as ComfyWorkflow | null
+    activeWorkflow: null as ComfyWorkflow | null,
+    createNewTemporary: vi.fn(),
+    openWorkflow: vi.fn(),
+    getWorkflowByPath: vi.fn(() => null)
   },
   mockRefreshMissingModelPipeline: vi.fn(),
   mockImportA1111: vi.fn<typeof importA1111>(),
@@ -123,6 +138,14 @@ vi.mock('@/scripts/metadata/parser', () => ({
   getWorkflowDataFromFile: vi.fn()
 }))
 
+vi.mock('@/utils/eventUtils', async (importOriginal) => {
+  const eventUtils = await importOriginal<typeof import('@/utils/eventUtils')>()
+  return {
+    ...eventUtils,
+    extractFilesFromDragEvent: vi.fn()
+  }
+})
+
 vi.mock('./pnginfo', () => ({
   importA1111: mockImportA1111
 }))
@@ -147,6 +170,13 @@ vi.mock('@/services/extensionService', () => ({
 
 vi.mock('@/stores/nodeOutputStore', () => ({
   useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
+}))
+
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: vi.fn(() => ({
+    saveCurrentViewport: vi.fn(),
+    updateHash: vi.fn()
+  }))
 }))
 
 vi.mock('@/stores/workspaceStore', () => ({
@@ -181,12 +211,41 @@ function createMockCanvas(): Partial<LGraphCanvas> {
     graph: mockGraph as LGraph,
     draw: vi.fn(),
     selectItems: vi.fn(),
+    setDirty: vi.fn(),
     setGraph: vi.fn()
   }
 }
 
 function createTestFile(name: string, type: string): File {
   return new File([''], name, { type })
+}
+
+/**
+ * Point the workflowService mock at the real implementation for tests that
+ * exercise the load lifecycle itself rather than app.ts's calls into it.
+ */
+async function useRealWorkflowService(): Promise<WorkflowService> {
+  const actual = await vi.importActual<
+    typeof import('@/platform/workflow/core/services/workflowService')
+  >('@/platform/workflow/core/services/workflowService')
+  const real = actual.useWorkflowService()
+  mockWorkflowService.beforeLoadNewGraph.mockImplementation(
+    real.beforeLoadNewGraph
+  )
+  mockWorkflowService.afterLoadNewGraph.mockImplementation(
+    real.afterLoadNewGraph
+  )
+  mockWorkflowService.showPendingWarnings.mockImplementation(
+    real.showPendingWarnings
+  )
+  return real
+}
+
+function markLoaded(workflow: ComfyWorkflow): LoadedComfyWorkflow {
+  workflow.changeTracker = createMockChangeTracker()
+  workflow.content = '{}'
+  workflow.originalContent = '{}'
+  return workflow as LoadedComfyWorkflow
 }
 
 function createWorkflowGraphData(): ComfyWorkflowJSON {
@@ -213,10 +272,21 @@ describe('ComfyApp', () => {
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
     mockWorkspaceWorkflow.activeWorkflow = null
+    const temporaryWorkflow = new ComfyWorkflow({
+      path: 'workflows/temporary.json',
+      modified: 0,
+      size: 0
+    })
+    mockWorkspaceWorkflow.createNewTemporary.mockReturnValue(temporaryWorkflow)
+    mockWorkspaceWorkflow.openWorkflow.mockImplementation(async (workflow) => {
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      return workflow
+    })
     mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
     mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
+    vi.mocked(extractFilesFromDragEvent).mockResolvedValue([])
     mockImportA1111.mockResolvedValue('imported')
     mockWorkflowService.afterLoadNewGraph.mockResolvedValue()
     mockSettingStore.get.mockImplementation((key: string) =>
@@ -718,6 +788,254 @@ describe('ComfyApp', () => {
     })
   })
 
+  describe('workflow lifecycle', () => {
+    it('clears missing node packs before loading API JSON without missing nodes', async () => {
+      const graph = new LGraph()
+      const activeSubgraph = createTestSubgraph({ rootGraph: graph })
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      Reflect.set(mockCanvas, 'graph', activeSubgraph)
+      Reflect.set(mockCanvas, 'subgraph', activeSubgraph)
+      vi.mocked(mockCanvas.setGraph).mockImplementation((nextGraph) => {
+        Reflect.set(mockCanvas, 'graph', nextGraph)
+        Reflect.set(mockCanvas, 'subgraph', null)
+      })
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      const nodeType = 'test/RegisteredApiNode'
+      class RegisteredApiNode extends LGraphNode {}
+      LiteGraph.registerNodeType(nodeType, RegisteredApiNode)
+
+      try {
+        await app.loadApiJson(
+          {
+            '1': {
+              class_type: nodeType,
+              inputs: {},
+              _meta: { title: 'Registered API Node' }
+            }
+          },
+          ''
+        )
+
+        expect(missingNodesStore.missingNodesError).toBeNull()
+        expect(mockCanvas.setGraph).toHaveBeenCalledWith(graph)
+        expect(mockCanvas.graph).toBe(graph)
+        expect(mockCanvas.subgraph).toBeNull()
+      } finally {
+        LiteGraph.unregisterNodeType(nodeType)
+      }
+    })
+
+    it('creates a removable placeholder for an API JSON missing node', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const cleanupErrorHooks = installErrorClearingHooks(graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      const missingNodeType = 'Uninstalled<&Node>'
+      const replacement: NodeReplacement = {
+        new_node_id: 'ReplacementNode',
+        old_node_id: missingNodeType,
+        old_widget_ids: null,
+        input_mapping: null,
+        output_mapping: null
+      }
+      const nodeReplacementStore = useNodeReplacementStore()
+      const loadReplacements = vi
+        .spyOn(nodeReplacementStore, 'load')
+        .mockResolvedValue()
+      const getReplacement = vi
+        .spyOn(nodeReplacementStore, 'getReplacementFor')
+        .mockReturnValue(replacement)
+      const apiData: unknown = {
+        '-1': {
+          class_type: missingNodeType,
+          inputs: {}
+        }
+      }
+      if (!app.isApiJson(apiData)) throw new Error('Expected valid API JSON')
+
+      try {
+        await app.loadApiJson(apiData, 'api-missing')
+
+        const placeholder = graph.nodes[0]
+        if (!placeholder) throw new Error('Expected missing-node placeholder')
+        expect(placeholder).toMatchObject({
+          type: 'UninstalledNode',
+          title: missingNodeType,
+          has_errors: true
+        })
+        expect(placeholder.id).not.toBe(toNodeId(-1))
+        expect(placeholder.serialize()).toMatchObject({
+          id: placeholder.id,
+          type: missingNodeType,
+          title: missingNodeType
+        })
+        expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+          {
+            type: missingNodeType,
+            nodeId: String(placeholder.id),
+            isReplaceable: true,
+            replacement
+          }
+        ])
+        expect(loadReplacements).toHaveBeenCalledOnce()
+        expect(getReplacement).toHaveBeenCalled()
+        expect(loadReplacements.mock.invocationCallOrder[0]).toBeLessThan(
+          getReplacement.mock.invocationCallOrder[0]
+        )
+
+        graph.remove(placeholder)
+        expect(missingNodesStore.missingNodesError).toBeNull()
+      } finally {
+        cleanupErrorHooks()
+      }
+    })
+
+    it('preserves API JSON inputs on a missing node across reload', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const sourceNodeType = 'test/ApiJsonSourceNode'
+      const missingNodeType = 'UninstalledInputNode'
+      class ApiJsonSourceNode extends LGraphNode {
+        constructor() {
+          super('API JSON source')
+          this.addOutput('images', 'IMAGE')
+        }
+      }
+      class InstalledInputNode extends LGraphNode {
+        constructor() {
+          super('Installed input node')
+          this.addInput('images', 'IMAGE')
+          this.addWidget('number', 'width', 0, null, {})
+          this.addWidget('text', 'caption', '', null, {})
+        }
+      }
+      LiteGraph.registerNodeType(sourceNodeType, ApiJsonSourceNode)
+      let installedTypeRegistered = false
+      const nodeReplacementStore = useNodeReplacementStore()
+      vi.spyOn(nodeReplacementStore, 'load').mockResolvedValue()
+      vi.spyOn(nodeReplacementStore, 'getReplacementFor').mockReturnValue(null)
+
+      try {
+        await app.loadApiJson(
+          {
+            '3': {
+              class_type: missingNodeType,
+              inputs: {
+                images: ['4', 0],
+                width: 512,
+                caption: 'preserved caption'
+              },
+              _meta: { title: 'Missing input node' }
+            },
+            '4': {
+              class_type: sourceNodeType,
+              inputs: {},
+              _meta: { title: 'API JSON source' }
+            }
+          },
+          'api-inputs'
+        )
+
+        const placeholder = graph.getNodeById(toNodeId(3))
+        if (!placeholder) throw new Error('Expected missing-node placeholder')
+        const imageInput = placeholder.inputs.find(
+          (input) => input.name === 'images'
+        )
+        expect(imageInput).toMatchObject({ name: 'images', type: '*' })
+        expect(imageInput?.link).not.toBeNull()
+        if (imageInput?.link == null) throw new Error('Expected input link')
+        expect(graph.links.get(imageInput.link)).toMatchObject({
+          origin_id: toNodeId(4),
+          target_id: toNodeId(3)
+        })
+
+        const serializedGraph = graph.serialize()
+        const serializedPlaceholder = serializedGraph.nodes.find(
+          (node) => node.id === placeholder.id
+        )
+        expect(serializedPlaceholder).toMatchObject({
+          widgets_values: [512, 'preserved caption'],
+          widgets_values_named: {
+            width: 512,
+            caption: 'preserved caption'
+          }
+        })
+
+        const roundTripGraph = new LGraph()
+        roundTripGraph.configure(serializedGraph)
+        const roundTripPlaceholder = roundTripGraph.getNodeById(toNodeId(3))
+        expect(roundTripPlaceholder?.inputs[0]).toMatchObject({
+          name: 'images',
+          type: '*',
+          link: imageInput.link
+        })
+        expect(roundTripPlaceholder?.serialize()).toMatchObject({
+          widgets_values: [512, 'preserved caption'],
+          widgets_values_named: {
+            width: 512,
+            caption: 'preserved caption'
+          }
+        })
+
+        LiteGraph.registerNodeType(missingNodeType, InstalledInputNode)
+        installedTypeRegistered = true
+        const installedGraph = new LGraph()
+        installedGraph.configure(serializedGraph)
+        expect(
+          installedGraph
+            .getNodeById(toNodeId(3))
+            ?.widgets?.map((widget) => widget.value)
+        ).toEqual([512, 'preserved caption'])
+      } finally {
+        LiteGraph.unregisterNodeType(sourceNodeType)
+        if (installedTypeRegistered) {
+          LiteGraph.unregisterNodeType(missingNodeType)
+        }
+      }
+    })
+
+    it('defers API JSON missing node warnings until they are flushed', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const nodeReplacementStore = useNodeReplacementStore()
+      vi.spyOn(nodeReplacementStore, 'load').mockResolvedValue()
+      vi.spyOn(nodeReplacementStore, 'getReplacementFor').mockReturnValue(null)
+      const missingNodesStore = useMissingNodesErrorStore()
+      const workflowService = await useRealWorkflowService()
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        prompt: {
+          '1': {
+            class_type: 'UninstalledDeferredNode',
+            inputs: {},
+            _meta: { title: 'Deferred missing node' }
+          }
+        }
+      })
+
+      await app.handleFile(
+        createTestFile('deferred.json', 'application/json'),
+        'file_drop',
+        { deferWarnings: true }
+      )
+
+      const deferredWorkflow = mockWorkspaceWorkflow.activeWorkflow
+      expect(missingNodesStore.missingNodesError).toBeNull()
+      expect(deferredWorkflow?.pendingWarnings?.missingNodeTypes).toEqual([
+        expect.objectContaining({ type: 'UninstalledDeferredNode' })
+      ])
+
+      workflowService.showPendingWarnings(deferredWorkflow)
+
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+        expect.objectContaining({ type: 'UninstalledDeferredNode' })
+      ])
+    })
+  })
   describe('refreshComboInNodes', () => {
     it('shows success toast and removes the pending toast after node defs reload', async () => {
       app.vueAppReady = true
@@ -1325,10 +1643,7 @@ describe('ComfyApp', () => {
   })
 
   describe('drop handler', () => {
-    it('syncs graph_mouse from the drop event before downstream handlers run', async () => {
-      // graph_mouse is only updated on mousemove, so when files are dragged in
-      // from another window the canvas-space cursor is stale. The drop handler
-      // must derive the position from the drop event itself.
+    it('syncs the drop position and waits for the replacement workflow before restoring warnings', async () => {
       const graphMouse: [number, number] = [-999, -999]
       const adjustMouseEvent = vi.fn((e: DragEvent) => {
         ;(e as DragEvent & { canvasX: number; canvasY: number }).canvasX = 123
@@ -1340,13 +1655,76 @@ describe('ComfyApp', () => {
         adjustMouseEvent
       } as unknown as LGraphCanvas
 
-      ;(app as unknown as { addDropHandler(): void }).addDropHandler()
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const outgoingWorkflow = new ComfyWorkflow({
+        path: 'workflows/outgoing.json',
+        modified: 0,
+        size: 0
+      })
+      outgoingWorkflow.pendingWarnings = {
+        missingNodeTypes: ['OutgoingMissingNode']
+      }
+      mockWorkspaceWorkflow.activeWorkflow = outgoingWorkflow
+      const realWorkflowStore = useWorkflowStore()
+      realWorkflowStore.activeWorkflow = markLoaded(outgoingWorkflow)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['OutgoingMissingNode'])
+      await useRealWorkflowService()
 
-      document.dispatchEvent(new DragEvent('drop'))
-      await Promise.resolve()
+      const nodeType = 'test/UninstalledDroppedApiNode'
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        prompt: {
+          '1': {
+            class_type: nodeType,
+            inputs: {}
+          }
+        }
+      })
+      vi.mocked(extractFilesFromDragEvent).mockResolvedValue([
+        createTestFile('workflow.json', 'application/json')
+      ])
 
-      expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
-      expect(graphMouse).toEqual([123, 456])
+      let releaseOpenWorkflow: () => void = () => {}
+      const openWorkflowGate = new Promise<void>((resolve) => {
+        releaseOpenWorkflow = resolve
+      })
+      mockWorkspaceWorkflow.openWorkflow.mockImplementation(
+        async (workflow: ComfyWorkflow) => {
+          await openWorkflowGate
+          mockWorkspaceWorkflow.activeWorkflow = workflow
+          realWorkflowStore.activeWorkflow = markLoaded(workflow)
+          return workflow
+        }
+      )
+
+      try {
+        ;(app as unknown as { addDropHandler(): void }).addDropHandler()
+
+        document.dispatchEvent(new DragEvent('drop'))
+        await vi.waitFor(() => {
+          expect(mockWorkspaceWorkflow.openWorkflow).toHaveBeenCalledOnce()
+        })
+
+        expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
+        expect(graphMouse).toEqual([123, 456])
+        expect(missingNodesStore.missingNodesError).toBeNull()
+
+        releaseOpenWorkflow()
+        await vi.waitFor(() => {
+          expect(mockWorkspaceWorkflow.activeWorkflow).not.toBe(
+            outgoingWorkflow
+          )
+        })
+        await vi.waitFor(() => {
+          expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+            expect.objectContaining({ type: nodeType, nodeId: '1' })
+          ])
+        })
+      } finally {
+        releaseOpenWorkflow()
+      }
     })
   })
 })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -15,6 +15,7 @@ import { st, t } from '@/i18n'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import {
+  inputAsSerialisable,
   LGraph,
   LGraphCanvas,
   LGraphNode,
@@ -22,7 +23,10 @@ import {
 } from '@/lib/litegraph/src/litegraph'
 import { snapPoint } from '@/lib/litegraph/src/measure'
 import type { Vector2 } from '@/lib/litegraph/src/litegraph'
-import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type {
+  IBaseWidget,
+  TWidgetValue
+} from '@/lib/litegraph/src/types/widgets'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { useFreeTierQuota } from '@/platform/cloud/subscription/composables/useFreeTierQuota'
 import { isCloud } from '@/platform/distribution/types'
@@ -41,6 +45,7 @@ import type {
   WorkflowQueueIntent
 } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowValidation } from '@/platform/workflow/validation/composables/useWorkflowValidation'
@@ -82,7 +87,6 @@ import { useCommandStore } from '@/stores/commandStore'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useExtensionStore } from '@/stores/extensionStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -1187,9 +1191,14 @@ export class ComfyApp {
     }
   }
 
-  private showMissingNodesError(missingNodeTypes: MissingNodeType[]) {
-    if (useMissingNodesErrorStore().surfaceMissingNodes(missingNodeTypes)) {
-      useExecutionErrorStore().showErrorOverlay()
+  private showMissingNodesError(
+    missingNodeTypes: MissingNodeType[],
+    options?: { deferWarnings?: boolean }
+  ) {
+    const activeWorkflow = useWorkspaceStore().workflow.activeWorkflow
+    updatePendingWarnings(activeWorkflow, { missingNodeTypes })
+    if (!options?.deferWarnings) {
+      useWorkflowService().showPendingWarnings(activeWorkflow)
     }
   }
 
@@ -1975,7 +1984,9 @@ export class ComfyApp {
             ? parseJsonWithNonFinite<ComfyApiWorkflow>(prompt)
             : prompt
         if (this.isApiJson(promptObj)) {
-          this.loadApiJson(promptObj, fileName)
+          await this.loadApiJson(promptObj, fileName, {
+            deferWarnings: options?.deferWarnings
+          })
           return
         }
       } catch (err) {
@@ -2130,25 +2141,71 @@ export class ComfyApp {
     })
   }
 
-  loadApiJson(apiData: ComfyApiWorkflow, fileName: string) {
+  async loadApiJson(
+    apiData: ComfyApiWorkflow,
+    fileName: string,
+    options: { deferWarnings?: boolean } = {}
+  ): Promise<void> {
     useWorkflowService().beforeLoadNewGraph()
-
-    const missingNodeTypes = Object.values(apiData).filter(
-      (n) => !LiteGraph.registered_node_types[n.class_type]
-    )
-    if (missingNodeTypes.length) {
-      this.showMissingNodesError(missingNodeTypes.map((t) => t.class_type))
-    }
+    this.canvas.setGraph(this.rootGraph)
+    this.clean()
 
     const ids = Object.keys(apiData)
-    app.rootGraph.clear()
+    const missingNodeTypes: MissingNodeType[] = []
+    const nodeReplacementStore = useNodeReplacementStore()
+    await nodeReplacementStore.load()
     for (const id of ids) {
       const data = apiData[id]
-      const node = LiteGraph.createNode(data.class_type)
-      if (!node) continue
-      node.id = toNodeId(isNaN(+id) ? id : +id)
+      const nodeId = toNodeId(isNaN(+id) ? id : +id)
+      let node = LiteGraph.createNode(data.class_type)
+      let placeholderEntry:
+        | Extract<MissingNodeType, { type: string }>
+        | undefined
+      if (!node) {
+        node = new LGraphNode(data._meta?.title ?? data.class_type)
+        node.type = sanitizeNodeName(data.class_type)
+        node.has_errors = true
+        const widgetValues: TWidgetValue[] = []
+        const widgetValuesNamed: Record<string, TWidgetValue> =
+          Object.create(null)
+        for (const [input, value] of Object.entries(data.inputs ?? {})) {
+          if (value instanceof Array) {
+            node.addInput(input, '*')
+          } else {
+            widgetValues.push(value)
+            widgetValuesNamed[input] = value
+          }
+        }
+        node.last_serialization = {
+          id: nodeId,
+          type: data.class_type,
+          pos: [node.pos[0], node.pos[1]],
+          size: [node.size[0], node.size[1]],
+          flags: {},
+          order: 0,
+          mode: node.mode,
+          title: data._meta?.title ?? data.class_type,
+          inputs: node.inputs.map(inputAsSerialisable),
+          widgets_values: widgetValues,
+          widgets_values_named: widgetValuesNamed
+        }
+        const replacement = nodeReplacementStore.getReplacementFor(
+          data.class_type
+        )
+        placeholderEntry = {
+          type: data.class_type,
+          isReplaceable: replacement !== null,
+          replacement: replacement ?? undefined
+        }
+        missingNodeTypes.push(placeholderEntry)
+      }
+      node.id = nodeId
       node.title = data._meta?.title ?? node.title
       app.rootGraph.add(node)
+      if (placeholderEntry && node.last_serialization) {
+        node.last_serialization.id = node.id
+        placeholderEntry.nodeId = String(node.id)
+      }
     }
 
     const processNodeInputs = (id: string) => {
@@ -2193,6 +2250,9 @@ export class ComfyApp {
           }
         }
       }
+      if (node.last_serialization) {
+        node.last_serialization.inputs = node.inputs.map(inputAsSerialisable)
+      }
     }
 
     for (const id of ids) processNodeInputs(id)
@@ -2200,10 +2260,13 @@ export class ComfyApp {
     for (const id of ids) processNodeInputs(id)
     app.rootGraph.arrange()
 
-    useWorkflowService().afterLoadNewGraph(
+    await useWorkflowService().afterLoadNewGraph(
       fileName,
       this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
     )
+    if (missingNodeTypes.length) {
+      this.showMissingNodesError(missingNodeTypes, options)
+    }
   }
 
   /**


### PR DESCRIPTION
Backport of #14555 to this branch.

Clean cherry-pick of `db147c098f` — no conflicts, no adjustments.

**Verification on this branch:** `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint` (0 errors) all pass; `src/scripts/app.test.ts` 51/51.

The automation reported this branch as failed only because it batched with the `1.48` targets, which did conflict. Those are handled separately and required a real adjustment — see the `1.48` backport PRs.
