### PR TITLE
fix(assets): fall back to bare-tag grouping for legacy tags in model_type mode

### DIFF
--- a/browser_tests/fixtures/assetApiFixture.ts
+++ b/browser_tests/fixtures/assetApiFixture.ts
@@ -35,8 +35,8 @@ export function countAssetRequestsByTag(
 }
 
 type ModelLibraryOptions = {
-  operators?: AssetOperator[]
   folders?: ModelFolderInfo[]
+  operators?: AssetOperator[]
 }
 
 export const assetApiFixture = base.extend<{

--- a/browser_tests/fixtures/data/assetFixtures.ts
+++ b/browser_tests/fixtures/data/assetFixtures.ts
@@ -167,6 +167,40 @@ export const MODEL_TYPE_CHECKPOINT_PRE_CUTOVER: CoreModelAsset =
     updated_at: '2025-02-18T09:00:00Z'
   })
 
+/**
+ * A legacy bare-tagged asset (no `model_type:` prefix) that still carries a
+ * `loader_path`, mimicking a `model_type:`-capable backend that has not
+ * finished re-tagging every asset. Asset grouping must fall back to bare-tag
+ * grouping for it instead of dropping it from the sidebar.
+ */
+export const MODEL_TYPE_CHECKPOINT_LEGACY_TAG: CoreModelAsset =
+  createCoreModelAsset({
+    id: 'mt-checkpoint-007',
+    name: 'legacy_tagged_checkpoint.safetensors',
+    tags: ['models', 'checkpoints'],
+    loader_path: 'legacy_tagged_checkpoint.safetensors',
+    created_at: '2025-02-22T09:00:00Z',
+    updated_at: '2025-02-22T09:00:00Z'
+  })
+
+/**
+ * An asset caught mid-migration: it already carries the authoritative
+ * `model_type:checkpoints` tag alongside its pre-migration bare-tag twin
+ * (`checkpoints`), plus an unrelated leftover bare tag (`loras`) that happens
+ * to match another real folder. A `model_type:`-covered asset must group by
+ * its `model_type:` tags alone, so it lands in `checkpoints` exactly once and
+ * never cross-lists into `loras`.
+ */
+export const MODEL_TYPE_CHECKPOINT_MID_RETAG: CoreModelAsset =
+  createCoreModelAsset({
+    id: 'mt-checkpoint-008',
+    name: 'mid_retag_checkpoint.safetensors',
+    tags: ['models', 'model_type:checkpoints', 'checkpoints', 'loras'],
+    loader_path: 'mid_retag_checkpoint.safetensors',
+    created_at: '2025-02-23T09:00:00Z',
+    updated_at: '2025-02-23T09:00:00Z'
+  })
+
 export const MODEL_TYPE_LORA: CoreModelAsset = createCoreModelAsset({
   id: 'mt-lora-001',
   name: 'detail_enhancer_v1.2.safetensors',

--- a/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
+++ b/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
@@ -54,8 +54,8 @@ test.use({
 test.describe('Model library sidebar - asset mode', () => {
   test.use({
     modelLibraryOptions: {
-      operators: [withModels(WALK_ASSETS)],
-      folders: REGISTERED_FOLDERS
+      folders: REGISTERED_FOLDERS,
+      operators: [withModels(WALK_ASSETS)]
     }
   })
 
@@ -298,8 +298,8 @@ test.describe('Model library sidebar - asset mode when the walk fails', () => {
 test.describe('Model library sidebar - asset mode before the loader_path cutover', () => {
   test.use({
     modelLibraryOptions: {
-      operators: [withModels([MODEL_TYPE_CHECKPOINT_PRE_CUTOVER])],
-      folders: REGISTERED_FOLDERS
+      folders: REGISTERED_FOLDERS,
+      operators: [withModels([MODEL_TYPE_CHECKPOINT_PRE_CUTOVER])]
     }
   })
 
@@ -347,18 +347,18 @@ test.describe('Model library sidebar - asset mode before the loader_path cutover
 test.describe('Model library sidebar - asset mode with a legacy bare tag', () => {
   test.use({
     modelLibraryOptions: {
-      operators: [
-        withModels([
-          MODEL_TYPE_CHECKPOINT_ROOT,
-          MODEL_TYPE_CHECKPOINT_LEGACY_TAG
-        ])
-      ],
       folders: [
         {
           name: 'checkpoints',
           folders: ['/models/checkpoints'],
           extensions: ['.safetensors']
         }
+      ],
+      operators: [
+        withModels([
+          MODEL_TYPE_CHECKPOINT_ROOT,
+          MODEL_TYPE_CHECKPOINT_LEGACY_TAG
+        ])
       ]
     }
   })
@@ -384,13 +384,6 @@ test.describe('Model library sidebar - asset mode with a legacy bare tag', () =>
 test.describe('Model library sidebar - asset mode with a mid-retag twin tag', () => {
   test.use({
     modelLibraryOptions: {
-      operators: [
-        withModels([
-          MODEL_TYPE_CHECKPOINT_ROOT,
-          MODEL_TYPE_CHECKPOINT_MID_RETAG,
-          MODEL_TYPE_LORA
-        ])
-      ],
       folders: [
         {
           name: 'checkpoints',
@@ -402,6 +395,13 @@ test.describe('Model library sidebar - asset mode with a mid-retag twin tag', ()
           folders: ['/models/loras'],
           extensions: ['.safetensors']
         }
+      ],
+      operators: [
+        withModels([
+          MODEL_TYPE_CHECKPOINT_ROOT,
+          MODEL_TYPE_CHECKPOINT_MID_RETAG,
+          MODEL_TYPE_LORA
+        ])
       ]
     }
   })
@@ -447,14 +447,14 @@ test.describe('Model library sidebar - asset mode with a mid-retag twin tag', ()
 test.describe('Model library sidebar - asset mode on bare-tag backends', () => {
   test.use({
     modelLibraryOptions: {
-      operators: [withModels([STABLE_CHECKPOINT])],
       folders: [
         {
           name: 'checkpoints',
           folders: ['/models/checkpoints'],
           extensions: ['.safetensors']
         }
-      ]
+      ],
+      operators: [withModels([STABLE_CHECKPOINT])]
     }
   })
 

--- a/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
+++ b/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
@@ -367,10 +367,6 @@ test.describe('Model library sidebar - asset mode with a legacy bare tag', () =>
     await comfyPage.modelLibrary.clearMocks()
   })
 
-  // Regression for the AC3 bug flagged in #13574's review: on a
-  // model_type-capable backend, a bare (non-namespaced) tag resolved to no
-  // category and buildModelBuckets dropped the asset with a console.warn
-  // instead of falling back to legacy bare-tag grouping.
   test('Falls back to legacy bare-tag grouping instead of dropping the asset', async ({
     comfyPage
   }) => {
@@ -416,11 +412,6 @@ test.describe('Model library sidebar - asset mode with a mid-retag twin tag', ()
     await comfyPage.modelLibrary.clearMocks()
   })
 
-  // Regression for the high-severity finding on #14217: an asset carrying
-  // both an authoritative `model_type:checkpoints` tag and a leftover bare
-  // `checkpoints` twin (a partial re-tagging artifact) must land in
-  // `checkpoints` exactly once, and its unrelated leftover `loras` bare tag
-  // must not cross-list it into that folder too.
   test('Groups a model_type-covered asset once and ignores its bare-tag twins', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
+++ b/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
@@ -345,26 +345,28 @@ test.describe('Model library sidebar - asset mode before the loader_path cutover
 })
 
 test.describe('Model library sidebar - asset mode with a legacy bare tag', () => {
-  test.beforeEach(async ({ comfyPage, assetApi }) => {
-    assetApi.configure(
-      withModels([MODEL_TYPE_CHECKPOINT_ROOT, MODEL_TYPE_CHECKPOINT_LEGACY_TAG])
-    )
-    await assetApi.mock()
-    await comfyPage.modelLibrary.mockModelFolders([
-      {
-        name: 'checkpoints',
-        folders: ['/models/checkpoints'],
-        extensions: ['.safetensors']
-      }
-    ])
-    await comfyPage.setup()
+  test.use({
+    modelLibraryOptions: {
+      operators: [
+        withModels([
+          MODEL_TYPE_CHECKPOINT_ROOT,
+          MODEL_TYPE_CHECKPOINT_LEGACY_TAG
+        ])
+      ],
+      folders: [
+        {
+          name: 'checkpoints',
+          folders: ['/models/checkpoints'],
+          extensions: ['.safetensors']
+        }
+      ]
+    }
+  })
+
+  test.beforeEach(async ({ assetApi: _, comfyPage }) => {
     await comfyPage.featureFlags.setServerFlagsPersistent({
       supports_model_type_tags: true
     })
-  })
-
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.modelLibrary.clearMocks()
   })
 
   test('Falls back to legacy bare-tag grouping instead of dropping the asset', async ({
@@ -380,36 +382,35 @@ test.describe('Model library sidebar - asset mode with a legacy bare tag', () =>
 })
 
 test.describe('Model library sidebar - asset mode with a mid-retag twin tag', () => {
-  test.beforeEach(async ({ comfyPage, assetApi }) => {
-    assetApi.configure(
-      withModels([
-        MODEL_TYPE_CHECKPOINT_ROOT,
-        MODEL_TYPE_CHECKPOINT_MID_RETAG,
-        MODEL_TYPE_LORA
-      ])
-    )
-    await assetApi.mock()
-    await comfyPage.modelLibrary.mockModelFolders([
-      {
-        name: 'checkpoints',
-        folders: ['/models/checkpoints'],
-        extensions: ['.safetensors']
-      },
-      {
-        name: 'loras',
-        folders: ['/models/loras'],
-        extensions: ['.safetensors']
-      }
-    ])
-    await comfyPage.setup()
+  test.use({
+    modelLibraryOptions: {
+      operators: [
+        withModels([
+          MODEL_TYPE_CHECKPOINT_ROOT,
+          MODEL_TYPE_CHECKPOINT_MID_RETAG,
+          MODEL_TYPE_LORA
+        ])
+      ],
+      folders: [
+        {
+          name: 'checkpoints',
+          folders: ['/models/checkpoints'],
+          extensions: ['.safetensors']
+        },
+        {
+          name: 'loras',
+          folders: ['/models/loras'],
+          extensions: ['.safetensors']
+        }
+      ]
+    }
+  })
+
+  test.beforeEach(async ({ assetApi: _, comfyPage }) => {
     await comfyPage.featureFlags.setServerFlagsPersistent({
       supports_model_type_tags: true
     })
     await comfyPage.menu.modelLibraryTab.open()
-  })
-
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.modelLibrary.clearMocks()
   })
 
   test('Groups a model_type-covered asset once and ignores its bare-tag twins', async ({

--- a/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
+++ b/browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts
@@ -5,6 +5,8 @@ import { assetApiFixture } from '@e2e/fixtures/assetApiFixture'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import {
   MODEL_TYPE_CHECKPOINT_GGUF,
+  MODEL_TYPE_CHECKPOINT_LEGACY_TAG,
+  MODEL_TYPE_CHECKPOINT_MID_RETAG,
   MODEL_TYPE_CHECKPOINT_NESTED,
   MODEL_TYPE_CHECKPOINT_ORPHAN,
   MODEL_TYPE_CHECKPOINT_PRE_CUTOVER,
@@ -339,6 +341,114 @@ test.describe('Model library sidebar - asset mode before the loader_path cutover
     // Degrades to empty, not broken: the panel stays interactive.
     await expect(tab.refreshButton).toBeEnabled()
     await expect(tab.searchInput).toBeEditable()
+  })
+})
+
+test.describe('Model library sidebar - asset mode with a legacy bare tag', () => {
+  test.beforeEach(async ({ comfyPage, assetApi }) => {
+    assetApi.configure(
+      withModels([MODEL_TYPE_CHECKPOINT_ROOT, MODEL_TYPE_CHECKPOINT_LEGACY_TAG])
+    )
+    await assetApi.mock()
+    await comfyPage.modelLibrary.mockModelFolders([
+      {
+        name: 'checkpoints',
+        folders: ['/models/checkpoints'],
+        extensions: ['.safetensors']
+      }
+    ])
+    await comfyPage.setup()
+    await comfyPage.featureFlags.setServerFlagsPersistent({
+      supports_model_type_tags: true
+    })
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.modelLibrary.clearMocks()
+  })
+
+  // Regression for the AC3 bug flagged in #13574's review: on a
+  // model_type-capable backend, a bare (non-namespaced) tag resolved to no
+  // category and buildModelBuckets dropped the asset with a console.warn
+  // instead of falling back to legacy bare-tag grouping.
+  test('Falls back to legacy bare-tag grouping instead of dropping the asset', async ({
+    comfyPage
+  }) => {
+    await comfyPage.menu.modelLibraryTab.open()
+    const tab = comfyPage.menu.modelLibraryTab
+
+    await tab.getFolderRowByLabel('checkpoints').click()
+    await expect(tab.getLeafByLabel('v1-5-pruned-emaonly')).toBeVisible()
+    await expect(tab.getLeafByLabel('legacy_tagged_checkpoint')).toBeVisible()
+  })
+})
+
+test.describe('Model library sidebar - asset mode with a mid-retag twin tag', () => {
+  test.beforeEach(async ({ comfyPage, assetApi }) => {
+    assetApi.configure(
+      withModels([
+        MODEL_TYPE_CHECKPOINT_ROOT,
+        MODEL_TYPE_CHECKPOINT_MID_RETAG,
+        MODEL_TYPE_LORA
+      ])
+    )
+    await assetApi.mock()
+    await comfyPage.modelLibrary.mockModelFolders([
+      {
+        name: 'checkpoints',
+        folders: ['/models/checkpoints'],
+        extensions: ['.safetensors']
+      },
+      {
+        name: 'loras',
+        folders: ['/models/loras'],
+        extensions: ['.safetensors']
+      }
+    ])
+    await comfyPage.setup()
+    await comfyPage.featureFlags.setServerFlagsPersistent({
+      supports_model_type_tags: true
+    })
+    await comfyPage.menu.modelLibraryTab.open()
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.modelLibrary.clearMocks()
+  })
+
+  // Regression for the high-severity finding on #14217: an asset carrying
+  // both an authoritative `model_type:checkpoints` tag and a leftover bare
+  // `checkpoints` twin (a partial re-tagging artifact) must land in
+  // `checkpoints` exactly once, and its unrelated leftover `loras` bare tag
+  // must not cross-list it into that folder too.
+  test('Groups a model_type-covered asset once and ignores its bare-tag twins', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.modelLibraryTab
+
+    await tab.getFolderRowByLabel('checkpoints').click()
+    await expect(
+      tab.modelTree
+        .locator('.p-tree-node-leaf')
+        .filter({ hasText: 'mid_retag_checkpoint' })
+    ).toHaveCount(1)
+
+    // loras carries a real model_type:loras asset so the folder itself
+    // renders (asset mode hides folders that load with zero models) —
+    // otherwise an absent 'loras' row would be ambiguous between "correctly
+    // empty" and "never loaded".
+    await tab.getFolderRowByLabel('loras').click()
+    await expect(tab.getLeafByLabel('detail_enhancer_v1.2')).toBeVisible()
+
+    // Scoped to the loras subtree, not tab.modelTree: checkpoints is still
+    // expanded from the assertion above, and its (correct) copy of the leaf
+    // would otherwise satisfy a tree-wide query on its own.
+    await expect(
+      tab
+        .getFolderByLabel('loras')
+        .locator('.p-tree-node-leaf')
+        .filter({ hasText: 'mid_retag_checkpoint' })
+    ).toHaveCount(0)
   })
 })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -23,7 +23,7 @@ import type {
   TagsOperationResult
 } from '@/platform/assets/schemas/assetSchema'
 import {
-  MODEL_TYPE_TAG_PREFIX,
+  getAssetCategories,
   getAssetFilename
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { isCloud } from '@/platform/distribution/types'
@@ -224,26 +224,6 @@ function normalizeAssetTags(tags: string[]): string[] {
 }
 
 /**
- * Resolves the model folder a tag represents, or undefined when the tag is not
- * a folder category. `supports_model_type_tags` backends carry the category as
- * a namespaced `model_type:<folder>` tag; older backends mint bare tags, which
- * may carry subfolder paths (e.g. `Chatterbox/sub/model`) and group by their
- * top-level segment, matching the asset browser's legacy grouping.
- */
-function modelFolderFromTag(
-  tag: string,
-  modelTypeMode: boolean
-): string | undefined {
-  if (modelTypeMode) {
-    return tag.startsWith(MODEL_TYPE_TAG_PREFIX)
-      ? tag.slice(MODEL_TYPE_TAG_PREFIX.length)
-      : undefined
-  }
-  if (tag === MODELS_TAG || tag.length === 0) return undefined
-  return tag.split('/')[0]
-}
-
-/**
  * Orders loader paths as subdirectories before files at every level,
  * alphabetical within each group. The asset API returns models in storage
  * order, which would otherwise interleave root-level files with folder
@@ -412,11 +392,13 @@ function createAssetService() {
   }
   /**
    * Walks every `models`-tagged asset once and buckets each into the folder
-   * categories carried by its `model_type:` tags. A single asset lands in every
-   * category it is tagged with (e.g. a shared-root model in both `checkpoints`
-   * and `diffusion_models`). Which folders are actually shown is decided by
-   * `/experiment/models`; models with no category tag are dropped with a warning
-   * rather than hidden silently.
+   * categories `getAssetCategories` resolves for it. A single asset lands in
+   * every category it is tagged with (e.g. a shared-root model in both
+   * `checkpoints` and `diffusion_models`); an asset covered by `model_type:`
+   * tags is grouped by those alone, so a legacy bare-tag twin left over from a
+   * partial re-tagging cannot also cross-list it into another folder. Which
+   * folders are actually shown is decided by `/experiment/models`; models with
+   * no category tag are dropped with a warning rather than hidden silently.
    */
   async function buildModelBuckets(
     modelTypeMode: boolean
@@ -427,9 +409,7 @@ function createAssetService() {
     const buckets = new Map<string, AssetItem[]>()
 
     for (const asset of assets) {
-      const folders = asset.tags
-        .map((tag) => modelFolderFromTag(tag, modelTypeMode))
-        .filter((folder): folder is string => folder !== undefined)
+      const folders = [...new Set(getAssetCategories(asset, modelTypeMode))]
 
       if (folders.length === 0) {
         console.warn(


### PR DESCRIPTION
## Summary

Fixes a bug where a legacy bare-tagged model asset silently disappears from the model library sidebar once the backend advertises `model_type:` support, instead of falling back to legacy bare-tag grouping.

_Recreated from #14217 — same change, opened directly under my own account for tracking. The High finding from Cursor's panel on that PR is already folded into this diff._

## Changes

- **What**: `modelFolderFromTag` returned `undefined` for any tag that didn't carry the `model_type:` prefix as soon as `modelTypeMode` was `true`. `buildModelBuckets` treats an asset whose tags resolve to no folder as "uncategorized" and drops it with a `console.warn`, so a model still carrying a legacy bare tag (e.g. `checkpoints` instead of `model_type:checkpoints`) vanished from the sidebar entirely on a `model_type:`-capable backend. Changed in `src/platform/assets/services/assetService.ts`.
- **Breaking**: none

## How

The fix deletes the local `modelFolderFromTag` helper and buckets via `getAssetCategories` from `assetMetadataUtils`, which already implements exactly the intended semantics and is already used by the other asset surfaces: `model_type:*` values are authoritative when present, and an asset with no `model_type:` tag still routes by its bare tags (with namespace residue filtered out). This makes the sidebar consistent with the rest of the asset code rather than carrying a second, subtly different grouping rule.

A side effect worth calling out: because `getAssetCategories` returns `model_type:` values *alone* when an asset has any, an asset covered by `model_type:` tags can no longer be cross-listed into a second folder by a leftover bare-tag twin from a partial re-tagging. The e2e suite covers that case (the "mid-retag twin" scenario).

Added an e2e scenario, `Model library sidebar - asset mode with a legacy bare tag`, in `browser_tests/tests/sidebar/modelLibraryAssetMode.spec.ts`, plus a matching fixture (`MODEL_TYPE_CHECKPOINT_LEGACY_TAG` in `browser_tests/fixtures/data/assetFixtures.ts`): a bare-tagged asset that still carries a `loader_path`, walked with `supports_model_type_tags: true`, asserting it still renders in the `checkpoints` folder rather than being dropped.

## Review Focus

- This targets `main` directly. The stack it was originally written on top of (#13574) has since merged, so the diff here is just the three files.
- Coverage for the regression lives in the e2e spec rather than a unit test — the unit-level version was dropped as duplicating it. Flagging that explicitly since it is a judgement call about test placement.
- Verified against `main` that the bug is still live: `modelFolderFromTag` on `main` still returns `undefined` for bare tags whenever `modelTypeMode` is true.
- Checked that the existing `assetService.test.ts` cases on `main` remain valid under the new path: `getBareTagCategories` filters out the reserved `models` tag, so the "drops uncategorized model assets with a warning" case still drops its `tags: ['models']` asset; the bare-tag grouping cases all run with `supports_model_type_tags = false`, an unchanged path.

## Test plan

- [ ] `pnpm typecheck` — **not run**: no Node/pnpm toolchain provisioned on the host I authored this on. Relying on CI.
- [ ] `pnpm exec vitest run src/platform/assets/services/assetService.test.ts` — **not run**, same reason. Compatibility with the existing cases was verified by reading them (see Review Focus).
- [x] Static check that the refactor is complete: `MODEL_TYPE_TAG_PREFIX` import removed with no remaining uses in the file, `modelFolderFromTag` has zero references repo-wide, `getAssetCategories` is exported from `assetMetadataUtils` on `main`.
- [x] The identical three-file diff passed a full CI run on #14217 (Playwright 1759 passed / 0 failed / 1 flaky; Codecov reported all modified lines covered).

---

**Review coverage note:** no Cursor panel has run on this PR — verified by querying for the panel review itself rather than inferring from an empty findings list. That is a *did-not-run*, not a clean result; the checks API reports success either way. CodeRabbit was rate-limited. Codex did review it, and its one finding was addressed in `f16560c`.

_(An earlier version of this note blamed an org-wide Cursor outage running to 2026-08-22. That attribution was wrong and is withdrawn — panels have since been seen running normally elsewhere. The measured fact, that none ran here, is unchanged.)_
