### PR TITLE
feat(website): announce Wan Animate 2 at /wan-animate-2

### DIFF
--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -1,0 +1,149 @@
+import { expect } from '@playwright/test'
+
+import { externalLinks, getRoutes } from '../src/config/routes'
+import { wanAnimate2Page } from '../src/data/wanAnimate2'
+import { t } from '../src/i18n/translations'
+import { test } from './fixtures/blockExternalMedia'
+
+const PATH = '/wan-animate-2'
+const ZH_PATH = '/zh-CN/wan-animate-2'
+const HERO_TITLE = t('wanAnimate2.hero.title')
+const HERO_EYEBROW = t('wanAnimate2.hero.eyebrow')
+const HERO_CTA = t('wanAnimate2.hero.primaryCta')
+const RUN_OPTIONS_HEADING = t('wanAnimate2.runOptions.heading')
+const REVIEWS_HEADING = t('wanAnimate2.reviews.heading')
+const MODELS_ROUTE = getRoutes('en').models
+
+test.describe('Wan Animate 2 announcement page @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
+  })
+
+  test('renders the hero over its backdrop and is indexable', async ({
+    page
+  }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+    await expect(hero.getByText(HERO_EYEBROW)).toBeVisible()
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+    await expect(hero.locator('img')).toHaveAttribute(
+      'src',
+      wanAnimate2Page.hero.placeholderImageSrc ?? ''
+    )
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
+  })
+
+  test('hero CTA sends visitors to the cloud in a new tab', async ({
+    page
+  }) => {
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      })
+      .getByRole('link', { name: HERO_CTA })
+    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+    await expect(cta).toHaveAttribute('target', '_blank')
+  })
+
+  test('breadcrumb trail links to the models catalog', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: t('ui.breadcrumb') })
+      .getByRole('link', { name: t('models.breadcrumb.models') })
+    await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
+  })
+
+  test('renders run options and reviews', async ({ page }) => {
+    const runOptions = page.getByRole('heading', {
+      level: 2,
+      name: RUN_OPTIONS_HEADING
+    })
+    await runOptions.scrollIntoViewIfNeeded()
+    await expect(runOptions).toBeVisible()
+
+    const reviews = page.getByRole('heading', {
+      level: 2,
+      name: REVIEWS_HEADING
+    })
+    await reviews.scrollIntoViewIfNeeded()
+    await expect(reviews).toBeVisible()
+  })
+
+  // The announcement omits gallery, pricing, FAQ and closing CTA, so these two
+  // are the only sections it should show. Asserting the whole set means
+  // reintroducing any of them has to be deliberate.
+  test('shows only the sections the announcement configures', async ({
+    page
+  }) => {
+    await expect(page.getByRole('heading', { level: 2 })).toHaveText([
+      RUN_OPTIONS_HEADING,
+      REVIEWS_HEADING
+    ])
+    await expect(page.locator('video')).toHaveCount(0)
+  })
+})
+
+test.describe('Wan Animate 2 announcement page — zh-CN', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ZH_PATH)
+  })
+
+  test('renders the localized hero and run options', async ({ page }) => {
+    const hero = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    })
+    await expect(
+      hero.getByText(t('wanAnimate2.hero.eyebrow', 'zh-CN'))
+    ).toBeVisible()
+    await expect(hero.getByRole('link')).toContainText(/[一-鿿]/)
+
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: t('wanAnimate2.runOptions.heading', 'zh-CN')
+      })
+    ).toBeVisible()
+  })
+
+  test('breadcrumb keeps visitors inside the locale', async ({ page }) => {
+    const modelsCrumb = page
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'zh-CN') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'zh-CN') })
+    await expect(modelsCrumb).toHaveAttribute('href', getRoutes('zh-CN').models)
+  })
+})
+
+test.describe('Wan Animate 2 announcement page — mobile @mobile', () => {
+  test('hero CTA stays visible and linked at narrow viewports', async ({
+    page
+  }) => {
+    await page.goto(PATH)
+
+    const cta = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      })
+      .getByRole('link', { name: HERO_CTA })
+
+    await cta.scrollIntoViewIfNeeded()
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+
+    const box = await cta.boundingBox()
+    const viewport = page.viewportSize()
+    if (!box || !viewport) {
+      throw new Error('hero CTA has no layout box to measure')
+    }
+
+    // toBeVisible() does not imply the element sits inside the viewport, so
+    // check all four edges. One pixel of tolerance for subpixel rounding.
+    expect(box.x).toBeGreaterThanOrEqual(-1)
+    expect(box.y).toBeGreaterThanOrEqual(-1)
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height + 1)
+  })
+})

--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -102,8 +102,14 @@ test.describe('Wan Animate 2 announcement page — zh-CN', () => {
   })
 
   test('renders the localized hero and run options', async ({ page }) => {
+    // Resolve the heading in zh-CN rather than reusing HERO_TITLE. The two are
+    // the same string today because the model name is not translated, but
+    // scoping by locale here is what the test actually means.
     const hero = page.locator('section').filter({
-      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
+      has: page.getByRole('heading', {
+        level: 1,
+        name: t('wanAnimate2.hero.title', 'zh-CN')
+      })
     })
     await expect(
       hero.getByText(t('wanAnimate2.hero.eyebrow', 'zh-CN'))

--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -56,6 +56,16 @@ test.describe('Wan Animate 2 announcement page @smoke', () => {
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
   })
 
+  test('footer links back to this page', async ({ page }) => {
+    const footerLink = page
+      .locator('footer')
+      .getByRole('link', { name: t('footer.wanAnimate2') })
+    await expect(footerLink).toHaveAttribute(
+      'href',
+      getRoutes('en').wanAnimate2
+    )
+  })
+
   test('renders run options and reviews', async ({ page }) => {
     const runOptions = page.getByRole('heading', {
       level: 2,
@@ -108,11 +118,21 @@ test.describe('Wan Animate 2 announcement page — zh-CN', () => {
     ).toBeVisible()
   })
 
-  test('breadcrumb keeps visitors inside the locale', async ({ page }) => {
+  test('breadcrumb and footer keep visitors inside the locale', async ({
+    page
+  }) => {
     const modelsCrumb = page
       .getByRole('navigation', { name: t('ui.breadcrumb', 'zh-CN') })
       .getByRole('link', { name: t('models.breadcrumb.models', 'zh-CN') })
     await expect(modelsCrumb).toHaveAttribute('href', getRoutes('zh-CN').models)
+
+    const footerLink = page
+      .locator('footer')
+      .getByRole('link', { name: t('footer.wanAnimate2', 'zh-CN') })
+    await expect(footerLink).toHaveAttribute(
+      'href',
+      getRoutes('zh-CN').wanAnimate2
+    )
   })
 })
 

--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -149,7 +149,6 @@ test.describe('Wan Animate 2 announcement page — mobile @mobile', () => {
       })
       .getByRole('link', { name: HERO_CTA })
 
-    await cta.scrollIntoViewIfNeeded()
     await expect(cta).toBeVisible()
     await expect(cta).toHaveAttribute('href', externalLinks.cloud)
 
@@ -159,8 +158,10 @@ test.describe('Wan Animate 2 announcement page — mobile @mobile', () => {
       throw new Error('hero CTA has no layout box to measure')
     }
 
-    // toBeVisible() does not imply the element sits inside the viewport, so
-    // check all four edges. One pixel of tolerance for subpixel rounding.
+    // Measured without scrolling first: the point is that the CTA is reachable
+    // on load, so scrolling it into view would make the vertical bounds pass no
+    // matter how far down the page it sat. One pixel of tolerance for subpixel
+    // rounding.
     expect(box.x).toBeGreaterThanOrEqual(-1)
     expect(box.y).toBeGreaterThanOrEqual(-1)
     expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)

--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -41,7 +41,8 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
       { label: t('nav.mcpServer', locale), href: routes.mcp },
       { label: t('nav.supportedModels', locale), href: routes.models },
       { label: t('footer.minimaxH3', locale), href: routes.minimax },
-      { label: t('footer.seedance', locale), href: routes.seedance }
+      { label: t('footer.seedance', locale), href: routes.seedance },
+      { label: t('footer.wanAnimate2', locale), href: routes.wanAnimate2 }
     ]
   },
   {

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -26,6 +26,7 @@ const baseRoutes = {
   minimax: '/minimax',
   flux3: '/flux-3',
   seedance: '/seedance-2.5',
+  wanAnimate2: '/wan-animate-2',
   brand: '/brand'
 } as const
 

--- a/apps/website/src/data/wanAnimate2.ts
+++ b/apps/website/src/data/wanAnimate2.ts
@@ -1,0 +1,38 @@
+import type { ModelLaunchPage } from '../templates/model-launch/types'
+
+import { externalLinks } from '../config/routes'
+import { COMING_SOON_HERO } from './comingSoonHero'
+
+// Wan Animate 2 has not shipped yet, so this page announces it and holds the URL.
+// On launch day, replace this config with the full one the way /flux-3 did; the
+// page stubs and the template stay as they are.
+export const wanAnimate2Page: ModelLaunchPage = {
+  metaTitleKey: 'wanAnimate2.meta.title',
+  metaDescriptionKey: 'wanAnimate2.meta.description',
+  breadcrumbLabelKey: 'wanAnimate2.breadcrumb.model',
+  breadcrumbUpdatedKey: 'wanAnimate2.breadcrumb.updated',
+  hero: {
+    layout: 'overlay',
+    placeholderImageSrc: COMING_SOON_HERO,
+    eyebrowKey: 'wanAnimate2.hero.eyebrow',
+    titleKey: 'wanAnimate2.hero.title',
+    primaryCta: {
+      labelKey: 'wanAnimate2.hero.primaryCta',
+      href: externalLinks.cloud,
+      target: '_blank'
+    }
+  },
+  runOptions: {
+    headingKey: 'wanAnimate2.runOptions.heading',
+    subtitleKey: 'wanAnimate2.runOptions.subtitle',
+    ctaKey: 'wanAnimate2.runOptions.cta'
+  },
+  reviews: {
+    headingKey: 'wanAnimate2.reviews.heading',
+    highlight: {
+      titleKey: 'wanAnimate2.reviews.highlightTitle',
+      descriptionKey: 'wanAnimate2.reviews.highlightDescription',
+      ctaKey: 'wanAnimate2.reviews.highlightCta'
+    }
+  }
+}

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5162,6 +5162,57 @@ const translations = {
       '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
   },
   'seedance.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
+  // Wan Animate 2 model page (/wan-animate-2) — announcement until the model ships
+  'wanAnimate2.meta.title': {
+    en: 'Wan Animate 2 on Comfy — Coming Soon',
+    'zh-CN': 'Comfy 上的 Wan Animate 2 — 即将推出'
+  },
+  'wanAnimate2.meta.description': {
+    en: 'Wan Animate 2 is coming to Comfy. Run it on Comfy Cloud the day it lands, or start building workflows for free now with every other model Comfy supports.',
+    'zh-CN':
+      'Wan Animate 2 即将登陆 Comfy。上线当天即可在 Comfy Cloud 上运行；现在就可以用 Comfy 支持的其他模型免费开始搭建工作流。'
+  },
+  'wanAnimate2.breadcrumb.model': {
+    en: 'Wan Animate 2',
+    'zh-CN': 'Wan Animate 2'
+  },
+  'wanAnimate2.breadcrumb.updated': {
+    en: 'Updated August 2026',
+    'zh-CN': '更新于 2026 年 8 月'
+  },
+  'wanAnimate2.hero.eyebrow': { en: 'Coming soon', 'zh-CN': '即将推出' },
+  'wanAnimate2.hero.title': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
+  'wanAnimate2.hero.primaryCta': {
+    en: 'RUN COMFY FOR FREE',
+    'zh-CN': '免费使用 Comfy'
+  },
+  'wanAnimate2.runOptions.heading': {
+    en: 'One engine, every way to run it',
+    'zh-CN': '同一引擎，多种运行方式'
+  },
+  'wanAnimate2.runOptions.subtitle': {
+    en: 'Build workflows in the browser today. Batch campaigns with the API, or bring it in-house.',
+    'zh-CN': '今天就在浏览器中搭建工作流。用 API 批量制作，或部署到自有环境。'
+  },
+  'wanAnimate2.runOptions.cta': { en: 'LEARN MORE', 'zh-CN': '了解更多' },
+  'wanAnimate2.reviews.heading': {
+    en: '4+ million Comfy creators say',
+    'zh-CN': '超过 400 万 Comfy 创作者这样说'
+  },
+  'wanAnimate2.reviews.highlightTitle': {
+    en: 'Comfy MCP: now turn your agent into a creative technologist.',
+    'zh-CN': 'Comfy MCP：让你的智能体成为创意技术专家。'
+  },
+  'wanAnimate2.reviews.highlightDescription': {
+    en: 'Your AI assistant can access the ecosystem, build workflows, and generate images, video, audio, or 3D.',
+    'zh-CN':
+      '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
+  },
+  'wanAnimate2.reviews.highlightCta': {
+    en: 'GET STARTED',
+    'zh-CN': '开始使用'
+  },
+  'footer.wanAnimate2': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
   'minimax.meta.title': {
     en: 'MiniMax H3 on Comfy — Open-Weight Video Model',
     'zh-CN': 'Comfy 上的 MiniMax H3 — 开源权重视频模型'

--- a/apps/website/src/pages/wan-animate-2.astro
+++ b/apps/website/src/pages/wan-animate-2.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../templates/model-launch/ModelLaunchPage.astro'
+import { wanAnimate2Page } from '../data/wanAnimate2'
+---
+
+<ModelLaunchPage page={wanAnimate2Page} />

--- a/apps/website/src/pages/zh-CN/wan-animate-2.astro
+++ b/apps/website/src/pages/zh-CN/wan-animate-2.astro
@@ -1,0 +1,6 @@
+---
+import ModelLaunchPage from '../../templates/model-launch/ModelLaunchPage.astro'
+import { wanAnimate2Page } from '../../data/wanAnimate2'
+---
+
+<ModelLaunchPage page={wanAnimate2Page} />

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { flux3Page } from '../../data/flux3'
 import { minimaxPage } from '../../data/minimax'
 import { seedancePage } from '../../data/seedance'
+import { wanAnimate2Page } from '../../data/wanAnimate2'
 import type { TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import type { ModelLaunchPage } from './types'
@@ -11,7 +12,8 @@ import type { ModelLaunchPage } from './types'
 const pages: { name: string; page: ModelLaunchPage }[] = [
   { name: 'minimax', page: minimaxPage },
   { name: 'flux3', page: flux3Page },
-  { name: 'seedance', page: seedancePage }
+  { name: 'seedance', page: seedancePage },
+  { name: 'wanAnimate2', page: wanAnimate2Page }
 ]
 
 describe.for(pages)('$name launch page config', ({ page }) => {


### PR DESCRIPTION
## Summary

Adds the Wan Animate 2 announcement page from Figma `10396-41358`.

**Stacked on #14822** (base is `website/seedance-coming-soon`, not main), because it needs the overlay hero layout that PR introduces. Retarget to main once #14822 lands.

## Changes

- **What**: New `/wan-animate-2` (en + zh-CN) rendered by the existing model-launch template, plus a footer link under Products.
- Pure data on the announcement shape /seedance-2.5 established: one config, its `wanAnimate2.*` keys, two five-line page stubs, one line in the registry test. **No new components.**
- Shares the backdrop with the other announcement pages rather than uploading a copy: the art is byte identical in all three Figma frames, so it lives once at `media.comfy.org/website/coming-soon/hero.webp`.

## Review Focus

The design and the Seedance frame disagreed on the hero treatment: this frame is newer and uses a transparent CTA with a white border over a 50% scrim, where Seedance used a filled pill over 33%. Rather than ship two styles a week apart, #14822 moves all three onto this newer treatment, so that change lives there and this PR inherits it.

Two defects in the design were corrected rather than copied: the CTA reads "RUN COMY FOR FREE" (missing F), and the breadcrumb still reads "SEEDANCE 2.0" from the frame it was duplicated off.

Gates: `astro check` 0 errors, unused-i18n clean, knip/format clean, build 585 pages, `validate:jsonld` 588, e2e 8/8 (English, zh-CN and mobile).

## Preview

- https://comfy-website-preview-pr-14849.vercel.app/wan-animate-2
- zh-CN: https://comfy-website-preview-pr-14849.vercel.app/zh-CN/wan-animate-2
