### PR TITLE
refactor(auth): use generated OpenAPI type for customer creation

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -36,7 +36,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import type { AuthHeader } from '@/types/authTypes'
-import type { components, operations } from '@/types/comfyRegistryTypes'
+import type { operations } from '@/types/comfyRegistryTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 
 type CreditPurchaseResponse =
@@ -45,6 +45,9 @@ type CreditPurchasePayload =
   operations['InitiateCreditPurchase']['requestBody']['content']['application/json']
 type CreateCustomerResponse =
   operations['createCustomer']['responses']['201']['content']['application/json']
+type CreateCustomerPayload = NonNullable<
+  operations['createCustomer']['requestBody']
+>['content']['application/json']
 type GetCustomerBalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']
 type AccessBillingPortalResponse =
@@ -376,10 +379,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const createCustomer = async (
-    payload?: Omit<
-      components['schemas']['CreateCustomerRequest'],
-      'signup_source'
-    >
+    payload?: Omit<CreateCustomerPayload, 'signup_source'>
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
     const authHeader = await getAuthHeader()
@@ -387,7 +387,7 @@ export const useAuthStore = defineStore('auth', () => {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
 
-    const body: components['schemas']['CreateCustomerRequest'] = {
+    const body: CreateCustomerPayload = {
       ...payload,
       signup_source: DISTRIBUTION
     }
@@ -547,10 +547,7 @@ export const useAuthStore = defineStore('auth', () => {
     action: (auth: Auth) => Promise<T>,
     options: {
       createCustomer?: boolean
-      customerPayload?: Omit<
-        components['schemas']['CreateCustomerRequest'],
-        'signup_source'
-      >
+      customerPayload?: Omit<CreateCustomerPayload, 'signup_source'>
     } = {}
   ): Promise<T> => {
     loading.value = true

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -36,7 +36,7 @@ import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspace
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import type { AuthHeader } from '@/types/authTypes'
-import type { operations } from '@/types/comfyRegistryTypes'
+import type { components, operations } from '@/types/comfyRegistryTypes'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 
 type CreditPurchaseResponse =
@@ -45,11 +45,6 @@ type CreditPurchasePayload =
   operations['InitiateCreditPurchase']['requestBody']['content']['application/json']
 type CreateCustomerResponse =
   operations['createCustomer']['responses']['201']['content']['application/json']
-
-type CreateCustomerRequest = NonNullable<
-  operations['createCustomer']['requestBody']
->['content']['application/json']
-type CreateCustomerInput = Omit<CreateCustomerRequest, 'signup_source'>
 type GetCustomerBalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']
 type AccessBillingPortalResponse =
@@ -381,7 +376,10 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const createCustomer = async (
-    payload?: CreateCustomerInput
+    payload?: Omit<
+      components['schemas']['CreateCustomerRequest'],
+      'signup_source'
+    >
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
     const authHeader = await getAuthHeader()
@@ -389,7 +387,7 @@ export const useAuthStore = defineStore('auth', () => {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
 
-    const body: CreateCustomerRequest = {
+    const body: components['schemas']['CreateCustomerRequest'] = {
       ...payload,
       signup_source: DISTRIBUTION
     }
@@ -549,7 +547,10 @@ export const useAuthStore = defineStore('auth', () => {
     action: (auth: Auth) => Promise<T>,
     options: {
       createCustomer?: boolean
-      customerPayload?: CreateCustomerInput
+      customerPayload?: Omit<
+        components['schemas']['CreateCustomerRequest'],
+        'signup_source'
+      >
     } = {}
   ): Promise<T> => {
     loading.value = true

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -46,14 +46,9 @@ type CreditPurchasePayload =
 type CreateCustomerResponse =
   operations['createCustomer']['responses']['201']['content']['application/json']
 
-// Request body for POST /customers, from the generated OpenAPI contract so the
-// field set drift-checks against the backend at compile time.
 type CreateCustomerRequest = NonNullable<
   operations['createCustomer']['requestBody']
 >['content']['application/json']
-
-// Fields a caller may supply. signup_source is always set from the client build
-// in createCustomer, so it is not part of the caller-facing input.
 type CreateCustomerInput = Omit<CreateCustomerRequest, 'signup_source'>
 type GetCustomerBalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -24,7 +24,6 @@ import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { fetchWithUnifiedRemint } from '@/platform/auth/unified/remintRetry'
 import { DISTRIBUTION, isCloud } from '@/platform/distribution/types'
-import type { Distribution } from '@/platform/distribution/types'
 import {
   clearPreservedQuery,
   getPreservedQueryParam
@@ -47,20 +46,15 @@ type CreditPurchasePayload =
 type CreateCustomerResponse =
   operations['createCustomer']['responses']['201']['content']['application/json']
 
-/**
- * Request body for createCustomer. The Cloudflare Turnstile token captured at
- * signup is forwarded to the backend as `turnstile_token` (snake_case), which
- * reads this field on the CreateCustomer request; it is omitted for non-signup
- * flows and on OSS / localhost where Turnstile is not rendered.
- *
- * TODO: replace with the generated `operations['createCustomer']` request-body
- * type once the backend OpenAPI spec includes `turnstile_token`, so the field
- * name/optionality drift-checks against the backend at compile time.
- */
-type CreateCustomerPayload = {
-  turnstile_token?: string
-  signup_source?: Distribution
-}
+// Request body for POST /customers, from the generated OpenAPI contract so the
+// field set drift-checks against the backend at compile time.
+type CreateCustomerRequest = NonNullable<
+  operations['createCustomer']['requestBody']
+>['content']['application/json']
+
+// Fields a caller may supply. signup_source is always set from the client build
+// in createCustomer, so it is not part of the caller-facing input.
+type CreateCustomerInput = Omit<CreateCustomerRequest, 'signup_source'>
 type GetCustomerBalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']
 type AccessBillingPortalResponse =
@@ -392,7 +386,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const createCustomer = async (
-    payload?: CreateCustomerPayload
+    payload?: CreateCustomerInput
   ): Promise<CreateCustomerResponse> => {
     const sessionUserId = currentUser.value?.uid
     const authHeader = await getAuthHeader()
@@ -400,7 +394,7 @@ export const useAuthStore = defineStore('auth', () => {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
     }
 
-    const body: CreateCustomerPayload = {
+    const body: CreateCustomerRequest = {
       ...payload,
       signup_source: DISTRIBUTION
     }
@@ -560,7 +554,7 @@ export const useAuthStore = defineStore('auth', () => {
     action: (auth: Auth) => Promise<T>,
     options: {
       createCustomer?: boolean
-      customerPayload?: CreateCustomerPayload
+      customerPayload?: CreateCustomerInput
     } = {}
   ): Promise<T> => {
     loading.value = true


### PR DESCRIPTION
## Summary

Replace the hand-rolled `CreateCustomerPayload` in `authStore` with the generated OpenAPI `CreateCustomerRequest`, now that the comfy-api spec declares both `turnstile_token` and `signup_source`.

## Changes

- **What**: `createCustomer` types its request body from `operations['createCustomer']` (the generated `@comfyorg/registry-types` contract) instead of a local interface, so the field set drift-checks against the backend at compile time. `signup_source` is always set from the client build (`DISTRIBUTION`), so the caller-facing param is `Omit<CreateCustomerRequest, 'signup_source'>` rather than a shape that advertises a field callers cannot actually set.
- **Breaking**: none. Runtime behavior is unchanged (body is still `{ ...payload, signup_source: DISTRIBUTION }`).

## Review Focus

Follow-up to #14528. The inline schema override is removed now that the backend regenerated types carry `turnstile_token` + `signup_source`, and the `payload` param no longer exposes the always-overwritten `signup_source`.

Verified locally: `vue-tsc --noEmit` clean, `authStore.test.ts` 88/88 pass, eslint clean.

## Screenshots (if applicable)
