### PR TITLE
fix: surface governance denials from class types

### DIFF
--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -201,6 +201,7 @@ const zError = z.object({
   type: z.string(),
   message: z.string(),
   details: z.string(),
+  class_types: z.array(z.string()).optional(),
   extra_info: z
     .object({
       input_name: z.string().optional()

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -714,6 +714,57 @@ describe('ComfyApp', () => {
       expect(showDialog).not.toHaveBeenCalled()
     })
 
+    it('builds governance node errors from denied class types', async () => {
+      prepareEmptyPromptQueue()
+      vi.mocked(app.graphToPrompt).mockResolvedValue({
+        output: {
+          '1': {
+            class_type: 'KlingImage2VideoNode',
+            inputs: {},
+            _meta: { title: 'Kling Image to Video' }
+          },
+          '2': {
+            class_type: 'OpenAIDalle3',
+            inputs: {},
+            _meta: { title: 'OpenAI DALL-E 3' }
+          }
+        },
+        workflow: createWorkflowGraphData()
+      })
+      const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+      vi.spyOn(api, 'queuePrompt').mockRejectedValue(
+        new PromptExecutionError(
+          {
+            error: {
+              type: 'PARTNER_NODE_DISABLED',
+              message: 'Workspace policy denied KlingImage2VideoNode',
+              details: '',
+              class_types: ['KlingImage2VideoNode']
+            }
+          },
+          403
+        )
+      )
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      expect(useExecutionErrorStore().lastNodeErrors).toEqual({
+        '1': {
+          class_type: 'KlingImage2VideoNode',
+          dependent_outputs: [],
+          errors: [
+            {
+              type: 'PARTNER_NODE_DISABLED',
+              message: 'Workspace policy denied KlingImage2VideoNode',
+              details: ''
+            }
+          ]
+        }
+      })
+      expect(useExecutionErrorStore().isErrorOverlayOpen).toBe(true)
+      expect(showDialog).not.toHaveBeenCalled()
+    })
+
     it('keeps the access dialog for unrelated 403 responses', async () => {
       prepareEmptyPromptQueue()
       const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
@@ -723,7 +774,8 @@ describe('ComfyApp', () => {
             error: {
               type: 'access_denied',
               message: 'This workspace cannot run prompts',
-              details: ''
+              details: '',
+              class_types: ['KlingImage2VideoNode']
             }
           },
           403

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -65,6 +65,7 @@ import type {
   ExecutionErrorWsMessage,
   NodeError,
   NodeExecutionOutput,
+  PromptResponse,
   ResultItem
 } from '@/schemas/apiSchema'
 import {
@@ -178,6 +179,46 @@ import {
 } from '@/composables/usePaste'
 
 export const ANIM_PREVIEW_WIDGET = '$$comfy_animation_preview'
+
+const MAX_PARTNER_NODE_ERRORS = 100
+
+function partnerNodeErrorsFromClassTypes(
+  prompt: ComfyApiWorkflow,
+  error: PromptResponse['error']
+): Record<string, NodeError> | undefined {
+  if (
+    typeof error !== 'object' ||
+    error.type !== 'PARTNER_NODE_DISABLED' ||
+    !Array.isArray(error.class_types)
+  )
+    return
+
+  const deniedClassTypes = new Set(
+    error.class_types.filter(
+      (classType): classType is string => typeof classType === 'string'
+    )
+  )
+  const entries: Array<[string, NodeError]> = []
+  for (const [nodeId, node] of Object.entries(prompt)) {
+    if (!deniedClassTypes.has(node.class_type)) continue
+    entries.push([
+      nodeId,
+      {
+        class_type: node.class_type,
+        dependent_outputs: [],
+        errors: [
+          {
+            type: 'PARTNER_NODE_DISABLED',
+            message: typeof error.message === 'string' ? error.message : '',
+            details: typeof error.details === 'string' ? error.details : ''
+          }
+        ]
+      }
+    ])
+    if (entries.length === MAX_PARTNER_NODE_ERRORS) break
+  }
+  return entries.length ? Object.fromEntries(entries) : undefined
+}
 
 function isMeshModelFile(file: File): boolean {
   const name = file.name.toLowerCase()
@@ -1781,9 +1822,20 @@ export class ComfyApp {
               ...workflowExecutionIntent,
               ...(workflowContext && { workflowContext })
             })
-            const hasPromptNodeErrors =
-              error instanceof PromptExecutionError &&
-              Object.keys(error.response.node_errors ?? {}).length > 0
+            const responseNodeErrors =
+              error instanceof PromptExecutionError
+                ? error.response.node_errors
+                : undefined
+            const nodeErrors =
+              responseNodeErrors && Object.keys(responseNodeErrors).length > 0
+                ? responseNodeErrors
+                : error instanceof PromptExecutionError
+                  ? partnerNodeErrorsFromClassTypes(
+                      p.output,
+                      error.response.error
+                    )
+                  : undefined
+            const hasPromptNodeErrors = nodeErrors !== undefined
             const preconditionResponseError =
               error instanceof PromptExecutionError &&
               typeof error.response.error === 'object'
@@ -1850,9 +1902,7 @@ export class ComfyApp {
             console.error(error)
 
             if (error instanceof PromptExecutionError) {
-              // Keep the legacy result before empty node errors are normalized.
-              const nodeErrors = error.response.node_errors
-              queueResultOverride = !nodeErrors
+              queueResultOverride = !(error.response.node_errors || nodeErrors)
               executionErrorStore.recordNodeErrors(nodeErrors ?? null)
 
               // Store prompt-level error separately only when no node-specific errors exist,


### PR DESCRIPTION
## Summary

Surface Cloud partner-node governance denials through the Errors panel using the merged `error.class_types` contract when `node_errors` is absent.

## Changes

- **What**: Prefer server-provided `node_errors`; otherwise synthesize at most 100 node errors by matching denied class types against the submitted prompt.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Confirm that `PARTNER_NODE_DISABLED` responses identify the correct submitted nodes while unrelated 403 responses continue to use the Access Restricted dialog.

## Verification

- `pnpm test:unit src/scripts/app.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- Focused formatting and diff checks