### PR TITLE
test(e2e): let a spec request auth without routing itself to Cloud

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -594,6 +594,9 @@ export const comfyPageFixture = base.extend<{
         route.fulfill({ json: ZERO_BALANCE })
       )
       await mockWorkspace(context, workspace('personal', 'owner'), [])
+    }
+
+    if (testInfo.tags.includes('@cloud') || testInfo.tags.includes('@auth')) {
       await comfyPage.cloudAuth.mockAuth()
     }
 

--- a/browser_tests/fixtures/localAuthFixture.ts
+++ b/browser_tests/fixtures/localAuthFixture.ts
@@ -14,10 +14,9 @@ const LOCAL_AUTH_BOOT_TIMEOUT = 45_000
  * Firebase auth must be seeded via `ComfyPage.cloudAuth` *before* the app's
  * first navigation: seeding it against an already-booted page races the
  * app's own Firebase listener and can hang indefinitely. `comfyPageFixture`
- * only seeds pre-boot for `@cloud`-tagged tests (which also run against the
- * Cloud-distribution build), so specs that need an authenticated local user
- * construct `ComfyPage` directly here and drive its setup themselves,
- * mirroring `ComfyPage.setup()` but with auth mocked first.
+ * seeds pre-boot for `@cloud`- and `@auth`-tagged tests. Prefer tagging a
+ * spec `@auth` over using this fixture; it exists for specs that also need
+ * the Free-tier subscription mocks and the bespoke boot below.
  */
 export const localAuthFixture = base.extend<{ comfyPage: ComfyPage }>({
   comfyPage: async ({ page, request }, use, testInfo) => {

--- a/browser_tests/tests/dialogs/topUpDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/topUpDeepLink.spec.ts
@@ -13,8 +13,7 @@ import { member, workspace } from '@e2e/fixtures/utils/workspaceMocks'
  * `page` so the cloud app boots against fully mocked endpoints, like the
  * pricing-table deep-link spec.
  */
-const topUpHeading = (page: Page) =>
-  page.getByRole('heading', { name: 'Add more credits' })
+const topUpDialog = (page: Page) => page.getByTestId('top-up-pay-amount')
 
 test.describe('Top-up deep link', { tag: '@cloud' }, () => {
   test('opens the top-up dialog for a personal owner', async ({ page }) => {
@@ -23,7 +22,7 @@ test.describe('Top-up deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?topup=1`)
 
-    await expect(topUpHeading(page)).toBeVisible({ timeout: 45_000 })
+    await expect(topUpDialog(page)).toBeVisible({ timeout: 45_000 })
     await expect(page).not.toHaveURL(/[?&]topup=/)
   })
 
@@ -42,7 +41,7 @@ test.describe('Top-up deep link', { tag: '@cloud' }, () => {
 
     await page.goto(`${APP_URL}/?topup=1`)
 
-    await expect(topUpHeading(page)).toBeVisible({ timeout: 45_000 })
+    await expect(topUpDialog(page)).toBeVisible({ timeout: 45_000 })
     await expect(page).not.toHaveURL(/[?&]topup=/)
   })
 
@@ -74,7 +73,7 @@ test.describe('Top-up deep link', { tag: '@cloud' }, () => {
     await expect(
       page.getByRole('heading', { name: 'Choose a Plan' })
     ).toBeVisible({ timeout: 45_000 })
-    await expect(topUpHeading(page)).toBeHidden()
+    await expect(topUpDialog(page)).toBeHidden()
     await expect(page).not.toHaveURL(/[?&]topup=/)
   })
 
@@ -101,6 +100,6 @@ test.describe('Top-up deep link', { tag: '@cloud' }, () => {
     await page.waitForURL((url) => !url.searchParams.has('topup'), {
       timeout: 45_000
     })
-    await expect(topUpHeading(page)).toBeHidden()
+    await expect(topUpDialog(page)).toBeHidden()
   })
 })


### PR DESCRIPTION
## Summary

`comfyPageFixture` seeded Firebase auth only for `@cloud`-tagged specs. But `@cloud` is a **project-routing** tag: `playwright.config.ts:40` has the default `chromium` project `grepInvert: /@mobile|@perf|@audit|@cloud/`, and `@cloud` routes the spec to the `cloud` project, which CI feeds the `frontend-dist-cloud` artifact.

So obtaining a signed-in user required the one tag that guarantees `isCloud === true`. That is the structural reason the local-credits P0 shipped despite heavy billing test investment — no billing flow was ever exercised as a signed-in user on a local build. `localAuthFixture` (added by #14587) works around it for a single spec, and its own docstring says so.

Auth seeding now also honours an `@auth` tag. `@auth` is not in chromium's `grepInvert`, so an `@auth` spec runs against the local `frontend-dist` build with a signed-in user. The Cloud API stubs (billing status/balance/plans, workspace) stay behind `@cloud`, and the pre-boot ordering `mockAuth()` depends on is preserved.

Also replaces `topUpDeepLink.spec.ts`'s translated-string locator:

```ts
page.getByRole('heading', { name: 'Add more credits' })
```

with `page.getByTestId('top-up-pay-amount')`, carried by both `TopUpCreditsDialogContentLegacy.vue` and `TopUpCreditsDialogContentWorkspace.vue`. `toBeHidden()` passes on zero matches, so a copy rewording silently turned the two negative assertions at `:76` and `:103` into no-ops.

## Scope

This is the enabling change only. `localAuthFixture` is left in place because it also installs Free-tier subscription mocks and a bespoke boot sequence; its docstring now points new specs at `@auth` first. Adding local-distribution coverage for the uncovered entry points named in #14863 is follow-up work.

`pnpm typecheck:browser` exit 0.

- Part of #14863
