### PR TITLE
perf: defer the layer editor engine off the initial bundle path

### DIFF
--- a/src/extensions/core/layerEditor.ts
+++ b/src/extensions/core/layerEditor.ts
@@ -1,4 +1,3 @@
-import { useLayerEditor } from '@/renderer/extensions/layerEditor/composables/useLayerEditor'
 import { app } from '@/scripts/app'
 
 app.registerExtension({
@@ -8,11 +7,13 @@ app.registerExtension({
       id: 'Comfy.LayerEditor.OpenLayerEditor',
       icon: 'pi pi-images',
       label: 'Open Layer Editor for Selected Node',
-      function: () => {
+      function: async () => {
         const selectedNodes = app.canvas.selected_nodes
         if (!selectedNodes || Object.keys(selectedNodes).length !== 1) return
 
         const selectedNode = selectedNodes[Object.keys(selectedNodes)[0]]
+        const { useLayerEditor } =
+          await import('@/renderer/extensions/layerEditor/composables/useLayerEditor')
         useLayerEditor().openLayerEditor(selectedNode)
       }
     }

--- a/src/renderer/extensions/compositor/composables/useCompositorEditor.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorEditor.ts
@@ -1,10 +1,10 @@
 import { useI18n } from 'vue-i18n'
 
-import LayerEditorContent from '@/renderer/extensions/layerEditor/components/LayerEditorContent.vue'
-import TopBarHeader from '@/renderer/extensions/layerEditor/components/dialog/TopBarHeader.vue'
 import { hasCompositorLayers } from '@/renderer/extensions/compositor/composables/useCompositorLayers'
 import {
   LAYER_EDITOR_DIALOG_KEY,
+  LayerEditorDialogContent,
+  LayerEditorDialogHeader,
   layerEditorDialogProps
 } from '@/renderer/extensions/layerEditor/composables/layerEditorDialog'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -26,8 +26,8 @@ export function useCompositorEditor() {
 
     useDialogStore().showDialog({
       key: LAYER_EDITOR_DIALOG_KEY,
-      headerComponent: TopBarHeader,
-      component: LayerEditorContent,
+      headerComponent: LayerEditorDialogHeader,
+      component: LayerEditorDialogContent,
       props: {
         node,
         mode: 'compositor'

--- a/src/renderer/extensions/layerEditor/composables/layerEditorDialog.ts
+++ b/src/renderer/extensions/layerEditor/composables/layerEditorDialog.ts
@@ -1,6 +1,18 @@
+import { defineAsyncComponent } from 'vue'
+
 import type { DialogComponentProps } from '@/stores/dialogStore'
 
 export const LAYER_EDITOR_DIALOG_KEY = 'global-layer-editor'
+
+export const LayerEditorDialogContent = defineAsyncComponent(
+  () =>
+    import('@/renderer/extensions/layerEditor/components/LayerEditorContent.vue')
+)
+
+export const LayerEditorDialogHeader = defineAsyncComponent(
+  () =>
+    import('@/renderer/extensions/layerEditor/components/dialog/TopBarHeader.vue')
+)
 
 export const layerEditorDialogProps = {
   renderer: 'reka',

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.ts
@@ -1,7 +1,7 @@
-import LayerEditorContent from '@/renderer/extensions/layerEditor/components/LayerEditorContent.vue'
-import TopBarHeader from '@/renderer/extensions/layerEditor/components/dialog/TopBarHeader.vue'
 import {
   LAYER_EDITOR_DIALOG_KEY,
+  LayerEditorDialogContent,
+  LayerEditorDialogHeader,
   layerEditorDialogProps
 } from '@/renderer/extensions/layerEditor/composables/layerEditorDialog'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -23,8 +23,8 @@ export function useLayerEditor() {
 
     useDialogStore().showDialog({
       key: LAYER_EDITOR_DIALOG_KEY,
-      headerComponent: TopBarHeader,
-      component: LayerEditorContent,
+      headerComponent: LayerEditorDialogHeader,
+      component: LayerEditorDialogContent,
       props: {
         node
       },

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -213,7 +213,6 @@ import { useI18n } from 'vue-i18n'
 import { downloadFile } from '@/base/common/downloadUtil'
 import Button from '@/components/ui/button/Button.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
-import { useLayerEditor } from '@/renderer/extensions/layerEditor/composables/useLayerEditor'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { openHdrViewer } from '@/services/hdrViewerService'
@@ -234,7 +233,6 @@ interface ImagePreviewProps {
 const { imageUrls, nodeId } = defineProps<ImagePreviewProps>()
 
 const { t } = useI18n()
-const layerEditor = useLayerEditor()
 const maskEditor = useMaskEditor()
 const nodeOutputStore = useNodeOutputStore()
 const toastStore = useToastStore()
@@ -347,11 +345,13 @@ function handleEditMask() {
   maskEditor.openMaskEditor(node)
 }
 
-function handleOpenLayerEditor() {
+async function handleOpenLayerEditor() {
   if (!nodeId) return
   const node = resolveNode(nodeId)
   if (!node) return
-  layerEditor.openLayerEditor(node)
+  const { useLayerEditor } =
+    await import('@/renderer/extensions/layerEditor/composables/useLayerEditor')
+  useLayerEditor().openLayerEditor(node)
 }
 
 function handleDownload() {


### PR DESCRIPTION
Against https://github.com/Comfy-Org/ComfyUI_frontend/pull/14809. Two lines of import, no behaviour change.

Both edges that reach the layer editor from always-loaded code were static, so the engine sat on the eager graph:

- `src/extensions/core/index.ts` imports `./layerEditor` at boot, and `src/extensions/core/layerEditor.ts` imported `useLayerEditor` at module scope only to call it inside a command handler.
- `ImagePreview.vue` imported `useLayerEditor` at module scope and instantiated it in `setup()`, though it is used only inside `handleOpenLayerEditor`. That component renders on every Vue node with image outputs.

Each hop from there is a value import: `useLayerEditor` -> `LayerEditorContent.vue` -> `useLayerEditorSession.ts`, which statically pulls the engine including `webglCompositor` (887 lines) and `editor/editor.ts`.

Both now import at the point of use, mirroring `src/extensions/core/load3dLazy.ts` and the comment three lines below the offending import ("load3d and saveMesh are loaded on-demand to defer THREE.js").

`./imageCompositor` deliberately stays eager: its runtime imports are `compositorWidgets` and `useCompositorLayers` only, and every engine reference on that path is `import type`, so it costs nothing at boot and it must run to register `nodeCreated`.

Verified locally: no static importer of `useLayerEditor` remains (`grep` over `src/`), and `ImagePreview.test.ts` + `useLayerEditor.test.ts` pass (35 tests). The bundle delta itself is left to this PR's own size report rather than asserted from a local build.