### PR TITLE
feat: add System Status link to the help center menu on Cloud

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -30,7 +30,11 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/useExternalLink', () => ({
   useExternalLink: () => ({
-    staticUrls: { discord: '', github: '' },
+    staticUrls: {
+      discord: '',
+      github: '',
+      status: 'https://status.comfy.org/'
+    },
     buildDocsUrl: () => 'https://docs.comfy.org'
   })
 }))
@@ -160,5 +164,40 @@ describe('HelpCenterMenuContent feedback item', () => {
 
     expect(openSpy).not.toHaveBeenCalled()
     expect(commandStoreExecute).toHaveBeenCalledWith('Comfy.ContactSupport')
+  })
+})
+
+describe('HelpCenterMenuContent system status item', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    distribution.isCloud = false
+    distribution.isDesktop = false
+    distribution.isNightly = false
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+    cleanup()
+  })
+
+  it('opens the status page on Cloud', async () => {
+    distribution.isCloud = true
+    const { user } = renderComponent()
+
+    await user.click(screen.getByRole('menuitem', { name: 'System Status' }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://status.comfy.org/',
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('is hidden outside Cloud', () => {
+    renderComponent()
+
+    expect(screen.queryByRole('menuitem', { name: 'System Status' })).toBeNull()
   })
 })

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -367,6 +367,22 @@ const menuItems = computed<MenuItem[]>(() => {
     }
   ]
 
+  // System status page - only in cloud distributions
+  if (isCloud) {
+    items.push({
+      key: 'status',
+      type: 'item',
+      icon: 'icon-[lucide--activity]',
+      label: t('helpCenter.systemStatus'),
+      showExternalIcon: true,
+      action: () => {
+        trackResourceClick('status', true)
+        openExternalLink(staticUrls.status)
+        emit('close')
+      }
+    })
+  }
+
   // Extension manager - only in non-cloud distributions
   if (!isCloud) {
     items.push({
@@ -420,7 +436,8 @@ const trackResourceClick = (
     | 'github'
     | 'help_feedback'
     | 'manager'
-    | 'release_notes',
+    | 'release_notes'
+    | 'status',
   isExternal: boolean
 ): void => {
   telemetry?.trackHelpResourceClicked({

--- a/src/composables/useExternalLink.ts
+++ b/src/composables/useExternalLink.ts
@@ -90,7 +90,8 @@ export function useExternalLink() {
     githubFrontend: 'https://github.com/Comfy-Org/ComfyUI_frontend',
     githubElectron: 'https://github.com/Comfy-Org/electron',
     forum: 'https://forum.comfy.org/',
-    comfyOrg: 'https://www.comfy.org/'
+    comfyOrg: 'https://www.comfy.org/',
+    status: 'https://status.comfy.org/'
   }
 
   /** Common doc paths for use with buildDocsUrl */

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1069,6 +1069,7 @@
     "docs": "Docs",
     "github": "Github",
     "help": "Help & Support",
+    "systemStatus": "System Status",
     "managerExtension": "Manager Extension",
     "more": "More...",
     "whatsNew": "What's New?",

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -574,6 +574,7 @@ export interface HelpResourceClickedMetadata {
     | 'help_feedback'
     | 'manager'
     | 'release_notes'
+    | 'status'
   is_external: boolean
   source:
     | 'menu'


### PR DESCRIPTION
## Summary

Adds a `status.comfy.org` entry to the help center menu so Cloud users can check service status without leaving the app.

## Changes

- **What**: New "System Status" help center item, gated to Cloud distributions (`isCloud`), opening https://status.comfy.org/ in a new tab and tracked as a `status` help resource click.

## Review Focus

Cloud-only gating and the new `status` value on the help resource telemetry union. Verified with `pnpm test:unit` (help center suite), `pnpm lint`, `pnpm typecheck`.