### PR TITLE
feat(website): link to status.comfy.org from the failed payment page

### DIFF
--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -81,12 +81,19 @@ test.describe('Payment failed page @smoke', () => {
     await expect(cta).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
   })
 
-  test('offers the status page so an outage can be ruled out', async ({
+  test('points at the status page and support so an outage can be ruled out', async ({
     page
   }) => {
-    const link = page.getByRole('link', { name: /CHECK SYSTEM STATUS/i })
-    await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute('href', STATUS_URL)
+    const statusLink = page.getByRole('link', {
+      name: 'status page',
+      exact: true
+    })
+    await expect(statusLink).toBeVisible()
+    await expect(statusLink).toHaveAttribute('href', STATUS_URL)
+
+    const supportLink = page.getByRole('link', { name: 'support', exact: true })
+    await expect(supportLink).toBeVisible()
+    await expect(supportLink).toHaveAttribute('href', SUPPORT_URL)
   })
 })
 
@@ -121,7 +128,10 @@ test.describe('Payment pages zh-CN @smoke', () => {
       page.getByRole('link', { name: '查看订阅文档' })
     ).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
     await expect(
-      page.getByRole('link', { name: '查看系统状态' })
+      page.getByRole('link', { name: '状态页面', exact: true })
     ).toHaveAttribute('href', STATUS_URL)
+    await expect(
+      page.getByRole('link', { name: '支持团队', exact: true })
+    ).toHaveAttribute('href', SUPPORT_URL)
   })
 })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -8,6 +8,7 @@ const CLOUD_URL = externalLinks.cloud
 const PLATFORM_USAGE_URL = externalLinks.platformUsage
 const SUPPORT_URL = externalLinks.support
 const DOCS_SUBSCRIPTION_URL = externalLinks.docsSubscription
+const STATUS_URL = externalLinks.cloudStatus
 
 async function expectNoIndex(page: Page) {
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
@@ -79,6 +80,14 @@ test.describe('Payment failed page @smoke', () => {
     await expect(cta).toBeVisible()
     await expect(cta).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
   })
+
+  test('offers the status page so an outage can be ruled out', async ({
+    page
+  }) => {
+    const link = page.getByRole('link', { name: /CHECK SYSTEM STATUS/i })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', STATUS_URL)
+  })
 })
 
 test.describe('Payment pages zh-CN @smoke', () => {
@@ -111,5 +120,8 @@ test.describe('Payment pages zh-CN @smoke', () => {
     await expect(
       page.getByRole('link', { name: '查看订阅文档' })
     ).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
+    await expect(
+      page.getByRole('link', { name: '查看系统状态' })
+    ).toHaveAttribute('href', STATUS_URL)
   })
 })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -81,7 +81,7 @@ test.describe('Payment failed page @smoke', () => {
     await expect(cta).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
   })
 
-  test('points at the status page and support so an outage can be ruled out', async ({
+  test('points at the status page so an outage can be ruled out', async ({
     page
   }) => {
     const statusLink = page.getByRole('link', {
@@ -90,10 +90,6 @@ test.describe('Payment failed page @smoke', () => {
     })
     await expect(statusLink).toBeVisible()
     await expect(statusLink).toHaveAttribute('href', STATUS_URL)
-
-    const supportLink = page.getByRole('link', { name: 'support', exact: true })
-    await expect(supportLink).toBeVisible()
-    await expect(supportLink).toHaveAttribute('href', SUPPORT_URL)
   })
 })
 
@@ -130,8 +126,5 @@ test.describe('Payment pages zh-CN @smoke', () => {
     await expect(
       page.getByRole('link', { name: '状态页面', exact: true })
     ).toHaveAttribute('href', STATUS_URL)
-    await expect(
-      page.getByRole('link', { name: '支持团队', exact: true })
-    ).toHaveAttribute('href', SUPPORT_URL)
   })
 })

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -75,13 +75,13 @@ const iconRingClass =
       <SectionLabel>{{ t(`payment.${status}.label`, locale) }}</SectionLabel>
 
       <h1
-        class="text-primary-comfy-canvas text-4xl/tight font-light md:text-5xl/tight lg:text-6xl/tight"
+        class="text-4xl/tight font-light text-primary-comfy-canvas md:text-5xl/tight lg:text-6xl/tight"
       >
         {{ t(`payment.${status}.title`, locale) }}
       </h1>
 
       <p
-        class="text-primary-comfy-canvas/80 max-w-xl text-base font-light lg:text-lg"
+        class="max-w-xl text-base font-light text-primary-comfy-canvas/80 lg:text-lg"
       >
         {{ t(`payment.${status}.subtitle`, locale) }}
       </p>
@@ -96,6 +96,14 @@ const iconRingClass =
           {{ t(`payment.${status}.secondaryCta`, locale) }}
         </BrandButton>
       </div>
+
+      <a
+        v-if="status === 'failed'"
+        :href="externalLinks.cloudStatus"
+        class="text-xs font-semibold tracking-wider text-primary-comfy-canvas/60 uppercase underline underline-offset-4 transition-colors hover:text-primary-comfy-canvas"
+      >
+        {{ t('payment.failed.statusLink', locale) }}
+      </a>
     </div>
   </section>
 </template>

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -97,13 +97,26 @@ const iconRingClass =
         </BrandButton>
       </div>
 
-      <a
+      <p
         v-if="status === 'failed'"
-        :href="externalLinks.cloudStatus"
-        class="text-xs font-semibold tracking-wider text-primary-comfy-canvas/60 uppercase underline underline-offset-4 transition-colors hover:text-primary-comfy-canvas"
+        class="max-w-xl text-sm font-light text-primary-comfy-canvas/60"
       >
-        {{ t('payment.failed.statusLink', locale) }}
-      </a>
+        {{ t('payment.failed.statusPrompt.prefix', locale) }}
+        <a
+          :href="externalLinks.cloudStatus"
+          class="text-primary-comfy-yellow underline underline-offset-4"
+        >
+          {{ t('payment.failed.statusPrompt.statusLink', locale) }}
+        </a>
+        {{ t('payment.failed.statusPrompt.middle', locale) }}
+        <a
+          :href="externalLinks.support"
+          class="text-primary-comfy-yellow underline underline-offset-4"
+        >
+          {{ t('payment.failed.statusPrompt.supportLink', locale) }}
+        </a>
+        {{ t('payment.failed.statusPrompt.suffix', locale) }}
+      </p>
     </div>
   </section>
 </template>

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -108,13 +108,6 @@ const iconRingClass =
         >
           {{ t('payment.failed.statusPrompt.statusLink', locale) }}
         </a>
-        {{ t('payment.failed.statusPrompt.middle', locale) }}
-        <a
-          :href="externalLinks.support"
-          class="text-primary-comfy-yellow underline underline-offset-4"
-        >
-          {{ t('payment.failed.statusPrompt.supportLink', locale) }}
-        </a>
         {{ t('payment.failed.statusPrompt.suffix', locale) }}
       </p>
     </div>

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4623,17 +4623,9 @@ const translations = {
     en: 'status page',
     'zh-CN': '状态页面'
   },
-  'payment.failed.statusPrompt.middle': {
-    en: 'for more information. Please reach out to',
-    'zh-CN': '了解更多信息。如果问题仍未解决，请联系'
-  },
-  'payment.failed.statusPrompt.supportLink': {
-    en: 'support',
-    'zh-CN': '支持团队'
-  },
   'payment.failed.statusPrompt.suffix': {
-    en: 'if your issue persists.',
-    'zh-CN': '获取进一步帮助。'
+    en: 'for more information.',
+    'zh-CN': '了解更多信息。'
   },
 
   // AffiliateHeroSection

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4615,6 +4615,10 @@ const translations = {
     en: 'READ SUBSCRIPTION DOCS',
     'zh-CN': '查看订阅文档'
   },
+  'payment.failed.statusLink': {
+    en: 'CHECK SYSTEM STATUS',
+    'zh-CN': '查看系统状态'
+  },
 
   // AffiliateHeroSection
   'affiliate.hero.label': { en: 'AFFILIATE', 'zh-CN': '联盟' },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4615,9 +4615,25 @@ const translations = {
     en: 'READ SUBSCRIPTION DOCS',
     'zh-CN': '查看订阅文档'
   },
-  'payment.failed.statusLink': {
-    en: 'CHECK SYSTEM STATUS',
-    'zh-CN': '查看系统状态'
+  'payment.failed.statusPrompt.prefix': {
+    en: 'Check our',
+    'zh-CN': '请查看我们的'
+  },
+  'payment.failed.statusPrompt.statusLink': {
+    en: 'status page',
+    'zh-CN': '状态页面'
+  },
+  'payment.failed.statusPrompt.middle': {
+    en: 'for more information. Please reach out to',
+    'zh-CN': '了解更多信息。如果问题仍未解决，请联系'
+  },
+  'payment.failed.statusPrompt.supportLink': {
+    en: 'support',
+    'zh-CN': '支持团队'
+  },
+  'payment.failed.statusPrompt.suffix': {
+    en: 'if your issue persists.',
+    'zh-CN': '获取进一步帮助。'
   },
 
   // AffiliateHeroSection


### PR DESCRIPTION
## Summary

Adds status-page guidance to `/payment/failed` (the `STRIPE_CANCEL_URL` target) so someone whose payment did not go through can rule out an outage before contacting support.

## Changes

- **What**: A line under the CTAs on the failed payment page only — "Check our [status page] for more information." — linking `externalLinks.cloudStatus`. Sentence is assembled from prefix/link/suffix translation keys (en + zh-CN), matching the existing pattern in `HubspotFormEmbed.vue`, since `t()` has no interpolation. Support is intentionally not repeated here; the CONTACT SUPPORT CTA above already covers it.

## Review Focus

`apps/website` unit tests, `astro check`, and the payment e2e suite (11 tests, en + zh-CN) pass locally against the built site.
<img width="1003" height="799" alt="Screenshot 2026-08-06 at 8 31 16 PM" src="https://github.com/user-attachments/assets/132d8b5f-1c92-4e2b-ba6e-db6b1265f185" />

