### PR TITLE
chore: add CODEOWNERS entries for src/renderer/extensions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,8 @@
+# Renderer extensions — fallback owner.
+# CODEOWNERS is last-match-wins, so this stays above the per-feature blocks
+# below and they continue to take precedence.
+/src/renderer/extensions/                         @Comfy-Org/comfy_frontend_devs
+
 # Partner Nodes
 /src/composables/node/useNodePricing.ts           @jojodecayz @bigcat88 @Comfy-Org/comfy_frontend_devs
 
@@ -33,6 +38,14 @@
 /src/composables/painter/                                                   @jtydhr88 @Comfy-Org/comfy_frontend_devs
 /src/renderer/extensions/vueNodes/widgets/composables/usePainterWidget.ts   @jtydhr88 @Comfy-Org/comfy_frontend_devs
 /src/lib/litegraph/src/widgets/PainterWidget.ts                             @jtydhr88 @Comfy-Org/comfy_frontend_devs
+
+# Image Compositor / Layer Editor
+/src/extensions/core/imageCompositor.ts                @jtydhr88 @Comfy-Org/comfy_frontend_devs
+/src/extensions/core/imageCompositor.test.ts           @jtydhr88 @Comfy-Org/comfy_frontend_devs
+/src/extensions/core/layerEditor.ts                    @jtydhr88 @Comfy-Org/comfy_frontend_devs
+/src/renderer/extensions/compositor/                   @jtydhr88 @Comfy-Org/comfy_frontend_devs
+/src/renderer/extensions/layerEditor/                  @jtydhr88 @Comfy-Org/comfy_frontend_devs
+/src/lib/litegraph/src/widgets/CompositorWidget.ts     @jtydhr88 @Comfy-Org/comfy_frontend_devs
 
 # GLSL
 /src/renderer/glsl/                               @jtydhr88 @pythongosssss @christian-byrne @Comfy-Org/comfy_frontend_devs


### PR DESCRIPTION
The `main` ruleset (`991238`) sets `require_code_owner_review: true`, but `CODEOWNERS` has no entry matching `src/renderer/extensions/` and no `*` fallback — the only `*`-leading lines are `**/CLAUDE.md` and `**/AGENTS.md`. So the code-owner gate does not apply to that subtree at all: `firstRunTour/`, `linearMode/`, `minimap/` and the non-widget parts of `vueNodes/` are unowned today.

It also means the gate would not apply to the 87 files under `src/renderer/extensions/{compositor,layerEditor}/` that https://github.com/Comfy-Org/ComfyUI_frontend/pull/14809 adds.

This looks like an omission rather than a policy: the sibling `renderer/extensions/vueNodes/widgets/**` paths **are** owned (lines 24-27), as are the adjacent Mask Editor, Image Crop, Image Compare and Painter features.

Two changes:

1. **Team fallback** `/src/renderer/extensions/ @Comfy-Org/comfy_frontend_devs`, placed at the top of the file. CODEOWNERS is last-match-wins, so every per-feature block below keeps precedence and no existing owner is displaced.
2. **Image Compositor / Layer Editor block**, following the same shape as the Image Crop and Painter blocks. `@jtydhr88` authors both features and has self-assigned to both compositor PRs; the paths do not exist on `main` yet, which is why this lands ahead of the feature rather than after it.

Happy to drop (1) if a blanket subtree owner is not wanted and keep only the compositor entries.
