### PR TITLE
chore: fail the CodeRabbit status when the review did not run

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,10 @@ reviews:
   profile: assertive
   high_level_summary: false
   request_changes_workflow: true
+  # Without this, a review that never happened (rate limit, internal error)
+  # still reports green, so an unreviewed PR is indistinguishable from a
+  # cleanly reviewed one.
+  fail_commit_status: true
   auto_review:
     drafts: true
     ignore_title_keywords:


### PR DESCRIPTION
`reviews.fail_commit_status` defaults to `false`, so a CodeRabbit review that never ran still reports green.

Measured on a sibling Comfy-Org repo:

```
$ gh api repos/.../commits/36659b8d/statuses
{"context":"CodeRabbit","state":"pending","description":"Review queued"}
{"context":"CodeRabbit","state":"pending","description":"Review in progress"}
{"context":"CodeRabbit","state":"success","description":"Review rate limited"}
```

`state: success`, and `gh pr checks` prints it as `pass`. A throttled review is indistinguishable from a clean one.

Recent batch on Comfy-Org repos: five PRs finished with no automated review while showing green, and one needed four `@coderabbitai review` invocations before a review actually ran — the run that finally happened found a Critical issue.

Caveat: the v2 schema documents this flag as applying to "review errors"; whether a rate limit is classified as an error is not provable from outside. `review_status` / `commit_status` / `fail_commit_status` are the only relevant knobs in the schema, and this is the one that closes the failure mode if it applies.

Companion change for core: https://github.com/Comfy-Org/ComfyUI/pull/15382
