### PR TITLE
fix: recover legacy top-up state after returning from Stripe checkout

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -12,7 +12,10 @@ const mockAuthStore = vi.hoisted(() => ({
   loginWithGoogle: vi.fn().mockResolvedValue(undefined),
   loginWithGithub: vi.fn().mockResolvedValue(undefined),
   register: vi.fn().mockResolvedValue(undefined),
-  logout: vi.fn().mockResolvedValue(undefined)
+  logout: vi.fn().mockResolvedValue(undefined),
+  initiateCreditPurchase: vi.fn().mockResolvedValue({
+    checkout_url: 'https://checkout.stripe.test'
+  })
 }))
 
 const mockToastStore = vi.hoisted(() => ({
@@ -33,7 +36,11 @@ const mockDialogService = vi.hoisted(() => ({
 
 const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockTrackAuthFailed = vi.hoisted(() => vi.fn())
+const mockStartTopupTracking = vi.hoisted(() => vi.fn())
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
+const mockBillingState = vi.hoisted(() => ({
+  canAccessSubscriptionFeatures: false
+}))
 const mockClearAllWorkflowStorage = vi.hoisted(() => vi.fn())
 
 const knownAuthErrorCodes = new Set([
@@ -59,7 +66,8 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({
-    trackAuthFailed: mockTrackAuthFailed
+    trackAuthFailed: mockTrackAuthFailed,
+    startTopupTracking: mockStartTopupTracking
   }))
 }))
 
@@ -89,7 +97,9 @@ vi.mock('@/stores/authStore', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    canAccessSubscriptionFeatures: { value: false },
+    canAccessSubscriptionFeatures: {
+      value: mockBillingState.canAccessSubscriptionFeatures
+    },
     isFreeTier: { value: true },
     type: { value: 'free' }
   }))
@@ -120,6 +130,28 @@ function makeWorkflow(path: string): ModifiedWorkflow {
 
 beforeEach(() => {
   mockDistributionState.isCloud = false
+  mockBillingState.canAccessSubscriptionFeatures = false
+})
+
+describe('useAuthActions.purchaseCreditsDirect', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockBillingState.canAccessSubscriptionFeatures = true
+  })
+
+  it('starts top-up tracking before opening Stripe checkout', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const { purchaseCreditsDirect } = useAuthActions()
+
+    await purchaseCreditsDirect(25)
+
+    expect(mockStartTopupTracking).toHaveBeenCalledOnce()
+    expect(open).toHaveBeenCalledWith('https://checkout.stripe.test', '_blank')
+    expect(mockStartTopupTracking.mock.invocationCallOrder[0]).toBeLessThan(
+      open.mock.invocationCallOrder[0]
+    )
+  })
 })
 
 describe('useAuthActions.logout', () => {

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -152,6 +152,30 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
       open.mock.invocationCallOrder[0]
     )
   })
+
+  it('does not start tracking or open checkout when no checkout URL is returned', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    mockAuthStore.initiateCreditPurchase.mockResolvedValueOnce({})
+    const { purchaseCreditsDirect } = useAuthActions()
+
+    await expect(purchaseCreditsDirect(25)).rejects.toThrow()
+
+    expect(mockStartTopupTracking).not.toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('does not start tracking or open checkout when the purchase request rejects', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    mockAuthStore.initiateCreditPurchase.mockRejectedValueOnce(
+      new Error('network down')
+    )
+    const { purchaseCreditsDirect } = useAuthActions()
+
+    await expect(purchaseCreditsDirect(25)).rejects.toThrow('network down')
+
+    expect(mockStartTopupTracking).not.toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
 })
 
 describe('useAuthActions.logout', () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -33,6 +33,9 @@ const state = vi.hoisted(() => ({
   showPricingTable: vi.fn(),
   showTopUpCreditsDialog: vi.fn(),
   trackAddApiCreditButtonClicked: vi.fn(),
+  checkForCompletedTopup: vi.fn(),
+  getBillingEvents: vi.fn().mockResolvedValue({ events: [] }),
+  getMyEvents: vi.fn().mockResolvedValue({ events: [] }),
   toastErrorHandler: vi.fn()
 }))
 
@@ -70,6 +73,12 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+vi.mock('@/composables/billing/useBillingRouting', () => ({
+  useBillingRouting: () => ({
+    shouldUseWorkspaceBilling: computed(() => state.type === 'workspace')
+  })
+}))
+
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: computed(() => ({ canTopUp: state.canTopUp }))
@@ -91,7 +100,20 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackAddApiCreditButtonClicked: state.trackAddApiCreditButtonClicked
+    trackAddApiCreditButtonClicked: state.trackAddApiCreditButtonClicked,
+    checkForCompletedTopup: state.checkForCompletedTopup
+  })
+}))
+
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: {
+    getBillingEvents: state.getBillingEvents
+  }
+}))
+
+vi.mock('@/services/customerEventsService', () => ({
+  useCustomerEventsService: () => ({
+    getMyEvents: state.getMyEvents
   })
 }))
 
@@ -171,6 +193,14 @@ function activeProSubscription() {
     cloudCreditBalanceMicros: 200, // -> 422 monthly remaining
     prepaidBalanceMicros: 300 // -> 633 additional
   }
+}
+
+function createDeferred() {
+  let resolve: () => void = () => {}
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
 }
 
 describe('CreditsTile', () => {
@@ -456,6 +486,125 @@ describe('CreditsTile', () => {
     await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(3))
     expect(state.fetchStatus).toHaveBeenCalledTimes(3)
     expect(localStorage.getItem('pending_topup_timestamp')).not.toBeNull()
+  })
+
+  it('runs a trailing refresh when focus returns during an active refresh', async () => {
+    activeProSubscription()
+    renderTile()
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    vi.clearAllMocks()
+
+    const balanceRefresh = createDeferred()
+    const statusRefresh = createDeferred()
+    state.fetchBalance
+      .mockImplementationOnce(() => balanceRefresh.promise)
+      .mockResolvedValue(undefined)
+    state.fetchStatus
+      .mockImplementationOnce(() => statusRefresh.promise)
+      .mockResolvedValue(undefined)
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
+    window.dispatchEvent(new Event('focus'))
+    expect(state.fetchBalance).toHaveBeenCalledOnce()
+
+    balanceRefresh.resolve()
+    statusRefresh.resolve()
+
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(2))
+    expect(state.fetchStatus).toHaveBeenCalledTimes(2)
+    expect(state.getBillingEvents).toHaveBeenCalledTimes(2)
+  })
+
+  it('waits for a failed refresh to settle before its trailing refresh', async () => {
+    activeProSubscription()
+    renderTile()
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    vi.clearAllMocks()
+
+    const statusRefresh = createDeferred()
+    state.fetchBalance
+      .mockRejectedValueOnce(new Error('balance unavailable'))
+      .mockResolvedValue(undefined)
+    state.fetchStatus
+      .mockImplementationOnce(() => statusRefresh.promise)
+      .mockResolvedValue(undefined)
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
+    window.dispatchEvent(new Event('focus'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(state.fetchBalance).toHaveBeenCalledOnce()
+
+    statusRefresh.resolve()
+
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(2))
+    expect(state.fetchStatus).toHaveBeenCalledTimes(2)
+    expect(state.getBillingEvents).toHaveBeenCalledOnce()
+  })
+
+  it('clears a confirmed workspace top-up before the next focus', async () => {
+    activeProSubscription()
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+    const events = [{ event_type: 'topup_completed' }]
+    state.getBillingEvents.mockResolvedValueOnce({ events })
+    state.checkForCompletedTopup.mockImplementationOnce(() => {
+      localStorage.removeItem('pending_topup_timestamp')
+      return true
+    })
+
+    renderTile()
+    await waitFor(() =>
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
+    )
+    expect(state.checkForCompletedTopup).toHaveBeenCalledWith(events)
+    vi.clearAllMocks()
+
+    window.dispatchEvent(new Event('focus'))
+
+    await waitFor(() => expect(state.fetchBalance).not.toHaveBeenCalled())
+    expect(state.getBillingEvents).not.toHaveBeenCalled()
+  })
+
+  it('reconciles pending legacy top-ups against customer events', async () => {
+    activeProSubscription()
+    state.type = 'legacy'
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+
+    renderTile()
+
+    await waitFor(() => expect(state.getMyEvents).toHaveBeenCalledOnce())
+    expect(state.getBillingEvents).not.toHaveBeenCalled()
+  })
+
+  it('retries completion reconciliation after a request failure', async () => {
+    activeProSubscription()
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+    const failure = new Error('events unavailable')
+    state.getBillingEvents
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ events: [{ event_type: 'topup_completed' }] })
+    state.checkForCompletedTopup.mockImplementationOnce(() => {
+      localStorage.removeItem('pending_topup_timestamp')
+      return true
+    })
+
+    renderTile()
+    await waitFor(() =>
+      expect(state.toastErrorHandler).toHaveBeenCalledWith(failure)
+    )
+    expect(localStorage.getItem('pending_topup_timestamp')).not.toBeNull()
+
+    window.dispatchEvent(new Event('focus'))
+
+    await waitFor(() =>
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
+    )
+    expect(state.getBillingEvents).toHaveBeenCalledTimes(2)
   })
 
   it('surfaces a failure toast when a refresh rejects', async () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -34,8 +34,8 @@ const state = vi.hoisted(() => ({
   showTopUpCreditsDialog: vi.fn(),
   trackAddApiCreditButtonClicked: vi.fn(),
   checkForCompletedTopup: vi.fn(),
-  getBillingEvents: vi.fn().mockResolvedValue({ events: [] }),
   getMyEvents: vi.fn().mockResolvedValue({ events: [] }),
+  customerEventsError: null as string | null,
   toastErrorHandler: vi.fn()
 }))
 
@@ -73,12 +73,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
-vi.mock('@/composables/billing/useBillingRouting', () => ({
-  useBillingRouting: () => ({
-    shouldUseWorkspaceBilling: computed(() => state.type === 'workspace')
-  })
-}))
-
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   useWorkspaceUI: () => ({
     permissions: computed(() => ({ canTopUp: state.canTopUp }))
@@ -105,15 +99,10 @@ vi.mock('@/platform/telemetry', () => ({
   })
 }))
 
-vi.mock('@/platform/workspace/api/workspaceApi', () => ({
-  workspaceApi: {
-    getBillingEvents: state.getBillingEvents
-  }
-}))
-
 vi.mock('@/services/customerEventsService', () => ({
   useCustomerEventsService: () => ({
-    getMyEvents: state.getMyEvents
+    getMyEvents: state.getMyEvents,
+    error: computed(() => state.customerEventsError)
   })
 }))
 
@@ -215,6 +204,7 @@ describe('CreditsTile', () => {
     state.isLoading = false
     state.canTopUp = true
     state.type = 'workspace'
+    state.customerEventsError = null
     mockIsCloud.value = true
     vi.clearAllMocks()
     vi.unstubAllEnvs()
@@ -476,6 +466,7 @@ describe('CreditsTile', () => {
 
   it('keeps refreshing on focus until a pending top-up is confirmed', async () => {
     activeProSubscription()
+    state.type = 'legacy'
     localStorage.setItem('pending_topup_timestamp', Date.now().toString())
     renderTile()
 
@@ -490,6 +481,7 @@ describe('CreditsTile', () => {
 
   it('runs a trailing refresh when focus returns during an active refresh', async () => {
     activeProSubscription()
+    state.type = 'legacy'
     renderTile()
     await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -515,11 +507,12 @@ describe('CreditsTile', () => {
 
     await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(2))
     expect(state.fetchStatus).toHaveBeenCalledTimes(2)
-    expect(state.getBillingEvents).toHaveBeenCalledTimes(2)
+    expect(state.getMyEvents).toHaveBeenCalledTimes(2)
   })
 
   it('waits for a failed refresh to settle before its trailing refresh', async () => {
     activeProSubscription()
+    state.type = 'legacy'
     renderTile()
     await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledOnce())
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -544,20 +537,22 @@ describe('CreditsTile', () => {
 
     await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(2))
     expect(state.fetchStatus).toHaveBeenCalledTimes(2)
-    expect(state.getBillingEvents).toHaveBeenCalledOnce()
+    expect(state.getMyEvents).toHaveBeenCalledOnce()
   })
 
-  it('clears a confirmed workspace top-up before the next focus', async () => {
+  it('clears a confirmed legacy top-up before the next focus', async () => {
     activeProSubscription()
+    state.type = 'legacy'
     localStorage.setItem('pending_topup_timestamp', Date.now().toString())
-    const events = [{ event_type: 'topup_completed' }]
-    state.getBillingEvents.mockResolvedValueOnce({ events })
+    const events = [{ event_type: 'credit_added' }]
+    state.getMyEvents.mockResolvedValueOnce({ events })
     state.checkForCompletedTopup.mockImplementationOnce(() => {
       localStorage.removeItem('pending_topup_timestamp')
       return true
     })
 
     renderTile()
+
     await waitFor(() =>
       expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     )
@@ -567,27 +562,17 @@ describe('CreditsTile', () => {
     window.dispatchEvent(new Event('focus'))
 
     await waitFor(() => expect(state.fetchBalance).not.toHaveBeenCalled())
-    expect(state.getBillingEvents).not.toHaveBeenCalled()
+    expect(state.getMyEvents).not.toHaveBeenCalled()
   })
 
-  it('reconciles pending legacy top-ups against customer events', async () => {
+  it('retries legacy completion reconciliation after a request failure', async () => {
     activeProSubscription()
     state.type = 'legacy'
     localStorage.setItem('pending_topup_timestamp', Date.now().toString())
-
-    renderTile()
-
-    await waitFor(() => expect(state.getMyEvents).toHaveBeenCalledOnce())
-    expect(state.getBillingEvents).not.toHaveBeenCalled()
-  })
-
-  it('retries completion reconciliation after a request failure', async () => {
-    activeProSubscription()
-    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
-    const failure = new Error('events unavailable')
-    state.getBillingEvents
-      .mockRejectedValueOnce(failure)
-      .mockResolvedValueOnce({ events: [{ event_type: 'topup_completed' }] })
+    state.customerEventsError = 'events unavailable'
+    state.getMyEvents
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ events: [{ event_type: 'credit_added' }] })
     state.checkForCompletedTopup.mockImplementationOnce(() => {
       localStorage.removeItem('pending_topup_timestamp')
       return true
@@ -595,7 +580,9 @@ describe('CreditsTile', () => {
 
     renderTile()
     await waitFor(() =>
-      expect(state.toastErrorHandler).toHaveBeenCalledWith(failure)
+      expect(state.toastErrorHandler).toHaveBeenCalledWith(
+        new Error('events unavailable')
+      )
     )
     expect(localStorage.getItem('pending_topup_timestamp')).not.toBeNull()
 
@@ -604,7 +591,7 @@ describe('CreditsTile', () => {
     await waitFor(() =>
       expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     )
-    expect(state.getBillingEvents).toHaveBeenCalledTimes(2)
+    expect(state.getMyEvents).toHaveBeenCalledTimes(2)
   })
 
   it('surfaces a failure toast when a refresh rejects', async () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -188,6 +188,7 @@ describe('CreditsTile', () => {
     mockIsCloud.value = true
     vi.clearAllMocks()
     vi.unstubAllEnvs()
+    localStorage.clear()
   })
 
   it('renders the total balance (cents converted to credits) with the remaining suffix', () => {
@@ -441,6 +442,20 @@ describe('CreditsTile', () => {
     )
     expect(state.fetchBalance).toHaveBeenCalledTimes(2)
     expect(state.fetchStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps refreshing on focus until a pending top-up is confirmed', async () => {
+    activeProSubscription()
+    localStorage.setItem('pending_topup_timestamp', Date.now().toString())
+    renderTile()
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(2))
+
+    window.dispatchEvent(new Event('focus'))
+    await waitFor(() => expect(state.fetchBalance).toHaveBeenCalledTimes(3))
+    expect(state.fetchStatus).toHaveBeenCalledTimes(3)
+    expect(localStorage.getItem('pending_topup_timestamp')).not.toBeNull()
   })
 
   it('surfaces a failure toast when a refresh rejects', async () => {

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -225,7 +225,6 @@ import { useI18n } from 'vue-i18n'
 import { formatCredits } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useSubscriptionCredits } from '@/platform/cloud/subscription/composables/useSubscriptionCredits'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -238,7 +237,6 @@ import {
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
 import { useTelemetry } from '@/platform/telemetry'
 import { pendingTopupNeedsRefresh } from '@/platform/telemetry/topupTracker'
-import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useCustomerEventsService } from '@/services/customerEventsService'
 import { useDialogService } from '@/services/dialogService'
@@ -270,7 +268,6 @@ const {
   isLoadingBalance
 } = useSubscriptionCredits()
 const { permissions } = useWorkspaceUI()
-const { shouldUseWorkspaceBilling } = useBillingRouting()
 const { showPricingTable } = useSubscriptionDialog()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
 const customerEventsService = useCustomerEventsService()
@@ -421,10 +418,16 @@ async function refreshCredits() {
 
   if (!pendingTopupNeedsRefresh()) return
 
-  const response = shouldUseWorkspaceBilling.value
-    ? await workspaceApi.getBillingEvents({ page: 1, limit: 10 })
-    : await customerEventsService.getMyEvents({ page: 1, limit: 10 })
-  telemetry?.checkForCompletedTopup(response?.events)
+  const response = await customerEventsService.getMyEvents({
+    page: 1,
+    limit: 10
+  })
+  if (!response) {
+    throw new Error(
+      customerEventsService.error.value ?? 'Fetching customer events failed'
+    )
+  }
+  telemetry?.checkForCompletedTopup(response.events)
 }
 
 let refreshRequested = false

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -225,6 +225,7 @@ import { useI18n } from 'vue-i18n'
 import { formatCredits } from '@/base/credits/comfyCredits'
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useBillingRouting } from '@/composables/billing/useBillingRouting'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useSubscriptionCredits } from '@/platform/cloud/subscription/composables/useSubscriptionCredits'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -237,7 +238,9 @@ import {
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
 import { useTelemetry } from '@/platform/telemetry'
 import { pendingTopupNeedsRefresh } from '@/platform/telemetry/topupTracker'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useCustomerEventsService } from '@/services/customerEventsService'
 import { useDialogService } from '@/services/dialogService'
 
 const { zeroState = false, inactivePlan } = defineProps<{
@@ -267,8 +270,10 @@ const {
   isLoadingBalance
 } = useSubscriptionCredits()
 const { permissions } = useWorkspaceUI()
+const { shouldUseWorkspaceBilling } = useBillingRouting()
 const { showPricingTable } = useSubscriptionDialog()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const customerEventsService = useCustomerEventsService()
 const dialogService = useDialogService()
 const telemetry = useTelemetry()
 
@@ -408,9 +413,49 @@ const emptyStateNotice = computed(() => {
   return null
 })
 
-const handleRefresh = wrapWithErrorHandlingAsync(async () => {
-  await Promise.all([fetchBalance(), fetchStatus()])
-})
+async function refreshCredits() {
+  const results = await Promise.allSettled([fetchBalance(), fetchStatus()])
+  for (const result of results) {
+    if (result.status === 'rejected') throw result.reason
+  }
+
+  if (!pendingTopupNeedsRefresh()) return
+
+  const response = shouldUseWorkspaceBilling.value
+    ? await workspaceApi.getBillingEvents({ page: 1, limit: 10 })
+    : await customerEventsService.getMyEvents({ page: 1, limit: 10 })
+  telemetry?.checkForCompletedTopup(response?.events)
+}
+
+let refreshRequested = false
+let activeRefresh: Promise<void> | null = null
+
+async function refreshLatestCredits() {
+  refreshRequested = true
+  if (activeRefresh) return activeRefresh
+
+  activeRefresh = (async () => {
+    let lastError: unknown
+    while (refreshRequested) {
+      refreshRequested = false
+      try {
+        await refreshCredits()
+        lastError = undefined
+      } catch (error) {
+        lastError = error
+      }
+    }
+    if (lastError) throw lastError
+  })()
+
+  try {
+    await activeRefresh
+  } finally {
+    activeRefresh = null
+  }
+}
+
+const handleRefresh = wrapWithErrorHandlingAsync(refreshLatestCredits)
 
 function handleAddCredits() {
   telemetry?.trackAddApiCreditButtonClicked({ source: 'credits_panel' })

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -236,7 +236,7 @@ import {
 } from '@/platform/cloud/subscription/constants/tierPricing'
 import { computeMonthlyUsage } from '@/platform/cloud/subscription/utils/creditsProgress'
 import { useTelemetry } from '@/platform/telemetry'
-import { consumePendingTopup } from '@/platform/telemetry/topupTracker'
+import { pendingTopupNeedsRefresh } from '@/platform/telemetry/topupTracker'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useDialogService } from '@/services/dialogService'
 
@@ -422,7 +422,7 @@ function handleUpgradeToAddCredits() {
 }
 
 async function handleWindowFocus() {
-  if (consumePendingTopup()) {
+  if (pendingTopupNeedsRefresh()) {
     await handleRefresh()
   }
 }

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -257,5 +257,17 @@ describe('topupTracker', () => {
         'pending_topup_timestamp'
       )
     })
+
+    it.for(['invalid', Number.MAX_SAFE_INTEGER.toString()])(
+      'clears and returns false for an invalid marker: %s',
+      (timestamp) => {
+        mockLocalStorage.getItem.mockReturnValue(timestamp)
+
+        expect(pendingTopupNeedsRefresh()).toBe(false)
+        expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+          'pending_topup_timestamp'
+        )
+      }
+    )
   })
 })

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -176,6 +176,25 @@ describe('topupTracker', () => {
       expect(result).toBe(false)
       expect(mockTelemetry.trackApiCreditTopupSucceeded).not.toHaveBeenCalled()
     })
+
+    it('ignores topup_completed, which belongs to the unified rail that tracks completion via billing_op_id polling', () => {
+      const startTimestamp = Date.now()
+      localStorage.setItem('pending_topup_timestamp', startTimestamp.toString())
+
+      const events: AuditLog[] = [
+        {
+          event_id: 'evt-unified',
+          event_type: 'topup_completed',
+          createdAt: new Date(startTimestamp + 1000).toISOString(),
+          params: {}
+        }
+      ]
+
+      const result = checkForCompletedTopup(events)
+
+      expect(result).toBe(false)
+      expect(mockTelemetry.trackApiCreditTopupSucceeded).not.toHaveBeenCalled()
+    })
   })
 
   describe('clearTopupTracking', () => {

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   pendingTopupNeedsRefresh,
@@ -7,18 +7,6 @@ import {
   clearTopupTracking
 } from '@/platform/telemetry/topupTracker'
 import type { AuditLog } from '@/services/customerEventsService'
-
-// Mock localStorage
-const mockLocalStorage = vi.hoisted(() => ({
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn()
-}))
-
-Object.defineProperty(window, 'localStorage', {
-  value: mockLocalStorage,
-  writable: true
-})
 
 // Mock telemetry
 const mockTelemetry = vi.hoisted(() => ({
@@ -31,33 +19,28 @@ vi.mock('@/platform/telemetry', () => ({
 
 describe('topupTracker', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-07T12:00:00Z'))
     vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('startTopupTracking', () => {
     it('should save current timestamp to localStorage', () => {
-      const beforeTimestamp = Date.now()
-
       startTopupTracking()
 
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp',
-        expect.any(String)
+      expect(localStorage.getItem('pending_topup_timestamp')).toBe(
+        Date.now().toString()
       )
-
-      const savedTimestamp = parseInt(
-        mockLocalStorage.setItem.mock.calls[0][1],
-        10
-      )
-      expect(savedTimestamp).toBeGreaterThanOrEqual(beforeTimestamp)
-      expect(savedTimestamp).toBeLessThanOrEqual(Date.now())
     })
   })
 
   describe('checkForCompletedTopup', () => {
     it('should return false if no pending topup exists', () => {
-      mockLocalStorage.getItem.mockReturnValue(null)
-
       const result = checkForCompletedTopup([])
 
       expect(result).toBe(false)
@@ -65,7 +48,7 @@ describe('topupTracker', () => {
     })
 
     it('should return false if events array is empty', () => {
-      mockLocalStorage.getItem.mockReturnValue(Date.now().toString())
+      localStorage.setItem('pending_topup_timestamp', Date.now().toString())
 
       const result = checkForCompletedTopup([])
 
@@ -74,7 +57,7 @@ describe('topupTracker', () => {
     })
 
     it('should return false if events array is null', () => {
-      mockLocalStorage.getItem.mockReturnValue(Date.now().toString())
+      localStorage.setItem('pending_topup_timestamp', Date.now().toString())
 
       const result = checkForCompletedTopup(null)
 
@@ -84,7 +67,7 @@ describe('topupTracker', () => {
 
     it('should auto-cleanup if timestamp is older than 24 hours', () => {
       const oldTimestamp = Date.now() - 25 * 60 * 60 * 1000 // 25 hours ago
-      mockLocalStorage.getItem.mockReturnValue(oldTimestamp.toString())
+      localStorage.setItem('pending_topup_timestamp', oldTimestamp.toString())
 
       const events: AuditLog[] = [
         {
@@ -98,15 +81,13 @@ describe('topupTracker', () => {
       const result = checkForCompletedTopup(events)
 
       expect(result).toBe(false)
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
       expect(mockTelemetry.trackApiCreditTopupSucceeded).not.toHaveBeenCalled()
     })
 
     it('should detect completed topup and fire telemetry', () => {
       const startTimestamp = Date.now() - 5 * 60 * 1000 // 5 minutes ago
-      mockLocalStorage.getItem.mockReturnValue(startTimestamp.toString())
+      localStorage.setItem('pending_topup_timestamp', startTimestamp.toString())
 
       const events: AuditLog[] = [
         {
@@ -127,36 +108,12 @@ describe('topupTracker', () => {
 
       expect(result).toBe(true)
       expect(mockTelemetry.trackApiCreditTopupSucceeded).toHaveBeenCalledOnce()
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
-    })
-
-    it('should detect completed topup for topup_completed (unified billing feed)', () => {
-      const startTimestamp = Date.now() - 5 * 60 * 1000 // 5 minutes ago
-      mockLocalStorage.getItem.mockReturnValue(startTimestamp.toString())
-
-      const events: AuditLog[] = [
-        {
-          event_id: 'evt-topup',
-          event_type: 'topup_completed',
-          createdAt: new Date(startTimestamp + 1000).toISOString(),
-          params: {}
-        }
-      ]
-
-      const result = checkForCompletedTopup(events)
-
-      expect(result).toBe(true)
-      expect(mockTelemetry.trackApiCreditTopupSucceeded).toHaveBeenCalledOnce()
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     })
 
     it('should not detect topup if credit_added event is before tracking started', () => {
       const startTimestamp = Date.now()
-      mockLocalStorage.getItem.mockReturnValue(startTimestamp.toString())
+      localStorage.setItem('pending_topup_timestamp', startTimestamp.toString())
 
       const events: AuditLog[] = [
         {
@@ -171,12 +128,14 @@ describe('topupTracker', () => {
 
       expect(result).toBe(false)
       expect(mockTelemetry.trackApiCreditTopupSucceeded).not.toHaveBeenCalled()
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled()
+      expect(localStorage.getItem('pending_topup_timestamp')).toBe(
+        startTimestamp.toString()
+      )
     })
 
     it('should ignore events without createdAt timestamp', () => {
       const startTimestamp = Date.now()
-      mockLocalStorage.getItem.mockReturnValue(startTimestamp.toString())
+      localStorage.setItem('pending_topup_timestamp', startTimestamp.toString())
 
       const events: AuditLog[] = [
         {
@@ -195,7 +154,7 @@ describe('topupTracker', () => {
 
     it('should only match credit_added events, not other event types', () => {
       const startTimestamp = Date.now()
-      mockLocalStorage.getItem.mockReturnValue(startTimestamp.toString())
+      localStorage.setItem('pending_topup_timestamp', startTimestamp.toString())
 
       const events: AuditLog[] = [
         {
@@ -223,50 +182,42 @@ describe('topupTracker', () => {
     it('should remove pending topup from localStorage', () => {
       clearTopupTracking()
 
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     })
   })
 
   describe('pendingTopupNeedsRefresh', () => {
     it('returns false and clears nothing when no marker exists', () => {
-      mockLocalStorage.getItem.mockReturnValue(null)
-
       expect(pendingTopupNeedsRefresh()).toBe(false)
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled()
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     })
 
     it('keeps a fresh marker available across focus events', () => {
-      mockLocalStorage.getItem.mockReturnValue(
-        (Date.now() - 5 * 60 * 1000).toString()
-      )
+      const timestamp = (Date.now() - 5 * 60 * 1000).toString()
+      localStorage.setItem('pending_topup_timestamp', timestamp)
 
       expect(pendingTopupNeedsRefresh()).toBe(true)
       expect(pendingTopupNeedsRefresh()).toBe(true)
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled()
+      expect(localStorage.getItem('pending_topup_timestamp')).toBe(timestamp)
     })
 
     it('clears and returns false for a marker older than 24 hours', () => {
-      mockLocalStorage.getItem.mockReturnValue(
+      localStorage.setItem(
+        'pending_topup_timestamp',
         (Date.now() - 25 * 60 * 60 * 1000).toString()
       )
 
       expect(pendingTopupNeedsRefresh()).toBe(false)
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
+      expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
     })
 
     it.for(['invalid', Number.MAX_SAFE_INTEGER.toString()])(
       'clears and returns false for an invalid marker: %s',
       (timestamp) => {
-        mockLocalStorage.getItem.mockReturnValue(timestamp)
+        localStorage.setItem('pending_topup_timestamp', timestamp)
 
         expect(pendingTopupNeedsRefresh()).toBe(false)
-        expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-          'pending_topup_timestamp'
-        )
+        expect(localStorage.getItem('pending_topup_timestamp')).toBeNull()
       }
     )
   })

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  consumePendingTopup,
+  pendingTopupNeedsRefresh,
   startTopupTracking,
   checkForCompletedTopup,
   clearTopupTracking
@@ -229,23 +229,22 @@ describe('topupTracker', () => {
     })
   })
 
-  describe('consumePendingTopup', () => {
+  describe('pendingTopupNeedsRefresh', () => {
     it('returns false and clears nothing when no marker exists', () => {
       mockLocalStorage.getItem.mockReturnValue(null)
 
-      expect(consumePendingTopup()).toBe(false)
+      expect(pendingTopupNeedsRefresh()).toBe(false)
       expect(mockLocalStorage.removeItem).not.toHaveBeenCalled()
     })
 
-    it('clears and returns true for a fresh marker', () => {
+    it('keeps a fresh marker available across focus events', () => {
       mockLocalStorage.getItem.mockReturnValue(
         (Date.now() - 5 * 60 * 1000).toString()
       )
 
-      expect(consumePendingTopup()).toBe(true)
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-        'pending_topup_timestamp'
-      )
+      expect(pendingTopupNeedsRefresh()).toBe(true)
+      expect(pendingTopupNeedsRefresh()).toBe(true)
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled()
     })
 
     it('clears and returns false for a marker older than 24 hours', () => {
@@ -253,7 +252,7 @@ describe('topupTracker', () => {
         (Date.now() - 25 * 60 * 60 * 1000).toString()
       )
 
-      expect(consumePendingTopup()).toBe(false)
+      expect(pendingTopupNeedsRefresh()).toBe(false)
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
         'pending_topup_timestamp'
       )

--- a/src/platform/telemetry/topupTracker.ts
+++ b/src/platform/telemetry/topupTracker.ts
@@ -4,6 +4,20 @@ import type { AuditLog } from '@/services/customerEventsService'
 const STORAGE_KEY = 'pending_topup_timestamp'
 const MAX_AGE_MS = 24 * 60 * 60 * 1000 // 24 hours
 
+function getPendingTopupTimestamp(): number | null {
+  const timestampStr = localStorage.getItem(STORAGE_KEY)
+  if (!timestampStr) return null
+
+  const timestamp = Number(timestampStr)
+  const age = Date.now() - timestamp
+  if (Number.isSafeInteger(timestamp) && age >= 0 && age <= MAX_AGE_MS) {
+    return timestamp
+  }
+
+  localStorage.removeItem(STORAGE_KEY)
+  return null
+}
+
 /**
  * Start tracking a credit top-up purchase.
  * Call this before opening the Stripe checkout window.
@@ -22,16 +36,8 @@ export function startTopupTracking(): void {
 export function checkForCompletedTopup(
   events: AuditLog[] | undefined | null
 ): boolean {
-  const timestampStr = localStorage.getItem(STORAGE_KEY)
-  if (!timestampStr) return false
-
-  const timestamp = parseInt(timestampStr, 10)
-
-  // Auto-cleanup if expired (older than 24 hours)
-  if (Date.now() - timestamp > MAX_AGE_MS) {
-    localStorage.removeItem(STORAGE_KEY)
-    return false
-  }
+  const timestamp = getPendingTopupTimestamp()
+  if (timestamp === null) return false
 
   if (!events || events.length === 0) return false
 
@@ -63,12 +69,5 @@ export function clearTopupTracking(): void {
 }
 
 export function pendingTopupNeedsRefresh(): boolean {
-  const timestampStr = localStorage.getItem(STORAGE_KEY)
-  if (!timestampStr) return false
-
-  const timestamp = parseInt(timestampStr, 10)
-  if (Date.now() - timestamp <= MAX_AGE_MS) return true
-
-  localStorage.removeItem(STORAGE_KEY)
-  return false
+  return getPendingTopupTimestamp() !== null
 }

--- a/src/platform/telemetry/topupTracker.ts
+++ b/src/platform/telemetry/topupTracker.ts
@@ -62,15 +62,13 @@ export function clearTopupTracking(): void {
   localStorage.removeItem(STORAGE_KEY)
 }
 
-/**
- * Consume a pending top-up marker on window focus. Clears the marker and
- * reports whether a non-expired purchase was awaiting a balance refresh.
- */
-export function consumePendingTopup(): boolean {
+export function pendingTopupNeedsRefresh(): boolean {
   const timestampStr = localStorage.getItem(STORAGE_KEY)
   if (!timestampStr) return false
 
-  localStorage.removeItem(STORAGE_KEY)
   const timestamp = parseInt(timestampStr, 10)
-  return Date.now() - timestamp <= MAX_AGE_MS
+  if (Date.now() - timestamp <= MAX_AGE_MS) return true
+
+  localStorage.removeItem(STORAGE_KEY)
+  return false
 }

--- a/src/platform/telemetry/topupTracker.ts
+++ b/src/platform/telemetry/topupTracker.ts
@@ -41,12 +41,9 @@ export function checkForCompletedTopup(
 
   if (!events || events.length === 0) return false
 
-  // Find a credit top-up event that occurred after our timestamp.
-  // Legacy /customers/events emits `credit_added`; the unified
-  // /api/billing/events feed emits `topup_completed`.
   const completedTopup = events.find(
     (e) =>
-      (e.event_type === 'credit_added' || e.event_type === 'topup_completed') &&
+      e.event_type === 'credit_added' &&
       e.createdAt &&
       new Date(e.createdAt).getTime() > timestamp
   )


### PR DESCRIPTION
## Summary

PAY-004 — Successful legacy top-up not reflected until refresh.

Fixes the frontend race that can leave Run locked and the credit balance stale after a successful legacy Stripe top-up through `/customers/credit`.

This PR does not change the normal workspace/new billing top-up flow. Workspace top-ups already track completion with `billing_op_id` polling.

## Changes

- Preserve a valid `pending_topup_timestamp` across focus events instead of consuming it on the first focus.
- Refresh balance and subscription status when the editor regains focus.
- Reconcile the pending legacy checkout against `/customers/events` and clear the marker only after a later `credit_added` event.
- Treat a failed legacy event request as a failed refresh so a later focus can retry it.
- Serialize overlapping refreshes and perform one trailing refresh when another request arrives in flight.
- Remove malformed, future, and older-than-24-hour markers.
- Breaking changes: none.
- Dependencies: none.

## Review focus and limitations

The marker controls refresh eligibility; the backend balance, subscription status, and `credit_added` event remain the state sources.

This PR intentionally does not add timed polling. If backend propagation is delayed beyond the return refresh, the marker remains and the next focus or manual refresh retries recovery. The broader legacy/workspace top-up and subscription comparison, API gaps, and possible recovery unification are documented in [Notion](https://app.notion.com/p/3b56d73d365081d1b9afd2d224673b73?pvs=204).

## Regression coverage

- Early focus preserves the pending marker.
- A later focus can confirm completion and clear it.
- Overlapping focus events produce one trailing refresh.
- Balance/status partial failures settle before retry.
- Legacy event-request failure remains retryable.
- Invalid and expired markers are removed.
- Checkout failures do not start tracking or open Stripe.

## Screenshots

**AS IS — production QA evidence:** after a real $10 Visa top-up on cloud.comfy.org, the editor still shows Run locked because the balance and entitlement remain stale.

![AS IS — Run remains locked after successful top-up](https://ampcode.com/user-content/artifacts/dfa635d7c74378e47259fc9e514d0587f95a51f0b93da0698b5e6b53151edee2-file.png)

**AS IS — deterministic pre-fix replay:** an early focus consumes the pending marker before payment completion; the real checkout return then performs no second balance request.

![AS IS — pre-fix top-up return leaves credits stale](https://ampcode.com/user-content/artifacts/d8c32f075bcc11d1dce2b5a1e48b8d535da470edef11e0fad97333af46bc6421-file.gif)

**TO BE — real Cloud editor with the fix:** the later checkout return refreshes billing state, updates the credit balance, and enables Run.

![TO BE — refreshed credits and enabled Run after checkout return](https://ampcode.com/user-content/artifacts/79366431f7f20bdc60a82ec3ddbfe1584d20c435ec65d11abf76b445d30620c7-file.png)