### PR TITLE
test: use test IDs for sidebar tabs

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -12,9 +12,9 @@ export class SidebarTab {
     public readonly page: Page,
     public readonly tabId: string
   ) {
-    this.tabButton = page.locator(`.${tabId}-tab-button`)
-    this.selectedTabButton = page.locator(
-      `.${tabId}-tab-button.side-bar-button-selected`
+    this.tabButton = page.getByTestId(TestIds.sidebar.tabButton(tabId))
+    this.selectedTabButton = this.tabButton.and(
+      page.locator('.side-bar-button-selected')
     )
   }
 

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -11,7 +11,8 @@ export const TestIds = {
     nodePreviewCard: 'node-preview-card',
     workflows: 'workflows-sidebar',
     workflowsRefreshButton: 'workflows-refresh-button',
-    modeToggle: 'mode-toggle'
+    modeToggle: 'mode-toggle',
+    tabButton: (tabId: string) => `${tabId}-tab-button`
   },
   tree: {
     folder: 'tree-folder',

--- a/browser_tests/tests/defaultKeybindings.spec.ts
+++ b/browser_tests/tests/defaultKeybindings.spec.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { SidebarTab } from '@e2e/fixtures/components/SidebarTab'
 
 async function pressKeyAndExpectRequest(
   comfyPage: ComfyPage,
@@ -33,17 +34,15 @@ test.describe('Default Keybindings', { tag: '@keyboard' }, () => {
 
     for (const { key, tabId, label } of sidebarTabs) {
       test(`'${key}' toggles ${label} sidebar`, async ({ comfyPage }) => {
-        const selectedButton = comfyPage.page.locator(
-          `.${tabId}-tab-button.side-bar-button-selected`
-        )
+        const { selectedTabButton } = new SidebarTab(comfyPage.page, tabId)
 
-        await expect(selectedButton).toBeHidden()
+        await expect(selectedTabButton).toBeHidden()
 
         await comfyPage.canvas.press(key)
-        await expect(selectedButton).toBeVisible()
+        await expect(selectedTabButton).toBeVisible()
 
         await comfyPage.canvas.press(key)
-        await expect(selectedButton).toBeHidden()
+        await expect(selectedTabButton).toBeHidden()
       })
     }
   })

--- a/browser_tests/tests/resultGallery.spec.ts
+++ b/browser_tests/tests/resultGallery.spec.ts
@@ -17,7 +17,7 @@ test.describe('MediaLightbox', { tag: ['@slow', '@vue-nodes'] }, () => {
     })
 
     // Open Assets sidebar tab and wait for it to load
-    await comfyPage.page.locator('.assets-tab-button').click()
+    await comfyPage.menu.assetsTab.open()
     await comfyPage.page
       .locator('.sidebar-content-container')
       .waitFor({ state: 'visible' })

--- a/browser_tests/tests/resultGallery.spec.ts
+++ b/browser_tests/tests/resultGallery.spec.ts
@@ -17,7 +17,7 @@ test.describe('MediaLightbox', { tag: ['@slow', '@vue-nodes'] }, () => {
     })
 
     // Open Assets sidebar tab and wait for it to load
-    await comfyPage.menu.assetsTab.open()
+    await comfyPage.menu.assetsTab.open({ waitForAssets: false })
     await comfyPage.page
       .locator('.sidebar-content-container')
       .waitFor({ state: 'visible' })

--- a/src/components/sidebar/SideToolbar.vue
+++ b/src/components/sidebar/SideToolbar.vue
@@ -30,7 +30,7 @@
           :label="tab.label || tab.title"
           :is-small="isSmall"
           :selected="tab.id === selectedTab?.id"
-          :class="tab.id + '-tab-button'"
+          :data-testid="`${tab.id}-tab-button`"
           @click="onTabClick(tab)"
         />
         <SidebarTemplatesButton />


### PR DESCRIPTION
## Summary

Use dedicated test IDs for sidebar tab buttons so test selectors are not represented as dynamically generated CSS classes.

## Changes

- **What**: Add dynamic sidebar tab test IDs, centralize their Playwright selector, and update the affected sidebar and gallery tests.

## Review Focus

Sidebar buttons no longer expose `{tabId}-tab-button` as a CSS class; the same identifier is now exposed through `data-testid`.