### PR TITLE
refactor: drop dead optional chaining on systemStatsStore in aboutPanelStore

### DIFF
--- a/.github/risk.json
+++ b/.github/risk.json
@@ -1,0 +1,273 @@
+{
+  "map_version": "v0-frontend",
+  "_comment": [
+    "ComfyUI_frontend override for the reusable pr-risk.yml grader (Comfy-Org/github-workflows).",
+    "REPLACES the generic map wholesale, so the generic R3 classes are re-stated here.",
+    "grade = worst(path_floor, provenance, reversibility); an axis can only raise a tier.",
+    "",
+    "Lane mapping to the Comfy CD risk-assessment fork:",
+    "  R0-R1 -> flagless merge lane (copy / docs / tests / storybook only)",
+    "  R2    -> feature flag required (default OFF) + ephemeral env validation",
+    "  R3    -> flag + ephemeral env + Sheriff/QA sign-off; serialization and auth/billing",
+    "           changes also need a (Feature) Test Plan entry"
+  ],
+  "tiers": ["R0", "R1", "R2", "R3"],
+  "default_tier": "R0",
+
+  "path_rules": [
+    {
+      "class": "risk-map",
+      "tier": "R3",
+      "why": "a PR must not be able to lower its own grade",
+      "paths": [
+        "**/risk-map.*.json",
+        "**/runbook-registry.*.json",
+        "**/pr-risk/**",
+        ".github/risk.json",
+        ".github/risk-runbooks.json",
+        "**/.github/risk.json",
+        "**/.github/risk-runbooks.json"
+      ]
+    },
+    {
+      "class": "codeowners",
+      "tier": "R3",
+      "why": "editing CODEOWNERS edits the review gate",
+      "paths": ["CODEOWNERS", ".github/CODEOWNERS", "**/CODEOWNERS"]
+    },
+    {
+      "class": "ci",
+      "tier": "R3",
+      "why": "workflows run with repo credentials",
+      "paths": [
+        ".github/workflows/**",
+        ".github/actions/**",
+        "**/.github/workflows/**"
+      ]
+    },
+    {
+      "class": "deps",
+      "tier": "R3",
+      "why": "manifests and the pnpm catalog pull in code nobody in the PR wrote",
+      "paths": [
+        "**/package.json",
+        "**/pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "**/.npmrc",
+        "**/requirements*.txt",
+        "**/pyproject.toml"
+      ]
+    },
+    {
+      "class": "secrets",
+      "tier": "R3",
+      "why": "secrets handling",
+      "paths": [
+        "**/secrets/**",
+        "**/*secret*.ts",
+        "secrets.env*",
+        "**/*credential*",
+        ".env*"
+      ]
+    },
+    {
+      "class": "auth",
+      "tier": "R3",
+      "why": "authentication / trust boundary",
+      "paths": [
+        "**/auth/**",
+        "src/platform/cloud/oauth/**",
+        "**/middleware/auth*",
+        "**/*token_validator*"
+      ]
+    },
+    {
+      "class": "billing",
+      "tier": "R3",
+      "why": "billing / credits — money moves",
+      "paths": ["**/billing/**", "**/pricing/**", "**/credits/**"]
+    },
+    {
+      "class": "workflow-serialization",
+      "tier": "R3",
+      "why": "saved user workflows are persistent state — a bad schema or serialize change corrupts files on save and does not cleanly revert",
+      "paths": [
+        "src/lib/litegraph/src/serialization*",
+        "src/schemas/**",
+        "src/core/schemas/**",
+        "src/platform/workflow/validation/schemas/**",
+        "**/workflowSchema*"
+      ]
+    },
+    {
+      "class": "extension-contract",
+      "tier": "R3",
+      "why": "entity callbacks, node.widgets, serialize and the app/api surface are consumed by 40+ custom-node repos — consumers break out of band (ADR 0003/0008)",
+      "paths": [
+        "src/scripts/app.ts",
+        "src/scripts/api.ts",
+        "src/types/comfy*.ts",
+        "src/lib/litegraph/src/LGraph.ts",
+        "src/lib/litegraph/src/LGraphNode.ts",
+        "src/lib/litegraph/src/LGraphCanvas.ts",
+        "src/lib/litegraph/src/subgraph/**"
+      ]
+    },
+    {
+      "class": "api-contract",
+      "tier": "R3",
+      "why": "cross-repo API contract",
+      "paths": [
+        "openapi.yaml",
+        "openapi.yml",
+        "**/openapi.yaml",
+        "**/openapi.yml",
+        "**/*.proto"
+      ]
+    },
+    {
+      "class": "migrations",
+      "tier": "R3",
+      "why": "kept from the generic map — schema migrations do not cleanly revert",
+      "paths": ["**/migrations/**", "**/migrate/**"]
+    },
+    {
+      "class": "iac",
+      "tier": "R3",
+      "why": "kept from the generic map",
+      "paths": [
+        "infrastructure/**",
+        "terraform/**",
+        "**/*.tf",
+        "charts/**",
+        "helm/**"
+      ]
+    },
+    {
+      "class": "data-deletion",
+      "tier": "R3",
+      "why": "kept from the generic map — irreversible by construction",
+      "paths": ["**/deletion/**", "**/gdpr/**"]
+    },
+
+    {
+      "class": "flag-defaults",
+      "tier": "R2",
+      "why": "the flag config and flag plumbing are the rollout lever — flipping a default changes behavior for every user at once",
+      "paths": [
+        "src/config/clientFeatureFlags.json",
+        "**/useFeatureFlags*",
+        "**/useVueFeatureFlags*",
+        "**/devFeatureFlagOverride*"
+      ]
+    },
+    {
+      "class": "build-config",
+      "tier": "R2",
+      "why": "build config decides what ships in the bundle",
+      "paths": [
+        "**/vite.config.*",
+        "tsconfig*.json",
+        "index.html",
+        "scripts/**"
+      ]
+    },
+    {
+      "class": "core-infra",
+      "tier": "R2",
+      "why": "cross-cutting state, API layer, routing, bootstrap, canvas engine and published packages — blast radius is every feature, and packages/** breaks consumers out of band",
+      "paths": [
+        "src/stores/**",
+        "src/services/**",
+        "src/router.ts",
+        "src/main.ts",
+        "src/bootstrap.ts",
+        "src/base/**",
+        "src/core/**",
+        "src/lib/litegraph/**",
+        "packages/**"
+      ]
+    },
+
+    {
+      "class": "docs",
+      "tier": "R0",
+      "why": "prose only",
+      "paths": ["**/*.md", "docs/**", "**/*.mdx", "**/*.txt", "LICENSE"]
+    },
+    {
+      "class": "i18n-copy",
+      "tier": "R0",
+      "why": "translation copy",
+      "paths": ["**/locales/**"]
+    },
+    {
+      "class": "storybook",
+      "tier": "R0",
+      "why": "stories and storybook config do not ship to users",
+      "paths": ["**/*.stories.ts", "src/storybook/**", ".storybook/**"]
+    },
+    {
+      "class": "tests",
+      "tier": "R0",
+      "why": "test-only changes cannot break production behaviour",
+      "paths": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "browser_tests/**",
+        "**/test/**",
+        "**/tests/**",
+        "**/__tests__/**",
+        "**/testdata/**"
+      ]
+    }
+  ],
+
+  "provenance_tiers": {
+    "runbook": "R0",
+    "agent-supervised": "R1",
+    "human": "R1",
+    "external": "R3"
+  },
+
+  "reversibility": {
+    "irreversible_classes": [
+      "workflow-serialization",
+      "migrations",
+      "data-deletion",
+      "secrets"
+    ],
+    "delete_sensitive_classes": [
+      "workflow-serialization",
+      "extension-contract",
+      "auth",
+      "billing",
+      "api-contract",
+      "migrations",
+      "data-deletion",
+      "iac"
+    ],
+    "no_green_checks_tier": "R2",
+    "no_test_touched_tier": "R1",
+    "clean_tier": "R0",
+    "test_path_patterns": [
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
+      "browser_tests/**",
+      "**/test/**",
+      "**/tests/**",
+      "**/__tests__/**",
+      "**/testdata/**"
+    ]
+  },
+
+  "flippable_flag_paths": [
+    "**/useFeatureFlags*",
+    "**/useVueFeatureFlags*",
+    "**/clientFeatureFlags.json",
+    "**/devFeatureFlagOverride*"
+  ]
+}

--- a/.github/workflows/ci-pr-risk.yml
+++ b/.github/workflows/ci-pr-risk.yml
@@ -1,0 +1,60 @@
+name: CI - PR Risk Grade
+
+# Thin caller for the shared ADVISORY PR risk grader (shadow check). Grades
+# every PR R0 (safest) .. R3 (riskiest) against .github/risk.json (read from
+# the BASE ref) and syncs exactly one `risk:*` label — nothing gates, routes,
+# or merges on it. Disagree with a grade by adding the human-owned
+# `risk-dispute` label plus a comment saying why.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Grade ONE pr by number (enrollment backfill, or a manual re-grade).
+        required: false
+      pr_numbers:
+        description: Grade several, comma-separated (12,15,20). Wins over pr_number.
+        required: false
+
+concurrency:
+  # Must carry the resolved target: on workflow_dispatch the event PR number is
+  # empty, and on pull_request the inputs are empty — one expression serves
+  # both. Trailing run_id keeps two no-input dispatches from cancelling each
+  # other. Keep a dispatched batch under ~40 numbers (255-char group cap).
+  group: ${{ github.workflow }}-${{ inputs.pr_numbers || inputs.pr_number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-risk:
+    # Token guards, not risk judgements: fork and Dependabot pull_request runs
+    # get a read-only GITHUB_TOKEN, so the label write would 403. Scoped to the
+    # pull_request event — an unscoped head.repo check makes workflow_dispatch
+    # skip silently. Fork PRs can still be graded on demand via pr_number.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: read # the .github/risk.json override, read from the BASE ref
+      issues: write # create the risk:* labels repo-side on first use
+      pull-requests: write # the label write rides pull-requests, not issues
+      checks: read # the check rollup the reversibility axis reads
+      actions: read # CheckRun -> checkSuite -> workflowRun for self-exclusion
+      statuses: read
+    # Pinned to github-workflows main (e4a8f7c); keep workflows_ref in
+    # lock-step so the grader + risk map schema load from the same commit.
+    # This permissions block must stay a superset of the reusable job's.
+    uses: Comfy-Org/github-workflows/.github/workflows/pr-risk.yml@e4a8f7cd4a073da082b03950136530d4df50738f # github-workflows main (e4a8f7c)
+    with:
+      workflows_ref: e4a8f7cd4a073da082b03950136530d4df50738f
+      # Required: upstream defaults enabled to FALSE. The repository variable
+      # RISK_CONFIG outranks this in both directions ({"enabled": false} is a
+      # kill switch that needs no PR).
+      enabled: true
+      pr_number: ${{ inputs.pr_number }}
+      pr_numbers: ${{ inputs.pr_numbers }}

--- a/src/stores/aboutPanelStore.ts
+++ b/src/stores/aboutPanelStore.ts
@@ -16,15 +16,14 @@ export const useAboutPanelStore = defineStore('aboutPanel', () => {
   const systemStatsStore = useSystemStatsStore()
   const { staticUrls } = useExternalLink()
   const coreVersion = computed(
-    () => systemStatsStore?.systemStats?.system?.comfyui_version ?? ''
+    () => systemStatsStore.systemStats?.system?.comfyui_version ?? ''
   )
   const templatesVersion = computed(
     () =>
-      systemStatsStore?.systemStats?.system?.installed_templates_version ?? ''
+      systemStatsStore.systemStats?.system?.installed_templates_version ?? ''
   )
   const requiredTemplatesVersion = computed(
-    () =>
-      systemStatsStore?.systemStats?.system?.required_templates_version ?? ''
+    () => systemStatsStore.systemStats?.system?.required_templates_version ?? ''
   )
   const isTemplatesOutdated = computed(
     () =>


### PR DESCRIPTION
## Summary

Demo PR for `risk:R2`, stacked on #14889: `useSystemStatsStore()` never returns a nullish value, so the `?.` on the store instance is dead — dropped it (3 occurrences).

Expected grade: **R2** — `src/stores/**` matches the `core-infra` path rule. Identical cleanup to the companion `src/platform/**` PR that grades R1 — the pair demonstrates path-based grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)