### PR TITLE
refactor(website): move the announcement hero onto the newer Figma treatment

### DIFF
--- a/apps/website/src/components/common/brandButton.variants.ts
+++ b/apps/website/src/components/common/brandButton.variants.ts
@@ -13,8 +13,8 @@ export const brandButtonVariants = cva({
         'hover:text-primary-comfy-yellow border-2 border-primary-comfy-ink text-primary-comfy-ink uppercase hover:bg-primary-comfy-ink',
       inverse:
         'text-primary-comfy-yellow bg-primary-comfy-ink transition-opacity hover:opacity-90',
-      canvas:
-        'bg-primary-comfy-canvas text-primary-comfy-ink transition-opacity hover:opacity-90'
+      'outline-light':
+        'border-2 border-primary-warm-white text-primary-warm-white hover:bg-primary-warm-white hover:text-primary-comfy-ink'
     },
     size: {
       xs: 'rounded-2xl px-6 py-3 text-xs font-bold',

--- a/apps/website/src/data/comingSoonHero.ts
+++ b/apps/website/src/data/comingSoonHero.ts
@@ -1,0 +1,5 @@
+// Every announcement page uses the same frosted backdrop: the art is byte
+// identical across the Figma frames, so they share one asset rather than
+// uploading a copy per model.
+export const COMING_SOON_HERO =
+  'https://media.comfy.org/website/coming-soon/hero.webp'

--- a/apps/website/src/data/seedance.ts
+++ b/apps/website/src/data/seedance.ts
@@ -1,15 +1,11 @@
 import type { ModelLaunchPage } from '../templates/model-launch/types'
 
 import { externalLinks } from '../config/routes'
+import { COMING_SOON_HERO } from './comingSoonHero'
 
 // Seedance 2.5 has not shipped yet, so this page announces it and holds the
 // URL. On launch day, replace this config with the full one the way /flux-3
 // did; the page stubs and the template stay as they are.
-const media = {
-  comingSoonHero:
-    'https://media.comfy.org/website/seedance-2.5/coming-soon-hero.webp'
-} as const
-
 export const seedancePage: ModelLaunchPage = {
   metaTitleKey: 'seedance.meta.title',
   metaDescriptionKey: 'seedance.meta.description',
@@ -17,7 +13,7 @@ export const seedancePage: ModelLaunchPage = {
   breadcrumbUpdatedKey: 'seedance.breadcrumb.updated',
   hero: {
     layout: 'overlay',
-    placeholderImageSrc: media.comingSoonHero,
+    placeholderImageSrc: COMING_SOON_HERO,
     eyebrowKey: 'seedance.hero.eyebrow',
     titleKey: 'seedance.hero.title',
     primaryCta: {

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -65,7 +65,7 @@ const OVERLAY_CELL = 'col-start-1 row-start-1'
       <div
         v-if="isOverlay"
         aria-hidden="true"
-        :class="cn(OVERLAY_CELL, 'bg-black/50')"
+        :class="cn(OVERLAY_CELL, 'bg-primary-comfy-ink/50')"
       />
 
       <div

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -65,7 +65,7 @@ const OVERLAY_CELL = 'col-start-1 row-start-1'
       <div
         v-if="isOverlay"
         aria-hidden="true"
-        :class="cn(OVERLAY_CELL, 'bg-black/30')"
+        :class="cn(OVERLAY_CELL, 'bg-black/50')"
       />
 
       <div
@@ -132,7 +132,7 @@ const OVERLAY_CELL = 'col-start-1 row-start-1'
           <BrandButton
             :href="hero.primaryCta.href"
             :target="hero.primaryCta.target"
-            :variant="isOverlay ? 'canvas' : 'solid'"
+            :variant="isOverlay ? 'outline-light' : 'solid'"
             size="lg"
             class="w-full p-4 text-center lg:w-auto lg:min-w-52"
           >


### PR DESCRIPTION
## Summary

The Wan Animate 2 (`10396-41358`) and Wan 3.0 (`10396-41778`) frames are newer than the Seedance one and use a different hero: a transparent CTA with a white border over a heavier scrim. Adopting it now keeps the three announcement pages looking like a set instead of shipping two visual styles a week apart.

Base for #14849 and #14850, which add those two pages.

## Changes

- **What**: Replaces the short-lived `canvas` BrandButton variant with `outline-light`, the white-border-on-media counterpart to the existing `outline-dark`. Nothing else used `canvas`; it shipped in #14822 hours ago and this supersedes it.
- Overlay scrim goes from 30% to 50%.
- Hoists the shared backdrop into `COMING_SOON_HERO`. The art is byte identical across all three Figma frames (verified by md5 on the exported layers), so they reference one asset on a neutral path instead of a copy per model under `seedance-2.5/`.

## Review Focus

Only `/seedance-2.5` renders with `layout: 'overlay'` today, so that page is the entire visual blast radius. `/minimax` and `/flux-3` use the stacked layout and are untouched, which the MiniMax suite confirms.

Gates: `astro check` 0 errors, knip/format clean, build 583 pages, `validate:jsonld` 586, e2e 24/24 across the Seedance and MiniMax suites.

## Preview

The treatment change is visible on the one announcement page currently on main:

- https://comfy-website-preview-pr-14894.vercel.app/seedance-2.5
- zh-CN: https://comfy-website-preview-pr-14894.vercel.app/zh-CN/seedance-2.5
