### PR TITLE
feat(telemetry): classify vite:preloadError by cause

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -70,7 +70,7 @@ onMounted(() => {
   window.addEventListener('vite:preloadError', (event) => {
     event.preventDefault()
     const info = parsePreloadError(event.payload)
-    console.error('[vite:preloadError]', {
+    console.error('[vite:preloadError]', info.cause, {
       url: info.url,
       fileType: info.fileType,
       chunkName: info.chunkName,
@@ -80,6 +80,7 @@ onMounted(() => {
       captureException(event.payload, {
         tags: {
           error_type: 'vite_preload_error',
+          cause: info.cause,
           file_type: info.fileType,
           chunk_name: info.chunkName ?? undefined
         },

--- a/src/utils/preloadErrorUtil.test.ts
+++ b/src/utils/preloadErrorUtil.test.ts
@@ -89,4 +89,34 @@ describe('parsePreloadError', () => {
 
     expect(result.chunkName).toBe('index')
   })
+
+  describe('cause classification', () => {
+    it.for([
+      [
+        'app-chunk',
+        'Failed to fetch dynamically imported module: https://cloud.comfy.org/assets/GraphView-SWkPe07q.js'
+      ],
+      [
+        'extension-fetch',
+        'Failed to fetch dynamically imported module: https://cloud.comfy.org/extensions/comfyui-sam3/sam3-editor.js'
+      ],
+      [
+        'other-fetch',
+        'Failed to fetch dynamically imported module: https://cdn.example.com/widget.js'
+      ],
+      ['css-preload', 'Unable to preload CSS for /assets/style-abc123.css'],
+      ['module-parse', "Unexpected token '}'"],
+      ['module-parse', 'Unexpected end of input'],
+      ['module-parse', 'Importing a module script failed.'],
+      ['module-parse', 'expected expression, got end of script'],
+      ['module-parse', "unexpected garbage after module, starting with '}'"],
+      ['module-exec', "Extension named 'ColorOverlay' already registered."],
+      [
+        'module-exec',
+        "Cannot read properties of undefined (reading 'ClipspaceDialog')"
+      ]
+    ])('classifies %s from %j', ([cause, message]) => {
+      expect(parsePreloadError(new Error(message)).cause).toBe(cause)
+    })
+  })
 })

--- a/src/utils/preloadErrorUtil.ts
+++ b/src/utils/preloadErrorUtil.ts
@@ -1,9 +1,18 @@
 type PreloadFileType = 'js' | 'css' | 'font' | 'image' | 'unknown'
 
+type PreloadErrorCause =
+  | 'app-chunk'
+  | 'extension-fetch'
+  | 'other-fetch'
+  | 'module-parse'
+  | 'module-exec'
+  | 'css-preload'
+
 interface PreloadErrorInfo {
   url: string | null
   fileType: PreloadFileType
   chunkName: string | null
+  cause: PreloadErrorCause
   message: string
 }
 
@@ -11,6 +20,8 @@ const CSS_PRELOAD_RE = /Unable to preload CSS for (.+)/
 const JS_DYNAMIC_IMPORT_RE =
   /Failed to fetch dynamically imported module:\s*(.+)/
 const URL_FALLBACK_RE = /https?:\/\/[^\s"')]+/
+const MODULE_PARSE_RE =
+  /unexpected token|unexpected end of input|invalid or unexpected token|importing a module script failed|expected expression|unexpected garbage after module|parser error/i
 
 const FONT_EXTENSIONS = new Set(['woff', 'woff2', 'ttf', 'otf', 'eot'])
 const IMAGE_EXTENSIONS = new Set([
@@ -64,6 +75,17 @@ function extractChunkName(url: string): string | null {
   return withoutHash || null
 }
 
+function detectCause(message: string, url: string | null): PreloadErrorCause {
+  if (CSS_PRELOAD_RE.test(message)) return 'css-preload'
+  if (url) {
+    const pathname = new URL(url, 'https://cloud.comfy.org').pathname
+    if (pathname.startsWith('/assets/')) return 'app-chunk'
+    if (pathname.startsWith('/extensions/')) return 'extension-fetch'
+    return 'other-fetch'
+  }
+  return MODULE_PARSE_RE.test(message) ? 'module-parse' : 'module-exec'
+}
+
 export function parsePreloadError(error: Error): PreloadErrorInfo {
   const message = error.message || String(error)
   const url = extractUrl(message)
@@ -72,6 +94,7 @@ export function parsePreloadError(error: Error): PreloadErrorInfo {
     url,
     fileType: url ? detectFileType(url) : 'unknown',
     chunkName: url ? extractChunkName(url) : null,
+    cause: detectCause(message, url),
     message
   }
 }


### PR DESCRIPTION
## Summary

Classify `vite:preloadError` telemetry by root cause so Datadog/Sentry can segment the ~17k daily events instead of reporting one undifferentiated bucket.

## Changes

- **What**: `parsePreloadError` now returns a `cause` — `app-chunk` / `extension-fetch` / `other-fetch` / `module-parse` / `module-exec` / `css-preload` — emitted in the RUM console line (`[vite:preloadError] <cause> {…}`) and as a Sentry tag. Classifier is unit-tested against real production error messages.

## Review Focus

- Taxonomy boundaries, especially `module-parse` vs `module-exec` for null-URL errors. Measured 2-day prod distribution: extension exec ~21k, module parse ~12k, extension 404 ~1.2k, own `/assets/` chunks ~200 — the chronic preloadError noise is extension loading, not stale deploy chunks.
- Companion dashboard: https://us5.datadoghq.com/dashboard/r6x-ufx-uwt (Sections 4–5).
