### PR TITLE
fix: repair workflow draft persistence and history recovery

### DIFF
--- a/browser_tests/tests/workflowPersistenceRecovery.spec.ts
+++ b/browser_tests/tests/workflowPersistenceRecovery.spec.ts
@@ -1,0 +1,249 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+const generateUniqueFilename = () =>
+  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+test.describe('Workflow persistence recovery regressions', () => {
+  test('Repairs real V1 workflow draft storage after a false V2 migration marker', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'PR #14897 — V2 migration looked for scoped V1 keys and treated an empty V2 index as a permanent migration marker'
+    })
+
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Topbar'
+    )
+
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    const legacyWorkflow = await comfyPage.workflow.getExportedWorkflow()
+    const legacyName = `legacy-${generateUniqueFilename()}`
+    const legacyPath = `workflows/${legacyName}.json`
+    const legacyData = JSON.stringify(legacyWorkflow)
+
+    await comfyPage.page.evaluate(
+      ({ path, name, data }) => {
+        const removeKeysWithPrefix = (storage: Storage, prefix: string) => {
+          for (let i = storage.length - 1; i >= 0; i--) {
+            const key = storage.key(i)
+            if (key?.startsWith(prefix)) storage.removeItem(key)
+          }
+        }
+
+        removeKeysWithPrefix(localStorage, 'Comfy.Workflow.Draft.v2:personal:')
+        localStorage.removeItem('Comfy.Workflow.LastActivePath:personal')
+        localStorage.removeItem('Comfy.Workflow.LastOpenPaths:personal')
+        removeKeysWithPrefix(sessionStorage, 'Comfy.Workflow.ActivePath:')
+        removeKeysWithPrefix(sessionStorage, 'Comfy.Workflow.OpenPaths:')
+
+        localStorage.setItem(
+          'Comfy.Workflow.Drafts',
+          JSON.stringify({
+            [path]: {
+              data,
+              updatedAt: Date.now(),
+              name: `${name}.json`,
+              isTemporary: true
+            }
+          })
+        )
+        localStorage.setItem(
+          'Comfy.Workflow.DraftOrder',
+          JSON.stringify([path])
+        )
+        localStorage.setItem(
+          'Comfy.Workflow.DraftIndex.v2:personal',
+          JSON.stringify({
+            v: 2,
+            updatedAt: Date.now(),
+            order: [],
+            entries: {}
+          })
+        )
+        localStorage.setItem('Comfy.OpenWorkflowsPaths', JSON.stringify([path]))
+        localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(0))
+        localStorage.setItem('workflow', data)
+      },
+      { path: legacyPath, name: legacyName, data: legacyData }
+    )
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    await expect
+      .poll(() => comfyPage.menu.topbar.getActiveTabName())
+      .toContain(legacyName)
+    await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
+
+    const storageState = await comfyPage.page.evaluate((path) => {
+      const rawIndex = localStorage.getItem(
+        'Comfy.Workflow.DraftIndex.v2:personal'
+      )
+      const index = rawIndex
+        ? (JSON.parse(rawIndex) as {
+            entries?: Record<string, { path?: string }>
+          })
+        : null
+      const rawOpenPaths = localStorage.getItem(
+        'Comfy.Workflow.LastOpenPaths:personal'
+      )
+      const openPaths = rawOpenPaths
+        ? (JSON.parse(rawOpenPaths) as { paths?: string[] })
+        : null
+
+      return {
+        hasV2Entry: Object.values(index?.entries ?? {}).some(
+          (entry) => entry.path === path
+        ),
+        legacyDrafts: localStorage.getItem('Comfy.Workflow.Drafts'),
+        legacyOrder: localStorage.getItem('Comfy.Workflow.DraftOrder'),
+        legacyWorkflow: localStorage.getItem('workflow'),
+        durableOpenPaths: openPaths?.paths ?? []
+      }
+    }, legacyPath)
+
+    expect(storageState.hasV2Entry).toBe(true)
+    expect(storageState.legacyDrafts).toBeNull()
+    expect(storageState.legacyOrder).toBeNull()
+    expect(storageState.legacyWorkflow).toBeNull()
+    expect(storageState.durableOpenPaths).toContain(legacyPath)
+    await expect(comfyPage.toast.toastErrors).toHaveCount(0)
+  })
+
+  test('Does not save a startup-only workflow and deduplicates load failures', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'PR #14897 — startup graph loads and repeated lifecycle draft writes could emit repeated quota errors'
+    })
+
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
+    await comfyPage.page.addInitScript(() => {
+      const originalSetItem = Storage.prototype.setItem
+      Storage.prototype.setItem = function (key: string, value: string) {
+        if (
+          key.startsWith('Comfy.Workflow.Draft.v2:') ||
+          key.startsWith('Comfy.Workflow.DraftIndex.v2:')
+        ) {
+          throw new DOMException('Quota exceeded', 'QuotaExceededError')
+        }
+        return originalSetItem.call(this, key, value)
+      }
+    })
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await comfyPage.workflow.waitForWorkflowIdle()
+    await expect(comfyPage.toast.toastErrors).toHaveCount(0)
+
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    await comfyPage.workflow.waitForWorkflowIdle()
+    await expect(comfyPage.toast.toastErrors).toHaveCount(1)
+
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    await comfyPage.workflow.waitForWorkflowIdle()
+    await comfyPage.page.evaluate(() => {
+      // pagehide flushes the pending debounce synchronously. Dispatch it twice
+      // to deterministically exercise repeated lifecycle persistence without a
+      // wall-clock observation window.
+      window.dispatchEvent(new Event('pagehide'))
+      window.dispatchEvent(new Event('pagehide'))
+    })
+
+    await expect(comfyPage.toast.toastErrors).toHaveCount(1)
+  })
+
+  test('Restores a clean saved workflow viewport from its persisted draft', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'PR #14897 — view-only drafts for saved workflows were deleted, so restart could fit the graph instead of restoring the last viewport'
+    })
+
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
+    await comfyPage.settings.setSetting('Comfy.EnableWorkflowViewRestore', true)
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+
+    const workflowName = `viewport-${generateUniqueFilename()}`
+    await comfyPage.menu.topbar.saveWorkflow(workflowName)
+    await expect
+      .poll(() => comfyPage.workflow.isCurrentWorkflowModified())
+      .toBe(false)
+
+    const draftSaveStartedAt = Date.now()
+    await comfyPage.canvasOps.setScale(0.73)
+    await comfyPage.canvasOps.pan({ x: 143, y: -87 })
+    const expectedScale = await comfyPage.canvasOps.getScale()
+    const expectedOffset = await comfyPage.canvasOps.getOffset()
+
+    await comfyPage.page.evaluate(() =>
+      window.dispatchEvent(new Event('pagehide'))
+    )
+    await comfyPage.workflow.waitForDraftIndexUpdatedSince(draftSaveStartedAt)
+
+    const activePath = await comfyPage.workflow.getActiveWorkflowPath()
+    expect(activePath).toBe(`workflows/${workflowName}.json`)
+    if (!activePath) throw new Error('Expected an active saved workflow path')
+
+    const persistedViewport = await comfyPage.page.evaluate((path) => {
+      const indexPrefix = 'Comfy.Workflow.DraftIndex.v2:'
+      for (let i = 0; i < localStorage.length; i++) {
+        const indexKey = localStorage.key(i)
+        if (!indexKey?.startsWith(indexPrefix)) continue
+
+        const rawIndex = localStorage.getItem(indexKey)
+        if (!rawIndex) continue
+        const index = JSON.parse(rawIndex) as {
+          entries?: Record<string, { path?: string }>
+        }
+        const draftKey = Object.entries(index.entries ?? {}).find(
+          ([, entry]) => entry.path === path
+        )?.[0]
+        if (!draftKey) continue
+
+        const workspaceId = indexKey.slice(indexPrefix.length)
+        const rawPayload = localStorage.getItem(
+          `Comfy.Workflow.Draft.v2:${workspaceId}:${draftKey}`
+        )
+        if (!rawPayload) continue
+        const payload = JSON.parse(rawPayload) as { data?: string }
+        if (!payload.data) continue
+        const workflow = JSON.parse(payload.data) as {
+          extra?: { ds?: { scale?: number; offset?: number[] } }
+        }
+        return workflow.extra?.ds ?? null
+      }
+      return null
+    }, activePath)
+
+    expect(persistedViewport?.scale).toBeCloseTo(expectedScale, 2)
+    expect(persistedViewport?.offset?.[0]).toBeCloseTo(expectedOffset[0], 1)
+    expect(persistedViewport?.offset?.[1]).toBeCloseTo(expectedOffset[1], 1)
+
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    await expect
+      .poll(() => comfyPage.canvasOps.getScale())
+      .toBeCloseTo(expectedScale, 2)
+    await expect
+      .poll(async () => (await comfyPage.canvasOps.getOffset())[0])
+      .toBeCloseTo(expectedOffset[0], 1)
+    await expect
+      .poll(async () => (await comfyPage.canvasOps.getOffset())[1])
+      .toBeCloseTo(expectedOffset[1], 1)
+    await expect
+      .poll(() => comfyPage.workflow.isCurrentWorkflowModified())
+      .toBe(false)
+  })
+})

--- a/src/platform/workflow/core/services/workflowService.persistence.test.ts
+++ b/src/platform/workflow/core/services/workflowService.persistence.test.ts
@@ -1,0 +1,196 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import { ComfyWorkflow as ComfyWorkflowClass } from '@/platform/workflow/management/stores/comfyWorkflow'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
+
+const draftStoreMocks = vi.hoisted(() => ({
+  saveDraft: vi.fn((_path: string, _data: string, _meta: unknown) => true),
+  getDraft: vi.fn(),
+  removeDraft: vi.fn(),
+  markDraftUsed: vi.fn(),
+  isPersistencePaused: vi.fn(() => false),
+  shouldNotifySaveFailure: vi.fn(() => true),
+  markSaveSucceeded: vi.fn()
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    prompt: vi.fn(),
+    confirm: vi.fn()
+  })
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: { ds: { offset: [0, 0], scale: 1 } },
+    rootGraph: { serialize: vi.fn(() => ({})), extra: {} },
+    loadGraphData: vi.fn(),
+    nodeOutputs: {},
+    nodePreviewImages: {}
+  }
+}))
+
+vi.mock('@/scripts/defaultGraph', () => ({
+  defaultGraph: {},
+  blankGraph: {}
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ linearMode: false })
+}))
+
+vi.mock('@/renderer/core/thumbnail/useWorkflowThumbnail', () => ({
+  useWorkflowThumbnail: () => ({
+    storeThumbnail: vi.fn(),
+    getThumbnail: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackDefaultViewSet: vi.fn(),
+    trackWorkflowSaved: vi.fn(),
+    trackEnterLinear: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/workflow/persistence/stores/workflowDraftStoreV2', () => ({
+  useWorkflowDraftStoreV2: () => draftStoreMocks
+}))
+
+vi.mock('@/stores/domWidgetStore', () => ({
+  useDomWidgetStore: () => ({ clear: vi.fn() })
+}))
+
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: () => ({ saveCurrentViewport: vi.fn() })
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({
+    get workflow() {
+      return useWorkflowStore()
+    }
+  })
+}))
+
+function createLoadedWorkflow(): LoadedComfyWorkflow {
+  const workflow = new ComfyWorkflowClass({
+    path: 'workflows/persistence.json',
+    modified: Date.now(),
+    size: 100
+  })
+  workflow.changeTracker = createMockChangeTracker()
+  workflow.content = '{}'
+  workflow.originalContent = '{}'
+  return workflow as LoadedComfyWorkflow
+}
+
+describe('workflow service persistence reconciliation', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia())
+    draftStoreMocks.saveDraft.mockReturnValue(true)
+    draftStoreMocks.isPersistencePaused.mockReturnValue(false)
+    draftStoreMocks.shouldNotifySaveFailure.mockReturnValue(true)
+    vi.spyOn(useSettingStore(), 'get').mockImplementation((key: string) => {
+      return key === 'Comfy.Workflow.Persist'
+    })
+  })
+
+  it('does not persist the outgoing workflow while persistence is paused', () => {
+    const workflowStore = useWorkflowStore()
+    workflowStore.activeWorkflow = createLoadedWorkflow()
+    draftStoreMocks.isPersistencePaused.mockReturnValue(true)
+
+    useWorkflowService().beforeLoadNewGraph()
+
+    expect(draftStoreMocks.saveDraft).not.toHaveBeenCalled()
+  })
+
+  it('persists the known dirty bit and marks a successful save', () => {
+    const workflowStore = useWorkflowStore()
+    const workflow = createLoadedWorkflow()
+    workflow.isModified = true
+    workflowStore.activeWorkflow = workflow
+
+    useWorkflowService().beforeLoadNewGraph()
+
+    expect(draftStoreMocks.saveDraft).toHaveBeenCalledWith(
+      workflow.path,
+      JSON.stringify(workflow.activeState),
+      {
+        name: workflow.key,
+        isTemporary: workflow.isTemporary,
+        isModified: true
+      }
+    )
+    expect(draftStoreMocks.markSaveSucceeded).toHaveBeenCalledOnce()
+  })
+
+  it('persists canvas view state when view restore is enabled', () => {
+    vi.spyOn(useSettingStore(), 'get').mockImplementation((key: string) => {
+      return (
+        key === 'Comfy.Workflow.Persist' ||
+        key === 'Comfy.EnableWorkflowViewRestore'
+      )
+    })
+    const workflowStore = useWorkflowStore()
+    const workflow = createLoadedWorkflow()
+    workflow.changeTracker.ds = { scale: 0.5, offset: [10, -20] }
+    workflowStore.activeWorkflow = workflow
+
+    useWorkflowService().beforeLoadNewGraph()
+
+    const [, payload] = draftStoreMocks.saveDraft.mock.calls[0]
+    expect(JSON.parse(payload).extra.ds).toEqual({
+      scale: 0.5,
+      offset: [10, -20]
+    })
+  })
+
+  it('deduplicates repeated failures through the shared failure episode', () => {
+    const workflowStore = useWorkflowStore()
+    workflowStore.activeWorkflow = createLoadedWorkflow()
+    const addToastSpy = vi.spyOn(useToastStore(), 'add')
+    draftStoreMocks.saveDraft.mockReturnValue(false)
+    draftStoreMocks.shouldNotifySaveFailure
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+
+    const service = useWorkflowService()
+    service.beforeLoadNewGraph()
+    service.beforeLoadNewGraph()
+
+    expect(draftStoreMocks.shouldNotifySaveFailure).toHaveBeenCalledTimes(2)
+    expect(addToastSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies once and logs when the draft store throws', () => {
+    const workflowStore = useWorkflowStore()
+    workflowStore.activeWorkflow = createLoadedWorkflow()
+    const addToastSpy = vi.spyOn(useToastStore(), 'add')
+    const error = new Error('quota')
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    draftStoreMocks.saveDraft.mockImplementationOnce(() => {
+      throw error
+    })
+
+    useWorkflowService().beforeLoadNewGraph()
+
+    expect(addToastSpy).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to persist active workflow draft',
+      error
+    )
+    expect(draftStoreMocks.markSaveSucceeded).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -159,6 +159,15 @@ beforeEach(() => {
   vi.mocked(useWorkflowDraftStoreV2().markDraftUsed).mockImplementation(
     () => {}
   )
+  vi.mocked(useWorkflowDraftStoreV2().isPersistencePaused).mockReturnValue(
+    false
+  )
+  vi.mocked(useWorkflowDraftStoreV2().shouldNotifySaveFailure).mockReturnValue(
+    true
+  )
+  vi.mocked(useWorkflowDraftStoreV2().markSaveSucceeded).mockImplementation(
+    () => {}
+  )
   vi.mocked(useDomWidgetStore().clear).mockImplementation(() => {})
   vi.mocked(
     useSubgraphNavigationStore().saveCurrentViewport
@@ -389,7 +398,8 @@ describe('useWorkflowService', () => {
         JSON.stringify(activeWorkflow.activeState),
         {
           name: activeWorkflow.key,
-          isTemporary: activeWorkflow.isTemporary
+          isTemporary: activeWorkflow.isTemporary,
+          isModified: activeWorkflow.isModified
         }
       )
     })

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -15,6 +15,7 @@ import {
   ensureWorkflowId,
   getLegacyWorkflowId
 } from '@/platform/workflow/core/utils/workflowId'
+import { withWorkflowViewState } from '@/platform/workflow/persistence/base/workflowViewState'
 import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
 import {
   ComfyWorkflow,
@@ -149,30 +150,52 @@ export const useWorkflowService = () => {
     })
   }
 
+  const getDraftStateWithView = (
+    activeWorkflow: ComfyWorkflow
+  ): ComfyWorkflowJSON | null => {
+    const activeState = activeWorkflow.activeState
+    if (!activeState) return null
+
+    return withWorkflowViewState(
+      activeState,
+      activeWorkflow.changeTracker?.ds,
+      settingStore.get('Comfy.EnableWorkflowViewRestore')
+    )
+  }
+
   const persistActiveWorkflowDraft = (activeWorkflow: ComfyWorkflow) => {
-    if (!settingStore.get('Comfy.Workflow.Persist') || !activeWorkflow.path) {
+    if (
+      workflowDraftStore.isPersistencePaused() ||
+      !settingStore.get('Comfy.Workflow.Persist') ||
+      !activeWorkflow.path
+    ) {
       return
     }
 
-    const activeState = activeWorkflow.activeState
-    if (!activeState) return
+    const draftState = getDraftStateWithView(activeWorkflow)
+    if (!draftState) return
 
     try {
       const saved = workflowDraftStore.saveDraft(
         activeWorkflow.path,
-        JSON.stringify(activeState),
+        JSON.stringify(draftState),
         {
           name: activeWorkflow.key,
-          isTemporary: activeWorkflow.isTemporary
+          isTemporary: activeWorkflow.isTemporary,
+          isModified: activeWorkflow.isModified
         }
       )
 
-      if (!saved) {
+      if (saved) {
+        workflowDraftStore.markSaveSucceeded()
+      } else if (workflowDraftStore.shouldNotifySaveFailure()) {
         showFailedToSaveDraftToast()
       }
     } catch (err) {
       console.error('Failed to persist active workflow draft', err)
-      showFailedToSaveDraftToast()
+      if (workflowDraftStore.shouldNotifySaveFailure()) {
+        showFailedToSaveDraftToast()
+      }
     }
   }
 
@@ -306,13 +329,14 @@ export const useWorkflowService = () => {
     const expectedPath =
       workflow.directory + '/' + appendWorkflowJsonExt(workflow.filename, isApp)
     if (workflow.path !== expectedPath) {
-      const existing = workflowStore.getWorkflowByPath(expectedPath)
-      if (existing && !existing.isTemporary) {
+      const existingWorkflow = workflowStore.getWorkflowByPath(expectedPath)
+      if (existingWorkflow && !existingWorkflow.isTemporary) {
         if ((await confirmOverwrite(expectedPath)) !== true) {
           await workflowStore.saveWorkflow(workflow)
           return true
         }
-        await deleteWorkflow(existing, true)
+        const deleted = await deleteWorkflow(existingWorkflow, true)
+        if (!deleted) return false
       }
       await renameWorkflow(workflow, expectedPath)
       toastStore.add({

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -1,6 +1,7 @@
 import { markRaw } from 'vue'
 
 import { t } from '@/i18n'
+import { getValidWorkflowViewState } from '@/platform/workflow/persistence/base/workflowViewState'
 import type { ChangeTracker } from '@/scripts/changeTracker'
 import { UserFile } from '@/stores/userFileStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -121,7 +122,11 @@ export class ComfyWorkflow extends UserFile {
     let draftState: ComfyWorkflowJSON | null = null
     let draftContent: string | null = null
 
-    if (draft) {
+    // Temporary workflows restored from a draft have a synthetic creation
+    // timestamp, not an authoritative backing-file modification time. Comparing
+    // the draft against that timestamp makes every restored temporary draft look
+    // stale and deletes it immediately after recovery.
+    if (draft && !this.isTemporary) {
       if (draft.updatedAt < this.lastModified) {
         draftStore.removeDraft(this.path)
         draft = undefined
@@ -149,13 +154,33 @@ export class ComfyWorkflow extends UserFile {
       throw new Error(`Workflow content is empty for '${this.path}'`)
     }
 
-    const initialState = JSON.parse(this.originalContent)
+    const initialState = JSON.parse(this.originalContent) as ComfyWorkflowJSON
+
+    // Older or malformed draft payloads may not carry a usable viewport. For a
+    // persisted workflow, retain the authoritative saved view when it is valid.
+    const savedViewState = getValidWorkflowViewState(initialState.extra?.ds)
+    const draftViewState = getValidWorkflowViewState(draftState?.extra?.ds)
+    if (draftState && !draftViewState && savedViewState) {
+      draftState = {
+        ...draftState,
+        extra: {
+          ...draftState.extra,
+          ds: savedViewState
+        }
+      }
+      draftContent = JSON.stringify(draftState)
+    }
+
     const { ChangeTracker } = await import('@/scripts/changeTracker')
     this.changeTracker = markRaw(new ChangeTracker(this, initialState))
     if (draftState && draftContent) {
       this.changeTracker.activeState = draftState
       this.content = draftContent
-      this._isModified = true
+      // New drafts persist this bit when the outgoing canvas snapshot is taken.
+      // Older V2 drafts lack it, so stay conservative and preserve the historical
+      // behavior of treating any recovered draft as modified rather than doing a
+      // full synchronous graph comparison during workflow activation.
+      this._isModified = draft?.isModified ?? true
       // Saved-workflow draft overlay path; direct persisted-draft restores
       // are touched in workflowDraftStoreV2.loadDraft().
       draftStore.markDraftUsed(this.path)

--- a/src/platform/workflow/management/stores/workflowStore.persistence.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.persistence.test.ts
@@ -1,0 +1,182 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/workflowDraftStoreV2'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { api } from '@/scripts/api'
+import { defaultGraphJSON } from '@/scripts/defaultGraph'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getUserData: vi.fn(),
+    storeUserData: vi.fn(),
+    listUserDataFullInfo: vi.fn(),
+    apiURL: vi.fn(),
+    addEventListener: vi.fn()
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {}
+  }
+}))
+
+vi.mock('@/utils/typeGuardUtil', () => ({
+  isSubgraph: vi.fn(() => false)
+}))
+
+describe('workflow store draft reconciliation', () => {
+  let store: ReturnType<typeof useWorkflowStore>
+
+  const enableWorkflowPersistence = () => {
+    useSettingStore().settingsById['Comfy.Workflow.Persist'] = {
+      id: 'Comfy.Workflow.Persist',
+      name: 'Persist workflow state',
+      type: 'boolean',
+      defaultValue: true
+    }
+  }
+
+  const syncRemoteWorkflowsWithMeta = async (
+    files: Array<{ path: string; modified: number; size: number }>
+  ) => {
+    vi.mocked(api.listUserDataFullInfo).mockResolvedValue(files)
+    await store.syncWorkflows()
+  }
+
+  const saveV2Draft = (
+    path: string,
+    options: {
+      data: string
+      name: string
+      isTemporary?: boolean
+      isModified?: boolean
+    }
+  ) => {
+    const draftStore = useWorkflowDraftStoreV2()
+    draftStore.saveDraft(path, options.data, {
+      name: options.name,
+      isTemporary: options.isTemporary ?? false,
+      ...(options.isModified === undefined
+        ? {}
+        : { isModified: options.isModified })
+    })
+    return draftStore
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    store = useWorkflowStore()
+    enableWorkflowPersistence()
+
+    vi.mocked(api.getUserData).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ favorites: [] })
+    } as Response)
+    vi.mocked(api.storeUserData).mockResolvedValue({
+      status: 200
+    } as Response)
+  })
+
+  it('restores a clean persisted draft from the stored dirty-state metadata', async () => {
+    await syncRemoteWorkflowsWithMeta([
+      { path: 'a.json', modified: 100, size: 1 }
+    ])
+
+    const workflow = store.getWorkflowByPath('workflows/a.json')!
+    const draftGraph = JSON.parse(defaultGraphJSON) as ComfyWorkflowJSON
+    draftGraph.extra = {
+      ...(draftGraph.extra ?? {}),
+      ds: { scale: 1.25, offset: [40, 80] }
+    }
+
+    saveV2Draft(workflow.path, {
+      data: JSON.stringify(draftGraph),
+      name: 'a.json',
+      isModified: false
+    })
+
+    vi.mocked(api.getUserData).mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve(defaultGraphJSON)
+    } as Response)
+
+    await workflow.load()
+
+    expect(workflow.activeState?.extra?.ds).toEqual({
+      scale: 1.25,
+      offset: [40, 80]
+    })
+    expect(workflow.isModified).toBe(false)
+  })
+
+  it('falls back to the saved viewport when a draft viewport is missing', async () => {
+    await syncRemoteWorkflowsWithMeta([
+      { path: 'viewport-fallback.json', modified: 100, size: 1 }
+    ])
+
+    const workflow = store.getWorkflowByPath(
+      'workflows/viewport-fallback.json'
+    )!
+    const savedGraph = JSON.parse(defaultGraphJSON) as ComfyWorkflowJSON
+    savedGraph.extra = {
+      ...(savedGraph.extra ?? {}),
+      ds: { scale: 0.85, offset: [12, -34] }
+    }
+
+    const draftGraph = JSON.parse(defaultGraphJSON) as ComfyWorkflowJSON
+    draftGraph.extra = {
+      ...(draftGraph.extra ?? {})
+    }
+    delete draftGraph.extra.ds
+
+    saveV2Draft(workflow.path, {
+      data: JSON.stringify(draftGraph),
+      name: 'viewport-fallback.json',
+      isModified: false
+    })
+
+    vi.mocked(api.getUserData).mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(savedGraph))
+    } as Response)
+
+    await workflow.load()
+
+    expect(workflow.activeState?.extra?.ds).toEqual({
+      scale: 0.85,
+      offset: [12, -34]
+    })
+    expect(workflow.isModified).toBe(false)
+  })
+
+  it('keeps a restored temporary draft despite a newer synthetic timestamp', async () => {
+    const path = 'workflows/restored-temporary.json'
+    const baseGraph = JSON.parse(defaultGraphJSON) as ComfyWorkflowJSON
+    const draftGraph: ComfyWorkflowJSON = {
+      ...baseGraph,
+      extra: {
+        ...(baseGraph.extra ?? {}),
+        draftMarker: 'restored-temporary'
+      }
+    }
+    const draftStore = saveV2Draft(path, {
+      data: JSON.stringify(draftGraph),
+      name: 'restored-temporary.json',
+      isTemporary: true
+    })
+
+    const workflow = store.createTemporary('restored-temporary.json')
+    workflow.lastModified = Date.now() + 60_000
+
+    await workflow.load()
+
+    expect(workflow.activeState?.extra?.draftMarker).toBe('restored-temporary')
+    expect(workflow.isModified).toBe(true)
+    expect(draftStore.getDraft(path)).not.toBeNull()
+  })
+})

--- a/src/platform/workflow/persistence/base/draftTypes.ts
+++ b/src/platform/workflow/persistence/base/draftTypes.ts
@@ -18,6 +18,11 @@ export interface DraftEntryMeta {
   /** Whether this is an unsaved temporary workflow */
   isTemporary: boolean
   /**
+   * Whether the persisted graph content differs from the backing workflow.
+   * Optional for indexes written by older V2 builds.
+   */
+  isModified?: boolean
+  /**
    * Last metadata update timestamp.
    * Use DraftPayloadV2.updatedAt for content freshness checks.
    */

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -13,6 +13,7 @@ import {
   readIndex,
   readOpenPaths,
   readPayload,
+  readPersistentOpenPaths,
   writeActivePath,
   writeIndex,
   writeOpenPaths,
@@ -68,6 +69,57 @@ describe('storageIO', () => {
         JSON.stringify({ v: 1 })
       )
       expect(readIndex(workspaceId)).toBeNull()
+    })
+
+    it('drops malformed persisted modification metadata', () => {
+      localStorage.setItem(
+        'Comfy.Workflow.DraftIndex.v2:test-workspace',
+        JSON.stringify({
+          v: 2,
+          updatedAt: 1,
+          order: ['abc123'],
+          entries: {
+            abc123: {
+              path: 'workflows/test.json',
+              name: 'test',
+              isTemporary: false,
+              isModified: 0,
+              updatedAt: 1
+            }
+          }
+        })
+      )
+
+      expect(readIndex(workspaceId)?.entries.abc123?.isModified).toBeUndefined()
+    })
+
+    it('drops malformed ordered entries without a valid path', () => {
+      localStorage.setItem(
+        'Comfy.Workflow.DraftIndex.v2:test-workspace',
+        JSON.stringify({
+          v: 2,
+          updatedAt: 1,
+          order: ['broken', 'valid'],
+          entries: {
+            broken: {
+              name: 'broken',
+              isTemporary: false,
+              updatedAt: 1
+            },
+            valid: {
+              path: 'workflows/valid.json',
+              name: 'valid',
+              isTemporary: false,
+              updatedAt: 1
+            }
+          }
+        })
+      )
+
+      const index = readIndex(workspaceId)
+      expect(index?.order).toEqual(['valid'])
+      expect(index?.entries.broken).toBeUndefined()
+      expect(index?.entries.valid?.path).toBe('workflows/valid.json')
     })
   })
 
@@ -180,6 +232,19 @@ describe('storageIO', () => {
 
     it('returns null for missing open paths', () => {
       expect(readOpenPaths('missing')).toBeNull()
+    })
+
+    it('rejects a durable open-path pointer from another workspace', () => {
+      localStorage.setItem(
+        'Comfy.Workflow.LastOpenPaths:ws-1',
+        JSON.stringify({
+          workspaceId: 'ws-2',
+          paths: ['workflows/foreign.json'],
+          activeIndex: 0
+        })
+      )
+
+      expect(readPersistentOpenPaths('ws-1')).toBeNull()
     })
 
     it('falls back to workspace search when clientId does not match and migrates', () => {

--- a/src/platform/workflow/persistence/base/storageIO.ts
+++ b/src/platform/workflow/persistence/base/storageIO.ts
@@ -85,7 +85,12 @@ function isQuotaExceeded(error: unknown): boolean {
   )
 }
 
-function isValidIndex(value: unknown): value is DraftIndexV2 {
+type PersistedDraftIndexV2 = Omit<DraftIndexV2, 'order' | 'entries'> & {
+  order: unknown[]
+  entries: Record<string, unknown>
+}
+
+function isValidIndex(value: unknown): value is PersistedDraftIndexV2 {
   if (typeof value !== 'object' || value === null) return false
   const obj = value as Record<string, unknown>
   return (
@@ -95,6 +100,60 @@ function isValidIndex(value: unknown): value is DraftIndexV2 {
     typeof obj.entries === 'object' &&
     obj.entries !== null
   )
+}
+
+function isValidPayload(value: unknown): value is DraftPayloadV2 {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return (
+    typeof obj.data === 'string' &&
+    typeof obj.updatedAt === 'number' &&
+    Number.isFinite(obj.updatedAt)
+  )
+}
+
+function sanitizeIndexEntries(index: PersistedDraftIndexV2): DraftIndexV2 {
+  const entries: DraftIndexV2['entries'] = {}
+
+  for (const [draftKey, entry] of Object.entries(index.entries)) {
+    if (typeof entry !== 'object' || entry === null) continue
+
+    const value = entry as unknown as Record<string, unknown>
+    if (
+      typeof value.path !== 'string' ||
+      value.path.length === 0 ||
+      typeof value.name !== 'string' ||
+      typeof value.isTemporary !== 'boolean' ||
+      typeof value.updatedAt !== 'number' ||
+      !Number.isFinite(value.updatedAt)
+    ) {
+      continue
+    }
+
+    const normalized = { ...value }
+    if (
+      'isModified' in normalized &&
+      typeof normalized.isModified !== 'boolean'
+    ) {
+      delete normalized.isModified
+    }
+    entries[draftKey] = normalized as unknown as DraftIndexV2['entries'][string]
+  }
+
+  const seen = new Set<string>()
+  const order = index.order.filter((draftKey): draftKey is string => {
+    if (
+      typeof draftKey !== 'string' ||
+      !(draftKey in entries) ||
+      seen.has(draftKey)
+    ) {
+      return false
+    }
+    seen.add(draftKey)
+    return true
+  })
+
+  return { ...index, order, entries }
 }
 
 /**
@@ -111,7 +170,7 @@ export function readIndex(workspaceId: string): DraftIndexV2 | null {
     const parsed = JSON.parse(json)
     if (!isValidIndex(parsed)) return null
 
-    return parsed
+    return sanitizeIndexEntries(parsed)
   } catch {
     return null
   }
@@ -133,6 +192,44 @@ export function writeIndex(workspaceId: string, index: DraftIndexV2): boolean {
   }
 }
 
+function draftPayloadStorageKey(workspaceId: string, draftKey: string): string {
+  return `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
+}
+
+/** Reads the exact serialized draft payload without parsing workflow data. */
+export function readPayloadRaw(
+  workspaceId: string,
+  draftKey: string
+): string | null {
+  if (!isStorageReadable()) return null
+
+  try {
+    return localStorage.getItem(draftPayloadStorageKey(workspaceId, draftKey))
+  } catch {
+    return null
+  }
+}
+
+/** Writes an exact serialized draft payload. Used for lossless rollback. */
+export function writePayloadRaw(
+  workspaceId: string,
+  draftKey: string,
+  serializedPayload: string
+): boolean {
+  if (!isStorageAvailable()) return false
+
+  try {
+    localStorage.setItem(
+      draftPayloadStorageKey(workspaceId, draftKey),
+      serializedPayload
+    )
+    return true
+  } catch (error) {
+    if (isQuotaExceeded(error)) return false
+    throw error
+  }
+}
+
 /**
  * Reads a draft payload from localStorage.
  */
@@ -140,14 +237,12 @@ export function readPayload(
   workspaceId: string,
   draftKey: string
 ): DraftPayloadV2 | null {
-  if (!isStorageReadable()) return null
+  const json = readPayloadRaw(workspaceId, draftKey)
+  if (json === null) return null
 
   try {
-    const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
-    const json = localStorage.getItem(key)
-    if (!json) return null
-
-    return JSON.parse(json) as DraftPayloadV2
+    const parsed = JSON.parse(json)
+    return isValidPayload(parsed) ? parsed : null
   } catch {
     return null
   }
@@ -161,27 +256,18 @@ export function writePayload(
   draftKey: string,
   payload: DraftPayloadV2
 ): boolean {
-  if (!isStorageAvailable()) return false
-
-  try {
-    const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
-    localStorage.setItem(key, JSON.stringify(payload))
-    return true
-  } catch (error) {
-    if (isQuotaExceeded(error)) return false
-    throw error
-  }
+  return writePayloadRaw(workspaceId, draftKey, JSON.stringify(payload))
 }
 
 /**
  * Deletes a draft payload from localStorage.
  */
-export function deletePayload(workspaceId: string, draftKey: string): void {
+export function deletePayload(workspaceId: string, draftKey: string): boolean {
   try {
-    const key = `${StorageKeys.prefixes.draftPayload}${workspaceId}:${draftKey}`
-    localStorage.removeItem(key)
+    localStorage.removeItem(draftPayloadStorageKey(workspaceId, draftKey))
+    return true
   } catch {
-    // Ignore errors during deletion
+    return false
   }
 }
 
@@ -359,6 +445,17 @@ export function clearActivePath(clientId: string, workspaceId: string): void {
   }
 }
 
+/** Reads the durable open-path pointer used for browser-restart recovery. */
+export function readPersistentOpenPaths(
+  workspaceId: string
+): OpenPathsPointer | null {
+  const pointer = readLocalPointer<OpenPathsPointer>(
+    StorageKeys.lastOpenPaths(workspaceId),
+    isValidOpenPathsPointer
+  )
+  return pointer?.workspaceId === workspaceId ? pointer : null
+}
+
 /**
  * Reads the open paths pointer from sessionStorage.
  * Falls back to workspace-based search when clientId changes after reload,
@@ -374,13 +471,7 @@ export function readOpenPaths(
       StorageKeys.prefixes.openPaths,
       targetWorkspaceId,
       isValidOpenPathsPointer
-    ) ??
-    (targetWorkspaceId
-      ? readLocalPointer<OpenPathsPointer>(
-          StorageKeys.lastOpenPaths(targetWorkspaceId),
-          isValidOpenPathsPointer
-        )
-      : null)
+    ) ?? (targetWorkspaceId ? readPersistentOpenPaths(targetWorkspaceId) : null)
   )
 }
 

--- a/src/platform/workflow/persistence/base/workflowViewState.test.ts
+++ b/src/platform/workflow/persistence/base/workflowViewState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGraph } from '@/scripts/defaultGraph'
+import {
+  getValidWorkflowViewState,
+  withWorkflowViewState,
+  workflowViewStateEqual
+} from './workflowViewState'
+
+describe('workflowViewState', () => {
+  it('accepts valid viewport data and rejects malformed saved data', () => {
+    expect(
+      getValidWorkflowViewState({ scale: 0.75, offset: [12, -4] })
+    ).toEqual({ scale: 0.75, offset: [12, -4] })
+    expect(getValidWorkflowViewState({ scale: 1 })).toBeNull()
+    expect(getValidWorkflowViewState({ scale: 0, offset: [0, 0] })).toBeNull()
+    expect(getValidWorkflowViewState({ scale: -1, offset: [0, 0] })).toBeNull()
+    expect(
+      getValidWorkflowViewState({
+        scale: Number.POSITIVE_INFINITY,
+        offset: [0, 0]
+      })
+    ).toBeNull()
+    expect(
+      getValidWorkflowViewState({ scale: 1, offset: [0, Number.NaN] })
+    ).toBeNull()
+  })
+
+  it('adds the current viewport without mutating the serialized workflow', () => {
+    const workflow = structuredClone(defaultGraph)
+    const result = withWorkflowViewState(
+      workflow,
+      { scale: 0.8, offset: [23, -17] },
+      true
+    )
+
+    expect(result).not.toBe(workflow)
+    expect(result.extra?.ds).toEqual({ scale: 0.8, offset: [23, -17] })
+    expect(workflow.extra?.ds).not.toEqual(result.extra?.ds)
+  })
+
+  it('returns the original workflow when view restore is disabled or unavailable', () => {
+    const workflow = structuredClone(defaultGraph)
+    const viewState = { scale: 0.8, offset: [23, -17] } as const
+
+    expect(withWorkflowViewState(workflow, viewState, false)).toBe(workflow)
+    expect(withWorkflowViewState(workflow, undefined, true)).toBe(workflow)
+    expect(workflow.extra?.ds).toEqual(defaultGraph.extra?.ds)
+  })
+
+  it('compares only validated viewport values', () => {
+    expect(
+      workflowViewStateEqual(
+        { scale: 0.8, offset: [23, -17] },
+        { scale: 0.8, offset: [23, -17] }
+      )
+    ).toBe(true)
+    expect(
+      workflowViewStateEqual(
+        { scale: 0.8, offset: [23, -17] },
+        { scale: 0.8, offset: [23, -18] }
+      )
+    ).toBe(false)
+    expect(workflowViewStateEqual({ scale: 1 }, undefined)).toBe(true)
+    expect(
+      workflowViewStateEqual({ scale: 0.8, offset: [23, -17] }, { scale: 1 })
+    ).toBe(false)
+    expect(
+      workflowViewStateEqual({ scale: 1 }, { scale: 0.8, offset: [23, -17] })
+    ).toBe(false)
+  })
+})

--- a/src/platform/workflow/persistence/base/workflowViewState.ts
+++ b/src/platform/workflow/persistence/base/workflowViewState.ts
@@ -1,0 +1,65 @@
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+export type WorkflowViewState = NonNullable<
+  NonNullable<ComfyWorkflowJSON['extra']>['ds']
+>
+
+type ViewStateSource = {
+  scale: number
+  offset: readonly [number, number]
+}
+
+export function getValidWorkflowViewState(
+  value: unknown
+): WorkflowViewState | null {
+  if (typeof value !== 'object' || value === null) return null
+
+  const viewState = value as Record<string, unknown>
+  const { scale, offset } = viewState
+  if (
+    typeof scale !== 'number' ||
+    !Number.isFinite(scale) ||
+    scale <= 0 ||
+    !Array.isArray(offset) ||
+    offset.length < 2 ||
+    typeof offset[0] !== 'number' ||
+    !Number.isFinite(offset[0]) ||
+    typeof offset[1] !== 'number' ||
+    !Number.isFinite(offset[1])
+  ) {
+    return null
+  }
+
+  return { scale, offset: [offset[0], offset[1]] }
+}
+
+export function withWorkflowViewState(
+  workflow: ComfyWorkflowJSON,
+  viewState: ViewStateSource | undefined,
+  enabled: boolean
+): ComfyWorkflowJSON {
+  if (!enabled || !viewState) return workflow
+
+  return {
+    ...workflow,
+    extra: {
+      ...workflow.extra,
+      ds: {
+        scale: viewState.scale,
+        offset: [viewState.offset[0], viewState.offset[1]]
+      }
+    }
+  }
+}
+
+export function workflowViewStateEqual(a: unknown, b: unknown): boolean {
+  const left = getValidWorkflowViewState(a)
+  const right = getValidWorkflowViewState(b)
+
+  if (!left || !right) return left === right
+  return (
+    left.scale === right.scale &&
+    left.offset[0] === right.offset[0] &&
+    left.offset[1] === right.offset[1]
+  )
+}

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.reconciliation.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.reconciliation.test.ts
@@ -1,0 +1,338 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, nextTick, reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
+import { useWorkflowPersistenceV2 } from './useWorkflowPersistenceV2'
+
+const settingMocks = vi.hoisted(() => ({
+  persistRef: null as { value: boolean } | null,
+  values: {} as Record<string, unknown>
+}))
+
+vi.mock('@/platform/settings/settingStore', async () => {
+  const { ref } = await import('vue')
+  settingMocks.persistRef = ref(true)
+  return {
+    useSettingStore: vi.fn(() => ({
+      get: vi.fn((key: string) => {
+        if (key === 'Comfy.Workflow.Persist') {
+          return settingMocks.persistRef!.value
+        }
+        return settingMocks.values[key]
+      }),
+      set: vi.fn((key: string, value: unknown) => {
+        settingMocks.values[key] = value
+      })
+    }))
+  }
+})
+
+const mockToastAdd = vi.fn()
+vi.mock('primevue', () => ({
+  useToast: () => ({ add: mockToastAdd })
+}))
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd })
+}))
+
+vi.mock(
+  '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader',
+  () => ({
+    useSharedWorkflowUrlLoader: () => ({
+      loadSharedWorkflowFromUrl: vi.fn().mockResolvedValue('not-present')
+    })
+  })
+)
+
+const openWorkflowMock = vi.fn()
+const loadBlankWorkflowMock = vi.fn()
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: () => ({
+    openWorkflow: openWorkflowMock,
+    loadBlankWorkflow: loadBlankWorkflowMock
+  })
+}))
+
+vi.mock(
+  '@/platform/workflow/templates/composables/useTemplateUrlLoader',
+  () => ({
+    useTemplateUrlLoader: () => ({ loadTemplateFromUrl: vi.fn() })
+  })
+)
+
+const commandStoreMocks = vi.hoisted(() => ({ execute: vi.fn() }))
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({ execute: commandStoreMocks.execute })
+}))
+
+const routeMocks = vi.hoisted(() => ({
+  query: {} as Record<string, unknown>
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    get query() {
+      return routeMocks.query
+    }
+  }),
+  useRouter: () => ({ replace: vi.fn() })
+}))
+
+const currentUserMocks = vi.hoisted(() => ({
+  onUserLogout: vi.fn(),
+  onUserResolved: vi.fn()
+}))
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    onUserLogout: currentUserMocks.onUserLogout,
+    onUserResolved: currentUserMocks.onUserResolved
+  })
+}))
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  payloads: {} as Record<string, Record<string, string> | undefined>
+}))
+vi.mock('@/platform/navigation/preservedQueryManager', () => ({
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn(
+    (namespace: string, query: Record<string, unknown> = {}) => {
+      const payload = preservedQueryMocks.payloads[namespace]
+      if (!payload) return undefined
+      const next: Record<string, unknown> = { ...query }
+      let changed = false
+      for (const [key, value] of Object.entries(payload)) {
+        if (typeof next[key] === 'string') continue
+        next[key] = value
+        changed = true
+      }
+      return changed ? next : undefined
+    }
+  )
+}))
+vi.mock('@/platform/navigation/preservedQueryNamespaces', () => ({
+  PRESERVED_QUERY_NAMESPACES: { TEMPLATE: 'template', SHARE: 'share' }
+}))
+
+const distributionMocks = vi.hoisted(() => ({ isCloud: false }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distributionMocks.isCloud
+  }
+}))
+
+const teamWorkspaceStoreMocks = reactive<{
+  initState: 'uninitialized' | 'ready' | 'error'
+  activeWorkspaceId: string | null
+}>({
+  initState: 'uninitialized',
+  activeWorkspaceId: null
+})
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => teamWorkspaceStoreMocks
+}))
+
+vi.mock('../migration/migrateV1toV2', () => ({
+  migrateV1toV2: vi.fn()
+}))
+
+type GraphChangedHandler = (() => void) | null
+const mocks = vi.hoisted(() => {
+  const state = {
+    graphChangedHandler: null as GraphChangedHandler,
+    currentGraph: {} as Record<string, unknown>
+  }
+  const serializeMock = vi.fn(() => state.currentGraph)
+  const loadGraphDataMock = vi.fn()
+  const apiMock = {
+    clientId: 'test-client',
+    initialClientId: 'test-client',
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      if (event === 'graphChanged') state.graphChangedHandler = handler
+    }),
+    removeEventListener: vi.fn()
+  }
+  return { state, serializeMock, loadGraphDataMock, apiMock }
+})
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    graph: { serialize: () => mocks.serializeMock() },
+    rootGraph: { serialize: () => mocks.serializeMock() },
+    loadGraphData: (...args: unknown[]) => mocks.loadGraphDataMock(...args),
+    canvas: {}
+  }
+}))
+vi.mock('@/scripts/api', () => ({ api: mocks.apiMock }))
+
+type WorkflowPersistence = ReturnType<typeof useWorkflowPersistenceV2>
+
+describe('workflow persistence lifecycle reconciliation', () => {
+  const mountedApps: Array<{
+    app: ReturnType<typeof createApp>
+    container: HTMLElement
+  }> = []
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.useFakeTimers()
+    settingMocks.persistRef!.value = true
+    settingMocks.values = {}
+    mocks.state.graphChangedHandler = null
+    mocks.state.currentGraph = { initial: true }
+    mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
+    mocks.apiMock.clientId = 'test-client'
+    mocks.apiMock.initialClientId = 'test-client'
+    mocks.apiMock.addEventListener.mockImplementation(
+      (event: string, handler: () => void) => {
+        if (event === 'graphChanged') mocks.state.graphChangedHandler = handler
+      }
+    )
+    mocks.apiMock.removeEventListener.mockImplementation(() => {})
+    routeMocks.query = {}
+    preservedQueryMocks.payloads = {}
+    distributionMocks.isCloud = false
+    teamWorkspaceStoreMocks.initState = 'uninitialized'
+    teamWorkspaceStoreMocks.activeWorkspaceId = null
+  })
+
+  afterEach(() => {
+    for (const { app, container } of mountedApps.splice(0)) {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  function mountWorkflowPersistence(): WorkflowPersistence {
+    let persistence: WorkflowPersistence | undefined
+    const HostComponent = defineComponent({
+      setup() {
+        persistence = useWorkflowPersistenceV2()
+        return () => null
+      }
+    })
+    const app = createApp(HostComponent)
+    app.use(
+      createI18n({
+        legacy: false,
+        locale: 'en',
+        messages: { en: {} },
+        missingWarn: false,
+        fallbackWarn: false
+      })
+    )
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    app.mount(container)
+    mountedApps.push({ app, container })
+    if (!persistence) {
+      throw new Error('Failed to mount workflow persistence composable')
+    }
+    return persistence
+  }
+
+  async function loadBlankIntoActiveWorkflow() {
+    const workflowStore = useWorkflowStore()
+    const blank = workflowStore.createTemporary('unsaved-workflow.json')
+    await workflowStore.openWorkflow(blank)
+  }
+
+  it('keeps one save-failure notification across workflow transitions until recovery', async () => {
+    await loadBlankIntoActiveWorkflow()
+
+    const workflowStore = useWorkflowStore()
+    const draftStore = useWorkflowDraftStoreV2()
+    const saveDraftSpy = vi.spyOn(draftStore, 'saveDraft')
+    saveDraftSpy.mockReturnValue(false)
+
+    mountWorkflowPersistence()
+
+    mocks.state.currentGraph = { nodes: [{ id: 1 }] }
+    mocks.state.graphChangedHandler?.()
+    await vi.runAllTimersAsync()
+
+    mocks.state.currentGraph = { nodes: [{ id: 2 }] }
+    mocks.state.graphChangedHandler?.()
+    await vi.runAllTimersAsync()
+    expect(mockToastAdd).toHaveBeenCalledTimes(1)
+
+    const second = workflowStore.createTemporary('second-workflow.json')
+    await workflowStore.openWorkflow(second)
+    await nextTick()
+    expect(mockToastAdd).toHaveBeenCalledTimes(1)
+
+    saveDraftSpy.mockReturnValueOnce(true)
+    mocks.state.currentGraph = { nodes: [{ id: 3 }] }
+    mocks.state.graphChangedHandler?.()
+    await vi.runAllTimersAsync()
+
+    saveDraftSpy.mockReturnValueOnce(false)
+    mocks.state.currentGraph = { nodes: [{ id: 4 }] }
+    mocks.state.graphChangedHandler?.()
+    await vi.runAllTimersAsync()
+    expect(mockToastAdd).toHaveBeenCalledTimes(2)
+  })
+
+  it('persists a modified temporary startup workflow synchronously only once', async () => {
+    loadBlankWorkflowMock.mockImplementation(async () => {
+      await loadBlankIntoActiveWorkflow()
+      const workflow = useWorkflowStore().activeWorkflow
+      if (workflow) workflow.isModified = true
+    })
+
+    const draftStore = useWorkflowDraftStoreV2()
+    const saveDraftSpy = vi.spyOn(draftStore, 'saveDraft')
+    vi.spyOn(draftStore, 'getDraft').mockReturnValue(null)
+
+    const { initializeWorkflow } = mountWorkflowPersistence()
+
+    await initializeWorkflow()
+    expect(saveDraftSpy).toHaveBeenCalledOnce()
+
+    await vi.runAllTimersAsync()
+    expect(saveDraftSpy).toHaveBeenCalledOnce()
+  })
+
+  it('uses a default temporary workflow for schema-invalid draft JSON', async () => {
+    const workflowStore = useWorkflowStore()
+    vi.spyOn(workflowStore, 'loadWorkflows').mockResolvedValue()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const draftStore = useWorkflowDraftStoreV2()
+    const path = 'workflows/invalid-draft.json'
+    const invalidDraftData = JSON.stringify({ title: 'not-a-workflow' })
+    expect(
+      draftStore.saveDraft(path, invalidDraftData, {
+        name: 'invalid-draft.json',
+        isTemporary: true
+      })
+    ).toBe(true)
+    sessionStorage.setItem(
+      'Comfy.Workflow.OpenPaths:test-client',
+      JSON.stringify({
+        workspaceId: 'personal',
+        paths: [path],
+        activeIndex: 0
+      })
+    )
+
+    const { restoreWorkflowTabsState } = mountWorkflowPersistence()
+    await restoreWorkflowTabsState()
+
+    const restored = workflowStore.getWorkflowByPath(path)
+    expect(restored).toBeDefined()
+    if (!restored?.content) {
+      throw new Error('Expected restored temporary workflow content')
+    }
+    const restoredData = JSON.parse(restored.content) as {
+      version?: unknown
+      title?: unknown
+    }
+    expect(typeof restoredData.version).toBe('number')
+    expect(restoredData.title).toBeUndefined()
+    expect(draftStore.getDraft(path)).toBeNull()
+  })
+})

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -29,6 +29,12 @@ import {
   ComfyWorkflow,
   useWorkflowStore
 } from '@/platform/workflow/management/stores/workflowStore'
+import { useSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
+import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { api } from '@/scripts/api'
+import { app as comfyApp } from '@/scripts/app'
 import { PERSIST_DEBOUNCE_MS } from '../base/draftTypes'
 import type { StartupOutcome } from '../base/draftTypes'
 import {
@@ -37,13 +43,13 @@ import {
   prepareWorkflowLogoutTransition,
   registerWorkflowPersistenceFlush
 } from '../base/storageIO'
+import {
+  withWorkflowViewState,
+  workflowViewStateEqual
+} from '../base/workflowViewState'
 import { migrateV1toV2 } from '../migration/migrateV1toV2'
 import { useWorkflowDraftStoreV2 } from '../stores/workflowDraftStoreV2'
 import { useWorkflowTabState } from './useWorkflowTabState'
-import { useSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader'
-import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
-import { api } from '@/scripts/api'
-import { app as comfyApp } from '@/scripts/app'
 
 export function useWorkflowPersistenceV2() {
   const { t } = useI18n()
@@ -67,8 +73,14 @@ export function useWorkflowPersistenceV2() {
     stopWorkspaceReadinessWatcher = undefined
   }
 
-  // Run migration on module load, passing clientId for tab state migration
-  migrateV1toV2(undefined, api.clientId ?? api.initialClientId ?? undefined)
+  // Run migration before the draft index is consumed. Reset a potentially
+  // primed cache when migration repaired or created V2 storage.
+  const migrationResult = migrateV1toV2(
+    undefined,
+    api.clientId ?? api.initialClientId ?? undefined
+  )
+  const migrationMutatedV2Storage = migrationResult >= 0
+  if (migrationMutatedV2Storage) draftStore.reset()
 
   const ensureTemplateQueryFromIntent = async () => {
     hydratePreservedQuery(TEMPLATE_NAMESPACE)
@@ -97,40 +109,68 @@ export function useWorkflowPersistenceV2() {
     }
   })
 
+  const getCurrentWorkflowDraft = (): {
+    state: ComfyWorkflowJSON
+    json: string
+  } => {
+    const graphData =
+      comfyApp.rootGraph.serialize() as unknown as ComfyWorkflowJSON
+    const state = withWorkflowViewState(
+      graphData,
+      comfyApp.canvas.ds,
+      settingStore.get('Comfy.EnableWorkflowViewRestore')
+    )
+    return { state, json: JSON.stringify(state) }
+  }
+
   const persistCurrentWorkflow = () => {
-    if (!workflowPersistenceEnabled.value) return
+    if (draftStore.isPersistencePaused() || !workflowPersistenceEnabled.value)
+      return
     const activeWorkflow = workflowStore.activeWorkflow
     if (!activeWorkflow) return
 
-    const graphData = comfyApp.rootGraph.serialize()
-    const workflowJson = JSON.stringify(graphData)
+    const { state: draftState, json: workflowJson } = getCurrentWorkflowDraft()
     const workflowPath = activeWorkflow.path
 
-    // Skip if unchanged
+    // Skip if unchanged, including the persisted viewport snapshot.
     if (workflowJson === lastSavedJsonByPath.value[workflowPath]) return
 
-    // Save to V2 draft store
-    const saved = draftStore.saveDraft(workflowPath, workflowJson, {
-      name: activeWorkflow.key,
-      isTemporary: activeWorkflow.isTemporary
-    })
+    let saved = false
+    try {
+      saved = draftStore.saveDraft(workflowPath, workflowJson, {
+        name: activeWorkflow.key,
+        isTemporary: activeWorkflow.isTemporary,
+        isModified: activeWorkflow.isModified
+      })
+    } catch (error) {
+      console.error('Failed to persist workflow draft', error)
+    }
 
     if (!saved) {
-      toast.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: t('toastMessages.failedToSaveDraft')
-      })
+      if (draftStore.shouldNotifySaveFailure()) {
+        toast.add({
+          severity: 'error',
+          summary: t('g.error'),
+          detail: t('toastMessages.failedToSaveDraft')
+        })
+      }
       return
     }
+
+    draftStore.markSaveSucceeded()
 
     // Update session pointer
     tabState.setActivePath(workflowPath)
 
     lastSavedJsonByPath.value[workflowPath] = workflowJson
 
-    // Clean up draft if workflow is saved and unmodified
-    if (!activeWorkflow.isTemporary && !activeWorkflow.isModified) {
+    const savedViewState = activeWorkflow.initialState.extra?.ds
+    const draftViewState = draftState.extra?.ds
+    if (
+      !activeWorkflow.isTemporary &&
+      !activeWorkflow.isModified &&
+      workflowViewStateEqual(savedViewState, draftViewState)
+    ) {
       draftStore.removeDraft(workflowPath)
     }
   }
@@ -139,7 +179,11 @@ export function useWorkflowPersistenceV2() {
   const debouncedPersist = debounce(persistCurrentWorkflow, PERSIST_DEBOUNCE_MS)
 
   function flushPendingPersistence() {
+    // Preserve #14575's pending-edit flush, then take one final snapshot so a
+    // viewport-only move after the last graph change is not lost on pagehide or
+    // a workspace transition.
     debouncedPersist.flush()
+    persistCurrentWorkflow()
   }
 
   const unregisterPersistenceFlush = registerWorkflowPersistenceFlush(
@@ -181,6 +225,20 @@ export function useWorkflowPersistenceV2() {
     )
   })
 
+  const runWithPersistencePaused = async <T>(
+    operation: () => Promise<T>
+  ): Promise<T> => {
+    const resumePersistence = draftStore.pausePersistence()
+    try {
+      return await operation()
+    } finally {
+      // Graph loads emit graphChanged. Discard any startup-only trailing save
+      // before allowing user-driven persistence again.
+      debouncedPersist.cancel()
+      resumePersistence()
+    }
+  }
+
   const loadPreviousWorkflowFromStorage = async () => {
     const sessionPath = tabState.getActivePath()
 
@@ -188,6 +246,7 @@ export function useWorkflowPersistenceV2() {
     if (
       sessionPath &&
       (await draftStore.loadPersistedWorkflow({
+        workflowName: null,
         preferredPath: sessionPath
       }))
     )
@@ -204,14 +263,15 @@ export function useWorkflowPersistenceV2() {
 
     // 3. Fall back to most recent draft
     return await draftStore.loadPersistedWorkflow({
+      workflowName: null,
       fallbackToLatestDraft: true
     })
   }
 
   /**
-   * The blank canvas startup opens for itself is not the user's work, but the
-   * active-workflow watcher has already saved it. Drop the draft and the
-   * pointer to it, or the next boot restores it and reports `restored`.
+   * The blank canvas startup opens for itself is not the user's work. Current
+   * startup persistence is paused, while older builds may already have saved
+   * this path. Drop any stale draft/pointer so it cannot win the next restore.
    */
   const discardStartupBlankDraft = () => {
     const blank = workflowStore.activeWorkflow
@@ -263,24 +323,41 @@ export function useWorkflowPersistenceV2() {
   }
 
   const initializeWorkflow = async (): Promise<StartupOutcome> => {
-    if (!workflowPersistenceEnabled.value) {
-      return await resolveStartupOutcome()
-    }
-
-    try {
-      if (getRestorableTabState()) {
-        // GraphCanvas calls restoreWorkflowTabsState next; skip the single-workflow
-        // fallback here so the saved tab order and active index drive startup.
-        return 'restored'
+    const outcome = await runWithPersistencePaused(async () => {
+      if (!workflowPersistenceEnabled.value) {
+        return await resolveStartupOutcome()
       }
 
-      await workflowStore.loadWorkflows()
-      const restored = await loadPreviousWorkflowFromStorage()
-      return restored ? 'restored' : await resolveStartupOutcome()
-    } catch (err) {
-      console.error('Error loading previous workflow', err)
-      return await resolveStartupOutcome()
+      try {
+        if (getRestorableTabState()) {
+          // GraphCanvas calls restoreWorkflowTabsState next; skip the single-workflow
+          // fallback here so the saved tab order and active index drive startup.
+          return 'restored' as const
+        }
+
+        await workflowStore.loadWorkflows()
+        const restored = await loadPreviousWorkflowFromStorage()
+        return restored ? ('restored' as const) : await resolveStartupOutcome()
+      } catch (err) {
+        console.error('Error loading previous workflow', err)
+        return await resolveStartupOutcome()
+      }
+    })
+
+    const startupWorkflow = workflowStore.activeWorkflow
+    if (
+      workflowPersistenceEnabled.value &&
+      startupWorkflow?.isTemporary &&
+      startupWorkflow.isModified &&
+      !draftStore.getDraft(startupWorkflow.path)
+    ) {
+      // A loader can produce genuine unsaved work during startup. It was
+      // intentionally suppressed while activation/graph-change noise ran, so
+      // persist it once after startup rather than losing it.
+      persistCurrentWorkflow()
     }
+
+    return outcome
   }
 
   const loadTemplateFromUrlIfPresent = async () => {
@@ -298,13 +375,23 @@ export function useWorkflowPersistenceV2() {
 
   // Setup watchers
   watch(
-    () => workflowStore.activeWorkflow?.key,
-    (activeWorkflowKey) => {
-      if (!activeWorkflowKey) return
-      // Flush any pending persistence from the previous workflow
-      debouncedPersist.flush()
-      // Persist the new workflow immediately
-      persistCurrentWorkflow()
+    () => workflowStore.activeWorkflow,
+    (activeWorkflow) => {
+      if (!activeWorkflow) return
+      // beforeLoadNewGraph owns the outgoing synchronous draft save. A pending
+      // graphChanged callback belongs to the old graph, so cancel it rather
+      // than resolving it against the newly active workflow.
+      debouncedPersist.cancel()
+      if (draftStore.isPersistencePaused() || !workflowPersistenceEnabled.value)
+        return
+
+      // Updating the active pointer is cheap and does not require serializing
+      // the newly opened graph. A new temporary workflow gets its first draft
+      // through the normal debounce, keeping workflow switching non-blocking.
+      tabState.setActivePath(activeWorkflow.path)
+      if (activeWorkflow.isTemporary) {
+        debouncedPersist()
+      }
     }
   )
 
@@ -359,62 +446,69 @@ export function useWorkflowPersistenceV2() {
    * Restores saved workflow tabs after initializeWorkflow skips the single-workflow fallback.
    * GraphCanvas must call this during startup when workflow persistence is enabled.
    */
-  const restoreWorkflowTabsState = async () => {
-    if (!workflowPersistenceEnabled.value) {
-      tabStateRestored = true
-      return
-    }
+  const restoreWorkflowTabsState = async () =>
+    await runWithPersistencePaused(async () => {
+      if (!workflowPersistenceEnabled.value) {
+        tabStateRestored = true
+        return
+      }
 
-    try {
-      await workflowStore.loadWorkflows()
-    } catch (err) {
-      console.error('Error loading workflows for tab restore', err)
-      await resolveStartupOutcome()
-      tabStateRestored = true
-      return
-    }
-
-    const restorableTabState = getRestorableTabState()
-    if (!restorableTabState) {
-      tabStateRestored = true
-      return
-    }
-    const { paths: storedWorkflows, activeIndex: storedActiveIndex } =
-      restorableTabState
-
-    storedWorkflows.forEach((path: string) => {
-      if (workflowStore.getWorkflowByPath(path)) return
-      const draft = draftStore.getDraft(path)
-      if (!draft?.isTemporary) return
       try {
-        const workflowData = JSON.parse(draft.data)
-        workflowStore.createTemporary(draft.name, workflowData)
+        await workflowStore.loadWorkflows()
       } catch (err) {
-        console.warn(
-          'Failed to parse workflow draft, creating with default',
-          err
-        )
-        draftStore.removeDraft(path)
-        workflowStore.createTemporary(draft.name)
+        console.error('Error loading workflows for tab restore', err)
+        await resolveStartupOutcome()
+        tabStateRestored = true
+        return
+      }
+
+      const restorableTabState = getRestorableTabState()
+      if (!restorableTabState) {
+        tabStateRestored = true
+        return
+      }
+      const { paths: storedWorkflows, activeIndex: storedActiveIndex } =
+        restorableTabState
+
+      for (const path of storedWorkflows) {
+        if (workflowStore.getWorkflowByPath(path)) continue
+        const draft = draftStore.getDraft(path)
+        if (!draft?.isTemporary) continue
+        try {
+          const parsedWorkflowData = JSON.parse(draft.data)
+          const workflowData = await validateComfyWorkflow(parsedWorkflowData)
+          if (!workflowData) {
+            draftStore.removeDraft(path)
+            workflowStore.createTemporary(draft.name)
+            continue
+          }
+          workflowStore.createTemporary(draft.name, workflowData)
+        } catch (err) {
+          console.warn(
+            'Failed to parse workflow draft, creating with default',
+            err
+          )
+          draftStore.removeDraft(path)
+          workflowStore.createTemporary(draft.name)
+        }
+      }
+
+      workflowStore.openWorkflowsInBackground({
+        left: storedWorkflows.slice(0, storedActiveIndex),
+        right: storedWorkflows.slice(storedActiveIndex)
+      })
+
+      tabStateRestored = true
+
+      // Activate the correct workflow at storedActiveIndex
+      const activePath = storedWorkflows[storedActiveIndex]
+      const workflow = activePath
+        ? workflowStore.getWorkflowByPath(activePath)
+        : null
+      if (workflow) {
+        await useWorkflowService().openWorkflow(workflow)
       }
     })
-
-    workflowStore.openWorkflowsInBackground({
-      left: storedWorkflows.slice(0, storedActiveIndex),
-      right: storedWorkflows.slice(storedActiveIndex)
-    })
-
-    tabStateRestored = true
-
-    // Activate the correct workflow at storedActiveIndex
-    const activePath = storedWorkflows[storedActiveIndex]
-    const workflow = activePath
-      ? workflowStore.getWorkflowByPath(activePath)
-      : null
-    if (workflow) {
-      await useWorkflowService().openWorkflow(workflow)
-    }
-  }
 
   return {
     initializeWorkflow,

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.collision.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.collision.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { hashPath } from '../base/hashUtil'
+import { migrateV1toV2 } from './migrateV1toV2'
+
+describe('migrateV1toV2 collision cleanup safety', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('keeps legacy data when a V2 draft key maps to a different path', () => {
+    const legacyPath = 'workflows/collide.json'
+    const draftKey = hashPath(legacyPath)
+    const legacyDrafts = JSON.stringify({
+      [legacyPath]: {
+        data: '{"legacy":true}',
+        updatedAt: 1000,
+        name: 'collide',
+        isTemporary: true
+      }
+    })
+    const legacyOrder = JSON.stringify([legacyPath])
+
+    localStorage.setItem(
+      'Comfy.Workflow.DraftIndex.v2:personal',
+      JSON.stringify({
+        v: 2,
+        updatedAt: 3000,
+        order: [draftKey],
+        entries: {
+          [draftKey]: {
+            path: 'workflows/different.json',
+            name: 'different',
+            isTemporary: true,
+            updatedAt: 3000
+          }
+        }
+      })
+    )
+    localStorage.setItem('Comfy.Workflow.Drafts', legacyDrafts)
+    localStorage.setItem('Comfy.Workflow.DraftOrder', legacyOrder)
+
+    migrateV1toV2('personal')
+
+    expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBe(legacyDrafts)
+    expect(localStorage.getItem('Comfy.Workflow.DraftOrder')).toBe(legacyOrder)
+  })
+})

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.malformedPayload.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.malformedPayload.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { hashPath } from '../base/hashUtil'
+import { migrateV1toV2 } from './migrateV1toV2'
+
+describe('migrateV1toV2 malformed V2 payload recovery', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('recovers valid V1 data when the matching V2 payload is malformed', () => {
+    const path = 'workflows/recover-malformed-v2.json'
+    const draftKey = hashPath(path)
+    const legacyData = '{"legacy":true}'
+
+    localStorage.setItem(
+      'Comfy.Workflow.DraftIndex.v2:personal',
+      JSON.stringify({
+        v: 2,
+        updatedAt: 3000,
+        order: [draftKey],
+        entries: {
+          [draftKey]: {
+            path,
+            name: 'recover-malformed-v2',
+            isTemporary: true,
+            updatedAt: 3000
+          }
+        }
+      })
+    )
+    localStorage.setItem(
+      `Comfy.Workflow.Draft.v2:personal:${draftKey}`,
+      JSON.stringify({})
+    )
+    localStorage.setItem(
+      'Comfy.Workflow.Drafts',
+      JSON.stringify({
+        [path]: {
+          data: legacyData,
+          updatedAt: 1000,
+          name: 'recover-malformed-v2',
+          isTemporary: true
+        }
+      })
+    )
+    localStorage.setItem('Comfy.Workflow.DraftOrder', JSON.stringify([path]))
+
+    expect(migrateV1toV2('personal')).toBe(1)
+
+    const recoveredPayload = JSON.parse(
+      localStorage.getItem(`Comfy.Workflow.Draft.v2:personal:${draftKey}`) ??
+        'null'
+    )
+    expect(recoveredPayload).toEqual({ data: legacyData, updatedAt: 1000 })
+  })
+})

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.recovery.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.recovery.test.ts
@@ -1,0 +1,823 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MAX_DRAFTS } from '../base/draftTypes'
+import { hashPath } from '../base/hashUtil'
+import { readOpenPaths, writeOpenPaths } from '../base/storageIO'
+import {
+  cleanupV1Data,
+  getMigrationStatus,
+  isV2MigrationComplete,
+  migrateV1toV2
+} from './migrateV1toV2'
+
+type V1Drafts = Record<
+  string,
+  { data: string; updatedAt: number; name: string; isTemporary: boolean }
+>
+
+const makeDraft = (id: string, updatedAt: number, isTemporary = true) => ({
+  data: JSON.stringify({ id }),
+  updatedAt,
+  name: id,
+  isTemporary
+})
+
+class FaultInjectingStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  constructor(
+    source: Storage,
+    private readonly writeError: (key: string, value: string) => Error | null,
+    private readonly readError: (key: string) => Error | null = () => null
+  ) {
+    for (let i = 0; i < source.length; i++) {
+      const key = source.key(i)
+      if (key !== null) {
+        const value = source.getItem(key)
+        if (value !== null) this.values.set(key, value)
+      }
+    }
+  }
+
+  get length(): number {
+    return this.values.size
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    const error = this.readError(key)
+    if (error) throw error
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    const error = this.writeError(key, value)
+    if (error) throw error
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  clear(): void {
+    this.values.clear()
+  }
+}
+
+function installFaultStorage(
+  writeError: (key: string, value: string) => Error | null,
+  readError: (key: string) => Error | null = () => null
+): () => void {
+  const original = globalThis.localStorage
+  const faultStorage = new FaultInjectingStorage(
+    original,
+    writeError,
+    readError
+  )
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: faultStorage,
+    configurable: true
+  })
+
+  return () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: original,
+      configurable: true
+    })
+  }
+}
+
+describe('migrateV1toV2', () => {
+  const personalWorkspace = 'personal'
+  const teamWorkspace = 'test-workspace'
+
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  function setActualV1Data(drafts: V1Drafts, order: string[]) {
+    localStorage.setItem('Comfy.Workflow.Drafts', JSON.stringify(drafts))
+    localStorage.setItem('Comfy.Workflow.DraftOrder', JSON.stringify(order))
+  }
+
+  function setScopedV1Data(
+    workspaceId: string,
+    drafts: V1Drafts,
+    order: string[]
+  ) {
+    localStorage.setItem(
+      `Comfy.Workflow.Drafts:${workspaceId}`,
+      JSON.stringify(drafts)
+    )
+    localStorage.setItem(
+      `Comfy.Workflow.DraftOrder:${workspaceId}`,
+      JSON.stringify(order)
+    )
+  }
+
+  function setV2Index(
+    workspaceId: string,
+    entries: Record<
+      string,
+      {
+        path: string
+        name: string
+        isTemporary: boolean
+        updatedAt: number
+      }
+    >,
+    order: string[]
+  ) {
+    localStorage.setItem(
+      `Comfy.Workflow.DraftIndex.v2:${workspaceId}`,
+      JSON.stringify({ v: 2, updatedAt: Date.now(), order, entries })
+    )
+  }
+
+  function getV2Payload(workspaceId: string, path: string) {
+    const raw = localStorage.getItem(
+      `Comfy.Workflow.Draft.v2:${workspaceId}:${hashPath(path)}`
+    )
+    return raw ? (JSON.parse(raw) as { data: string; updatedAt: number }) : null
+  }
+
+  function getV2Index(workspaceId: string) {
+    const raw = localStorage.getItem(
+      `Comfy.Workflow.DraftIndex.v2:${workspaceId}`
+    )
+    return raw
+      ? (JSON.parse(raw) as {
+          v: number
+          order: string[]
+          entries: Record<string, { path: string }>
+        })
+      : null
+  }
+
+  describe('migration completeness', () => {
+    it('is incomplete when the actual V1 blob remains behind an existing V2 index', () => {
+      setV2Index(personalWorkspace, {}, [])
+      setActualV1Data({ 'workflows/legacy.json': makeDraft('legacy', 1) }, [
+        'workflows/legacy.json'
+      ])
+
+      expect(isV2MigrationComplete(personalWorkspace)).toBe(false)
+    })
+
+    it('is complete when a V2 index exists and no relevant V1 blob remains', () => {
+      setV2Index(personalWorkspace, {}, [])
+      expect(isV2MigrationComplete(personalWorkspace)).toBe(true)
+    })
+
+    it('cleans an exact-match legacy workflow singleton after draft migration already completed', () => {
+      const path = 'workflows/current.json'
+      const draftKey = hashPath(path)
+      const data = '{"already":"v2"}'
+      setV2Index(
+        personalWorkspace,
+        {
+          [draftKey]: {
+            path,
+            name: 'current',
+            isTemporary: true,
+            updatedAt: 1000
+          }
+        },
+        [draftKey]
+      )
+      localStorage.setItem(
+        `Comfy.Workflow.Draft.v2:${personalWorkspace}:${draftKey}`,
+        JSON.stringify({ data, updatedAt: 1000 })
+      )
+      localStorage.setItem('workflow', data)
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(-1)
+      expect(localStorage.getItem('workflow')).toBeNull()
+      expect(getV2Payload(personalWorkspace, path)?.data).toBe(data)
+    })
+
+    it('keeps a unique legacy workflow singleton after draft migration already completed', () => {
+      const path = 'workflows/current.json'
+      const draftKey = hashPath(path)
+      setV2Index(
+        personalWorkspace,
+        {
+          [draftKey]: {
+            path,
+            name: 'current',
+            isTemporary: true,
+            updatedAt: 1000
+          }
+        },
+        [draftKey]
+      )
+      localStorage.setItem(
+        `Comfy.Workflow.Draft.v2:${personalWorkspace}:${draftKey}`,
+        JSON.stringify({ data: '{"already":"v2"}', updatedAt: 1000 })
+      )
+      localStorage.setItem('workflow', '{"unique":"legacy"}')
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(-1)
+      expect(localStorage.getItem('workflow')).toBe('{"unique":"legacy"}')
+    })
+
+    it('degrades safely when localStorage reads are blocked', () => {
+      const restoreStorage = installFaultStorage(
+        () => null,
+        () => new DOMException('Storage blocked', 'SecurityError')
+      )
+
+      try {
+        expect(migrateV1toV2(personalWorkspace)).toBe(-1)
+        expect(isV2MigrationComplete(personalWorkspace)).toBe(false)
+        expect(getMigrationStatus(personalWorkspace)).toEqual({
+          v1Exists: false,
+          v2Exists: false,
+          v1DraftCount: 0,
+          v2DraftCount: 0
+        })
+      } finally {
+        restoreStorage()
+      }
+    })
+  })
+
+  describe('legacy key compatibility', () => {
+    it('migrates the unscoped keys written by the real V1 draft store', () => {
+      const drafts = {
+        'workflows/a.json': makeDraft('a', 1000),
+        'workflows/b.json': makeDraft('b', 2000, false)
+      }
+      setActualV1Data(drafts, ['workflows/a.json', 'workflows/b.json'])
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(2)
+
+      expect(getV2Payload(personalWorkspace, 'workflows/a.json')?.data).toBe(
+        drafts['workflows/a.json'].data
+      )
+      expect(getV2Payload(personalWorkspace, 'workflows/b.json')?.data).toBe(
+        drafts['workflows/b.json'].data
+      )
+      expect(getV2Index(personalWorkspace)?.order).toEqual([
+        hashPath('workflows/a.json'),
+        hashPath('workflows/b.json')
+      ])
+      expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBeNull()
+      expect(localStorage.getItem('Comfy.Workflow.DraftOrder')).toBeNull()
+    })
+
+    it('repairs a prior empty V2 migration marker instead of short-circuiting', () => {
+      setV2Index(personalWorkspace, {}, [])
+      setActualV1Data(
+        { 'workflows/recovered.json': makeDraft('recovered', 1000) },
+        ['workflows/recovered.json']
+      )
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(1)
+      expect(
+        getV2Payload(personalWorkspace, 'workflows/recovered.json')?.data
+      ).toBe(JSON.stringify({ id: 'recovered' }))
+    })
+
+    it('keeps compatibility with interim workspace-scoped legacy keys', () => {
+      setScopedV1Data(
+        teamWorkspace,
+        { 'workflows/team.json': makeDraft('team', 1000) },
+        ['workflows/team.json']
+      )
+
+      expect(migrateV1toV2(teamWorkspace)).toBe(1)
+      expect(getV2Payload(teamWorkspace, 'workflows/team.json')?.data).toBe(
+        JSON.stringify({ id: 'team' })
+      )
+      expect(
+        localStorage.getItem(`Comfy.Workflow.Drafts:${teamWorkspace}`)
+      ).toBeNull()
+    })
+
+    it('does not adopt unscoped V1 drafts into a team workspace', () => {
+      setActualV1Data(
+        { 'workflows/personal.json': makeDraft('personal', 1000) },
+        ['workflows/personal.json']
+      )
+
+      expect(migrateV1toV2(teamWorkspace)).toBe(0)
+      expect(getV2Index(teamWorkspace)?.order).toEqual([])
+      expect(localStorage.getItem('Comfy.Workflow.Drafts')).not.toBeNull()
+    })
+
+    it('recovers valid drafts when the legacy order key is missing', () => {
+      localStorage.setItem(
+        'Comfy.Workflow.Drafts',
+        JSON.stringify({
+          'workflows/b.json': makeDraft('b', 2000),
+          'workflows/a.json': makeDraft('a', 1000)
+        })
+      )
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(2)
+      expect(getV2Index(personalWorkspace)?.order).toEqual([
+        hashPath('workflows/a.json'),
+        hashPath('workflows/b.json')
+      ])
+    })
+  })
+
+  describe('V2 repair', () => {
+    it('preserves an existing V2 payload when V1 has an older copy', () => {
+      const path = 'workflows/current.json'
+      const draftKey = hashPath(path)
+      setV2Index(
+        personalWorkspace,
+        {
+          [draftKey]: {
+            path,
+            name: 'current',
+            isTemporary: true,
+            updatedAt: 3000
+          }
+        },
+        [draftKey]
+      )
+      localStorage.setItem(
+        `Comfy.Workflow.Draft.v2:${personalWorkspace}:${draftKey}`,
+        JSON.stringify({ data: '{"version":2}', updatedAt: 3000 })
+      )
+      setActualV1Data(
+        {
+          [path]: {
+            data: '{"version":1}',
+            updatedAt: 1000,
+            name: 'current',
+            isTemporary: true
+          }
+        },
+        [path]
+      )
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(0)
+      expect(getV2Payload(personalWorkspace, path)?.data).toBe('{"version":2}')
+      expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBeNull()
+    })
+
+    it('restores a V2 index entry whose payload was lost', () => {
+      const path = 'workflows/lost-payload.json'
+      const draftKey = hashPath(path)
+      setV2Index(
+        personalWorkspace,
+        {
+          [draftKey]: {
+            path,
+            name: 'current-name',
+            isTemporary: true,
+            updatedAt: 3000
+          }
+        },
+        [draftKey]
+      )
+      setActualV1Data({ [path]: makeDraft('legacy-backup', 1000) }, [path])
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(1)
+      expect(getV2Payload(personalWorkspace, path)?.data).toBe(
+        JSON.stringify({ id: 'legacy-backup' })
+      )
+      expect(getV2Index(personalWorkspace)?.entries[draftKey].path).toBe(path)
+    })
+
+    it('keeps current V2 history ahead of recovered legacy-only history', () => {
+      const currentPath = 'workflows/current.json'
+      const currentKey = hashPath(currentPath)
+      setV2Index(
+        personalWorkspace,
+        {
+          [currentKey]: {
+            path: currentPath,
+            name: 'current',
+            isTemporary: true,
+            updatedAt: 3000
+          }
+        },
+        [currentKey]
+      )
+      localStorage.setItem(
+        `Comfy.Workflow.Draft.v2:${personalWorkspace}:${currentKey}`,
+        JSON.stringify({ data: '{"current":true}', updatedAt: 3000 })
+      )
+      setActualV1Data(
+        {
+          'workflows/legacy-a.json': makeDraft('legacy-a', 1000),
+          'workflows/legacy-b.json': makeDraft('legacy-b', 2000)
+        },
+        ['workflows/legacy-a.json', 'workflows/legacy-b.json']
+      )
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(2)
+      expect(getV2Index(personalWorkspace)?.order).toEqual([
+        hashPath('workflows/legacy-a.json'),
+        hashPath('workflows/legacy-b.json'),
+        currentKey
+      ])
+    })
+  })
+
+  describe('retention limits', () => {
+    it('keeps existing V2 history ahead of over-limit legacy-only drafts', () => {
+      const existingPaths = [
+        'workflows/v2-a.json',
+        'workflows/v2-b.json',
+        'workflows/v2-c.json'
+      ]
+      const existingEntries: Record<
+        string,
+        {
+          path: string
+          name: string
+          isTemporary: boolean
+          updatedAt: number
+        }
+      > = {}
+      const existingOrder: string[] = []
+
+      existingPaths.forEach((existingPath, index) => {
+        const key = hashPath(existingPath)
+        existingOrder.push(key)
+        existingEntries[key] = {
+          path: existingPath,
+          name: `v2-${index}`,
+          isTemporary: true,
+          updatedAt: 10_000 + index
+        }
+        localStorage.setItem(
+          `Comfy.Workflow.Draft.v2:${personalWorkspace}:${key}`,
+          JSON.stringify({
+            data: JSON.stringify({ existing: index }),
+            updatedAt: 10_000 + index
+          })
+        )
+      })
+      setV2Index(personalWorkspace, existingEntries, existingOrder)
+
+      const legacyPaths = Array.from(
+        { length: MAX_DRAFTS + 4 },
+        (_, index) => `workflows/legacy-${index}.json`
+      )
+      const legacyDrafts: V1Drafts = {}
+      legacyPaths.forEach((legacyPath, index) => {
+        legacyDrafts[legacyPath] = makeDraft(`legacy-${index}`, index + 1)
+      })
+      setActualV1Data(legacyDrafts, legacyPaths)
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(
+        MAX_DRAFTS - existingPaths.length
+      )
+
+      const index = getV2Index(personalWorkspace)
+      expect(index?.order).toHaveLength(MAX_DRAFTS)
+      for (const existingPath of existingPaths) {
+        const key = hashPath(existingPath)
+        expect(index?.order).toContain(key)
+        expect(getV2Payload(personalWorkspace, existingPath)).not.toBeNull()
+      }
+
+      const discardedLegacyPath = legacyPaths[0]
+      expect(index?.order).not.toContain(hashPath(discardedLegacyPath))
+      expect(getV2Payload(personalWorkspace, discardedLegacyPath)).toBeNull()
+    })
+
+    it('does not write payloads for over-limit discarded V2 recovery candidates', () => {
+      const paths = Array.from(
+        { length: MAX_DRAFTS + 2 },
+        (_, index) => `workflows/recoverable-v2-${index}.json`
+      )
+      const entries: Record<
+        string,
+        {
+          path: string
+          name: string
+          isTemporary: boolean
+          updatedAt: number
+        }
+      > = {}
+      const order: string[] = []
+      const backups: V1Drafts = {}
+
+      paths.forEach((workflowPath, index) => {
+        const key = hashPath(workflowPath)
+        order.push(key)
+        entries[key] = {
+          path: workflowPath,
+          name: `recoverable-${index}`,
+          isTemporary: true,
+          updatedAt: index + 1
+        }
+        backups[workflowPath] = makeDraft(`backup-${index}`, index + 1)
+      })
+      // Every V2 index entry is missing its payload but is recoverable from V1.
+      // This intentionally fills payloadsToWrite before retainedExisting trims
+      // the over-limit index, exercising the pruning loop directly.
+      setV2Index(personalWorkspace, entries, order)
+      setActualV1Data(backups, paths)
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(MAX_DRAFTS)
+
+      const index = getV2Index(personalWorkspace)
+      expect(index?.order).toHaveLength(MAX_DRAFTS)
+      const discardedPath = paths[0]
+      const retainedPath = paths.at(-1)!
+      expect(index?.order).not.toContain(hashPath(discardedPath))
+      expect(index?.order).toContain(hashPath(retainedPath))
+      expect(getV2Payload(personalWorkspace, discardedPath)).toBeNull()
+      expect(getV2Payload(personalWorkspace, retainedPath)).not.toBeNull()
+    })
+  })
+
+  describe('quota recovery', () => {
+    it('preserves legacy recovery data when workflow writes are deliberately blocked', async () => {
+      // Use fresh module instances so the deliberate transition fence is
+      // isolated from the rest of this suite.
+      vi.resetModules()
+      const storageIO = await import('../base/storageIO')
+      const migration = await import('./migrateV1toV2')
+      storageIO.prepareWorkflowWorkspaceTransition()
+
+      const drafts = {
+        'workflows/blocked.json': makeDraft('blocked', 1000)
+      }
+      setActualV1Data(drafts, ['workflows/blocked.json'])
+      const originalDrafts = localStorage.getItem('Comfy.Workflow.Drafts')
+      const originalOrder = localStorage.getItem('Comfy.Workflow.DraftOrder')
+
+      try {
+        expect(migration.migrateV1toV2(personalWorkspace)).toBe(-1)
+        expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBe(
+          originalDrafts
+        )
+        expect(localStorage.getItem('Comfy.Workflow.DraftOrder')).toBe(
+          originalOrder
+        )
+        expect(
+          localStorage.getItem(
+            `Comfy.Workflow.Draft.v2:${personalWorkspace}:${hashPath('workflows/blocked.json')}`
+          )
+        ).toBeNull()
+        expect(getV2Index(personalWorkspace)).toBeNull()
+      } finally {
+        vi.resetModules()
+      }
+    })
+
+    it('frees the legacy blob and retries when duplication itself hits quota', () => {
+      setActualV1Data({ 'workflows/large.json': makeDraft('large', 1000) }, [
+        'workflows/large.json'
+      ])
+
+      const restoreStorage = installFaultStorage((key) =>
+        key.startsWith('Comfy.Workflow.Draft.v2:') &&
+        localStorage.getItem('Comfy.Workflow.Drafts') !== null
+          ? new DOMException('Quota exceeded', 'QuotaExceededError')
+          : null
+      )
+      try {
+        expect(migrateV1toV2(personalWorkspace)).toBe(1)
+        expect(
+          getV2Payload(personalWorkspace, 'workflows/large.json')
+        ).not.toBeNull()
+        expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBeNull()
+      } finally {
+        restoreStorage()
+      }
+    })
+
+    it('restores the legacy blob when recovery still cannot be committed', () => {
+      const drafts = {
+        'workflows/large.json': makeDraft('large', 1000)
+      }
+      setActualV1Data(drafts, ['workflows/large.json'])
+      const originalDrafts = localStorage.getItem('Comfy.Workflow.Drafts')
+      const originalOrder = localStorage.getItem('Comfy.Workflow.DraftOrder')
+
+      const restoreStorage = installFaultStorage((key) =>
+        key.startsWith('Comfy.Workflow.Draft.v2:')
+          ? new DOMException('Quota exceeded', 'QuotaExceededError')
+          : null
+      )
+      try {
+        expect(migrateV1toV2(personalWorkspace)).toBe(-1)
+        expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBe(
+          originalDrafts
+        )
+        expect(localStorage.getItem('Comfy.Workflow.DraftOrder')).toBe(
+          originalOrder
+        )
+        expect(
+          getV2Payload(personalWorkspace, 'workflows/large.json')
+        ).toBeNull()
+        expect(getV2Index(personalWorkspace)).toBeNull()
+      } finally {
+        restoreStorage()
+      }
+    })
+
+    it('does not delete legacy data after a non-quota storage failure', () => {
+      setActualV1Data({ 'workflows/legacy.json': makeDraft('legacy', 1000) }, [
+        'workflows/legacy.json'
+      ])
+      const originalDrafts = localStorage.getItem('Comfy.Workflow.Drafts')
+      const originalOrder = localStorage.getItem('Comfy.Workflow.DraftOrder')
+
+      const restoreStorage = installFaultStorage((key) =>
+        key.startsWith('Comfy.Workflow.Draft.v2:')
+          ? new DOMException('Storage blocked', 'SecurityError')
+          : null
+      )
+      try {
+        expect(migrateV1toV2(personalWorkspace)).toBe(-1)
+        expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBe(
+          originalDrafts
+        )
+        expect(localStorage.getItem('Comfy.Workflow.DraftOrder')).toBe(
+          originalOrder
+        )
+      } finally {
+        restoreStorage()
+      }
+    })
+
+    it('uses and removes the redundant legacy workflow singleton during quota retry', () => {
+      const draft = makeDraft('large', 1000)
+      setActualV1Data({ 'workflows/large.json': draft }, [
+        'workflows/large.json'
+      ])
+      localStorage.setItem('workflow', draft.data)
+
+      const restoreStorage = installFaultStorage((key) =>
+        key.startsWith('Comfy.Workflow.Draft.v2:') &&
+        localStorage.getItem('workflow') !== null
+          ? new DOMException('Quota exceeded', 'QuotaExceededError')
+          : null
+      )
+      try {
+        expect(migrateV1toV2(personalWorkspace)).toBe(1)
+        expect(
+          getV2Payload(personalWorkspace, 'workflows/large.json')?.data
+        ).toBe(draft.data)
+        expect(localStorage.getItem('workflow')).toBeNull()
+      } finally {
+        restoreStorage()
+      }
+    })
+
+    it('preserves a unique legacy workflow singleton', () => {
+      setActualV1Data({ 'workflows/a.json': makeDraft('a', 1000) }, [
+        'workflows/a.json'
+      ])
+      localStorage.setItem('workflow', '{"unique":true}')
+
+      expect(migrateV1toV2(personalWorkspace)).toBe(1)
+      expect(localStorage.getItem('workflow')).toBe('{"unique":true}')
+    })
+  })
+
+  describe('V1 tab state migration', () => {
+    it('migrates legacy tab state without overwriting a current V2 pointer', () => {
+      setActualV1Data({ 'workflows/a.json': makeDraft('a', 1000) }, [
+        'workflows/a.json'
+      ])
+      localStorage.setItem(
+        'Comfy.OpenWorkflowsPaths',
+        JSON.stringify(['workflows/a.json'])
+      )
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(0))
+
+      const clientId = 'client-123'
+      writeOpenPaths(clientId, {
+        workspaceId: personalWorkspace,
+        paths: ['workflows/current.json'],
+        activeIndex: 0
+      })
+
+      expect(migrateV1toV2(personalWorkspace, clientId)).toBe(1)
+      expect(readOpenPaths(clientId, personalWorkspace)?.paths).toEqual([
+        'workflows/current.json'
+      ])
+      expect(localStorage.getItem('Comfy.OpenWorkflowsPaths')).toBeNull()
+    })
+
+    it('leaves legacy tab state intact when the durable V2 pointer cannot be written', () => {
+      setActualV1Data({ 'workflows/a.json': makeDraft('a', 1000) }, [
+        'workflows/a.json'
+      ])
+      localStorage.setItem(
+        'Comfy.OpenWorkflowsPaths',
+        JSON.stringify(['workflows/a.json'])
+      )
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(0))
+
+      const restoreStorage = installFaultStorage((key) =>
+        key === 'Comfy.Workflow.LastOpenPaths:personal'
+          ? new DOMException('Quota exceeded', 'QuotaExceededError')
+          : null
+      )
+      try {
+        expect(migrateV1toV2(personalWorkspace, 'client-tab-fail')).toBe(1)
+        expect(localStorage.getItem('Comfy.OpenWorkflowsPaths')).not.toBeNull()
+        expect(localStorage.getItem('Comfy.ActiveWorkflowIndex')).not.toBeNull()
+      } finally {
+        restoreStorage()
+      }
+    })
+
+    it('migrates legacy tab state when current V2 tab state is empty', () => {
+      setActualV1Data(
+        {
+          'workflows/a.json': makeDraft('a', 1000),
+          'workflows/b.json': makeDraft('b', 2000)
+        },
+        ['workflows/a.json', 'workflows/b.json']
+      )
+      localStorage.setItem(
+        'Comfy.OpenWorkflowsPaths',
+        JSON.stringify(['workflows/a.json', 'workflows/b.json'])
+      )
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(1))
+
+      const clientId = 'client-456'
+      expect(migrateV1toV2(personalWorkspace, clientId)).toBe(2)
+      expect(readOpenPaths(clientId, personalWorkspace)).toMatchObject({
+        paths: ['workflows/a.json', 'workflows/b.json'],
+        activeIndex: 1
+      })
+    })
+
+    it('clamps an out-of-range legacy active index to the last migrated path', () => {
+      setActualV1Data(
+        {
+          'workflows/a.json': makeDraft('a', 1000),
+          'workflows/b.json': makeDraft('b', 2000)
+        },
+        ['workflows/a.json', 'workflows/b.json']
+      )
+      localStorage.setItem(
+        'Comfy.OpenWorkflowsPaths',
+        JSON.stringify(['workflows/a.json', 'workflows/b.json'])
+      )
+      localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(7))
+
+      const clientId = 'client-clamp'
+      expect(migrateV1toV2(personalWorkspace, clientId)).toBe(2)
+      expect(readOpenPaths(clientId, personalWorkspace)).toMatchObject({
+        paths: ['workflows/a.json', 'workflows/b.json'],
+        activeIndex: 1
+      })
+    })
+  })
+
+  describe('cleanup and status', () => {
+    it('cleans actual V1 keys only for the personal workspace', () => {
+      setActualV1Data({ 'workflows/personal.json': makeDraft('personal', 1) }, [
+        'workflows/personal.json'
+      ])
+      setScopedV1Data(
+        teamWorkspace,
+        { 'workflows/team.json': makeDraft('team', 1) },
+        ['workflows/team.json']
+      )
+
+      cleanupV1Data(teamWorkspace)
+      expect(localStorage.getItem('Comfy.Workflow.Drafts')).not.toBeNull()
+      expect(
+        localStorage.getItem(`Comfy.Workflow.Drafts:${teamWorkspace}`)
+      ).toBeNull()
+
+      cleanupV1Data(personalWorkspace)
+      expect(localStorage.getItem('Comfy.Workflow.Drafts')).toBeNull()
+    })
+
+    it('reports actual unscoped V1 history', () => {
+      setActualV1Data(
+        {
+          'workflows/a.json': makeDraft('a', 1),
+          'workflows/b.json': makeDraft('b', 2)
+        },
+        ['workflows/a.json', 'workflows/b.json']
+      )
+
+      expect(getMigrationStatus(personalWorkspace)).toEqual({
+        v1Exists: true,
+        v2Exists: false,
+        v1DraftCount: 2,
+        v2DraftCount: 0
+      })
+    })
+  })
+})

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
@@ -2,10 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { hashPath } from '../base/hashUtil'
 import { readOpenPaths } from '../base/storageIO'
-import { isV2MigrationComplete, migrateV1toV2 } from './migrateV1toV2'
+import {
+  cleanupV1Data,
+  getMigrationStatus,
+  isV2MigrationComplete,
+  migrateV1toV2
+} from './migrateV1toV2'
 
 describe('migrateV1toV2', () => {
   const workspaceId = 'test-workspace'
+  const personalWorkspaceId = 'personal'
 
   beforeEach(() => {
     vi.resetModules()
@@ -26,6 +32,17 @@ describe('migrateV1toV2', () => {
       `Comfy.Workflow.DraftOrder:${workspaceId}`,
       JSON.stringify(order)
     )
+  }
+
+  function setPersonalV1Data(
+    drafts: Record<
+      string,
+      { data: string; updatedAt: number; name: string; isTemporary: boolean }
+    >,
+    order: string[]
+  ) {
+    localStorage.setItem('Comfy.Workflow.Drafts', JSON.stringify(drafts))
+    localStorage.setItem('Comfy.Workflow.DraftOrder', JSON.stringify(order))
   }
 
   describe('isV2MigrationComplete', () => {
@@ -152,10 +169,56 @@ describe('migrateV1toV2', () => {
       ]
       expect(index.order).toEqual(expectedOrder)
     })
+
+    it('removes fully migrated V1 data after a successful commit', () => {
+      const v1Drafts = {
+        'workflows/test.json': {
+          data: '{}',
+          updatedAt: 1000,
+          name: 'test',
+          isTemporary: true
+        }
+      }
+      setV1Data(v1Drafts, ['workflows/test.json'])
+
+      migrateV1toV2(workspaceId)
+
+      expect(
+        localStorage.getItem(`Comfy.Workflow.Drafts:${workspaceId}`)
+      ).toBeNull()
+      expect(
+        localStorage.getItem(`Comfy.Workflow.DraftOrder:${workspaceId}`)
+      ).toBeNull()
+    })
+  })
+
+  describe('cleanupV1Data', () => {
+    it('removes V1 keys', () => {
+      setV1Data(
+        {
+          'workflows/test.json': {
+            data: '{}',
+            updatedAt: 1,
+            name: 'test',
+            isTemporary: true
+          }
+        },
+        ['workflows/test.json']
+      )
+
+      cleanupV1Data(workspaceId)
+
+      expect(
+        localStorage.getItem(`Comfy.Workflow.Drafts:${workspaceId}`)
+      ).toBeNull()
+      expect(
+        localStorage.getItem(`Comfy.Workflow.DraftOrder:${workspaceId}`)
+      ).toBeNull()
+    })
   })
 
   describe('V1 tab state migration', () => {
-    it('migrates V1 tab state pointers to V2 format', () => {
+    it('migrates personal V1 tab state pointers to V2 format', () => {
       // Simulate V1 state: user had 3 workflows open, 2nd was active
       const v1Drafts = {
         'workflows/a.json': {
@@ -177,7 +240,7 @@ describe('migrateV1toV2', () => {
           isTemporary: false
         }
       }
-      setV1Data(v1Drafts, [
+      setPersonalV1Data(v1Drafts, [
         'workflows/a.json',
         'workflows/b.json',
         'workflows/c.json'
@@ -194,15 +257,13 @@ describe('migrateV1toV2', () => {
       )
       localStorage.setItem('Comfy.ActiveWorkflowIndex', JSON.stringify(1))
 
-      // Run migration (simulating upgrade from pre-V2 to V2)
+      // Global V1 state belongs to the personal workspace only.
       const clientId = 'client-123'
-      const result = migrateV1toV2(workspaceId, clientId)
+      const result = migrateV1toV2(personalWorkspaceId, clientId)
       expect(result).toBe(3)
 
-      // V2 tab state should be readable via the V2 API
-      const openPaths = readOpenPaths(clientId, workspaceId)
+      const openPaths = readOpenPaths(clientId, personalWorkspaceId)
 
-      // V2 tab state should be reconstructed from V1 localStorage keys
       expect(openPaths).not.toBeNull()
       expect(openPaths!.paths).toEqual([
         'workflows/a.json',
@@ -221,15 +282,43 @@ describe('migrateV1toV2', () => {
           isTemporary: true
         }
       }
-      setV1Data(v1Drafts, ['workflows/a.json'])
+      setPersonalV1Data(v1Drafts, ['workflows/a.json'])
 
       // No V1 tab state keys in localStorage
-      migrateV1toV2(workspaceId)
+      migrateV1toV2(personalWorkspaceId)
 
-      const openPaths = readOpenPaths('any-client-id', workspaceId)
+      const openPaths = readOpenPaths('any-client-id', personalWorkspaceId)
 
       // No tab state to migrate — should remain null
       expect(openPaths).toBeNull()
+    })
+  })
+
+  describe('getMigrationStatus', () => {
+    it('reports correct status', () => {
+      setV1Data(
+        {
+          'workflows/a.json': {
+            data: '{}',
+            updatedAt: 1,
+            name: 'a',
+            isTemporary: true
+          },
+          'workflows/b.json': {
+            data: '{}',
+            updatedAt: 2,
+            name: 'b',
+            isTemporary: true
+          }
+        },
+        ['workflows/a.json', 'workflows/b.json']
+      )
+
+      const status = getMigrationStatus(workspaceId)
+      expect(status.v1Exists).toBe(true)
+      expect(status.v2Exists).toBe(false)
+      expect(status.v1DraftCount).toBe(2)
+      expect(status.v2DraftCount).toBe(0)
     })
   })
 })

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.ts
@@ -1,24 +1,30 @@
 /**
  * V1 to V2 Migration
  *
- * Migrates draft data from V1 blob format to V2 per-draft keys.
- * Runs once on first load if V2 index doesn't exist.
+ * Migrates the legacy monolithic draft cache into V2 per-draft keys. The
+ * original V1 store used unscoped `Comfy.Workflow.Drafts` / `DraftOrder`
+ * keys. Early V2 migration code incorrectly looked only for workspace-scoped
+ * variants, so this module also repairs installations where a V2 index already
+ * exists while the real V1 blob is still present.
  */
 
 import type { DraftIndexV2 } from '../base/draftTypes'
-import { upsertEntry, createEmptyIndex } from '../base/draftCacheV2'
+import { MAX_DRAFTS } from '../base/draftTypes'
+import { createEmptyIndex } from '../base/draftCacheV2'
 import { hashPath } from '../base/hashUtil'
 import { getWorkspaceId } from '../base/storageKeys'
 import {
+  deletePayload,
+  isStorageAvailable,
   readIndex,
+  readOpenPaths,
+  readPayload,
+  readPersistentOpenPaths,
   writeIndex,
   writeOpenPaths,
   writePayload
 } from '../base/storageIO'
 
-/**
- * Legacy V1 draft snapshot structure.
- */
 interface V1DraftSnapshot {
   data: string
   updatedAt: number
@@ -26,144 +32,694 @@ interface V1DraftSnapshot {
   isTemporary: boolean
 }
 
-/**
- * V1 storage keys - workspace-scoped blob format
- */
+interface V1StorageSource {
+  draftsKey: string
+  orderKey: string
+  rawDrafts: string
+  rawOrder: string | null
+  drafts: Record<string, V1DraftSnapshot>
+  order: string[]
+  cleanupSafe: boolean
+}
+
+interface V1ReadResult {
+  sources: V1StorageSource[]
+  hasMalformedSource: boolean
+}
+
+interface RawStorageEntry {
+  key: string
+  value: string
+}
+
+type CommitResult = 'success' | 'quota' | 'blocked' | 'error'
+
 const V1_KEYS = {
-  drafts: (workspaceId: string) => `Comfy.Workflow.Drafts:${workspaceId}`,
-  order: (workspaceId: string) => `Comfy.Workflow.DraftOrder:${workspaceId}`,
+  drafts: 'Comfy.Workflow.Drafts',
+  order: 'Comfy.Workflow.DraftOrder',
+  scopedDrafts: (workspaceId: string) => `Comfy.Workflow.Drafts:${workspaceId}`,
+  scopedOrder: (workspaceId: string) =>
+    `Comfy.Workflow.DraftOrder:${workspaceId}`,
   openPaths: 'Comfy.OpenWorkflowsPaths',
   activeIndex: 'Comfy.ActiveWorkflowIndex'
 }
 
-/**
- * Checks if V2 migration has been completed for the current workspace.
- */
-export function isV2MigrationComplete(workspaceId: string): boolean {
-  const v2Index = readIndex(workspaceId)
-  return v2Index !== null
+function v1KeyPairs(workspaceId: string) {
+  const scoped = {
+    draftsKey: V1_KEYS.scopedDrafts(workspaceId),
+    orderKey: V1_KEYS.scopedOrder(workspaceId)
+  }
+
+  // The real V1 cache was global. Only the personal workspace may adopt it;
+  // using it for a team workspace would recreate the cross-workspace leak V2
+  // was introduced to eliminate. Keep scoped-key support for interim builds.
+  return workspaceId === 'personal'
+    ? [{ draftsKey: V1_KEYS.drafts, orderKey: V1_KEYS.order }, scoped]
+    : [scoped]
 }
 
-/**
- * Reads V1 drafts from localStorage.
- */
-function readV1Drafts(
-  workspaceId: string
-): { drafts: Record<string, V1DraftSnapshot>; order: string[] } | null {
+function isV1DraftSnapshot(value: unknown): value is V1DraftSnapshot {
+  if (typeof value !== 'object' || value === null) return false
+  const draft = value as Record<string, unknown>
+  return (
+    typeof draft.data === 'string' &&
+    typeof draft.updatedAt === 'number' &&
+    Number.isFinite(draft.updatedAt) &&
+    typeof draft.name === 'string' &&
+    typeof draft.isTemporary === 'boolean'
+  )
+}
+
+function readV1Sources(workspaceId: string): V1ReadResult {
+  const sources: V1StorageSource[] = []
+  let hasMalformedSource = false
+
+  for (const { draftsKey, orderKey } of v1KeyPairs(workspaceId)) {
+    let rawDrafts: string | null
+    let rawOrder: string | null
+    try {
+      rawDrafts = localStorage.getItem(draftsKey)
+      if (rawDrafts === null) continue
+      rawOrder = localStorage.getItem(orderKey)
+    } catch {
+      hasMalformedSource = true
+      continue
+    }
+
+    try {
+      const parsed = JSON.parse(rawDrafts) as unknown
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        hasMalformedSource = true
+        continue
+      }
+
+      const drafts: Record<string, V1DraftSnapshot> = {}
+      let cleanupSafe = true
+      for (const [path, value] of Object.entries(
+        parsed as Record<string, unknown>
+      )) {
+        if (!isV1DraftSnapshot(value)) {
+          cleanupSafe = false
+          continue
+        }
+        drafts[path] = value
+      }
+
+      let order: string[] = []
+      if (rawOrder !== null) {
+        try {
+          const parsedOrder = JSON.parse(rawOrder) as unknown
+          if (Array.isArray(parsedOrder)) {
+            order = parsedOrder.filter(
+              (path): path is string => typeof path === 'string'
+            )
+          }
+        } catch {
+          // Draft payloads are still recoverable without the old LRU order.
+        }
+      }
+
+      sources.push({
+        draftsKey,
+        orderKey,
+        rawDrafts,
+        rawOrder,
+        drafts,
+        order,
+        cleanupSafe
+      })
+    } catch {
+      hasMalformedSource = true
+    }
+  }
+
+  return { sources, hasMalformedSource }
+}
+
+function getV1Draft(
+  drafts: Record<string, V1DraftSnapshot>,
+  path: string
+): V1DraftSnapshot | undefined {
+  return drafts[path]
+}
+
+function getIndexEntry(
+  index: DraftIndexV2,
+  key: string
+): DraftIndexV2['entries'][string] | undefined {
+  return index.entries[key]
+}
+
+function mergedV1Data(sources: V1StorageSource[]): {
+  drafts: Record<string, V1DraftSnapshot>
+  order: string[]
+} {
+  const drafts: Record<string, V1DraftSnapshot> = {}
+  let order: string[] = []
+
+  for (const source of sources) {
+    const inOrder = new Set<string>()
+    const sourceOrder: string[] = []
+
+    for (const path of source.order) {
+      const draft = getV1Draft(source.drafts, path)
+      if (!draft || inOrder.has(path)) continue
+      inOrder.add(path)
+      sourceOrder.push(path)
+    }
+
+    const unordered = Object.keys(source.drafts)
+      .filter((path) => !inOrder.has(path))
+      .sort(
+        (a, b) =>
+          source.drafts[a].updatedAt - source.drafts[b].updatedAt ||
+          a.localeCompare(b)
+      )
+
+    for (const path of [...sourceOrder, ...unordered]) {
+      const candidate = getV1Draft(source.drafts, path)
+      if (!candidate) continue
+      const previous = getV1Draft(drafts, path)
+      if (!previous || candidate.updatedAt >= previous.updatedAt) {
+        drafts[path] = candidate
+      }
+
+      // Later sources/order occurrences are treated as more recent, matching
+      // the V1 touch-order semantics.
+      order = order.filter((entry) => entry !== path)
+      order.push(path)
+    }
+  }
+
+  return { drafts, order }
+}
+
+function hasLegacyDraftStorage(workspaceId: string): boolean {
   try {
-    const draftsJson = localStorage.getItem(V1_KEYS.drafts(workspaceId))
-    const orderJson = localStorage.getItem(V1_KEYS.order(workspaceId))
-
-    if (!draftsJson) return null
-
-    const drafts = JSON.parse(draftsJson) as Record<string, V1DraftSnapshot>
-    const order = orderJson ? (JSON.parse(orderJson) as string[]) : []
-
-    return { drafts, order }
+    return v1KeyPairs(workspaceId).some(
+      ({ draftsKey }) => localStorage.getItem(draftsKey) !== null
+    )
   } catch {
-    return null
+    return false
   }
 }
 
 /**
- * Migrates V1 drafts to V2 format.
+ * Migration is complete only when a V2 index exists and no relevant V1 draft
+ * blob remains. This lets current builds repair the previously-created empty
+ * V2 index instead of treating it as a permanent migration marker.
+ */
+export function isV2MigrationComplete(workspaceId: string): boolean {
+  return readIndex(workspaceId) !== null && !hasLegacyDraftStorage(workspaceId)
+}
+
+function orderedIndexKeys(index: DraftIndexV2): string[] {
+  const seen = new Set<string>()
+  const ordered: string[] = []
+
+  for (const key of index.order) {
+    if (!getIndexEntry(index, key) || seen.has(key)) continue
+    seen.add(key)
+    ordered.push(key)
+  }
+
+  const missingFromOrder = Object.keys(index.entries)
+    .filter((key) => !seen.has(key))
+    .sort(
+      (a, b) =>
+        index.entries[a].updatedAt - index.entries[b].updatedAt ||
+        a.localeCompare(b)
+    )
+
+  return [...ordered, ...missingFromOrder]
+}
+
+function commitV2Recovery(
+  workspaceId: string,
+  finalIndex: DraftIndexV2,
+  payloadsToWrite: Map<string, V1DraftSnapshot>
+): CommitResult {
+  // The workspace-transition fence deliberately makes write helpers return
+  // false. Treating that as quota would temporarily delete legacy recovery
+  // data in an attempt to free space even though no write can succeed.
+  if (!isStorageAvailable()) return 'blocked'
+
+  const newlyWritten: string[] = []
+  const rollbackPayloadWrites = () => {
+    for (const writtenKey of newlyWritten) {
+      deletePayload(workspaceId, writtenKey)
+    }
+  }
+  const writeFailure = (): CommitResult =>
+    isStorageAvailable() ? 'quota' : 'blocked'
+
+  try {
+    for (const [draftKey, draft] of payloadsToWrite) {
+      if (
+        !writePayload(workspaceId, draftKey, {
+          data: draft.data,
+          updatedAt: draft.updatedAt
+        })
+      ) {
+        rollbackPayloadWrites()
+        return writeFailure()
+      }
+      newlyWritten.push(draftKey)
+    }
+
+    if (!writeIndex(workspaceId, finalIndex)) {
+      rollbackPayloadWrites()
+      return writeFailure()
+    }
+
+    return 'success'
+  } catch (error) {
+    rollbackPayloadWrites()
+    console.warn('[V2 Migration] Failed to commit recovered draft data', error)
+    return 'error'
+  }
+}
+
+function sourceStorageEntries(source: V1StorageSource): RawStorageEntry[] {
+  const entries: RawStorageEntry[] = [
+    { key: source.draftsKey, value: source.rawDrafts }
+  ]
+  if (source.rawOrder !== null) {
+    entries.push({ key: source.orderKey, value: source.rawOrder })
+  }
+  return entries
+}
+
+function restoreRawEntries(entries: RawStorageEntry[]): boolean {
+  let restored = true
+  for (const entry of entries) {
+    try {
+      localStorage.setItem(entry.key, entry.value)
+    } catch (error) {
+      restored = false
+      console.error(
+        `[V2 Migration] Failed to restore legacy storage key ${entry.key}`,
+        error
+      )
+    }
+  }
+  return restored
+}
+
+function removeRawEntriesForRetry(
+  entries: RawStorageEntry[]
+): RawStorageEntry[] | null {
+  const removed: RawStorageEntry[] = []
+  for (const entry of entries) {
+    try {
+      localStorage.removeItem(entry.key)
+      if (localStorage.getItem(entry.key) !== null) {
+        restoreRawEntries(removed)
+        console.warn(
+          `[V2 Migration] Could not free legacy storage for quota recovery: legacy storage key ${entry.key} was not removed`
+        )
+        return null
+      }
+    } catch (error) {
+      restoreRawEntries(removed)
+      console.warn(
+        '[V2 Migration] Could not free legacy storage for quota recovery',
+        error
+      )
+      return null
+    }
+    removed.push(entry)
+  }
+  return removed
+}
+
+function removeRawEntriesBestEffort(entries: RawStorageEntry[]): void {
+  for (const entry of entries) {
+    try {
+      localStorage.removeItem(entry.key)
+    } catch (error) {
+      console.warn(
+        `[V2 Migration] Could not clean legacy storage key ${entry.key}`,
+        error
+      )
+    }
+  }
+}
+
+function redundantLegacyWorkflowEntry(
+  workspaceId: string,
+  finalIndex: DraftIndexV2,
+  payloadsToWrite: Map<string, V1DraftSnapshot>
+): RawStorageEntry | null {
+  if (workspaceId !== 'personal') return null
+
+  let legacyWorkflow: string | null
+  try {
+    legacyWorkflow = localStorage.getItem('workflow')
+  } catch {
+    return null
+  }
+  if (legacyWorkflow === null) return null
+
+  for (const draftKey of finalIndex.order) {
+    // Staged migration payloads are already available as parsed snapshots.
+    // Check them before touching localStorage so quota-recovery candidates do
+    // not get parsed again during the legacy-singleton redundancy scan.
+    const pendingPayload = payloadsToWrite.get(draftKey)
+    if (pendingPayload) {
+      if (pendingPayload.data === legacyWorkflow) {
+        return { key: 'workflow', value: legacyWorkflow }
+      }
+      continue
+    }
+
+    const currentPayload = readPayload(workspaceId, draftKey)
+    if (currentPayload?.data === legacyWorkflow) {
+      return { key: 'workflow', value: legacyWorkflow }
+    }
+  }
+  return null
+}
+
+function hasPersistentOpenPaths(
+  workspaceId: string,
+  expectedPaths: string[]
+): boolean {
+  const pointer = readPersistentOpenPaths(workspaceId)
+  return (
+    pointer !== null &&
+    pointer.workspaceId === workspaceId &&
+    pointer.paths.length === expectedPaths.length &&
+    pointer.paths.every((path, index) => path === expectedPaths[index])
+  )
+}
+
+function migrateV1TabState(workspaceId: string, clientId?: string): boolean {
+  if (workspaceId !== 'personal' || !clientId) return false
+
+  try {
+    const current = readOpenPaths(clientId, workspaceId)
+    if (current?.paths.length) {
+      // Older V2 builds may have only the session-scoped copy. Refresh it and
+      // require the durable local fallback before deleting the V1 pointer.
+      writeOpenPaths(clientId, current)
+      return hasPersistentOpenPaths(workspaceId, current.paths)
+    }
+
+    const pathsJson = localStorage.getItem(V1_KEYS.openPaths)
+    if (!pathsJson) return true
+
+    const parsedPaths = JSON.parse(pathsJson) as unknown
+    if (!Array.isArray(parsedPaths)) return false
+    const paths = parsedPaths.filter(
+      (path): path is string => typeof path === 'string'
+    )
+    if (paths.length === 0) return true
+
+    const indexJson = localStorage.getItem(V1_KEYS.activeIndex)
+    let activeIndex = 0
+    if (indexJson !== null) {
+      const parsedIndex = JSON.parse(indexJson) as unknown
+      if (typeof parsedIndex === 'number' && Number.isFinite(parsedIndex)) {
+        activeIndex = Math.min(Math.max(0, parsedIndex), paths.length - 1)
+      }
+    }
+
+    writeOpenPaths(clientId, { workspaceId, paths, activeIndex })
+    return hasPersistentOpenPaths(workspaceId, paths)
+  } catch {
+    return false
+  }
+}
+
+function migrateAndCleanupV1TabState(
+  workspaceId: string,
+  clientId?: string
+): void {
+  if (workspaceId !== 'personal') return
+  if (!migrateV1TabState(workspaceId, clientId)) return
+
+  try {
+    localStorage.removeItem(V1_KEYS.openPaths)
+    localStorage.removeItem(V1_KEYS.activeIndex)
+  } catch {
+    // Best effort. Leaving tiny legacy pointers is safe.
+  }
+}
+
+/**
+ * Migrates or repairs V1 drafts into V2.
  *
- * @returns Number of drafts migrated, or -1 if migration not needed/failed
+ * Existing V2 payloads always win. A V1 payload is used only for a legacy-only
+ * path or to repair a V2 index entry whose payload was lost. If quota prevents
+ * the repair while the legacy monolithic blob is still present, cleanly parsed
+ * V1 sources are temporarily removed and the transaction is retried; they are
+ * restored if the V2 commit still fails.
+ *
+ * @returns Number of V1 payloads recovered into V2, 0 for an empty migration,
+ * or -1 for a non-mutating outcome. The -1 result intentionally covers both a
+ * healthy no-op and a preserved-data recovery failure: the only current caller
+ * needs to know whether V2 storage changed so it can invalidate its cache.
+ * Failed recovery keeps legacy data in place and is retried on the next
+ * persistence initialization.
  */
 export function migrateV1toV2(
   workspaceId: string = getWorkspaceId(),
   clientId?: string
 ): number {
-  // Check if V2 already exists
-  if (isV2MigrationComplete(workspaceId)) {
-    return -1
-  }
+  const originalIndex = readIndex(workspaceId)
+  const { sources, hasMalformedSource } = readV1Sources(workspaceId)
 
-  // Read V1 data
-  const v1Data = readV1Drafts(workspaceId)
-  if (!v1Data) {
-    // No V1 data to migrate - create empty V2 index
+  if (sources.length === 0) {
+    if (hasMalformedSource) return -1
+    if (originalIndex) {
+      const redundantWorkflow = redundantLegacyWorkflowEntry(
+        workspaceId,
+        originalIndex,
+        new Map()
+      )
+      if (redundantWorkflow) {
+        removeRawEntriesBestEffort([redundantWorkflow])
+      }
+      migrateAndCleanupV1TabState(workspaceId, clientId)
+      return -1
+    }
+
     if (!writeIndex(workspaceId, createEmptyIndex())) return -1
+    migrateAndCleanupV1TabState(workspaceId, clientId)
     return 0
   }
 
-  // Build V2 index and write payloads
-  let index: DraftIndexV2 = createEmptyIndex()
-  let migrated = 0
+  const legacy = mergedV1Data(sources)
+  const baseIndex = originalIndex ?? createEmptyIndex()
+  const legacyByKey = new Map<
+    string,
+    { path: string; draft: V1DraftSnapshot }
+  >()
+  let hasHashCollision = false
 
-  // Process in order (oldest first) to maintain LRU order
-  const draftsByPath: Partial<Record<string, V1DraftSnapshot>> = v1Data.drafts
-  for (const path of v1Data.order) {
+  const draftsByPath: Partial<Record<string, V1DraftSnapshot>> = legacy.drafts
+  for (const path of legacy.order) {
     const draft = draftsByPath[path]
     if (!draft) continue
 
     const draftKey = hashPath(path)
+    const previous = legacyByKey.get(draftKey)
+    if (previous && previous.path !== path) {
+      hasHashCollision = true
+      console.warn(
+        `[V2 Migration] Draft-key collision between ${previous.path} and ${path}`
+      )
+      continue
+    }
+    legacyByKey.set(draftKey, { path, draft })
+  }
 
-    // Write payload
-    const payloadWritten = writePayload(workspaceId, draftKey, {
-      data: draft.data,
-      updatedAt: draft.updatedAt
-    })
+  for (const path of legacy.order) {
+    const draftKey = hashPath(path)
+    const previous = legacyByKey.get(draftKey)
+    if (previous && previous.path !== path) {
+      hasHashCollision = true
+      console.warn(
+        `[V2 Migration] Draft-key collision between ${previous.path} and ${path}`
+      )
+      continue
+    }
+    legacyByKey.set(draftKey, { path, draft: legacy.drafts[path] })
+  }
 
-    if (!payloadWritten) {
-      console.warn(`[V2 Migration] Failed to write payload for ${path}`)
+  const existingKeys: string[] = []
+  const existingSet = new Set<string>()
+  const payloadsToWrite = new Map<string, V1DraftSnapshot>()
+
+  for (const draftKey of orderedIndexKeys(baseIndex)) {
+    const entry = baseIndex.entries[draftKey]
+    const currentPayload = readPayload(workspaceId, draftKey)
+    const legacyEntry = legacyByKey.get(draftKey)
+    const recoverableLegacy =
+      legacyEntry && legacyEntry.path === entry.path ? legacyEntry.draft : null
+
+    if (!currentPayload && !recoverableLegacy) continue
+
+    existingKeys.push(draftKey)
+    existingSet.add(draftKey)
+    if (!currentPayload && recoverableLegacy) {
+      payloadsToWrite.set(draftKey, recoverableLegacy)
+    }
+  }
+
+  // Preserve every currently recoverable V2 entry first. Legacy-only entries
+  // fill the remaining retention slots from newest to oldest.
+  const retainedExisting = existingKeys.slice(-MAX_DRAFTS)
+  const retainedExistingSet = new Set(retainedExisting)
+  const legacyOnlyKeys: string[] = []
+
+  for (const path of legacy.order) {
+    const draftKey = hashPath(path)
+    const legacyEntry = legacyByKey.get(draftKey)
+    if (!legacyEntry || legacyEntry.path !== path) continue
+
+    const currentEntry = getIndexEntry(baseIndex, draftKey)
+    if (currentEntry) {
+      if (currentEntry.path !== path) hasHashCollision = true
+      continue
+    }
+    if (existingSet.has(draftKey) || legacyOnlyKeys.includes(draftKey)) continue
+    legacyOnlyKeys.push(draftKey)
+  }
+
+  const legacyCapacity = Math.max(0, MAX_DRAFTS - retainedExisting.length)
+  const retainedLegacy =
+    legacyCapacity > 0 ? legacyOnlyKeys.slice(-legacyCapacity) : []
+  const finalOrder = [...retainedLegacy, ...retainedExisting]
+  const finalEntries: DraftIndexV2['entries'] = {}
+
+  for (const draftKey of finalOrder) {
+    const currentEntry = getIndexEntry(baseIndex, draftKey)
+    if (currentEntry) {
+      finalEntries[draftKey] = currentEntry
       continue
     }
 
-    // Update index
-    const { index: newIndex } = upsertEntry(index, path, {
-      name: draft.name,
-      isTemporary: draft.isTemporary,
-      updatedAt: draft.updatedAt
-    })
-    index = newIndex
-    migrated++
+    const legacyEntry = legacyByKey.get(draftKey)
+    if (!legacyEntry) continue
+    finalEntries[draftKey] = {
+      path: legacyEntry.path,
+      name: legacyEntry.draft.name,
+      isTemporary: legacyEntry.draft.isTemporary,
+      updatedAt: legacyEntry.draft.updatedAt
+    }
+    // A V2 payload can survive after its index entry was lost. Re-index that
+    // newer payload instead of overwriting it with an older V1 copy.
+    if (!readPayload(workspaceId, draftKey)) {
+      payloadsToWrite.set(draftKey, legacyEntry.draft)
+    }
   }
 
-  // Write final index
-  if (!writeIndex(workspaceId, index)) {
-    console.error('[V2 Migration] Failed to write index')
-    return -1
+  // A retained-existing slice can discard only an already-invalid over-limit
+  // index. Never write payloads for entries that are not part of the commit.
+  for (const draftKey of [...payloadsToWrite.keys()]) {
+    if (
+      !retainedExistingSet.has(draftKey) &&
+      !retainedLegacy.includes(draftKey)
+    ) {
+      payloadsToWrite.delete(draftKey)
+    }
   }
 
-  // Migrate V1 tab state pointers to V2 sessionStorage format.
-  // V1 used setStorageValue which stored tab state in localStorage as fallback.
-  // V2 uses sessionStorage keyed by clientId. Without this migration,
-  // users upgrading from V1 lose their open tab list.
-  migrateV1TabState(workspaceId, clientId)
+  const finalIndex: DraftIndexV2 = {
+    v: 2,
+    updatedAt: Date.now(),
+    order: finalOrder,
+    entries: finalEntries
+  }
 
+  let commitResult = commitV2Recovery(workspaceId, finalIndex, payloadsToWrite)
+  const removableSources = hasHashCollision
+    ? []
+    : sources.filter((source) => source.cleanupSafe)
+  const cleanupEntries = removableSources.flatMap(sourceStorageEntries)
+  const redundantWorkflow = redundantLegacyWorkflowEntry(
+    workspaceId,
+    finalIndex,
+    payloadsToWrite
+  )
+  if (redundantWorkflow) cleanupEntries.push(redundantWorkflow)
+  let removedForRetry = false
+
+  if (commitResult === 'quota' && cleanupEntries.length > 0) {
+    // The old monolithic draft blob and legacy singleton can consume most of
+    // the origin's localStorage quota. Remove only data that is either fully
+    // parsed or byte-for-byte redundant, then retry the V2 commit.
+    const removedEntries = removeRawEntriesForRetry(cleanupEntries)
+    if (!removedEntries) return -1
+
+    removedForRetry = true
+    commitResult = commitV2Recovery(workspaceId, finalIndex, payloadsToWrite)
+    if (commitResult !== 'success') {
+      restoreRawEntries(removedEntries)
+      return -1
+    }
+  }
+
+  if (commitResult !== 'success') return -1
+
+  if (!removedForRetry) {
+    removeRawEntriesBestEffort(cleanupEntries)
+  }
+
+  migrateAndCleanupV1TabState(workspaceId, clientId)
+
+  if (hasHashCollision || sources.some((source) => !source.cleanupSafe)) {
+    console.warn(
+      '[V2 Migration] Some legacy data was left intact because it could not be safely cleaned'
+    )
+  }
+
+  const migrated = payloadsToWrite.size
   if (migrated > 0) {
-    console.warn(`[V2 Migration] Migrated ${migrated} drafts from V1 to V2`)
+    console.warn(`[V2 Migration] Recovered ${migrated} legacy draft(s) into V2`)
   }
   return migrated
 }
 
 /**
- * Migrates V1 tab state (open paths + active index) to V2 format.
- * V1 stored these in localStorage via setStorageValue fallback.
- * V2 uses sessionStorage keyed by clientId.
+ * Removes legacy workflow persistence keys for a workspace. The unscoped V1
+ * keys belong to the personal workspace only.
  */
-function migrateV1TabState(workspaceId: string, clientId?: string): void {
-  if (!clientId) return
-
+export function cleanupV1Data(workspaceId: string = getWorkspaceId()): void {
   try {
-    const pathsJson = localStorage.getItem(V1_KEYS.openPaths)
-    if (!pathsJson) return
-
-    const paths = JSON.parse(pathsJson)
-    if (!Array.isArray(paths) || paths.length === 0) return
-
-    const indexJson = localStorage.getItem(V1_KEYS.activeIndex)
-    let activeIndex = 0
-    if (indexJson !== null) {
-      const parsed = JSON.parse(indexJson)
-      if (typeof parsed === 'number' && Number.isFinite(parsed)) {
-        activeIndex = Math.min(Math.max(0, parsed), paths.length - 1)
-      }
+    for (const { draftsKey, orderKey } of v1KeyPairs(workspaceId)) {
+      localStorage.removeItem(draftsKey)
+      localStorage.removeItem(orderKey)
     }
-
-    writeOpenPaths(clientId, { workspaceId, paths, activeIndex })
+    if (workspaceId === 'personal') {
+      localStorage.removeItem(V1_KEYS.openPaths)
+      localStorage.removeItem(V1_KEYS.activeIndex)
+    }
   } catch {
-    // Best effort - don't block draft migration on tab state errors
+    // Ignore cleanup errors.
+  }
+}
+
+export function getMigrationStatus(workspaceId: string = getWorkspaceId()): {
+  v1Exists: boolean
+  v2Exists: boolean
+  v1DraftCount: number
+  v2DraftCount: number
+} {
+  const { sources } = readV1Sources(workspaceId)
+  const v1Data = mergedV1Data(sources)
+  const v2Index = readIndex(workspaceId)
+
+  return {
+    v1Exists: hasLegacyDraftStorage(workspaceId),
+    v2Exists: v2Index !== null,
+    v1DraftCount: v1Data.order.length,
+    v2DraftCount: v2Index ? v2Index.order.length : 0
   }
 }

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.persistenceControl.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.persistenceControl.test.ts
@@ -1,0 +1,57 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useWorkflowDraftStoreV2 } from './workflowDraftStoreV2'
+
+describe('workflowDraftStoreV2 persistence control', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    localStorage.clear()
+  })
+
+  it('supports nested idempotent persistence pauses', () => {
+    const store = useWorkflowDraftStoreV2()
+    const resumeOuter = store.pausePersistence()
+    const resumeInner = store.pausePersistence()
+
+    expect(store.isPersistencePaused()).toBe(true)
+    resumeInner()
+    expect(store.isPersistencePaused()).toBe(true)
+    resumeInner()
+    expect(store.isPersistencePaused()).toBe(true)
+    resumeOuter()
+    expect(store.isPersistencePaused()).toBe(false)
+  })
+
+  it('deduplicates one continuous save-failure episode', () => {
+    const store = useWorkflowDraftStoreV2()
+
+    expect(store.shouldNotifySaveFailure()).toBe(true)
+    expect(store.shouldNotifySaveFailure()).toBe(false)
+
+    store.markSaveSucceeded()
+    expect(store.shouldNotifySaveFailure()).toBe(true)
+    expect(store.shouldNotifySaveFailure()).toBe(false)
+
+    store.reset()
+    expect(store.shouldNotifySaveFailure()).toBe(true)
+  })
+
+  it('round-trips persisted graph modification metadata', () => {
+    const store = useWorkflowDraftStoreV2()
+    const path = 'workflows/dirty-metadata.json'
+
+    for (const isModified of [false, true]) {
+      expect(
+        store.saveDraft(path, '{"nodes":[]}', {
+          name: 'dirty-metadata.json',
+          isTemporary: false,
+          isModified
+        })
+      ).toBe(true)
+
+      expect(store.getDraft(path)?.isModified).toBe(isModified)
+    }
+  })
+})

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.quotaSafety.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.quotaSafety.test.ts
@@ -1,0 +1,603 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MAX_DRAFTS } from '../base/draftTypes'
+import { hashPath } from '../base/hashUtil'
+import { StorageKeys } from '../base/storageKeys'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    clientId: 'test-client',
+    initialClientId: 'test-client'
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    loadGraphData: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+class FakeStorage implements Storage {
+  [key: string]: unknown
+
+  readonly map = new Map<string, string>()
+  shouldFailWrite: (key: string, value: string) => boolean = () => false
+
+  get length(): number {
+    return this.map.size
+  }
+
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.shouldFailWrite(key, value)) {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError')
+    }
+    this.map.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}
+
+let fakeStorage: FakeStorage
+let realLocalStorage: Storage
+
+async function freshStore() {
+  vi.resetModules()
+  const { useWorkflowDraftStoreV2 } = await import('./workflowDraftStoreV2')
+  return useWorkflowDraftStoreV2()
+}
+
+describe('workflowDraftStoreV2 quota safety', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    realLocalStorage = globalThis.localStorage
+    fakeStorage = new FakeStorage()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: fakeStorage,
+      configurable: true,
+      writable: true
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: realLocalStorage,
+      configurable: true,
+      writable: true
+    })
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('restores existing draft history when an incoming draft can never fit', async () => {
+    const store = await freshStore()
+    expect(
+      store.saveDraft('workflows/a.json', '{"id":"a"}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft('workflows/b.json', '{"id":"b"}', {
+        name: 'b',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const targetKey = StorageKeys.draftPayload(
+      'workflows/too-large.json',
+      'personal'
+    )
+    fakeStorage.shouldFailWrite = (key) => key === targetKey
+
+    expect(
+      store.saveDraft('workflows/too-large.json', 'x'.repeat(1024), {
+        name: 'too-large',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(store.getDraft('workflows/a.json')?.data).toBe('{"id":"a"}')
+    expect(store.getDraft('workflows/b.json')?.data).toBe('{"id":"b"}')
+    expect(store.getDraft('workflows/too-large.json')).toBeNull()
+  })
+
+  it('persists again after a transient quota failure without reloading', async () => {
+    const store = await freshStore()
+    const failingKey = StorageKeys.draftPayload(
+      'workflows/blocked.json',
+      'personal'
+    )
+    fakeStorage.shouldFailWrite = (key) => key === failingKey
+
+    expect(
+      store.saveDraft('workflows/blocked.json', 'x'.repeat(64), {
+        name: 'blocked',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    fakeStorage.shouldFailWrite = () => false
+
+    expect(
+      store.saveDraft('workflows/recovered.json', '{"nodes":[]}', {
+        name: 'recovered',
+        isTemporary: true
+      })
+    ).toBe(true)
+    expect(store.getDraft('workflows/recovered.json')?.data).toBe(
+      '{"nodes":[]}'
+    )
+  })
+
+  it('restores the previous payload when an index update hits quota', async () => {
+    const store = await freshStore()
+    expect(
+      store.saveDraft('workflows/a.json', '{"version":1}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const indexKey = StorageKeys.draftIndex('personal')
+    let failNextIndexWrite = true
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key !== indexKey || !failNextIndexWrite) return false
+      failNextIndexWrite = false
+      return true
+    }
+
+    expect(
+      store.saveDraft('workflows/a.json', '{"version":2}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(store.getDraft('workflows/a.json')?.data).toBe('{"version":1}')
+  })
+
+  it('restores prior evictions when a later eviction-index write fails', async () => {
+    const store = await freshStore()
+    expect(
+      store.saveDraft('workflows/a.json', '{"id":"a"}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft('workflows/b.json', '{"id":"b"}', {
+        name: 'b',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const targetKey = StorageKeys.draftPayload(
+      'workflows/incoming.json',
+      'personal'
+    )
+    const indexKey = StorageKeys.draftIndex('personal')
+    let targetAttempts = 0
+    let evictionIndexWrites = 0
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key === targetKey) {
+        targetAttempts++
+        return true
+      }
+      if (key === indexKey) {
+        evictionIndexWrites++
+        return evictionIndexWrites === 2
+      }
+      return false
+    }
+
+    expect(
+      store.saveDraft('workflows/incoming.json', 'x'.repeat(1024), {
+        name: 'incoming',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(targetAttempts).toBeGreaterThan(1)
+    expect(store.getDraft('workflows/a.json')?.data).toBe('{"id":"a"}')
+    expect(store.getDraft('workflows/b.json')?.data).toBe('{"id":"b"}')
+    expect(store.getDraft('workflows/incoming.json')).toBeNull()
+  })
+
+  it('restores prior evictions when the final incoming index cannot commit', async () => {
+    const store = await freshStore()
+    expect(
+      store.saveDraft('workflows/a.json', '{"id":"a"}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft('workflows/b.json', '{"id":"b"}', {
+        name: 'b',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const targetPath = 'workflows/incoming.json'
+    const targetKey = StorageKeys.draftPayload(targetPath, 'personal')
+    const targetDraftKey = hashPath(targetPath)
+    const indexKey = StorageKeys.draftIndex('personal')
+    let targetWrites = 0
+    fakeStorage.shouldFailWrite = (key, value) => {
+      if (key === targetKey) {
+        targetWrites++
+        return targetWrites === 1
+      }
+      if (key === indexKey) {
+        const index = JSON.parse(value) as {
+          entries: Partial<Record<string, unknown>>
+        }
+        return Boolean(index.entries[targetDraftKey])
+      }
+      return false
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"id":"incoming"}', {
+        name: 'incoming',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(targetWrites).toBeGreaterThan(1)
+    expect(store.getDraft('workflows/a.json')?.data).toBe('{"id":"a"}')
+    expect(store.getDraft('workflows/b.json')?.data).toBe('{"id":"b"}')
+    expect(store.getDraft(targetPath)).toBeNull()
+  })
+
+  it('rolls back the payload under the exact key removed from a drifted index', async () => {
+    const path = 'workflows/a.json'
+    const actualKey = hashPath(path)
+    const staleKey = actualKey === 'deadbeef' ? 'feedface' : 'deadbeef'
+    const indexKey = StorageKeys.draftIndex('personal')
+    const payloadPrefix = `${StorageKeys.prefixes.draftPayload}personal:`
+
+    fakeStorage.setItem(
+      indexKey,
+      JSON.stringify({
+        v: 2,
+        updatedAt: 1,
+        order: [staleKey, actualKey],
+        entries: {
+          [staleKey]: {
+            path,
+            name: 'stale-alias',
+            isTemporary: false,
+            updatedAt: 1
+          },
+          [actualKey]: {
+            path,
+            name: 'a',
+            isTemporary: false,
+            updatedAt: 2
+          }
+        }
+      })
+    )
+    fakeStorage.setItem(
+      `${payloadPrefix}${staleKey}`,
+      JSON.stringify({ data: '{"id":"wrong"}', updatedAt: 1 })
+    )
+    fakeStorage.setItem(
+      `${payloadPrefix}${actualKey}`,
+      JSON.stringify({ data: '{"id":"correct"}', updatedAt: 2 })
+    )
+
+    const store = await freshStore()
+    const targetKey = StorageKeys.draftPayload(
+      'workflows/incoming.json',
+      'personal'
+    )
+    fakeStorage.shouldFailWrite = (key) => key === targetKey
+
+    expect(
+      store.saveDraft('workflows/incoming.json', 'x'.repeat(1024), {
+        name: 'incoming',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(store.getDraft(path)?.data).toBe('{"id":"correct"}')
+  })
+
+  it('removes a drifted entry together with its stale order key', async () => {
+    const driftedPath = 'workflows/drifted.json'
+    const canonicalDriftedKey = hashPath(driftedPath)
+    const staleKey =
+      canonicalDriftedKey === 'deadbeef' ? 'feedface' : 'deadbeef'
+    const validPath = 'workflows/valid.json'
+    const validKey = hashPath(validPath)
+    const indexKey = StorageKeys.draftIndex('personal')
+    const payloadPrefix = `${StorageKeys.prefixes.draftPayload}personal:`
+
+    fakeStorage.setItem(
+      indexKey,
+      JSON.stringify({
+        v: 2,
+        updatedAt: 1,
+        order: [staleKey, validKey],
+        entries: {
+          [staleKey]: {
+            path: driftedPath,
+            name: 'drifted',
+            isTemporary: false,
+            updatedAt: 1
+          },
+          [validKey]: {
+            path: validPath,
+            name: 'valid',
+            isTemporary: false,
+            updatedAt: 2
+          }
+        }
+      })
+    )
+    fakeStorage.setItem(
+      `${payloadPrefix}${staleKey}`,
+      JSON.stringify({ data: '{"id":"drifted"}', updatedAt: 1 })
+    )
+    fakeStorage.setItem(
+      `${payloadPrefix}${validKey}`,
+      JSON.stringify({ data: '{"id":"valid"}', updatedAt: 2 })
+    )
+
+    const store = await freshStore()
+    const targetPath = 'workflows/incoming-after-drift.json'
+    const targetStorageKey = StorageKeys.draftPayload(targetPath, 'personal')
+    let targetWrites = 0
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key !== targetStorageKey) return false
+      targetWrites++
+      return targetWrites === 1
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"id":"incoming"}', {
+        name: 'incoming',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const persistedIndex = JSON.parse(fakeStorage.getItem(indexKey)!) as {
+      order: string[]
+      entries: Record<string, unknown>
+    }
+    expect(persistedIndex.order).not.toContain(staleKey)
+    expect(persistedIndex.entries[staleKey]).toBeUndefined()
+    expect(fakeStorage.getItem(`${payloadPrefix}${staleKey}`)).toBeNull()
+    expect(store.getDraft(targetPath)?.data).toBe('{"id":"incoming"}')
+  })
+
+  it('restores exact previous payload bytes when an index update fails', async () => {
+    const path = 'workflows/raw-rollback.json'
+    const draftKey = hashPath(path)
+    const indexKey = StorageKeys.draftIndex('personal')
+    const payloadKey = StorageKeys.draftPayload(path, 'personal')
+    const rawPayload = 'malformed-but-previously-stored-payload'
+
+    fakeStorage.setItem(
+      indexKey,
+      JSON.stringify({
+        v: 2,
+        updatedAt: 1,
+        order: [draftKey],
+        entries: {
+          [draftKey]: {
+            path,
+            name: 'raw-rollback',
+            isTemporary: false,
+            updatedAt: 1
+          }
+        }
+      })
+    )
+    fakeStorage.setItem(payloadKey, rawPayload)
+
+    const store = await freshStore()
+    let failNextIndexWrite = true
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key !== indexKey || !failNextIndexWrite) return false
+      failNextIndexWrite = false
+      return true
+    }
+
+    expect(
+      store.saveDraft(path, '{"new":true}', {
+        name: 'raw-rollback',
+        isTemporary: false
+      })
+    ).toBe(false)
+    expect(fakeStorage.getItem(payloadKey)).toBe(rawPayload)
+  })
+
+  it('drops a recovered cache when the rollback index itself cannot persist', async () => {
+    const store = await freshStore()
+    const aPath = 'workflows/a.json'
+    const bPath = 'workflows/b.json'
+    expect(
+      store.saveDraft(aPath, '{"id":"a"}', {
+        name: 'a',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(bPath, '{"id":"b"}', {
+        name: 'b',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const aKey = hashPath(aPath)
+    const bKey = hashPath(bPath)
+    const targetPath = 'workflows/rollback-index-failure.json'
+    const targetKey = StorageKeys.draftPayload(targetPath, 'personal')
+    const targetDraftKey = hashPath(targetPath)
+    const indexKey = StorageKeys.draftIndex('personal')
+    let targetPayloadRejected = false
+    let rejectedRollbackIndex = false
+
+    fakeStorage.shouldFailWrite = (key, value) => {
+      if (key === targetKey && !targetPayloadRejected) {
+        targetPayloadRejected = true
+        return true
+      }
+      if (key !== indexKey) return false
+
+      const index = JSON.parse(value) as {
+        entries: Partial<Record<string, unknown>>
+      }
+      if (index.entries[targetDraftKey]) return true
+      if (
+        index.entries[aKey] &&
+        index.entries[bKey] &&
+        !rejectedRollbackIndex
+      ) {
+        rejectedRollbackIndex = true
+        return true
+      }
+      return false
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"id":"target"}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(false)
+    expect(rejectedRollbackIndex).toBe(true)
+
+    const durableIndex = JSON.parse(fakeStorage.getItem(indexKey)!) as {
+      entries: Record<string, unknown>
+    }
+    expect(durableIndex.entries[aKey]).toBeUndefined()
+    expect(durableIndex.entries[bKey]).toBeDefined()
+
+    fakeStorage.shouldFailWrite = () => false
+    expect(
+      store.saveDraft('workflows/after-rollback.json', '{"id":"after"}', {
+        name: 'after',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(store.getDraft(aPath)).toBeNull()
+    expect(store.getDraft(bPath)?.data).toBe('{"id":"b"}')
+  })
+
+  it('deletes payloads evicted by the final quota-retry upsert', async () => {
+    const paths = Array.from(
+      { length: MAX_DRAFTS + 1 },
+      (_, index) => `workflows/over-limit-${index}.json`
+    )
+    const order: string[] = []
+    const entries: Record<
+      string,
+      {
+        path: string
+        name: string
+        isTemporary: boolean
+        updatedAt: number
+      }
+    > = {}
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    for (const [index, path] of paths.entries()) {
+      const draftKey = hashPath(path)
+      order.push(draftKey)
+      entries[draftKey] = {
+        path,
+        name: `over-limit-${index}`,
+        isTemporary: false,
+        updatedAt: index + 1
+      }
+      fakeStorage.setItem(
+        StorageKeys.draftPayload(path, 'personal'),
+        JSON.stringify({ data: `{"id":${index}}`, updatedAt: index + 1 })
+      )
+    }
+    fakeStorage.setItem(
+      indexKey,
+      JSON.stringify({ v: 2, updatedAt: 1, order, entries })
+    )
+
+    const store = await freshStore()
+    const targetPath = 'workflows/quota-retry.json'
+    const targetPayloadKey = StorageKeys.draftPayload(targetPath, 'personal')
+    let targetWrites = 0
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key !== targetPayloadKey) return false
+      targetWrites++
+      return targetWrites === 1
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"id":"target"}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    expect(
+      fakeStorage.getItem(StorageKeys.draftPayload(paths[0], 'personal'))
+    ).toBeNull()
+    expect(
+      fakeStorage.getItem(StorageKeys.draftPayload(paths[1], 'personal'))
+    ).toBeNull()
+    const persistedIndex = JSON.parse(fakeStorage.getItem(indexKey)!) as {
+      order: string[]
+    }
+    expect(persistedIndex.order).toHaveLength(MAX_DRAFTS)
+    expect(store.getDraft(targetPath)?.data).toBe('{"id":"target"}')
+  })
+
+  it('does not delete an LRU draft before the replacement index commits', async () => {
+    const store = await freshStore()
+    for (let i = 0; i < MAX_DRAFTS; i++) {
+      expect(
+        store.saveDraft(`workflows/draft${i}.json`, `{"id":${i}}`, {
+          name: `draft${i}`,
+          isTemporary: false
+        })
+      ).toBe(true)
+    }
+
+    const indexKey = StorageKeys.draftIndex('personal')
+    let failNextIndexWrite = true
+    fakeStorage.shouldFailWrite = (key) => {
+      if (key !== indexKey || !failNextIndexWrite) return false
+      failNextIndexWrite = false
+      return true
+    }
+
+    expect(
+      store.saveDraft('workflows/new.json', '{"id":"new"}', {
+        name: 'new',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(store.getDraft('workflows/draft0.json')?.data).toBe('{"id":0}')
+    expect(store.getDraft('workflows/new.json')).toBeNull()
+  })
+})

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.rollbackSafety.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.rollbackSafety.test.ts
@@ -1,0 +1,490 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { hashPath } from '../base/hashUtil'
+import { StorageKeys } from '../base/storageKeys'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    clientId: 'test-client',
+    initialClientId: 'test-client'
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    loadGraphData: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+class FaultInjectingStorage implements Storage {
+  [key: string]: unknown
+
+  readonly map = new Map<string, string>()
+  writeError: (key: string, value: string) => Error | null = () => null
+
+  get length(): number {
+    return this.map.size
+  }
+
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    const error = this.writeError(key, value)
+    if (error) throw error
+    this.map.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}
+
+let storage: FaultInjectingStorage
+let realLocalStorage: Storage
+
+async function freshStore() {
+  vi.resetModules()
+  const { useWorkflowDraftStoreV2 } = await import('./workflowDraftStoreV2')
+  return useWorkflowDraftStoreV2()
+}
+
+function quotaError(): DOMException {
+  return new DOMException('Quota exceeded', 'QuotaExceededError')
+}
+
+describe('workflowDraftStoreV2 overwrite and rollback safety', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    realLocalStorage = globalThis.localStorage
+    storage = new FaultInjectingStorage()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: storage,
+      configurable: true,
+      writable: true
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: realLocalStorage,
+      configurable: true,
+      writable: true
+    })
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('does not read the existing workflow payload on a successful overwrite', async () => {
+    const store = await freshStore()
+    const path = 'workflows/target.json'
+    const payloadKey = StorageKeys.draftPayload(path, 'personal')
+
+    expect(
+      store.saveDraft(path, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const getItemSpy = vi.spyOn(storage, 'getItem')
+    getItemSpy.mockClear()
+
+    expect(
+      store.saveDraft(path, '{"version":2}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    expect(getItemSpy).not.toHaveBeenCalledWith(payloadKey)
+    expect(store.getDraft(path)?.data).toBe('{"version":2}')
+  })
+
+  it('leaves the committed payload untouched when the metadata write fails', async () => {
+    const store = await freshStore()
+    const path = 'workflows/target.json'
+    const payloadKey = StorageKeys.draftPayload(path, 'personal')
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(path, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    const previousPayload = storage.getItem(payloadKey)!
+
+    storage.writeError = (key) => (key === indexKey ? quotaError() : null)
+
+    expect(
+      store.saveDraft(path, '{"version":2}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(storage.getItem(payloadKey)).toBe(previousPayload)
+    storage.writeError = () => null
+    expect(store.getDraft(path)?.data).toBe('{"version":1}')
+  })
+
+  it('recovers an overwrite when its metadata write hits quota', async () => {
+    const store = await freshStore()
+    const evictedPath = 'workflows/evicted.json'
+    const targetPath = 'workflows/target.json'
+    const evictedDraftKey = hashPath(evictedPath)
+    const targetDraftKey = hashPath(targetPath)
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(evictedPath, '{"id":"evicted"}', {
+        name: 'evicted',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(targetPath, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    let metadataWriteRejected = false
+    storage.writeError = (key, value) => {
+      if (key !== indexKey || metadataWriteRejected) return null
+      const index = JSON.parse(value) as {
+        entries?: Partial<Record<string, { name?: string }>>
+      }
+      if (
+        index.entries?.[targetDraftKey]?.name === 'target-updated' &&
+        index.entries[evictedDraftKey]
+      ) {
+        metadataWriteRejected = true
+        return quotaError()
+      }
+      return null
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"version":2}', {
+        name: 'target-updated',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    expect(metadataWriteRejected).toBe(true)
+    expect(store.getDraft(evictedPath)).toBeNull()
+    expect(store.getDraft(targetPath)?.data).toBe('{"version":2}')
+    expect(store.getDraft(targetPath)?.name).toBe('target-updated')
+  })
+
+  it('keeps the old payload recoverable if restoring metadata after quota failure also fails', async () => {
+    const store = await freshStore()
+    const path = 'workflows/target.json'
+    const payloadKey = StorageKeys.draftPayload(path, 'personal')
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(path, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    const previousPayload = storage.getItem(payloadKey)!
+
+    let payloadWrites = 0
+    let indexWrites = 0
+    storage.writeError = (key) => {
+      if (key === indexKey) {
+        indexWrites++
+        if (indexWrites === 2) return quotaError()
+      }
+      if (key === payloadKey) {
+        payloadWrites++
+        if (payloadWrites === 1) return quotaError()
+      }
+      return null
+    }
+
+    expect(
+      store.saveDraft(path, '{"version":2}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(payloadWrites).toBeGreaterThan(0)
+    expect(indexWrites).toBeGreaterThan(1)
+    expect(storage.getItem(payloadKey)).toBe(previousPayload)
+
+    storage.writeError = () => null
+    expect(store.getDraft(path)?.data).toBe('{"version":1}')
+  })
+
+  it('takes the raw rollback snapshot only after an overwrite hits quota', async () => {
+    const store = await freshStore()
+    const targetPath = 'workflows/target.json'
+    const evictedPath = 'workflows/evicted.json'
+    const targetPayloadKey = StorageKeys.draftPayload(targetPath, 'personal')
+
+    expect(
+      store.saveDraft(targetPath, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(evictedPath, '{"id":"evicted"}', {
+        name: 'evicted',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    const getItemSpy = vi.spyOn(storage, 'getItem')
+    getItemSpy.mockClear()
+
+    let targetWrites = 0
+    storage.writeError = (key) => {
+      if (key === targetPayloadKey && targetWrites++ === 0) {
+        return quotaError()
+      }
+      return null
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"version":2}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+
+    expect(getItemSpy).toHaveBeenCalledWith(targetPayloadKey)
+    expect(store.getDraft(targetPath)?.data).toBe('{"version":2}')
+  })
+
+  it('retries exact target rollback after removing an uncommitted replacement', async () => {
+    const store = await freshStore()
+    const targetPath = 'workflows/target.json'
+    const evictedPath = 'workflows/evicted.json'
+    const targetPayloadKey = StorageKeys.draftPayload(targetPath, 'personal')
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(targetPath, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(evictedPath, '{"id":"evicted"}', {
+        name: 'evicted',
+        isTemporary: false
+      })
+    ).toBe(true)
+    const previousPayload = storage.getItem(targetPayloadKey)!
+    const targetDraftKey = hashPath(targetPath)
+    const evictedDraftKey = hashPath(evictedPath)
+
+    let incomingWriteRejected = false
+    let finalIndexRejected = false
+    let directRollbackFailed = false
+    storage.writeError = (key, value) => {
+      if (key === targetPayloadKey) {
+        if (value === previousPayload && !directRollbackFailed) {
+          directRollbackFailed = true
+          return quotaError()
+        }
+        if (value !== previousPayload && !incomingWriteRejected) {
+          incomingWriteRejected = true
+          return quotaError()
+        }
+      }
+      if (key === indexKey && !finalIndexRejected) {
+        const index = JSON.parse(value) as {
+          entries?: Partial<Record<string, { name?: string }>>
+        }
+        if (
+          index.entries?.[targetDraftKey]?.name === 'target-updated' &&
+          !index.entries[evictedDraftKey]
+        ) {
+          finalIndexRejected = true
+          return quotaError()
+        }
+      }
+      return null
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"version":2}', {
+        name: 'target-updated',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    expect(incomingWriteRejected).toBe(true)
+    expect(finalIndexRejected).toBe(true)
+    expect(directRollbackFailed).toBe(true)
+    expect(storage.getItem(targetPayloadKey)).toBe(previousPayload)
+    expect(store.getDraft(targetPath)?.data).toBe('{"version":1}')
+    expect(store.getDraft(evictedPath)?.data).toBe('{"id":"evicted"}')
+  })
+
+  it('restores target and evictions when the final index write throws', async () => {
+    const store = await freshStore()
+    const evictedPath = 'workflows/evicted.json'
+    const targetPath = 'workflows/target.json'
+    const evictedDraftKey = hashPath(evictedPath)
+    const targetDraftKey = hashPath(targetPath)
+    const targetPayloadKey = StorageKeys.draftPayload(targetPath, 'personal')
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(evictedPath, '{"id":"evicted"}', {
+        name: 'evicted',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(targetPath, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    const previousPayload = storage.getItem(targetPayloadKey)!
+    const interruption = new Error('index write interrupted')
+    let incomingWriteRejected = false
+    let finalIndexInterrupted = false
+
+    storage.writeError = (key, value) => {
+      if (
+        key === targetPayloadKey &&
+        value !== previousPayload &&
+        !incomingWriteRejected
+      ) {
+        incomingWriteRejected = true
+        return quotaError()
+      }
+      if (key === indexKey && incomingWriteRejected && !finalIndexInterrupted) {
+        const index = JSON.parse(value) as {
+          entries?: Partial<Record<string, { name?: string }>>
+        }
+        if (
+          index.entries?.[targetDraftKey]?.name === 'target-updated' &&
+          !index.entries[evictedDraftKey]
+        ) {
+          finalIndexInterrupted = true
+          return interruption
+        }
+      }
+      return null
+    }
+
+    expect(() =>
+      store.saveDraft(targetPath, '{"version":2}', {
+        name: 'target-updated',
+        isTemporary: false
+      })
+    ).toThrow(interruption)
+
+    expect(incomingWriteRejected).toBe(true)
+    expect(finalIndexInterrupted).toBe(true)
+    expect(storage.getItem(targetPayloadKey)).toBe(previousPayload)
+
+    storage.writeError = () => null
+    expect(store.getDraft(targetPath)?.data).toBe('{"version":1}')
+    expect(store.getDraft(targetPath)?.name).toBe('target')
+    expect(store.getDraft(evictedPath)?.data).toBe('{"id":"evicted"}')
+  })
+
+  it('continues quota rollback and drops target ownership when target restoration is interrupted', async () => {
+    const store = await freshStore()
+    const targetPath = 'workflows/target.json'
+    const evictedPath = 'workflows/evicted.json'
+    const targetPayloadKey = StorageKeys.draftPayload(targetPath, 'personal')
+    const targetDraftKey = hashPath(targetPath)
+    const evictedDraftKey = hashPath(evictedPath)
+    const indexKey = StorageKeys.draftIndex('personal')
+
+    expect(
+      store.saveDraft(targetPath, '{"version":1}', {
+        name: 'target',
+        isTemporary: false
+      })
+    ).toBe(true)
+    expect(
+      store.saveDraft(evictedPath, '{"id":"evicted"}', {
+        name: 'evicted',
+        isTemporary: false
+      })
+    ).toBe(true)
+    const previousPayload = storage.getItem(targetPayloadKey)!
+
+    let incomingWriteRejected = false
+    let finalIndexRejected = false
+    let rollbackPayloadAttempts = 0
+    storage.writeError = (key, value) => {
+      if (key === targetPayloadKey) {
+        if (value === previousPayload) {
+          rollbackPayloadAttempts++
+          if (rollbackPayloadAttempts === 1) return quotaError()
+          if (rollbackPayloadAttempts === 2) {
+            return new Error('rollback interrupted')
+          }
+        } else if (!incomingWriteRejected) {
+          incomingWriteRejected = true
+          return quotaError()
+        }
+      }
+      if (key === indexKey && !finalIndexRejected) {
+        const index = JSON.parse(value) as {
+          entries?: Partial<Record<string, { name?: string }>>
+        }
+        if (
+          index.entries?.[targetDraftKey]?.name === 'target-updated' &&
+          !index.entries[evictedDraftKey]
+        ) {
+          finalIndexRejected = true
+          return quotaError()
+        }
+      }
+      return null
+    }
+
+    expect(
+      store.saveDraft(targetPath, '{"version":2}', {
+        name: 'target-updated',
+        isTemporary: false
+      })
+    ).toBe(false)
+
+    storage.writeError = () => null
+    const durableIndex = JSON.parse(storage.getItem(indexKey)!) as {
+      order: string[]
+      entries: Record<string, unknown>
+    }
+
+    expect(incomingWriteRejected).toBe(true)
+    expect(finalIndexRejected).toBe(true)
+    expect(rollbackPayloadAttempts).toBe(2)
+    expect(storage.getItem(targetPayloadKey)).toBeNull()
+    expect(durableIndex.order).not.toContain(targetDraftKey)
+    expect(durableIndex.entries[targetDraftKey]).toBeUndefined()
+    expect(durableIndex.order).toContain(evictedDraftKey)
+    expect(durableIndex.entries[evictedDraftKey]).toBeDefined()
+    expect(store.getDraft(targetPath)).toBeNull()
+    expect(store.getDraft(evictedPath)?.data).toBe('{"id":"evicted"}')
+  })
+})

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -2,6 +2,7 @@ import type { MockInstance } from 'vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { reportError } from '@/platform/telemetry/reportError'
+import { app as comfyApp } from '@/scripts/app'
 
 import { createEmptyIndex } from '../base/draftCacheV2'
 import { MAX_DRAFTS } from '../base/draftTypes'
@@ -22,6 +23,8 @@ vi.mock<unknown>(import('@/scripts/app'), () => ({
     loadGraphData: vi.fn().mockResolvedValue(undefined)
   }
 }))
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 
 const reportErrorMock = vi.hoisted(() => vi.fn<typeof reportError>())
 vi.mock(import('@/platform/telemetry/reportError'), () => ({
@@ -372,19 +375,22 @@ describe('workflowDraftStoreV2', () => {
       )
     })
 
-    it('rolls the persisted index back when the final index write fails after eviction', () => {
+    it('restores the evicted draft when the final index write fails', () => {
       const store = useWorkflowDraftStoreV2()
       seedDraftDirect('workflows/a.json', '{"id":"a"}', 'a')
 
       let payloadFailures = 0
-      let indexFailureInjected = false
+      let indexWrites = 0
+      let finalIndexFailureInjected = false
       withQuotaMock((key) => {
         if (key.startsWith(PAYLOAD_PREFIX) && payloadFailures === 0) {
           payloadFailures++
           return true
         }
-        if (key !== INDEX_KEY || indexFailureInjected) return false
-        indexFailureInjected = true
+        if (key !== INDEX_KEY) return false
+        indexWrites++
+        if (indexWrites !== 2 || finalIndexFailureInjected) return false
+        finalIndexFailureInjected = true
         return true
       })
 
@@ -393,12 +399,13 @@ describe('workflowDraftStoreV2', () => {
         isTemporary: true
       })
       expect(ok).toBe(false)
-      expect(indexFailureInjected).toBe(true)
+      expect(finalIndexFailureInjected).toBe(true)
 
       const persisted = readIndexFromStorage()
       expect(persisted.order).not.toContain(hashPath('workflows/incoming.json'))
-      expect(persisted.order).not.toContain(hashPath('workflows/a.json'))
+      expect(persisted.order).toContain(hashPath('workflows/a.json'))
       expect(store.getDraft('workflows/incoming.json')).toBeNull()
+      expect(store.getDraft('workflows/a.json')?.data).toBe('{"id":"a"}')
     })
   })
 
@@ -491,6 +498,7 @@ describe('workflowDraftStoreV2', () => {
       })
 
       const result = await store.loadPersistedWorkflow({
+        workflowName: null,
         preferredPath: 'workflows/test.json'
       })
 
@@ -506,6 +514,7 @@ describe('workflowDraftStoreV2', () => {
       })
 
       const result = await store.loadPersistedWorkflow({
+        workflowName: null,
         preferredPath: 'workflows/missing.json',
         fallbackToLatestDraft: true
       })
@@ -513,10 +522,47 @@ describe('workflowDraftStoreV2', () => {
       expect(result).toBe(true)
     })
 
+    it('does not use unscoped legacy fallbacks outside personal workspace', async () => {
+      sessionStorage.setItem(
+        'Comfy.Workspace.Current',
+        JSON.stringify({ type: 'team', id: 'team-workspace' })
+      )
+      sessionStorage.setItem('workflow:test-client', '{"nodes":[1]}')
+      localStorage.setItem('workflow', '{"nodes":[2]}')
+      const store = useWorkflowDraftStoreV2()
+
+      const result = await store.loadPersistedWorkflow({
+        workflowName: null,
+        fallbackToLatestDraft: true
+      })
+
+      expect(result).toBe(false)
+      expect(comfyApp.loadGraphData).not.toHaveBeenCalled()
+    })
+
+    it('keeps the legacy fallback available in personal workspace', async () => {
+      sessionStorage.setItem('workflow:test-client', '{"nodes":[]}')
+      const store = useWorkflowDraftStoreV2()
+
+      const result = await store.loadPersistedWorkflow({
+        workflowName: null,
+        fallbackToLatestDraft: true
+      })
+
+      expect(result).toBe(true)
+      expect(comfyApp.loadGraphData).toHaveBeenCalledWith(
+        { nodes: [] },
+        true,
+        true,
+        null
+      )
+    })
+
     it('returns false when no drafts available', async () => {
       const store = useWorkflowDraftStoreV2()
 
       const result = await store.loadPersistedWorkflow({
+        workflowName: null,
         fallbackToLatestDraft: true
       })
 

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.ts
@@ -9,9 +9,10 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 import { reportError } from '@/platform/telemetry/reportError'
+import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 
-import type { DraftIndexV2 } from '../base/draftTypes'
+import type { DraftIndexV2, DraftPayloadV2 } from '../base/draftTypes'
 import { MAX_DRAFTS } from '../base/draftTypes'
 import {
   createEmptyIndex,
@@ -31,19 +32,22 @@ import {
   deletePayloads,
   getPayloadKeys,
   isStorageAvailable,
-  markStorageUnavailable,
   readIndex,
   readPayload,
+  readPayloadRaw,
   writeIndex,
-  writePayload
+  writePayload,
+  writePayloadRaw
 } from '../base/storageIO'
 
 interface DraftMeta {
   name: string
   isTemporary: boolean
+  isModified?: boolean
 }
 
 interface LoadPersistedWorkflowOptions {
+  workflowName: string | null
   preferredPath?: string | null
   fallbackToLatestDraft?: boolean
 }
@@ -52,6 +56,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
   // In-memory cache of the index per workspace (synced with localStorage)
   // Key is workspaceId, value is the cached index
   const indexCacheByWorkspace = ref<Record<string, DraftIndexV2>>({})
+  let saveFailureNotified = false
+  let persistencePauseDepth = 0
 
   /**
    * Gets the current workspace ID fresh (not cached).
@@ -59,6 +65,42 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
    */
   function currentWorkspaceId(): string {
     return getWorkspaceId()
+  }
+
+  /**
+   * Returns true only for the first failure in a continuous persistence-failure
+   * episode. localStorage quota/availability is shared by all workflow paths,
+   * and a single graph load can invoke both draft-save callers.
+   */
+  function shouldNotifySaveFailure(): boolean {
+    if (saveFailureNotified) return false
+    saveFailureNotified = true
+    return true
+  }
+
+  /** Any successful draft save proves persistence recovered and resets the episode. */
+  function markSaveSucceeded(): void {
+    saveFailureNotified = false
+  }
+
+  /**
+   * Temporarily suppresses draft writes initiated by graph-load lifecycle hooks.
+   * This is caller-coordination state rather than a storage mutex: lifecycle
+   * callers check isPersistencePaused() before invoking the low-level saveDraft
+   * primitive. The returned resume function is idempotent and supports nesting.
+   */
+  function pausePersistence(): () => void {
+    persistencePauseDepth++
+    let resumed = false
+    return () => {
+      if (resumed) return
+      resumed = true
+      persistencePauseDepth = Math.max(0, persistencePauseDepth - 1)
+    }
+  }
+
+  function isPersistencePaused(): boolean {
+    return persistencePauseDepth > 0
   }
 
   /**
@@ -104,7 +146,8 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
 
   /**
    * Saves a draft (data + metadata).
-   * Primes index cache, writes payload, then persists updated index.
+   * Existing overwrites commit small metadata before atomically replacing the
+   * payload; exceptional failure paths retain exact rollback semantics.
    */
   function saveDraft(path: string, data: string, meta: DraftMeta): boolean {
     if (!isStorageAvailable()) return false
@@ -117,17 +160,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     // loadIndex() runs orphan cleanup on cache miss, which would
     // delete a payload written before the index is updated.
     const index = loadIndex()
-
-    // Write payload before persisting the updated index
-    const payloadWritten = writePayload(workspaceId, draftKey, {
-      data,
-      updatedAt: now
-    })
-
-    if (!payloadWritten) {
-      // Quota exceeded - try eviction loop
-      return handleQuotaExceeded(path, data, meta)
-    }
+    const existingEntry = getIndexEntry(index, draftKey)
     const { index: newIndex, evicted } = upsertEntry(
       index,
       path,
@@ -135,9 +168,72 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       MAX_DRAFTS
     )
 
+    // Overwriting an indexed draft is the normal autosave/tab-switch path.
+    // Commit its small metadata update first so we do not synchronously read
+    // and copy the entire previous workflow payload solely for a rollback that
+    // is only needed if a later index write fails. localStorage.setItem() is
+    // atomic: if the payload write fails, the previous payload is unchanged.
+    if (existingEntry && evicted.length === 0) {
+      if (!persistIndex(newIndex)) {
+        indexCacheByWorkspace.value[workspaceId] = index
+        const previousPayload = readPayloadRaw(workspaceId, draftKey)
+        return handleQuotaExceeded(path, data, meta, previousPayload)
+      }
+
+      let payloadWritten: boolean
+      try {
+        payloadWritten = writePayload(workspaceId, draftKey, {
+          data,
+          updatedAt: now
+        })
+      } catch (error) {
+        if (!persistIndex(index)) {
+          delete indexCacheByWorkspace.value[workspaceId]
+        }
+        throw error
+      }
+
+      if (payloadWritten) return true
+
+      // A failed setItem leaves the old payload intact. Restore the old index
+      // before entering quota recovery, then take the expensive raw snapshot
+      // only on this exceptional path where rollback may actually need it.
+      if (!persistIndex(index)) {
+        delete indexCacheByWorkspace.value[workspaceId]
+        return false
+      }
+      const previousPayload = readPayloadRaw(workspaceId, draftKey)
+      return handleQuotaExceeded(path, data, meta, previousPayload)
+    }
+
+    // New/unindexed targets can be rolled back by deletion, so there is no
+    // committed payload to snapshot on the successful path. Keep the raw read
+    // for the unusual indexed+eviction case only.
+    const previousPayload = existingEntry
+      ? readPayloadRaw(workspaceId, draftKey)
+      : null
+
+    // Write payload before persisting the updated index.
+    const payloadWritten = writePayload(workspaceId, draftKey, {
+      data,
+      updatedAt: now
+    })
+
+    if (!payloadWritten) {
+      return handleQuotaExceeded(path, data, meta, previousPayload)
+    }
+
+    // Commit index ownership before deleting LRU payloads. If the index write
+    // fails, the previous payload/index pair remains recoverable.
     if (!persistIndex(newIndex)) {
-      deletePayload(workspaceId, draftKey)
-      persistIndex(index)
+      if (restoreTargetPayload(workspaceId, draftKey, previousPayload)) {
+        indexCacheByWorkspace.value[workspaceId] = index
+      } else {
+        delete indexCacheByWorkspace.value[workspaceId]
+        console.error(
+          '[Workflow Drafts] Failed to restore target payload after index write failure'
+        )
+      }
       return false
     }
 
@@ -145,68 +241,240 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     return true
   }
 
+  function restoreTargetPayload(
+    workspaceId: string,
+    draftKey: string,
+    previousPayload: string | null
+  ): boolean {
+    if (previousPayload === null) {
+      return deletePayload(workspaceId, draftKey)
+    }
+
+    try {
+      if (writePayloadRaw(workspaceId, draftKey, previousPayload)) return true
+    } catch (error) {
+      console.error(
+        '[Workflow Drafts] Failed to restore target payload directly',
+        error
+      )
+    }
+
+    // Replacing a larger failed payload can itself hit quota. Removing the
+    // uncommitted replacement first frees its bytes before retrying the exact
+    // previous payload.
+    if (!deletePayload(workspaceId, draftKey)) return false
+
+    try {
+      return writePayloadRaw(workspaceId, draftKey, previousPayload)
+    } catch (error) {
+      console.error(
+        '[Workflow Drafts] Failed to restore target payload after cleanup',
+        error
+      )
+      return false
+    }
+  }
+
+  function stripOrderKey(index: DraftIndexV2, draftKey: string): DraftIndexV2 {
+    const entries = { ...index.entries }
+    delete entries[draftKey]
+    return {
+      ...index,
+      updatedAt: Date.now(),
+      order: index.order.filter((key) => key !== draftKey),
+      entries
+    }
+  }
+
+  function discardDriftedKey(
+    workspaceId: string,
+    index: DraftIndexV2,
+    draftKey: string,
+    evictedPayloads: Map<string, DraftPayloadV2>
+  ): DraftIndexV2 | null {
+    const driftedPayload = readPayload(workspaceId, draftKey)
+    const cleanedIndex = stripOrderKey(index, draftKey)
+    if (!persistIndex(cleanedIndex)) return null
+
+    // The index no longer owns this corrupt key. Remove its payload as part of
+    // the same quota-recovery transaction so stale storage actually frees
+    // space; rollbackQuotaEvictions restores it if the incoming save fails.
+    if (driftedPayload) evictedPayloads.set(draftKey, driftedPayload)
+    if (!deletePayload(workspaceId, draftKey)) return null
+    return cleanedIndex
+  }
+
+  function rollbackQuotaEvictions(
+    workspaceId: string,
+    originalIndex: DraftIndexV2,
+    evictedPayloads: Map<string, DraftPayloadV2>,
+    unrestoredTargetKey?: string
+  ): boolean {
+    let payloadRestoreFailed = false
+    for (const [draftKey, payload] of evictedPayloads) {
+      try {
+        if (
+          !readPayload(workspaceId, draftKey) &&
+          !writePayload(workspaceId, draftKey, payload)
+        ) {
+          payloadRestoreFailed = true
+        }
+      } catch (error) {
+        payloadRestoreFailed = true
+        console.error(
+          '[Workflow Drafts] Failed to restore an evicted draft payload',
+          error
+        )
+      }
+    }
+
+    // If target rollback failed, do not let stale uncommitted target bytes make
+    // the recovered index appear complete. Any surviving bytes remain orphaned
+    // and are removed by normal cold-load cleanup.
+    const payloadKeys = new Set(getPayloadKeys(workspaceId))
+    if (unrestoredTargetKey) payloadKeys.delete(unrestoredTargetKey)
+    const recoveredIndex = removeOrphanedEntries(originalIndex, payloadKeys)
+
+    try {
+      if (!writeIndex(workspaceId, recoveredIndex)) {
+        delete indexCacheByWorkspace.value[workspaceId]
+        console.error(
+          '[Workflow Drafts] Failed to restore draft index after quota rollback'
+        )
+        return false
+      }
+    } catch (error) {
+      delete indexCacheByWorkspace.value[workspaceId]
+      console.error(
+        '[Workflow Drafts] Failed to restore draft index after quota rollback',
+        error
+      )
+      return false
+    }
+
+    if (payloadRestoreFailed) {
+      delete indexCacheByWorkspace.value[workspaceId]
+      console.error(
+        '[Workflow Drafts] Quota rollback could not restore every evicted payload'
+      )
+      return false
+    }
+
+    indexCacheByWorkspace.value[workspaceId] = recoveredIndex
+    return true
+  }
+
   /**
    * Handles quota exceeded by evicting oldest drafts until write succeeds.
-   *
-   * Tolerates index/payload desync: orphaned `order` keys with no matching
-   * entry in `entries` are stripped in-place and the loop continues, rather
-   * than bailing out and leaving evictable drafts behind.
-   *
-   * Recovery writes (`persistIndex(currentIndex)` after a failed write) are
-   * best-effort; their return value is intentionally ignored because there
-   * is no useful action to take when the recovery itself also fails — the
-   * caller will already see `false` and surface the toast. A subsequent
-   * `saveDraft` will re-converge the index via `removeOrphanedEntries`.
+   * Evictions are rolled back if the incoming draft cannot be committed.
    */
   function handleQuotaExceeded(
     path: string,
     data: string,
-    meta: DraftMeta
+    meta: DraftMeta,
+    previousPayload: string | null
   ): boolean {
     const workspaceId = currentWorkspaceId()
+    const originalIndex = loadIndex()
     const draftKey = hashPath(path)
+    const evictedPayloads = new Map<string, DraftPayloadV2>()
+    let targetWritten = false
 
-    let currentIndex = loadIndex()
-    let evictedCount = 0
+    try {
+      let currentIndex = originalIndex
+      let evictedCount = 0
+      while (currentIndex.order.length > 0) {
+        const oldestKey = currentIndex.order.find((key) => key !== draftKey)
+        if (!oldestKey) break
 
-    while (currentIndex.order.length > 0) {
-      const oldestKey = currentIndex.order.find((key) => key !== draftKey)
-      if (!oldestKey) break
+        const oldestEntry = getIndexEntry(currentIndex, oldestKey)
+        const result = oldestEntry
+          ? removeEntry(currentIndex, oldestEntry.path)
+          : null
+        if (!result?.removedKey) {
+          const cleanedIndex = discardDriftedKey(
+            workspaceId,
+            currentIndex,
+            oldestKey,
+            evictedPayloads
+          )
+          if (!cleanedIndex) {
+            rollbackQuotaEvictions(workspaceId, originalIndex, evictedPayloads)
+            return false
+          }
+          currentIndex = cleanedIndex
+          continue
+        }
 
-      const oldestEntry = currentIndex.entries[oldestKey]
-      if (!getIndexEntry(currentIndex, oldestKey)) {
-        currentIndex = stripOrderKey(currentIndex, oldestKey)
-        continue
-      }
+        const evictedPayload = readPayload(workspaceId, result.removedKey)
 
-      const result = removeEntry(currentIndex, oldestEntry.path)
-      currentIndex = result.index
-      if (result.removedKey) {
-        deletePayload(workspaceId, result.removedKey)
-        evictedCount++
-      }
-
-      const now = Date.now()
-      if (writePayload(workspaceId, draftKey, { data, updatedAt: now })) {
-        const { index: finalIndex } = upsertEntry(
-          currentIndex,
-          path,
-          { ...meta, updatedAt: now },
-          MAX_DRAFTS
-        )
-        if (!persistIndex(finalIndex)) {
-          deletePayload(workspaceId, draftKey)
-          persistIndex(currentIndex)
+        // Make the index stop owning this payload before deleting it. This keeps
+        // index/payload invariants recoverable even if the page dies mid-retry.
+        if (!persistIndex(result.index)) {
+          rollbackQuotaEvictions(workspaceId, originalIndex, evictedPayloads)
           return false
         }
-        return true
-      }
-    }
+        currentIndex = result.index
 
-    persistIndex(currentIndex)
-    reportQuotaExhausted(currentIndex, evictedCount, payloadByteSize(data))
-    markStorageUnavailable()
-    return false
+        if (evictedPayload) {
+          evictedPayloads.set(result.removedKey, evictedPayload)
+        }
+        if (!deletePayload(workspaceId, result.removedKey)) {
+          rollbackQuotaEvictions(workspaceId, originalIndex, evictedPayloads)
+          return false
+        }
+        evictedCount++
+
+        const now = Date.now()
+        if (writePayload(workspaceId, draftKey, { data, updatedAt: now })) {
+          targetWritten = true
+          const { index: finalIndex, evicted } = upsertEntry(
+            currentIndex,
+            path,
+            { ...meta, updatedAt: now },
+            MAX_DRAFTS
+          )
+          if (persistIndex(finalIndex)) {
+            deletePayloads(workspaceId, evicted)
+            return true
+          }
+
+          const targetRestored = restoreTargetPayload(
+            workspaceId,
+            draftKey,
+            previousPayload
+          )
+          const evictionsRestored = rollbackQuotaEvictions(
+            workspaceId,
+            originalIndex,
+            evictedPayloads,
+            targetRestored ? undefined : draftKey
+          )
+          if (!targetRestored || !evictionsRestored) {
+            delete indexCacheByWorkspace.value[workspaceId]
+          }
+          return false
+        }
+      }
+
+      reportQuotaExhausted(currentIndex, evictedCount, payloadByteSize(data))
+      rollbackQuotaEvictions(workspaceId, originalIndex, evictedPayloads)
+      return false
+    } catch (error) {
+      const targetRestored =
+        !targetWritten ||
+        restoreTargetPayload(workspaceId, draftKey, previousPayload)
+      const evictionsRestored = rollbackQuotaEvictions(
+        workspaceId,
+        originalIndex,
+        evictedPayloads,
+        targetRestored ? undefined : draftKey
+      )
+      if (!targetRestored || !evictionsRestored) {
+        delete indexCacheByWorkspace.value[workspaceId]
+      }
+      throw error
+    }
   }
 
   function getIndexEntry(
@@ -217,22 +485,11 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
   }
 
   /**
-   * Approximates the UTF-8 byte size of the envelope `writePayload` actually
-   * stores. We hard-code `updatedAt: 0` rather than the real timestamp because
-   * the missing ~12 bytes are noise compared to the kilobyte-scale workflow
-   * payload this telemetry exists to measure.
+   * Measures the UTF-8 byte size of the serialized payload envelope.
    */
   function payloadByteSize(data: string): number {
     return new TextEncoder().encode(JSON.stringify({ data, updatedAt: 0 }))
       .length
-  }
-
-  function stripOrderKey(index: DraftIndexV2, orphanKey: string): DraftIndexV2 {
-    return {
-      ...index,
-      updatedAt: Date.now(),
-      order: index.order.filter((key) => key !== orphanKey)
-    }
   }
 
   function reportQuotaExhausted(
@@ -302,6 +559,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     data: string
     name: string
     isTemporary: boolean
+    isModified?: boolean
     updatedAt: number
   } | null {
     const workspaceId = currentWorkspaceId()
@@ -321,6 +579,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       data: payload.data,
       name: entry.name,
       isTemporary: entry.isTemporary,
+      isModified: entry.isModified,
       updatedAt: payload.updatedAt
     }
   }
@@ -396,7 +655,11 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
   async function loadPersistedWorkflow(
     options: LoadPersistedWorkflowOptions
   ): Promise<boolean> {
-    const { preferredPath, fallbackToLatestDraft = false } = options
+    const {
+      workflowName,
+      preferredPath,
+      fallbackToLatestDraft = false
+    } = options
 
     // 1. Try preferred path
     if (preferredPath && (await loadDraft(preferredPath))) {
@@ -411,7 +674,33 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
       }
     }
 
-    return false
+    // Legacy fallbacks are NOT workspace-scoped and must only be used for
+    // personal workspace to prevent cross-workspace data leakage.
+    // These exist only for migration from V1 and should be removed after 2026-07-15.
+    if (currentWorkspaceId() !== 'personal') {
+      return false
+    }
+
+    // 3. Legacy fallback: sessionStorage payload (remove after 2026-07-15)
+    const clientId = api.initialClientId ?? api.clientId
+    if (clientId) {
+      try {
+        const sessionPayload = sessionStorage.getItem(`workflow:${clientId}`)
+        if (await tryLoadGraph(sessionPayload, workflowName)) {
+          return true
+        }
+      } catch {
+        // Ignore storage access errors and continue fallback chain
+      }
+    }
+
+    // 4. Legacy fallback: localStorage payload (remove after 2026-07-15)
+    try {
+      const localPayload = localStorage.getItem('workflow')
+      return await tryLoadGraph(localPayload, workflowName)
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -420,6 +709,7 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
   function reset(): void {
     const workspaceId = currentWorkspaceId()
     delete indexCacheByWorkspace.value[workspaceId]
+    saveFailureNotified = false
   }
 
   return {
@@ -430,6 +720,10 @@ export const useWorkflowDraftStoreV2 = defineStore('workflowDraftV2', () => {
     getDraft,
     getMostRecentPath,
     loadPersistedWorkflow,
-    reset
+    reset,
+    shouldNotifySaveFailure,
+    markSaveSucceeded,
+    pausePersistence,
+    isPersistencePaused
   }
 })


### PR DESCRIPTION
## Summary

Repairs workflow draft/history recovery and lifecycle edge cases that remain after the quota-recovery work now present on `main`.

Current topology:

- head: `dc808aa1dd979d33bf85618ffa80fbfc148f24d0`
- base/current `main`: `c6e0bfe255aef8c996ca362735ab539edb4f0029`
- **1 commit**, **22 changed files**, **0 behind**, mergeable
- commit retains `Co-authored-by: bymyself <cbyrne@comfy.org>`

## Relationship to current main

Since this PR was opened, upstream #11818 merged a real quota-recovery path: quota writes are detected, older drafts are evicted/retried, orphaned order keys are tolerated, and the workflow-service error toast is shown only after recovery ultimately fails.

This PR no longer claims ownership of that basic quota-recovery behavior. Its remaining quota work hardens failure cases around the upstream path:

- existing target payload bytes are preserved for rollback
- index ownership commits before destructive payload deletion
- evicted payloads are restored if a later replacement/index commit fails
- drifted index entries and their exact payload keys are repaired transactionally
- rollback failures invalidate stale in-memory cache rather than exposing state that was not durably restored
- final-retry LRU payload deletion happens only after the replacement index commits
- thrown/interrupted rollback paths retain recoverable history where possible

These are data-integrity guarantees beyond the normal successful eviction/retry path currently on `main`.

#17313 remains open and addresses the separate identity-scoping/logout class of persistence failures. This reconciliation does not fold or duplicate that unmerged implementation.

## Migration and history recovery

The V1→V2 migration still runs on current `main`, so the migration repair remains relevant even though #15730 correctly removed the expired *runtime* V1 fallback paths.

This PR therefore keeps the migration fixes but does **not** reintroduce those retired runtime fallbacks or their cleanup/debug helper API.

Migration coverage includes:

- real unscoped legacy V1 history
- false/empty V2 migration markers
- malformed or missing V2 payloads
- valid-V1 / malformed-V2 collisions
- path/hash collisions
- retention limits
- storage read/write failures
- recoverable orphan payloads
- legacy tab-state restoration and active-index clamping

A V2 payload is considered valid only when it contains string `data` and a finite numeric `updatedAt`; parseable junk such as `{}` can no longer suppress recovery of a valid V1 draft.

## Lifecycle, dirty state, and viewport recovery

The branch also keeps fixes that are independent of quota eviction:

- prevents pending persistence work from crossing workflow/workspace transition boundaries
- preserves the known dirty bit in draft metadata
- preserves temporary drafts despite their synthetic creation timestamp
- includes validated viewport state in persisted drafts when view restore is enabled
- falls back to the authoritative saved-workflow viewport when a recovered draft has no valid viewport
- deduplicates one continuous save-failure episode across persistence callers and resets it after a successful save
- validates restored draft JSON before treating it as a workflow

The existing workspace/logout fencing semantics remain preserved.

## Upstream reconciliation

A real cherry-pick onto current `main` produced one textual conflict in:

- `src/platform/workflow/management/stores/comfyWorkflow.ts`

That conflict came from merged #18121, which made `promptSave()` fail gracefully when the dialog-service dynamic import is unavailable. The resolution starts from current `main`, preserves #18121's reporting/`null` behavior, and layers back only this PR's draft-restoration semantics.

The PR-added tests were also migrated to current repository conventions: global testing Pinia, typed dynamic `vi.mock(import(...))` mocks, and the formerly separate mock-heavy reconciliation suites were folded into the canonical workflow-service/persistence suites.

#15730's removal of expired runtime V1 fallbacks is preserved.

## Validation

Exact current head `dc808aa1dd979d33bf85618ffa80fbfc148f24d0` passed:

- `pnpm typecheck`
- `pnpm typecheck:browser`
- focused workflow/persistence Vitest: **14 files / 266 tests**
- changed-file Oxfmt
- changed-file ESLint
- type-aware Oxlint under current `.oxlintrc.json`
- Vitest cleanup-policy Oxlint
- `git diff --check`
- one-commit / exact-parent topology assertions

The immediately preceding candidate also passed the full root `pnpm test:coverage` run: **1636 test files / 22,539 passed tests**, with 17 expected failures and 7 skipped. The upstream movement between that covered candidate and the current head had no overlap with PR files and no dependency/Vitest/typecheck configuration changes; the later global Oxlint-config change was revalidated on the exact current head.

No merge has been performed.