### PR TITLE
fix(errors): keep missing node packs across prompt submissions

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -30,6 +30,34 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     ).toHaveText(/\S/)
   })
 
+  test('Should keep the missing node pack card after submitting a prompt', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'Submitting a prompt cleared missing-node state, emptying the Errors tab'
+    })
+
+    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
+
+    const missingNodeCard = comfyPage.page.getByTestId(
+      TestIds.dialogs.missingNodeCard
+    )
+    await expect(missingNodeCard).toBeVisible()
+
+    // The clear this guards against runs inside queuePrompt, several awaits
+    // after the click resolves, so assert only once the submit has landed.
+    const prompted = comfyPage.page.waitForResponse((response) =>
+      response.url().includes('/api/prompt')
+    )
+    await comfyPage.runButton.click()
+    await prompted
+
+    await expect(missingNodeCard).toBeVisible()
+    await expect(missingNodeCard.getByText('Unknown pack')).toBeVisible()
+  })
+
   test('Should show unknown pack node rows by default', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -46,8 +46,6 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     )
     await expect(missingNodeCard).toBeVisible()
 
-    // The clear this guards against runs inside queuePrompt, several awaits
-    // after the click resolves, so assert only once the submit has landed.
     const prompted = comfyPage.page.waitForResponse((response) =>
       response.url().includes('/api/prompt')
     )

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1064,7 +1064,6 @@ describe('ComfyApp', () => {
     it('clears missing node packs, which its graph swap skips clean() for', async () => {
       const graph = new LGraph()
       Reflect.set(app, 'rootGraphInternal', graph)
-      Reflect.set(singletonApp, 'rootGraphInternal', graph)
       const missingNodesStore = useMissingNodesErrorStore()
       missingNodesStore.setMissingNodeTypes(['OutgoingMissingNode'])
       vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
@@ -1081,6 +1080,26 @@ describe('ComfyApp', () => {
 
       expect(missingNodesStore.missingNodesError).toBeNull()
     })
+
+    it.for(['not-a1111', 'core-nodes-unavailable'] as const)(
+      'keeps missing node packs when the import fails with %s',
+      async (outcome) => {
+        const graph = new LGraph()
+        Reflect.set(app, 'rootGraphInternal', graph)
+        const missingNodesStore = useMissingNodesErrorStore()
+        missingNodesStore.setMissingNodeTypes(['OutgoingMissingNode'])
+        vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+          parameters: 'positive\nNegative prompt: negative\nSteps: 20'
+        })
+        mockImportA1111.mockResolvedValue(outcome)
+
+        await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+        expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+          'OutgoingMissingNode'
+        ])
+      }
+    )
   })
 
   describe('clean', () => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -308,6 +308,34 @@ describe('ComfyApp', () => {
       vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
     }
 
+    it('preserves missing node packs when submitting a prompt', async () => {
+      prepareEmptyPromptQueue()
+      const missingNodesStore = useMissingNodesErrorStore()
+      const executionErrorStore = useExecutionErrorStore()
+      missingNodesStore.setMissingNodeTypes(['test/UninstalledLiveNode'])
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      await app.queuePrompt(0)
+
+      expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+        'test/UninstalledLiveNode'
+      ])
+      expect(executionErrorStore.lastExecutionError).toBeNull()
+    })
+
     it('shows the error overlay for successful prompt responses with node errors', async () => {
       const graph = new LGraph()
       const workflow = new ComfyWorkflow({
@@ -1032,6 +1060,54 @@ describe('ComfyApp', () => {
       ])
     })
   })
+  describe('A1111 import', () => {
+    it('clears missing node packs, which its graph swap skips clean() for', async () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      Reflect.set(singletonApp, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes(['OutgoingMissingNode'])
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({
+        parameters: 'positive\nNegative prompt: negative\nSteps: 20'
+      })
+      mockImportA1111.mockImplementation(
+        async (_graph, _parameters, beforeGraphClear) => {
+          beforeGraphClear?.()
+          return 'imported'
+        }
+      )
+
+      await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
+    })
+  })
+
+  describe('clean', () => {
+    it('clears missing node packs when the graph is discarded', () => {
+      const graph = new LGraph()
+      Reflect.set(app, 'rootGraphInternal', graph)
+      const missingNodesStore = useMissingNodesErrorStore()
+      const executionErrorStore = useExecutionErrorStore()
+      missingNodesStore.setMissingNodeTypes(['MissingGroupNode'])
+      executionErrorStore.recordExecutionError({
+        prompt_id: 'previous-run',
+        timestamp: 0,
+        node_id: '1',
+        node_type: 'Test',
+        executed: [],
+        exception_message: 'fail',
+        exception_type: 'RuntimeError',
+        traceback: []
+      })
+
+      app.clean()
+
+      expect(missingNodesStore.missingNodesError).toBeNull()
+      expect(executionErrorStore.lastExecutionError).toBeNull()
+    })
+  })
+
   describe('refreshComboInNodes', () => {
     it('shows success toast and removes the pending toast after node defs reload', async () => {
       app.vueAppReady = true

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2020,9 +2020,11 @@ export class ComfyApp {
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
       const outcome = await importA1111(this.rootGraph, parameters, () => {
-        useWorkflowService().beforeLoadNewGraph()
-        // This path replaces the graph without reaching `clean()`.
-        useMissingNodesErrorStore().setMissingNodeTypes([])
+        try {
+          useWorkflowService().beforeLoadNewGraph()
+        } finally {
+          useMissingNodesErrorStore().setMissingNodeTypes([])
+        }
         this.canvas.setGraph(this.rootGraph)
       })
       if (outcome === 'core-nodes-unavailable') {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -113,6 +113,7 @@ import { normalizePromptError } from '@/utils/executionErrorUtil'
 import { graphToPrompt } from '@/utils/executionUtil'
 import { parseJsonWithNonFinite } from '@/utils/jsonUtil'
 import { getCnrIdFromProperties } from '@/platform/nodeReplacement/cnrIdUtil'
+import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { rescanAndSurfaceMissingNodes } from '@/platform/nodeReplacement/missingNodeScan'
 import {
   refreshMissingModelPipeline,
@@ -1645,7 +1646,7 @@ export class ComfyApp {
     const executionStore = useExecutionStore()
     const executionErrorStore = useExecutionErrorStore()
     const telemetry = useTelemetry()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
     let queueResultOverride: boolean | null = null
 
     // Get auth token for backend nodes - uses workspace token if enabled, otherwise Firebase token
@@ -2020,6 +2021,8 @@ export class ComfyApp {
     if (parameters && typeof parameters === 'string') {
       const outcome = await importA1111(this.rootGraph, parameters, () => {
         useWorkflowService().beforeLoadNewGraph()
+        // This path replaces the graph without reaching `clean()`.
+        useMissingNodesErrorStore().setMissingNodeTypes([])
         this.canvas.setGraph(this.rootGraph)
       })
       if (outcome === 'core-nodes-unavailable') {
@@ -2430,7 +2433,8 @@ export class ComfyApp {
     const nodeOutputStore = useNodeOutputStore()
     nodeOutputStore.resetAllOutputsAndPreviews()
     const executionErrorStore = useExecutionErrorStore()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
+    useMissingNodesErrorStore().setMissingNodeTypes([])
 
     useDomWidgetStore().clear()
 

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -778,7 +778,9 @@ describe('hasMissingError', () => {
     {
       type: 'nodes',
       seedMissingError: () => {
-        useMissingNodesErrorStore().missingNodesError = fromAny({})
+        useMissingNodesErrorStore().setMissingNodeTypes([
+          { type: 'TestNode', hint: '' }
+        ])
       }
     },
     {
@@ -803,7 +805,7 @@ describe('hasMissingError', () => {
     expect(executionErrorStore.hasMissingError).toBe(true)
   })
 
-  it('excludes node validation errors', () => {
+  it('returns false when only node validation errors exist', () => {
     const executionErrorStore = useExecutionErrorStore()
     executionErrorStore.recordNodeErrors({
       '1': nodeError([validationError('required_input_missing', 'input')])

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -3,7 +3,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { nodeError, validationError } from '@/utils/__tests__/nodeErrorHelpers'
-import type { MissingNodeType } from '@/types/comfy'
 import {
   createBoundaryLinkedSubgraph,
   createTestRootGraph,
@@ -814,7 +813,7 @@ describe('hasMissingError', () => {
   })
 })
 
-describe('clearAllErrors', () => {
+describe('clearRunErrors', () => {
   let executionErrorStore: ReturnType<typeof useExecutionErrorStore>
   let missingNodesStore: ReturnType<typeof useMissingNodesErrorStore>
 
@@ -825,7 +824,7 @@ describe('clearAllErrors', () => {
     missingNodesStore = useMissingNodesErrorStore()
   })
 
-  it('resets all error categories and closes error overlay', () => {
+  it('resets run errors and closes the overlay, leaving missing resources', () => {
     executionErrorStore.recordExecutionError({
       prompt_id: 'test',
       timestamp: 0,
@@ -855,19 +854,19 @@ describe('clearAllErrors', () => {
         class_type: 'Test'
       }
     })
-    missingNodesStore.setMissingNodeTypes(
-      fromAny<MissingNodeType[], unknown>([{ type: 'MissingNode', hint: '' }])
-    )
+    missingNodesStore.setMissingNodeTypes([{ type: 'MissingNode', hint: '' }])
     executionErrorStore.showErrorOverlay()
 
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearRunErrors()
 
     expect(executionErrorStore.lastExecutionError).toBeNull()
     expect(executionErrorStore.lastPromptError).toBeNull()
     expect(executionErrorStore.lastNodeErrors).toBeNull()
-    expect(missingNodesStore.missingNodesError).toBeNull()
     expect(executionErrorStore.isErrorOverlayOpen).toBe(false)
-    expect(executionErrorStore.hasAnyError).toBe(false)
+    expect(missingNodesStore.missingNodesError?.nodeTypes).toEqual([
+      { type: 'MissingNode', hint: '' }
+    ])
+    expect(executionErrorStore.hasAnyError).toBe(true)
   })
 })
 

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -118,15 +118,12 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /** Clear all error state.
-   *  Missing model state is intentionally preserved here to avoid wiping
-   *  in-progress model repairs (importTaskIds, URL inputs, etc.).
-   *  Missing models are cleared separately during workflow load/clean paths. */
-  function clearAllErrors() {
+  /** Clear error state produced by a run. Missing-resource state describes the
+   *  loaded graph rather than the run, so only a graph swap invalidates it. */
+  function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null
     lastNodeErrors.value = null
-    missingNodesStore.setMissingNodeTypes([])
     isErrorOverlayOpen.value = false
   }
 
@@ -585,7 +582,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     recordPromptError,
 
     // Clearing
-    clearAllErrors,
+    clearRunErrors,
     clearExecutionStartErrors,
     clearPromptError,
 

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -119,7 +119,8 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
   }
 
   /** Clear error state produced by a run. Missing-resource state describes the
-   *  loaded graph rather than the run, so only a graph swap invalidates it. */
+   *  loaded graph rather than the run, so only replacing or discarding the
+   *  graph invalidates it. */
   function clearRunErrors() {
     lastExecutionError.value = null
     lastPromptError.value = null


### PR DESCRIPTION
## Summary

Pressing Run emptied the missing-node-pack rows from the Errors tab; the nodes were still missing, the panel just stopped saying so.

## Changes

- **What**: `clearAllErrors` was shared by `queuePrompt` ("forget the last run") and `clean()` ("forget this graph"), and cleared missing-node state for both. A submission carries no evidence about the environment — it never checks whether the pack was installed — so it cannot justify dropping the row. The clear moves to `clean()`, and the function is renamed `clearRunErrors` to match what it now does.

Missing **model** and **media** state already followed this rule: `clearAllErrors` never touched it, and it is cleared in `loadGraphData` instead. This aligns missing nodes with the two resources that were already right; it does not change when models or media are cleared.

Production change is four lines.

## Review Focus

**Every discard path still clears.** `clean()` is reached by `loadGraphData`, `loadApiJson`, `Comfy.ClearWorkflow` (`useCoreCommands.ts:279`) and the legacy Clear button (`ui.ts:680`).

**Except one, which needed the clear spelled out.** The A1111 import replaces the graph from inside `importA1111` through a `beforeGraphClear` callback and never reaches `clean()`, so it already left the store describing the outgoing graph. That was survivable only because the next submission happened to wipe it — with submissions no longer clearing, the stale rows would persist indefinitely. `afterLoadNewGraph` does not call `showPendingWarnings`, so nothing else re-syncs that path. The callback runs after the parameters and required core nodes validate, so a failed import keeps the current state.

**What this deliberately does not do.** An earlier version of this PR generalised the same rule to the missing-model and missing-media stores. It was abandoned: those two carry async verification that outlives the graph that started it, plus a per-workflow cache and a two-tier repair state, and unifying them produced five separate defects (cache resurrection after discard, cache not synced on per-node removal, verification not aborted, an abort whose signal was passed but never checked after the await, and the A1111 bypass for all three resources). None of that is in this PR. It is written up separately and will be its own change.

## Verification

Four tests, each mutation-proved — revert the production line, watch the named test fail, restore, watch it pass:

| mutation | fails |
|---|---|
| restore the clear inside `clearRunErrors` | `preserves missing node packs when submitting a prompt`, store test, E2E |
| drop `clean()`'s clear | `clears missing node packs when the graph is discarded` |
| drop the A1111 callback clear | `clears missing node packs, which its graph swap skips clean() for` |
| drop `queuePrompt`'s `clearRunErrors()` | queue unit test |

The E2E (`errorsTabMissingNodes.spec.ts`) waits on the `POST /api/prompt` response before re-asserting, so it observes the state after the submit path has run rather than racing it.

`pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint` (0 errors), `pnpm knip`, `pnpm format` all clean; 88 unit tests and the E2E pass.

Replaces #14557.
