### PR TITLE
fix(billing): stop reporting "processing" while a payment waits on the customer

### DIFF
--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -8,8 +8,13 @@
         <i
           v-if="slotProps.message.severity === 'warn'"
           class="pi pi-exclamation-circle text-warning-background"
+          aria-hidden="true"
         />
-        <i v-else class="pi pi-spin pi-spinner text-primary" />
+        <i
+          v-else
+          class="pi pi-spin pi-spinner text-primary"
+          aria-hidden="true"
+        />
         <span>{{ slotProps.message.summary }}</span>
       </div>
     </template>

--- a/src/components/toast/GlobalToast.vue
+++ b/src/components/toast/GlobalToast.vue
@@ -3,7 +3,13 @@
   <Toast group="billing-operation" position="top-right">
     <template #message="slotProps">
       <div class="flex items-center gap-2">
-        <i class="pi pi-spin pi-spinner text-primary" />
+        <!-- A spinner claims work is underway; an operation waiting on the
+             customer is not underway, so it gets a prompt icon instead. -->
+        <i
+          v-if="slotProps.message.severity === 'warn'"
+          class="pi pi-exclamation-circle text-warning-background"
+        />
+        <i v-else class="pi pi-spin pi-spinner text-primary" />
         <span>{{ slotProps.message.summary }}</span>
       </div>
     </template>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2695,11 +2695,13 @@
   },
   "billingOperation": {
     "subscriptionProcessing": "Processing payment — setting up your workspace...",
+    "subscriptionActionRequired": "Verify your payment to finish setting up your workspace",
     "subscriptionSuccess": "Subscription updated successfully",
     "subscriptionFailed": "Subscription update failed",
     "subscriptionFailedDetail": "We couldn't update your subscription. Please try again.",
     "subscriptionTimeout": "Subscription verification timed out",
     "topupProcessing": "Processing payment — adding credits...",
+    "topupActionRequired": "Verify your payment to add your credits",
     "topupSuccess": "Credits added successfully",
     "topupFailed": "Top-up failed",
     "topupTimeout": "Top-up verification timed out",

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -753,6 +753,43 @@ describe('billingOperationStore', () => {
       )
     })
 
+    it('returns to processing when the action URL clears while still pending', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus)
+        .mockResolvedValueOnce({
+          id: 'op-1',
+          status: 'pending',
+          started_at: new Date().toISOString(),
+          action_url: 'https://verify.example/sensitive-token'
+        })
+        .mockResolvedValue({
+          id: 'op-1',
+          status: 'pending',
+          started_at: new Date().toISOString()
+        })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      const actionRequiredToast = {
+        severity: 'warn',
+        summary: 'billingOperation.subscriptionActionRequired',
+        group: 'billing-operation'
+      }
+      expect(mockToastAdd).toHaveBeenCalledWith(actionRequiredToast)
+
+      // The verification action is gone, so the prompt pointing at it must go
+      // too rather than asking for something the customer can no longer do.
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(mockToastRemove).toHaveBeenCalledWith(actionRequiredToast)
+      expect(mockToastAdd).toHaveBeenLastCalledWith({
+        severity: 'info',
+        summary: 'billingOperation.subscriptionProcessing',
+        group: 'billing-operation'
+      })
+    })
+
     it('does not re-announce verification on later polls', async () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -698,6 +698,87 @@ describe('billingOperationStore', () => {
       )
     })
 
+    it('replaces the processing toast when the operation parks on a bank challenge', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        action_url: 'https://verify.example/sensitive-token'
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+
+      const processingToast = {
+        severity: 'info',
+        summary: 'billingOperation.subscriptionProcessing',
+        group: 'billing-operation'
+      }
+      expect(mockToastAdd).toHaveBeenCalledWith(processingToast)
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(mockToastRemove).toHaveBeenCalledWith(processingToast)
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'warn',
+        summary: 'billingOperation.subscriptionActionRequired',
+        group: 'billing-operation'
+      })
+    })
+
+    it('announces verification immediately when the action URL is known at start', () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation(
+        'op-1',
+        'topup',
+        undefined,
+        'https://verify.example/sensitive-token'
+      )
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: 'warn',
+        summary: 'billingOperation.topupActionRequired',
+        group: 'billing-operation'
+      })
+      expect(mockToastAdd).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          summary: 'billingOperation.topupProcessing'
+        })
+      )
+    })
+
+    it('does not re-announce verification on later polls', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString(),
+        action_url: 'https://verify.example/sensitive-token'
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'subscription')
+      await vi.advanceTimersByTimeAsync(0)
+
+      const actionRequiredAdds = () =>
+        mockToastAdd.mock.calls.filter(
+          (call) =>
+            call[0]?.summary === 'billingOperation.subscriptionActionRequired'
+        ).length
+
+      expect(actionRequiredAdds()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(actionRequiredAdds()).toBe(1)
+    })
+
     it('rejects an action URL received after the discovery deadline', async () => {
       const actionUrl = 'https://verify.example/sensitive-token'
       let resolveStatus!: (response: BillingOpStatusResponse) => void

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -182,7 +182,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     intervals.set(opId, INITIAL_INTERVAL_MS)
 
     if (type !== 'cancel') {
-      showProgressToast(opId, type, operation.authenticationRequiredSeen)
+      showProgressToast(opId, type, operation.actionUrl !== null)
     }
 
     const terminal = new Promise<BillingOperation>((resolve) => {
@@ -282,22 +282,20 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   function updateOperationActionUrl(opId: string, actionUrl: string | null) {
     const operation = operations.value.get(opId)
     if (!operation || operation.status !== 'pending') return
-    const authenticationRequiredSeen =
-      operation.authenticationRequiredSeen || actionUrl !== null
     operations.value = new Map(operations.value).set(opId, {
       ...operation,
       actionUrl,
-      authenticationRequiredSeen
+      authenticationRequiredSeen:
+        operation.authenticationRequiredSeen || actionUrl !== null
     })
-    // Only on the first transition: the toast is otherwise stable for the life
-    // of the operation, and re-adding it on every poll would resurface a
-    // notification the customer has already dismissed.
-    if (
-      operation.type !== 'cancel' &&
-      authenticationRequiredSeen &&
-      !operation.authenticationRequiredSeen
-    ) {
-      showProgressToast(opId, operation.type, true)
+    // Tracks the CURRENT action_url, which the contract defines as present
+    // exactly while the operation cannot proceed without the customer — so the
+    // toast never outlives the verification action it points at. Swapped only
+    // when that answer changes, or a dismissed toast would return every poll.
+    const wasActionRequired = operation.actionUrl !== null
+    const isActionRequired = actionUrl !== null
+    if (operation.type !== 'cancel' && wasActionRequired !== isActionRequired) {
+      showProgressToast(opId, operation.type, isActionRequired)
     }
   }
 

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -118,6 +118,37 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     return operations.value.get(opId)
   }
 
+  // An operation parked on a bank challenge is waiting on the customer, not on
+  // us, so it must not keep announcing "processing" — that reads as "nothing to
+  // do here" next to the verification prompt the same state renders.
+  function showProgressToast(
+    opId: string,
+    type: Exclude<OperationType, 'cancel'>,
+    actionRequired: boolean
+  ) {
+    const toastStore = useToastStore()
+    const previous = receivedToasts.get(opId)
+    if (previous) toastStore.remove(previous)
+
+    const messageKey =
+      type === 'subscription'
+        ? actionRequired
+          ? 'billingOperation.subscriptionActionRequired'
+          : 'billingOperation.subscriptionProcessing'
+        : actionRequired
+          ? 'billingOperation.topupActionRequired'
+          : 'billingOperation.topupProcessing'
+
+    const toastMessage: ToastMessageOptions = {
+      // 'warn' selects the prompt icon over the spinner in GlobalToast.
+      severity: actionRequired ? 'warn' : 'info',
+      summary: t(messageKey),
+      group: 'billing-operation'
+    }
+    receivedToasts.set(opId, toastMessage)
+    toastStore.add(toastMessage)
+  }
+
   function startOperation(
     opId: string,
     type: OperationType,
@@ -151,18 +182,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     intervals.set(opId, INITIAL_INTERVAL_MS)
 
     if (type !== 'cancel') {
-      const messageKey =
-        type === 'subscription'
-          ? 'billingOperation.subscriptionProcessing'
-          : 'billingOperation.topupProcessing'
-
-      const toastMessage: ToastMessageOptions = {
-        severity: 'info',
-        summary: t(messageKey),
-        group: 'billing-operation'
-      }
-      receivedToasts.set(opId, toastMessage)
-      useToastStore().add(toastMessage)
+      showProgressToast(opId, type, operation.authenticationRequiredSeen)
     }
 
     const terminal = new Promise<BillingOperation>((resolve) => {
@@ -262,12 +282,23 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   function updateOperationActionUrl(opId: string, actionUrl: string | null) {
     const operation = operations.value.get(opId)
     if (!operation || operation.status !== 'pending') return
+    const authenticationRequiredSeen =
+      operation.authenticationRequiredSeen || actionUrl !== null
     operations.value = new Map(operations.value).set(opId, {
       ...operation,
       actionUrl,
-      authenticationRequiredSeen:
-        operation.authenticationRequiredSeen || actionUrl !== null
+      authenticationRequiredSeen
     })
+    // Only on the first transition: the toast is otherwise stable for the life
+    // of the operation, and re-adding it on every poll would resurface a
+    // notification the customer has already dismissed.
+    if (
+      operation.type !== 'cancel' &&
+      authenticationRequiredSeen &&
+      !operation.authenticationRequiredSeen
+    ) {
+      showProgressToast(opId, operation.type, true)
+    }
   }
 
   async function handleSuccess(opId: string) {


### PR DESCRIPTION
## Summary

The billing-operation toast is created once when the operation starts and never revised, so an operation that parks on a 3DS challenge kept announcing "Processing payment — setting up your workspace..." while it was in fact waiting on the customer.

## Changes

- **What**: Drive the toast from the current `action_url`, which the generated contract defines as present exactly while a pending operation cannot proceed without the customer. The store already tracks that field and already renders a verification prompt from it — only the toast was left behind, so it contradicted the prompt beside it. The toast swaps whenever that answer changes, in either direction, so it can never outlive the action it points at.

## Reproduction

Any environment in Stripe test mode:

1. New workspace, no subscription.
2. Subscribe to a monthly plan; complete checkout with the 3DS test card `4000 0027 6000 3184`.
3. The first invoice needs authentication, so the operation parks and the status endpoint returns `status: "pending"` with `action_url` set to the Stripe-hosted invoice page.
4. Observe the toast while parked.

**AS IS** — "Processing payment — setting up your workspace..." with a spinner, for the whole time the operation waits on the customer, beside a "Complete verification" affordance rendered from the same `action_url`. A reload does not clear it.

**TO BE** — "Verify your payment to finish setting up your workspace" with a prompt icon, for as long as `action_url` is present.

The same state is reached before any payment exists, when the operation is waiting for the customer to finish checkout.

## Before / after

```mermaid
flowchart TD
    A["Subscription operation starts"] --> B["⟳ Processing payment —<br/>setting up your workspace…"]
    B --> C["Poll returns action_url<br/>(bank challenge required)"]
    C --> D["Before: ⟳ Processing payment —<br/>setting up your workspace…"]
    C --> E["After: ⚠ Verify your payment to<br/>finish setting up your workspace"]
    D --> F["Contradicts the 'Complete<br/>verification' prompt beside it"]
    E --> G["Matches the 'Complete<br/>verification' prompt beside it"]
    E --> H["action_url clears →<br/>reverts to processing"]
```

## Review Focus

- The toast keys on the **current** `action_url`, not on the sticky `authenticationRequiredSeen` — so it cannot ask for verification after the verification action has gone. `authenticationRequiredSeen` continues to carry only polling cadence and the 23h timeout.
- Swapped only when the answer changes, so a toast the customer dismissed is not resurfaced on every poll (cadence is 30s while parked).
- `severity: 'warn'` only selects the icon in `GlobalToast`; this toast group renders through a custom `#message` slot, so severity carries no other behaviour here. The state is conveyed in the summary text, not by icon or colour alone.
- English strings only — other locales are generated during release PRs.
- Deliberately out of scope: the same stale copy appears in the subscription settings panel (`SubscriptionPanelContentWorkspace.vue`). Same fix, different surface — left for a follow-up to keep this reviewable.

## Verification

- `billingOperationStore` tests: 56 passed, 4 new. Each new test fails without the store change (verified by stashing it).
- `vitest run src/platform/workspace src/components/toast` — 1075 passed.
- `vue-tsc --noEmit`, `oxfmt --check`, `oxlint --type-aware`, `eslint` — clean.
- Reproduced end to end on a fresh workspace with the 3DS test card before and after the change.
