### PR TITLE
fix(templates): read isApp instead of guessing from the .app filename

### DIFF
--- a/src/platform/workflow/templates/types/template.ts
+++ b/src/platform/workflow/templates/types/template.ts
@@ -19,6 +19,13 @@ export interface TemplateInfo {
   localizedTitle?: string
   localizedDescription?: string
   isEssential?: boolean
+  /**
+   * Whether App Mode is this template's default view, from the workflow's own
+   * `extra.linearMode`. Supplied by `templates/index.json`; absent means a node
+   * graph. Do not fall back to the `.app` filename suffix, which is wrong in
+   * both directions (see the App badge in WorkflowTemplateSelectorDialog).
+   */
+  isApp?: boolean
   sourceModule?: string
   tags?: string[]
   models?: string[]

--- a/src/platform/workflow/templates/utils/templateDisplay.test.ts
+++ b/src/platform/workflow/templates/utils/templateDisplay.test.ts
@@ -5,7 +5,8 @@ import {
   filterTemplatesByType,
   getProviderBadges,
   getProviderIconClass,
-  getTemplateTags
+  getTemplateTags,
+  isAppTemplate
 } from '@/platform/workflow/templates/utils/templateDisplay'
 
 function template(overrides: Partial<TemplateInfo> = {}): TemplateInfo {
@@ -126,10 +127,43 @@ describe('getProviderBadges', () => {
   })
 })
 
+describe('isAppTemplate', () => {
+  it('reads the isApp flag rather than the filename', () => {
+    expect(isAppTemplate(template({ name: 'anything', isApp: true }))).toBe(
+      true
+    )
+    expect(isAppTemplate(template({ name: 'anything' }))).toBe(false)
+  })
+
+  // The suffix records how a workflow was saved, not what it is, so it was wrong
+  // in both directions against templates/index.json.
+  it('does not treat a .app filename as an App on its own', () => {
+    expect(
+      isAppTemplate(
+        template({ name: 'templates_all_in_one_image_edit_models.app' })
+      )
+    ).toBe(false)
+  })
+
+  it('recognises an App whose name has no .app suffix', () => {
+    expect(
+      isAppTemplate(
+        template({ name: 'template_qwen_image_illustration_lora', isApp: true })
+      )
+    ).toBe(true)
+  })
+
+  it('treats an explicit false as a node graph', () => {
+    expect(isAppTemplate(template({ name: 'thing.app', isApp: false }))).toBe(
+      false
+    )
+  })
+})
+
 describe('filterTemplatesByType', () => {
   const templates = [
     template({ name: 'graph-one' }),
-    template({ name: 'thing.app' }),
+    template({ name: 'thing.app', isApp: true }),
     template({ name: 'graph-two' })
   ]
 

--- a/src/platform/workflow/templates/utils/templateDisplay.ts
+++ b/src/platform/workflow/templates/utils/templateDisplay.ts
@@ -4,8 +4,21 @@ import type {
   TemplateTypeFilter
 } from '@/platform/workflow/templates/types/template'
 
+/**
+ * Whether a template opens in App Mode rather than as a node graph.
+ *
+ * Reads `isApp`, which `templates/index.json` derives from the workflow's own
+ * `extra.linearMode`. That is the author's choice, recorded in the workflow.
+ *
+ * This previously read `name.endsWith('.app')`, which is wrong in both
+ * directions: `templates_all_in_one_image_edit_models.app` carries the suffix but
+ * is a node graph, while `template_qwen_image_illustration_lora` and
+ * `template_sugar_coated_gummy_style_qwen` are Apps without it. The suffix
+ * records how a workflow was saved, not what it is, so no amount of renaming
+ * would have fixed the Apps filter.
+ */
 export function isAppTemplate(template: TemplateInfo): boolean {
-  return template.name.endsWith('.app')
+  return template.isApp === true
 }
 
 export function filterTemplatesByType<T extends TemplateInfo>(


### PR DESCRIPTION
The template browser decides App Mode with `name.endsWith('.app')`. That guess is wrong in both directions.

## The bug

Measured against the 574 entries in `templates/index.json`:

| Template | Filename says | Actually |
| --- | --- | --- |
| `templates_all_in_one_image_edit_models.app` | App | **node graph** |
| `template_qwen_image_illustration_lora` | node graph | **App** |
| `template_sugar_coated_gummy_style_qwen` | node graph | **App** |

So the Apps filter hides two real Apps and offers one that is not. Renaming files would not fix it: the suffix records how a workflow was *saved*, not what it *is*. The author's choice lives in the workflow itself as `extra.linearMode`.

The same guess is what made comfy.org/workflows show 14 apps instead of 55.

## The change

`isAppTemplate` now reads `TemplateInfo.isApp`, supplied by `index.json`.

The existing tests encoded the old behaviour, using `name: 'thing.app'` to stand in for an App, so they are updated. Added regression cases for both directions and for an explicit `isApp: false`.

## Dependency

Needs Comfy-Org/workflow_templates#1104, which derives `isApp` in `index.json` from each workflow's `extra.linearMode`, plus a template package release carrying it.

**Until that ships, `isApp` is absent and every template reads as a node graph**, so this should land after #1104 rather than before. Flagging it explicitly rather than adding a `.app` fallback, because keeping the fallback would preserve the exact mislabelling this fixes.

## Context

Part of a set making App Mode a real field everywhere instead of a filename convention, requested by @christian-byrne:

- `Comfy-Org/workflow_templates#1104` adds `isApp` to `index.json` (this PR's dependency)
- `Comfy-Org/cloud#6399` adds the `is_app` column and the backfill runner
- `Comfy-Org/cloud#6401` surfaces it through the ingest API response

## Verification

`pnpm vitest` on `templateDisplay.test.ts`: 24 passed. `pnpm typecheck` clean. No other `endsWith('.app')` remains in `src/`.
