### PR TITLE
fix(website): give the payment status link hover and focus-visible affordances

### DIFF
--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -104,7 +104,7 @@ const iconRingClass =
         {{ t('payment.failed.statusPrompt.prefix', locale) }}
         <a
           :href="externalLinks.cloudStatus"
-          class="text-primary-comfy-yellow underline underline-offset-4"
+          class="text-primary-comfy-yellow focus-visible:ring-primary-comfy-yellow/50 rounded-sm underline underline-offset-4 transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
         >
           {{ t('payment.failed.statusPrompt.statusLink', locale) }}
         </a>


### PR DESCRIPTION
## Summary

Follow-up to #14877: the status-page link on `/payment/failed` had no hover or keyboard-focus affordance.

## Changes

- **What**: Adds `hover:opacity-70` and a `focus-visible` ring to the anchor, matching the inline-link pattern already used in `FAQSplit01.vue`. One line, styling only.

## Review Focus

Addresses two CodeRabbit findings on #14877 that arrived after it entered the merge queue, so they could not be pushed to that branch. Verified by focusing the link in a real browser (ring renders) plus the payment e2e suite (11 tests, en + zh-CN), unit tests, and `astro check`.
