### PR TITLE
feat: show workspace-disabled partner nodes as disabled in search

### DIFF
--- a/src/components/common/TreeExplorerV2Node.vue
+++ b/src/components/common/TreeExplorerV2Node.vue
@@ -9,7 +9,13 @@
     <div
       v-if="item.value.type === 'node'"
       v-bind="$attrs"
-      :class="cn(ROW_CLASS, isSelected && 'bg-comfy-input')"
+      :class="
+        cn(
+          ROW_CLASS,
+          isSelected && 'bg-comfy-input',
+          isDisabled && 'opacity-60'
+        )
+      "
       :style="rowStyle"
       draggable="true"
       @click.stop="handleClick($event, handleToggle, handleSelect)"
@@ -104,6 +110,7 @@ import { computed, inject, useTemplateRef } from 'vue'
 
 import NodePreviewCard from '@/components/node/NodePreviewCard.vue'
 import { useNodePreviewAndDrag } from '@/composables/node/useNodePreviewAndDrag'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import Button from '@/components/ui/button/Button.vue'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -136,6 +143,11 @@ const subgraphStore = useSubgraphStore()
 const previewRef = useTemplateRef('previewRef')
 
 const nodeDef = computed(() => item.value.data)
+
+const { isNodeDisabled } = useNodeDisabledState()
+const isDisabled = computed(
+  () => nodeDef.value !== undefined && isNodeDisabled(nodeDef.value)
+)
 
 const isBookmarked = computed(() => {
   if (!nodeDef.value) return false

--- a/src/components/node/NodePreviewCard.vue
+++ b/src/components/node/NodePreviewCard.vue
@@ -16,6 +16,15 @@
 
     <!-- Content Section -->
     <div class="flex flex-col gap-2 p-3 pt-1">
+      <div
+        v-if="isDisabled"
+        data-testid="node-preview-disabled-note"
+        class="rounded-sm bg-amber-500/20 px-2 py-1 text-2xs/normal text-amber-400"
+      >
+        {{
+          $t('errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage')
+        }}
+      </div>
       <!-- Title -->
       <h3 class="text-foreground m-0 text-xs font-semibold">
         {{ nodeDef.display_name }}
@@ -102,6 +111,7 @@ import { computed, ref } from 'vue'
 
 import NodePricingBadge from '@/components/node/NodePricingBadge.vue'
 import NodeProviderBadge from '@/components/node/NodeProviderBadge.vue'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import LGraphNodePreview from '@/renderer/extensions/vueNodes/components/LGraphNodePreview.vue'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 
@@ -131,6 +141,9 @@ useResizeObserver(previewWrapperRef, (entries) => {
     previewContainerRef.value.style.height = `${scaledHeight + PREVIEW_CONTAINER_PADDING_PX}px`
   }
 })
+
+const { isNodeDisabled } = useNodeDisabledState()
+const isDisabled = computed(() => isNodeDisabled(nodeDef))
 
 const categoryPath = computed(() => nodeDef.category?.replaceAll('/', ' / '))
 

--- a/src/components/node/NodePreviewCard.vue
+++ b/src/components/node/NodePreviewCard.vue
@@ -4,6 +4,15 @@
     :style="{ width: `${BASE_WIDTH_PX * (scaleFactor / BASE_SCALE)}px` }"
     data-testid="node-preview-card"
   >
+    <div
+      v-if="isDisabled"
+      data-testid="node-preview-disabled-note"
+      class="mx-3 mt-3 rounded-sm bg-amber-500/20 px-2 py-1 text-2xs/normal text-amber-400"
+    >
+      {{
+        $t('errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage')
+      }}
+    </div>
     <div ref="previewContainerRef" class="overflow-hidden p-3">
       <div
         ref="previewWrapperRef"
@@ -16,15 +25,6 @@
 
     <!-- Content Section -->
     <div class="flex flex-col gap-2 p-3 pt-1">
-      <div
-        v-if="isDisabled"
-        data-testid="node-preview-disabled-note"
-        class="rounded-sm bg-amber-500/20 px-2 py-1 text-2xs/normal text-amber-400"
-      >
-        {{
-          $t('errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage')
-        }}
-      </div>
       <!-- Title -->
       <h3 class="text-foreground m-0 text-xs font-semibold">
         {{ nodeDef.display_name }}

--- a/src/components/searchbox/NodeSearchItem.vue
+++ b/src/components/searchbox/NodeSearchItem.vue
@@ -1,6 +1,11 @@
 <template>
   <div
-    class="option-container flex w-full cursor-pointer items-center justify-between overflow-hidden px-2 py-0"
+    :class="
+      cn(
+        'option-container flex w-full cursor-pointer items-center justify-between overflow-hidden px-2 py-0',
+        isDisabled && 'opacity-60'
+      )
+    "
   >
     <div class="option-display-name flex flex-col font-semibold">
       <div>
@@ -21,6 +26,11 @@
       </div>
     </div>
     <div class="option-badges">
+      <Tag
+        v-if="isDisabled"
+        :value="$t('workspacePanel.partnerNodes.disabledBadge')"
+        severity="warn"
+      />
       <Tag
         v-if="nodeDef.deprecated"
         :value="$t('g.deprecated')"
@@ -52,12 +62,14 @@ import Chip from 'primevue/chip'
 import Tag from 'primevue/tag'
 import { computed } from 'vue'
 
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { NodeSourceType } from '@/types/nodeSource'
 import { formatNumberWithSuffix, highlightQuery } from '@/utils/formatUtil'
+import { cn } from '@comfyorg/tailwind-utils'
 
 const settingStore = useSettingStore()
 const showCategory = computed(() =>
@@ -78,6 +90,9 @@ const nodeBookmarkStore = useNodeBookmarkStore()
 const isBookmarked = computed(() =>
   nodeBookmarkStore.isBookmarked(props.nodeDef)
 )
+
+const { isNodeDisabled } = useNodeDisabledState()
+const isDisabled = computed(() => isNodeDisabled(props.nodeDef))
 
 const props = defineProps<{
   nodeDef: ComfyNodeDefImpl

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -1,6 +1,11 @@
 <template>
   <div
-    class="option-container flex w-full cursor-pointer items-center justify-between overflow-hidden"
+    :class="
+      cn(
+        'option-container flex w-full cursor-pointer items-center justify-between overflow-hidden',
+        isDisabled && 'opacity-60'
+      )
+    "
   >
     <div class="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
       <!-- Row 1: Name (left) + badges (right) -->
@@ -22,6 +27,13 @@
           class="shrink-0 rounded-sm bg-secondary-background px-1.5 py-0.5 text-xs text-muted-foreground"
           v-html="highlightQuery(nodeDef.name, currentQuery)"
         />
+        <span
+          v-if="isDisabled"
+          data-testid="node-disabled-badge"
+          class="shrink-0 rounded-sm bg-amber-500/20 px-1.5 py-0.5 text-xs text-amber-400"
+        >
+          {{ $t('workspacePanel.partnerNodes.disabledBadge') }}
+        </span>
 
         <template v-if="showDescription">
           <div class="flex-1" />
@@ -125,6 +137,7 @@ import TextTicker from '@/components/common/TextTicker.vue'
 import NodePricingBadge from '@/components/node/NodePricingBadge.vue'
 import NodeProviderBadge from '@/components/node/NodeProviderBadge.vue'
 import { NODE_TO_ESSENTIALS_CATEGORY } from '@/constants/essentialsNodes'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -150,6 +163,9 @@ const {
 
 const badgePillClass =
   'flex h-[18px] max-w-28 shrink-0 items-center justify-center gap-1 rounded-full bg-secondary-background-hover/80 px-2'
+
+const { isNodeDisabled } = useNodeDisabledState()
+const isDisabled = computed(() => isNodeDisabled(nodeDef))
 
 const settingStore = useSettingStore()
 const showCategory = computed(() =>

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -27,17 +27,18 @@
           class="shrink-0 rounded-sm bg-secondary-background px-1.5 py-0.5 text-xs text-muted-foreground"
           v-html="highlightQuery(nodeDef.name, currentQuery)"
         />
-        <span
-          v-if="isDisabled"
-          data-testid="node-disabled-badge"
-          class="shrink-0 rounded-sm bg-amber-500/20 px-1.5 py-0.5 text-xs text-amber-400"
-        >
-          {{ $t('workspacePanel.partnerNodes.disabledBadge') }}
-        </span>
-
         <template v-if="showDescription">
           <div class="flex-1" />
           <div class="flex shrink-0 items-center gap-1">
+            <span
+              v-if="isDisabled"
+              data-testid="node-disabled-badge"
+              :class="badgePillClass"
+            >
+              <span class="truncate text-2xs text-amber-400">
+                {{ $t('workspacePanel.partnerNodes.disabledBadge') }}
+              </span>
+            </span>
             <span v-if="showSourceBadge && isCore" :class="badgePillClass">
               <span class="truncate text-2xs">{{ $t('g.comfy') }}</span>
             </span>
@@ -95,6 +96,13 @@
       </div>
     </div>
     <div v-if="!showDescription" class="flex items-center gap-1">
+      <span
+        v-if="isDisabled"
+        data-testid="node-disabled-badge"
+        class="rounded-sm bg-amber-500/20 px-1.5 py-0.5 text-xs text-amber-400"
+      >
+        {{ $t('workspacePanel.partnerNodes.disabledBadge') }}
+      </span>
       <span
         v-if="nodeDef.deprecated"
         class="rounded-sm bg-red-500/20 px-1.5 py-0.5 text-xs text-red-400"

--- a/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="container"
-    class="node-lib-node-container size-full"
+    :class="cn('node-lib-node-container size-full', isDisabled && 'opacity-60')"
     data-testid="node-tree-leaf"
     :data-node-name="nodeDef.display_name"
   >
@@ -68,6 +68,17 @@
 
     <teleport v-if="isHovered" to="#node-library-node-preview-container">
       <div class="node-lib-node-preview" :style="nodePreviewStyle">
+        <div
+          v-if="isDisabled"
+          data-testid="node-preview-disabled-note"
+          class="mb-1 rounded-sm bg-amber-500/20 px-2 py-1 text-xs text-amber-400"
+        >
+          {{
+            $t(
+              'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage'
+            )
+          }}
+        </div>
         <NodePreview :node-def="nodeDef" />
       </div>
     </teleport>
@@ -86,6 +97,7 @@ import { useI18n } from 'vue-i18n'
 import TreeExplorerTreeNode from '@/components/common/TreeExplorerTreeNode.vue'
 import NodePreview from '@/components/node/NodePreview.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
@@ -108,6 +120,8 @@ const nodeBookmarkStore = useNodeBookmarkStore()
 const isBookmarked = computed(() =>
   nodeBookmarkStore.isBookmarked(nodeDef.value)
 )
+const { isNodeDisabled } = useNodeDisabledState()
+const isDisabled = computed(() => isNodeDisabled(nodeDef.value))
 const settingStore = useSettingStore()
 const sidebarLocation = computed<'left' | 'right'>(() =>
   settingStore.get('Comfy.Sidebar.Location')

--- a/src/composables/node/useNodeDragToCanvas.test.ts
+++ b/src/composables/node/useNodeDragToCanvas.test.ts
@@ -8,7 +8,8 @@ const {
   mockConvertEventToCanvasOffset,
   mockSelectItems,
   mockCanvas,
-  mockToastAdd
+  mockToastAdd,
+  mockIsNodeDisabled
 } = vi.hoisted(() => {
   const mockConvertEventToCanvasOffset = vi.fn()
   const mockSelectItems = vi.fn()
@@ -17,6 +18,7 @@ const {
     mockConvertEventToCanvasOffset,
     mockSelectItems,
     mockToastAdd: vi.fn(),
+    mockIsNodeDisabled: vi.fn(),
     mockCanvas: {
       canvas: {
         getBoundingClientRect: vi.fn()
@@ -43,6 +45,10 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: vi.fn(() => ({ add: mockToastAdd }))
 }))
 
+vi.mock('@/platform/nodeDisabled/nodeDisabledState', () => ({
+  useNodeDisabledState: vi.fn(() => ({ isNodeDisabled: mockIsNodeDisabled }))
+}))
+
 vi.mock('@/i18n', () => ({ t: (key: string) => key }))
 
 describe('useNodeDragToCanvas', () => {
@@ -56,6 +62,7 @@ describe('useNodeDragToCanvas', () => {
   beforeEach(async () => {
     vi.resetModules()
     vi.resetAllMocks()
+    mockIsNodeDisabled.mockReturnValue(false)
 
     const module = await import('./useNodeDragToCanvas')
     useNodeDragToCanvas = module.useNodeDragToCanvas
@@ -78,6 +85,51 @@ describe('useNodeDragToCanvas', () => {
 
       expect(isDragging.value).toBe(true)
       expect(draggedNode.value).toBe(mockNodeDef)
+    })
+  })
+
+  describe('policy-disabled nodes', () => {
+    it('should refuse to start dragging a disabled node and show the policy toast', () => {
+      mockIsNodeDisabled.mockReturnValue(true)
+
+      const { isDragging, draggedNode, startDrag } = useNodeDragToCanvas()
+      startDrag(mockNodeDef)
+
+      expect(isDragging.value).toBe(false)
+      expect(draggedNode.value).toBeNull()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'warn',
+          detail:
+            'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage'
+        })
+      )
+    })
+
+    it('should not show a creation-failure toast when the node is disabled mid-drag', () => {
+      mockCanvas.canvas.getBoundingClientRect.mockReturnValue({
+        left: 0,
+        right: 500,
+        top: 0,
+        bottom: 500
+      })
+      mockConvertEventToCanvasOffset.mockReturnValue([150, 150])
+      mockAddNodeOnGraph.mockReturnValue(null)
+
+      const { startDrag } = useNodeDragToCanvas()
+      startDrag(mockNodeDef)
+      mockIsNodeDisabled.mockReturnValue(true)
+
+      document.dispatchEvent(
+        new PointerEvent('pointerup', {
+          clientX: 250,
+          clientY: 250,
+          bubbles: true
+        })
+      )
+
+      expect(mockToastAdd).not.toHaveBeenCalled()
+      expect(mockSelectItems).not.toHaveBeenCalled()
     })
   })
 

--- a/src/composables/node/useNodeDragToCanvas.ts
+++ b/src/composables/node/useNodeDragToCanvas.ts
@@ -2,6 +2,7 @@ import { ref, shallowRef } from 'vue'
 
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { withNodeAddSource } from '@/platform/telemetry/nodeAdded/nodeAddSource'
 import type { NodeAddSource } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -157,6 +158,19 @@ export function useNodeDragToCanvas() {
       source = 'sidebar_drag'
     }: StartDragOptions = {}
   ) {
+    if (useNodeDisabledState().isNodeDisabled(nodeDef)) {
+      useToastStore().add({
+        severity: 'warn',
+        summary: t(
+          'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastTitle'
+        ),
+        detail: t(
+          'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage'
+        ),
+        life: 3000
+      })
+      return
+    }
     isDragging.value = true
     draggedNode.value = nodeDef
     dragMode.value = mode

--- a/src/composables/node/useNodeDragToCanvas.ts
+++ b/src/composables/node/useNodeDragToCanvas.ts
@@ -82,6 +82,7 @@ function addNodeAtPosition(clientX: number, clientY: number): boolean {
     useLitegraphService().addNodeOnGraph(nodeDef, { pos })
   )
   if (!node) {
+    if (useNodeDisabledState().isNodeDisabled(nodeDef)) return true
     console.error(`Failed to add node to graph: ${nodeDef.name}`)
     useToastStore().add({
       severity: 'error',

--- a/src/lib/litegraph/public/css/litegraph.css
+++ b/src/lib/litegraph/public/css/litegraph.css
@@ -111,8 +111,12 @@
 }
 
 .litegraph .litemenu-entry.disabled {
-  opacity: 0.5;
+  opacity: 0.35;
   cursor: default;
+}
+
+.litegraph .litemenu-entry.dimmed {
+  opacity: 0.35;
 }
 
 .litegraph .litemenu-entry.separator {

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -296,6 +296,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   static gradients: Record<string, CanvasGradient> = {}
 
   static search_limit = -1
+  static isNodeTypeDisabled?: (nodeType: typeof LGraphNode) => boolean
   static node_colors: Record<string, ColorOption> = {
     red: { color: '#322', bgcolor: '#533', groupcolor: '#A88' },
     brown: { color: '#332922', bgcolor: '#593930', groupcolor: '#b06634' },
@@ -1254,7 +1255,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           value: node.type,
           content: node.title,
           has_submenu: false,
-          disabled: node.list_disabled === true,
+          disabled: LGraphCanvas.isNodeTypeDisabled?.(node) === true,
           callback: function (value, _event, _mouseEvent, contextMenu) {
             if (!canvas.graph) throw new NullGraphError()
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1204,6 +1204,27 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       ).filter((category) => category.startsWith(base_category))
       const categoryEntries: AddNodeMenu[] = []
 
+      const categoriesWithNodes = new Set<string>()
+      const categoriesWithEnabledNodes = new Set<string>()
+      if (LGraphCanvas.isNodeTypeDisabled) {
+        for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
+          if (nodeType.skip_list || !nodeType.category) continue
+          categoriesWithNodes.add(nodeType.category)
+          if (LGraphCanvas.isNodeTypeDisabled(nodeType) !== true) {
+            categoriesWithEnabledNodes.add(nodeType.category)
+          }
+        }
+      }
+      function isCategoryFullyDisabled(categoryPath: string): boolean {
+        let sawAny = false
+        for (const category of categoriesWithNodes) {
+          if (!`${category}/`.startsWith(categoryPath)) continue
+          if (categoriesWithEnabledNodes.has(category)) return false
+          sawAny = true
+        }
+        return sawAny
+      }
+
       for (const category of categories) {
         if (!category) continue
 
@@ -1228,6 +1249,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
             value: category_path,
             content: name,
             has_submenu: true,
+            className: isCategoryFullyDisabled(category_path)
+              ? 'dimmed'
+              : undefined,
             callback: function (value, _event, _mouseEvent, contextMenu) {
               inner_onMenuAdded(value.value, contextMenu)
             }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1254,6 +1254,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           value: node.type,
           content: node.title,
           has_submenu: false,
+          disabled: node.list_disabled === true,
           callback: function (value, _event, _mouseEvent, contextMenu) {
             if (!canvas.graph) throw new NullGraphError()
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3,6 +3,7 @@ import { toValue } from 'vue'
 
 import { isMiddleButtonEvent } from '@/base/pointerUtils'
 import { MovingInputLink } from '@/lib/litegraph/src/canvas/MovingInputLink'
+import { isNodeTypeDisabled } from '@/lib/litegraph/src/nodeTypeAvailability'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
 import { LitegraphLinkAdapter } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
@@ -296,7 +297,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   static gradients: Record<string, CanvasGradient> = {}
 
   static search_limit = -1
-  static isNodeTypeDisabled?: (nodeType: typeof LGraphNode) => boolean
   static node_colors: Record<string, ColorOption> = {
     red: { color: '#322', bgcolor: '#533', groupcolor: '#A88' },
     brown: { color: '#332922', bgcolor: '#593930', groupcolor: '#b06634' },
@@ -1206,13 +1206,11 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
       const categoriesWithNodes = new Set<string>()
       const categoriesWithEnabledNodes = new Set<string>()
-      if (LGraphCanvas.isNodeTypeDisabled) {
-        for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
-          if (nodeType.skip_list || !nodeType.category) continue
-          categoriesWithNodes.add(nodeType.category)
-          if (LGraphCanvas.isNodeTypeDisabled(nodeType) !== true) {
-            categoriesWithEnabledNodes.add(nodeType.category)
-          }
+      for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
+        if (nodeType.skip_list || !nodeType.category) continue
+        categoriesWithNodes.add(nodeType.category)
+        if (!isNodeTypeDisabled(nodeType)) {
+          categoriesWithEnabledNodes.add(nodeType.category)
         }
       }
       function isCategoryFullyDisabled(categoryPath: string): boolean {
@@ -1279,7 +1277,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           value: node.type,
           content: node.title,
           has_submenu: false,
-          disabled: LGraphCanvas.isNodeTypeDisabled?.(node) === true,
+          disabled: isNodeTypeDisabled(node),
           callback: function (value, _event, _mouseEvent, contextMenu) {
             if (!canvas.graph) throw new NullGraphError()
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -264,6 +264,7 @@ export class LGraphNode
   static description?: string
   static filter?: string
   static skip_list?: boolean
+  static list_disabled?: boolean
   static nodeData?: {
     dev_only?: boolean
     deprecated?: boolean

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -264,7 +264,6 @@ export class LGraphNode
   static description?: string
   static filter?: string
   static skip_list?: boolean
-  static list_disabled?: boolean
   static nodeData?: {
     dev_only?: boolean
     deprecated?: boolean

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -271,6 +271,7 @@ export class LGraphNode
     experimental?: boolean
     output_node?: boolean
     api_node?: boolean
+    category?: string
     name?: string
   }
 

--- a/src/lib/litegraph/src/nodeTypeAvailability.ts
+++ b/src/lib/litegraph/src/nodeTypeAvailability.ts
@@ -1,0 +1,15 @@
+import type { LGraphNode } from './LGraphNode'
+
+export type NodeTypeDisabledPredicate = (nodeType: typeof LGraphNode) => boolean
+
+let nodeTypeDisabledPredicate: NodeTypeDisabledPredicate | undefined
+
+export function setNodeTypeDisabledPredicate(
+  predicate: NodeTypeDisabledPredicate | undefined
+): void {
+  nodeTypeDisabledPredicate = predicate
+}
+
+export function isNodeTypeDisabled(nodeType: typeof LGraphNode): boolean {
+  return nodeTypeDisabledPredicate?.(nodeType) === true
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3185,6 +3185,7 @@
       },
       "nodeCount": "{count} enabled",
       "enableAll": "Enable all",
+      "disabledBadge": "Disabled",
       "disableAll": "Disable all",
       "toggleProvider": "Set access for {provider}",
       "disableAllTitle": "Disable all providers?",

--- a/src/platform/nodeDisabled/nodeDisabledState.ts
+++ b/src/platform/nodeDisabled/nodeDisabledState.ts
@@ -1,6 +1,7 @@
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import type { ComputedRef } from 'vue'
 
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { PartnerProvider } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
@@ -47,5 +48,31 @@ export function useNodeDisabledState() {
     )
   }
 
-  return { isNodeDisabled }
+  return { isNodeDisabled, getDisabledNodeCategories }
+}
+
+let listDisabledSyncStarted = false
+
+// Registered node types carry list_disabled as a static, stamped at
+// registration time — re-stamp them whenever the policy changes so the
+// legacy add-node menu stays correct regardless of load order.
+export function startListDisabledSync(): void {
+  if (listDisabledSyncStarted) return
+  listDisabledSyncStarted = true
+
+  const { isNodeDisabled, getDisabledNodeCategories } = useNodeDisabledState()
+  watch(
+    getDisabledNodeCategories(),
+    () => {
+      for (const ctor of Object.values(LiteGraph.registered_node_types)) {
+        const nodeData = ctor.nodeData
+        if (nodeData?.api_node !== true) continue
+        ctor.list_disabled = isNodeDisabled({
+          api_node: nodeData.api_node,
+          category: nodeData.category ?? ''
+        })
+      }
+    },
+    { immediate: true }
+  )
 }

--- a/src/platform/nodeDisabled/nodeDisabledState.ts
+++ b/src/platform/nodeDisabled/nodeDisabledState.ts
@@ -1,7 +1,6 @@
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
 
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { PartnerProvider } from '@/platform/workspace/api/partnerNodePolicyApi'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
@@ -48,31 +47,5 @@ export function useNodeDisabledState() {
     )
   }
 
-  return { isNodeDisabled, getDisabledNodeCategories }
-}
-
-let listDisabledSyncStarted = false
-
-// Registered node types carry list_disabled as a static, stamped at
-// registration time — re-stamp them whenever the policy changes so the
-// legacy add-node menu stays correct regardless of load order.
-export function startListDisabledSync(): void {
-  if (listDisabledSyncStarted) return
-  listDisabledSyncStarted = true
-
-  const { isNodeDisabled, getDisabledNodeCategories } = useNodeDisabledState()
-  watch(
-    getDisabledNodeCategories(),
-    () => {
-      for (const ctor of Object.values(LiteGraph.registered_node_types)) {
-        const nodeData = ctor.nodeData
-        if (nodeData?.api_node !== true) continue
-        ctor.list_disabled = isNodeDisabled({
-          api_node: nodeData.api_node,
-          category: nodeData.category ?? ''
-        })
-      }
-    },
-    { immediate: true }
-  )
+  return { isNodeDisabled }
 }

--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 import { app } from '@/scripts/app'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -53,7 +53,7 @@ describe('useLitegraphService().registerNodeDef', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it('reactively applies policy-disabled discovery state in developer mode', async () => {
+  it('keeps policy-disabled nodes discoverable and flags them for menus', async () => {
     const nodeDefStore = useNodeDefStore()
     const settingStore = useSettingStore()
     const governanceStore = usePartnerNodeGovernanceStore()
@@ -87,21 +87,24 @@ describe('useLitegraphService().registerNodeDef', () => {
     nodeDefStore.updateNodeDefs([nodeDef])
 
     try {
+      const nodeType = LiteGraph.registered_node_types[nodeDef.name]
       expect(LiteGraph.getNodeTypesCategories()).toContain(nodeDef.category)
+      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(false)
 
       governanceStore.policy = {
         enforcementEnabled: true,
         providers: [{ providerId: 'openai', enabled: false }]
       }
       await nextTick()
-      expect(LiteGraph.getNodeTypesCategories()).not.toContain(nodeDef.category)
+      expect(LiteGraph.getNodeTypesCategories()).toContain(nodeDef.category)
+      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(true)
 
       governanceStore.policy = {
         enforcementEnabled: true,
         providers: [{ providerId: 'openai', enabled: true }]
       }
       await nextTick()
-      expect(LiteGraph.getNodeTypesCategories()).toContain(nodeDef.category)
+      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(false)
     } finally {
       LiteGraph.unregisterNodeType(nodeDef.name)
     }

--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -9,7 +9,9 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 import { app } from '@/scripts/app'
-import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { isNodeTypeDisabled } from '@/lib/litegraph/src/nodeTypeAvailability'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { usePartnerNodeGovernanceStore } from '@/platform/workspace/stores/partnerNodeGovernanceStore'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -89,7 +91,7 @@ describe('useLitegraphService().registerNodeDef', () => {
     try {
       const nodeType = LiteGraph.registered_node_types[nodeDef.name]
       expect(LiteGraph.getNodeTypesCategories()).toContain(nodeDef.category)
-      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(false)
+      expect(isNodeTypeDisabled(nodeType)).toBe(false)
 
       governanceStore.policy = {
         enforcementEnabled: true,
@@ -97,16 +99,47 @@ describe('useLitegraphService().registerNodeDef', () => {
       }
       await nextTick()
       expect(LiteGraph.getNodeTypesCategories()).toContain(nodeDef.category)
-      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(true)
+      expect(isNodeTypeDisabled(nodeType)).toBe(true)
 
       governanceStore.policy = {
         enforcementEnabled: true,
         providers: [{ providerId: 'openai', enabled: true }]
       }
       await nextTick()
-      expect(LGraphCanvas.isNodeTypeDisabled?.(nodeType)).toBe(false)
+      expect(isNodeTypeDisabled(nodeType)).toBe(false)
     } finally {
       LiteGraph.unregisterNodeType(nodeDef.name)
     }
+  })
+
+  it('rejects placing a policy-disabled node with the policy toast', async () => {
+    const governanceStore = usePartnerNodeGovernanceStore()
+    governanceStore.providers = [
+      { id: 'openai', displayName: 'OpenAI', nodeCategories: ['OpenAI'] }
+    ]
+    governanceStore.policy = {
+      enforcementEnabled: true,
+      providers: [{ providerId: 'openai', enabled: false }]
+    }
+    const nodeDef: ComfyNodeDef = {
+      name: 'RejectedTestNode',
+      display_name: 'Rejected Test Node',
+      category: '_for_testing/partner-governance/OpenAI',
+      python_module: 'test',
+      description: '',
+      input: {},
+      output: [],
+      output_node: false,
+      api_node: true
+    }
+    const service = useLitegraphService()
+    const toastAdd = vi.spyOn(useToastStore(), 'add')
+
+    const node = service.addNodeOnGraph(nodeDef)
+
+    expect(node).toBeNull()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' })
+    )
   })
 })

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -604,7 +604,7 @@ export const useLitegraphService = () => {
     node.title = nodeDef.display_name || nodeDef.name
 
     if (isNodeDisabled(nodeDef)) {
-      node.skip_list = true
+      node.list_disabled = true
     } else if (nodeDef.dev_only) {
       const settingStore = useSettingStore()
       node.skip_list = !settingStore.get('Comfy.DevMode')

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -36,10 +36,7 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import {
-  startListDisabledSync,
-  useNodeDisabledState
-} from '@/platform/nodeDisabled/nodeDisabledState'
+import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -182,7 +179,16 @@ function getMinSize(node: LGraphNode) {
 export const useLitegraphService = () => {
   const extensionService = useExtensionService()
   const { isNodeDisabled } = useNodeDisabledState()
-  startListDisabledSync()
+  LGraphCanvas.isNodeTypeDisabled = (nodeType) => {
+    const nodeData = nodeType.nodeData
+    return (
+      nodeData?.api_node === true &&
+      isNodeDisabled({
+        api_node: nodeData.api_node,
+        category: nodeData.category ?? ''
+      })
+    )
+  }
   const toastStore = useToastStore()
   const widgetStore = useWidgetStore()
   const canvasStore = useCanvasStore()
@@ -607,9 +613,7 @@ export const useLitegraphService = () => {
     node.category = nodeDef.category
     node.title = nodeDef.display_name || nodeDef.name
 
-    if (isNodeDisabled(nodeDef)) {
-      node.list_disabled = true
-    } else if (nodeDef.dev_only) {
+    if (nodeDef.dev_only) {
       const settingStore = useSettingStore()
       node.skip_list = !settingStore.get('Comfy.DevMode')
     }

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -881,6 +881,20 @@ export const useLitegraphService = () => {
     options: CreateNodeOptions = {},
     addOptions?: GraphAddOptions
   ): LGraphNode | null {
+    if (isNodeDisabled(nodeDef)) {
+      toastStore.add({
+        severity: 'warn',
+        summary: t(
+          'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastTitle'
+        ),
+        detail: t(
+          'errorCatalog.validationErrors.PARTNER_NODE_DISABLED.toastMessage'
+        ),
+        life: 3000
+      })
+      return null
+    }
+
     options.pos ??= getCanvasCenter()
 
     if (isBlueprintType(nodeDef.name)) {

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -36,7 +36,10 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
+import {
+  startListDisabledSync,
+  useNodeDisabledState
+} from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -179,6 +182,7 @@ function getMinSize(node: LGraphNode) {
 export const useLitegraphService = () => {
   const extensionService = useExtensionService()
   const { isNodeDisabled } = useNodeDisabledState()
+  startListDisabledSync()
   const toastStore = useToastStore()
   const widgetStore = useWidgetStore()
   const canvasStore = useCanvasStore()

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -36,6 +36,7 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { setNodeTypeDisabledPredicate } from '@/lib/litegraph/src/nodeTypeAvailability'
 import { useNodeDisabledState } from '@/platform/nodeDisabled/nodeDisabledState'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -179,7 +180,7 @@ function getMinSize(node: LGraphNode) {
 export const useLitegraphService = () => {
   const extensionService = useExtensionService()
   const { isNodeDisabled } = useNodeDisabledState()
-  LGraphCanvas.isNodeTypeDisabled = (nodeType) => {
+  setNodeTypeDisabledPredicate((nodeType) => {
     const nodeData = nodeType.nodeData
     return (
       nodeData?.api_node === true &&
@@ -188,7 +189,7 @@ export const useLitegraphService = () => {
         category: nodeData.category ?? ''
       })
     )
-  }
+  })
   const toastStore = useToastStore()
   const widgetStore = useWidgetStore()
   const canvasStore = useCanvasStore()

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -264,7 +264,7 @@ describe('useNodeDefStore', () => {
       expect(store.visibleNodeDefs).toHaveLength(2)
     })
 
-    it('should reactively hide nodes disabled by provider policy', () => {
+    it('keeps policy-disabled nodes visible in search results', () => {
       setPartnerProviderEnabled(false)
       store.updateNodeDefs([
         createMockNodeDef({ name: 'enabled' }),
@@ -276,7 +276,8 @@ describe('useNodeDefStore', () => {
       ])
 
       expect(store.visibleNodeDefs.map((node) => node.name)).toEqual([
-        'enabled'
+        'enabled',
+        'disabled'
       ])
 
       setPartnerProviderEnabled(true)

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -383,10 +383,8 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
   })
 
   const visibleNodeDefs = computed(() => {
-    return nodeDefs.value.filter(
-      (nodeDef) =>
-        nodeDefFilters.value.every((filter) => filter.predicate(nodeDef)) &&
-        !isNodeDisabled(nodeDef)
+    return nodeDefs.value.filter((nodeDef) =>
+      nodeDefFilters.value.every((filter) => filter.predicate(nodeDef))
     )
   })
   const nodeSearchService = computed(
@@ -567,6 +565,7 @@ export const useNodeFrequencyStore = defineStore('nodeFrequency', () => {
   }
 
   const nodeDefStore = useNodeDefStore()
+  const { isNodeDisabled } = useNodeDisabledState()
   const topNodeDefs = computed<ComfyNodeDefImpl[]>(() => {
     const visibleNodeNames = new Set(
       nodeDefStore.visibleNodeDefs.map((nodeDef) => nodeDef.name)
@@ -575,7 +574,9 @@ export const useNodeFrequencyStore = defineStore('nodeFrequency', () => {
       .map((nodeName: string) => nodeDefStore.nodeDefsByName[nodeName])
       .filter(
         (nodeDef): nodeDef is ComfyNodeDefImpl =>
-          nodeDef !== undefined && visibleNodeNames.has(nodeDef.name)
+          nodeDef !== undefined &&
+          visibleNodeNames.has(nodeDef.name) &&
+          !isNodeDisabled(nodeDef)
       )
       .slice(0, topNodeDefLimit.value)
   })

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -326,7 +326,6 @@ export interface NodeDefFilter {
 
 export const useNodeDefStore = defineStore('nodeDef', () => {
   const settingStore = useSettingStore()
-  const { isNodeDisabled } = useNodeDisabledState()
 
   const nodeDefsByName = ref<Record<string, ComfyNodeDefImpl>>({})
   const nodeDefsByDisplayName = ref<Record<string, ComfyNodeDefImpl>>({})
@@ -341,9 +340,7 @@ export const useNodeDefStore = defineStore('nodeDef', () => {
     for (const nodeType of Object.values(LiteGraph.registered_node_types)) {
       const nodeData =
         registeredNodeDefs[nodeType.nodeData?.name ?? ''] ?? nodeType.nodeData
-      if (nodeData && isNodeDisabled(nodeData)) {
-        nodeType.skip_list = true
-      } else if (nodeData?.dev_only) {
+      if (nodeData?.dev_only) {
         nodeType.skip_list = !devModeEnabled
       } else if (nodeData?.api_node) {
         nodeType.skip_list = false


### PR DESCRIPTION
## Summary

Design-comparison spike stacked on #14531: instead of hiding workspace-disabled partner nodes from discovery, show them **in a disabled state** — reduced opacity plus an amber `Disabled` badge — so members learn a node exists-but-is-gated rather than experiencing silent disappearance. Companion artifact for the DES-660 show-vs-hide decision; #14531's `isNodeDisabled` seam is reused unchanged, only the consumers flip from filter-out to annotate.

## Changes

- **What**:
  - `visibleNodeDefs` no longer filters policy-disabled nodes — they stay in the search corpus and node library
  - Both search result items (`NodeSearchItem`, v2 `NodeSearchListItem`) render disabled nodes at 60% opacity with an amber `Disabled` badge. In the v2 dialog the badge sits in the right-hand badge cluster using the shared pill style (amber label); the compact layout keeps the status-tag style alongside deprecated/experimental
  - Disabled nodes cannot be placed: `addNodeOnGraph` rejects them with a warn toast (reuses the `PARTNER_NODE_DISABLED` catalog copy), covering search click/Enter, drag-to-canvas, and canvas drop in one gate
  - Frequency suggestions stay curated: `topNodeDefs` excludes disabled nodes explicitly (limited slots shouldn't carry dead entries)
  - LiteGraph legacy add-node menu shows disabled nodes as native disabled entries (dimmed, unclickable) via a live `LGraphCanvas.isNodeTypeDisabled` hook — evaluated at menu open, so policy changes apply without reload. The reactive `skip_list` hiding from the base branch is removed.
  - Node library (v2 panel): disabled rows dim to 60%; the hover preview card carries the policy note; click/drag pickup is blocked with the policy toast
- **Breaking**: none

## Open (design review inputs)

- Grouping: whether disabled matches sink below enabled matches / group under a divider
- Node library tree renders returned nodes without annotation yet
- If this direction wins, #14531's search/library filtering reverts while its `isNodeDisabled` module and menu handling stay

Linear: DES-660 · FE-1473

## Screenshots
<img width="842" height="465" alt="Screenshot 2026-08-12 at 2 26 16 PM" src="https://github.com/user-attachments/assets/4e1f2db9-6e61-45ed-8fdd-200017db96fd" />
<img width="802" height="560" alt="Screenshot 2026-08-12 at 2 26 47 PM" src="https://github.com/user-attachments/assets/2d950cfa-dc3f-42e2-86c3-4a5405c8add0" />
<img width="1246" height="832" alt="Screenshot 2026-08-12 at 2 26 57 PM" src="https://github.com/user-attachments/assets/3edc5700-4199-4ae5-b209-300b349c40b2" />

