### PR TITLE
Optimize lint-staged for large changes

### DIFF
--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -18,8 +18,8 @@ export default function lintStaged(stagedFiles: string[]) {
   const styleFiles = relativePaths.filter((fileName) =>
     /\.(css|vue)$/.test(fileName)
   )
-  const typecheckFiles = formattableFiles.filter(
-    (fileName) => !fileName.endsWith('.js')
+  const typecheckFiles = formattableFiles.filter((fileName) =>
+    /\.(ts|tsx|vue|mts)$/.test(fileName)
   )
 
   return [

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -1,51 +1,74 @@
 import path from 'node:path'
 
-export default {
-  'tests-ui/**': () =>
-    'echo "Files in tests-ui/ are deprecated. Colocate tests with source files." && exit 1',
+export default function lintStaged(stagedFiles: string[]) {
+  const relativePaths = stagedFiles.map(toRelativePath)
 
-  './**/*.{css,vue}': (stagedFiles: string[]) => {
-    const joinedPaths = toJoinedRelativePaths(stagedFiles)
-    return [`pnpm exec stylelint --allow-empty-input ${joinedPaths}`]
-  },
+  if (relativePaths.some((fileName) => fileName.startsWith('tests-ui/'))) {
+    return 'echo "Files in tests-ui/ are deprecated. Colocate tests with source files." && exit 1'
+  }
 
-  './**/*.js': (stagedFiles: string[]) => formatAndEslint(stagedFiles),
+  const formattable = relativePaths.filter(
+    (fileName) =>
+      /\.(js|ts|tsx|vue|mts|json|yaml|md)$/.test(fileName) &&
+      !fileName.endsWith('pnpm-lock.yaml')
+  )
+  const codeFiles = relativePaths.filter((fileName) =>
+    /\.(js|ts|tsx|vue|mts)$/.test(fileName)
+  )
+  const styleFiles = relativePaths.filter((fileName) =>
+    /\.(css|vue)$/.test(fileName)
+  )
+  const typecheckFiles = formattable.filter(
+    (fileName) => !fileName.endsWith('.js')
+  )
+  const lintFileCount = new Set([...codeFiles, ...styleFiles]).size
+  const commands: string[] = []
 
-  './**/*.{ts,tsx,vue,mts,json,yaml,md}': (stagedFiles: string[]) => {
-    // oxfmt ignores the lockfile and errors when left with zero targets
-    const formattable = stagedFiles.filter((f) => !f.endsWith('pnpm-lock.yaml'))
-    if (formattable.length === 0) return []
+  if (formattable.length > 0) {
+    commands.push(`pnpm exec oxfmt --write ${joinPaths(formattable)}`)
+  }
 
-    const commands = [...formatAndEslint(formattable), 'pnpm typecheck']
+  if (lintFileCount > 10) {
+    commands.push('pnpm lint')
+  } else {
+    if (styleFiles.length > 0) {
+      commands.push(
+        `pnpm exec stylelint --allow-empty-input ${joinPaths(styleFiles)}`
+      )
+    }
 
-    const relativePaths = stagedFiles.map((f) =>
-      path.relative(process.cwd(), f).replace(/\\/g, '/')
-    )
+    if (codeFiles.length > 0) {
+      const joinedPaths = joinPaths(codeFiles)
+      commands.push(
+        `pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern --fix ${joinedPaths}`,
+        `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
+      )
+    }
+  }
 
-    if (relativePaths.some((f) => f.startsWith('browser_tests/'))) {
+  if (typecheckFiles.length > 0) {
+    commands.push('pnpm typecheck')
+
+    if (
+      typecheckFiles.some((fileName) => fileName.startsWith('browser_tests/'))
+    ) {
       commands.push('pnpm typecheck:browser')
     }
 
-    if (relativePaths.some((f) => f.startsWith('apps/website/'))) {
+    if (
+      typecheckFiles.some((fileName) => fileName.startsWith('apps/website/'))
+    ) {
       commands.push('pnpm typecheck:website')
     }
-
-    return commands
   }
+
+  return commands
 }
 
-function formatAndEslint(fileNames: string[]) {
-  const joinedPaths = toJoinedRelativePaths(fileNames)
-  return [
-    `pnpm exec oxfmt --write ${joinedPaths}`,
-    `pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern --fix ${joinedPaths}`,
-    `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
-  ]
+function toRelativePath(fileName: string) {
+  return path.relative(process.cwd(), fileName).replace(/\\/g, '/')
 }
 
-function toJoinedRelativePaths(fileNames: string[]) {
-  const relativePaths = fileNames.map((f) =>
-    path.relative(process.cwd(), f).replace(/\\/g, '/')
-  )
-  return relativePaths.map((p) => `"${p}"`).join(' ')
+function joinPaths(fileNames: string[]) {
+  return fileNames.map((fileName) => `"${fileName}"`).join(' ')
 }

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -7,7 +7,7 @@ export default function lintStaged(stagedFiles: string[]) {
     return 'echo "Files in tests-ui/ are deprecated. Colocate tests with source files." && exit 1'
   }
 
-  const formattable = relativePaths.filter(
+  const formattableFiles = relativePaths.filter(
     (fileName) =>
       /\.(js|ts|tsx|vue|mts|json|yaml|md)$/.test(fileName) &&
       !fileName.endsWith('pnpm-lock.yaml')
@@ -18,57 +18,57 @@ export default function lintStaged(stagedFiles: string[]) {
   const styleFiles = relativePaths.filter((fileName) =>
     /\.(css|vue)$/.test(fileName)
   )
-  const typecheckFiles = formattable.filter(
+  const typecheckFiles = formattableFiles.filter(
     (fileName) => !fileName.endsWith('.js')
   )
-  const lintFileCount = new Set([...codeFiles, ...styleFiles]).size
-  const commands: string[] = []
 
-  if (formattable.length > 0) {
-    commands.push(`pnpm exec oxfmt --write ${joinPaths(formattable)}`)
+  return [
+    ...commandsWithFiles(formattableFiles, 'pnpm exec oxfmt --write'),
+    ...lintCommands(codeFiles, styleFiles),
+    ...typecheckCommands(typecheckFiles)
+  ]
+}
+
+function lintCommands(codeFiles: string[], styleFiles: string[]) {
+  if (new Set([...codeFiles, ...styleFiles]).size > 10) {
+    return ['pnpm lint']
   }
 
-  if (lintFileCount > 10) {
-    commands.push('pnpm lint')
-  } else {
-    if (styleFiles.length > 0) {
-      commands.push(
-        `pnpm exec stylelint --allow-empty-input ${joinPaths(styleFiles)}`
-      )
-    }
+  return [
+    ...commandsWithFiles(styleFiles, 'pnpm exec stylelint --allow-empty-input'),
+    ...commandsWithFiles(
+      codeFiles,
+      'pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern --fix',
+      'pnpm exec eslint --cache --fix --no-warn-ignored'
+    )
+  ]
+}
 
-    if (codeFiles.length > 0) {
-      const joinedPaths = joinPaths(codeFiles)
-      commands.push(
-        `pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern --fix ${joinedPaths}`,
-        `pnpm exec eslint --cache --fix --no-warn-ignored ${joinedPaths}`
-      )
-    }
+function typecheckCommands(fileNames: string[]) {
+  if (fileNames.length === 0) {
+    return []
   }
 
-  if (typecheckFiles.length > 0) {
-    commands.push('pnpm typecheck')
+  return [
+    'pnpm typecheck',
+    ...(fileNames.some((fileName) => fileName.startsWith('browser_tests/'))
+      ? ['pnpm typecheck:browser']
+      : []),
+    ...(fileNames.some((fileName) => fileName.startsWith('apps/website/'))
+      ? ['pnpm typecheck:website']
+      : [])
+  ]
+}
 
-    if (
-      typecheckFiles.some((fileName) => fileName.startsWith('browser_tests/'))
-    ) {
-      commands.push('pnpm typecheck:browser')
-    }
-
-    if (
-      typecheckFiles.some((fileName) => fileName.startsWith('apps/website/'))
-    ) {
-      commands.push('pnpm typecheck:website')
-    }
+function commandsWithFiles(fileNames: string[], ...commands: string[]) {
+  if (fileNames.length === 0) {
+    return []
   }
 
-  return commands
+  const joinedPaths = fileNames.map((fileName) => `"${fileName}"`).join(' ')
+  return commands.map((command) => `${command} ${joinedPaths}`)
 }
 
 function toRelativePath(fileName: string) {
   return path.relative(process.cwd(), fileName).replace(/\\/g, '/')
-}
-
-function joinPaths(fileNames: string[]) {
-  return fileNames.map((fileName) => `"${fileName}"`).join(' ')
 }


### PR DESCRIPTION
## Summary

Run the repository-wide lint command instead of per-file linters when more than 10 lintable files are staged.

## Changes

- **What**: Uses lint-staged function configuration to count all staged code and style files together, retaining targeted formatting and typechecks while switching lint execution to `pnpm lint` above the threshold.

## Review Focus

Verify that mixed file types contribute to the shared threshold and that 10 files still use targeted lint commands.