### PR TITLE
Fix litegraph properties XSS vulnerabilities.

### DIFF
--- a/browser_tests/assets/xss/xss-e1-subgraph-type.json
+++ b/browser_tests/assets/xss/xss-e1-subgraph-type.json
@@ -1,0 +1,566 @@
+{
+  "id": "976d6e9a-927d-42db-abd4-96bfc0ecf8d9",
+  "revision": 0,
+  "last_node_id": 10,
+  "last_link_id": 11,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "<img src=x onerror=\"var b=document.createElement('div');b.textContent='XSS E1 subgraph node.type \\u2014 '+document.domain;b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#c0392b;color:#fff;font:bold 16px/1.4 sans-serif;padding:14px;text-align:center;box-shadow:0 2px 8px rgba(0,0,0,.4)';document.body.appendChild(b)\">",
+      "pos": [532, 412.5],
+      "size": [140, 46],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [10]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [11]
+        }
+      ],
+      "title": "subgraph 2",
+      "properties": {},
+      "widgets_values": []
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [758.2109985351562, 398.3681335449219],
+      "size": [210, 46],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 10
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 11
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [9]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [1028.9615478515625, 381.83746337890625],
+      "size": [210, 270],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 9
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["ComfyUI"]
+    }
+  ],
+  "links": [
+    [9, 8, 0, 9, 0, "IMAGE"],
+    [10, 10, 0, 8, 0, "LATENT"],
+    [11, 10, 1, 8, 1, "VAE"]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "<img src=x onerror=\"var b=document.createElement('div');b.textContent='XSS E1 subgraph node.type \\u2014 '+document.domain;b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#c0392b;color:#fff;font:bold 16px/1.4 sans-serif;padding:14px;text-align:center;box-shadow:0 2px 8px rgba(0,0,0,.4)';document.body.appendChild(b)\">",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 10,
+          "lastLinkId": 14,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "subgraph 2",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-154, 415.5, 120, 40]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1238, 395.5, 120, 80]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "4d6c7e4e-971e-4f78-9218-9a604db53a4b",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [7],
+            "localized_name": "LATENT",
+            "pos": {
+              "0": 1258,
+              "1": 415.5
+            }
+          },
+          {
+            "id": "f8201d4f-7fc6-4a1b-b8c9-9f0716d9c09a",
+            "name": "VAE",
+            "type": "VAE",
+            "linkIds": [14],
+            "localized_name": "VAE",
+            "pos": {
+              "0": 1258,
+              "1": 435.5
+            }
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 6,
+            "type": "CLIPTextEncode",
+            "pos": [415, 186],
+            "size": [422.84503173828125, 164.31304931640625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 13
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "slot_index": 0,
+                "links": [4]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode"
+            },
+            "widgets_values": [
+              "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"
+            ]
+          },
+          {
+            "id": 3,
+            "type": "KSampler",
+            "pos": [863, 186],
+            "size": [315, 262],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 12
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 4
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 10
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 11
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [7]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler"
+            },
+            "widgets_values": [
+              32115495257102,
+              "randomize",
+              20,
+              8,
+              "euler",
+              "normal",
+              1
+            ]
+          },
+          {
+            "id": 10,
+            "type": "dbe5763f-440b-47b4-82ac-454f1f98b0e3",
+            "pos": [194.13900756835938, 657.3333740234375],
+            "size": [140, 106],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [10]
+              },
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [11]
+              },
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [12]
+              },
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [13]
+              },
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [14]
+              }
+            ],
+            "title": "subgraph 3",
+            "properties": {},
+            "widgets_values": []
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 4,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 7,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 10,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 11,
+            "origin_id": 10,
+            "origin_slot": 1,
+            "target_id": 3,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 10,
+            "origin_slot": 2,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 13,
+            "origin_id": 10,
+            "origin_slot": 3,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 14,
+            "origin_id": 10,
+            "origin_slot": 4,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "VAE"
+          }
+        ],
+        "extra": {}
+      },
+      {
+        "id": "dbe5763f-440b-47b4-82ac-454f1f98b0e3",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 9,
+          "lastLinkId": 9,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "subgraph 3",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-154, 517, 120, 40]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [898.2780151367188, 467, 128.6640625, 140]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "b4882169-329b-43f6-a373-81abfbdea55b",
+            "name": "CONDITIONING",
+            "type": "CONDITIONING",
+            "linkIds": [6],
+            "localized_name": "CONDITIONING",
+            "pos": {
+              "0": 918.2780151367188,
+              "1": 487
+            }
+          },
+          {
+            "id": "01f51f96-a741-428e-8772-9557ee50b609",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [2],
+            "localized_name": "LATENT",
+            "pos": {
+              "0": 918.2780151367188,
+              "1": 507
+            }
+          },
+          {
+            "id": "47fa906e-d80b-45c3-a596-211a0e59d4a1",
+            "name": "MODEL",
+            "type": "MODEL",
+            "linkIds": [1],
+            "localized_name": "MODEL",
+            "pos": {
+              "0": 918.2780151367188,
+              "1": 527
+            }
+          },
+          {
+            "id": "f03dccd7-10e8-4513-9994-15854a92d192",
+            "name": "CLIP",
+            "type": "CLIP",
+            "linkIds": [3],
+            "localized_name": "CLIP",
+            "pos": {
+              "0": 918.2780151367188,
+              "1": 547
+            }
+          },
+          {
+            "id": "a666877f-e34f-49bc-8a78-b26156656b83",
+            "name": "VAE",
+            "type": "VAE",
+            "linkIds": [8],
+            "localized_name": "VAE",
+            "pos": {
+              "0": 918.2780151367188,
+              "1": 567
+            }
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 7,
+            "type": "CLIPTextEncode",
+            "pos": [413, 389],
+            "size": [425.27801513671875, 180.6060791015625],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 5
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "slot_index": 0,
+                "links": [6]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode"
+            },
+            "widgets_values": ["text, watermark"]
+          },
+          {
+            "id": 5,
+            "type": "EmptyLatentImage",
+            "pos": [473, 609],
+            "size": [315, 106],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [2]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptyLatentImage"
+            },
+            "widgets_values": [512, 512, 1]
+          },
+          {
+            "id": 4,
+            "type": "CheckpointLoaderSimple",
+            "pos": [26, 474],
+            "size": [315, 98],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [1]
+              },
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "slot_index": 1,
+                "links": [3, 5]
+              },
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 2,
+                "links": [8]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CheckpointLoaderSimple"
+            },
+            "widgets_values": ["v1-5-pruned-emaonly-fp16.safetensors"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 5,
+            "origin_id": 4,
+            "origin_slot": 1,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 6,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 2,
+            "origin_id": 5,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1,
+            "origin_id": 4,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "MODEL"
+          },
+          {
+            "id": 3,
+            "origin_id": 4,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "CLIP"
+          },
+          {
+            "id": 8,
+            "origin_id": 4,
+            "origin_slot": 2,
+            "target_id": -20,
+            "target_slot": 4,
+            "type": "VAE"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.24.0-1"
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/xss/xss-e2-property-key.json
+++ b/browser_tests/assets/xss/xss-e2-property-key.json
@@ -1,0 +1,27 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "Note",
+      "pos": [400, 300],
+      "size": [340, 130],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Right-click -> Properties -> click the entry",
+      "properties": {
+        "<img src=x onerror=\"var b=document.createElement('div');b.textContent='XSS E2 property-key \\u2014 '+document.domain;b.style.cssText='position:fixed;top:0;left:0;right:0;z-index:2147483647;background:#c0392b;color:#fff;font:bold 16px/1.4 sans-serif;padding:14px;text-align:center;box-shadow:0 2px 8px rgba(0,0,0,.4)';document.body.appendChild(b)\">": "anything"
+      },
+      "widgets_values": ["hi"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/tests/xss.spec.ts
+++ b/browser_tests/tests/xss.spec.ts
@@ -3,7 +3,7 @@ import {
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
 
-test('Is not vulnarble to xss', async ({ comfyPage }) => {
+test('Is not vulnerable to xss', async ({ comfyPage }) => {
   await test.step('in subgraph type', async () => {
     await comfyPage.workflow.loadWorkflow('xss/xss-e1-subgraph-type')
     const node = await comfyPage.nodeOps.getNodeRefById(10)

--- a/browser_tests/tests/xss.spec.ts
+++ b/browser_tests/tests/xss.spec.ts
@@ -1,0 +1,27 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+
+test('Is not vulnarble to xss', async ({ comfyPage }) => {
+  await test.step('in subgraph type', async () => {
+    await comfyPage.workflow.loadWorkflow('xss/xss-e1-subgraph-type')
+    const node = await comfyPage.nodeOps.getNodeRefById(10)
+    await node.click('title', { button: 'right' })
+    await comfyPage.contextMenu.clickLitegraphMenuItem('Properties Panel')
+    await comfyPage.nextFrame()
+    await expect(comfyPage.page.getByText('XSS E1')).toBeHidden()
+  })
+
+  await test.step('in property key', async () => {
+    await comfyPage.workflow.loadWorkflow('xss/xss-e2-property-key')
+    const node = await comfyPage.nodeOps.getNodeRefById(1)
+    await node.click('title', { button: 'right' })
+    await comfyPage.contextMenu.menuItems
+      .getByText('Properties', { exact: true })
+      .click()
+    await comfyPage.contextMenu.clickLitegraphMenuItem('anything')
+    await comfyPage.nextFrame()
+    await expect(comfyPage.page.getByText('XSS E2')).toBeHidden()
+  })
+})

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1397,7 +1397,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         value = LGraphCanvas.getPropertyPrintableValue(value, info.values)
 
       // value could contain invalid html characters, clean that
-      value = LGraphCanvas.decodeHTML(toString(value))
+      value = DOMPurify.sanitize(toString(value))
       entries.push({
         content:
           `<span class='property_name'>${info.label || i}</span>` +
@@ -1433,9 +1433,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
   /** @deprecated */
   static decodeHTML(str: string): string {
-    const e = document.createElement('div')
-    e.textContent = str
-    return e.innerHTML
+    return DOMPurify.sanitize(str)
   }
 
   static onMenuResizeNode(
@@ -8360,9 +8358,10 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       // clear
       panel.content.innerHTML = ''
       const nodeType = DOMPurify.sanitize(node.type)
+      // @ts-expect-error - FIXME: desc doesn't actually exist?
+      const nodeDescription = DOMPurify.sanitize(node.constructor.desc || '')
       panel.addHTML(
-        // @ts-expect-error - desc property
-        `<span class='node_type'>${nodeType}</span><span class='node_desc'>${node.constructor.desc || ''}</span><span class='separator'></span>`
+        `<span class='node_type'>${nodeType}</span><span class='node_desc'>${nodeDescription}</span><span class='separator'></span>`
       )
 
       panel.addHTML('<h3>Properties</h3>')

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,3 +1,4 @@
+import { default as DOMPurify } from 'dompurify'
 import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
@@ -7918,8 +7919,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       return
     }
 
+    const displayName = DOMPurify.sanitize(info.label || property)
     const dialog = this.createDialog(
-      `<span class='name'>${info.label || property}</span>${input_html}<button>OK</button>`,
+      `<span class='name'>${displayName}</span>${input_html}<button>OK</button>`,
       options
     )
 
@@ -8357,9 +8359,10 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     const inner_refresh = () => {
       // clear
       panel.content.innerHTML = ''
+      const nodeType = DOMPurify.sanitize(node.type)
       panel.addHTML(
         // @ts-expect-error - desc property
-        `<span class='node_type'>${node.type}</span><span class='node_desc'>${node.constructor.desc || ''}</span><span class='separator'></span>`
+        `<span class='node_type'>${nodeType}</span><span class='node_desc'>${node.constructor.desc || ''}</span><span class='separator'></span>`
       )
 
       panel.addHTML('<h3>Properties</h3>')


### PR DESCRIPTION
Patch 2 XSS vulnerablities in workflows
- Subgraph types when the litegraph node properties panel is opened
- Property labels in the litegraph 'Properties' context sub-menu

Special thanks to @Nynxz for finding these.