### PR TITLE
fix(hooks): make pre-commit fail when lint-staged fails

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 pnpm exec lint-staged
 pnpm exec tsx scripts/check-unused-i18n-keys.ts


### PR DESCRIPTION
## Summary

`.husky/pre-commit` runs two commands in sequence with no `set -e`, so the script exits with the status of the last one. When lint-staged fails, the i18n check that follows still runs, and if it succeeds the hook exits 0 and the commit goes through with the lint failure unaddressed.

## Changes

- **What**: add `set -e` to `.husky/pre-commit` so any failing step aborts the commit

## Review Focus

Verified by probe rather than inspection, on a stubbed copy of the hook:

| state | lint-staged | hook exit |
|---|---|---|
| before | fails | 0 (commit proceeds) |
| after | fails | 1 (commit blocked) |
| after | passes | 0 (both steps ran) |

The third row matters as much as the second: `set -e` does not break the passing path.