### PR TITLE
fix: per-instance svg clip path ids in SlotConnectionDot

### DIFF
--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.test.ts
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
 
 import { render, screen } from '@testing-library/vue'
 
@@ -39,28 +40,30 @@ describe('SlotConnectionDot', () => {
     expect(dot).not.toHaveClass('rounded-full')
     expect(dot.tagName).toBe('DIV')
   })
-  it('gives each instance unique svg clip path ids', () => {
-    const first = renderDot({ ...defaultSlot, shape: RenderShape.HollowCircle })
-    const second = renderDot({
-      ...defaultSlot,
-      shape: RenderShape.HollowCircle
+  it('gives each instance unique svg clip path ids within one app', () => {
+    const hollow = { ...defaultSlot, shape: RenderShape.HollowCircle }
+    const TwoDots = defineComponent(() => {
+      return () =>
+        h('div', [
+          h(SlotConnectionDot, { slotData: hollow }),
+          h(SlotConnectionDot, { slotData: hollow })
+        ])
     })
+    const { container } = render(TwoDots)
 
-    const ids = [first, second].flatMap(({ container }) =>
-      // eslint-disable-next-line testing-library/no-node-access
-      [...container.querySelectorAll('clipPath')].map((el) => el.id)
-    )
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const clipPaths = [...container.querySelectorAll('clipPath')]
+    const ids = clipPaths.map((el) => el.id)
     expect(ids).toHaveLength(4)
     expect(new Set(ids).size).toBe(ids.length)
 
-    for (const { container } of [first, second]) {
-      // eslint-disable-next-line testing-library/no-node-access
-      const clipped = container.querySelector('[clip-path]')
-      const ref = clipped?.getAttribute('clip-path')
-      const id = ref?.match(/url\(#(.+)\)/)?.[1]
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const clipped = [...container.querySelectorAll('[clip-path]')]
+    expect(clipped).toHaveLength(2)
+    for (const el of clipped) {
+      const id = el.getAttribute('clip-path')?.match(/url\(#(.+)\)/)?.[1]
       expect(id).toBeTruthy()
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(container.querySelector(`clipPath[id="${id}"]`)).toBeTruthy()
+      expect(ids).toContain(id)
     }
   })
 })

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.test.ts
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.test.ts
@@ -39,4 +39,28 @@ describe('SlotConnectionDot', () => {
     expect(dot).not.toHaveClass('rounded-full')
     expect(dot.tagName).toBe('DIV')
   })
+  it('gives each instance unique svg clip path ids', () => {
+    const first = renderDot({ ...defaultSlot, shape: RenderShape.HollowCircle })
+    const second = renderDot({
+      ...defaultSlot,
+      shape: RenderShape.HollowCircle
+    })
+
+    const ids = [first, second].flatMap(({ container }) =>
+      // eslint-disable-next-line testing-library/no-node-access
+      [...container.querySelectorAll('clipPath')].map((el) => el.id)
+    )
+    expect(ids).toHaveLength(4)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    for (const { container } of [first, second]) {
+      // eslint-disable-next-line testing-library/no-node-access
+      const clipped = container.querySelector('[clip-path]')
+      const ref = clipped?.getAttribute('clip-path')
+      const id = ref?.match(/url\(#(.+)\)/)?.[1]
+      expect(id).toBeTruthy()
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(container.querySelector(`clipPath[id="${id}"]`)).toBeTruthy()
+    }
+  })
 })

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue'
+import { computed, useId, useTemplateRef } from 'vue'
 
 import { getSlotColor, MAX_MULTITYPE_SLICES } from '@/constants/slotColors'
 import type { INodeSlot } from '@/lib/litegraph/src/litegraph'
@@ -14,12 +14,16 @@ const props = defineProps<{
   multi?: boolean
 }>()
 
+const uid = useId()
+const squareClipId = `square-${uid}`
+const hollowClipId = `hollow-${uid}`
+
 const clipPath = computed(() => {
   switch (props.slotData?.shape) {
     case 6:
-      return 'url(#square)'
+      return `url(#${squareClipId})`
     case 7:
-      return 'url(#hollow)'
+      return `url(#${hollowClipId})`
     default:
       return undefined
   }
@@ -83,10 +87,10 @@ const slotClass = computed(() =>
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>
-        <clipPath id="square">
+        <clipPath :id="squareClipId">
           <rect x="20" y="20" width="60" height="60" />
         </clipPath>
-        <clipPath id="hollow">
+        <clipPath :id="hollowClipId">
           <path
             d="M-50 50
            A100 100 0 0 1 150 50


### PR DESCRIPTION
## Summary

`SlotConnectionDot` renders `<clipPath id="square">` and `<clipPath id="hollow">` inside its inlined SVG. SVG ids are document-global, and one of these components renders per slot, so every dot on the canvas defines the same two ids. It looks correct today only because every instance's definitions are identical — `url(#square)` resolves to whichever copy the document happens to hold first.

## Changes

- **What**: mint the two clip-path ids per instance with `useId()` and bind them with `:id`, referencing them through the computed `url(#...)` string

## Review Focus

The test renders two dots inside a single app and asserts four distinct ids, plus that each dot's `clip-path` reference resolves to an id that exists. That structure is deliberate: `useId()` counters are per-app, so two separate `render()` calls would produce colliding ids even with the fix in place — the first version of this test did exactly that and stayed red against correct code.

Full related suite: 8,769 tests passing.