### PR TITLE
fix: reject getEmbeddings on HTTP failures and report A1111 import connectivity distinctly

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2355,6 +2355,7 @@
     "exportSuccess": "Successfully exported model as {format}",
     "fileLoadError": "Unable to find workflow in {fileName}",
     "a1111CoreNodesUnavailable": "Could not load the workflow because this ComfyUI installation is missing core nodes. Check that the backend started correctly.",
+    "a1111EmbeddingsUnavailable": "Could not load embeddings from the backend. Check the server connection and try again.",
     "dropFileError": "Unable to process dropped item: {error}",
     "missingMediaVerificationFailed": "Failed to verify missing media. Some inputs may not be shown in the Errors tab.",
     "missingModelVerificationFailed": "Failed to verify missing models. Some models may not be shown in the Errors tab.",

--- a/src/scripts/api.getEmbeddings.test.ts
+++ b/src/scripts/api.getEmbeddings.test.ts
@@ -51,6 +51,35 @@ describe('api.getEmbeddings', () => {
     )
   })
 
+  it('keeps the status even when reading the failure body itself rejects', async () => {
+    fetchApiSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+      text: () => Promise.reject(new Error('body stream lost'))
+    } as unknown as Response)
+
+    await expect(api.getEmbeddings()).rejects.toSatisfy(
+      (e) =>
+        e instanceof Error &&
+        e.name === 'ApiHttpError' &&
+        e.message.includes('/embeddings') &&
+        e.message.includes('500')
+    )
+  })
+
+  it('rejects identifiably when the fetch itself fails (backend down)', async () => {
+    fetchApiSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await expect(api.getEmbeddings()).rejects.toSatisfy(
+      (e) =>
+        e instanceof Error &&
+        e.name === 'ApiHttpError' &&
+        e.message.includes('/embeddings') &&
+        e.message.includes('Failed to fetch')
+    )
+  })
+
   it('rejects identifiably on a non-ok response with an HTML body', async () => {
     fetchApiSpy.mockResolvedValueOnce(
       htmlResponse(502, '<html>bad gateway</html>')

--- a/src/scripts/api.getEmbeddings.test.ts
+++ b/src/scripts/api.getEmbeddings.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+
+// Tests for api.getEmbeddings; fetchApi is stubbed.
+const jsonResponse = (status: number, body: unknown) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  }) as unknown as Response
+
+const htmlResponse = (status: number, body: string) =>
+  ({
+    ok: false,
+    status,
+    json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    text: () => Promise.resolve(body)
+  }) as unknown as Response
+
+describe('api.getEmbeddings', () => {
+  let fetchApiSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchApiSpy = vi.spyOn(api, 'fetchApi')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves the embeddings list on success', async () => {
+    fetchApiSpy.mockResolvedValueOnce(jsonResponse(200, ['emb-a', 'emb-b']))
+
+    await expect(api.getEmbeddings()).resolves.toEqual(['emb-a', 'emb-b'])
+    expect(fetchApiSpy).toHaveBeenCalledWith('/embeddings', {
+      cache: 'no-store'
+    })
+  })
+
+  it('rejects identifiably on a non-ok response with a JSON body', async () => {
+    fetchApiSpy.mockResolvedValueOnce(jsonResponse(500, { error: 'boom' }))
+
+    await expect(api.getEmbeddings()).rejects.toSatisfy(
+      (e) =>
+        e instanceof Error &&
+        e.name === 'ApiHttpError' &&
+        e.message.includes('/embeddings') &&
+        e.message.includes('500')
+    )
+  })
+
+  it('rejects identifiably on a non-ok response with an HTML body', async () => {
+    fetchApiSpy.mockResolvedValueOnce(
+      htmlResponse(502, '<html>bad gateway</html>')
+    )
+
+    await expect(api.getEmbeddings()).rejects.toSatisfy(
+      (e) =>
+        e instanceof Error &&
+        e.name === 'ApiHttpError' &&
+        e.message.includes('/embeddings') &&
+        e.message.includes('502')
+    )
+  })
+})

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -209,6 +209,17 @@ interface ApiMessage<T extends keyof ApiCalls> {
 
 export class UnauthorizedError extends Error {}
 
+export class ApiHttpError extends Error {
+  constructor(
+    readonly endpoint: string,
+    readonly status: number,
+    body = ''
+  ) {
+    super(`Request to ${endpoint} failed: ${status}${body ? ` — ${body}` : ''}`)
+    this.name = 'ApiHttpError'
+  }
+}
+
 /** Ensures workers get a fair shake. */
 type Unionize<T> = T[keyof T]
 
@@ -1004,6 +1015,13 @@ export class ComfyApi extends EventTarget {
    */
   async getEmbeddings(): Promise<EmbeddingsResponse> {
     const resp = await this.fetchApi('/embeddings', { cache: 'no-store' })
+    if (!resp.ok) {
+      throw new ApiHttpError(
+        '/embeddings',
+        resp.status,
+        await resp.text().catch(() => '')
+      )
+    }
     return await resp.json()
   }
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -209,13 +209,18 @@ interface ApiMessage<T extends keyof ApiCalls> {
 
 export class UnauthorizedError extends Error {}
 
+export function httpFailureDetail(status: number | string, body = ''): string {
+  return `${status}${body ? ` — ${body}` : ''}`
+}
+
+/** Rejection carrying endpoint + status; status 0 means a transport failure. */
 export class ApiHttpError extends Error {
   constructor(
     readonly endpoint: string,
     readonly status: number,
     body = ''
   ) {
-    super(`Request to ${endpoint} failed: ${status}${body ? ` — ${body}` : ''}`)
+    super(`Request to ${endpoint} failed: ${httpFailureDetail(status, body)}`)
     this.name = 'ApiHttpError'
   }
 }
@@ -1014,7 +1019,12 @@ export class ComfyApi extends EventTarget {
    * Gets a list of embedding names
    */
   async getEmbeddings(): Promise<EmbeddingsResponse> {
-    const resp = await this.fetchApi('/embeddings', { cache: 'no-store' })
+    let resp: Response
+    try {
+      resp = await this.fetchApi('/embeddings', { cache: 'no-store' })
+    } catch (err) {
+      throw new ApiHttpError('/embeddings', 0, String(err))
+    }
     if (!resp.ok) {
       throw new ApiHttpError(
         '/embeddings',
@@ -1323,7 +1333,7 @@ export class ComfyApi extends EventTarget {
     if (!res.ok) {
       const body = await res.text().catch(() => '')
       throw new Error(
-        `Failed to cancel job ${jobId}: ${res.status}${body ? ` — ${body}` : ''}`
+        `Failed to cancel job ${jobId}: ${httpFailureDetail(res.status, body)}`
       )
     }
   }
@@ -1347,7 +1357,7 @@ export class ComfyApi extends EventTarget {
     if (!res.ok) {
       const body = await res.text().catch(() => '')
       throw new Error(
-        `Failed to cancel jobs: ${res.status}${body ? ` — ${body}` : ''}`
+        `Failed to cancel jobs: ${httpFailureDetail(res.status, body)}`
       )
     }
   }

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -51,6 +51,7 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { extractFilesFromDragEvent } from '@/utils/eventUtils'
+import { ApiHttpError } from './api'
 import type { importA1111 } from './pnginfo'
 
 type WorkflowService = ReturnType<typeof useWorkflowService>
@@ -1597,6 +1598,25 @@ describe('ComfyApp', () => {
       expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
       expect(mockToastStore.addAlert).toHaveBeenCalledWith(
         'Unable to find workflow in parameters.png'
+      )
+      expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
+      expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
+    })
+
+    it('reports a backend failure distinctly when the embeddings fetch rejects', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockRejectedValue(
+        new ApiHttpError('/embeddings', 502, 'bad gateway')
+      )
+
+      await app.handleFile(createTestFile('a1111.png', 'image/png'))
+
+      expect(mockToastStore.addAlert).toHaveBeenCalledOnce()
+      expect(mockToastStore.addAlert).toHaveBeenCalledWith(
+        'Could not load embeddings from the backend. Check the server connection and try again.'
       )
       expect(mockWorkflowService.beforeLoadNewGraph).not.toHaveBeenCalled()
       expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -1622,6 +1622,20 @@ describe('ComfyApp', () => {
       expect(mockWorkflowService.afterLoadNewGraph).not.toHaveBeenCalled()
     })
 
+    it('lets non-connectivity import failures propagate without the connectivity toast', async () => {
+      const graph = new LGraph()
+      const parameters = 'positive\nNegative prompt: negative\nSteps: 20'
+      Reflect.set(app, 'rootGraphInternal', graph)
+      vi.mocked(getWorkflowDataFromFile).mockResolvedValue({ parameters })
+      mockImportA1111.mockRejectedValue(new RangeError('boom'))
+
+      await expect(
+        app.handleFile(createTestFile('a1111.png', 'image/png'))
+      ).rejects.toThrow('boom')
+
+      expect(mockToastStore.addAlert).not.toHaveBeenCalled()
+    })
+
     it('awaits persistence and orders its clear callback before setGraph', async () => {
       const graph = new LGraph()
       const parameters = 'positive\nNegative prompt: negative\nSteps: 20'

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -149,7 +149,7 @@ import {
 } from '@/utils/migration/migrateReroute'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
 
-import { type ComfyApi, PromptExecutionError, api } from './api'
+import { type ComfyApi, ApiHttpError, PromptExecutionError, api } from './api'
 import { defaultGraph } from './defaultGraph'
 import { importA1111 } from './pnginfo'
 import { applyPromotedWidgetControl } from './promotedWidgetControl'
@@ -2018,10 +2018,21 @@ export class ComfyApp {
 
     // Use parameters strictly as the final fallback
     if (parameters && typeof parameters === 'string') {
-      const outcome = await importA1111(this.rootGraph, parameters, () => {
-        useWorkflowService().beforeLoadNewGraph()
-        this.canvas.setGraph(this.rootGraph)
-      })
+      let outcome: Awaited<ReturnType<typeof importA1111>>
+      try {
+        outcome = await importA1111(this.rootGraph, parameters, () => {
+          useWorkflowService().beforeLoadNewGraph()
+          this.canvas.setGraph(this.rootGraph)
+        })
+      } catch (err) {
+        if (err instanceof ApiHttpError) {
+          useToastStore().addAlert(
+            t('toastMessages.a1111EmbeddingsUnavailable')
+          )
+          return
+        }
+        throw err
+      }
       if (outcome === 'core-nodes-unavailable') {
         useToastStore().addAlert(t('toastMessages.a1111CoreNodesUnavailable'))
         return

--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -271,6 +271,20 @@ describe('importA1111', () => {
     expect(beforeGraphClear).not.toHaveBeenCalled()
   })
 
+  it('propagates an embeddings fetch failure before any lifecycle effect', async () => {
+    const graph = new LGraph()
+    const clear = vi.spyOn(graph, 'clear')
+    const beforeGraphClear = vi.fn()
+    const failure = new Error('embeddings down')
+    vi.mocked(api.getEmbeddings).mockRejectedValue(failure)
+
+    await expect(importA1111(graph, parameters, beforeGraphClear)).rejects.toBe(
+      failure
+    )
+    expect(beforeGraphClear).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
+  })
+
   it('returns core-nodes-unavailable without clearing the graph', async () => {
     const graph = new LGraph()
     const clear = vi.spyOn(graph, 'clear')


### PR DESCRIPTION

## Summary

`api.getEmbeddings()` never checked `resp.ok`, so a backend failure during an A1111 PNG import either resolved silently with garbage (500 with a JSON body, import proceeds with unresolved embeddings and no feedback) or surfaced as "Unable to find workflow in \<file\>" (500 with an HTML body, via the SyntaxError from parsing it). Connectivity problems now reject identifiably at the source and the import path reports them as what they are.

- Fixes #14655
- Fixes #14737

## Changes

- `api.getEmbeddings()` throws a new `ApiHttpError` (endpoint, status, defensive body text) on non-ok responses, and wraps fetch-level rejections as status 0 so a fully unreachable backend is identifiable the same way
- `app.handleFile()`'s A1111 parameters fall-through catches `ApiHttpError` and shows a connectivity toast; any other rejection propagates unchanged
- Extracted `httpFailureDetail()` and reused it in `cancelJob`/`cancelJobs`, which already built the identical failure string (messages unchanged, their tests stay green)
- New locale key `toastMessages.a1111EmbeddingsUnavailable`
- Tests: `api.getEmbeddings.test.ts` (success, non-ok JSON body, non-ok HTML body, rejecting body read, fetch-level failure), app-level cases pinning the connectivity toast for `ApiHttpError` and propagation for everything else, and a pnginfo pin that an embeddings failure rejects before any lifecycle effect runs

## Review Focus

- `src/scripts/api.ts`: the transport wrap (status 0) is the one behavior judgment call, and `getEmbeddings` changing from always-resolving to rejecting is a contract change on the `window.comfyAPI` surface
- `src/scripts/app.ts`: the catch narrows on `instanceof ApiHttpError`; a dedicated test pins that non-connectivity rejections still propagate untoasted

Note for extension authors: `api.getEmbeddings()` previously resolved whatever a failed response parsed to; it now rejects with `ApiHttpError`. Direct callers should add a catch.

## Testing

- Red first: the api tests fail on the unfixed code (promise resolved instead of rejecting; SyntaxError instead of an identifiable error) and the app test fails before the class exists
- Green after: 83 tests across the four touched suites; full unit suite 15,200 passing, with the only 12 failures in `scripts/cicd/check-binary-size.test.ts`, a CI-script test untouched by this diff that exits 127 (missing tool) in the sandbox that ran it