### PR TITLE
feat(website): build the Wan Animate 2 launch page on the model-launch template

### DIFF
--- a/apps/website/e2e/minimax.spec.ts
+++ b/apps/website/e2e/minimax.spec.ts
@@ -17,7 +17,11 @@ const CTA_HEADING = t('minimax.cta.heading', 'en')
 const CTA_PRIMARY = t('minimax.cta.primaryCta', 'en')
 const CLOUD_URL = externalLinks.cloud
 const CLOUD_RUN_URL = minimaxLinks.cloudRun
-const FAQS = minimaxPage.faq?.items ?? []
+// `faq` is optional on the template (Wan Animate 2 ships without one), but
+// this page must have it, so fail loudly rather than silently testing nothing.
+const FAQ_SECTION = minimaxPage.faq
+if (!FAQ_SECTION) throw new Error('minimaxPage must configure a FAQ section')
+const FAQS = FAQ_SECTION.items
 const FAQ_COUNT = FAQS.length
 const FIRST_FAQ = FAQS[0]
 const PRICING_HEADING = t('pricing.title', 'en')

--- a/apps/website/e2e/seedance.spec.ts
+++ b/apps/website/e2e/seedance.spec.ts
@@ -18,7 +18,11 @@ const SEEDANCE_RUN = seedancePage.hero.primaryCta.href
 const CLOUD_WORKFLOWS_HUB = externalLinks.workflows
 const PROMPT_CTA = t('seedance.hero.promptCta', 'en')
 const COPY_PROMPT = t('modelLaunch.copyPrompt', 'en')
-const FAQS = seedancePage.faq?.items ?? []
+// `faq` is optional on the template (Wan Animate 2 ships without one), but
+// this page must have it, so fail loudly rather than silently testing nothing.
+const FAQ_SECTION = seedancePage.faq
+if (!FAQ_SECTION) throw new Error('seedancePage must configure a FAQ section')
+const FAQS = FAQ_SECTION.items
 const FAQ_COUNT = FAQS.length
 const FIRST_FAQ = FAQS[0]
 const REVIEWS_HEADING = t('seedance.reviews.heading', 'en')
@@ -129,9 +133,9 @@ test.describe('Seedance 2.5 page — link targets', () => {
   })
 
   test('cards with a prompt offer a copy button', async ({ page }) => {
-    const withPrompt = (seedancePage.gallery?.cards ?? []).filter(
-      (card) => card.prompt
-    )
+    const gallery = seedancePage.gallery
+    if (!gallery) throw new Error('seedancePage must configure a gallery')
+    const withPrompt = gallery.cards.filter((card) => card.prompt)
     const buttons = page.getByRole('button', { name: COPY_PROMPT })
     await buttons.first().scrollIntoViewIfNeeded()
     await expect(buttons).toHaveCount(withPrompt.length)

--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -1,136 +1,155 @@
 import { expect } from '@playwright/test'
 
-import { externalLinks, getRoutes } from '../src/config/routes'
+import { getRoutes } from '../src/config/routes'
+import { creatorReviews } from '../src/data/creatorReviews'
 import { wanAnimate2Page } from '../src/data/wanAnimate2'
 import { t } from '../src/i18n/translations'
 import { test } from './fixtures/blockExternalMedia'
 
 const PATH = '/wan-animate-2'
 const ZH_PATH = '/zh-CN/wan-animate-2'
-const HERO_TITLE = t('wanAnimate2.hero.title')
-const HERO_EYEBROW = t('wanAnimate2.hero.eyebrow')
-const HERO_CTA = t('wanAnimate2.hero.primaryCta')
-const RUN_OPTIONS_HEADING = t('wanAnimate2.runOptions.heading')
-const REVIEWS_HEADING = t('wanAnimate2.reviews.heading')
+const HERO_TITLE = t('wanAnimate2.hero.title', 'en')
+const HERO_PRIMARY = t('wanAnimate2.hero.primaryCta', 'en')
 const MODELS_ROUTE = getRoutes('en').models
+const STEPS_HEADING = t('wanAnimate2.steps.heading', 'en')
+const REVIEWS_HEADING = t('wanAnimate2.reviews.heading', 'en')
+const HIGHLIGHT_CTA = t('wanAnimate2.reviews.highlightCta', 'en')
+const MCP_ROUTE = getRoutes('en').mcp
+const FIRST_REVIEW = creatorReviews[0]
+const WORKFLOW_URL = wanAnimate2Page.hero.primaryCta.href
 
-test.describe('Wan Animate 2 announcement page @smoke', () => {
+test.describe('Wan Animate 2 page — desktop @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(PATH)
   })
 
-  test('renders the hero over its backdrop and is indexable', async ({
-    page
-  }) => {
-    const hero = page.locator('section').filter({
-      has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
-    })
-    await expect(hero.getByText(HERO_EYEBROW)).toBeVisible()
+  test('renders the hero heading and is indexable', async ({ page }) => {
     await expect(
       page.getByRole('heading', { level: 1, name: HERO_TITLE })
     ).toBeVisible()
-    await expect(hero.locator('img')).toHaveAttribute(
-      'src',
-      wanAnimate2Page.hero.placeholderImageSrc ?? ''
-    )
+
     await expect(page.locator('meta[name="robots"]')).toHaveCount(0)
   })
 
-  test('hero CTA sends visitors to the cloud in a new tab', async ({
+  test('renders the reviews section heading and first quote', async ({
     page
   }) => {
-    const cta = page
-      .locator('section')
-      .filter({
-        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
-      })
-      .getByRole('link', { name: HERO_CTA })
-    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
-    await expect(cta).toHaveAttribute('target', '_blank')
+    const heading = page.getByRole('heading', {
+      level: 2,
+      name: REVIEWS_HEADING
+    })
+    await heading.scrollIntoViewIfNeeded()
+    await expect(heading).toBeVisible()
+    await expect(page.getByText(FIRST_REVIEW.name)).toBeVisible()
+  })
+})
+
+test.describe('Wan Animate 2 page — link targets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PATH)
   })
 
   test('breadcrumb trail links to the models catalog', async ({ page }) => {
     const modelsCrumb = page
-      .getByRole('navigation', { name: t('ui.breadcrumb') })
-      .getByRole('link', { name: t('models.breadcrumb.models') })
+      .getByRole('navigation', { name: t('ui.breadcrumb', 'en') })
+      .getByRole('link', { name: t('models.breadcrumb.models', 'en') })
     await expect(modelsCrumb).toHaveAttribute('href', MODELS_ROUTE)
+  })
+
+  // Wan Animate 2 ships one workflow template, so both CTAs on the page have to
+  // resolve to that same URL.
+  test('every CTA points at the single Wan Animate 2 workflow', async ({
+    page
+  }) => {
+    const ctas = page.getByRole('link', { name: HERO_PRIMARY })
+    await expect(ctas).toHaveCount(2)
+    for (const cta of await ctas.all()) {
+      await expect(cta).toHaveAttribute('href', WORKFLOW_URL)
+      await expect(cta).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  // The examples we were sent were Wan 2.6 renders, not Wan Animate 2, so the
+  // gallery is hidden until real output arrives. Assert it is actually gone
+  // rather than just empty, and that no stray hub link came back with it.
+  test('ships no gallery and no Try Workflows CTA', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: t('modelLaunch.copyPrompt', 'en') })
+    ).toHaveCount(0)
+    // Named explicitly so the diff records exactly which clips were pulled. The
+    // hero also lives under /wan-animate-2/, so a path-wide check would match it.
+    for (const clip of ['dragon', 'cat', 'fisherman', 'highway']) {
+      await expect(page.locator(`video[src*="${clip}.webm"]`)).toHaveCount(0)
+    }
+    await expect(
+      page.locator('a[href="https://comfy.org/workflows"]')
+    ).toHaveCount(0)
+  })
+
+  test('renders one step card per configured step', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 2, name: STEPS_HEADING })
+    await heading.scrollIntoViewIfNeeded()
+    const steps = page
+      .locator('section')
+      .filter({ has: heading })
+      .locator('ol > li')
+    await expect(steps).toHaveCount(wanAnimate2Page.steps?.items.length ?? 0)
   })
 
   test('footer links back to this page', async ({ page }) => {
     const footerLink = page
       .locator('footer')
-      .getByRole('link', { name: t('footer.wanAnimate2') })
+      .getByRole('link', { name: t('footer.wanAnimate2', 'en') })
     await expect(footerLink).toHaveAttribute(
       'href',
       getRoutes('en').wanAnimate2
     )
   })
 
-  test('renders run options and reviews', async ({ page }) => {
-    const runOptions = page.getByRole('heading', {
-      level: 2,
-      name: RUN_OPTIONS_HEADING
+  test('MCP highlight card CTA links to the MCP page', async ({ page }) => {
+    const reviewsSection = page.locator('section').filter({
+      has: page.getByRole('heading', { level: 2, name: REVIEWS_HEADING })
     })
-    await runOptions.scrollIntoViewIfNeeded()
-    await expect(runOptions).toBeVisible()
-
-    const reviews = page.getByRole('heading', {
-      level: 2,
-      name: REVIEWS_HEADING
-    })
-    await reviews.scrollIntoViewIfNeeded()
-    await expect(reviews).toBeVisible()
-  })
-
-  // The announcement omits gallery, pricing, FAQ and closing CTA, so these two
-  // are the only sections it should show. Asserting the whole set means
-  // reintroducing any of them has to be deliberate.
-  test('shows only the sections the announcement configures', async ({
-    page
-  }) => {
-    await expect(page.getByRole('heading', { level: 2 })).toHaveText([
-      RUN_OPTIONS_HEADING,
-      REVIEWS_HEADING
-    ])
-    await expect(page.locator('video')).toHaveCount(0)
+    const cta = reviewsSection.getByRole('link', { name: HIGHLIGHT_CTA })
+    await cta.scrollIntoViewIfNeeded()
+    await expect(cta).toHaveAttribute('href', MCP_ROUTE)
   })
 })
 
-test.describe('Wan Animate 2 announcement page — zh-CN', () => {
+test.describe('Wan Animate 2 page — interactions', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(ZH_PATH)
+    await page.goto(PATH)
   })
 
-  test('renders the localized hero and run options', async ({ page }) => {
-    // Resolve the heading in zh-CN rather than reusing HERO_TITLE. The two are
-    // the same string today because the model name is not translated, but
-    // scoping by locale here is what the test actually means.
-    const hero = page.locator('section').filter({
-      has: page.getByRole('heading', {
-        level: 1,
-        name: t('wanAnimate2.hero.title', 'zh-CN')
-      })
-    })
-    await expect(
-      hero.getByText(t('wanAnimate2.hero.eyebrow', 'zh-CN'))
-    ).toBeVisible()
-    await expect(hero.getByRole('link')).toContainText(/[一-鿿]/)
+  // The Q&A is hidden until real answers land (better no info than poor info).
+  // Assert it is gone from the page AND from the structured data, so restoring
+  // it has to be deliberate.
+  test('ships no Q&A section and no FAQPage structured data', async ({
+    page
+  }) => {
+    await expect(page.getByRole('heading', { name: 'Q&A' })).toHaveCount(0)
+
+    const hasFaqNode = await page.evaluate(() =>
+      Array.from(
+        document.querySelectorAll('script[type="application/ld+json"]')
+      ).some((s) => (s.textContent ?? '').includes('FAQPage'))
+    )
+    expect(hasFaqNode).toBe(false)
+  })
+})
+
+test.describe('Wan Animate 2 page — zh-CN', () => {
+  test('renders the localized hero and keeps the footer in locale', async ({
+    page
+  }) => {
+    await page.goto(ZH_PATH)
 
     await expect(
       page.getByRole('heading', {
-        level: 2,
-        name: t('wanAnimate2.runOptions.heading', 'zh-CN')
+        level: 1,
+        name: t('wanAnimate2.hero.title', 'zh-CN')
       })
     ).toBeVisible()
-  })
-
-  test('breadcrumb and footer keep visitors inside the locale', async ({
-    page
-  }) => {
-    const modelsCrumb = page
-      .getByRole('navigation', { name: t('ui.breadcrumb', 'zh-CN') })
-      .getByRole('link', { name: t('models.breadcrumb.models', 'zh-CN') })
-    await expect(modelsCrumb).toHaveAttribute('href', getRoutes('zh-CN').models)
 
     const footerLink = page
       .locator('footer')
@@ -142,35 +161,29 @@ test.describe('Wan Animate 2 announcement page — zh-CN', () => {
   })
 })
 
-test.describe('Wan Animate 2 announcement page — mobile @mobile', () => {
-  test('hero CTA stays visible and linked at narrow viewports', async ({
-    page
-  }) => {
+test.describe('Wan Animate 2 page — mobile @mobile', () => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(PATH)
+  })
 
-    const cta = page
-      .locator('section')
-      .filter({
-        has: page.getByRole('heading', { level: 1, name: HERO_TITLE })
-      })
-      .getByRole('link', { name: HERO_CTA })
+  test('renders the hero heading at narrow viewports', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { level: 1, name: HERO_TITLE })
+    ).toBeVisible()
+  })
 
-    await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', externalLinks.cloud)
+  test('steps heading stays within the viewport width', async ({ page }) => {
+    const ctaHeading = page.getByRole('heading', {
+      level: 2,
+      name: STEPS_HEADING
+    })
+    await ctaHeading.scrollIntoViewIfNeeded()
+    await expect(ctaHeading).toBeVisible()
 
-    const box = await cta.boundingBox()
-    const viewport = page.viewportSize()
-    if (!box || !viewport) {
-      throw new Error('hero CTA has no layout box to measure')
-    }
-
-    // Measured without scrolling first: the point is that the CTA is reachable
-    // on load, so scrolling it into view would make the vertical bounds pass no
-    // matter how far down the page it sat. One pixel of tolerance for subpixel
-    // rounding.
-    expect(box.x).toBeGreaterThanOrEqual(-1)
-    expect(box.y).toBeGreaterThanOrEqual(-1)
-    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1)
-    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height + 1)
+    const box = await ctaHeading.boundingBox()
+    expect(box, 'CTA heading bounding box').not.toBeNull()
+    expect(box!.x + box!.width).toBeLessThanOrEqual(
+      page.viewportSize()!.width + 1
+    )
   })
 })

--- a/apps/website/e2e/wan-animate-2.spec.ts
+++ b/apps/website/e2e/wan-animate-2.spec.ts
@@ -41,6 +41,8 @@ test.describe('Wan Animate 2 page — desktop @smoke', () => {
     await heading.scrollIntoViewIfNeeded()
     await expect(heading).toBeVisible()
     await expect(page.getByText(FIRST_REVIEW.name)).toBeVisible()
+    // The name alone would still pass if the quote itself failed to render.
+    await expect(page.getByText(FIRST_REVIEW.body.en)).toBeVisible()
   })
 })
 
@@ -182,6 +184,9 @@ test.describe('Wan Animate 2 page — mobile @mobile', () => {
 
     const box = await ctaHeading.boundingBox()
     expect(box, 'CTA heading bounding box').not.toBeNull()
+    // Both edges: checking only the right edge lets a heading overflow to the
+    // left and still pass. One pixel of tolerance for subpixel rounding.
+    expect(box!.x).toBeGreaterThanOrEqual(-1)
     expect(box!.x + box!.width).toBeLessThanOrEqual(
       page.viewportSize()!.width + 1
     )

--- a/apps/website/src/data/comingSoonHero.ts
+++ b/apps/website/src/data/comingSoonHero.ts
@@ -1,5 +1,0 @@
-// Every announcement page uses the same frosted backdrop: the art is byte
-// identical across the Figma frames, so they share one asset rather than
-// uploading a copy per model.
-export const COMING_SOON_HERO =
-  'https://media.comfy.org/website/coming-soon/hero.webp'

--- a/apps/website/src/data/wanAnimate2.ts
+++ b/apps/website/src/data/wanAnimate2.ts
@@ -1,24 +1,93 @@
-import type { ModelLaunchPage } from '../templates/model-launch/types'
+import type {
+  ModelLaunchMedia,
+  ModelLaunchPage
+} from '../templates/model-launch/types'
 
 import { externalLinks } from '../config/routes'
-import { COMING_SOON_HERO } from './comingSoonHero'
 
-// Wan Animate 2 has not shipped yet, so this page announces it and holds the URL.
-// On launch day, replace this config with the full one the way /flux-3 did; the
-// page stubs and the template stay as they are.
+// Wan Animate 2 ships a single workflow template, so every CTA resolves to it.
+const WAN_ANIMATE_2_WORKFLOW =
+  'https://cloud.comfy.org/?template=video_wan_animate2'
+
+// The hero clip, encoded to the site's web video profile and served from
+// media.comfy.org. Its poster is the clip's own first frame. There is no gallery
+// yet: the examples we were sent turned out to be Wan 2.6 output, and the real
+// Wan Animate 2 renders are blocked on workflow access.
+const media = {
+  hero: {
+    kind: 'video',
+    src: 'https://media.comfy.org/website/wan-animate-2/hero.mp4',
+    posterSrc: 'https://media.comfy.org/website/wan-animate-2/hero-poster.webp'
+  }
+} as const satisfies Record<string, ModelLaunchMedia>
+
 export const wanAnimate2Page: ModelLaunchPage = {
   metaTitleKey: 'wanAnimate2.meta.title',
   metaDescriptionKey: 'wanAnimate2.meta.description',
   breadcrumbLabelKey: 'wanAnimate2.breadcrumb.model',
   breadcrumbUpdatedKey: 'wanAnimate2.breadcrumb.updated',
   hero: {
-    layout: 'overlay',
-    placeholderImageSrc: COMING_SOON_HERO,
-    eyebrowKey: 'wanAnimate2.hero.eyebrow',
+    layout: 'content-first',
+    videoSrc: media.hero.src,
+    posterSrc: media.hero.posterSrc,
+    logoSrc: '/icons/ai-models/wan.svg',
+    badgeKeys: [
+      'wanAnimate2.hero.tagOpenSource',
+      'wanAnimate2.hero.tagReferenceToVideo'
+    ],
     titleKey: 'wanAnimate2.hero.title',
+    descriptionKey: 'wanAnimate2.hero.description',
     primaryCta: {
       labelKey: 'wanAnimate2.hero.primaryCta',
-      href: externalLinks.cloud,
+      href: WAN_ANIMATE_2_WORKFLOW,
+      target: '_blank'
+    },
+    footnoteKey: 'wanAnimate2.hero.footnote'
+  },
+  pricing: {
+    defaultBillingCycle: 'monthly',
+    banner: {
+      titleKey: 'wanAnimate2.pricing.banner.title',
+      subtitleKey: 'wanAnimate2.pricing.banner.subtitle',
+      cta: {
+        labelKey: 'wanAnimate2.pricing.banner.cta',
+        href: externalLinks.cloud,
+        target: '_blank'
+      }
+    }
+  },
+  steps: {
+    headingKey: 'wanAnimate2.steps.heading',
+    stepLabelKey: 'wanAnimate2.steps.step',
+    items: [
+      {
+        id: 'upload-your-reference',
+        title: {
+          en: 'Upload your reference',
+          'zh-CN': '上传你的参考素材'
+        },
+        description: {
+          en: 'A reference image of your character, plus a driving video of the motion you want to transfer.',
+          'zh-CN': '一张角色参考图，加上一段你想要迁移的动作驱动视频。'
+        }
+      },
+      {
+        id: 'write-the-shot',
+        title: { en: 'Write the shot', 'zh-CN': '写下你的镜头' },
+        description: {
+          en: 'Add your prompt, zero credits',
+          'zh-CN': '添加提示词，零积分消耗'
+        }
+      },
+      {
+        id: 'run-wan-animate-2',
+        title: { en: 'Run Wan Animate 2', 'zh-CN': '运行 Wan Animate 2' },
+        description: { en: 'Final render', 'zh-CN': '最终渲染' }
+      }
+    ],
+    primaryCta: {
+      labelKey: 'wanAnimate2.steps.primaryCta',
+      href: WAN_ANIMATE_2_WORKFLOW,
       target: '_blank'
     }
   },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -5222,15 +5222,15 @@ const translations = {
       '你的 AI 助手可以接入整个生态、构建工作流，并生成图像、视频、音频或 3D 内容。'
   },
   'flux3.reviews.highlightCta': { en: 'GET STARTED', 'zh-CN': '开始使用' },
-  // Wan Animate 2 model page (/wan-animate-2) — announcement until the model ships
+  // Wan Animate 2 model page (/wan-animate-2)
   'wanAnimate2.meta.title': {
-    en: 'Wan Animate 2 on Comfy — Coming Soon',
-    'zh-CN': 'Comfy 上的 Wan Animate 2 — 即将推出'
+    en: 'Wan Animate 2 on Comfy — Open-Source Character Animation',
+    'zh-CN': 'Comfy 上的 Wan Animate 2 — 开源角色动画模型'
   },
   'wanAnimate2.meta.description': {
-    en: 'Wan Animate 2 is coming to Comfy. Run it on Comfy Cloud the day it lands, or start building workflows for free now with every other model Comfy supports.',
+    en: 'Run Wan Animate 2 on Comfy: upload a reference image of your character plus a driving video, and it transfers that motion onto your character. Open source, on Comfy Cloud or your own hardware.',
     'zh-CN':
-      'Wan Animate 2 即将登陆 Comfy。上线当天即可在 Comfy Cloud 上运行；现在就可以用 Comfy 支持的其他模型免费开始搭建工作流。'
+      '在 Comfy 上运行 Wan Animate 2：上传角色参考图和一段驱动视频，即可把动作迁移到你的角色上。开源模型，可在 Comfy Cloud 或自有硬件上运行。'
   },
   'wanAnimate2.breadcrumb.model': {
     en: 'Wan Animate 2',
@@ -5240,11 +5240,48 @@ const translations = {
     en: 'Updated August 2026',
     'zh-CN': '更新于 2026 年 8 月'
   },
-  'wanAnimate2.hero.eyebrow': { en: 'Coming soon', 'zh-CN': '即将推出' },
-  'wanAnimate2.hero.title': { en: 'Wan Animate 2', 'zh-CN': 'Wan Animate 2' },
+  'wanAnimate2.hero.title': {
+    en: 'Wan Animate 2 is here',
+    'zh-CN': 'Wan Animate 2 已上线'
+  },
+  'wanAnimate2.hero.description': {
+    en: 'Introducing Wan Animate 2, the new state of the art model for character animation: upload a reference image of your character plus a video of the motion you want, and it transfers that motion onto your character.',
+    'zh-CN':
+      '隆重推出 Wan Animate 2，业界领先的角色动画模型：上传一张角色参考图，再加上一段你想要的动作视频，它就会把该动作迁移到你的角色上。'
+  },
   'wanAnimate2.hero.primaryCta': {
-    en: 'RUN COMFY FOR FREE',
-    'zh-CN': '免费使用 Comfy'
+    en: 'RUN WAN ANIMATE 2',
+    'zh-CN': '运行 Wan Animate 2'
+  },
+  'wanAnimate2.hero.footnote': {
+    en: 'Open source · Free to try on Comfy Cloud · Pay-as-you-go after that',
+    'zh-CN': '开源 · 可在 Comfy Cloud 免费试用 · 之后按量付费'
+  },
+  'wanAnimate2.hero.tagOpenSource': {
+    en: 'Open Source',
+    'zh-CN': '开源'
+  },
+  'wanAnimate2.hero.tagReferenceToVideo': {
+    en: 'Reference to Video',
+    'zh-CN': '参考图生成视频'
+  },
+  'wanAnimate2.pricing.banner.title': {
+    en: "Start Comfy Cloud for free. Upgrade when you're ready.",
+    'zh-CN': '免费开始使用 Comfy Cloud，准备好了再升级。'
+  },
+  'wanAnimate2.pricing.banner.subtitle': {
+    en: '5 free runs on real GPUs — no credit card required.',
+    'zh-CN': '在真实 GPU 上免费运行 5 次 — 无需信用卡。'
+  },
+  'wanAnimate2.pricing.banner.cta': { en: 'TRY FREE', 'zh-CN': '免费试用' },
+  'wanAnimate2.steps.heading': {
+    en: 'How to direct your first shot',
+    'zh-CN': '如何执导你的第一个镜头'
+  },
+  'wanAnimate2.steps.step': { en: 'Step', 'zh-CN': '步骤' },
+  'wanAnimate2.steps.primaryCta': {
+    en: 'RUN WAN ANIMATE 2',
+    'zh-CN': '运行 Wan Animate 2'
   },
   'wanAnimate2.runOptions.heading': {
     en: 'One engine, every way to run it',
@@ -5252,12 +5289,15 @@ const translations = {
   },
   'wanAnimate2.runOptions.subtitle': {
     en: 'Build workflows in the browser today. Batch campaigns with the API, or bring it in-house.',
-    'zh-CN': '今天就在浏览器中搭建工作流。用 API 批量制作，或部署到自有环境。'
+    'zh-CN': '今天就在浏览器中构建工作流。用 API 批量制作，或部署到自有环境。'
   },
-  'wanAnimate2.runOptions.cta': { en: 'LEARN MORE', 'zh-CN': '了解更多' },
+  'wanAnimate2.runOptions.cta': {
+    en: 'LEARN MORE',
+    'zh-CN': '了解更多'
+  },
   'wanAnimate2.reviews.heading': {
     en: '4+ million Comfy creators say',
-    'zh-CN': '超过 400 万 Comfy 创作者这样说'
+    'zh-CN': '400 万+ Comfy 创作者这样说'
   },
   'wanAnimate2.reviews.highlightTitle': {
     en: 'Comfy MCP: now turn your agent into a creative technologist.',

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -160,7 +160,7 @@ const isContentFirst = hero.layout === 'content-first'
       :class="
         cn(
           'mx-auto flex w-full max-w-2xl flex-col items-center text-center',
-          isContentFirst ? 'order-1 mb-10 lg:mb-0' : 'order-2 mt-10'
+          isContentFirst ? 'order-1 mb-10' : 'order-2 mt-10'
         )
       "
     >
@@ -232,8 +232,8 @@ const isContentFirst = hero.layout === 'content-first'
       rel="noopener"
       :class="
         cn(
-          'bg-transparency-white-t4 hover:border-primary-comfy-yellow/40 mt-10 hidden w-full flex-col items-start gap-4 rounded-4xl border border-white/10 p-6 text-left transition-colors sm:flex-row sm:items-center sm:justify-between lg:flex lg:px-10 lg:py-7',
-          isContentFirst ? 'order-2 mb-10' : 'order-3'
+          'bg-transparency-white-t4 hover:border-primary-comfy-yellow/40 hidden w-full flex-col items-start gap-4 rounded-4xl border border-white/10 p-6 text-left transition-colors sm:flex-row sm:items-center sm:justify-between lg:flex lg:px-10 lg:py-7',
+          isContentFirst ? 'order-2 mb-10' : 'order-3 mt-10'
         )
       "
     >

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -13,7 +13,7 @@ import type { LocalizedText, TranslationKey } from '../../i18n/translations'
 // An announcement page for a model that has not shipped is the same config with
 // less in it: give the hero `layout: 'overlay'` and a `placeholderImageSrc`,
 // omit gallery/pricing/faq/closingCta, and swap in the full config on launch
-// day. `src/data/wanAnimate2.ts` is the worked example.
+// day.
 
 interface ModelLaunchCta {
   labelKey: TranslationKey


### PR DESCRIPTION
## Summary

Upgrades /wan-animate-2 from the coming-soon announcement (#14849) to the full launch page on the model-launch template, ported from Figma `10421-41926`.

## Changes

- **What**: Replaces the announcement config in `src/data/wanAnimate2.ts` with the launch config: content-first hero (video + Wan mark, two badges, footnote), pricing banner, three-step section, run options, reviews. New `wanAnimate2.*` launch copy in en and zh-CN; the unused eyebrow key and the now-orphaned `comingSoonHero.ts` are removed.
- Wan Animate 2 ships a single workflow template, so both CTAs resolve to `cloud.comfy.org/?template=video_wan_animate2`; the e2e spec asserts that rather than trusting it.
- Deliberately ships **no gallery** (the sample clips we were sent were Wan 2.6 output, not Wan Animate 2) and **no Q&A** (answers not signed off). The e2e spec asserts both are absent — from the page and from the FAQPage structured data — so restoring them has to be deliberate.
- Shared template fix: a content-first hero previously got its desktop gap above the video from the prompt bar's own `mt-10`. This is the first content-first page with no prompt bar, so the margin now lives on the content column and the prompt bar carries its own spacing in the media-first branch. Measured after the change: /wan-animate-2 `[40]`, /seedance-2.5 `[40, 40]`, /minimax `[40]` — Seedance and MiniMax unchanged.
- `faq`/`gallery` guards in the MiniMax and Seedance e2e specs now fail loudly instead of silently testing nothing when a section is missing.

## Review Focus

- The launch copy (steps, footnote, meta) mirrors the reviewed private-repo copy; zh-CN wording for `runOptions.subtitle` and `reviews.heading` was updated to match it.
- Gates: unit 363/363, astro check 0 errors, knip clean, validate:jsonld 588 pages, e2e 43/43 across Wan Animate 2, Seedance and MiniMax including zh-CN and mobile.