### PR TITLE
fix(website): drop 4K claims from the Seedance 2.5 landing page

### DIFF
--- a/apps/website/src/data/seedance.test.ts
+++ b/apps/website/src/data/seedance.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Locale } from '../i18n/translations'
+import { t, translationKeys } from '../i18n/translations'
+import { seedancePage } from './seedance'
+
+const LOCALES = ['en', 'zh-CN'] as const satisfies readonly Locale[]
+
+// Seedance 2.5 tops out below 4K, so nothing this page renders may advertise
+// it — the gallery prompts included, since they are reproduced verbatim and the
+// clips render whatever they asked for.
+const RESOLUTION_CLAIM = /4\s*k\b/i
+
+function pageCopy(locale: Locale): { label: string; text: string }[] {
+  return [
+    ...(seedancePage.gallery?.cards ?? []).flatMap((card) => [
+      { label: `card ${card.id} name`, text: card.name[locale] },
+      { label: `card ${card.id} note`, text: card.note[locale] },
+      { label: `card ${card.id} description`, text: card.description[locale] },
+      { label: `card ${card.id} prompt`, text: card.prompt?.[locale] ?? '' }
+    ]),
+    ...(seedancePage.faq?.items ?? []).flatMap((faq) => [
+      { label: `faq ${faq.id} question`, text: faq.question[locale] },
+      { label: `faq ${faq.id} answer`, text: faq.answer[locale] }
+    ]),
+    ...(seedancePage.steps?.items ?? []).flatMap((step) => [
+      { label: `step ${step.id} title`, text: step.title[locale] },
+      { label: `step ${step.id} description`, text: step.description[locale] }
+    ])
+  ]
+}
+
+describe('seedance 2.5 landing copy', () => {
+  // Offenders are collected rather than asserted one by one so a failure names
+  // every surface that has to change.
+  it('claims no 4K output anywhere in the page config', () => {
+    const offenders = LOCALES.flatMap((locale) =>
+      pageCopy(locale)
+        .filter(({ text }) => RESOLUTION_CLAIM.test(text))
+        .map(({ label }) => `${label} (${locale})`)
+    )
+
+    expect(offenders).toEqual([])
+  })
+
+  it('claims no 4K output in any seedance translation', () => {
+    const offenders = translationKeys
+      .filter((key) => key.startsWith('seedance.'))
+      .flatMap((key) =>
+        LOCALES.filter((locale) => RESOLUTION_CLAIM.test(t(key, locale))).map(
+          (locale) => `${key} (${locale})`
+        )
+      )
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/website/src/data/seedance.ts
+++ b/apps/website/src/data/seedance.ts
@@ -34,12 +34,6 @@ const media = {
     src: 'https://media.comfy.org/website/seedance-2.5/grass.webm',
     posterSrc: 'https://media.comfy.org/website/seedance-2.5/grass-poster.webp'
   },
-  worldcup: {
-    kind: 'video',
-    src: 'https://media.comfy.org/website/seedance-2.5/worldcup.webm',
-    posterSrc:
-      'https://media.comfy.org/website/seedance-2.5/worldcup-poster.webp'
-  },
   city: {
     kind: 'video',
     src: 'https://media.comfy.org/website/seedance-2.5/city.webm',
@@ -73,8 +67,6 @@ const sharedCardIdentity = {
 const BALLOONS_PROMPT = `Animals crossing a rainy city street at dusk, holding up floating gold foil balloons that spell SEEDANCE 2.5. A bear, a giraffe, and a fox walk the wet crosswalk together, each gripping balloon strings. After the letters, a gold foil balloon shaped like the Comfy logo drifts into frame. Intercut between a POV through the car windshield with wipers and a shot from outside looking into the car, where a sloth sits at the steering wheel. Umbrellas, traffic lights, rain reflections, cinematic 16:9, natural handheld motion.`
 
 const GRASS_PROMPT = `Start in a dark surreal outdoor office corridor; lights turn on one by one, gradually revealing that the space is enormous. Cut to a close action sequence following an older man pushing a red lawnmower across a lush green lawn that covers the courtyard floor. Camera tracks him tightly from behind and beside. Then the camera rises up into a high-angle overhead shot of the courtyard: mowed into the grass in dry straw-colored lettering, SEEDANCE on top, 2.5 centered below it, and the Comfy logo underneath with clear space between 2.5 and the logo, 16:9.`
-
-const WORLDCUP_PROMPT = `Handheld shot inside a packed Brazilian soccer stadium at night. The camera finds a fan in a yellow jersey holding up a handmade cardboard sign with black marker handwriting that reads SEEDANCE 2.5 on top and 4K below. The camera pans across the cheering crowd and lands on another fan holding a second cardboard sign with the Comfy logo drawn on it in marker. Brazilian flags waving, stadium lights, shallow depth of field, energetic documentary feel, 16:9`
 
 const CITY_PROMPT = `Cool blue dusk lighting at the start, the same four people sitting and standing outside a café on a city sidewalk, warm lit windows behind them, chatting and laughing, drinking coffee, holding their same general positions but full of lively, animated physical movement — leaning in and back, gesturing broadly with their hands, shifting in their seats, turning to look at each other, genuinely active and expressive rather than mostly still. Partway through the shot, the scene cuts hard and instantly to a new setting with a fun, playful, almost cheeky snap — no blend, no dissolve, just a sudden, bouncy pop-cut, like a magic trick — the same four people now in warm, golden late-afternoon sunlight, seated in the same relative positions at a charming French bistro with a green awning, colorful flower pots, warm string lights, and cobblestone underfoot. No additional or new people appear at any point — only the original four throughout. The instant the cut happens, all four people react with visible confusion — pausing mid-gesture, glancing around at their unfamiliar new surroundings, exchanging puzzled looks with each other, one or two double-taking or squinting at the sudden change in light, before their conversation slowly resumes. Ambient café chatter and city sounds abruptly cut and restart at the pop-cut moment, a beat of surprised murmurs and puzzled “huh?” reactions, followed by a bright, playful whoosh-pop sound and a cheerful little musical sting marking the fun, sudden transition.
 
@@ -125,15 +117,6 @@ const clips = [
     description: {
       en: 'A meadow running down the middle of an empty office floor.',
       'zh-CN': '一片草地从空荡的办公楼中间蔓延开来。'
-    }
-  },
-  {
-    id: 'worldcup',
-    media: media.worldcup,
-    prompt: { en: WORLDCUP_PROMPT, 'zh-CN': WORLDCUP_PROMPT },
-    description: {
-      en: 'A packed stadium crowd, shot handheld from the stands.',
-      'zh-CN': '看台上人声鼎沸的球迷，手持镜头拍摄。'
     }
   },
   {
@@ -240,9 +223,8 @@ export const seedancePage: ModelLaunchPage = {
           'zh-CN': 'Seedance 2.5 相比 Seedance 2.0 有哪些新变化？'
         },
         answer: {
-          en: 'Longer native clips, higher resolution, and support for many more reference inputs than 2.0.',
-          'zh-CN':
-            '更长的原生片段、更高的分辨率，以及比 2.0 多得多的参考输入支持。'
+          en: 'Longer native clips and support for many more reference inputs than 2.0.',
+          'zh-CN': '更长的原生片段，以及比 2.0 多得多的参考输入支持。'
         }
       },
       {
@@ -267,17 +249,6 @@ export const seedancePage: ModelLaunchPage = {
           en: 'Up to 30 seconds natively, and you can chain shots on the canvas when you need a longer cut.',
           'zh-CN':
             '最长可原生生成 30 秒。需要更长的成片时，你可以在画布上串联多个镜头。'
-        }
-      },
-      {
-        id: 'generate-4k',
-        question: {
-          en: 'Can Seedance 2.5 generate 4K video?',
-          'zh-CN': 'Seedance 2.5 能生成 4K 视频吗？'
-        },
-        answer: {
-          en: 'Yes. Seedance 2.5 renders up to 4K.',
-          'zh-CN': '可以。Seedance 2.5 最高支持 4K 渲染。'
         }
       },
       {
@@ -347,8 +318,8 @@ export const seedancePage: ModelLaunchPage = {
           'zh-CN': '切换到 Seedance 2.5'
         },
         description: {
-          en: 'Final render, up to 4K',
-          'zh-CN': '最终渲染，最高 4K'
+          en: 'Final render, native audio',
+          'zh-CN': '最终渲染，原生音频'
         }
       }
     ],

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4798,9 +4798,9 @@ const translations = {
     'zh-CN': 'Comfy 上的 Seedance 2.5 — 电影级 AI 视频模型'
   },
   'seedance.meta.description': {
-    en: 'Run ByteDance Seedance 2.5 on Comfy: multi-shot cinematic video from text or image, 1080p to 4K. Draft free on Wan 2.2 and spend credits only on the final render.',
+    en: 'Run ByteDance Seedance 2.5 on Comfy: multi-shot cinematic video with native audio, from text or image. Draft free on Wan 2.2 and spend credits only on the final render.',
     'zh-CN':
-      '在 Comfy 上运行字节跳动 Seedance 2.5：从文本或图像生成多镜头电影级视频，支持 1080p 至 4K。先用 Wan 2.2 免费打样，只在最终渲染时消耗积分。'
+      '在 Comfy 上运行字节跳动 Seedance 2.5：从文本或图像生成带原生音频的多镜头电影级视频。先用 Wan 2.2 免费打样，只在最终渲染时消耗积分。'
   },
   'seedance.breadcrumb.model': { en: 'Seedance 2.5', 'zh-CN': 'Seedance 2.5' },
   'seedance.breadcrumb.updated': {
@@ -4812,9 +4812,9 @@ const translations = {
     'zh-CN': 'Seedance 2.5 已上线'
   },
   'seedance.hero.description': {
-    en: "ByteDance's cinematic video model — multi-shot sequences, 1080p to 4K, text or image in. You direct on the canvas; Seedance renders the cut.",
+    en: "ByteDance's cinematic video model — multi-shot sequences with native audio, text or image in. You direct on the canvas; Seedance renders the cut.",
     'zh-CN':
-      '字节跳动的电影级视频模型：多镜头序列，1080p 至 4K，支持文本或图像输入。你在画布上执导，Seedance 负责渲染成片。'
+      '字节跳动的电影级视频模型：多镜头序列，原生音频，支持文本或图像输入。你在画布上执导，Seedance 负责渲染成片。'
   },
   'seedance.hero.primaryCta': {
     en: 'RUN SEEDANCE 2.5',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Seedance 2.5 does not render 4K, so `/seedance-2.5` can't advertise it. Flagged in #gtm-seedance-launches: *"We cant say 4K.. lp still says 4k w 1080"*.

## Changes

`apps/website/src/i18n/translations.ts`
- `seedance.meta.description` — "multi-shot cinematic video from text or image, **1080p to 4K**" → "multi-shot cinematic video **with native audio**, from text or image"
- `seedance.hero.description` — "multi-shot sequences, **1080p to 4K**, text or image in" → "multi-shot sequences **with native audio**, text or image in"

`apps/website/src/data/seedance.ts`
- FAQ "Can Seedance 2.5 generate 4K video? / Yes. Seedance 2.5 renders up to 4K." — removed (8 → 7 entries, FAQPage JSON-LD follows the data)
- Step 3 — "Final render, up to 4K" → "Final render, native audio"
- FAQ "What's new in 2.5 vs 2.0" — dropped "higher resolution" (2.0 is the tier that goes to 4K, so the comparison was backwards)
- Gallery — removed the `worldcup` clip, its prompt and its media entry

Both en and zh-CN strings updated. `RUN SEEDANCE 2.5`, pricing, and every CTA target are untouched.

## Why the worldcup clip had to go

The clip itself renders the claim: a fan holds a cardboard sign reading `SEEDANCE 2.5 / 4K` for most of its runtime (it was in the generation prompt). Copy edits can't fix footage, so the card is removed. **The gallery is now 5 cards, so the last row holds a single card** — if marketing wants the 3×2 grid back, re-render that shot without the "4K" text and I'll add it straight back.

I checked all six remaining clips frame by frame: hero, balloons, grass, city, shark and giraffe show only "SEEDANCE 2.5" / "Comfy" — no resolution text.

## Deliberately not asserted

I removed the resolution claim rather than swapping in a number. The Slack thread says 1080, but `comfy_api_nodes/nodes_bytedance.py` currently exposes only `480p`/`720p` for Seedance 2.5 (`1080p`/`4k` are Seedance 2.0 options). If you want the LP to state a max resolution, confirm the number and it's a one-line change.

## Out of scope (separate repo)

`workflow_templates/site/src/content/landing/models/seedance.json` (templates.comfy.org) still says *"ByteDance previewed Seedance 2.5 … with native 30-second clips, 4K output, and up to 50 reference inputs"*. It's attributed to ByteDance's announcement rather than claimed by us, and it's a different repo — say the word and I'll open a matching PR.

## Verification

Rendered `/seedance-2.5` and `/zh-CN/seedance-2.5` from a production build: the only remaining "4K" strings on the page are `84.4K` / `295.4K` in the pricing credit slider.

- `pnpm --filter @comfyorg/website test:unit` — 363 passed
- `pnpm --filter @comfyorg/website typecheck` — 0 errors
- `pnpm --filter @comfyorg/website build` — 585 pages
- `pnpm --filter @comfyorg/website validate:jsonld` — passed (588 pages)
- `pnpm exec playwright test e2e/seedance.spec.ts` — 13 passed
- `pnpm lint`, `pnpm format:check`, `pnpm knip` — clean
- No visual snapshots cover this page, so none needed updating


## Screenshots

![Frame from the removed worldcup gallery clip: a fan holds a cardboard sign reading SEEDANCE 2.5 4K](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/107b1c07ed96cee47f0f2d4a2415d1fe128c4a21e87ee2119bec90a441fe78a9/pr-images/1786166741158-1a17d5f2-a9ed-482a-950a-b9814163fc75.png)

![Updated hero: multi-shot sequences with native audio, text or image in](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/107b1c07ed96cee47f0f2d4a2415d1fe128c4a21e87ee2119bec90a441fe78a9/pr-images/1786166741548-f1433da6-542f-4c45-9b44-84fae519ee0e.png)

![Steps section with step 3 now reading Final render, native audio](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/107b1c07ed96cee47f0f2d4a2415d1fe128c4a21e87ee2119bec90a441fe78a9/pr-images/1786166741929-623683aa-3634-4c64-8acd-888caec6ee83.png)

![FAQ section with the Can Seedance 2.5 generate 4K video entry removed](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/107b1c07ed96cee47f0f2d4a2415d1fe128c4a21e87ee2119bec90a441fe78a9/pr-images/1786166742276-18ad5b30-f52e-40b6-a4a4-4522c3805958.png)

![Gallery now showing 5 clips after the worldcup card was removed](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/107b1c07ed96cee47f0f2d4a2415d1fe128c4a21e87ee2119bec90a441fe78a9/pr-images/1786166742607-5dccc82d-d80b-46ad-8712-10e2008e885c.png)