### PR TITLE
fix: layer editor UX and review follow-ups

### DIFF
--- a/src/extensions/core/imageCompositor.test.ts
+++ b/src/extensions/core/imageCompositor.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearCompositorLayers,
   getCompositorBBoxes,
+  getCompositorCanvas,
   getCompositorInputsFingerprint,
   getCompositorLayers
 } from '@/renderer/extensions/compositor/composables/useCompositorLayers'
@@ -108,6 +109,29 @@ describe('ImageCompositor extension', () => {
     })
 
     expect(getCompositorBBoxes(node)).toBeUndefined()
+  })
+
+  it('caches the document canvas reported by the backend', () => {
+    const { node } = createdNode()
+
+    node.onExecuted?.({
+      compositor_layers: [{ filename: 'a.png' }],
+      compositor_inputs: ['hash-a'],
+      compositor_canvas: [{ w: 1280, h: 1280 }]
+    })
+
+    expect(getCompositorCanvas(node)).toEqual({ w: 1280, h: 1280 })
+  })
+
+  it('leaves the canvas cache empty when the output has none', () => {
+    const { node } = createdNode()
+
+    node.onExecuted?.({
+      compositor_layers: [{ filename: 'a.png' }],
+      compositor_inputs: ['hash-a']
+    })
+
+    expect(getCompositorCanvas(node)).toBeUndefined()
   })
 
   it('resets the compositor widget when the state is stale', () => {

--- a/src/extensions/core/imageCompositor.ts
+++ b/src/extensions/core/imageCompositor.ts
@@ -13,6 +13,7 @@ type ImageCompositorOutput = NodeOutputWith<{
   compositor_layers?: Record<string, string>[]
   compositor_inputs?: string[]
   compositor_bboxes?: (CompositorBBox | null)[]
+  compositor_canvas?: { w: number; h: number }[]
   compositor_state_stale?: boolean[]
 }>
 
@@ -44,7 +45,13 @@ useExtensionService().registerExtension({
         ? kept.map(([, index]) => rawBboxes[index] ?? null)
         : undefined
       if (layers.length)
-        setCompositorLayers(node, layers, output.compositor_inputs, bboxes)
+        setCompositorLayers(
+          node,
+          layers,
+          output.compositor_inputs,
+          bboxes,
+          output.compositor_canvas?.[0]
+        )
       clearCompositorPreviewOverride(node)
 
       if (output.compositor_state_stale?.[0]) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1291,6 +1291,7 @@
     "title": "Compositor",
     "webglUnavailable": "WebGL is unavailable - the canvas cannot render",
     "loadFailed": "Failed to load layers",
+    "needsTwoImages": "The layer editor needs at least two output images",
     "layersFailedToLoad": "One layer failed to load | {count} layers failed to load",
     "selectTool": "Select",
     "handTool": "Hand",

--- a/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { toNodeId } from '@/types/nodeId'
@@ -40,9 +41,20 @@ vi.mock(
     })
   })
 )
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({ t: (key: string) => key })
-}))
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      compositor: {
+        empty: 'Run the workflow to generate a composite',
+        open: 'Open Compositor',
+        runWorkflowFirst: 'Run the workflow once to load input images',
+        downloadPsd: 'Download PSD'
+      }
+    }
+  }
+})
 
 const nodeId = toNodeId(9)
 const graphNode = { id: nodeId, graph: null } as unknown as LGraphNode
@@ -50,7 +62,12 @@ const graphNode = { id: nodeId, graph: null } as unknown as LGraphNode
 function renderWidget() {
   return render(WidgetCompositor, {
     props: { nodeId },
-    global: { stubs: { Button: { template: '<button v-bind="$attrs" />' } } }
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: { template: '<button v-bind="$attrs"><slot /></button>' }
+      }
+    }
   })
 }
 
@@ -64,8 +81,11 @@ describe('WidgetCompositor', () => {
   it('renders the empty state when the node is not in the graph (search preview)', () => {
     renderWidget()
 
-    expect(screen.getByTestId('compositor-empty')).toBeTruthy()
+    expect(screen.getByTestId('compositor-empty').textContent).toContain(
+      'Run the workflow to generate a composite'
+    )
     const open = screen.getByTestId('compositor-open-button')
+    expect(open.textContent).toContain('Open Compositor')
     expect(open.hasAttribute('disabled')).toBe(true)
   })
 

--- a/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.test.ts
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { toNodeId } from '@/types/nodeId'
+
+import {
+  clearCompositorLayers,
+  setCompositorLayers
+} from '../composables/useCompositorLayers'
+import WidgetCompositor from './WidgetCompositor.vue'
+
+const { getNodeById } = vi.hoisted(() => ({
+  getNodeById: vi.fn<() => unknown>(() => undefined)
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: { graph: { getNodeById } } }
+}))
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({
+    getNodeImageUrls: () => undefined,
+    nodeOutputs: {},
+    nodePreviewImages: {}
+  })
+}))
+vi.mock(
+  '@/renderer/extensions/compositor/composables/useCompositorEditor',
+  () => ({
+    useCompositorEditor: () => ({ openCompositorEditor: vi.fn() })
+  })
+)
+vi.mock(
+  '@/renderer/extensions/compositor/composables/useCompositorPsdDownload',
+  () => ({
+    useCompositorPsdDownload: () => ({
+      exporting: ref(false),
+      downloadPsd: vi.fn()
+    })
+  })
+)
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+const nodeId = toNodeId(9)
+const graphNode = { id: nodeId, graph: null } as unknown as LGraphNode
+
+function renderWidget() {
+  return render(WidgetCompositor, {
+    props: { nodeId },
+    global: { stubs: { Button: { template: '<button v-bind="$attrs" />' } } }
+  })
+}
+
+describe('WidgetCompositor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearCompositorLayers(graphNode)
+    getNodeById.mockReturnValue(undefined)
+  })
+
+  it('renders the empty state when the node is not in the graph (search preview)', () => {
+    renderWidget()
+
+    expect(screen.getByTestId('compositor-empty')).toBeTruthy()
+    const open = screen.getByTestId('compositor-open-button')
+    expect(open.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('enables opening once the graph node exists with cached layers', () => {
+    getNodeById.mockReturnValue(graphNode)
+    setCompositorLayers(graphNode, [
+      { filename: 'a.png', subfolder: '', type: 'temp' }
+    ])
+
+    renderWidget()
+
+    const open = screen.getByTestId('compositor-open-button')
+    expect(open.hasAttribute('disabled')).toBe(false)
+  })
+})

--- a/src/renderer/extensions/compositor/components/WidgetCompositor.vue
+++ b/src/renderer/extensions/compositor/components/WidgetCompositor.vue
@@ -93,7 +93,7 @@ const outputUrl = ref<string | null>(null)
 
 const litegraphNode = computed(() => {
   if (!nodeId || !app.canvas.graph) return null
-  return app.canvas.graph.getNodeById(nodeId)
+  return app.canvas.graph.getNodeById(nodeId) ?? null
 })
 
 function updateOutputUrl(): void {
@@ -125,7 +125,7 @@ const dimensionsLabel = computed(() =>
 
 const canOpen = computed(() => {
   const node = litegraphNode.value
-  return node !== null && hasCompositorLayers(node)
+  return !!node && hasCompositorLayers(node)
 })
 
 function onPreviewLoad(event: Event): void {

--- a/src/renderer/extensions/compositor/composables/compositorLayerState.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorLayerState.test.ts
@@ -474,6 +474,27 @@ describe('resolveInitialLayerState', () => {
     })
   })
 
+  it('carries the document canvas into the synthesized bbox layout', () => {
+    const resolved = resolveInitialLayerState(null, ['hash-a'], bboxes, {
+      w: 1280,
+      h: 1280
+    })
+    expect(resolved?.canvas).toEqual({ w: 1280, h: 1280 })
+  })
+
+  it('omits the canvas when the backend reports none', () => {
+    const resolved = resolveInitialLayerState(null, ['hash-a'], bboxes)
+    expect(resolved?.canvas).toBeUndefined()
+  })
+
+  it('ignores a malformed canvas', () => {
+    const resolved = resolveInitialLayerState(null, ['hash-a'], bboxes, {
+      w: Number.NaN,
+      h: 1280
+    } as { w: number; h: number })
+    expect(resolved?.canvas).toBeUndefined()
+  })
+
   it('returns null without a saved state or usable bboxes', () => {
     expect(resolveInitialLayerState(null, undefined, undefined)).toBeNull()
     expect(resolveInitialLayerState(null, undefined, [])).toBeNull()

--- a/src/renderer/extensions/compositor/composables/compositorLayerState.ts
+++ b/src/renderer/extensions/compositor/composables/compositorLayerState.ts
@@ -282,10 +282,13 @@ export function layerStateInputsMatch(
 }
 
 function bboxLayerState(
-  bboxes: ReadonlyArray<CompositorBBox | null> | undefined
+  bboxes: ReadonlyArray<CompositorBBox | null> | undefined,
+  canvas?: { w: number; h: number }
 ): CompositorLayerStateInit | null {
   if (!bboxes?.some((bbox) => bbox !== null)) return null
+  const canvasSize = parseCanvasSize(canvas)
   return {
+    ...(canvasSize ? { canvas: canvasSize } : {}),
     layers: bboxes.map((bbox) =>
       bbox
         ? {
@@ -315,11 +318,12 @@ function bboxLayerState(
 export function resolveInitialLayerState(
   savedState: CompositorLayerState | null,
   currentInputs: readonly string[] | undefined,
-  bboxes: ReadonlyArray<CompositorBBox | null> | undefined
+  bboxes: ReadonlyArray<CompositorBBox | null> | undefined,
+  canvas?: { w: number; h: number }
 ): CompositorLayerStateInit | null {
   if (savedState && layerStateInputsMatch(savedState.inputs, currentInputs))
     return savedState
-  return bboxLayerState(bboxes)
+  return bboxLayerState(bboxes, canvas)
 }
 
 export function applyLayerState(

--- a/src/renderer/extensions/compositor/composables/compositorSession.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSession.test.ts
@@ -6,12 +6,17 @@ import { toNodeId } from '@/types/nodeId'
 
 import { loadCompositorSession } from './compositorSession'
 
-const { applyLayerState, getCompositorLayers, resolveInitialLayerState } =
-  vi.hoisted(() => ({
-    applyLayerState: vi.fn(),
-    getCompositorLayers: vi.fn<() => unknown>(() => []),
-    resolveInitialLayerState: vi.fn<() => unknown>(() => null)
-  }))
+const {
+  applyLayerState,
+  getCompositorCanvas,
+  getCompositorLayers,
+  resolveInitialLayerState
+} = vi.hoisted(() => ({
+  applyLayerState: vi.fn(),
+  getCompositorCanvas: vi.fn<() => unknown>(() => undefined),
+  getCompositorLayers: vi.fn<() => unknown>(() => []),
+  resolveInitialLayerState: vi.fn<() => unknown>(() => null)
+}))
 
 vi.mock(
   '@/renderer/extensions/compositor/composables/compositorLayerState',
@@ -25,6 +30,7 @@ vi.mock(
   '@/renderer/extensions/compositor/composables/useCompositorLayers',
   () => ({
     getCompositorBBoxes: () => undefined,
+    getCompositorCanvas,
     getCompositorInputsFingerprint: () => undefined,
     getCompositorLayers
   })
@@ -47,7 +53,8 @@ function makeSession() {
     loadImages: vi.fn().mockResolvedValue(0),
     imageLayers: { value: [{ id: 'a', visible: true }] },
     editor: { history: { clear: vi.fn() } },
-    fitView: vi.fn()
+    fitView: vi.fn(),
+    setCanvasSize: vi.fn()
   }
 }
 
@@ -57,6 +64,7 @@ const fallbackName = (i: number) => `Layer ${i + 1}`
 describe('loadCompositorSession', () => {
   beforeEach(() => {
     getCompositorLayers.mockReturnValue([])
+    getCompositorCanvas.mockReturnValue(undefined)
     resolveInitialLayerState.mockReturnValue(null)
   })
 
@@ -113,5 +121,37 @@ describe('loadCompositorSession', () => {
 
     expect(applyLayerState).not.toHaveBeenCalled()
     expect(session.editor.history.clear).not.toHaveBeenCalled()
+    expect(session.setCanvasSize).not.toHaveBeenCalled()
+  })
+
+  it('sizes the canvas from the backend when there is no per-layer state', async () => {
+    getCompositorCanvas.mockReturnValue({ w: 1280, h: 1280 })
+    const session = makeSession()
+
+    await loadCompositorSession(
+      session as unknown as LayerEditorSession,
+      node,
+      fallbackName
+    )
+
+    expect(applyLayerState).not.toHaveBeenCalled()
+    expect(session.setCanvasSize).toHaveBeenCalledWith(1280, 1280)
+    expect(session.editor.history.clear).toHaveBeenCalled()
+    expect(session.fitView).toHaveBeenCalled()
+  })
+
+  it('lets the resolved initial state own the canvas over the raw fallback', async () => {
+    getCompositorCanvas.mockReturnValue({ w: 1280, h: 1280 })
+    resolveInitialLayerState.mockReturnValue({ layers: [] })
+    const session = makeSession()
+
+    await loadCompositorSession(
+      session as unknown as LayerEditorSession,
+      node,
+      fallbackName
+    )
+
+    expect(applyLayerState).toHaveBeenCalled()
+    expect(session.setCanvasSize).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/compositor/composables/compositorSession.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSession.ts
@@ -7,6 +7,7 @@ import { imageRefViewQuery } from '@/renderer/extensions/compositor/composables/
 import { getCompositorWidgetValue } from '@/renderer/extensions/compositor/composables/compositorWidgets'
 import {
   getCompositorBBoxes,
+  getCompositorCanvas,
   getCompositorInputsFingerprint,
   getCompositorLayers
 } from '@/renderer/extensions/compositor/composables/useCompositorLayers'
@@ -31,13 +32,19 @@ export async function loadCompositorSession(
   )
   const failed = await session.loadImages(urls, names)
 
+  const canvas = getCompositorCanvas(node)
   const initialState = resolveInitialLayerState(
     parseLayerState(getCompositorWidgetValue(node)),
     getCompositorInputsFingerprint(node),
-    getCompositorBBoxes(node)
+    getCompositorBBoxes(node),
+    canvas
   )
   if (initialState) {
     applyLayerState(initialState, session.imageLayers.value, session)
+    session.editor.history.clear()
+    session.fitView()
+  } else if (canvas) {
+    session.setCanvasSize(canvas.w, canvas.h)
     session.editor.history.clear()
     session.fitView()
   }

--- a/src/renderer/extensions/compositor/composables/useCompositorLayers.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorLayers.ts
@@ -13,6 +13,7 @@ interface CompositorNodeCache {
   layers: ImageFileRef[]
   inputsFingerprint?: string[]
   bboxes?: (CompositorBBox | null)[]
+  canvas?: { w: number; h: number }
 }
 
 const cacheByNode = reactive(new Map<NodeLocatorId, CompositorNodeCache>())
@@ -29,12 +30,14 @@ export function setCompositorLayers(
   node: CompositorNodeRef,
   refs: ImageFileRef[],
   inputsFingerprint?: string[],
-  bboxes?: (CompositorBBox | null)[]
+  bboxes?: (CompositorBBox | null)[],
+  canvas?: { w: number; h: number }
 ): void {
   cacheByNode.set(cacheKey(node), {
     layers: refs,
     ...(inputsFingerprint ? { inputsFingerprint } : {}),
-    ...(bboxes ? { bboxes } : {})
+    ...(bboxes ? { bboxes } : {}),
+    ...(canvas ? { canvas } : {})
   })
 }
 
@@ -54,6 +57,12 @@ export function getCompositorBBoxes(
   node: CompositorNodeRef
 ): (CompositorBBox | null)[] | undefined {
   return cacheByNode.get(cacheKey(node))?.bboxes
+}
+
+export function getCompositorCanvas(
+  node: CompositorNodeRef
+): { w: number; h: number } | undefined {
+  return cacheByNode.get(cacheKey(node))?.canvas
 }
 
 export function clearCompositorLayers(node: CompositorNodeRef): void {

--- a/src/renderer/extensions/layerEditor/components/LayerEditorCanvas.vue
+++ b/src/renderer/extensions/layerEditor/components/LayerEditorCanvas.vue
@@ -3,7 +3,7 @@
     ref="viewportRef"
     tabindex="0"
     data-testid="layer-editor-viewport"
-    class="relative min-h-0 min-w-0 flex-1 touch-none overflow-hidden bg-base-background outline-none"
+    class="focus-visible:ring-ring relative min-h-0 min-w-0 flex-1 touch-none overflow-hidden bg-base-background outline-none focus-visible:ring-1"
     :style="{ cursor: viewportCursor }"
     @pointerdown="session.onPointerDown"
     @pointermove="session.onPointerMove"
@@ -67,7 +67,9 @@ const checkerboardStyle = {
 }
 
 let firstLayout = true
-useResizeObserver(viewportRef, () => {
+useResizeObserver(viewportRef, (entries) => {
+  const rect = entries[0]?.contentRect
+  if (!rect?.width || !rect?.height) return
   if (firstLayout) {
     firstLayout = false
     session.fitView()

--- a/src/renderer/extensions/layerEditor/components/LayerPanel.vue
+++ b/src/renderer/extensions/layerEditor/components/LayerPanel.vue
@@ -12,9 +12,14 @@
       <div
         v-for="node in rows"
         :key="node.id"
-        :class="rowClass(isRowSelected(node.id))"
+        :class="cn(rowClass(isRowSelected(node.id)), dropHintClass(node.id))"
         data-testid="layer-panel-row"
+        :draggable="renamingId !== node.id"
         @click="onRowClick(node.id, $event)"
+        @dragstart="onRowDragStart(node.id, $event)"
+        @dragover="onRowDragOver(node.id, $event)"
+        @drop="onRowDrop(node.id, $event)"
+        @dragend="endDrag"
       >
         <button
           :class="eyeButtonClass(node.visible)"
@@ -34,7 +39,7 @@
           <input
             v-if="renamingId === node.id"
             :ref="focusInput"
-            class="min-w-0 rounded-sm border border-border-default bg-base-background px-1 text-xs text-base-foreground"
+            class="min-w-0 rounded-sm border border-border-default bg-base-background px-1 text-xs text-base-foreground select-text"
             :value="node.name"
             @blur="commitRename(node.id, $event)"
             @keydown.enter="commitRename(node.id, $event)"
@@ -115,6 +120,11 @@ import { computed, ref, watch } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import type { LayerDropPos } from '@/renderer/extensions/layerEditor/composables/layerPanelDnd'
+import {
+  dropPositionFor,
+  reorderDropIndex
+} from '@/renderer/extensions/layerEditor/composables/layerPanelDnd'
 import { DEFAULT_BACKGROUND_COLOR } from '@/renderer/extensions/layerEditor/composables/useLayerEditorSession'
 import type { LayerEditorSession } from '@/renderer/extensions/layerEditor/composables/useLayerEditorSession'
 import type {
@@ -167,7 +177,7 @@ function isRowSelected(id: string): boolean {
 
 function rowClass(selected: boolean, extra?: string): string {
   return cn(
-    'group flex cursor-pointer items-center gap-2 border-border-default px-2 py-1.5',
+    'group flex cursor-pointer items-center gap-2 border-border-default px-2 py-1.5 select-none',
     'hover:bg-secondary-background-hover',
     selected && 'bg-secondary-background-selected',
     extra
@@ -186,6 +196,60 @@ function eyeIconClass(visible: boolean): string {
     'size-4',
     visible ? 'icon-[lucide--eye]' : 'icon-[lucide--eye-off] opacity-50'
   )
+}
+
+const dragId = ref<string | null>(null)
+const dropHint = ref<{ id: string; pos: LayerDropPos } | null>(null)
+
+function endDrag(): void {
+  dragId.value = null
+  dropHint.value = null
+}
+
+function dropHintClass(id: string): string {
+  const hint = dropHint.value
+  if (hint?.id !== id) return 'relative'
+  return cn(
+    'relative',
+    hint.pos === 'above'
+      ? "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-base-foreground before:content-['']"
+      : "after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-base-foreground after:content-['']"
+  )
+}
+
+function onRowDragStart(id: string, e: DragEvent): void {
+  dragId.value = id
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', id)
+  }
+}
+
+function onRowDragOver(id: string, e: DragEvent): void {
+  if (!dragId.value || dragId.value === id) return
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  const ratio = rect.height > 0 ? (e.clientY - rect.top) / rect.height : 0.5
+  const pos = dropPositionFor(ratio)
+  if (dropHint.value?.id !== id || dropHint.value?.pos !== pos)
+    dropHint.value = { id, pos }
+}
+
+function onRowDrop(id: string, e: DragEvent): void {
+  e.preventDefault()
+  const dragged = dragId.value
+  const hint = dropHint.value
+  if (dragged && hint?.id === id) {
+    const toIndex = reorderDropIndex(
+      imageLayers.value.map((n) => n.id),
+      id,
+      hint.pos,
+      backgroundLayer.value ? 1 : 0
+    )
+    if (toIndex !== null) session.moveLayerTo(dragged, toIndex)
+  }
+  endDrag()
 }
 
 function onRowClick(id: string, e: MouseEvent): void {

--- a/src/renderer/extensions/layerEditor/components/LayerPanel.vue
+++ b/src/renderer/extensions/layerEditor/components/LayerPanel.vue
@@ -8,7 +8,7 @@
       </span>
     </div>
 
-    <div class="min-h-0 flex-1 overflow-y-auto">
+    <div class="min-h-0 flex-1 overflow-y-auto" @dragleave="onListDragLeave">
       <div
         v-for="node in rows"
         :key="node.id"
@@ -177,7 +177,7 @@ function isRowSelected(id: string): boolean {
 
 function rowClass(selected: boolean, extra?: string): string {
   return cn(
-    'group flex cursor-pointer items-center gap-2 border-border-default px-2 py-1.5 select-none',
+    'group relative flex cursor-pointer items-center gap-2 border-border-default px-2 py-1.5 select-none',
     'hover:bg-secondary-background-hover',
     selected && 'bg-secondary-background-selected',
     extra
@@ -208,20 +208,19 @@ function endDrag(): void {
 
 function dropHintClass(id: string): string {
   const hint = dropHint.value
-  if (hint?.id !== id) return 'relative'
-  return cn(
-    'relative',
-    hint.pos === 'above'
-      ? "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-base-foreground before:content-['']"
-      : "after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-base-foreground after:content-['']"
-  )
+  if (hint?.id !== id) return ''
+  return hint.pos === 'above'
+    ? "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-base-foreground before:content-['']"
+    : "after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-base-foreground after:content-['']"
 }
 
 function onRowDragStart(id: string, e: DragEvent): void {
   dragId.value = id
   if (e.dataTransfer) {
     e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', id)
+    // Firefox refuses to start the drag without data; empty keeps text
+    // inputs from receiving the layer id on a stray drop.
+    e.dataTransfer.setData('text/plain', '')
   }
 }
 
@@ -237,19 +236,26 @@ function onRowDragOver(id: string, e: DragEvent): void {
 }
 
 function onRowDrop(id: string, e: DragEvent): void {
-  e.preventDefault()
   const dragged = dragId.value
   const hint = dropHint.value
-  if (dragged && hint?.id === id) {
-    const toIndex = reorderDropIndex(
-      imageLayers.value.map((n) => n.id),
-      id,
-      hint.pos,
-      backgroundLayer.value ? 1 : 0
-    )
-    if (toIndex !== null) session.moveLayerTo(dragged, toIndex)
+  if (!dragged || hint?.id !== id) {
+    endDrag()
+    return
   }
+  e.preventDefault()
+  const toIndex = reorderDropIndex(
+    imageLayers.value.map((n) => n.id),
+    id,
+    hint.pos,
+    backgroundLayer.value ? 1 : 0
+  )
+  if (toIndex !== null) session.moveLayerTo(dragged, toIndex)
   endDrag()
+}
+
+function onListDragLeave(e: DragEvent): void {
+  const container = e.currentTarget as HTMLElement
+  if (!container.contains(e.relatedTarget as Node | null)) dropHint.value = null
 }
 
 function onRowClick(id: string, e: MouseEvent): void {

--- a/src/renderer/extensions/layerEditor/components/LayerPropertiesPanel.vue
+++ b/src/renderer/extensions/layerEditor/components/LayerPropertiesPanel.vue
@@ -345,7 +345,7 @@ function onOpacity(percent: number): void {
 }
 
 function isBlendFn(value: unknown): value is BlendFn {
-  return typeof value === 'string' && value in LAYER_MODES
+  return typeof value === 'string' && Object.hasOwn(LAYER_MODES, value)
 }
 
 function onBlendChange(value: AcceptableValue): void {

--- a/src/renderer/extensions/layerEditor/components/PropertyNumberField.test.ts
+++ b/src/renderer/extensions/layerEditor/components/PropertyNumberField.test.ts
@@ -1,0 +1,34 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import PropertyNumberField from './PropertyNumberField.vue'
+
+async function commitValue(value: string) {
+  const input = screen.getByLabelText<HTMLInputElement>('X')
+  await userEvent.clear(input)
+  if (value !== '') await userEvent.type(input, value)
+  await userEvent.tab()
+  return input
+}
+
+function renderField() {
+  return render(PropertyNumberField, {
+    props: { label: 'X', value: 40, min: 0, max: 100 }
+  })
+}
+
+describe('PropertyNumberField', () => {
+  it('commits a clamped value on change', async () => {
+    const { emitted } = renderField()
+    await commitValue('250')
+    expect(emitted('commit')).toEqual([[100]])
+  })
+
+  it('reverts an emptied field instead of committing 0', async () => {
+    const { emitted } = renderField()
+    const input = await commitValue('')
+    expect(emitted('commit')).toBeUndefined()
+    expect(input.value).toBe('40')
+  })
+})

--- a/src/renderer/extensions/layerEditor/components/PropertyNumberField.test.ts
+++ b/src/renderer/extensions/layerEditor/components/PropertyNumberField.test.ts
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 
 import PropertyNumberField from './PropertyNumberField.vue'
 
@@ -28,6 +29,7 @@ describe('PropertyNumberField', () => {
   it('reverts an emptied field instead of committing 0', async () => {
     const { emitted } = renderField()
     const input = await commitValue('')
+    await nextTick()
     expect(emitted('commit')).toBeUndefined()
     expect(input.value).toBe('40')
   })

--- a/src/renderer/extensions/layerEditor/components/PropertyNumberField.vue
+++ b/src/renderer/extensions/layerEditor/components/PropertyNumberField.vue
@@ -46,7 +46,9 @@ watch(
 )
 
 function onChange(): void {
-  const next = Number(draft.value)
+  const raw = draft.value
+  const next =
+    typeof raw === 'string' && raw.trim() === '' ? Number.NaN : Number(raw)
   if (Number.isFinite(next)) {
     const low = min ?? -Infinity
     const high = max ?? Infinity

--- a/src/renderer/extensions/layerEditor/composables/layerPanelDnd.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/layerPanelDnd.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { dropPositionFor, reorderDropIndex } from './layerPanelDnd'
+
+describe('dropPositionFor', () => {
+  it('splits the row at the midpoint', () => {
+    expect(dropPositionFor(0.2)).toBe('above')
+    expect(dropPositionFor(0.8)).toBe('below')
+    expect(dropPositionFor(0.5)).toBe('below')
+  })
+})
+
+describe('reorderDropIndex', () => {
+  const ids = ['a', 'b', 'c']
+
+  it('above a layer lands directly over it in z-order', () => {
+    expect(reorderDropIndex(ids, 'b', 'above', 0)).toBe(2)
+  })
+
+  it('below a layer lands directly under it', () => {
+    expect(reorderDropIndex(ids, 'b', 'below', 0)).toBe(1)
+  })
+
+  it('offsets past a background layer', () => {
+    expect(reorderDropIndex(ids, 'a', 'below', 1)).toBe(1)
+    expect(reorderDropIndex(ids, 'c', 'above', 1)).toBe(4)
+  })
+
+  it('returns null for an unknown target', () => {
+    expect(reorderDropIndex(ids, 'x', 'above', 0)).toBeNull()
+  })
+})

--- a/src/renderer/extensions/layerEditor/composables/layerPanelDnd.ts
+++ b/src/renderer/extensions/layerEditor/composables/layerPanelDnd.ts
@@ -1,0 +1,16 @@
+export type LayerDropPos = 'above' | 'below'
+
+export function dropPositionFor(ratio: number): LayerDropPos {
+  return ratio < 0.5 ? 'above' : 'below'
+}
+
+export function reorderDropIndex(
+  bottomUpIds: readonly string[],
+  targetId: string,
+  pos: LayerDropPos,
+  offset: number
+): number | null {
+  const index = bottomUpIds.indexOf(targetId)
+  if (index === -1) return null
+  return offset + (pos === 'above' ? index + 1 : index)
+}

--- a/src/renderer/extensions/layerEditor/composables/layerPanelDnd.ts
+++ b/src/renderer/extensions/layerEditor/composables/layerPanelDnd.ts
@@ -4,6 +4,12 @@ export function dropPositionFor(ratio: number): LayerDropPos {
   return ratio < 0.5 ? 'above' : 'below'
 }
 
+/**
+ * Target index in root.children for a panel drag-drop.
+ * @param bottomUpIds ids ordered z=0 (bottom) first - the inverse of the
+ *   panel's display order, so visually "above" means a higher index.
+ * @param offset reserved bottom slots (1 when a background fill is pinned).
+ */
 export function reorderDropIndex(
   bottomUpIds: readonly string[],
   targetId: string,

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
@@ -4,9 +4,10 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
 import { useLayerEditor } from './useLayerEditor'
 
-const { showDialog, getNodeImageUrls } = vi.hoisted(() => ({
+const { showDialog, getNodeImageUrls, toastAdd } = vi.hoisted(() => ({
   showDialog: vi.fn(),
-  getNodeImageUrls: vi.fn()
+  getNodeImageUrls: vi.fn(),
+  toastAdd: vi.fn()
 }))
 
 vi.mock('@/stores/dialogStore', () => ({
@@ -15,6 +16,12 @@ vi.mock('@/stores/dialogStore', () => ({
 vi.mock('@/stores/nodeOutputStore', () => ({
   useNodeOutputStore: () => ({ getNodeImageUrls })
 }))
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: toastAdd })
+}))
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
 
 describe('useLayerEditor', () => {
   it('does nothing without a node', () => {
@@ -22,11 +29,17 @@ describe('useLayerEditor', () => {
     expect(showDialog).not.toHaveBeenCalled()
   })
 
-  it('does nothing when the node has fewer than 2 output images', () => {
+  it('toasts instead of opening when the node has fewer than 2 output images', () => {
     const node = {} as LGraphNode
     getNodeImageUrls.mockReturnValue(['only-one.png'])
     useLayerEditor().openLayerEditor(node)
     expect(showDialog).not.toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'info',
+        detail: 'layerEditor.needsTwoImages'
+      })
+    )
   })
 
   it('opens the layer editor dialog for a node with multiple images', () => {

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.ts
@@ -4,7 +4,9 @@ import {
   LayerEditorDialogHeader,
   layerEditorDialogProps
 } from '@/renderer/extensions/layerEditor/composables/layerEditorDialog'
+import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
@@ -17,7 +19,11 @@ export function useLayerEditor() {
 
     const imageUrls = useNodeOutputStore().getNodeImageUrls(node)
     if (!imageUrls || imageUrls.length < 2) {
-      console.error('[LayerEditor] Node needs at least 2 output images')
+      useToastStore().add({
+        severity: 'info',
+        summary: t('layerEditor.title'),
+        detail: t('layerEditor.needsTwoImages')
+      })
       return
     }
 

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
@@ -24,6 +24,7 @@ import type {
   RasterData
 } from '@/renderer/extensions/layerEditor/engine/node'
 
+import { reorderDropIndex } from './layerPanelDnd'
 import { useLayerEditorSession } from './useLayerEditorSession'
 
 class FakeCompositor implements Compositor {
@@ -381,6 +382,39 @@ describe('useLayerEditorSession', () => {
 
       session.undo()
       expect(session.imageLayers.value.map((n) => n.name)).toEqual(['A', 'B'])
+    })
+
+    it('drag-drop math lands the dragged layer around the target in both directions', async () => {
+      const { session } = makeSession()
+      await session.loadImages(['a.png', 'b.png', 'c.png'], ['A', 'B', 'C'])
+      const names = () => session.imageLayers.value.map((n) => n.name)
+      const idOf = (name: string) =>
+        session.imageLayers.value.find((n) => n.name === name)!.id
+      const drop = (
+        dragged: string,
+        target: string,
+        pos: 'above' | 'below'
+      ) => {
+        const toIndex = reorderDropIndex(
+          session.imageLayers.value.map((n) => n.id),
+          idOf(target),
+          pos,
+          1
+        )
+        session.moveLayerTo(idOf(dragged), toIndex!)
+      }
+
+      drop('A', 'C', 'above')
+      expect(names()).toEqual(['B', 'C', 'A'])
+
+      drop('A', 'B', 'below')
+      expect(names()).toEqual(['A', 'B', 'C'])
+
+      drop('C', 'B', 'below')
+      expect(names()).toEqual(['A', 'C', 'B'])
+
+      drop('A', 'B', 'below')
+      expect(names()).toEqual(['C', 'A', 'B'])
     })
 
     it('moveLayerTo refuses to drop below the background fill', async () => {

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.test.ts
@@ -169,7 +169,10 @@ const IMAGE_SIZES: Record<string, [number, number]> = {
   'c.png': [40, 80]
 }
 
-function makeSession(initResult = true) {
+function makeSession(
+  initResult = true,
+  alphaSampler?: (canvas: HTMLCanvasElement, x: number, y: number) => number
+) {
   const compositor = new FakeCompositor()
   compositor.initResult = initResult
   const session = useLayerEditorSession({
@@ -178,7 +181,8 @@ function makeSession(initResult = true) {
       const size = IMAGE_SIZES[url]
       if (!size) throw new Error(`unknown image: ${url}`)
       return fakeCanvas(size[0], size[1])
-    }
+    },
+    alphaSampler
   })
   return { session, compositor }
 }
@@ -368,6 +372,27 @@ describe('useLayerEditorSession', () => {
       expect(session.layers.value[0].kind).toBe('fill')
     })
 
+    it('moveLayerTo drops a layer at an explicit index and undoes', async () => {
+      const { session } = await loadedSession()
+      const [, b] = session.imageLayers.value
+
+      session.moveLayerTo(b.id, 1)
+      expect(session.imageLayers.value.map((n) => n.name)).toEqual(['B', 'A'])
+
+      session.undo()
+      expect(session.imageLayers.value.map((n) => n.name)).toEqual(['A', 'B'])
+    })
+
+    it('moveLayerTo refuses to drop below the background fill', async () => {
+      const { session } = await loadedSession()
+      const [a] = session.imageLayers.value
+
+      session.moveLayerTo(a.id, 0)
+
+      expect(session.imageLayers.value.map((n) => n.name)).toEqual(['A', 'B'])
+      expect(session.layers.value[0].kind).toBe('fill')
+    })
+
     it('never swallows Escape so the dialog close stays reachable', async () => {
       const { session } = await loadedSession()
       const preventDefault = vi.fn()
@@ -427,6 +452,65 @@ describe('useLayerEditorSession', () => {
       expect(session.canUndo.value).toBe(true)
       session.undo()
       expect(top.transform.x).toBe(0)
+    })
+
+    it('clicking an overlapping upper layer selects it while a lower layer is selected', async () => {
+      const { session } = await loadedSession()
+      session.setElements(makeElements())
+      await flushFrames()
+      const [a, b] = session.imageLayers.value
+      session.setActiveNode(a.id)
+
+      session.onPointerDown(pointer({ clientX: 10, clientY: 10 }))
+      session.onPointerUp(pointer({ clientX: 10, clientY: 10 }))
+
+      expect(session.activeNodeId.value).toBe(b.id)
+    })
+
+    it('re-picks the layer on top when the selection is transparent under the click', async () => {
+      const { session } = makeSession(true, (canvas) =>
+        canvas.width === 64 ? 0 : 1
+      )
+      await session.loadImages(['a.png', 'b.png'], ['A', 'B'])
+      session.setElements(makeElements())
+      await flushFrames()
+      const [a, b] = session.imageLayers.value
+      session.setActiveNode(a.id)
+
+      session.onPointerDown(pointer({ clientX: 10, clientY: 10 }))
+      session.onPointerUp(pointer({ clientX: 10, clientY: 10 }))
+
+      expect(session.activeNodeId.value).toBe(b.id)
+    })
+
+    it('clicks fall through transparent pixels to the layer below', async () => {
+      const { session } = makeSession(true, (canvas) =>
+        canvas.width === 32 ? 0 : 1
+      )
+      await session.loadImages(['a.png', 'b.png'], ['A', 'B'])
+      session.setElements(makeElements())
+      session.setActiveNode(null)
+      await flushFrames()
+      const [a] = session.imageLayers.value
+
+      session.onPointerDown(pointer({ clientX: 10, clientY: 10 }))
+      session.onPointerUp(pointer({ clientX: 10, clientY: 10 }))
+
+      expect(session.activeNodeId.value).toBe(a.id)
+    })
+
+    it('gizmo handles win over re-picking even on transparent pixels', async () => {
+      const { session } = makeSession(true, () => 0)
+      await session.loadImages(['a.png', 'b.png'], ['A', 'B'])
+      session.setElements(makeElements())
+      await flushFrames()
+      const [, b] = session.imageLayers.value
+      session.setActiveNode(b.id)
+
+      session.onPointerDown(pointer({ clientX: 0, clientY: 0 }))
+      session.onPointerUp(pointer({ clientX: 0, clientY: 0 }))
+
+      expect(session.selectedNodeIds.value).toEqual([b.id])
     })
 
     it('clears the selection on empty-space click', async () => {

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorSession.ts
@@ -14,6 +14,7 @@ import {
   findNode
 } from '@/renderer/extensions/layerEditor/engine/document'
 import { createEditor } from '@/renderer/extensions/layerEditor/engine/editor/editor'
+import type { AlphaSampler } from '@/renderer/extensions/layerEditor/engine/editor/pickOps'
 import { pickLayerAt } from '@/renderer/extensions/layerEditor/engine/editor/pickOps'
 import { Dirty } from '@/renderer/extensions/layerEditor/engine/history'
 import type { FillSpec } from '@/renderer/extensions/layerEditor/engine/fill'
@@ -42,7 +43,6 @@ import { registerBuiltinTools } from '@/renderer/extensions/layerEditor/engine/t
 import { canTransformNode } from '@/renderer/extensions/layerEditor/engine/tools/transformTool'
 import {
   hitHandle,
-  insideBox,
   unionBounds
 } from '@/renderer/extensions/layerEditor/engine/tools/transformMath'
 import { createPanZoom } from '@/renderer/extensions/layerEditor/panZoom'
@@ -66,6 +66,7 @@ const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
 export interface LayerEditorSessionOptions {
   createCompositor?: () => Compositor
   loadImage?: (url: string) => Promise<HTMLCanvasElement>
+  alphaSampler?: AlphaSampler
 }
 
 export interface LayerEditorElements {
@@ -578,6 +579,12 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     })
   }
 
+  function moveLayerTo(id: string, toIndex: number): void {
+    const bg = backgroundLayer.value
+    if (bg && (id === bg.id || toIndex < 1)) return
+    editor.moveNodeTo(id, undefined, toIndex)
+  }
+
   function moveLayer(id: string, dir: 1 | -1): void {
     const bg = backgroundLayer.value
     if (bg) {
@@ -840,11 +847,15 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     }
   }
 
-  function selectionGizmo(): Transform | null {
+  function selectedTransformTargets(): SceneNode[] {
     const root = editor.document().root
-    const targets = filterTopmost(root, editor.selectedNodeIds())
+    return filterTopmost(root, editor.selectedNodeIds())
       .map((id) => findNode(root, id)?.node ?? null)
       .filter((n): n is SceneNode => canTransformNode(n))
+  }
+
+  function selectionGizmo(): Transform | null {
+    const targets = selectedTransformTargets()
     if (!targets.length) return null
     return targets.length === 1
       ? { ...targets[0].transform }
@@ -857,10 +868,14 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     if (!additive) {
       const gizmo = selectionGizmo()
       const tol = 8 / Math.max(1e-3, panZoom.zoom())
-      if (gizmo && (hitHandle(gizmo, pt, tol) || insideBox(gizmo, pt)))
-        return true
+      if (gizmo && hitHandle(gizmo, pt, tol)) return true
     }
-    const picked = pickLayerAt(editor.document().root.children, pt, content)
+    const picked = pickLayerAt(
+      editor.document().root.children,
+      pt,
+      content,
+      opts.alphaSampler
+    )
     if (!picked) {
       if (!additive) editor.setSelectedNodes([])
       return false
@@ -1049,6 +1064,7 @@ export function useLayerEditorSession(opts: LayerEditorSessionOptions = {}) {
     toggleVisible,
     renameLayer,
     moveLayer,
+    moveLayerTo,
     setLayerOrder,
     inputLayerIds,
     setActiveNode,

--- a/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
+++ b/src/renderer/extensions/layerEditor/engine/compositor/webglCompositor.ts
@@ -527,7 +527,7 @@ export function createWebGLCompositor(): Compositor {
         if (canvas !== c) return
         contextLost = true
         if (disposed) return
-        console.warn('[pentrado] WebGL context lost — recreating')
+        console.warn('[LayerEditor] WebGL context lost — recreating')
         queueMicrotask(() => {
           if (recover()) onRestored?.()
         })

--- a/src/renderer/extensions/layerEditor/engine/editor/pickOps.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/pickOps.test.ts
@@ -79,6 +79,24 @@ describe('layerOpacityAt', () => {
     expect(layerOpacityAt(node, { x: 20, y: 100 }, content)).toBe(0)
     expect(layerOpacityAt(node, { x: 200, y: 100 }, content)).toBe(1)
   })
+  it('scales a group pick by the group opacity', () => {
+    const child = mkRaster('a', 0, 0, 100, 100)
+    const content = fakeContent({ a: fakeCanvas(10, 10, () => 1) })
+    const group = {
+      id: 'g',
+      kind: 'group',
+      name: 'g',
+      visible: true,
+      opacity: 0.2,
+      mode: {},
+      transform: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      locks: { content: false, position: false, visibility: false },
+      children: [child],
+      passThrough: false
+    } as unknown as SceneNode
+    expect(layerOpacityAt(group, { x: 50, y: 50 }, content)).toBeCloseTo(0.2)
+    expect(pickLayerAt([group], { x: 50, y: 50 }, content)).toBeNull()
+  })
   it('returns 0 outside the transform and for invisible layers', () => {
     const node = mkRaster('a', 0, 0, 100, 100)
     const content = fakeContent({ a: fakeCanvas(10, 10, () => 1) })

--- a/src/renderer/extensions/layerEditor/engine/editor/pickOps.ts
+++ b/src/renderer/extensions/layerEditor/engine/editor/pickOps.ts
@@ -10,24 +10,16 @@ export type AlphaSampler = (
   y: number
 ) => number
 
-const sampleCache = new WeakMap<
-  HTMLCanvasElement,
-  CanvasRenderingContext2D | null
->()
-
 function defaultAlphaSampler(
   canvas: HTMLCanvasElement,
   x: number,
   y: number
 ): number {
-  let ctx = sampleCache.get(canvas)
-  if (ctx === undefined) {
-    try {
-      ctx = canvas.getContext('2d', { willReadFrequently: true })
-    } catch {
-      ctx = null
-    }
-    sampleCache.set(canvas, ctx)
+  let ctx: CanvasRenderingContext2D | null
+  try {
+    ctx = canvas.getContext('2d', { willReadFrequently: true })
+  } catch {
+    ctx = null
   }
   if (!ctx) return 1
   try {
@@ -78,7 +70,7 @@ export function layerOpacityAt(
         best = Math.max(best, layerOpacityAt(child, pt, content, sample))
         if (best >= 1) break
       }
-      return best
+      return best * node.opacity
     }
     case 'raster':
       return rasterAlphaAt(node as RasterData, pt, content, sample)

--- a/src/renderer/extensions/layerEditor/engine/history.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.test.ts
@@ -162,6 +162,28 @@ describe('History — merging', () => {
     h.push(new MergingCommand('opacity'))
     expect(first.merged).toBe(0)
   })
+
+  it('a merged edit is one dirty step that a single undo clears', () => {
+    const h = new History()
+    h.push(new MergingCommand('opacity'))
+    h.push(new MergingCommand('opacity'))
+    h.push(new MergingCommand('opacity'))
+    expect(h.dirty()).toBe(true)
+    h.undo()
+    expect(h.dirty()).toBe(false)
+  })
+
+  it('never merges across a save point, so the new edit stays undoable to clean', () => {
+    const h = new History()
+    const first = new MergingCommand('opacity')
+    h.push(first)
+    h.markSaved()
+    h.push(new MergingCommand('opacity'))
+    expect(first.merged).toBe(0)
+    expect(h.dirty()).toBe(true)
+    h.undo()
+    expect(h.dirty()).toBe(false)
+  })
 })
 
 describe('History — dirty tracking and eviction', () => {

--- a/src/renderer/extensions/layerEditor/engine/history.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.test.ts
@@ -215,6 +215,19 @@ describe('History — dirty tracking and eviction', () => {
     expect(h.labels().undo).toHaveLength(3)
   })
 
+  it('a branch that discards the save point stays dirty', () => {
+    const h = new History()
+    h.push(new TestCommand('a'))
+    h.markSaved()
+    h.undo()
+    h.push(new TestCommand('b'))
+    expect(h.dirty()).toBe(true)
+    h.undo()
+    expect(h.dirty()).toBe(true)
+    h.markSaved()
+    expect(h.dirty()).toBe(false)
+  })
+
   it('an evicted history stays dirty until the next markSaved', () => {
     const h = new History({ byteBudget: 1, minSteps: 1 })
     h.push(new TestCommand('a', Dirty.DRAWABLE, 64))

--- a/src/renderer/extensions/layerEditor/engine/history.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.test.ts
@@ -173,6 +173,18 @@ describe('History — merging', () => {
     expect(h.dirty()).toBe(false)
   })
 
+  it('redo after undoing a post-save merge reads dirty again', () => {
+    const h = new History()
+    h.push(new MergingCommand('opacity'))
+    h.push(new MergingCommand('opacity'))
+    h.markSaved()
+    h.push(new MergingCommand('opacity'))
+    h.undo()
+    expect(h.dirty()).toBe(false)
+    h.redo()
+    expect(h.dirty()).toBe(true)
+  })
+
   it('never merges across a save point, so the new edit stays undoable to clean', () => {
     const h = new History()
     const first = new MergingCommand('opacity')

--- a/src/renderer/extensions/layerEditor/engine/history.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.ts
@@ -58,6 +58,7 @@ export class History {
   private groupStack: CommandGroup[] = []
   private dirtyCount = 0
   private cleanReachable = true
+  private mergeBarrier: Command | null = null
   private readonly byteBudget: number
   private readonly minSteps: number
   private listeners = new Set<(mask: number) => void>()
@@ -96,10 +97,14 @@ export class History {
     }
 
     const top = this.undoStack[this.undoStack.length - 1]
-    if (top && this.redoStack.length === 0 && cmd.tryMerge?.(top)) {
+    if (
+      top &&
+      top !== this.mergeBarrier &&
+      this.redoStack.length === 0 &&
+      cmd.tryMerge?.(top)
+    ) {
       this.undoBytes += top.sizeBytes() - (this.sizes.get(top) ?? 0)
       this.sizes.set(top, top.sizeBytes())
-      this.bumpDirty()
       this.emit(cmd.dirtyMask)
       return
     }
@@ -147,6 +152,7 @@ export class History {
     this.dirtyCount = 0
     this.undoBytes = 0
     this.cleanReachable = true
+    this.mergeBarrier = null
     this.emit(DIRTY_ALL)
   }
 
@@ -171,6 +177,7 @@ export class History {
   markSaved(): void {
     this.dirtyCount = 0
     this.cleanReachable = true
+    this.mergeBarrier = this.undoStack[this.undoStack.length - 1] ?? null
   }
 
   private bumpDirty(): void {

--- a/src/renderer/extensions/layerEditor/engine/history.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.ts
@@ -105,6 +105,7 @@ export class History {
     ) {
       this.undoBytes += top.sizeBytes() - (this.sizes.get(top) ?? 0)
       this.sizes.set(top, top.sizeBytes())
+      // Merged edits share the first commit's dirty step - no bumpDirty() here.
       this.emit(cmd.dirtyMask)
       return
     }
@@ -194,6 +195,7 @@ export class History {
     ) {
       const dropped = this.undoStack.shift()
       if (!dropped) break
+      if (dropped === this.mergeBarrier) this.mergeBarrier = null
       this.undoBytes -= this.sizes.get(dropped) ?? 0
       this.cleanReachable = false
     }

--- a/src/renderer/extensions/layerEditor/engine/history.ts
+++ b/src/renderer/extensions/layerEditor/engine/history.ts
@@ -115,6 +115,9 @@ export class History {
     this.undoStack.push(cmd)
     this.sizes.set(cmd, cmd.sizeBytes())
     this.undoBytes += this.sizes.get(cmd) ?? 0
+    if (this.redoStack.length > 0 && this.dirtyCount < 0) {
+      this.cleanReachable = false
+    }
     this.redoStack = []
     this.bumpDirty()
     this.evict()

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
@@ -153,6 +153,24 @@ describe('renderDocument', () => {
     expect(c.freed).toEqual([c.allocated[0].id])
   })
 
+  it('frees the group target even when the final composite throws', () => {
+    class ExplodingCompositor extends FakeCompositor {
+      override composite(
+        inputs: CompositeInput[],
+        target?: FBOHandle | null,
+        region?: Rect
+      ) {
+        if (!target) throw new Error('boom')
+        super.composite(inputs, target, region)
+      }
+    }
+    const c = new ExplodingCompositor()
+    const g = group([leaf(1)], { id: 'grp' })
+    expect(() => renderDocument(doc([leaf(1), g]), deps(c))).toThrow('boom')
+    expect(c.allocated).toHaveLength(1)
+    expect(c.freed).toEqual([c.allocated[0].id])
+  })
+
   it('splices a pass-through group directly into the parent stack (no isolation target)', () => {
     const c = new FakeCompositor()
     const g = group([leaf(1), leaf(1)], { passThrough: true })

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
@@ -171,6 +171,26 @@ describe('renderDocument', () => {
     expect(c.freed).toEqual([c.allocated[0].id])
   })
 
+  it('frees every allocated target when a group composite throws mid-build', () => {
+    class ExplodingCompositor extends FakeCompositor {
+      targetComposites = 0
+      override composite(
+        inputs: CompositeInput[],
+        target?: FBOHandle | null,
+        region?: Rect
+      ) {
+        if (target && ++this.targetComposites === 2) throw new Error('boom')
+        super.composite(inputs, target, region)
+      }
+    }
+    const c = new ExplodingCompositor()
+    const first = group([leaf(1)], { id: 'g1' })
+    const second = group([leaf(0.9)], { id: 'g2' })
+    expect(() => renderDocument(doc([first, second]), deps(c))).toThrow('boom')
+    expect(c.allocated).toHaveLength(2)
+    expect([...c.freed].sort()).toEqual(c.allocated.map((h) => h.id).sort())
+  })
+
   it('splices a pass-through group directly into the parent stack (no isolation target)', () => {
     const c = new FakeCompositor()
     const g = group([leaf(1), leaf(1)], { passThrough: true })

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.test.ts
@@ -191,6 +191,24 @@ describe('renderDocument', () => {
     expect([...c.freed].sort()).toEqual(c.allocated.map((h) => h.id).sort())
   })
 
+  it('frees nested targets when a later allocTarget throws', () => {
+    class RationedCompositor extends FakeCompositor {
+      allocs = 0
+      override allocTarget(width: number, height: number): FBOHandle {
+        if (++this.allocs === 2) throw new Error('out of targets')
+        return super.allocTarget(width, height)
+      }
+    }
+    const c = new RationedCompositor()
+    const inner = group([leaf(1)], { id: 'inner' })
+    const outer = group([inner], { id: 'outer' })
+    expect(() => renderDocument(doc([outer]), deps(c))).toThrow(
+      'out of targets'
+    )
+    expect(c.allocated).toHaveLength(1)
+    expect(c.freed).toEqual([c.allocated[0].id])
+  })
+
   it('splices a pass-through group directly into the parent stack (no isolation target)', () => {
     const c = new FakeCompositor()
     const g = group([leaf(1), leaf(1)], { passThrough: true })

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
@@ -283,12 +283,15 @@ export function renderDocument(
   deps.compositor.beginFrame?.()
   const used = new Set<string>()
   const { inputs, cleanup } = buildInputs(doc.root, doc, deps, used)
-  deps.compositor.composite(
-    extra?.length ? [...inputs, ...extra] : inputs,
-    null,
-    region ?? undefined
-  )
-  cleanup()
+  try {
+    deps.compositor.composite(
+      extra?.length ? [...inputs, ...extra] : inputs,
+      null,
+      region ?? undefined
+    )
+  } finally {
+    cleanup()
+  }
   if (deps.placedCache) {
     for (const key of [...deps.placedCache.keys()]) {
       if (!used.has(key)) deps.placedCache.delete(key)

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
@@ -1,4 +1,9 @@
-import type { Compositor, CompositeInput, NodeTexture } from '../compositor'
+import type {
+  Compositor,
+  CompositeInput,
+  FBOHandle,
+  NodeTexture
+} from '../compositor'
 import type { ContentStore } from '../content'
 import type { Document } from '../document'
 import { resolveMode } from '../mode'
@@ -239,7 +244,13 @@ function buildInputs(
           cleanups.push(sub.cleanup)
           continue
         }
-        const handle = deps.compositor.allocTarget(doc.width, doc.height)
+        let handle: FBOHandle
+        try {
+          handle = deps.compositor.allocTarget(doc.width, doc.height)
+        } catch (err) {
+          sub.cleanup()
+          throw err
+        }
         try {
           deps.compositor.composite(sub.inputs, handle)
         } catch (err) {

--- a/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
+++ b/src/renderer/extensions/layerEditor/engine/render/renderStack.ts
@@ -227,41 +227,52 @@ function buildInputs(
     devicePixelRatio: deps.devicePixelRatio ?? 1
   }
 
-  for (const node of group.children) {
-    if (!node.visible || node.opacity <= 0) continue
+  try {
+    for (const node of group.children) {
+      if (!node.visible || node.opacity <= 0) continue
 
-    if (node.kind === 'group') {
-      const g = node as GroupData
-      const sub = buildInputs(g, doc, deps, used)
-      if (g.passThrough) {
-        inputs.push(...sub.inputs)
-        cleanups.push(sub.cleanup)
+      if (node.kind === 'group') {
+        const g = node as GroupData
+        const sub = buildInputs(g, doc, deps, used)
+        if (g.passThrough) {
+          inputs.push(...sub.inputs)
+          cleanups.push(sub.cleanup)
+          continue
+        }
+        const handle = deps.compositor.allocTarget(doc.width, doc.height)
+        try {
+          deps.compositor.composite(sub.inputs, handle)
+        } catch (err) {
+          deps.compositor.freeTarget(handle)
+          sub.cleanup()
+          throw err
+        }
+        sub.cleanup()
+        cleanups.push(() => deps.compositor.freeTarget(handle))
+        const groupTexture = deps.compositor.targetTexture(handle)
+        if (groupTexture) {
+          inputs.push({
+            texture: { source: groupTexture, rect: region, linear: true },
+            opacity: node.opacity,
+            mode: resolveMode(node.mode),
+            mask: renderMaskTexture(node, region, deps, placed, used)
+          })
+        }
         continue
       }
-      const handle = deps.compositor.allocTarget(doc.width, doc.height)
-      deps.compositor.composite(sub.inputs, handle)
-      sub.cleanup()
-      cleanups.push(() => deps.compositor.freeTarget(handle))
-      const groupTexture = deps.compositor.targetTexture(handle)
-      if (groupTexture) {
-        inputs.push({
-          texture: { source: groupTexture, rect: region, linear: true },
-          opacity: node.opacity,
-          mode: resolveMode(node.mode),
-          mask: renderMaskTexture(node, region, deps, placed, used)
-        })
-      }
-      continue
-    }
 
-    const texture = renderLeafTexture(node, ctx, deps, used)
-    if (!texture) continue
-    inputs.push({
-      texture,
-      opacity: node.opacity,
-      mode: resolveMode(node.mode),
-      mask: renderMaskTexture(node, region, deps, placed, used)
-    })
+      const texture = renderLeafTexture(node, ctx, deps, used)
+      if (!texture) continue
+      inputs.push({
+        texture,
+        opacity: node.opacity,
+        mode: resolveMode(node.mode),
+        mask: renderMaskTexture(node, region, deps, placed, used)
+      })
+    }
+  } catch (err) {
+    cleanups.forEach((fn) => fn())
+    throw err
   }
 
   return { inputs, cleanup: () => cleanups.forEach((fn) => fn()) }


### PR DESCRIPTION
## Summary
- pixel-accurate canvas picking: clicks select the topmost layer with opaque pixels under the cursor, transparent pixels fall through, and gizmo handles still win, instead of pinning to the selected bounding box
- drag to reorder layers in the panel with an above/below indicator, landing as a single undoable reorder above the pinned background
- shift-click multi-select no longer drags text selection along
- compositor widget no longer crashes in the node search preview when the node is not in the graph
- History: merges no longer inflate the dirty counter and cannot cross a save point, so dirty tracking survives merged edits
- renderStack frees group targets when the composite throws; zero-size resize observations no longer consume the first fitView; an emptied number field reverts instead of committing 0; refusing to open the editor toasts; visible focus ring on the viewport

