### PR TITLE
fix: surface failed email sign-in as an inline error

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthActions } from '@/composables/auth/useAuthActions'
+import type * as ErrorHandlingModule from '@/composables/useErrorHandling'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 
 type ModifiedWorkflow = Pick<ComfyWorkflow, 'path' | 'isModified'>
@@ -95,7 +96,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   }))
 }))
 
-vi.mock('@/composables/useErrorHandling', () => ({
+vi.mock('@/composables/useErrorHandling', async (importOriginal) => ({
+  ...(await importOriginal<typeof ErrorHandlingModule>()),
   useErrorHandling: () => ({
     wrapWithErrorHandlingAsync:
       <TArgs extends unknown[], TReturn>(
@@ -434,5 +436,13 @@ describe('useAuthActions.reportError', () => {
 
     expect(mockToastErrorHandler).toHaveBeenCalledWith(networkError)
     expect(mockToastStore.add).not.toHaveBeenCalled()
+  })
+
+  it('records the same network copy the toast shows, not the raw browser text', () => {
+    const { reportError, lastAuthErrorMessage } = useAuthActions()
+
+    reportError(new TypeError('Failed to fetch'))
+
+    expect(lastAuthErrorMessage.value).toBe('g.disconnectedFromBackend')
   })
 })

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -18,6 +18,37 @@ import { useAuthStore } from '@/stores/authStore'
 import type { BillingPortalTargetTier } from '@/stores/authStore'
 import { usdToMicros } from '@/utils/formatUtil'
 
+const isUnauthorizedDomainError = (error: unknown) =>
+  error instanceof FirebaseError &&
+  [
+    'auth/unauthorized-domain',
+    'auth/invalid-dynamic-link-domain',
+    'auth/unauthorized-continue-uri'
+  ].includes(error.code)
+
+/**
+ * User-facing copy for an auth failure, shared by the toast and any inline
+ * banner so the two never diverge.
+ */
+const authErrorMessage = (error: unknown): string => {
+  if (isUnauthorizedDomainError(error)) {
+    return t('toastMessages.unauthorizedDomain', {
+      domain: window.location.hostname,
+      email: 'support@comfy.org'
+    })
+  }
+  if (!(error instanceof FirebaseError)) {
+    return error instanceof Error ? error.message : t('g.unknownError')
+  }
+  // Firebase `beforeUserCreated` rejections collapse the thrown code into a
+  // generic `auth/internal-error`, so the message is the only reliable channel.
+  // `signup_blocked` is a cross-repo contract token; matched case-insensitively.
+  if (error.message.toLowerCase().includes('signup_blocked')) {
+    return t('auth.errors.signupBlocked')
+  }
+  return st(`auth.errors.${error.code}`, t('auth.errors.generic'))
+}
+
 /**
  * Service for Firebase Auth actions.
  * All actions are wrapped with error handling.
@@ -30,6 +61,12 @@ export const useAuthActions = () => {
 
   const accessError = ref(false)
 
+  /**
+   * Message for the most recent failure, for callers that render an inline
+   * banner. Empty until an action fails; each action resets it before running.
+   */
+  const lastAuthErrorMessage = ref('')
+
   const reportAuthFlowError =
     (authAction: AuthFlowAction) => (error: unknown) => {
       useTelemetry()?.trackAuthFailed({
@@ -39,47 +76,20 @@ export const useAuthActions = () => {
       reportError(error)
     }
 
+  // Ref: https://firebase.google.com/docs/auth/admin/errors
   const reportError = (error: unknown) => {
-    // Ref: https://firebase.google.com/docs/auth/admin/errors
-    if (
-      error instanceof FirebaseError &&
-      [
-        'auth/unauthorized-domain',
-        'auth/invalid-dynamic-link-domain',
-        'auth/unauthorized-continue-uri'
-      ].includes(error.code)
-    ) {
-      accessError.value = true
-      toastStore.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: t('toastMessages.unauthorizedDomain', {
-          domain: window.location.hostname,
-          email: 'support@comfy.org'
-        })
-      })
-    } else if (
-      error instanceof FirebaseError &&
-      error.message.toLowerCase().includes('signup_blocked')
-    ) {
-      // Match on `error.message`, not `error.code`: Firebase `beforeUserCreated`
-      // rejections collapse the thrown code into a generic `auth/internal-error`,
-      // so the message is the only reliable channel. `signup_blocked` is a
-      // cross-repo contract token; matched case-insensitively.
-      toastStore.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: t('auth.errors.signupBlocked')
-      })
-    } else if (error instanceof FirebaseError) {
-      toastStore.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: st(`auth.errors.${error.code}`, t('auth.errors.generic'))
-      })
-    } else {
+    const message = authErrorMessage(error)
+    lastAuthErrorMessage.value = message
+    if (!(error instanceof FirebaseError)) {
       toastErrorHandler(error)
+      return
     }
+    if (isUnauthorizedDomainError(error)) accessError.value = true
+    toastStore.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: message
+    })
   }
 
   const logout = wrapWithErrorHandlingAsync(async () => {
@@ -302,6 +312,7 @@ export const useAuthActions = () => {
     signUpWithEmail,
     updatePassword,
     accessError,
+    lastAuthErrorMessage,
     reportError
   }
 }

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -3,7 +3,10 @@ import { AuthErrorCodes } from 'firebase/auth'
 import { ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { useErrorHandling } from '@/composables/useErrorHandling'
+import {
+  genericErrorMessage,
+  useErrorHandling
+} from '@/composables/useErrorHandling'
 import type { ErrorRecoveryStrategy } from '@/composables/useErrorHandling'
 import { st, t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
@@ -38,7 +41,7 @@ const authErrorMessage = (error: unknown): string => {
     })
   }
   if (!(error instanceof FirebaseError)) {
-    return error instanceof Error ? error.message : t('g.unknownError')
+    return genericErrorMessage(error)
   }
   // Firebase `beforeUserCreated` rejections collapse the thrown code into a
   // generic `auth/internal-error`, so the message is the only reliable channel.

--- a/src/composables/useErrorHandling.ts
+++ b/src/composables/useErrorHandling.ts
@@ -49,17 +49,23 @@ export interface ErrorRecoveryStrategy<
   ) => Promise<void>
 }
 
+/** A fetch that never reached the backend, across browser wordings. */
+export const isNetworkError = (error: unknown) =>
+  error instanceof TypeError &&
+  /failed to fetch|networkerror|load failed/i.test(error.message)
+
+/** The copy a raw (non-domain) error should surface, toast or inline. */
+export const genericErrorMessage = (error: unknown) =>
+  isNetworkError(error)
+    ? t('g.disconnectedFromBackend')
+    : error instanceof Error
+      ? error.message
+      : t('g.unknownError')
+
 export function useErrorHandling() {
   const toast = useToastStore()
   const toastErrorHandler = (error: unknown) => {
-    const isNetworkError =
-      error instanceof TypeError &&
-      /failed to fetch|networkerror|load failed/i.test(error.message)
-    const message = isNetworkError
-      ? t('g.disconnectedFromBackend')
-      : error instanceof Error
-        ? error.message
-        : t('g.unknownError')
+    const message = genericErrorMessage(error)
     toast.add({
       severity: 'error',
       summary: t('g.error'),

--- a/src/platform/cloud/onboarding/CloudLoginView.test.ts
+++ b/src/platform/cloud/onboarding/CloudLoginView.test.ts
@@ -1,21 +1,28 @@
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import CloudLoginView from '@/platform/cloud/onboarding/CloudLoginView.vue'
 
+const authActions = vi.hoisted(() => ({
+  signInWithGoogle: vi.fn(),
+  signInWithGithub: vi.fn(),
+  signInWithEmail: vi.fn(),
+  lastAuthErrorMessage: { value: '' }
+}))
 vi.mock('@/composables/auth/useAuthActions', () => ({
-  useAuthActions: () => ({
-    signInWithGoogle: vi.fn(),
-    signInWithGithub: vi.fn(),
-    signInWithEmail: vi.fn()
-  })
+  useAuthActions: () => authActions
 }))
 
+const onAuthSuccess = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/cloud/onboarding/composables/usePostAuthRedirect', () => ({
-  usePostAuthRedirect: () => ({ onAuthSuccess: vi.fn() })
+  usePostAuthRedirect: () => ({ onAuthSuccess })
 }))
+
+vi.mock('@/i18n', () => ({ t: (key: string) => key }))
 
 const isEmbeddedWebView = vi.hoisted(() => ({ value: false }))
 vi.mock('@/base/webviewDetection', () => ({
@@ -65,6 +72,93 @@ async function renderLoginView(
 
 afterEach(() => {
   isEmbeddedWebView.value = false
+  authActions.lastAuthErrorMessage.value = ''
+  vi.clearAllMocks()
+})
+
+/**
+ * Drives the email sign-in path and returns the banner text CloudSignInForm
+ * ends up with. The form is stubbed to a plain submit button; that the banner
+ * renders from that prop is covered by CloudSignInForm.test.ts.
+ */
+async function submitEmailSignIn() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/cloud/login', name: 'cloud-login', component: CloudLoginView }
+    ]
+  })
+  await router.push('/cloud/login')
+  await router.isReady()
+
+  render(CloudLoginView, {
+    global: {
+      plugins: [
+        router,
+        createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+      ],
+      stubs: {
+        RouterLink: true,
+        Message: true,
+        CloudSocialAuthButtons: true,
+        CloudSignInForm: {
+          props: ['authError'],
+          template:
+            '<div><span v-if="authError" data-testid="auth-error">{{ authError }}</span>' +
+            "<button data-testid=\"do-submit\" @click=\"$emit('submit', { email: 'a@b.co', password: 'pw123456' })\" /></div>"
+        }
+      }
+    }
+  })
+
+  const user = userEvent.setup()
+  await user.click(
+    screen.getByRole('button', { name: 'auth.login.useEmailInstead' })
+  )
+  await user.click(screen.getByTestId('do-submit'))
+  await nextTick()
+}
+
+describe('CloudLoginView email sign-in failures', () => {
+  it('surfaces the failure inline instead of losing it', async () => {
+    authActions.signInWithEmail.mockImplementation(() => {
+      authActions.lastAuthErrorMessage.value = 'auth.errors.auth/wrong-password'
+      return Promise.resolve(undefined)
+    })
+
+    await submitEmailSignIn()
+
+    expect(screen.getByTestId('auth-error')).toHaveTextContent(
+      'auth.errors.auth/wrong-password'
+    )
+  })
+
+  it('falls back to generic copy when no message was recorded', async () => {
+    authActions.signInWithEmail.mockResolvedValue(undefined)
+
+    await submitEmailSignIn()
+
+    expect(screen.getByTestId('auth-error')).toHaveTextContent(
+      'auth.errors.generic'
+    )
+  })
+
+  it('does not redirect on a failed sign-in', async () => {
+    authActions.signInWithEmail.mockResolvedValue(undefined)
+
+    await submitEmailSignIn()
+
+    expect(onAuthSuccess).not.toHaveBeenCalled()
+  })
+
+  it('redirects and shows no banner on a successful sign-in', async () => {
+    authActions.signInWithEmail.mockResolvedValue({ user: {} })
+
+    await submitEmailSignIn()
+
+    expect(onAuthSuccess).toHaveBeenCalled()
+    expect(screen.queryByTestId('auth-error')).not.toBeInTheDocument()
+  })
 })
 
 describe('CloudLoginView', () => {

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -64,36 +64,26 @@ import Message from 'primevue/message'
 import { useI18n } from 'vue-i18n'
 import { RouterLink, useRoute } from 'vue-router'
 
-import { useAuthActions } from '@/composables/auth/useAuthActions'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
 import CloudSocialAuthButtons from '@/platform/cloud/onboarding/components/CloudSocialAuthButtons.vue'
 import { useCloudAuthPage } from '@/platform/cloud/onboarding/composables/useCloudAuthPage'
 import { CLOUD_AUTH_LINK_BUTTON_CLASS } from '@/platform/cloud/onboarding/constants/authClasses'
-import type { SignInData } from '@/schemas/signInSchema'
 
 const { t } = useI18n()
 const route = useRoute()
-const authActions = useAuthActions()
 
 const {
   authError,
   showEmailForm,
-  onAuthSuccess,
   isSecureContext,
   showGoogleSsoInAppBrowserNotice,
   switchToEmailForm,
   switchToSocialLogin,
   signInWithGoogle,
-  signInWithGithub
+  signInWithGithub,
+  signInWithEmail
 } = useCloudAuthPage({
   successSummary: 'Login Completed',
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
-
-const signInWithEmail = async (values: SignInData) => {
-  authError.value = ''
-  if (await authActions.signInWithEmail(values.email, values.password)) {
-    await onAuthSuccess()
-  }
-}
 </script>

--- a/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
+++ b/src/platform/cloud/onboarding/components/CloudSignInForm.test.ts
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/vue'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({ loading: false })
+}))
+
+function renderForm(authError?: string) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/cloud/forgot-password',
+        name: 'cloud-forgot-password',
+        component: { template: '<div />' }
+      }
+    ]
+  })
+  return render(CloudSignInForm, {
+    props: { authError },
+    global: {
+      plugins: [
+        router,
+        PrimeVue,
+        createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+      ]
+    }
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('CloudSignInForm', () => {
+  it('renders the auth error inline', () => {
+    renderForm('The password you entered is incorrect.')
+
+    expect(
+      screen.getByText('The password you entered is incorrect.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no auth error', () => {
+    renderForm()
+
+    expect(
+      screen.queryByText('The password you entered is incorrect.')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/cloud/onboarding/composables/useCloudAuthPage.ts
+++ b/src/platform/cloud/onboarding/composables/useCloudAuthPage.ts
@@ -4,7 +4,9 @@ import type { RouteLocationRaw } from 'vue-router'
 
 import { isEmbeddedWebView } from '@/base/webviewDetection'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
+import { t } from '@/i18n'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
+import type { SignInData } from '@/schemas/signInSchema'
 
 /**
  * State shared by CloudLoginView and CloudSignupView. Sign-up passes
@@ -40,6 +42,22 @@ export function useCloudAuthPage(options: {
     }
   }
 
+  /**
+   * Social failures stay toast-only: no form is mounted to host a banner.
+   * Email sign-in also mirrors the failure into `authError` so CloudSignInForm
+   * can show it next to the fields the user is about to correct.
+   */
+  const signInWithEmail = async ({ email, password }: SignInData) => {
+    authError.value = ''
+    authActions.lastAuthErrorMessage.value = ''
+    if (await authActions.signInWithEmail(email, password)) {
+      await onAuthSuccess()
+      return
+    }
+    authError.value =
+      authActions.lastAuthErrorMessage.value || t('auth.errors.generic')
+  }
+
   return {
     authError,
     showEmailForm,
@@ -54,6 +72,7 @@ export function useCloudAuthPage(options: {
       showEmailForm.value = false
     },
     signInWithGoogle: () => signInWith(authActions.signInWithGoogle),
-    signInWithGithub: () => signInWith(authActions.signInWithGithub)
+    signInWithGithub: () => signInWith(authActions.signInWithGithub),
+    signInWithEmail
   }
 }


### PR DESCRIPTION
## Summary

A failed email sign-in now shows an error next to the form instead of only a toast that fades.

## Changes

- **What**: `CloudSignInForm` already rendered a `<Message v-if="authError">`, but nothing ever wrote a sign-in failure into `authError`, so that banner was unreachable for the ordinary wrong-password case. The auth actions are wrapped in `wrapWithErrorHandlingAsync`, which swallows the rejection and resolves `undefined`, so the caller only saw a falsy value and the failure surfaced as a corner toast. `useCloudAuthPage` now owns `signInWithEmail` and writes the failure message into `authError`.

  The message derivation was extracted out of `reportError` into a pure `authErrorMessage()` and exposed as `lastAuthErrorMessage`, so the banner and the toast render identical copy rather than maintaining two strings that drift.

  `CloudLoginView` had its own local `signInWithEmail` duplicating the composable's social-only `signInWith`. Both had the same swallow. They are now one path.

- **Breaking**: None. `reportError` keeps its signature and behaviour.

## Review Focus

The `useAuthActions.ts` hunk is the one to read closely. It restructures shared error handling that 15 modules consume, and while it is intended to be behaviour-preserving, that is worth confirming rather than trusting. The three branches (unauthorized-domain, `signup_blocked`, generic Firebase) keep their original order and messages; `accessError` still flips only for the domain family. The 20 pre-existing `useAuthActions` tests passed unchanged after the extraction, which is the evidence it did not shift behaviour.

Email failures now surface **both** a toast and an inline banner. That duplication is deliberate. The toast comes from `reportAuthFlowError`, the handler baked in at wrap time, and that same handler fires `trackAuthFailed` telemetry. Suppressing just the toast would mean splitting that handler and threading a flag through the public API. Social sign-in stays toast-only because no form is mounted to host a banner.

Known gap, deliberately out of scope: `CloudSignupView.vue:55` binds `:auth-error` to `SignUpForm`, which declares no such prop, so sign-up still has no reachable banner. Fixing that means adding a banner to a form shared with the `SignInContent` dialog, which is a UI decision rather than a wiring fix.

Note this branch and `fix/auth-popup-error-codes` both modify `reportError`. Whichever merges second will need a small conflict resolution.

## Testing

Four tests on `CloudLoginView` covering the failure surfacing inline, the generic-copy fallback when no message was recorded, no redirect on failure, and redirect with no banner on success. Two on the new `CloudSignInForm.test.ts` for the banner rendering and staying absent when there is no error.

Each was mutation-checked: deleting the `authError` assignment fails 2 tests, removing the `if (await ...)` guard fails 2, forcing the generic message fails 2 pre-existing tests.
