### PR TITLE
fix: drop stale missing-media candidates when the widget value changes

### DIFF
--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -87,13 +87,12 @@ async function startPendingPromotedMediaVerification() {
     rootGraph,
     hosts: [outerHost],
     sourceNodes: [leafNode]
-  } = createPromotedMediaRuntime({ depth: 2 })
+  } = createPromotedMediaRuntime({ depth: 2, hostValue: 'pending.png' })
   outerHost.mode = LGraphEventMode.BYPASS
   vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
 
   const pendingCandidate = {
     ...createPromotedMissingMediaCandidate(outerHost),
-    name: 'pending.png',
     isMissing: undefined
   }
   vi.spyOn(missingModelScan, 'scanNodeModelCandidates').mockReturnValue([])

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -962,6 +962,19 @@ describe('realtime verification staleness guards', () => {
     })
   })
 
+  it('skips verified media whose host widget value changed while verification was pending', async () => {
+    const { outerHost, resolveVerification } =
+      await startPendingPromotedMediaVerification()
+    const hostWidget = outerHost.widgets?.[0]
+    if (!hostWidget) throw new Error('Expected promoted image host widget')
+
+    hostWidget.value = 'corrected.png'
+    resolveVerification()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useMissingMediaStore().missingMediaCandidates).toBeNull()
+  })
+
   it('skips verified media when its sole promoted consumer becomes bypassed', async () => {
     const { leafNode, resolveVerification } =
       await startPendingPromotedMediaVerification()

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -503,6 +503,17 @@ describe('isMissingMediaCandidateScopeActive', () => {
 
     expect(isMissingMediaCandidateScopeActive(graph, candidate)).toBe(false)
   })
+
+  it('drops a candidate whose widget value changed while verification was pending', () => {
+    const { graph, node, widget } = createLoadImageGraph()
+    const candidate = makeCandidate(String(node.id), 'missing.png')
+
+    expect.soft(isMissingMediaCandidateScopeActive(graph, candidate)).toBe(true)
+
+    widget.value = 'valid.png'
+
+    expect(isMissingMediaCandidateScopeActive(graph, candidate)).toBe(false)
+  })
 })
 
 describe('scanAllMediaCandidates', () => {

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -176,7 +176,7 @@ export function isMissingMediaCandidateScopeActive(
   // Removed or renamed while verification was pending: nothing owns the value.
   if (!widget) return false
 
-  return isEditableValueOwner(node, widget)
+  return widget.value === candidate.name && isEditableValueOwner(node, widget)
 }
 
 export function isMissingMediaCandidateActive(


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/Comfy-Org/ComfyUI_frontend/pull/14578, addressing the highest-priority item from @DrJKL's post-merge review. Since that PR is already merged, the finding had no home.

`isMissingMediaCandidateScopeActive` verifies that the candidate's node and widget are still present and still the editable value owner, but not that the widget still holds the value the candidate captured. Media verification is async, so if the user corrects `missing-a.png` to `valid-b.png` while verification is in flight, the stale candidate still passes the predicate and gets surfaced as missing against a value that is no longer there.

The predicate guards both the realtime and workflow-load paths, so the fix closes it once at the shared site rather than at each caller.

## Root cause

`scanNodeMediaCandidates` stores the raw widget value as `candidate.name`, but nothing compares it back to the live widget on the way out.

## Red-green verification

| Commit | CI | Purpose |
|---|---|---|
| `test: add failing test ...` | red | Proves the test detects the stale candidate |
| `fix: ...` | green | Proves the fix resolves it |

## Test plan

- [x] New unit test fails on `main` for the right reason (`expected true to be false`), passes with the fix
- [x] `pnpm typecheck`, oxfmt, oxlint, eslint clean
- [ ] CI red on the test-only commit, green on the fix commit

## Not included

Two other items from the same review remain open and are better handled separately:

- repeated global reconciliation during multi-node deletion (`useErrorClearingHooks.ts:405`) — a perf refactor with an open design question about queueing the global pass per removal burst
- a regression test that synthesizes an impossible mode transition (`useErrorClearingHooks.test.ts:1246`)