### PR TITLE
fix: restore E2E coverage source mapping

### DIFF
--- a/.github/actions/setup-frontend/action.yaml
+++ b/.github/actions/setup-frontend/action.yaml
@@ -5,13 +5,6 @@ inputs:
     description: 'Include the build step to build the frontend. Set to true for workflows that need a built frontend'
     required: false
     default: 'false'
-  expose_sourcemap_url:
-    description: >
-      Emit the browser-facing `//# sourceMappingURL=` comment in the built
-      bundles. Required by the E2E coverage build: monocart only finds source
-      maps through that comment. Leave false for anything that ships to users.
-    required: false
-    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -38,4 +31,3 @@ runs:
       run: pnpm build
       env:
         VITE_USE_LEGACY_DEFAULT_GRAPH: 'true'
-        EXPOSE_SOURCEMAP_URL: ${{ inputs.expose_sourcemap_url }}

--- a/.github/actions/setup-frontend/action.yaml
+++ b/.github/actions/setup-frontend/action.yaml
@@ -5,6 +5,13 @@ inputs:
     description: 'Include the build step to build the frontend. Set to true for workflows that need a built frontend'
     required: false
     default: 'false'
+  expose_sourcemap_url:
+    description: >
+      Emit the browser-facing `//# sourceMappingURL=` comment in the built
+      bundles. Required by the E2E coverage build: monocart only finds source
+      maps through that comment. Leave false for anything that ships to users.
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -31,3 +38,4 @@ runs:
       run: pnpm build
       env:
         VITE_USE_LEGACY_DEFAULT_GRAPH: 'true'
+        EXPOSE_SOURCEMAP_URL: ${{ inputs.expose_sourcemap_url }}

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -91,7 +91,7 @@ jobs:
           MAPPED_SF=$(grep -cE '^SF:(src|packages)/' coverage/playwright/coverage.lcov || true)
           echo "Source-mapped files: $MAPPED_SF" >> "$GITHUB_STEP_SUMMARY"
           if [ "${MAPPED_SF:-0}" -lt 100 ]; then
-            echo "::error::Only $MAPPED_SF source-mapped files in the merged tracefile. The E2E bundles are missing their '//# sourceMappingURL=' comment, so monocart reported raw bundle paths instead of src/**. Check EXPOSE_SOURCEMAP_URL in the E2E build (vite.config.mts build.sourcemap)."
+            echo "::error::Only $MAPPED_SF source-mapped files in the merged tracefile. The E2E bundles are missing their '//# sourceMappingURL=' comment, so monocart reported raw bundle paths instead of src/**. Check that the E2E build ran with COLLECT_COVERAGE=true (vite.config.mts build.sourcemap)."
             exit 1
           fi
 

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -91,7 +91,7 @@ jobs:
           MAPPED_SF=$(grep -cE '^SF:(src|packages)/' coverage/playwright/coverage.lcov || true)
           echo "Source-mapped files: $MAPPED_SF" >> "$GITHUB_STEP_SUMMARY"
           if [ "${MAPPED_SF:-0}" -lt 100 ]; then
-            echo "::error::Only $MAPPED_SF source-mapped files in the merged tracefile. The E2E bundles are missing their '//# sourceMappingURL=' comment, so monocart reported raw bundle paths instead of src/**. Check that the E2E build ran with COLLECT_COVERAGE=true (vite.config.mts build.sourcemap)."
+            echo "::error::Only $MAPPED_SF files under src/ or packages/ in the merged tracefile. Observed paths: $(grep -m 5 '^SF:' coverage/playwright/coverage.lcov | tr '\n' ' '). Served bundle paths mean the E2E build dropped its '//# sourceMappingURL=' comment — check it ran with COLLECT_COVERAGE=true (vite.config.mts build.sourcemap)."
             exit 1
           fi
 

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -85,6 +85,16 @@ jobs:
             fi
           done
 
+      - name: Assert coverage was mapped back to source
+        if: steps.coverage-shards.outputs.has-coverage == 'true'
+        run: |
+          MAPPED_SF=$(grep -cE '^SF:(src|packages)/' coverage/playwright/coverage.lcov || true)
+          echo "Source-mapped files: $MAPPED_SF" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${MAPPED_SF:-0}" -lt 100 ]; then
+            echo "::error::Only $MAPPED_SF source-mapped files in the merged tracefile. The E2E bundles are missing their '//# sourceMappingURL=' comment, so monocart reported raw bundle paths instead of src/**. Check EXPOSE_SOURCEMAP_URL in the E2E build (vite.config.mts build.sourcemap)."
+            exit 1
+          fi
+
       - name: Strip non-source entries from coverage
         if: steps.coverage-shards.outputs.has-coverage == 'true'
         run: |

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -29,6 +29,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
+    # The build must emit `//# sourceMappingURL=` comments or monocart cannot map
+    # the sharded job's V8 coverage back to src/**. See vite.config.mts.
+    env:
+      COLLECT_COVERAGE: 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -36,9 +40,6 @@ jobs:
         uses: ./.github/actions/setup-frontend
         with:
           include_build_step: true
-          # The sharded chromium job collects V8 coverage; monocart can only map
-          # it back to src/** if the bundles carry a sourceMappingURL comment.
-          expose_sourcemap_url: true
 
       # Upload only built dist/ (containerized test jobs will pnpm install without cache)
       - name: Upload built frontend

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -36,8 +36,6 @@ jobs:
         uses: ./.github/actions/setup-frontend
         with:
           include_build_step: true
-        # The build must emit `//# sourceMappingURL=` comments or monocart cannot
-        # map the sharded job's V8 coverage back to src/**. See vite.config.mts.
         env:
           COLLECT_COVERAGE: 'true'
 

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -36,6 +36,9 @@ jobs:
         uses: ./.github/actions/setup-frontend
         with:
           include_build_step: true
+          # The sharded chromium job collects V8 coverage; monocart can only map
+          # it back to src/** if the bundles carry a sourceMappingURL comment.
+          expose_sourcemap_url: true
 
       # Upload only built dist/ (containerized test jobs will pnpm install without cache)
       - name: Upload built frontend

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -29,10 +29,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
-    # The build must emit `//# sourceMappingURL=` comments or monocart cannot map
-    # the sharded job's V8 coverage back to src/**. See vite.config.mts.
-    env:
-      COLLECT_COVERAGE: 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -40,6 +36,10 @@ jobs:
         uses: ./.github/actions/setup-frontend
         with:
           include_build_step: true
+        # The build must emit `//# sourceMappingURL=` comments or monocart cannot
+        # map the sharded job's V8 coverage back to src/**. See vite.config.mts.
+        env:
+          COLLECT_COVERAGE: 'true'
 
       # Upload only built dist/ (containerized test jobs will pnpm install without cache)
       - name: Upload built frontend

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Download built frontend
         if: steps.detect.outputs.has-new-tests == 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: dist/

--- a/scripts/coverage-slack-notify.test.ts
+++ b/scripts/coverage-slack-notify.test.ts
@@ -52,6 +52,7 @@ describe('parseLcovContent', () => {
     ).toBeNull()
 
     expect(parseLcovContent(lcov(sourceEntries(99, 10, 10)))).toBeNull()
+    expect(parseLcovContent(lcov(sourceEntries(100, 10, 10)))).not.toBeNull()
   })
 
   it('returns null for an empty tracefile', () => {

--- a/scripts/coverage-slack-notify.test.ts
+++ b/scripts/coverage-slack-notify.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseLcovContent } from './coverage-slack-notify'
+
+function lcov(entries: [file: string, lf: number, lh: number][]): string {
+  return entries
+    .map(([file, lf, lh]) => `SF:${file}\nLF:${lf}\nLH:${lh}\nend_of_record`)
+    .join('\n')
+}
+
+function sourceEntries(
+  count: number,
+  lf: number,
+  lh: number
+): [string, number, number][] {
+  return Array.from({ length: count }, (_, i) => [
+    `src/components/Component${i}.vue`,
+    lf,
+    lh
+  ])
+}
+
+describe('parseLcovContent', () => {
+  it('reports the ratio of covered to total lines', () => {
+    const result = parseLcovContent(lcov(sourceEntries(120, 10, 7)))
+
+    expect(result).toEqual({
+      percentage: 70,
+      totalLines: 1200,
+      coveredLines: 840
+    })
+  })
+
+  it('ignores files outside src/ and packages/', () => {
+    const result = parseLcovContent(
+      lcov([
+        ...sourceEntries(120, 10, 5),
+        ['localhost-8188/assets/index-a1b2c3.js', 1000, 1000],
+        ['js.stripe.com/dahlia/stripe.js', 500, 500]
+      ])
+    )
+
+    expect(result?.totalLines).toBe(1200)
+    expect(result?.percentage).toBe(50)
+  })
+
+  // E2E coverage that fails to map back to source leaves only third-party
+  // scripts behind, which are fully covered and would report as 100%.
+  it('returns null when too few project files are present', () => {
+    expect(
+      parseLcovContent(lcov([['js.stripe.com/dahlia/stripe.js', 500, 500]]))
+    ).toBeNull()
+
+    expect(parseLcovContent(lcov(sourceEntries(99, 10, 10)))).toBeNull()
+  })
+
+  it('returns null for an empty tracefile', () => {
+    expect(parseLcovContent('')).toBeNull()
+  })
+})

--- a/scripts/coverage-slack-notify.ts
+++ b/scripts/coverage-slack-notify.ts
@@ -5,6 +5,15 @@ const MILESTONE_STEP = 5
 const MIN_DELTA = 0.05
 const BAR_WIDTH = 20
 
+/** Repo-relative prefixes of the files whose coverage this report is about. */
+const PROJECT_SOURCE = /^(src|packages)\//
+/**
+ * Below this, the tracefile is degenerate rather than sparse — e.g. E2E coverage
+ * that failed to map back to source leaves only third-party scripts behind, and
+ * a handful of fully-covered ones reads as 100%.
+ */
+const MIN_SOURCE_FILES = 100
+
 interface CoverageData {
   percentage: number
   totalLines: number
@@ -19,13 +28,16 @@ interface SlackBlock {
   }
 }
 
-function parseLcovContent(content: string): CoverageData | null {
+export function parseLcovContent(content: string): CoverageData | null {
   const perFile = new Map<string, { lf: number; lh: number }>()
   let currentFile = ''
 
   for (const line of content.split('\n')) {
     if (line.startsWith('SF:')) {
-      currentFile = line.slice(3)
+      const file = line.slice(3)
+      currentFile = PROJECT_SOURCE.test(file) ? file : ''
+    } else if (!currentFile) {
+      continue
     } else if (line.startsWith('LF:')) {
       const n = parseInt(line.slice(3), 10) || 0
       const entry = perFile.get(currentFile) ?? { lf: 0, lh: 0 }
@@ -46,7 +58,7 @@ function parseLcovContent(content: string): CoverageData | null {
     coveredLines += lh
   }
 
-  if (totalLines === 0) return null
+  if (totalLines === 0 || perFile.size < MIN_SOURCE_FILES) return null
 
   return {
     percentage: (coveredLines / totalLines) * 100,
@@ -230,4 +242,6 @@ function main() {
   process.stdout.write(JSON.stringify(payload))
 }
 
-main()
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/coverage-slack-notify.ts
+++ b/scripts/coverage-slack-notify.ts
@@ -7,11 +7,7 @@ const BAR_WIDTH = 20
 
 /** Repo-relative prefixes of the files whose coverage this report is about. */
 const PROJECT_SOURCE = /^(src|packages)\//
-/**
- * Below this, the tracefile is degenerate rather than sparse — e.g. E2E coverage
- * that failed to map back to source leaves only third-party scripts behind, and
- * a handful of fully-covered ones reads as 100%.
- */
+/** Below this the tracefile is degenerate, not sparse, and its ratio is noise. */
 const MIN_SOURCE_FILES = 100
 
 interface CoverageData {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -28,7 +28,7 @@ const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === 'true'
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
-const EXPOSE_SOURCEMAP_URL = process.env.EXPOSE_SOURCEMAP_URL === 'true'
+const COLLECT_COVERAGE = process.env.COLLECT_COVERAGE === 'true'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
 
 const CRITICAL_COVERAGE_DIRS = [
@@ -547,10 +547,10 @@ export default defineConfig({
     // browser-facing `//# sourceMappingURL=` comment is NOT injected into the JS
     // bundles. This kills the ~57k/3d `/assets/*.js.map` 404 noise in prod
     // (the .map files aren't served) without losing Sentry symbolication. See FE-1405.
-    // EXPOSE_SOURCEMAP_URL re-injects it for the CI E2E build, which serves its
-    // own .map files and needs them to map V8 coverage back to src/**.
+    // A coverage build serves its own .map files and needs the comment back:
+    // monocart maps V8 coverage to src/** only by following it.
     sourcemap: GENERATE_SOURCEMAP
-      ? EXPOSE_SOURCEMAP_URL
+      ? COLLECT_COVERAGE
         ? true
         : 'hidden'
       : false,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -28,6 +28,7 @@ const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === 'true'
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
+const EXPOSE_SOURCEMAP_URL = process.env.EXPOSE_SOURCEMAP_URL === 'true'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
 
 const CRITICAL_COVERAGE_DIRS = [
@@ -546,7 +547,13 @@ export default defineConfig({
     // browser-facing `//# sourceMappingURL=` comment is NOT injected into the JS
     // bundles. This kills the ~57k/3d `/assets/*.js.map` 404 noise in prod
     // (the .map files aren't served) without losing Sentry symbolication. See FE-1405.
-    sourcemap: GENERATE_SOURCEMAP ? 'hidden' : false,
+    // EXPOSE_SOURCEMAP_URL re-injects it for the CI E2E build, which serves its
+    // own .map files and needs them to map V8 coverage back to src/**.
+    sourcemap: GENERATE_SOURCEMAP
+      ? EXPOSE_SOURCEMAP_URL
+        ? true
+        : 'hidden'
+      : false,
     // Exclude heavy optional vendor chunks from initial module preload
     // These chunks are only needed when their features are used (3D, terminal, etc.)
     modulePreload: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -549,11 +549,7 @@ export default defineConfig({
     // (the .map files aren't served) without losing Sentry symbolication. See FE-1405.
     // A coverage build serves its own .map files and needs the comment back:
     // monocart maps V8 coverage to src/** only by following it.
-    sourcemap: GENERATE_SOURCEMAP
-      ? COLLECT_COVERAGE
-        ? true
-        : 'hidden'
-      : false,
+    sourcemap: GENERATE_SOURCEMAP && (COLLECT_COVERAGE || 'hidden'),
     // Exclude heavy optional vendor chunks from initial module preload
     // These chunks are only needed when their features are used (3D, terminal, etc.)
     modulePreload: {


### PR DESCRIPTION
## Summary

E2E coverage has been reported as either missing or 100% since `build.sourcemap: 'hidden'` landed; this restores the source mapping and adds guards so a degenerate tracefile fails loudly instead of being announced as a milestone.

## Changes

- **What**:
  - The E2E build sets `COLLECT_COVERAGE=true`, which re-injects the `//# sourceMappingURL=` comment. Everything that ships to users keeps `'hidden'`, so the `.js.map` 404 noise FE-1405 removed stays gone. `GENERATE_SOURCEMAP` can't carry this — `Comfy-Org/cloud` already sets it true for the staging and prod builds.
  - `CI: E2E Coverage` asserts the merged tracefile still has source-mapped files before stripping bundle paths, with an error that names the cause.
  - `coverage-slack-notify.ts` counts only `src/`/`packages/` files and treats an implausibly small file set as no data.

## Review Focus

Root cause: monocart-coverage-reports resolves source maps *only* from the `//# sourceMappingURL=` comment in the served bundle (`lib/converter/collect-source-maps.js`). https://github.com/Comfy-Org/ComfyUI_frontend/pull/14209 switched `build.sourcemap` to `'hidden'`, which emits the `.map` files but strips that comment, so every V8 coverage entry stayed at its served path (`localhost-8188/assets/*.js`).

The merge job strips those paths, which left two failure modes:

- Nothing survives → `lcov: ERROR: no valid records found` → job fails → no `e2e-coverage` artifact → the Slack report silently drops its E2E line (what you see after https://github.com/Comfy-Org/ComfyUI_frontend/pull/14809).
- One third-party script survives (`js.stripe.com/dahlia/stripe.js`, fully covered) → E2E reported as 100% (`e2e-coverage` artifacts drop from ~350 KB to ~28 KB). That is the source of the "GOAL REACHED: E2E test coverage hit 100%" messages.

Replaying the current script against the real 28 KB artifact reproduces the Slack message exactly (`E2E: 68.5% → 100.0% (+31.5%)`); with this change the same input produces no post.

The only source-mapped E2E artifacts after 2026-07-30 came from PR branches not yet rebased past #14209 — hence the decay from ~170/day to zero rather than a clean cutover.

Note the stored `e2e-coverage-baseline` currently holds the bogus 100%, so the first run after this merges will look like a large regression and post nothing; the baseline self-heals on that same run.
