### PR TITLE
fix(e2e): unbreak the merge queue's typecheck

### DIFF
--- a/browser_tests/fixtures/data/workspaceAuthFixtures.ts
+++ b/browser_tests/fixtures/data/workspaceAuthFixtures.ts
@@ -2,9 +2,10 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
 import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
 
-export const mockWorkspacesRemoteConfig: RemoteConfig = {
-  team_workspaces_enabled: true
-}
+// `/api/features` is mocked with no overrides. `team_workspaces_enabled` was
+// set here but is not a key of `RemoteConfig`, and nothing in `src/` reads it —
+// team workspaces are gated on the workspace's own `type`, not a remote flag.
+export const mockWorkspacesRemoteConfig: RemoteConfig = {}
 
 export const mockPersonalWorkspace: WorkspaceWithRole = {
   id: 'ws-personal',


### PR DESCRIPTION
## The merge queue is down repo-wide

`typecheck:browser` fails on `main`:

```
browser_tests/fixtures/data/workspaceAuthFixtures.ts(6,3): error TS2353:
Object literal may only specify known properties, and
'team_workspaces_enabled' does not exist in type 'RemoteConfig'.
```

Because the merge queue re-runs **CI: Lint Format** against the queue branch,
this fails there too — so PRs are being **added to the queue and then dequeued
without merging**, whatever their own CI said. Two of mine were dequeued this
way in the last hour (#14691 at 02:59Z, #14669 at 03:05Z), and four unrelated
branches hit the sibling `validate-pins` breakage in the same window.

Introduced by #12940 (`e544b2ad90`), merged ~4 hours ago.

## Why removing the key is the right fix

`team_workspaces_enabled` appears **exactly once in the entire repository** —
this line. No `src/` code reads it. Team workspaces are gated on the
workspace's own `type` (`'personal' | 'team'`), not on a remote-config flag,
and there is no corresponding entry in `useFeatureFlags`. The fixture was
enabling nothing, so `{}` is behaviour-identical.

The alternative — adding the key to `RemoteConfig` — would invent frontend API
surface that nothing consumes.

## Verification

Matched control, same machine, same install:

| tree | `pnpm run typecheck:browser` |
| ---- | --- |
| `origin/main` | **exit 2**, the error above |
| this branch | **exit 0** |

`pnpm run format:check` clean.

## Relationship to #14955

#14955 contains this same one-line fix, but bundled with an unrelated litegraph
subgraph-serialization change. That change looks sound to me, but it deserves
review on its own merits by someone who owns litegraph — and the queue outage
shouldn't wait on it. This PR is the fixture fix alone so it can land
immediately. Whichever merges first, the other's hunk drops out trivially.
