### PR TITLE
ci: unbreak validate-action-pins

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Download built frontend
         if: steps.detect.outputs.has-new-tests == 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: dist/


### PR DESCRIPTION
## `validate-pins` is failing for anyone who touches a workflow file

```
##[error]        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
.github/workflows/ci-tests-e2e.yaml:263
##[error]GitHub Actions aren't pinned.
```

`.pinact.yaml` allowlists `actions/download-artifact` at **`v8` only**:

```yaml
ignore_actions:
  - name: actions/download-artifact
    ref: v8
```

so the lone `@v7` step is neither allowlisted nor SHA-pinned, and fails.

## How it got in

- **#14000** (dependabot) bumped `download-artifact` 7 → 8 across the workflows
  *and* moved the `.pinact.yaml` allowlist to `v8`.
- **#14560** then added a **new** step still on `@v7`.

`validate-pins` only runs when workflow files change, so `main` stayed green and
this surfaced one PR at a time instead of once. Four unrelated branches failed
it inside a two-hour window (`ci__harden-core-release`,
`cb__release-stranded-guard`, `fix/e2e-coverage-sourcemap-url`,
`glary/design-system-brand-yellow-f2ff59`), plus #14682.

## The change

One line, `@v7` → `@v8`. Every other `download-artifact` step in the repo is
already on `v8` — after this, all **12** usages agree:

```
$ grep -rn "actions/download-artifact@" .github/ | sed 's/.*@/@/' | sort | uniq -c
     12 @v8
```

So this restores consistency rather than introducing a version.

## Relationship to #14950

#14950 contains this same one-line fix, but alongside the E2E coverage
source-mapping work, and its approval has since been dismissed — so it is not
close to landing. Extracting the fix so the repo-wide breakage isn't gated on
that review. Whichever lands first, the other's hunk drops out.

Same pattern as #14959, which fixed the sibling `main` breakage that was
ejecting every PR from the merge queue.
