### PR TITLE
fix: prevent 3D presentation state from re-queueing

### DIFF
--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -856,7 +856,15 @@ describe('Comfy.Preview3DAdvanced.nodeCreated', () => {
   it('serializeValue returns live camera_info plus empty media fields, omitting model_3d_info when none', async () => {
     const { preview3DAdvancedExt } = await loadExtensionsFresh()
     const widgets: FakeWidget[] = [{ name: 'viewport_state', value: '' }]
-    const node = makePreview3DAdvancedNode({ widgets })
+    const properties = {
+      'Camera Config': {
+        cameraType: 'orthographic',
+        state: { position: [9, 8, 7], target: [0, 0, 0] }
+      },
+      'Model Config': { materialMode: 'wireframe' }
+    }
+    const propertiesBeforeSerialization = structuredClone(properties)
+    const node = makePreview3DAdvancedNode({ widgets, properties })
 
     const load3d = makeLoad3dMock()
     waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
@@ -875,6 +883,7 @@ describe('Comfy.Preview3DAdvanced.nodeCreated', () => {
       recording: '',
       model_3d_info: []
     })
+    expect(node.properties).toEqual(propertiesBeforeSerialization)
   })
 
   it('serializeValue wraps a present getModelInfo result in a single-element list', async () => {
@@ -1165,6 +1174,8 @@ describe('Comfy.Load3D scene widget serializeValue caching', () => {
     await load3DExt.nodeCreated(node)
     const serialize = widgets[3].serializeValue! as () => Promise<{
       image: string
+      camera_info: unknown
+      model_3d_info: unknown[]
     } | null>
 
     return { node, serialize, uploadTempImage, useLoad3dModule }
@@ -1195,6 +1206,24 @@ describe('Comfy.Load3D scene widget serializeValue caching', () => {
     const refreshed = await serialize()
     expect(uploadTempImage).toHaveBeenCalledTimes(6)
     expect(refreshed?.image).toBe('threed/scene-4.png [temp]')
+  })
+
+  it('does not mutate Camera Config after the workflow snapshot is captured', async () => {
+    const { node, serialize } = await setup()
+    node.properties = {
+      'Camera Config': {
+        cameraType: 'orthographic',
+        state: { position: { x: 9, y: 8, z: 7 } }
+      },
+      'Node name for S&R': 'Load3D'
+    }
+    const workflowProperties = structuredClone(node.properties)
+
+    const payload = await serialize()
+
+    expect(payload?.camera_info).toEqual({ position: { x: 0, y: 0, z: 0 } })
+    expect(payload?.model_3d_info).toEqual([])
+    expect(node.properties).toEqual(workflowProperties)
   })
 
   it('returns null when no load3d instance is registered for the node', async () => {

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -423,10 +423,8 @@ useExtensionService().registerExtension({
             if (cached) return cached
           }
 
-          const { camera_info, model_3d_info } = snapshotLoad3dState(
-            node,
-            currentLoad3d
-          )
+          const { camera_info, model_3d_info } =
+            snapshotLoad3dState(currentLoad3d)
 
           const {
             scene: imageData,
@@ -837,14 +835,7 @@ function createPreview3DAdvancedExtension(
             return null
           }
 
-          const cameraConfig: CameraConfig = (node.properties[
-            'Camera Config'
-          ] as CameraConfig | undefined) || {
-            cameraType: currentLoad3d.getCurrentCameraType(),
-            fov: currentLoad3d.cameraManager.perspectiveCamera.fov
-          }
-          cameraConfig.state = currentLoad3d.getCameraState()
-          node.properties['Camera Config'] = cameraConfig
+          const camera_info = currentLoad3d.getCameraState() || null
 
           const modelInfo = currentLoad3d.getModelInfo()
           const model_3d_info: Model3DInfo = modelInfo ? [modelInfo] : []
@@ -853,7 +844,7 @@ function createPreview3DAdvancedExtension(
             image: '',
             mask: '',
             normal: '',
-            camera_info: cameraConfig.state || null,
+            camera_info,
             recording: '',
             model_3d_info
           }

--- a/src/extensions/core/load3d/load3dSerialize.test.ts
+++ b/src/extensions/core/load3d/load3dSerialize.test.ts
@@ -3,11 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import { snapshotLoad3dState } from '@/extensions/core/load3d/load3dSerialize'
 import type { CameraState } from '@/extensions/core/load3d/interfaces'
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-
-function makeNode(props: Record<string, unknown> = {}): LGraphNode {
-  return { properties: { ...props } } as unknown as LGraphNode
-}
 
 const baseCameraState: CameraState = {
   position: { x: 1, y: 2, z: 3 },
@@ -17,18 +12,14 @@ const baseCameraState: CameraState = {
 } as unknown as CameraState
 
 function makeLoad3d({
-  cameraType = 'perspective',
-  fov = 35,
+  cameraState = baseCameraState,
   modelInfo = { transform: { position: [0, 0, 0] } } as unknown
 }: {
-  cameraType?: string
-  fov?: number
+  cameraState?: CameraState
   modelInfo?: unknown
 } = {}) {
   return {
-    getCurrentCameraType: vi.fn(() => cameraType),
-    cameraManager: { perspectiveCamera: { fov } },
-    getCameraState: vi.fn(() => baseCameraState),
+    getCameraState: vi.fn(() => cameraState),
     stopRecording: vi.fn(),
     getModelInfo: vi.fn(() => modelInfo)
   } as unknown as Load3d
@@ -36,52 +27,34 @@ function makeLoad3d({
 
 describe('snapshotLoad3dState', () => {
   it('returns only camera_info and model_3d_info', () => {
-    const result = snapshotLoad3dState(makeNode(), makeLoad3d())
+    const result = snapshotLoad3dState(makeLoad3d())
     expect(Object.keys(result).sort()).toEqual(['camera_info', 'model_3d_info'])
   })
 
-  it('writes the camera state into properties["Camera Config"]', () => {
-    const node = makeNode()
-    snapshotLoad3dState(node, makeLoad3d({ fov: 42 }))
-    const cfg = node.properties['Camera Config'] as Record<string, unknown>
-    expect(cfg).toMatchObject({
-      cameraType: 'perspective',
-      fov: 42,
-      state: baseCameraState
-    })
-  })
+  it('returns the current camera state as camera_info', () => {
+    const cameraState = {
+      ...baseCameraState,
+      position: { x: 4, y: 5, z: 6 }
+    } as unknown as CameraState
+    const result = snapshotLoad3dState(makeLoad3d({ cameraState }))
 
-  it('preserves an existing Camera Config object instead of replacing it', () => {
-    const existing = { cameraType: 'orthographic', fov: 99 }
-    const node = makeNode({ 'Camera Config': existing })
-    snapshotLoad3dState(node, makeLoad3d())
-    // Same object reference (mutated in place), with state attached.
-    expect(node.properties['Camera Config']).toBe(existing)
-    expect(
-      (node.properties['Camera Config'] as Record<string, unknown>).state
-    ).toBe(baseCameraState)
+    expect(result.camera_info).toBe(cameraState)
   })
 
   it('stops in-progress recording as a side effect', () => {
     const load3d = makeLoad3d()
-    snapshotLoad3dState(makeNode(), load3d)
+    snapshotLoad3dState(load3d)
     expect(load3d.stopRecording).toHaveBeenCalledOnce()
   })
 
   it('returns model_3d_info as a single-element list when a model is loaded', () => {
     const info = { transform: { position: [1, 2, 3] } }
-    const result = snapshotLoad3dState(
-      makeNode(),
-      makeLoad3d({ modelInfo: info })
-    )
+    const result = snapshotLoad3dState(makeLoad3d({ modelInfo: info }))
     expect(result.model_3d_info).toEqual([info])
   })
 
   it('returns an empty model_3d_info list when no model is loaded', () => {
-    const result = snapshotLoad3dState(
-      makeNode(),
-      makeLoad3d({ modelInfo: null })
-    )
+    const result = snapshotLoad3dState(makeLoad3d({ modelInfo: null }))
     expect(result.model_3d_info).toEqual([])
   })
 })

--- a/src/extensions/core/load3d/load3dSerialize.ts
+++ b/src/extensions/core/load3d/load3dSerialize.ts
@@ -1,28 +1,16 @@
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import type {
-  CameraConfig,
   CameraState,
   Model3DInfo
 } from '@/extensions/core/load3d/interfaces'
-import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
 type Load3dSerializedBase = {
   camera_info: CameraState | null
   model_3d_info: Model3DInfo
 }
 
-export function snapshotLoad3dState(
-  node: LGraphNode,
-  load3d: Load3d
-): Load3dSerializedBase {
-  const cameraConfig: CameraConfig = (node.properties['Camera Config'] as
-    | CameraConfig
-    | undefined) || {
-    cameraType: load3d.getCurrentCameraType(),
-    fov: load3d.cameraManager.perspectiveCamera.fov
-  }
-  cameraConfig.state = load3d.getCameraState()
-  node.properties['Camera Config'] = cameraConfig
+export function snapshotLoad3dState(load3d: Load3d): Load3dSerializedBase {
+  const camera_info = load3d.getCameraState() ?? null
 
   load3d.stopRecording()
 
@@ -30,7 +18,7 @@ export function snapshotLoad3dState(
   const model_3d_info: Model3DInfo = modelInfo ? [modelInfo] : []
 
   return {
-    camera_info: cameraConfig.state ?? null,
+    camera_info,
     model_3d_info
   }
 }

--- a/src/extensions/core/load3dAdvanced.ts
+++ b/src/extensions/core/load3dAdvanced.ts
@@ -96,7 +96,7 @@ useExtensionService().registerExtension({
           console.error('No load3d instance found for node')
           return null
         }
-        return snapshotLoad3dState(node, currentLoad3d)
+        return snapshotLoad3dState(currentLoad3d)
       }
     })
   }

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -348,20 +348,30 @@ describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
     const { splatExt } = await loadExtensionsFresh()
     const load3d = makeLoad3dMock()
     const cameraState = { position: { x: 1, y: 2, z: 3 } }
-    load3d.getCameraState = vi.fn(() => cameraState)
-    load3d.getModelInfo = vi.fn(() => ({
+    const modelInfo = {
       position: { x: 0, y: 0, z: 0 },
       quaternion: { x: 0, y: 0, z: 0, w: 1 },
       scale: { x: 1, y: 1, z: 1 }
-    }))
+    }
+    load3d.getCameraState = vi.fn(() => cameraState)
+    load3d.getModelInfo = vi.fn(() => modelInfo)
     waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
       cb(load3d)
     )
     const sceneWidget: FakeWidget & {
       serializeValue?: () => Promise<unknown>
     } = { name: 'viewport_state', value: '' }
+    const properties = {
+      'Camera Config': {
+        cameraType: 'perspective',
+        state: { position: { x: 9, y: 8, z: 7 } }
+      },
+      'Model Config': { materialMode: 'wireframe' }
+    }
+    const propertiesBeforeSerialization = structuredClone(properties)
     const node = makePreviewNode({
-      widgets: [{ name: 'model_file', value: '' }, sceneWidget]
+      widgets: [{ name: 'model_file', value: '' }, sceneWidget],
+      properties
     })
     nodeToLoad3dMapMock.set(node, load3d)
 
@@ -373,7 +383,8 @@ describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
       model_3d_info: unknown[]
     }
     expect(payload.camera_info).toEqual(cameraState)
-    expect(payload.model_3d_info).toHaveLength(1)
+    expect(payload.model_3d_info).toEqual([modelInfo])
+    expect(node.properties).toEqual(propertiesBeforeSerialization)
   })
 
   it('shows an error toast when onExecuted has no file path', async () => {

--- a/src/extensions/core/load3dPreviewExtensions.ts
+++ b/src/extensions/core/load3dPreviewExtensions.ts
@@ -178,14 +178,7 @@ function createPreview3DExtension(
               return null
             }
 
-            const cameraConfig: CameraConfig = (node.properties[
-              'Camera Config'
-            ] as CameraConfig | undefined) || {
-              cameraType: currentLoad3d.getCurrentCameraType(),
-              fov: currentLoad3d.cameraManager.perspectiveCamera.fov
-            }
-            cameraConfig.state = currentLoad3d.getCameraState()
-            node.properties['Camera Config'] = cameraConfig
+            const camera_info = currentLoad3d.getCameraState() || null
 
             const modelInfo = currentLoad3d.getModelInfo()
             const model_3d_info: Model3DInfo = modelInfo ? [modelInfo] : []
@@ -194,7 +187,7 @@ function createPreview3DExtension(
               image: '',
               mask: '',
               normal: '',
-              camera_info: cameraConfig.state || null,
+              camera_info,
               recording: '',
               model_3d_info
             }

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -590,6 +590,278 @@ describe('ChangeTracker', () => {
         expectAutoQueueGraphChangedNotDispatched()
       })
 
+      describe('3D presentation state', () => {
+        const advancedResultNodeTypes = [
+          'Preview3DAdvanced',
+          'Save3DAdvanced',
+          'PreviewGaussianSplat',
+          'PreviewPointCloud',
+          'SaveGaussianSplat',
+          'SavePointCloud'
+        ]
+        const previewProperties = {
+          'Camera Config': {
+            cameraType: 'perspective',
+            fov: 35,
+            state: { position: { x: 0, y: 0, z: 1 } }
+          },
+          'Light Config': { intensity: 1 },
+          'Scene Config': {
+            showGrid: true,
+            backgroundColor: '#000000'
+          },
+          'Model Config': {
+            upDirection: 'original',
+            materialMode: 'original',
+            showSkeleton: false
+          },
+          'Resource Folder': 'models',
+          'Last Time Model File': 'preview.glb'
+        }
+        const updatedPreviewProperties = {
+          'Camera Config': {
+            cameraType: 'orthographic',
+            fov: 50,
+            state: { position: { x: 1, y: 2, z: 3 } }
+          },
+          'Light Config': { intensity: 2 },
+          'Scene Config': {
+            showGrid: false,
+            backgroundColor: '#ffffff'
+          },
+          'Model Config': {
+            upDirection: '+z',
+            materialMode: 'wireframe',
+            showSkeleton: true
+          },
+          'Resource Folder': 'updated-models',
+          'Last Time Model File': 'updated-preview.glb'
+        }
+        const advancedProperties = {
+          'Light Config': { intensity: 1 },
+          'Resource Folder': 'models',
+          'Last Time Model File': 'preview.glb'
+        }
+        const updatedAdvancedProperties = {
+          'Light Config': { intensity: 2 },
+          'Resource Folder': 'updated-models',
+          'Last Time Model File': 'updated-preview.glb'
+        }
+        const presentationOnlyCases = [
+          {
+            nodeType: 'Load3D',
+            added: { 'Resource Folder': 'models' },
+            updated: { 'Resource Folder': 'updated-models' }
+          },
+          {
+            nodeType: 'Load3DAdvanced',
+            added: {
+              'Light Config': { intensity: 1 },
+              'Resource Folder': 'models'
+            },
+            updated: {
+              'Light Config': { intensity: 2 },
+              'Resource Folder': 'updated-models'
+            }
+          },
+          {
+            nodeType: 'Preview3D',
+            added: previewProperties,
+            updated: updatedPreviewProperties
+          },
+          {
+            nodeType: 'SaveGLB',
+            added: {
+              ...previewProperties,
+              'Last Time Model Folder': 'output'
+            },
+            updated: {
+              ...updatedPreviewProperties,
+              'Last Time Model Folder': 'temp'
+            }
+          },
+          ...advancedResultNodeTypes.map((nodeType) => ({
+            nodeType,
+            added: advancedProperties,
+            updated: updatedAdvancedProperties
+          }))
+        ]
+
+        it.each(presentationOnlyCases)(
+          'ignores $nodeType presentation property addition and mutation',
+          ({ nodeType, added, updated }) => {
+            const initial = createState(1)
+            initial.nodes[0].type = nodeType
+            initial.nodes[0].properties = {
+              'Node name for S&R': nodeType
+            }
+            const tracker = createTracker(initial)
+
+            const addedState = structuredClone(initial)
+            Object.assign(addedState.nodes[0].properties, added)
+            mockCanvasState(addedState)
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'graphChanged',
+              addedState
+            )
+            expectAutoQueueGraphChangedNotDispatched()
+
+            vi.mocked(api.dispatchCustomEvent).mockClear()
+            const updatedState = structuredClone(addedState)
+            Object.assign(updatedState.nodes[0].properties, updated)
+            mockCanvasState(updatedState)
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'graphChanged',
+              updatedState
+            )
+            expectAutoQueueGraphChangedNotDispatched()
+
+            vi.mocked(api.dispatchCustomEvent).mockClear()
+            const executionChanged = structuredClone(updatedState)
+            executionChanged.nodes[0].properties['Node name for S&R'] =
+              `${nodeType} changed`
+            mockCanvasState(executionChanged)
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'autoQueueGraphChanged'
+            )
+          }
+        )
+
+        it('ignores deletion of Preview3D presentation state', () => {
+          const initial = createState(1)
+          initial.nodes[0].type = 'Preview3D'
+          initial.nodes[0].properties['Camera Config'] = {
+            state: { position: { x: 1, y: 2, z: 3 } }
+          }
+          const tracker = createTracker(initial)
+          const changed = structuredClone(initial)
+          delete changed.nodes[0].properties['Camera Config']
+          mockCanvasState(changed)
+
+          tracker.captureCanvasState()
+
+          expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+            'graphChanged',
+            changed
+          )
+          expectAutoQueueGraphChangedNotDispatched()
+        })
+
+        it.each([
+          {
+            property: 'Camera Config',
+            initialValue: {
+              cameraType: 'perspective',
+              fov: 35,
+              state: { position: { x: 0, y: 0, z: 1 } }
+            },
+            updatedValue: {
+              cameraType: 'perspective',
+              fov: 35,
+              state: { position: { x: 1, y: 2, z: 3 } }
+            }
+          },
+          {
+            property: 'Scene Config',
+            initialValue: { showGrid: true, backgroundColor: '#000000' },
+            updatedValue: { showGrid: false, backgroundColor: '#ffffff' }
+          },
+          {
+            property: 'Light Config',
+            initialValue: { intensity: 1 },
+            updatedValue: { intensity: 2 }
+          },
+          {
+            property: 'Model Config',
+            initialValue: { materialMode: 'original' },
+            updatedValue: { materialMode: 'wireframe' }
+          }
+        ])(
+          'keeps Load3D $property execution-relevant',
+          ({ property, initialValue, updatedValue }) => {
+            const initial = createState(1)
+            initial.nodes[0].type = 'Load3D'
+            initial.nodes[0].properties[property] = initialValue
+            const tracker = createTracker(initial)
+            const changed = structuredClone(initial)
+            changed.nodes[0].properties[property] = updatedValue
+            mockCanvasState(changed)
+
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'autoQueueGraphChanged'
+            )
+          }
+        )
+
+        it.each(['Load3DAdvanced', ...advancedResultNodeTypes])(
+          'keeps %s camera and model state execution-relevant',
+          (nodeType) => {
+            const initial = createState(1)
+            initial.nodes[0].type = nodeType
+            initial.nodes[0].properties = {
+              'Camera Config': {
+                state: { position: { x: 0, y: 0, z: 1 } }
+              },
+              'Model Config': {
+                gizmo: { position: { x: 0, y: 0, z: 0 } }
+              }
+            }
+            const tracker = createTracker(initial)
+            const cameraChanged = structuredClone(initial)
+            cameraChanged.nodes[0].properties['Camera Config'] = {
+              state: { position: { x: 1, y: 2, z: 3 } }
+            }
+            mockCanvasState(cameraChanged)
+
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'autoQueueGraphChanged'
+            )
+
+            vi.mocked(api.dispatchCustomEvent).mockClear()
+            const modelChanged = structuredClone(cameraChanged)
+            modelChanged.nodes[0].properties['Model Config'] = {
+              gizmo: { position: { x: 1, y: 0, z: 0 } }
+            }
+            mockCanvasState(modelChanged)
+
+            tracker.captureCanvasState()
+
+            expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+              'autoQueueGraphChanged'
+            )
+          }
+        )
+
+        it('keeps matching properties execution-relevant for non-core nodes', () => {
+          const initial = createState(1)
+          initial.nodes[0].properties['Camera Config'] = {
+            state: { position: { x: 0, y: 0, z: 1 } }
+          }
+          const tracker = createTracker(initial)
+          const changed = structuredClone(initial)
+          changed.nodes[0].properties['Camera Config'] = {
+            state: { position: { x: 1, y: 2, z: 3 } }
+          }
+          mockCanvasState(changed)
+
+          tracker.captureCanvasState()
+
+          expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+            'autoQueueGraphChanged'
+          )
+        })
+      })
+
       it('does not dispatch a graph change for the canvas viewport', () => {
         const initial = createState(1)
         const tracker = createTracker(initial)

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -239,6 +239,57 @@ describe('ChangeTracker', () => {
     vi.useRealTimers()
   })
 
+  describe('updateModified', () => {
+    it('reuses a current-state projection as the next previous-state projection', () => {
+      const initial = createState(1)
+      initial.nodes[0].widgets_values = [1]
+      const first = structuredClone(initial)
+      first.nodes[0].widgets_values = [2]
+      const second = structuredClone(first)
+      second.nodes[0].widgets_values = [3]
+      const firstProjectionTraversals = vi.fn()
+      const trackedFirst = new Proxy(first, {
+        ownKeys(target) {
+          firstProjectionTraversals()
+          return Reflect.ownKeys(target)
+        }
+      })
+      const tracker = createTracker(initial)
+
+      tracker.activeState = trackedFirst
+      tracker.updateModified(initial)
+      tracker.activeState = second
+      tracker.updateModified(trackedFirst)
+
+      expect(firstProjectionTraversals).toHaveBeenCalledOnce()
+    })
+
+    it('recomputes the projection for a different but equivalent state object', () => {
+      const initial = createState(1)
+      initial.nodes[0].widgets_values = [1]
+      const first = structuredClone(initial)
+      first.nodes[0].widgets_values = [2]
+      const equivalent = structuredClone(first)
+      const equivalentProjectionTraversals = vi.fn()
+      const trackedEquivalent = new Proxy(equivalent, {
+        ownKeys(target) {
+          equivalentProjectionTraversals()
+          return Reflect.ownKeys(target)
+        }
+      })
+      const tracker = createTracker(initial)
+
+      tracker.activeState = first
+      tracker.updateModified(initial)
+      vi.mocked(api.dispatchCustomEvent).mockClear()
+      tracker.activeState = trackedEquivalent
+      tracker.updateModified(first)
+
+      expect(equivalentProjectionTraversals).toHaveBeenCalledOnce()
+      expectAutoQueueGraphChangedNotDispatched()
+    })
+  })
+
   describe('captureCanvasState', () => {
     describe('guards', () => {
       it('is a no-op when app.graph is falsy', () => {

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -229,6 +229,27 @@ function getExecutionGraphState(value: unknown): unknown {
   return executionGraph
 }
 
+const lastProjectionByTracker = new WeakMap<
+  ChangeTracker,
+  { state: ComfyWorkflowJSON; projection: unknown }
+>()
+
+/**
+ * Memoizes by snapshot identity. Callers must replace snapshots rather than
+ * mutate them in place; graphChanged listener mutation is unsupported.
+ */
+function executionStateOf(
+  tracker: ChangeTracker,
+  state: ComfyWorkflowJSON
+): unknown {
+  const lastProjection = lastProjectionByTracker.get(tracker)
+  if (lastProjection?.state === state) return lastProjection.projection
+
+  const projection = getExecutionGraphState(state)
+  lastProjectionByTracker.set(tracker, { state, projection })
+  return projection
+}
+
 const reportedInactiveCalls = new Set<string>()
 
 /**
@@ -386,8 +407,8 @@ export class ChangeTracker {
       !!previousState &&
       isAutoQueueOnChange() &&
       !_.isEqual(
-        getExecutionGraphState(previousState),
-        getExecutionGraphState(this.activeState)
+        executionStateOf(this, previousState),
+        executionStateOf(this, this.activeState)
       )
 
     api.dispatchCustomEvent('graphChanged', this.activeState)

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -87,6 +87,39 @@ const nonExecutionSlotProperties = new Set([
 const nonExecutionBoundaryNodeProperties = new Set(['bounding', 'pinned'])
 const nonExecutableNodeTypes = new Set(['Note', 'MarkdownNote'])
 
+const nonExecution3dUploadProperties = new Set(['Resource Folder'])
+const nonExecution3dAdvancedProperties = new Set([
+  ...nonExecution3dUploadProperties,
+  'Light Config'
+])
+const nonExecution3dAdvancedResultProperties = new Set([
+  ...nonExecution3dAdvancedProperties,
+  'Last Time Model File'
+])
+const nonExecution3dPreviewProperties = new Set([
+  ...nonExecution3dAdvancedResultProperties,
+  'Camera Config',
+  'Scene Config',
+  'Model Config'
+])
+const nonExecutionSaveGlbProperties = new Set([
+  ...nonExecution3dPreviewProperties,
+  'Last Time Model Folder'
+])
+
+const nonExecution3dPropertiesByNodeType = new Map([
+  ['Load3D', nonExecution3dUploadProperties],
+  ['Load3DAdvanced', nonExecution3dAdvancedProperties],
+  ['Preview3D', nonExecution3dPreviewProperties],
+  ['SaveGLB', nonExecutionSaveGlbProperties],
+  ['Preview3DAdvanced', nonExecution3dAdvancedResultProperties],
+  ['Save3DAdvanced', nonExecution3dAdvancedResultProperties],
+  ['PreviewGaussianSplat', nonExecution3dAdvancedResultProperties],
+  ['PreviewPointCloud', nonExecution3dAdvancedResultProperties],
+  ['SaveGaussianSplat', nonExecution3dAdvancedResultProperties],
+  ['SavePointCloud', nonExecution3dAdvancedResultProperties]
+])
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -109,11 +142,26 @@ function getExecutionSlotState(value: unknown): unknown {
   return slot ? omitProperties(slot, nonExecutionSlotProperties) : value
 }
 
+function getExecutionNodePropertiesState(node: Record<string, unknown>) {
+  const properties = asRecord(node.properties)
+  const ignoredProperties =
+    typeof node.type === 'string'
+      ? nonExecution3dPropertiesByNodeType.get(node.type)
+      : undefined
+
+  return properties && ignoredProperties
+    ? omitProperties(properties, ignoredProperties)
+    : node.properties
+}
+
 function getExecutionNodeState(value: unknown): unknown {
   const node = asRecord(value)
   if (!node) return value
 
   const executionNode = omitProperties(node, nonExecutionNodeProperties)
+  if ('properties' in node) {
+    executionNode.properties = getExecutionNodePropertiesState(node)
+  }
   if ('id' in node) {
     executionNode.id = normalizeNodeId(node.id)
   }


### PR DESCRIPTION
## ELI5

A 3D preview has controls that can either change the generated result or merely change what the viewer looks like. This PR ignores only the viewer-only state and prevents preparing a run from writing fresh state that could be mistaken for another user edit.

## Motivation

#14453 — Run (on change) still re-queues when orbiting the Load3D preview camera followed the Run on Change layout-filtering review. Core 3D nodes persist frontend state under `properties`, where indiscriminate comparison can treat presentation changes as execution changes. Their serializers also wrote camera state after the workflow snapshot was captured, which could appear as a new change after queueing. The Load3D example itself is not presentation-only because its camera and scene affect generated outputs, so this change preserves those execution-relevant values while addressing the confirmed UI-only and serialization paths.

## Provenance

- **Authored by:** `interactive session`
- **From:** #14453 — Run (on change) still re-queues when orbiting the Load3D preview camera
- **Verified:** Targeted Vitest suites: 164 passed; `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format:check`, and `git diff --check`: passed.
- **Deviations:** Load3D camera, scene, light, and model changes remain execution-relevant because they alter its serialized or rendered outputs; only audited presentation-only state is ignored.

## Reviewer context

- **Type:** bug fix; prevent presentation-only 3D state and serialization writes from causing redundant Run on Change signals
- **Slots into:** stacked on #14971 — perf: reuse execution graph projections
- **Not in scope:** A public custom-node property-ignore API, nested per-field policies, or treating output-affecting Load3D camera state as presentation-only.

## Summary

- Ignore audited presentation-only `properties` for the relevant core 3D node types.
- Keep Load3D camera, scene, light, and model state plus advanced camera and model state execution-relevant.
- Make Load3D-family execution serializers return live camera/model prompt data without mutating `node.properties`.
- Preserve existing recording behavior and fail safely for unknown nodes and properties.

## Changes

- **What:** Adds node-specific 3D projection rules and removes state writes from execution serialization.
- **Breaking:** None; prompt payloads and execution-relevant state remain unchanged.
- **Dependencies:** None.

## Review Focus

Please verify the boundary between presentation-only 3D properties and values that influence backend or rendered outputs, plus the serializer purity change.

## Test plan

- [x] Presentation-only 3D property addition, mutation, and representative deletion do not auto-queue.
- [x] Load3D and advanced output-affecting properties still auto-queue.
- [x] Production serializer paths return current camera/model data without changing node properties.
- [x] Targeted unit tests and static quality gates pass.
- [ ] Manually exercise Run on Change with Preview3D and Load3D in a browser.

Fixes #14453
