### PR TITLE
fix(i18n): disclose that API Nodes cost credits on the sign-in wall

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2130,7 +2130,7 @@
   },
   "apiNodesSignInDialog": {
     "title": "Sign In Required to Use API Nodes",
-    "message": "This workflow contains API Nodes, which require you to be signed in to your account in order to run."
+    "message": "This workflow contains API Nodes, which run on paid third-party services. You need to be signed in to run them, and each run uses credits."
   },
   "apiNodesCostBreakdown": {
     "title": "API Node(s)",


### PR DESCRIPTION
## Summary

The API Nodes sign-in dialog never told users that API Nodes cost money. It described only the account requirement, so cost was first encountered after signing in.

## Changes

- **What**: One string. `apiNodesSignInDialog.message` now states that API Nodes run on paid third-party services and that each run uses credits.

Before:
> This workflow contains API Nodes, which require you to be signed in to your account in order to run.

After:
> This workflow contains API Nodes, which run on paid third-party services. You need to be signed in to run them, and each run uses credits.

Only `en` is edited; the other locales regenerate via `pnpm locale`.

## Review Focus

Deliberately scoped to the one change that is unambiguous. Three adjacent problems were found in the same dialog and are **not** fixed here, because each needs a decision rather than a copy edit:

1. **The title still states half the requirement.** "Sign In Required to Use API Nodes" names the account gate but not the credit gate. Worth a follow-up once the wording above settles.

2. **`ApiNodesList` renders no cost, under a heading keyed `apiNodesCostBreakdown.title`.** The locale file already contains `apiNodesCostBreakdown.costPerRun` ("Cost per run") and `apiNodesCostBreakdown.totalCost` ("Total Cost"), and neither string is referenced anywhere in the component, which lists node names only. The UI slot exists and the number does not. Putting a real per-run cost here is the substantive fix; this PR is the stopgap.

3. **"API Nodes" vs "Partner Nodes".** The dialog says API Nodes. The node library filter, section header and template category all say Partner Nodes. Settings carries both as separate categories. `en/main.json` has 6 occurrences of one and 7 of the other, so neither is canonical and this PR does not pick a side. Users meet the category under one name and are gated under the other.

## Context

Found while walking the partner-node path as a user who does not know API Nodes are a paid category. Roughly 26,000 people per 28 days place an API node, press Run, are not signed in, and produce no revenue. Calling an API node is the single sharpest predictor of payment in the product, so what this dialog says is disproportionately important.
