### PR TITLE
test: harden run-on-change regression tests

### DIFF
--- a/browser_tests/fixtures/components/Actionbar.ts
+++ b/browser_tests/fixtures/components/Actionbar.ts
@@ -21,14 +21,6 @@ function isPromptRequest(request: Request): boolean {
   )
 }
 
-async function waitForPromptRequest(page: Page, timeout: number) {
-  await page
-    .waitForRequest(isPromptRequest, { timeout })
-    .catch((error: unknown) => {
-      if (!(error instanceof errors.TimeoutError)) throw error
-    })
-}
-
 export class ComfyActionbar {
   public readonly root: Locator
   public readonly card: Locator
@@ -98,9 +90,18 @@ export class ComfyActionbar {
     return className?.includes('static') ?? false
   }
 
+  /** After the action completes, keeps observing until maxRequests or timeout. */
   async collectPromptRequestsDuring(
     action: () => Promise<void>,
-    timeout = 3000
+    {
+      minRequests,
+      maxRequests,
+      timeout
+    }: {
+      minRequests: number
+      maxRequests: number
+      timeout: number
+    }
   ): Promise<Request[]> {
     const requests: Request[] = []
     function onRequest(request: Request) {
@@ -110,12 +111,28 @@ export class ComfyActionbar {
     this.page.on('request', onRequest)
     try {
       await action()
-      if (requests.length === 0) {
-        await waitForPromptRequest(this.page, timeout)
+
+      const deadline = Date.now() + timeout
+      while (requests.length < maxRequests) {
+        const remaining = deadline - Date.now()
+        if (remaining <= 0) break
+
+        try {
+          await this.page.waitForRequest(isPromptRequest, {
+            timeout: remaining
+          })
+        } catch (error: unknown) {
+          if (!(error instanceof errors.TimeoutError)) throw error
+          break
+        }
       }
-      if (requests.length === 1) {
-        await waitForPromptRequest(this.page, timeout)
+
+      if (requests.length < minRequests) {
+        throw new errors.TimeoutError(
+          `Timed out after ${timeout}ms waiting for at least ${minRequests} prompt requests; received ${requests.length}`
+        )
       }
+
       return requests
     } finally {
       this.page.off('request', onRequest)

--- a/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeOperationsHelper.ts
@@ -254,6 +254,14 @@ export class NodeOperationsHelper {
     await this.comfyPage.nextFrame()
   }
 
+  async fillLegacyWidgetDialog(value: string): Promise<void> {
+    const dialogInput = this.page.locator('.graphdialog input[type="text"]')
+    await dialogInput.click()
+    await dialogInput.fill(value)
+    await dialogInput.press('Enter')
+    await this.comfyPage.nextFrame()
+  }
+
   async panToNode(nodeRef: NodeReference): Promise<void> {
     const nodePos = await nodeRef.getPosition()
     await this.page.evaluate((pos) => {
@@ -284,11 +292,7 @@ export class NodeOperationsHelper {
     await this.page.locator('#graph-canvas').click({
       position: DefaultGraphPositions.emptyLatentWidgetClick
     })
-    const dialogInput = this.page.locator('.graphdialog input[type="text"]')
-    await dialogInput.click()
-    await dialogInput.fill('128')
-    await dialogInput.press('Enter')
-    await this.comfyPage.nextFrame()
+    await this.fillLegacyWidgetDialog('128')
   }
 }
 

--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -99,11 +99,18 @@ webSocketTest.describe(
         const START = 32
         const END = 64
         const initialPromptRequests =
-          await comfyPage.actionbar.collectPromptRequestsDuring(async () => {
-            for (let i = START; i <= END; i += 8) {
-              await triggerChange(i)
+          await comfyPage.actionbar.collectPromptRequestsDuring(
+            async () => {
+              for (let i = START; i <= END; i += 8) {
+                await triggerChange(i)
+              }
+            },
+            {
+              minRequests: 1,
+              maxRequests: 2,
+              timeout: 2000
             }
-          }, 2000)
+          )
 
         expect(
           initialPromptRequests,
@@ -119,10 +126,17 @@ webSocketTest.describe(
 
         // Trigger a status update so auto-queue re-runs
         const deferredPromptRequests =
-          await comfyPage.actionbar.collectPromptRequestsDuring(async () => {
-            triggerStatus(1)
-            triggerStatus(0)
-          }, 2000)
+          await comfyPage.actionbar.collectPromptRequestsDuring(
+            async () => {
+              triggerStatus(1)
+              triggerStatus(0)
+            },
+            {
+              minRequests: 1,
+              maxRequests: 2,
+              timeout: 2000
+            }
+          )
 
         // Ensure the queued width is the last queued value
         expect(
@@ -164,10 +178,27 @@ test.describe('Actionbar', { tag: '@ui' }, () => {
     })
 
     test('Auto-queues after changing a widget', async ({ comfyPage }) => {
+      const latentNodes =
+        await comfyPage.nodeOps.getNodeRefsByType('EmptyLatentImage')
+      expect(
+        latentNodes,
+        'the default workflow should contain an EmptyLatentImage node'
+      ).toHaveLength(1)
+      const widthWidget = await latentNodes[0].getWidgetByName('width')
+      const { x, y } = await widthWidget.getPosition()
+
       const promptRequests =
-        await comfyPage.actionbar.collectPromptRequestsDuring(async () => {
-          await comfyPage.nodeOps.adjustEmptyLatentWidth()
-        })
+        await comfyPage.actionbar.collectPromptRequestsDuring(
+          async () => {
+            await comfyPage.page.mouse.click(x, y)
+            await comfyPage.nodeOps.fillLegacyWidgetDialog('128')
+          },
+          {
+            minRequests: 1,
+            maxRequests: 1,
+            timeout: 3000
+          }
+        )
 
       expect(
         promptRequests,
@@ -198,7 +229,14 @@ test.describe('Actionbar', { tag: '@ui' }, () => {
         )
       }
       const promptRequests =
-        await comfyPage.actionbar.collectPromptRequestsDuring(resizeLatentNode)
+        await comfyPage.actionbar.collectPromptRequestsDuring(
+          resizeLatentNode,
+          {
+            minRequests: 0,
+            maxRequests: 1,
+            timeout: 3000
+          }
+        )
 
       expect(
         await latentNode.getSize(),

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -225,6 +225,7 @@ describe('ChangeTracker', () => {
     resetSubgraphFixtureState()
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
+    ChangeTracker.resetCheckStateWarningForTest()
     mockWorkflowStore.activeWorkflow = null
     mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
     vi.mocked(app.rootGraph.serialize).mockReset()
@@ -235,6 +236,7 @@ describe('ChangeTracker', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.clearAllTimers()
     vi.useRealTimers()
   })
@@ -1227,14 +1229,25 @@ describe('ChangeTracker', () => {
   })
 
   describe('checkState (deprecated)', () => {
-    it('delegates to captureCanvasState', () => {
+    it('captures each state and warns once across repeated calls', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       const tracker = createTracker(createState(1))
-      const changed = createState(2)
-      mockCanvasState(changed)
+      const firstChanged = createState(2)
+      mockCanvasState(firstChanged)
 
       tracker.checkState()
 
-      expect(tracker.activeState).toEqual(changed)
+      expect(tracker.activeState).toEqual(firstChanged)
+
+      const secondChanged = createState(3)
+      mockCanvasState(secondChanged)
+      tracker.checkState()
+
+      expect(tracker.activeState).toEqual(secondChanged)
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledWith(
+        'checkState() is deprecated — use captureCanvasState() instead.'
+      )
     })
   })
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -463,6 +463,10 @@ export class ChangeTracker {
 
   private static _checkStateWarned = false
 
+  static resetCheckStateWarningForTest() {
+    ChangeTracker._checkStateWarned = false
+  }
+
   async updateState(source: ComfyWorkflowJSON[], target: ComfyWorkflowJSON[]) {
     const prevState = source.pop()
     if (prevState) {


### PR DESCRIPTION
## ELI5

Run-on-change tests are like a smoke alarm: they should clearly say when no signal arrived and should press the actual control instead of guessing where it is. This PR gives those tests an explicit waiting contract, locates the real widget, and resets one-time warning state so failures remain meaningful and independent.

## Motivation

The Run (on change) regression suite had several durability risks deferred from review: a request timeout could surface later as an unhelpful array-length failure, one positive browser test clicked coordinates calibrated for a different menu layout, and process-wide warning state could couple tests by execution order. This addresses those risks without changing product behavior.

## Provenance

- **Authored by:** interactive session
- **From:** [#14471: changeTracker / actionbar test-hygiene follow-ups from the Run (on change) review](https://github.com/Comfy-Org/ComfyUI_frontend/issues/14471)
- **Verified:** `pnpm test:unit src/scripts/changeTracker.test.ts`: 61 passed; `pnpm test:browser:local actionbar.spec.ts`: 4 passed; `pnpm typecheck`, `pnpm typecheck:browser`, `pnpm lint`, `pnpm knip`, and `pnpm format:check`: passed. Independent review found 0 blockers and 0 quick-win nits.

## Reviewer context

- **Type:** Test hygiene for Run (on change) regression coverage
- **Slots into:** Existing ChangeTracker unit tests and Actionbar browser tests
- **Not in scope:** Product behavior changes or legacy-menu helper behavior

Fixes #14471

## Summary

- Give prompt-request observation an explicit minimum, maximum, and timeout contract with a contextual timeout error.
- Derive the positive widget-change interaction from the actual node and widget position.
- Reset and cover the deprecated `checkState()` warn-once state without test-order coupling.
- Reset serialization mocks to an explicit baseline for every test.

## Changes

- **What:** Harden Actionbar browser fixtures and ChangeTracker unit coverage.

## Review Focus

- Request collection around action-time and delayed prompt requests.
- Absolute client coordinates for the top-menu widget interaction.
- Test-only reset scope for the process-wide deprecation warning.

## Acceptance criteria

- [x] A timed-out prompt wait names the timeout instead of failing later with a length mismatch.
- [x] The positive auto-queue E2E no longer depends on legacy-menu coordinate constants.
- [x] A queued serialization mock return value cannot leak between tests.
- [x] `checkState()` warn-once behavior is covered independently of test order.

## Test plan

- [x] `pnpm test:unit src/scripts/changeTracker.test.ts`
- [x] `pnpm test:browser:local actionbar.spec.ts`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:browser`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm format:check`