### PR TITLE
refactor(missing-model): centralize metadata state

### DIFF
--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -90,7 +90,6 @@ import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.
 import Button from '@/components/ui/button/Button.vue'
 import { useMissingModelDownload } from '@/platform/missingModel/composables/useMissingModelDownload'
 import { getDownloadableModels } from '@/platform/missingModel/missingModelViewUtils'
-import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { formatSize } from '@/utils/formatUtil'
 
 interface MissingModelRowEntry {
@@ -120,8 +119,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const gatedHintId = useId()
-const missingModelStore = useMissingModelStore()
-const { downloadMissingModel } = useMissingModelDownload()
+const { downloadMissingModel, fileSizeFor, gatedRepoUrlFor } =
+  useMissingModelDownload()
 
 const sortedModelRows = computed(() =>
   missingModelGroups
@@ -151,15 +150,13 @@ const downloadableModels = computed(() => {
 })
 
 const showGatedModelsHint = computed(() =>
-  downloadableModels.value.some(
-    (model) => !!missingModelStore.gatedRepoUrls[model.url]
-  )
+  downloadableModels.value.some((model) => !!gatedRepoUrlFor(model.url))
 )
 
 const downloadAllLabel = computed(() => {
   const base = t('rightSidePanel.missingModels.downloadAll')
   const total = downloadableModels.value.reduce(
-    (sum, model) => sum + (missingModelStore.fileSizes[model.url] ?? 0),
+    (sum, model) => sum + (fileSizeFor(model.url) ?? 0),
     0
   )
   return total > 0 ? `${base} (${formatSize(total)})` : base

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -320,8 +320,13 @@ const store = useMissingModelStore()
 const { selectedLibraryModel } = storeToRefs(store)
 const cloudProgress = useTemplateRef<HTMLElement>('cloudProgress')
 const modelLabelControl = useTemplateRef<HTMLButtonElement>('modelLabelControl')
-const { prefetchModelMetadata, downloadMissingModel, openModelAccessPage } =
-  useMissingModelDownload()
+const {
+  fileSizeFor,
+  gatedRepoUrlFor,
+  prefetchModelMetadata,
+  downloadMissingModel,
+  openModelAccessPage
+} = useMissingModelDownload()
 
 const expanded = computed(
   () =>
@@ -360,7 +365,7 @@ const downloadable = computed(() => {
 const showDownloadAction = computed(() => !isCloud && downloadable.value)
 const gatedRepoUrl = computed(() => {
   const url = model.representative.url
-  return url ? store.gatedRepoUrls[url] : undefined
+  return url ? gatedRepoUrlFor(url) : undefined
 })
 const showGatedRepoAction = computed(
   () => showDownloadAction.value && !!gatedRepoUrl.value
@@ -381,7 +386,7 @@ const downloadSizeLabel = computed(() => {
   if (!showDownloadAction.value) return undefined
 
   const url = model.representative.url
-  const size = url ? store.fileSizes[url] : undefined
+  const size = url ? fileSizeFor(url) : undefined
   return size ? formatSize(size) : undefined
 })
 const modelTypeLabel = computed(

--- a/src/platform/missingModel/composables/useMissingModelDownload.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.test.ts
@@ -42,26 +42,28 @@ describe('useMissingModelDownload', () => {
     vi.restoreAllMocks()
   })
 
-  it('stores fetched file metadata', async () => {
+  it('exposes fetched file metadata to components', async () => {
     mocks.fetchModelMetadata.mockResolvedValueOnce({
       fileSize: 1024,
       gatedRepoUrl: null
     })
 
-    await useMissingModelDownload().prefetchModelMetadata(downloadUrl)
+    const { fileSizeFor, prefetchModelMetadata } = useMissingModelDownload()
+    await prefetchModelMetadata(downloadUrl)
 
-    expect(useMissingModelStore().fileSizes[downloadUrl]).toBe(1024)
+    expect(fileSizeFor(downloadUrl)).toBe(1024)
   })
 
-  it('stores fetched gated repository metadata', async () => {
+  it('exposes fetched gated repository metadata to components', async () => {
     mocks.fetchModelMetadata.mockResolvedValueOnce({
       fileSize: null,
       gatedRepoUrl: repoUrl
     })
 
-    await useMissingModelDownload().prefetchModelMetadata(downloadUrl)
+    const { gatedRepoUrlFor, prefetchModelMetadata } = useMissingModelDownload()
+    await prefetchModelMetadata(downloadUrl)
 
-    expect(useMissingModelStore().gatedRepoUrls[downloadUrl]).toBe(repoUrl)
+    expect(gatedRepoUrlFor(downloadUrl)).toBe(repoUrl)
   })
 
   it('skips metadata already classified by the store', async () => {

--- a/src/platform/missingModel/composables/useMissingModelDownload.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.ts
@@ -1,25 +1,27 @@
 import {
   downloadModel,
-  fetchModelMetadata,
   isTrustedHuggingFaceUrl,
   openGatedRepoPage
 } from '@/platform/missingModel/missingModelDownload'
 import type { ModelWithUrl } from '@/platform/missingModel/missingModelDownload'
+import { fetchAndStoreModelMetadata } from '@/platform/missingModel/missingModelMetadata'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 
 export function useMissingModelDownload() {
   const store = useMissingModelStore()
 
-  async function prefetchModelMetadata(url: string): Promise<void> {
-    if (store.fileSizes[url] !== undefined || store.gatedRepoUrls[url]) return
+  function fileSizeFor(url: string): number | undefined {
+    return store.fileSizes[url]
+  }
 
-    const metadata = await fetchModelMetadata(url)
-    if (metadata.fileSize !== null) {
-      store.setFileSize(url, metadata.fileSize)
-    }
-    if (metadata.gatedRepoUrl) {
-      store.setGatedRepoUrl(url, metadata.gatedRepoUrl)
-    }
+  function gatedRepoUrlFor(url: string): string | undefined {
+    return store.gatedRepoUrls[url]
+  }
+
+  async function prefetchModelMetadata(url: string): Promise<void> {
+    if (fileSizeFor(url) !== undefined || gatedRepoUrlFor(url)) return
+
+    await fetchAndStoreModelMetadata(url, store)
   }
 
   function downloadMissingModel(model: ModelWithUrl): void {
@@ -49,6 +51,8 @@ export function useMissingModelDownload() {
   }
 
   return {
+    fileSizeFor,
+    gatedRepoUrlFor,
     prefetchModelMetadata,
     downloadMissingModel,
     openModelAccessPage

--- a/src/platform/missingModel/missingModelMetadata.ts
+++ b/src/platform/missingModel/missingModelMetadata.ts
@@ -1,0 +1,20 @@
+import { fetchModelMetadata } from '@/platform/missingModel/missingModelDownload'
+
+interface MissingModelMetadataStore {
+  setFileSize: (url: string, size: number) => void
+  setGatedRepoUrl: (url: string, repoUrl: string) => void
+}
+
+export async function fetchAndStoreModelMetadata(
+  url: string,
+  store: MissingModelMetadataStore,
+  signal?: AbortSignal
+): Promise<void> {
+  const metadata = await fetchModelMetadata(url)
+  if (!signal?.aborted && metadata.fileSize !== null) {
+    store.setFileSize(url, metadata.fileSize)
+  }
+  if (!signal?.aborted && metadata.gatedRepoUrl) {
+    store.setGatedRepoUrl(url, metadata.gatedRepoUrl)
+  }
+}

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -204,18 +204,16 @@ export async function runMissingModelPipeline({
           cacheModelCandidates(activeWf, confirmedCandidates)
         })
 
-      const missingModelDownload =
-        import('@/platform/missingModel/missingModelDownload')
+      const missingModelMetadata =
+        import('@/platform/missingModel/missingModelMetadata')
       void Promise.allSettled(
         downloadableCandidates.map(async (c) => {
-          const { fetchModelMetadata } = await missingModelDownload
-          const metadata = await fetchModelMetadata(c.url)
-          if (!controller.signal.aborted && metadata.fileSize !== null) {
-            missingModelStore.setFileSize(c.url, metadata.fileSize)
-          }
-          if (!controller.signal.aborted && metadata.gatedRepoUrl) {
-            missingModelStore.setGatedRepoUrl(c.url, metadata.gatedRepoUrl)
-          }
+          const { fetchAndStoreModelMetadata } = await missingModelMetadata
+          await fetchAndStoreModelMetadata(
+            c.url,
+            missingModelStore,
+            controller.signal
+          )
         })
       )
     }


### PR DESCRIPTION
## ELI5

Three missing-model consumers were each reading or recording the same metadata in their own way, like keeping three copies of one address book. They now use one shared path, so future changes are less likely to make them disagree, while downloads, gated-model hints, file sizes, and all other user-facing behavior remain unchanged.

## Motivation

The missing-model row, bulk card, and verification pipeline each reached into metadata state differently. They agree today, but a future change to URL normalization or provider support would require coordinated edits across all three and could drift. This refactor was requested after the duplication was identified during review. Centralizing component reads and the fetch-to-store step removes that structural risk while retaining the existing abort, skip, and cache semantics.

## Provenance

- **Authored by:** agent-work loop
- **From:** #14364 — Gated-state reads bypass useMissingModelDownload, so three places decide whether a model is gated
- **Verified:** `pnpm install --frozen-lockfile` (already up to date); `pnpm test:unit src/platform/missingModel` (10 files, 235 passed); `pnpm test:unit src/components/rightSidePanel/errors/ErrorGroupList.test.ts src/components/rightSidePanel/errors/TabErrors.test.ts` (2 files, 20 passed); `pnpm typecheck` (passed); `pnpm lint` (passed with 6 existing warnings outside the changed files); `pnpm knip` (passed); `pnpm format:check` (passed); `git diff origin/main...HEAD --check` (passed)
- **Deviations:** None.

## Reviewer context

- **Type:** hygiene, centralizing missing-model metadata reads and persistence without behavior changes
- **Slots into:** #14364 — Gated-state reads bypass useMissingModelDownload, so three places decide whether a model is gated
- **Not in scope:** accessibility, wording, or other user-facing changes

## Summary

- Routes file-size and gated-repository lookups through the missing-model download composable.
- Shares one fetch-to-store implementation between component prefetch and pipeline verification.
- Preserves verification abort checks, known-URL prefetch skips, pipeline fetch behavior, and the metadata cache.

## Changes

- **What:** Centralized missing-model metadata reads and writes behind focused module boundaries.

## Review Focus

Please verify that the optional abort signal still gates only store writes, while component prefetch retains its known-URL skip and pipeline verification still performs metadata fetches.

Fixes #14364

## Test plan

- [ ] Confirm missing-model row file sizes and gated actions still update from stored metadata.
- [ ] Confirm bulk gated guidance uses the same stored repository URL lookup.
- [ ] Confirm aborted pipeline verification does not write late metadata.

## Screenshots (if applicable)

Not applicable, no user-facing visual changes.
