### PR TITLE
fix: use payment recovery as the billing banner gate

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/BillingStatusBanner.test.ts
@@ -182,11 +182,11 @@ describe('BillingStatusBanner', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
-  it('renders nothing when billing control is rolled back, even out of credits', () => {
+  it('does not gate out-of-credits on billing control', () => {
     state.billingControlEnabled = false
     state.subscription = { hasFunds: false, isCancelled: false, endDate: null }
     renderBanner()
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Out of credits')
   })
 
   it('shows out-of-credits with an Add credits action for owners', async () => {
@@ -289,7 +289,7 @@ describe('BillingStatusBanner', () => {
     expect(state.manageSubscription).not.toHaveBeenCalled()
   })
 
-  it('hides payment recovery states while preserving existing notices when the new flag is off', () => {
+  it('hides all billing banners when payment recovery is off', () => {
     state.v1PaymentRecovery = false
     paymentFailedState()
     const { unmount } = renderBanner()
@@ -300,7 +300,7 @@ describe('BillingStatusBanner', () => {
     state.billingStatus = 'paid'
     exhausted()
     renderBanner()
-    expect(screen.getByRole('status')).toHaveTextContent('Out of credits')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
   it('lets a promoted owner reactivate an ending plan', async () => {

--- a/src/platform/workspace/composables/deriveBillingBanner.test.ts
+++ b/src/platform/workspace/composables/deriveBillingBanner.test.ts
@@ -4,7 +4,6 @@ import type { BillingBannerInputs } from './useBillingBanner'
 import { deriveBillingBanner } from './useBillingBanner'
 
 const funded: BillingBannerInputs = {
-  billingControlEnabled: true,
   v1PaymentRecovery: true,
   isTeamPlan: true,
   isLoaded: true,
@@ -44,25 +43,17 @@ describe('deriveBillingBanner', () => {
     expect(derive({ isTeamPlan: false, hasFunds: false })).toBeNull()
   })
 
-  it('hides existing notices when billing control is rolled back', () => {
-    expect(derive({ billingControlEnabled: false, hasFunds: false })).toBeNull()
-  })
-
-  it('keeps payment recovery independent from billing control', () => {
-    expect(derive({ ...paymentFailed, billingControlEnabled: false })).toBe(
-      'paymentFailed'
-    )
-  })
-
-  it('hides payment recovery states when their flag is off', () => {
+  it('hides every billing banner when payment recovery is off', () => {
     expect(derive({ ...paymentFailed, v1PaymentRecovery: false })).toBeNull()
     expect(derive({ ...paused, v1PaymentRecovery: false })).toBeNull()
-  })
-
-  it('does not move existing notices onto the payment recovery flag', () => {
-    expect(derive({ hasFunds: false, v1PaymentRecovery: false })).toBe(
-      'outOfCredits'
-    )
+    expect(derive({ hasFunds: false, v1PaymentRecovery: false })).toBeNull()
+    expect(
+      derive({
+        isCancelled: true,
+        endDate: '2026-08-01T00:00:00Z',
+        v1PaymentRecovery: false
+      })
+    ).toBeNull()
   })
 
   it('shows no banner until the subscription snapshot has loaded', () => {

--- a/src/platform/workspace/composables/useBillingBanner.test.ts
+++ b/src/platform/workspace/composables/useBillingBanner.test.ts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => ({
     fetchStatus: ReturnType<typeof vi.fn>
     fetchBalance: ReturnType<typeof vi.fn>
   } | null,
-  billingControlEnabled: null as { value: boolean } | null,
   v1PaymentRecovery: null as { value: boolean } | null
 }))
 
@@ -18,16 +17,11 @@ vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 
 vi.mock('@/composables/useFeatureFlags', async () => {
   const { ref } = await import('vue')
-  const billingControlEnabled = ref(true)
   const v1PaymentRecovery = ref(true)
-  mocks.billingControlEnabled = billingControlEnabled
   mocks.v1PaymentRecovery = v1PaymentRecovery
   return {
     useFeatureFlags: () => ({
       flags: {
-        get billingControlEnabled() {
-          return billingControlEnabled.value
-        },
         get v1PaymentRecovery() {
           return v1PaymentRecovery.value
         }
@@ -72,13 +66,12 @@ describe('useBillingBanner', () => {
     b.isTeamPlan.value = true
     b.billingStatus.value = 'paid'
     b.subscription.value = { hasFunds: true }
-    mocks.billingControlEnabled!.value = true
     mocks.v1PaymentRecovery!.value = true
     b.fetchStatus.mockClear()
     b.fetchBalance.mockClear()
   })
 
-  it('suppresses the banner entirely when billing control is rolled back', async () => {
+  it('suppresses the banner entirely when payment recovery is rolled back', async () => {
     const b = mocks.billing!
     const { kind } = useBillingBanner()
 
@@ -86,7 +79,7 @@ describe('useBillingBanner', () => {
     await nextTick()
     expect(kind.value).toBe('outOfCredits')
 
-    mocks.billingControlEnabled!.value = false
+    mocks.v1PaymentRecovery!.value = false
     await nextTick()
     expect(kind.value).toBeNull()
   })

--- a/src/platform/workspace/composables/useBillingBanner.ts
+++ b/src/platform/workspace/composables/useBillingBanner.ts
@@ -14,7 +14,6 @@ export type BillingBannerKind =
   | 'ending'
 
 export interface BillingBannerInputs {
-  billingControlEnabled: boolean
   v1PaymentRecovery: boolean
   isTeamPlan: boolean
   isLoaded: boolean
@@ -27,25 +26,19 @@ export interface BillingBannerInputs {
   outOfCreditsDismissed: boolean
 }
 
-// The single billing banner slot, in priority order: paused > paymentFailed >
-// outOfCredits > ending. Payment recovery and the existing billing-control
-// notices have independent rollout gates.
 export function deriveBillingBanner(
   inputs: BillingBannerInputs
 ): BillingBannerKind | null {
-  if (!inputs.isTeamPlan || !inputs.isLoaded) {
+  if (!inputs.v1PaymentRecovery || !inputs.isTeamPlan || !inputs.isLoaded) {
     return null
   }
 
-  if (inputs.v1PaymentRecovery) {
-    if (inputs.billingStatus === 'paused') return 'paused'
-    if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
-      return 'paymentFailed'
-    }
+  if (inputs.billingStatus === 'paused') return 'paused'
+  if (inputs.billingStatus === 'payment_failed' && inputs.canManage) {
+    return 'paymentFailed'
   }
 
   if (!inputs.isActiveSubscription) return null
-  if (!inputs.billingControlEnabled) return null
 
   if (inputs.hasFunds === false && !inputs.outOfCreditsDismissed) {
     return 'outOfCredits'
@@ -74,7 +67,6 @@ function useBillingBannerInternal() {
   const kind = computed<BillingBannerKind | null>(() => {
     if (!isCloud) return null
     return deriveBillingBanner({
-      billingControlEnabled: flags.billingControlEnabled,
       v1PaymentRecovery: flags.v1PaymentRecovery,
       isTeamPlan: isTeamPlan.value,
       isLoaded: subscription.value !== null,


### PR DESCRIPTION
## Summary

Use `v1_payment_recovery` as the only feature gate for the billing banner slot and stop reading `billing_control_enabled` in banner selection. This supersedes the closed #14909.

## Root cause

The banner selector currently has two rollout gates: `v1_payment_recovery` controls `paused` and `payment_failed`, while `billing_control_enabled` controls `outOfCredits` and `ending`. That lets the frontend compose a mixed banner rollout state even though the banner surface should be deterministic from the payment-recovery rollout alone.

## Changes

- **What**: Return no billing banner when `v1_payment_recovery` is disabled, covering `paused`, `paymentFailed`, `outOfCredits`, and `ending`.
- Remove `billingControlEnabled` from `BillingBannerInputs` and from the banner composable.
- Update behavioral tests to cover every banner kind with payment recovery disabled.

## Review Focus

Confirm that `billing_control_enabled` no longer participates in banner visibility while its unrelated workspace controls remain unchanged.

## Screenshots

These real cloud app screenshots show the intended payment-recovery flag boundary for the banner slot.

### AS IS: `v1_payment_recovery=false`

No billing recovery banner is rendered.

![Payment recovery off](https://ampcode.com/user-content/artifacts/6ea7b69079c0475894797f2eb0db358a3606b9f9ce43783ff53e64e8b5d42b6c-file.png)

### TO BE: `v1_payment_recovery=true`

The billing recovery banner is rendered with its recovery action.

![Payment recovery on](https://ampcode.com/user-content/artifacts/8cabcec244fb47d796fc8d8024b78782151e7300d3788ee1bfdae3326c905639-file.png)

## Verification

- `pnpm test:unit src/platform/workspace/composables/deriveBillingBanner.test.ts src/platform/workspace/composables/useBillingBanner.test.ts` (20 tests)
- `pnpm typecheck`
- Targeted ESLint, type-aware Oxlint, and format check
- Pre-push `pnpm knip`
