### PR TITLE
fix(cicd): don't cut a second patch when a bump is already pending

### DIFF
--- a/scripts/cicd/check-stranded-release-commits.test.ts
+++ b/scripts/cicd/check-stranded-release-commits.test.ts
@@ -6,6 +6,7 @@ import {
   minorLineOf,
   evaluatePin,
   hasPendingBump,
+  shouldRequestDispatch,
   newestStableVersion,
   parsePinnedVersion,
   releaseBranchFor
@@ -210,6 +211,35 @@ describe('hasPendingBump', () => {
   it('tolerates a tag without the v prefix', () => {
     expect(
       hasPendingBump({ branchVersion: '1.48.7', latestTag: '1.48.7' })
+    ).toBe(false)
+  })
+})
+
+describe('shouldRequestDispatch', () => {
+  it('requests a dispatch when the branch matches its tag', () => {
+    expect(
+      shouldRequestDispatch({ latestTag: 'v1.48.7', branchVersion: '1.48.7' })
+    ).toBe(true)
+  })
+
+  it('declines when a bump already landed unreleased', () => {
+    expect(
+      shouldRequestDispatch({ latestTag: 'v1.48.7', branchVersion: '1.48.8' })
+    ).toBe(false)
+  })
+
+  it('fails closed when either value is unavailable', () => {
+    // Unreadable package.json or a tagless branch means we cannot prove a bump
+    // is not already pending. Dispatching on an unproven assumption is what
+    // burned 1.48.8 and 1.48.9.
+    expect(
+      shouldRequestDispatch({ latestTag: 'v1.48.7', branchVersion: null })
+    ).toBe(false)
+    expect(
+      shouldRequestDispatch({ latestTag: null, branchVersion: '1.48.7' })
+    ).toBe(false)
+    expect(
+      shouldRequestDispatch({ latestTag: null, branchVersion: null })
     ).toBe(false)
   })
 })

--- a/scripts/cicd/check-stranded-release-commits.test.ts
+++ b/scripts/cicd/check-stranded-release-commits.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateLine,
   minorLineOf,
   evaluatePin,
+  hasPendingBump,
   newestStableVersion,
   parsePinnedVersion,
   releaseBranchFor
@@ -188,5 +189,27 @@ describe('evaluatePin', () => {
     expect(
       evaluatePin({ pinned: '1.47.11', newestOnPinnedLine: '1.47.11' })
     ).toBeNull()
+  })
+})
+
+describe('hasPendingBump', () => {
+  it('detects a bump that landed but was never tagged', () => {
+    // core/1.48 on 2026-08-10: #14973 merged the 1.48.8 bump, but draft_release
+    // 403'd so v1.48.8 never existed. Dispatching again just burns 1.48.9.
+    expect(
+      hasPendingBump({ branchVersion: '1.48.8', latestTag: 'v1.48.7' })
+    ).toBe(true)
+  })
+
+  it('is false when the branch matches its latest tag', () => {
+    expect(
+      hasPendingBump({ branchVersion: '1.48.7', latestTag: 'v1.48.7' })
+    ).toBe(false)
+  })
+
+  it('tolerates a tag without the v prefix', () => {
+    expect(
+      hasPendingBump({ branchVersion: '1.48.7', latestTag: '1.48.7' })
+    ).toBe(false)
   })
 })

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -137,6 +137,24 @@ export function evaluatePin({
   }
 }
 
+/**
+ * Whether a version bump already landed on the branch without being tagged.
+ *
+ * The release is then already in flight and needs recovering, not restarting:
+ * dispatching again resolves the *next* patch and burns a version per run. On
+ * 2026-08-10 core/1.48 sat at 1.48.8 with v1.48.7 as its newest tag, because
+ * draft_release 403'd, and the check cut a pointless 1.48.9.
+ */
+export function hasPendingBump({
+  branchVersion,
+  latestTag
+}: {
+  branchVersion: string
+  latestTag: string
+}): boolean {
+  return branchVersion !== latestTag.replace(/^v/, '')
+}
+
 function git(...args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf-8' }).trim()
 }
@@ -169,6 +187,21 @@ export function newestStableVersion(versions: string[]): string | null {
 function latestTagOn(branch: string): string | null {
   try {
     return git('describe', '--tags', '--abbrev=0', `origin/${branch}`)
+  } catch {
+    return null
+  }
+}
+
+function branchPackageVersion(branch: string): string | null {
+  try {
+    const pkg: unknown = JSON.parse(
+      git('show', `origin/${branch}:package.json`)
+    )
+    if (typeof pkg === 'object' && pkg !== null && 'version' in pkg) {
+      const { version } = pkg as { version: unknown }
+      return typeof version === 'string' ? version : null
+    }
+    return null
   } catch {
     return null
   }
@@ -261,10 +294,24 @@ async function main(): Promise<void> {
     (f) => f.kind === 'stranded-commits' && f.severity === 'failure'
   )
   if (process.env.GITHUB_OUTPUT && strandedPinnedLine) {
-    appendFileSync(
-      process.env.GITHUB_OUTPUT,
-      `needs_patch_branch=${strandedPinnedLine.branch}\n`
-    )
+    const { branch } = strandedPinnedLine
+    const tag = latestTagOn(branch)
+    const branchVersion = branchPackageVersion(branch)
+    const pending =
+      tag && branchVersion && hasPendingBump({ branchVersion, latestTag: tag })
+
+    if (pending) {
+      console.error(
+        `${branch} is at ${branchVersion} but its newest tag is ${tag}: a bump ` +
+          `already landed and was never released. Recover that release rather ` +
+          `than cutting another patch; not requesting a dispatch.`
+      )
+    } else {
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `needs_patch_branch=${branch}\n`
+      )
+    }
   }
 
   if (allFindings.some((f) => f.severity === 'failure')) {

--- a/scripts/cicd/check-stranded-release-commits.ts
+++ b/scripts/cicd/check-stranded-release-commits.ts
@@ -155,6 +155,22 @@ export function hasPendingBump({
   return branchVersion !== latestTag.replace(/^v/, '')
 }
 
+/**
+ * Whether to ask CI to cut a patch. Fails closed: if either the tag or the
+ * branch version is unreadable we cannot prove a bump is not already pending,
+ * and dispatching on that unproven assumption is what burned 1.48.8 and 1.48.9.
+ */
+export function shouldRequestDispatch({
+  latestTag,
+  branchVersion
+}: {
+  latestTag: string | null
+  branchVersion: string | null
+}): boolean {
+  if (!latestTag || !branchVersion) return false
+  return !hasPendingBump({ branchVersion, latestTag })
+}
+
 function git(...args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf-8' }).trim()
 }
@@ -295,21 +311,25 @@ async function main(): Promise<void> {
   )
   if (process.env.GITHUB_OUTPUT && strandedPinnedLine) {
     const { branch } = strandedPinnedLine
-    const tag = latestTagOn(branch)
+    const latestTag = latestTagOn(branch)
     const branchVersion = branchPackageVersion(branch)
-    const pending =
-      tag && branchVersion && hasPendingBump({ branchVersion, latestTag: tag })
 
-    if (pending) {
-      console.error(
-        `${branch} is at ${branchVersion} but its newest tag is ${tag}: a bump ` +
-          `already landed and was never released. Recover that release rather ` +
-          `than cutting another patch; not requesting a dispatch.`
-      )
-    } else {
+    if (shouldRequestDispatch({ latestTag, branchVersion })) {
       appendFileSync(
         process.env.GITHUB_OUTPUT,
         `needs_patch_branch=${branch}\n`
+      )
+    } else if (!latestTag || !branchVersion) {
+      console.error(
+        `Could not read ${!latestTag ? 'the newest tag' : 'package.json'} for ` +
+          `${branch}; cannot prove a bump is not already pending, so not ` +
+          `requesting a dispatch.`
+      )
+    } else {
+      console.error(
+        `${branch} is at ${branchVersion} but its newest tag is ${latestTag}: a ` +
+          `bump already landed and was never released. Recover that release ` +
+          `rather than cutting another patch; not requesting a dispatch.`
       )
     }
   }


### PR DESCRIPTION
Bug in the stranded-commits check from #14429, which is live and currently misfiring once a day.

## What happens

The idempotency guard asked "is a Release bump PR open against this branch?". Once that PR merges but the tag is never cut, the answer is no, so the next scheduled run dispatches another patch release.

Observed on `core/1.48`:

```
2026-08-09 16:10  check finds e136c130aa stranded, dispatches a patch
2026-08-09 16:13  #14973 "1.48.8" opened
2026-08-10 04:58  #14973 merged; draft_release fails 403, v1.48.8 never created
2026-08-10 16:20  check runs again, sees no open bump PR, dispatches
2026-08-10 16:21  #14991 "1.48.9" opened
```

`core/1.48` now has `package.json` at 1.48.8 with `v1.48.7` as its newest tag. Left alone this burns one version per day for as long as the underlying failure persists.

## Fix

Compare the branch's `package.json` against its newest tag. When they differ, a bump has already landed unreleased, so the release needs recovering rather than restarting, and no dispatch is requested. Stranded commits are still reported and the job still fails, so nothing goes quiet.

Verified against the live state that caused the loop:

```
[FAIL] 1 fix commit(s) sit past v1.48.7 on core/1.48 and have not shipped:
    e136c130aa [backport core/1.48] fix(billing): stop reporting "processing" ...
core/1.48 is at 1.48.8 but its newest tag is v1.48.7: a bump already landed and
was never released. Recover that release rather than cutting another patch; not
requesting a dispatch.
```

`needs_patch_branch` is not emitted, so the dispatch step is skipped.

## Separate, and the actual blocker

`draft_release` fails with `403 Resource not accessible by integration` when creating the GitHub release. No core release can be tagged until that is resolved, and this PR does not address it.

#14991 should probably be closed so the version stops advancing, leaving `core/1.48` at 1.48.8 ready to tag.