### PR TITLE
fix: route subscription deep links through billing facade

### DIFF
--- a/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
+++ b/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from '@playwright/test'
+import type { PreviewSubscribeResponse } from '@comfyorg/ingest-types'
+
+import type { BillingPlansResponse } from '@/platform/workspace/api/workspaceApi'
+
+import { cloudAppFixture as test } from '@e2e/fixtures/cloudAppFixture'
+import {
+  DEFAULT_TEAM_MEMBERS,
+  LEGACY_PERSONAL_BILLING_STATUS
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import { workspace } from '@e2e/fixtures/utils/workspaceMocks'
+
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const CREATOR_MONTHLY_PLANS = {
+  plans: [
+    {
+      slug: 'creator-monthly',
+      tier: 'CREATOR',
+      duration: 'MONTHLY',
+      price_cents: 2000,
+      credits_cents: 2400,
+      max_seats: 1,
+      availability: { available: true },
+      seat_summary: {
+        seat_count: 1,
+        total_cost_cents: 2000,
+        total_credits_cents: 2400
+      }
+    }
+  ]
+} satisfies BillingPlansResponse
+
+const CREATOR_MONTHLY_PREVIEW = {
+  allowed: true,
+  transition_type: 'new_subscription',
+  is_immediate: true,
+  effective_at: '2026-08-24T00:00:00Z',
+  cost_today_cents: 2000,
+  cost_next_period_cents: 2000,
+  credits_today_cents: 2400,
+  credits_next_period_cents: 2400,
+  new_plan: {
+    slug: 'creator-monthly',
+    tier: 'CREATOR',
+    duration: 'MONTHLY',
+    price_cents: 2000,
+    credits_cents: 2400,
+    seat_summary: {
+      seat_count: 1,
+      total_cost_cents: 2000,
+      total_credits_cents: 2400
+    }
+  }
+} satisfies PreviewSubscribeResponse
+
+test.describe('Cloud subscribe deep link', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('dismisses the splash loader and opens the unified personal checkout', async ({
+    page
+  }) => {
+    const helper = new CloudWorkspaceMockHelper(page)
+    await helper.setup(DEFAULT_TEAM_MEMBERS, workspace('personal', 'owner'), {
+      ...LEGACY_PERSONAL_BILLING_STATUS,
+      billing_rail: 'stripe'
+    })
+    await page.route('**/api/billing/plans', (r) =>
+      r.fulfill(jsonRoute(CREATOR_MONTHLY_PLANS))
+    )
+    await page.route('**/api/billing/preview-subscribe', (r) =>
+      r.fulfill(jsonRoute(CREATOR_MONTHLY_PREVIEW))
+    )
+
+    const legacyCheckoutRequests: string[] = []
+    page.on('request', (request) => {
+      if (request.url().includes('/customers/')) {
+        legacyCheckoutRequests.push(request.url())
+      }
+    })
+
+    await page.goto(`${APP_URL}/cloud/subscribe?tier=creator&cycle=monthly`)
+
+    await expect(
+      page.getByRole('heading', { name: 'Confirm your payment' })
+    ).toBeVisible({ timeout: 45_000 })
+    await expect(page.locator('#splash-loader')).toHaveCount(0)
+    expect(legacyCheckoutRequests).toEqual([])
+  })
+})

--- a/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
+++ b/browser_tests/tests/cloudSubscribeDeepLink.spec.ts
@@ -74,6 +74,20 @@ test.describe('Cloud subscribe deep link', { tag: '@cloud' }, () => {
       r.fulfill(jsonRoute(CREATOR_MONTHLY_PREVIEW))
     )
 
+    // The OSS server that hosts the built frontend in CI has no SPA fallback
+    // for /cloud/subscribe (Chromium treats its response as a download), so
+    // serve the app shell for the deep-link document request directly. The
+    // base tag keeps the shell's relative asset paths resolving from the root.
+    const appShell = await page.request
+      .get(APP_URL)
+      .then((response) => response.text())
+      .then((html) => html.replace('<head>', '<head><base href="/">'))
+    await page.route('**/cloud/subscribe*', (route) =>
+      route.request().resourceType() === 'document'
+        ? route.fulfill({ contentType: 'text/html', body: appShell })
+        : route.fallback()
+    )
+
     const legacyCheckoutRequests: string[] = []
     page.on('request', (request) => {
       if (request.url().includes('/customers/')) {

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -231,6 +231,38 @@ describe('CloudSubscriptionRedirectView', () => {
     ).not.toHaveBeenCalled()
   })
 
+  test('opens the generic team pricing table when plan loading fails', async () => {
+    subscriptionMocks.teamCreditStops.value = null
+    subscriptionMocks.fetchPlans.mockRejectedValue(new Error('plans down'))
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team',
+      initialCheckout: undefined
+    })
+    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(
+      legacyCheckoutMocks.performTeamSubscriptionCheckout
+    ).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('removes the pre-Vue splash loader on mount', async () => {
+    const splashLoader = document.createElement('div')
+    splashLoader.id = 'splash-loader'
+    document.body.append(splashLoader)
+
+    await mountView({ tier: 'creator' })
+
+    expect(splashLoader).not.toBeInTheDocument()
+  })
+
   test('redirects to home for a team link with no stop', async () => {
     await mountView({ tier: 'team', cycle: 'yearly' })
 

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import type { TeamCreditStops } from '@/platform/workspace/api/workspaceApi'
+
 import CloudSubscriptionRedirectView from './CloudSubscriptionRedirectView.vue'
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -41,32 +43,52 @@ vi.mock('@/composables/useErrorHandling', () => ({
 const subscriptionMocks = vi.hoisted(() => ({
   canAccessSubscriptionFeatures: { value: false },
   isInitialized: { value: true },
-  subscriptionStatus: { value: null }
-}))
-
-vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
-  useSubscription: () => subscriptionMocks
+  teamCreditStops: { value: null as TeamCreditStops | null },
+  initialize: vi.fn(),
+  fetchPlans: vi.fn(),
+  manageSubscription: vi.fn()
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => subscriptionMocks
 }))
 
-// Avoid real network / isCloud behavior
-const mockPerformSubscriptionCheckout = vi.fn()
-vi.mock('@/platform/cloud/subscription/utils/subscriptionCheckoutUtil', () => ({
-  performSubscriptionCheckout: (...args: unknown[]) =>
-    mockPerformSubscriptionCheckout(...args)
+const mockShowPricingTable = vi.hoisted(() => vi.fn())
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({ showPricingTable: mockShowPricingTable })
+  })
+)
+
+const legacyCheckoutMocks = vi.hoisted(() => ({
+  performSubscriptionCheckout: vi.fn(),
+  performTeamSubscriptionCheckout: vi.fn()
 }))
 
-const mockPerformTeamSubscriptionCheckout = vi.fn()
+vi.mock('@/platform/cloud/subscription/utils/subscriptionCheckoutUtil', () => ({
+  performSubscriptionCheckout: legacyCheckoutMocks.performSubscriptionCheckout
+}))
+
 vi.mock(
   '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil',
   () => ({
-    performTeamSubscriptionCheckout: (...args: unknown[]) =>
-      mockPerformTeamSubscriptionCheckout(...args)
+    performTeamSubscriptionCheckout:
+      legacyCheckoutMocks.performTeamSubscriptionCheckout
   })
 )
+
+const TEAM_CREDIT_STOPS = {
+  default_stop_index: 0,
+  stops: [
+    {
+      id: 'team_700',
+      credits: 147700,
+      monthly: { list_price_cents: 70000, price_cents: 69000 },
+      yearly: { list_price_cents: 70000, price_cents: 63000 }
+    }
+  ]
+} satisfies TeamCreditStops
 
 const createI18nInstance = () =>
   createI18n({
@@ -86,7 +108,8 @@ const createI18nInstance = () =>
           tiers: {
             standard: { name: 'Standard' },
             creator: { name: 'Creator' },
-            pro: { name: 'Pro' }
+            pro: { name: 'Pro' },
+            founder: { name: 'Founder' }
           }
         }
       }
@@ -113,6 +136,10 @@ describe('CloudSubscriptionRedirectView', () => {
     mockQuery = {}
     subscriptionMocks.canAccessSubscriptionFeatures.value = false
     subscriptionMocks.isInitialized.value = true
+    subscriptionMocks.teamCreditStops.value = TEAM_CREDIT_STOPS
+    subscriptionMocks.initialize.mockResolvedValue(undefined)
+    subscriptionMocks.fetchPlans.mockResolvedValue(undefined)
+    subscriptionMocks.manageSubscription.mockResolvedValue(undefined)
   })
 
   test('redirects to home when subscriptionType is missing', async () => {
@@ -136,15 +163,18 @@ describe('CloudSubscriptionRedirectView', () => {
     // Shows copy under logo
     expect(screen.getByText('Subscribe to Creator')).toBeInTheDocument()
 
-    // Triggers checkout flow
-    expect(mockPerformSubscriptionCheckout).toHaveBeenCalledWith(
-      'creator',
-      'monthly',
-      {
-        openInNewTab: false,
-        paymentIntentSource: 'deep_link'
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'personal',
+      initialCheckout: {
+        planMode: 'personal',
+        tierKey: 'creator',
+        billingCycle: 'monthly'
       }
-    )
+    })
+    expect(
+      legacyCheckoutMocks.performSubscriptionCheckout
+    ).not.toHaveBeenCalled()
 
     // Shows loading affordances
     expect(
@@ -158,8 +188,9 @@ describe('CloudSubscriptionRedirectView', () => {
     await mountView({ tier: 'creator' })
 
     expect(mockRouterPush).not.toHaveBeenCalledWith('/')
-    expect(authActionMocks.accessBillingPortal).toHaveBeenCalledTimes(1)
-    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+    expect(subscriptionMocks.manageSubscription).toHaveBeenCalledTimes(1)
+    expect(authActionMocks.accessBillingPortal).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
   })
 
   test('uses first value when subscriptionType is an array', async () => {
@@ -169,13 +200,10 @@ describe('CloudSubscriptionRedirectView', () => {
 
     expect(mockRouterPush).not.toHaveBeenCalledWith('/')
     expect(screen.getByText('Subscribe to Creator')).toBeInTheDocument()
-    expect(mockPerformSubscriptionCheckout).toHaveBeenCalledWith(
-      'creator',
-      'monthly',
-      {
-        openInNewTab: false,
-        paymentIntentSource: 'deep_link'
-      }
+    expect(mockShowPricingTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialCheckout: expect.objectContaining({ tierKey: 'creator' })
+      })
     )
   })
 
@@ -184,19 +212,64 @@ describe('CloudSubscriptionRedirectView', () => {
 
     expect(mockRouterPush).not.toHaveBeenCalledWith('/')
     expect(screen.getByText('Subscribe to Team Plan')).toBeInTheDocument()
-    expect(mockPerformTeamSubscriptionCheckout).toHaveBeenCalledWith(
-      'team_700',
-      'yearly',
-      { paymentIntentSource: 'deep_link' }
-    )
-    // Team never goes through the personal checkout path
-    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team',
+      initialCheckout: {
+        planMode: 'team',
+        stop: {
+          id: 'team_700',
+          credits: 147700,
+          usd: 700,
+          discountedUsd: 630
+        },
+        billingCycle: 'yearly'
+      }
+    })
+    expect(
+      legacyCheckoutMocks.performTeamSubscriptionCheckout
+    ).not.toHaveBeenCalled()
   })
 
   test('redirects to home for a team link with no stop', async () => {
     await mountView({ tier: 'team', cycle: 'yearly' })
 
     expect(mockRouterPush).toHaveBeenCalledWith('/')
-    expect(mockPerformTeamSubscriptionCheckout).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+  })
+
+  test('routes a personal tier in an active Team workspace to workspace subscription management', async () => {
+    subscriptionMocks.canAccessSubscriptionFeatures.value = true
+
+    await mountView({ tier: 'creator', cycle: 'yearly' })
+
+    expect(subscriptionMocks.manageSubscription).toHaveBeenCalledTimes(1)
+    expect(authActionMocks.accessBillingPortal).not.toHaveBeenCalled()
+    expect(
+      legacyCheckoutMocks.performSubscriptionCheckout
+    ).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+  })
+
+  test('routes an active founder subscription to facade management', async () => {
+    subscriptionMocks.canAccessSubscriptionFeatures.value = true
+
+    await mountView({ tier: 'founder' })
+
+    expect(subscriptionMocks.manageSubscription).toHaveBeenCalledTimes(1)
+    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+  })
+
+  test('opens personal pricing without unsupported direct checkout for an inactive founder link', async () => {
+    await mountView({ tier: 'founder' })
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'personal'
+    })
+    expect(
+      legacyCheckoutMocks.performSubscriptionCheckout
+    ).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -233,13 +233,12 @@ describe('CloudSubscriptionRedirectView', () => {
 
   test('opens the generic team pricing table when plan loading fails', async () => {
     subscriptionMocks.teamCreditStops.value = null
-    subscriptionMocks.fetchPlans.mockRejectedValue(new Error('plans down'))
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+    const plansError = new Error('plans down')
+    subscriptionMocks.fetchPlans.mockRejectedValue(plansError)
 
     await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
 
+    expect(authActionMocks.reportError).toHaveBeenCalledWith(plansError)
     expect(mockShowPricingTable).toHaveBeenCalledWith({
       reason: 'deep_link',
       planMode: 'team',
@@ -249,8 +248,6 @@ describe('CloudSubscriptionRedirectView', () => {
     expect(
       legacyCheckoutMocks.performTeamSubscriptionCheckout
     ).not.toHaveBeenCalled()
-
-    consoleErrorSpy.mockRestore()
   })
 
   test('removes the pre-Vue splash loader on mount', async () => {

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -141,12 +141,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
   }
 
   if (!teamCreditStops.value) {
-    await fetchPlans().catch((error) => {
-      console.error(
-        '[CloudSubscriptionRedirectView] Failed to load Team pricing plans:',
-        error
-      )
-    })
+    await fetchPlans().catch(reportError)
   }
   const initialCheckout = getPricingCheckoutSelection(
     tierKeyParam,

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -140,7 +140,14 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     return
   }
 
-  if (!teamCreditStops.value) await fetchPlans()
+  if (!teamCreditStops.value) {
+    await fetchPlans().catch((error) => {
+      console.error(
+        '[CloudSubscriptionRedirectView] Failed to load Team pricing plans:',
+        error
+      )
+    })
+  }
   const initialCheckout = getPricingCheckoutSelection(
     tierKeyParam,
     stopId,
@@ -155,6 +162,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
 }, reportError)
 
 onMounted(() => {
+  document.getElementById('splash-loader')?.remove()
   void runRedirect()
 })
 </script>

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -9,8 +9,9 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
-import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
-import { performTeamSubscriptionCheckout } from '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import { getPricingCheckoutSelection } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
+import type { CheckoutTierKey } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import type { BillingCycle } from '../subscription/utils/subscriptionTierRank'
 
@@ -19,18 +20,31 @@ function isBillingCycle(value: string): value is BillingCycle {
 }
 
 // Only paid personal tiers can be checked out via this redirect.
-function isCheckoutTierKey(value: string): value is TierKey {
-  return ['standard', 'creator', 'pro', 'founder'].includes(value)
+function isCheckoutTierKey(value: string): value is CheckoutTierKey {
+  return ['standard', 'creator', 'pro'].includes(value)
+}
+
+function isPaidPersonalTierKey(
+  value: string
+): value is Exclude<TierKey, 'free'> {
+  return isCheckoutTierKey(value) || value === 'founder'
 }
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { reportError, accessBillingPortal } = useAuthActions()
+const { reportError } = useAuthActions()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const { showPricingTable } = useSubscriptionDialog()
 
-const { canAccessSubscriptionFeatures, isInitialized, initialize } =
-  useBillingContext()
+const {
+  canAccessSubscriptionFeatures,
+  isInitialized,
+  teamCreditStops,
+  initialize,
+  fetchPlans,
+  manageSubscription
+} = useBillingContext()
 
 const selectedTierKey = ref<TierKey | null>(null)
 
@@ -79,12 +93,10 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     ? cycleParam
     : 'monthly'
 
-  // Team is a per-credit plan picked on a slider, so it carries a `stop` (the
-  // chosen credit commitment) instead of a tier and checks out through the
-  // workspace billing endpoint rather than the personal one.
+  let stopId: string | null = null
   if (tierKeyParam === 'team') {
     const rawStop = route.query.stop
-    const stopId =
+    stopId =
       typeof rawStop === 'string'
         ? rawStop
         : Array.isArray(rawStop)
@@ -95,31 +107,51 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
       return
     }
     isTeamCheckout.value = true
-    await performTeamSubscriptionCheckout(stopId, billingCycle, {
-      paymentIntentSource: 'deep_link'
-    })
-    return
-  }
-
-  if (!isCheckoutTierKey(tierKeyParam)) {
+  } else if (!isPaidPersonalTierKey(tierKeyParam)) {
     await router.push('/')
     return
+  } else {
+    selectedTierKey.value = tierKeyParam
   }
-
-  selectedTierKey.value = tierKeyParam
 
   if (!isInitialized.value) {
     await initialize()
   }
 
   if (canAccessSubscriptionFeatures.value) {
-    await accessBillingPortal(undefined, false)
-  } else {
-    await performSubscriptionCheckout(tierKeyParam, billingCycle, {
-      openInNewTab: false,
-      paymentIntentSource: 'deep_link'
-    })
+    await manageSubscription()
+    return
   }
+
+  if (isPaidPersonalTierKey(tierKeyParam)) {
+    if (!isCheckoutTierKey(tierKeyParam)) {
+      showPricingTable({ reason: 'deep_link', planMode: 'personal' })
+      return
+    }
+    showPricingTable({
+      reason: 'deep_link',
+      planMode: 'personal',
+      initialCheckout: {
+        planMode: 'personal',
+        tierKey: tierKeyParam,
+        billingCycle
+      }
+    })
+    return
+  }
+
+  if (!teamCreditStops.value) await fetchPlans()
+  const initialCheckout = getPricingCheckoutSelection(
+    tierKeyParam,
+    stopId,
+    billingCycle,
+    teamCreditStops.value
+  )
+  showPricingTable({
+    reason: 'deep_link',
+    planMode: 'team',
+    initialCheckout
+  })
 }, reportError)
 
 onMounted(() => {

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -119,13 +119,19 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         component: () =>
           import('@/platform/cloud/onboarding/CloudAuthTimeoutView.vue'),
         props: true
-      },
+      }
+    ]
+  },
+  {
+    path: '/cloud/subscribe',
+    component: () => import('@/views/layouts/LayoutDefault.vue'),
+    meta: { requiresAuth: true },
+    children: [
       {
-        path: 'subscribe',
+        path: '',
         name: 'cloud-subscribe',
         component: () =>
-          import('@/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue'),
-        meta: { requiresAuth: true }
+          import('@/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue')
       }
     ]
   },

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -51,7 +51,7 @@ function getTeamCheckoutRequest(
   return { stop, billingCycle: cycle }
 }
 
-function getCheckoutSelection(
+export function getPricingCheckoutSelection(
   pricing: string,
   stop: unknown,
   cycle: unknown,
@@ -164,7 +164,7 @@ export function usePricingTableUrlLoader() {
       }
     }
 
-    const initialCheckout = getCheckoutSelection(
+    const initialCheckout = getPricingCheckoutSelection(
       param,
       query.stop,
       query.cycle,


### PR DESCRIPTION
## Summary

Route `/cloud/subscribe` through workspace initialization and the canonical billing facade. Personal and Team selections now enter the unified pricing checkout, while active subscriptions use facade-owned subscription management.

## Root cause

The deep-link view directly chose backend/API families instead of using server/workspace-derived facade routing:

- Personal checkout called legacy `/customers/cloud-subscription-checkout`.
- Team checkout called `workspaceApi.subscribe` directly.
- Active subscriptions called legacy `/customers/billing` directly.

This let a selected Team workspace invoke user-scoped legacy APIs from a personal-tier link and duplicated checkout ownership outside `useBillingContext` / `useSubscriptionCheckout`.

## Why this change is needed

Checkout routing must be independent from legacy account-operation routing. The active workspace and billing rail are the source of truth, while `useSubscriptionCheckout` owns plan resolution, preview/reactivation confirmation, permissions, billing operation tracking, payment actions, telemetry, and terminal outcomes.

## AS IS / TO BE

**AS IS**

```mermaid
flowchart TD
  A[cloud/subscribe deep link] --> B{Tier query}
  B -->|Personal| C[performSubscriptionCheckout]
  C --> D[Legacy customers checkout API]
  B -->|Team| E[performTeamSubscriptionCheckout]
  E --> F[Workspace subscribe API]
  A -->|Active subscription| G[accessBillingPortal]
  G --> H[Legacy customers billing API]
```

**TO BE**

```mermaid
flowchart TD
  A[cloud/subscribe deep link] --> B[WorkspaceAuthGate initializes active workspace]
  B --> C[useBillingContext]
  C -->|Active subscription| D[manageSubscription]
  C -->|Personal or Team selection| E[useSubscriptionDialog initialCheckout]
  E --> F[useSubscriptionCheckout]
  F --> G[Workspace billing subscribe and preview APIs]
  D --> H[Portal selected by active billing rail]
```

## API behavior

| Scenario | Checkout / action owner | API behavior |
|---|---|---|
| Personal selection | `useSubscriptionDialog` → `useSubscriptionCheckout` → `useBillingContext` checkout context | Workspace/new billing checkout (`/api/billing/*`) |
| Team selection | Same unified checkout path with catalog-backed credit stop | Workspace/new billing checkout (`/api/billing/*`) |
| Active subscription deep link | `useBillingContext.manageSubscription()` | Portal selected by the active workspace billing rail |
| `legacy_stripe` account operations | Billing facade active account context | Manage/top-up/cancel remain on intentional legacy `/customers/*` APIs; checkout remains workspace-backed |
| Inactive Founder deep link | Unified personal pricing table | No unsupported direct Founder checkout; user selects a current purchasable plan |

## Regression coverage and validation

- Personal selections open unified initial checkout and never call `performSubscriptionCheckout`.
- Team selections open unified initial checkout with the catalog-derived stop and never call `performTeamSubscriptionCheckout`.
- Active subscriptions, including active Founder and Team-workspace/personal-tier cases, call facade `manageSubscription`, not direct `accessBillingPortal`.
- Missing, invalid, array-valued, and Team-without-stop query behavior remains covered.
- `/cloud/subscribe` now mounts through `LayoutDefault` / `WorkspaceAuthGate` so facade routing sees the restored active workspace.
- The redirect view dismisses the pre-Vue `#splash-loader` on mount (dismissal previously owned by `CloudLayoutView`; mirrors `UserSelectView` under `LayoutDefault`), so the unified checkout is never covered by the splash.
- Team plan-load failures fall back to the generic Team pricing table instead of aborting the redirect, matching `usePricingTableUrlLoader` recovery.
- E2E `@cloud` spec `browser_tests/tests/cloudSubscribeDeepLink.spec.ts` boots the route-mocked real app at `/cloud/subscribe?tier=creator&cycle=monthly` and asserts the unified `creator-monthly` confirmation renders with the splash detached and zero legacy `/customers/*` requests. The spec fails at 6930046 (pre-fix, splash regression) and passes at head.

Validation:

- `pnpm test:unit src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts` — 51 passed
- `pnpm test:unit src/platform/cloud/ src/platform/workspace/` — 1631 passed
- `playwright test browser_tests/tests/cloudSubscribeDeepLink.spec.ts --project=cloud` — passed against the cloud dev server
- `pnpm typecheck` — passed
- targeted `oxfmt`, ESLint, Stylelint, Oxlint, and pre-push `knip` — passed
- independent committed-diff review — no blockers

Residual intentional legacy callers remain in legacy pricing and `legacy_stripe` resubscribe/pending-checkout recovery. They are outside this redirect migration and are retained intentionally.

## Screenshots

No intentional visual change. The redirect loading surface and unified checkout UI are existing components, so screenshots are not applicable.
