### PR TITLE
refactor: extract entity ID allocation into idAllocation module

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -18,6 +18,16 @@ import {
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
+import {
+  createLGraphState,
+  mintGroupId,
+  mintNodeId,
+  mintRerouteId,
+  observeGroupId,
+  observeNodeId,
+  observeRerouteId
+} from './idAllocation'
+import type { LGraphState } from './idAllocation'
 import { useLinkStore } from '@/stores/linkStore'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
@@ -44,7 +54,6 @@ import type { DragAndScaleState } from './DragAndScale'
 import { LGraphCanvas } from './LGraphCanvas'
 import { Rectangle } from './infrastructure/Rectangle'
 import { LGraphGroup } from './LGraphGroup'
-import { toGroupId } from '@/types/groupId'
 import {
   LGraphNode,
   registerNodeState,
@@ -144,20 +153,9 @@ function isLGraphTriggerAction(action: string): action is LGraphTriggerAction {
   return validTriggerActions.has(action as LGraphTriggerAction)
 }
 
-function nextNodeId(state: LGraphState): NodeId {
-  return toNodeId(++state.lastNodeId)
-}
-
 function numericNodeId(id: NodeId): number | null {
   const numericId = Number(id)
   return Number.isInteger(numericId) ? numericId : null
-}
-
-function syncLastNodeId(state: LGraphState, id: NodeId): void {
-  const numericId = numericNodeId(id)
-  if (numericId !== null && state.lastNodeId < numericId) {
-    state.lastNodeId = numericId
-  }
 }
 
 export type RendererType = 'LG' | 'Vue' | 'Vue-corrected'
@@ -168,13 +166,7 @@ export type RendererType = 'LG' | 'Vue' | 'Vue-corrected'
  */
 export type SubgraphId = UUID
 
-export interface LGraphState {
-  /** Counter, not an id — brand at the point a group is constructed. */
-  lastGroupId: number
-  lastNodeId: number
-  lastLinkId: LinkId
-  lastRerouteId: RerouteId
-}
+export type { LGraphState } from './idAllocation'
 
 type ParamsArray<T, K extends MethodNames<T>> = Parameters<
   Extract<T[K], (...args: never[]) => unknown>
@@ -349,12 +341,7 @@ export class LGraph
   list_of_graphcanvas: LGraphCanvas[] | null
   status: number = LGraph.STATUS_STOPPED
 
-  private _state: LGraphState = {
-    lastGroupId: 0,
-    lastNodeId: 0,
-    lastLinkId: toLinkId(0),
-    lastRerouteId: toRerouteId(0)
-  }
+  private _state: LGraphState = createLGraphState()
 
   get state(): LGraphState {
     return this._state
@@ -516,12 +503,7 @@ export class LGraph
     this.id = zeroUuid
     this.revision = 0
 
-    this.state = {
-      lastGroupId: 0,
-      lastNodeId: 0,
-      lastLinkId: toLinkId(0),
-      lastRerouteId: toRerouteId(0)
-    }
+    this.state = createLGraphState()
 
     // used to detect changes
     this._version = -1
@@ -1078,9 +1060,8 @@ export class LGraph
     // groups
     if (node instanceof LGraphGroup) {
       // Assign group ID
-      if (node.id == null || node.id === -1)
-        node.id = toGroupId(++state.lastGroupId)
-      if (node.id > state.lastGroupId) state.lastGroupId = node.id
+      if (node.id == null || node.id === -1) node.id = mintGroupId(state)
+      observeGroupId(state, node.id)
 
       this._groups.push(node)
       this.setDirtyCanvas(true)
@@ -1097,7 +1078,7 @@ export class LGraph
       console.warn(
         'LiteGraph: there is already a node with this ID, changing it'
       )
-      node.id = nextNodeId(state)
+      node.id = mintNodeId(state)
     }
 
     if (this._nodes.length >= LiteGraph.MAX_NUMBER_OF_NODES) {
@@ -1106,9 +1087,9 @@ export class LGraph
 
     // give him an id
     if (node.id == null || node.id === UNASSIGNED_NODE_ID) {
-      node.id = nextNodeId(state)
+      node.id = mintNodeId(state)
     } else {
-      syncLastNodeId(state, node.id)
+      observeNodeId(state, node.id)
     }
 
     // Set ghost flag before registration so the node state carries it
@@ -1627,12 +1608,8 @@ export class LGraph
     floating
   }: OptionalProps<SerialisableReroute, 'id'>): Reroute {
     const rerouteId =
-      id === undefined
-        ? toRerouteId(Number(this.state.lastRerouteId) + 1)
-        : toRerouteId(id)
-    if (rerouteId > this.state.lastRerouteId) {
-      this.state.lastRerouteId = rerouteId
-    }
+      id === undefined ? mintRerouteId(this.state) : toRerouteId(id)
+    observeRerouteId(this.state, rerouteId)
 
     const existingReroute = this.reroutes.get(rerouteId)
     const reroute = existingReroute ?? new Reroute(rerouteId, this, pos)
@@ -1655,8 +1632,7 @@ export class LGraph
     if (!(before instanceof LLink) && !(before instanceof Reroute)) {
       return
     }
-    const rerouteId = toRerouteId(Number(this.state.lastRerouteId) + 1)
-    this.state.lastRerouteId = rerouteId
+    const rerouteId = mintRerouteId(this.state)
     const chainLinks =
       before instanceof Reroute
         ? [
@@ -2116,7 +2092,7 @@ export class LGraph
         }
       }
 
-      const newNodeId = nextNodeId(this.state)
+      const newNodeId = mintNodeId(this.state)
       nodeIdMap.set(toNodeId(n_info.id), newNodeId)
       node.id = newNodeId
       n_info.id = newNodeId
@@ -2219,7 +2195,7 @@ export class LGraph
     // Shared definitions may survive, so unpacked groups need fresh layout
     // ids, like the reroutes below.
     for (const groupInfo of groups) {
-      groupInfo.id = ++this.rootGraph.state.lastGroupId
+      groupInfo.id = mintGroupId(this.rootGraph.state)
       const group = new LGraphGroup(groupInfo.title, groupInfo.id)
       this.add(group, true)
       group.configure(groupInfo)
@@ -2291,8 +2267,7 @@ export class LGraph
     const rerouteIdMap = new Map<RerouteId, RerouteId>()
     const oldReroutes = subgraphNode.subgraph.reroutes
     for (const reroute of oldReroutes.values()) {
-      const migratedId = toRerouteId(Number(this.state.lastRerouteId) + 1)
-      this.state.lastRerouteId = migratedId
+      const migratedId = mintRerouteId(this.state)
       const migratedReroute = new Reroute(migratedId, this, [
         reroute.pos[0] + offsetX,
         reroute.pos[1] + offsetY

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -9,6 +9,7 @@ import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMuta
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import { toLinkId } from '@/types/linkId'
+import { mintLinkId } from './idAllocation'
 import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { UNASSIGNED_NODE_ID, toNodeId, serializeNodeId } from '@/types/nodeId'
@@ -3124,8 +3125,7 @@ export class LGraphNode
     const maybeCommonType =
       input.type && output.type && commonType(input.type, output.type)
 
-    const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
-    graph.state.lastLinkId = linkId
+    const linkId = mintLinkId(graph.state)
 
     const link = new LLink(
       linkId,

--- a/src/lib/litegraph/src/idAllocation.test.ts
+++ b/src/lib/litegraph/src/idAllocation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createLGraphState,
+  mintGroupId,
+  mintLinkId,
+  mintNodeId,
+  mintRerouteId,
+  observeGroupId,
+  observeLinkId,
+  observeNodeId,
+  observeRerouteId
+} from '@/lib/litegraph/src/idAllocation'
+import { toGroupId } from '@/types/groupId'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
+
+describe('idAllocation', () => {
+  it('mints increasing ids for each entity kind', () => {
+    const state = createLGraphState()
+
+    expect([mintNodeId(state), mintNodeId(state)]).toEqual(['1', '2'])
+    expect([mintGroupId(state), mintGroupId(state)]).toEqual([1, 2])
+    expect([mintLinkId(state), mintLinkId(state)]).toEqual([1, 2])
+    expect([mintRerouteId(state), mintRerouteId(state)]).toEqual([1, 2])
+  })
+
+  it('observes higher ids and ignores lower ids', () => {
+    const state = createLGraphState()
+
+    observeNodeId(state, toNodeId(4))
+    observeNodeId(state, toNodeId(2))
+    observeGroupId(state, toGroupId(5))
+    observeGroupId(state, toGroupId(3))
+    observeLinkId(state, toLinkId(6))
+    observeLinkId(state, toLinkId(4))
+    observeRerouteId(state, toRerouteId(7))
+    observeRerouteId(state, toRerouteId(5))
+
+    expect(state).toEqual({
+      lastGroupId: 5,
+      lastNodeId: 4,
+      lastLinkId: 6,
+      lastRerouteId: 7
+    })
+  })
+
+  it('observes numeric-string node ids', () => {
+    const state = createLGraphState()
+
+    observeNodeId(state, toNodeId('12'))
+    observeNodeId(state, toNodeId('named'))
+
+    expect(state.lastNodeId).toBe(12)
+  })
+})

--- a/src/lib/litegraph/src/idAllocation.ts
+++ b/src/lib/litegraph/src/idAllocation.ts
@@ -1,0 +1,62 @@
+import { toGroupId } from '@/types/groupId'
+import type { GroupId } from '@/types/groupId'
+import { toLinkId } from '@/types/linkId'
+import type { LinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
+import type { RerouteId } from '@/types/rerouteId'
+
+export interface LGraphState {
+  /** Counter, not an id — brand at the point a group is constructed. */
+  lastGroupId: number
+  lastNodeId: number
+  lastLinkId: LinkId
+  lastRerouteId: RerouteId
+}
+
+export function createLGraphState(): LGraphState {
+  return {
+    lastGroupId: 0,
+    lastNodeId: 0,
+    lastLinkId: toLinkId(0),
+    lastRerouteId: toRerouteId(0)
+  }
+}
+
+export function mintNodeId(state: LGraphState): NodeId {
+  return toNodeId(++state.lastNodeId)
+}
+
+export function mintGroupId(state: LGraphState): GroupId {
+  return toGroupId(++state.lastGroupId)
+}
+
+export function mintLinkId(state: LGraphState): LinkId {
+  state.lastLinkId = toLinkId(Number(state.lastLinkId) + 1)
+  return state.lastLinkId
+}
+
+export function mintRerouteId(state: LGraphState): RerouteId {
+  state.lastRerouteId = toRerouteId(Number(state.lastRerouteId) + 1)
+  return state.lastRerouteId
+}
+
+export function observeNodeId(state: LGraphState, id: NodeId): void {
+  const numericId = Number(id)
+  if (Number.isInteger(numericId) && numericId > state.lastNodeId) {
+    state.lastNodeId = numericId
+  }
+}
+
+export function observeGroupId(state: LGraphState, id: GroupId): void {
+  if (id > state.lastGroupId) state.lastGroupId = id
+}
+
+export function observeLinkId(state: LGraphState, id: LinkId): void {
+  if (id > state.lastLinkId) state.lastLinkId = id
+}
+
+export function observeRerouteId(state: LGraphState, id: RerouteId): void {
+  if (id > state.lastRerouteId) state.lastRerouteId = id
+}

--- a/src/lib/litegraph/src/subgraph/SubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInput.ts
@@ -1,7 +1,7 @@
 import { inputLink } from '@/lib/litegraph/src/node/slotLinks'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
-import { toLinkId } from '@/types/linkId'
+import { mintLinkId } from '../idAllocation'
 import { anchorRerouteChain } from '@/lib/litegraph/src/Reroute'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -102,8 +102,7 @@ export class SubgraphInput extends SubgraphSlot {
       this.events.dispatch('input-connected', { input: slot })
     }
 
-    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
-    subgraph.state.lastLinkId = linkId
+    const linkId = mintLinkId(subgraph.state)
 
     const link = new LLink(
       linkId,

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -2,7 +2,7 @@ import type { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { NodeId } from '@/types/nodeId'
 import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
-import { toLinkId } from '@/types/linkId'
+import { mintLinkId } from '../idAllocation'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
@@ -108,8 +108,7 @@ export class SubgraphInputNode
     if (outputIndex === -1 || inputIndex === -1)
       throw new Error('Invalid slot indices.')
 
-    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
-    subgraph.state.lastLinkId = linkId
+    const linkId = mintLinkId(subgraph.state)
 
     return new LLink(
       linkId,

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -1,6 +1,6 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
-import { toLinkId } from '@/types/linkId'
+import { mintLinkId } from '../idAllocation'
 import { anchorRerouteChain } from '@/lib/litegraph/src/Reroute'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type {
@@ -60,8 +60,7 @@ export class SubgraphOutput extends SubgraphSlot {
       existingLink.disconnect(subgraph, 'input')
     }
 
-    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
-    subgraph.state.lastLinkId = linkId
+    const linkId = mintLinkId(subgraph.state)
 
     const link = new LLink(
       linkId,

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -1,4 +1,14 @@
-import type { LGraph, LGraphState } from '../LGraph'
+import type { LGraph } from '../LGraph'
+import { toGroupId } from '@/types/groupId'
+import {
+  mintGroupId,
+  mintNodeId,
+  mintRerouteId,
+  observeGroupId,
+  observeNodeId,
+  observeRerouteId
+} from '../idAllocation'
+import type { LGraphState } from '../idAllocation'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 import { toRerouteId } from '@/types/rerouteId'
@@ -87,7 +97,9 @@ function remapNodeIds(
     const numericId = numericSerializedNodeId(id)
 
     if (usedNodeIdKeys.has(key)) {
-      const newId = findNextAvailableId(usedNodeIds, () => ++state.lastNodeId)
+      const newId = findNextAvailableId(usedNodeIds, () =>
+        Number(mintNodeId(state))
+      )
       remappedIds.set(key, newId)
       node.id = newId
       usedNodeIds.add(newId)
@@ -99,7 +111,7 @@ function remapNodeIds(
       usedNodeIdKeys.add(key)
       if (numericId !== null) {
         usedNodeIds.add(numericId)
-        if (numericId > state.lastNodeId) state.lastNodeId = numericId
+        observeNodeId(state, toNodeId(numericId))
       }
     }
   }
@@ -181,22 +193,19 @@ export function deduplicateSubgraphGroupIds(
   state: LGraphState
 ): void {
   const usedGroupIds = new Set(reservedGroupIds)
-  for (const id of reservedGroupIds) reserveGroupId(id, state)
+  for (const id of reservedGroupIds) observeGroupId(state, toGroupId(id))
 
   for (const subgraph of subgraphs) {
     remapNumericIds(
       subgraph.groups ?? [],
       usedGroupIds,
-      () => ++state.lastGroupId,
-      (id) => reserveGroupId(id, state),
+      () => mintGroupId(state),
+      (id) => observeGroupId(state, toGroupId(id)),
       'group'
     )
   }
 }
 
-function reserveGroupId(id: number, state: LGraphState): void {
-  if (id > state.lastGroupId) state.lastGroupId = id
-}
 export function collectReservedRerouteIds(
   graph: Pick<LGraph, 'reroutes' | 'subgraphs'>
 ): Set<number> {
@@ -222,17 +231,12 @@ export function deduplicateSubgraphRerouteIds(
   state: LGraphState
 ): void {
   const usedRerouteIds = new Set(reservedRerouteIds)
-  for (const id of reservedRerouteIds) reserveRerouteId(id, state)
+  for (const id of reservedRerouteIds) observeRerouteId(state, toRerouteId(id))
 
   for (const subgraph of subgraphs) {
     const remapped = remapRerouteIds(subgraph, usedRerouteIds, state)
     if (remapped.size > 0) patchRerouteReferences(subgraph, remapped)
   }
-}
-
-/** Advances `state.lastRerouteId` so future allocations skip `id`. */
-function reserveRerouteId(id: number, state: LGraphState): void {
-  if (id > state.lastRerouteId) state.lastRerouteId = toRerouteId(id)
 }
 
 /**
@@ -248,11 +252,8 @@ function remapRerouteIds(
   return remapNumericIds(
     subgraph.reroutes ?? [],
     usedRerouteIds,
-    () => {
-      state.lastRerouteId = toRerouteId(state.lastRerouteId + 1)
-      return state.lastRerouteId
-    },
-    (id) => reserveRerouteId(id, state),
+    () => mintRerouteId(state),
+    (id) => observeRerouteId(state, toRerouteId(id)),
     'reroute'
   )
 }


### PR DESCRIPTION
Split 1/6 of #14480 (see that PR for the full map).

Collapses the copy-pasted `lastLinkId`/`lastNodeId`/`lastGroupId`/`lastRerouteId` increment-and-sync idioms across `LGraph`, `LGraphNode`, subgraph slots, and `subgraphDeduplication` into `mint*`/`observe*` helpers in `src/lib/litegraph/src/idAllocation.ts`. No behavior change.

Notes for review:
- Module lives in `src/lib/litegraph/src/` (litegraph-only behavior), not `src/types/` as in #14480.
- `snapshotIdState`/`restoreIdState` from #14480 are omitted — no callers until the layout rollback PR; they land there.
- `LGraphState` is re-exported from `LGraph.ts` so existing importers are unaffected.