### PR TITLE
fix(cicd): create releases with the release PAT

### DIFF
--- a/.github/workflows/release-draft-create.yaml
+++ b/.github/workflows/release-draft-create.yaml
@@ -81,9 +81,10 @@ jobs:
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # GITHUB_TOKEN is refused on core/* lines — 403 "Resource not
+          # accessible by integration" with contents: write granted.
+          token: ${{ secrets.PR_GH_TOKEN }}
           files: |
             dist.zip
             dist-desktop.zip


### PR DESCRIPTION
## Summary

Create GitHub releases with `PR_GH_TOKEN` instead of `GITHUB_TOKEN`, which is refused on `core/*` lines.

## Changes

- **What**: `draft_release` passes `secrets.PR_GH_TOKEN` to `action-gh-release` (replacing the `GITHUB_TOKEN` env).

No `core/*` release can currently be tagged. `Create release` fails with:

```
👩‍🏭 Creating new GitHub release for tag v1.48.9 using commit "core/1.48"...
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration", ...}
```

Every downstream consumer of the tag then stalls: `release-weekly-comfyui` spends its budget waiting on a tag that never appears, PyPI is never published, and the ComfyUI pin PR is skipped.

Failures — https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31161471965 (v1.49.4), https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31357150866 (v1.48.8), https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31427014048 (v1.48.9).

## Review Focus

It is not a token-scope problem, and it is specific to `core/*`:

- `GITHUB_TOKEN Permissions` in the failing runs shows `Contents: write`, identical to the last success (v1.48.7, https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31206459072).
- The `action-gh-release` input block is byte-identical between that success and the failures — only the version differs.
- `core/1.48` has had no `.github/` commit since June.
- `main` releases keep working: v1.50.5 succeeded three minutes after v1.48.8 failed.

So the refusal comes from something outside these workflows. `Resource not accessible by integration` is the GitHub App (`github-actions`) being refused; a PAT is not an integration, and `PR_GH_TOKEN` already has write access here — it opens the bump and pin PRs.

Worth confirming separately whether an org-level ruleset or policy started refusing the Actions app on these refs; I don't have `admin:org` to read that. If one exists, this PR still leaves core releases working, but the policy is the thing to fix.

Side effect: releases will be attributed to the PAT's user rather than `github-actions[bot]`.
