### PR TITLE
feat(cicd): add a way to tag a release that was never created

### DIFF
--- a/.github/workflows/release-recover-tag.yaml
+++ b/.github/workflows/release-recover-tag.yaml
@@ -1,12 +1,5 @@
 ---
 # Creates the release a merged version bump never got.
-#
-# release-draft-create.yaml only fires when a Release-labelled bump PR closes,
-# so when its release step fails the tag has no other path into existence: the
-# branch sits at a version nothing points at, PyPI publishing and the ComfyUI
-# pin bump both wait on a tag that will never appear, and every later run
-# resolves the *next* patch instead. core/1.48 stalled this way at 1.48.9 with
-# v1.48.7 as its newest tag.
 name: 'Release: Recover Tag'
 
 on:

--- a/.github/workflows/release-recover-tag.yaml
+++ b/.github/workflows/release-recover-tag.yaml
@@ -1,0 +1,111 @@
+---
+# Creates the release a merged version bump never got.
+#
+# release-draft-create.yaml only fires when a Release-labelled bump PR closes,
+# so when its release step fails the tag has no other path into existence: the
+# branch sits at a version nothing points at, PyPI publishing and the ComfyUI
+# pin bump both wait on a tag that will never appear, and every later run
+# resolves the *next* patch instead. core/1.48 stalled this way at 1.48.9 with
+# v1.48.7 as its newest tag.
+name: 'Release: Recover Tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch whose package.json version has no tag (e.g. core/1.48)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-recover-tag-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    if: github.repository == 'Comfy-Org/ComfyUI_frontend'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Resolve the untagged version
+        id: version
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "::error title=Nothing to recover::v${VERSION} already exists, so ${BRANCH} is not missing its tag. Cut a new patch with release-version-bump.yaml instead."
+            exit 1
+          fi
+
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Recovering v${VERSION} on ${BRANCH}"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      # Same artifacts release-draft-create.yaml attaches, built the same way:
+      # a recovered release must be indistinguishable from an on-time one.
+      - name: Build project
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ENABLE_MINIFY: 'true'
+          USE_PROD_CONFIG: 'true'
+          IS_NIGHTLY: ${{ inputs.branch == 'main' }}
+        run: |
+          pnpm install --frozen-lockfile
+
+          DISTRIBUTION=desktop pnpm build
+          pnpm zipdist ./dist ./dist-desktop.zip
+
+          pnpm build
+          pnpm zipdist
+
+      - name: Create release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          token: ${{ secrets.PR_GH_TOKEN }}
+          files: |
+            dist.zip
+            dist-desktop.zip
+          tag_name: v${{ steps.version.outputs.version }}
+          target_commitish: ${{ inputs.branch }}
+          make_latest: >-
+            ${{ inputs.branch == 'main' &&
+                steps.version.outputs.is_prerelease == 'false' }}
+          draft: ${{ steps.version.outputs.is_prerelease == 'true' }}
+          prerelease: >-
+            ${{ steps.version.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true
+
+      - name: Summary
+        run: |
+          {
+            echo "## Recovered release"
+            echo
+            echo "- Branch: \`${{ inputs.branch }}\`"
+            echo "- Tag: \`v${{ steps.version.outputs.version }}\`"
+            echo
+            echo "Re-run \`release-weekly-comfyui.yaml\` to publish it to PyPI and open the ComfyUI pin PR."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Add `release-recover-tag.yaml`: a dispatchable way to publish the release a merged version bump never got.

## Changes

- **What**: new workflow. Takes a branch, reads its `package.json` version, refuses to run if that tag exists, builds the same artifacts as `release-draft-create.yaml`, and publishes the release.

`release-draft-create.yaml` only fires when a Release-labelled bump PR closes, so when its release step fails the tag has no second path into existence. The branch then sits at a version nothing points at, and:

- `publish-pypi` waits out its budget on a tag that cannot appear
- the ComfyUI pin PR is never opened
- every later run resolves the *next* patch instead of finishing this one, burning a version per run (#14997, #15004)

`core/1.48` is stalled this way right now: `package.json` at 1.48.9, newest tag `v1.48.7`, two bumps (1.48.8, 1.48.9) merged and unreleased. There is currently no way to tag them short of doing it by hand.

## Review Focus

- Refuses when `vVERSION` already exists, so it can only finish a release, never cut one. It has no bump step and writes no commit.
- Build steps are copied from `release-draft-create.yaml` so a recovered release carries the same `dist.zip` / `dist-desktop.zip` as an on-time one. That duplication is the main cost; the alternative is converting `release-draft-create.yaml`'s `build` + `draft_release` into a `workflow_call` and calling it from both, which is a larger change to the critical release path. Happy to do that instead if preferred.
- Uses `PR_GH_TOKEN` for the same reason as #15003 — `GITHUB_TOKEN` is currently refused on `core/*`. Without #15003 this workflow hits the same 403.
