### PR TITLE
feat(website): move the model-page hero labels below the CTA and drop the fine print

### DIFF
--- a/apps/website/src/data/minimax.ts
+++ b/apps/website/src/data/minimax.ts
@@ -80,8 +80,7 @@ export const minimaxPage: ModelLaunchPage = {
       href: minimaxLinks.imageToVideo,
       target: '_blank'
     },
-    badgeKeys: ['minimax.hero.tagOpenWeights', 'minimax.hero.tagPartnerNodes'],
-    footnoteKey: 'minimax.hero.footnote'
+    badgeKeys: ['minimax.hero.tagOpenWeights', 'minimax.hero.tagPartnerNodes']
   },
   gallery: {
     headingKey: 'minimax.models.heading',

--- a/apps/website/src/data/seedance.ts
+++ b/apps/website/src/data/seedance.ts
@@ -181,8 +181,7 @@ export const seedancePage: ModelLaunchPage = {
       labelKey: 'seedance.hero.secondaryCta',
       href: externalLinks.workflows,
       target: '_blank'
-    },
-    footnoteKey: 'seedance.hero.footnote'
+    }
   },
   gallery: {
     headingKey: 'seedance.models.heading',

--- a/apps/website/src/data/wanAnimate2.ts
+++ b/apps/website/src/data/wanAnimate2.ts
@@ -41,8 +41,7 @@ export const wanAnimate2Page: ModelLaunchPage = {
       labelKey: 'wanAnimate2.hero.primaryCta',
       href: WAN_ANIMATE_2_WORKFLOW,
       target: '_blank'
-    },
-    footnoteKey: 'wanAnimate2.hero.footnote'
+    }
   },
   pricing: {
     defaultBillingCycle: 'monthly',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -4837,10 +4837,6 @@ const translations = {
     'zh-CN': '运行 Seedance 2.5'
   },
   'seedance.hero.secondaryCta': { en: 'TRY WORKFLOWS', 'zh-CN': '试用工作流' },
-  'seedance.hero.footnote': {
-    en: 'Pay-as-you-go credits · No watermark · Commercial use included',
-    'zh-CN': '按量付费积分 · 无水印 · 包含商业使用授权'
-  },
   'seedance.models.heading': {
     en: 'Shot on Seedance',
     'zh-CN': '用 Seedance 拍摄'
@@ -5269,10 +5265,6 @@ const translations = {
     en: 'RUN WAN ANIMATE 2',
     'zh-CN': '运行 Wan Animate 2'
   },
-  'wanAnimate2.hero.footnote': {
-    en: 'Open source · Free to try on Comfy Cloud · Pay-as-you-go after that',
-    'zh-CN': '开源 · 可在 Comfy Cloud 免费试用 · 之后按量付费'
-  },
   'wanAnimate2.hero.tagOpenSource': {
     en: 'Open Source',
     'zh-CN': '开源'
@@ -5368,10 +5360,6 @@ const translations = {
   'minimax.hero.tagPartnerNodes': {
     en: 'Partner Nodes',
     'zh-CN': '合作伙伴节点'
-  },
-  'minimax.hero.footnote': {
-    en: 'Free to start · No watermark · Commercial use included',
-    'zh-CN': '免费开始 · 无水印 · 包含商业使用授权'
   },
   'minimax.models.heading': {
     en: 'Made with MiniMax H3',

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroSection.vue
@@ -113,13 +113,6 @@ const isContentFirst = hero.layout === 'content-first'
             {{ t(badgeKey, locale) }}
           </Badge>
         </div>
-
-        <p
-          v-if="hero.footnoteKey"
-          class="mt-6 text-xs text-primary-warm-white/80"
-        >
-          {{ t(hero.footnoteKey, locale) }}
-        </p>
       </div>
     </div>
   </section>
@@ -204,12 +197,7 @@ const isContentFirst = hero.layout === 'content-first'
 
       <div
         v-if="hero.badgeKeys?.length"
-        :class="
-          cn(
-            'flex flex-wrap items-center justify-center gap-3',
-            isContentFirst ? 'order-first mb-6' : 'mt-6'
-          )
-        "
+        class="mt-6 flex flex-wrap items-center justify-center gap-3"
       >
         <Badge
           v-for="badgeKey in hero.badgeKeys"
@@ -219,10 +207,6 @@ const isContentFirst = hero.layout === 'content-first'
           {{ t(badgeKey, locale) }}
         </Badge>
       </div>
-
-      <p v-if="hero.footnoteKey" class="mt-6 text-xs text-primary-warm-gray">
-        {{ t(hero.footnoteKey, locale) }}
-      </p>
     </div>
 
     <a

--- a/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
+++ b/apps/website/src/templates/model-launch/modelLaunchPages.test.ts
@@ -41,7 +41,6 @@ describe.for(pages)('$name launch page config', ({ page }) => {
       page.hero.promptBar?.sampleKey,
       page.hero.promptBar?.cta.labelKey,
       ...(page.hero.badgeKeys ?? []),
-      page.hero.footnoteKey,
       page.gallery?.headingKey,
       page.pricing?.banner?.titleKey,
       page.pricing?.banner?.subtitleKey,

--- a/apps/website/src/templates/model-launch/types.ts
+++ b/apps/website/src/templates/model-launch/types.ts
@@ -51,7 +51,6 @@ export interface ModelLaunchHero {
   primaryCta: ModelLaunchCta
   secondaryCta?: ModelLaunchCta
   badgeKeys?: readonly TranslationKey[]
-  footnoteKey?: TranslationKey
 }
 
 type ModelLaunchTier = 'free' | 'premium'


### PR DESCRIPTION
June's request in #gtm-wan, for `/minimax`, `/seedance-2.5` and `/wan-animate-2` and for every model page from here on:

> Can we remove the fine texts under CTA? In minimax, seedance and wan animate 2? and moving forward.. Let's move the open source labels, below CTA, basically swap the placement.
>
> Opensource and Ref to video labels can be the same style and just move down to where the small copy is (below yell cta)

## What changed

The labels already followed the CTA in the DOM, but the content-first layout gave them `order-first`, which lifted them above the heading. Removing that override is the whole visual change: they now sit directly under the CTA, in the same style, in both layouts.

The footnote is removed outright rather than left unused: the optional `footnoteKey`, both render branches, the three configs that set it, and the three now-orphaned translation entries. Leaving the field would have kept a knob nobody is meant to reach for again, and `check-unused-i18n-keys` would flag the strings anyway.

Before and after, on `/wan-animate-2`:

| | Order |
| --- | --- |
| before | labels, heading, description, CTA, fine print |
| after | heading, description, CTA, labels |

## Verification

- `astro check` 0 errors; 20 unit tests in `modelLaunchPages.test.ts`; `check-unused-i18n-keys` exit 0; `knip` clean
- build 587 pages, and the rendered HTML of all three pages confirms the new order and no footnote:

```
/minimax          badge AFTER cta    no footnote
/seedance-2.5     badge AFTER cta    no footnote
/wan-animate-2    badge AFTER cta    no footnote
```

- checked visually on a local preview of `/wan-animate-2`

No page keeps a hero footnote after this, so nothing else needed updating. `/flux-3` and `/wan-3.0` never had one.