### PR TITLE
ci: alert release sheriff degradation only from scheduled runs

### DIFF
--- a/.github/workflows/pr-assign-release-sheriff.yaml
+++ b/.github/workflows/pr-assign-release-sheriff.yaml
@@ -62,9 +62,17 @@ jobs:
       # muted, which is the failure this alert exists to prevent. Alert on the
       # transition into failure: skip if the previous decisive run already did.
       # Skipped runs (the pull_request_target gate) are not decisive.
+      #
+      # Only scheduled runs alert, because only scheduled runs are read back.
+      # A run can recognise a duplicate only within the history it looks at,
+      # so alerting from a wider set than that history covers is how five
+      # pull_request_target failures posted in nine minutes, each blind to
+      # the last.
       - name: Check whether this failure is already known
         id: known
-        if: failure() && steps.sheriff.outcome == 'failure'
+        if: >-
+          failure() && github.event_name == 'schedule' &&
+          steps.sheriff.outcome == 'failure'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,7 +106,8 @@ jobs:
       # how an alert channel gets muted.
       - name: Report a degraded run to Slack
         if: >-
-          failure() && steps.sheriff.outcome == 'failure' &&
+          failure() && github.event_name == 'schedule' &&
+          steps.sheriff.outcome == 'failure' &&
           steps.known.outputs.previous != 'failure'
         continue-on-error: true
         env:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -131,6 +131,14 @@ the `pull_request_target` gate skips most other runs, so they are the ones
 dense in runs that decided anything. If the check itself cannot run it fails
 open and alerts, since a duplicate beats a silence.
 
+Only scheduled runs **alert**, for the same reason: a run can recognise a
+duplicate only within the history it reads, so the runs that post have to be
+the runs that get read back. While the two sets differed, every PR-triggered
+failure was invisible to every other one — five posts in nine minutes when a
+rotation member turned up without a `github:` tag. PR-triggered runs still go
+red on the PR itself; the alert rides the hourly sweep instead, so a new
+breakage is announced within the hour rather than on the spot.
+
 ## Publishing
 
 Merged PRs with the `Release` label trigger `release-draft-create.yaml`,


### PR DESCRIPTION
## Summary

The release-sheriff degradation alert posted five times in nine minutes today; only scheduled runs alert now, because only scheduled runs are read back when deciding whether the failure is already known.

## Changes

- **What**: gate both `Check whether this failure is already known` and `Report a degraded run to Slack` on `github.event_name == 'schedule'`, and document why.

The de-duplication added in https://github.com/Comfy-Org/ComfyUI_frontend/pull/14735 alerts on the *transition* into failure: it walks recent runs, reads the `Assign release sheriff` step conclusion, and stays quiet if the previous decisive run already failed. That lookup is filtered to `event=schedule` — deliberately, since the `pull_request_target` gate skips most other runs and they would otherwise crowd out the ones that decided anything.

But the alert itself fired from *every* run. So a `pull_request_target` failure compared itself only against scheduled history and never against the four other PR-triggered failures minutes earlier:

| run | event | slack |
| --- | --- | --- |
| [31418302878](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31418302878) | pull_request_target | posted |
| [31418516631](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31418516631) | pull_request_target | posted |
| [31418702868](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31418702868) | pull_request_target | posted |
| [31419097641](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31419097641) | pull_request_target | posted |
| [31419966276](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31419966276) | schedule | posted |
| everything after | either | suppressed |

The last one is the transition check working exactly as designed — once a *scheduled* run had failed, the next nine failures stayed quiet. The set that alerts and the set that gets read back have to be the same set.

## Review Focus

The trade-off is alerting latency: a breakage that starts right after a sweep is now announced up to an hour later, on the next `23 * * * *` run. PR-triggered runs still fail red on the PR, so the signal is not lost, only the Slack post is delayed. The alternative — widening the lookup to all events — needs deep pagination past the long runs of skipped `pull_request_target` entries to find anything decisive, which fails open into exactly the spam this removes.

Trigger for today's burst was a rotation member without a `github:<user>:<login>` tag on the Datadog schedule; that tag is now added, and [this run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31433830151) is green.