### PR TITLE
DO NOT COMMIT (EXPERIMENTAL): docs: v1 API design decisions and conversion findings

### DIFF
--- a/.claude/skills/converting-custom-nodes/SKILL.md
+++ b/.claude/skills/converting-custom-nodes/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: converting-custom-nodes
+description: 'Converts third-party custom-node JS off deprecated/unpublished ComfyUI APIs onto the published node API. Use for Magic Patch conversion work, migrating a pack, or reviewing a generated patch. Triggers on: convert custom node, magic patch, migrate pack, port to node API, output.links, input.link, widgets.splice, converted-widget.'
+---
+
+# Converting Custom Nodes
+
+Converts third-party pack JS from the old, unpublished ComfyUI internals onto
+the published node API (`src/platform/nodeApi/`, specified in `docs/node_api_WIP.md`).
+
+This is **migration, not compatibility work**. The goal is that the old surface
+can be _deleted_, so never add a shim — rewrite the call site.
+
+## When to Use
+
+- Converting a pack that Magic Patch escalated (`convert()` reported it in
+  `escalated`, meaning the mechanical rules deliberately refused).
+- Hand-writing a conversion for an upstream PR.
+- Reviewing a generated patch before it ships.
+
+Do **not** use it to make broken code work again by any means available. A
+conversion that reintroduces the old coupling is worse than no conversion.
+
+## The two invariants
+
+Everything below serves these. If a conversion violates either, it is wrong even
+if the pack appears to work.
+
+**1. The wire format must be byte-identical.**
+`graphToPrompt` output and the serialized workflow must not change. This is the
+frontend's contract with the backend, and it holds for 1,801/1,801 packs today —
+which makes it an extremely sharp detector. The most common way to break it is
+disconnect-and-reconnect, which allocates **new link ids**. Use
+`output.moveLinksTo()` when re-homing links.
+
+**2. Behaviour must be equivalent, except where the old code threw.**
+The generated test has two halves: `equivalence` (must pass on the original
+_and_ the converted source) and `fix` (must fail before, pass after). If you
+cannot state an equivalence claim, you do not yet understand the code well
+enough to convert it.
+
+## Steps
+
+### 1. Read what the code is actually doing
+
+Do not pattern-match on the API name. The census surfaces are misleading:
+
+- A `widgets.splice(i, 1)` immediately followed by `splice(i, 0, w)` is **not a
+  reorder** — it is a cache-invalidation hack. Replace it with
+  `widget.setOption(key, value)`, which invalidates properly.
+- `onDrawForeground` is often **not drawing**. 47% of draw-callback bodies never
+  touch a drawing primitive; they enforce size, poll for changes, or sync DOM
+  visibility. Those become `setSizeConstraints`, `widget.on('change')`, and the
+  widget mount lifecycle respectively.
+
+### 2. Check whether the object is live or serialized
+
+**The single most dangerous confusion in this work.** These look identical:
+
+```js
+node.inputs[0].link = null // live slot — convert
+p.workflow.nodes[i].inputs[0].link = null // serialized JSON — LEAVE ALONE
+```
+
+The second is correct as written; rewriting it corrupts a working pack. Trace
+the variable to its origin before touching anything named `link`, `links`,
+`inputs`, `outputs` or `widgets`. If it came from `graphToPrompt`, a fetch, a
+`JSON.parse`, or a `.workflow` property, it is data — not a graph.
+
+### 3. Apply the mapping
+
+| Old                                      | New                                       | Notes                                                                     |
+| ---------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| `output.links.push(id)`                  | `output.connectTo(nodeId, inputRef)`      | creating a connection                                                     |
+| moving links between own outputs         | `output.moveLinksTo(ref)`                 | **preserves link ids** — required for the wire gate                       |
+| `output.links` (read)                    | `output.links()`                          | frozen snapshot, safe to iterate while disconnecting                      |
+| `input.link = null`                      | `input.disconnect()`                      | check step 2 first                                                        |
+| `input.link` (read)                      | `input.source()` / `input.isConnected`    |                                                                           |
+| `node.type = x`                          | delete the line                           | usually a defensive no-op; true type replacement is a **gap** — punt it   |
+| `slot.type = x`, `slot.name = x`         | `slot.modify({ type, name })`             | atomic, one undo step; keeps existing links                               |
+| `widget.type = 'converted-widget'`       | `widget.setHidden(true)`                  | ⚠️ old hack also suppressed serialization — see `references/widgets.md`   |
+| `widgets.splice` to reorder              | `widgets.reorder(names)`                  | throws on a partial list instead of dropping widgets                      |
+| `widgets.splice(i,1)` + `splice(i,0,w)`  | `widget.setOption(key, value)`            | same index in/out = cache invalidation, **not** a reorder                 |
+| `widgets.push(w)`                        | `widgets.add(def)`                        |                                                                           |
+| `widgets = [...]` / `widgets.length = n` | `widgets.remove(name)`                    | assignment drops renderer tracking; length skips teardown                 |
+| `getCustomWidgets` POJO                  | `widgets.mount({ mount })`                |                                                                           |
+| `{...input}` / `{...node}`               | `.snapshot()`                             | accessors moved to the prototype, so spread yields nothing                |
+| `nodeType.prototype.onNodeCreated = ...` | `defs.extend(sel, b => b.onCreated(...))` | selector = the hook's existing guard clause                               |
+| `nodeType.prototype.onExecuted = ...`    | `b.onExecuted(node, result)`              | see `references/node-definitions.md`                                      |
+| `nodeType.prototype.onConfigure = ...`   | `b.onConfigured(node, data)`              |                                                                           |
+| `nodeType.prototype.onRemoved = ...`     | `b.onRemoved(node)`                       |                                                                           |
+| `widget.inputEl`                         | `widgets.mount({ render })`               | the element arrives as `render`'s argument; there is no `inputEl` to read |
+| `this.widgets.length = n`                | remove by name                            | assigning length skips widget teardown                                    |
+| `+!!this.inputs[0].widget`               | `input.isWidgetInput`                     | converted-widget sniffing                                                 |
+| `onDrawForeground` (drawing)             | `widgets.canvas({ draw })`                | renders in canvas _and_ Nodes 2.0                                         |
+| `onDrawForeground` (sizing)              | `node.setSizeConstraints({ autoHeight })` | see `references/draw-callbacks.md`                                        |
+| `onDrawForeground` (polling)             | `widget.on('change')`                     | pick the narrowest event                                                  |
+| `extends LGraphNode`                     | `defs.define({ type, ... })`              | virtual nodes use `resolve(ctx)`                                          |
+| `onConnectInput` returning `false`       | `b.onBeforeConnect((node, e) => false)`   | any listener refusing is enough                                           |
+| `getExtraMenuOptions` (node menu)        | `b.addMenuItem({ label, run })`           | entries accumulate; canvas/slot menus are still a **gap**                 |
+
+Prefer `comfy.supports('...')` over version comparisons — see `docs/node_api_WIP.md` §2.
+
+### 4. Watch for the frame-to-event shift
+
+A draw callback recomputed from current state every repaint, so nothing ever
+needed to announce a change. Declarations and decorations must be **set when the
+value changes**. A port that calls `decorations.set()` from inside the old
+callback body will appear to work and quietly run on every repaint forever.
+
+### 5. Write the test before claiming success
+
+State an equivalence claim and a fix claim. Run the file against both sources:
+equivalence green on both, fix red on the original and green on the converted.
+A fix-only test proves the conversion did _something_, not that it was safe.
+
+### 6. Refuse when you should
+
+Escalate or decline rather than guess when:
+
+- You cannot tell whether the object is live or serialized (step 2).
+- The replacement depends on intent you cannot recover — e.g. re-homing links
+  versus rebuilding a mirror have different correct answers.
+- The published API has no destination. A missing API is a **core gap to file**,
+  not something to work around in a pack. `docs/node_api_WIP.md` §1 lists what is and is
+  not covered.
+
+A refusal costs a round trip. A wrong rewrite of working code is invisible until
+a user hits it.
+
+**A partial conversion is worse than a punt.** Two checks enforce this and both
+fail the whole file:
+
+- `retires-the-old-surface` — no `X.prototype.foo = ...` may remain. Converting
+  a function body while leaving the prototype assignment that reaches it moves
+  nothing; the old surface still cannot be deleted, which is the only reason
+  this programme exists.
+- `no-unknown-api-members` — every member you introduce must exist in the
+  published API. Do not invent a plausible-sounding method. If the capability
+  you need is absent, that is `api-gap`, and naming it precisely is the most
+  useful thing you can do.
+
+Both of these caught real conversions that every other check passed.
+
+## Keep the diff small — it is the message
+
+These diffs are read by the pack's author, often as a pull request. A patch that
+touches ten lines says _we moved you off two deprecated calls_. A patch that
+rewrites the file says _we rewrote your code_, and it will be rejected on sight
+even when it is correct. Restructuring you did not need is not neutral.
+
+**Change the registration. Leave everything else where it is.**
+
+```js
+// before
+app.registerExtension({
+  name: 'x.ShowText',
+  async beforeRegisterNodeDef(nodeType, nodeData, app) {
+    if (nodeData.name === 'ShowText') {
+      function populate(text) {
+        /* 30 lines */
+      }
+      nodeType.prototype.onExecuted = function (message) {
+        populate.call(this, message.text)
+      }
+    }
+  }
+})
+```
+
+Two conversions of that, both correct:
+
+```js
+// ✗ restructured — populate hoisted, dedented, renamed, signature changed.
+//   Every line of a 30-line helper shows as changed.
+function populateText(node, lines) {
+  /* 30 lines, reflowed */
+}
+comfy.defs.extend('ShowText', (b) => b.onExecuted(populateText))
+
+// ✓ minimal — the helper stays exactly where and as it was.
+comfy.defs.extend('ShowText', (b) => {
+  function populate(text) {
+    /* 30 lines, byte-identical */
+  }
+  b.onExecuted((node, result) => populate.call(node, result.text))
+})
+```
+
+Both work. The second is the one an author merges.
+
+Rules that follow from this:
+
+- **Do not hoist, reorder or rename anything** the conversion does not require.
+  Keep helper names, parameter names and their order.
+- **Keep helpers nested where they were nested.** Pulling one to module scope
+  changes every line of it.
+- **Do not normalise style.** Quotes, semicolons, spacing and line breaks are
+  the author's, not yours.
+- **Do not "improve" adjacent code.** A bug next to your change is not your
+  change.
+
+### Indentation: match the original where you can, fix it where you must
+
+The patch gets applied to the author's working tree, so a diff that minimises
+its own size by leaving the body at its old depth ships them badly indented
+code. That is a worse outcome than a larger diff.
+
+The rule, in order:
+
+1. **Prefer the original indentation.** If a line's nesting depth has not
+   actually changed, do not touch its leading whitespace.
+2. **Re-indent when the nesting genuinely changed.** Removing a
+   `registerExtension` wrapper takes two levels off everything inside it, and
+   the result has to be correctly indented. Do it.
+3. **Never re-indent anything whose nesting did not change.** That is the
+   churn worth eliminating, and it is entirely elective.
+
+So the thing to avoid is not re-indentation, it is _gratuitous restructuring_ —
+hoisting a helper to module scope, renaming its parameters, reflowing a function
+the conversion never touched. Those change every line of code that did not need
+to change. Correct indentation is not negotiable; unnecessary movement is.
+
+Across the current database the unavoidable dedent accounts for 17–39% of added
+lines. `run_checks` reports the proportion so you can see whether yours is in
+that range or well past it.
+
+## Recognise the intent, not the call
+
+Most old-API code is a workaround for something missing. Port the call and you
+carry the workaround across; recognise what it was _for_ and it usually
+collapses. Check these before converting anything mechanically.
+
+**If you are converting `api.addEventListener('b_preview')` or
+`'b_preview_with_metadata'` or `'executing'`** — check whether the pack is
+correlating frames to one node (a module-level `execId`, a
+`displayNodeId === this.id` test, a `serverSupportsFeature` probe). That whole
+apparatus answers "is this frame mine?". **Use `b.onPreview((node, frame) =>
+…)`**, which answers it for you. Delete the global; it also mis-attributes
+frames when two nodes preview at once.
+
+**If you are converting `onDrawForeground` / `onDrawBackground` / anything
+using `ctx`** — check what it actually draws. Rectangles, images, text and
+lines are all a canvas can give you and all a DOM can. **Use
+`node.widgets.canvas({ name, height, draw(ctx, [w, h]) })`** and keep the
+drawing code as it is. It renders under both the old graph renderer and Nodes
+2.0. Do not reach for the graph's shared context — that is the thing that ties
+a pack to the old renderer.
+
+**If you are converting hand-rolled hit testing** — bounding-box maths against
+`node.pos`/`node.size`, pointer capture on `document`, hit tests against link
+curves. Check whether it exists only because canvas has nothing to attach a
+listener to. **Mount the control with `node.widgets.mount(...)` and use
+ordinary DOM events**; most of the geometry disappears rather than being
+ported.
+
+**If you are converting `node.addDOMWidget(...)`** — **use
+`node.widgets.mount({ name, render(container), destroy() })`**. Put the teardown
+in `destroy`: a mounted element owns listeners, timers and observers that node
+removal would otherwise leave running.
+
+**If you are converting `node.addInput` / `removeInput` / `addOutput`** — the
+pack is almost certainly growing slots as the last one fills (the "Multi"
+combiner shape). **Use `node.inputs.add(name, type)` / `node.inputs.remove(ref)`**
+and the matching `node.outputs` calls, driven from `b.onConnectionsChanged`.
+
+**If you are converting `canvas.selected_nodes` / `selectedItems`** — the pack
+wants the user's current selection, and is reaching into the canvas for it.
+**Use `comfy.graph.selection()`**, which returns node handles.
+
+**If you are writing to a node or widget handle** — every read and write is a
+**method**, never a property: `setTitle`, `setColor`, `setBgColor`, `setMode`,
+`setCollapsed`, `setProperty`, `getSize`/`setSize([w, h])` on nodes;
+`getValue`/`setValue`, `isHidden`/`setHidden`, `setOption` on widgets. Property
+syntax compiles and silently does nothing. See the table in
+`references/node-definitions.md`.
+
+**If you are converting `registerCustomNodes` / `extends LGraphNode` /
+`isVirtualNode` / `applyToGraph`** — identify which of four intents the node
+serves (annotation, wire, value, or acting on other nodes) and use **`comfy.defs.define`**
+with `execution: 'frontend'` and, for wires and values, a pure `resolve`. See
+`references/node-definitions.md` — nodes that act on others mutate neighbours through
+handles in widget callbacks, never in `resolve`.
+
+**If you are converting `onResize` / `computeSize` / a per-frame `setSize`** —
+check whether the pack is enforcing a minimum, or growing to fit something it
+mounted. **Use `node.setSizeConstraints({ minWidth, minHeight, maxWidth,
+maxHeight, autoHeight })`** once, rather than re-asserting size on every frame.
+`autoHeight` is usually the real intent.
+
+**If you are converting `onSerialize` / `chainCallback(node, 'onSerialize')`** —
+the pack is saving its own state into the node. **Use `b.onSerialize((node) =>
+({ myKey: … }))`**; it comes back through `b.onConfigured`. Core fields —
+`type`, `widgets_values`, `inputs`, `pos` and the rest — are ignored if you
+return them, because changing those changes what the workflow means.
+
+**If you are converting `onConnectInput` / `onConnectOutput`** — check what the
+pack does with the return value. If it returns `false` to refuse a wire, **use
+`b.onBeforeConnect((node, e) => …)`** and return `false` to refuse; `e` carries
+`side`, `index`, `peerNodeId` and `peerType`. Any listener refusing is enough —
+one pack cannot be overruled by another's silence. If it does not return
+`false`, it is only observing, so **use `b.onConnectionsChanged`** instead: a
+veto that never vetoes is a listener wearing the wrong hat.
+
+**If you are converting `getExtraMenuOptions` or a `ContextMenu` the pack builds
+itself** — check whether it is a menu _on a node_. If so, **use
+`b.addMenuItem({ label, run(node) })`**; entries from every pack accumulate
+rather than overwrite. A `ContextMenu` constructed to build a canvas-wide or
+slot menu is not this, and is still a gap — punt it and name it.
+
+**If you are converting a pack that writes its own name-keyed shape into
+`widgets_values`** (a dict keyed by widget name, rather than the positional
+array) — the pack is reaching for something the new model already gives it.
+**Widget values are keyed by name at runtime**: `widgetValueStore` is keyed by
+`graphId:nodeId:name` (`src/types/widgetId.ts`), with no index in the identity.
+The positional array is only the legacy _serialized_ form, which is why
+`widgets_values` is reserved.
+
+So **delete the override, do not translate it.** Address widgets by name — that
+is native — and let core serialize the positional array as it already does. The
+pack's serialize hook largely disappears rather than being ported.
+
+What you must keep is the _reading_ of old workflows. Core assigns positionally
+and _then_ calls `onConfigure`, so `b.onConfigured` receives the saved node with
+its legacy shape intact. Port the pack's rename maps, retired-widget handling
+and positional-to-named fallbacks into that hook: those are the conversion, and
+dropping them silently loses user data.
+
+**If you are converting reads of `canvas.connecting_links`, `resizing_node` or
+`node_widget`** — the pack is asking one question, not three: _is the editor
+already mid-gesture?_ **Use `comfy.isInteracting()`** and stand down while it is
+true. Do not reach for the individual fields; which gestures exist is the
+editor's business and will change.
+
+**If you are converting a pack that listens on `document` for pointer moves to
+build an editing gesture** (drag one node onto another, shake to disconnect,
+drop onto a link) — **use `comfy.onNodeMoved`**, which reports node movement
+under both renderers from one subscription. Two cautions: it does not say
+whether a _person_ moved the node, so guard your own writes against re-entry;
+and for a gesture that commits on release, pair it with
+`comfy.onNodeDragEnd(nodes => …)`, which reports every node the drag moved.
+
+`onNodeDragEnd` is **Nodes 2.0 only** — the legacy canvas renderer publishes no
+drag lifecycle, so it never fires there. Say so in your summary rather than
+pretending the conversion is renderer-neutral.
+
+**If you are converting `canvas.setDirty(...)` / `setDirtyCanvas(...)`** —
+**delete it.** There is no published repaint request, deliberately. Handle
+writes invalidate on their own, and a `widgets.canvas` surface has `redraw()`.
+If something genuinely fails to repaint after a handle write, that is a bug in
+the API — report it rather than working around it.
+
+**If you are converting `addWidget('button', name, null, callback)` or any
+widget whose callback is an action rather than a value change** — **use
+`widget.on('activate', fn)`**. A button's value never moves, so `on('change')`
+can never fire for one. Keep the widget itself (`widgets.add({ type: 'button',
+name, value: null })`) — its `widgets_values` entry is positional, and dropping
+it shifts every widget after it.
+
+**If you are converting `registerExtension({ commands, keybindings })` or
+`app.extensionManager.toast`** — **use `comfy.commands`**:
+`register({ id, label, run, keybinding })` declares the command and binds its
+key together, and `notify({ severity, summary, detail })` raises a toast. Ids
+must be namespaced. The key is registered as a _default_, so a user's own
+binding survives the pack re-registering on every load.
+
+**If you are converting `api.apiURL(...)` or `api.addEventListener(...)`** —
+**use `comfy.backend`**: `url('/view?…')` builds a route that honours how the
+host is served, and `on(event, detail => …)` subscribes to any backend message,
+including one your own Python side emits. For the built-in preview channel
+prefer `b.onPreview`, which answers "is this frame for my node?" — `backend.on`
+hands you the raw payload and leaves correlation to you.
+
+**If you are converting `app.ui.settings.getSettingValue` / `addSetting`, or a
+`settings: [...]` array in `registerExtension`** — **use `comfy.settings`**:
+`declare({ id, name, type, defaultValue })` once at load, then `get(id)` and
+`await set(id, value)`. Ids must be namespaced (`MyPack.thing`) — one flat space
+is shared with core and every other pack, and the id is where the value lives
+permanently. Re-declaring does not reset a stored value, so declaring on every
+load is correct.
+
+**If you are converting a read of `LiteGraph.NODE_SLOT_HEIGHT`,
+`NODE_TITLE_HEIGHT`, `ROUND_RADIUS` or `vueNodesMode`** — **use
+`comfy.constants`** (`slotHeight`, `titleHeight`, `cornerRadius`,
+`domRenderer`). It returns a frozen snapshot by value; do not hold the object.
+Reach for `domRenderer` only when you genuinely must pick a strategy —
+`widgets.mount` and `widgets.canvas` already work under both renderers, so
+needing it usually means the conversion took a wrong turn.
+
+**If you are converting `this._somethingPrivate = x` on a node** — handles hold
+no arbitrary properties. **Keep a `Map` keyed by `node.id`** and clear the entry
+in `b.onRemoved`. This is supported, not a workaround; the old property was
+collected with the node and a Map is not.
+
+**If you are converting `node.imgs = [img]` + `setDirtyCanvas`** — the pack is
+showing an image on the node. **Use `widgets.canvas` and `drawImage` in
+`draw`**, then `redraw()` when the image changes.
+
+**If you are converting a captured-and-chained `widget.callback`** — check
+whether it only wants to know the value changed. **Use `widget.on('change', (v,
+old) => …)`**, which is additive: no other pack can drop your listener by
+forgetting to call through.
+
+**If you are converting `widget.serializeValue = async () => {}`** — the pack is
+keeping a derived value out of what gets saved. **Use `serialize: false`** on
+the widget definition. Note the two are distinct: `options.serialize` gates the
+API prompt, `widget.serialize` gates workflow persistence.
+
+**If you are converting `widget.type = 'converted-widget'`** — the pack is
+hiding a widget, not changing its kind. **Use `widget.setHidden(true)`.** The
+`origType`/`origComputeSize`/`origSerializeValue` bookkeeping around it existed
+only to undo the hack; it has no readers and goes away.
+
+## Pattern references
+
+Deep dives, loaded only when relevant. `SKILL.md` stays short on purpose; detail
+lives here.
+
+| Reference                        | Covers                                                                                                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `references/nodegraph-101.md`    | **Read first if you have not converted a pack before.** What a node graph is, the definition/class/instance distinction, the lifecycle, workflow vs prompt, and why packs patch prototypes at all. |
+| `references/node-definitions.md` | `beforeRegisterNodeDef` + prototype patching — **1,265 packs, 47.4% of installs, the largest surface**. The selector is already written as the hook's guard clause.                                |
+| `references/widgets.md`          | Widget-array mutation and the converted-widget protocol — 286 packs / 21.6%, overlapping cohorts totalling more. Where naive conversions are most often silently wrong.                            |
+| `references/draw-callbacks.md`   | `onDraw*` — 420 packs, 32.2% of installs. Measured breakdown showing 47% never draw at all, a decision tree, and the canvas→CSS mapping.                                                           |
+
+### Adding a capability
+
+If a conversion is blocked and the fix is a **new API capability**, the addition
+is a design decision, not a detail. Record it in `docs/node_api_WIP.md` §4f
+alongside: what forced it, the alternative that was rejected, and what it would
+cost to reverse. An addition made under conversion pressure with its rationale
+only in a commit message is one nobody can argue with later.
+
+### Adding a pattern
+
+Add a reference when a pattern is (a) seen in real pack code, not anticipated,
+and (b) large or subtle enough that the mapping table row is insufficient.
+
+Each reference should carry:
+
+1. **How common it is**, measured — not estimated. Counts come from the corpus
+   at `~/comfy/nodes-compat-study/`, and should be labelled grep-derived where
+   they are.
+2. **What the code is actually doing**, which is often not what the API name
+   suggests. Classify before mapping.
+3. **Real before/after**, quoted from a named pack and file.
+4. **The trap** — the way a plausible conversion silently goes wrong.
+
+If a pattern turns out to be mechanically safe, add it to
+`conversion/rules.ts` instead: a rule with golden cases beats prose, because CI
+runs it. Prose is for the judgement calls.
+
+## Where things live
+
+|                                     |                                                           |
+| ----------------------------------- | --------------------------------------------------------- |
+| Published API spec                  | `docs/node_api_WIP.md`                                    |
+| Published API code                  | `src/platform/nodeApi/`                                   |
+| Rule catalog (per-pattern guidance) | `src/workbench/extensions/magicPatch/conversion/rules.ts` |
+| Verdict grading                     | `src/workbench/extensions/magicPatch/verify/verdict.ts`   |
+| Programme design                    | `docs/magic_patch_WIP.md`                                 |
+
+The rule catalog's `guidance` field is injected into the agent prompt for
+**only the rules that matched**, so this skill covers method and the catalog
+covers specifics. Keep it that way — duplicating pattern detail here means it
+will drift.
+
+## Checklist
+
+- [ ] Traced every `link`/`links`/`widgets` reference to live-vs-serialized
+- [ ] No shim, no compatibility wrapper, no reintroduced old API
+- [ ] Link ids preserved where links were moved
+- [ ] Equivalence claim stated and passing on both sources
+- [ ] Fix claim red on the original, green on the converted source
+- [ ] `graphToPrompt` and serialized workflow byte-identical
+- [ ] Anything uncertain escalated rather than guessed

--- a/.claude/skills/converting-custom-nodes/references/draw-callbacks.md
+++ b/.claude/skills/converting-custom-nodes/references/draw-callbacks.md
@@ -1,0 +1,210 @@
+# Converting draw callbacks
+
+`onDrawForeground`, `onDrawBackground`, `onDrawTitle*`, `onDrawCollapsed`.
+
+**420 packs / 34.3M downloads / 32.2% of registry installs** touch these. They
+are canvas-only, so they silently do nothing in Nodes 2.0 — no warning, no
+error, no visible failure. That silence is why this cohort needs care.
+
+## The hook name is misleading — most of it is not drawing
+
+Measured over all **2,787 draw-callback bodies** in the corpus:
+
+| What the body actually does              | Bodies | %     | Packs |
+| ---------------------------------------- | ------ | ----- | ----- |
+| Draws something                          | 1,468  | 52.7% | 289   |
+| Prototype-patch plumbing                 | 901    | 32.3% | 198   |
+| Layout / size enforcement — _no drawing_ | 178    | 6.4%  | 39    |
+| State sync / polling — _no drawing_      | 169    | 6.1%  | 46    |
+| DOM element sync — _no drawing_          | 71     | 2.5%  | 37    |
+
+**47.3% never touch a drawing primitive. 127 packs hook a draw callback and
+never draw at all.** They are using it as the only recurring callback available.
+
+## Decide which of four things it is — before writing anything
+
+```
+Does the body call ctx.fillText/fillRect/drawImage/arc/... ?
+├─ no
+│  ├─ only calls the original (`orig?.apply(this, arguments)`) → DELETE (plumbing)
+│  ├─ assigns this.size / ensureMinimumSize / computeSize   → setSizeConstraints
+│  ├─ compares state and rebuilds on difference             → widget.on('change') / onConnectionsChanged
+│  └─ toggles .hidden / .style / wrapperEl                  → widget.setHidden() / mount's own element
+└─ yes
+   ├─ informational (text, badge, bar, border, tint, icon)  → widgets.canvas()
+   ├─ interactive (hit-testing, dragging, mouse handling)   → widgets.mount() + own DOM/canvas
+   └─ arbitrary composition                                 → widgets.mount()
+```
+
+## 1. Prototype plumbing — 32.3%, just delete it
+
+```js
+// before
+const onDrawForeground = nodeType.prototype.onDrawForeground
+nodeType.prototype.onDrawForeground = function (ctx) {
+  const r = onDrawForeground?.apply?.(this, arguments)
+  /* ...actual work... */
+  return r
+}
+```
+
+The capture-and-chain wrapper exists only because prototype patching has no
+composition. Registered callbacks compose by construction, so the wrapper
+disappears entirely — keep only the body.
+
+This is the highest-volume, lowest-risk transform in the whole programme.
+
+## 2. Size enforcement — 39 packs
+
+```js
+// before — re-asserted on every repaint
+if (Number.isFinite(desired) && Math.abs(this.size?.[1] - desired) > 1) {
+  this.size[1] = desired
+}
+
+// after — declared once
+node.setSizeConstraints({ minHeight: desired })
+```
+
+`autoHeight: true` is usually what the pack actually wants: it added a DOM
+widget of unknown height and hand-computed the node size to fit. In a
+DOM-rendered node that is just layout, and needs no pack code at all.
+
+## 3. Polling — 46 packs
+
+```js
+// before — string-joins every group title on every repaint, and mouse
+// movement marks the canvas dirty, so this ran constantly
+const titles = (app.graph._groups?.map((g) => g.title) || []).join()
+if (this.lastKnownGroupTitles !== titles) {
+  this.lastKnownGroupTitles = titles
+  rebuildUI(this)
+}
+
+// after — for the cases the API reaches
+node.widgets.get('mode').on('change', () => rebuildUI(node))
+```
+
+Pick the **narrowest** event that exists. `widget.on('change')` covers polling
+for a widget's own value, and `b.onConnectionsChanged` covers polling for
+wiring.
+
+**Polling for graph structure — group titles, node counts, anything outside the
+node — is a gap.** There is no `graph.onChange`; do not emit one. Punt the file
+and name the event you needed.
+
+## 4. DOM visibility sync — 37 packs
+
+```js
+// before
+node.painter.canvas.wrapperEl.hidden = this.flags.collapsed
+```
+
+A mounted DOM widget's lifecycle handles this. If you find yourself syncing an
+element's visibility to node state, the element should be a widget.
+
+## 5. Actual decoration — the informational half
+
+Every canvas primitive in use has an exact DOM equivalent, so this is a
+translation rather than a redesign:
+
+| Canvas (packs using)                                | DOM/CSS                                 |
+| --------------------------------------------------- | --------------------------------------- |
+| `fillText` 326, `measureText` 206                   | a text node — measurement becomes free  |
+| `fillRect` 234 / `roundRect` 193 / `strokeRect` 159 | `background`, `border-radius`, `border` |
+| `drawImage` 203                                     | `<img>`                                 |
+| `arc` 181 / `ellipse` 58                            | `border-radius: 50%`                    |
+| `translate` 170 / `rotate` 136                      | `transform`                             |
+| `globalAlpha` 150                                   | `opacity`                               |
+| `clip` 138                                          | `overflow: hidden`                      |
+| `setLineDash` 115                                   | `border-style: dashed`                  |
+| `shadowBlur` 95                                     | `box-shadow`                            |
+| `createLinearGradient` 79                           | `linear-gradient()`                     |
+
+The shipped destination is **`node.widgets.canvas()`** — a per-node drawing
+surface that works under both renderers, because the canvas is a DOM element
+the legacy renderer positions over the graph and Nodes 2.0 renders natively:
+
+```js
+// before — ComfyUI-Custom-Scripts mathExpression.js, ran every repaint
+nodeType.prototype.onDrawForeground = function (ctx) {
+  const v = app.nodeOutputs?.[this.id]
+  if (!this.flags.collapsed && v) {
+    ctx.save()
+    ctx.font = 'bold 12px sans-serif'
+    ctx.fillText(v.value[0], x, y)
+    ctx.restore()
+  }
+}
+
+// after — same drawing code, but event-driven
+b.onCreated((node) => {
+  const surface = node.widgets.canvas({
+    name: 'result',
+    height: 22,
+    draw(ctx) {
+      ctx.font = 'bold 12px sans-serif'
+      ctx.fillText(stateFor(node.id).value ?? '', 4, 15)
+    }
+  })
+  stateFor(node.id).surface = surface
+})
+b.onExecuted((node, result) => {
+  stateFor(node.id).value = String(result.text[0] ?? '')
+  stateFor(node.id).surface?.redraw()
+})
+```
+
+`draw` runs on mount, on resize, and on `redraw()` — never per frame. Keep the
+pack's `ctx` code as close to verbatim as you can; the conversion is _when_ it
+runs, not _what_ it draws. The collapsed check disappears (a hidden widget is
+not drawn), and pixel positions are relative to the surface, not the node.
+
+A declarative `node.decorations` API (badges/anchors, renders without pack
+code) is specified but **not implemented** — do not emit it; `widgets.canvas`
+is the destination today.
+
+## 6. Interactive controls — becomes a widget
+
+```js
+// mxtoolkit Slider2D.js — a full draggable 2D slider painted by hand
+this.node.onDrawForeground = function (ctx) {
+  ctx.fillStyle = 'rgba(20,20,20,0.8)'
+  ctx.beginPath()
+  ctx.roundRect(shiftLeft - 4, shiftLeft - 4, ...)
+  ctx.fill()
+  // dots, handles, hit-testing...
+}
+```
+
+This is not decoration. It was painted by hand because no custom-widget API
+existed. It becomes **`node.widgets.mount({ name, render, destroy })`** — the
+pack appends its own `<canvas>` (or any DOM) to the container and keeps its
+drawing code, but pointer events now land on a real element, so hand-rolled
+hit-testing against bounding boxes mostly disappears. kjnodes' `editor_base.js`
+already works exactly this way and needs only the mount call swapped.
+
+## The trap: frame to event
+
+A draw callback recomputes from current state on every repaint, so **nothing
+ever needs to announce a change**. After conversion, the drawing must be
+refreshed _when the value changes_.
+
+A naive port that calls `redraw()` from inside a per-frame path will appear to
+work — and quietly run on every repaint forever. Redraw from the event that
+changes the data: `onExecuted`, `widget.on('change')`, `onConnectionsChanged`.
+
+## What you can stop doing
+
+- **LOD checks.** rgthree hand-rolls `canvas.ds.scale < 0.6` to skip drawing
+  when zoomed out. Handled centrally now.
+- **Collapsed checks.** `if (this.flags.collapsed) return` — layout's problem.
+- **Defensive try/catch around drawing.** Several packs wrap draw calls to avoid
+  breaking node rendering; a `canvas()` surface draws into its own element, so
+  a throw cannot take node rendering down with it.
+
+## Source data
+
+Measured over `~/comfy/nodes-compat-study/corpus/registry_js` (4,969 packs).
+Counts are grep-derived and have a known false-positive rate — sample-verify
+before citing any individual number.

--- a/.claude/skills/converting-custom-nodes/references/node-definitions.md
+++ b/.claude/skills/converting-custom-nodes/references/node-definitions.md
@@ -1,0 +1,315 @@
+# Converting `beforeRegisterNodeDef` and prototype patching
+
+**1,265 packs / 50.4M downloads / 47.4% of registry installs** register a
+`beforeRegisterNodeDef` hook, and **1,191 of them use it to patch the generated
+class's prototype**. This is the largest surface in the ecosystem — bigger than
+the widget and painting cohorts combined — and the one that couples packs to our
+internals most tightly.
+
+## What they patch — measured
+
+Prototype assignments across those 1,265 packs, litegraph methods only
+(bundled-library noise like `_next`, `dispose`, `toString` filtered out):
+
+| Patched method        | Sites | Packs   | Destination                    |
+| --------------------- | ----- | ------- | ------------------------------ |
+| `onNodeCreated`       | 3,161 | **943** | `b.onCreated(cb)`              |
+| `onExecuted`          | 964   | **497** | `b.onExecuted(cb)`             |
+| `onConfigure`         | 1,272 | **429** | `b.onConfigured(cb)`           |
+| `onConnectionsChange` | 454   | 223     | `b.onConnectionsChanged(cb)`   |
+| `onDrawForeground`    | 446   | 199     | `references/draw-callbacks.md` |
+| `onRemoved`           | 353   | 158     | `b.onRemoved(cb)`              |
+| `constructor`         | 473   | 49      | `b.onCreated(cb)`              |
+| `getDefaultShape`     | 335   | 3       | no replacement — escalate      |
+
+## The selector is already written — it's the guard clause
+
+Every one of these hooks runs for **every registered node type**, so essentially
+all of them open with a filter and return. That filter _is_ the selector:
+
+```js
+// before — ComfyUI-KJNodes jsnodes.js:37
+async beforeRegisterNodeDef(nodeType, nodeData, app) {
+  if (!nodeData?.category?.startsWith('KJNodes')) return
+  switch (nodeData.name) {
+    case 'ImageBatchMulti':
+    case 'ImageAddMulti':
+      nodeType.prototype.onNodeCreated = function () {
+        setupDynamicInputs(this, { type: 'IMAGE', prefix: 'image_' })
+      }
+      break
+    ...
+  }
+}
+
+// after
+comfy.defs.extend(['ImageBatchMulti', 'ImageAddMulti'], (b) => {
+  b.onCreated((node) => setupDynamicInputs(node, { type: 'IMAGE', prefix: 'image_' }))
+})
+```
+
+This is mechanical: lift the `if`/`switch` condition into the selector, one
+`extend` call per case group.
+
+It is also a real performance fix, not just tidiness. With 1,265 packs hooking
+and a few thousand node types, boot currently runs **millions of callbacks that
+immediately return**. A declarative predicate can be indexed.
+
+Selector forms: exact type, array of types, `RegExp` over the type, or
+`{ category }` where category is a string or a `RegExp`. The regex form covers
+the prefix filter 53 packs open with —
+`nodeData.category.startsWith('KJNodes')` becomes `{ category: /^KJNodes/ }`.
+
+`onCreated` fires when the node **joins a graph**, not inside the constructor.
+Litegraph's `onNodeCreated` runs before the node has an id, a graph, or store
+registration, so widget writes made there are lost on insert. If a pack relied
+on running before insertion, escalate — that ordering is not reproducible.
+
+## Chaining boilerplate disappears
+
+```js
+// before — capture-and-chain, because prototype patching has no composition
+const onExecuted = nodeType.prototype.onExecuted
+nodeType.prototype.onExecuted = function (message) {
+  onExecuted?.apply(this, arguments)
+  populate.call(this, message.text)
+}
+
+// after — registered callbacks compose by construction
+b.onExecuted((node, result) => populate(node, result.text))
+```
+
+Whether the old form worked at all depended on load order and on every pack
+remembering to call through. Two packs patching the same method with one
+forgetting silently broke the other.
+
+## `onExecuted` — the second-largest, and easy to get wrong
+
+497 packs. The result shape is now explicit rather than a raw backend payload:
+
+```js
+// before
+nodeType.prototype.onExecuted = function (message) {
+  populate.call(this, message.text)
+}
+
+// after
+b.onExecuted((node, result) => populate(node, result.text))
+```
+
+`ExecutionResult` exposes `images`, `text`, and `raw` for everything else.
+Custom output keys survive in `raw` — ADR 0007's passthrough schema guarantees
+it — so a pack reading a bespoke key keeps working.
+
+## A worked example touching four surfaces at once
+
+ComfyUI-Custom-Scripts `showText.js:10` is representative of the harder cases:
+
+```js
+// before
+async beforeRegisterNodeDef(nodeType, nodeData, app) {
+  if (nodeData.name === 'ShowText|pysssss') {
+    function populate(text) {
+      if (this.widgets) {
+        // On older frontend versions there is a hidden converted-widget
+        const isConvertedWidget = +!!this.inputs?.[0].widget
+        for (let i = isConvertedWidget; i < this.widgets.length; i++) {
+          this.widgets[i].onRemove?.()
+        }
+        this.widgets.length = isConvertedWidget
+      }
+      for (const l of text) {
+        const w = ComfyWidgets.STRING(this, 'text_' + this.widgets?.length, ...).widget
+        w.inputEl.readOnly = true
+        w.inputEl.style.opacity = 0.6
+      }
+    }
+    ...
+  }
+}
+```
+
+Four separate conversions:
+
+| Old                                                    | New                         |
+| ------------------------------------------------------ | --------------------------- |
+| `nodeData.name === 'ShowText\|pysssss'` guard          | the `defs.extend` selector  |
+| `+!!this.inputs?.[0].widget` converted-widget sniffing | `input.isWidgetInput`       |
+| `this.widgets.length = n` truncation                   | remove by name (below)      |
+| `w.inputEl` DOM access                                 | `widgets.mount({ render })` |
+
+Truncation has no single-call replacement, deliberately — assigning `length`
+skips each widget's teardown, which is why the pack has to call `onRemove()` by
+hand first:
+
+```js
+// after — removal runs teardown for you
+for (const name of node.widgets.names().slice(keep)) {
+  node.widgets.remove(name)
+}
+```
+
+Note `isConvertedWidget` exists only to skip a widget the _old frontend_ hid via
+the converted-widget protocol. With `setHidden()` as a real property, that
+whole line of reasoning goes away — check `input.isWidgetInput` if you actually
+care whether an input is a widget's socket form.
+
+## Pack-owned node types — `registerCustomNodes` / `extends LGraphNode`
+
+86 packs / 18.2% of installs define their own types by subclassing. The
+replacement is `comfy.defs.define(...)`: the definition is plain data, and no
+class is ever yours.
+
+**First identify the intent.** "Virtual node" is four different things, and the
+conversion differs for each:
+
+| The node exists to…                     | Examples                     | Convert to                                                  |
+| --------------------------------------- | ---------------------------- | ----------------------------------------------------------- |
+| annotate — never executes               | Note nodes                   | `execution: 'frontend'`, no `resolve`                       |
+| be a wire — indirection                 | Reroute, `SetNode`/`GetNode` | `resolve` returning `forwardTo`                             |
+| be a value — UI-held literal            | Primitive, constants         | `resolve` returning `literal`                               |
+| act on _other_ nodes — a remote control | rgthree Fast Muter           | **not `resolve` at all** — handle calls in widget callbacks |
+
+```js
+// before
+class GetNode extends LGraphNode {
+  constructor() {
+    super()
+    this.addOutput('value', '*')
+    this.isVirtualNode = true
+  }
+  applyToGraph() {
+    /* rewrites links on the LIVE graph mid-serialize */
+  }
+}
+LiteGraph.registerNodeType('GetNode', GetNode)
+
+// after — declared, and resolution is a pure answer over a read-only view
+comfy.defs.define({
+  type: 'GetNode',
+  execution: 'frontend',
+  outputs: [{ name: 'value', type: '*' }],
+  widgets: [{ type: 'string', name: 'key', value: '' }],
+  resolve: ({ self, nodesOfType }) => {
+    const setter = nodesOfType('SetNode').find(
+      (n) => n.widgetValue('key') === self.widgetValue('key')
+    )
+    return {
+      value: setter ? { forwardTo: setter.input('value') } : { omit: true }
+    }
+  }
+})
+```
+
+`resolve` answers, per output: `{ forwardTo: inputRef }` ("whatever feeds that
+input"), `{ literal: value }`, or `{ omit: true }`. Our pass follows chains
+(Get → Set → Reroute → …) with cycle detection. You never see or touch the
+prompt being built — a resolver that throws poisons one prompt build and the
+graph is untouched, which is exactly what `applyToGraph` could not guarantee.
+A simple reroute is one line: `resolve: ({ self }) => ({ out: { forwardTo:
+self.input('in') } })`.
+
+**Nodes that act on other nodes are ordinary nodes.** A Fast Muter is a remote control: a row of toggles, one per wired-in node. A Fast Muter is `defs.define` with
+`execution: 'frontend'`, buttons via `widgets`, and callbacks that call
+`comfy.graph.nodesOfType(...)` + `node.setMode('bypass')` — edit-time changes
+the user can undo, not serialization behaviour. Do not put neighbour mutation
+in `resolve`; `resolve` cannot write anything, by design.
+
+**Do not carry over** `isVirtualNode`, `applyToGraph`, or the subclass itself.
+If the node's `applyToGraph` does something none of the three resolution shapes
+can express, that is an `api-gap` punt — name what it rewrites.
+
+## Node handles are accessors, not properties
+
+Every read and write on a `NodeHandle` is a method — the contract in
+`src/types/extensionV2.ts`, so a read can be a store query and a write can
+become a command. Property syntax silently does nothing or throws.
+
+| Old (on the raw node)    | Published API                               |
+| ------------------------ | ------------------------------------------- |
+| `node.title = t`         | `node.setTitle(t)` / `getTitle()`           |
+| `node.color = c`         | `node.setColor(c)` / `getColor()`           |
+| `node.bgcolor = c`       | `node.setBgColor(c)` / `getBgColor()`       |
+| `node.mode = 4`          | `node.setMode('bypass')` / `getMode()`      |
+| `node.flags.collapsed`   | `node.isCollapsed()` / `setCollapsed(b)`    |
+| `node.flags.pinned`      | `node.isPinned()` / `setPinned(b)`          |
+| `node.shape = s`         | `node.setShape(s)` / `getShape()`           |
+| `node.properties[k] = v` | `node.setProperty(k, v)` / `getProperty(k)` |
+| `node.size` / `node.pos` | `node.getSize()` / `getPosition()`          |
+
+**Both setters take one tuple**, not two numbers — the legacy `setSize(w, h)`
+and `setPos(x, y)` arities are gone:
+
+```js
+// before
+node.setSize([200, 58]) // litegraph took an array here
+node.color = '#1b4669'
+node.bgcolor = '#29699c'
+
+// after
+node.setSize([200, 58]) // unchanged — still one tuple
+node.setColor('#1b4669')
+node.setBgColor('#29699c')
+```
+
+Widget handles follow the same rule: `getValue()`/`setValue()`,
+`isHidden()`/`setHidden()`, `getOptions()`/`setOption()`, and `widgetType`
+rather than `type`. See `widgets.md`.
+
+## Per-instance state
+
+Handles hold no arbitrary properties, so `node._myState = x` has no target. Keep
+the state yourself, keyed by node id:
+
+```js
+// before — a property stashed on the node instance
+nodeType.prototype.onExecuted = function (output) {
+  if (this._lastHash === hash) return
+  this._lastHash = hash
+}
+
+// after — the pack owns its own state
+const stateByNode = new Map()
+const stateFor = (id) => {
+  let s = stateByNode.get(id)
+  if (!s) stateByNode.set(id, (s = {}))
+  return s
+}
+
+comfy.defs.extend('MyNode', (b) => {
+  b.onExecuted((node, result) => {
+    const state = stateFor(node.id)
+    if (state.lastHash === hash) return
+    state.lastHash = hash
+  })
+  b.onRemoved((node) => stateByNode.delete(node.id))
+})
+```
+
+This is a supported conversion, not a workaround. Clean up in `onRemoved` — the
+old form was collected with the node, and a Map is not.
+
+## Traps
+
+**The constructor self-assignment.** `this.type = this.type ?? undefined` is a
+defensive no-op that now throws, killing construction entirely. Handled
+mechanically by the `type-write-noop` rule — 8 packs, 3.86M downloads, including
+rgthree's whole 12-type virtual-node family.
+
+**`nodeData` is a definition, not a node.** Reading `nodeData.input.required.x`
+is fine; it becomes `b.def.inputs`. But the shape differs — do not assume a
+field-by-field rename.
+
+**Async hooks.** `async beforeRegisterNodeDef` is common and usually gratuitous.
+`defs.extend` is synchronous; if a pack genuinely needs async setup, do it in
+`onCreated` and guard for the node being removed before it resolves.
+
+**Order-dependent patches.** A pack that reads `nodeType.prototype.onNodeCreated`
+expecting another pack's patch to already be installed has no equivalent, by
+design. Escalate — it needs the author.
+
+## Source data
+
+Prototype-assignment counts derived from the corpus at
+`~/comfy/nodes-compat-study/corpus/registry_js` (4,969 packs, 2,562 files
+scanned). Grep-derived; sample-verify before citing an individual number.

--- a/.claude/skills/converting-custom-nodes/references/nodegraph-101.md
+++ b/.claude/skills/converting-custom-nodes/references/nodegraph-101.md
@@ -1,0 +1,183 @@
+# ComfyUI node graphs in ten minutes
+
+Read this first if you have not converted a pack before. It exists because the
+alternative is inferring the model from the pack's source, which is slow and
+tends to produce a plausible but wrong mental picture.
+
+## What the thing is
+
+ComfyUI is a **node graph editor whose graph is a program**. The user wires
+nodes together; the frontend compiles that wiring into a JSON payload; a Python
+backend executes it and streams results back.
+
+```
+user edits graph  →  graphToPrompt()  →  POST /prompt  →  backend executes
+       ▲                                                        │
+       └────────────── node.onExecuted(message) ◀───────────────┘
+```
+
+Two artifacts come out of the same graph, and confusing them is the single most
+common conversion error:
+
+|                     | **Workflow**                                               | **Prompt**                 |
+| ------------------- | ---------------------------------------------------------- | -------------------------- |
+| Purpose             | what the user saves and reloads                            | what the backend runs      |
+| Contains            | positions, colours, titles, collapsed state, widget values | node inputs and links only |
+| Produced by         | `graph.serialize()`                                        | `graphToPrompt()`          |
+| Frontend-only nodes | present                                                    | must be resolved away      |
+
+**Both must come out byte-identical after a conversion.** That is the hard
+constraint: a user's saved file and the job they queue cannot change.
+
+## What a node actually is
+
+A node exists in two halves.
+
+**The backend half** is a Python class. It declares its inputs, outputs and
+category, and the server sends that declaration to the frontend as a **node
+definition** — `nodeData` in the old hook. This is a _description_, not a node.
+
+**The frontend half** is a JavaScript class generated _from_ that definition,
+registered by type name. Every node the user drops on the canvas is an instance
+of it.
+
+```
+node definition (from backend)  →  generated class  →  instances on the canvas
+   "KSampler", inputs, outputs        KSampler            node #7, node #12
+```
+
+So there are three distinct things, and packs act on all three:
+
+- **the definition** — before any class exists
+- **the class** — affects every instance of that type
+- **the instance** — one node on one canvas
+
+A conversion that moves code between these levels changes behaviour. Watch for
+it: `nodeData.name` is a _definition_; `this` inside `onNodeCreated` is an
+_instance_.
+
+## The lifecycle
+
+Everything a pack hooks hangs off this sequence:
+
+1. **Definitions arrive** from the backend.
+2. **`beforeRegisterNodeDef`** — for each definition, every extension gets a
+   chance to modify the definition and patch the about-to-be-registered class.
+   _This is where nearly half of all packs do their work._
+3. **`registerNodeType`** puts the class in the registry under its type name.
+4. **Instance created** — user drops a node, or a workflow loads one.
+   `onNodeCreated` fires (before the node has an id or a graph).
+5. **`onAdded`** — the node joins the graph. Now it has an id and is
+   addressable. _This is where the published `onCreated` fires, deliberately._
+6. **`onConfigure`** — only for nodes loaded from a saved workflow; restores
+   widget values and any pack-specific state.
+7. **`onExecuted(message)`** — backend produced output for this node.
+8. **`onRemoved`** — node deleted.
+
+## Inputs, outputs, widgets
+
+- **Inputs / outputs** are sockets. Links connect an output to an input.
+- **Widgets** are the controls drawn _on_ the node — a seed number, a sampler
+  dropdown, a text box. A widget holds a value that becomes an input at
+  execution time.
+
+The wrinkle: a widget can be **promoted to a socket** so another node can drive
+it. Historically the frontend faked this by setting `widget.type =
+'converted-widget'` and stashing the old type — a hack that packs learned to
+detect and imitate. It is now a real property. When you see
+`'converted-widget'`, the pack is almost always trying to _hide_ a widget, not
+change its kind.
+
+`widgets_values` in a saved workflow is a **positional array** — index matters,
+names are not stored. This is why widget order and count are part of the wire
+format, and why removing a widget is not a cosmetic change.
+
+## Why packs customise the frontend at all
+
+Packs are not being gratuitous. There are a handful of recurring motives, and
+recognising which one you are looking at usually tells you the replacement.
+Counts are sites across the ~5,000-pack registry corpus; a pack often has
+several motives at once.
+
+| Motive                                                          | What it looks like                                   | Scale               |
+| --------------------------------------------------------------- | ---------------------------------------------------- | ------------------- |
+| **Show backend output on the node** — text, previews, progress  | patch `onExecuted`, create a display widget          | 497 packs           |
+| **Set up per-instance state** — dynamic inputs, defaults, DOM   | patch `onNodeCreated`                                | 943 packs           |
+| **Restore that state on load**                                  | patch `onConfigure`                                  | 429 packs           |
+| **React to wiring** — add a slot when the last one fills        | patch `onConnectionsChange`                          | 223 packs           |
+| **Draw on the node** — badges, overlays, custom controls        | patch `onDrawForeground`                             | 199 packs           |
+| **Define frontend-only nodes** — reroutes, switches, note nodes | `registerCustomNodes`, `isVirtualNode`               | 86 packs            |
+| **Change what gets saved or queued**                            | patch `serialize`, `serializeValue`, `graphToPrompt` | fewer, highest risk |
+
+The last row is where conversions do damage, because it is the row that touches
+the wire format.
+
+## Why any of this needs converting
+
+Almost all of the above is done by **monkey-patching the generated class's
+prototype**:
+
+```js
+const original = nodeType.prototype.onExecuted
+nodeType.prototype.onExecuted = function (message) {
+  original?.apply(this, arguments) // ← if you forget this, you break other packs
+  myBehaviour.call(this, message)
+}
+```
+
+Three things are wrong with this, and they motivate the whole published API:
+
+1. **It reaches into internals.** `nodeType.prototype`, `node.widgets`,
+   `link.origin_id` are implementation, and they are being reshaped.
+2. **It does not compose.** Whether your handler survives depends on every
+   other pack remembering to call through. One that forgets silently disables
+   yours, and load order decides who wins.
+3. **It cannot be undone.** There is no unpatch, so nothing can be torn down.
+
+The published API replaces each of these with something registered rather than
+patched: handlers are additive, ordered, and individually removable, and the
+entity classes stay closed.
+
+## The mental model to convert with
+
+> A pack **declares** what it wants for **which node types**, and **reacts** to
+> a small set of lifecycle events using **handles** that expose behaviour but
+> not internals.
+
+Concretely, the shape of nearly every conversion is:
+
+```js
+// before: run for every type, filter, patch the prototype
+app.registerExtension({
+  name: 'x',
+  beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== 'MyNode') return // ← the selector
+    const orig = nodeType.prototype.onExecuted // ← the chaining
+    nodeType.prototype.onExecuted = function (m) {
+      orig?.apply(this, arguments)
+      populate.call(this, m.text) // ← the actual behaviour
+    }
+  }
+})
+
+// after: the selector is declared, the chaining disappears, behaviour is unchanged
+comfy.defs.extend('MyNode', (b) => {
+  b.onExecuted((node, result) => populate(node, result.text))
+})
+```
+
+The guard clause becomes the selector. The capture-and-chain boilerplate goes
+away entirely. What is left is the behaviour, which you should be changing as
+little as possible.
+
+## Things that will mislead you
+
+- **`this` is not always a node.** Inside a patched prototype method it is an
+  instance; inside `beforeRegisterNodeDef` it is not.
+- **`nodeData` is a definition, not a node.** It has no widgets and no id.
+- **A widget named the same is not the same widget.** Packs remove and recreate
+  readout widgets on every execution.
+- **`app` is the whole application.** A pack reaching for `app.graph` usually
+  wants its own node's graph, and often only needs the node.
+- **Absence of a hook means nothing.** Plenty of packs put their logic in a
+  module-level side effect that runs at import.

--- a/.claude/skills/converting-custom-nodes/references/widgets.md
+++ b/.claude/skills/converting-custom-nodes/references/widgets.md
@@ -1,0 +1,308 @@
+# Converting widget-array mutation and the converted-widget protocol
+
+> **Accessor style.** The published handles follow `src/types/extensionV2.ts`
+> (PR #11251): reads and writes are methods, not properties —
+> `widget.getValue()` / `setValue(v)`, `isHidden()` / `setHidden(b)`,
+> `getOptions()` / `setOption(key, value)`, `setLabel(s)`, and `widgetType` for
+> the type. Node handles keep `getTitle()`/`setTitle()` style likewise.
+
+The largest cohort by pack count, and the one where naive conversions are most
+likely to be silently wrong.
+
+| Surface                   | Packs | Installs |
+| ------------------------- | ----- | -------- |
+| `widgets.splice`          | 286   | 21.6%    |
+| `widget.type` overwrite   | 270   | 18.6%    |
+| converted-widget protocol | 238   | 25.1%    |
+| `widgets = [...]`         | 226   | 10.9%    |
+| `widgets.push`            | 142   | —        |
+| `getCustomWidgets` POJO   | 91    | 16.8%    |
+| `widgets.length = 0`      | 31    | —        |
+
+These overlap heavily; the same pack usually hits several.
+
+## Classify before converting — `splice` is often not a reorder
+
+```js
+// ComfyUI-KJNodes setgetnodes.js:988
+// Fresh options object (live getter preserved) + remove/re-add to force
+// Vue re-extraction.
+w.options = newOpts
+const idx = this.widgets.indexOf(w)
+if (idx >= 0) {
+  this.widgets.splice(idx, 1)
+  this.widgets.splice(idx, 0, w)
+}
+```
+
+Removed and reinserted **at the same index** — the array is unchanged. This is
+cache invalidation, not reordering. It converts to:
+
+```js
+node.widgets.get(name).setOption('values', newValues)
+```
+
+The hack disappears: invalidation is the API's problem now. A converter that
+assumes "splice means reorder" produces nonsense here.
+
+**Read the indices before choosing a rule.** Same index in and out → invalidation.
+Different index → a real move (`widgets.move`). A full rewrite of the array →
+`widgets.reorder`.
+
+## The converted-widget protocol — ~20 lines become one property
+
+The full pattern, from ComfyUI-Easy-Use `easyExtraMenu.js:339`:
+
+```js
+const CONVERTED_TYPE = 'converted-widget'
+
+function hideWidget(node, widget, suffix = '') {
+  widget.origType = widget.type
+  widget.origComputeSize = widget.computeSize
+  widget.origSerializeValue = widget.serializeValue
+  widget.computeSize = () => [0, -4] // -4 offsets litegraph's inter-widget gap
+  widget.type = CONVERTED_TYPE + suffix
+  widget.serializeValue = () => {
+    if (!node.inputs) return undefined
+    const input = node.inputs.find((i) => i.widget?.name === widget.name)
+    if (!input || !input.link) return undefined // unlinked → do not serialize
+    return widget.origSerializeValue
+      ? widget.origSerializeValue()
+      : widget.value
+  }
+  if (widget.linkedWidgets) {
+    for (const w of widget.linkedWidgets) hideWidget(node, w, ':' + widget.name)
+  }
+}
+```
+
+Everything above exists to emulate a property that did not exist:
+
+```js
+node.widgets.get(name).hidden = true
+```
+
+Gone with it: the `origType`/`origComputeSize`/`origSerializeValue` save-and-
+restore dance, the `[0, -4]` magic number, and the type-string mangling.
+
+### ⚠️ The trap: `hidden` does not imply "do not serialize"
+
+The old hack **coupled** two things. Hiding a widget also installed a
+`serializeValue` that returned `undefined` unless the matching input was linked.
+
+In the published API those are orthogonal — `hidden` is presentation,
+`serialize` is persistence. That is the better design, but it means a literal
+one-line conversion **changes behaviour**: a hidden widget now serializes where
+it previously did not.
+
+So check what the pack relied on:
+
+- Hiding purely for presentation → `hidden = true` is complete.
+- Hiding _and_ suppressing serialization → set `hidden`, and handle
+  serialization explicitly. If the value should persist only when the socket is
+  connected, that condition belongs in the pack's own `onSerialize`.
+
+This is a wire-format change if you get it wrong, so it will be caught by the
+gate — but understand it rather than letting the gate find it.
+
+### Linked widgets
+
+The recursion over `widget.linkedWidgets` (seed + seed-control being the classic
+pair) has **no published equivalent**. Hide each widget explicitly by name, or
+escalate if the linkage is computed rather than fixed.
+
+## `widget.type` overwrite — 270 packs
+
+Almost always the converted-widget hack above. If it is genuinely trying to
+change a widget's _kind_, there is no replacement: type is identity. Remove the
+widget and add the intended one.
+
+```js
+// before
+widget.type = 'converted-widget' // → widget.setHidden(true)
+
+// before — genuinely changing kind
+widget.type = 'combo' // → remove + add, or escalate
+```
+
+## Array assignment and truncation
+
+```js
+// before
+this.widgets = this.widgets.filter((w) => w.name !== 'seed')
+this.widgets.length = 0
+this.widgets.push(w)
+
+// after
+node.widgets.remove('seed')
+for (const name of node.widgets.names()) node.widgets.remove(name)
+node.widgets.add(def)
+```
+
+Two reasons not to translate these literally:
+
+- **Assigning a new array drops the renderer's tracking.** The array identity is
+  what the renderer watches; `widgets.reorder` splices in place for exactly this
+  reason.
+- **Assigning `length` skips teardown.** Packs that do it correctly call
+  `widget.onRemove?.()` first — see Custom-Scripts `showText.js`. `remove()`
+  runs teardown for you, so the manual loop goes away.
+
+## Creating a widget
+
+`ComfyWidgets.*` is an unpublished internal. `node.widgets.add(def)` replaces it,
+and the `def` is plain data — no `node`, no `app`, no return-value unwrapping:
+
+```js
+// before
+const w = ComfyWidgets.STRING(
+  this,
+  'text',
+  ['STRING', { multiline: true }],
+  app
+).widget
+w.inputEl.readOnly = true
+w.inputEl.style.opacity = 0.6
+
+// after
+const widget = node.widgets.add({
+  type: 'textarea',
+  name: 'text',
+  value: '',
+  disabled: true
+})
+```
+
+`disabled: true` replaces the `readOnly` + `opacity` pair — the two lines packs
+use to fake a read-only widget. It is a real property, so the styling stays
+consistent with every other disabled widget instead of being hand-rolled.
+
+| Old factory                                     | `type`                                      |
+| ----------------------------------------------- | ------------------------------------------- |
+| `ComfyWidgets.STRING(..., { multiline: true })` | `'textarea'`                                |
+| `ComfyWidgets.STRING(...)`                      | `'string'`                                  |
+| `ComfyWidgets.INT` / `FLOAT`                    | `'number'` (or `'slider'` with `min`/`max`) |
+| `ComfyWidgets.BOOLEAN`                          | `'toggle'`                                  |
+| `ComfyWidgets.COMBO`                            | `'combo'`, values via `options.values`      |
+| `ComfyWidgets.MARKDOWN`                         | `'markdown'`                                |
+| `ComfyWidgets.COLOR`                            | `'color'`                                   |
+
+### Keeping a widget out of the saved workflow
+
+```js
+// before
+widget.serializeValue = async () => {} // per widget
+this.serialize_widgets = false // whole node
+
+// after
+node.widgets.add({ type: 'textarea', name: 'text', serialize: false })
+node.serializesWidgets = false
+```
+
+Both are wire-format switches, so a conversion that drops them changes what the
+saved workflow contains. `serialize` is orthogonal to `hidden` and `disabled`:
+a widget can be visible and unsaved, or hidden and saved.
+
+`add` throws if the name is already taken — rebuild is remove-then-add, and the
+throw catches the common bug of appending a duplicate every execution.
+
+**Do not convert a remove-and-recreate into `remove` plus a bare
+`ComfyWidgets.*` call.** That leaves the pack on the unpublished surface, which
+is the entire thing the conversion exists to end. If the widget it needs has no
+`add` equivalent, that is an `api-gap` punt, not a partial conversion.
+
+## Never let a write vanish
+
+A handle lookup can fail. Reached through `?.`, a _write_ behind it does
+nothing at all and the pack cannot tell:
+
+```js
+// ✗ silently does nothing when the node has not joined a graph yet — which is
+//   exactly when a helper like this is usually called
+comfy.graph.node(String(node.id))?.widgets.get(name)?.setHidden(true)
+
+// ✓ use the handle you were given
+function hideForGood(node, name) {
+  node.widgets.get(name)?.setHidden(true) // reads may be optional
+}
+```
+
+`comfy.graph.node(id)` resolves through the graph, so it returns nothing for a
+node that has not been added yet. If you find yourself looking a node up by id
+inside a helper, the helper should be taking a `NodeHandle` instead — its
+caller has one.
+
+Optional chaining on a _read_ is fine: `?.getValue()` returning undefined is
+visible. On a write it is a bug that never reports itself.
+
+## Reordering
+
+```js
+node.widgets.reorder(['prompt', 'seed', 'steps']) // full permutation
+node.widgets.move('prompt', 0) // single move
+```
+
+`reorder` **throws on a partial list** rather than dropping the widgets you
+omitted — which is precisely how the splice idiom lost them. The error names
+what is missing.
+
+## `setOption` preserves accessors — do not hand-merge
+
+```js
+// kjnodes builds dynamic combos with a live getter
+Object.defineProperty(
+  newOpts,
+  'values',
+  Object.getOwnPropertyDescriptor(comboOptions, 'values')
+)
+```
+
+`setOption` merges by **property descriptor**, so getters stay getters. If you
+hand-roll `{ ...widget.options(), ...patch }` you will invoke the getter and
+freeze its result — pinning a dynamic combo to a one-time snapshot, silently.
+
+`options()` returns a frozen _snapshot_ by design; use `setOption` to write.
+
+## `getCustomWidgets` — 91 packs
+
+Returning plain objects the store never sees. The widget is mounted on the node
+that needs it instead of registered as a global type:
+
+```js
+node.widgets.mount({
+  name: 'slider',
+  height: 40,
+  render(container) {
+    /* build DOM; call widget.setValue on change */
+  },
+  destroy() {
+    /* release listeners, timers, observers */
+  }
+})
+```
+
+`render` receives the container and gets a plain DOM element, deliberately:
+packs bundle their own Vue since ADR 0005, and a component from a foreign Vue
+instance cannot be mounted. A render function is framework-agnostic and
+sidesteps the dual-instance problem.
+
+There is no global widget-type registry. If a pack genuinely needs one type
+reused across many node types, mount it from a shared helper — that is the
+supported shape, not a workaround.
+
+## Traps summary
+
+| Trap                                                                    | Consequence                                      |
+| ----------------------------------------------------------------------- | ------------------------------------------------ |
+| Treating same-index splice as a reorder                                 | Nonsense conversion of a cache-invalidation hack |
+| `hidden = true` alone, where the old code also suppressed serialization | Wire-format change                               |
+| Hand-merging options                                                    | Live getters flattened; dynamic combos freeze    |
+| Assigning a new `widgets` array                                         | Renderer stops tracking                          |
+| Assigning `widgets.length`                                              | Widget teardown skipped                          |
+| Partial `reorder` list                                                  | Throws — by design; supply every name            |
+
+## Source data
+
+Counts from the registry census at `~/comfy/nodes-compat-study/`
+(`results/registry_scan.json`, 4,969 packs). Grep-derived with a known
+false-positive rate — sample-verify before citing an individual number.

--- a/docs/API_DECISIONS_FOR_REVIEW.md
+++ b/docs/API_DECISIONS_FOR_REVIEW.md
@@ -1,0 +1,698 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> Companion to `magic_patch_WIP.md`, `node_api_WIP.md` and
+> `magic_patch_test_plan_WIP.md`.
+> Notion copy for review: **API Decisions for Review** in the Documents Hub.
+
+# API decisions for review — node API / Magic Patch
+
+**The design is settled. Everything here is an implementation issue.** Each
+entry surfaced from converting real packs onto the published node API
+(`src/platform/nodeApi/`) and loading them in a real ComfyUI — defects, format
+mismatches, and places where the implementation does not yet reach what the
+design already calls for.
+
+**Who signs off what.**
+
+| Area                                                               | Owner                              |
+| ------------------------------------------------------------------ | ---------------------------------- |
+| API surface shape, widgets, node definitions, Nodes 2.0 theming    | **Christian**                      |
+| Graph model, resolution/supply, ECS-side invariants, slot identity | **Alex**                           |
+| Scope, sequencing, what we decline to support                      | **Ben** (owner), escalate to Miles |
+
+The choices recorded below were taken to unblock a proof of concept and get it
+to a go/no-go, not to settle policy. Where one was made to keep moving, it is
+marked _provisional_ and the reasoning is written out so it can be overturned
+cheaply. Several have blast radius well beyond this programme, and are flagged
+as such.
+
+**This file is one half of the review.** The other half lives in
+`node_api_WIP.md`:
+
+- **§4f Contested additions** — surface we _added_ that is arguable, each with
+  the alternative rejected and the cost of reversing it.
+- **§7 Deliberately excluded** — asks we are refusing.
+- **§8 Open questions** — Q1–Q9, including the Nodes 2.0 re-theming question.
+
+The split: _"we added this to the API, argue with it"_ → `node_api_WIP.md` §4f.
+_"this is broken or undecided, someone must rule"_ → here.
+
+**Status key:** ✅ fixed · 🟡 provisional, not yet built · ❓ needs a call before
+it can be built.
+
+Each entry states: what was found, the evidence, what was done for now, and what
+is still open.
+
+---
+
+## 1. `widgets_values` round trip — serialize and configure disagreed ✅
+
+**The defect.** `LGraphNode.serialize()` writes each value at the widget's _own_
+index, so a widget with `serialize === false` leaves a hole. `configure()` read
+the array _compacted_, skipping non-serialising widgets and consuming values in
+order. The two disagree whenever a non-serialising widget precedes a persisted
+one.
+
+Minimal reproduction — widgets `[panel (serialize:false), seed]`, `seed = 1234`:
+
+```
+saved:    widgets_values = [null, 1234]
+reloaded: seed === null
+```
+
+Silent user data loss. No error, no warning.
+
+**Why it went unnoticed.** PR #921, which introduced the compacted read, says so
+itself: _"Current usage in frontend should not be affected as preview media
+widgets are mostly dynamically added at the end of widget list."_ Where the
+non-serialising widget is last, the two layouts coincide. The programme's own
+`widgets.mount()` is what breaks that assumption, since it sets
+`serialize: false` on a widget a pack may mount anywhere.
+
+**History.** `serialize()` has written by index since the file was first
+authored — `o.widgets_values[i] = …`, never `push`. The compacted read arrived
+later (#921) and was carried forward through #6661 and #7205. So the write is
+the long-standing format and the read is the deviation.
+
+**Provisional — implemented.** `configure()` now reads the indexed layout, and falls back to the
+compacted one. The two are distinguishable: a saved array is longer than the
+count of serialising widgets _exactly when_ a hole precedes a value, and where
+they are not distinguishable they agree. Hand-written and older compacted data
+keeps loading — including the array asserted by #921's own test.
+
+`serialize()` is unchanged; it was always correct.
+
+**Verification.** `widgetsValuesRoundTrip.test.ts` covers five widget layouts;
+the three with a hole before a value fail against the old read and pass against
+the new one. Full litegraph suite: 1152 passing.
+
+**Question.** Should `serialize()` stop emitting the hole
+altogether — i.e. write compacted and drop indexed support after a deprecation
+window? That would make the format smaller and unambiguous, at the cost of a
+migration. Current change is deliberately compatible in both directions and
+takes no position on that.
+
+---
+
+## 2. What "byte-identical wire format" means for mounted widgets ✅
+
+The verification gate rests on the invariant that a conversion must not change
+the saved workflow or the queued prompt. **The code and the invariant currently
+disagree**, and the disagreement is in the API layer, not the packs.
+
+`widgets.mount()` sets _both_ serialization flags. The legacy
+`addDOMWidget(…, { serialize: false })` set only `options.serialize` and left
+`widget.serialize` undefined. So a converted node saves **one fewer**
+`widgets_values` entry than the original.
+
+Hit independently in three packs:
+
+- **kjnodes** `context_windows_visualizer` — 11 entries became 10.
+- **Impact Pack** `MaskRectArea` — one trailing `null` dropped.
+- **LayerStyle** — the agent _declined to mount_ a colour picker for this
+  reason: mounting would have silently stopped persisting users' colours. It
+  used core's `COLOR` widget instead, and the wire format was preserved.
+
+The two flags are genuinely distinct and documented
+(`src/lib/litegraph/docs/WIDGET_SERIALIZATION.md`): `widget.serialize` gates
+workflow persistence, `widget.options.serialize` gates the API prompt.
+`MountDef` collapses them into one boolean, so the "persist but do not send"
+and "send but do not persist" quadrants are inexpressible.
+
+**Provisional — now implemented.** `MountDef` gained `sendToPrompt`, which
+defaults to `serialize` and overrides only the prompt half. The two states that
+one boolean could not say are now sayable, and "saved but not sent" — exactly
+what legacy `addDOMWidget(…, { serialize: false })` did — is the one packs
+actually need.
+
+The case that forced it: bjornulf's `show_text` creates one readout widget per
+line of its result, and the original named **every one of them `text`**. Widget
+identity is now the name, so the conversion had to rename them `text`, `text_1`,
+`text_2` — and since `graphToPrompt` writes `inputs[widget.name]`, each rename
+became a **new key in the queued prompt** that the original never sent. The
+renamed duplicates are now `sendToPrompt: false`, so the prompt keeps exactly
+one `text` key.
+
+One residual delta, stated rather than buried: same-named widgets overwrite in
+order, so the original sent the _last_ line under `text` and the conversion
+sends the _first_. Matching that exactly is not expressible while the prompt key
+is the widget name. For a readout the node fills in from its own execution
+result the echoed value is inert, so this was judged acceptable — but it is a
+real difference, and it is the same duplicate-name root cause that blocked
+pysssss' `betterCombos` and easy-use's `showAnything`.
+
+**Question.** Should a _newly mounted_ widget (one with no
+legacy counterpart — e.g. a pack adding a canvas preview to a node that had no
+widgets) default to persisting? Defaulting to "yes" matches legacy exactly but
+means a pack that merely _draws_ something adds an entry to the user's saved
+workflow. Defaulting to "no" is cleaner but is not byte-identical for
+conversions.
+
+---
+
+## 3. Custom widgets are silently discarded when they shadow a core name ❓
+
+`src/stores/widgetStore.ts:14`:
+
+```ts
+;() => new Map([...customWidgets.value, ...Object.entries(coreWidgets)])
+```
+
+Core widgets are spread **last**, so on a name collision core silently wins. A
+pack registering a widget named `COLOR`, `STRING`, `INT`, `COMBO`, … via
+`getCustomWidgets` has no effect and gets no error.
+
+**Measured blast radius** (corpus of 4,998 registry packs): 91 packs use
+`getCustomWidgets`; **12 register a name that collides with a core widget**,
+totalling **6.8M downloads (6.4% of all)**:
+
+| downloads | pack                     | colliding names    |
+| --------- | ------------------------ | ------------------ |
+| 3,301,869 | comfyui-easy-use (#3)    | COMBO, INT, STRING |
+| 1,986,588 | comfyui_layerstyle (#12) | COLOR              |
+| 908,221   | comfy-mtb (#25)          | COLOR              |
+| 573,364   | comfyui-mixlab-nodes     | INT, STRING        |
+| … 8 more  |                          |                    |
+
+This was found because LayerStyle's DZ colour widget turned out to be
+**already unreachable** — so its removal during conversion was not a regression.
+
+**Needs a call, because both directions are defensible.** Either:
+
+- **Core wins is intended** — then `getCustomWidgets` is misleading and should
+  fail loudly (or warn) when a pack shadows a core type, rather than silently
+  discarding the registration; or
+- **Packs should win** — then swapping the spread order hands `STRING` / `INT` /
+  `COMBO` rendering to third-party packs across the ecosystem in one release.
+  Large blast radius for a one-line change.
+
+Not touched pending a decision.
+
+---
+
+## 4. Resolution does not yet implement the supply direction ❓
+
+`resolveFrontendNodes` answers _"what feeds my output"_. It iterates only nodes
+that registered a resolver, and only over **their own outputs**
+(`src/platform/nodeApi/resolution.ts:180-186`):
+
+```ts
+for (const node of graph.nodes ?? []) {
+  if (!resolvers.has(node.type ?? '')) continue
+  const outputs = node.outputs?.length ?? 0
+  for (let output = 0; output < outputs; output++)
+    follow(String(node.id), output, new Set())
+}
+```
+
+**cg-use-everywhere** (#13, 1.89M downloads) broadcasts a value to every
+matching _unconnected input_ in the graph. Two independent blockers:
+
+1. Its nodes have **zero outputs**, so the loop body never runs and a
+   registered resolver is silently never called.
+2. `ResolvedSource` is returned per `nodeId:output`. There is no channel by
+   which a resolver can name _another node's input_.
+
+Result: 2 of 20 files converted; 12 refused. The pack is not shippable on the
+current API.
+
+The read-only view is also far narrower than the matching needs. UE matches on
+link type, node title regex, input name regex, group membership, node colour,
+`properties.ue_properties.*` and priority. `ResolveView` offers:
+
+```ts
+interface ResolvedNodeView {
+  id
+  type
+  widgetValue(name)
+  input(ref)
+}
+interface ResolveView {
+  self
+  nodesOfType(type)
+}
+```
+
+Missing: title, properties, colour, slot names/labels/types, `isConnected`, an
+all-nodes enumeration — and **there is no group API anywhere in
+`src/platform/nodeApi/`**.
+
+**Provisional position:** this must be supported. The two graphs hold the same
+data before and after conversion, and a node having no output does not prevent inferring the
+value it carried — the information is all present. The gap is in the
+implementation, not the model.
+
+**Question — what shape?** The straightforward one is a
+graph-level supply pass folded into the same fixpoint, e.g.
+`supply(view) => Map<InputRef, OutputResolution>`, so injected sources chain
+through Reroutes like ordinary ones. That needs a view rich enough to express
+the matching **without** handing packs the live graph — the sandbox constraint
+is that resolution stays pure and read-only over a projection we control.
+
+**This is not one pack.** rgthree (#2, 3.7M downloads) is the same broadcast
+shape at roughly seven times the size. Together ≈5.6% of all downloads.
+
+---
+
+## 4a. rgthree is blocked, but not by resolution ❓
+
+**Correction to §4.** rgthree-comfy (#2, 3.69M downloads) was assumed to be the
+same broadcast shape as cg-use-everywhere. It is not, and the assumption was
+made from surface similarity rather than evidence.
+
+- **Reroute** (`reroute.ts:397`) and **Node Collector** are ordinary demand-side
+  passthroughs. Reroute is exactly `{forwardTo: {nodeId: self.id, input: 0}}`,
+  and `resolution.ts:165-174` already chains reroute→reroute to a fixpoint.
+- **Context, Context Big, Context Switch/Merge** and **Any Switch** are
+  **backend** nodes (`extends RgthreeBaseServerNode`, registered through
+  `beforeRegisterNodeDef`). Python does the switching; the frontend only does
+  connection ergonomics.
+- There is **no `applyToGraph` anywhere in the pack**, no fan-out, no injection
+  into another node's unconnected input.
+
+**What actually blocks it is larger.** rgthree replaced ComfyUI's node class,
+extension system, widget layer and menu system with its own: it intercepts
+`LiteGraph.registerNodeType` to substitute its own class
+(`base_node.ts:482-504`), patches 14 core prototypes (`rgthree.ts`), and ships a
+parallel widget framework (`utils_widgets.ts`). It is not a pack that calls a
+few deprecated APIs.
+
+| bucket                   | files | note                         |
+| ------------------------ | ----- | ---------------------------- |
+| converts cleanly today   | 7     | but cannot _run_ — see below |
+| blocked on a known gap   | 21    | loses named features         |
+| blocked on something new | 20    | 15 distinct new capabilities |
+
+The bucket counts understate it: `utils.js` is imported by **28** of 48,
+`rgthree.js` by 19, `base_node.js` by 17 — and all three are in the blocked set.
+So the 7 clean files can be written but not run until the foundation is
+rearchitected.
+
+**Recommendation: do not convert rgthree pack-wide.** If it is worth revisiting,
+three additions carry most of it, in order of leverage per cost:
+
+1. **A node-mode-change notification** (`onModeChange`). Cheap. rgthree does it
+   with `defineProperty(this, 'mode', {set})` (`base_node.ts:96-107`); it is the
+   sole driver of Node Mode Repeater.
+2. **A group API** (gap 18). Fast Groups Muter, Fast Groups Bypasser and the
+   group-header toggles are 100% dead without it.
+3. **A prompt-serialization lifecycle hook** (between serialize and POST).
+   Distinct from gap 26 ("no snapshot") and 27 ("no queueing"). Unblocks Seed
+   and Random Unmuter.
+
+Two things it needs that I would **not** build for it: substituting the node
+class for a backend-registered type, and intercepting an in-flight link drag.
+
+**The wire-format item that matters most, at this install base.** `context.ts`
+runs a slot-name migration on every load — including a `CLIP_HEIGTH` →
+`CLIP_HEIGHT` typo fix whose comment says it must live "in perpetuity". It _is_
+expressible (`b.onConfigured` + `slot.modify({name})` + `output.moveLinksTo()`),
+but only carried over verbatim. Dropped, old workflows silently land links on
+the wrong slot.
+
+**Seed is the other one.** `widgets_values` keeps the sentinel `-1` and the real
+seed is injected into the prompt after `graphToPrompt`. Converted without a
+prompt lifecycle hook, every queued prompt sends `-1` and the backend
+randomizes — reproducibility breaks, not just bytes.
+
+## 5. `diff-is-mostly-substance` contradicts the conversion guidance ✅
+
+The check fails a file when most added lines differ only in indentation, on the
+theory that the file was reflowed rather than converted. But unwrapping
+`app.registerExtension` around a 500-line callback dedents the entire body, and
+the skill explicitly requires correct re-indentation when nesting genuinely
+changed. Three kjnodes files fail on ~93% indentation-only lines that are
+entirely mandatory.
+
+**Provisional — cheap either way.** Compare whitespace-blind, and make it
+advisory rather than gating.
+
+---
+
+## 6. Gap backlog ✅ (scope decided)
+
+**Provisional scope:** every gap that is not cosmetic, and that does not
+violate the sandbox around internal graph state and behaviour, gets implemented.
+The ranking below is by observed functional loss, and is the part most worth
+challenging — it decides what gets built first.
+
+Ranked by functional loss observed in real packs:
+
+| gap                                                                 | what breaks today                                                                                                                                                                 |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prompt-time widget value (old `widget.serializeValue`)              | kjnodes `screencap_stream` is inert; Impact Pack no longer embeds images in the workflow; VHS path widgets lost                                                                   |
+| Workflow/prompt snapshot (`graphToPrompt`)                          | Crystools `Show Metadata` renders with no data                                                                                                                                    |
+| Per-node-instance subscription                                      | `onExecuted`/`onConnectionsChanged` are per _type_, so a helper holding a `NodeHandle` cannot subscribe — cost VHS/kjnodes editors their "background from connected node" feature |
+| Prompt queueing (`app.queuePrompt`)                                 | Impact Pack control-bridge cannot resume; LayerStyle Animation Builder button dead                                                                                                |
+| App-chrome surface                                                  | Crystools monitor has nowhere to render — the pack's entire purpose                                                                                                               |
+| Group API                                                           | no group concept at all; blocks UE matching and others                                                                                                                            |
+| Node chrome / badges                                                | help buttons, progress badges, error highlighting                                                                                                                                 |
+| Canvas/viewport (pan, zoom, screen↔graph, node rect, slot position) | floating docks, tooltips, gesture hit-testing                                                                                                                                     |
+| Canvas-wide overlay drawing                                         | UE virtual links, node-insert previews                                                                                                                                            |
+| Menus: submenus, visibility predicates, canvas and slot menus       | many packs                                                                                                                                                                        |
+| Settings: `attrs` (min/max/step), value/label option pairs          | sliders lose bounds; UE settings undeclarable                                                                                                                                     |
+| Localized slot names on `NodeDef`                                   | **locale-dependent silent prompt change** — see below                                                                                                                             |
+| Slot colour in `SlotPatch`                                          | blocks an otherwise-clean UE file                                                                                                                                                 |
+| Authenticated backend requests                                      | cloud uploads 401                                                                                                                                                                 |
+| Undo-transaction grouping                                           | multi-link edits land as N undo steps                                                                                                                                             |
+| Keybinding scope, command `active` state                            | shortcuts bind globally                                                                                                                                                           |
+
+**Explicitly out of scope (cosmetic, will not support):** kjnodes
+`canvas_background` (decorative canvas patterns) and `performance` (renderer
+tuning flags). Note the second is _not_ cosmetic in the usual sense — two of its
+five toggles change nothing on screen and exist purely for software renderers.
+Recorded as _editor render-loop tuning, out of scope for the node API_ so the
+eventual "panning got slow on my VM" report can be traced back here.
+
+---
+
+## 6a. Sanctioned hold-outs: workflow save/load 🟡
+
+Some packs exist _to_ hook workflow save and load. `comfyui-workflow-encrypt`
+encrypts the workflow itself; without a hook into serialization there is nothing
+left of it. `comfyui-get-meta` and VHS's `videoinfo.js` want the other half —
+opening a workflow parsed out of a file.
+
+Neither `app.graphToPrompt()` nor `loadGraphData`/`handleFile` has a published
+destination (gaps 26 and 30).
+
+**Provisional:** allow these packs to keep hooking save/load on the old surface
+rather than refusing them. The alternative is refusing a pack whose entire
+purpose is that hook, which teaches us nothing.
+
+Sites are marked in the converted source as:
+
+```js
+// SANCTIONED-HOLDOUT(workflow-save-load): <what this does, why it has no destination>
+```
+
+so they are greppable and can be retired the moment a document/workflow surface
+exists. A file carrying one **will fail `retires-the-legacy-global` by design** —
+that failure is the record, not a defeat, and should not be worked around.
+
+**Open question.** Is a document/workflow surface in scope at all, or is
+encrypt-the-workflow simply out of bounds for the node API? The answer decides
+whether these hold-outs are temporary or permanent. If temporary, the marker
+above is the migration list.
+
+## 7. Two traps worth a second pair of eyes
+
+**Localized slot names — a silent, locale-dependent prompt change.**
+cg-use-everywhere builds its matching regex from `localized_name`. `NodeDef`
+exposes only `{name, type}`. Substituting `name` looks harmless in English, but
+matching is tested against `label || localized_name || name`, so in a
+non-English locale `Seed Everywhere` **stops broadcasting and produces a
+different prompt** — and the result is persisted into
+`properties.ue_properties.input_regex` and `inputs[].label`. Nothing in the
+harness would catch this. The conversion was reverted rather than shipped.
+
+**`color_on` is serialized.** Writing `input.color_on` is a provable runtime
+no-op (`renderingColor()` falls back to the same table), so deleting it looks
+free — but `shallowCloneCommonProps` includes it, so dropping the write removes
+`nodes[].inputs[].color_on` from every saved workflow. `SlotPatch` has no colour
+field, so it can be neither set nor safely dropped.
+
+---
+
+## 6b. Capabilities built since this document was written ✅
+
+Every one of these came from a pack that could not be converted without it, and
+each closed a refusal rather than a nicety.
+
+| capability                                                       | what it replaces                                           | what it unblocked                                                                       |
+| ---------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `comfy.backend.assetUrl()`                                       | `api.fileURL`                                              | any pack serving its own images, fonts, html — `backend.url()` prepends `/api` and 404s |
+| `node.getBounds()` / `node.getSlotPosition()` / `graph.nodeAt()` | packs re-deriving geometry from renderer constants         | retired `comfy.constants` entirely                                                      |
+| `b.setExecution('frontend')`                                     | `node.isVirtualNode = true` on a _backend-registered_ type | enricos' `tools.js` — one line, whole file refused                                      |
+| `comfy.storage`                                                  | `api.storeUserData` and friends                            | kjnodes' ideogram template store                                                        |
+| `node.getScreenRect()`                                           | reading pan and zoom to place a panel over a node          | ideogram's floating dock                                                                |
+| `comfy.onViewportChanged()`                                      | chaining a renderer draw callback                          | the same dock, and anything anchored                                                    |
+| `defs.defineWidgetType()`                                        | `getCustomWidgets`                                         | **four files in comfy-mtb**, plus rmbg `COLORCODE` and mtb `FLOAT_CURVE`                |
+| `widgets.mount({ defaultValue })`                                | a mounted control that holds a value                       | the root cause of most wire-format deltas                                               |
+
+Two are worth reading as design notes rather than entries.
+
+**`getScreenRect` instead of the viewport transform.** The dock needed "where is
+this node on screen" and "tell me when that changed". Exposing pan and zoom
+would have been the mechanism; these two are the intent. The arithmetic proves
+it — the pan offset and canvas rect cancel out of the old expression, and the
+zoom factor is recoverable as `getScreenRect().width / getBounds().width`. The
+renderer's transform stays private and nothing is lost.
+
+**`defineWidgetType` is not decoration.** The host decides widget-vs-socket by a
+single lookup, and `addInputSocket`/`addInputWidget` are exact complements on
+it. An unregistered type does not degrade to a plain widget — the input becomes
+a **socket**, changing the serialized `inputs` array and dropping its
+`widgets_values` entry. That is why three packs were refused rather than
+converted with a warning.
+
+### Still open, and now the largest items
+
+- **Supply-side resolution** (§4) — cg-use-everywhere and rgthree.
+- **Sidebar tabs** (gap 23) — mtb's input/output sidebar is entirely that.
+- **A dialog surface** (gap 30) — mtb's `note_plus` needs an editor; several
+  packs want a modal.
+- **Prompt-time widget values** (gap 6) — still the most-cited functional loss:
+  `screencap_stream` is inert, Impact Pack no longer embeds images, and
+  prompt-reader's seed control would queue `-1`.
+- **Prompt post-processing / node expansion** (new). `resolve` maps one output
+  to one existing source or a literal; it cannot _add_ nodes to the prompt.
+  Custom-Scripts' `repeater.js` patched `app.graphToPrompt` and cloned the
+  upstream node once per repeat, so its `multi` and `create` modes are now
+  inert — the largest single behaviour loss in that pack. Distinct from gap 6:
+  that one wants a different _value_, this one wants a different _graph_.
+- **A mounted widget cannot declare a fixed height** (new). Found independently
+  by two agents on different packs, which is why it sits here rather than in a
+  single report. `_arrangeWidgets` treats a widget with `computeSize` as fixed
+  and one with only `computeLayoutSize` as growable; a `mount` is always the
+  latter, and `MountDef.height` only sets `container.style.height` — an inline
+  style _inside_ an allocation the renderer sized independently. So `height`
+  pins content within a larger box, and a node with several fixed strips has
+  its free space divided between them. Packs said this with
+  `widget.computeSize = () => [w, h]`, which is unpublished. Corollary worth
+  stating: for a panel meant to fill the node, passing `height` is actively
+  wrong and omitting it is correct — the opposite of what the name suggests.
+- **No pack-internal channel between files** (new, small but sharp). Packs
+  publish helpers on the node class for their _own_ other files to call —
+  `nodeType.prototype["pysssss.updateExamples"]`, called from two sibling
+  files. Handles hold no arbitrary properties, so there is no destination. Both
+  call sites were optional-chained, so the failure is silent degradation rather
+  than a crash, which is worse. Note this is a pack talking to itself, not
+  cross-pack coupling, so it does not raise the sandbox question the way a
+  general extension registry would.
+
+## 7a. Conversion keeps finding packs that were already broken
+
+Worth knowing before reading any conversion result: some of what the migration
+"loses" was never working.
+
+**A copied-and-broken stylesheet idiom.** Three packs (~1.0M downloads) contain
+`$el('style', { textContent: style })` where `style` is never declared anywhere
+in the file — `comfyui-art-venture` (842K), `comfyui-workflow-encrypt` (169K)
+and `comfyui-thumbnails` (8K). It throws a `ReferenceError` every load. In
+workflow-encrypt it sits at module scope, so the whole file dies with it. Same
+shape in all three: a template that propagated.
+
+**Widgets already shadowed by core.** LayerStyle's DZ colour widget was
+unreachable before we touched it — see §3. Removing it during conversion was not
+a regression.
+
+**Dead guards and inert code.** LanPaint's de-duplication guard compared a
+widget's _name_ against a string that was actually its _value_, so it never
+fired. kjnodes' `hideWidgetForGood` recursion passed two arguments in swapped
+positions, so linked widgets were always re-enabled. Both were carried forward
+faithfully or removed with the behaviour they never had.
+
+The practical consequence: an upstream PR should state plainly which defects
+pre-date the conversion, or the conversion gets blamed for them.
+
+## 8. Bugs found in the node API itself
+
+All found by converting real packs or loading them in a browser; **none** was
+caught by the 255 unit tests covering this layer.
+
+| bug                                                                 | effect                                                                                                                                                                                                        | status |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `NodeHandle.comfyClass` registered as a method, declared a property | read back as a bound function, so every `switch (node.comfyClass)` fell through silently — including the reference conversion given to every conversion agent                                                 | fixed  |
+| `widgets.mount()` assigned `widget.onRemove`                        | shadowed the `DOMWidgetImpl` method that unregisters from the store; every mounted widget leaked for the page's lifetime                                                                                      | fixed  |
+| `installNodeMoveBridge()` ran after `loadExtensions()`              | any pack subscribing to `comfy.onNodeMoved` at module scope threw                                                                                                                                             | fixed  |
+| `setSizeConstraints` chained a new `onResize` per call              | handler list grew without bound; re-declaring added a competing clamp instead of replacing it                                                                                                                 | fixed  |
+| `/comfy/api/v1.js` served by nothing                                | every converted pack failed at its first import; the harness masked it via its own loader hook                                                                                                                | fixed  |
+| Frontend-node resolution never ran in `graphToPrompt`               | the resolution system was dead code in production                                                                                                                                                             | fixed  |
+| `defs.define`'s generated class never set `serialize_widgets`       | the host's own node class sets it and `LGraphNode.serialize` gates `widgets_values` on it, so every defined node's widget values were dropped from the saved workflow — no error, visible only after a reload | fixed  |
+| `NodeDef.inputs` discarded each input's declaration dict            | a pack declares bespoke keys on its own Python input spec and reads them back to drive the frontend; dropping them broke the pack against its own data, and blocked pysssss `binding.js` outright             | fixed  |
+
+The pattern is consistent: this layer was a well-tested island that almost
+nothing called. The check that finds these is _"which production code path calls
+this, and what test covers that path"_ — not more unit tests.
+
+---
+
+## 8a. Decided this session: asks we are NOT building (cosmetic)
+
+Ben's standing rule is that _all gaps that are not cosmetic, and do not violate
+the sandbox around our internal graph state, must be implemented_. These three
+landed on the cosmetic side and were closed rather than built. Provisional —
+Christian's call, as with everything here.
+
+| ask                                                                             | decision                                                       | reasoning                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A pack rebuilding the host UI, or injecting global CSS that restyles our chrome | **Not supported** — "we will not support a parallel front end" | Selector-coupled to markup we change freely; the same objection that excluded canvas painting                                                                                                             |
+| A sanctioned way to re-theme Nodes 2.0                                          | **Should exist, not built** — Q9 in the API doc                | Distinct from the row above. A named CSS-variable contract is reviewable, versionable, and survives markup changes. Worth settling _before_ packs re-establish selector coupling against Nodes 2.0 markup |
+| Slot `shape` on `SlotPatch`                                                     | **Not supported**                                              | Cosmetic, and exactly one call site in the whole corpus. Consequence: the saved `shape` byte is dropped — an accepted wire delta, recorded here so it is not discovered later as a surprise               |
+
+The distinction that made the CSS question tractable: a pack styling **its own**
+mounted widget DOM is legitimate and needs no API at all — it owns those
+elements. Only a pack reaching **our** chrome is the parallel front end.
+
+One correction belongs here too, because it was my error rather than a pack's:
+conversion guidance told agents to route a pack's own asset paths through
+`comfy.backend.assetUrl('/extensions/<pack>/…')`. That is wrong. ComfyUI serves
+those files from the **install directory name**, which is chosen at install time
+and can be renamed, so it cannot be written in source — `new URL(path,
+import.meta.url)` is correct and always was. One pack ships two spellings of its
+own directory with an `onerror` fallback between them, which is what guessing
+costs. An agent pushed back on this guidance and was right; two call sites had
+already been converted the wrong way and are fixed.
+
+---
+
+## 8b. The ceiling: packs that ship built output cannot be converted at all
+
+This is structural, not a gap, and it belongs in the go/no-go rather than the
+backlog. Magic Patch rewrites the JavaScript ComfyUI serves. Where that
+JavaScript is **minified build output**, there is nothing to rewrite — the fix
+has to happen upstream in a source repo we do not process.
+
+`comfyui-easy-use` (#3, 3.3M downloads) is the confirmed case, and it is worth
+reading closely because it is the worst shape this can take. Its `__init__.py`
+sets `web_default_version = 'v2'`, so an install with no `config.yaml` — the
+default — is served `web_version/v2`. That directory is the built artifact of a
+**separate repository** (`yolain/ComfyUI-Easy-Use-Frontend`), wired in as a git
+submodule, with no source in the distribution. It is also thoroughly coupled to
+the old surface: one bundle alone carries 16 `registerExtension`, 93
+`LiteGraph`, 46 `LGraphCanvas`, 7 `comfyAPI`. The `web_version/v1` tree we
+converted is served only to users who explicitly opt in.
+
+Measured across the top 135 packs (85.2M downloads, ≈80% of all):
+
+| pack ships              | packs | downloads  | share     |
+| ----------------------- | ----- | ---------- | --------- |
+| no JavaScript at all    | 71    | 35,097,791 | **41.2%** |
+| readable source         | 57    | 45,179,249 | **53.0%** |
+| majority built/minified | 7     | 4,968,438  | **5.8%**  |
+
+So ≈94% of downloads are reachable: 41% need nothing, 53% are convertible. The
+ceiling is **5.8%**, and two packs are most of it — easy-use (3.3M) and
+comfy-mtb (0.9M).
+
+Two honest caveats. Only easy-use is _confirmed_ by reading its loader; the rest
+are classified by a heuristic (majority of non-vendored JS bytes in files with
+
+> 400-char mean line length, `.min.js`, or hashed bundle names). And the
+> byte-majority test mis-reads packs that ship one large vendored bundle beside
+> real source — `ComfyUI_LayerStyle_Advance` shows 8.2MB built against 1KB source,
+> which is far more likely a vendored asset than a built frontend. **5.8% is
+> therefore an upper bound.** An earlier, cruder version of this measurement said
+> 14.7% by flagging a pack on any single built-looking file; that version wrongly
+> condemned kjnodes and Impact Pack, both of which we have in fact converted.
+
+What it means for the programme: artifact-level conversion cannot be the whole
+answer, and should not be sold as one. For these packs the deliverable is an
+upstream PR against the source repo, which is a different workflow with a
+different cost — worth deciding before the go/no-go, not after.
+
+---
+
+## 8c. A class of conversion failure that no check could see
+
+Worth recording because it changes what "verified" means, and because it was
+found late.
+
+A conversion that drops `import { app } from '.../scripts/app.js'` but leaves
+`app.graph` in the body is **perfectly valid JavaScript**. It parses, so every
+syntax check passes it. It throws `ReferenceError` at load and takes the whole
+file with it. The conformance checker missed it too, because
+`retires-the-legacy-global` looks for `app.registerExtension`, not a bare
+`app.`.
+
+Two ways it arose:
+
+- **A dangling registration tail.** `crt-nodes/WAN_Compare.js` ended with
+  `app.registerExtension(WANCompareExtension)` where _neither_ name was still
+  defined — the body had already moved to `comfy.defs.extend`. One leftover
+  line.
+- **A body that was never finished.** Three files kept `app.graph`,
+  `app.queuePrompt` and `api.fetchApi` throughout while their headers had been
+  converted.
+
+The fix is scope analysis, not pattern matching: `scripts/magic-patch/verify/undef.sh` runs
+ESLint's `no-undef` over every converted file. Two details make it usable.
+It compares against the **original**, because every pack has pre-existing
+undefined names — script-tag globals like `marked`, `Sortable`, `ace` — and
+without that subtraction the noise buries the signal (18 files flagged, 3 real).
+And it deliberately is _not_ a `\bapp\.` regex, which false-positives on packs
+that legitimately declare their own local named `api`.
+
+Result across 453 converted files: **3 genuine breakages, all introduced by the
+conversion**, in `prompt-assistant/captionFrame.js`,
+`comfyui-enricos-nodes/compositor4.js` and `alekpet/painternode/helpers.js`.
+All three were reverted to source, so those packs now honestly report the work
+as outstanding rather than shipping a file that dies on load. Two of them sat in
+packs previously reported as **complete**.
+
+The lesson for the programme: "the conformance checker passes" is not the same
+as "the file runs". The runtime load check in the harness is what closes this,
+and it should be treated as load-bearing rather than optional.
+
+---
+
+## 9. What a go/no-go turns on
+
+Three things, in order of how much they'd change the answer:
+
+1. **§4 (supply-side resolution).** Decides whether broadcast/injection packs —
+   cg-use-everywhere plus rgthree, ≈5.6% of downloads — are convertible at all.
+   If they are not, the old surface cannot be deleted, which is the programme's
+   premise.
+2. **§1 and §2 (wire format).** Every conversion inherits whatever these settle.
+   Re-deciding later means revisiting every pack already converted.
+3. **§6 (gap scope).** The ranked list decides build order. Roughly a third of
+   the entries are the difference between "the pack loads" and "the pack works".
+
+Not blocking: §3 and §5 are cheap and reversible either way.
+
+## 10. Status
+
+**139 pass, 3 sanctioned hold-outs, 0 genuine failures** across every converted
+file, run by the repo's own conformance checker.
+
+Scope, measured honestly: a file counts only if it actually touches the old
+surface (`scripts/app.js`, `registerExtension`, `window.comfyAPI`). Vendored
+libraries, test suites, build tooling and packs' own standalone web apps are
+excluded — which changes the picture enough to be worth stating, because the raw
+file counts are badly misleading. `comfy-mtb` looked like 112 files of work and
+is 2. `comfyui-lora-manager` looked like 180 and is 28; the other ~150 are its
+separate model-manager web app and its test suite, neither of which ComfyUI ever
+loads. On that basis: **131 files converted, 356 remaining, across 27 packs.**
+
+The early sample below is kept because the per-pack results are still the most
+concrete evidence of what conversion actually costs:
+
+| pack              | rank | downloads | result                                                |
+| ----------------- | ---- | --------- | ----------------------------------------------------- |
+| kjnodes           | #1   | 4.0M      | 21/25 — 3 indentation heuristic, 1 documented partial |
+| VideoHelperSuite  | #4   | 3.2M      | 3/3 — `VHS.core.js` 2570 → 1552 lines                 |
+| Impact Pack       | #5   | 3.1M      | 7/7                                                   |
+| Crystools         | #10  | 2.1M      | 6/6, 3 shim files deleted outright                    |
+| LayerStyle        | #12  | 2.0M      | 3/3, 1 correctly untouched                            |
+| cg-use-everywhere | #13  | 1.9M      | 2/20 — blocked on §4                                  |
+
+That measurement has since been taken across the whole top 135 packs (together
+≈80% of all downloads), and it is the single most encouraging number here:
+**71 of the 135 ship no JavaScript at all** — 33% of packs, needing no work of
+any kind. Only about 55 packs genuinely need converting. Counting those, roughly
+**61% of downloads** are now either converted or provably need nothing.
+
+Nothing is validated yet. `compile_db` ships only entries marked `validated`,
+which requires a human to confirm the pack works.

--- a/docs/magic_patch_WIP.md
+++ b/docs/magic_patch_WIP.md
@@ -1,0 +1,798 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> A working design artifact living on `benjcooley/magic-patch` so it is version
+> controlled and reviewable alongside the code it describes. It is **not** a
+> finished document and is not intended to land on `main` in this form. When the
+> design settles, the durable parts become a proper ADR under `docs/adr/` and
+> this file goes away.
+
+# Magic Patch — precomputed migration patches for custom-node JS
+
+**Status:** working design artifact. An ADR will be cut from a subset once
+settled. Companion to `node_api_WIP.md`, which specifies the API this depends on.
+
+**Architecture:** patches are **generated offline, verified against the test
+harness, and shipped as a hash-keyed manifest.** The client does a hash lookup and
+applies a known-good artifact. No model runs on the user's machine.
+
+**Goal:** move custom-node JS off deprecated and unpublished APIs onto a real
+published API — so the old surfaces can be **deleted**, not carried forever.
+
+**Scope:** desktop + localhost. PoC: config-gated, off by default, silent, one toast
+with a count.
+
+---
+
+## Adding to the API
+
+Any capability added to `src/platform/nodeApi/` is finished only when the skill
+can teach it. Three things, in the same change:
+
+1. **A capability entry** in `CAPABILITIES` (`comfyApi.ts`), so `supports()`
+   answers honestly and `apiSurface.ts` regenerates.
+2. **An intent rule** in `SKILL.md` — _"if you are converting X, check whether
+   it is for Y, and use Z"_. Not a mapping table entry. Agents convert what they
+   recognise, and they recognise intent, not call names. `onPreview` is the
+   example: an agent asked for `api.addEventListener`, which is a faithful port
+   of the shape that causes the problem.
+3. **A reference example** in `references/` if the shape is not obvious from one
+   line.
+
+An API the skill cannot teach converts nothing. It shows up as an `api-gap`
+punt naming a capability that already exists, which is worse than a real gap
+because it looks like a missing feature.
+
+## 0. The shape
+
+**One generator, two sinks.** The patch engine is identical either way; only where
+the output lands differs.
+
+```
+                    ┌──────────────── ONE GENERATOR (CI) ────────────────┐
+                    │  corpus → detect → patch (rules; agent for residue)│
+                    │              → verify against the matrix           │
+                    └───────────────────────┬───────────────────────────┘
+                                            │
+             ┌──────────────────────────────┴──────────────────────────────┐
+             ▼                                                             ▼
+   SINK A — upstream PR                                    SINK B — shipped manifest
+   registry pack, author opted in                          everything else
+             │                                                             │
+   adds a new web dir with                                 nodes_patches, hash-keyed
+   upgraded JS; author merges                              applied at load on the user's
+             │                                             machine
+             ▼                                                             ▼
+   fixed at the source, for                                fixed for our users only,
+   every user of that pack                                 until upstream catches up
+```
+
+Sink A is strictly better where it's available: the fix lands at the source, helps
+every user of that pack regardless of frontend distribution, and needs no runtime
+machinery at all. Sink B is the fallback, and it is unavoidable — **many custom nodes
+aren't in the registry**, are installed by git URL or dropped into `custom_nodes/`
+by hand, and many registry authors will never opt in or respond.
+
+Both sinks consume the same verified diff. Sink A is a delivery decision, not a
+different product.
+
+There is a third output, **Sink C** (§10): where a custom node duplicates something
+Comfy now ships natively, replace it rather than patch it. Different artifact
+(keyed by node type), different transform (graph rewrite, not source), different
+verification, and — unlike A and B — it should _not_ be silent. Shipped last.
+
+---
+
+## 1. Why this is the right call
+
+The previous draft put an agentic loop in the browser. This is better on every axis
+that matters, and it is worth being explicit about how much it deletes:
+
+| Previous design                                                 | This design                                                                                                                                           |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LLM in the client                                               | **Gone.** No API keys in localStorage, no provider abstraction, no CORS work for Anthropic/Ollama, no consent flow for shipping user code off-machine |
+| Model-authored code executed unreviewed                         | **Reviewed, tested, versioned artifacts** — same trust level as shipping frontend code                                                                |
+| Capability-diff validator, guardrail layers, claim verification | **Gone.** Verification moved to CI, where it can run the real harness instead of regex heuristics                                                     |
+| First run degraded, "reload to apply"                           | **Gone.** Patch is present before the user ever hits the pack                                                                                         |
+| Patch quality varies per user by model/provider                 | **Identical for every user.** Reproducible, bisectable, revertable                                                                                    |
+| Failure = broken pack in front of a user                        | Failure = **red CI**, before release                                                                                                                  |
+
+The AI doesn't disappear — it **relocates to where it can be verified**. In CI it has
+the full 3 GB corpus, the 1,801-pack execution matrix, and the byte-identical
+`graphToPrompt` invariant to check against. In the browser it had a regex.
+
+That is the whole argument: _a patch good enough to ship silently is a patch that
+must be verified before shipping, and verification is only possible offline._
+
+---
+
+## 2. Step 1 — commit to a published API
+
+> **Specified in full in `docs/node_api_WIP.md`.** Closed proxy handles + free functions, no
+> internal object reachable. Its completeness test is that every census surface below
+> has exactly one destination — which it now does, including the vue-only cohort.
+
+This is the precondition, the hardest item, and correctly listed first. You cannot
+migrate code onto a target that doesn't exist.
+
+**The scoping rule:** a migration is possible iff a documented replacement exists.
+
+Two useful facts:
+
+**(a) Much of the mapping is already written down.** The deprecation warnings
+prescribe, they don't just flag:
+
+```ts
+// src/lib/litegraph/src/node/NodeOutputSlot.ts:26-44
+'output.links is deprecated. Read connectivity via node.isOutputConnected(slot) /
+ node.getOutputNodes(slot); enumerate links via outputLinks(graph, node.id, slot);
+ mutate via node.connect() / node.disconnectOutput().'
+```
+
+So for the unconditional cohort, "the published API" largely means **publishing what
+is already there** — `slotLinks.ts` helpers, `isInputConnected`, `getOutputNodes`,
+`connect`/`disconnect` — and committing to them.
+
+**(b) The vue-only cohort is blocked on API that does not exist.** From the census
+(`~/comfy/nodes-compat-study`, 4,969 packs):
+
+| Surface                 | Packs   | Replacement today                   |
+| ----------------------- | ------- | ----------------------------------- |
+| `out_links_write`       | 58      | ✅ documented                       |
+| `link_endpoint_write`   | 36      | ✅ documented                       |
+| `node_shape_write`      | 27      | ✅ enum, not string                 |
+| `slot_spread`           | 23      | ✅ read fields explicitly           |
+| `in_link_write`         | 21      | ✅ documented                       |
+| `type_write_nodevar`    | 11      | ✅ usually delete the line          |
+| `widgets_splice`        | **286** | ❌ no public reorder API            |
+| `widget_type_write`     | **270** | ❌ no successor to converted-widget |
+| `converted_widget`      | **238** | ❌ same                             |
+| `widgets_assign`        | **226** | ❌ same as splice                   |
+| `widgets_push`          | **142** | ❌ same as splice                   |
+| `hook_getCustomWidgets` | **91**  | ❌ `widgetRegistry` table is closed |
+
+**~124 packs (16.1% of installs) are migratable today. ~653 packs (35.0%) are
+waiting on an API decision.** The bottom six rows are the single highest-leverage
+item in this document — they are ~80% of the affected mass, and no amount of
+patching machinery touches them until someone publishes a widget-reorder API and a
+Vue-widget registration API.
+
+Recommendation: **scope the PoC to the top six rows**, and treat the bottom six as
+the API work that step 1 actually refers to.
+
+---
+
+## 2a. The assembled pipeline
+
+Three parts, one flow:
+
+```
+OFFLINE (CI)                                  RUNTIME (desktop / localhost)
+──────────────────────────────                ─────────────────────────────────
+corpus of registry packs                      GET /api/extensions
+      ↓                                             ↓
+detect old-API use                            fetch each .js  → sha256
+      ↓                                             ↓
+convert to docs/node_api_WIP.md surface                look up hash in conversion DB
+  (rules; agent for residue)                        ↓
+      ↓                                       hit  → serve converted artifact,
+verify: matrix + wire-identical                      bound to its declared major
+      ↓                                       miss → serve original unchanged
+conversion DB, keyed by sha256                      ↓
+                                              app runs; converted packs speak
+                                              only the published API
+```
+
+### The artifact record
+
+Each entry pins the source it was verified against **and the API major it
+targets** — which is what makes "all majors stay supported" load-bearing rather
+than decorative:
+
+```jsonc
+{
+  "<sha256-of-original>": {
+    "pack": "rgthree-comfy",
+    "file": "web/comfyui/base_node.js",
+    "apiMajor": 1, // docs/node_api_WIP.md §2 — the contract it uses
+    "rules": ["type-write-noop", "output-links-mutation"],
+    "author": "rules", // or "agent:<model>", then human-reviewed
+    "verified": {
+      "wireIdentical": true,
+      "deprecationsBefore": 12,
+      "deprecationsAfter": 0,
+      "matrixVerdict": "SAME"
+    },
+    "artifact": "<converted source>"
+  }
+}
+```
+
+A converted pack declares `apiMajor` and the loader hands it exactly that
+surface. A pack converted today against v1 keeps running after v2 ships, without
+reconversion — which is the only way this stays a one-time cost per pack rather
+than a treadmill.
+
+---
+
+## 2b. "No shim" — what it can and cannot mean
+
+This is the decision that governs the whole programme, so it is worth being
+precise. Two readings:
+
+**(a) The converted artifact contains no compatibility layer.** It is genuinely
+rewritten to the published API — not the old code wrapped in an adapter. ✅
+**This is correct and should be the rule.** A wrapped artifact would preserve the
+coupling we are trying to delete, and would have to be rewritten again later.
+
+**(b) The host stops serving the legacy `window.comfyAPI` surface entirely.**
+⚠️ This cannot happen on the timetable the conversion pipeline implies, for one
+structural reason:
+
+> **Not every installed pack is in the registry.** Git-URL installs, hand-dropped
+> folders, private/in-house packs, and forks have no upstream entry and therefore
+> no pre-computed artifact. The conversion DB can never reach them.
+
+So a global switch-off breaks an unbounded, unmeasured set of working
+installations. The realistic end state is:
+
+|      | Converted pack         | Unconverted / unregistered pack |
+| ---- | ---------------------- | ------------------------------- |
+| API  | published surface only | legacy surface                  |
+| Shim | **not used**           | still served                    |
+
+The legacy surface stays _available_ while its _usage_ trends toward zero — and
+because usage is now measurable, "can we delete it?" becomes a question with an
+answer rather than a permanent no. That is the same argument as counting v1
+imports in `docs/node_api_WIP.md` §2: **instrument first, delete when the data says so.**
+
+Practical consequence: **conversion coverage, not conversion quality, is the
+gating metric.** A perfect converter that reaches 60% of installs does not let us
+delete anything.
+
+### Closing the unregistered tail
+
+Ranked by cost:
+
+1. **Registry coverage** — most installs come from the registry; start there.
+2. **Upstream PRs** (Sink A) — a merged conversion needs no artifact at all,
+   because the published pack is already converted.
+3. **Rules shipped to the client** — version-independent transforms can run
+   locally on an unknown pack without any DB entry. Cheaper and safer than the
+   agent, and covers the mechanical majority.
+4. **On-device agent** — still deferred. Only worth it if 1–3 leave a
+   user-visible gap.
+
+Option 3 is the one that makes the tail tractable, and it is why the rule
+catalog must be executable in the browser, not only in CI.
+
+---
+
+## 2c. What has to be true to flip a pack to "converted"
+
+A per-pack gate, not a global one:
+
+1. Its source hash matches an artifact, **or** client-side rules fully convert it.
+2. The artifact declares an `apiMajor` this host serves.
+3. Verification passed: zero attributable deprecation warnings, `graphToPrompt`
+   byte-identical, no op-level regression (§5).
+4. Delivery works for that pack — the unproven piece (§4).
+
+Failing any of these, the pack loads unchanged, exactly as today. **The fallback
+is always "behave like the current release",** which is what makes the feature
+safe to enable by default later.
+
+---
+
+## 3. Step 2 — the `nodes_patches` manifest
+
+Keyed by source-file hash, so a patch can never apply to a file it wasn't verified
+against.
+
+```jsonc
+{
+  "formatVersion": 1,
+  "generatedAt": "2026-08-04T00:00:00Z",
+  "harness": { "corpusLock": "<sha>", "matrixRun": "<ci-run-id>" },
+  "patches": {
+    "<sha256-of-original-file>": {
+      "pack": "rgthree-comfy",
+      "file": "web/comfyui/base_node.js",
+      "packVersion": "1.2.3",
+      "rules": ["type-write-noop"],
+      "author": "rules", // or "agent:<model>" — recorded, then human-reviewed
+      "verified": {
+        "wireIdentical": true, // graphToPrompt byte-identical
+        "warningsBefore": 12, // warnDeprecated fires, pre-patch baseline
+        "warningsAfter": 0,
+        "matrixVerdict": "SAME"
+      },
+      "patch": "<unified diff | full replacement text>"
+    }
+  }
+}
+```
+
+Design notes:
+
+- **Hash-keyed = exact.** No misapplication, no fuzzy matching, no "this looks like
+  version 1.2." If the file differs by a byte, there is no patch and we serve the
+  original. Fails safe by construction.
+- **`verified` is carried in the artifact**, not just in CI logs. The client can
+  refuse to apply a patch whose recorded `wireIdentical` is false, and a human
+  reviewing the manifest sees the evidence inline.
+- **`author` is recorded.** Agent-authored patches are distinguishable from
+  rule-authored ones forever — for auditing, and for prioritising review.
+- **Distribution:** bundle it with the frontend for the PoC. No network dependency,
+  works offline, ships on the normal release train. Later, optionally fetch a fresher
+  manifest with the bundled one as fallback.
+
+### Hash-keyed patches are not the whole answer
+
+The cost of exactness is coverage: **one patch covers exactly one version of one
+file.** Packs update constantly — the study notes its own corpus drifts week to week
+because packs are fetched from HEAD. Every pack release invalidates its patch.
+
+So the manifest should carry **two kinds of entry**:
+
+|                  | Keyed by  | Version-independent? | Use for                                                                            |
+| ---------------- | --------- | -------------------- | ---------------------------------------------------------------------------------- |
+| **Rule**         | pattern   | ✅ yes               | the mechanical majority — `type-write-noop`, `output.links` → `disconnectOutput()` |
+| **Pinned patch** | file hash | ❌ no                | residue where the transform depends on surrounding control flow                    |
+
+Rules survive pack updates and cover packs never seen in the corpus. Pinned patches
+handle what rules can't express. Both are generated and verified by the same offline
+job; only the key differs.
+
+Getting the ratio right is the difference between a manifest that stabilises and one
+that needs regenerating every week. **Push everything possible into rules.**
+
+---
+
+## 4. Step 3 — the client
+
+Small, and the only part that lives in this repo's hot path:
+
+```ts
+// src/services/extensionService.ts:57 — the single interception point
+const source = await (await fetch(api.fileURL(ext))).text()
+const patch = manifest.lookup(sha256(source)) // + version-independent rules
+await import(patch ? applyPatch(source, patch) : api.fileURL(ext))
+```
+
+Guarded by one setting, `!isCloud`, and `shouldLoadExtension()` (which already
+excludes `extensions/core` and `extensions/cloud`, so first-party code is never
+touched).
+
+### The one genuinely hard part: delivery
+
+`applyPatch` returns _text_, and the browser needs to _execute_ it. Three options,
+and this is the main remaining engineering decision:
+
+**A. Service worker intercept.** Register a SW that intercepts `/extensions/**`,
+returns the patched body with `Content-Type: text/javascript`.
+
+- ✅ **The URL is unchanged**, so relative specifiers (`./common.js`,
+  `../../scripts/app.js`), `import.meta.url`, runtime asset loads, and stack traces
+  all work natively. No rewriting, no link step, no module-graph analysis.
+- ✅ Confirmed viable: SWs need HTTPS _or localhost_ — desktop is localhost.
+- ⚠️ New moving part; there is no SW in this repo today (checked).
+- ⚠️ Registration timing: a SW doesn't control the page on first load without
+  `clients.claim()`. Needs `claim()` on activate plus awaiting readiness before
+  `ComfyApp.setup()`. Feasible — extensions load late — but must be proven.
+- ⚠️ SW cache staleness is a classic source of "why is my fix not applying."
+
+**B. Blob URL + specifier rewriting.** Patch, rewrite every import specifier to
+absolute, link the pack's module graph to sibling Blob URLs, `import()` that.
+
+- ✅ No new platform machinery; entirely inside our one interception point.
+- ❌ Blob URLs have no base URL, so **every relative specifier breaks** and we need a
+  per-pack link step in dependency order, plus `import.meta.url` rewriting.
+- ✅ Proven: `~/comfy/nodes-compat-study/compat/build_l2_fixture.py` does exactly this
+  to load 1,801 packs' real JS in vitest. The specifier map is reusable.
+- ❌ Degrades stack traces and debugging.
+
+**C. Apply on disk at install time.** ComfyUI-Manager patches the file after
+unpacking; everything downstream is unchanged.
+
+- ✅ **By far the simplest runtime** — zero frontend involvement, normal static
+  serving, correct URLs, correct everything.
+- ❌ Mutates the user's installation. Reverting means reinstalling.
+- ❌ Python-side, `Comfy-Org/ComfyUI-Manager` — out of this repo.
+- ⚠️ Interacts with the manager's `.tracking` manifest: on version switch, files
+  listed in `.tracking` are overwritten, so patches are silently reverted on update
+  (arguably correct — the new version needs a new patch anyway).
+
+**Recommendation: spike A, keep B as the fallback.** A is dramatically cleaner if
+the registration timing works, and it eliminates the largest chunk of remaining
+complexity — the module-graph link step — outright. C is worth raising with whoever
+owns the manager, because it may simply be someone else's easier problem.
+
+Why the constraint exists at all: `/userdata` accepts `.js` writes but can **never**
+serve them as modules (`is_dangerous_content_type` forces `octet-stream` + `nosniff`
+
+- `attachment`, `app/user_manager.py:345-361`), the desktop app exposes **zero**
+  filesystem API (`~/comfy/desktop/src/preload.ts`), and no writable-and-served static
+  directory exists (`server.py:1244`). Verified, not assumed.
+
+---
+
+## 5. Step 4 — the generation job
+
+Runs in CI. This is where the AI lives, and where it can be held to account.
+
+```
+./run fetch --frozen            # pinned corpus, reproducible
+      ↓
+detect       rule detectors over source (census regexes, already validated on 4,969 packs)
+      ↓
+generate     Tier 1: deterministic rules
+             Tier 2: agent, only for what Tier 1 declares unfixable
+      ↓
+verify       build_matrix.py + matrix_runner.ts, per pack, isolated
+      ↓
+gate         emit only patches that pass
+```
+
+### The gate
+
+A patch ships iff, against a **pre-patch baseline on the same battery**:
+
+1. `warnDeprecated` fires attributable to the pack drop to **zero** — this is the
+   literal statement of the goal, and `LiteGraph.onDeprecationWarning` already
+   stack-attributes warnings to the triggering pack file.
+2. `graphToPrompt` output is **byte-identical**. Holds 1,801/1,801 today, making it
+   an extremely sharp regression detector.
+3. No op-level verdict regresses from `SAME` across the 20-op battery.
+
+**The coverage trap, stated so we don't fall into it:** zero warnings can mean
+"migrated" or "that path never executed" — indistinguishable from outside. So (1)
+only counts against a baseline that was non-zero. A rule whose baseline is 0 needs a
+targeted `PROBE`-style stimulus before its patch is trusted. The study hit exactly
+this: it measured 0 deprecation warnings across the entire L2 run, and that was a
+_coverage_ finding, not a clean bill of health.
+
+### Why the agent is safe here
+
+It cannot reach a user. Its output is a diff that must survive the matrix, then
+human review before landing in the manifest. A hallucinated patch is a red build.
+
+---
+
+## 6. The real cost: the treadmill
+
+Precomputed patches trade an on-device problem for a maintenance one. Being honest
+about it:
+
+- **Pack updates invalidate pinned patches.** Mitigated by pushing work into
+  version-independent rules (§3), but not eliminated.
+- **The corpus drifts.** `corpus.lock.json` + `./run fetch --frozen` make a run
+  reproducible; keeping it _current_ is a recurring job.
+- **Someone owns regeneration.** A scheduled CI job over the top-N packs by
+  downloads, opening a PR when the manifest changes, is the minimum viable answer.
+  19 packs cover 30% of affected installs — a small watched set covers most value.
+
+**The metric that tells you it's working: the manifest should shrink over time.**
+Which leads to the endgame.
+
+---
+
+## 7. Sink A — the upstream PR path
+
+For registry packs whose author has ticked **"accepts upgrade PRs"**, the generator
+opens a PR instead of (or as well as) shipping a manifest entry.
+
+### Consent is the whole design
+
+Auto-PRs without opt-in are spam at a scale that would poison the relationship with
+the entire ecosystem — 697 unsolicited PRs from the platform vendor is not outreach,
+it's a denial-of-service on maintainer attention. **The registry flag is not a
+formality; it is the feature.**
+
+Targeting is already solved: the registry has `repo` for all 4,984 packs, and
+`results/affected_packs.csv` has publisher, repo, downloads and exact surfaces hit
+for the 697 affected. What's missing is purely the consent field and the bot.
+
+Suggested flag semantics — worth being precise, because "accepts upgrade PRs" is
+ambiguous:
+
+| Level           | Meaning                                                                   |
+| --------------- | ------------------------------------------------------------------------- |
+| `off` (default) | Never open a PR. Manifest-only.                                           |
+| `notify`        | Open an issue describing the needed migration, no code.                   |
+| `pr`            | Open a PR with the upgraded code, author reviews and merges.              |
+| `pr-automerge`  | For maintainers who want it hands-off. Probably out of scope for the PoC. |
+
+Default must be `off`. Opt-in, never opt-out.
+
+### The "new folder" detail is the crux, and it exposes a gap
+
+The PR adds a **new JS folder with the upgraded code**, rather than rewriting the
+existing one in place. That is the right call, and the reason matters:
+
+> **Authors don't refuse to migrate because migration is hard. They refuse because
+> migrating breaks their users on older frontends.** A pack that moves to the new
+> API strands everyone who hasn't updated ComfyUI.
+
+Shipping both directories removes that objection entirely — one release supports old
+and new frontends. It's what makes the PR _mergeable_ rather than merely correct.
+
+**But nothing in ComfyUI serves a second web directory today.** Both registration
+paths bind exactly one:
+
+```python
+# nodes.py:2253-2266 — pyproject [tool.comfy] web
+EXTENSION_WEB_DIRS[project_name] = web_dir_path
+# nodes.py:2270-2273 — legacy WEB_DIRECTORY
+EXTENSION_WEB_DIRS[module_name] = web_dir
+```
+
+So this path needs a **dual-web-dir convention** before any PR is worth sending:
+
+- a new pyproject key (say `[tool.comfy] web-next = "web_v2"`),
+- backend logic selecting it when the frontend advertises support,
+- and a negotiation signal — frontend version is the obvious candidate, since
+  `EXTENSION_WEB_DIRS` is populated at Python import time and the served frontend
+  version is knowable there.
+
+That is a **backend + registry change, not a frontend one**, and it gates Sink A
+entirely. It should be scoped and owned before the bot is built — otherwise we
+generate PRs that authors can't safely merge, which is worse than sending none.
+
+Cheaper interim option: PR the migration in place, gated at runtime by a frontend
+version check inside the pack's own JS. Uglier, no platform work, and it lets the
+path be validated on a handful of friendly maintainers before committing to a
+convention.
+
+### Coverage — why Sink B never goes away
+
+```
+all installed custom nodes
+ └─ in the registry (4,984)
+     └─ affected (697)
+         └─ author opted in  ← only these get Sink A
+```
+
+Every other branch — unregistered packs, git-URL installs, hand-dropped folders,
+opted-out authors, abandoned packs, and any author who simply never responds — is
+Sink B. Given that the #2 pack by downloads is in the affected set, Sink B is
+carrying real weight regardless of how well the PR programme goes.
+
+### The endgame
+
+Intended lifecycle of a manifest entry:
+
+```
+detected → manifest entry → PR (if opted in) → merged → entry deleted
+```
+
+**The metric that says it's working is that the manifest shrinks.** If it only ever
+grows, the migration isn't happening — it's being permanently papered over, and
+we've recreated the compat-shim problem in a different file. Record upstream PR
+status per entry from the start, so "how much of this is retired?" is a query and
+not an archaeology exercise.
+
+---
+
+## 8. Milestones
+
+1. **Publish the API** for the six migratable surfaces (§2). Precondition for
+   everything else. Separately, decide the vue-only cohort's fate — that's the
+   653-pack question.
+2. **Delivery spike.** Service worker intercepting `/extensions/**`, proving
+   registration lands before `ComfyApp.setup()`. Prove kjnodes (4.03M dl, 28 JS
+   files) loads through it byte-equivalently, unpatched. _Highest remaining risk,
+   and no AI in it._ Fall back to Blob URL + link step if timing can't be made safe.
+3. **The flagship rule: `type-write-noop`.** Delete `this.type = this.type ?? undefined`
+   — a defensive no-op. 11 packs by census, 8 confirmed by the matrix, 3.86M
+   downloads, and it takes rgthree's entire 12-type virtual-node family from _fails
+   to construct_ to _works_, by removing a line that was never trying to do
+   anything. Smallest transform, largest payoff. **This is the demo.**
+4. **Manifest format + client lookup + toast.** End-to-end with one rule.
+5. **Generation job in CI**, rules only, gated on the matrix.
+6. **Remaining in-scope rules**; measure coverage over the ~124-pack cohort.
+7. **Agent tier in CI** for residue, human-reviewed before manifest inclusion.
+
+Milestones 1–6 have no model anywhere. It is a real possible outcome that this ships
+without one — the mappings are pre-documented (§2a), so the mechanical tier may cover
+the in-scope cohort outright. The ordering is designed to discover that early.
+
+**Sink A runs on a parallel track, and is not on the PoC critical path:**
+
+|     |                                                                                                                                                    |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Scope the dual-web-dir convention (backend + registry). **Gates everything else here.**                                                            |
+| A2  | Add the registry consent flag, default `off`                                                                                                       |
+| A3  | PR bot, seeded from `affected_packs.csv`, opted-in authors only                                                                                    |
+| A4  | Hand-run milestone 3's patch as a manual PR to 2–3 friendly maintainers first — validate that the artifact is actually mergeable before automating |
+
+A4 before A3 is deliberate. The failure mode of a PR bot is reputational and hard to
+walk back; the failure mode of three hand-sent PRs is an awkward conversation.
+
+---
+
+## 9. Open questions
+
+- **Q1 (blocking).** Does the service worker register reliably before extension
+  import, on cold start, in Electron and in a browser? If not, fall back to B.
+- **Q2 (product, highest leverage).** Is the vue-only cohort in or out? That's the
+  653-pack / 35%-of-installs decision, and it's an API commitment, not a patching
+  question.
+- **Q3.** Manifest distribution — bundled only, or fetchable? Bundled is simpler and
+  offline-safe; fetchable is fresher but adds a trust boundary and a network
+  dependency.
+- **Q4.** Do we patch a pack the user has hand-modified? Hash-keying makes this
+  automatic — a modified file has a different hash, so no patch applies. That's
+  probably the correct behaviour for free; worth confirming it's intended.
+- **Q5.** Pack identity is ambiguous: `EXTENSION_WEB_DIRS` is keyed by pyproject
+  `project.name` _or_ directory basename, and both can exist for one pack
+  (`nodes.py:2253-2273`). Hash-keying sidesteps this for lookup, but manifest
+  metadata and reporting still need a canonical name.
+- **Q6.** Where does the manifest live — this repo, or alongside the study? It's a
+  data artifact with a different release cadence than the frontend.
+- **Q7 (gates Sink A).** Who owns the dual-web-dir convention? It's backend +
+  registry work, and no upgrade PR is safely mergeable without it. Is there appetite
+  for a `[tool.comfy] web-next` key and frontend-version negotiation, or do we start
+  with in-pack runtime version checks?
+- **Q8.** If a pack merges our PR, its file hashes change and its manifest entries go
+  dead automatically — correct behaviour, but it means Sink A silently retires Sink B
+  entries only if we regenerate. Does the scheduled job re-detect merged upstreams, or
+  do we track PR state explicitly? Explicit tracking is more work but makes the
+  "is it shrinking?" metric trustworthy.
+
+---
+
+## 10. Sink C — the replacement-node mapping
+
+A third output, and strategically the strongest one: for custom nodes that duplicate
+something ComfyUI now ships natively, **don't patch them — replace them.**
+
+```jsonc
+// replacement_nodes.json — keyed by node type, not file hash
+{
+  "formatVersion": 1,
+  "replacements": {
+    "KJNodes.ImageResizeKJ": {
+      "replaceWith": "ImageScale",
+      "confidence": "exact", // exact | lossy | suggest-only
+      "inputs": { "image": "image" },
+      "widgets": {
+        "width": "width",
+        "height": "height",
+        "upscale_method": {
+          "map": { "lanczos": "lanczos", "bicubic": "bicubic" }
+        }
+      },
+      "outputs": { "IMAGE": "IMAGE" },
+      "appliesWhen": "widgets.keep_proportion === false", // predicate; else don't offer
+      "verified": { "outputsMatch": true, "harnessRun": "<ci-run-id>" }
+    }
+  }
+}
+```
+
+### Why this is different from Sinks A and B
+
+Source patches preserve the dependency; this **retires** it. A workflow whose custom
+nodes have all been substituted no longer needs the pack installed at all — which
+removes it from the migration problem permanently, not until the next pack release.
+It's the only sink whose entries can never go stale.
+
+It is also the one that should probably **not** be AI-generated. The mapping is a
+curated table: a human decides "this node is the same as that node," and the value
+is entirely in that judgment being correct. An LLM could _propose_ candidates by
+similarity, but a wrong entry here silently changes what a user's workflow produces.
+
+### The line I'd draw: this one is not silent
+
+Everywhere else in this design, silent is right — patching JS to use a supported API
+is invisible by construction, and the wire format is byte-identical by gate (§5).
+
+Substitution is categorically different. It **changes the user's workflow document**.
+Even an exact-equivalence mapping alters what's saved, what's shared, and what runs.
+Doing that silently would be the one genuinely user-hostile thing in this document.
+
+Suggested behaviour by confidence:
+
+| Confidence     | Behaviour                                          |
+| -------------- | -------------------------------------------------- |
+| `exact`        | Offer, one click, undoable. Still not automatic.   |
+| `lossy`        | Offer with an explicit diff of what changes        |
+| `suggest-only` | Surface in a "this pack may be unnecessary" report |
+
+The natural trigger is the **missing-node dialog** — a user opening a workflow whose
+pack isn't installed currently gets a dead end; offering a native substitution there
+is pure upside and requires no opt-in reasoning at all.
+
+### Mechanism
+
+Graph rewrite, not source rewrite, so it flows through the command pattern per
+ADR 0003/0008 — serializable, idempotent, undoable. That's the correct substrate and
+it gives undo for free, which matters a great deal for a transform that edits user
+documents.
+
+```ts
+type PatchArtifact =
+  | { kind: 'source'; patch: string } // Sinks A/B
+  | { kind: 'graph-rewrite'; operations: LayoutOperation[] } // Sink C
+```
+
+### Verification
+
+Different gate from §5, because the invariant is different. Source patches must keep
+`graphToPrompt` **byte-identical**; a substitution deliberately changes it. So the
+gate becomes: **execute both graphs and compare outputs.** That is L4 — explicitly
+out of scope for the compat study by decision, and a genuinely harder harness
+(needs models, a backend, determinism control via fixed seeds).
+
+Which is the honest reason this ships last: _we don't currently have a way to prove a
+substitution is correct._ Until we do, `exact` is a human claim, not a measured one —
+so keep the confidence field, keep it user-confirmed, and don't let it go silent.
+
+---
+
+## 10a. What lives here, and what does not
+
+**This repo holds Magic Patch and the node API — the code. It does not hold the
+conversion database — the data.**
+
+Belongs here:
+
+- `src/platform/nodeApi/` — the published API packs are converted onto
+- `src/workbench/extensions/magicPatch/` — conversion rules, conformance,
+  verdicts, the runner
+- `scripts/magic-patch/` — the CLI around them
+- `.claude/skills/converting-custom-nodes/` — the conversion method
+
+Does not:
+
+- `db/` — the per-pack `<original>` / `v1` trees. Third-party source, large, and
+  with a different lifecycle: it changes when a pack changes or a conversion is
+  redone, not when the frontend does. It has no reason to share a history or a
+  review process with this repo.
+
+**Decision: extract `db/` to its own repository. Not yet — deferred, not
+declined.**
+
+Until then it stays gitignored, and the working copy is _not_ protected by
+version control. That is a real hazard and it has already cost a day's work
+once: 25 converted kjnodes files were removed by a clean and were unrecoverable.
+Snapshots are taken to `~/comfy/magic-patch-db-<stamp>-<commit>.tar.gz` after
+each batch, which survives a clean but is not versioned, reviewable, or portable.
+
+Do not "fix" this by tracking `db/` here. Tracking it also drags the commit
+hooks across vendored and minified pack sources, which is how the previous
+attempt failed — but that is a symptom. The reason not to track it is that it is
+a different artifact with a different lifecycle.
+
+What the extraction needs, when it happens:
+
+- the `<pack>/<commit>/{original,v1}` layout, which is already what `db/` holds
+- the conformance checker and `verify_db`/`compile_db`, which read that layout
+- a pointer from this repo to the pack database, and a pinned revision so a
+  frontend commit names the conversion set it was verified against
+- the snapshots as the migration source — they are currently the only copy
+
+## 11. Explicitly deferred
+
+**On-device agent** for packs with no manifest entry. If the offline pipeline works,
+the marginal case is a pack nobody has seen — better served by adding it to the
+corpus than by shipping an LLM to every desktop.
+
+---
+
+## Appendix — source references
+
+| Topic                                       | Location                                                                                                                               |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Interception point + core filter            | `src/services/extensionService.ts:23,49-67`                                                                                            |
+| Extension list (recursive `**/*.js`)        | `server.py:356-368`                                                                                                                    |
+| Static mount, `text/javascript`, `no-store` | `server.py:1244`, `middleware/cache_middleware.py:34`                                                                                  |
+| userdata mime block (why not C2)            | `app/user_manager.py:345-361`, `folder_paths.py:279-306`                                                                               |
+| No desktop FS API                           | `~/comfy/desktop/src/preload.ts`                                                                                                       |
+| Deprecation fan-out hook                    | `src/lib/litegraph/src/utils/feedback.ts:13`                                                                                           |
+| Deleted link mirrors + replacement APIs     | `NodeInputSlot.ts:23-40`, `NodeOutputSlot.ts:26-44`, `node/slotLinks.ts:11-81`                                                         |
+| Closed Vue widget table                     | `widgetRegistry.ts:272-288`                                                                                                            |
+| `.tracking` manifest (option C)             | `manager_core.py:1286-1334`                                                                                                            |
+| Census + corpus + matrix                    | `~/comfy/nodes-compat-study/` — `docs/REPORT.md`, `results/registry_scan.json`, `results/affected_packs.csv`, `compat/build_matrix.py` |
+| Specifier-rewriting precedent (option B)    | `~/comfy/nodes-compat-study/compat/build_l2_fixture.py`                                                                                |
+| ECS charter                                 | `docs/adr/0008-entity-component-system.md`                                                                                             |

--- a/docs/magic_patch_prd_WIP.md
+++ b/docs/magic_patch_prd_WIP.md
@@ -1,0 +1,387 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> PRD/TDD for work still in validation. The product sections are firm; the
+> technical design is deliberately partial, and says so where it is. What is
+> built is a validation harness, not a shippable feature — read the Validation
+> section before treating any number here as a result. Companions:
+> `node_api_WIP.md` (the API), `magic_patch_WIP.md` (the delivery design),
+> `magic_patch_test_plan_WIP.md` (manual validation).
+
+# Magic Patch — automated migration of custom-node JS
+
+## Executive summary
+
+ComfyUI's frontend is being rebuilt: entity state moves into stores (ECS,
+ADR 0008), rendering moves from canvas to DOM (Nodes 2.0). The surfaces custom
+nodes are built on — prototype patching, `node.widgets` mutation, link
+internals, `applyToGraph` — do not survive that. **Measured across the registry:
+2,673 of 4,983 packs (54%) reach the frontend at all, and 4,349 JS files in 537
+packs use surfaces that are changing.**
+
+Left alone this forces a choice between breaking half the ecosystem and never
+finishing the migration. Asking thousands of unpaid authors to each rewrite
+against a new API is not a plan; it is a hope.
+
+Magic Patch is the third option: **generate the migration offline, verify it by
+running it, and ship the result as data.** An agent converts a pack against a
+published API, a harness loads the pack before and after and compares what it
+does, and only conversions that survive that are kept. Nothing runs on a user's
+machine; no model is invoked at runtime.
+
+The bet is that the conversions are mechanical enough to generate and
+consequential enough to be worth verifying properly.
+
+**Status: the harness exists and runs; validation is in progress.**
+
+What is built is not the product — it is the instrument for answering whether
+the product is possible. Three questions are open, and the pipeline exists to
+answer them:
+
+1. **Is the published API sufficient?** Every refusal names a capability that
+   does not exist. The refusal rate is the measurement.
+2. **Can conversions be trusted?** Every accepted conversion is a claim that
+   behaviour is preserved. The regressions caught are the measurement.
+3. **Does it pay?** Generation is offline and cheap per file; the question is
+   whether yield times ecosystem size beats the alternatives.
+
+None is answered yet. Best verified run: 3 of 25 files in one pack, no
+observable regression. That is an early reading of question 1, not a result.
+
+## Goals
+
+1. **Move packs off surfaces we intend to delete.** Success is that the old
+   surface becomes _deletable_, not that the pack keeps working — a shim would
+   achieve the second and defeat the first.
+2. **Never change what a workflow means.** The saved workflow and the queued
+   prompt must be byte-identical before and after. This is the one hard
+   invariant.
+3. **Verify by execution, not inspection.** A conversion is not accepted
+   because it looks right.
+4. **Produce a reviewable artifact.** A unified diff and a `v1/` tree the pack's
+   author could merge, not an opaque blob.
+5. **Feed the API.** Every refusal names a missing capability; that list is the
+   API's work queue.
+6. **Be visibly ours.** A patched node is marked in the UI and its patch is
+   inspectable. We wrote the change, so the user must be able to see that
+   before they blame the pack's author.
+
+## Non-goals
+
+- **Not a runtime code generator.** Patches are generated in CI and shipped as
+  data. No model runs on a user's machine, no API key is needed at runtime.
+- **Not for core nodes.** Custom packs only.
+- **Not for cloud.** Node/Electron only.
+- **Not a compatibility layer.** No shims, no polyfills, no dual-path code.
+- **Not automatic for everything.** Packs that genuinely cannot be expressed in
+  the new model are refused and routed to their author.
+- **Not node substitution.** Replacing an unmaintained pack with a core
+  equivalent is a separate feature; the design leaves room for it.
+
+## General description
+
+Four pieces, each independently useful:
+
+**1. The published API** (`src/platform/nodeApi/`) — closed, id-backed proxy
+handles. No internal object is reachable; a handle survives its entity's
+deletion and reports `isDeleted`. Conforms to the extension-v2 contract from
+PR #11251 so the ecosystem gets one surface, not two. **20 capabilities, 161
+members.**
+
+**2. The conversion pipeline** (`scripts/magic-patch/`) — a lead agent reads a
+whole pack, converts one file to establish the pattern, then briefs converter
+subagents on files grouped by shared contract. Agents edit a `v1/` tree in place
+with `Edit`; the pack as shipped sits beside it for reference.
+
+**3. Verification** — `verify_pack` loads a pack twice, as shipped and as
+converted, in separate processes, and compares: does it load, which types
+register, which construct, and the serialised wire per type. Only _changes_ are
+reported, so a pack that was already broken is not blamed on the conversion.
+
+**4. The patch database** — `db/<pack>/<commit7>/` holds the pack; `v1/` inside
+it holds the upgraded code. `compile_db` inverts this into an artifact keyed by
+**source content hash**, so a patch can only ever apply to the exact bytes it
+was verified against.
+
+### Delivery
+
+Three sinks from one generator:
+
+- **A — upstream PR.** For packs whose authors accept them: the `v1/` folder as
+  a pull request. Best outcome; the author owns the result.
+- **B — shipped manifest.** Hash-keyed patches applied at load time for packs
+  that will not be updated.
+- **C — replacement mapping.** Future: substitute a core node entirely.
+
+### What may ship
+
+A conversion that was _written_ and one that was _run_ are different artifacts,
+and the difference is invisible in the diff. Every entry therefore carries a
+validation tier, and `compile_db` refuses anything below `harness`:
+
+| Tier        | Means                                                           | Ships |
+| ----------- | --------------------------------------------------------------- | ----- |
+| `none`      | Written; static checks only. Never executed.                    | No    |
+| `harness`   | Loaded before and after; types, construction and wire compared. | No    |
+| `validated` | A **named human** drove it in a real ComfyUI and says it works. | Yes   |
+
+An entry carrying no tier is treated as `none`. Absent evidence is not weak
+evidence — an unstamped entry has never been run, and the field's absence must
+not excuse it from the check that would have condemned it. `verify_db` stamps
+the tier as a side effect of running, so the tier cannot drift from the evidence:
+there is no way to claim `harness` except by passing the harness.
+
+`--allow-unvalidated` exists for local iteration and warns loudly. CI does not
+pass it.
+
+_This gate found its first defect immediately:_ all three patches in the DB were
+`none`, and the previous `compile_db` shipped every one of them without comment.
+
+## Validation
+
+**This POC is the validation harness.** It is not a deliverable being
+validated; it is how the migration hypothesis gets tested. The hypothesis:
+
+> An agent, given a sufficient published API and a skill describing the
+> mappings, can convert the ecosystem's custom-node JS off the surfaces we
+> intend to delete, and a harness can prove the conversions safe well enough to
+> ship them.
+
+Nothing here decides that yet. What follows is the reading so far.
+
+### What the instrument has established
+
+| Claim                                   | Evidence                                                       |
+| --------------------------------------- | -------------------------------------------------------------- |
+| An agent can convert real pack files    | 3 files in kjnodes, from 25                                    |
+| Conversions can be behaviour-preserving | `EQUIVALENT` over 39 node types                                |
+| Verification catches real regressions   | Caught two that every static check passed                      |
+| Small diffs are achievable              | 272-line file converted with an 8-line diff                    |
+| Refusals are accurate and specific      | Punts name exact missing capabilities, confirmed by inspection |
+
+### What it has not
+
+- **Yield is 3 of 25** on the one pack driven to completion — an early reading
+  of API sufficiency, on a pack that turned out to be unusually canvas-heavy.
+- **One pack, one model, one corpus.** No breadth. kjnodes may be atypical in
+  either direction.
+- **Nothing has run in a real ComfyUI.** Every result is from the harness, and
+  the harness is itself unvalidated against reality. This is the largest hole:
+  `EQUIVALENT` currently means "the harness saw nothing change", and nobody has
+  checked the harness sees what matters.
+- **No pack converted whole.** Partial conversion leaves the old surface in
+  place, so goal 1 is unmet everywhere so far.
+- **One run in five completed.** The rest died on expired auth, a stall, or a
+  prompt bug — fixed, but not proven over a long run.
+
+### What would end validation
+
+Validation is done when these are answerable with evidence, not opinion:
+
+| Question                             | Signal                                                                                                                                | Where it stands                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Is the API sufficient?               | Refusal rate across a representative sample stabilises, and residual refusals are things that genuinely cannot exist in the new model | 11 gaps open, enumerated; sample is one pack |
+| Is the harness trustworthy?          | A manually-tested pack agrees with the harness verdict — and any disagreement becomes a check                                         | Not started; test plan written               |
+| Are conversions safe enough to ship? | A converted pack runs in real ComfyUI, both renderers, byte-identical save/reload, alongside unconverted packs                        | Not started                                  |
+| Does it scale?                       | A run over the download-weighted top band completes without hand-holding                                                              | Not started; longest clean run is one pack   |
+| Would authors accept them?           | A PR opened against a real pack is merged                                                                                             | Not started                                  |
+
+The first two gate the rest. Until a human has driven a converted pack in
+ComfyUI and agreed with the harness, every `EQUIVALENT` is a claim about the
+harness rather than about the pack.
+
+### The failure that best characterises the state
+
+The most recent run converted `fast_preview.js` and emitted:
+
+```js
+node.setSize({ width: 550, height: 550 }) // the API takes a tuple: [w, h]
+```
+
+Array-destructuring an object throws, so every node in the pack failed to
+construct — **40 types lost from one line**. The agent had the full API
+declarations in its working copy and still got the shape wrong.
+
+Three things follow, and they are the shape of the whole project:
+
+1. **Verification earned its place.** Every static check passed this. Only
+   running the pack caught it.
+2. **Documentation is not a control.** Shipping types reduced this class of
+   error but did not eliminate it. Anything that must not happen needs a check,
+   not a paragraph.
+3. **The failure mode is silent and total.** One bad line takes out a whole
+   pack, which is why the conservative posture — refuse rather than guess — is
+   correct even though it costs yield.
+
+### The gap list
+
+`gap_inventory` scans the corpus statically and maps every legacy construct to
+its destination or to nothing. Across 400 packs / 664 files:
+
+| Gap                        | Packs blocked |
+| -------------------------- | ------------- |
+| ContextMenu / slot menu    | 36            |
+| `api.fetchApi`             | 36            |
+| pointer gestures on canvas | 27            |
+| `queuePrompt`              | 19            |
+| `app.extensionManager`     | 18            |
+| settings get/set           | 14            |
+| `LGraphCanvas` internals   | 13            |
+| `graphToPrompt`            | 12            |
+| `onConnectInput` (veto)    | 3             |
+
+Closed so far: `defs.extend`, `defs.define` + `resolve`, `widgets.mount`,
+`widgets.canvas`, `onPreview`, `onSerialize`, `setSizeConstraints`,
+`slots.dynamic`, `graph.selection`, serialization control.
+
+**The loop is: inventory → close the top gaps → rerun → re-inventory**, until
+refusals are only things that genuinely cannot be expressed.
+
+## Testing
+
+**Unit — 347 tests.** The API's own behaviour, the conversion rules, the
+verification harness.
+
+**Conformance — 13 checks per converted file.** Static properties a conversion
+must have: the old surface is retired, no invented API members, no writes that
+silently vanish, handle state through accessors, nothing dropped without
+account, no net-new capabilities, diff is mostly substance.
+
+Each check exists because something got through: `handles-use-accessors` was
+added after property writes took down 39 node types.
+
+**Execution — `verify_db`.** The load/register/construct/serialise comparison.
+Its limits are known and stated: it drives node lifecycle only, never clicks,
+never renders, and **never calls a converted file's exported helpers**.
+
+**Manual — the test plan.** Covers what the harness cannot: both renderers,
+interaction, teardown, byte-identical save/reload, and coexistence with
+unconverted packs. Every manual failure is recorded with _"could a check have
+caught this?"_, so the plan shrinks over time.
+
+## Risks
+
+| Risk                                                            | Severity | Mitigation                                                                                         | Residual                                                                     |
+| --------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **A conversion changes what a workflow means**                  | Critical | Wire comparison before/after; reserved serialization keys a pack cannot write                      | Comparison covers types the harness can construct                            |
+| **A silent partial conversion** — looks converted, does nothing | High     | `retires-the-old-surface`, `no-silently-dropped-writes`, `mark_complete` refuses an unchanged file | Novel silent shapes need new checks; each has been found by inspection first |
+| **API drift** — docs claim more or less than the code           | High     | Capability list generated; `.d.ts` shipped into every working copy; drift test                     | Has caused two large misfires; the class is closed, instances may recur      |
+| **Cross-file breakage** from parallel agents                    | Medium   | Stranded-caller guard; whole-pack verification over merged output                                  | An agent can still break a caller it does not own                            |
+| **Verification over-claims**                                    | Medium   | `EQUIVALENT` documented as "nothing observable got worse"                                          | Files whose exports are never called are barely verified                     |
+| **Cost**                                                        | Medium   | ~99.5% of runtime is model time; in-place editing cut generation sharply                           | 4,349 files is days of model time                                            |
+| **Author rejection of PRs**                                     | Medium   | Minimal-diff policy, surgical edits, no restructuring                                              | A pack may still decline                                                     |
+| **Patch applies to wrong bytes**                                | Low      | Content-hash keying; strict diff applier that refuses fuzzy matches                                | —                                                                            |
+
+## Rollout
+
+**The patcher is a tool, not a plan.** It converts pack JS from the ad-hoc API to
+V1. It has no opinion about who runs it, on which packs, or when — those are
+decisions of the rollout, and keeping them out of the tool is what lets the same
+binary serve all three paths below.
+
+The rollout announces two things together: **ECS / Nodes 2.0 is the supported
+graph for the frontend**, and **auto-patch is the primary tool for moving old
+packs onto it**.
+
+### Three paths, by who runs the patcher
+
+| Path                | Who runs it                      | Coverage                      | Who owns defects |
+| ------------------- | -------------------------------- | ----------------------------- | ---------------- |
+| **Maintainer**      | The pack's author, with our help | Any pack whose author engages | The author       |
+| **Comfy backstop**  | Comfy, in CI                     | Top 80% of packs by usage     | **Comfy**        |
+| **User self-serve** | The user, locally                | The long tail                 | Nobody           |
+
+**Maintainer-led is the preferred outcome, and we bend over backwards for it.**
+We engage active maintainers, help them produce a V1 version of their pack,
+discuss and vet the result. A pack the maintainer has moved to V1 **is not
+patched** — their release wins, and the marking drops away because the code is
+theirs again.
+
+**The Comfy backstop exists so users are not the ones discovering breakage.** We
+auto-patch and verify the top 80% by usage. We reserve the right to patch again
+later if the API changes underneath a pack: the commitment is to the end user and
+to ComfyUI "just working", not to a one-time conversion.
+
+**The long tail gets the tool rather than the patches.** We may ship patches for
+individual critical packs at our discretion, but the general answer is that
+auto-patch is available to users as an end-user tool for patching whatever they
+happen to run. **No guarantee it works.** It is offered because an unmaintained
+pack's alternative is not working at all.
+
+**A small set will not be patchable** — packs whose design conflicts with how the
+frontend works now. We keep that list small and aim to provide the functionality
+by another route rather than leaving a hole.
+
+### Who owns a defect
+
+- **Comfy-patched** — the patch set we generate _and verify_. **We own the bugs.**
+  The node is marked `COMFY-PATCHED` in the UI, and the marking says who to
+  contact when it breaks. A user must never file our change against the author.
+- **User-patched** — a patch the user generated locally. **Neither Comfy nor the
+  maintainer is responsible.** If patching fails and no maintainer is porting the
+  pack, rewriting it by hand is the remaining option. Saying so plainly up front
+  is kinder than implying a support path that does not exist.
+
+Marking therefore carries **two independent facts**: who patched it, and how well
+it was checked. Either alone would mislead — a verified user patch is still
+unsupported, and an unverified Comfy patch is still ours.
+
+### Unpatching
+
+**Any patched pack can be unpatched**, restoring the code as its author shipped
+it. We patch because the pack is broken against the current frontend, so
+unpatching will often stop it working — that is the user's call to make, and
+refusing to offer it would make the patch feel like something done _to_ them
+rather than _for_ them.
+
+### What this changes about the design
+
+The user self-serve path means **the patcher runs on user machines**, which
+earlier drafts of this document ruled out. Local generation needs a model the
+user supplies or a hosted endpoint, and it cannot assume CI's corpus or its
+verification harness — so a user-generated patch is `validation: none` by
+construction, and the badge must say so. **Open: which of the three model
+backends serves this path.**
+
+## Deployment and operations
+
+_Partial by intent — this is the least-developed section, and shipping is
+gated on yield rather than on deployment work._
+
+**Generation** runs in CI for the Comfy backstop, and locally for user
+self-serve. Inputs: the registry corpus and
+a Claude Code session. Outputs: `db/` entries and a compiled artifact. Auth is
+probed before any work is spawned, after four batches were lost to expired
+tokens.
+
+**Distribution** is undecided. `magic_patch_WIP.md` §4 works through service
+worker, blob URL and on-disk delivery; each has problems, and the choice
+interacts with Electron's filesystem constraints. **Open.**
+
+**Operation** is off by default, config-gated, silent, with one toast reporting
+a count. A patch is applied only when the source hash matches exactly;
+otherwise the original loads untouched.
+
+**Rollback** is inherent: patches are data, so disabling the setting or shipping
+an empty manifest restores original behaviour with no code change.
+
+**Monitoring** is unspecified. At minimum: how many patches applied, how many
+skipped on hash mismatch, and any error attributable to a patched file. **Open.**
+
+**Ownership: Comfy owns the patch.** _(Decided 2026-08-06.)_ We wrote it, so a
+defect in a patched pack is ours, not the author's. Two things follow, and both
+are requirements rather than nice-to-haves:
+
+- **A patched node is visibly marked in the UI** — a badge, symbol or border
+  distinguishing it from an unpatched one. A user hitting a problem must be able
+  to see that we changed this node before they file it against the author, and
+  an author receiving a report must be able to ask "was it patched?". The mark
+  carries the validation tier, because a badge that cannot tell `harness` from
+  `manual` would claim more than the patch earned — and under the rule above,
+  nothing weaker than `harness` reaches a user to be marked at all.
+- **Patch provenance is inspectable** — which patch, generated when, against
+  which source hash. A bug report about a patched node is only actionable if the
+  exact conversion can be recovered.
+
+This also sharpens the preference for sink A: a merged upstream PR transfers
+both the code and the ownership, and the marking can drop away because the
+author's own release now contains it.

--- a/docs/magic_patch_support_WIP.md
+++ b/docs/magic_patch_support_WIP.md
@@ -1,0 +1,187 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> Companion to `magic_patch_WIP.md`, `node_api_WIP.md` and
+> `API_DECISIONS_FOR_REVIEW.md`.
+
+# Magic Patch — support status
+
+What we claim to support, what we knowingly do not, and what is still unproven.
+Written to be read before hands-on testing, so that behaviour we already
+decided to drop is not re-reported as a defect.
+
+## What the statuses mean
+
+A file is **converted** when it was rewritten onto the published node API. It is
+**refused** when the conversion was impossible and the whole file was replaced
+with an `// API-GAP:` block naming what is missing — an honest refusal, not a
+silent half-rewrite. A pack is:
+
+| status             | meaning                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| **full**           | every in-scope file converted, nothing refused                                                  |
+| **partial**        | converted, with a minority of files refused — the pack loads and mostly works                   |
+| **mostly refused** | more files refused than converted — the node types still run, but much of the pack's UI is gone |
+| **INCOMPLETE**     | files remain untouched; not ready to assess                                                     |
+
+"Full" is a statement about _disposition_, not about proven behaviour. See
+§Unproven.
+
+## Coverage
+
+Measured against the top 135 packs, which are ~80% of all downloads:
+
+|                                   |  downloads |             share |
+| --------------------------------- | ---------: | ----------------: |
+| ship no JavaScript — need nothing | 35,097,791 |             41.2% |
+| ship JS — need work               | 50,147,687 |             58.8% |
+| ↳ in a fully-converted pack       | 36,995,003 | 73.8% of the work |
+| ↳ partially converted             | 10,549,060 |             21.0% |
+| ↳ never touched                   |  2,603,624 |              5.2% |
+
+**84.6% of top-135 downloads either need nothing or sit in a fully-converted
+pack.** 504 of 530 in-scope files are done (95.1%); 52 of 61 packs complete.
+
+Two numbers that qualify that headline:
+
+- **19% of touched files are refusals** (101 of 535), and they are concentrated.
+  rgthree counts as covered on downloads while 32 of its 48 files are refused.
+- **5.8% of downloads are unreachable in principle** — packs whose served
+  frontend is minified build output with no source in the distribution
+  (`comfyui-easy-use` is the confirmed case; its `__init__.py` serves
+  `web_version/v2`, the build artifact of a separate repo). Those need an
+  upstream PR, not a patch.
+
+## Per-pack status
+
+| pack                            | downloads | converted | refused | left | status         | on test box |
+| ------------------------------- | --------: | --------: | ------: | ---: | -------------- | ----------- |
+| comfyui-kjnodes                 | 4,039,686 |        25 |       0 |    0 | full           | yes         |
+| rgthree-comfy                   | 3,692,630 |        15 |      32 |    1 | INCOMPLETE     | yes         |
+| comfyui-easy-use                | 3,301,869 |        12 |      10 |    2 | INCOMPLETE     |             |
+| comfyui-videohelpersuite        | 3,176,624 |         3 |       0 |    0 | full           | yes         |
+| comfyui-impact-pack             | 3,141,920 |         7 |       0 |    0 | full           |             |
+| comfyui_essentials              | 2,794,415 |         2 |       0 |    0 | full           | yes         |
+| comfyui-custom-scripts          | 2,760,706 |        23 |       7 |    0 | partial        | yes         |
+| ComfyUI-Crystools               | 2,095,275 |         5 |       0 |    0 | full           | yes         |
+| comfyui_layerstyle              | 1,986,588 |         2 |       1 |    0 | partial        |             |
+| cg-use-everywhere               | 1,889,056 |         2 |       0 |   12 | INCOMPLETE     |             |
+| comfyui-mxtoolkit               | 1,089,798 |         5 |       0 |    0 | full           | yes         |
+| efficiency-nodes-comfyui        | 1,020,005 |         7 |       9 |    0 | mostly refused | yes         |
+| comfy-mtb                       |   908,221 |         7 |       2 |    0 | partial        |             |
+| comfyui-image-saver             |   858,668 |         1 |       0 |    0 | full           |             |
+| comfyui-inspire-pack            |   851,413 |         7 |       0 |    0 | full           |             |
+| comfyui-art-venture             |   842,381 |         3 |       0 |    0 | full           |             |
+| comfyui-inpaint-cropandstitch   |   826,424 |         1 |       0 |    0 | full           |             |
+| comfyui-rmbg                    |   809,573 |         2 |       0 |    0 | full           |             |
+| comfyui-lora-manager            |   712,614 |        18 |       2 |    2 | INCOMPLETE     |             |
+| derfuu_comfyui_moddednodes      |   697,415 |         1 |       0 |    0 | full           |             |
+| controlaltai-nodes              |   611,357 |         1 |       0 |    0 | full           |             |
+| comfyui_tinyterranodes          |   574,205 |         7 |       2 |    0 | partial        |             |
+| comfyui-mixlab-nodes            |   573,364 |        17 |       3 |    0 | partial        |             |
+| comfyui-wd14-tagger             |   557,854 |         1 |       0 |    0 | full           |             |
+| comfyui_custom_nodes_alekpet    |   535,919 |         9 |       1 |    0 | partial        |             |
+| comfyui_fill-nodes              |   455,168 |        38 |       5 |    0 | partial        |             |
+| comfyui-ollama                  |   434,727 |         1 |       0 |    0 | full           |             |
+| ComfyUI-QwenVL                  |   383,199 |         1 |       0 |    0 | full           |             |
+| comfyui_ttp_toolset             |   378,616 |         1 |       0 |    0 | full           |             |
+| comfyui-jakeupgrade             |   373,287 |         2 |       0 |    0 | full           |             |
+| crt-nodes                       |   330,138 |        20 |       3 |    0 | partial        |             |
+| Comfyui-Resolution-Master       |   277,504 |         2 |       0 |    4 | INCOMPLETE     |             |
+| bjornulf_custom_nodes           |   251,260 |        42 |       0 |    1 | INCOMPLETE     |             |
+| deno-custom-nodes               |   240,294 |        16 |       3 |    0 | partial        |             |
+| basic_data_handling             |   213,497 |         0 |       1 |    0 | mostly refused |             |
+| comfyui-get-meta                |   202,731 |         2 |       0 |    0 | full           |             |
+| comfyui-tooling-nodes           |   195,154 |         1 |       0 |    0 | full           |             |
+| aigodlike-comfyui-translation   |   191,901 |         2 |       0 |    0 | full           |             |
+| cg-image-filter                 |   188,962 |         4 |       0 |    0 | full           |             |
+| LanPaint                        |   177,770 |         1 |       0 |    0 | full           |             |
+| promptmodels                    |   174,322 |         2 |       0 |    0 | full           |             |
+| comfyui-workflow-encrypt        |   168,678 |         1 |       0 |    0 | full           |             |
+| ComfyUI_LayerStyle_Advance      |   166,160 |         1 |       0 |    0 | full           |             |
+| comfyui-ppm                     |   165,286 |         2 |       0 |    0 | full           |             |
+| ComfyUI-3D-Pack                 |   157,754 |         1 |       0 |    0 | full           |             |
+| comfyui-utils-nodes             |   148,199 |         1 |       0 |    0 | full           |             |
+| comfyui-lora-auto-trigger-words |   147,304 |         0 |       1 |    0 | mostly refused |             |
+| comfyui-enricos-nodes           |   143,251 |         4 |       0 |    1 | INCOMPLETE     |             |
+| ComfyUI-Copilot                 |   141,023 |         1 |       0 |    1 | INCOMPLETE     |             |
+| prompt-assistant                |   139,853 |         5 |       6 |    2 | INCOMPLETE     |             |
+| tts_audio_suite                 |   137,017 |        25 |       2 |    0 | partial        |             |
+| comfyui_smznodes                |   136,323 |         0 |       2 |    0 | mostly refused |             |
+| wan22fmlf                       |   131,486 |         1 |       0 |    0 | full           |             |
+| comfyui_lg_tools                |   129,872 |        18 |       3 |    0 | partial        |             |
+| comfyui_llm_party               |   126,144 |         3 |       0 |    0 | full           |             |
+| kaytool                         |   122,365 |        13 |       1 |    0 | partial        |             |
+| save-image-extended-comfyui     |   122,290 |         2 |       0 |    0 | full           |             |
+| comfyui-qwenmultiangle          |   113,100 |         1 |       0 |    0 | full           |             |
+| comfyui_essentials_mb           |   112,891 |         2 |       0 |    0 | full           |             |
+| comfyui-prompt-reader-node      |   110,389 |         6 |       0 |    0 | full           |             |
+| comfyui-quadmoons-nodes         |   108,168 |         3 |       0 |    0 | full           |             |
+
+## The test box
+
+`http://127.0.0.1:8189` — ComfyUI running against
+`comfyui-frontend-2/dist`, with **1344 node types**, 518 from custom packs, 481
+of those from converted packs. Eight converted packs are installed, each with
+its upstream Python and our converted JS overlaid on top:
+
+kjnodes · essentials · VideoHelperSuite · efficiency-nodes · Crystools ·
+rgthree · Custom-Scripts · mxToolkit
+
+Reinstall or add more with `sh scripts/magic-patch/verify/install_converted.sh <pack>`. It
+clones upstream, syntax-checks every converted file as ESM, then overlays only
+files the pack actually ships. ComfyUI must be started from its venv
+(`.venv/bin/python`) — the bare Homebrew interpreter is missing the deps.
+
+## Known losses — please do NOT report these as bugs
+
+These are decisions, recorded here so testing spends its time on the unknown.
+
+**rgthree** — the largest deliberate loss in the set. Every rgthree _frontend_
+node is gone: Reroute, Label, Bookmark, Fast Muter, Fast Bypasser, Fast Groups
+Muter/Bypasser, Fast Actions Button, Node Collector, Mute/Bypass Repeater and
+Relay, Random Unmuter. Its overrides on backend nodes are gone too — Seed,
+Context (all variants), Any Switch, Image Comparer, Power Primitive, Power
+Puter, Power Lora Loader, Power Prompt. The backend node types still exist and
+still execute; they simply have no rgthree UI. Also gone: the progress bar, the
+settings dialog, top-bar buttons, the rgthree canvas menu, and `window.rgthree`.
+Two consequences worth knowing while testing: **Seed no longer holds its `-1`
+sentinel**, so a re-run randomises; and **Context no longer migrates its slots**,
+so an old Context workflow can land links on the wrong slot.
+
+**Custom-Scripts (pysssss)** — autocomplete is gone entirely (embeddings, LoRA
+tags, custom word list). Workflow management (server-side save/load, default
+workflow, "send to workflow") is gone. Workflow image export/import including
+SVG is gone. Reroute/MultiPrimitive retyping and permutation are gone. The image
+feed still works, but the 🖼️ button is gone — show it via the command
+`pysssss.ImageFeed.Show`. The `pysssss.updateExamples` bridge is gone, so the
+example list refreshes on the next model change rather than immediately.
+
+**efficiency-nodes** — the entire right-click node menu is gone (Swap-with ×4,
+Add-link, Add-script, Add-XY-input, Set-Resolution, View-model-info,
+Seed-behavior); that is roughly half the pack's UI. The seed control button is
+gone.
+
+**Everywhere** — anything that needed to change a value _at prompt time_, or to
+queue a prompt itself, is inert. That is one root cause (no prompt-time value
+substitution, no queueing) behind most individual losses above.
+
+## What is NOT proven
+
+Be appropriately sceptical of everything above.
+
+- **Nothing has been exercised in a browser.** Every wire-format claim is read
+  off `LGraphNode.serialize`/`configure` and `executionUtil`, not observed. The
+  single most valuable thing this testing can produce is a save → reload →
+  queue round trip on a real workflow per pack.
+- **The conformance checker passing is not the same as the file running.** Three
+  conversions were found referencing identifiers that no longer existed —
+  syntactically valid, clean under every syntax check, dead on load. They are
+  now caught by `scripts/magic-patch/verify/undef.sh` (ESLint `no-undef`, diffed against the
+  original to subtract each pack's pre-existing globals), but the class is a
+  reminder that static gates have a ceiling.
+- **Only 8 of 52 completed packs are installed here.** The rest are converted
+  and verified statically, and have never been loaded.
+- Current gate state: 496 conformance pass, 3 sanctioned hold-outs, 11 fail —
+  of the failures, 6 are an advisory line-growth heuristic, 2 are a verified
+  false positive on lora-manager's own widget facade, 1 is three.js inside a
+  build artifact, 1 is mixlab's `graph._nodes` (genuinely outstanding).

--- a/docs/magic_patch_test_plan_WIP.md
+++ b/docs/magic_patch_test_plan_WIP.md
@@ -1,0 +1,109 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> Companion to `magic_patch_WIP.md` and `node_api_WIP.md`. Becomes part of an
+> ADR or a QA doc once the approach settles.
+
+# Testing a converted pack by hand
+
+`verify_db` proves something narrow and worth stating exactly: **the pack loads,
+registers the same node types, constructs them, and serialises identically**.
+It drives node lifecycle only. It does not click anything, does not render, and
+**never calls a converted file's exported helpers** — which is how a broken
+`hideWidgetForGood` passed it earlier.
+
+So a human pass is not belt-and-braces. It covers a different surface.
+
+## Setup
+
+```bash
+# 1. The converted pack, from the entry the agent worked in
+db/<pack>/<commit7>/v1/…        # upgraded code
+db/<pack>/<commit7>/…           # the pack as shipped, for comparison
+
+# 2. Install both into a real ComfyUI
+cp -r db/<pack>/<commit7>/<packRoot>  ~/comfy/ComfyUI/custom_nodes/<pack>-before
+cp -r db/<pack>/<commit7>/v1/<packRoot> ~/comfy/ComfyUI/custom_nodes/<pack>-after
+```
+
+Test **A/B, one at a time** — install one, restart, exercise, then swap. Both at
+once means two packs registering the same node types, and whichever loses is
+not a finding about the conversion.
+
+Run each pass **twice**: once on the legacy canvas renderer and once with Nodes
+2.0. Anything mounted (`widgets.mount`, `widgets.canvas`) renders through a
+different path in each, and that is exactly where a conversion can look right in
+one and be invisible in the other.
+
+## What to check, in order of what has actually broken
+
+**1. It loads at all.** Open the browser console before anything else. A
+converted file that throws at registration takes out _every_ node type in the
+pack — that happened, and the whole pack silently vanished from the node menu.
+
+- [ ] No errors in console at startup
+- [ ] Every node type still appears in the Add Node menu (compare against before)
+
+**2. Each node still constructs.** Drop one of every type on the canvas.
+
+- [ ] Node appears, with the same widgets in the same order
+- [ ] Widget defaults match the before-install
+- [ ] Node size/colour/title match
+
+**3. Widget behaviour.** For each widget the conversion touched:
+
+- [ ] Changing a value updates the node
+- [ ] Values that drive other widgets (combos, toggles) still do
+- [ ] A widget that should be hidden is hidden, and one that should be disabled
+      is greyed but readable
+
+**4. Execution.** Queue a prompt that runs each node.
+
+- [ ] Node executes without console errors
+- [ ] Any on-node display (text readouts, previews, progress) still updates
+- [ ] Re-running does not accumulate widgets — the remove-then-recreate pattern
+      is where duplicates appear
+
+**5. Save and reload — the wire format.** This is the invariant the whole
+migration promises.
+
+- [ ] Save the workflow. Reload the page. Load it back.
+- [ ] Widget values restored exactly
+- [ ] `diff` the saved JSON against one saved from the before-install with the
+      same graph: **it should be byte-identical** apart from node ids
+- [ ] Queue from the reloaded workflow and confirm the same result
+
+**6. Interaction, for anything mounted.** `verify_db` cannot see any of this.
+
+- [ ] Mounted controls (editors, previews, panels) draw
+- [ ] Dragging, clicking and hovering work
+- [ ] Resizing the node reflows the mounted element
+- [ ] Deleting the node leaves nothing behind — no orphaned DOM, no timer still
+      firing, no listener still bound (check the console after deleting)
+
+**7. Coexistence.** Convert one pack, not all of them.
+
+- [ ] Install the converted pack **alongside unconverted ones** and confirm both
+      still work. Composition is the thing the published API claims to fix; a
+      pack that only works alone has not demonstrated it.
+
+## Pack-specific: kjnodes
+
+Its signature features are the ones most likely to break:
+
+- [ ] **Multi combiners** (`ImageBatchMulti`, `JoinStringMulti`, …) — wiring the
+      last input grows a new one; unwiring shrinks it
+- [ ] **`SetNode` / `GetNode`** — set a key on one, read it on another, confirm
+      the wire resolves and the prompt runs
+- [ ] **Point / spline editors** — drag a handle, add a point, delete one; save
+      and reload and confirm the curve survives
+- [ ] **`PlaySoundKJ`** — plays on completion, honours the mode widget, does not
+      play twice
+
+## Recording the result
+
+Anything that fails is worth more than the fix: it is a hole in `verify_db`.
+
+For each failure record **what broke**, **which of the seven sections found it**,
+and **whether an automated check could have**. A failure in section 5 means the
+wire comparison missed something; a failure in section 6 is expected, and the
+question is whether it can be driven in the harness at all.

--- a/docs/node_api_WIP.md
+++ b/docs/node_api_WIP.md
@@ -1,0 +1,1847 @@
+> # ⚠ WORK IN PROGRESS — SHOULD NOT BE SUBMITTED TO MAIN
+>
+> A working design artifact living on `benjcooley/magic-patch` so it is version
+> controlled and reviewable alongside the code it describes. It is **not** a
+> finished document and is not intended to land on `main` in this form. When the
+> design settles, the durable parts become a proper ADR under `docs/adr/` and
+> this file goes away.
+
+# The published custom-node API
+
+**Status:** working design artifact. Companion to `magic_patch_WIP.md` — this is
+its step 1. Nothing else in that document is buildable until this exists.
+
+**Constraint:** functions and closed proxy objects only. **No internal frontend
+object is reachable from this surface** — not `LGraphNode`, not `LLink`, not a
+widget instance, not a Pinia store, not a Vue reactive proxy, not a constructor.
+
+> ### ⚠ This document specifies more than `src/platform/nodeApi/` implements
+>
+> **Do not convert a pack against a section marked ⛔.** Doing so produces code
+> that references a member that does not exist. That has happened twice: one
+> conversion used a selector shape the registry rejects, another called
+> `setSizeConstraints` from §4a. Both read as successful.
+>
+> The authority on what exists is `CAPABILITIES` in `comfyApi.ts`, enforced by
+> the `no-unknown-api-members` conformance check against the generated
+> `apiSurface.ts`. Sections below carry a status marker:
+>
+> |     | Meaning                                                 |
+> | --- | ------------------------------------------------------- |
+> | ✅  | Implemented, tested, in `CAPABILITIES`                  |
+> | ⛔  | Specified only — a pack needing it is an `api-gap` punt |
+>
+> **Implemented (v1.0):** `backend`, `commands`, `defs.define`,
+> `defs.extend`, `graph.nodes`, `graph.selection`, `interaction.nodeDragEnd`,
+> `interaction.nodeMoved`, `interaction.state`, `node.connectVeto`,
+> `node.geometry`, `node.menu`, `node.onPreview`, `node.onSerialize`,
+> `node.resolve`, `node.sizeConstraints`, `serialization.control`,
+> `settings`, `slots.connect`, `slots.dynamic`, `slots.identity`,
+> `slots.moveLinks`, `slots.retype`, `storage`, `viewport.changed`,
+> `widgets.canvas`, `widgets.create`, `widgets.hidden`, `widgets.mount`,
+> `widgets.reorder`.
+>
+> **Specified only:** §4a declarative decorations (badges/anchors — note
+> `setSizeConstraints` and `widgets.canvas` DID ship), §4b chrome, §4c
+> `onChange`, `graph.replaceNode`, `batch`.
+
+---
+
+## 1. Completeness criterion
+
+An API is "done" when it's neither speculative nor short. The census gives us an
+objective test:
+
+> **Every surface custom nodes actually use must have exactly one documented
+> destination here.**
+
+| Census surface                            | Packs    | Destination                                                            |
+| ----------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `widgets_splice`                          | 286      | `node.widgets.reorder()` / `.remove()` / `.move()`                     |
+| `widget_type_write`                       | 270      | `widget.hidden` (this was the hack's real intent)                      |
+| `converted_widget`                        | 238      | `widget.hidden` + `input.isWidgetInput`                                |
+| `widgets_assign`                          | 226      | `node.widgets.reorder()`                                               |
+| `widgets_push`                            | 142      | `node.widgets.add()`                                                   |
+| `hook_getCustomWidgets`                   | 91       | `comfy.widgets.register()`                                             |
+| `out_links_write`                         | 58       | `output.connectTo()` / `output.disconnect()`                           |
+| `link_endpoint_write`                     | 36       | `output.connectTo()` / `input.disconnect()`                            |
+| `node_shape_write`                        | 27       | `node.shape` (enum)                                                    |
+| `slot_spread`                             | 23       | `input.snapshot()` — plain frozen object                               |
+| `in_link_write`                           | 21       | `input.disconnect()` / `input.source()`                                |
+| `type_write_nodevar`                      | 11       | **none — deliberately.** `type` is identity; use `graph.replaceNode()` |
+| **canvas draw hooks**                     | **420**  | Four destinations — §4a. Only ~53% is drawing at all                   |
+| **`beforeRegisterNodeDef`**               | **1265** | `defs.extend(selector, fn)` — §4d. **47.4% of installs**               |
+| `nodeType.prototype.*`                    | 1191     | `NodeDefBuilder` behaviour hooks — §4d                                 |
+| `extends LGraphNode` / `registerNodeType` | 86       | `defs.define()` — §4d                                                  |
+| `onExecuted`                              | 497      | `onExecuted(node, result)` — §4d                                       |
+| `applyToGraph` (virtual nodes)            | 10       | `resolve(ctx)` against a prompt draft — §4d                            |
+
+Eighteen surfaces, eighteen answers. Anything not on this list is out of scope until
+a pack demonstrably needs it — the future problem gets solved when it has a shape.
+
+### The painting surface is bigger than expected
+
+Measured over the corpus (`grep`, so a candidate count with a known false-positive
+rate — sample-verify before citing):
+
+| Hook                                                     | Packs   |
+| -------------------------------------------------------- | ------- |
+| `onDrawForeground`                                       | 343     |
+| `onDrawBackground`                                       | 169     |
+| `onDrawTitleBar`                                         | 14      |
+| `onDrawTitleBox` / `onDrawTitleText` / `onDrawCollapsed` | 6 each  |
+| **distinct packs painting anything**                     | **420** |
+
+**420 packs / 34,299,457 downloads / 32.2% of registry installs** — comparable to the
+entire vue-only widget cohort, and it includes essentially every major pack: kjnodes,
+rgthree, easy-use, VideoHelperSuite, impact-pack, custom-scripts, LayerStyle,
+cg-use-everywhere, mxtoolkit.
+
+This cannot be written off as a capability loss. It's a third of the ecosystem.
+
+---
+
+## 2. Access and versioning
+
+### The version number
+
+**`major.minor`. No patch component.**
+
+|           | Meaning                                         | May break a pack? |
+| --------- | ----------------------------------------------- | ----------------- |
+| **major** | something was removed, or its behaviour changed | yes               |
+| **minor** | something was added                             | no                |
+
+A patch component would describe a change that is neither — which needs no
+announcement, and only tempts packs into comparing on it. Fine-grained detail
+belongs in capabilities, not in the number.
+
+**The promise, within a major:** nothing is removed, nothing changes behaviour,
+and every addition is discoverable at runtime. That promise is the entire reason
+this surface is worth migrating onto — and it is exactly the promise the current
+situation broke.
+
+### Capabilities are the contract, not the version
+
+```ts
+comfy.version // '1.0' — for logging and bug reports
+comfy.major // 1     — breaking-change generation
+comfy.supports('widgets.reorder') // boolean, cheap, never throws
+comfy.require('widgets.reorder') // throws a named, actionable error
+comfy.capabilities() // everything this host provides
+```
+
+Packs should branch on `supports()`, not on `version`. A capability survives
+being backported to an older line or shipped a minor earlier or later than
+planned; a `version >= 1.3` comparison silently breaks in both cases. The
+version exists so a bug report is legible, and so `require()` can say _when_:
+
+```
+This ComfyUI frontend does not support 'node.decorations'. API version is 1.0;
+'node.decorations' requires 1.2. Guard with comfy.supports('node.decorations')
+to degrade gracefully.
+```
+
+That message is the difference between an actionable report and
+`undefined is not a function`. Planned-but-unshipped capabilities are registered
+precisely so the error can name a version.
+
+### Supporting several frontends from one pack
+
+This is the constraint that actually governs adoption. **Authors do not refuse
+to migrate because migration is hard — they refuse because migrating strands
+users on older frontends.** So the pattern must be first-class:
+
+```js
+import { comfy } from '/comfy/api/v1.js'
+
+if (comfy.supports('widgets.reorder')) {
+  node.widgets.reorder(['prompt', 'seed'])
+} else {
+  legacySplice(node) // old path, still shipped
+}
+```
+
+One build, both hosts, no version table. Combined with the dual-web-dir
+convention (`docs/magic_patch_WIP.md` §7), a pack can also ship two whole trees and let
+the backend pick — with the API major as the natural negotiation signal.
+
+### Every major stays supported
+
+**No major is ever withdrawn.** v1 keeps working when v2 ships, and when v3
+ships. A pack written once against v1 runs indefinitely.
+
+That is a strong promise, and it is affordable only because of how a major is
+built: **a major is a spec, not a fork.** Each one is a declarative mapping from
+public names onto whatever the internals currently are, sharing a single engine
+— the proxy factory, slot resolution, the collections. Adding a major adds a
+mapping; it does not freeze internals, duplicate logic, or pin us to an old
+implementation.
+
+```
+/comfy/api/v1.js   ┐
+/comfy/api/v2.js   ├─ different specs, one engine, current internals
+/comfy/api/v3.js   ┘
+window.comfy       ← latest major, for the console
+comfy.forMajor(1)  ← pin explicitly
+```
+
+The cost is therefore not ongoing maintenance. It is the day an old major's
+semantics become genuinely **inexpressible** against current internals — when
+some concept it exposed no longer has any equivalent. That is the case to watch,
+and the reason majors should be **rare and batched**: collect breaking changes
+and ship them together. `node.type` immutability, removing `input.link` /
+`output.links`, and the hook rewrite (§5) all belong to the _same_ major, not
+three.
+
+Deletion of the old _internal_ surfaces still happens — that is the point of the
+programme. What survives is the _published_ one.
+
+### Cross-major identity — the same node has two proxies
+
+A consequence that must be designed for rather than discovered: **handles from
+different majors, or different API instances, are different objects.** One
+object cannot have two shapes. So:
+
+```js
+a === b // false, even for the same node
+comfy.sameEntity(a, b) // true — this is the supported comparison
+comfy.adopt(foreign) // re-resolve a foreign handle into this instance
+```
+
+This matters because packs pass handles to each other through hooks. Every
+handle carries `{ kind, id }` under `Symbol.for('comfy.handle')` — readable by
+any major, exposing nothing internal, and invisible to `Object.keys`, spreads
+and `JSON.stringify`.
+
+Rules of thumb, worth stating in the pack-facing docs:
+
+- `===` is reliable **only** for handles you obtained yourself, from one instance.
+- Any handle that arrived from elsewhere — a hook argument, another pack —
+  should be compared with `sameEntity` and converted with `adopt`.
+
+Note this bites even _within_ one major: two API instances mint separate
+proxies. The token makes identity correct regardless of how many instances or
+majors exist, which is why it is the mechanism rather than "just use one
+instance".
+
+### What a major bump costs
+
+Two live specs, two test surfaces, and a compatibility obligation that never
+expires. Cheap per-major, but not free — so bump rarely, batch aggressively, and
+prefer adding a capability over changing an existing one.
+
+## 3. Core principles
+
+1. **Handles are ID-backed, not reference-backed.** A handle stores a string id and
+   resolves on every access. No stale references, no leak of the live object, no
+   retention of deleted entities.
+2. **Every mutation is a command.** Setters dispatch through the command layer per
+   ADR 0003/0008 — serializable, idempotent, undoable. No handle mutates anything
+   directly.
+3. **All returned data is inert.** Frozen plain objects or primitives. Never a
+   reactive proxy, never a live collection, never a class instance.
+4. **Snapshots over live views.** Anything list-shaped returns a frozen array
+   snapshot, so iterating while mutating is safe — the exact hazard that made
+   `output.links` mutation break.
+5. **Closed proxies.** Property access outside the declared surface returns
+   `undefined`; `ownKeys` enumerates only the surface. There is no path from a
+   handle to an internal object, including via prototype, `constructor`, or
+   Vue's `__v_raw`.
+6. **Deleted entities fail predictably.** Reads return `undefined`, mutations throw
+   `ComfyNodeGoneError`. Never a silent no-op — silent discard is precisely what made
+   the current breakage unreportable.
+
+---
+
+## 4. The surface
+
+```ts
+// ─── Roots ────────────────────────────────────────────────────────────────
+
+interface Comfy {
+  readonly version: string
+  supports(capability: string): boolean
+
+  readonly graph: GraphHandle
+  readonly widgets: WidgetRegistry
+  readonly extensions: ExtensionRegistry
+  readonly ui: UiSurface
+}
+
+// ─── Identity ─────────────────────────────────────────────────────────────
+
+type NodeId = string & { readonly __brand: 'NodeId' }
+type LinkId = string & { readonly __brand: 'LinkId' }
+type SlotId = string & { readonly __brand: 'SlotId' }
+
+/** A slot reference is a string (id or name), or an EXPLICIT index.
+ *
+ *  A bare `number` is deliberately not accepted: index use must be visible at the
+ *  call site, because an index is a *position*, not an identity, and it shifts when
+ *  slots are added or removed.
+ *
+ *      output.connectTo(node, 'image')       // by name — preferred
+ *      output.connectTo(node, { index: 0 })  // by position — explicit, opt-in
+ *
+ *  Resolution order for a string ref:
+ *    1. exact SlotId
+ *    2. exact slot name (undefined if ambiguous)
+ *    3. TRANSITIONAL: a canonical integer string resolves positionally, so '0'
+ *       means slot 0 while the backend does not yet supply names.
+ *    4. undefined
+ *
+ *  Step 3 is a migration affordance, not a permanent rule. Gate on
+ *  `comfy.supports('slots.named')` to know whether names are available. */
+type SlotRef = SlotId | string | { readonly index: number }
+
+// ─── Graph ────────────────────────────────────────────────────────────────
+
+interface GraphHandle {
+  readonly id: string
+
+  node(id: NodeId): NodeHandle | undefined
+  nodes(): readonly NodeHandle[] // snapshot
+  nodesOfType(type: string): readonly NodeHandle[]
+
+  add(type: string, init?: NodeInit): NodeHandle
+  remove(id: NodeId): boolean
+
+  /** `node.type = x` has no equivalent — type is identity. This is the honest
+   *  replacement: build a new node and rewire. Reports what it couldn't carry. */
+  replaceNode(
+    id: NodeId,
+    newType: string,
+    opts?: {
+      widgets?: Record<string, string> // old name -> new name
+      keepPosition?: boolean
+    }
+  ): { node: NodeHandle; unmapped: { widgets: string[]; inputs: string[] } }
+
+  link(id: LinkId): LinkInfo | undefined
+  links(): readonly LinkInfo[]
+
+  /** Batch mutations into one undo step and one re-render. */
+  batch<T>(fn: () => T): T
+
+  onChange(cb: (ev: GraphChangeEvent) => void): Unsubscribe
+}
+
+// ─── Node ─────────────────────────────────────────────────────────────────
+
+interface NodeHandle {
+  readonly id: NodeId
+  readonly type: string // identity — see graph.replaceNode()
+  readonly exists: boolean
+
+  title: string
+  mode: NodeMode // 'always' | 'never' | 'bypass'
+  color: string | undefined
+  bgColor: string | undefined
+  shape: NodeShape // enum — string assignment is rejected loudly
+  collapsed: boolean
+  pinned: boolean
+
+  readonly position: Readonly<Point>
+  readonly size: Readonly<Size>
+  setPosition(x: number, y: number): void
+  setSize(width: number, height: number): void
+
+  readonly inputs: InputCollection
+  readonly outputs: OutputCollection
+  readonly widgets: WidgetCollection
+
+  /** Inert plain object. Replaces `{...node}`, which now yields nothing useful. */
+  snapshot(): Readonly<NodeSnapshot>
+
+  remove(): void
+  onChange(cb: (ev: NodeChangeEvent) => void): Unsubscribe
+}
+
+// ─── Slots ────────────────────────────────────────────────────────────────
+
+interface InputCollection {
+  readonly length: number
+
+  /** Unified lookup: id, name, or index. Throws on an ambiguous name. */
+  get(ref: SlotRef): InputSlotHandle | undefined
+  byId(id: SlotId): InputSlotHandle | undefined
+  byName(name: string): InputSlotHandle | undefined // undefined if ambiguous
+  at(index: number): InputSlotHandle | undefined // explicit positional access
+
+  all(): readonly InputSlotHandle[]
+  ids(): readonly SlotId[]
+  [Symbol.iterator](): Iterator<InputSlotHandle>
+
+  add(def: SlotDef): InputSlotHandle // def.id optional; generated if absent
+  remove(ref: SlotRef): boolean
+  reorder(refs: readonly SlotRef[]): void
+}
+
+interface InputSlotHandle {
+  /** Stable identity. Survives insertion, removal and reordering. Use this to
+   *  store a reference to a slot. */
+  readonly id: SlotId
+  /** Current position. **Volatile** — shifts when other slots are added/removed. */
+  readonly index: number
+  readonly name: string
+  readonly type: string
+  label: string | undefined
+
+  readonly isConnected: boolean
+  /** Whether this input is the socket form of a widget. */
+  readonly isWidgetInput: boolean
+
+  link(): LinkInfo | undefined
+  source(): { node: NodeHandle; outputIndex: number } | undefined
+  disconnect(): boolean
+
+  snapshot(): Readonly<SlotSnapshot> // replaces `{...input}`
+}
+
+interface OutputCollection {
+  readonly length: number
+
+  get(ref: SlotRef): OutputSlotHandle | undefined
+  byId(id: SlotId): OutputSlotHandle | undefined
+  byName(name: string): OutputSlotHandle | undefined // undefined if ambiguous
+  at(index: number): OutputSlotHandle | undefined // explicit positional access
+
+  all(): readonly OutputSlotHandle[]
+  ids(): readonly SlotId[]
+  [Symbol.iterator](): Iterator<OutputSlotHandle>
+
+  add(def: SlotDef): OutputSlotHandle
+  remove(ref: SlotRef): boolean
+  reorder(refs: readonly SlotRef[]): void
+}
+
+interface OutputSlotHandle {
+  readonly id: SlotId
+  /** Volatile — see InputSlotHandle.index. */
+  readonly index: number
+  readonly name: string
+  readonly type: string
+  label: string | undefined
+
+  readonly isConnected: boolean
+
+  /** Frozen snapshot — safe to iterate while disconnecting. */
+  links(): readonly LinkInfo[]
+  targets(): readonly { node: NodeHandle; inputIndex: number }[]
+
+  connectTo(target: NodeHandle | NodeId, input: SlotRef): LinkInfo | undefined
+  disconnect(target?: NodeHandle | NodeId, input?: SlotRef): boolean
+
+  snapshot(): Readonly<SlotSnapshot>
+}
+
+/** Plain frozen data. Never an LLink. */
+interface LinkInfo {
+  readonly id: LinkId
+  readonly sourceNodeId: NodeId
+  readonly sourceSlotId: SlotId
+  readonly targetNodeId: NodeId
+  readonly targetSlotId: SlotId
+  readonly type: string
+
+  /** Positions at the time of the snapshot. Present for wire-format work and
+   *  legacy porting; do not store these across mutations. */
+  readonly sourceIndex: number
+  readonly targetIndex: number
+}
+
+// ─── Widgets ──────────────────────────────────────────────────────────────
+
+interface WidgetCollection {
+  readonly length: number
+  get(name: string): WidgetHandle | undefined
+  at(index: number): WidgetHandle | undefined
+  all(): readonly WidgetHandle[]
+  names(): readonly string[]
+  [Symbol.iterator](): Iterator<WidgetHandle>
+
+  add(def: WidgetDef): WidgetHandle
+  remove(name: string): boolean
+
+  /** Replaces splice/assign reordering. Names must be a permutation of names();
+   *  a partial list throws rather than silently dropping widgets. */
+  reorder(names: readonly string[]): void
+  move(name: string, toIndex: number): void
+}
+
+interface WidgetHandle {
+  readonly name: string
+  readonly type: string // identity — see the note on converted-widget below
+  readonly exists: boolean
+
+  value: WidgetValue
+  label: string | undefined
+  disabled: boolean
+
+  /** The documented replacement for the converted-widget hack. Hidden widgets
+   *  keep their value and still serialize. */
+  hidden: boolean
+
+  readonly serialize: boolean
+  options(): Readonly<WidgetOptions>
+  setOptions(patch: Partial<WidgetOptions>): void
+
+  onChange(cb: (value: WidgetValue) => void): Unsubscribe
+  remove(): void
+}
+
+// ─── Custom widget registration ───────────────────────────────────────────
+
+interface WidgetRegistry {
+  register(def: CustomWidgetDef): void
+  isRegistered(type: string): boolean
+}
+
+interface CustomWidgetDef {
+  readonly type: string
+  defaultValue?: WidgetValue
+  serialize?: boolean
+
+  /** DOM widget. Framework-agnostic by design: packs bundle their own Vue since
+   *  ADR 0005, so a Vue component from a foreign instance cannot be mounted.
+   *  A mount function sidesteps the dual-instance problem entirely. */
+  mount?(el: HTMLElement, ctx: WidgetMountContext): Unmount
+
+  /** Classic-canvas rendering. Optional; if absent the widget is DOM-only. */
+  draw?(
+    ctx: CanvasRenderingContext2D,
+    rect: Readonly<Rect>,
+    state: WidgetDrawState
+  ): void
+
+  hitTest?(point: Readonly<Point>, rect: Readonly<Rect>): boolean
+}
+
+interface WidgetMountContext {
+  readonly node: NodeHandle
+  readonly widget: WidgetHandle
+  onValueChange(cb: (v: WidgetValue) => void): Unsubscribe
+  setValue(v: WidgetValue): void
+}
+
+type Unmount = () => void
+type Unsubscribe = () => void
+
+// ─── Extensions ───────────────────────────────────────────────────────────
+
+interface ExtensionRegistry {
+  register(ext: ExtensionDef): void
+}
+
+interface ExtensionDef {
+  readonly name: string
+
+  init?(): void | Promise<void>
+  setup?(): void | Promise<void>
+
+  /** Replaces beforeRegisterNodeDef. Receives a *definition builder*, never the
+   *  node constructor — handing out the class is the current leak. */
+  defineNode?(def: NodeDefBuilder): void
+
+  nodeCreated?(node: NodeHandle): void
+  nodeRemoved?(node: NodeHandle): void
+  graphLoaded?(graph: GraphHandle): void
+
+  commands?: readonly CommandDef[]
+  keybindings?: readonly KeybindingDef[]
+  settings?: readonly SettingDef[]
+}
+
+interface NodeDefBuilder {
+  readonly type: string
+  readonly category: string
+  readonly inputs: readonly Readonly<SlotSnapshot>[]
+  readonly outputs: readonly Readonly<SlotSnapshot>[]
+
+  addWidget(def: WidgetDef): void
+  setWidgetOptions(name: string, patch: Partial<WidgetOptions>): void
+  hideWidget(name: string): void
+  setTitle(title: string): void
+  setColor(color: string): void
+
+  /** Per-instance behaviour, scoped to this type. Replaces prototype patching. */
+  onCreated(cb: (node: NodeHandle) => void): void
+  onConnectionsChanged(
+    cb: (node: NodeHandle, ev: ConnectionChangeEvent) => void
+  ): void
+  onSerialize(cb: (node: NodeHandle) => Record<string, unknown> | void): void
+  onDeserialize(
+    cb: (node: NodeHandle, data: Record<string, unknown>) => void
+  ): void
+}
+```
+
+### Slot identity — why `SlotId` and not just an index
+
+**An index is a position, not an identity.** It shifts the moment another slot is
+inserted or removed, and the packs most affected are exactly the ones doing that:
+kjnodes' `SetNode`/`GetNode` retype slots dynamically, rgthree's context switches add
+and remove them, VideoHelperSuite rebuilds them. Any index a pack stores across a
+mutation is a latent bug, and today the API offers nothing else.
+
+Three ways to address a slot, with an explicit hierarchy:
+
+| Form                   | Stable?                                              | Use for                                                        |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `SlotId`               | ✅ across insert/remove/reorder                      | storing a reference                                            |
+| name (string)          | ⚠️ unique for inputs; **not guaranteed for outputs** | readable lookup — the target state                             |
+| `{ index: n }`         | ❌ volatile                                          | explicit positional access, opt-in                             |
+| `'0'` (integer string) | ❌ volatile                                          | **transitional only** — resolves positionally until names ship |
+
+**Index access stays supported, but never implicit.** A bare `number` is not a
+`SlotRef`, so every positional use reads as `{ index: 0 }` at the call site and is
+greppable. `at(n)` remains the explicit positional accessor for lookup.
+
+Where the id comes from: explicit via `add({ id })`, otherwise derived from the name
+when unambiguous, otherwise generated. Stable for the slot's lifetime either way.
+
+**On name ambiguity:** input names are unique per node, but output names come from
+`RETURN_NAMES` and can legitimately repeat — `("IMAGE", "IMAGE")` is valid. So
+`byName` returns `undefined` on ambiguity rather than silently picking the first.
+Guessing here would produce exactly the kind of silent-wrong-slot bug this API exists
+to eliminate.
+
+**Names are not available yet.** The backend does not currently supply slot names,
+so today `'0'` is how a pack addresses slot 0 and the transitional rule above carries
+it. When names ship, the same call sites move to `'image'` with no structural change
+— which is the point of taking a string rather than a number now. Packs that need to
+branch can probe `comfy.supports('slots.named')`.
+
+**The tension worth naming.** The wire format stores links positionally
+(`origin_slot` / `target_slot` are numbers), and `docs/magic_patch_WIP.md` §5 makes
+byte-identical serialization a hard gate. So `SlotId` is **runtime identity, re-derived
+on load** — stable within a session, not across save/reload — and serialization stays
+index-based.
+
+That's the right trade for now: it fixes the bug class that actually bites (indexes
+shifting _during_ a session, from the pack's own mutations) at zero wire-format cost.
+Persisting slot ids would need a schema version bump and backend coordination, and
+should be a separate decision — see Q8.
+
+---
+
+## 4a. ⛔ Node decorations — replacing canvas painting
+
+### What they are actually doing — measured, not inferred
+
+The hook name is misleading. Extracting and classifying all **2,787 draw-callback
+bodies** across the 420 packs:
+
+| What the body actually does              | Bodies | %     | Packs |
+| ---------------------------------------- | ------ | ----- | ----- |
+| **Draws something**                      | 1,468  | 52.7% | 289   |
+| Passthrough / prototype-patch plumbing   | 901    | 32.3% | 198   |
+| Layout / size enforcement — _no drawing_ | 178    | 6.4%  | 39    |
+| State sync / polling — _no drawing_      | 169    | 6.1%  | 46    |
+| DOM element sync — _no drawing_          | 71     | 2.5%  | 37    |
+
+> **47.3% of draw-callback bodies never touch a drawing primitive. 127 packs hook
+> the draw callback and never draw at all.**
+
+The draw hook is being used as a **per-frame tick**, because it was the only one
+available. Real examples:
+
+```js
+// comfyui_inteliweb_nodes — enforcing height, every frame
+if (Number.isFinite(desired) && Math.abs(this.size?.[1] - desired) > 1)
+  this.size[1] = desired
+
+// ComfyUI_Custom_Switch — polling for group renames, every frame
+const titles = (app.graph._groups?.map((g) => g.title) || []).join()
+if (this.lastKnownGroupTitles !== titles) {
+  this.lastKnownGroupTitles = titles
+  rebuildUI(this)
+}
+
+// comfyui-ig-motion-i2v — syncing DOM visibility, every frame
+node.painter.canvas.wrapperEl.hidden = this.flags.collapsed
+```
+
+None of that is drawing. It is **polling in place of reactivity, and per-frame
+enforcement in place of layout constraints.** Packs do it because the API offers
+neither.
+
+### So the 420 packs need four different things, not one
+
+| Need                                                        | Share | Destination                                                                        |
+| ----------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------- |
+| Prototype-patch plumbing (`orig?.apply(this, arguments)`)   | 32.3% | **Vanishes.** `defineNode` (§5) removes the need to wrap anything                  |
+| Genuine decoration — status, badges, borders, previews      | ~40%  | `node.decorations` (below) + `node.chrome` to hide/replace default rendering (§4b) |
+| Interactive controls painted by hand (mxtoolkit `Slider2D`) | ~13%  | `widgets.register()` + `mount()` (§4)                                              |
+| Reactivity + layout substitutes                             | 15.0% | `onChange` (§4c), `setSizeConstraints` (below)                                     |
+
+This reframes the migration substantially. **A third of the work is deleting
+boilerplate that only existed to chain prototype patches**, and another sixth is
+replacing polling with subscriptions the API already provides. The genuinely hard
+part — hand-painted interactive controls — is roughly an eighth, not the whole 420.
+
+### ⛔ Size constraints — the missing piece the data exposed
+
+39 packs re-assert node size on every frame. That needs a declarative home, or they
+have nowhere to go:
+
+```ts
+interface NodeHandle {
+  /** Declarative, enforced by layout. Replaces per-frame `this.size[1] = h`. */
+  setSizeConstraints(c: {
+    minWidth?: number
+    minHeight?: number
+    maxWidth?: number
+    maxHeight?: number
+    autoHeight?: boolean // size to content — what most of the 39 actually want
+  }): void
+}
+```
+
+`autoHeight` is likely the real intent in most cases: the pack adds a DOM widget of
+unknown height and hand-computes the node size to fit it. In a DOM-rendered node that
+is just layout, and should require no pack code at all.
+
+### The decorative remainder
+
+What genuinely draws: status text, badges, counts, progress bars, borders and
+highlights, background tints, image/output previews, per-slot annotations, and
+error/invalid markers (impact-pack draws a red X over an incompatible slot).
+
+### Why declarative, not a DOM mount
+
+The measured vocabulary maps onto CSS exactly — every primitive has a native
+equivalent, so "convertible to DOM behaviours that are the same" is literally true
+rather than aspirational:
+
+| Canvas (packs using)                                | DOM/CSS equivalent                                               |
+| --------------------------------------------------- | ---------------------------------------------------------------- |
+| `fillText` 326, `measureText` 206                   | a text node — and measurement becomes free, the browser lays out |
+| `fillRect` 234 / `roundRect` 193 / `strokeRect` 159 | `background`, `border-radius`, `border`                          |
+| `drawImage` 203                                     | `<img>`                                                          |
+| `arc` 181 / `ellipse` 58                            | `border-radius: 50%`                                             |
+| `translate` 170 / `rotate` 136                      | `transform`                                                      |
+| `globalAlpha` 150                                   | `opacity`                                                        |
+| `clip` 138                                          | `overflow: hidden`                                               |
+| `setLineDash` 115                                   | `border-style: dashed`                                           |
+| `shadowBlur` 95                                     | `box-shadow`                                                     |
+| `createLinearGradient` 79                           | `linear-gradient()`                                              |
+
+But a DOM mount API would be the wrong shape, for one decisive reason:
+
+> **A declarative decoration can be rendered to _both_ canvas and DOM. A DOM mount
+> can only render in Nodes 2.0.**
+
+If packs migrate to a mount API, they must _keep_ their canvas code for classic mode
+— so they carry both forever and we can never delete the draw hooks. If they migrate
+to declarations, we render them in whichever mode is active, they delete their canvas
+code, and the hooks become removable. That is the entire objective of this programme.
+
+It's the same argument as the dual-web-dir convention in `docs/magic_patch_WIP.md` §7:
+authors will not adopt something that forces them to drop half their users.
+
+Secondary wins: LOD handling disappears (rgthree hand-rolls a
+`canvas.ds.scale < 0.6` check that we do centrally), and decorations can be made to
+respect Comfy design standards instead of 420 packs each inventing a badge style.
+
+### The surface
+
+```ts
+interface NodeHandle {
+  readonly decorations: DecorationCollection // added to §4
+}
+
+interface DecorationCollection {
+  /** Keyed, so repeated calls update rather than accumulate — the common bug when
+   *  porting from a draw callback that ran every frame. */
+  set(key: string, dec: Decoration): void
+  delete(key: string): boolean
+  clear(): void
+  keys(): readonly string[]
+}
+
+type Decoration = { anchor: Anchor; hidden?: boolean } & (
+  | {
+      kind: 'text'
+      text: string
+      color?: Color
+      size?: 'sm' | 'md' | 'lg'
+      align?: 'start' | 'center' | 'end'
+    }
+  | {
+      kind: 'badge'
+      text: string
+      color?: Color
+      background?: Color
+      icon?: IconName
+    }
+  | {
+      kind: 'bar'
+      value: number /* 0..1 */
+      color?: Color
+      background?: Color
+      label?: string
+    }
+  | { kind: 'dot'; color: Color; pulse?: boolean }
+  | {
+      kind: 'image'
+      src: string
+      fit?: 'contain' | 'cover'
+      width?: Length
+      height?: Length
+    }
+  | {
+      kind: 'box'
+      fill?: Color
+      stroke?: Color
+      dashed?: boolean
+      radius?: Length
+    }
+  | { kind: 'border'; color: Color; width?: number; dashed?: boolean }
+  | { kind: 'tint'; color: Color; opacity?: number }
+)
+
+/** Layout-relative, never pixel coordinates — canvas-space pixels don't survive
+ *  DOM layout, and this is what makes one declaration render in both modes. */
+type Anchor =
+  | 'title-left'
+  | 'title-right'
+  | 'body-top'
+  | 'body-bottom'
+  | 'overlay-top-left'
+  | 'overlay-top-right'
+  | 'overlay-bottom-left'
+  | 'overlay-bottom-right'
+  | 'below'
+  | 'node' // whole-node: border, tint
+  | { slot: SlotRef; side: 'input' | 'output' } // rgthree's per-slot status text
+```
+
+Usage, replacing the custom-scripts case:
+
+```js
+// before — ran every frame, in a prototype patch
+nodeType.prototype.onDrawForeground = function (ctx) {
+  /* fillText(value) */
+}
+
+// after — set when the value changes
+node.decorations.set('output-value', {
+  kind: 'badge',
+  anchor: 'overlay-top-right',
+  text: String(value)
+})
+```
+
+### The escape hatch
+
+Some painting won't be expressible. For that, an explicitly Nodes-2.0-only mount,
+with honest semantics rather than a silent no-op:
+
+```ts
+interface NodeDefBuilder {
+  /** DOM-only. In classic canvas mode this does not render; `fallback` declares
+   *  what to show instead. Prefer decorations — this cannot render to canvas. */
+  decorate(opts: {
+    region: 'body' | 'overlay' | 'below'
+    mount(el: HTMLElement, ctx: { node: NodeHandle }): Unmount
+    fallback?: Decoration
+  }): void
+}
+```
+
+`fallback` matters: it keeps a migrated pack working in classic mode at reduced
+fidelity, instead of silently rendering nothing — which is exactly the failure mode
+Nodes 2.0 has today.
+
+### Migration difficulty, honestly
+
+| Class                                                  | Share of bodies         | Mechanical?                                                                            |
+| ------------------------------------------------------ | ----------------------- | -------------------------------------------------------------------------------------- |
+| Prototype-patch plumbing                               | 32.3%                   | ✅ **deleted outright** — highest-volume, lowest-risk transform in the whole programme |
+| Size enforcement → `setSizeConstraints` / `autoHeight` | 6.4%                    | ✅ largely                                                                             |
+| Reconcile-on-change → `onChange`                       | 6.1%                    | ✅ near-rename; ⚠️ pick the narrowest event, don't default to `graph.onChange`         |
+| DOM visibility sync                                    | 2.5%                    | ✅ handled by widget mount lifecycle                                                   |
+| Static text / badge / status                           | large part of the 52.7% | ✅ modulo the frame→event shift below                                                  |
+| Slot-anchored text and markers                         | rgthree, impact-pack    | ⚠️ needs the slot anchor; layout maths is discarded, not translated                    |
+| Interactive controls                                   | ~13%                    | ❌ becomes a custom widget — substantial rewrite                                       |
+| Arbitrary composed graphics                            | tail                    | ❌ escape hatch, or stays canvas-only                                                  |
+
+**The frame→event shift is the trap.** A draw callback recomputes from current state
+every frame, so nothing ever needs to announce a change. Declarations must instead be
+_set when the value changes_. A naive port that calls `decorations.set()` from the old
+callback body will appear to work — and quietly run every frame forever. This is the
+single most likely defect in an automated port of this cohort, it will not show up as
+an error, and it deserves both a lint rule and a dedicated harness probe.
+
+---
+
+## 4b. ⛔ Chrome control — hide and replace
+
+Decorations are additive. Packs also need to _suppress_ or _substitute_ the node's
+own rendering — mxtoolkit paints over the whole body, others replace the title bar or
+hide slot rows. Without this, decoration alone can't express what they do today.
+
+The node exposes named regions, and each can be defaulted, hidden, or replaced:
+
+```ts
+interface NodeHandle {
+  readonly chrome: NodeChrome
+}
+
+type Region =
+  | 'title'
+  | 'title-icon'
+  | 'title-text'
+  | 'body'
+  | 'widgets'
+  | 'inputs'
+  | 'outputs'
+  | 'background'
+  | 'border'
+  | 'footer'
+
+interface NodeChrome {
+  hide(region: Region): void
+  show(region: Region): void
+  isHidden(region: Region): boolean
+
+  /** Declarative substitution — renders in both modes, like decorations. */
+  replace(region: Region, dec: Decoration): void
+
+  /** Escape hatch. DOM-only; `fallback` covers classic canvas mode. */
+  mount(
+    region: Region,
+    opts: {
+      mount(el: HTMLElement, ctx: { node: NodeHandle }): Unmount
+      fallback?: Decoration
+    }
+  ): void
+
+  reset(region?: Region): void
+}
+```
+
+Also available at definition level, which is where most of it belongs — "all nodes of
+this type look like this" rather than "this instance does":
+
+```ts
+interface NodeDefBuilder {
+  chrome: Omit<NodeChrome, 'isHidden'> // defaults for every node of this type
+}
+```
+
+**Deliberate constraint: `replace` takes a `Decoration`, and `mount` is separate and
+flagged.** Replacing a region with arbitrary DOM is how packs re-implement the node
+and re-break on every internal change — precisely the coupling this API exists to
+end. Declarative substitution stays mode-agnostic and survives our refactors; `mount`
+is the acknowledged escape hatch, and its usage is worth tracking as a signal that
+the declarative vocabulary is short.
+
+`inputs` / `outputs` as hideable regions deserve care: hiding a slot visually while it
+remains connectable is a genuine footgun. Suggest hiding only renders it collapsed,
+never changes connectability — visual state must not diverge from graph state, which
+is the class of bug the ECS migration was trying to eliminate.
+
+---
+
+## 4c. ⛔ There is no tick — it's `onChange`
+
+**The trigger is the graph changing.** Not a timer, and not a repaint either.
+
+`startRendering()` runs a continuous rAF loop (`LGraphCanvas.ts:2185-2199`), but
+`draw()` gates on `dirty_canvas` (`:5079`) — so `onDrawForeground` fires when
+something marked the canvas dirty. Packs latched onto that because it was the only
+available notification, but the thing they're reacting to is **the graph mutating**.
+Repaint was just the messenger, and a noisy one: mouse-move sets `dirty_canvas`
+(`:2305`, `:3287`), so today a pack watching for a group rename re-runs its check on
+every pointer move.
+
+So no new hook is needed. This cohort migrates onto the `onChange` subscriptions
+already in §4 — the design _shrinks_.
+
+### The contract that makes it usable
+
+```ts
+interface GraphHandle {
+  onChange(cb: (ev: GraphChangeEvent) => void): Unsubscribe
+}
+
+interface NodeHandle {
+  /** Fires only for changes affecting this node. */
+  onChange(cb: (ev: NodeChangeEvent) => void): Unsubscribe
+}
+
+interface GraphChangeEvent {
+  /** Coalesced. Loading a workflow is ONE event, not 500. */
+  readonly kinds: ReadonlySet<ChangeKind>
+  readonly nodes: readonly NodeId[]
+  has(kind: ChangeKind): boolean
+}
+
+type ChangeKind =
+  | 'node-added'
+  | 'node-removed'
+  | 'node-state'
+  | 'node-moved'
+  | 'node-resized'
+  | 'link-added'
+  | 'link-removed'
+  | 'widget-value'
+  | 'group-added'
+  | 'group-removed'
+  | 'group-state'
+  | 'execution'
+```
+
+Three properties do the real work:
+
+- **Coalesced per frame, delivered before paint.** Without this, a pack reconciling
+  on every mutation is catastrophically slow during workflow load — the exact hazard
+  the draw hook accidentally protected them from, since it fired once per repaint
+  rather than once per mutation. Coalescing must be the default, not an option.
+- **Scoped.** `node.onChange` fires only for that node. Today every node reconciles
+  on every canvas repaint regardless of relevance, which in a 500-node graph is
+  almost entirely waste.
+- **Described.** `kinds` lets a pack early-out in one set lookup instead of
+  recomputing state to discover nothing moved.
+
+Validating against the observed cases:
+
+| Real pack behaviour                                      | Destination                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| `ComfyUI_Custom_Switch` polls `app.graph._groups` titles | `graph.onChange` → `has('group-state')`                       |
+| `UI-Decorators` mirrors link state                       | `node.onChange` → `has('link-added' \| 'link-removed')`       |
+| `comfyui-ig-motion-i2v` syncs DOM on collapse            | `node.onChange` → `has('node-state')`                         |
+| `inteliweb` re-asserts height                            | `setSizeConstraints({ autoHeight })` — no subscription at all |
+
+All four served, none needing a tick.
+
+### Explicitly not for
+
+- **Animation.** Use a mounted DOM widget with CSS or its own rAF, scoped to that
+  element. `onChange` makes no frame-rate guarantee and fires only on change.
+- **External polling** (server state, filesystem). Use `setInterval` — genuinely a
+  timer concern, and the platform already has one.
+
+### Preferred order
+
+1. `widget.onChange` — narrowest
+2. `node.onChange` — scoped to one node
+3. `graph.onChange` — structural changes only
+
+### Instrument the coarse end
+
+A pack subscribing to `graph.onChange` and filtering for one `ChangeKind` is telling
+us the scoped event it wanted doesn't exist. Worth tracking: it turns "packs are
+using the blunt instrument" into a precise list of the events we're missing, so the
+API can grow toward the narrow end instead of accumulating coarse subscriptions.
+
+---
+
+## 4d. Definitions — the largest surface of all
+
+Everything above is the _instance_ API. Packs spend most of their time on
+_definitions_, and the numbers make this the dominant concern in the whole
+programme:
+
+| Surface                                                                                    | Packs     | Downloads      | % installs |
+| ------------------------------------------------------------------------------------------ | --------- | -------------- | ---------- |
+| **`beforeRegisterNodeDef`**                                                                | **1,265** | **50,399,739** | **47.4%**  |
+| `nodeType.prototype.*` patching                                                            | 1,191     | —              | —          |
+| Reads `nodeData.input`                                                                     | 158       | —              | —          |
+| Authors own node types (`registerCustomNodes` / `registerNodeType` / `extends LGraphNode`) | 86        | 19,362,040     | 18.2%      |
+
+**Nearly half of all installs run a `beforeRegisterNodeDef` hook**, and 1,191 of
+those 1,265 packs use it to patch the generated class's prototype. This is bigger
+than the widget cohort and the painting cohort combined, and it is the surface that
+couples the ecosystem to our internals most tightly.
+
+### What they patch — measured, not guessed
+
+Prototype assignments across the 1,265 packs, litegraph methods only (bundled-library
+noise like `_next`, `dispose`, `toString` filtered out):
+
+| Patched method        | Sites | Packs   | Destination               |
+| --------------------- | ----- | ------- | ------------------------- |
+| `onNodeCreated`       | 3,161 | **943** | `onCreated`               |
+| `onExecuted`          | 964   | **497** | `onExecuted`              |
+| `onConfigure`         | 1,272 | **429** | `onConfigured`            |
+| `onConnectionsChange` | 454   | 223     | `onConnectionsChanged`    |
+| `onDrawForeground`    | 446   | 199     | decorations (§4a)         |
+| `onRemoved`           | 353   | 158     | `onRemoved`               |
+| `constructor`         | 473   | 49      | `onCreated`               |
+| `type`                | 310   | 9       | none — identity (§4)      |
+| `getDefaultShape`     | 335   | 3       | `setShape` on the builder |
+
+**This corrected a real gap in my draft:** `onExecuted` — 497 packs, the second most
+patched method — had no destination. It's how a node receives its execution result
+from the backend, and it's the backbone of every preview, readout and result display
+in the ecosystem. An API without it is unusable.
+
+### The registry
+
+```ts
+interface Comfy {
+  readonly defs: DefRegistry
+}
+
+interface DefRegistry {
+  get(type: string): NodeDef | undefined
+  all(): readonly NodeDef[]
+  byCategory(category: string): readonly NodeDef[]
+  has(type: string): boolean
+
+  /** Replaces beforeRegisterNodeDef. */
+  extend(selector: DefSelector, fn: (b: NodeDefBuilder) => void): Unsubscribe
+
+  /** Replaces registerCustomNodes / registerNodeType / `extends LGraphNode`. */
+  define(def: NodeTypeDef): void
+}
+
+/** Indexed, so a pack's hook runs only for defs it cares about. */
+type DefSelector =
+  | string // exact type
+  | readonly string[] // any of
+  | RegExp // type pattern
+  | { category?: string; test?(def: NodeDef): boolean }
+```
+
+**The selector is not sugar — it's a fix.** Today `beforeRegisterNodeDef` fires for
+every registered type in every extension. With 1,265 packs hooking it and a few
+thousand node types, boot runs millions of callbacks, nearly all of which
+immediately `return` after a type-name check. Making the predicate declarative lets
+us index it and invoke only what matches.
+
+### Reading a definition
+
+```ts
+interface NodeDef {
+  readonly type: string
+  readonly title: string
+  readonly category: string
+  readonly description: string
+  readonly inputs: readonly Readonly<InputDef>[]
+  readonly outputs: readonly Readonly<OutputDef>[]
+  readonly isOutputNode: boolean
+  readonly deprecated: boolean
+  readonly experimental: boolean
+  /** Which pack supplied it — packs use this to scope their own behaviour. */
+  readonly source: string | undefined
+}
+```
+
+Frozen and inert, like every other read in this API. Replaces poking at `nodeData`.
+
+### Modifying a definition
+
+```ts
+interface NodeDefBuilder {
+  readonly def: NodeDef // current state, post other extensions
+
+  // ── structure ────────────────────────────────────────────────────────────
+  addInput(def: SlotDef): void
+  removeInput(ref: SlotRef): boolean
+  modifyInput(ref: SlotRef, patch: Partial<SlotDef>): void
+  addOutput(def: SlotDef): void
+  removeOutput(ref: SlotRef): boolean
+  modifyOutput(ref: SlotRef, patch: Partial<SlotDef>): void
+
+  addWidget(def: WidgetDef): void
+  removeWidget(name: string): boolean
+  setWidgetOptions(name: string, patch: Partial<WidgetOptions>): void
+  hideWidget(name: string): void
+
+  // ── presentation ─────────────────────────────────────────────────────────
+  setTitle(title: string): void
+  setCategory(category: string): void
+  setColor(color: string): void
+  setShape(shape: NodeShape): void
+  chrome: Omit<NodeChrome, 'isHidden'> // §4b defaults for this type
+
+  // ── behaviour — replaces prototype patching, ordered by measured usage ────
+  onCreated(cb: (node: NodeHandle) => void): void // 943 packs
+  onExecuted(cb: (node: NodeHandle, result: ExecutionResult) => void): void // 497
+  onConfigured(cb: (node: NodeHandle, data: SerializedNodeExtras) => void): void // 429
+  onConnectionsChanged(
+    cb: (node: NodeHandle, ev: ConnectionChangeEvent) => void
+  ): void // 223
+  onRemoved(cb: (node: NodeHandle) => void): void // 158
+  onSerialize(cb: (node: NodeHandle) => SerializedNodeExtras | void): void
+}
+
+interface ExecutionResult {
+  readonly images: readonly Readonly<ImageRef>[]
+  readonly text: readonly string[]
+  /** Everything else the backend returned for this node, frozen. Custom output
+   *  keys survive — the passthrough schema in ADR 0007 guarantees it. */
+  readonly raw: Readonly<Record<string, unknown>>
+}
+```
+
+Two deliberate properties:
+
+- **Multiple packs extending the same type compose.** Today, two packs patching
+  `onNodeCreated` chain via `orig?.apply(this, arguments)`, and whether that works
+  depends on load order and whether both remembered to call through. Registered
+  callbacks compose by construction — which is why 32.3% of draw-callback bodies
+  (the chaining plumbing) simply disappear.
+- **`onSerialize` returns extras rather than mutating.** Returning data instead of
+  writing to a passed object is what keeps serialization deterministic and lets us
+  detect two packs fighting over the same key.
+
+### Authoring new node types
+
+86 packs / 18.2% of installs define their own types, today via `extends LGraphNode` —
+which ADR 0008 rules out for entity modelling and which is unavailable in a closed
+API anyway.
+
+```ts
+interface NodeTypeDef {
+  readonly type: string
+  title?: string
+  category?: string
+  description?: string
+
+  inputs?: readonly SlotDef[]
+  outputs?: readonly SlotDef[]
+  widgets?: readonly WidgetDef[]
+
+  /** Frontend-only. Never sent to the backend as an executable node. */
+  execution?: 'backend' | 'frontend'
+
+  /** Pure question-answering over a read-only view. See below. */
+  resolve?(view: ResolveView): Record<string, OutputResolution>
+
+  onCreated?(node: NodeHandle): void
+  onExecuted?(node: NodeHandle, result: ExecutionResult): void
+  onConfigured?(node: NodeHandle, data: SerializedNodeExtras): void
+  onConnectionsChanged?(node: NodeHandle, ev: ConnectionChangeEvent): void
+  onRemoved?(node: NodeHandle): void
+  onSerialize?(node: NodeHandle): SerializedNodeExtras | void
+}
+```
+
+### Virtual nodes — settled design (supersedes the draft-context sketch)
+
+**Status: ✅ decided 2026-08-05, replacing the earlier `PromptResolveContext`
+proposal, which handed packs a mutable draft and imperative verbs. Implemented
+in `src/platform/nodeApi/resolution.ts`.**
+
+Strip the mechanism away and "virtual node" is four different intents:
+
+| Intent                 | Examples                             | Resolution means                                      |
+| ---------------------- | ------------------------------------ | ----------------------------------------------------- |
+| **Annotate**           | Note nodes                           | omit from prompt                                      |
+| **Be a wire**          | Reroute, kjnodes `SetNode`/`GetNode` | _my output forwards to whatever feeds X_              |
+| **Be a value**         | `PrimitiveNode`, constants           | _my output is this literal_                           |
+| **Act on other nodes** | rgthree Fast Muter                   | **not resolution** — edit-time commands on neighbours |
+
+The legacy `isVirtualNode` + `applyToGraph()` collapses all four into an
+imperative callback that mutates the live graph mid-serialize
+(`executionUtil.ts:38` — our own core does this today). Under ECS that is a
+system with side effects: not replayable, corrupts the document if it throws
+halfway, and syncs phantom mutations under CRDT.
+
+The ECS-consistent mapping:
+
+- **"Virtual" is data, not a class.** `execution: 'frontend'` on the
+  definition. The node is an ordinary entity in ordinary stores; it renders
+  with the same widget/mount/canvas API as everything else; Nodes 2.0 needs
+  nothing special.
+- **Resolution is a pure system.** `prompt = resolve(graph)`. The pack never
+  touches a draft — it answers a question about its own outputs against a
+  read-only view:
+
+```ts
+type OutputResolution =
+  | { readonly omit: true }
+  | { readonly forwardTo: InputRef } // "whatever feeds that input"
+  | { readonly literal: WidgetValue }
+
+interface ResolveView {
+  readonly self: ResolvedNodeView
+  nodesOfType(type: string): readonly ResolvedNodeView[]
+}
+
+interface ResolvedNodeView {
+  readonly id: string
+  readonly type: string
+  widgetValue(name: string): WidgetValue | undefined
+  input(ref: string | number): InputRef | undefined
+}
+```
+
+Our pass follows `forwardTo` chains (Get → Set → Reroute → …) to fixpoint
+with cycle detection. A resolver that throws poisons that one prompt build;
+the graph was never touched — the property `applyToGraph` structurally cannot
+have.
+
+- **Nodes that act on other nodes are not virtual-node API.** Fast Muter is a frontend-only
+  node whose button callbacks mutate neighbours through handles — which under
+  ECS become commands: serializable, undoable, the only legal mutation path.
+  Its sole "virtual" property is `execution: 'frontend'`.
+- **Core migrates onto the same system.** Reroute and Primitive become the
+  first resolvers; `applyToGraph` is then deletable from core. Known external
+  consumers to migrate with it: ComfyUI-Custom-Scripts `presetText.js`,
+  VideoHelperSuite `VHS.core.js` (named in `litegraph-augmentation.d.ts:122`).
+
+### Migration difficulty
+
+| From                                                 | To                         | Mechanical?                                                 |
+| ---------------------------------------------------- | -------------------------- | ----------------------------------------------------------- |
+| `beforeRegisterNodeDef` + type-name `if`             | `defs.extend(selector, …)` | ✅ the selector is usually the `if` condition already there |
+| `nodeType.prototype.onNodeCreated = …` with chaining | `onCreated(cb)`            | ✅ high volume, low risk — chaining boilerplate deleted     |
+| `nodeData.input.required.x` reads                    | `b.def.inputs`             | ✅ shape differs, mapping is total                          |
+| `extends LGraphNode` + `registerNodeType`            | `defs.define({...})`       | ❌ real rewrite; 86 packs, but 18.2% of installs            |
+| `applyToGraph`                                       | `resolve(ctx)`             | ❌ semantics change from live-graph to draft                |
+
+The first three are the bulk — roughly 1,200 packs of largely mechanical work. The
+last two are 86 packs of genuine rewrite, and they include rgthree and kjnodes, which
+is another argument for handling the top packs as upstream relationships rather than
+automated patches.
+
+---
+
+## 4e. Sample conversions — what real pack code exposed
+
+Converting real files from the corpus, rather than reasoning about the census
+counts, found three things the design had wrong or missing. This is the cheapest
+validation available and should run before the API is frozen.
+
+### ✅ Win — kjnodes `setgetnodes.js:988`
+
+```js
+// before — splice out and back in at the same index, purely to force the
+// renderer to re-read the options object. Not a reorder at all.
+w.options = newOpts
+const idx = this.widgets.indexOf(w)
+if (idx >= 0) {
+  this.widgets.splice(idx, 1)
+  this.widgets.splice(idx, 0, w)
+}
+
+// after
+node.widgets.get(name).setOptions(newOpts)
+```
+
+The hack disappears entirely: invalidation is the API's problem, not the pack's.
+Note this instance is counted in the 286-pack `widgets_splice` cohort but is
+**not** a reordering — a converter keyed on "splice means reorder" would produce
+nonsense here.
+
+### 🐞 Bug found in this API — accessor options
+
+The same pack builds its options with a **live getter**:
+
+```js
+Object.defineProperty(
+  newOpts,
+  'values',
+  Object.getOwnPropertyDescriptor(comboOptions, 'values')
+)
+```
+
+`setOptions` merged with `{ ...w.options, ...patch }`, which **invokes the getter
+and freezes its result** — silently pinning every dynamic combo to a one-time
+snapshot. Verified, then fixed to a descriptor-preserving merge with a
+regression test. Dynamic combos are common (kjnodes `SetNode`/`GetNode`), so this
+would have been a widespread, silent, hard-to-attribute breakage.
+
+### ✅ Closed — link retargeting (`moveLinksTo`)
+
+rgthree `power_prompt.js:22` moves every link from output 0 to output 3, keeping
+the links themselves:
+
+```js
+node.outputs[3].links.push(link)
+;(node.graph || app.graph).links[link].origin_slot = 3 // retarget in place
+node.outputs[0].links = null
+```
+
+The closest expression in the current API is disconnect-and-reconnect:
+
+```js
+for (const link of from.links()) {
+  to.connectTo(link.targetNodeId, { index: link.targetIndex })
+}
+from.disconnect()
+```
+
+**Which is not equivalent: it allocates new link ids.** Serialized workflows
+would differ, failing `docs/magic_patch_WIP.md` §5's byte-identical gate — the one hard
+gate in the programme.
+
+Added, and it preserves link ids — the link store patches endpoints in place
+(`linkStore.ts:256`), so the serialized workflow is unchanged:
+
+```ts
+// after — one call, ids preserved, wire format intact
+node.outputs.byName('STRING').moveLinksTo({ index: 3 })
+node.outputs.at(0).modify({ type: 'CONDITIONING', name: 'CONDITIONING' })
+```
+
+Nine lines of link-surgery become two, and the byte-identical gate holds.
+
+**Deliberately permissive:** `moveLinksTo` does not re-validate slot types,
+because the real sequence moves links off an output and _then_ retypes it —
+enforcing compatibility mid-move would reject the exact case it exists for. Pinned
+by a test so the behaviour is chosen rather than accidental.
+
+### ✅ Closed — slot retype and rename (`modify`)
+
+The same file continues:
+
+```js
+node.outputs[0].type = nodeData.output[0]
+node.outputs[0].name = nodeData.output_name[0] || node.outputs[0].type
+```
+
+Dynamic retyping is exactly what `SetNode`/`GetNode`-style packs do, and §4
+originally exposed only `label` as writable.
+
+Added as **one atomic method rather than three setters**, so a retype-plus-rename
+is a single command and therefore a single undo step:
+
+```ts
+slot.modify({ type: 'MODEL', name: 'model' })
+```
+
+Retyping **keeps existing links**. Dynamic retyping (`*` -> `MODEL`) is the whole
+point for `SetNode`-style packs, and silently dropping connections is the failure
+mode this API exists to end.
+
+### ⚠️ Converter hazard — serialized data looks like live data
+
+easy-use `image_chooser/prompt.js:82`:
+
+```js
+p.workflow.nodes.forEach((node) => {
+  if (node.id === here_id)
+    node.inputs.forEach((i) => {
+      i.link = null
+    })
+})
+```
+
+This is flagged by the census as `in_link_write`, but `p.workflow` is a
+**serialized prompt payload**, not the live graph. Nulling `link` there is
+correct and must not be rewritten.
+
+So a rule matching `.link =` textually will corrupt this file. The converter
+needs to distinguish live handles from plain workflow JSON — which is not
+decidable by regex, and is a concrete argument for the agent tier being scoped to
+exactly this kind of judgment rather than to bulk mechanical edits.
+
+It also confirms the study's warning that L0 counts include false positives:
+**every rule needs sampled verification before its autofix is trusted.**
+
+### Contract growth from this exercise
+
+Three methods added, chosen to be the smallest surface that covers the cases:
+
+| Added                     | Why not smaller                                     | Why not larger                                                          |
+| ------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------- |
+| `slot.modify(patch)`      | `label` alone could not express retype or rename    | one atomic method instead of three setters — one command, one undo step |
+| `output.moveLinksTo(ref)` | no composition of existing calls preserves link ids | only same-node moves; cross-node retargeting has no observed use        |
+
+Rejected as speculative: cross-node link retargeting, slot insertion at an index,
+per-link retarget. None appeared in the sampled code, so none is in the contract.
+
+### What this exercise is worth
+
+Four files, one afternoon, and it produced: one confirmed bug in the new API, two
+missing capabilities, and one converter hazard that would have silently corrupted
+a working pack. **Do this for the top 20 packs before freezing the interface** —
+it is far cheaper than discovering the same things after authors have migrated.
+
+---
+
+## 4f. ⚖️ Contested additions — argue with these
+
+Everything here was added because a real pack could not be converted without
+it, under time pressure, and every one is arguable. They are collected rather
+than scattered so a reviewer can overturn them in one pass.
+
+Each entry states what forced it, what the alternative was, why the alternative
+was rejected, and **what it would cost to reverse**. The cost line is the one
+that matters: some of these are cheap to withdraw and some are not.
+
+### `node.getScreenRect()` and `comfy.onViewportChanged()`
+
+**Forced by** kjnodes `ideogram4_prompt_builder.js` — a floating dock anchored
+to a node. It was the last file holding `window.comfyAPI` open for reasons that
+were not gaps: it worked before, so the capability was real.
+
+**The tension.** These are viewport-adjacent, and the standing instruction is
+that _how the graph draws_ does not belong in a node API. `comfy.constants` was
+removed for exactly that reason.
+
+**Why these are different.** They are the _question_, not the _mechanism_.
+`getScreenRect` answers "where is this node on screen"; it does not expose pan,
+zoom, or the transform. `onViewportChanged` says "that answer may have changed"
+and carries no payload. The arithmetic confirms the distinction: the old
+expression was
+
+```
+rect.left + (pos.x + offset.x) * scale
+```
+
+and the new one is `hostScreen.x + (pos.x - hostGraph.x) * scale` — **the pan
+offset and canvas rect cancel out**. The zoom factor is likewise recoverable as
+`getScreenRect().width / getBounds().width`, so it never had to be published.
+
+**Alternative rejected.** Exposing `viewport.transform()` (pan + scale). That is
+the mechanism, invites packs to re-derive geometry, and is the mistake
+`comfy.constants` made.
+
+**Cost to reverse.** Moderate. One pack uses them today. If withdrawn,
+node-anchored floating UI becomes unimplementable and ideogram's dock is lost.
+
+### `comfy.storage`
+
+**Forced by** the same file: named caption templates the user authors, kept
+server-side via `api.storeUserData`.
+
+**The tension.** Is per-user file storage a _node_ API concern at all? It is not
+about nodes, graphs or widgets. A reasonable reviewer could say packs should use
+`localStorage` and be done.
+
+**Why it was added.** `localStorage` does not follow a user between machines,
+and this is content a user _authored_ — losing it on a new machine is a data
+loss, not an inconvenience. `comfy.settings` is the wrong home: that is for
+values configured once, not documents.
+
+**Guardrails.** Names must be namespaced, exactly as setting ids are, and `..`
+is refused so a pack cannot climb out of its namespace into another pack's data
+or the user's own files.
+
+**Cost to reverse.** Low. One pack, one feature.
+
+**Open question.** Should there be a quota, or a way for a user to see and clear
+what a pack has stored? Neither exists.
+
+### `b.setExecution('frontend')`
+
+**Forced by** enricos `tools.js`. One line — `node.isVirtualNode = true` on a
+**backend-registered** type — was the whole refusal.
+
+**The tension.** This is the most powerful thing added. It lets a pack declare
+that a node the _server_ registered will never reach the prompt. Get it wrong,
+or apply it to the wrong selector, and nodes silently vanish from execution.
+
+**Why it was added anyway.** The alternative is worse. Without it a conversion
+must drop the line, which **adds** a node to `graphToPrompt` that was never
+there — a wire-format break rather than a degradation. `defs.define` could
+already say this for pack-owned types; `defs.extend` could not say it for
+existing ones, which is an asymmetry rather than a safety property.
+
+**Alternative rejected.** `setMode('never')` also keeps a node out of the
+prompt, but writes `mode: 2` into the saved workflow and reads to the user as
+manual muting. Not equivalent.
+
+**Cost to reverse.** High. Removing it re-refuses the file and leaves no
+expressible way to convert a frontend-only tools node.
+
+### `defs.defineWidgetType()`
+
+**Forced by** comfy-mtb (`MTB_COLOR`), rmbg (`COLORCODE`), mtb (`FLOAT_CURVE`).
+In mtb it cascaded: one registration blocked four files.
+
+**The tension.** It is a _global type registry_ — a pack claims a type name for
+the whole application. Two packs claiming the same name is unresolvable, and the
+existing precedent (`widgetStore` spreading core last) silently discards the
+loser.
+
+**Why it is not optional.** The host decides widget-vs-socket by a single
+lookup, and `addInputSocket` / `addInputWidget` are exact complements on it. An
+unregistered type does not degrade to a plain widget — the input becomes a
+**socket**, changing the serialized `inputs` array and dropping its
+`widgets_values` entry. That is a wire-format break, so "just leave it
+unregistered" was never available.
+
+**Known sharp edge, unresolved.** Core still wins a name collision. A pack
+registering `COLOR` is silently ignored, which is how three packs' widgets were
+found already dead. The published API therefore has a mode where a correct call
+does nothing. Fixing that means either failing loudly on collision or letting
+packs override core — see §3 of `API_DECISIONS_FOR_REVIEW.md`.
+
+**Cost to reverse.** Very high. Six files across three packs, and no
+alternative expression.
+
+### `widgets.mount({ defaultValue })`
+
+**The tension.** `mount` was deliberately for _decoration_, and decoration must
+not touch the wire format. Giving it a value blurs that line.
+
+**Why it was added.** Packs mount value-holding controls — colour pickers, text
+boxes, vector editors — because that is what `addDOMWidget` was. Without a
+value cell those controls kept their `widgets_values` slot and **silently lost
+what the user typed**. mtb's `Constant` node was saving `''` for its colour,
+string and vector inputs. This was the root cause of most of the wire deltas
+reported during conversion.
+
+**How the line is held.** A mount is decoration _unless_ it declares
+`defaultValue`. Serialization follows that: a control that holds a value is
+saved and sent, a drawing is not, and the pack's explicit `serialize` still
+wins either way.
+
+**Cost to reverse.** High, and it would reintroduce silent data loss.
+
+### `node.getBounds()`, `node.getSlotPosition()`, `graph.nodeAt()`
+
+**Forced by** retiring `comfy.constants`. Every use of that was a pack
+reimplementing editor hit-testing and slot layout from raw metrics.
+
+**The tension.** Geometry is renderer-owned, and these publish it.
+
+**Why they are better than what they replaced.** They route to the renderer's
+own answers, so they stay correct for collapsed nodes, widget-backed inputs and
+Nodes 2.0 — all cases the `(index + 0.7) * slotHeight` reconstruction got wrong.
+The converted `utility.js` admitted as much in a comment before this existed.
+
+**Deliberate omission.** `nodeAt` answers against the _rendered_ layout and is
+not refreshed per call: a gesture asks it on every pointer move, and remeasuring
+every node each time is the expensive mistake. Before the first frame it finds
+nothing. This is documented on the method.
+
+**Cost to reverse.** High — five kjnodes files, and the alternative is
+`comfy.constants`, which was removed on instruction.
+
+### `DefSelector` accepts a predicate
+
+**Forced by** pysssss `quickNodes.js` — a menu entry for "any node taking a VAE
+input", which is a _shape_, not a name.
+
+**The tension.** This partially undoes the reason selectors are declarative.
+§4d opens by arguing that a name check can be indexed while today's hooks run
+for every registered type, "millions of wasted callbacks at boot". A predicate
+has to run per type, which is the cost the design set out to remove.
+
+**Why it was added.** The alternative is worse in the same dimension: without
+it, a pack registers a `/./` catch-all and does the shape test inside the
+callback — which is _exactly_ the run-and-return pattern, plus a callback
+invocation. The predicate at least lets the host see the test and, in future,
+index or memoise it.
+
+**Guardrail.** It is documented as discouraged and listed last, and the doc
+comment names the only case it is for. If it starts appearing in place of a
+name, that is a signal the selector vocabulary is missing something.
+
+**Cost to reverse.** Low today — one pack, and it degrades to a catch-all with
+an internal guard.
+
+### `graph.duplicate()`
+
+Uncontested and listed only for completeness. `add(type)` makes a fresh node, so
+a pack duplicating a _configured_ node — a prompt box the user has filled in —
+lost its contents; pysssss's "Add 2nd Pass" dropped a menu entry rather than
+lose the user's text. Links are deliberately not copied: a duplicate wired into
+the same places is a different operation.
+
+### The pattern worth noticing
+
+Four of these six exist because **the wire format has no safe failure mode.** A
+missing capability does not degrade a pack, it changes what the user's saved
+workflow contains — a socket where a widget was, a node appearing in the prompt,
+a value silently emptied. That is why the refusals were refusals rather than
+partial conversions, and why the fixes could not wait for a design round.
+
+If any of these are overturned, the packs concerned should be **re-refused**,
+not converted with a warning.
+
+## 5. Why the hooks are rewritten too
+
+**This is the part most likely to be argued with, so the reasoning is explicit.**
+
+Today's hooks are the primary leak vector, and no amount of care in §4 closes the
+surface while they stand:
+
+```ts
+beforeRegisterNodeDef(nodeType, nodeData, app) // hands out the constructor
+nodeCreated(node, app) // hands out the LGraphNode
+```
+
+`nodeType` is the real class. Packs patch its prototype, wrap its methods, and
+capture `app` — which reaches the entire frontend. Any pack doing this is coupled to
+internals by construction, and every ECS refactor breaks it. That is the actual root
+cause of this whole programme, not the individual property renames.
+
+`defineNode(builder)` replaces prototype patching with declared intent:
+`onCreated`, `onConnectionsChanged`, `onSerialize`. It covers what packs actually do
+with the constructor, without handing it over.
+
+**Honest cost:** this is the largest migration in the API, and it is the least
+mechanical — prototype patches don't map to declarations by regex. Expect this
+cohort to need the agent tier, and expect some packs to be genuinely unconvertible
+without author involvement. That's an argument for prioritising Sink A (upstream
+PRs) on exactly these packs.
+
+`app` is deliberately absent everywhere. If something is only reachable via `app`,
+either it belongs on this surface or it isn't public.
+
+---
+
+## 6. Proxy implementation contract
+
+The anti-leak rules, stated as testable requirements:
+
+```ts
+const ALLOWED = new Set(['id', 'type', 'title' /* … per handle */])
+
+new Proxy(Object.create(null), {
+  get(_, key) {
+    if (typeof key === 'symbol') return SYMBOL_ALLOWLIST[key]
+    if (!ALLOWED.has(key)) return undefined // no constructor, no __v_raw, no prototype
+    return read(id, key)
+  },
+  set(_, key, value) {
+    if (!WRITABLE.has(key)) throw new ComfyReadonlyError(key)
+    dispatch(commandFor(id, key, value)) // never a direct mutation
+    return true
+  },
+  ownKeys: () => [...ALLOWED],
+  getOwnPropertyDescriptor: (_, k) =>
+    ALLOWED.has(k) ? { configurable: true, enumerable: true } : undefined,
+  has: (_, k) => ALLOWED.has(k),
+  getPrototypeOf: () => null,
+  setPrototypeOf: () => false,
+  defineProperty: () => false,
+  deleteProperty: () => false
+})
+```
+
+Test requirements — these are the ones worth writing first, because they're what
+"closed" actually means:
+
+- `JSON.stringify(handle)` yields only surface fields, and never throws
+- `{...handle}` yields a usable plain object (the `slot_spread` fix, 23 packs)
+- No property path from any handle reaches an `LGraphNode`, `LLink`, store, or Vue
+  reactive — assert by walking the object graph to a fixed depth
+- `structuredClone(handle.snapshot())` succeeds — proves inertness
+- Every getter on a removed entity returns `undefined`; every setter throws
+- `Object.getPrototypeOf(handle) === null`
+
+---
+
+## 7. Deliberately excluded
+
+> Additions that are _included_ but arguable are collected in
+> [§4f Contested additions](#4f-️-contested-additions--argue-with-these), with
+> the alternative that was rejected and the cost of reversing each one.
+
+| Not exposed                                              | Why                                         | If you need it                                                   |
+| -------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+| `app` / `ComfyApp`                                       | Reaches everything                          | Named capability on `comfy`                                      |
+| The node constructor                                     | Prototype patching is the coupling          | `defineNode()`                                                   |
+| `LGraphCanvas`                                           | Rendering internals, changes constantly     | `comfy.ui` for the sanctioned subset                             |
+| Pinia stores                                             | Internal state layout                       | Handles                                                          |
+| `LLink`                                                  | Live mutable link object                    | `LinkInfo` snapshots                                             |
+| `graph._nodes`                                           | Internal array                              | `graph.nodes()`                                                  |
+| `node.type` setter                                       | Type is identity                            | `graph.replaceNode()`                                            |
+| `widget.type` setter                                     | The hack's intent was hiding                | `widget.hidden`                                                  |
+| `onDrawForeground` / `onDrawBackground` / `onDrawTitle*` | Canvas-only; already no-op under Nodes 2.0  | `node.decorations` (§4a), or `widgets.register()` if interactive |
+| Global CSS reaching host markup                          | Selector-coupled to chrome we change freely | Q9 — a sanctioned theming surface                                |
+| Slot `shape` on `SlotPatch`                              | Cosmetic; one site in the whole corpus      | Nothing — the saved `shape` byte is dropped                      |
+
+No capability loss remains here — §4a covers it, and covers it in a form that renders
+in _both_ modes, which the raw callbacks never did.
+
+---
+
+## 8. Open questions
+
+> See also [§4f](#4f-️-contested-additions--argue-with-these) for decisions
+> already taken that a reviewer may want to reverse, and
+> `API_DECISIONS_FOR_REVIEW.md` for the ones blocking packs today.
+
+- **Q1.** `mount(el, ctx)` for custom widgets is framework-agnostic and dodges the
+  dual-Vue problem — but it gives up Vue's reactivity and scoped styling for the
+  pack. Is that acceptable, or do we want a custom-element convention instead?
+- **Q2.** Does `defineNode` genuinely cover what prototype patching is used for?
+  This should be validated against the top 20 packs' actual patches _before_ the
+  interface is frozen — it's the single most likely place to discover a missing
+  capability after committing.
+- **Q3.** Is `type` truly immutable? cg-use-everywhere and rgthree both write it,
+  though rgthree's is a no-op. Confirm no pack has a legitimate need before closing
+  it off.
+- **Q4.** Do we ship a compatibility layer implementing the _old_ surface on top of
+  the new one? It would smooth migration — but it perpetuates exactly what we're
+  trying to delete, and `docs/magic_patch_WIP.md` §1 argues against shims. My read: no.
+- **Q5 — resolved.** Node body decoration is specified in §4a as a declarative,
+  mode-agnostic surface. Remaining sub-question: is the `Decoration` vocabulary
+  sufficient? It was derived from measured canvas primitives across 420 packs, but
+  should be validated by hand-porting the top 10 painters before freezing.
+- **Q8.** Should `SlotId` persist in the wire format? Today it's runtime-only, so a
+  slot reference doesn't survive save/reload and links still serialize positionally.
+  Persisting it would make link restoration robust against slot reordering between
+  versions of a pack — a real class of "my workflow rewired itself after updating"
+  bug — but costs a schema bump, backend coordination, and the byte-identical
+  invariant in `docs/magic_patch_WIP.md` §5. Worth costing separately; not a blocker for v1.
+- **Q7.** Decorations are keyed and mode-agnostic, which means we control their
+  visual language. Do they follow Comfy design standards strictly (consistent badges
+  everywhere, packs lose fine-grained colour control), or do we accept arbitrary
+  colours and lose visual coherence? Leaning strict, with a small named palette.
+- **Q9.** Packs inject a global `<link>` and restyle whatever a selector reaches.
+  Two different things hide in that. A pack styling **its own** mounted widget DOM
+  is legitimate — it owns those elements, and plain `new URL(…, import.meta.url)`
+  keeps resolving correctly no matter what the install directory is called. A pack
+  restyling **our** node chrome is a parallel front end: coupled to markup we
+  change freely, and the same objection that excluded canvas painting. We should
+  not support the second by selector, but Nodes 2.0 **should** have a sanctioned
+  way to be re-themed — most plausibly a named CSS-variable contract, which is
+  reviewable, versionable, and survives markup changes. Worth settling early:
+  once packs re-establish selector coupling against Nodes 2.0 markup, it is as
+  unshakeable as the coupling this whole migration exists to remove.
+- **Q6.** Where does this live — `packages/comfyui-node-api/` as a published types
+  package, so pack authors can `npm i` the types and get autocomplete? That seems
+  clearly right and cheap.
+
+---
+
+## 9. What this unblocks
+
+Every census surface gets a destination, which means:
+
+- **The vue-only cohort** (653 packs / 35.0% of installs) is blocked _only_ on
+  `widgets.reorder()`, `widget.hidden`, and `comfy.widgets.register()`. Three
+  additions retire it.
+- **The painting cohort** (420 packs / 32.2% of installs) is blocked only on §4a.
+- The old surfaces become deletable, which was the entire point.
+- Pack authors get a contract they can target across frontend versions — the
+  precondition for the upstream-PR programme being worth an author's time.
+
+The reverse, stated plainly: **without this, `docs/magic_patch_WIP.md` can only ever address
+16% of installs**, because there is nowhere to migrate the rest to.
+
+### The de-duplicated numbers
+
+Computed over `registry_scan.json` (4,983 packs, 106,413,232 downloads). **Do not
+add the cohorts — they overlap heavily:**
+
+| Cohort                    | Packs   | Downloads      | % installs |
+| ------------------------- | ------- | -------------- | ---------- |
+| Unconditional             | 124     | 17,130,463     | 16.1%      |
+| Vue-only                  | 657     | 37,239,896     | 35.0%      |
+| Painting                  | 420     | 34,299,457     | 32.2%      |
+| **Union (de-duplicated)** | **851** | **42,594,125** | **40.0%**  |
+| _(naive sum — wrong)_     |         |                | _83.3%_    |
+
+**52 packs are in all three cohorts**, including rgthree, easy-use, VideoHelperSuite,
+comfy-mtb, inspire-pack and mixlab.
+
+Two consequences, pulling in opposite directions:
+
+- **Per-pack migration is harder than any single cohort suggests.** The biggest packs
+  need connectivity _and_ widget _and_ painting migration, plus the hook rewrite
+  (§5). For these, a mechanical patch is unlikely to be the whole answer.
+- **But the distribution is extremely concentrated: the top 20 affected packs carry
+  77.9% of all affected downloads.**
+
+That second number is the most actionable fact in this analysis. It says the
+upstream-PR programme (`docs/magic_patch_WIP.md` Sink A) should not be a broad 851-pack
+campaign — **it should be ~20 hand-managed maintainer relationships**, with the
+automated manifest covering the long tail. Twenty conversations get ~78% of the
+user-visible benefit, and those are exactly the packs where an automated patch is
+least likely to be correct unattended.


### PR DESCRIPTION
> # ⚠️ DO NOT COMMIT — EXPERIMENTAL
>
> Open for review and discussion only. Do not merge.
>
> **Stacked on #15014.**

## Summary

The design decisions behind the v1 API, what converting real packs found, and the method the conversion agents follow.

## Changes

- **What**: `docs/API_DECISIONS_FOR_REVIEW.md` is the one to read — per item: what was found, the evidence, what was decided provisionally to unblock a proof of concept, and what still needs a call. Plus `.claude/skills/converting-custom-nodes`, the conversion method.
- **Breaking**: None. Documentation only.

## Review Focus

Every decision recorded is **provisional** and was taken to reach a go/no-go, not to set policy. Christian owns the final call; each entry states the evidence and the cost of reversing it.

The four questions that actually need answering are listed in that document, ordered by how much each changes the answer. Supply-side resolution is first: if it stays unsupported, the old surface cannot be deleted, which is the programme's premise.

The `*_WIP.md` files carry a work-in-progress banner and mean it. They are here so the reasoning is reviewable, not because they are finished.
