### PR TITLE
refactor: preserve subgraph topology during unpack

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -39,7 +39,7 @@ import { useNodeDataStore } from '@/stores/nodeDataStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
 import {
   inputHasLink,
-  inputLinkId,
+  inputLink,
   outputHasLinks,
   outputLinks
 } from './node/slotLinks'
@@ -2232,30 +2232,22 @@ export class LGraph
       externalFirst: boolean
     }[] = []
     for (const [, link] of subgraphNode.subgraph.links) {
-      let externalParentId: RerouteId | undefined
-      let originId: NodeId
-      let originSlot = link.origin_slot
-      if (link.origin_id === SUBGRAPH_INPUT_ID) {
-        const outerLinkId = inputLinkId(this, subgraphNode.id, link.origin_slot)
-        if (!outerLinkId) {
-          console.error('Missing Link ID when unpacking')
-          continue
-        }
-        const outerLink = this.links[outerLinkId]
-        originId = outerLink.origin_id
-        originSlot = outerLink.origin_slot
-        externalParentId = outerLink.parentId
-      } else {
-        const mappedOriginId =
-          link.origin_id === UNASSIGNED_NODE_ID
+      const outerLink =
+        link.origin_id === SUBGRAPH_INPUT_ID
+          ? inputLink(this, subgraphNode.id, link.origin_slot)
+          : undefined
+      const originId =
+        link.origin_id === SUBGRAPH_INPUT_ID
+          ? outerLink?.origin_id
+          : link.origin_id === UNASSIGNED_NODE_ID
             ? undefined
             : nodeIdMap.get(link.origin_id)
-        if (!mappedOriginId) {
-          console.error('Missing Link ID when unpacking')
-          continue
-        }
-        originId = mappedOriginId
+      if (!originId) {
+        console.error('Missing Link ID when unpacking')
+        continue
       }
+      const originSlot = outerLink?.origin_slot ?? link.origin_slot
+      const externalParentId = outerLink?.parentId
       if (link.target_id === SUBGRAPH_OUTPUT_ID) {
         for (const sublink of outputLinks(
           this,

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2233,6 +2233,8 @@ export class LGraph
     }[] = []
     for (const [, link] of subgraphNode.subgraph.links) {
       let externalParentId: RerouteId | undefined
+      let originId: NodeId
+      let originSlot = link.origin_slot
       if (link.origin_id === SUBGRAPH_INPUT_ID) {
         const outerLinkId = inputLinkId(this, subgraphNode.id, link.origin_slot)
         if (!outerLinkId) {
@@ -2240,19 +2242,19 @@ export class LGraph
           continue
         }
         const outerLink = this.links[outerLinkId]
-        link.origin_id = outerLink.origin_id
-        link.origin_slot = outerLink.origin_slot
+        originId = outerLink.origin_id
+        originSlot = outerLink.origin_slot
         externalParentId = outerLink.parentId
       } else {
-        const origin_id =
+        const mappedOriginId =
           link.origin_id === UNASSIGNED_NODE_ID
             ? undefined
             : nodeIdMap.get(link.origin_id)
-        if (!origin_id) {
+        if (!mappedOriginId) {
           console.error('Missing Link ID when unpacking')
           continue
         }
-        link.origin_id = origin_id
+        originId = mappedOriginId
       }
       if (link.target_id === SUBGRAPH_OUTPUT_ID) {
         for (const sublink of outputLinks(
@@ -2261,8 +2263,8 @@ export class LGraph
           link.target_slot
         )) {
           newLinks.push({
-            oid: link.origin_id,
-            oslot: link.origin_slot,
+            oid: originId,
+            oslot: originSlot,
             tid: sublink.target_id,
             tslot: sublink.target_slot,
             id: link.id,
@@ -2273,21 +2275,19 @@ export class LGraph
           sublink.parentId = undefined
         }
         continue
-      } else {
-        const target_id =
-          link.target_id === UNASSIGNED_NODE_ID
-            ? undefined
-            : nodeIdMap.get(link.target_id)
-        if (!target_id) {
-          console.error('Missing Link ID when unpacking')
-          continue
-        }
-        link.target_id = target_id
+      }
+      const targetId =
+        link.target_id === UNASSIGNED_NODE_ID
+          ? undefined
+          : nodeIdMap.get(link.target_id)
+      if (!targetId) {
+        console.error('Missing Link ID when unpacking')
+        continue
       }
       newLinks.push({
-        oid: link.origin_id,
-        oslot: link.origin_slot,
-        tid: link.target_id,
+        oid: originId,
+        oslot: originSlot,
+        tid: targetId,
         tslot: link.target_slot,
         id: link.id,
         iparent: link.parentId,

--- a/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
@@ -148,20 +148,44 @@ describe('SubgraphConversion', () => {
   })
 
   describe('Subgraph Unpacking Functionality', () => {
-    it('Should keep interior nodes and links', () => {
+    it('keeps a shared definition link registered while copying it to the parent', () => {
       const subgraph = createTestSubgraph()
       const subgraphNode = createTestSubgraphNode(subgraph)
       const graph = subgraphNode.graph!
       graph.add(subgraphNode)
+      graph.add(createTestSubgraphNode(subgraph))
 
       const node1 = createTestNode(subgraph, [], ['number'])
       const node2 = createTestNode(subgraph, ['number'])
-      node1.connect(0, node2, 0)
+      const innerLink = node1.connect(0, node2, 0)
+      assert(innerLink)
+      const topology = useLinkStore().getInputSlotLink(
+        graphScopeOf(subgraph),
+        node2.id,
+        0
+      )
 
       graph.unpackSubgraph(subgraphNode)
 
-      expect(graph.nodes.length).toBe(2)
+      expect(topology).toMatchObject({
+        originNodeId: node1.id,
+        originSlot: 0,
+        targetNodeId: node2.id,
+        targetSlot: 0
+      })
+      expect(
+        useLinkStore().getInputSlotLink(graphScopeOf(subgraph), node2.id, 0)
+      ).toBe(topology)
       expect(graph.links.size).toBe(1)
+      const [parentLink] = graph.links.values()
+      expect(parentLink).toMatchObject({
+        origin_slot: 0,
+        target_slot: 0
+      })
+      expect(parentLink.origin_id).not.toBe(node1.id)
+      expect(parentLink.target_id).not.toBe(node2.id)
+      expect(graph.getNodeById(parentLink.origin_id)).toBeDefined()
+      expect(graph.getNodeById(parentLink.target_id)).toBeDefined()
     })
     it('Should merge boundary links', () => {
       const subgraph = createTestSubgraph({


### PR DESCRIPTION
Split 3/6 of #14480. Stacked on #15009.

The original version replaced every rewired link with a fresh ID. #15009 now addresses that root cause more simply: endpoint changes are validated and applied atomically at the link-store mutation boundary while preserving link identity. This PR has therefore been reduced to the remaining independent cleanup.

`LGraph._unpackSubgraphImpl()` previously rewrote the registered links in the shared subgraph definition while calculating their parent-graph endpoints. Unpacking one instance could transiently reindex or partially mutate topology still used by another instance.

This change computes mapped origin/target endpoints in local variables, leaving the source definition and its store registration untouched. The behavioral test keeps another instance of the definition alive, unpacks one instance, and verifies both the original topology and copied parent link.

Deliberately omitted:
- no `linkReplacement.ts`
- no fresh IDs for endpoint changes
- no immutable/warn-and-ignore endpoint setters
- no second topology mutation boundary outside `linkStore`

Test plan:
- `pnpm test:unit src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts`
- typecheck, changed-file lint/format, and diff checks