### PR TITLE
fix: transfer node ownership during replacement

### DIFF
--- a/browser_tests/tests/nodeReplacement.spec.ts
+++ b/browser_tests/tests/nodeReplacement.spec.ts
@@ -259,4 +259,43 @@ test.describe('Node replacement', { tag: ['@node', '@ui'] }, () => {
       })
     })
   }
+
+  test(
+    'Replacement keeps its position when enabling Vue Nodes',
+    { tag: ['@vue-nodes'] },
+    async ({ comfyPage }) => {
+      test.slow()
+      await setupNodeReplacement(comfyPage, mockNodeReplacementsSingle)
+      await loadWorkflowAndOpenErrorsTab(
+        comfyPage,
+        'missing/node_replacement_simple'
+      )
+      await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', false)
+      await comfyPage.nextFrame()
+
+      await getSwapNodesGroup(comfyPage.page)
+        .getByRole('button', { name: /replace node/i })
+        .click()
+
+      const [ksampler] = await comfyPage.nodeOps.getNodeRefsByTitle('KSampler')
+      await ksampler.dragBy({ x: 120, y: 90 })
+      await comfyPage.nextFrame()
+      const draggedTitlePosition = await ksampler.getTitlePosition()
+
+      await comfyPage.menu.topbar.setVueNodesEnabled(true)
+      await comfyPage.vueNodes.waitForNodes()
+
+      const { header } = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
+      await expect
+        .poll(async () => {
+          const box = await header.boundingBox()
+          if (!box) return Number.POSITIVE_INFINITY
+          return Math.max(
+            Math.abs(box.x + box.width / 2 - draggedTitlePosition.x),
+            Math.abs(box.y + box.height / 2 - draggedTitlePosition.y)
+          )
+        })
+        .toBeLessThanOrEqual(2)
+    }
+  )
 })

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -6,8 +6,10 @@ import {
 } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import type { SlotPositionContext } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import {
+  canTransferLayoutAttachment,
   moveNodeLayout,
-  resizeNodeLayout
+  resizeNodeLayout,
+  transferLayoutAttachment
 } from '@/renderer/core/layout/operations/graphLayoutAttachment'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { toLinkId } from '@/types/linkId'
@@ -4472,6 +4474,62 @@ export function unregisterNodeState(node: LGraphNode): void {
   if (!node._graphScope) return
   useNodeDataStore().deleteNode(node._graphScope, node._state)
   node._graphScope = undefined
+}
+
+function canTransferNodeState(
+  node: LGraphNode,
+  replacement: LGraphNode
+): boolean {
+  return (
+    node.id === replacement.id &&
+    replacement._graphScope === undefined &&
+    node._graphScope !== undefined &&
+    useNodeDataStore().ownsNode(node._graphScope, node._state)
+  )
+}
+
+function transferNodeState(node: LGraphNode, replacement: LGraphNode): void {
+  const registeredState = node._state
+  const detachedState = { ...registeredState }
+  const replacementState = replacement._state
+  Object.assign(registeredState, {
+    flags: replacementState.flags,
+    inputs: replacementState.inputs,
+    mode: replacementState.mode,
+    outputs: replacementState.outputs,
+    title: replacementState.title,
+    type: replacementState.type,
+    bgcolor: replacementState.bgcolor,
+    color: replacementState.color,
+    resizable: replacementState.resizable,
+    shape: replacementState.shape,
+    showAdvanced: replacementState.showAdvanced,
+    titleMode: replacementState.titleMode
+  })
+  replacement._state = registeredState
+  replacement._graphScope = node._graphScope
+  node._state = detachedState
+  node._graphScope = undefined
+}
+
+export function canTransferReplacementOwnership(
+  node: LGraphNode,
+  replacement: LGraphNode
+): boolean {
+  return (
+    canTransferNodeState(node, replacement) &&
+    canTransferLayoutAttachment(node, replacement)
+  )
+}
+
+export function transferReplacementOwnership(
+  node: LGraphNode,
+  replacement: LGraphNode
+): boolean {
+  if (!canTransferReplacementOwnership(node, replacement)) return false
+  if (!transferLayoutAttachment(node, replacement)) return false
+  transferNodeState(node, replacement)
+  return true
 }
 
 /**

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -4498,7 +4498,12 @@ function transferNodeState(node: LGraphNode, replacement: LGraphNode): void {
     resizable: undefined,
     shape: undefined,
     showAdvanced: undefined,
+    titleMode: undefined,
     ...replacementState
+  } satisfies {
+    [K in Exclude<keyof NodeState, 'graphId' | 'id'>]-?:
+      | NodeState[K]
+      | undefined
   })
   replacement._state = registeredState
   replacement._graphScope = node._graphScope

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -4491,20 +4491,14 @@ function canTransferNodeState(
 function transferNodeState(node: LGraphNode, replacement: LGraphNode): void {
   const registeredState = node._state
   const detachedState = { ...registeredState }
-  const replacementState = replacement._state
+  const { graphId: _graphId, id: _id, ...replacementState } = replacement._state
   Object.assign(registeredState, {
-    flags: replacementState.flags,
-    inputs: replacementState.inputs,
-    mode: replacementState.mode,
-    outputs: replacementState.outputs,
-    title: replacementState.title,
-    type: replacementState.type,
-    bgcolor: replacementState.bgcolor,
-    color: replacementState.color,
-    resizable: replacementState.resizable,
-    shape: replacementState.shape,
-    showAdvanced: replacementState.showAdvanced,
-    titleMode: replacementState.titleMode
+    bgcolor: undefined,
+    color: undefined,
+    resizable: undefined,
+    shape: undefined,
+    showAdvanced: undefined,
+    ...replacementState
   })
   replacement._state = registeredState
   replacement._graphScope = node._graphScope

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -4,11 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
-import {
-  LiteGraph,
-  registerNodeState,
-  unregisterNodeState
-} from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useLinkStore } from '@/stores/linkStore'
 import type { MissingNodeType } from '@/types/comfy'
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
@@ -21,9 +17,12 @@ vi.mock('@/lib/litegraph/src/litegraph', () => ({
   LiteGraph: {
     createNode: vi.fn(),
     registered_node_types: {}
-  },
-  registerNodeState: vi.fn(),
-  unregisterNodeState: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/litegraph/src/LGraphNode', () => ({
+  canTransferReplacementOwnership: vi.fn(() => true),
+  transferReplacementOwnership: vi.fn(() => true)
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -487,6 +486,7 @@ describe('useNodeReplacement', () => {
       )
       placeholder.pos = [300, 400]
       placeholder.size = [250, 150]
+      placeholder.onRemoved = vi.fn()
 
       const graph = createMockGraph([placeholder], [link])
       placeholder.graph = graph
@@ -517,12 +517,7 @@ describe('useNodeReplacement', () => {
       expect(newNode.pos).toEqual([300, 400])
       expect(newNode.size).toEqual([250, 150])
       expect(graph._nodes[0]).toBe(newNode)
-
-      expect(unregisterNodeState).toHaveBeenCalledWith(placeholder)
-      expect(registerNodeState).toHaveBeenCalledWith(graph, newNode)
-      expect(
-        vi.mocked(unregisterNodeState).mock.invocationCallOrder[0]
-      ).toBeLessThan(vi.mocked(registerNodeState).mock.invocationCallOrder[0])
+      expect(placeholder.onRemoved).toHaveBeenCalledOnce()
     })
 
     it('should transfer all widget values for ImageScaleBy with real workflow data', () => {

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -5,6 +5,10 @@ import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEven
 import type { LGraphEventMap } from '@/lib/litegraph/src/infrastructure/LGraphEventMap'
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  canTransferReplacementOwnership,
+  transferReplacementOwnership
+} from '@/lib/litegraph/src/LGraphNode'
 import { useLinkStore } from '@/stores/linkStore'
 import type { MissingNodeType } from '@/types/comfy'
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
@@ -34,9 +38,14 @@ vi.mock('@/utils/graphTraversalUtil', () => ({
   collectAllNodes: vi.fn()
 }))
 
+const { mockRemoveMissingNodesByType, mockToastAdd } = vi.hoisted(() => ({
+  mockRemoveMissingNodesByType: vi.fn(),
+  mockToastAdd: vi.fn()
+}))
+
 vi.mock('@/platform/updates/common/toastStore', () => ({
   useToastStore: vi.fn(() => ({
-    add: vi.fn()
+    add: mockToastAdd
   }))
 }))
 
@@ -56,9 +65,6 @@ vi.mock('@/i18n', () => ({
     params ? `${key}:${JSON.stringify(params)}` : key
 }))
 
-const { mockRemoveMissingNodesByType } = vi.hoisted(() => ({
-  mockRemoveMissingNodesByType: vi.fn()
-}))
 vi.mock('@/platform/nodeReplacement/missingNodesErrorStore', () => ({
   useMissingNodesErrorStore: vi.fn(() => ({
     removeMissingNodesByType: mockRemoveMissingNodesByType
@@ -430,6 +436,42 @@ describe('useNodeReplacement', () => {
 
       expect(result).toEqual([])
     })
+
+    it.for([
+      ['preflight', false, true, false],
+      ['transfer', true, false, true]
+    ] as const)(
+      'reports an ownership %s refusal',
+      ([_stage, canTransfer, didTransfer, removed]) => {
+        const placeholder = createPlaceholderNode(1, 'OldNode')
+        placeholder.onRemoved = vi.fn()
+        const graph = createMockGraph([placeholder])
+        placeholder.graph = graph
+        Object.assign(app, { rootGraph: graph })
+        vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+        vi.mocked(LiteGraph.createNode).mockReturnValue(createNewNode())
+        vi.mocked(canTransferReplacementOwnership).mockReturnValue(canTransfer)
+        vi.mocked(transferReplacementOwnership).mockReturnValue(didTransfer)
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        const result = useNodeReplacement().replaceNodesInPlace([
+          makeMissingNodeType('OldNode', {
+            new_node_id: 'NewNode',
+            old_node_id: 'OldNode',
+            old_widget_ids: null,
+            input_mapping: null,
+            output_mapping: null
+          })
+        ])
+
+        expect(result).toEqual([])
+        expect(graph._nodes[0]).toBe(placeholder)
+        expect(placeholder.onRemoved).toHaveBeenCalledTimes(removed ? 1 : 0)
+        expect(mockToastAdd).toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'error' })
+        )
+      }
+    )
 
     it('should replace multiple different node types at once', () => {
       const placeholder1 = createPlaceholderNode(1, 'Load3DAnimation')

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -158,7 +158,7 @@ function replaceWithMapping(
   replacement: NodeReplacement,
   nodeGraph: LGraph,
   idx: number
-): boolean {
+): void {
   newNode.id = node.id
   newNode.pos = [...node.pos]
   newNode.size = [...node.size]
@@ -171,7 +171,7 @@ function replaceWithMapping(
     nodeGraph._nodes_by_id[node.id] !== node ||
     !canTransferReplacementOwnership(node, newNode)
   )
-    return false
+    throw new Error(`Cannot replace node ${node.id}: ownership is invalid`)
 
   node.onRemoved?.()
   if (
@@ -179,7 +179,9 @@ function replaceWithMapping(
     nodeGraph._nodes_by_id[node.id] !== node ||
     !transferReplacementOwnership(node, newNode)
   )
-    return false
+    throw new Error(
+      `Cannot replace node ${node.id}: ownership changed during removal`
+    )
   nodeGraph._nodes[idx] = newNode
   newNode.graph = nodeGraph
   node.graph = null
@@ -242,7 +244,6 @@ function replaceWithMapping(
   // Announce the add that graph.add() would have.
   nodeGraph.onNodeAdded?.(newNode)
   nodeGraph.events.dispatch('node:added', { node: newNode })
-  return true
 }
 
 export function useNodeReplacement() {
@@ -308,17 +309,7 @@ export function useNodeReplacement() {
                 newNode
               )
             }
-        if (
-          !replaceWithMapping(
-            node,
-            newNode,
-            effectiveReplacement,
-            nodeGraph,
-            idx
-          )
-        ) {
-          continue
-        }
+        replaceWithMapping(node, newNode, effectiveReplacement, nodeGraph, idx)
 
         if (!replacedTypes.includes(match.type)) {
           replacedTypes.push(match.type)

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -1,9 +1,9 @@
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
-  LiteGraph,
-  registerNodeState,
-  unregisterNodeState
-} from '@/lib/litegraph/src/litegraph'
+  canTransferReplacementOwnership,
+  transferReplacementOwnership
+} from '@/lib/litegraph/src/LGraphNode'
 import { inputLinkId, outputLinks } from '@/lib/litegraph/src/node/slotLinks'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
@@ -158,8 +158,7 @@ function replaceWithMapping(
   replacement: NodeReplacement,
   nodeGraph: LGraph,
   idx: number
-): void {
-  node.onRemoved?.()
+): boolean {
   newNode.id = node.id
   newNode.pos = [...node.pos]
   newNode.size = [...node.size]
@@ -167,13 +166,24 @@ function replaceWithMapping(
   newNode.mode = node.mode
   if (node.flags) newNode.flags = { ...node.flags }
 
+  if (
+    nodeGraph._nodes[idx] !== node ||
+    nodeGraph._nodes_by_id[node.id] !== node ||
+    !canTransferReplacementOwnership(node, newNode)
+  )
+    return false
+
+  node.onRemoved?.()
+  if (
+    nodeGraph._nodes[idx] !== node ||
+    nodeGraph._nodes_by_id[node.id] !== node ||
+    !transferReplacementOwnership(node, newNode)
+  )
+    return false
   nodeGraph._nodes[idx] = newNode
   newNode.graph = nodeGraph
+  node.graph = null
   nodeGraph._nodes_by_id[newNode.id] = newNode
-
-  // Bypasses graph.add(), so move the node-data registration by hand.
-  unregisterNodeState(node)
-  registerNodeState(nodeGraph, newNode)
 
   for (const widget of newNode.widgets ?? []) {
     if (isNodeBindable(widget)) widget.setNodeId(newNode.id)
@@ -232,6 +242,7 @@ function replaceWithMapping(
   // Announce the add that graph.add() would have.
   nodeGraph.onNodeAdded?.(newNode)
   nodeGraph.events.dispatch('node:added', { node: newNode })
+  return true
 }
 
 export function useNodeReplacement() {
@@ -297,7 +308,17 @@ export function useNodeReplacement() {
                 newNode
               )
             }
-        replaceWithMapping(node, newNode, effectiveReplacement, nodeGraph, idx)
+        if (
+          !replaceWithMapping(
+            node,
+            newNode,
+            effectiveReplacement,
+            nodeGraph,
+            idx
+          )
+        ) {
+          continue
+        }
 
         if (!replacedTypes.includes(match.type)) {
           replacedTypes.push(match.type)

--- a/src/renderer/core/layout/operations/graphLayoutAttachment.ts
+++ b/src/renderer/core/layout/operations/graphLayoutAttachment.ts
@@ -81,6 +81,51 @@ function adoptNodeAttachment(graphId: UUID, node: LGraphNode): void {
   }
 }
 
+function transferableNodeAttachment(
+  node: LGraphNode,
+  replacement: LGraphNode
+): LayoutAttachment<LGraphNode['id']> | undefined {
+  const attachment = nodeAttachments.get(node)
+  if (
+    !attachment ||
+    nodeAttachments.has(replacement) ||
+    attachment.id !== replacement.id ||
+    !layoutStore.getNodeLayout(attachment.graphId, attachment.id)
+  )
+    return
+  return attachment
+}
+
+export function canTransferLayoutAttachment(
+  node: LGraphNode,
+  replacement: LGraphNode
+): boolean {
+  return transferableNodeAttachment(node, replacement) !== undefined
+}
+
+export function transferLayoutAttachment(
+  node: LGraphNode,
+  replacement: LGraphNode
+): boolean {
+  const attachment = transferableNodeAttachment(node, replacement)
+  if (!attachment) return false
+
+  const geometrySynchronized = layoutStore.readNodeRect(
+    attachment.graphId,
+    attachment.id,
+    replacement._posSize
+  )
+
+  nodeAttachments.delete(node)
+  node._layoutRegistered = false
+  nodeAttachments.set(replacement, attachment)
+  replacement._layoutRegistered = true
+  if (geometrySynchronized) {
+    replacement._geometryVersion = layoutStore.geometryVersion
+  }
+  return true
+}
+
 export function detachNodeLayout(node: LGraphNode): void {
   const attachment = nodeAttachments.get(node)
   if (!attachment) return

--- a/src/stores/nodeDataStore.test.ts
+++ b/src/stores/nodeDataStore.test.ts
@@ -1,9 +1,10 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { assert, beforeEach, describe, expect, it } from 'vitest'
 import { computed } from 'vue'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { transferReplacementOwnership } from '@/lib/litegraph/src/LGraphNode'
 import { toOwningGraphId, toRootGraphId } from '@/types/graphScopeId'
 import type { GraphScope } from '@/types/graphScopeId'
 import type { NodeState } from '@/types/nodeState'
@@ -151,6 +152,59 @@ describe('nodeDataStore registration via LGraph', () => {
     lgraphNode.removeInput(1)
     expect(state?.inputs.map((i) => i.name)).toEqual(['third', 'first'])
     expect(state?.inputs).toBe(lgraphNode.inputs)
+  })
+
+  it('moves registered state to a same-id replacement without changing store membership', () => {
+    const graph = new LGraph()
+    const original = new LGraphNode('original')
+    original.color = '#123456'
+    graph.add(original)
+    const replacement = new LGraphNode('replacement')
+    replacement.id = original.id
+    const registered = registeredState(graph, original)
+    assert(registered)
+
+    expect(transferReplacementOwnership(original, replacement)).toBe(true)
+    expect(replacement._state).toBe(registered)
+    expect(replacement.title).toBe('replacement')
+    expect(replacement.color).toBeUndefined()
+    expect(registeredState(graph, replacement)).toBe(registered)
+    expect(registered.graphId).toBe(graph.id)
+    expect(original._graphScope).toBeUndefined()
+    expect(original._state).not.toBe(registered)
+
+    original.title = 'detached'
+    expect(replacement.title).toBe('replacement')
+  })
+
+  it('transfers the latest store geometry to the replacement', () => {
+    const graph = new LGraph()
+    const original = new LGraphNode('original')
+    graph.add(original)
+    const replacement = new LGraphNode('replacement')
+    replacement.id = original.id
+    replacement.pos = [...original.pos]
+    replacement.size = [...original.size]
+
+    original.pos = [300, 400]
+    original.size = [220, 160]
+
+    expect(transferReplacementOwnership(original, replacement)).toBe(true)
+    expect([...replacement.pos]).toEqual([300, 400])
+    expect([...replacement.size]).toEqual([220, 160])
+  })
+
+  it('keeps ownership unchanged when replacement identity does not match', () => {
+    const graph = new LGraph()
+    const original = new LGraphNode('original')
+    graph.add(original)
+    const replacement = new LGraphNode('replacement')
+    const registered = registeredState(graph, original)
+
+    expect(transferReplacementOwnership(original, replacement)).toBe(false)
+    expect(registeredState(graph, original)).toBe(registered)
+    expect(original._graphScope).toBeDefined()
+    expect(replacement._graphScope).toBeUndefined()
   })
 
   it('drops the registration when the node is removed', () => {

--- a/src/stores/nodeDataStore.ts
+++ b/src/stores/nodeDataStore.ts
@@ -83,6 +83,14 @@ export const useNodeDataStore = defineStore('nodeData', () => {
     })
   }
 
+  function ownsNode(graphScope: GraphScope, state: NodeState): boolean {
+    const registered = roots.get(graphScope.rootGraphId)?.byId.get(state.id)
+    return (
+      registered?.graphId === graphScope.owningGraphId &&
+      toRaw(registered) === toRaw(state)
+    )
+  }
+
   function deleteNode(graphScope: GraphScope, state: NodeState): boolean {
     const bucket = roots.get(graphScope.rootGraphId)
     const registered = bucket?.byId.get(state.id)
@@ -118,6 +126,7 @@ export const useNodeDataStore = defineStore('nodeData', () => {
     clearGraph,
     deleteNode,
     getGraphNodesFor,
+    ownsNode,
     registerNode
   }
 })


### PR DESCRIPTION
Split 5/6 of #14480. Stacked on #15017.

Node replacement bypasses `graph.add()`. Copying `pos` and `size` preserved legacy canvas geometry only; the replacement did not own the existing layout attachment and could lose its position when Vue Nodes read from the layout store.

This change centralizes replacement ownership transfer in the existing node-replacement subsystem:
- Preflights graph indices, node-state store ownership, same-ID identity, and layout attachment before mutation.
- Runs the existing `onRemoved` callback while ownership is unchanged, then revalidates before committing.
- Moves the existing registered node-state proxy and layout attachment to the replacement without delete/recreate windows.
- Reads canonical geometry before stamping the replacement’s geometry version.
- Detaches the old instance from graph, state, and layout ownership so retained stale references cannot mutate the replacement.
- Keeps orchestration private to `useNodeReplacement`; no new public `LGraph` mutation API.

The browser regression performs replacement, drags the node on the legacy canvas, enables Vue Nodes, and verifies the rendered position remains within 2px. Unit coverage verifies exact state transfer, graph identity preservation, stale-instance isolation, mismatched ownership rejection, and latest-geometry adoption.

Test plan:
- 178 focused node replacement, node store, LGraph, and LGraphNode tests
- application and browser typechecks
- changed-file lint/format and diff checks