### PR TITLE
Update login redirect destination URL

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -82,7 +82,7 @@
     },
     {
       "source": "/login",
-      "destination": "https://cloud.comfy.org/login",
+      "destination": "https://cloud.comfy.org/cloud/login",
       "permanent": false
     }
   ]


### PR DESCRIPTION
## Summary

`comfy.org/login` was redirecting to `cloud.comfy.org/login`, which is not the real sign-in experience — the cloud app's login page lives at `/cloud/login`. One-line redirect destination fix.

## Changes

- **What**: the `/login` redirect destination in `apps/website/vercel.json` now points to `https://cloud.comfy.org/cloud/login` (was `https://cloud.comfy.org/login`).

## Review Focus

- The redirect is `permanent: false` (307), so the old destination is not pinned in browser or CDN caches — the fix takes effect on deploy for everyone.
- `cloud.comfy.org/login` still returns 200 (SPA catch-all), which is why this looked fine in checks while landing users on the wrong page.
- Only reference to the old URL in the website app; no other routes point at it.

## Screenshots (if applicable)
