### PR TITLE
Fix legacy Cloud login route

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -17,10 +17,13 @@ import {
 const VALID_REQUEST_ID = '550e8400-e29b-41d4-a716-446655440000'
 
 const createSessionOrThrow = vi.fn().mockResolvedValue(undefined)
+const useCurrentUser = vi.fn(() => ({ isLoggedIn: { value: false } }))
 
 vi.mock('@/platform/auth/session/useSessionCookie', () => ({
   useSessionCookie: () => ({ createSessionOrThrow })
 }))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({ useCurrentUser }))
 
 const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
 const consentRoute = oauthLayout?.children?.find(
@@ -84,8 +87,7 @@ describe('cloudOnboardingRoutes', () => {
           children: [
             {
               ...cloudLoginRoute,
-              component: { template: '<div />' },
-              beforeEnter: undefined
+              component: { template: '<div />' }
             }
           ]
         }
@@ -98,6 +100,7 @@ describe('cloudOnboardingRoutes', () => {
 
     expect(guardedRouteNames).toHaveBeenCalledOnce()
     expect(guardedRouteNames).toHaveBeenCalledWith('cloud-login')
+    expect(useCurrentUser).toHaveBeenCalledOnce()
     expect(router.currentRoute.value.name).toBe('cloud-login')
     expect(router.currentRoute.value.path).toBe('/cloud/login')
     expect(router.currentRoute.value.query).toEqual({

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
 
 import {
   cloudOnboardingRoutes,
@@ -46,6 +47,39 @@ const resolvedComponents = await Promise.all(
 )
 
 describe('cloudOnboardingRoutes', () => {
+  it('redirects the legacy login path to Cloud login with its query', async () => {
+    const legacyLoginRoute = cloudOnboardingRoutes.find(
+      (route) => route.path === '/login'
+    )
+    expect(legacyLoginRoute).toBeDefined()
+    if (!legacyLoginRoute) return
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        legacyLoginRoute,
+        {
+          path: '/cloud/login',
+          name: 'cloud-login',
+          component: { template: '<div />' }
+        }
+      ]
+    })
+    const guardedRouteNames = vi.fn()
+    router.beforeEach((to) => guardedRouteNames(to.name))
+
+    await router.push('/login?source=legacy&campaign=one&campaign=two')
+
+    expect(guardedRouteNames).toHaveBeenCalledOnce()
+    expect(guardedRouteNames).toHaveBeenCalledWith('cloud-login')
+    expect(router.currentRoute.value.name).toBe('cloud-login')
+    expect(router.currentRoute.value.path).toBe('/cloud/login')
+    expect(router.currentRoute.value.query).toEqual({
+      source: 'legacy',
+      campaign: ['one', 'two']
+    })
+  })
+
   it('consent route is not a child of the /cloud layout', () => {
     const cloudLayout = cloudOnboardingRoutes.find((r) => r.path === '/cloud')
     const childPaths = (cloudLayout?.children ?? []).map((c) => c.path)

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  RouteRecordSingleView,
+  RouteRecordSingleViewWithChildren
+} from 'vue-router'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import {
@@ -52,10 +56,18 @@ describe('cloudOnboardingRoutes', () => {
       (route) => route.path === '/login'
     )
     const cloudLayoutRoute = cloudOnboardingRoutes.find(
-      (route) => route.path === '/cloud'
+      (route): route is RouteRecordSingleViewWithChildren =>
+        route.path === '/cloud' &&
+        'component' in route &&
+        'children' in route &&
+        !('components' in route)
     )
     const cloudLoginRoute = cloudLayoutRoute?.children?.find(
-      (route) => route.name === 'cloud-login'
+      (route): route is RouteRecordSingleView =>
+        route.name === 'cloud-login' &&
+        'component' in route &&
+        !('children' in route) &&
+        !('components' in route)
     )
     expect(legacyLoginRoute).toBeDefined()
     expect(cloudLayoutRoute).toBeDefined()

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -51,17 +51,31 @@ describe('cloudOnboardingRoutes', () => {
     const legacyLoginRoute = cloudOnboardingRoutes.find(
       (route) => route.path === '/login'
     )
+    const cloudLayoutRoute = cloudOnboardingRoutes.find(
+      (route) => route.path === '/cloud'
+    )
+    const cloudLoginRoute = cloudLayoutRoute?.children?.find(
+      (route) => route.name === 'cloud-login'
+    )
     expect(legacyLoginRoute).toBeDefined()
-    if (!legacyLoginRoute) return
+    expect(cloudLayoutRoute).toBeDefined()
+    expect(cloudLoginRoute).toBeDefined()
+    if (!legacyLoginRoute || !cloudLayoutRoute || !cloudLoginRoute) return
 
     const router = createRouter({
       history: createMemoryHistory(),
       routes: [
         legacyLoginRoute,
         {
-          path: '/cloud/login',
-          name: 'cloud-login',
-          component: { template: '<div />' }
+          ...cloudLayoutRoute,
+          component: { template: '<div />' },
+          children: [
+            {
+              ...cloudLoginRoute,
+              component: { template: '<div />' },
+              beforeEnter: undefined
+            }
+          ]
         }
       ]
     })

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -42,6 +42,10 @@ export async function oauthConsentRedirect() {
 
 export const cloudOnboardingRoutes: RouteRecordRaw[] = [
   {
+    path: '/login',
+    redirect: (to) => ({ name: 'cloud-login', query: to.query })
+  },
+  {
     path: '/cloud',
     component: () =>
       import('@/platform/cloud/onboarding/components/CloudLayoutView.vue'),


### PR DESCRIPTION
## Summary

Add a Cloud router compatibility redirect from the legacy `/login` path to the canonical named `cloud-login` route while preserving query parameters.

This is the consumer-side companion to #15021, which stops the marketing website from generating new `https://cloud.comfy.org/login` URLs. This PR keeps existing bookmarks, browser history, emails, documentation, and externally shared legacy links working deterministically.

## Root cause

The canonical Cloud login route is `/cloud/login`, but `/login` is not registered in the Cloud Vue router.

For logged-out users, the global auth guard previously masked the invalid route by redirecting to `cloud-login` and preserving the original path as `previousFullPath=/login`. The Login → Sign Up link preserves that query. After successful signup, the shared post-auth redirect restores `previousFullPath`, returning the now-authenticated user to unmatched `/login`. Because authenticated users pass the global guard, the application has no matched component to render and can remain blank or stuck on the loading UI.

This routing bug is independent of IR-105's cached JavaScript 404s. The asset-loading incident made the invalid URL more visible because no client-side routing could execute when the SPA failed to boot, but the signup reproduction exists without the cached 404.

## AS IS

```text
legacy /login
  → logged-out auth guard redirects to /cloud/login?previousFullPath=/login
  → user selects Sign Up
  → successful signup restores /login
  → authenticated guard allows the unmatched route
  → blank/loading UI
```

## TO BE

```text
legacy /login?<query>
  → named cloud-login route
  → /cloud/login?<query>
```

The compatibility redirect runs as route matching, before authentication-state-specific guard behavior can expose the invalid route.

## Changes

- Register `/login` as a Cloud-only compatibility redirect to the named `cloud-login` route.
- Preserve all query parameters, including repeated values.
- Add focused router coverage verifying the canonical destination, one redirect navigation, and query preservation.

## Validation

The implementation was validated in an isolated project checkout before being applied to this branch:

- Targeted Vitest: **9/9 passed**
- `oxfmt` check: passed
- Type-aware Oxlint: **0 warnings, 0 errors**
- ESLint: passed
- `pnpm typecheck`: passed
- `git diff --check`: passed

## Regression risk

Low. The new top-level route is part of `cloudOnboardingRoutes`, which is only installed for Cloud builds. It affects only the previously unregistered exact path `/login`; existing `/cloud/login` behavior is unchanged. Query preservation is covered by the regression test.

## Screenshots

Not applicable. This changes URL routing only and does not modify rendered UI.