### PR TITLE
test: a 5xx prompt rejection is an environment fault, not a pack verdict

### DIFF
--- a/browser_tests/fixtures/customNode/ComfyTarget.ts
+++ b/browser_tests/fixtures/customNode/ComfyTarget.ts
@@ -57,6 +57,24 @@ export function summarizePromptError(body: unknown): string | undefined {
   return parts.length > 0 ? parts.join('; ') : undefined
 }
 
+// A non-2xx /prompt response, with attribution decided by its status: 400 is
+// the backend REJECTING this graph (pack-attributable validation), 5xx is the
+// backend FAILING (an environment fault that is never a per-node verdict).
+interface PromptRejection {
+  status: number
+  summary?: string
+}
+
+const describeRejection = (rejection: PromptRejection): string =>
+  rejection.summary ?? `HTTP ${rejection.status} prompt submission failed`
+
+const serverSideFault = (rejection: PromptRejection): Error =>
+  new Error(
+    `prompt submission failed server-side (HTTP ${rejection.status} POST /prompt)` +
+      (rejection.summary ? ` - ${rejection.summary}` : '') +
+      ' - backend/environment fault, not a pack validation reject'
+  )
+
 export function toPromptEvent(raw: RawEvent): PromptEvent {
   if (raw.type === 'executing')
     return { type: 'executing', node: raw.node ?? null }
@@ -157,12 +175,12 @@ export class LocalDesktopTarget {
     // check below stay as defense in depth (capture can lose a race with a
     // transient refusal, and `executing` events carry no prompt id at all).
     let capturedPromptId: string | undefined
-    // A backend validation rejection answers /prompt with a non-2xx body
-    // carrying { error, node_errors }. app.queuePrompt swallows it and just
-    // returns false, so without capturing it here a VALIDATION_FAIL result
-    // names nothing. Snapshot the failing node/input so the outcome is
-    // actionable instead of an empty object.
-    let capturedValidationError: string | undefined
+    // A backend rejection answers /prompt with a non-2xx body carrying
+    // { error, node_errors }. app.queuePrompt swallows it and just returns
+    // false, so without capturing it here the verdict names nothing. The
+    // status is kept alongside the summarized body because it decides
+    // attribution (see PromptRejection).
+    let capturedRejection: PromptRejection | undefined
     let capturedResponseSequence = 0
     const { detach: stopCapture, settled: captureSettled } = onPromptIdResponse(
       page,
@@ -170,10 +188,9 @@ export class LocalDesktopTarget {
         if (sequence < capturedResponseSequence) return
         capturedResponseSequence = sequence
         capturedPromptId = promptId
-        capturedValidationError =
+        capturedRejection =
           status >= 400
-            ? (summarizePromptError(body) ??
-              `HTTP ${status} prompt submission failed`)
+            ? { status, summary: summarizePromptError(body) }
             : undefined
       }
     )
@@ -206,6 +223,10 @@ export class LocalDesktopTarget {
       if (refused(queued)) {
         await captureSettled()
         stopCapture()
+        // A captured 5xx outranks a client-side throw: the backend
+        // demonstrably failed this submission server-side.
+        if (capturedRejection !== undefined && capturedRejection.status >= 500)
+          throw serverSideFault(capturedRejection)
         return {
           outcome: 'VALIDATION_FAIL',
           executedNodes: [],
@@ -214,7 +235,7 @@ export class LocalDesktopTarget {
           // the backend's node_errors captured off the /prompt response.
           clientError:
             (typeof queued === 'object' ? queued.__cnThrew : undefined) ??
-            capturedValidationError
+            (capturedRejection && describeRejection(capturedRejection))
         }
       }
     }
@@ -225,19 +246,21 @@ export class LocalDesktopTarget {
     const captureDeadline = Date.now() + 2_000
     while (
       capturedPromptId === undefined &&
-      capturedValidationError === undefined &&
+      capturedRejection === undefined &&
       Date.now() < captureDeadline
     ) {
       await new Promise((resolve) => setTimeout(resolve, 50))
       await captureSettled()
     }
-    if (capturedValidationError !== undefined) {
+    if (capturedRejection !== undefined) {
       stopCapture()
+      if (capturedRejection.status >= 500)
+        throw serverSideFault(capturedRejection)
       return {
         outcome: 'VALIDATION_FAIL',
         executedNodes: [],
         outputsByNode: {},
-        clientError: capturedValidationError
+        clientError: describeRejection(capturedRejection)
       }
     }
     // A silent permanent miss would degrade every run to the legacy filters

--- a/browser_tests/fixtures/customNode/ComfyTarget.ts
+++ b/browser_tests/fixtures/customNode/ComfyTarget.ts
@@ -60,9 +60,20 @@ export function summarizePromptError(body: unknown): string | undefined {
 // A non-2xx /prompt response, with attribution decided by its status: 400 is
 // the backend REJECTING this graph (pack-attributable validation), 5xx is the
 // backend FAILING (an environment fault that is never a per-node verdict).
+// errorType is the body's typed provenance when the backend supplies one
+// (Cloud infra faults carry e.g. DATABASE_ERROR; an OSS validation-time crash
+// or a proxy 5xx arrives untyped, which is itself diagnostic).
 interface PromptRejection {
   status: number
   summary?: string
+  errorType?: string
+}
+
+export function extractPromptErrorType(body: unknown): string | undefined {
+  const error = (body as Partial<PromptResponse> | null)?.error
+  if (typeof error !== 'object' || error === null) return undefined
+  const type = (error as { type?: unknown }).type
+  return typeof type === 'string' && type ? type : undefined
 }
 
 const describeRejection = (rejection: PromptRejection): string =>
@@ -72,6 +83,7 @@ const serverSideFault = (rejection: PromptRejection): Error =>
   new Error(
     `prompt submission failed server-side (HTTP ${rejection.status} POST /prompt)` +
       (rejection.summary ? ` - ${rejection.summary}` : '') +
+      (rejection.errorType ? ` [type: ${rejection.errorType}]` : '') +
       ' - backend/environment fault, not a pack validation reject'
   )
 
@@ -190,7 +202,11 @@ export class LocalDesktopTarget {
         capturedPromptId = promptId
         capturedRejection =
           status >= 400
-            ? { status, summary: summarizePromptError(body) }
+            ? {
+                status,
+                summary: summarizePromptError(body),
+                errorType: extractPromptErrorType(body)
+              }
             : undefined
       }
     )

--- a/browser_tests/fixtures/customNode/ComfyTarget.ts
+++ b/browser_tests/fixtures/customNode/ComfyTarget.ts
@@ -69,7 +69,7 @@ interface PromptRejection {
   errorType?: string
 }
 
-export function extractPromptErrorType(body: unknown): string | undefined {
+function extractPromptErrorType(body: unknown): string | undefined {
   const error = (body as Partial<PromptResponse> | null)?.error
   if (typeof error !== 'object' || error === null) return undefined
   const type = (error as { type?: unknown }).type
@@ -79,9 +79,20 @@ export function extractPromptErrorType(body: unknown): string | undefined {
 const describeRejection = (rejection: PromptRejection): string =>
   rejection.summary ?? `HTTP ${rejection.status} prompt submission failed`
 
+const SERVER_SIDE_FAULT_PREFIX = 'prompt submission failed server-side'
+
+// Callers that accumulate per-node verdicts use this to catch the fault,
+// record it, and still report the failures found before it - a late 5xx must
+// never mask real regressions from earlier batches.
+export function isServerSideFault(error: unknown): error is Error {
+  return (
+    error instanceof Error && error.message.startsWith(SERVER_SIDE_FAULT_PREFIX)
+  )
+}
+
 const serverSideFault = (rejection: PromptRejection): Error =>
   new Error(
-    `prompt submission failed server-side (HTTP ${rejection.status} POST /prompt)` +
+    `${SERVER_SIDE_FAULT_PREFIX} (HTTP ${rejection.status} POST /prompt)` +
       (rejection.summary ? ` - ${rejection.summary}` : '') +
       (rejection.errorType ? ` [type: ${rejection.errorType}]` : '') +
       ' - backend/environment fault, not a pack validation reject'

--- a/browser_tests/tests/customNodes/allNodes.spec.ts
+++ b/browser_tests/tests/customNodes/allNodes.spec.ts
@@ -22,7 +22,10 @@ import {
   disabledHarnessNodes,
   stalenessCheckedKeys
 } from '@e2e/fixtures/customNode/cloudExclusions'
-import { LocalDesktopTarget } from '@e2e/fixtures/customNode/ComfyTarget'
+import {
+  LocalDesktopTarget,
+  isServerSideFault
+} from '@e2e/fixtures/customNode/ComfyTarget'
 import {
   allowlistRulesFor,
   isForeignExecutionNoise,
@@ -1631,8 +1634,20 @@ for (const entry of loadManifest()) {
         const hardFailures: string[] = []
         const cannotRun = new Map<string, string>()
         const ranClean = new Set<string>()
-        for (const batch of batches) {
-          const outcome = await runBatch(comfyPage.page, batch)
+        // A server-side 5xx means the backend is failing, not this batch's
+        // nodes: stop submitting, but keep every verdict already collected -
+        // real failures found before the fault take precedence over it and
+        // must still be reported (the abort is appended after them below).
+        let environmentAbort: string | undefined
+        batchLoop: for (const batch of batches) {
+          let outcome: string
+          try {
+            outcome = await runBatch(comfyPage.page, batch)
+          } catch (error) {
+            if (!isServerSideFault(error)) throw error
+            environmentAbort = `[${batch.map((verdict) => verdict.key).join(', ')}]: ${error.message} - remaining auto-runs skipped`
+            break
+          }
           if (outcome === 'PASS') {
             for (const verdict of batch) ranClean.add(verdict.key)
             continue
@@ -1647,11 +1662,18 @@ for (const entry of loadManifest()) {
           // Rerun singles so the bad node names itself, with a longer timeout
           // so a slow-under-load node is not misread as a regression.
           for (const verdict of batch) {
-            const single = await runBatch(
-              comfyPage.page,
-              [verdict],
-              SINGLE_RERUN_TIMEOUT
-            )
+            let single: string
+            try {
+              single = await runBatch(
+                comfyPage.page,
+                [verdict],
+                SINGLE_RERUN_TIMEOUT
+              )
+            } catch (error) {
+              if (!isServerSideFault(error)) throw error
+              environmentAbort = `${verdict.key}: ${error.message} - remaining auto-runs skipped`
+              break batchLoop
+            }
             if (single === 'PASS') ranClean.add(verdict.key)
             else if (single.startsWith('HUNG_BACKEND')) {
               hardFailures.push(
@@ -1722,6 +1744,8 @@ for (const entry of loadManifest()) {
         console.log(
           `${entry.pack} auto-ran ${ranClean.size} node(s) clean; ${cannotRun.size} cannot run alone (baseline ${baseline.size})`
         )
+        // Appended last: per-node failures keep precedence over the 5xx.
+        if (environmentAbort !== undefined) hardFailures.push(environmentAbort)
         const autoRunFailureSummary = failureSummary(
           `${entry.pack} auto-run failures`,
           hardFailures,

--- a/browser_tests/tests/customNodes/promptError.pure.spec.ts
+++ b/browser_tests/tests/customNodes/promptError.pure.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import {
   LocalDesktopTarget,
+  isServerSideFault,
   summarizePromptError,
   toPromptEvent
 } from '@e2e/fixtures/customNode/ComfyTarget'
@@ -209,14 +210,25 @@ test('a backend 5xx during submission cannot be pinned on the node under test', 
     }
   } as unknown as Page
 
-  await expect(
-    new LocalDesktopTarget().runWorkflow(page, {
+  const failure = await new LocalDesktopTarget()
+    .runWorkflow(page, {
       expectedNodeIds: ['1'],
       timeoutMs: 60_000
     })
-  ).rejects.toThrow(
+    .then(
+      () => undefined,
+      (error: unknown) => error
+    )
+  // The batch driver catches THIS shape to stop submitting while still
+  // reporting every verdict collected before the fault - the predicate is
+  // part of the contract, not just the message text.
+  expect(isServerSideFault(failure)).toBe(true)
+  expect((failure as Error).message).toBe(
     'prompt submission failed server-side (HTTP 500 POST /prompt) - Failed to create job record [type: DATABASE_ERROR] - backend/environment fault, not a pack validation reject'
   )
+  expect(
+    isServerSideFault(new Error('VALIDATION_FAIL (client threw: boom)'))
+  ).toBe(false)
   expect(waitedForExecution).toBe(false)
   expect(listeners.size).toBe(0)
 })

--- a/browser_tests/tests/customNodes/promptError.pure.spec.ts
+++ b/browser_tests/tests/customNodes/promptError.pure.spec.ts
@@ -215,7 +215,7 @@ test('a backend 5xx during submission cannot be pinned on the node under test', 
       timeoutMs: 60_000
     })
   ).rejects.toThrow(
-    'prompt submission failed server-side (HTTP 500 POST /prompt) - Failed to create job record - backend/environment fault, not a pack validation reject'
+    'prompt submission failed server-side (HTTP 500 POST /prompt) - Failed to create job record [type: DATABASE_ERROR] - backend/environment fault, not a pack validation reject'
   )
   expect(waitedForExecution).toBe(false)
   expect(listeners.size).toBe(0)

--- a/browser_tests/tests/customNodes/promptError.pure.spec.ts
+++ b/browser_tests/tests/customNodes/promptError.pure.spec.ts
@@ -83,7 +83,7 @@ test('returns a captured prompt rejection without waiting for execution events',
   const response = {
     request: () => ({ method: () => 'POST' }),
     url: () => 'http://backend/api/prompt',
-    status: () => 500,
+    status: () => 400,
     json: () =>
       Promise.resolve({
         error: { message: 'prompt rejected' },
@@ -124,7 +124,7 @@ test('returns a captured prompt rejection without waiting for execution events',
   expect(listeners.size).toBe(0)
 })
 
-test('returns a non-JSON prompt rejection without waiting for execution events', async () => {
+test('a 5xx rejection without a JSON body is an environment fault, not a pack verdict', async () => {
   const listeners = new Set<(response: Response) => void>()
   let evaluateCalls = 0
   let waitedForExecution = false
@@ -153,17 +153,70 @@ test('returns a non-JSON prompt rejection without waiting for execution events',
     }
   } as unknown as Page
 
-  const result = await new LocalDesktopTarget().runWorkflow(page, {
-    expectedNodeIds: ['1'],
-    timeoutMs: 60_000
-  })
+  await expect(
+    new LocalDesktopTarget().runWorkflow(page, {
+      expectedNodeIds: ['1'],
+      timeoutMs: 60_000
+    })
+  ).rejects.toThrow(
+    'prompt submission failed server-side (HTTP 502 POST /prompt) - backend/environment fault, not a pack validation reject'
+  )
+  expect(waitedForExecution).toBe(false)
+  expect(listeners.size).toBe(0)
+})
 
-  expect(result).toEqual({
-    outcome: 'VALIDATION_FAIL',
-    executedNodes: [],
-    outputsByNode: {},
-    clientError: 'HTTP 502 prompt submission failed'
-  })
+// The 2026-08-09 testcloud incident shape: an out-of-order migration left
+// ingest unable to INSERT jobs, every POST /prompt answered 500
+// DATABASE_ERROR, and the suite reported 1,563 per-node VALIDATION_FAIL
+// "regressions" across 68 packs. A 5xx during submission must fail the tier
+// once, naming the backend - it can never become a per-node verdict.
+test('a backend 5xx during submission cannot be pinned on the node under test', async () => {
+  const listeners = new Set<(response: Response) => void>()
+  let evaluateCalls = 0
+  let waitedForExecution = false
+  const response = {
+    request: () => ({ method: () => 'POST' }),
+    url: () => 'http://backend/api/prompt',
+    status: () => 500,
+    json: () =>
+      Promise.resolve({
+        error: {
+          message: 'Failed to create job record',
+          type: 'DATABASE_ERROR',
+          details: ''
+        }
+      })
+  } as unknown as Response
+  const page = {
+    on: (_event: string, listener: (value: Response) => void) => {
+      listeners.add(listener)
+    },
+    off: (_event: string, listener: (value: Response) => void) => {
+      listeners.delete(listener)
+    },
+    // The incident path: app.queuePrompt swallows the 500 and returns false
+    // on BOTH attempts, so the environment verdict must come from the
+    // captured /prompt response, after the client-flap retry is spent.
+    evaluate: async () => {
+      evaluateCalls += 1
+      if (evaluateCalls === 1) return []
+      for (const listener of listeners) listener(response)
+      return false
+    },
+    waitForFunction: async () => {
+      waitedForExecution = true
+      throw new Error('a rejected submission cannot emit execution events')
+    }
+  } as unknown as Page
+
+  await expect(
+    new LocalDesktopTarget().runWorkflow(page, {
+      expectedNodeIds: ['1'],
+      timeoutMs: 60_000
+    })
+  ).rejects.toThrow(
+    'prompt submission failed server-side (HTTP 500 POST /prompt) - Failed to create job record - backend/environment fault, not a pack validation reject'
+  )
   expect(waitedForExecution).toBe(false)
   expect(listeners.size).toBe(0)
 })


### PR DESCRIPTION
## Summary

A backend 5xx on `POST /prompt` now fails the run tier once, naming the backend, instead of classifying `VALIDATION_FAIL` against the node under test. 400 stays a pack-attributable validation reject.

## Changes

- **What**: `runWorkflow` keeps the captured `/prompt` status alongside the summarized body (`PromptRejection`). When the final captured status is >= 500 it throws `prompt submission failed server-side (HTTP <status> POST /prompt) - <body message> - backend/environment fault, not a pack validation reject` at both classification sites (double-refusal and resolved-with-rejection), matching the fail-loud nomenclature of the boot check (`cloud required boot request failed: HTTP ...`) and the token check (`workspace token mint failed (HTTP ...)`). A captured 5xx outranks a client-side throw: the backend demonstrably failed that submission server-side. The client-flap retry and the stale-response sequence guard are unchanged - the 500-then-200 retry pure test passes untouched.

## Review Focus

- Attribution is the point. During the 2026-08-09 testcloud incident (out-of-order migration, fixed by Comfy-Org/cloud#6486, left ingest unable to INSERT jobs) every submission answered 500 `DATABASE_ERROR` and the cloud gate reported **1,563 per-node VALIDATION_FAIL "regressions" across 68 packs**, each labeled `not in cannotRunAlone; a regression, or a new baseline entry` (run 31418724428). With this change each affected test fails once with the true cause.
- One core-gate edge is deliberate: pack Python that crashes inside `/prompt` validation also 500s, and now reads as an environment fault rather than a per-node verdict. The tier still fails red either way; only the attribution changes. The 400-with-`node_errors` path packs actually exercise is untouched.
- Red-green: both new pure tests fail against the previous classifier (resolve to `VALIDATION_FAIL`); 9/9 promptError pure tests and the 183-test pure/self-check battery pass with the change. No `AUTO_RUN_ALLOWED_FAILURES` entry depends on a 5xx-shaped `VALIDATION_FAIL` (all are `TIMEOUT`/`EXECUTION_ERROR`-shaped).

Fixes [FE-1555](https://linear.app/comfyorg/issue/FE-1555/custom-node-suite-backend-5xx-misattributed-as-per-node-pack)
