### PR TITLE
test: remove redundant timer cleanup

### DIFF
--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -354,18 +354,14 @@ describe('usePanAndZoom', () => {
     it('triggers undo on two-finger double-tap', () => {
       vi.useFakeTimers()
 
-      try {
-        const pz = usePanAndZoom()
-        const touches = createTouchList({ x: 100, y: 200 }, { x: 300, y: 200 })
+      const pz = usePanAndZoom()
+      const touches = createTouchList({ x: 100, y: 200 }, { x: 300, y: 200 })
 
-        pz.handleTouchStart(createTouchEvent(touches))
-        vi.advanceTimersByTime(100)
-        pz.handleTouchStart(createTouchEvent(touches))
+      pz.handleTouchStart(createTouchEvent(touches))
+      vi.advanceTimersByTime(100)
+      pz.handleTouchStart(createTouchEvent(touches))
 
-        expect(mockStore.canvasHistory.undo).toHaveBeenCalled()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(mockStore.canvasHistory.undo).toHaveBeenCalled()
     })
 
     it('single-touch move pans the canvas', async () => {

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -619,24 +619,20 @@ describe('useTemplateFiltering', () => {
 
     it('reports the visible sort to telemetry, not the persisted browse sort', async () => {
       vi.useFakeTimers()
-      try {
-        const composable = useTemplateFiltering(
-          ref([buildTemplate({ name: 'only', title: 'Only' })])
-        )
-        composable.sortBy.value = 'newest'
-        composable.searchQuery.value = 'only'
-        await nextTick()
-        await vi.runOnlyPendingTimersAsync()
+      const composable = useTemplateFiltering(
+        ref([buildTemplate({ name: 'only', title: 'Only' })])
+      )
+      composable.sortBy.value = 'newest'
+      composable.searchQuery.value = 'only'
+      await nextTick()
+      await vi.runOnlyPendingTimersAsync()
 
-        expect(
-          trackTemplateFilterChanged,
-          'telemetry must report the search default, not the persisted browse sort'
-        ).toHaveBeenLastCalledWith(
-          expect.objectContaining({ sort_by: 'popular' })
-        )
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(
+        trackTemplateFilterChanged,
+        'telemetry must report the search default, not the persisted browse sort'
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sort_by: 'popular' })
+      )
     })
 
     it('preserves relevance order after a model filter narrows the results', async () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -470,8 +470,6 @@ describe('PrimitiveNode', () => {
       vi.advanceTimersByTime(15)
       expect(node.lastType).toBeUndefined()
       expect(node.controlValues).toBeUndefined()
-
-      vi.useRealTimers()
     })
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -932,22 +932,18 @@ describe('useSubscription', () => {
         renewal_date: '2025-11-16'
       })
 
-      try {
-        const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
+      const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
 
-        await fetchStatus()
-        mockGetBillingStatus.mockClear()
+      await fetchStatus()
+      mockGetBillingStatus.mockClear()
 
-        await manageSubscription()
-        await vi.advanceTimersByTimeAsync(5000)
+      await manageSubscription()
+      await vi.advanceTimersByTimeAsync(5000)
 
-        expect(mockGetBillingStatus).not.toHaveBeenCalled()
-        expect(
-          mockTelemetry.trackMonthlySubscriptionCancelled
-        ).not.toHaveBeenCalled()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(mockGetBillingStatus).not.toHaveBeenCalled()
+      expect(
+        mockTelemetry.trackMonthlySubscriptionCancelled
+      ).not.toHaveBeenCalled()
     })
 
     it('tracks cancellation after manage subscription when status flips', async () => {
@@ -971,20 +967,16 @@ describe('useSubscription', () => {
         .mockResolvedValueOnce(activeStatus)
         .mockResolvedValueOnce(cancelledStatus)
 
-      try {
-        const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
+      const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
 
-        await fetchStatus()
-        await manageSubscription()
+      await fetchStatus()
+      await manageSubscription()
 
-        await vi.advanceTimersByTimeAsync(5000)
+      await vi.advanceTimersByTimeAsync(5000)
 
-        expect(
-          mockTelemetry.trackMonthlySubscriptionCancelled
-        ).toHaveBeenCalledTimes(1)
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(
+        mockTelemetry.trackMonthlySubscriptionCancelled
+      ).toHaveBeenCalledTimes(1)
     })
 
     it('handles rapid focus events during cancellation polling', async () => {
@@ -1008,21 +1000,17 @@ describe('useSubscription', () => {
         .mockResolvedValueOnce(activeStatus)
         .mockResolvedValueOnce(cancelledStatus)
 
-      try {
-        const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
+      const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
 
-        await fetchStatus()
-        await manageSubscription()
+      await fetchStatus()
+      await manageSubscription()
 
-        window.dispatchEvent(new Event('focus'))
-        await vi.waitFor(() => {
-          expect(
-            mockTelemetry.trackMonthlySubscriptionCancelled
-          ).toHaveBeenCalledTimes(1)
-        })
-      } finally {
-        vi.useRealTimers()
-      }
+      window.dispatchEvent(new Event('focus'))
+      await vi.waitFor(() => {
+        expect(
+          mockTelemetry.trackMonthlySubscriptionCancelled
+        ).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -54,7 +54,6 @@ describe('TourSpotlight', () => {
     cleanup()
     clearCoachmarks()
     document.body.replaceChildren()
-    vi.useRealTimers()
   })
 
   it('renders the spotlight and card for a step', () => {

--- a/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
+++ b/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
@@ -37,7 +37,6 @@ describe('useSearchQueryTracking', () => {
   afterEach(() => {
     scopes.forEach((s) => s.stop())
     scopes.length = 0
-    vi.useRealTimers()
   })
 
   it('fires with surface, trimmed query, length, and result_count', async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -180,7 +180,6 @@ describe('useWorkspaceBilling', () => {
   afterEach(() => {
     scope?.stop()
     scope = undefined
-    vi.useRealTimers()
   })
 
   describe('initialize', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1120,8 +1120,6 @@ describe('linearOutputStore', () => {
       expect(store.inProgressItems.some((i) => i.jobId === 'job-1')).toBe(false)
       // Job 2 is now pending resolve
       expect(store.pendingResolve.has('job-2')).toBe(true)
-
-      vi.useRealTimers()
     })
 
     it('cleans up finished tracked job on exit when job ended while in app mode', async () => {
@@ -1168,8 +1166,6 @@ describe('linearOutputStore', () => {
       expect(store.pendingResolve.size).toBe(1)
       expect(store.pendingResolve.has('job-5')).toBe(true)
       expect(store.inProgressItems.every((i) => i.jobId === 'job-5')).toBe(true)
-
-      vi.useRealTimers()
     })
 
     it('does not adopt another workflow job when switching back', async () => {

--- a/src/services/gateway/registrySearchGateway.test.ts
+++ b/src/services/gateway/registrySearchGateway.test.ts
@@ -20,7 +20,6 @@ describe('useRegistrySearchGateway', () => {
   afterEach(() => {
     consoleWarnSpy.mockRestore()
     consoleInfoSpy.mockRestore()
-    vi.useRealTimers()
   })
 
   describe('Provider initialization', () => {


### PR DESCRIPTION
## Summary

Remove `vi.useRealTimers()` calls that are unpaired or duplicate an enclosing cleanup hook.

## Changes

- **What**: Removes 12 redundant timer cleanup calls across 9 test files while retaining the 102 calls required to restore fake timers between tests.

## Review Focus

Each removed call was audited in context: four files never enable fake timers, and eight test-local calls duplicate guaranteed enclosing `afterEach` cleanup. Vitest does not restore timer mode automatically, so the remaining cleanup calls are intentionally preserved.