### PR TITLE
test: use generated asset export request type

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
+import type { CreateAssetExportData } from '@comfyorg/ingest-types'
 import { fromAny } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { useToast } from 'primevue/usetoast'
@@ -152,13 +153,9 @@ vi.mock('../utils/outputAssetUtil', async (importOriginal) => {
 const mockDeleteAsset = vi.hoisted(() => vi.fn())
 const mockCreateAssetExport = vi.hoisted(() =>
   vi.fn<
-    (params: {
-      job_ids?: string[]
-      asset_ids?: string[]
-      naming_strategy?: string
-      job_asset_name_filters?: Record<string, string[]>
-      include_previews?: boolean
-    }) => Promise<{ task_id: string; status: string; message?: string }>
+    (
+      params: CreateAssetExportData['body']
+    ) => Promise<{ task_id: string; status: string; message?: string }>
   >(async () => ({ task_id: 'test-task-id', status: 'pending' }))
 )
 vi.mock('../services/assetService', () => ({


### PR DESCRIPTION
## Summary

Use the generated ingest API request type for the asset-export mock.

## Changes

- **What**: Replaces the hand-written asset export request shape with `CreateAssetExportData['body']`.

## Review Focus

This is the follow-up requested on #14836 so the test mock stays aligned with the generated API contract.