### PR TITLE
fix: combo widget renders literal "null" inside a red invalid ring

### DIFF
--- a/browser_tests/assets/vueNodes/null-combo-value.json
+++ b/browser_tests/assets/vueNodes/null-combo-value.json
@@ -1,0 +1,35 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [256, 256],
+      "size": [315, 98],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": null },
+        { "name": "CLIP", "type": "CLIP", "links": null },
+        { "name": "VAE", "type": "VAE", "links": null }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [null]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/widgets/combo/nullComboValue.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/nullComboValue.spec.ts
@@ -1,0 +1,49 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture
+} from '@e2e/fixtures/ComfyPage'
+import {
+  routeObjectInfoFromSetupApi,
+  setComboInputOptions
+} from '@e2e/fixtures/utils/objectInfo'
+
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    const unrouteObjectInfo = await routeObjectInfoFromSetupApi(
+      page,
+      (objectInfo) =>
+        setComboInputOptions(
+          objectInfo,
+          'CheckpointLoaderSimple',
+          'ckpt_name',
+          []
+        )
+    )
+
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
+
+test.describe(
+  'Vue combo widget null values',
+  { tag: ['@vue-nodes', '@widget'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('vueNodes/null-combo-value')
+    })
+
+    test('loading a workflow with an unset combo value does not display "null"', async ({
+      comfyPage
+    }) => {
+      const checkpointCombo = comfyPage.vueNodes
+        .getNodeByTitle('Load Checkpoint')
+        .getByRole('combobox', { name: 'ckpt_name', exact: true })
+
+      await expect(checkpointCombo).toHaveText('')
+    })
+  }
+)

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -356,6 +356,22 @@ describe('WidgetSelectDefault', () => {
       ).toHaveAttribute('data-capture-wheel', 'true')
     })
 
+    it('treats a null value like no selection instead of an invalid value', () => {
+      renderComponent(createWidget(['a', 'b']), null)
+
+      const trigger = screen.getByTestId('widget-select-default-trigger')
+      expect(trigger).not.toHaveAttribute('aria-invalid')
+      expect(trigger).not.toHaveTextContent('null')
+    })
+
+    it('does not render "null" while the option list is still empty', () => {
+      renderComponent(createWidget([]), null)
+
+      const trigger = screen.getByTestId('widget-select-default-trigger')
+      expect(trigger).not.toHaveTextContent('null')
+      expect(trigger).not.toHaveAttribute('aria-invalid')
+    })
+
     it('shows invalid current values as the trigger label', () => {
       renderComponent(createWidget(['a', 'b']), 'missing')
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -400,12 +400,12 @@ describe('WidgetSelectDefault', () => {
       await openDropdown(user)
 
       const options = screen.getAllByRole('option')
-      expect(options.map((option) => option.textContent?.trim())).toEqual([
-        'a',
-        'b'
-      ])
+      expect(options).toHaveLength(2)
+      expect(options.map((option) => option.textContent?.trim())).toEqual(
+        expect.arrayContaining(['a', 'b'])
+      )
       for (const option of options) {
-        expect(option).not.toHaveAttribute('data-state', 'checked')
+        expect(option).not.toHaveAttribute('aria-selected', 'true')
       }
     })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -372,6 +372,43 @@ describe('WidgetSelectDefault', () => {
       expect(trigger).not.toHaveAttribute('aria-invalid')
     })
 
+    it('renders an empty trigger for a null value with no placeholder', () => {
+      renderComponent(createWidget(['a', 'b']), null)
+
+      const trigger = screen.getByTestId('widget-select-default-trigger')
+      expect(trigger.textContent?.trim()).toBe('')
+    })
+
+    it('selects the first option for undefined but leaves null empty', () => {
+      const { unmount } = renderComponent(createWidget(['a', 'b']))
+
+      expect(
+        screen.getByTestId('widget-select-default-trigger')
+      ).toHaveTextContent('a')
+      unmount()
+
+      renderComponent(createWidget(['a', 'b']), null)
+
+      expect(
+        screen.getByTestId('widget-select-default-trigger').textContent?.trim()
+      ).toBe('')
+    })
+
+    it('shows all options as unselected for a null value', async () => {
+      const { user } = renderComponent(createWidget(['a', 'b']), null)
+
+      await openDropdown(user)
+
+      const options = screen.getAllByRole('option')
+      expect(options.map((option) => option.textContent?.trim())).toEqual([
+        'a',
+        'b'
+      ])
+      for (const option of options) {
+        expect(option).not.toHaveAttribute('data-state', 'checked')
+      }
+    })
+
     it('shows invalid current values as the trigger label', () => {
       renderComponent(createWidget(['a', 'b']), 'missing')
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.test.ts
@@ -361,43 +361,21 @@ describe('WidgetSelectDefault', () => {
 
       const trigger = screen.getByTestId('widget-select-default-trigger')
       expect(trigger).not.toHaveAttribute('aria-invalid')
-      expect(trigger).not.toHaveTextContent('null')
-    })
-
-    it('does not render "null" while the option list is still empty', () => {
-      renderComponent(createWidget([]), null)
-
-      const trigger = screen.getByTestId('widget-select-default-trigger')
-      expect(trigger).not.toHaveTextContent('null')
-      expect(trigger).not.toHaveAttribute('aria-invalid')
-    })
-
-    it('renders an empty trigger for a null value with no placeholder', () => {
-      renderComponent(createWidget(['a', 'b']), null)
-
-      const trigger = screen.getByTestId('widget-select-default-trigger')
       expect(trigger.textContent?.trim()).toBe('')
     })
 
-    it('selects the first option for undefined but leaves null empty', () => {
-      const { unmount } = renderComponent(createWidget(['a', 'b']))
+    it('selects the first option when the value is undefined', () => {
+      renderComponent(createWidget(['a', 'b']))
 
       expect(
         screen.getByTestId('widget-select-default-trigger')
       ).toHaveTextContent('a')
-      unmount()
-
-      renderComponent(createWidget(['a', 'b']), null)
-
-      expect(
-        screen.getByTestId('widget-select-default-trigger').textContent?.trim()
-      ).toBe('')
     })
 
-    it('shows all options as unselected for a null value', async () => {
-      const { user } = renderComponent(createWidget(['a', 'b']), null)
+    it('marks only a matching value as selected in the dropdown', async () => {
+      const first = renderComponent(createWidget(['a', 'b']), null)
 
-      await openDropdown(user)
+      await openDropdown(first.user)
 
       const options = screen.getAllByRole('option')
       expect(options).toHaveLength(2)
@@ -407,6 +385,20 @@ describe('WidgetSelectDefault', () => {
       for (const option of options) {
         expect(option).not.toHaveAttribute('aria-selected', 'true')
       }
+      first.unmount()
+
+      const second = renderComponent(createWidget(['a', 'b']), 'a')
+
+      await openDropdown(second.user)
+
+      expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
     })
 
     it('shows invalid current values as the trigger label', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
@@ -326,7 +326,7 @@ const viewportStyle = computed<CSSProperties>(() => ({
 }))
 
 const normalizedModelValue = computed(() =>
-  modelValue.value === undefined ? undefined : String(modelValue.value)
+  modelValue.value == null ? undefined : String(modelValue.value)
 )
 
 const selectedOption = computed(() =>
@@ -339,9 +339,7 @@ const comboboxValue = computed(() => selectedOption.value?.comboboxValue ?? '')
 
 const isInvalid = computed(
   () =>
-    modelValue.value !== undefined &&
-    modelValue.value !== '' &&
-    !selectedOption.value
+    modelValue.value != null && modelValue.value !== '' && !selectedOption.value
 )
 
 const selectedLabel = computed(() => {


### PR DESCRIPTION
## Summary

A combo widget whose value is `null` (produced by serialize's `val ?? null` round-trip when options load asynchronously) renders the literal text "null" inside the red invalid ring instead of showing the placeholder.

## Changes

- **What**: `WidgetSelectDefault.vue` treats `null` like `undefined` ("nothing selected"): `normalizedModelValue` and `isInvalid` switch from `=== undefined` comparisons to `== null`, matching the semantics `WidgetSelectDropdown` already uses. Genuinely invalid values (a non-null value not in the option list) keep the red ring.

## Review Focus

The E2E mocks `/api/object_info` (typed `routeObjectInfoFromSetupApi` + `setComboInputOptions`) to empty only `CheckpointLoaderSimple.ckpt_name`, reproducing the async/empty-options window in which `app.ts` cannot repair the null.

Intentional asymmetry: a `null` value no longer shows the invalid ring even when options are populated — `null` is a serialization artifact, not a value the user chose, unlike a stale filename (e.g. `missing.safetensors`) which still gets the ring.

## Red-green proof

| Phase | Commit | Unit | E2E |
| ----- | ------ | ---- | --- |
| Red | [`d563c7be54`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/d563c7be543452e0ea1bf0a7ad888beb44aa14b4) `test: add failing coverage for combo widget rendering literal "null"` | [failed (2 failed / 15820 passed, both are the new tests)](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31477489987/job/93734533097) | [failed (1 failed / 111 passed on shard 15, the new spec)](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31477490009/job/93735102319) |
| Green | [`973d583d76`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/973d583d767a4e6895045ac920621e0285f054b9) `fix: treat null combo value as no selection instead of invalid` | [passed](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31480239712/job/93743331471) | [passed (shard 15)](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31480239717/job/93744393558) |

The red run proves the tests fail without the fix; the green run proves the fix resolves it.

Post-green test consolidation (`2b1ddb5543`): review found the unit null-state tests asserted overlapping facts across three tests, so they were consolidated — one test pins "null renders as an empty, non-invalid trigger" exactly, one pins the `undefined` → first-option default, and one pins dropdown selection state with a positive control (`'a'` → `aria-selected="true"`). The red proof was re-established against the consolidated set: with the fix commit reverted locally, the null test fails (`aria-invalid` present, trigger text `null`); with it restored, 28/28 pass. The E2E spec is unchanged from the red run throughout.

Fixes #14535