### PR TITLE
fix: price badge cache cannot recover after a failed evaluation (10 vs '10')

### DIFF
--- a/src/composables/node/useNodePricing.test.ts
+++ b/src/composables/node/useNodePricing.test.ts
@@ -657,6 +657,64 @@ describe('useNodePricing', () => {
     })
   })
 
+  describe('failed evaluation caching', () => {
+    it('recovers the price badge when a failed string value is corrected to its numeric equivalent', async () => {
+      const { getNodeDisplayPrice } = useNodePricing()
+      const rule = priceBadge('{"type":"usd","usd": widgets.steps * 0.01}', [
+        { name: 'steps', type: 'COMBO' }
+      ])
+      const numericNode = createMockNodeWithPriceBadge(
+        'TestNumericPriceBadgeNode',
+        rule,
+        [{ name: 'steps', value: 10 }]
+      )
+      const correctedNode = createMockNodeWithPriceBadge(
+        'TestCorrectedPriceBadgeNode',
+        rule,
+        [{ name: 'steps', value: '10' }]
+      )
+
+      getNodeDisplayPrice(numericNode)
+      await new Promise((r) => setTimeout(r, 50))
+      expect(getNodeDisplayPrice(numericNode)).toBe(creditsLabel(0.1))
+
+      expect(getNodeDisplayPrice(correctedNode)).toBe('')
+      await new Promise((r) => setTimeout(r, 50))
+      expect(getNodeDisplayPrice(correctedNode)).toBe('')
+
+      const stepsWidget = correctedNode.widgets?.find(
+        (widget) => widget.name === 'steps'
+      )
+      if (!stepsWidget) throw new Error('Expected a steps widget')
+      stepsWidget.value = 10
+
+      expect(getNodeDisplayPrice(correctedNode)).toBe('')
+      await new Promise((r) => setTimeout(r, 50))
+      expect(getNodeDisplayPrice(correctedNode)).toBe(creditsLabel(0.1))
+    })
+
+    it('does not retry a failed price badge evaluation for an unchanged value', async () => {
+      const { getNodeDisplayPrice, pricingRevision } = useNodePricing()
+      const node = createMockNodeWithPriceBadge(
+        'TestFailedPriceBadgeCacheNode',
+        priceBadge('{"type":"usd","usd": widgets.steps * 0.01}', [
+          { name: 'steps', type: 'COMBO' }
+        ]),
+        [{ name: 'steps', value: '10' }]
+      )
+
+      const revisionBeforeFailure = pricingRevision.value
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await new Promise((r) => setTimeout(r, 50))
+      const revisionAfterFailure = pricingRevision.value
+      expect(revisionAfterFailure).toBeGreaterThan(revisionBeforeFailure)
+
+      expect(getNodeDisplayPrice(node)).toBe('')
+      await new Promise((r) => setTimeout(r, 20))
+      expect(pricingRevision.value).toBe(revisionAfterFailure)
+    })
+  })
+
   describe('getNodeRevisionRef', () => {
     it('should return a ref for a node ID', () => {
       const { getNodeRevisionRef } = useNodePricing()

--- a/src/composables/node/useNodePricing.ts
+++ b/src/composables/node/useNodePricing.ts
@@ -272,11 +272,11 @@ const buildJsonataContext = (
 const safeValueForSig = (v: unknown): string => {
   if (v === null || v === undefined) return ''
   if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
-    return String(v)
+    return `${typeof v}:${String(v)}`
   try {
-    return JSON.stringify(v)
+    return `json:${JSON.stringify(v)}`
   } catch {
-    return String(v)
+    return `fallback:${String(v)}`
   }
 }
 


### PR DESCRIPTION
## Summary

Once a node's price badge evaluation fails on a stringified widget value, correcting the value to its numeric equivalent cannot recover the badge, because `safeValueForSig` gives `10` and `'10'` the same cache signature and the failed-empty label keeps being served.

## Changes

- **What**: `safeValueForSig` tags primitives with their runtime type (`number:10` vs `string:10`) and prefixes the JSON/fallback paths (`json:`/`fallback:`), so a type change is a signature change and triggers re-evaluation. The null/undefined representation, failure caching, and scheduling are unchanged; an unchanged value+type still hits the cache (pinned by a guard test).

## Review Focus

Tests go through the public `useNodePricing` surface only. Mutation proof: reverting the signature change re-reds exactly the recovery test while the retry-spam guard stays green.

## Red-green proof

| Phase | Commit | Unit |
| ----- | ------ | ---- |
| Red | [`45e9510480`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/45e9510480f4285595e073ac3d5f11a6c1fe2d15) `test: add failing coverage for price badge cache signature type collision` | [failed (1 failed / 15821 passed, the new recovery test)](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31477496409/job/93734556154) |
| Green | [`8267022f15`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/8267022f15bd2f38928762dc547661e1b7fdff86) `fix: include value type in price badge cache signature` | [passed](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31479991708/job/93742543093) |

The red run proves the test fails without the fix; the green run proves the fix resolves it. Same tests, unmodified, in both runs. E2E intentionally omitted: price badges require cloud API node definitions with no existing E2E fixture; the defect is cache-layer logic fully observable in unit tests.

Fixes #14540