### PR TITLE
refactor(featureFlags): centralize ?ff= reading with the other query-state readers

### DIFF
--- a/src/utils/sessionFeatureFlagOverride.ts
+++ b/src/utils/sessionFeatureFlagOverride.ts
@@ -1,3 +1,4 @@
+import { parseQuery } from 'vue-router'
 import { useCurrentUser } from 'vuefire'
 
 import { isCloud } from '@/platform/distribution/types'
@@ -103,11 +104,9 @@ function splitRequest(request: string): [name: string, value?: string] {
 }
 
 function readOverrideRequests(search: string): string[] {
-  try {
-    return new URLSearchParams(search).getAll(QUERY_PARAM)
-  } catch {
-    return []
-  }
+  const value = parseQuery(search)[QUERY_PARAM]
+  if (value === undefined) return []
+  return (Array.isArray(value) ? value : [value]).map((value) => value ?? '')
 }
 
 /**


### PR DESCRIPTION
## Summary

Reuse Vue Router's existing query parser for `?ff=` instead of parsing `window.location.search` independently with `URLSearchParams`.

## Changes

- Replace the local `URLSearchParams` reader in `sessionFeatureFlagOverride.ts` with `parseQuery`.
- Preserve pre-router synchronous access, repeated `?ff=` parameters, nameless clearing, typed values, persistence, and employee gating.
- No new modules, router hooks, state, dependencies, or tests.

Fixes FE-1551

## Verification

- `pnpm test:unit src/utils/sessionFeatureFlagOverride.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm exec oxfmt --check src/utils/sessionFeatureFlagOverride.ts`
