### PR TITLE
test: skip coverage teardown on a page the test legitimately closed

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -813,9 +813,7 @@ export const comfyPageFixture = base.extend<{
 
     await page.coverage.startJSCoverage({ resetOnNavigation: false })
     await use(page)
-    // A test may legitimately close its page (finalizeCloudCustomNodeBootGuard
-    // closes it as the enforcement boundary); a closed page has no coverage to
-    // collect, and stopJSCoverage on it throws, failing a test that passed.
+    // A closed page has no coverage to collect
     if (page.isClosed()) return
     const coverage = await page.coverage.stopJSCoverage()
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -813,6 +813,10 @@ export const comfyPageFixture = base.extend<{
 
     await page.coverage.startJSCoverage({ resetOnNavigation: false })
     await use(page)
+    // A test may legitimately close its page (finalizeCloudCustomNodeBootGuard
+    // closes it as the enforcement boundary); a closed page has no coverage to
+    // collect, and stopJSCoverage on it throws, failing a test that passed.
+    if (page.isClosed()) return
     const coverage = await page.coverage.stopJSCoverage()
 
     const mcr = MCR({


### PR DESCRIPTION
## Summary

The shared coverage fixture called `stopJSCoverage` on a page the test had legitimately closed, converting a passing test into a deterministic CI failure.

## Changes

- **What**: `page.isClosed()` guard before `stopJSCoverage` in the coverage-collecting `page` fixture override. A closed page has no coverage to collect; behavior is unchanged for every test that leaves its page open.

## Review Focus

- `customNodeSuite.pure.spec.ts › does not count same-document hash navigation as a second boot` calls `finalizeCloudCustomNodeBootGuard(page)`, whose `close` action is `page.close()` by design (the enforcement boundary). The fixture teardown then threw `coverage.stopJSCoverage: Target page, context or browser has been closed` (`ComfyPage.ts:816`) - failing chromium shard 3/16 identically on three consecutive runs while passing locally, because the fixture is gated on `COLLECT_COVERAGE=true` (CI shards only).
- Red-green reproduced locally: `COLLECT_COVERAGE=true pnpm exec playwright test browser_tests/tests/customNodes/customNodeSuite.pure.spec.ts -g "hash navigation"` fails on the base branch and passes with the guard; the promptError pure specs confirm coverage collection is untouched for tests that keep their page open.