### PR TITLE
test: centralize fake timer cleanup

### DIFF
--- a/apps/desktop-ui/src/utils/refUtil.test.ts
+++ b/apps/desktop-ui/src/utils/refUtil.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, ref } from 'vue'
 
 import { withSetup } from '@/test/withSetup'
@@ -7,10 +7,6 @@ import { useMinLoadingDurationRef } from '@/utils/refUtil'
 describe('useMinLoadingDurationRef', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('reflects false when source is initially false', () => {

--- a/apps/desktop-ui/vitest.config.mts
+++ b/apps/desktop-ui/vitest.config.mts
@@ -21,6 +21,6 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
-    setupFiles: ['./src/test/setup.ts']
+    setupFiles: ['../../vitest.timer.setup.ts', './src/test/setup.ts']
   }
 })

--- a/apps/website/src/composables/useCarouselAutoplay.test.ts
+++ b/apps/website/src/composables/useCarouselAutoplay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 
 import { useCarouselAutoplay } from './useCarouselAutoplay'
@@ -12,10 +12,6 @@ function runInScope(fn: () => void): () => void {
 describe('useCarouselAutoplay', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('advances after the active slide delay elapses', () => {

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     unstubGlobals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
-    globals: false
+    globals: false,
+    setupFiles: ['../../vitest.timer.setup.ts']
   }
 })

--- a/packages/object-info-parser/vitest.config.ts
+++ b/packages/object-info-parser/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     unstubGlobals: true,
     environment: 'node',
     include: ['src/__tests__/**/*.test.ts'],
-    globals: false
+    globals: false,
+    setupFiles: ['../../vitest.timer.setup.ts']
   }
 })

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -1,5 +1,5 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   downloadFile,
@@ -320,10 +320,6 @@ describe('downloadUtil', () => {
     beforeEach(() => {
       vi.useFakeTimers()
       windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     it('opens URL directly when not in cloud mode', async () => {

--- a/src/components/common/TextTicker.test.ts
+++ b/src/components/common/TextTicker.test.ts
@@ -30,7 +30,6 @@ describe(TextTicker, () => {
 
   afterEach(() => {
     cleanup?.()
-    vi.useRealTimers()
   })
 
   it('renders slot content', () => {

--- a/src/components/common/TreeExplorerTreeNode.test.ts
+++ b/src/components/common/TreeExplorerTreeNode.test.ts
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/vue'
 import Badge from 'primevue/badge'
 import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -35,10 +35,6 @@ describe('TreeExplorerTreeNode', () => {
     const app = createApp({})
     app.use(PrimeVue)
     vi.useFakeTimers()
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
   })
 
   it('renders correctly', () => {

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -307,41 +307,33 @@ describe('TurnstileWidget', () => {
 
     it('falls back once the widget fails to resolve within the load timeout', async () => {
       vi.useFakeTimers()
-      try {
-        const { api, options } = fakeTurnstile()
-        mockLoadTurnstile.mockResolvedValue(api)
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
 
-        const { emitted } = renderWidget()
-        // Let the onMounted hook's `await loadTurnstile()` microtask settle
-        // and render() run, without yet advancing to the timeout itself.
-        await vi.advanceTimersByTimeAsync(0)
-        expect(options()).toBeDefined()
-        expect(emitted()['update:unavailable']).toBeUndefined()
+      const { emitted } = renderWidget()
+      // Let the onMounted hook's `await loadTurnstile()` microtask settle
+      // and render() run, without yet advancing to the timeout itself.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(options()).toBeDefined()
+      expect(emitted()['update:unavailable']).toBeUndefined()
 
-        await vi.advanceTimersByTimeAsync(9_000)
+      await vi.advanceTimersByTimeAsync(9_000)
 
-        expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
     })
 
     it('does not fall back once a token arrives before the load timeout', async () => {
       vi.useFakeTimers()
-      try {
-        const { api, options } = fakeTurnstile()
-        mockLoadTurnstile.mockResolvedValue(api)
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
 
-        const { emitted } = renderWidget()
-        await vi.advanceTimersByTimeAsync(0)
+      const { emitted } = renderWidget()
+      await vi.advanceTimersByTimeAsync(0)
 
-        options()!.callback!('token-abc')
-        await vi.advanceTimersByTimeAsync(9_000)
+      options()!.callback!('token-abc')
+      await vi.advanceTimersByTimeAsync(9_000)
 
-        expect(emitted()['update:unavailable']).toBeUndefined()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(emitted()['update:unavailable']).toBeUndefined()
     })
 
     it('resets the widget to fetch a fresh challenge on token expiry', async () => {
@@ -361,37 +353,33 @@ describe('TurnstileWidget', () => {
 
     it('falls back if a post-solve expiry is not followed by a fresh token within the load timeout', async () => {
       vi.useFakeTimers()
-      try {
-        const { api, options } = fakeTurnstile()
-        mockLoadTurnstile.mockResolvedValue(api)
-        window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
+      window.turnstile = api as unknown as NonNullable<Window['turnstile']>
 
-        const { emitted } = renderWidget()
-        await vi.advanceTimersByTimeAsync(0)
+      const { emitted } = renderWidget()
+      await vi.advanceTimersByTimeAsync(0)
 
-        // Establish a solved, available widget: an initial error marks it
-        // unavailable, then solving a challenge clears that (the same
-        // transition the existing "clears the unavailable fallback" test
-        // verifies), so the expiry below is the only thing driving fallback.
-        options()!['error-callback']!()
-        options()!.callback!('token-abc')
-        expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
+      // Establish a solved, available widget: an initial error marks it
+      // unavailable, then solving a challenge clears that (the same
+      // transition the existing "clears the unavailable fallback" test
+      // verifies), so the expiry below is the only thing driving fallback.
+      options()!['error-callback']!()
+      options()!.callback!('token-abc')
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
 
-        // The token later expires (e.g. tab backgrounded past its ~300s
-        // lifetime) without the widget itself erroring.
-        options()!['expired-callback']!()
-        await vi.advanceTimersByTimeAsync(0)
+      // The token later expires (e.g. tab backgrounded past its ~300s
+      // lifetime) without the widget itself erroring.
+      options()!['expired-callback']!()
+      await vi.advanceTimersByTimeAsync(0)
 
-        // A fresh challenge was requested, but nothing solves it before the
-        // re-armed load timeout elapses, so submission must eventually be
-        // unblocked rather than staying stuck forever.
-        expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
-        await vi.advanceTimersByTimeAsync(9_000)
+      // A fresh challenge was requested, but nothing solves it before the
+      // re-armed load timeout elapses, so submission must eventually be
+      // unblocked rather than staying stuck forever.
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
+      await vi.advanceTimersByTimeAsync(9_000)
 
-        expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
     })
   })
 })

--- a/src/components/graph/NodeDragPreview.test.ts
+++ b/src/components/graph/NodeDragPreview.test.ts
@@ -32,7 +32,6 @@ describe('NodeDragPreview', () => {
 
   afterEach(() => {
     useNodeDragToCanvas().cancelDrag()
-    vi.useRealTimers()
   })
 
   it('shows no ghost when nothing is being dragged', async () => {

--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -180,7 +180,6 @@ describe('NodeTooltip', () => {
   afterEach(() => {
     mergeOutputTooltipMessage(null)
     cleanup()
-    vi.useRealTimers()
   })
 
   it('shows input slot JSON tooltips without i18n placeholder errors', async () => {

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable testing-library/prefer-user-event -- fireEvent needed: fake timers require fireEvent for mouseEnter/mouseLeave */
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import type * as RekaUi from 'reka-ui'
 
@@ -234,10 +234,6 @@ function renderJobAssetsList({
 
   return { ...result, user }
 }
-
-afterEach(() => {
-  vi.useRealTimers()
-})
 
 describe('JobAssetsList', () => {
   it('renders grouped headers alongside job rows', () => {

--- a/src/components/ui/search-input/AsyncSearchInput.test.ts
+++ b/src/components/ui/search-input/AsyncSearchInput.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
@@ -47,10 +47,6 @@ function renderSearch(
 describe('AsyncSearchInput', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('Input binding', () => {

--- a/src/components/ui/search-input/SearchInput.test.ts
+++ b/src/components/ui/search-input/SearchInput.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -32,10 +32,6 @@ const i18n = createI18n({
 describe('SearchInput', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   function renderComponent(props = {}) {

--- a/src/composables/auth/turnstileScript.test.ts
+++ b/src/composables/auth/turnstileScript.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TurnstileApi } from '@/composables/auth/turnstileScript'
 
@@ -75,10 +75,6 @@ describe('loadTurnstile', () => {
       inserted.push(node as unknown as FakeScript)
       return node
     })
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('resolves immediately with the existing global and appends no script', async () => {

--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { usePanAndZoom } from '@/composables/maskeditor/usePanAndZoom'
 
@@ -118,10 +118,6 @@ describe('usePanAndZoom', () => {
     mockStore.brushVisible = true
     mockStore.displayZoomRatio = 1
     mockStore.resetZoomTrigger = 0
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('initializeCanvasPanZoom', () => {

--- a/src/composables/node/useNodeImage.test.ts
+++ b/src/composables/node/useNodeImage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import { useNodeVideo } from '@/composables/node/useNodeImage'
 import { createMockMediaNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
@@ -25,10 +25,6 @@ vi.mock('@/utils/imageUtil', () => ({
 }))
 
 describe('useNodeVideo', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   async function setup() {
     vi.clearAllMocks()
     vi.useFakeTimers()

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -243,7 +243,6 @@ describe('useJobList', () => {
     unmount?.()
     unmount = null
     api = null
-    vi.useRealTimers()
   })
 
   const initComposable = () => {

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -126,7 +126,6 @@ describe(useQueueNotificationBanners, () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers()
-    vi.useRealTimers()
     resetState()
   })
 

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -469,8 +469,6 @@ describe('useLoad3d', () => {
 
       vi.advanceTimersByTime(150)
       expect(mockLoad3d.handleResize).toHaveBeenCalledOnce()
-
-      vi.useRealTimers()
     })
 
     it('debounces rapid zoom changes into a single handleResize call', async () => {
@@ -497,8 +495,6 @@ describe('useLoad3d', () => {
 
       vi.advanceTimersByTime(150)
       expect(mockLoad3d.handleResize).toHaveBeenCalledOnce()
-
-      vi.useRealTimers()
     })
   })
 

--- a/src/composables/useReconnectingNotification.test.ts
+++ b/src/composables/useReconnectingNotification.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -60,10 +60,6 @@ describe('useReconnectingNotification', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.useFakeTimers()
     settingMocks.disableToast = false
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('does not show toast immediately on reconnecting', () => {

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
@@ -67,10 +67,6 @@ describe('useTemplateFiltering', () => {
     setActivePinia(createPinia())
     vi.stubGlobal('__DISTRIBUTION__', 'localhost')
     mockSystemStatsStore.systemStats.system.os = 'linux'
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('filters by search text, models, tags, and license with debounce handling', async () => {

--- a/src/composables/video/useTrimPlayback.test.ts
+++ b/src/composables/video/useTrimPlayback.test.ts
@@ -241,27 +241,23 @@ describe('useTrimPlayback', () => {
 
   it('releases the seek lock when no seeked event ever arrives', async () => {
     vi.useFakeTimers()
-    try {
-      const { video, playheadFrame, isPlaying, handleTimeUpdate } =
-        createPlayback()
-      video.emitSeeked = false
-      playheadFrame.value = 30
+    const { video, playheadFrame, isPlaying, handleTimeUpdate } =
+      createPlayback()
+    video.emitSeeked = false
+    playheadFrame.value = 30
 
-      isPlaying.value = true
-      await nextTick()
+    isPlaying.value = true
+    await nextTick()
 
-      video.currentTime = 4
-      handleTimeUpdate()
-      expect(playheadFrame.value).toBe(30)
+    video.currentTime = 4
+    handleTimeUpdate()
+    expect(playheadFrame.value).toBe(30)
 
-      await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(5000)
 
-      video.currentTime = 4.5
-      handleTimeUpdate()
-      expect(playheadFrame.value).toBe(45)
-    } finally {
-      vi.useRealTimers()
-    }
+    video.currentTime = 4.5
+    handleTimeUpdate()
+    expect(playheadFrame.value).toBe(45)
   })
 
   it('clamps the playhead when the trim handles move past it', async () => {

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ModelExporter } from './ModelExporter'
 
@@ -59,10 +59,6 @@ vi.mock('@comfyorg/fbx-exporter-three', () => ({
 describe('ModelExporter', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('detectFormatFromURL', () => {

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Viewport3dDeps } from '@/extensions/core/load3d/Viewport3d'
 import { Viewport3d } from '@/extensions/core/load3d/Viewport3d'
@@ -539,10 +539,6 @@ describe('Viewport3d', () => {
       })
     })
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
     it('start schedules a deferred forceRender and remove clears it before the timer fires', () => {
       ctx.viewport.start()
       ctx.forceRender.mockClear()
@@ -619,10 +615,6 @@ describe('Viewport3d', () => {
 
     beforeEach(() => {
       vi.useFakeTimers({ toFake: ['performance'] })
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     it('forceRender feeds elapsed time between frames to per-frame updates and renders the view', () => {

--- a/src/extensions/core/load3d/load3dRenderLoop.test.ts
+++ b/src/extensions/core/load3d/load3dRenderLoop.test.ts
@@ -1,14 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { startRenderLoop } from './load3dRenderLoop'
 
 describe('startRenderLoop', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('runs tick on each frame while isActive returns true', () => {

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
@@ -157,10 +157,6 @@ function setupGraphWithLink(node: PrimitiveNode, targetNode: LGraphNode) {
 }
 
 describe('PrimitiveNode', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   describe('constructor', () => {
     it('initializes with wildcard output and virtual node properties', () => {
       const node = createPrimitiveNode()

--- a/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
+++ b/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
@@ -700,8 +700,6 @@ describe('CanvasPointer Device Detection - Efficient Timestamp-Based TDD Tests',
       vi.runOnlyPendingTimers()
       expect(pointer.bufferedLinuxEvent).toBeUndefined()
       expect(pointer.linuxBufferTimeoutId).toBeUndefined()
-
-      vi.useRealTimers() // Restore for other tests
     })
 
     it('should handle negative Linux wheel values', () => {

--- a/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
@@ -64,7 +64,6 @@ describe('LGraphCanvas ghost placement auto-pan', () => {
   afterEach(() => {
     if (canvas.state.ghostNodeId != null) canvas.finalizeGhostPlacement(false)
     canvasElement.remove()
-    vi.useRealTimers()
   })
 
   it('moves the ghost node when pointer is near edge', () => {

--- a/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
@@ -47,7 +47,6 @@ describe('LGraphCanvas link drag auto-pan', () => {
 
   afterEach(() => {
     canvas.pointer.finally?.()
-    vi.useRealTimers()
   })
 
   function startLinkDrag() {

--- a/src/lib/litegraph/src/widgets/ColorWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/ColorWidget.test.ts
@@ -57,7 +57,6 @@ describe('ColorWidget', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     document
       .querySelectorAll('input[type="color"]')
       .forEach((el) => el.remove())

--- a/src/platform/assets/composables/useMediaAssetFiltering.test.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
 
 import { useMediaAssetFiltering } from '@/platform/assets/composables/useMediaAssetFiltering'
@@ -43,10 +43,6 @@ function ids(assets: AssetItem[]): string[] {
 describe('useMediaAssetFiltering', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('media-type filter', () => {

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import DesktopCloudNotificationController from './DesktopCloudNotificationController.vue'
@@ -66,10 +66,6 @@ describe('DesktopCloudNotificationController', () => {
       }
     )
     dialogService.showCloudNotification.mockResolvedValue(undefined)
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('waits for settings to load before deciding whether to show the notification', async () => {

--- a/src/platform/cloud/onboarding/composables/useVideoCarousel.test.ts
+++ b/src/platform/cloud/onboarding/composables/useVideoCarousel.test.ts
@@ -48,7 +48,6 @@ beforeEach(() => {
 
 afterEach(() => {
   scope?.stop()
-  vi.useRealTimers()
 })
 
 describe('useVideoCarousel', () => {

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
@@ -9,8 +9,6 @@ import type { RouteRecordRaw } from 'vue-router'
  * stash is the only carrier, and redemption fires from router.afterEach, an
  * auth watcher, and a delayed retry after a transient failure.
  *
- * The fake clock (installed for every test) keeps those retry timers from
- * leaking into later tests: afterEach discards them with vi.useRealTimers().
  */
 
 const mockConfirm = vi.hoisted(() => vi.fn())
@@ -145,10 +143,6 @@ describe('installDesktopLoginRedemption', () => {
       getIdToken: mockStoreGetIdToken
     })
     authStoreHolder.store = mockAuthStore
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('does nothing on navigation when no code is stashed', async () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -182,7 +182,6 @@ global.fetch = vi.fn()
 
 describe('useSubscription', () => {
   afterEach(() => {
-    vi.useRealTimers()
     scope?.stop()
     scope = undefined
     setDistribution('localhost')

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -57,7 +57,6 @@ describe('useSubscriptionCancellationWatcher', () => {
   afterEach(() => {
     activeScopes.forEach((scope) => scope.stop())
     activeScopes.length = 0
-    vi.useRealTimers()
   })
 
   it('polls with exponential backoff and fires telemetry once cancellation detected', async () => {

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -61,7 +61,6 @@ describe('TourSpotlight interactive and masked steps', () => {
     cleanup()
     clearCoachmarks()
     document.body.replaceChildren()
-    vi.useRealTimers()
   })
 
   it('keeps the blocking scrim and no hit region on a plain step', () => {

--- a/src/platform/onboarding/coachmarkRegistry.test.ts
+++ b/src/platform/onboarding/coachmarkRegistry.test.ts
@@ -69,7 +69,6 @@ describe('waitForTarget', () => {
   afterEach(() => {
     clearCoachmarks()
     document.body.replaceChildren()
-    vi.useRealTimers()
   })
 
   /** Lets the poll sample once, and the resulting promise settle. */

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -121,7 +121,6 @@ describe('onboardingTourStore', () => {
     if (appModeMock.mode) appModeMock.mode.value = 'graph'
     if (appModeMock.hasOutputs) appModeMock.hasOutputs.value = false
     telemetry.track.mockClear()
-    vi.useRealTimers()
   })
 
   /** Register one laid-out element for a coach id, so its step resolves at once. */

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue'
 import { nextTick, reactive } from 'vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
 
@@ -43,10 +43,6 @@ describe('useQueuePolling', () => {
     store.activeJobsCount = 0
     store.isLoading = false
     store.update.mockReset()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('does not call update on creation', () => {

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -56,7 +56,6 @@ describe('NightlySurveyPopover', () => {
 
   afterEach(() => {
     localStorage.clear()
-    vi.useRealTimers()
   })
 
   async function renderComponent(

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -35,35 +35,27 @@ describe('useFeatureUsageTracker', () => {
     vi.useFakeTimers()
     const firstTs = 1000000
     vi.setSystemTime(firstTs)
-    try {
-      const { usage, trackUsage } = useFeatureUsageTracker('test-feature-3')
+    const { usage, trackUsage } = useFeatureUsageTracker('test-feature-3')
 
-      trackUsage()
-      expect(usage.value?.firstUsed).toBe(firstTs)
+    trackUsage()
+    expect(usage.value?.firstUsed).toBe(firstTs)
 
-      vi.setSystemTime(firstTs + 5000)
-      trackUsage()
-      expect(usage.value?.firstUsed).toBe(firstTs)
-    } finally {
-      vi.useRealTimers()
-    }
+    vi.setSystemTime(firstTs + 5000)
+    trackUsage()
+    expect(usage.value?.firstUsed).toBe(firstTs)
   })
 
   it('updates lastUsed on each use', () => {
     vi.useFakeTimers()
-    try {
-      const { usage, trackUsage } = useFeatureUsageTracker('test-feature-4')
+    const { usage, trackUsage } = useFeatureUsageTracker('test-feature-4')
 
-      trackUsage()
-      const firstLastUsed = usage.value?.lastUsed ?? 0
+    trackUsage()
+    const firstLastUsed = usage.value?.lastUsed ?? 0
 
-      vi.advanceTimersByTime(10)
-      trackUsage()
+    vi.advanceTimersByTime(10)
+    trackUsage()
 
-      expect(usage.value?.lastUsed).toBeGreaterThan(firstLastUsed)
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(usage.value?.lastUsed).toBeGreaterThan(firstLastUsed)
   })
 
   it('reset clears feature data', () => {
@@ -92,17 +84,13 @@ describe('useFeatureUsageTracker', () => {
 
   it('persists to localStorage', async () => {
     vi.useFakeTimers()
-    try {
-      const { trackUsage } = useFeatureUsageTracker('persisted-feature')
+    const { trackUsage } = useFeatureUsageTracker('persisted-feature')
 
-      trackUsage()
-      await vi.runAllTimersAsync()
+    trackUsage()
+    await vi.runAllTimersAsync()
 
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
-      expect(stored['persisted-feature']?.useCount).toBe(1)
-    } finally {
-      vi.useRealTimers()
-    }
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+    expect(stored['persisted-feature']?.useCount).toBe(1)
   })
 
   it('loads existing data from localStorage', () => {

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -41,7 +41,6 @@ describe('useSurveyEligibility', () => {
 
   afterEach(() => {
     localStorage.clear()
-    vi.useRealTimers()
   })
 
   function setFeatureUsage(featureId: string, useCount: number) {

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hoisted = vi.hoisted(() => {
   const analytics = {
@@ -93,10 +93,6 @@ describe('CustomerIoTelemetryProvider', () => {
     hoisted.userEmail.value = null
     i18n.global.locale.value = 'en'
     window.__CONFIG__ = {} as typeof window.__CONFIG__
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('loads the client and registers the in-app plugin with the site id', async () => {

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   pendingTopupNeedsRefresh,
@@ -22,10 +22,6 @@ describe('topupTracker', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-07T12:00:00Z'))
     localStorage.clear()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('startTopupTracking', () => {

--- a/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
+++ b/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   captureCheckoutAttributionFromSearch,
@@ -17,10 +17,6 @@ describe('getCheckoutAttribution', () => {
     window.rewardful = undefined
     window.Rewardful = undefined
     window.history.pushState({}, '', '/')
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('reads GA identity and URL attribution, and prefers generated click id', async () => {

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -1,7 +1,7 @@
 import { until } from '@vueuse/core'
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useVersionCompatibilityStore } from '@/platform/updates/common/versionCompatibilityStore'
@@ -60,10 +60,6 @@ describe('useVersionCompatibilityStore', () => {
     mockUseSettingStore.mockReturnValue(mockSettingStore)
 
     store = useVersionCompatibilityStore()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('version compatibility detection', () => {

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -314,45 +314,37 @@ describe('ReleaseNotificationToast', () => {
 
   it('auto-hides after timeout', async () => {
     vi.useFakeTimers()
-    try {
-      mockReleaseStore.recentRelease = {
-        version: '1.2.3',
-        content: '# Test Release'
-      } as ReleaseNote
+    mockReleaseStore.recentRelease = {
+      version: '1.2.3',
+      content: '# Test Release'
+    } as ReleaseNote
 
-      renderComponent()
+    renderComponent()
 
-      expect(screen.getByText('New update is out!')).toBeInTheDocument()
+    expect(screen.getByText('New update is out!')).toBeInTheDocument()
 
-      vi.advanceTimersByTime(8000)
-      await nextTick()
+    vi.advanceTimersByTime(8000)
+    await nextTick()
 
-      expect(vi.getTimerCount()).toBe(0)
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('clears auto-hide timer when manually dismissed', async () => {
     vi.useFakeTimers()
-    try {
-      mockReleaseStore.recentRelease = {
-        version: '1.2.3',
-        content: '# Test Release'
-      } as ReleaseNote
+    mockReleaseStore.recentRelease = {
+      version: '1.2.3',
+      content: '# Test Release'
+    } as ReleaseNote
 
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
 
-      renderComponent()
+    renderComponent()
 
-      vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(1000)
 
-      await user.click(screen.getByRole('button', { name: /skip/i }))
+    await user.click(screen.getByRole('button', { name: /skip/i }))
 
-      expect(vi.getTimerCount()).toBe(0)
-      expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalled()
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(vi.getTimerCount()).toBe(0)
+    expect(mockReleaseStore.handleSkipRelease).toHaveBeenCalled()
   })
 })

--- a/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowAutoSave } from '@/platform/workflow/persistence/composables/useWorkflowAutoSave'
@@ -42,10 +42,6 @@ let mockActiveWorkflow: { isModified: boolean; isPersisted?: boolean } | null =
 describe('useWorkflowAutoSave', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('should auto-save workflow after delay when modified and autosave enabled', async () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -219,7 +219,6 @@ describe('useWorkflowPersistenceV2', () => {
       app.unmount()
       container.remove()
     }
-    vi.useRealTimers()
   })
 
   function mountWorkflowPersistence(): WorkflowPersistence {

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -82,33 +82,29 @@ describe('workflowDraftStoreV2', () => {
     it('keeps payload updatedAt stable when only recency is refreshed', () => {
       vi.useFakeTimers()
 
-      try {
-        const store = useWorkflowDraftStoreV2()
+      const store = useWorkflowDraftStoreV2()
 
-        vi.setSystemTime(new Date('2026-03-21T10:00:00Z'))
-        store.saveDraft('workflows/a.json', '{"id":"a"}', {
-          name: 'a',
-          isTemporary: true
-        })
-        const initialUpdatedAt = store.getDraft('workflows/a.json')!.updatedAt
+      vi.setSystemTime(new Date('2026-03-21T10:00:00Z'))
+      store.saveDraft('workflows/a.json', '{"id":"a"}', {
+        name: 'a',
+        isTemporary: true
+      })
+      const initialUpdatedAt = store.getDraft('workflows/a.json')!.updatedAt
 
-        vi.setSystemTime(new Date('2026-03-21T10:01:00Z'))
-        store.saveDraft('workflows/b.json', '{"id":"b"}', {
-          name: 'b',
-          isTemporary: true
-        })
-        expect(store.getMostRecentPath()).toBe('workflows/b.json')
+      vi.setSystemTime(new Date('2026-03-21T10:01:00Z'))
+      store.saveDraft('workflows/b.json', '{"id":"b"}', {
+        name: 'b',
+        isTemporary: true
+      })
+      expect(store.getMostRecentPath()).toBe('workflows/b.json')
 
-        vi.setSystemTime(new Date('2026-03-21T10:02:00Z'))
-        store.markDraftUsed('workflows/a.json')
+      vi.setSystemTime(new Date('2026-03-21T10:02:00Z'))
+      store.markDraftUsed('workflows/a.json')
 
-        expect(store.getDraft('workflows/a.json')!.updatedAt).toBe(
-          initialUpdatedAt
-        )
-        expect(store.getMostRecentPath()).toBe('workflows/a.json')
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(store.getDraft('workflows/a.json')!.updatedAt).toBe(
+        initialUpdatedAt
+      )
+      expect(store.getMostRecentPath()).toBe('workflows/a.json')
     })
 
     it('evicts oldest when over limit', () => {
@@ -218,26 +214,21 @@ describe('workflowDraftStoreV2', () => {
     it('preserves payload updatedAt when moving a draft', () => {
       vi.useFakeTimers()
 
-      try {
-        const store = useWorkflowDraftStoreV2()
+      const store = useWorkflowDraftStoreV2()
 
-        vi.setSystemTime(new Date('2026-05-13T00:00:00Z'))
-        store.saveDraft('workflows/old.json', '{"data":"test"}', {
-          name: 'old',
-          isTemporary: true
-        })
-        const originalUpdatedAt =
-          store.getDraft('workflows/old.json')!.updatedAt
+      vi.setSystemTime(new Date('2026-05-13T00:00:00Z'))
+      store.saveDraft('workflows/old.json', '{"data":"test"}', {
+        name: 'old',
+        isTemporary: true
+      })
+      const originalUpdatedAt = store.getDraft('workflows/old.json')!.updatedAt
 
-        vi.setSystemTime(new Date('2026-05-13T00:05:00Z'))
-        store.moveDraft('workflows/old.json', 'workflows/new.json', 'new')
+      vi.setSystemTime(new Date('2026-05-13T00:05:00Z'))
+      store.moveDraft('workflows/old.json', 'workflows/new.json', 'new')
 
-        expect(store.getDraft('workflows/new.json')!.updatedAt).toBe(
-          originalUpdatedAt
-        )
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(store.getDraft('workflows/new.json')!.updatedAt).toBe(
+        originalUpdatedAt
+      )
     })
   })
 

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -181,18 +181,14 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows the recovery panel when Firebase initialization times out', async () => {
       vi.useFakeTimers()
-      try {
-        mountComponent()
+      mountComponent()
 
-        await vi.advanceTimersByTimeAsync(16_001)
+      await vi.advanceTimersByTimeAsync(16_001)
 
-        expect(
-          screen.getByText("Couldn't load your workspace")
-        ).toBeInTheDocument()
-        expect(mockCaptureException).toHaveBeenCalledOnce()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
+      expect(mockCaptureException).toHaveBeenCalledOnce()
     })
   })
 
@@ -309,28 +305,24 @@ describe('WorkspaceAuthGate', () => {
 
     it('shows a recoverable error when remote config refresh times out', async () => {
       vi.useFakeTimers()
-      try {
-        // Never-resolving promise simulates a hanging request
-        mockRefreshRemoteConfig.mockReturnValue(new Promise(() => {}))
+      // Never-resolving promise simulates a hanging request
+      mockRefreshRemoteConfig.mockReturnValue(new Promise(() => {}))
 
-        mountComponent()
-        await vi.advanceTimersByTimeAsync(0)
+      mountComponent()
+      await vi.advanceTimersByTimeAsync(0)
 
-        // Slot not yet rendered before timeout
-        expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
-        expect(
-          screen.queryByText("Couldn't load your workspace")
-        ).not.toBeInTheDocument()
+      // Slot not yet rendered before timeout
+      expect(screen.queryByTestId('slot-content')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Couldn't load your workspace")
+      ).not.toBeInTheDocument()
 
-        // Advance past the 10 second timeout
-        await vi.advanceTimersByTimeAsync(10_001)
+      // Advance past the 10 second timeout
+      await vi.advanceTimersByTimeAsync(10_001)
 
-        expect(
-          screen.getByText("Couldn't load your workspace")
-        ).toBeInTheDocument()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(
+        screen.getByText("Couldn't load your workspace")
+      ).toBeInTheDocument()
     })
 
     it('shows a recoverable error when authenticated config is unavailable', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import type { BillingOpStatusResponse } from '@/platform/workspace/api/workspaceApi'
@@ -86,10 +86,6 @@ describe('billingOperationStore', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.useFakeTimers()
     mockActiveWorkspaceId.value = 'workspace-1'
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('startOperation', () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -299,8 +299,6 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.error).toBeInstanceOf(Error)
       // Should have been called 4 times (initial + 3 retries)
       expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(4)
-
-      vi.useRealTimers()
     })
 
     it('does not reinitialize if already initialized', async () => {
@@ -411,7 +409,6 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.initState).toBe('error')
       expect(store.activeWorkspaceId).toBeNull()
       expect(store.error).toEqual(new Error('Token exchange failed'))
-      vi.useRealTimers()
     })
   })
 

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia, storeToRefs } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   useWorkspaceAuthStore,
@@ -112,10 +112,6 @@ describe('useWorkspaceAuthStore', () => {
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
     mockEnsureSessionCookie.mockResolvedValue(undefined)
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('initial state', () => {

--- a/src/renderer/core/canvas/useAutoPan.test.ts
+++ b/src/renderer/core/canvas/useAutoPan.test.ts
@@ -101,7 +101,6 @@ describe('AutoPanController', () => {
 
   afterEach(() => {
     controller.stop()
-    vi.useRealTimers()
   })
 
   it('does not pan when pointer is in the center', () => {

--- a/src/renderer/core/layout/transform/useTransformSettling.test.ts
+++ b/src/renderer/core/layout/transform/useTransformSettling.test.ts
@@ -14,7 +14,6 @@ describe('useTransformSettling', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     document.body.removeChild(element)
   })
 

--- a/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
@@ -58,7 +58,6 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  vi.useRealTimers()
   clearCompositorLayers(cacheNode)
 })
 

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -76,7 +76,6 @@ describe('FirstRunTourNudge', () => {
 
   afterEach(() => {
     cleanup()
-    vi.useRealTimers()
   })
 
   it('shows a nudge that came due before it mounted', async () => {

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
@@ -119,7 +119,6 @@ describe('frameNode', () => {
 
   afterEach(() => {
     endRunningSteps()
-    vi.useRealTimers()
     camera.animateToBounds.mockClear()
     camera.ds.fitToBounds.mockClear()
     camera.ds.offset = [0, 0]

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -251,7 +251,6 @@ describe('useFirstRunTourController', () => {
     controllerScope = undefined
     document.body.innerHTML = ''
     setViewportWidth(1280)
-    vi.useRealTimers()
   })
 
   describe('starting', () => {

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -143,7 +143,6 @@ describe('linearOutputStore', () => {
     expect(store.inProgressItems[0].state).toBe('latent')
     expect(store.inProgressItems[0].latentPreviewUrl).toBe('blob:preview')
     expect(store.selectedId).toBe(`slot:${itemId}`)
-    vi.useRealTimers()
   })
 
   it('ignores latent preview for other jobs', () => {
@@ -318,7 +317,6 @@ describe('linearOutputStore', () => {
     expect(store.inProgressItems[0].state).toBe('latent')
     expect(store.inProgressItems[0].latentPreviewUrl).toBe('blob:next')
     expect(store.inProgressItems).toHaveLength(2)
-    vi.useRealTimers()
   })
 
   it('handles execute without prior skeleton (no latent preview)', () => {
@@ -381,7 +379,6 @@ describe('linearOutputStore', () => {
 
     expect(store.inProgressItems[0].state).toBe('latent')
     expect(store.inProgressItems[0].latentPreviewUrl).toBe('blob:preview-1')
-    vi.useRealTimers()
   })
 
   it('completes previous job on direct job transition', async () => {
@@ -543,7 +540,6 @@ describe('linearOutputStore', () => {
     expect(
       store.inProgressItems.filter((i) => i.state === 'latent')
     ).toHaveLength(0)
-    vi.useRealTimers()
   })
 
   it('accepts latent previews for new nodes after prior node executed', () => {
@@ -562,7 +558,6 @@ describe('linearOutputStore', () => {
       store.inProgressItems.filter((i) => i.state === 'latent')
     ).toHaveLength(1)
     expect(store.inProgressItems[0].latentPreviewUrl).toBe('blob:node2-latent')
-    vi.useRealTimers()
   })
 
   it('cancels pending RAF when a node executes', () => {
@@ -583,7 +578,6 @@ describe('linearOutputStore', () => {
     expect(
       store.inProgressItems.filter((i) => i.state === 'image')
     ).toHaveLength(1)
-    vi.useRealTimers()
   })
 
   it('discards latent previews arriving after job completion', () => {
@@ -603,7 +597,6 @@ describe('linearOutputStore', () => {
     expect(
       store.inProgressItems.filter((i) => i.state === 'latent')
     ).toHaveLength(0)
-    vi.useRealTimers()
   })
 
   it('discards latent previews for completed job after RAF', () => {
@@ -620,7 +613,6 @@ describe('linearOutputStore', () => {
     expect(
       store.inProgressItems.filter((i) => i.state === 'latent')
     ).toHaveLength(0)
-    vi.useRealTimers()
   })
 
   it('ignores executed events for other jobs', () => {
@@ -704,7 +696,6 @@ describe('linearOutputStore', () => {
     )
     expect(latentItems).toHaveLength(1)
     expect(latentItems[0].latentPreviewUrl).toBe('blob:preview-while-away')
-    vi.useRealTimers()
   })
 
   it('does not show in-progress items from another workflow', () => {
@@ -772,7 +763,6 @@ describe('linearOutputStore', () => {
     expect(items).toHaveLength(1)
     expect(items[0].jobId).toBe('job-2')
     expect(items[0].latentPreviewUrl).toBe('blob:landscape')
-    vi.useRealTimers()
   })
 
   it('skips output items for nodes not in selectedOutputs', () => {
@@ -852,10 +842,6 @@ describe('linearOutputStore', () => {
       const store = useLinearOutputStore()
       return { store, nextTick }
     }
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
 
     it('preserves images and latent previews across tab switch', async () => {
       const { store, nextTick } = await setup()

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -484,36 +484,32 @@ describe('ImagePreview', () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })
-      try {
-        const sameUrl = '/api/view?filename=test.png&type=output'
-        const { container } = renderImagePreview({
-          imageUrls: [sameUrl, sameUrl, sameUrl]
-        })
-        await switchToGallery(user)
+      const sameUrl = '/api/view?filename=test.png&type=output'
+      const { container } = renderImagePreview({
+        imageUrls: [sameUrl, sameUrl, sameUrl]
+      })
+      await switchToGallery(user)
 
-        // Simulate initial image load
-        await fireEvent.load(screen.getByRole('img'))
-        await nextTick()
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+      // Simulate initial image load
+      await fireEvent.load(screen.getByRole('img'))
+      await nextTick()
+      expect(
+        container.querySelector('[aria-busy="true"]')
+      ).not.toBeInTheDocument()
 
-        // Click second navigation dot to cycle
-        const dots = screen.getAllByRole('button', { name: /View image/ })
-        await user.click(dots[1])
-        await nextTick()
+      // Click second navigation dot to cycle
+      const dots = screen.getAllByRole('button', { name: /View image/ })
+      await user.click(dots[1])
+      await nextTick()
 
-        // Advance past the delayed loader timeout
-        await vi.advanceTimersByTimeAsync(300)
-        await nextTick()
+      // Advance past the delayed loader timeout
+      await vi.advanceTimersByTimeAsync(300)
+      await nextTick()
 
-        // Should NOT be in loading state since URL didn't change
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
-      } finally {
-        vi.useRealTimers()
-      }
+      // Should NOT be in loading state since URL didn't change
+      expect(
+        container.querySelector('[aria-busy="true"]')
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -523,37 +519,33 @@ describe('ImagePreview', () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })
-      try {
-        const urls = ['/api/view?filename=test.png&type=output']
-        const { container, rerender } = renderImagePreview({
-          imageUrls: urls
-        })
-        void user
+      const urls = ['/api/view?filename=test.png&type=output']
+      const { container, rerender } = renderImagePreview({
+        imageUrls: urls
+      })
+      void user
 
-        // Simulate image load completing
-        await fireEvent.load(screen.getByRole('img'))
-        await nextTick()
+      // Simulate image load completing
+      await fireEvent.load(screen.getByRole('img'))
+      await nextTick()
 
-        // Verify loader is hidden after load
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+      // Verify loader is hidden after load
+      expect(
+        container.querySelector('[aria-busy="true"]')
+      ).not.toBeInTheDocument()
 
-        // Reassign with new array reference but same content
-        await rerender({ imageUrls: [...urls] })
-        await nextTick()
+      // Reassign with new array reference but same content
+      await rerender({ imageUrls: [...urls] })
+      await nextTick()
 
-        // Advance past the 250ms delayed loader timeout
-        await vi.advanceTimersByTimeAsync(300)
-        await nextTick()
+      // Advance past the 250ms delayed loader timeout
+      await vi.advanceTimersByTimeAsync(300)
+      await nextTick()
 
-        // Loading state should NOT have been reset
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
-      } finally {
-        vi.useRealTimers()
-      }
+      // Loading state should NOT have been reset
+      expect(
+        container.querySelector('[aria-busy="true"]')
+      ).not.toBeInTheDocument()
     })
 
     it('should reset loading state when imageUrls prop changes to different URLs', async () => {
@@ -561,38 +553,32 @@ describe('ImagePreview', () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })
-      try {
-        const urls = ['/api/view?filename=test.png&type=output']
-        const { container, rerender } = renderImagePreview({
-          imageUrls: urls
-        })
+      const urls = ['/api/view?filename=test.png&type=output']
+      const { container, rerender } = renderImagePreview({
+        imageUrls: urls
+      })
 
-        // Simulate image load completing
-        await fireEvent.load(screen.getByRole('img'))
-        await nextTick()
+      // Simulate image load completing
+      await fireEvent.load(screen.getByRole('img'))
+      await nextTick()
 
-        // Verify loader is hidden
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+      // Verify loader is hidden
+      expect(
+        container.querySelector('[aria-busy="true"]')
+      ).not.toBeInTheDocument()
 
-        void user
-        // Change to different URL
-        await rerender({
-          imageUrls: ['/api/view?filename=different.png&type=output']
-        })
-        await nextTick()
+      void user
+      // Change to different URL
+      await rerender({
+        imageUrls: ['/api/view?filename=different.png&type=output']
+      })
+      await nextTick()
 
-        // Advance past the 250ms delayed loader timeout
-        await vi.advanceTimersByTimeAsync(300)
-        await nextTick()
+      // Advance past the 250ms delayed loader timeout
+      await vi.advanceTimersByTimeAsync(300)
+      await nextTick()
 
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).toBeInTheDocument()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument()
     })
 
     it('should handle empty to non-empty URL transitions correctly', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -1,5 +1,5 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { CanvasPointer, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -137,13 +137,6 @@ describe('useImagePreviewWidget', () => {
     mockCanvas.graph_mouse = [0, 0]
     mockCanvas.pointer_is_down = false
     mockCanvas.canvas.style.cursor = ''
-  })
-
-  // Restore real timers unconditionally so a thrown assertion in any
-  // useFakeTimers() test does not leak fake timers into later tests.
-  // Idempotent when timers are already real.
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('widget construction', () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
@@ -211,10 +211,6 @@ describe('useRemoteWidget', () => {
       vi.useFakeTimers()
     })
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
     describe('permanent widgets (no refresh)', () => {
       it('permanent widgets should not attempt fetch after initialization', async () => {
         const mockData = ['data that is permanent after initialization']
@@ -331,10 +327,6 @@ describe('useRemoteWidget', () => {
   describe('error handling and backoff', () => {
     beforeEach(() => {
       vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     it('should implement exponential backoff on errors', async () => {

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -1,6 +1,6 @@
 import { fromAny } from '@total-typescript/shoehorn'
 import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, shallowRef } from 'vue'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -104,10 +104,6 @@ describe('GLSL live preview reads the shader written by the customtext widget', 
     setActivePinia(createPinia())
     for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('compiles the shader value written through the widget store path', async () => {

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,6 +1,6 @@
 import { fromAny } from '@total-typescript/shoehorn'
 import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, ref, shallowRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
@@ -181,10 +181,6 @@ describe('useGLSLPreview', () => {
       vi.useFakeTimers()
     })
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
     async function triggerRender(node: LGraphNode) {
       mockNodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
@@ -246,10 +242,6 @@ describe('useGLSLPreview', () => {
   describe('render pipeline', () => {
     beforeEach(() => {
       vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     async function setupAndRender(node: LGraphNode) {

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -49,10 +49,6 @@ describe('API Feature Flags', () => {
     })
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   describe('Feature flags negotiation', () => {
     it('should send client feature flags as first message on connection', async () => {
       // Initialize API connection

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -237,7 +237,6 @@ describe('ChangeTracker', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.clearAllTimers()
-    vi.useRealTimers()
   })
 
   describe('captureCanvasState', () => {

--- a/src/stores/assetDownloadStore.test.ts
+++ b/src/stores/assetDownloadStore.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TaskResponse } from '@/platform/tasks/services/taskService'
 import { taskService } from '@/platform/tasks/services/taskService'
@@ -58,10 +58,6 @@ describe('useAssetDownloadStore', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.useFakeTimers({ shouldAdvanceTime: false })
     eventHandler.current = null
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   describe('handleAssetDownload', () => {

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1,5 +1,5 @@
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { app } from '@/scripts/app'
@@ -469,10 +469,6 @@ describe('useExecutionStore - nodeProgressStatesByJob eviction', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
     store.bindExecutionEvents()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('should retain entries below the limit', () => {
@@ -1493,10 +1489,6 @@ describe('useExecutionStore - RAF batching', () => {
     store.bindExecutionEvents()
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   describe('handleProgress', () => {
     function makeProgressEvent(value: number, max: number): CustomEvent {
       return new CustomEvent('progress', {
@@ -2156,35 +2148,27 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
     it('discards a progress update still queued when the next node starts', () => {
       vi.useFakeTimers()
-      try {
-        fire('progress', { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' })
+      fire('progress', { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' })
 
-        fire('executing', 'n2')
-        vi.advanceTimersToNextFrame()
+      fire('executing', 'n2')
+      vi.advanceTimersToNextFrame()
 
-        expect(store._executingNodeProgress).toBeNull()
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(store._executingNodeProgress).toBeNull()
     })
   })
 
   describe('progress', () => {
     it('sets _executingNodeProgress from the event payload (RAF-batched)', () => {
       vi.useFakeTimers()
-      try {
-        const payload = { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' }
+      const payload = { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' }
 
-        fire('progress', payload)
-        // RAF-batched: not applied synchronously
-        expect(store._executingNodeProgress).toBeNull()
+      fire('progress', payload)
+      // RAF-batched: not applied synchronously
+      expect(store._executingNodeProgress).toBeNull()
 
-        vi.advanceTimersToNextFrame()
+      vi.advanceTimersToNextFrame()
 
-        expect(store._executingNodeProgress).toEqual(payload)
-      } finally {
-        vi.useRealTimers()
-      }
+      expect(store._executingNodeProgress).toEqual(payload)
     })
   })
 

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { assetService } from '@/platform/assets/services/assetService'
@@ -492,10 +492,6 @@ describe('useModelStore', () => {
   describe('scan fast-phase completion', () => {
     beforeEach(() => {
       vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
     })
 
     function getScanCallback() {

--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   dateKey,
@@ -155,10 +155,6 @@ describe('isToday', () => {
     vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   it('returns true for a timestamp on the same day', () => {
     const ts = new Date(2024, 5, 15, 8, 0, 0).getTime()
     expect(isToday(ts)).toBe(true)
@@ -179,10 +175,6 @@ describe('isYesterday', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('returns true for a timestamp yesterday', () => {

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -1,14 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createRafCoalescer } from '@/utils/rafBatch'
 
 describe('createRafCoalescer', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('applies the latest pushed value on the next frame', () => {

--- a/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
@@ -137,20 +137,16 @@ describe('ManagerSurveyDialog', () => {
 
   it('removes the iframe and shows the error state when loading times out', async () => {
     vi.useFakeTimers()
-    try {
-      mocks.remoteConfig.value = { manager_survey_url: SURVEY_URL }
+    mocks.remoteConfig.value = { manager_survey_url: SURVEY_URL }
 
-      renderDialog()
-      expect(screen.getByTestId('manager-survey-iframe')).toBeTruthy()
+    renderDialog()
+    expect(screen.getByTestId('manager-survey-iframe')).toBeTruthy()
 
-      await vi.advanceTimersByTimeAsync(8000)
-      await nextTick()
+    await vi.advanceTimersByTimeAsync(8000)
+    await nextTick()
 
-      expect(screen.queryByTestId('manager-survey-iframe')).toBeNull()
-      expect(screen.getByTestId('manager-survey-error')).toBeTruthy()
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(screen.queryByTestId('manager-survey-iframe')).toBeNull()
+    expect(screen.getByTestId('manager-survey-error')).toBeTruthy()
   })
 
   it('closes the dialog when the close button is clicked', async () => {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -750,7 +750,7 @@ export default defineConfig({
     // Pin the timezone so date-formatting assertions are deterministic
     // regardless of the contributor's local timezone (CI runs in UTC).
     env: { TZ: 'UTC' },
-    setupFiles: ['./vitest.setup.ts'],
+    setupFiles: ['./vitest.timer.setup.ts', './vitest.setup.ts'],
     retry: process.env.CI ? 2 : 0,
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -1,0 +1,5 @@
+import { afterEach, vi } from 'vitest'
+
+afterEach(() => {
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary

Centralize Vitest fake-timer restoration so individual test files no longer need lifecycle cleanup calls.

## Changes

- **What**: Adds one shared `afterEach(() => vi.useRealTimers())` setup hook to all four Vitest projects and removes 101 per-file restoration calls across 73 test files.

## Review Focus

The shared setup restores timer mode after file-local teardown under Vitest's default stacked hook ordering. The seven suites that produced 36 failures without restoration now pass 264/264, and the complete affected root set passes 1,745/1,745. Desktop UI, Website, and Object Info Parser configurations also load the shared setup successfully.

Follows #15035, which has merged.