### PR TITLE
test: run each test with fake timers

### DIFF
--- a/apps/desktop-ui/src/utils/refUtil.test.ts
+++ b/apps/desktop-ui/src/utils/refUtil.test.ts
@@ -1,14 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, ref } from 'vue'
 
 import { withSetup } from '@/test/withSetup'
 import { useMinLoadingDurationRef } from '@/utils/refUtil'
 
 describe('useMinLoadingDurationRef', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   it('reflects false when source is initially false', () => {
     const source = ref(false)
     const result = withSetup(() => useMinLoadingDurationRef(source))

--- a/apps/desktop-ui/src/utils/refUtil.test.ts
+++ b/apps/desktop-ui/src/utils/refUtil.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, ref } from 'vue'
 
 import { withSetup } from '@/test/withSetup'
 import { useMinLoadingDurationRef } from '@/utils/refUtil'
 
 describe('useMinLoadingDurationRef', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+  })
+
   it('reflects false when source is initially false', () => {
     const source = ref(false)
     const result = withSetup(() => useMinLoadingDurationRef(source))

--- a/apps/desktop-ui/vitest.config.mts
+++ b/apps/desktop-ui/vitest.config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    fakeTimers: { shouldAdvanceTime: true },
     globals: true,
     environment: 'happy-dom',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],

--- a/apps/website/src/composables/useCarouselAutoplay.test.ts
+++ b/apps/website/src/composables/useCarouselAutoplay.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 
 import { useCarouselAutoplay } from './useCarouselAutoplay'
@@ -10,10 +10,6 @@ function runInScope(fn: () => void): () => void {
 }
 
 describe('useCarouselAutoplay', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   it('advances after the active slide delay elapses', () => {
     const index = ref(0)
     const advance = vi.fn(() => {

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    fakeTimers: { shouldAdvanceTime: true },
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
     globals: false,

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -103,7 +103,8 @@ export default defineConfig([
           allowDefaultProject: [
             'packages/object-info-parser/vitest.config.ts',
             'vite.electron.config.mts',
-            'vite.types.config.mts'
+            'vite.types.config.mts',
+            'vitest.timer.setup.ts'
           ]
         }
       }

--- a/packages/object-info-parser/vitest.config.ts
+++ b/packages/object-info-parser/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    fakeTimers: { shouldAdvanceTime: true },
     environment: 'node',
     include: ['src/__tests__/**/*.test.ts'],
     globals: false,

--- a/src/base/common/downloadUtil.test.ts
+++ b/src/base/common/downloadUtil.test.ts
@@ -318,7 +318,6 @@ describe('downloadUtil', () => {
     let windowOpenSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
-      vi.useFakeTimers()
       windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     })
 

--- a/src/components/common/TextTicker.test.ts
+++ b/src/components/common/TextTicker.test.ts
@@ -18,7 +18,6 @@ describe(TextTicker, () => {
   let cleanup: (() => void) | undefined
 
   beforeEach(() => {
-    vi.useFakeTimers()
     rafCallbacks = []
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       rafCallbacks.push(cb)

--- a/src/components/common/TreeExplorerTreeNode.test.ts
+++ b/src/components/common/TreeExplorerTreeNode.test.ts
@@ -34,7 +34,6 @@ describe('TreeExplorerTreeNode', () => {
   beforeAll(() => {
     const app = createApp({})
     app.use(PrimeVue)
-    vi.useFakeTimers()
   })
 
   it('renders correctly', () => {

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -306,7 +306,6 @@ describe('TurnstileWidget', () => {
     })
 
     it('falls back once the widget fails to resolve within the load timeout', async () => {
-      vi.useFakeTimers()
       const { api, options } = fakeTurnstile()
       mockLoadTurnstile.mockResolvedValue(api)
 
@@ -323,7 +322,6 @@ describe('TurnstileWidget', () => {
     })
 
     it('does not fall back once a token arrives before the load timeout', async () => {
-      vi.useFakeTimers()
       const { api, options } = fakeTurnstile()
       mockLoadTurnstile.mockResolvedValue(api)
 
@@ -352,7 +350,6 @@ describe('TurnstileWidget', () => {
     })
 
     it('falls back if a post-solve expiry is not followed by a fresh token within the load timeout', async () => {
-      vi.useFakeTimers()
       const { api, options } = fakeTurnstile()
       mockLoadTurnstile.mockResolvedValue(api)
       window.turnstile = api as unknown as NonNullable<Window['turnstile']>

--- a/src/components/graph/NodeDragPreview.test.ts
+++ b/src/components/graph/NodeDragPreview.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import NodeDragPreview from '@/components/graph/NodeDragPreview.vue'
@@ -26,10 +26,6 @@ function ghostElement() {
 }
 
 describe('NodeDragPreview', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   afterEach(() => {
     useNodeDragToCanvas().cancelDrag()
   })

--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -151,7 +151,6 @@ async function renderAndHoverCanvas() {
 
 describe('NodeTooltip', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     setActivePinia(createTestingPinia({ stubActions: false }))
 
     vi.spyOn(useSettingStore(), 'get').mockImplementation(

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -444,7 +444,6 @@ describe('JobAssetsList', () => {
   })
 
   it('anchors the popover to the active row through Reka', async () => {
-    vi.useFakeTimers()
     const job = buildJob()
     const { container } = renderJobAssetsList({ jobs: [job] })
 
@@ -464,7 +463,6 @@ describe('JobAssetsList', () => {
   })
 
   it('clears the previous popover when hovering a new row briefly and leaving the list', async () => {
-    vi.useFakeTimers()
     const firstJob = buildJob({ id: 'job-1' })
     const secondJob = buildJob({ id: 'job-2', title: 'Job 2' })
     const { container } = renderJobAssetsList({
@@ -494,7 +492,6 @@ describe('JobAssetsList', () => {
   })
 
   it('updates the visible popover without closing when hovering another row', async () => {
-    vi.useFakeTimers()
     const firstJob = buildJob({ id: 'job-1' })
     const secondJob = buildJob({ id: 'job-2', title: 'Job 2' })
     const { container } = renderJobAssetsList({
@@ -532,7 +529,6 @@ describe('JobAssetsList', () => {
   })
 
   it('does not show details if the hovered row disappears before the show delay ends', async () => {
-    vi.useFakeTimers()
     const job = buildJob()
     const { container, rerender } = renderJobAssetsList({ jobs: [job] })
 

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -381,7 +381,7 @@ describe('JobAssetsList', () => {
   })
 
   it('shows and hides the job details popover with hover delays', async () => {
-    vi.useFakeTimers()
+    vi.useFakeTimers({ shouldAdvanceTime: false })
     const job = buildJob()
     const { container } = renderJobAssetsList({ jobs: [job] })
 
@@ -411,7 +411,7 @@ describe('JobAssetsList', () => {
   })
 
   it('keeps the job details popover open while hovering the popover', async () => {
-    vi.useFakeTimers()
+    vi.useFakeTimers({ shouldAdvanceTime: false })
     const job = buildJob()
     const { container } = renderJobAssetsList({ jobs: [job] })
 

--- a/src/components/ui/search-input/AsyncSearchInput.test.ts
+++ b/src/components/ui/search-input/AsyncSearchInput.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
@@ -45,10 +45,6 @@ function renderSearch(
 }
 
 describe('AsyncSearchInput', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   describe('Input binding', () => {
     it('renders the initial query', () => {
       renderSearch('hello')

--- a/src/components/ui/search-input/SearchInput.test.ts
+++ b/src/components/ui/search-input/SearchInput.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -30,10 +30,6 @@ const i18n = createI18n({
 })
 
 describe('SearchInput', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   function renderComponent(props = {}) {
     const result = render(SearchInput, {
       global: {

--- a/src/composables/auth/turnstileScript.test.ts
+++ b/src/composables/auth/turnstileScript.test.ts
@@ -113,7 +113,6 @@ describe('loadTurnstile', () => {
   })
 
   it('polls for the global when it is published asynchronously after the load event', async () => {
-    vi.useFakeTimers()
     const loadTurnstile = await freshLoadTurnstile()
 
     const promise = loadTurnstile()
@@ -129,7 +128,6 @@ describe('loadTurnstile', () => {
   })
 
   it('rejects and clears the cache when the global never appears after load (poll timeout)', async () => {
-    vi.useFakeTimers()
     const loadTurnstile = await freshLoadTurnstile()
 
     const promise = loadTurnstile()
@@ -168,7 +166,6 @@ describe('loadTurnstile', () => {
   })
 
   it('rejects, removes the script, and clears the cache on timeout', async () => {
-    vi.useFakeTimers()
     const loadTurnstile = await freshLoadTurnstile()
 
     const promise = loadTurnstile()
@@ -179,7 +176,6 @@ describe('loadTurnstile', () => {
   })
 
   it('reuses a pre-existing script tag and resolves promptly once the global appears (no duplicate, tag left in place)', async () => {
-    vi.useFakeTimers()
     const existing = new FakeScript()
     existing.src = TURNSTILE_SRC
     inserted.push(existing)
@@ -203,7 +199,6 @@ describe('loadTurnstile', () => {
   })
 
   it('reuses a pre-existing script tag and times out (clearing the cache) if the global never appears, leaving the tag in place', async () => {
-    vi.useFakeTimers()
     const existing = new FakeScript()
     existing.src = TURNSTILE_SRC
     inserted.push(existing)

--- a/src/composables/maskeditor/usePanAndZoom.test.ts
+++ b/src/composables/maskeditor/usePanAndZoom.test.ts
@@ -348,8 +348,6 @@ describe('usePanAndZoom', () => {
     })
 
     it('triggers undo on two-finger double-tap', () => {
-      vi.useFakeTimers()
-
       const pz = usePanAndZoom()
       const touches = createTouchList({ x: 100, y: 200 }, { x: 300, y: 200 })
 

--- a/src/composables/node/useNodeImage.test.ts
+++ b/src/composables/node/useNodeImage.test.ts
@@ -27,7 +27,6 @@ vi.mock('@/utils/imageUtil', () => ({
 describe('useNodeVideo', () => {
   async function setup() {
     vi.clearAllMocks()
-    vi.useFakeTimers()
 
     nodeOutputStoreMock.getNodeImageUrls.mockReturnValue(['http://video/1.mp4'])
     const node = createMockMediaNode({

--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -253,7 +253,6 @@ describe('useJobList', () => {
   }
 
   it('tracks recently added pending jobs and clears the hint after expiry', async () => {
-    vi.useFakeTimers()
     queueStoreMock.pendingTasks = [
       createTask({ jobId: '1', job: { priority: 1 }, mockState: 'pending' })
     ]
@@ -281,7 +280,6 @@ describe('useJobList', () => {
   })
 
   it('removes pending hint immediately when the task leaves the queue', async () => {
-    vi.useFakeTimers()
     const taskId = '2'
     queueStoreMock.pendingTasks = [
       createTask({ jobId: taskId, job: { priority: 1 }, mockState: 'pending' })
@@ -309,7 +307,6 @@ describe('useJobList', () => {
   })
 
   it('cleans up timeouts on unmount', async () => {
-    vi.useFakeTimers()
     queueStoreMock.pendingTasks = [
       createTask({ jobId: '3', job: { priority: 1 }, mockState: 'pending' })
     ]
@@ -419,7 +416,6 @@ describe('useJobList', () => {
   })
 
   it('filters jobs by search query', async () => {
-    vi.useFakeTimers()
     queueStoreMock.historyTasks = [
       createTask({
         jobId: 'alpha',
@@ -559,7 +555,6 @@ describe('useJobList', () => {
   })
 
   it('groups terminal jobs without an execution end timestamp by create time', async () => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-01-10T12:00:00Z'))
     queueStoreMock.historyTasks = [
       createTask({
@@ -588,7 +583,6 @@ describe('useJobList', () => {
   })
 
   it('groups job items by date label and sorts by total generation time when requested', async () => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-01-10T12:00:00Z'))
     queueStoreMock.historyTasks = [
       createTask({

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -119,7 +119,6 @@ describe(useQueueNotificationBanners, () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.setSystemTime(0)
     resetState()
   })

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -449,8 +449,6 @@ describe('useLoad3d', () => {
 
   describe('zoom watcher', () => {
     it('calls load3d.handleResize after debounce when canvas appScalePercentage changes', async () => {
-      vi.useFakeTimers()
-
       const canvasStore = reactive({ appScalePercentage: 100 })
       vi.mocked(getActivePinia).mockReturnValue({} as unknown as Pinia)
       vi.mocked(useCanvasStore).mockReturnValue(
@@ -472,8 +470,6 @@ describe('useLoad3d', () => {
     })
 
     it('debounces rapid zoom changes into a single handleResize call', async () => {
-      vi.useFakeTimers()
-
       const canvasStore = reactive({ appScalePercentage: 100 })
       vi.mocked(getActivePinia).mockReturnValue({} as unknown as Pinia)
       vi.mocked(useCanvasStore).mockReturnValue(

--- a/src/composables/useReconnectingNotification.test.ts
+++ b/src/composables/useReconnectingNotification.test.ts
@@ -58,7 +58,6 @@ vi.mock('@/platform/settings/settingStore', () => ({
 describe('useReconnectingNotification', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
     settingMocks.disableToast = false
   })
 

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -70,8 +70,6 @@ describe('useTemplateFiltering', () => {
   })
 
   it('filters by search text, models, tags, and license with debounce handling', async () => {
-    vi.useFakeTimers()
-
     const templates = ref<TemplateInfo[]>([
       {
         name: 'api-template',
@@ -614,7 +612,6 @@ describe('useTemplateFiltering', () => {
     })
 
     it('reports the visible sort to telemetry, not the persisted browse sort', async () => {
-      vi.useFakeTimers()
       const composable = useTemplateFiltering(
         ref([buildTemplate({ name: 'only', title: 'Only' })])
       )
@@ -967,7 +964,6 @@ describe('useTemplateFiltering', () => {
     })
 
     it('distribution filter composes with search filter', async () => {
-      vi.useFakeTimers()
       setDistribution('cloud')
 
       const searchableTemplate: TemplateInfo = {

--- a/src/composables/video/useTrimPlayback.test.ts
+++ b/src/composables/video/useTrimPlayback.test.ts
@@ -240,7 +240,6 @@ describe('useTrimPlayback', () => {
   })
 
   it('releases the seek lock when no seeked event ever arrives', async () => {
-    vi.useFakeTimers()
     const { video, playheadFrame, isPlaying, handleTimeUpdate } =
       createPlayback()
     video.emitSeeked = false

--- a/src/composables/video/useVideoFilmstrip.test.ts
+++ b/src/composables/video/useVideoFilmstrip.test.ts
@@ -311,24 +311,19 @@ describe('useVideoFilmstrip', () => {
   })
 
   it('still completes when the first-frame seek times out', async () => {
-    vi.useFakeTimers()
-    try {
-      installVideoMocks({
-        onVideoCreated: (video) => {
-          video.shouldEmitSeeked = () => false
-        }
-      })
+    installVideoMocks({
+      onVideoCreated: (video) => {
+        video.shouldEmitSeeked = () => false
+      }
+    })
 
-      const videoUrl = ref('https://example.com/video.mp4')
-      const { error, loading } = runWithScope(() => useVideoFilmstrip(videoUrl))
+    const videoUrl = ref('https://example.com/video.mp4')
+    const { error, loading } = runWithScope(() => useVideoFilmstrip(videoUrl))
 
-      await vi.advanceTimersByTimeAsync(6000)
-      await vi.waitFor(() => expect(loading.value).toBe(false))
+    await vi.advanceTimersByTimeAsync(6000)
+    await vi.waitFor(() => expect(loading.value).toBe(false))
 
-      expect(error.value).toBeNull()
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(error.value).toBeNull()
   })
 
   it('captures the thumbnail via createImageBitmap when available', async () => {

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { ModelExporter } from './ModelExporter'
 
@@ -57,10 +57,6 @@ vi.mock('@comfyorg/fbx-exporter-three', () => ({
 }))
 
 describe('ModelExporter', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   describe('detectFormatFromURL', () => {
     it('extracts the lowercase extension from the filename query parameter', () => {
       expect(

--- a/src/extensions/core/load3d/Viewport3d.test.ts
+++ b/src/extensions/core/load3d/Viewport3d.test.ts
@@ -524,7 +524,6 @@ describe('Viewport3d', () => {
 
   describe('start / remove lifecycle', () => {
     beforeEach(() => {
-      vi.useFakeTimers()
       Object.assign(ctx.viewport, {
         hasStarted: false,
         initialRenderTimer: null,

--- a/src/extensions/core/load3d/load3dRenderLoop.test.ts
+++ b/src/extensions/core/load3d/load3dRenderLoop.test.ts
@@ -1,12 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { startRenderLoop } from './load3dRenderLoop'
 
 describe('startRenderLoop', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   it('runs tick on each frame while isActive returns true', () => {
     const tick = vi.fn()
     const handle = startRenderLoop({ tick, isActive: () => true })

--- a/src/extensions/core/widgetInputs.test.ts
+++ b/src/extensions/core/widgetInputs.test.ts
@@ -450,8 +450,6 @@ describe('PrimitiveNode', () => {
     })
 
     it('temporarily stores controlValues and lastType for recreation', () => {
-      vi.useFakeTimers()
-
       const node = createPrimitiveNode()
       node.widgets = [
         makeWidget({ value: 42 }),

--- a/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
+++ b/src/lib/litegraph/src/CanvasPointer.deviceDetection.test.ts
@@ -687,7 +687,6 @@ describe('CanvasPointer Device Detection - Efficient Timestamp-Based TDD Tests',
 
     it('should call clearLinuxBuffer method after 10ms timeout', () => {
       vi.spyOn(performance, 'now').mockReturnValue(500)
-      vi.useFakeTimers() // Use fake timers just for this test
 
       const event = new WheelEvent('wheel', {
         deltaY: 10,

--- a/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
@@ -54,7 +54,6 @@ describe('LGraphCanvas ghost placement auto-pan', () => {
   let node: LGraphNode
 
   beforeEach(() => {
-    vi.useFakeTimers()
     ;({ canvas, canvasElement, node } = createGhostTestHarness())
     // Near left edge so autopan fires by default
     canvas.mouse[0] = 5

--- a/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.linkDragAutoPan.test.ts
@@ -17,8 +17,6 @@ describe('LGraphCanvas link drag auto-pan', () => {
   let canvasElement: HTMLCanvasElement
 
   beforeEach(() => {
-    vi.useFakeTimers()
-
     canvasElement = document.createElement('canvas')
     canvasElement.width = 800
     canvasElement.height = 600

--- a/src/lib/litegraph/src/widgets/ColorWidget.test.ts
+++ b/src/lib/litegraph/src/widgets/ColorWidget.test.ts
@@ -40,7 +40,6 @@ describe('ColorWidget', () => {
   let LGraphNode: typeof LGraphNodeType
 
   beforeEach(async () => {
-    vi.useFakeTimers()
     // Reset modules to get fresh globalColorInput state
     vi.resetModules()
 

--- a/src/platform/assets/composables/useMediaAssetFiltering.test.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.test.ts
@@ -115,7 +115,6 @@ describe('useMediaAssetFiltering', () => {
     const now = new Date(2026, 6, 27, 12).getTime()
 
     beforeEach(() => {
-      vi.useFakeTimers()
       vi.setSystemTime(now)
     })
 
@@ -379,7 +378,6 @@ describe('useMediaAssetFiltering', () => {
     })
 
     it('combines media type and date before sorting', () => {
-      vi.useFakeTimers()
       const now = new Date(2026, 6, 27, 12).getTime()
       vi.setSystemTime(now)
 

--- a/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
+++ b/src/platform/cloud/notification/components/DesktopCloudNotificationController.test.ts
@@ -55,8 +55,6 @@ function createDeferred() {
 
 describe('DesktopCloudNotificationController', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
-
     settingState.shown = false
     electron.getPlatform.mockReturnValue('darwin')
     settingStore.load.mockResolvedValue(undefined)

--- a/src/platform/cloud/onboarding/composables/useVideoCarousel.test.ts
+++ b/src/platform/cloud/onboarding/composables/useVideoCarousel.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, shallowRef } from 'vue'
 import type { EffectScope } from 'vue'
 
@@ -41,10 +41,6 @@ async function mountCarousel(slideCount: number) {
   await nextTick()
   return { carousel, videos, rootEl }
 }
-
-beforeEach(() => {
-  vi.useFakeTimers()
-})
 
 afterEach(() => {
   scope?.stop()

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -128,7 +128,6 @@ async function setup(
 describe('installDesktopLoginRedemption', () => {
   beforeEach(() => {
     vi.resetModules()
-    vi.useFakeTimers()
     sessionStorage.clear()
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -921,7 +921,6 @@ describe('useSubscription', () => {
     })
 
     it('does not start cancellation watching when the billing portal does not open', async () => {
-      vi.useFakeTimers()
       mockIsLoggedIn.value = true
       mockAccessBillingPortal.mockResolvedValueOnce(false)
 
@@ -946,7 +945,6 @@ describe('useSubscription', () => {
     })
 
     it('tracks cancellation after manage subscription when status flips', async () => {
-      vi.useFakeTimers()
       mockIsLoggedIn.value = true
 
       const activeStatus = {
@@ -979,7 +977,6 @@ describe('useSubscription', () => {
     })
 
     it('handles rapid focus events during cancellation polling', async () => {
-      vi.useFakeTimers()
       mockIsLoggedIn.value = true
 
       const activeStatus = {

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -47,7 +47,6 @@ describe('useSubscriptionCancellationWatcher', () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     trackMonthlySubscriptionCancelled.mockReset()
     subscriptionStatus.value = { ...baseStatus }
     isActive.value = true

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -171,7 +171,6 @@ describe('TourSpotlight interactive and masked steps', () => {
   })
 
   it('glides to the next step’s target, then rides it', async () => {
-    vi.useFakeTimers()
     registerCoachmark(FIRST_RUN_COACH_IDS.prompt, canvasNode())
     const { rerender } = renderSpotlight({
       step: spotlightStep({ coachId: FIRST_RUN_COACH_IDS.prompt })
@@ -199,7 +198,6 @@ describe('TourSpotlight interactive and masked steps', () => {
   })
 
   it('rides a canvas target that arrives after its step opened', async () => {
-    vi.useFakeTimers()
     renderSpotlight({
       step: spotlightStep({ coachId: FIRST_RUN_COACH_IDS.prompt })
     })

--- a/src/platform/onboarding/coachmarkRegistry.test.ts
+++ b/src/platform/onboarding/coachmarkRegistry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import {
@@ -62,10 +62,6 @@ describe('targetMounted', () => {
 })
 
 describe('waitForTarget', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   afterEach(() => {
     clearCoachmarks()
     document.body.replaceChildren()

--- a/src/platform/onboarding/onboardingTourStore.test.ts
+++ b/src/platform/onboarding/onboardingTourStore.test.ts
@@ -273,7 +273,6 @@ describe('onboardingTourStore', () => {
     })
 
     it('records a tour torn down by a target that never mounted', async () => {
-      vi.useFakeTimers()
       const store = mountStore()
       store.replayTour('appMode')
       await vi.advanceTimersByTimeAsync(0)
@@ -345,7 +344,6 @@ describe('onboardingTourStore', () => {
   })
 
   it('holds the card on its step while a deferred target is awaited', async () => {
-    vi.useFakeTimers()
     const store = mountStore()
     store.replayTour('appMode')
     await vi.advanceTimersByTimeAsync(0)
@@ -362,7 +360,6 @@ describe('onboardingTourStore', () => {
   })
 
   it('skips without the seen-flag and toasts when a deferred target never appears', async () => {
-    vi.useFakeTimers()
     const store = mountStore()
     store.replayTour('appMode')
     await vi.advanceTimersByTimeAsync(0)
@@ -406,7 +403,6 @@ describe('onboardingTourStore', () => {
   })
 
   it('keeps the original deadline when advance is requested again mid-wait', async () => {
-    vi.useFakeTimers()
     const store = mountStore()
     store.replayTour('appMode')
     await vi.advanceTimersByTimeAsync(0)
@@ -421,7 +417,6 @@ describe('onboardingTourStore', () => {
   })
 
   it('does not toast or double-report when the user skips during a deferred wait', async () => {
-    vi.useFakeTimers()
     const store = mountStore()
     store.replayTour('appMode')
     await vi.advanceTimersByTimeAsync(0)
@@ -462,7 +457,6 @@ describe('onboardingTourStore', () => {
   })
 
   it('aborts a pending deferred wait without a toast when the trigger stops holding', async () => {
-    vi.useFakeTimers()
     const store = mountStore()
     enterApp('app', true)
     await vi.advanceTimersByTimeAsync(0)

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -39,7 +39,6 @@ describe('useQueuePolling', () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     store.activeJobsCount = 0
     store.isLoading = false
     store.update.mockReset()

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -46,7 +46,6 @@ describe('NightlySurveyPopover', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.resetModules()
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
 
     mockIsNightly.value = true

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -32,7 +32,6 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('sets firstUsed only on first use', () => {
-    vi.useFakeTimers()
     const firstTs = 1000000
     vi.setSystemTime(firstTs)
     const { usage, trackUsage } = useFeatureUsageTracker('test-feature-3')
@@ -46,7 +45,6 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('updates lastUsed on each use', () => {
-    vi.useFakeTimers()
     const { usage, trackUsage } = useFeatureUsageTracker('test-feature-4')
 
     trackUsage()
@@ -83,7 +81,6 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('persists to localStorage', async () => {
-    vi.useFakeTimers()
     const { trackUsage } = useFeatureUsageTracker('persisted-feature')
 
     trackUsage()

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -31,7 +31,6 @@ describe('useSurveyEligibility', () => {
 
   beforeEach(() => {
     localStorage.clear()
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
 
     mockDistribution.isNightly = true

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -679,7 +679,6 @@ describe('CustomerIoTelemetryProvider', () => {
   })
 
   it('does not stall later events when identification never settles', async () => {
-    vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     hoisted.analytics.identify.mockReturnValueOnce(new Promise(() => {}))
     const provider = createProvider()

--- a/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/DatadogRumTelemetryProvider.test.ts
@@ -152,7 +152,7 @@ describe('DatadogRumTelemetryProvider', () => {
         ...workflowExecutionIntent
       },
       duration: 20,
-      context: {
+      context: () => ({
         success: false,
         failure_reason: 'submission_rejected',
         terminal_stage: 'submission',
@@ -160,7 +160,7 @@ describe('DatadogRumTelemetryProvider', () => {
         workflow_ended_at_unix_ms: performance.timeOrigin + 62,
         submission_duration_ms: 20,
         trigger_source: 'keybinding'
-      }
+      })
     },
     {
       name: 'queue wait',
@@ -173,7 +173,7 @@ describe('DatadogRumTelemetryProvider', () => {
         ...workflowExecutionIntent
       },
       duration: 40,
-      context: {
+      context: () => ({
         success: false,
         failure_reason: 'execution_failed',
         terminal_stage: 'queue_wait',
@@ -183,7 +183,7 @@ describe('DatadogRumTelemetryProvider', () => {
         submission_duration_ms: 20,
         queue_wait_duration_ms: 20,
         trigger_source: 'keybinding'
-      }
+      })
     },
     {
       name: 'execution',
@@ -197,7 +197,7 @@ describe('DatadogRumTelemetryProvider', () => {
         ...workflowExecutionIntent
       },
       duration: 100,
-      context: {
+      context: () => ({
         success: false,
         failure_reason: 'execution_failed',
         terminal_stage: 'execution',
@@ -209,7 +209,7 @@ describe('DatadogRumTelemetryProvider', () => {
         queue_wait_duration_ms: 30,
         execution_duration_ms: 50,
         trigger_source: 'keybinding'
-      }
+      })
     }
   ] as const)(
     'records a failed workflow vital ending during $name',
@@ -221,7 +221,7 @@ describe('DatadogRumTelemetryProvider', () => {
       expect(addDurationVital).toHaveBeenCalledWith('workflow_execution', {
         startTime: performance.timeOrigin + 42,
         duration,
-        context
+        context: context()
       })
     }
   )

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -19,7 +19,6 @@ vi.mock('@/platform/telemetry', () => ({
 
 describe('topupTracker', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-07T12:00:00Z'))
     localStorage.clear()
   })

--- a/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
+++ b/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
@@ -268,7 +268,6 @@ describe('getCheckoutAttribution', () => {
   })
 
   it('continues checkout attribution when Rewardful ready never runs', async () => {
-    vi.useFakeTimers()
     window.rewardful = vi.fn() as Window['rewardful']
 
     const attributionPromise = getCheckoutAttribution()

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -275,7 +275,6 @@ describe('useVersionCompatibilityStore', () => {
   describe('dismissal persistence', () => {
     it('should save dismissal to reactive storage with expiration', async () => {
       const mockNow = 1000000
-      vi.useFakeTimers()
       vi.setSystemTime(mockNow)
 
       mockSystemStatsStore.systemStats = {
@@ -483,7 +482,6 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should include outdated packages in dismissal key', async () => {
       const mockNow = 1000000
-      vi.useFakeTimers()
       vi.setSystemTime(mockNow)
 
       mockSystemStatsStore.systemStats = {
@@ -512,7 +510,6 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should produce the same dismissal key regardless of package order', async () => {
       const mockNow = 1000000
-      vi.useFakeTimers()
       vi.setSystemTime(mockNow)
 
       const packageA = {
@@ -555,7 +552,6 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should prune expired dismissals when writing a new one', async () => {
       const mockNow = 10_000_000
-      vi.useFakeTimers()
       vi.setSystemTime(mockNow)
 
       mockDismissalStorage.value = {
@@ -580,7 +576,6 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should allow dismissal when only package warnings are present', async () => {
       const mockNow = 1000000
-      vi.useFakeTimers()
       vi.setSystemTime(mockNow)
 
       mockSystemStatsStore.systemStats = {

--- a/src/platform/updates/components/ReleaseNotificationToast.test.ts
+++ b/src/platform/updates/components/ReleaseNotificationToast.test.ts
@@ -313,7 +313,6 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('auto-hides after timeout', async () => {
-    vi.useFakeTimers()
     mockReleaseStore.recentRelease = {
       version: '1.2.3',
       content: '# Test Release'
@@ -330,7 +329,6 @@ describe('ReleaseNotificationToast', () => {
   })
 
   it('clears auto-hide timer when manually dismissed', async () => {
-    vi.useFakeTimers()
     mockReleaseStore.recentRelease = {
       version: '1.2.3',
       content: '# Test Release'

--- a/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowAutoSave.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useWorkflowAutoSave } from '@/platform/workflow/persistence/composables/useWorkflowAutoSave'
@@ -40,10 +40,6 @@ let mockActiveWorkflow: { isModified: boolean; isPersisted?: boolean } | null =
   null
 
 describe('useWorkflowAutoSave', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   it('should auto-save workflow after delay when modified and autosave enabled', async () => {
     mockAutoSaveSetting = 'after delay'
     mockAutoSaveDelay = 1000

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -186,7 +186,6 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
     setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -80,8 +80,6 @@ describe('workflowDraftStoreV2', () => {
     })
 
     it('keeps payload updatedAt stable when only recency is refreshed', () => {
-      vi.useFakeTimers()
-
       const store = useWorkflowDraftStoreV2()
 
       vi.setSystemTime(new Date('2026-03-21T10:00:00Z'))
@@ -212,8 +210,6 @@ describe('workflowDraftStoreV2', () => {
     })
 
     it('preserves payload updatedAt when moving a draft', () => {
-      vi.useFakeTimers()
-
       const store = useWorkflowDraftStoreV2()
 
       vi.setSystemTime(new Date('2026-05-13T00:00:00Z'))

--- a/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.test.ts
@@ -180,7 +180,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows the recovery panel when Firebase initialization times out', async () => {
-      vi.useFakeTimers()
       mountComponent()
 
       await vi.advanceTimersByTimeAsync(16_001)
@@ -304,7 +303,6 @@ describe('WorkspaceAuthGate', () => {
     })
 
     it('shows a recoverable error when remote config refresh times out', async () => {
-      vi.useFakeTimers()
       // Never-resolving promise simulates a hanging request
       mockRefreshRemoteConfig.mockReturnValue(new Promise(() => {}))
 

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -84,7 +84,6 @@ import { useBillingOperationStore } from './billingOperationStore'
 describe('billingOperationStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
     mockActiveWorkspaceId.value = 'workspace-1'
   })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -275,7 +275,6 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('sets error state when workspaces fetch fails after retries', async () => {
-      vi.useFakeTimers()
       mockWorkspaceApi.list.mockRejectedValue(new Error('Network error'))
 
       const store = useTeamWorkspaceStore()
@@ -393,7 +392,6 @@ describe('useTeamWorkspaceStore', () => {
     })
 
     it('does not activate a workspace when token exchange fails', async () => {
-      vi.useFakeTimers()
       mockWorkspaceAuthStore.switchWorkspace.mockRejectedValue(
         new Error('Token exchange failed')
       )

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -107,7 +107,7 @@ describe('useWorkspaceAuthStore', () => {
       origin: 'http://localhost'
     })
     setActivePinia(createPinia())
-    vi.useFakeTimers()
+    vi.useFakeTimers({ shouldAdvanceTime: false })
     sessionStorage.clear()
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }

--- a/src/renderer/core/canvas/useAutoPan.test.ts
+++ b/src/renderer/core/canvas/useAutoPan.test.ts
@@ -72,8 +72,6 @@ describe('AutoPanController', () => {
   let controller: AutoPanController
 
   beforeEach(() => {
-    vi.useFakeTimers()
-
     mockCanvas = fromPartial<HTMLCanvasElement>({
       getBoundingClientRect: () => ({
         left: 0,

--- a/src/renderer/core/layout/__tests__/TransformPane.test.ts
+++ b/src/renderer/core/layout/__tests__/TransformPane.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { computed, nextTick } from 'vue'
 
 import { useTransformState } from '@/renderer/core/layout/transform/useTransformState'
@@ -42,10 +42,6 @@ function createMockLGraphCanvas() {
 }
 
 describe('TransformPane', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   describe('component mounting', () => {
     it('should mount successfully with minimal props', () => {
       const mockCanvas = createMockLGraphCanvas()

--- a/src/renderer/core/layout/transform/useTransformSettling.test.ts
+++ b/src/renderer/core/layout/transform/useTransformSettling.test.ts
@@ -8,7 +8,6 @@ describe('useTransformSettling', () => {
   let element: HTMLDivElement
 
   beforeEach(() => {
-    vi.useFakeTimers()
     element = document.createElement('div')
     document.body.appendChild(element)
   })

--- a/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorAutoSave.test.ts
@@ -49,7 +49,6 @@ function makeNode() {
 const cacheNode = { id: toNodeId(7) } as unknown as LGraphNode
 
 beforeEach(() => {
-  vi.useFakeTimers()
   setCompositorLayers(
     cacheNode,
     [{ filename: 'a.png', subfolder: '', type: 'temp' }],

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -68,7 +68,6 @@ function nudge() {
 describe('FirstRunTourNudge', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
     mocks.nudgeArmed.value = false
     mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []

--- a/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/cameraFraming.test.ts
@@ -112,7 +112,6 @@ describe('frameNode', () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     setReducedMotion(false)
     canvasRect = new DOMRect(0, 0, VIEWPORT.width, VIEWPORT.height)
   })

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -231,7 +231,6 @@ function mountRunButton(
 describe('useFirstRunTourController', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    vi.useFakeTimers()
     mocks.canRunWorkflows = ref(true)
     mocks.workflowStatus.value = new Map()
     mocks.executionErrors.hasNodeError = false

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -131,7 +131,6 @@ describe('linearOutputStore', () => {
   })
 
   it('transitions to latent on preview', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     setJobWorkflowPath('job-1', 'workflows/test-workflow.json')
     store.onJobStart('job-1')
@@ -300,7 +299,6 @@ describe('linearOutputStore', () => {
   })
 
   it('creates skeleton on-demand when latent arrives after execute', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
@@ -359,7 +357,6 @@ describe('linearOutputStore', () => {
   })
 
   it('transitions to latent via previews watcher', async () => {
-    vi.useFakeTimers()
     const { nextTick } = await import('vue')
     const store = useLinearOutputStore()
 
@@ -523,7 +520,6 @@ describe('linearOutputStore', () => {
   })
 
   it('discards latent previews for already-executed nodes', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
 
@@ -543,7 +539,6 @@ describe('linearOutputStore', () => {
   })
 
   it('accepts latent previews for new nodes after prior node executed', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
 
@@ -561,7 +556,6 @@ describe('linearOutputStore', () => {
   })
 
   it('cancels pending RAF when a node executes', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
 
@@ -581,7 +575,6 @@ describe('linearOutputStore', () => {
   })
 
   it('discards latent previews arriving after job completion', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
@@ -600,7 +593,6 @@ describe('linearOutputStore', () => {
   })
 
   it('discards latent previews for completed job after RAF', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
     store.onJobStart('job-1')
     store.onNodeExecuted('job-1', makeExecutedDetail('job-1'))
@@ -666,7 +658,6 @@ describe('linearOutputStore', () => {
   })
 
   it('recovers latent preview when re-entering app mode', async () => {
-    vi.useFakeTimers()
     const { nextTick } = await import('vue')
     const store = useLinearOutputStore()
 
@@ -738,7 +729,6 @@ describe('linearOutputStore', () => {
   })
 
   it('scopes in-progress items per workflow with concurrent jobs', () => {
-    vi.useFakeTimers()
     const store = useLinearOutputStore()
 
     // Job-1 on workflow-a (dog)
@@ -837,7 +827,6 @@ describe('linearOutputStore', () => {
 
   describe('workflow switching during generation', () => {
     async function setup() {
-      vi.useFakeTimers()
       const { nextTick } = await import('vue')
       const store = useLinearOutputStore()
       return { store, nextTick }
@@ -1085,7 +1074,6 @@ describe('linearOutputStore', () => {
     })
 
     it('evicts prior pendingResolve entries when a new job completes', () => {
-      vi.useFakeTimers()
       const store = useLinearOutputStore()
 
       // Job 1: produce image, complete
@@ -1136,7 +1124,6 @@ describe('linearOutputStore', () => {
     })
 
     it('does not leak items across many job cycles', () => {
-      vi.useFakeTimers()
       const store = useLinearOutputStore()
 
       for (let i = 1; i <= 5; i++) {

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -480,7 +480,6 @@ describe('ImagePreview', () => {
 
   describe('batch cycling with identical URLs', () => {
     it('should not enter persistent loading state when cycling through identical images', async () => {
-      vi.useFakeTimers()
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })
@@ -515,7 +514,6 @@ describe('ImagePreview', () => {
 
   describe('URL change detection', () => {
     it('should NOT reset loading state when imageUrls prop is reassigned with identical URLs', async () => {
-      vi.useFakeTimers()
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })
@@ -549,7 +547,6 @@ describe('ImagePreview', () => {
     })
 
     it('should reset loading state when imageUrls prop changes to different URLs', async () => {
-      vi.useFakeTimers()
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime
       })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -197,7 +197,6 @@ describe('useImagePreviewWidget', () => {
 
   describe('drawWidget — upload spinner', () => {
     it('renders spinner when node.isUploading is true', () => {
-      vi.useFakeTimers()
       vi.setSystemTime(500)
 
       const constructor = useImagePreviewWidget()
@@ -218,7 +217,6 @@ describe('useImagePreviewWidget', () => {
     })
 
     it('uses LiteGraph.NODE_TEXT_COLOR for spinner stroke', () => {
-      vi.useFakeTimers()
       vi.setSystemTime(0)
 
       const constructor = useImagePreviewWidget()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -207,10 +207,6 @@ describe('useRemoteWidget', () => {
   })
 
   describe('refresh behavior', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
     describe('permanent widgets (no refresh)', () => {
       it('permanent widgets should not attempt fetch after initialization', async () => {
         const mockData = ['data that is permanent after initialization']
@@ -325,10 +321,6 @@ describe('useRemoteWidget', () => {
   })
 
   describe('error handling and backoff', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
     it('should implement exponential backoff on errors', async () => {
       mockAxiosError('Network error')
 

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -103,7 +103,6 @@ describe('GLSL live preview reads the shader written by the customtext widget', 
   beforeEach(() => {
     setActivePinia(createPinia())
     for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
-    vi.useFakeTimers()
   })
 
   it('compiles the shader value written through the widget store path', async () => {

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -177,10 +177,6 @@ describe('useGLSLPreview', () => {
   })
 
   describe('autogrow config extraction', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
     async function triggerRender(node: LGraphNode) {
       mockNodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]
@@ -240,10 +236,6 @@ describe('useGLSLPreview', () => {
   })
 
   describe('render pipeline', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
     async function setupAndRender(node: LGraphNode) {
       mockNodeOutputs[String(node.id)] = {
         images: [{ filename: 'test.png', subfolder: '', type: 'temp' }]

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -17,9 +17,6 @@ describe('API Feature Flags', () => {
   const wsEventHandlers: { [key: string]: (event: unknown) => void } = {}
 
   beforeEach(() => {
-    // Use fake timers
-    vi.useFakeTimers()
-
     // Mock WebSocket
     mockWebSocket = {
       readyState: 1, // WebSocket.OPEN

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -219,7 +219,6 @@ function omitOptionalSubgraphCollections(state: ComfyWorkflowJSON) {
 describe('ChangeTracker', () => {
   beforeEach(() => {
     vi.mocked(api.dispatchCustomEvent).mockReset()
-    vi.useFakeTimers()
     setActivePinia(createTestingPinia({ stubActions: false }))
     resetSubgraphFixtureState()
     nodeIdCounter = 0

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -464,7 +464,6 @@ describe('useExecutionStore - nodeProgressStatesByJob eviction', () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     apiEventHandlers.clear()
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
@@ -1482,7 +1481,6 @@ describe('useExecutionStore - RAF batching', () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.clearAllMocks()
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
@@ -2147,7 +2145,6 @@ describe('useExecutionStore - WebSocket event handlers', () => {
     })
 
     it('discards a progress update still queued when the next node starts', () => {
-      vi.useFakeTimers()
       fire('progress', { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' })
 
       fire('executing', 'n2')
@@ -2159,7 +2156,6 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
   describe('progress', () => {
     it('sets _executingNodeProgress from the event payload (RAF-batched)', () => {
-      vi.useFakeTimers()
       const payload = { value: 3, max: 10, prompt_id: 'job-1', node: 'n1' }
 
       fire('progress', payload)

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -490,10 +490,6 @@ describe('useModelStore', () => {
   })
 
   describe('scan fast-phase completion', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
     function getScanCallback() {
       return vi.mocked(assetService.onModelsScanned).mock.calls[0]?.[0]
     }

--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -151,7 +151,6 @@ describe('dateKey', () => {
 
 describe('isToday', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
   })
 
@@ -173,7 +172,6 @@ describe('isToday', () => {
 
 describe('isYesterday', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
   })
 

--- a/src/utils/rafBatch.test.ts
+++ b/src/utils/rafBatch.test.ts
@@ -1,12 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { createRafCoalescer } from '@/utils/rafBatch'
 
 describe('createRafCoalescer', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   it('applies the latest pushed value on the next frame', () => {
     const apply = vi.fn()
     const coalescer = createRafCoalescer<number>(apply)

--- a/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
@@ -136,7 +136,6 @@ describe('ManagerSurveyDialog', () => {
   })
 
   it('removes the iframe and shows the error state when loading times out', async () => {
-    vi.useFakeTimers()
     mocks.remoteConfig.value = { manager_survey_url: SURVEY_URL }
 
     renderDialog()

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -745,6 +745,7 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    fakeTimers: { shouldAdvanceTime: true },
     globals: true,
     environment: 'happy-dom',
     // Pin the timezone so date-formatting assertions are deterministic

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -1,4 +1,8 @@
-import { afterEach, vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
 
 afterEach(() => {
   vi.useRealTimers()


### PR DESCRIPTION
## Summary

Alternative to #15048: make fake timers the default for every test while retaining real-timer restoration after every test.

- installs fake timers in the global `beforeEach`
- restores real timers in the global `afterEach` so pending timers and `vi.setSystemTime()` state cannot leak
- enables auto-advancing fake time in all four Vitest projects so Testing Library and `userEvent` remain usable without per-test clock advancement
- keeps exact timer-boundary suites deterministic with `shouldAdvanceTime: false`
- evaluates `performance.timeOrigin` expectations after the per-test fake clock is installed
- adds the root timer setup to ESLint's TypeScript project-service allowlist

## Why both hooks

A before-only implementation was not sufficient. Reinstalling fake timers on an already-faked clock did not reset prior `vi.setSystemTime()` state, and pending auto-advancing timers from the last test in a file could execute after Happy DOM destroyed `document`. The symmetric lifecycle gives each test fake timers by default and guarantees teardown afterward.

Plain global fake timers without auto-advance also broke Testing Library/user-event behavior: 21 of 32 representative root tests failed or timed out, including all 5 search-query tracking tests. With auto-advance enabled, the full matrix passes. Two hover-delay tests and the workspace-auth suite explicitly disable auto-advance because they assert exact clock boundaries or manually drive exponential-backoff time.

## Validation

| Project | Test files | Passed | Skipped | Failed |
|---|---:|---:|---:|---:|
| Root | 1,159 | 15,892 | 8 | 0 |
| Desktop UI | 16 | 125 | 0 | 0 |
| Website | 38 | 377 | 0 | 0 |
| Object info parser | 4 | 33 | 0 | 0 |
| **Total** | **1,217** | **16,427** | **8** | **0** |

Also passed:

- `pnpm typecheck`
- `pnpm typecheck:website`
- staged ESLint, Oxlint, and oxfmt checks
- pre-push `pnpm knip --cache`