### PR TITLE
feat(workspace): expose workspace switcher on desktop/local for credit selection

### DIFF
--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -101,7 +101,7 @@ const showWorkspaceSkeleton = computed(
   () => isCloud && initState.value === 'loading'
 )
 const showWorkspaceIcon = computed(
-  () => isCloud && initState.value === 'ready' && !isInPersonalWorkspace.value
+  () => initState.value === 'ready' && !isInPersonalWorkspace.value
 )
 
 const workspaceName = computed(() => {

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -80,6 +80,7 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     subscription: mockSubscription,
     balance: mockBalance,
     isLoading: mockIsLoading,
+    isTeamPlan: ref(false),
     fetchStatus: mockFetchStatus,
     fetchBalance: mockFetchBalance
   }))
@@ -165,7 +166,7 @@ describe('CurrentUserPopoverLegacy', () => {
     mockIsLoading.value = false
   })
 
-  function renderComponent() {
+  function renderComponent(teamWorkspaceState?: Record<string, unknown>) {
     const i18n = createI18n({
       legacy: false,
       locale: 'en',
@@ -176,7 +177,15 @@ describe('CurrentUserPopoverLegacy', () => {
 
     render(CurrentUserPopoverLegacy, {
       global: {
-        plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
+        plugins: [
+          i18n,
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: teamWorkspaceState
+              ? { teamWorkspace: teamWorkspaceState }
+              : {}
+          })
+        ],
         stubs: {
           Divider: true
         }
@@ -530,6 +539,60 @@ describe('CurrentUserPopoverLegacy', () => {
     it('still shows logout menu item', () => {
       renderComponent()
       expect(screen.getByTestId('logout-menu-item')).toBeInTheDocument()
+    })
+  })
+
+  describe('workspace selector (non-cloud)', () => {
+    const workspace = (overrides: Record<string, unknown>) => ({
+      isSubscribed: false,
+      subscriptionPlan: null,
+      subscriptionTier: null,
+      members: [],
+      pendingInvites: [],
+      ...overrides
+    })
+
+    const readyWorkspaceState = {
+      initState: 'ready',
+      activeWorkspaceId: 'ws-personal',
+      isFetchingWorkspaces: false,
+      workspaces: [
+        workspace({
+          id: 'ws-personal',
+          name: 'Personal Workspace',
+          type: 'personal',
+          role: 'owner'
+        }),
+        workspace({
+          id: 'ws-team',
+          name: 'Team Comfy',
+          type: 'team',
+          role: 'member'
+        })
+      ]
+    }
+
+    beforeEach(() => {
+      mockIsCloud.value = false
+    })
+
+    it('stays hidden while the workspace store is not hydrated', () => {
+      renderComponent()
+
+      expect(screen.queryByTestId('workspace-switcher-trigger')).toBeNull()
+    })
+
+    it('shows the trigger and opens the switcher once the store is ready', async () => {
+      const { user } = renderComponent(readyWorkspaceState)
+
+      const trigger = screen.getByTestId('workspace-switcher-trigger')
+      expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByTestId('workspace-switcher-panel')).toBeNull()
+
+      await user.click(trigger)
+
+      expect(screen.getByTestId('workspace-switcher-panel')).toBeInTheDocument()
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
     })
   })
 })

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -1,3 +1,4 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -175,7 +176,7 @@ describe('CurrentUserPopoverLegacy', () => {
 
     render(CurrentUserPopoverLegacy, {
       global: {
-        plugins: [i18n],
+        plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
         stubs: {
           Divider: true
         }

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -32,9 +32,11 @@
 
     <!-- Workspace Selector -->
     <div v-if="showWorkspaceSwitcher" class="relative">
-      <div
+      <Button
         v-tooltip="{ value: workspaceName, showDelay: 300 }"
-        class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        variant="muted-textonly"
+        class="flex h-auto w-full items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        :aria-expanded="isWorkspaceSwitcherOpen"
         data-testid="workspace-switcher-trigger"
         @click="isWorkspaceSwitcherOpen = !isWorkspaceSwitcherOpen"
       >
@@ -48,7 +50,7 @@
           </span>
         </div>
         <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
-      </div>
+      </Button>
 
       <div
         v-if="isWorkspaceSwitcherOpen"
@@ -89,7 +91,7 @@
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
       <Button
-        v-else-if="canAccessSubscriptionFeatures"
+        v-else-if="showAddCredits"
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -209,6 +211,7 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import WorkspaceSwitcherPopover from '@/platform/workspace/components/WorkspaceSwitcherPopover.vue'
 import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 
@@ -242,6 +245,13 @@ const { initState, workspaces, workspaceName } = storeToRefs(
 const isWorkspaceSwitcherOpen = ref(false)
 const showWorkspaceSwitcher = computed(
   () => initState.value === 'ready' && workspaces.value.length > 0
+)
+
+const { permissions } = useWorkspaceUI()
+const showAddCredits = computed(
+  () =>
+    canAccessSubscriptionFeatures.value &&
+    (!showWorkspaceSwitcher.value || permissions.value.canTopUp)
 )
 
 const subscriptionTierName = computed(() =>

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -30,6 +30,35 @@
       </span>
     </div>
 
+    <!-- Workspace Selector -->
+    <div v-if="showWorkspaceSwitcher" class="relative">
+      <div
+        v-tooltip="{ value: workspaceName, showDelay: 300 }"
+        class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        data-testid="workspace-switcher-trigger"
+        @click="isWorkspaceSwitcherOpen = !isWorkspaceSwitcherOpen"
+      >
+        <div class="flex w-0 flex-1 items-center gap-2">
+          <WorkspaceProfilePic
+            class="size-6 shrink-0 text-xs"
+            :workspace-name="workspaceName"
+          />
+          <span class="truncate text-sm text-base-foreground">
+            {{ workspaceName }}
+          </span>
+        </div>
+        <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
+      </div>
+
+      <div
+        v-if="isWorkspaceSwitcherOpen"
+        class="absolute top-0 right-full z-10 mr-4 rounded-lg border border-border-default bg-base-background shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+        data-testid="workspace-switcher-panel"
+      >
+        <WorkspaceSwitcherPopover @select="isWorkspaceSwitcherOpen = false" />
+      </div>
+    </div>
+
     <!-- Credits Section -->
     <div
       v-if="canAccessSubscriptionFeatures"
@@ -160,9 +189,10 @@
 
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import { storeToRefs } from 'pinia'
 import Divider from 'primevue/divider'
 import Skeleton from 'primevue/skeleton'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
@@ -176,7 +206,10 @@ import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
+import WorkspaceSwitcherPopover from '@/platform/workspace/components/WorkspaceSwitcherPopover.vue'
 import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 
 const emit = defineEmits<{
@@ -202,6 +235,14 @@ const {
 const { formatTierName } = useWorkspaceTierLabel()
 const subscriptionDialog = useSubscriptionDialog()
 const { locale, t } = useI18n()
+
+const { initState, workspaces, workspaceName } = storeToRefs(
+  useTeamWorkspaceStore()
+)
+const isWorkspaceSwitcherOpen = ref(false)
+const showWorkspaceSwitcher = computed(
+  () => initState.value === 'ready' && workspaces.value.length > 0
+)
 
 const subscriptionTierName = computed(() =>
   formatTierName(tier.value, subscription.value?.duration === 'ANNUAL')

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -247,11 +247,13 @@ const showWorkspaceSwitcher = computed(
   () => initState.value === 'ready' && workspaces.value.length > 0
 )
 
+// Local keeps its top-up-and-go model: with a workspace context, top-up needs
+// only billing rights, not an active subscription (unlike cloud's rail).
 const { permissions } = useWorkspaceUI()
-const showAddCredits = computed(
-  () =>
-    canAccessSubscriptionFeatures.value &&
-    (!showWorkspaceSwitcher.value || permissions.value.canTopUp)
+const showAddCredits = computed(() =>
+  showWorkspaceSwitcher.value
+    ? permissions.value.canTopUp
+    : canAccessSubscriptionFeatures.value
 )
 
 const subscriptionTierName = computed(() =>

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -61,7 +61,7 @@
 
     <!-- Credits Section -->
     <div
-      v-if="canAccessSubscriptionFeatures"
+      v-if="canAccessSubscriptionFeatures || showWorkspaceSwitcher"
       class="flex items-center gap-2 px-4 py-2"
     >
       <i class="icon-[lucide--component] text-sm text-credit" />
@@ -89,7 +89,7 @@
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
       <Button
-        v-else
+        v-else-if="canAccessSubscriptionFeatures"
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -143,7 +143,7 @@
     </div>
 
     <div
-      v-if="canAccessSubscriptionFeatures"
+      v-if="canAccessSubscriptionFeatures || showWorkspaceSwitcher"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="manage-plan-menu-item"
       @click="handleOpenPlanAndCreditsSettings"

--- a/src/composables/billing/useBillingRouting.test.ts
+++ b/src/composables/billing/useBillingRouting.test.ts
@@ -42,14 +42,24 @@ describe('useBillingRouting', () => {
     mockActiveWorkspaceBillingRail.value = null
   })
 
-  it('uses legacy billing off Cloud', () => {
+  it('uses legacy billing off Cloud until a workspace context loads', () => {
     mockIsCloud.value = false
-    mockActiveWorkspace.value = team
+    mockActiveWorkspace.value = null
 
     const { type, shouldUseWorkspaceBilling } = useBillingRouting()
 
     expect(type.value).toBe('legacy')
     expect(shouldUseWorkspaceBilling.value).toBe(false)
+  })
+
+  it('uses workspace billing off Cloud once a workspace context loads', () => {
+    mockIsCloud.value = false
+    mockActiveWorkspace.value = team
+
+    const { type, shouldUseWorkspaceBilling } = useBillingRouting()
+
+    expect(type.value).toBe('workspace')
+    expect(shouldUseWorkspaceBilling.value).toBe(true)
   })
 
   it('uses workspace billing for a Cloud personal workspace', () => {

--- a/src/composables/billing/useBillingRouting.ts
+++ b/src/composables/billing/useBillingRouting.ts
@@ -20,10 +20,10 @@ export function useBillingRouting() {
   })
 
   const type = computed<BillingType>(() => {
-    if (!isCloud) return 'legacy'
-
     // An unloaded workspace has no type yet; stay legacy so bootstrap never
-    // eagerly routes to workspace billing.
+    // eagerly routes to workspace billing. On non-cloud this also keeps OSS
+    // on legacy billing until the switcher's background hydration lands a
+    // workspace context.
     const workspaceType = workspaceStore.activeWorkspace?.type
     if (!workspaceType) return 'legacy'
 

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -59,7 +59,14 @@
 import { captureException } from '@sentry/vue'
 import { until } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { nextTick, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import {
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -261,5 +268,14 @@ async function initializeWorkspacesInBackground(): Promise<void> {
 onMounted(() => {
   void initialize()
 })
+
+// Non-cloud has no router-driven remount after login, so re-run the
+// background hydration when a user signs in mid-session.
+if (!isCloud) {
+  const { currentUser } = storeToRefs(useAuthStore())
+  watch(currentUser, (user) => {
+    if (user) void initializeWorkspacesInBackground()
+  })
+}
 onUnmounted(cancelInitialization)
 </script>

--- a/src/platform/workspace/auth/WorkspaceAuthGate.vue
+++ b/src/platform/workspace/auth/WorkspaceAuthGate.vue
@@ -94,7 +94,10 @@ function cancelInitialization(): void {
 }
 
 async function initialize(): Promise<void> {
-  if (!isCloud) return
+  if (!isCloud) {
+    void initializeWorkspacesInBackground()
+    return
+  }
 
   cancelInitialization()
   const generation = initializationGeneration
@@ -227,6 +230,28 @@ async function initializeWorkspaceMode(): Promise<void> {
     !workspaceStore.activeWorkspaceId
   ) {
     throw new Error('Failed to initialize workspace context')
+  }
+}
+
+// On non-cloud distributions the gate never blocks rendering; workspace
+// context (credit-wallet selection) is hydrated in the background so the
+// switcher can appear once ready, and the app works untouched if it fails.
+async function initializeWorkspacesInBackground(): Promise<void> {
+  const { isInitialized, currentUser } = storeToRefs(useAuthStore())
+  try {
+    if (!isInitialized.value) {
+      await until(isInitialized).toBe(true, {
+        timeout: FIREBASE_INIT_TIMEOUT_MS,
+        throwOnTimeout: true
+      })
+    }
+    if (!currentUser.value) return
+    await initializeWorkspaceMode()
+  } catch (error) {
+    console.warn(
+      '[WorkspaceAuthGate] Background workspace initialization failed:',
+      error
+    )
   }
 }
 

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({ subscription: billingMocks.subscription })
 }))
 
+const distributionMocks = vi.hoisted(() => ({ isCloud: true }))
+
+vi.mock('@/platform/distribution/types', () => distributionMocks)
+
 const LONG_WORKSPACE_NAME =
   'Quantum Renaissance Collective for Hyperdimensional Latent Diffusion Research and Experimental Workflow Engineering'
 
@@ -101,6 +105,7 @@ function renderComponent(
 describe('WorkspaceSwitcherPopover', () => {
   beforeEach(() => {
     billingMocks.subscription.value = null
+    distributionMocks.isCloud = true
   })
 
   it.for([
@@ -238,5 +243,14 @@ describe('WorkspaceSwitcherPopover', () => {
 
     const createWorkspaceButton = screen.getByText('Create a team workspace')
     expect(list).not.toContainElement(createWorkspaceButton)
+  })
+
+  it('hides the create-workspace footer on non-cloud distributions', () => {
+    distributionMocks.isCloud = false
+
+    renderComponent()
+
+    expect(screen.queryByText('Create a team workspace')).toBeNull()
+    expect(screen.queryByText(/You can only own 10 workspaces/)).toBeNull()
   })
 })

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -71,7 +71,7 @@
     </div>
 
     <!-- Create workspace button -->
-    <div class="shrink-0 border-t border-border-default p-2">
+    <div v-if="isCloud" class="shrink-0 border-t border-border-default p-2">
       <div
         :class="
           cn(
@@ -113,6 +113,7 @@ import { useI18n } from 'vue-i18n'
 
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { isCloud } from '@/platform/distribution/types'
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
 import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
 import type {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -253,12 +253,13 @@ export const useAuthStore = defineStore('auth', () => {
       return token ? { Authorization: `Bearer ${token}` } : null
     }
 
-    if (isCloud) {
+    {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 
       // Recover the workspace token rather than downgrade to the personal
-      // identity, which is what makes cloud requests oscillate.
+      // identity, which is what makes cloud requests oscillate. Non-cloud
+      // only has an active workspace once the switcher hydration succeeds.
       if (activeWorkspaceId) {
         return workspaceAuth.ensureWorkspaceAuthHeader(activeWorkspaceId)
       }
@@ -297,7 +298,7 @@ export const useAuthStore = defineStore('auth', () => {
       return useWorkspaceAuthStore().getUnifiedToken()
     }
 
-    if (isCloud) {
+    {
       const workspaceAuth = useWorkspaceAuthStore()
       const activeWorkspaceId = useTeamWorkspaceStore().activeWorkspaceId
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -171,6 +171,7 @@ const workspaceDevProxyConfig = WORKSPACE_DEV_PROXY
       [
         '/api/workspaces',
         '/api/workspace',
+        '/api/billing',
         '/api/auth/token',
         '/api/auth/session'
       ].map((route) => [

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -165,7 +165,8 @@ const cloudProxyConfig =
 // against a local ComfyUI backend, set WORKSPACE_DEV_PROXY (e.g.
 // https://cloud.comfy.org) to route them there so the workspace switcher can
 // be exercised; everything else keeps hitting DEV_SERVER_COMFYUI_URL.
-const WORKSPACE_DEV_PROXY = process.env.WORKSPACE_DEV_PROXY
+const WORKSPACE_DEV_PROXY =
+  DISTRIBUTION !== 'cloud' ? process.env.WORKSPACE_DEV_PROXY : undefined
 const workspaceDevProxyConfig = WORKSPACE_DEV_PROXY
   ? Object.fromEntries(
       [
@@ -176,7 +177,7 @@ const workspaceDevProxyConfig = WORKSPACE_DEV_PROXY
         '/api/auth/session'
       ].map((route) => [
         route,
-        { target: WORKSPACE_DEV_PROXY, secure: false, changeOrigin: true }
+        { target: WORKSPACE_DEV_PROXY, secure: true, changeOrigin: true }
       ])
     )
   : {}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -161,6 +161,25 @@ const DEV_SERVER_COMFYUI_URL =
 const cloudProxyConfig =
   DISTRIBUTION === 'cloud' ? { secure: false, changeOrigin: true } : {}
 
+// Workspace/auth routes only exist on the cloud gateway. On non-cloud dev
+// against a local ComfyUI backend, set WORKSPACE_DEV_PROXY (e.g.
+// https://cloud.comfy.org) to route them there so the workspace switcher can
+// be exercised; everything else keeps hitting DEV_SERVER_COMFYUI_URL.
+const WORKSPACE_DEV_PROXY = process.env.WORKSPACE_DEV_PROXY
+const workspaceDevProxyConfig = WORKSPACE_DEV_PROXY
+  ? Object.fromEntries(
+      [
+        '/api/workspaces',
+        '/api/workspace',
+        '/api/auth/token',
+        '/api/auth/session'
+      ].map((route) => [
+        route,
+        { target: WORKSPACE_DEV_PROXY, secure: false, changeOrigin: true }
+      ])
+    )
+  : {}
+
 function handleGcsRedirect(
   proxyRes: IncomingMessage,
   _req: IncomingMessage,
@@ -266,6 +285,8 @@ export default defineConfig({
             '/api/viewvideo': gcsRedirectProxyConfig
           }
         : {}),
+
+      ...workspaceDevProxyConfig,
 
       '/api': {
         target: DEV_SERVER_COMFYUI_URL,


### PR DESCRIPTION
## Summary

Local/desktop users can't switch workspaces, so credits purchased on any non-Personal workspace are unusable locally ([Pylon 15986](https://app.usepylon.com/issues?issueNumber=15986)). This exposes the existing cloud workspace switcher on non-cloud distributions, scoped to credit-wallet selection only — no asset/file semantics, no settings-surface changes.

- `WorkspaceAuthGate`: on non-cloud, hydrate the team workspace store in the background after Firebase auth resolves — never blocks rendering, and the app is untouched if it fails (offline keeps the cached last selection)
- `CurrentUserPopoverLegacy`: workspace row + switcher panel (same components as cloud), shown once the store is ready
- `WorkspaceSwitcherPopover`: create-workspace footer is now cloud-only — a workspace created from local would be an empty wallet with no local way to subscribe or manage it
- `CurrentUserButton`: topbar shows the workspace avatar whenever a non-personal workspace is active (was cloud-only)

No new strings. Switch behavior is the existing store path: context clear + reload, selection persisted per device (personal default).

Design: [stripped MVP board](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=5874-73181) · [popover + menu](https://www.figma.com/design/CkFTD4c20PyRGpNVAJgpfV/Team-Plan---Workspaces?node-id=5874-72771)
Linear: [FE-1584](https://linear.app/comfyorg/issue/FE-1584/add-workspace-switcher-to-localdesktop-credits-only-no-settings)

## Review notes

- Draft pending desktop verification of the acceptance criteria on FE-1584 — especially that balance reads, Add credits, and run submission follow the selected workspace context, and that the workspace token exchange works on the desktop client
- Existing `CurrentUserPopoverLegacy` tests gained a testing Pinia (component now reads the team workspace store); switcher tests pin `isCloud` and cover the hidden footer

┆Linear: FE-1584

## Status & handoff (2026-08-11)

Verified working end-to-end on localhost dev (switcher renders, switch reloads into the selected workspace, balance follows) via the opt-in dev proxy: `DISTRIBUTION=localhost WORKSPACE_DEV_PROXY=https://testcloud.comfy.org pnpm dev` with a local ComfyUI on 8188. Dev builds pair with staging Firebase, so testcloud is the only valid gateway for local testing.

**Merged as-is this ships dormant**: production non-cloud builds cannot reach the workspace routes (gateway-only + CORS), so init fails silently and the switcher stays hidden. Remaining to activate and finish:

1. **BE dependency (ship blocker)**: expose `/workspaces`, `/auth/token`, `/auth/session`, workspace `/billing/*` to non-cloud clients — on `api.comfy.org` (pattern local billing already uses) or via gateway CORS for desktop origins; prod-Firebase tokens must validate. Then swap these clients to a distribution-aware absolute base instead of relative `api.apiURL()` paths.
2. **Open bug**: Settings → Credits activity spins indefinitely for some workspaces on the non-cloud workspace-billing path (suspect token exchange or `getBillingEvents`; needs a network capture).
3. **Follow-up fix**: `customerEventsService` uses `getAuthHeader()` (now workspace-preferring) for a user-scoped `/customers/*` endpoint — should use `getFirebaseAuthHeader()` per authStore's contract.
4. **Verify**: top-up lands in the selected workspace; a partner-node run from local debits the selected team pool (backend node auth now receives the workspace token — unverified end-to-end).

Details and acceptance criteria on FE-1584.
