### PR TITLE
test: use a common fake clock baseline

### DIFF
--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -555,7 +555,6 @@ describe('useJobList', () => {
   })
 
   it('groups terminal jobs without an execution end timestamp by create time', async () => {
-    vi.setSystemTime(new Date('2024-01-10T12:00:00Z'))
     queueStoreMock.historyTasks = [
       createTask({
         jobId: 'failed-before-execution',
@@ -583,7 +582,6 @@ describe('useJobList', () => {
   })
 
   it('groups job items by date label and sorts by total generation time when requested', async () => {
-    vi.setSystemTime(new Date('2024-01-10T12:00:00Z'))
     queueStoreMock.historyTasks = [
       createTask({
         jobId: 'today-small',

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -119,7 +119,6 @@ describe(useQueueNotificationBanners, () => {
   }
 
   beforeEach(() => {
-    vi.setSystemTime(0)
     resetState()
   })
 
@@ -204,14 +203,15 @@ describe(useQueueNotificationBanners, () => {
 
   it('shows a completed notification from a finished batch', async () => {
     const { unmount, composable } = mountComposable()
+    const now = Date.now()
 
     try {
       await runBatch({
-        start: 1_000,
-        finish: 1_200,
+        start: now + 1_000,
+        finish: now + 1_200,
         tasks: [
           createTask({
-            ts: 1_050,
+            ts: now + 1_050,
             previewUrl: 'https://example.com/preview.png'
           })
         ]
@@ -229,13 +229,14 @@ describe(useQueueNotificationBanners, () => {
 
   it('shows one completion notification when history updates after queue becomes idle', async () => {
     const { unmount, composable } = mountComposable()
+    const now = Date.now()
 
     try {
-      vi.setSystemTime(4_000)
+      vi.setSystemTime(now + 4_000)
       executionStore().isIdle = false
       await nextTick()
 
-      vi.setSystemTime(4_100)
+      vi.setSystemTime(now + 4_100)
       executionStore().isIdle = true
       queueStore().historyTasks = []
       await nextTick()
@@ -244,7 +245,7 @@ describe(useQueueNotificationBanners, () => {
 
       queueStore().historyTasks = [
         createTask({
-          ts: 4_050,
+          ts: now + 4_050,
           previewUrl: 'https://example.com/race-preview.png'
         })
       ]
@@ -270,19 +271,20 @@ describe(useQueueNotificationBanners, () => {
 
   it('queues both completed and failed notifications for mixed batches', async () => {
     const { unmount, composable } = mountComposable()
+    const now = Date.now()
 
     try {
       await runBatch({
-        start: 2_000,
-        finish: 2_200,
+        start: now + 2_000,
+        finish: now + 2_200,
         tasks: [
           createTask({
-            ts: 2_050,
+            ts: now + 2_050,
             previewUrl: 'https://example.com/result.png'
           }),
-          createTask({ ts: 2_060 }),
-          createTask({ ts: 2_070 }),
-          createTask({ state: 'Failed', ts: 2_080 })
+          createTask({ ts: now + 2_060 }),
+          createTask({ ts: now + 2_070 }),
+          createTask({ state: 'Failed', ts: now + 2_080 })
         ]
       })
 
@@ -306,26 +308,27 @@ describe(useQueueNotificationBanners, () => {
 
   it('uses up to two completion thumbnails for notification icon previews', async () => {
     const { unmount, composable } = mountComposable()
+    const now = Date.now()
 
     try {
       await runBatch({
-        start: 3_000,
-        finish: 3_300,
+        start: now + 3_000,
+        finish: now + 3_300,
         tasks: [
           createTask({
-            ts: 3_050,
+            ts: now + 3_050,
             previewUrl: 'https://example.com/preview-1.png'
           }),
           createTask({
-            ts: 3_060,
+            ts: now + 3_060,
             previewUrl: 'https://example.com/preview-2.png'
           }),
           createTask({
-            ts: 3_070,
+            ts: now + 3_070,
             previewUrl: 'https://example.com/preview-3.png'
           }),
           createTask({
-            ts: 3_080,
+            ts: now + 3_080,
             previewUrl: 'https://example.com/preview-4.png'
           })
         ]

--- a/src/platform/assets/composables/useMediaAssetFiltering.test.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.test.ts
@@ -380,8 +380,7 @@ describe('useMediaAssetFiltering', () => {
     })
 
     it('combines media type and date before sorting', () => {
-      const now = new Date(2026, 6, 27, 12).getTime()
-      vi.setSystemTime(now)
+      const now = Date.now()
 
       const assets = ref<AssetItem[]>([
         makeAsset({

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -46,7 +46,6 @@ describe('NightlySurveyPopover', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.resetModules()
-    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
 
     mockIsNightly.value = true
     mockIsCloud.value = false

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -32,14 +32,13 @@ describe('useFeatureUsageTracker', () => {
   })
 
   it('sets firstUsed only on first use', () => {
-    const firstTs = 1000000
-    vi.setSystemTime(firstTs)
+    const firstTs = Date.now()
     const { usage, trackUsage } = useFeatureUsageTracker('test-feature-3')
 
     trackUsage()
     expect(usage.value?.firstUsed).toBe(firstTs)
 
-    vi.setSystemTime(firstTs + 5000)
+    vi.advanceTimersByTime(5_000)
     trackUsage()
     expect(usage.value?.firstUsed).toBe(firstTs)
   })

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -31,7 +31,6 @@ describe('useSurveyEligibility', () => {
 
   beforeEach(() => {
     localStorage.clear()
-    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
 
     mockDistribution.isNightly = true
     mockDistribution.isCloud = false

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -19,7 +19,6 @@ vi.mock('@/platform/telemetry', () => ({
 
 describe('topupTracker', () => {
   beforeEach(() => {
-    vi.setSystemTime(new Date('2026-08-07T12:00:00Z'))
     localStorage.clear()
   })
 

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -274,8 +274,7 @@ describe('useVersionCompatibilityStore', () => {
 
   describe('dismissal persistence', () => {
     it('should save dismissal to reactive storage with expiration', async () => {
-      const mockNow = 1000000
-      vi.setSystemTime(mockNow)
+      const now = Date.now()
 
       mockSystemStatsStore.systemStats = {
         system: {
@@ -290,7 +289,7 @@ describe('useVersionCompatibilityStore', () => {
 
       // Check that the dismissal was added to reactive storage
       expect(mockDismissalStorage.value).toEqual({
-        '1.24.0-1.25.0-1.25.0': mockNow + 7 * 24 * 60 * 60 * 1000
+        '1.24.0-1.25.0-1.25.0': now + 7 * 24 * 60 * 60 * 1000
       })
     })
 
@@ -481,8 +480,7 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should include outdated packages in dismissal key', async () => {
-      const mockNow = 1000000
-      vi.setSystemTime(mockNow)
+      const now = Date.now()
 
       mockSystemStatsStore.systemStats = {
         system: {
@@ -504,14 +502,11 @@ describe('useVersionCompatibilityStore', () => {
 
       expect(mockDismissalStorage.value).toEqual({
         '1.24.0-1.24.0-1.24.0-comfyui-workflow-templates@0.9.0->0.9.5':
-          mockNow + 7 * 24 * 60 * 60 * 1000
+          now + 7 * 24 * 60 * 60 * 1000
       })
     })
 
     it('should produce the same dismissal key regardless of package order', async () => {
-      const mockNow = 1000000
-      vi.setSystemTime(mockNow)
-
       const packageA = {
         name: 'comfy-aimdo',
         installed: '0.1.0',
@@ -551,12 +546,11 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should prune expired dismissals when writing a new one', async () => {
-      const mockNow = 10_000_000
-      vi.setSystemTime(mockNow)
+      const now = Date.now()
 
       mockDismissalStorage.value = {
-        'expired-key': mockNow - 1,
-        'still-valid-key': mockNow + 5000
+        'expired-key': now - 1,
+        'still-valid-key': now + 5000
       }
 
       mockSystemStatsStore.systemStats = {
@@ -575,9 +569,6 @@ describe('useVersionCompatibilityStore', () => {
     })
 
     it('should allow dismissal when only package warnings are present', async () => {
-      const mockNow = 1000000
-      vi.setSystemTime(mockNow)
-
       mockSystemStatsStore.systemStats = {
         system: {
           comfyui_version: '',

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -186,7 +186,6 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
     setActivePinia(createTestingPinia({ stubActions: false }))
     localStorage.clear()
     sessionStorage.clear()

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -82,21 +82,20 @@ describe('workflowDraftStoreV2', () => {
     it('keeps payload updatedAt stable when only recency is refreshed', () => {
       const store = useWorkflowDraftStoreV2()
 
-      vi.setSystemTime(new Date('2026-03-21T10:00:00Z'))
       store.saveDraft('workflows/a.json', '{"id":"a"}', {
         name: 'a',
         isTemporary: true
       })
       const initialUpdatedAt = store.getDraft('workflows/a.json')!.updatedAt
 
-      vi.setSystemTime(new Date('2026-03-21T10:01:00Z'))
+      vi.advanceTimersByTime(60_000)
       store.saveDraft('workflows/b.json', '{"id":"b"}', {
         name: 'b',
         isTemporary: true
       })
       expect(store.getMostRecentPath()).toBe('workflows/b.json')
 
-      vi.setSystemTime(new Date('2026-03-21T10:02:00Z'))
+      vi.advanceTimersByTime(60_000)
       store.markDraftUsed('workflows/a.json')
 
       expect(store.getDraft('workflows/a.json')!.updatedAt).toBe(
@@ -212,14 +211,13 @@ describe('workflowDraftStoreV2', () => {
     it('preserves payload updatedAt when moving a draft', () => {
       const store = useWorkflowDraftStoreV2()
 
-      vi.setSystemTime(new Date('2026-05-13T00:00:00Z'))
       store.saveDraft('workflows/old.json', '{"data":"test"}', {
         name: 'old',
         isTemporary: true
       })
       const originalUpdatedAt = store.getDraft('workflows/old.json')!.updatedAt
 
-      vi.setSystemTime(new Date('2026-05-13T00:05:00Z'))
+      vi.advanceTimersByTime(5 * 60_000)
       store.moveDraft('workflows/old.json', 'workflows/new.json', 'new')
 
       expect(store.getDraft('workflows/new.json')!.updatedAt).toBe(

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -90,7 +90,7 @@ const mockWorkspaceWithRole = {
 
 const mockTokenResponse = {
   token: 'workspace-token-abc',
-  expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+  expires_at: new Date('2024-06-15T13:00:00Z').toISOString(),
   workspace: mockWorkspace,
   role: 'owner' as const,
   permissions: ['owner:*']

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -197,8 +197,6 @@ describe('useImagePreviewWidget', () => {
 
   describe('drawWidget — upload spinner', () => {
     it('renders spinner when node.isUploading is true', () => {
-      vi.setSystemTime(500)
-
       const constructor = useImagePreviewWidget()
       const node = createMockNode({ isUploading: true })
       constructor(node, defaultInputSpec)
@@ -217,8 +215,6 @@ describe('useImagePreviewWidget', () => {
     })
 
     it('uses LiteGraph.NODE_TEXT_COLOR for spinner stroke', () => {
-      vi.setSystemTime(0)
-
       const constructor = useImagePreviewWidget()
       const node = createMockNode({ isUploading: true })
       constructor(node, defaultInputSpec)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -245,7 +245,7 @@ describe('useRemoteWidget', () => {
         await getResolvedValue(hook)
         expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1)
 
-        vi.setSystemTime(Date.now() + FIRST_BACKOFF)
+        vi.advanceTimersByTime(FIRST_BACKOFF)
         const secondData = await getResolvedValue(hook)
         expect(secondData).toBe('Loading...')
         expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(2)
@@ -269,7 +269,7 @@ describe('useRemoteWidget', () => {
       const { hook } = await setupHookWithResponse(mockData1, { refresh })
       mockAxiosResponse(mockData2)
 
-      vi.setSystemTime(Date.now() + refresh)
+      vi.advanceTimersByTime(refresh)
       const newData = await getResolvedValue(hook)
 
       expect(newData).toEqual(mockData2)
@@ -281,7 +281,7 @@ describe('useRemoteWidget', () => {
         refresh: 512
       })
 
-      vi.setSystemTime(Date.now() + 128)
+      vi.advanceTimersByTime(128)
       await getResolvedValue(hook)
 
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1)
@@ -294,12 +294,12 @@ describe('useRemoteWidget', () => {
       })
 
       mockAxiosError('Network error')
-      vi.setSystemTime(Date.now() + refresh)
+      vi.advanceTimersByTime(refresh)
       await getResolvedValue(hook)
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(2)
 
       mockAxiosResponse(['second success'])
-      vi.setSystemTime(Date.now() + FIRST_BACKOFF)
+      vi.advanceTimersByTime(FIRST_BACKOFF)
       const thirdData = await getResolvedValue(hook)
       expect(thirdData).toEqual(['second success'])
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(3)
@@ -312,7 +312,7 @@ describe('useRemoteWidget', () => {
       })
 
       mockAxiosError('Network error')
-      vi.setSystemTime(Date.now() + refresh)
+      vi.advanceTimersByTime(refresh)
       const secondData = await getResolvedValue(hook)
 
       expect(secondData).toEqual(['a valid value'])
@@ -332,11 +332,11 @@ describe('useRemoteWidget', () => {
       await getResolvedValue(hook)
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1)
 
-      vi.setSystemTime(Date.now() + 500)
+      vi.advanceTimersByTime(500)
       await getResolvedValue(hook)
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(1) // Still backing off
 
-      vi.setSystemTime(Date.now() + 3000)
+      vi.advanceTimersByTime(3000)
       await getResolvedValue(hook)
       expect(vi.mocked(axios.get)).toHaveBeenCalledTimes(2)
       expect(entry1?.data).toBeDefined()
@@ -348,7 +348,7 @@ describe('useRemoteWidget', () => {
       const firstData = await getResolvedValue(hook)
       expect(firstData).toBe('Loading...')
 
-      vi.setSystemTime(Date.now() + 3000)
+      vi.advanceTimersByTime(3000)
       mockAxiosResponse(['option1'])
       const secondData = await getResolvedValue(hook)
       expect(secondData).toEqual(['option1'])
@@ -365,7 +365,7 @@ describe('useRemoteWidget', () => {
       const entry1 = hook.getCacheEntry()
       expect(entry1?.error).toBeTruthy()
 
-      vi.setSystemTime(Date.now() + 3000)
+      vi.advanceTimersByTime(3000)
       mockAxiosResponse(['success after backoff'])
       const secondData = await getResolvedValue(hook)
       expect(secondData).toEqual(['success after backoff'])
@@ -384,17 +384,17 @@ describe('useRemoteWidget', () => {
       const entry1 = hook.getCacheEntry()
       expect(entry1?.error).toBeTruthy()
 
-      vi.setSystemTime(Date.now() + 3000)
+      vi.advanceTimersByTime(3000)
       const secondData = await getResolvedValue(hook)
       expect(secondData).toBe('Loading...')
       expect(entry1?.error).toBeDefined()
 
-      vi.setSystemTime(Date.now() + 9000)
+      vi.advanceTimersByTime(9000)
       const thirdData = await getResolvedValue(hook)
       expect(thirdData).toBe('Loading...')
       expect(entry1?.error).toBeDefined()
 
-      vi.setSystemTime(Date.now() + 120_000)
+      vi.advanceTimersByTime(120_000)
       mockAxiosResponse(['success after multiple backoffs'])
       const fourthData = await getResolvedValue(hook)
       expect(fourthData).toEqual(['success after multiple backoffs'])

--- a/src/stores/templateRankingStore.test.ts
+++ b/src/stores/templateRankingStore.test.ts
@@ -54,12 +54,14 @@ describe('templateRankingStore', () => {
     it('scores an uncurated template from usage and freshness alone', () => {
       const store = useTemplateRankingStore()
       store.largestUsageScore = 100
+      const threeYearsAgo = new Date(Date.now() - 3 * 365 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[0]
       // curation = neutral 0.5, freshness = 0.1 (old date), usage = 0
       // score = 0 * 0.5 + 0.5 * 0.3 + 0.1 * 0.2 = 0.17
-      expect(store.computeDefaultScore('2024-01-01', undefined, 0)).toBeCloseTo(
-        0.17,
-        2
-      )
+      expect(
+        store.computeDefaultScore(threeYearsAgo, undefined, 0)
+      ).toBeCloseTo(0.17, 2)
     })
 
     it('ranks promoted above neutral above demoted', () => {

--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   dateKey,
@@ -150,10 +150,6 @@ describe('dateKey', () => {
 })
 
 describe('isToday', () => {
-  beforeEach(() => {
-    vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
-  })
-
   it('returns true for a timestamp on the same day', () => {
     const ts = new Date(2024, 5, 15, 8, 0, 0).getTime()
     expect(isToday(ts)).toBe(true)
@@ -171,10 +167,6 @@ describe('isToday', () => {
 })
 
 describe('isYesterday', () => {
-  beforeEach(() => {
-    vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
-  })
-
   it('returns true for a timestamp yesterday', () => {
     const ts = new Date(2024, 5, 14, 10, 0, 0).getTime()
     expect(isYesterday(ts)).toBe(true)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -30,6 +30,7 @@ const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
 const COLLECT_COVERAGE = process.env.COLLECT_COVERAGE === 'true'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
+const TEST_SYSTEM_TIME = Date.parse('2024-06-15T12:00:00Z')
 
 const CRITICAL_COVERAGE_DIRS = [
   'src/base',
@@ -745,7 +746,7 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
-    fakeTimers: { shouldAdvanceTime: true },
+    fakeTimers: { now: TEST_SYSTEM_TIME, shouldAdvanceTime: true },
     globals: true,
     environment: 'happy-dom',
     // Pin the timezone so date-formatting assertions are deterministic


### PR DESCRIPTION
## Summary

Child of #15050. Give every root Vitest test the same named fake-clock baseline and express scenario time as relative movement from that baseline.

```ts
const TEST_SYSTEM_TIME = Date.parse('2024-06-15T12:00:00Z')
```

- reduces test-local `vi.setSystemTime()` calls from 44 to 7
- replaces arbitrary Unix-adjacent timestamps and unrelated calendar dates with `Date.now()`-relative fixtures
- uses `vi.advanceTimersByTime()` when elapsed time, rather than a wall-clock jump, is the behavior under test
- retains six non-firing wall-clock jumps where advancing timers would execute scheduled work and change the scenario
- retains one explicit July 2026 clock for calendar-boundary filtering
- makes a template-freshness fixture relative to the baseline instead of depending on the actual current date
- aligns a module-scoped workspace-token expiry with the deterministic test clock

## Baseline choice

The most frequent exact timestamp was `1_000_000` ms (five calls), equivalent to `1970-01-01T00:16:40Z`. That value was common but arbitrary.

June 15, 2024 was the most common meaningful calendar anchor: four date-oriented setups used that day. Noon UTC is explicit, stable, and compatible with the root project's existing `TZ=UTC` configuration.

## Results

| Metric | Before | After | Change |
|---|---:|---:|---:|
| `vi.setSystemTime()` calls | 44 | 7 | −37 (−84%) |
| Files containing those calls | 14 | 3 | −11 (−79%) |
| Root tests passed | 15,892 | 15,892 | No regression |
| Root tests skipped | 8 | 8 | No change |

The first full run exposed one hidden real-date dependency in `templateRankingStore.test.ts`: a hardcoded January 2024 template was only “very old” relative to the present day. It is now represented as three years before `Date.now()`, matching the behavior the assertion describes.

## Validation

- `pnpm test:unit`: 1,159 files passed; 15,892 tests passed; 8 skipped
- `pnpm lint`
- `pnpm typecheck`
- oxfmt and type-aware Oxlint on all changed files
- pre-push `pnpm knip --cache`