### PR TITLE
test: clear local storage before each test

### DIFF
--- a/src/components/TopMenuSection.test.ts
+++ b/src/components/TopMenuSection.test.ts
@@ -196,7 +196,6 @@ function createComfyActionbarStub(actionbarTarget: HTMLElement) {
 
 describe('TopMenuSection', () => {
   beforeEach(() => {
-    localStorage.clear()
     mockData.isLoggedIn = false
     mockData.setShowConflictRedDot(false)
   })

--- a/src/components/actionbar/ComfyActionbar.test.ts
+++ b/src/components/actionbar/ComfyActionbar.test.ts
@@ -63,7 +63,6 @@ const renderActionbar = (showRunProgressBar: boolean) => {
 describe('ComfyActionbar', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    localStorage.clear()
   })
 
   it('teleports inline progress when run progress bar is enabled', async () => {

--- a/src/composables/maskeditor/useBrushPersistence.test.ts
+++ b/src/composables/maskeditor/useBrushPersistence.test.ts
@@ -28,7 +28,6 @@ const STORAGE_KEY = 'maskeditor_brush_settings'
 
 beforeEach(() => {
   setActivePinia(createTestingPinia({ stubActions: false }))
-  localStorage.clear()
 })
 
 describe('loadAndApply', () => {

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -235,10 +235,6 @@ describe('useFeatureFlags', () => {
   })
 
   describe('dev override via localStorage', () => {
-    afterEach(() => {
-      localStorage.clear()
-    })
-
     it('resolveFlag returns localStorage override over remoteConfig and server value', () => {
       vi.mocked(api.getServerFeature).mockReturnValue(false)
       localStorage.setItem('ff:model_upload_button_enabled', 'true')
@@ -301,7 +297,6 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {}
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
-      localStorage.clear()
     })
 
     afterEach(() => {
@@ -310,7 +305,6 @@ describe('useFeatureFlags', () => {
       remoteConfig.value = {}
       cachedBillingControlEnabled.value = undefined
       cachedV1PaymentRecovery.value = undefined
-      localStorage.clear()
     })
 
     it('returns the cached session value during the auth window', () => {
@@ -359,10 +353,6 @@ describe('useFeatureFlags', () => {
   })
 
   describe('signupTurnstileMode', () => {
-    afterEach(() => {
-      localStorage.clear()
-    })
-
     it('falls back to the server feature flag with default off', () => {
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
@@ -436,7 +426,6 @@ describe('useFeatureFlags', () => {
     afterEach(() => {
       vi.mocked(distributionTypes).isCloud = false
       remoteConfig.value = {}
-      localStorage.clear()
     })
 
     it('is disabled outside the cloud distribution', () => {
@@ -466,10 +455,6 @@ describe('useFeatureFlags', () => {
   })
 
   describe('unifiedCloudAuthEnabled', () => {
-    afterEach(() => {
-      localStorage.clear()
-    })
-
     it('reads the unified_cloud_auth server feature when set', () => {
       vi.mocked(api.getServerFeature).mockImplementation(
         (path, defaultValue) => {
@@ -497,7 +482,6 @@ describe('useFeatureFlags', () => {
       vi.mocked(distributionTypes).isCloud = false
       remoteConfigState.value = 'unloaded'
       cachedBillingControlEnabled.value = undefined
-      localStorage.clear()
       remoteConfig.value = {}
     })
 

--- a/src/composables/useRunButtonTelemetry.test.ts
+++ b/src/composables/useRunButtonTelemetry.test.ts
@@ -45,7 +45,6 @@ import {
 
 describe('useRunButtonTelemetry', () => {
   beforeEach(() => {
-    localStorage.clear()
     state.telemetry.trackRunButton.mockClear()
     state.mode.value = 'graph'
     state.isAppMode.value = false

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -209,7 +209,6 @@ describe('CreditsTile', () => {
     state.type = 'workspace'
     state.customerEventsError = null
     mockIsCloud.value = true
-    localStorage.clear()
   })
 
   it('renders the total balance (cents converted to credits) with the remaining suffix', () => {

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 const FEATURE_USAGE_KEY = 'Comfy.FeatureUsage'
@@ -82,7 +82,6 @@ describe('ErrorPanelSurveyCta', () => {
   }
 
   beforeEach(() => {
-    localStorage.clear()
     vi.resetModules()
     mockOpen.mockReset()
 
@@ -95,10 +94,6 @@ describe('ErrorPanelSurveyCta', () => {
       triggerThreshold: 3,
       presentation: PRESENTATION_INLINE_CTA
     }
-  })
-
-  afterEach(() => {
-    localStorage.clear()
   })
 
   async function renderComponent() {

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -44,16 +44,11 @@ describe('NightlySurveyPopover', () => {
   }
 
   beforeEach(() => {
-    localStorage.clear()
     vi.resetModules()
 
     mockIsNightly.value = true
     mockIsCloud.value = false
     mockIsDesktop.value = false
-  })
-
-  afterEach(() => {
-    localStorage.clear()
   })
 
   async function renderComponent(

--- a/src/platform/surveys/useFeatureUsageTracker.test.ts
+++ b/src/platform/surveys/useFeatureUsageTracker.test.ts
@@ -1,18 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useFeatureUsageTracker } from './useFeatureUsageTracker'
 
 const STORAGE_KEY = 'Comfy.FeatureUsage'
 
 describe('useFeatureUsageTracker', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
-  afterEach(() => {
-    localStorage.clear()
-  })
-
   it('initializes with zero count for new feature', () => {
     const { useCount } = useFeatureUsageTracker('test-feature-1')
 

--- a/src/platform/surveys/useSurveyEligibility.test.ts
+++ b/src/platform/surveys/useSurveyEligibility.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSurveyEligibility } from './useSurveyEligibility'
 
@@ -30,15 +30,9 @@ describe('useSurveyEligibility', () => {
   }
 
   beforeEach(() => {
-    localStorage.clear()
-
     mockDistribution.isNightly = true
     mockDistribution.isCloud = false
     mockDistribution.isDesktop = false
-  })
-
-  afterEach(() => {
-    localStorage.clear()
   })
 
   function setFeatureUsage(featureId: string, useCount: number) {

--- a/src/platform/surveys/useSurveyFeatureTracking.test.ts
+++ b/src/platform/surveys/useSurveyFeatureTracking.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getSurveyConfig = vi.hoisted(() =>
   vi.fn<(featureId: string) => { enabled: boolean } | undefined>()
@@ -10,13 +10,8 @@ vi.mock('./surveyRegistry', () => ({
 
 describe('useSurveyFeatureTracking', () => {
   beforeEach(() => {
-    localStorage.clear()
     vi.resetModules()
     getSurveyConfig.mockReset()
-  })
-
-  afterEach(() => {
-    localStorage.clear()
   })
 
   it('tracks usage when config is enabled', async () => {

--- a/src/platform/telemetry/initHostTelemetry.test.ts
+++ b/src/platform/telemetry/initHostTelemetry.test.ts
@@ -15,7 +15,6 @@ describe('initHostTelemetry', () => {
   afterEach(() => {
     remoteConfig.value = {}
     setTelemetryRegistry(null)
-    localStorage.clear()
     delete window.__comfyDesktop2
   })
 

--- a/src/platform/telemetry/manualRefreshTracker.test.ts
+++ b/src/platform/telemetry/manualRefreshTracker.test.ts
@@ -20,7 +20,6 @@ function mockNavigationType(type: string): void {
 describe('trackUserManualRefresh', () => {
   beforeEach(() => {
     hoisted.getInternalContext.mockReturnValue({ session_id: 'session-1' })
-    localStorage.clear()
   })
 
   it('counts reloads within the same session', () => {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -18,7 +18,6 @@ describe('GtmTelemetryProvider', () => {
     window.dataLayer = undefined
     window.gtag = undefined
     document.head.innerHTML = ''
-    localStorage.clear()
   })
 
   it('injects the GTM runtime script', () => {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -58,10 +58,6 @@ const waitForMixpanelInit = () =>
 
 type ConfigWindow = { __CONFIG__?: { mixpanel_token?: string } }
 
-beforeEach(() => {
-  localStorage.clear()
-})
-
 describe('MixpanelTelemetryProvider — without configured token', () => {
   beforeEach(() => {
     delete (window as unknown as ConfigWindow).__CONFIG__

--- a/src/platform/telemetry/topupTracker.test.ts
+++ b/src/platform/telemetry/topupTracker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   pendingTopupNeedsRefresh,
@@ -18,10 +18,6 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 describe('topupTracker', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
   describe('startTopupTracking', () => {
     it('should save current timestamp to localStorage', () => {
       startTopupTracking()

--- a/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
+++ b/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
@@ -7,7 +7,6 @@ import {
 
 describe('getCheckoutAttribution', () => {
   beforeEach(() => {
-    window.localStorage.clear()
     window.__CONFIG__ = {
       ...window.__CONFIG__,
       ga_measurement_id: undefined

--- a/src/platform/telemetry/utils/getActionbarDockState.test.ts
+++ b/src/platform/telemetry/utils/getActionbarDockState.test.ts
@@ -1,12 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { getActionbarDockState } from './getActionbarDockState'
 
 describe('getActionbarDockState', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
   it('returns docked when no preference is stored', () => {
     expect(getActionbarDockState()).toBe('docked')
   })

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
@@ -36,7 +36,6 @@ import { getShellLayoutSnapshot } from './getShellLayoutSnapshot'
 
 describe('getShellLayoutSnapshot', () => {
   beforeEach(() => {
-    localStorage.clear()
     state.settings = { 'Comfy.UseNewMenu': 'Top' }
     state.activeSidebarTabId = null
     state.rightSidePanelOpen = false

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -100,7 +100,6 @@ describe('useWorkflowStore', () => {
 
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    localStorage.clear()
     sessionStorage.clear()
     store = useWorkflowStore()
     bookmarkStore = useWorkflowBookmarkStore()
@@ -116,7 +115,6 @@ describe('useWorkflowStore', () => {
   })
 
   afterEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
   })
 

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -21,13 +21,11 @@ import {
 
 describe('storageIO', () => {
   beforeEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
     vi.resetModules()
   })
 
   afterEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
   })
 

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -187,7 +187,6 @@ describe('useWorkflowPersistenceV2', () => {
 
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    localStorage.clear()
     sessionStorage.clear()
     settingMocks.persistRef!.value = true
     settingMocks.values = {}

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
@@ -14,12 +14,10 @@ describe('migrateV1toV2', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    localStorage.clear()
     sessionStorage.clear()
   })
 
   afterEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
   })
 

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
@@ -303,12 +303,10 @@ class StoreResetCommand implements Command<PersistenceModel, PersistenceReal> {
 describe('workflowDraftStoreV2 FSM', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    localStorage.clear()
     sessionStorage.clear()
   })
 
   afterEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
   })
 

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -22,12 +22,10 @@ vi.mock('@/scripts/app', () => ({
 describe('workflowDraftStoreV2', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    localStorage.clear()
     sessionStorage.clear()
   })
 
   afterEach(() => {
-    localStorage.clear()
     sessionStorage.clear()
   })
 

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -427,13 +427,11 @@ describe('API Feature Flags', () => {
    */
   describe('characterization: resolution with no override present', () => {
     beforeEach(() => {
-      localStorage.clear()
       sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
 
     afterEach(() => {
-      localStorage.clear()
       sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
@@ -487,10 +485,6 @@ describe('API Feature Flags', () => {
   })
 
   describe('Dev override via localStorage', () => {
-    afterEach(() => {
-      localStorage.clear()
-    })
-
     it('getServerFeature returns localStorage override over server value', () => {
       api.serverFeatureFlags.value = { some_flag: false }
       localStorage.setItem('ff:some_flag', 'true')

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -31,14 +31,12 @@ describe('api.getServerFeature session override outside component setup', () => 
     mockCurrentUser.value = { email: 'dev@comfy.org', emailVerified: true }
     api.serverFeatureFlags.value = {}
     sessionStorage.clear()
-    localStorage.clear()
   })
 
   afterEach(() => {
     window.history.replaceState({}, '', '/')
     api.serverFeatureFlags.value = {}
     sessionStorage.clear()
-    localStorage.clear()
     vi.restoreAllMocks()
   })
 

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -15,7 +15,6 @@ describe('userStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     getUserConfig.mockReset()
-    localStorage.clear()
   })
 
   describe('initialize', () => {

--- a/src/utils/devFeatureFlagOverride.test.ts
+++ b/src/utils/devFeatureFlagOverride.test.ts
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { getDevOverride } from '@/utils/devFeatureFlagOverride'
 
 describe('getDevOverride', () => {
-  afterEach(() => {
-    localStorage.clear()
-  })
-
   it('returns undefined when no override is set', () => {
     expect(getDevOverride('some_flag')).toBeUndefined()
   })

--- a/src/workbench/extensions/manager/composables/useConflictAcknowledgment.test.ts
+++ b/src/workbench/extensions/manager/composables/useConflictAcknowledgment.test.ts
@@ -1,19 +1,13 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useConflictAcknowledgment', () => {
   beforeEach(() => {
     // Set up Pinia for each test
     setActivePinia(createTestingPinia({ stubActions: false }))
-    // Clear localStorage before each test
-    localStorage.clear()
     // Reset modules to ensure fresh state
     vi.resetModules()
-  })
-
-  afterEach(() => {
-    localStorage.clear()
   })
 
   describe('initial state loading', () => {

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
+  globalThis.localStorage?.clear()
   vi.useFakeTimers()
 })
 


### PR DESCRIPTION
## Summary

Child of #15052. Give every test a clean localStorage baseline through the shared Vitest setup.

```ts
beforeEach(() => {
  globalThis.localStorage?.clear()
})
```

The optional access keeps the shared setup compatible with the website and object-parser projects, which use Vitest's Node environment and do not expose localStorage.

## Audit results

| Classification | Calls | Outcome |
|---|---:|---|
| Test-boundary setup/teardown | 50 | Removed as globally redundant |
| Intra-test fast-check run isolation | 1 | Retained |
| **Total audited** | **51** | **30 test files** |

The retained call separates generated command sequences and shrink attempts inside a single Vitest test. A global `beforeEach` cannot replace it.

The cleanup also removes empty hooks, stale comments, and unused lifecycle imports. Net diff: 10 additions and 106 deletions across 31 files.

## Validation

| Project | Test files | Passed | Skipped | Failed |
|---|---:|---:|---:|---:|
| Root | 1,159 | 15,896 | 8 | 0 |
| Desktop UI | 16 | 125 | 0 | 0 |
| Website | 41 | 387 | 0 | 0 |
| Object info parser | 4 | 33 | 0 | 0 |

Also passed:

- `pnpm typecheck`
- `pnpm lint` (six pre-existing warnings, zero errors)
- oxfmt and type-aware Oxlint on all changed files
- pre-push `pnpm knip --cache`