### PR TITLE
test: cover repeated legacy login query params

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -78,10 +78,13 @@ describe('cloudOnboardingRoutes', () => {
   })
 
   it('preserves the query and hash through the legacy /login redirect', async () => {
-    const to = await attemptNavigation('/login?previousFullPath=%2Ffoo#section')
+    const to = await attemptNavigation(
+      '/login?previousFullPath=%2Ffoo&campaign=one&campaign=two#section'
+    )
 
     expect(to.name).toBe('cloud-login')
     expect(to.query.previousFullPath).toBe('/foo')
+    expect(to.query.campaign).toEqual(['one', 'two'])
     expect(to.hash).toBe('#section')
   })
 


### PR DESCRIPTION
## Summary

Ports the repeated-query regression coverage identified in superseded PR #15022 after #15026 merged the legacy `/login` redirect. Original coverage and test approach are attributed to #15022 / @dante01yoon.

## Changes

- **What**: Extend the existing real-router redirect test to verify `/login?campaign=one&campaign=two` reaches `cloud-login` with `query.campaign` equal to `['one', 'two']`.

## Review Focus

Confirm the assertion covers Vue Router's repeated-query parsing while retaining the existing query, hash, and no-loop coverage.

## Validation

- `pnpm test:unit src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts` — 11 tests passed
- `pnpm exec oxfmt --check src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- Commit hooks: typecheck, Oxlint, ESLint, and formatting passed; push hook Knip passed

## Screenshots (if applicable)

Not applicable; this PR is test-only.
