### PR TITLE
test(router): drive the legacy /login redirect through the cloud-login guard

### DIFF
--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
-import type { RouteLocationNormalized } from 'vue-router'
+import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
 
 import {
   cloudOnboardingRoutes,
@@ -18,6 +18,15 @@ const createSessionOrThrow = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/platform/auth/session/useSessionCookie', () => ({
   useSessionCookie: () => ({ createSessionOrThrow })
 }))
+
+// The `cloud-login` guard reads only `isLoggedIn.value`, so a plain box stands
+// in for the ref and keeps the factory hoistable.
+const { useCurrentUser, isLoggedIn } = vi.hoisted(() => {
+  const isLoggedIn = { value: false }
+  return { isLoggedIn, useCurrentUser: vi.fn(() => ({ isLoggedIn })) }
+})
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({ useCurrentUser }))
 
 const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
 const consentRoute = oauthLayout?.children?.find(
@@ -68,6 +77,40 @@ async function attemptNavigation(target: string) {
   return attempts[0]
 }
 
+/**
+ * Swaps every view component for a render-null stub while leaving names, paths,
+ * meta, redirects and `beforeEnter` guards untouched. `render` rather than
+ * `template` so the stubs need no runtime template compiler.
+ */
+function stubViews(routes: readonly RouteRecordRaw[]): RouteRecordRaw[] {
+  return routes.map((route) => ({
+    ...route,
+    ...('component' in route && route.component
+      ? { component: { render: () => null } }
+      : {}),
+    ...('children' in route && route.children
+      ? { children: stubViews(route.children) }
+      : {})
+  })) as RouteRecordRaw[]
+}
+
+/**
+ * Lets navigation run to completion, unlike `attemptNavigation`, which aborts in
+ * a global guard and so never reaches a per-route `beforeEnter`. Use this when
+ * the guard itself is the thing under test.
+ */
+async function completeNavigation(target: string) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: stubViews(cloudOnboardingRoutes)
+  })
+
+  await router.push(target)
+  await router.isReady()
+
+  return router.currentRoute.value
+}
+
 describe('cloudOnboardingRoutes', () => {
   it('redirects the legacy /login path to the cloud login route', async () => {
     const to = await attemptNavigation('/login')
@@ -83,6 +126,25 @@ describe('cloudOnboardingRoutes', () => {
     expect(to.name).toBe('cloud-login')
     expect(to.query.previousFullPath).toBe('/foo')
     expect(to.hash).toBe('#section')
+  })
+
+  /**
+   * A repeated key arrives as an array, which a redirect that rebuilt the query
+   * value by value would flatten to whichever copy it saw last. Marketing links
+   * are the ones most likely to carry repeated UTM-style keys, and they are also
+   * the traffic this redirect exists to catch. Case contributed by @dante01yoon
+   * from the parallel fix in #15022.
+   */
+  it('preserves repeated query keys through the legacy /login redirect', async () => {
+    const to = await attemptNavigation(
+      '/login?source=legacy&campaign=one&campaign=two'
+    )
+
+    expect(to.name).toBe('cloud-login')
+    expect(to.query).toEqual({
+      source: 'legacy',
+      campaign: ['one', 'two']
+    })
   })
 
   it('resolves /cloud/login without redirecting', async () => {
@@ -126,6 +188,47 @@ describe('cloudOnboardingRoutes', () => {
     const [layoutModule, consentModule] = resolvedComponents
     expect(layoutModule).toHaveProperty('default')
     expect(consentModule).toHaveProperty('default')
+  })
+})
+
+/**
+ * The redirect tests above abort before any per-route guard runs, so they prove
+ * the route table resolves `/login` but not that the destination still works
+ * once it is entered. These drive the real `cloud-login` `beforeEnter` through
+ * the redirect, which is the journey the reported bug actually took.
+ */
+describe('legacy /login through the cloud-login guard', () => {
+  beforeEach(() => {
+    clearOAuthRequestId()
+    isLoggedIn.value = false
+    useCurrentUser.mockClear()
+  })
+
+  it('lands a signed-out visitor on the login view', async () => {
+    const to = await completeNavigation('/login')
+
+    expect(useCurrentUser).toHaveBeenCalled()
+    expect(to.name).toBe('cloud-login')
+    expect(to.path).toBe('/cloud/login')
+  })
+
+  it('forwards a signed-in visitor past the login view', async () => {
+    isLoggedIn.value = true
+
+    const to = await completeNavigation('/login')
+
+    expect(useCurrentUser).toHaveBeenCalled()
+    expect(to.name).toBe('cloud-user-check')
+  })
+
+  it('honours switchAccount through the redirect, leaving the guard inert', async () => {
+    isLoggedIn.value = true
+
+    const to = await completeNavigation('/login?switchAccount=true')
+
+    expect(useCurrentUser).not.toHaveBeenCalled()
+    expect(to.name).toBe('cloud-login')
+    expect(to.query.switchAccount).toBe('true')
   })
 })
 

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts
@@ -1,3 +1,4 @@
+import { mapValues } from 'es-toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
@@ -27,6 +28,10 @@ const { useCurrentUser, isLoggedIn } = vi.hoisted(() => {
 })
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({ useCurrentUser }))
+
+beforeEach(() => {
+  isLoggedIn.value = false
+})
 
 const oauthLayout = cloudOnboardingRoutes.find((r) => r.path === '/oauth')
 const consentRoute = oauthLayout?.children?.find(
@@ -78,15 +83,18 @@ async function attemptNavigation(target: string) {
 }
 
 /**
- * Swaps every view component for a render-null stub while leaving names, paths,
- * meta, redirects and `beforeEnter` guards untouched. `render` rather than
- * `template` so the stubs need no runtime template compiler.
+ * Swaps every view component — single or named — for a render-null stub while
+ * leaving names, paths, meta, redirects and `beforeEnter` guards untouched.
+ * `render` rather than `template` so the stubs need no runtime template
+ * compiler.
  */
 function stubViews(routes: readonly RouteRecordRaw[]): RouteRecordRaw[] {
+  const stub = { render: () => null }
   return routes.map((route) => ({
     ...route,
-    ...('component' in route && route.component
-      ? { component: { render: () => null } }
+    ...('component' in route && route.component ? { component: stub } : {}),
+    ...('components' in route && route.components
+      ? { components: mapValues(route.components, () => stub) }
       : {}),
     ...('children' in route && route.children
       ? { children: stubViews(route.children) }
@@ -98,6 +106,10 @@ function stubViews(routes: readonly RouteRecordRaw[]): RouteRecordRaw[] {
  * Lets navigation run to completion, unlike `attemptNavigation`, which aborts in
  * a global guard and so never reaches a per-route `beforeEnter`. Use this when
  * the guard itself is the thing under test.
+ *
+ * A guard that aborts or redirects unexpectedly makes `push` resolve with a
+ * `NavigationFailure` rather than throw, so the failure is asserted here instead
+ * of surfacing as a puzzling `currentRoute` mismatch in the caller.
  */
 async function completeNavigation(target: string) {
   const router = createRouter({
@@ -105,8 +117,7 @@ async function completeNavigation(target: string) {
     routes: stubViews(cloudOnboardingRoutes)
   })
 
-  await router.push(target)
-  await router.isReady()
+  expect(await router.push(target)).toBeUndefined()
 
   return router.currentRoute.value
 }
@@ -200,7 +211,6 @@ describe('cloudOnboardingRoutes', () => {
 describe('legacy /login through the cloud-login guard', () => {
   beforeEach(() => {
     clearOAuthRequestId()
-    isLoggedIn.value = false
     useCurrentUser.mockClear()
   })
 


### PR DESCRIPTION
## Summary

Follow-up test coverage for the legacy `/login` redirect landed in #15026, driving the redirect through the real `cloud-login` guard instead of stopping at route resolution.

## Changes

- **What**: adds `completeNavigation`, a helper that runs navigation to completion against the real route table with view components swapped for render-null stubs, so names, paths, meta, redirects and `beforeEnter` all stay intact. Covers three journeys through `/login`: signed-out lands on the login view, signed-in is forwarded past it, and `switchAccount` leaves the guard inert. Also ports the repeated-query-key case from the parallel fix in #15022, contributed by @dante01yoon.
- **Breaking**: none. Test-only change, no production code touched.

## Review Focus

The existing `attemptNavigation` helper aborts in a global `beforeEach`, which is what keeps it cheap, but it means navigation never reaches a per-route `beforeEnter`. Every redirect assertion we had stopped one step short of the destination actually being entered. The reported failure was someone completing that journey, so the untested step was the interesting one.

Worth knowing for anyone reading the route record: vue-router carries query and hash across a redirect by default. The explicit `query: to.query, hash: to.hash` in the record restates the default rather than providing it. I verified this by mutation, stripping the passthrough entirely leaves every existing assertion passing. I have deliberately left the code as-is, since it is harmless and reads as intent, but it should not be mistaken for load-bearing.

That does mean the query assertions are narrower than they look. What they genuinely catch is someone replacing the redirect with a hand-built query, which flattens repeated keys. Substituting an explicit `query: { only: 'this' }` fails three of these tests immediately, so the guard is real, just narrower than "preserves the query" suggests.

Mutation results for the whole file, since tests that cannot fail are decoration:

| Mutation | Result |
|---|---|
| Delete the `/login` record | 6 tests fail |
| Strip explicit `query`/`hash` from the redirect | 15 pass (vue-router default) |
| Replace with an explicit overriding query | 3 tests fail |

## ELI5

Opening `cloud.comfy.org/login` used to hang forever, because the app had no `/login` page registered and just sat there looking for one. That was fixed by pointing `/login` at the real sign-in page.

The tests that shipped with that fix checked that the signpost points the right way. They did not check that you can actually walk through the door it points at, because they stopped the moment the direction was known. The original bug was someone walking through the door, so this adds tests that make the whole trip.

There are three trips worth making: a logged-out visitor should arrive at the sign-in page, a logged-in visitor should be sent onward rather than asked to sign in again, and someone deliberately switching accounts should be left alone at the sign-in page even though they are already logged in. All three now have tests.

While writing them I checked whether the tests could actually fail, by deliberately breaking the redirect in three different ways and confirming the right tests complained each time. One of those experiments turned up something worth recording: part of the original fix is redundant, because the router already does that work by default. It is harmless and I have left it alone, but the note above means the next person will not assume it is doing something it is not.
