### PR TITLE
ci: serialize every cloud-gate run and stop the per-PR stampede

### DIFF
--- a/.github/workflows/ci-tests-custom-nodes-cloud.yaml
+++ b/.github/workflows/ci-tests-custom-nodes-cloud.yaml
@@ -34,10 +34,16 @@
 name: 'CI: Tests Custom Nodes Cloud'
 
 on:
-  pull_request:
-    branches-ignore: [wip/*, draft/*, temp/*]
+  # No pull_request trigger. Every automatic run shares ONE serial Cloud
+  # resource (the smoke account's queue), and GitHub keeps a single pending
+  # slot per concurrency group - so per-PR pushes stampeded the group and
+  # evicted each other instead of queueing (16 of the 40 runs before this
+  # change were cancelled; none of the PR-triggered survivors produced a
+  # verdict PRs acted on). PR-time custom-node coverage stays with the core
+  # gate and the pure specs in the main shards; Cloud verdicts come from
+  # suite-branch/main pushes, the merge queue, and manual dispatch.
   push:
-    branches: [main, master]
+    branches: [main, master, nathaniel/custom-node-e2e-suite]
   merge_group:
   workflow_dispatch:
 
@@ -60,13 +66,14 @@ concurrency:
   # newer one queues into the group - under 3+ concurrent triggers the middle
   # run is cancelled, not queued. This is not safe for a required check. Do not
   # mark this check required while pending runs can be evicted from this group.
-  # workflow_dispatch runs get their own group: main-push runs share the
-  # instance group and each new pending run EVICTS the older pending one
-  # (GitHub keeps one pending slot per group) - calibration dispatches
-  # 30316897509/30317780440/30318407927 died queued or displaced under main
-  # churn. Keep dispatches isolated from automatic runs and preserve serial
-  # execution while whole-queue observation remains part of the proof.
-  group: ${{ github.event_name == 'workflow_dispatch' && 'custom-nodes-cloud-dispatch' || 'custom-nodes-cloud-instance' }}
+  # Dispatches share the SAME group: the separate dispatch group let a manual
+  # run execute CONCURRENTLY with an instance-group run (observed live
+  # 2026-08-11: dispatch 31541231667 co-tenant with pull_request run
+  # 31530265854, which then wedged past 125m in the suite step) - and
+  # co-tenancy corrupts whole-queue observation for BOTH runs. The eviction
+  # pressure that once justified the split is gone now that per-PR triggers
+  # are removed. One group, one run at a time, for every event.
+  group: custom-nodes-cloud-instance
   cancel-in-progress: false
 
 jobs:
@@ -98,6 +105,9 @@ jobs:
       (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    # Bounded: the longest healthy run observed is ~110m of suite; a wedged
+    # run otherwise occupies the serial group for GitHub's 360m default.
+    timeout-minutes: 150
     # This proof is intentionally one worker and unsharded. Cloud app boots are
     # network-bound, and waitForQueueQuiet observes the whole shared queue.
     # Preserve the serial execution contract for the S1-S12 gate.

--- a/.github/workflows/record-custom-nodes-geometry-cloud.yaml
+++ b/.github/workflows/record-custom-nodes-geometry-cloud.yaml
@@ -45,10 +45,9 @@ concurrency:
   # queue still makes a record run and a gate run interfere: waitForQueueQuiet
   # (customNodeSuite.ts) waits on the whole queue and cannot tell whose work
   # it is. Retire this group when the smoke-account pool lands (see the
-  # gate's concurrency comment for the full semantics).
-  # EXCEPTION since the gate's dispatch-group split: gate workflow_dispatch
-  # calibration runs use their own group and CAN overlap this record - do not
-  # dispatch both at once (manual exclusion until the in-job lock lands).
+  # gate's concurrency comment for the full semantics). Every gate event -
+  # including workflow_dispatch - now shares this group, so a record run and
+  # a gate run can no longer overlap.
   group: custom-nodes-cloud-instance
   cancel-in-progress: false
 


### PR DESCRIPTION
## Summary

The cloud gate has zero genuine green runs and constant cancellations - both are structural, not test-content, problems. This makes every run serial and stops per-PR pushes from evicting each other.

## Changes

- **What**:
  - **Drop the `pull_request` trigger.** Every automatic run shares one serial resource (the smoke account's queue) behind a single-pending-slot concurrency group, so per-PR pushes stampeded it: **16 of the last 40 runs were cancelled**, mostly PR-triggered runs evicting each other (four in a row 21:03-21:18 on 2026-08-11), and no PR-triggered run produced a verdict a PR acted on. PR-time custom-node coverage stays with the core gate and the pure specs in the main shards; Cloud verdicts come from suite-branch/main pushes, the merge queue, and dispatch.
  - **Fold dispatches into the instance group.** The separate dispatch group allowed a manual run to execute concurrently with an instance-group run - observed live: dispatch 31541231667 co-tenant with run 31530265854, which then sat 125m+ in its suite step. Co-tenancy corrupts whole-queue observation (`waitForQueueQuiet`) for both runs. The eviction pressure that justified the split dies with the per-PR trigger.
  - **`timeout-minutes: 150`** on the job (longest healthy suite ~110m): a wedged run can no longer hold the serial group for GitHub's 360m default.

## Review Focus

- This trades PR-time cloud signal (which the eviction data shows was ~never delivered) for runs that actually complete. If per-PR cloud coverage is wanted later, it needs the prompt-scoped queue observation change first - the serial contract is the binding constraint, not this workflow.
- The fork-safety job `if:` still references `pull_request`; left in place deliberately as defence-in-depth if the trigger ever returns.