### PR TITLE
fix(release-sheriff): retry gh calls on transient 502/503 gateway errors

### DIFF
--- a/scripts/release-sheriff/release-sheriff.ts
+++ b/scripts/release-sheriff/release-sheriff.ts
@@ -333,6 +333,24 @@ function gh(args: string[]): string {
   return execFileSync('gh', args, { encoding: 'utf8' })
 }
 
+// GitHub's GraphQL API occasionally returns 502/503; retry with backoff before
+// giving up so a transient gateway error doesn't degrade the whole run.
+function ghWithRetry(args: string[], retries = 3): string {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return gh(args)
+    } catch (err) {
+      if (attempt === retries) throw err
+      const delayMs = 2000 * attempt
+      warn(
+        `gh command failed (attempt ${attempt}/${retries}), retrying in ${delayMs}ms: ${String(err)}`
+      )
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs)
+    }
+  }
+  throw new Error('unreachable')
+}
+
 function ghPrList(selector: string[]): PullRequestSummary[] {
   const fixed = [
     'pr',
@@ -344,7 +362,7 @@ function ghPrList(selector: string[]): PullRequestSummary[] {
     '--json'
   ]
   const prs = JSON.parse(
-    gh([...fixed, PR_FIELDS, ...selector])
+    ghWithRetry([...fixed, PR_FIELDS, ...selector])
   ) as PullRequestSummary[]
   if (prs.length === QUERY_LIMIT) {
     warn(


### PR DESCRIPTION
## Root cause

The release sheriff job at run [#31508324202](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31508324202) failed with:

```
Error: Command failed: gh pr list ... --search author:app/dependabot
HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)
```

GitHub's GraphQL API returned a transient 502. The `gh()` helper calls `execFileSync` which throws immediately on non-zero exit, so one bad gateway took down the whole run before any sheriff could be assigned.

The query itself is valid — running it now returns results correctly.

## Fix

Add `ghWithRetry()` that wraps `gh()` with up to 3 attempts and exponential backoff (2s → 4s). `ghPrList` now calls `ghWithRetry` instead of `gh`. On the third failure it re-throws so the degraded-run reporter still fires.

## Test plan

- [x] All 34 existing unit tests pass (`npx vitest run scripts/release-sheriff/release-sheriff.test.ts`)
- [x] No new TS errors in the sheriff script