### PR TITLE
fix: bound auth wait in startStoreBootstrap + catch-all for unknown routes (IR-105)

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -46,4 +46,14 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
     // Verify cloud-specific login UI is rendered
     await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
   })
+
+  test('unknown paths redirect to cloud login instead of hanging on splash screen', async ({
+    page
+  }) => {
+    await page.goto(new URL('/woiadawd', APP_URL).toString())
+    // Catch-all redirects unknown paths to /, auth guard sends unauthenticated
+    // users to /cloud/login. Regression: before the fix the SPA had no route
+    // match and startStoreBootstrap hung indefinitely on the splash screen.
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+  })
 })

--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -50,10 +50,21 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
   test('unknown paths redirect to cloud login instead of hanging on splash screen', async ({
     page
   }) => {
-    await page.goto(new URL('/woiadawd', APP_URL).toString())
-    // Catch-all redirects unknown paths to /, auth guard sends unauthenticated
-    // users to /cloud/login. Regression: before the fix the SPA had no route
-    // match and startStoreBootstrap hung indefinitely on the splash screen.
+    // Load the SPA at root (the backend serves index.html for /).
+    // Then push an unknown path client-side so Vue Router handles it.
+    // The backend serves ComfyUI file responses for arbitrary paths, so a
+    // direct page.goto('/woiadawd') would trigger a download rather than the SPA.
+    await page.goto(APP_URL)
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+
+    // Navigate client-side to an unknown path. The catch-all route redirects to /,
+    // then the auth guard sends unauthenticated users back to /cloud/login.
+    // Regression: before the catch-all was added, the SPA found no route and
+    // startStoreBootstrap hung indefinitely on the splash screen.
+    await page.evaluate(() => {
+      window.history.pushState(null, '', '/woiadawd')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
     await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
   })
 })

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,32 +1,32 @@
-import { until } from "@vueuse/core";
-import { storeToRefs } from "pinia";
+import { until } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
 import {
   createRouter,
   createWebHashHistory,
-  createWebHistory,
-} from "vue-router";
-import type { RouteLocationNormalized } from "vue-router";
+  createWebHistory
+} from 'vue-router'
+import type { RouteLocationNormalized } from 'vue-router'
 
-import { useFeatureFlags } from "@/composables/useFeatureFlags";
-import { isCloud, isDesktop } from "@/platform/distribution/types";
-import { useTelemetry } from "@/platform/telemetry";
-import { useDialogService } from "@/services/dialogService";
-import { useAuthStore } from "@/stores/authStore";
-import { useUserStore } from "@/stores/userStore";
-import LayoutDefault from "@/views/layouts/LayoutDefault.vue";
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { isCloud, isDesktop } from '@/platform/distribution/types'
+import { useTelemetry } from '@/platform/telemetry'
+import { useDialogService } from '@/services/dialogService'
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
+import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 
-import { captureOAuthRequestId } from "@/platform/cloud/oauth/oauthState";
-import { installDesktopLoginRedemption } from "@/platform/cloud/onboarding/desktopLoginRedemption";
-import { installPreservedQueryTracker } from "@/platform/navigation/preservedQueryTracker";
-import { PRESERVED_QUERY_NAMESPACES } from "@/platform/navigation/preservedQueryNamespaces";
-import { preserveLoggedOutShareAuthAttribution } from "@/platform/workflow/sharing/utils/shareAuthAttribution";
+import { captureOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
+import { installDesktopLoginRedemption } from '@/platform/cloud/onboarding/desktopLoginRedemption'
+import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { preserveLoggedOutShareAuthAttribution } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
 
 const cloudOnboardingRoutes = isCloud
-  ? (await import("./platform/cloud/onboarding/onboardingCloudRoutes"))
+  ? (await import('./platform/cloud/onboarding/onboardingCloudRoutes'))
       .cloudOnboardingRoutes
-  : [];
+  : []
 
-const isFileProtocol = window.location.protocol === "file:";
+const isFileProtocol = window.location.protocol === 'file:'
 
 /**
  * Determine base path for the router.
@@ -36,17 +36,17 @@ const isFileProtocol = window.location.protocol === "file:";
  *   to support deployments like http://mysite.com/ComfyUI/
  */
 function getBasePath(): string {
-  if (isDesktop) return "/";
-  if (isCloud) return import.meta.env?.BASE_URL || "/";
-  return window.location.pathname;
+  if (isDesktop) return '/'
+  if (isCloud) return import.meta.env?.BASE_URL || '/'
+  return window.location.pathname
 }
 
-const basePath = getBasePath();
+const basePath = getBasePath()
 
 function trackPageView(): void {
   useTelemetry()?.trackPageView(document.title, {
-    path: window.location.href,
-  });
+    path: window.location.href
+  })
 }
 
 const router = createRouter({
@@ -59,213 +59,213 @@ const router = createRouter({
   routes: [
     ...(isCloud ? cloudOnboardingRoutes : []),
     {
-      path: "/",
+      path: '/',
       component: LayoutDefault,
       children: [
         {
-          path: "",
-          name: "GraphView",
-          component: () => import("@/views/GraphView.vue"),
+          path: '',
+          name: 'GraphView',
+          component: () => import('@/views/GraphView.vue'),
           beforeEnter: async (_to, _from, next) => {
             // Then check user store
-            const userStore = useUserStore();
-            await userStore.initialize();
+            const userStore = useUserStore()
+            await userStore.initialize()
             if (userStore.needsLogin) {
-              next("/user-select");
+              next('/user-select')
             } else {
-              next();
+              next()
             }
-          },
+          }
         },
         {
-          path: "user-select",
-          name: "UserSelectView",
-          component: () => import("@/views/UserSelectView.vue"),
-        },
-      ],
+          path: 'user-select',
+          name: 'UserSelectView',
+          component: () => import('@/views/UserSelectView.vue')
+        }
+      ]
     },
     // Catch-all: unknown paths redirect to root rather than hanging on the
     // splash screen with no route match. The global auth guard then routes
     // unauthenticated users to /cloud/login as normal.
-    { path: "/:pathMatch(.*)*", redirect: "/" },
+    { path: '/:pathMatch(.*)*', redirect: '/' }
   ],
 
   scrollBehavior(_to, _from, savedPosition) {
     if (savedPosition) {
-      return savedPosition;
+      return savedPosition
     } else {
-      return { top: 0 };
+      return { top: 0 }
     }
-  },
-});
+  }
+})
 
 installPreservedQueryTracker(router, [
   {
     namespace: PRESERVED_QUERY_NAMESPACES.TEMPLATE,
-    keys: ["template", "source", "mode"],
+    keys: ['template', 'source', 'mode']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.SHARE,
-    keys: ["share"],
+    keys: ['share']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.INVITE,
-    keys: ["invite"],
+    keys: ['invite']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE,
-    keys: ["create_workspace"],
+    keys: ['create_workspace']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.OAUTH,
-    keys: ["oauth_request_id"],
+    keys: ['oauth_request_id']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.PRICING,
-    keys: ["pricing", "stop", "cycle"],
-    requiredKey: "pricing",
+    keys: ['pricing', 'stop', 'cycle'],
+    requiredKey: 'pricing'
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.TOPUP,
-    keys: ["topup"],
+    keys: ['topup']
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN,
-    keys: ["desktop_login_code"],
-    stripAfterCapture: true,
-  },
-]);
+    keys: ['desktop_login_code'],
+    stripAfterCapture: true
+  }
+])
 
 router.beforeEach((to, _from, next) => {
-  captureOAuthRequestId(to.query);
-  next();
-});
+  captureOAuthRequestId(to.query)
+  next()
+})
 
 router.afterEach(() => {
-  trackPageView();
-});
+  trackPageView()
+})
 
 if (isCloud) {
-  const { flags } = useFeatureFlags();
+  const { flags } = useFeatureFlags()
   const PUBLIC_ROUTE_NAMES = new Set([
-    "cloud-login",
-    "cloud-signup",
-    "cloud-forgot-password",
-    "cloud-oauth-consent",
-    "cloud-sorry-contact-support",
-  ]);
+    'cloud-login',
+    'cloud-signup',
+    'cloud-forgot-password',
+    'cloud-oauth-consent',
+    'cloud-sorry-contact-support'
+  ])
   const PUBLIC_ROUTE_PATHS = new Set([
-    "/cloud/login",
-    "/cloud/signup",
-    "/cloud/forgot-password",
-    "/oauth/consent",
-    "/cloud/sorry-contact-support",
-  ]);
+    '/cloud/login',
+    '/cloud/signup',
+    '/cloud/forgot-password',
+    '/oauth/consent',
+    '/cloud/sorry-contact-support'
+  ])
 
   function isPublicRoute(to: RouteLocationNormalized) {
-    const name = String(to.name);
-    if (PUBLIC_ROUTE_NAMES.has(name)) return true;
-    const path = to.path;
-    return PUBLIC_ROUTE_PATHS.has(path);
+    const name = String(to.name)
+    if (PUBLIC_ROUTE_NAMES.has(name)) return true
+    const path = to.path
+    return PUBLIC_ROUTE_PATHS.has(path)
   }
   // Global authentication guard
   router.beforeEach(async (to, _from, next) => {
-    const authStore = useAuthStore();
+    const authStore = useAuthStore()
 
     // Wait for Firebase auth to initialize
     // Timeout after 16 seconds
     if (!authStore.isInitialized) {
       try {
-        const { isInitialized } = storeToRefs(authStore);
-        await until(isInitialized).toBe(true, { timeout: 16_000 });
+        const { isInitialized } = storeToRefs(authStore)
+        await until(isInitialized).toBe(true, { timeout: 16_000 })
       } catch (error) {
-        console.error("Auth initialization failed:", error);
-        return next({ name: "cloud-auth-timeout" });
+        console.error('Auth initialization failed:', error)
+        return next({ name: 'cloud-auth-timeout' })
       }
     }
 
     // Pass authenticated users
-    const authHeader = await authStore.getAuthHeader();
-    const isLoggedIn = !!authHeader;
-    preserveLoggedOutShareAuthAttribution(to.query, isLoggedIn);
+    const authHeader = await authStore.getAuthHeader()
+    const isLoggedIn = !!authHeader
+    preserveLoggedOutShareAuthAttribution(to.query, isLoggedIn)
 
     // Allow public routes
     if (isPublicRoute(to)) {
-      return next();
+      return next()
     }
 
     // Special handling for user-check
     // These routes need auth but handle their own routing logic
-    if (to.name === "cloud-user-check") {
+    if (to.name === 'cloud-user-check') {
       if (to.meta.requiresAuth && !isLoggedIn) {
-        return next({ name: "cloud-login" });
+        return next({ name: 'cloud-login' })
       }
-      return next();
+      return next()
     }
 
     // Prevent redirect loop when coming from user-check
-    if (_from.name === "cloud-user-check" && to.path === "/") {
-      return next();
+    if (_from.name === 'cloud-user-check' && to.path === '/') {
+      return next()
     }
 
     const query =
-      to.fullPath === "/"
+      to.fullPath === '/'
         ? undefined
-        : { previousFullPath: encodeURIComponent(to.fullPath) };
+        : { previousFullPath: encodeURIComponent(to.fullPath) }
 
     // Check if route requires authentication
     if (to.meta.requiresAuth && !isLoggedIn) {
       return next({
-        name: "cloud-login",
-        query,
-      });
+        name: 'cloud-login',
+        query
+      })
     }
 
     // Handle other protected routes
     if (!isLoggedIn) {
       // For Electron, use dialog
       if (isDesktop) {
-        const dialogService = useDialogService();
-        const loginSuccess = await dialogService.showSignInDialog();
-        return loginSuccess ? next() : next(false);
+        const dialogService = useDialogService()
+        const loginSuccess = await dialogService.showSignInDialog()
+        return loginSuccess ? next() : next(false)
       }
 
       // For web, redirect to login
       return next({
-        name: "cloud-login",
-        query,
-      });
+        name: 'cloud-login',
+        query
+      })
     }
 
     // User is logged in - check if they need onboarding (when enabled)
     // For root path, check actual user status to handle waitlisted users
-    if (!isDesktop && isLoggedIn && to.path === "/") {
+    if (!isDesktop && isLoggedIn && to.path === '/') {
       if (!flags.onboardingSurveyEnabled) {
-        return next();
+        return next()
       }
       // Import auth functions dynamically to avoid circular dependency
       const { getSurveyCompletedStatus } =
-        await import("@/platform/cloud/onboarding/auth");
+        await import('@/platform/cloud/onboarding/auth')
       try {
         // Check user's actual status
-        const surveyCompleted = await getSurveyCompletedStatus();
+        const surveyCompleted = await getSurveyCompletedStatus()
 
         // Survey is required for all users (when feature flag enabled)
         if (!surveyCompleted) {
-          return next({ name: "cloud-survey" });
+          return next({ name: 'cloud-survey' })
         }
       } catch (error) {
-        console.error("Failed to check user status:", error);
+        console.error('Failed to check user status:', error)
         // On error, redirect to user-check as fallback
-        return next({ name: "cloud-user-check" });
+        return next({ name: 'cloud-user-check' })
       }
     }
 
     // User is logged in and accessing protected route
-    return next();
-  });
+    return next()
+  })
 
-  installDesktopLoginRedemption(router);
+  installDesktopLoginRedemption(router)
 }
 
-export default router;
+export default router

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,32 +1,32 @@
-import { until } from '@vueuse/core'
-import { storeToRefs } from 'pinia'
+import { until } from "@vueuse/core";
+import { storeToRefs } from "pinia";
 import {
   createRouter,
   createWebHashHistory,
-  createWebHistory
-} from 'vue-router'
-import type { RouteLocationNormalized } from 'vue-router'
+  createWebHistory,
+} from "vue-router";
+import type { RouteLocationNormalized } from "vue-router";
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
-import { isCloud, isDesktop } from '@/platform/distribution/types'
-import { useTelemetry } from '@/platform/telemetry'
-import { useDialogService } from '@/services/dialogService'
-import { useAuthStore } from '@/stores/authStore'
-import { useUserStore } from '@/stores/userStore'
-import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
+import { useFeatureFlags } from "@/composables/useFeatureFlags";
+import { isCloud, isDesktop } from "@/platform/distribution/types";
+import { useTelemetry } from "@/platform/telemetry";
+import { useDialogService } from "@/services/dialogService";
+import { useAuthStore } from "@/stores/authStore";
+import { useUserStore } from "@/stores/userStore";
+import LayoutDefault from "@/views/layouts/LayoutDefault.vue";
 
-import { captureOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
-import { installDesktopLoginRedemption } from '@/platform/cloud/onboarding/desktopLoginRedemption'
-import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
-import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
-import { preserveLoggedOutShareAuthAttribution } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
+import { captureOAuthRequestId } from "@/platform/cloud/oauth/oauthState";
+import { installDesktopLoginRedemption } from "@/platform/cloud/onboarding/desktopLoginRedemption";
+import { installPreservedQueryTracker } from "@/platform/navigation/preservedQueryTracker";
+import { PRESERVED_QUERY_NAMESPACES } from "@/platform/navigation/preservedQueryNamespaces";
+import { preserveLoggedOutShareAuthAttribution } from "@/platform/workflow/sharing/utils/shareAuthAttribution";
 
 const cloudOnboardingRoutes = isCloud
-  ? (await import('./platform/cloud/onboarding/onboardingCloudRoutes'))
+  ? (await import("./platform/cloud/onboarding/onboardingCloudRoutes"))
       .cloudOnboardingRoutes
-  : []
+  : [];
 
-const isFileProtocol = window.location.protocol === 'file:'
+const isFileProtocol = window.location.protocol === "file:";
 
 /**
  * Determine base path for the router.
@@ -36,17 +36,17 @@ const isFileProtocol = window.location.protocol === 'file:'
  *   to support deployments like http://mysite.com/ComfyUI/
  */
 function getBasePath(): string {
-  if (isDesktop) return '/'
-  if (isCloud) return import.meta.env?.BASE_URL || '/'
-  return window.location.pathname
+  if (isDesktop) return "/";
+  if (isCloud) return import.meta.env?.BASE_URL || "/";
+  return window.location.pathname;
 }
 
-const basePath = getBasePath()
+const basePath = getBasePath();
 
 function trackPageView(): void {
   useTelemetry()?.trackPageView(document.title, {
-    path: window.location.href
-  })
+    path: window.location.href,
+  });
 }
 
 const router = createRouter({
@@ -59,209 +59,213 @@ const router = createRouter({
   routes: [
     ...(isCloud ? cloudOnboardingRoutes : []),
     {
-      path: '/',
+      path: "/",
       component: LayoutDefault,
       children: [
         {
-          path: '',
-          name: 'GraphView',
-          component: () => import('@/views/GraphView.vue'),
+          path: "",
+          name: "GraphView",
+          component: () => import("@/views/GraphView.vue"),
           beforeEnter: async (_to, _from, next) => {
             // Then check user store
-            const userStore = useUserStore()
-            await userStore.initialize()
+            const userStore = useUserStore();
+            await userStore.initialize();
             if (userStore.needsLogin) {
-              next('/user-select')
+              next("/user-select");
             } else {
-              next()
+              next();
             }
-          }
+          },
         },
         {
-          path: 'user-select',
-          name: 'UserSelectView',
-          component: () => import('@/views/UserSelectView.vue')
-        }
-      ]
-    }
+          path: "user-select",
+          name: "UserSelectView",
+          component: () => import("@/views/UserSelectView.vue"),
+        },
+      ],
+    },
+    // Catch-all: unknown paths redirect to root rather than hanging on the
+    // splash screen with no route match. The global auth guard then routes
+    // unauthenticated users to /cloud/login as normal.
+    { path: "/:pathMatch(.*)*", redirect: "/" },
   ],
 
   scrollBehavior(_to, _from, savedPosition) {
     if (savedPosition) {
-      return savedPosition
+      return savedPosition;
     } else {
-      return { top: 0 }
+      return { top: 0 };
     }
-  }
-})
+  },
+});
 
 installPreservedQueryTracker(router, [
   {
     namespace: PRESERVED_QUERY_NAMESPACES.TEMPLATE,
-    keys: ['template', 'source', 'mode']
+    keys: ["template", "source", "mode"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.SHARE,
-    keys: ['share']
+    keys: ["share"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.INVITE,
-    keys: ['invite']
+    keys: ["invite"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.CREATE_WORKSPACE,
-    keys: ['create_workspace']
+    keys: ["create_workspace"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.OAUTH,
-    keys: ['oauth_request_id']
+    keys: ["oauth_request_id"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.PRICING,
-    keys: ['pricing', 'stop', 'cycle'],
-    requiredKey: 'pricing'
+    keys: ["pricing", "stop", "cycle"],
+    requiredKey: "pricing",
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.TOPUP,
-    keys: ['topup']
+    keys: ["topup"],
   },
   {
     namespace: PRESERVED_QUERY_NAMESPACES.DESKTOP_LOGIN,
-    keys: ['desktop_login_code'],
-    stripAfterCapture: true
-  }
-])
+    keys: ["desktop_login_code"],
+    stripAfterCapture: true,
+  },
+]);
 
 router.beforeEach((to, _from, next) => {
-  captureOAuthRequestId(to.query)
-  next()
-})
+  captureOAuthRequestId(to.query);
+  next();
+});
 
 router.afterEach(() => {
-  trackPageView()
-})
+  trackPageView();
+});
 
 if (isCloud) {
-  const { flags } = useFeatureFlags()
+  const { flags } = useFeatureFlags();
   const PUBLIC_ROUTE_NAMES = new Set([
-    'cloud-login',
-    'cloud-signup',
-    'cloud-forgot-password',
-    'cloud-oauth-consent',
-    'cloud-sorry-contact-support'
-  ])
+    "cloud-login",
+    "cloud-signup",
+    "cloud-forgot-password",
+    "cloud-oauth-consent",
+    "cloud-sorry-contact-support",
+  ]);
   const PUBLIC_ROUTE_PATHS = new Set([
-    '/cloud/login',
-    '/cloud/signup',
-    '/cloud/forgot-password',
-    '/oauth/consent',
-    '/cloud/sorry-contact-support'
-  ])
+    "/cloud/login",
+    "/cloud/signup",
+    "/cloud/forgot-password",
+    "/oauth/consent",
+    "/cloud/sorry-contact-support",
+  ]);
 
   function isPublicRoute(to: RouteLocationNormalized) {
-    const name = String(to.name)
-    if (PUBLIC_ROUTE_NAMES.has(name)) return true
-    const path = to.path
-    return PUBLIC_ROUTE_PATHS.has(path)
+    const name = String(to.name);
+    if (PUBLIC_ROUTE_NAMES.has(name)) return true;
+    const path = to.path;
+    return PUBLIC_ROUTE_PATHS.has(path);
   }
   // Global authentication guard
   router.beforeEach(async (to, _from, next) => {
-    const authStore = useAuthStore()
+    const authStore = useAuthStore();
 
     // Wait for Firebase auth to initialize
     // Timeout after 16 seconds
     if (!authStore.isInitialized) {
       try {
-        const { isInitialized } = storeToRefs(authStore)
-        await until(isInitialized).toBe(true, { timeout: 16_000 })
+        const { isInitialized } = storeToRefs(authStore);
+        await until(isInitialized).toBe(true, { timeout: 16_000 });
       } catch (error) {
-        console.error('Auth initialization failed:', error)
-        return next({ name: 'cloud-auth-timeout' })
+        console.error("Auth initialization failed:", error);
+        return next({ name: "cloud-auth-timeout" });
       }
     }
 
     // Pass authenticated users
-    const authHeader = await authStore.getAuthHeader()
-    const isLoggedIn = !!authHeader
-    preserveLoggedOutShareAuthAttribution(to.query, isLoggedIn)
+    const authHeader = await authStore.getAuthHeader();
+    const isLoggedIn = !!authHeader;
+    preserveLoggedOutShareAuthAttribution(to.query, isLoggedIn);
 
     // Allow public routes
     if (isPublicRoute(to)) {
-      return next()
+      return next();
     }
 
     // Special handling for user-check
     // These routes need auth but handle their own routing logic
-    if (to.name === 'cloud-user-check') {
+    if (to.name === "cloud-user-check") {
       if (to.meta.requiresAuth && !isLoggedIn) {
-        return next({ name: 'cloud-login' })
+        return next({ name: "cloud-login" });
       }
-      return next()
+      return next();
     }
 
     // Prevent redirect loop when coming from user-check
-    if (_from.name === 'cloud-user-check' && to.path === '/') {
-      return next()
+    if (_from.name === "cloud-user-check" && to.path === "/") {
+      return next();
     }
 
     const query =
-      to.fullPath === '/'
+      to.fullPath === "/"
         ? undefined
-        : { previousFullPath: encodeURIComponent(to.fullPath) }
+        : { previousFullPath: encodeURIComponent(to.fullPath) };
 
     // Check if route requires authentication
     if (to.meta.requiresAuth && !isLoggedIn) {
       return next({
-        name: 'cloud-login',
-        query
-      })
+        name: "cloud-login",
+        query,
+      });
     }
 
     // Handle other protected routes
     if (!isLoggedIn) {
       // For Electron, use dialog
       if (isDesktop) {
-        const dialogService = useDialogService()
-        const loginSuccess = await dialogService.showSignInDialog()
-        return loginSuccess ? next() : next(false)
+        const dialogService = useDialogService();
+        const loginSuccess = await dialogService.showSignInDialog();
+        return loginSuccess ? next() : next(false);
       }
 
       // For web, redirect to login
       return next({
-        name: 'cloud-login',
-        query
-      })
+        name: "cloud-login",
+        query,
+      });
     }
 
     // User is logged in - check if they need onboarding (when enabled)
     // For root path, check actual user status to handle waitlisted users
-    if (!isDesktop && isLoggedIn && to.path === '/') {
+    if (!isDesktop && isLoggedIn && to.path === "/") {
       if (!flags.onboardingSurveyEnabled) {
-        return next()
+        return next();
       }
       // Import auth functions dynamically to avoid circular dependency
       const { getSurveyCompletedStatus } =
-        await import('@/platform/cloud/onboarding/auth')
+        await import("@/platform/cloud/onboarding/auth");
       try {
         // Check user's actual status
-        const surveyCompleted = await getSurveyCompletedStatus()
+        const surveyCompleted = await getSurveyCompletedStatus();
 
         // Survey is required for all users (when feature flag enabled)
         if (!surveyCompleted) {
-          return next({ name: 'cloud-survey' })
+          return next({ name: "cloud-survey" });
         }
       } catch (error) {
-        console.error('Failed to check user status:', error)
+        console.error("Failed to check user status:", error);
         // On error, redirect to user-check as fallback
-        return next({ name: 'cloud-user-check' })
+        return next({ name: "cloud-user-check" });
       }
     }
 
     // User is logged in and accessing protected route
-    return next()
-  })
+    return next();
+  });
 
-  installDesktopLoginRedemption(router)
+  installDesktopLoginRedemption(router);
 }
 
-export default router
+export default router;

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,164 +1,217 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { AxiosResponse } from 'axios'
-import { AxiosError } from 'axios'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { createTestingPinia } from "@pinia/testing";
+import type { AxiosResponse } from "axios";
+import { AxiosError } from "axios";
+import { setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
 
-import { mergeCustomNodesI18n } from '@/i18n'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { api } from '@/scripts/api'
+import { mergeCustomNodesI18n } from "@/i18n";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { api } from "@/scripts/api";
 
-import { useBootstrapStore } from './bootstrapStore'
+import { useBootstrapStore } from "./bootstrapStore";
 
-vi.mock('@/scripts/api', () => ({
+vi.mock("@/scripts/api", () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({})
-  }
-}))
+    getUserConfig: vi.fn().mockResolvedValue({}),
+  },
+}));
 
-vi.mock('@/i18n', () => ({
-  mergeCustomNodesI18n: vi.fn()
-}))
+vi.mock("@/i18n", () => ({
+  mergeCustomNodesI18n: vi.fn(),
+}));
 
-const mockIsSettingsReady = ref(false)
+const mockIsSettingsReady = ref(false);
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock("@/platform/settings/settingStore", () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true
+      mockIsSettingsReady.value = true;
     }),
     get isReady() {
-      return mockIsSettingsReady.value
+      return mockIsSettingsReady.value;
     },
     isLoading: ref(false),
-    error: ref(undefined)
-  }))
-}))
+    error: ref(undefined),
+  })),
+}));
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined)
-  }))
-}))
+    syncWorkflows: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
-const mockNeedsLogin = ref(false)
-vi.mock('@/stores/userStore', () => ({
+const mockNeedsLogin = ref(false);
+vi.mock("@/stores/userStore", () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin
-  }))
-}))
+    needsLogin: mockNeedsLogin,
+  })),
+}));
 
-const mockIsAuthInitialized = ref(false)
-const mockIsAuthAuthenticated = ref(false)
-vi.mock('@/stores/authStore', () => ({
+const mockIsAuthInitialized = ref(false);
+const mockIsAuthAuthenticated = ref(false);
+vi.mock("@/stores/authStore", () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated
-  }))
-}))
+    isAuthenticated: mockIsAuthAuthenticated,
+  })),
+}));
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false
-}))
-vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+  isCloud: false,
+}));
+vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
+
+const mockCaptureException = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/vue", () => ({
+  captureException: mockCaptureException,
+}));
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`)
-  error.response = { status } as AxiosResponse
-  return error
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = { status } as AxiosResponse;
+  return error;
 }
 
-describe('bootstrapStore', () => {
+describe("bootstrapStore", () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false
-    mockIsAuthInitialized.value = false
-    mockIsAuthAuthenticated.value = false
-    mockNeedsLogin.value = false
-    mockDistributionTypes.isCloud = false
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+    mockIsSettingsReady.value = false;
+    mockIsAuthInitialized.value = false;
+    mockIsAuthAuthenticated.value = false;
+    mockNeedsLogin.value = false;
+    mockDistributionTypes.isCloud = false;
+    setActivePinia(createTestingPinia({ stubActions: false }));
+  });
 
-  it('initializes with all flags false', () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    expect(settingStore.isReady).toBe(false)
-    expect(store.isI18nReady).toBe(false)
-  })
+  it("initializes with all flags false", () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    expect(settingStore.isReady).toBe(false);
+    expect(store.isI18nReady).toBe(false);
+  });
 
-  it('starts store bootstrap (settings, i18n)', async () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    void store.startStoreBootstrap()
+  it("starts store bootstrap (settings, i18n)", async () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    void store.startStoreBootstrap();
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true)
-      expect(store.isI18nReady).toBe(true)
-    })
-  })
+      expect(settingStore.isReady).toBe(true);
+      expect(store.isI18nReady).toBe(true);
+    });
+  });
 
-  describe('custom node translations', () => {
-    it('treats a missing /api/i18n endpoint as no translations', async () => {
+  describe("custom node translations", () => {
+    it("treats a missing /api/i18n endpoint as no translations", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(404),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-      })
-      expect(store.i18nError).toBeUndefined()
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
-    })
+        expect(store.isI18nReady).toBe(true);
+      });
+      expect(store.i18nError).toBeUndefined();
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
+    });
 
-    it('surfaces failures other than a missing endpoint', async () => {
+    it("surfaces failures other than a missing endpoint", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(500),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined()
-      })
-      expect(store.isI18nReady).toBe(false)
-    })
-  })
+        expect(store.i18nError).toBeDefined();
+      });
+      expect(store.isI18nReady).toBe(false);
+    });
+  });
 
-  describe('cloud mode', () => {
+  describe("cloud mode", () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true
-    })
+      mockDistributionTypes.isCloud = true;
+      mockCaptureException.mockReset();
+    });
 
-    it('waits for Firebase auth before loading stores', async () => {
-      const store = useBootstrapStore()
-      const settingStore = useSettingStore()
-      const bootstrapPromise = store.startStoreBootstrap()
+    it("waits for Firebase auth before loading stores", async () => {
+      const store = useBootstrapStore();
+      const settingStore = useSettingStore();
+      const bootstrapPromise = store.startStoreBootstrap();
 
-      expect(store.isI18nReady).toBe(false)
-      expect(settingStore.isReady).toBe(false)
+      expect(store.isI18nReady).toBe(false);
+      expect(settingStore.isReady).toBe(false);
 
       // Firebase initialized but user not yet authenticated
-      mockIsAuthInitialized.value = true
-      await nextTick()
+      mockIsAuthInitialized.value = true;
+      await nextTick();
 
-      expect(store.isI18nReady).toBe(false)
-      expect(settingStore.isReady).toBe(false)
+      expect(store.isI18nReady).toBe(false);
+      expect(settingStore.isReady).toBe(false);
 
       // User authenticates (e.g. signs in on login page)
-      mockIsAuthAuthenticated.value = true
-      await bootstrapPromise
+      mockIsAuthAuthenticated.value = true;
+      await bootstrapPromise;
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-        expect(settingStore.isReady).toBe(true)
-      })
-    })
-  })
-})
+        expect(store.isI18nReady).toBe(true);
+        expect(settingStore.isReady).toBe(true);
+      });
+    });
+
+    it("retries once and proceeds if auth resolves during the backoff", async () => {
+      vi.useFakeTimers();
+      try {
+        mockIsAuthInitialized.value = true;
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
+
+        // First wait times out with user still unauthenticated.
+        await vi.advanceTimersByTimeAsync(16_001);
+        expect(settingStore.isReady).toBe(false);
+
+        // Auth resolves during the retry backoff.
+        mockIsAuthAuthenticated.value = true;
+        await vi.advanceTimersByTimeAsync(3_001);
+        await bootstrapPromise;
+
+        expect(settingStore.isReady).toBe(true);
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
+      vi.useFakeTimers();
+      try {
+        mockIsAuthInitialized.value = true;
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
+
+        // Auth never resolves through the initial wait, the backoff, or the retry.
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
+        await bootstrapPromise;
+
+        expect(mockCaptureException).toHaveBeenCalledOnce();
+        expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), {
+          tags: { error_type: "bootstrap_auth_wait_timeout" },
+        });
+        // Bootstrap must not stay stuck: stores load even without confirmed auth.
+        expect(settingStore.isReady).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,210 +1,210 @@
-import { createTestingPinia } from "@pinia/testing";
-import type { AxiosResponse } from "axios";
-import { AxiosError } from "axios";
-import { setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
+import { createTestingPinia } from '@pinia/testing'
+import type { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
-import { mergeCustomNodesI18n } from "@/i18n";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { api } from "@/scripts/api";
+import { mergeCustomNodesI18n } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
 
-import { useBootstrapStore } from "./bootstrapStore";
+import { useBootstrapStore } from './bootstrapStore'
 
-vi.mock("@/scripts/api", () => ({
+vi.mock('@/scripts/api', () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({}),
-  },
-}));
+    getUserConfig: vi.fn().mockResolvedValue({})
+  }
+}))
 
-vi.mock("@/i18n", () => ({
-  mergeCustomNodesI18n: vi.fn(),
-}));
+vi.mock('@/i18n', () => ({
+  mergeCustomNodesI18n: vi.fn()
+}))
 
-const mockIsSettingsReady = ref(false);
+const mockIsSettingsReady = ref(false)
 
-vi.mock("@/platform/settings/settingStore", () => ({
+vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true;
+      mockIsSettingsReady.value = true
     }),
     get isReady() {
-      return mockIsSettingsReady.value;
+      return mockIsSettingsReady.value
     },
     isLoading: ref(false),
-    error: ref(undefined),
-  })),
-}));
+    error: ref(undefined)
+  }))
+}))
 
-vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined),
-  })),
-}));
+    syncWorkflows: vi.fn().mockResolvedValue(undefined)
+  }))
+}))
 
-const mockNeedsLogin = ref(false);
-vi.mock("@/stores/userStore", () => ({
+const mockNeedsLogin = ref(false)
+vi.mock('@/stores/userStore', () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin,
-  })),
-}));
+    needsLogin: mockNeedsLogin
+  }))
+}))
 
-const mockIsAuthInitialized = ref(false);
-const mockIsAuthAuthenticated = ref(false);
-vi.mock("@/stores/authStore", () => ({
+const mockIsAuthInitialized = ref(false)
+const mockIsAuthAuthenticated = ref(false)
+vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated,
-  })),
-}));
+    isAuthenticated: mockIsAuthAuthenticated
+  }))
+}))
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false,
-}));
-vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
+  isCloud: false
+}))
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
-const mockCaptureException = vi.hoisted(() => vi.fn());
-vi.mock("@sentry/vue", () => ({
-  captureException: mockCaptureException,
-}));
+const mockCaptureException = vi.hoisted(() => vi.fn())
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
+}))
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`);
-  error.response = { status } as AxiosResponse;
-  return error;
+  const error = new AxiosError(`Request failed with status code ${status}`)
+  error.response = { status } as AxiosResponse
+  return error
 }
 
-describe("bootstrapStore", () => {
+describe('bootstrapStore', () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false;
-    mockIsAuthInitialized.value = false;
-    mockIsAuthAuthenticated.value = false;
-    mockNeedsLogin.value = false;
-    mockDistributionTypes.isCloud = false;
-    setActivePinia(createTestingPinia({ stubActions: false }));
-  });
+    mockIsSettingsReady.value = false
+    mockIsAuthInitialized.value = false
+    mockIsAuthAuthenticated.value = false
+    mockNeedsLogin.value = false
+    mockDistributionTypes.isCloud = false
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
 
-  it("initializes with all flags false", () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    expect(settingStore.isReady).toBe(false);
-    expect(store.isI18nReady).toBe(false);
-  });
+  it('initializes with all flags false', () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    expect(settingStore.isReady).toBe(false)
+    expect(store.isI18nReady).toBe(false)
+  })
 
-  it("starts store bootstrap (settings, i18n)", async () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    void store.startStoreBootstrap();
+  it('starts store bootstrap (settings, i18n)', async () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    void store.startStoreBootstrap()
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true);
-      expect(store.isI18nReady).toBe(true);
-    });
-  });
+      expect(settingStore.isReady).toBe(true)
+      expect(store.isI18nReady).toBe(true)
+    })
+  })
 
-  describe("custom node translations", () => {
-    it("treats a missing /api/i18n endpoint as no translations", async () => {
+  describe('custom node translations', () => {
+    it('treats a missing /api/i18n endpoint as no translations', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(404)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-      });
-      expect(store.i18nError).toBeUndefined();
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
-    });
+        expect(store.isI18nReady).toBe(true)
+      })
+      expect(store.i18nError).toBeUndefined()
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
+    })
 
-    it("surfaces failures other than a missing endpoint", async () => {
+    it('surfaces failures other than a missing endpoint', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(500)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined();
-      });
-      expect(store.isI18nReady).toBe(false);
-    });
-  });
+        expect(store.i18nError).toBeDefined()
+      })
+      expect(store.isI18nReady).toBe(false)
+    })
+  })
 
-  describe("cloud mode", () => {
+  describe('cloud mode', () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true;
-      mockCaptureException.mockReset();
-    });
+      mockDistributionTypes.isCloud = true
+      mockCaptureException.mockReset()
+    })
 
-    it("waits for Firebase init before loading stores, then proceeds regardless of auth state", async () => {
-      const store = useBootstrapStore();
-      const settingStore = useSettingStore();
-      const bootstrapPromise = store.startStoreBootstrap();
+    it('waits for Firebase init before loading stores, then proceeds regardless of auth state', async () => {
+      const store = useBootstrapStore()
+      const settingStore = useSettingStore()
+      const bootstrapPromise = store.startStoreBootstrap()
 
-      expect(store.isI18nReady).toBe(false);
-      expect(settingStore.isReady).toBe(false);
+      expect(store.isI18nReady).toBe(false)
+      expect(settingStore.isReady).toBe(false)
 
       // Firebase resolves with no user (signed-out) — bootstrap must unblock.
       // Previously it also waited for isAuthenticated, which made every
       // signed-out load wait 35s and fire a false Sentry timeout.
-      mockIsAuthInitialized.value = true;
-      await bootstrapPromise;
+      mockIsAuthInitialized.value = true
+      await bootstrapPromise
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-        expect(settingStore.isReady).toBe(true);
-      });
-    });
+        expect(store.isI18nReady).toBe(true)
+        expect(settingStore.isReady).toBe(true)
+      })
+    })
 
-    it("retries once and proceeds if Firebase init resolves during the backoff", async () => {
-      vi.useFakeTimers();
+    it('retries once and proceeds if Firebase init resolves during the backoff', async () => {
+      vi.useFakeTimers()
       try {
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // First wait times out with Firebase still not initialized.
-        await vi.advanceTimersByTimeAsync(16_001);
-        expect(settingStore.isReady).toBe(false);
+        await vi.advanceTimersByTimeAsync(16_001)
+        expect(settingStore.isReady).toBe(false)
 
         // Firebase resolves during the retry backoff.
-        mockIsAuthInitialized.value = true;
-        await vi.advanceTimersByTimeAsync(3_001);
-        await bootstrapPromise;
+        mockIsAuthInitialized.value = true
+        await vi.advanceTimersByTimeAsync(3_001)
+        await bootstrapPromise
 
-        expect(settingStore.isReady).toBe(true);
-        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(settingStore.isReady).toBe(true)
+        expect(mockCaptureException).not.toHaveBeenCalled()
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
+    })
 
-    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
-      vi.useFakeTimers();
+    it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
+      vi.useFakeTimers()
       try {
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // Firebase never resolves through the initial wait, the backoff, or the retry.
-        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
-        await bootstrapPromise;
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
+        await bootstrapPromise
 
-        expect(mockCaptureException).toHaveBeenCalledOnce();
+        expect(mockCaptureException).toHaveBeenCalledOnce()
         expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), {
-          tags: { error_type: "bootstrap_auth_wait_timeout" },
-        });
+          tags: { error_type: 'bootstrap_auth_wait_timeout' }
+        })
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.
-        expect(settingStore.isReady).toBe(true);
+        expect(settingStore.isReady).toBe(true)
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,220 +1,220 @@
-import { createTestingPinia } from "@pinia/testing";
-import type { AxiosResponse } from "axios";
-import { AxiosError } from "axios";
-import { setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
+import { createTestingPinia } from '@pinia/testing'
+import type { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
-import { mergeCustomNodesI18n } from "@/i18n";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { api } from "@/scripts/api";
+import { mergeCustomNodesI18n } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
 
-import { useBootstrapStore } from "./bootstrapStore";
+import { useBootstrapStore } from './bootstrapStore'
 
-vi.mock("@/scripts/api", () => ({
+vi.mock('@/scripts/api', () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({}),
-  },
-}));
+    getUserConfig: vi.fn().mockResolvedValue({})
+  }
+}))
 
-vi.mock("@/i18n", () => ({
-  mergeCustomNodesI18n: vi.fn(),
-}));
+vi.mock('@/i18n', () => ({
+  mergeCustomNodesI18n: vi.fn()
+}))
 
-const mockIsSettingsReady = ref(false);
+const mockIsSettingsReady = ref(false)
 
-vi.mock("@/platform/settings/settingStore", () => ({
+vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true;
+      mockIsSettingsReady.value = true
     }),
     get isReady() {
-      return mockIsSettingsReady.value;
+      return mockIsSettingsReady.value
     },
     isLoading: ref(false),
-    error: ref(undefined),
-  })),
-}));
+    error: ref(undefined)
+  }))
+}))
 
-vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined),
-  })),
-}));
+    syncWorkflows: vi.fn().mockResolvedValue(undefined)
+  }))
+}))
 
-const mockNeedsLogin = ref(false);
-vi.mock("@/stores/userStore", () => ({
+const mockNeedsLogin = ref(false)
+vi.mock('@/stores/userStore', () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin,
-  })),
-}));
+    needsLogin: mockNeedsLogin
+  }))
+}))
 
-const mockIsAuthInitialized = ref(false);
-const mockIsAuthAuthenticated = ref(false);
-vi.mock("@/stores/authStore", () => ({
+const mockIsAuthInitialized = ref(false)
+const mockIsAuthAuthenticated = ref(false)
+vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated,
-  })),
-}));
+    isAuthenticated: mockIsAuthAuthenticated
+  }))
+}))
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false,
-}));
-vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
+  isCloud: false
+}))
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
-const mockCaptureException = vi.hoisted(() => vi.fn());
-vi.mock("@sentry/vue", () => ({
-  captureException: mockCaptureException,
-}));
+const mockCaptureException = vi.hoisted(() => vi.fn())
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
+}))
 
-const mockAddError = vi.hoisted(() => vi.fn());
-vi.mock("@datadog/browser-rum", () => ({
-  datadogRum: { addError: mockAddError },
-}));
+const mockAddError = vi.hoisted(() => vi.fn())
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: { addError: mockAddError }
+}))
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`);
-  error.response = { status } as AxiosResponse;
-  return error;
+  const error = new AxiosError(`Request failed with status code ${status}`)
+  error.response = { status } as AxiosResponse
+  return error
 }
 
-describe("bootstrapStore", () => {
+describe('bootstrapStore', () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false;
-    mockIsAuthInitialized.value = false;
-    mockIsAuthAuthenticated.value = false;
-    mockNeedsLogin.value = false;
-    mockDistributionTypes.isCloud = false;
-    setActivePinia(createTestingPinia({ stubActions: false }));
-  });
+    mockIsSettingsReady.value = false
+    mockIsAuthInitialized.value = false
+    mockIsAuthAuthenticated.value = false
+    mockNeedsLogin.value = false
+    mockDistributionTypes.isCloud = false
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
 
-  it("initializes with all flags false", () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    expect(settingStore.isReady).toBe(false);
-    expect(store.isI18nReady).toBe(false);
-  });
+  it('initializes with all flags false', () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    expect(settingStore.isReady).toBe(false)
+    expect(store.isI18nReady).toBe(false)
+  })
 
-  it("starts store bootstrap (settings, i18n)", async () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    void store.startStoreBootstrap();
+  it('starts store bootstrap (settings, i18n)', async () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    void store.startStoreBootstrap()
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true);
-      expect(store.isI18nReady).toBe(true);
-    });
-  });
+      expect(settingStore.isReady).toBe(true)
+      expect(store.isI18nReady).toBe(true)
+    })
+  })
 
-  describe("custom node translations", () => {
-    it("treats a missing /api/i18n endpoint as no translations", async () => {
+  describe('custom node translations', () => {
+    it('treats a missing /api/i18n endpoint as no translations', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(404)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-      });
-      expect(store.i18nError).toBeUndefined();
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
-    });
+        expect(store.isI18nReady).toBe(true)
+      })
+      expect(store.i18nError).toBeUndefined()
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
+    })
 
-    it("surfaces failures other than a missing endpoint", async () => {
+    it('surfaces failures other than a missing endpoint', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(500)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined();
-      });
-      expect(store.isI18nReady).toBe(false);
-    });
-  });
+        expect(store.i18nError).toBeDefined()
+      })
+      expect(store.isI18nReady).toBe(false)
+    })
+  })
 
-  describe("cloud mode", () => {
+  describe('cloud mode', () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true;
-      mockCaptureException.mockReset();
-      mockAddError.mockReset();
-    });
+      mockDistributionTypes.isCloud = true
+      mockCaptureException.mockReset()
+      mockAddError.mockReset()
+    })
 
-    it("waits for Firebase init before loading stores, then proceeds regardless of auth state", async () => {
-      const store = useBootstrapStore();
-      const settingStore = useSettingStore();
-      const bootstrapPromise = store.startStoreBootstrap();
+    it('waits for Firebase init before loading stores, then proceeds regardless of auth state', async () => {
+      const store = useBootstrapStore()
+      const settingStore = useSettingStore()
+      const bootstrapPromise = store.startStoreBootstrap()
 
-      expect(store.isI18nReady).toBe(false);
-      expect(settingStore.isReady).toBe(false);
+      expect(store.isI18nReady).toBe(false)
+      expect(settingStore.isReady).toBe(false)
 
       // Firebase resolves with no user (signed-out) — bootstrap must unblock.
       // Previously it also waited for isAuthenticated, which made every
       // signed-out load wait 35s and fire a false Sentry timeout.
-      mockIsAuthInitialized.value = true;
-      await bootstrapPromise;
+      mockIsAuthInitialized.value = true
+      await bootstrapPromise
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-        expect(settingStore.isReady).toBe(true);
-      });
-    });
+        expect(store.isI18nReady).toBe(true)
+        expect(settingStore.isReady).toBe(true)
+      })
+    })
 
-    it("retries once and proceeds if Firebase init resolves during the backoff", async () => {
-      vi.useFakeTimers();
+    it('retries once and proceeds if Firebase init resolves during the backoff', async () => {
+      vi.useFakeTimers()
       try {
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // First wait times out with Firebase still not initialized.
-        await vi.advanceTimersByTimeAsync(16_001);
-        expect(settingStore.isReady).toBe(false);
+        await vi.advanceTimersByTimeAsync(16_001)
+        expect(settingStore.isReady).toBe(false)
 
         // Firebase resolves during the retry backoff.
-        mockIsAuthInitialized.value = true;
-        await vi.advanceTimersByTimeAsync(3_001);
-        await bootstrapPromise;
+        mockIsAuthInitialized.value = true
+        await vi.advanceTimersByTimeAsync(3_001)
+        await bootstrapPromise
 
-        expect(settingStore.isReady).toBe(true);
-        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(settingStore.isReady).toBe(true)
+        expect(mockCaptureException).not.toHaveBeenCalled()
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
+    })
 
-    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
-      vi.useFakeTimers();
+    it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
+      vi.useFakeTimers()
       try {
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // Firebase never resolves through the initial wait, the backoff, or the retry.
-        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
-        await bootstrapPromise;
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
+        await bootstrapPromise
 
-        expect(mockCaptureException).toHaveBeenCalledOnce();
+        expect(mockCaptureException).toHaveBeenCalledOnce()
         expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
-          tags: { error_type: "bootstrap_auth_wait_timeout" },
-        });
-        expect(mockAddError).toHaveBeenCalledOnce();
+          tags: { error_type: 'bootstrap_auth_wait_timeout' }
+        })
+        expect(mockAddError).toHaveBeenCalledOnce()
         expect(mockAddError).toHaveBeenCalledWith(expect.any(Error), {
-          error_type: "bootstrap_auth_wait_timeout",
-        });
+          error_type: 'bootstrap_auth_wait_timeout'
+        })
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.
-        expect(settingStore.isReady).toBe(true);
+        expect(settingStore.isReady).toBe(true)
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,217 +1,217 @@
-import { createTestingPinia } from "@pinia/testing";
-import type { AxiosResponse } from "axios";
-import { AxiosError } from "axios";
-import { setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { nextTick, ref } from "vue";
+import { createTestingPinia } from '@pinia/testing'
+import type { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
-import { mergeCustomNodesI18n } from "@/i18n";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { api } from "@/scripts/api";
+import { mergeCustomNodesI18n } from '@/i18n'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
 
-import { useBootstrapStore } from "./bootstrapStore";
+import { useBootstrapStore } from './bootstrapStore'
 
-vi.mock("@/scripts/api", () => ({
+vi.mock('@/scripts/api', () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({}),
-  },
-}));
+    getUserConfig: vi.fn().mockResolvedValue({})
+  }
+}))
 
-vi.mock("@/i18n", () => ({
-  mergeCustomNodesI18n: vi.fn(),
-}));
+vi.mock('@/i18n', () => ({
+  mergeCustomNodesI18n: vi.fn()
+}))
 
-const mockIsSettingsReady = ref(false);
+const mockIsSettingsReady = ref(false)
 
-vi.mock("@/platform/settings/settingStore", () => ({
+vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true;
+      mockIsSettingsReady.value = true
     }),
     get isReady() {
-      return mockIsSettingsReady.value;
+      return mockIsSettingsReady.value
     },
     isLoading: ref(false),
-    error: ref(undefined),
-  })),
-}));
+    error: ref(undefined)
+  }))
+}))
 
-vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined),
-  })),
-}));
+    syncWorkflows: vi.fn().mockResolvedValue(undefined)
+  }))
+}))
 
-const mockNeedsLogin = ref(false);
-vi.mock("@/stores/userStore", () => ({
+const mockNeedsLogin = ref(false)
+vi.mock('@/stores/userStore', () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin,
-  })),
-}));
+    needsLogin: mockNeedsLogin
+  }))
+}))
 
-const mockIsAuthInitialized = ref(false);
-const mockIsAuthAuthenticated = ref(false);
-vi.mock("@/stores/authStore", () => ({
+const mockIsAuthInitialized = ref(false)
+const mockIsAuthAuthenticated = ref(false)
+vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated,
-  })),
-}));
+    isAuthenticated: mockIsAuthAuthenticated
+  }))
+}))
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false,
-}));
-vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
+  isCloud: false
+}))
+vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
 
-const mockCaptureException = vi.hoisted(() => vi.fn());
-vi.mock("@sentry/vue", () => ({
-  captureException: mockCaptureException,
-}));
+const mockCaptureException = vi.hoisted(() => vi.fn())
+vi.mock('@sentry/vue', () => ({
+  captureException: mockCaptureException
+}))
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`);
-  error.response = { status } as AxiosResponse;
-  return error;
+  const error = new AxiosError(`Request failed with status code ${status}`)
+  error.response = { status } as AxiosResponse
+  return error
 }
 
-describe("bootstrapStore", () => {
+describe('bootstrapStore', () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false;
-    mockIsAuthInitialized.value = false;
-    mockIsAuthAuthenticated.value = false;
-    mockNeedsLogin.value = false;
-    mockDistributionTypes.isCloud = false;
-    setActivePinia(createTestingPinia({ stubActions: false }));
-  });
+    mockIsSettingsReady.value = false
+    mockIsAuthInitialized.value = false
+    mockIsAuthAuthenticated.value = false
+    mockNeedsLogin.value = false
+    mockDistributionTypes.isCloud = false
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
 
-  it("initializes with all flags false", () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    expect(settingStore.isReady).toBe(false);
-    expect(store.isI18nReady).toBe(false);
-  });
+  it('initializes with all flags false', () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    expect(settingStore.isReady).toBe(false)
+    expect(store.isI18nReady).toBe(false)
+  })
 
-  it("starts store bootstrap (settings, i18n)", async () => {
-    const store = useBootstrapStore();
-    const settingStore = useSettingStore();
-    void store.startStoreBootstrap();
+  it('starts store bootstrap (settings, i18n)', async () => {
+    const store = useBootstrapStore()
+    const settingStore = useSettingStore()
+    void store.startStoreBootstrap()
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true);
-      expect(store.isI18nReady).toBe(true);
-    });
-  });
+      expect(settingStore.isReady).toBe(true)
+      expect(store.isI18nReady).toBe(true)
+    })
+  })
 
-  describe("custom node translations", () => {
-    it("treats a missing /api/i18n endpoint as no translations", async () => {
+  describe('custom node translations', () => {
+    it('treats a missing /api/i18n endpoint as no translations', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(404)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-      });
-      expect(store.i18nError).toBeUndefined();
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
-    });
+        expect(store.isI18nReady).toBe(true)
+      })
+      expect(store.i18nError).toBeUndefined()
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
+    })
 
-    it("surfaces failures other than a missing endpoint", async () => {
+    it('surfaces failures other than a missing endpoint', async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500),
-      );
-      const store = useBootstrapStore();
-      void store.startStoreBootstrap();
+        requestFailure(500)
+      )
+      const store = useBootstrapStore()
+      void store.startStoreBootstrap()
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined();
-      });
-      expect(store.isI18nReady).toBe(false);
-    });
-  });
+        expect(store.i18nError).toBeDefined()
+      })
+      expect(store.isI18nReady).toBe(false)
+    })
+  })
 
-  describe("cloud mode", () => {
+  describe('cloud mode', () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true;
-      mockCaptureException.mockReset();
-    });
+      mockDistributionTypes.isCloud = true
+      mockCaptureException.mockReset()
+    })
 
-    it("waits for Firebase auth before loading stores", async () => {
-      const store = useBootstrapStore();
-      const settingStore = useSettingStore();
-      const bootstrapPromise = store.startStoreBootstrap();
+    it('waits for Firebase auth before loading stores', async () => {
+      const store = useBootstrapStore()
+      const settingStore = useSettingStore()
+      const bootstrapPromise = store.startStoreBootstrap()
 
-      expect(store.isI18nReady).toBe(false);
-      expect(settingStore.isReady).toBe(false);
+      expect(store.isI18nReady).toBe(false)
+      expect(settingStore.isReady).toBe(false)
 
       // Firebase initialized but user not yet authenticated
-      mockIsAuthInitialized.value = true;
-      await nextTick();
+      mockIsAuthInitialized.value = true
+      await nextTick()
 
-      expect(store.isI18nReady).toBe(false);
-      expect(settingStore.isReady).toBe(false);
+      expect(store.isI18nReady).toBe(false)
+      expect(settingStore.isReady).toBe(false)
 
       // User authenticates (e.g. signs in on login page)
-      mockIsAuthAuthenticated.value = true;
-      await bootstrapPromise;
+      mockIsAuthAuthenticated.value = true
+      await bootstrapPromise
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true);
-        expect(settingStore.isReady).toBe(true);
-      });
-    });
+        expect(store.isI18nReady).toBe(true)
+        expect(settingStore.isReady).toBe(true)
+      })
+    })
 
-    it("retries once and proceeds if auth resolves during the backoff", async () => {
-      vi.useFakeTimers();
+    it('retries once and proceeds if auth resolves during the backoff', async () => {
+      vi.useFakeTimers()
       try {
-        mockIsAuthInitialized.value = true;
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        mockIsAuthInitialized.value = true
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // First wait times out with user still unauthenticated.
-        await vi.advanceTimersByTimeAsync(16_001);
-        expect(settingStore.isReady).toBe(false);
+        await vi.advanceTimersByTimeAsync(16_001)
+        expect(settingStore.isReady).toBe(false)
 
         // Auth resolves during the retry backoff.
-        mockIsAuthAuthenticated.value = true;
-        await vi.advanceTimersByTimeAsync(3_001);
-        await bootstrapPromise;
+        mockIsAuthAuthenticated.value = true
+        await vi.advanceTimersByTimeAsync(3_001)
+        await bootstrapPromise
 
-        expect(settingStore.isReady).toBe(true);
-        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(settingStore.isReady).toBe(true)
+        expect(mockCaptureException).not.toHaveBeenCalled()
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
+    })
 
-    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
-      vi.useFakeTimers();
+    it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
+      vi.useFakeTimers()
       try {
-        mockIsAuthInitialized.value = true;
-        const store = useBootstrapStore();
-        const settingStore = useSettingStore();
-        const bootstrapPromise = store.startStoreBootstrap();
+        mockIsAuthInitialized.value = true
+        const store = useBootstrapStore()
+        const settingStore = useSettingStore()
+        const bootstrapPromise = store.startStoreBootstrap()
 
         // Auth never resolves through the initial wait, the backoff, or the retry.
-        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
-        await bootstrapPromise;
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
+        await bootstrapPromise
 
-        expect(mockCaptureException).toHaveBeenCalledOnce();
+        expect(mockCaptureException).toHaveBeenCalledOnce()
         expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), {
-          tags: { error_type: "bootstrap_auth_wait_timeout" },
-        });
+          tags: { error_type: 'bootstrap_auth_wait_timeout' }
+        })
         // Bootstrap must not stay stuck: stores load even without confirmed auth.
-        expect(settingStore.isReady).toBe(true);
+        expect(settingStore.isReady).toBe(true)
       } finally {
-        vi.useRealTimers();
+        vi.useRealTimers()
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,210 +1,220 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { AxiosResponse } from 'axios'
-import { AxiosError } from 'axios'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { createTestingPinia } from "@pinia/testing";
+import type { AxiosResponse } from "axios";
+import { AxiosError } from "axios";
+import { setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
 
-import { mergeCustomNodesI18n } from '@/i18n'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { api } from '@/scripts/api'
+import { mergeCustomNodesI18n } from "@/i18n";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { api } from "@/scripts/api";
 
-import { useBootstrapStore } from './bootstrapStore'
+import { useBootstrapStore } from "./bootstrapStore";
 
-vi.mock('@/scripts/api', () => ({
+vi.mock("@/scripts/api", () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({})
-  }
-}))
+    getUserConfig: vi.fn().mockResolvedValue({}),
+  },
+}));
 
-vi.mock('@/i18n', () => ({
-  mergeCustomNodesI18n: vi.fn()
-}))
+vi.mock("@/i18n", () => ({
+  mergeCustomNodesI18n: vi.fn(),
+}));
 
-const mockIsSettingsReady = ref(false)
+const mockIsSettingsReady = ref(false);
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock("@/platform/settings/settingStore", () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true
+      mockIsSettingsReady.value = true;
     }),
     get isReady() {
-      return mockIsSettingsReady.value
+      return mockIsSettingsReady.value;
     },
     isLoading: ref(false),
-    error: ref(undefined)
-  }))
-}))
+    error: ref(undefined),
+  })),
+}));
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined)
-  }))
-}))
+    syncWorkflows: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
-const mockNeedsLogin = ref(false)
-vi.mock('@/stores/userStore', () => ({
+const mockNeedsLogin = ref(false);
+vi.mock("@/stores/userStore", () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin
-  }))
-}))
+    needsLogin: mockNeedsLogin,
+  })),
+}));
 
-const mockIsAuthInitialized = ref(false)
-const mockIsAuthAuthenticated = ref(false)
-vi.mock('@/stores/authStore', () => ({
+const mockIsAuthInitialized = ref(false);
+const mockIsAuthAuthenticated = ref(false);
+vi.mock("@/stores/authStore", () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated
-  }))
-}))
+    isAuthenticated: mockIsAuthAuthenticated,
+  })),
+}));
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false
-}))
-vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+  isCloud: false,
+}));
+vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
 
-const mockCaptureException = vi.hoisted(() => vi.fn())
-vi.mock('@sentry/vue', () => ({
-  captureException: mockCaptureException
-}))
+const mockCaptureException = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/vue", () => ({
+  captureException: mockCaptureException,
+}));
+
+const mockAddError = vi.hoisted(() => vi.fn());
+vi.mock("@datadog/browser-rum", () => ({
+  datadogRum: { addError: mockAddError },
+}));
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`)
-  error.response = { status } as AxiosResponse
-  return error
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = { status } as AxiosResponse;
+  return error;
 }
 
-describe('bootstrapStore', () => {
+describe("bootstrapStore", () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false
-    mockIsAuthInitialized.value = false
-    mockIsAuthAuthenticated.value = false
-    mockNeedsLogin.value = false
-    mockDistributionTypes.isCloud = false
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+    mockIsSettingsReady.value = false;
+    mockIsAuthInitialized.value = false;
+    mockIsAuthAuthenticated.value = false;
+    mockNeedsLogin.value = false;
+    mockDistributionTypes.isCloud = false;
+    setActivePinia(createTestingPinia({ stubActions: false }));
+  });
 
-  it('initializes with all flags false', () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    expect(settingStore.isReady).toBe(false)
-    expect(store.isI18nReady).toBe(false)
-  })
+  it("initializes with all flags false", () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    expect(settingStore.isReady).toBe(false);
+    expect(store.isI18nReady).toBe(false);
+  });
 
-  it('starts store bootstrap (settings, i18n)', async () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    void store.startStoreBootstrap()
+  it("starts store bootstrap (settings, i18n)", async () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    void store.startStoreBootstrap();
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true)
-      expect(store.isI18nReady).toBe(true)
-    })
-  })
+      expect(settingStore.isReady).toBe(true);
+      expect(store.isI18nReady).toBe(true);
+    });
+  });
 
-  describe('custom node translations', () => {
-    it('treats a missing /api/i18n endpoint as no translations', async () => {
+  describe("custom node translations", () => {
+    it("treats a missing /api/i18n endpoint as no translations", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(404),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-      })
-      expect(store.i18nError).toBeUndefined()
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
-    })
+        expect(store.isI18nReady).toBe(true);
+      });
+      expect(store.i18nError).toBeUndefined();
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
+    });
 
-    it('surfaces failures other than a missing endpoint', async () => {
+    it("surfaces failures other than a missing endpoint", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(500),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined()
-      })
-      expect(store.isI18nReady).toBe(false)
-    })
-  })
+        expect(store.i18nError).toBeDefined();
+      });
+      expect(store.isI18nReady).toBe(false);
+    });
+  });
 
-  describe('cloud mode', () => {
+  describe("cloud mode", () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true
-      mockCaptureException.mockReset()
-    })
+      mockDistributionTypes.isCloud = true;
+      mockCaptureException.mockReset();
+      mockAddError.mockReset();
+    });
 
-    it('waits for Firebase init before loading stores, then proceeds regardless of auth state', async () => {
-      const store = useBootstrapStore()
-      const settingStore = useSettingStore()
-      const bootstrapPromise = store.startStoreBootstrap()
+    it("waits for Firebase init before loading stores, then proceeds regardless of auth state", async () => {
+      const store = useBootstrapStore();
+      const settingStore = useSettingStore();
+      const bootstrapPromise = store.startStoreBootstrap();
 
-      expect(store.isI18nReady).toBe(false)
-      expect(settingStore.isReady).toBe(false)
+      expect(store.isI18nReady).toBe(false);
+      expect(settingStore.isReady).toBe(false);
 
       // Firebase resolves with no user (signed-out) — bootstrap must unblock.
       // Previously it also waited for isAuthenticated, which made every
       // signed-out load wait 35s and fire a false Sentry timeout.
-      mockIsAuthInitialized.value = true
-      await bootstrapPromise
+      mockIsAuthInitialized.value = true;
+      await bootstrapPromise;
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-        expect(settingStore.isReady).toBe(true)
-      })
-    })
+        expect(store.isI18nReady).toBe(true);
+        expect(settingStore.isReady).toBe(true);
+      });
+    });
 
-    it('retries once and proceeds if Firebase init resolves during the backoff', async () => {
-      vi.useFakeTimers()
+    it("retries once and proceeds if Firebase init resolves during the backoff", async () => {
+      vi.useFakeTimers();
       try {
-        const store = useBootstrapStore()
-        const settingStore = useSettingStore()
-        const bootstrapPromise = store.startStoreBootstrap()
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
 
         // First wait times out with Firebase still not initialized.
-        await vi.advanceTimersByTimeAsync(16_001)
-        expect(settingStore.isReady).toBe(false)
+        await vi.advanceTimersByTimeAsync(16_001);
+        expect(settingStore.isReady).toBe(false);
 
         // Firebase resolves during the retry backoff.
-        mockIsAuthInitialized.value = true
-        await vi.advanceTimersByTimeAsync(3_001)
-        await bootstrapPromise
+        mockIsAuthInitialized.value = true;
+        await vi.advanceTimersByTimeAsync(3_001);
+        await bootstrapPromise;
 
-        expect(settingStore.isReady).toBe(true)
-        expect(mockCaptureException).not.toHaveBeenCalled()
+        expect(settingStore.isReady).toBe(true);
+        expect(mockCaptureException).not.toHaveBeenCalled();
       } finally {
-        vi.useRealTimers()
+        vi.useRealTimers();
       }
-    })
+    });
 
-    it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
-      vi.useFakeTimers()
+    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
+      vi.useFakeTimers();
       try {
-        const store = useBootstrapStore()
-        const settingStore = useSettingStore()
-        const bootstrapPromise = store.startStoreBootstrap()
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
 
         // Firebase never resolves through the initial wait, the backoff, or the retry.
-        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
-        await bootstrapPromise
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
+        await bootstrapPromise;
 
-        expect(mockCaptureException).toHaveBeenCalledOnce()
-        expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), {
-          tags: { error_type: 'bootstrap_auth_wait_timeout' }
-        })
+        expect(mockCaptureException).toHaveBeenCalledOnce();
+        expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+          tags: { error_type: "bootstrap_auth_wait_timeout" },
+        });
+        expect(mockAddError).toHaveBeenCalledOnce();
+        expect(mockAddError).toHaveBeenCalledWith(expect.any(Error), {
+          error_type: "bootstrap_auth_wait_timeout",
+        });
         // Bootstrap must not stay stuck: stores load even when Firebase never fires.
-        expect(settingStore.isReady).toBe(true)
+        expect(settingStore.isReady).toBe(true);
       } finally {
-        vi.useRealTimers()
+        vi.useRealTimers();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,217 +1,210 @@
-import { createTestingPinia } from '@pinia/testing'
-import type { AxiosResponse } from 'axios'
-import { AxiosError } from 'axios'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { createTestingPinia } from "@pinia/testing";
+import type { AxiosResponse } from "axios";
+import { AxiosError } from "axios";
+import { setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
 
-import { mergeCustomNodesI18n } from '@/i18n'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { api } from '@/scripts/api'
+import { mergeCustomNodesI18n } from "@/i18n";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { api } from "@/scripts/api";
 
-import { useBootstrapStore } from './bootstrapStore'
+import { useBootstrapStore } from "./bootstrapStore";
 
-vi.mock('@/scripts/api', () => ({
+vi.mock("@/scripts/api", () => ({
   api: {
     init: vi.fn().mockResolvedValue(undefined),
-    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: 'TestNode' } }),
+    getNodeDefs: vi.fn().mockResolvedValue({ TestNode: { name: "TestNode" } }),
     getCustomNodesI18n: vi.fn().mockResolvedValue({}),
-    getUserConfig: vi.fn().mockResolvedValue({})
-  }
-}))
+    getUserConfig: vi.fn().mockResolvedValue({}),
+  },
+}));
 
-vi.mock('@/i18n', () => ({
-  mergeCustomNodesI18n: vi.fn()
-}))
+vi.mock("@/i18n", () => ({
+  mergeCustomNodesI18n: vi.fn(),
+}));
 
-const mockIsSettingsReady = ref(false)
+const mockIsSettingsReady = ref(false);
 
-vi.mock('@/platform/settings/settingStore', () => ({
+vi.mock("@/platform/settings/settingStore", () => ({
   useSettingStore: vi.fn(() => ({
     load: vi.fn(() => {
-      mockIsSettingsReady.value = true
+      mockIsSettingsReady.value = true;
     }),
     get isReady() {
-      return mockIsSettingsReady.value
+      return mockIsSettingsReady.value;
     },
     isLoading: ref(false),
-    error: ref(undefined)
-  }))
-}))
+    error: ref(undefined),
+  })),
+}));
 
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+vi.mock("@/platform/workflow/management/stores/workflowStore", () => ({
   useWorkflowStore: vi.fn(() => ({
     loadWorkflows: vi.fn(),
-    syncWorkflows: vi.fn().mockResolvedValue(undefined)
-  }))
-}))
+    syncWorkflows: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
-const mockNeedsLogin = ref(false)
-vi.mock('@/stores/userStore', () => ({
+const mockNeedsLogin = ref(false);
+vi.mock("@/stores/userStore", () => ({
   useUserStore: vi.fn(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
-    needsLogin: mockNeedsLogin
-  }))
-}))
+    needsLogin: mockNeedsLogin,
+  })),
+}));
 
-const mockIsAuthInitialized = ref(false)
-const mockIsAuthAuthenticated = ref(false)
-vi.mock('@/stores/authStore', () => ({
+const mockIsAuthInitialized = ref(false);
+const mockIsAuthAuthenticated = ref(false);
+vi.mock("@/stores/authStore", () => ({
   useAuthStore: vi.fn(() => ({
     isInitialized: mockIsAuthInitialized,
-    isAuthenticated: mockIsAuthAuthenticated
-  }))
-}))
+    isAuthenticated: mockIsAuthAuthenticated,
+  })),
+}));
 
 const mockDistributionTypes = vi.hoisted(() => ({
-  isCloud: false
-}))
-vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+  isCloud: false,
+}));
+vi.mock("@/platform/distribution/types", () => mockDistributionTypes);
 
-const mockCaptureException = vi.hoisted(() => vi.fn())
-vi.mock('@sentry/vue', () => ({
-  captureException: mockCaptureException
-}))
+const mockCaptureException = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/vue", () => ({
+  captureException: mockCaptureException,
+}));
 
 function requestFailure(status: number) {
-  const error = new AxiosError(`Request failed with status code ${status}`)
-  error.response = { status } as AxiosResponse
-  return error
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = { status } as AxiosResponse;
+  return error;
 }
 
-describe('bootstrapStore', () => {
+describe("bootstrapStore", () => {
   beforeEach(() => {
-    mockIsSettingsReady.value = false
-    mockIsAuthInitialized.value = false
-    mockIsAuthAuthenticated.value = false
-    mockNeedsLogin.value = false
-    mockDistributionTypes.isCloud = false
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
+    mockIsSettingsReady.value = false;
+    mockIsAuthInitialized.value = false;
+    mockIsAuthAuthenticated.value = false;
+    mockNeedsLogin.value = false;
+    mockDistributionTypes.isCloud = false;
+    setActivePinia(createTestingPinia({ stubActions: false }));
+  });
 
-  it('initializes with all flags false', () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    expect(settingStore.isReady).toBe(false)
-    expect(store.isI18nReady).toBe(false)
-  })
+  it("initializes with all flags false", () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    expect(settingStore.isReady).toBe(false);
+    expect(store.isI18nReady).toBe(false);
+  });
 
-  it('starts store bootstrap (settings, i18n)', async () => {
-    const store = useBootstrapStore()
-    const settingStore = useSettingStore()
-    void store.startStoreBootstrap()
+  it("starts store bootstrap (settings, i18n)", async () => {
+    const store = useBootstrapStore();
+    const settingStore = useSettingStore();
+    void store.startStoreBootstrap();
 
     await vi.waitFor(() => {
-      expect(settingStore.isReady).toBe(true)
-      expect(store.isI18nReady).toBe(true)
-    })
-  })
+      expect(settingStore.isReady).toBe(true);
+      expect(store.isI18nReady).toBe(true);
+    });
+  });
 
-  describe('custom node translations', () => {
-    it('treats a missing /api/i18n endpoint as no translations', async () => {
+  describe("custom node translations", () => {
+    it("treats a missing /api/i18n endpoint as no translations", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(404)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(404),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-      })
-      expect(store.i18nError).toBeUndefined()
-      expect(mergeCustomNodesI18n).not.toHaveBeenCalled()
-    })
+        expect(store.isI18nReady).toBe(true);
+      });
+      expect(store.i18nError).toBeUndefined();
+      expect(mergeCustomNodesI18n).not.toHaveBeenCalled();
+    });
 
-    it('surfaces failures other than a missing endpoint', async () => {
+    it("surfaces failures other than a missing endpoint", async () => {
       vi.mocked(api.getCustomNodesI18n).mockRejectedValueOnce(
-        requestFailure(500)
-      )
-      const store = useBootstrapStore()
-      void store.startStoreBootstrap()
+        requestFailure(500),
+      );
+      const store = useBootstrapStore();
+      void store.startStoreBootstrap();
 
       await vi.waitFor(() => {
-        expect(store.i18nError).toBeDefined()
-      })
-      expect(store.isI18nReady).toBe(false)
-    })
-  })
+        expect(store.i18nError).toBeDefined();
+      });
+      expect(store.isI18nReady).toBe(false);
+    });
+  });
 
-  describe('cloud mode', () => {
+  describe("cloud mode", () => {
     beforeEach(() => {
-      mockDistributionTypes.isCloud = true
-      mockCaptureException.mockReset()
-    })
+      mockDistributionTypes.isCloud = true;
+      mockCaptureException.mockReset();
+    });
 
-    it('waits for Firebase auth before loading stores', async () => {
-      const store = useBootstrapStore()
-      const settingStore = useSettingStore()
-      const bootstrapPromise = store.startStoreBootstrap()
+    it("waits for Firebase init before loading stores, then proceeds regardless of auth state", async () => {
+      const store = useBootstrapStore();
+      const settingStore = useSettingStore();
+      const bootstrapPromise = store.startStoreBootstrap();
 
-      expect(store.isI18nReady).toBe(false)
-      expect(settingStore.isReady).toBe(false)
+      expect(store.isI18nReady).toBe(false);
+      expect(settingStore.isReady).toBe(false);
 
-      // Firebase initialized but user not yet authenticated
-      mockIsAuthInitialized.value = true
-      await nextTick()
-
-      expect(store.isI18nReady).toBe(false)
-      expect(settingStore.isReady).toBe(false)
-
-      // User authenticates (e.g. signs in on login page)
-      mockIsAuthAuthenticated.value = true
-      await bootstrapPromise
+      // Firebase resolves with no user (signed-out) — bootstrap must unblock.
+      // Previously it also waited for isAuthenticated, which made every
+      // signed-out load wait 35s and fire a false Sentry timeout.
+      mockIsAuthInitialized.value = true;
+      await bootstrapPromise;
 
       await vi.waitFor(() => {
-        expect(store.isI18nReady).toBe(true)
-        expect(settingStore.isReady).toBe(true)
-      })
-    })
+        expect(store.isI18nReady).toBe(true);
+        expect(settingStore.isReady).toBe(true);
+      });
+    });
 
-    it('retries once and proceeds if auth resolves during the backoff', async () => {
-      vi.useFakeTimers()
+    it("retries once and proceeds if Firebase init resolves during the backoff", async () => {
+      vi.useFakeTimers();
       try {
-        mockIsAuthInitialized.value = true
-        const store = useBootstrapStore()
-        const settingStore = useSettingStore()
-        const bootstrapPromise = store.startStoreBootstrap()
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
 
-        // First wait times out with user still unauthenticated.
-        await vi.advanceTimersByTimeAsync(16_001)
-        expect(settingStore.isReady).toBe(false)
+        // First wait times out with Firebase still not initialized.
+        await vi.advanceTimersByTimeAsync(16_001);
+        expect(settingStore.isReady).toBe(false);
 
-        // Auth resolves during the retry backoff.
-        mockIsAuthAuthenticated.value = true
-        await vi.advanceTimersByTimeAsync(3_001)
-        await bootstrapPromise
+        // Firebase resolves during the retry backoff.
+        mockIsAuthInitialized.value = true;
+        await vi.advanceTimersByTimeAsync(3_001);
+        await bootstrapPromise;
 
-        expect(settingStore.isReady).toBe(true)
-        expect(mockCaptureException).not.toHaveBeenCalled()
+        expect(settingStore.isReady).toBe(true);
+        expect(mockCaptureException).not.toHaveBeenCalled();
       } finally {
-        vi.useRealTimers()
+        vi.useRealTimers();
       }
-    })
+    });
 
-    it('gives up after a second timeout, reports it, and continues bootstrap unauthenticated', async () => {
-      vi.useFakeTimers()
+    it("gives up after a second timeout, reports it, and continues bootstrap unauthenticated", async () => {
+      vi.useFakeTimers();
       try {
-        mockIsAuthInitialized.value = true
-        const store = useBootstrapStore()
-        const settingStore = useSettingStore()
-        const bootstrapPromise = store.startStoreBootstrap()
+        const store = useBootstrapStore();
+        const settingStore = useSettingStore();
+        const bootstrapPromise = store.startStoreBootstrap();
 
-        // Auth never resolves through the initial wait, the backoff, or the retry.
-        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001)
-        await bootstrapPromise
+        // Firebase never resolves through the initial wait, the backoff, or the retry.
+        await vi.advanceTimersByTimeAsync(16_000 + 3_000 + 16_001);
+        await bootstrapPromise;
 
-        expect(mockCaptureException).toHaveBeenCalledOnce()
+        expect(mockCaptureException).toHaveBeenCalledOnce();
         expect(mockCaptureException).toHaveBeenCalledWith(expect.anything(), {
-          tags: { error_type: 'bootstrap_auth_wait_timeout' }
-        })
-        // Bootstrap must not stay stuck: stores load even without confirmed auth.
-        expect(settingStore.isReady).toBe(true)
+          tags: { error_type: "bootstrap_auth_wait_timeout" },
+        });
+        // Bootstrap must not stay stuck: stores load even when Firebase never fires.
+        expect(settingStore.isReady).toBe(true);
       } finally {
-        vi.useRealTimers()
+        vi.useRealTimers();
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,16 +1,16 @@
-import { datadogRum } from "@datadog/browser-rum";
-import { captureException } from "@sentry/vue";
-import { until, useAsyncState } from "@vueuse/core";
-import axios from "axios";
-import { defineStore, storeToRefs } from "pinia";
+import { datadogRum } from '@datadog/browser-rum'
+import { captureException } from '@sentry/vue'
+import { until, useAsyncState } from '@vueuse/core'
+import axios from 'axios'
+import { defineStore, storeToRefs } from 'pinia'
 
-import { isCloud } from "@/platform/distribution/types";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
-import type { CustomNodesI18n } from "@/schemas/apiSchema";
-import { api } from "@/scripts/api";
-import { useAuthStore } from "@/stores/authStore";
-import { useUserStore } from "@/stores/userStore";
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -18,18 +18,18 @@ import { useUserStore } from "@/stores/userStore";
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n();
+    return await api.getCustomNodesI18n()
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return;
-    throw error;
+    if (axios.isAxiosError(error) && error.response?.status === 404) return
+    throw error
   }
 }
 
 // Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
 // WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
 // on the same schedule those already fail theirs.
-const AUTH_WAIT_TIMEOUT_MS = 16_000;
-const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
+const AUTH_WAIT_TIMEOUT_MS = 16_000
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000
 
 /**
  * Waits for Firebase auth initialization to complete, bounded so a stale
@@ -45,89 +45,87 @@ const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
  * to Sentry and lets bootstrap continue rather than leaving the caller stuck.
  */
 async function waitForCloudAuth(): Promise<void> {
-  const { isInitialized } = storeToRefs(useAuthStore());
+  const { isInitialized } = storeToRefs(useAuthStore())
   const waitForResolution = () =>
     until(isInitialized).toBe(true, {
       timeout: AUTH_WAIT_TIMEOUT_MS,
-      throwOnTimeout: true,
-    });
+      throwOnTimeout: true
+    })
 
   try {
-    await waitForResolution();
+    await waitForResolution()
   } catch (error) {
     console.warn(
-      "[bootstrapStore] Auth did not resolve in time, retrying once",
-      error,
-    );
+      '[bootstrapStore] Auth did not resolve in time, retrying once',
+      error
+    )
     await new Promise((resolve) =>
-      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
-    );
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS)
+    )
     try {
-      await waitForResolution();
+      await waitForResolution()
     } catch (retryError) {
       console.error(
-        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
-        retryError,
-      );
+        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
+        retryError
+      )
       const err =
-        retryError instanceof Error
-          ? retryError
-          : new Error(String(retryError));
+        retryError instanceof Error ? retryError : new Error(String(retryError))
       // Report to both Datadog RUM and Sentry so the error surfaces in
       // whichever observability platform is being monitored.
-      datadogRum.addError(err, { error_type: "bootstrap_auth_wait_timeout" });
+      datadogRum.addError(err, { error_type: 'bootstrap_auth_wait_timeout' })
       captureException(err, {
-        tags: { error_type: "bootstrap_auth_wait_timeout" },
-      });
+        tags: { error_type: 'bootstrap_auth_wait_timeout' }
+      })
     }
   }
 }
 
-export const useBootstrapStore = defineStore("bootstrap", () => {
-  const settingStore = useSettingStore();
-  const workflowStore = useWorkflowStore();
+export const useBootstrapStore = defineStore('bootstrap', () => {
+  const settingStore = useSettingStore()
+  const workflowStore = useWorkflowStore()
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n,
+    execute: loadI18n
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import("@/i18n");
-      const i18nData = await fetchCustomNodesI18n();
-      if (i18nData) mergeCustomNodesI18n(i18nData);
+      const { mergeCustomNodesI18n } = await import('@/i18n')
+      const i18nData = await fetchCustomNodesI18n()
+      if (i18nData) mergeCustomNodesI18n(i18nData)
     },
     undefined,
-    { immediate: false },
-  );
+    { immediate: false }
+  )
 
-  let storesLoaded = false;
+  let storesLoaded = false
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return;
-    storesLoaded = true;
-    void settingStore.load();
-    void workflowStore.loadWorkflows();
+    if (storesLoaded) return
+    storesLoaded = true
+    void settingStore.load()
+    void workflowStore.loadWorkflows()
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      await waitForCloudAuth();
+      await waitForCloudAuth()
     }
 
-    const userStore = useUserStore();
-    await userStore.initialize();
+    const userStore = useUserStore()
+    await userStore.initialize()
 
-    const { needsLogin } = storeToRefs(userStore);
-    await until(needsLogin).toBe(false);
+    const { needsLogin } = storeToRefs(userStore)
+    await until(needsLogin).toBe(false)
 
-    void loadI18n();
-    loadAuthenticatedStores();
+    void loadI18n()
+    loadAuthenticatedStores()
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap,
-  };
-});
+    startStoreBootstrap
+  }
+})

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,15 +1,16 @@
-import { captureException } from '@sentry/vue'
-import { until, useAsyncState } from '@vueuse/core'
-import axios from 'axios'
-import { defineStore, storeToRefs } from 'pinia'
+import { datadogRum } from "@datadog/browser-rum";
+import { captureException } from "@sentry/vue";
+import { until, useAsyncState } from "@vueuse/core";
+import axios from "axios";
+import { defineStore, storeToRefs } from "pinia";
 
-import { isCloud } from '@/platform/distribution/types'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
-import type { CustomNodesI18n } from '@/schemas/apiSchema'
-import { api } from '@/scripts/api'
-import { useAuthStore } from '@/stores/authStore'
-import { useUserStore } from '@/stores/userStore'
+import { isCloud } from "@/platform/distribution/types";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
+import type { CustomNodesI18n } from "@/schemas/apiSchema";
+import { api } from "@/scripts/api";
+import { useAuthStore } from "@/stores/authStore";
+import { useUserStore } from "@/stores/userStore";
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -17,18 +18,18 @@ import { useUserStore } from '@/stores/userStore'
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n()
+    return await api.getCustomNodesI18n();
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return
-    throw error
+    if (axios.isAxiosError(error) && error.response?.status === 404) return;
+    throw error;
   }
 }
 
 // Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
 // WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
 // on the same schedule those already fail theirs.
-const AUTH_WAIT_TIMEOUT_MS = 16_000
-const AUTH_WAIT_RETRY_DELAY_MS = 3_000
+const AUTH_WAIT_TIMEOUT_MS = 16_000;
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
 
 /**
  * Waits for Firebase auth initialization to complete, bounded so a stale
@@ -44,82 +45,89 @@ const AUTH_WAIT_RETRY_DELAY_MS = 3_000
  * to Sentry and lets bootstrap continue rather than leaving the caller stuck.
  */
 async function waitForCloudAuth(): Promise<void> {
-  const { isInitialized } = storeToRefs(useAuthStore())
+  const { isInitialized } = storeToRefs(useAuthStore());
   const waitForResolution = () =>
     until(isInitialized).toBe(true, {
       timeout: AUTH_WAIT_TIMEOUT_MS,
-      throwOnTimeout: true
-    })
+      throwOnTimeout: true,
+    });
 
   try {
-    await waitForResolution()
+    await waitForResolution();
   } catch (error) {
     console.warn(
-      '[bootstrapStore] Auth did not resolve in time, retrying once',
-      error
-    )
+      "[bootstrapStore] Auth did not resolve in time, retrying once",
+      error,
+    );
     await new Promise((resolve) =>
-      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS)
-    )
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
+    );
     try {
-      await waitForResolution()
+      await waitForResolution();
     } catch (retryError) {
       console.error(
-        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
-        retryError
-      )
-      captureException(retryError, {
-        tags: { error_type: 'bootstrap_auth_wait_timeout' }
-      })
+        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
+        retryError,
+      );
+      const err =
+        retryError instanceof Error
+          ? retryError
+          : new Error(String(retryError));
+      // Report to both Datadog RUM and Sentry so the error surfaces in
+      // whichever observability platform is being monitored.
+      datadogRum.addError(err, { error_type: "bootstrap_auth_wait_timeout" });
+      captureException(err, {
+        tags: { error_type: "bootstrap_auth_wait_timeout" },
+      });
     }
   }
 }
 
-export const useBootstrapStore = defineStore('bootstrap', () => {
-  const settingStore = useSettingStore()
-  const workflowStore = useWorkflowStore()
+export const useBootstrapStore = defineStore("bootstrap", () => {
+  const settingStore = useSettingStore();
+  const workflowStore = useWorkflowStore();
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n
+    execute: loadI18n,
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import('@/i18n')
-      const i18nData = await fetchCustomNodesI18n()
-      if (i18nData) mergeCustomNodesI18n(i18nData)
+      const { mergeCustomNodesI18n } = await import("@/i18n");
+      const i18nData = await fetchCustomNodesI18n();
+      if (i18nData) mergeCustomNodesI18n(i18nData);
     },
     undefined,
-    { immediate: false }
-  )
+    { immediate: false },
+  );
 
-  let storesLoaded = false
+  let storesLoaded = false;
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return
-    storesLoaded = true
-    void settingStore.load()
-    void workflowStore.loadWorkflows()
+    if (storesLoaded) return;
+    storesLoaded = true;
+    void settingStore.load();
+    void workflowStore.loadWorkflows();
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      await waitForCloudAuth()
+      await waitForCloudAuth();
     }
 
-    const userStore = useUserStore()
-    await userStore.initialize()
+    const userStore = useUserStore();
+    await userStore.initialize();
 
-    const { needsLogin } = storeToRefs(userStore)
-    await until(needsLogin).toBe(false)
+    const { needsLogin } = storeToRefs(userStore);
+    await until(needsLogin).toBe(false);
 
-    void loadI18n()
-    loadAuthenticatedStores()
+    void loadI18n();
+    loadAuthenticatedStores();
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap
-  }
-})
+    startStoreBootstrap,
+  };
+});

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,15 +1,15 @@
-import { captureException } from "@sentry/vue";
-import { until, useAsyncState } from "@vueuse/core";
-import axios from "axios";
-import { defineStore, storeToRefs } from "pinia";
+import { captureException } from '@sentry/vue'
+import { until, useAsyncState } from '@vueuse/core'
+import axios from 'axios'
+import { defineStore, storeToRefs } from 'pinia'
 
-import { isCloud } from "@/platform/distribution/types";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
-import type { CustomNodesI18n } from "@/schemas/apiSchema";
-import { api } from "@/scripts/api";
-import { useAuthStore } from "@/stores/authStore";
-import { useUserStore } from "@/stores/userStore";
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -17,18 +17,18 @@ import { useUserStore } from "@/stores/userStore";
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n();
+    return await api.getCustomNodesI18n()
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return;
-    throw error;
+    if (axios.isAxiosError(error) && error.response?.status === 404) return
+    throw error
   }
 }
 
 // Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
 // WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
 // on the same schedule those already fail theirs.
-const AUTH_WAIT_TIMEOUT_MS = 16_000;
-const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
+const AUTH_WAIT_TIMEOUT_MS = 16_000
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000
 
 /**
  * Waits for Firebase auth initialization to complete, bounded so a stale
@@ -44,82 +44,82 @@ const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
  * to Sentry and lets bootstrap continue rather than leaving the caller stuck.
  */
 async function waitForCloudAuth(): Promise<void> {
-  const { isInitialized } = storeToRefs(useAuthStore());
+  const { isInitialized } = storeToRefs(useAuthStore())
   const waitForResolution = () =>
     until(isInitialized).toBe(true, {
       timeout: AUTH_WAIT_TIMEOUT_MS,
-      throwOnTimeout: true,
-    });
+      throwOnTimeout: true
+    })
 
   try {
-    await waitForResolution();
+    await waitForResolution()
   } catch (error) {
     console.warn(
-      "[bootstrapStore] Auth did not resolve in time, retrying once",
-      error,
-    );
+      '[bootstrapStore] Auth did not resolve in time, retrying once',
+      error
+    )
     await new Promise((resolve) =>
-      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
-    );
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS)
+    )
     try {
-      await waitForResolution();
+      await waitForResolution()
     } catch (retryError) {
       console.error(
-        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
-        retryError,
-      );
+        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
+        retryError
+      )
       captureException(retryError, {
-        tags: { error_type: "bootstrap_auth_wait_timeout" },
-      });
+        tags: { error_type: 'bootstrap_auth_wait_timeout' }
+      })
     }
   }
 }
 
-export const useBootstrapStore = defineStore("bootstrap", () => {
-  const settingStore = useSettingStore();
-  const workflowStore = useWorkflowStore();
+export const useBootstrapStore = defineStore('bootstrap', () => {
+  const settingStore = useSettingStore()
+  const workflowStore = useWorkflowStore()
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n,
+    execute: loadI18n
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import("@/i18n");
-      const i18nData = await fetchCustomNodesI18n();
-      if (i18nData) mergeCustomNodesI18n(i18nData);
+      const { mergeCustomNodesI18n } = await import('@/i18n')
+      const i18nData = await fetchCustomNodesI18n()
+      if (i18nData) mergeCustomNodesI18n(i18nData)
     },
     undefined,
-    { immediate: false },
-  );
+    { immediate: false }
+  )
 
-  let storesLoaded = false;
+  let storesLoaded = false
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return;
-    storesLoaded = true;
-    void settingStore.load();
-    void workflowStore.loadWorkflows();
+    if (storesLoaded) return
+    storesLoaded = true
+    void settingStore.load()
+    void workflowStore.loadWorkflows()
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      await waitForCloudAuth();
+      await waitForCloudAuth()
     }
 
-    const userStore = useUserStore();
-    await userStore.initialize();
+    const userStore = useUserStore()
+    await userStore.initialize()
 
-    const { needsLogin } = storeToRefs(userStore);
-    await until(needsLogin).toBe(false);
+    const { needsLogin } = storeToRefs(userStore)
+    await until(needsLogin).toBe(false)
 
-    void loadI18n();
-    loadAuthenticatedStores();
+    void loadI18n()
+    loadAuthenticatedStores()
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap,
-  };
-});
+    startStoreBootstrap
+  }
+})

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,15 +1,15 @@
-import { captureException } from "@sentry/vue";
-import { until, useAsyncState } from "@vueuse/core";
-import axios from "axios";
-import { defineStore, storeToRefs } from "pinia";
+import { captureException } from '@sentry/vue'
+import { until, useAsyncState } from '@vueuse/core'
+import axios from 'axios'
+import { defineStore, storeToRefs } from 'pinia'
 
-import { isCloud } from "@/platform/distribution/types";
-import { useSettingStore } from "@/platform/settings/settingStore";
-import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
-import type { CustomNodesI18n } from "@/schemas/apiSchema";
-import { api } from "@/scripts/api";
-import { useAuthStore } from "@/stores/authStore";
-import { useUserStore } from "@/stores/userStore";
+import { isCloud } from '@/platform/distribution/types'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import { useAuthStore } from '@/stores/authStore'
+import { useUserStore } from '@/stores/userStore'
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -17,18 +17,18 @@ import { useUserStore } from "@/stores/userStore";
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n();
+    return await api.getCustomNodesI18n()
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return;
-    throw error;
+    if (axios.isAxiosError(error) && error.response?.status === 404) return
+    throw error
   }
 }
 
 // Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
 // WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
 // on the same schedule those already fail theirs.
-const AUTH_WAIT_TIMEOUT_MS = 16_000;
-const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
+const AUTH_WAIT_TIMEOUT_MS = 16_000
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000
 
 /**
  * Waits for Firebase auth to resolve, bounded so a stale session or a
@@ -37,86 +37,86 @@ const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
  * bootstrap continue rather than leaving the caller stuck indefinitely.
  */
 async function waitForCloudAuth(): Promise<void> {
-  const { isInitialized, isAuthenticated } = storeToRefs(useAuthStore());
+  const { isInitialized, isAuthenticated } = storeToRefs(useAuthStore())
   const waitForResolution = () =>
     until(isInitialized)
       .toBe(true, { timeout: AUTH_WAIT_TIMEOUT_MS, throwOnTimeout: true })
       .then(() =>
         until(isAuthenticated).toBe(true, {
           timeout: AUTH_WAIT_TIMEOUT_MS,
-          throwOnTimeout: true,
-        }),
-      );
+          throwOnTimeout: true
+        })
+      )
 
   try {
-    await waitForResolution();
+    await waitForResolution()
   } catch (error) {
     console.warn(
-      "[bootstrapStore] Auth did not resolve in time, retrying once",
-      error,
-    );
+      '[bootstrapStore] Auth did not resolve in time, retrying once',
+      error
+    )
     await new Promise((resolve) =>
-      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
-    );
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS)
+    )
     try {
-      await waitForResolution();
+      await waitForResolution()
     } catch (retryError) {
       console.error(
-        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
-        retryError,
-      );
+        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
+        retryError
+      )
       captureException(retryError, {
-        tags: { error_type: "bootstrap_auth_wait_timeout" },
-      });
+        tags: { error_type: 'bootstrap_auth_wait_timeout' }
+      })
     }
   }
 }
 
-export const useBootstrapStore = defineStore("bootstrap", () => {
-  const settingStore = useSettingStore();
-  const workflowStore = useWorkflowStore();
+export const useBootstrapStore = defineStore('bootstrap', () => {
+  const settingStore = useSettingStore()
+  const workflowStore = useWorkflowStore()
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n,
+    execute: loadI18n
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import("@/i18n");
-      const i18nData = await fetchCustomNodesI18n();
-      if (i18nData) mergeCustomNodesI18n(i18nData);
+      const { mergeCustomNodesI18n } = await import('@/i18n')
+      const i18nData = await fetchCustomNodesI18n()
+      if (i18nData) mergeCustomNodesI18n(i18nData)
     },
     undefined,
-    { immediate: false },
-  );
+    { immediate: false }
+  )
 
-  let storesLoaded = false;
+  let storesLoaded = false
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return;
-    storesLoaded = true;
-    void settingStore.load();
-    void workflowStore.loadWorkflows();
+    if (storesLoaded) return
+    storesLoaded = true
+    void settingStore.load()
+    void workflowStore.loadWorkflows()
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      await waitForCloudAuth();
+      await waitForCloudAuth()
     }
 
-    const userStore = useUserStore();
-    await userStore.initialize();
+    const userStore = useUserStore()
+    await userStore.initialize()
 
-    const { needsLogin } = storeToRefs(userStore);
-    await until(needsLogin).toBe(false);
+    const { needsLogin } = storeToRefs(userStore)
+    await until(needsLogin).toBe(false)
 
-    void loadI18n();
-    loadAuthenticatedStores();
+    void loadI18n()
+    loadAuthenticatedStores()
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap,
-  };
-});
+    startStoreBootstrap
+  }
+})

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,14 +1,15 @@
-import { until, useAsyncState } from '@vueuse/core'
-import axios from 'axios'
-import { defineStore, storeToRefs } from 'pinia'
+import { captureException } from "@sentry/vue";
+import { until, useAsyncState } from "@vueuse/core";
+import axios from "axios";
+import { defineStore, storeToRefs } from "pinia";
 
-import { isCloud } from '@/platform/distribution/types'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
-import type { CustomNodesI18n } from '@/schemas/apiSchema'
-import { api } from '@/scripts/api'
-import { useAuthStore } from '@/stores/authStore'
-import { useUserStore } from '@/stores/userStore'
+import { isCloud } from "@/platform/distribution/types";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
+import type { CustomNodesI18n } from "@/schemas/apiSchema";
+import { api } from "@/scripts/api";
+import { useAuthStore } from "@/stores/authStore";
+import { useUserStore } from "@/stores/userStore";
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -16,60 +17,106 @@ import { useUserStore } from '@/stores/userStore'
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n()
+    return await api.getCustomNodesI18n();
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return
-    throw error
+    if (axios.isAxiosError(error) && error.response?.status === 404) return;
+    throw error;
   }
 }
 
-export const useBootstrapStore = defineStore('bootstrap', () => {
-  const settingStore = useSettingStore()
-  const workflowStore = useWorkflowStore()
+// Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
+// WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
+// on the same schedule those already fail theirs.
+const AUTH_WAIT_TIMEOUT_MS = 16_000;
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
+
+/**
+ * Waits for Firebase auth to resolve, bounded so a stale session or a
+ * broken auth response can never hang bootstrap forever. Retries once after
+ * a short delay; if auth is still unresolved after that, reports it and lets
+ * bootstrap continue rather than leaving the caller stuck indefinitely.
+ */
+async function waitForCloudAuth(): Promise<void> {
+  const { isInitialized, isAuthenticated } = storeToRefs(useAuthStore());
+  const waitForResolution = () =>
+    until(isInitialized)
+      .toBe(true, { timeout: AUTH_WAIT_TIMEOUT_MS, throwOnTimeout: true })
+      .then(() =>
+        until(isAuthenticated).toBe(true, {
+          timeout: AUTH_WAIT_TIMEOUT_MS,
+          throwOnTimeout: true,
+        }),
+      );
+
+  try {
+    await waitForResolution();
+  } catch (error) {
+    console.warn(
+      "[bootstrapStore] Auth did not resolve in time, retrying once",
+      error,
+    );
+    await new Promise((resolve) =>
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
+    );
+    try {
+      await waitForResolution();
+    } catch (retryError) {
+      console.error(
+        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
+        retryError,
+      );
+      captureException(retryError, {
+        tags: { error_type: "bootstrap_auth_wait_timeout" },
+      });
+    }
+  }
+}
+
+export const useBootstrapStore = defineStore("bootstrap", () => {
+  const settingStore = useSettingStore();
+  const workflowStore = useWorkflowStore();
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n
+    execute: loadI18n,
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import('@/i18n')
-      const i18nData = await fetchCustomNodesI18n()
-      if (i18nData) mergeCustomNodesI18n(i18nData)
+      const { mergeCustomNodesI18n } = await import("@/i18n");
+      const i18nData = await fetchCustomNodesI18n();
+      if (i18nData) mergeCustomNodesI18n(i18nData);
     },
     undefined,
-    { immediate: false }
-  )
+    { immediate: false },
+  );
 
-  let storesLoaded = false
+  let storesLoaded = false;
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return
-    storesLoaded = true
-    void settingStore.load()
-    void workflowStore.loadWorkflows()
+    if (storesLoaded) return;
+    storesLoaded = true;
+    void settingStore.load();
+    void workflowStore.loadWorkflows();
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      const { isInitialized, isAuthenticated } = storeToRefs(useAuthStore())
-      await until(isInitialized).toBe(true)
-      await until(isAuthenticated).toBe(true)
+      await waitForCloudAuth();
     }
 
-    const userStore = useUserStore()
-    await userStore.initialize()
+    const userStore = useUserStore();
+    await userStore.initialize();
 
-    const { needsLogin } = storeToRefs(userStore)
-    await until(needsLogin).toBe(false)
+    const { needsLogin } = storeToRefs(userStore);
+    await until(needsLogin).toBe(false);
 
-    void loadI18n()
-    loadAuthenticatedStores()
+    void loadI18n();
+    loadAuthenticatedStores();
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap
-  }
-})
+    startStoreBootstrap,
+  };
+});

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -1,15 +1,15 @@
-import { captureException } from '@sentry/vue'
-import { until, useAsyncState } from '@vueuse/core'
-import axios from 'axios'
-import { defineStore, storeToRefs } from 'pinia'
+import { captureException } from "@sentry/vue";
+import { until, useAsyncState } from "@vueuse/core";
+import axios from "axios";
+import { defineStore, storeToRefs } from "pinia";
 
-import { isCloud } from '@/platform/distribution/types'
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
-import type { CustomNodesI18n } from '@/schemas/apiSchema'
-import { api } from '@/scripts/api'
-import { useAuthStore } from '@/stores/authStore'
-import { useUserStore } from '@/stores/userStore'
+import { isCloud } from "@/platform/distribution/types";
+import { useSettingStore } from "@/platform/settings/settingStore";
+import { useWorkflowStore } from "@/platform/workflow/management/stores/workflowStore";
+import type { CustomNodesI18n } from "@/schemas/apiSchema";
+import { api } from "@/scripts/api";
+import { useAuthStore } from "@/stores/authStore";
+import { useUserStore } from "@/stores/userStore";
 
 /**
  * Backends that vendor no custom-node locale files do not implement
@@ -17,106 +17,109 @@ import { useUserStore } from '@/stores/userStore'
  */
 async function fetchCustomNodesI18n(): Promise<CustomNodesI18n | undefined> {
   try {
-    return await api.getCustomNodesI18n()
+    return await api.getCustomNodesI18n();
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) return
-    throw error
+    if (axios.isAxiosError(error) && error.response?.status === 404) return;
+    throw error;
   }
 }
 
 // Matches the Firebase-auth-wait timeout used elsewhere (router.ts,
 // WorkspaceAuthGate.vue) so a broken/stale session fails this bounded wait
 // on the same schedule those already fail theirs.
-const AUTH_WAIT_TIMEOUT_MS = 16_000
-const AUTH_WAIT_RETRY_DELAY_MS = 3_000
+const AUTH_WAIT_TIMEOUT_MS = 16_000;
+const AUTH_WAIT_RETRY_DELAY_MS = 3_000;
 
 /**
- * Waits for Firebase auth to resolve, bounded so a stale session or a
- * broken auth response can never hang bootstrap forever. Retries once after
- * a short delay; if auth is still unresolved after that, reports it and lets
- * bootstrap continue rather than leaving the caller stuck indefinitely.
+ * Waits for Firebase auth initialization to complete, bounded so a stale
+ * token or a broken auth response can never hang bootstrap forever.
+ *
+ * Only isInitialized is awaited — onAuthStateChanged fires with null for
+ * signed-out users, which sets isInitialized but not isAuthenticated.
+ * Awaiting isAuthenticated here would make every signed-out page load wait
+ * 35s and fire a false Sentry timeout. The router guard handles the
+ * login redirect for unauthenticated users separately.
+ *
+ * Retries once after a short delay; if auth is still unresolved, reports it
+ * to Sentry and lets bootstrap continue rather than leaving the caller stuck.
  */
 async function waitForCloudAuth(): Promise<void> {
-  const { isInitialized, isAuthenticated } = storeToRefs(useAuthStore())
+  const { isInitialized } = storeToRefs(useAuthStore());
   const waitForResolution = () =>
-    until(isInitialized)
-      .toBe(true, { timeout: AUTH_WAIT_TIMEOUT_MS, throwOnTimeout: true })
-      .then(() =>
-        until(isAuthenticated).toBe(true, {
-          timeout: AUTH_WAIT_TIMEOUT_MS,
-          throwOnTimeout: true
-        })
-      )
+    until(isInitialized).toBe(true, {
+      timeout: AUTH_WAIT_TIMEOUT_MS,
+      throwOnTimeout: true,
+    });
 
   try {
-    await waitForResolution()
+    await waitForResolution();
   } catch (error) {
     console.warn(
-      '[bootstrapStore] Auth did not resolve in time, retrying once',
-      error
-    )
+      "[bootstrapStore] Auth did not resolve in time, retrying once",
+      error,
+    );
     await new Promise((resolve) =>
-      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS)
-    )
+      setTimeout(resolve, AUTH_WAIT_RETRY_DELAY_MS),
+    );
     try {
-      await waitForResolution()
+      await waitForResolution();
     } catch (retryError) {
       console.error(
-        '[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth',
-        retryError
-      )
+        "[bootstrapStore] Auth still unresolved after retry; continuing bootstrap without confirmed auth",
+        retryError,
+      );
       captureException(retryError, {
-        tags: { error_type: 'bootstrap_auth_wait_timeout' }
-      })
+        tags: { error_type: "bootstrap_auth_wait_timeout" },
+      });
     }
   }
 }
 
-export const useBootstrapStore = defineStore('bootstrap', () => {
-  const settingStore = useSettingStore()
-  const workflowStore = useWorkflowStore()
+export const useBootstrapStore = defineStore("bootstrap", () => {
+  const settingStore = useSettingStore();
+  const workflowStore = useWorkflowStore();
 
   const {
     isReady: isI18nReady,
     error: i18nError,
-    execute: loadI18n
+    execute: loadI18n,
   } = useAsyncState(
     async () => {
-      const { mergeCustomNodesI18n } = await import('@/i18n')
-      const i18nData = await fetchCustomNodesI18n()
-      if (i18nData) mergeCustomNodesI18n(i18nData)
+      const { mergeCustomNodesI18n } = await import("@/i18n");
+      const i18nData = await fetchCustomNodesI18n();
+      if (i18nData) mergeCustomNodesI18n(i18nData);
     },
     undefined,
-    { immediate: false }
-  )
+    { immediate: false },
+  );
 
-  let storesLoaded = false
+  let storesLoaded = false;
 
   function loadAuthenticatedStores() {
-    if (storesLoaded) return
-    storesLoaded = true
-    void settingStore.load()
-    void workflowStore.loadWorkflows()
+    if (storesLoaded) return;
+    storesLoaded = true;
+    void settingStore.load();
+    void workflowStore.loadWorkflows();
   }
 
   async function startStoreBootstrap() {
     if (isCloud) {
-      await waitForCloudAuth()
+      await waitForCloudAuth();
     }
 
-    const userStore = useUserStore()
-    await userStore.initialize()
+    const userStore = useUserStore();
+    await userStore.initialize();
 
-    const { needsLogin } = storeToRefs(userStore)
-    await until(needsLogin).toBe(false)
+    const { needsLogin } = storeToRefs(userStore);
+    await until(needsLogin).toBe(false);
 
-    void loadI18n()
-    loadAuthenticatedStores()
+    void loadI18n();
+    loadAuthenticatedStores();
   }
 
   return {
     isI18nReady,
     i18nError,
-    startStoreBootstrap
-  }
-})
+    startStoreBootstrap,
+  };
+});


### PR DESCRIPTION
## Summary

Two durable fixes for the IR-105 splash-screen hang incident.

### Fix 1 — Bootstrap auth wait timeout (`bootstrapStore.ts`)

**Root cause:** `until(isInitialized).toBe(true)` and `until(isAuthenticated).toBe(true)` in `startStoreBootstrap` have no timeout. A stale Firebase session or broken auth response hangs bootstrap silently and indefinitely — no error, no log, just a forever splash screen.

**Fix:** Extract `waitForCloudAuth()` with:
- 16 s timeout (matching `router.ts:176` and `WorkspaceAuthGate.vue:78` — existing convention)
- One retry after 3 s backoff
- On second timeout: `captureException` to Sentry + **continue bootstrap** rather than blocking

This means the worst case is now 35 s to a usable (logged-out) state instead of infinity.

### Fix 2 — Catch-all route for unknown paths (`router.ts`)

**Root cause:** A request to e.g. `cloud.comfy.org/woiadawd` gets a 200 + app shell from the static host, Vue boots, finds **no matching route**, and the global auth guard's `until(isInitialized)` then hangs (see Fix 1). Even with Fix 1, a no-match route leaves the app on the splash screen.

**Fix:** Add `{ path: '/:pathMatch(.*)*', redirect: '/' }` at the end of the route list. Unknown paths redirect to root; the global auth guard then sends unauthenticated users to `/cloud/login` as normal.

## Red-Green Verification

| Commit | Purpose |
|--------|---------|
| `test: add failing tests for unbounded auth wait in startStoreBootstrap` | :red_circle: Proves test catches the bug — the "gives up" test times out in 5 s against the unpatched code |
| `fix: bound auth wait in startStoreBootstrap and add catch-all route` | :green_circle: Both new tests pass, all 18 tests in the two affected files pass |

## Relation to open PRs

- Supersedes / closes the scope of #15032 (`fix/bootstrap-auth-wait-timeout`) — same fix, same tests. If reviewers prefer to land #15032 first this PR can drop Fix 1.
- Companion to #15022 (marketing-site redirect) and #15026 (`/login` → `cloud-login` route, already on main).

## Test Plan

- [x] `pnpm vitest run src/stores/bootstrapStore.test.ts` — 7/7 pass (including 2 new timeout tests)
- [x] `pnpm vitest run src/platform/cloud/onboarding/onboardingCloudRoutes.test.ts` — 11/11 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec eslint src/stores/bootstrapStore.ts src/router.ts` — clean
- [ ] CI green (Playwright, Storybook, Codecov)

🤖 Generated with [Claude Code](https://claude.com/claude-code)