### PR TITLE
fix: acknowledge a new run ahead of outcome banners

### DIFF
--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -163,15 +163,19 @@ test.describe('Queue notification banners', { tag: ['@ui'] }, () => {
       jobsRoutes
     }) => {
       const failedJobId = 'failed-job-1'
-      // The banner only reports jobs that finished after the queue last went
-      // active, and that moment is later than this mock is built.
-      await jobsRoutes.mockJobsHistory([
-        createRouteMockJob({
-          id: failedJobId,
-          status: 'failed',
-          execution_end_time: Date.now() + BANNER_MOCK_FINISH_SKEW_MS
-        })
-      ])
+      // mockJobsScenario matches queueStore's own maxHistoryItems (64); the bare
+      // mockJobsHistory default is 200 and never matches the request. The finish
+      // time has to beat the moment the queue goes active, which is later than
+      // this mock is built.
+      await jobsRoutes.mockJobsScenario({
+        history: [
+          createRouteMockJob({
+            id: failedJobId,
+            status: 'failed',
+            execution_end_time: Date.now() + BANNER_MOCK_FINISH_SKEW_MS
+          })
+        ]
+      })
 
       const exec = new ExecutionHelper(comfyPage, await getWebSocket())
       exec.executionStart(failedJobId)

--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -1,8 +1,16 @@
 import type { Page } from '@playwright/test'
-import { expect } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
 
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import {
+  createRouteMockJob,
+  jobsRouteFixture
+} from '@e2e/fixtures/jobsRouteFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const test = mergeTests(comfyPageFixture, webSocketFixture, jobsRouteFixture)
 
 // Mirrors BANNER_DISMISS_DELAY_MS in src/composables/queue/useQueueNotificationBanners.ts.
 // Duplicated here to avoid pulling production source (and its litegraph
@@ -144,6 +152,37 @@ test.describe('Queue notification banners', { tag: ['@ui'] }, () => {
       await expect(banner).toContainText('2 jobs added to queue', {
         timeout: BANNER_ASSERT_TIMEOUT_MS
       })
+    })
+  })
+
+  test.describe('Run acknowledgement priority', () => {
+    test('a new run is acknowledged over an outcome banner still on screen', async ({
+      comfyPage,
+      getWebSocket,
+      jobsRoutes
+    }) => {
+      const failedJobId = 'failed-job-1'
+      await jobsRoutes.mockJobsHistory([
+        createRouteMockJob({
+          id: failedJobId,
+          status: 'failed',
+          execution_end_time: Date.now()
+        })
+      ])
+
+      const exec = new ExecutionHelper(comfyPage, await getWebSocket())
+      exec.executionStart(failedJobId)
+      exec.executionError(failedJobId, '1', 'boom')
+      exec.status(0)
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toContainText('failed', {
+        timeout: BANNER_ASSERT_TIMEOUT_MS
+      })
+
+      await dispatchPromptQueueing(comfyPage.page)
+
+      await expect(banner).toContainText('queuing')
     })
   })
 

--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -17,6 +17,7 @@ const test = mergeTests(comfyPageFixture, webSocketFixture, jobsRouteFixture)
 // transitive deps) into the Playwright TS loader.
 const BANNER_DISMISS_DELAY_MS = 4000
 const BANNER_ASSERT_TIMEOUT_MS = BANNER_DISMISS_DELAY_MS + 2000
+const BANNER_MOCK_FINISH_SKEW_MS = 60_000
 
 const REQUEST_ID_PRIMARY = 1
 const REQUEST_ID_SECONDARY = 2
@@ -162,11 +163,13 @@ test.describe('Queue notification banners', { tag: ['@ui'] }, () => {
       jobsRoutes
     }) => {
       const failedJobId = 'failed-job-1'
+      // The banner only reports jobs that finished after the queue last went
+      // active, and that moment is later than this mock is built.
       await jobsRoutes.mockJobsHistory([
         createRouteMockJob({
           id: failedJobId,
           status: 'failed',
-          execution_end_time: Date.now()
+          execution_end_time: Date.now() + BANNER_MOCK_FINISH_SKEW_MS
         })
       ])
 

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -343,4 +343,80 @@ describe(useQueueNotificationBanners, () => {
       unmount()
     }
   })
+
+  it('acknowledges a new run over an outcome notification still on screen', async () => {
+    const { unmount, composable } = mountComposable()
+
+    try {
+      await runBatch({
+        start: 5_000,
+        finish: 5_100,
+        tasks: [createTask({ state: 'Failed', ts: 5_050 })]
+      })
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'failed',
+        count: 1
+      })
+
+      mockApi.dispatchEvent(
+        new CustomEvent('promptQueueing', {
+          detail: { requestId: 7, batchCount: 1 }
+        })
+      )
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'queuedPending',
+        count: 1,
+        requestId: 7
+      })
+    } finally {
+      unmount()
+    }
+  })
+
+  it('acknowledges a new run ahead of outcome notifications still waiting', async () => {
+    const { unmount, composable } = mountComposable()
+
+    try {
+      await runBatch({
+        start: 6_000,
+        finish: 6_100,
+        tasks: [
+          createTask({ ts: 6_050 }),
+          createTask({ state: 'Failed', ts: 6_060 })
+        ]
+      })
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'completed',
+        count: 1,
+        thumbnailUrls: []
+      })
+
+      mockApi.dispatchEvent(
+        new CustomEvent('promptQueueing', {
+          detail: { requestId: 8, batchCount: 1 }
+        })
+      )
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'queuedPending',
+        count: 1,
+        requestId: 8
+      })
+
+      await vi.advanceTimersByTimeAsync(4000)
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'failed',
+        count: 1
+      })
+    } finally {
+      unmount()
+    }
+  })
 })

--- a/src/composables/queue/useQueueNotificationBanners.test.ts
+++ b/src/composables/queue/useQueueNotificationBanners.test.ts
@@ -419,4 +419,58 @@ describe(useQueueNotificationBanners, () => {
       unmount()
     }
   })
+
+  it('keeps a later run ahead of outcomes while an acknowledgement shows', async () => {
+    const { unmount, composable } = mountComposable()
+
+    try {
+      await runBatch({
+        start: 7_000,
+        finish: 7_100,
+        tasks: [
+          createTask({ ts: 7_050 }),
+          createTask({ state: 'Failed', ts: 7_060 })
+        ]
+      })
+
+      mockApi.dispatchEvent(
+        new CustomEvent('promptQueueing', {
+          detail: { requestId: 9, batchCount: 1 }
+        })
+      )
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'queuedPending',
+        count: 1,
+        requestId: 9
+      })
+
+      mockApi.dispatchEvent(
+        new CustomEvent('promptQueueing', {
+          detail: { requestId: 10, batchCount: 1 }
+        })
+      )
+      await nextTick()
+
+      await vi.advanceTimersByTimeAsync(4000)
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'queuedPending',
+        count: 1,
+        requestId: 10
+      })
+
+      await vi.advanceTimersByTimeAsync(4000)
+      await nextTick()
+
+      expect(composable.currentNotification.value).toEqual({
+        type: 'failed',
+        count: 1
+      })
+    } finally {
+      unmount()
+    }
+  })
 })

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -36,6 +36,12 @@ export type QueueNotificationBanner =
   | QueueCompletedNotification
   | QueueFailedNotification
 
+const isRunAcknowledgement = (notification: QueueNotificationBanner) =>
+  notification.type === 'queuedPending' || notification.type === 'queued'
+
+const isOutcome = (notification: QueueNotificationBanner) =>
+  notification.type === 'completed' || notification.type === 'failed'
+
 const sanitizeCount = (value: number | undefined) => {
   if (!(typeof value === 'number' && value > 0)) {
     return 1
@@ -102,6 +108,22 @@ export const useQueueNotificationBanners = () => {
   }
 
   const queueNotification = (notification: QueueNotificationBanner) => {
+    // An outcome banner reports history; a run acknowledgement reports the
+    // action the user just took and is the only one that can still inform them.
+    if (isRunAcknowledgement(notification)) {
+      const active = activeNotification.value
+      if (active === null || isOutcome(active)) {
+        clearDismissTimer()
+        activeNotification.value = null
+        pendingNotifications.value = [
+          notification,
+          ...pendingNotifications.value
+        ]
+        showNextNotification()
+        return
+      }
+    }
+
     pendingNotifications.value = [...pendingNotifications.value, notification]
     showNextNotification()
   }

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -108,8 +108,6 @@ export const useQueueNotificationBanners = () => {
   }
 
   const queueNotification = (notification: QueueNotificationBanner) => {
-    // An outcome banner reports history; a run acknowledgement reports the
-    // action the user just took and is the only one that can still inform them.
     if (isRunAcknowledgement(notification)) {
       const active = activeNotification.value
       if (active === null || isOutcome(active)) {

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -107,6 +107,16 @@ export const useQueueNotificationBanners = () => {
     )
   }
 
+  const queuePositionFor = (notification: QueueNotificationBanner) => {
+    if (!isRunAcknowledgement(notification)) {
+      return pendingNotifications.value.length
+    }
+    const firstOutcome = pendingNotifications.value.findIndex(isOutcome)
+    return firstOutcome === -1
+      ? pendingNotifications.value.length
+      : firstOutcome
+  }
+
   const queueNotification = (notification: QueueNotificationBanner) => {
     if (isRunAcknowledgement(notification)) {
       const active = activeNotification.value
@@ -122,7 +132,11 @@ export const useQueueNotificationBanners = () => {
       }
     }
 
-    pendingNotifications.value = [...pendingNotifications.value, notification]
+    pendingNotifications.value = pendingNotifications.value.toSpliced(
+      queuePositionFor(notification),
+      0,
+      notification
+    )
     showNextNotification()
   }
 


### PR DESCRIPTION
## Summary

Clicking Run after a batch of jobs failed looks like it did nothing. The run *is* accepted immediately, but the banner that says so is queued behind outcome banners that each hold the screen for 4s.

`useQueueNotificationBanners` keeps a single active banner plus a FIFO of pending ones (`BANNER_DISMISS_DELAY_MS = 4000`). `queueNotification` appends unconditionally, so the acknowledgement for the action the user just took waits out every already-queued "N jobs failed" banner first.

Verified against the composable before the fix: with a `failed` banner active, a `promptQueueing` event leaves `currentNotification` on `failed` for the full 4s.

## Changes

- **What (Before/After)**: a `queuedPending`/`queued` notification now preempts an active *outcome* (`completed`/`failed`) banner and jumps the pending queue. Before: up to 4s per already-queued banner before the user learns their run was accepted. After: immediate. Acknowledgement-vs-acknowledgement ordering is unchanged, so the existing FIFO test still passes.
- **Breaking**: none.
- **Dependencies**: none.

## Review Focus

- The judgment call: an outcome banner reports history and is also recorded in Job History; a run acknowledgement reports the action the user just took and is the only notification that can still inform them. Dropping the former for the latter is the trade this makes.
- Not fixed here, filed separately: consecutive outcome batches are neither coalesced nor capped, so N failure batches produce N serialized banners draining at 4s each. That is the "ton of job-failed toasts arriving over minutes" half of the report and is a distinct UX gap.
- The delay before the failures arrive is **backend**, not frontend: the cloud job monitor batch-fails stagnated jobs on a 10s tick against `StagnationTimeouts` (Submitted 1m, Allocated 1m, PendingExecution 3m) with a single `UPDATE ... RETURNING`, then emits one `execution_error` per row in a tight loop. No frontend change can make those arrive sooner.

## How

- `useQueueNotificationBanners.ts`: `queueNotification` unshifts run acknowledgements and clears an active outcome banner's dismiss timer.
- Failing repro committed first (`test:` commit), then the fix.
- E2E in `browser_tests/tests/queueNotificationBanners.spec.ts` drives a failed job through the mocked jobs route + WS helper, then asserts a dispatched `promptQueueing` shows immediately.

- Part of FE-1586 (reported by Pablo in #comfy-creatives, 2026-08-11: "very often i click on run and it seems like it didnt work")
