### PR TITLE
fix: disambiguate canvas clicks from drags by distance only

### DIFF
--- a/browser_tests/fixtures/helpers/CanvasHelper.ts
+++ b/browser_tests/fixtures/helpers/CanvasHelper.ts
@@ -2,7 +2,7 @@ import type { Locator, Page } from '@playwright/test'
 
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
 import type { Position } from '@e2e/fixtures/types'
-import { nextFrame, sleep } from '@e2e/fixtures/utils/timing'
+import { nextFrame } from '@e2e/fixtures/utils/timing'
 
 export class CanvasHelper {
   constructor(
@@ -65,27 +65,22 @@ export class CanvasHelper {
   }
 
   /**
-   * Double-clicks at absolute page coordinates the way a person does: each
-   * press is held down for a while, and the pointer drifts a little before
-   * release. Pen, touch and trackpad devices report `pointermove` continuously
-   * while the pointer is held, so a real double click always carries movement
-   * that `page.mouse.dblclick` never sends.
+   * Double-clicks at absolute page coordinates the way a person does: the
+   * pointer drifts a little between press and release instead of staying
+   * pixel-perfect still, the way `page.mouse.dblclick` sends it.
    *
    * `driftPx` stays inside `Comfy.Pointer.ClickDrift` so both presses remain
    * clicks, and alternates sign so the pointer does not walk away from the
-   * start. `holdMs` is press duration, not a wait for application state — it
-   * is kept well under `Comfy.Pointer.DoubleClickTime` so the two presses pair
-   * up even when CDP round-trips are slow.
+   * start.
    */
-  async doubleClickHeld(
+  async doubleClickWithDrift(
     position: Position,
-    { holdMs = 60, driftPx = 2 }: { holdMs?: number; driftPx?: number } = {}
+    { driftPx = 2 }: { driftPx?: number } = {}
   ): Promise<void> {
     const { x, y } = position
     await this.page.mouse.move(x, y)
     for (const drift of [driftPx, 0]) {
       await this.page.mouse.down()
-      await sleep(holdMs)
       await this.page.mouse.move(x + drift, y)
       await this.page.mouse.up()
     }

--- a/browser_tests/fixtures/helpers/CanvasHelper.ts
+++ b/browser_tests/fixtures/helpers/CanvasHelper.ts
@@ -2,7 +2,7 @@ import type { Locator, Page } from '@playwright/test'
 
 import { DefaultGraphPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
 import type { Position } from '@e2e/fixtures/types'
-import { nextFrame } from '@e2e/fixtures/utils/timing'
+import { nextFrame, sleep } from '@e2e/fixtures/utils/timing'
 
 export class CanvasHelper {
   constructor(
@@ -61,6 +61,34 @@ export class CanvasHelper {
 
   async doubleClick(): Promise<void> {
     await this.page.mouse.dblclick(10, 10, { delay: 5 })
+    await nextFrame(this.page)
+  }
+
+  /**
+   * Double-clicks at absolute page coordinates the way a person does: each
+   * press is held down for a while, and the pointer drifts a little before
+   * release. Pen, touch and trackpad devices report `pointermove` continuously
+   * while the pointer is held, so a real double click always carries movement
+   * that `page.mouse.dblclick` never sends.
+   *
+   * `driftPx` stays inside `Comfy.Pointer.ClickDrift` so both presses remain
+   * clicks, and alternates sign so the pointer does not walk away from the
+   * start. `holdMs` is press duration, not a wait for application state — it
+   * is kept well under `Comfy.Pointer.DoubleClickTime` so the two presses pair
+   * up even when CDP round-trips are slow.
+   */
+  async doubleClickHeld(
+    position: Position,
+    { holdMs = 60, driftPx = 2 }: { holdMs?: number; driftPx?: number } = {}
+  ): Promise<void> {
+    const { x, y } = position
+    await this.page.mouse.move(x, y)
+    for (const drift of [driftPx, 0]) {
+      await this.page.mouse.down()
+      await sleep(holdMs)
+      await this.page.mouse.move(x + drift, y)
+      await this.page.mouse.up()
+    }
     await nextFrame(this.page)
   }
 

--- a/browser_tests/tests/canvas/pointerClickDisambiguation.spec.ts
+++ b/browser_tests/tests/canvas/pointerClickDisambiguation.spec.ts
@@ -8,7 +8,6 @@ test.describe(
   { tag: ['@canvas', '@node'] },
   () => {
     test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.searchBoxV2.setup()
       // The gesture under test is the drift, not the interval. Playwright's
       // per-action delay (SLOW_MO=1000 in the video-recording job) lands
       // between the two presses, so the default 300ms would unpair them.
@@ -18,10 +17,10 @@ test.describe(
       )
     })
 
-    test('opens node search on a held double click that drifts within the click threshold', async ({
+    test('opens node search on a double click that drifts within the click threshold', async ({
       comfyPage
     }) => {
-      await comfyPage.canvasOps.doubleClickHeld({ x: 200, y: 200 })
+      await comfyPage.canvasOps.doubleClickWithDrift({ x: 200, y: 200 })
 
       await expect(comfyPage.searchBoxV2.dialog).toBeVisible()
     })

--- a/browser_tests/tests/canvas/pointerClickDisambiguation.spec.ts
+++ b/browser_tests/tests/canvas/pointerClickDisambiguation.spec.ts
@@ -1,0 +1,29 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe(
+  'Canvas pointer click and drag disambiguation',
+  { tag: ['@canvas', '@node'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.searchBoxV2.setup()
+      // The gesture under test is the drift, not the interval. Playwright's
+      // per-action delay (SLOW_MO=1000 in the video-recording job) lands
+      // between the two presses, so the default 300ms would unpair them.
+      await comfyPage.settings.setSetting(
+        'Comfy.Pointer.DoubleClickTime',
+        10000
+      )
+    })
+
+    test('opens node search on a held double click that drifts within the click threshold', async ({
+      comfyPage
+    }) => {
+      await comfyPage.canvasOps.doubleClickHeld({ x: 200, y: 200 })
+
+      await expect(comfyPage.searchBoxV2.dialog).toBeVisible()
+    })
+  }
+)

--- a/browser_tests/tests/canvasSettings.spec.ts
+++ b/browser_tests/tests/canvasSettings.spec.ts
@@ -295,54 +295,9 @@ test.describe('Canvas settings', { tag: '@canvas' }, () => {
       })
     })
 
-    test('ClickBufferTime governs the click-vs-drag time threshold', async ({
-      comfyPage
-    }) => {
-      // Keep drift generous so only elapsed time distinguishes click vs drag.
-      await comfyPage.settings.setSetting('Comfy.Pointer.ClickDrift', 20)
-      const node = (
-        await comfyPage.nodeOps.getNodeRefsByType('CLIPTextEncode')
-      )[0]
-      const titlePos = await node.getTitlePosition()
-      const NUDGE = 2
-      const HOLD_MS = 250
-
-      await test.step(`Buffer=2000ms (hold=${HOLD_MS}ms within buffer) → click, node stays put`, async () => {
-        await comfyPage.settings.setSetting(
-          'Comfy.Pointer.ClickBufferTime',
-          2000
-        )
-        const before = await node.getPosition()
-        await holdDragAt(comfyPage, titlePos, {
-          dx: NUDGE,
-          dy: NUDGE,
-          holdMs: HOLD_MS
-        })
-        const after = await node.getPosition()
-        expect(after.x).toBeCloseTo(before.x, 0)
-        expect(after.y).toBeCloseTo(before.y, 0)
-      })
-
-      await test.step(`Buffer=50ms (hold=${HOLD_MS}ms exceeds buffer) → drag, node moves`, async () => {
-        await comfyPage.settings.setSetting('Comfy.Pointer.ClickBufferTime', 50)
-        const before = await node.getPosition()
-        await holdDragAt(comfyPage, titlePos, {
-          dx: NUDGE,
-          dy: NUDGE,
-          holdMs: HOLD_MS
-        })
-        const after = await node.getPosition()
-        expect(
-          Math.abs(after.x - before.x) + Math.abs(after.y - before.y)
-        ).toBeGreaterThan(0)
-      })
-    })
-
     test('ClickDrift governs the click-vs-drag distance threshold', async ({
       comfyPage
     }) => {
-      // Keep buffer generous so only drift distance matters.
-      await comfyPage.settings.setSetting('Comfy.Pointer.ClickBufferTime', 2000)
       const node = (
         await comfyPage.nodeOps.getNodeRefsByType('CLIPTextEncode')
       )[0]

--- a/src/lib/litegraph/src/CanvasPointer.test.ts
+++ b/src/lib/litegraph/src/CanvasPointer.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+import { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+
+interface PointerEventOptions {
+  x: number
+  y: number
+  timeStamp: number
+  buttons?: number
+}
+
+function createEvent(
+  type: string,
+  { x, y, timeStamp, buttons = 1 }: PointerEventOptions
+): CanvasPointerEvent {
+  const event = new PointerEvent(type, {
+    clientX: x,
+    clientY: y,
+    button: 0,
+    buttons,
+    pointerId: 1,
+    isPrimary: true
+  })
+  Object.defineProperty(event, 'timeStamp', { value: timeStamp })
+  return Object.assign(event, {
+    canvasX: x,
+    canvasY: y,
+    deltaX: 0,
+    deltaY: 0,
+    safeOffsetX: x,
+    safeOffsetY: y
+  })
+}
+
+type PointerCallback = (upEvent: CanvasPointerEvent) => unknown
+
+function createElement(): Element {
+  const element = document.createElement('div')
+  element.setPointerCapture = vi.fn<(pointerId: number) => void>()
+  element.releasePointerCapture = vi.fn<(pointerId: number) => void>()
+  element.hasPointerCapture = vi
+    .fn<(pointerId: number) => boolean>()
+    .mockReturnValue(false)
+  return element
+}
+
+describe('CanvasPointer click and drag disambiguation', () => {
+  let pointer: CanvasPointer
+  let onClick: Mock<PointerCallback>
+  let onDoubleClick: Mock<PointerCallback>
+  let onDragEnd: Mock<PointerCallback>
+
+  beforeEach(() => {
+    pointer = new CanvasPointer(createElement())
+    onClick = vi.fn<PointerCallback>()
+    onDoubleClick = vi.fn<PointerCallback>()
+    onDragEnd = vi.fn<PointerCallback>()
+  })
+
+  /**
+   * Simulates one press-and-release at ({@link x}, {@link y}), delivering a
+   * `pointermove` at {@link moveOffset} pixels after {@link moveDelay} ms.
+   */
+  function press({
+    downAt,
+    x = 100,
+    y = 100,
+    moveDelay,
+    moveOffset = 0
+  }: {
+    downAt: number
+    x?: number
+    y?: number
+    moveDelay?: number
+    moveOffset?: number
+  }) {
+    pointer.down(createEvent('pointerdown', { x, y, timeStamp: downAt }))
+
+    // Matches LGraphCanvas.processMouseDown: callbacks are registered after
+    // pointer.down(), which resets any left over from the previous gesture.
+    pointer.onClick = onClick
+    pointer.onDoubleClick = onDoubleClick
+    pointer.onDragEnd = onDragEnd
+
+    if (moveDelay !== undefined) {
+      pointer.move(
+        createEvent('pointermove', {
+          x: x + moveOffset,
+          y,
+          timeStamp: downAt + moveDelay
+        })
+      )
+    }
+    pointer.up(
+      createEvent('pointerup', {
+        x: x + moveOffset,
+        y,
+        timeStamp: downAt + (moveDelay ?? 0) + 10,
+        buttons: 0
+      })
+    )
+  }
+
+  // Pen, touch and trackpad devices emit pointermove continuously while the
+  // pointer is held still, so a click held longer than a frame or two always
+  // produces a stationary pointermove.
+  it('detects a double click when each press emits a stationary pointermove long after pointerdown', () => {
+    press({ downAt: 0, moveDelay: 80 })
+    press({ downAt: 150, moveDelay: 80 })
+
+    expect(onDoubleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a press that moves beyond the click drift threshold as a drag', () => {
+    press({
+      downAt: 0,
+      moveDelay: 5,
+      moveOffset: CanvasPointer.maxClickDrift * 4
+    })
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/litegraph/src/CanvasPointer.ts
+++ b/src/lib/litegraph/src/CanvasPointer.ts
@@ -23,20 +23,6 @@ import type { CanvasPointerEvent } from './types/events'
  * - {@link LGraphCanvas.processMouseUp}
  */
 export class CanvasPointer {
-  /**
-   * Maximum time in milliseconds to ignore click drift.
-   *
-   * This is the upper bound on how long after pointerdown the system will wait
-   * before deciding "this is a drag, not a click" when the pointer hasn't moved
-   * past {@link maxClickDrift}. Keep this short — drags should feel instant.
-   * Disambiguation between click and drag is primarily handled by distance
-   * ({@link maxClickDrift}); this time threshold only matters when the user
-   * holds the pointer still then releases. ~2 frames at 60fps is plenty.
-   *
-   * Overridden at runtime by the `Comfy.Pointer.ClickBufferTime` user setting.
-   */
-  static bufferTime = 32
-
   /** Maximum gap between pointerup and pointerdown events to be considered as a double click */
   static doubleClickTime = 300
 
@@ -218,11 +204,7 @@ export class CanvasPointer {
     // Dragging, but no callback to run
     if (this.dragStarted) return
 
-    const longerThanBufferTime =
-      e.timeStamp - eDown.timeStamp > CanvasPointer.bufferTime
-    if (longerThanBufferTime || !this._hasSamePosition(e, eDown)) {
-      this._setDragStarted(e)
-    }
+    if (!this._hasSamePosition(e, eDown)) this._setDragStarted(e)
   }
 
   /**

--- a/src/platform/settings/composables/useLitegraphSettings.ts
+++ b/src/platform/settings/composables/useLitegraphSettings.ts
@@ -114,10 +114,6 @@ export const useLitegraphSettings = () => {
   })
 
   watchEffect(() => {
-    CanvasPointer.bufferTime = settingStore.get('Comfy.Pointer.ClickBufferTime')
-  })
-
-  watchEffect(() => {
     CanvasPointer.maxClickDrift = settingStore.get('Comfy.Pointer.ClickDrift')
   })
 

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -807,24 +807,6 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.4.3'
   },
   {
-    id: 'Comfy.Pointer.ClickBufferTime',
-    category: ['LiteGraph', 'Pointer', 'ClickBufferTime'],
-    name: 'Pointer click drift delay (deprecated)',
-    tooltip:
-      'No longer used. Clicks and drags are disambiguated by distance alone (Pointer click drift).',
-    deprecated: true,
-    experimental: true,
-    type: 'slider',
-    attrs: {
-      min: 0,
-      max: 1000,
-      step: 1
-    },
-    defaultValue: 32,
-    versionAdded: '1.4.3',
-    versionModified: '1.44.19'
-  },
-  {
     id: 'Comfy.Pointer.DoubleClickTime',
     category: ['LiteGraph', 'Pointer', 'DoubleClickTime'],
     name: 'Double click interval (maximum)',

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -809,9 +809,10 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.Pointer.ClickBufferTime',
     category: ['LiteGraph', 'Pointer', 'ClickBufferTime'],
-    name: 'Pointer click drift delay',
+    name: 'Pointer click drift delay (deprecated)',
     tooltip:
-      'After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the pointer is held still then released. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty.',
+      'No longer used. Clicks and drags are disambiguated by distance alone (Pointer click drift).',
+    deprecated: true,
     experimental: true,
     type: 'slider',
     attrs: {

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -361,7 +361,6 @@ const zSettings = z.object({
   'Comfy.Node.ShowDeprecated': z.boolean(),
   'Comfy.Node.ShowExperimental': z.boolean(),
   'Comfy.NodeReplacement.Enabled': z.boolean(),
-  'Comfy.Pointer.ClickBufferTime': z.number(),
   'Comfy.Pointer.ClickDrift': z.number(),
   'Comfy.Pointer.DoubleClickTime': z.number(),
   'Comfy.PreviewFormat': z.string(),


### PR DESCRIPTION
Canvas double-click stopped registering for anyone whose pointer device reports movement while the button is held — pen/tablet, touch, trackpad, and any mouse nudged a pixel during a click that lasts longer than a frame or two.

## Root cause

`CanvasPointer.move()` promoted a press to a drag on elapsed time alone:

```ts
const longerThanBufferTime = e.timeStamp - eDown.timeStamp > CanvasPointer.bufferTime
if (longerThanBufferTime || !this._hasSamePosition(e, eDown)) this._setDragStarted(e)
```

Once `dragStarted` is set, `_completeClick()` takes the `onDragEnd` branch and never assigns `eLastDown`. `_isDoubleClick()` requires `eLastDown`, so after the first press is swallowed the second press can never complete a double click — `onDoubleClick` is unreachable.

The trigger is a `pointermove` arriving more than `Comfy.Pointer.ClickBufferTime` after `pointerdown`, at *any* distance, including zero. Pen, touch and trackpad devices emit `pointermove` continuously while stationary, so every click they make that lasts longer than the buffer becomes a drag. #12032 lowered the default from 150 ms to 32 ms, which moved the threshold from "longer than a human click" to "shorter than a human click" — matching the reporter's observation that double-click only works when performed very fast, and that it got worse again after 1.45.

Elapsed time is not evidence of a drag. Distance already does the whole job, as #12032 itself noted, so the time threshold could only ever suppress `onClick`/`onDoubleClick` for gestures that never left the drift radius.

## Changes

- `CanvasPointer.move()` promotes to a drag on distance only; `static bufferTime` removed.
- `Comfy.Pointer.ClickBufferTime` marked `deprecated` (kept for ID stability per `coreSettings.ts`). Its `src/locales/*/settings.json` entries are now orphaned and will drop out on the next `collect-i18n` run.
- `Comfy.Pointer.ClickDrift` is the sole click/drag threshold.
- **Deletes one e2e step**: `canvasSettings.spec.ts` had `ClickBufferTime governs the
  click-vs-drag time threshold`, which set `ClickDrift: 20` so that "only elapsed time
  distinguishes click vs drag", then asserted that holding for 250 ms turns a 2 px
  nudge into a node drag. That is the defect written down as an assertion — a gesture
  the user's own drift setting classifies as a click, dragged anyway because it was
  slow. It came from #11604 ("add tests for canvas related settings"), a
  coverage-adding commit, not a bugfix guarding a past regression. The sibling
  `ClickDrift governs the click-vs-drag distance threshold` test now covers the whole
  disambiguation. Flagging it explicitly rather than quietly.

Behaviour change worth a reviewer's eye: previously, holding the button still for
longer than the buffer armed the drag early, so the next move of any size dragged
immediately. Now every drag starts after the same 6 px regardless of how long you
held first. That trades a hold-duration-dependent dead zone for a consistent one,
and `Comfy.Pointer.ClickDrift` still tunes it.

More gestures now return `isClick === true` from `pointer.up()` and take the early
return in `processMouseUp` (`LGraphCanvas.ts:3861`). That is the pre-existing
normal-click path — the same one a fast stationary click already took — so this is
a reclassification, not a new code path.

## Tests

Two commits, test first. Verified at the test commit `8651c0bb5` (source unmodified):

```
× detects a double click when each press emits a stationary pointermove long after pointerdown
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

and passing at the fix commit.

- `src/lib/litegraph/src/CanvasPointer.test.ts` — a double click whose presses each emit a stationary `pointermove` long after `pointerdown`, plus a control asserting movement past the drift radius is still a drag.
- `browser_tests/tests/canvas/pointerClickDisambiguation.spec.ts` — held double click with sub-threshold drift opens node search.
- `CanvasHelper.doubleClickHeld()` models the real gesture; `page.mouse.dblclick` sends no `pointermove` at all, which is why the existing coverage never caught this.

Affects both renderers: empty-canvas double-click, group and link handling, and classic-canvas node-title double-click all route through `CanvasPointer`. Reproduces locally with no cloud backend.

- Fixes #13004
