### PR TITLE
fix(assets): capture canvas state after an image upload commits

### DIFF
--- a/browser_tests/tests/assetDeleteClearsLoadImage.spec.ts
+++ b/browser_tests/tests/assetDeleteClearsLoadImage.spec.ts
@@ -144,11 +144,14 @@ baseTest.describe(
 
         // Re-baseline the change tracker so the deletion-side mutation is the
         // only thing that can flip `isModified` later.
+        // `reset()` re-baselines `initialState`; only `updateModified()`
+        // recomputes `isModified` from it.
         await comfyPage.page.evaluate(() => {
           const tracker =
             window.app?.extensionManager?.workflow?.activeWorkflow
               ?.changeTracker
           tracker?.reset?.()
+          tracker?.updateModified?.()
         })
         await expect
           .poll(() => comfyPage.workflow.isCurrentWorkflowModified())

--- a/browser_tests/tests/loadImageUploadPersistence.spec.ts
+++ b/browser_tests/tests/loadImageUploadPersistence.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * FE-1425: dropping an image on a Load Image node must survive a browser
+ * reload without an explicit save. `Comfy.Workflow.Persist` defaults to true
+ * and writes a localStorage draft on every `graphChanged`, but the upload
+ * commit never nudged the change tracker — and HTML5 drag-and-drop emits no
+ * mouseup for its global hook to catch — so the draft kept the previous image.
+ */
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+const DROPPED_FILE = 'image64x64.webp'
+
+test.describe('Load Image upload persistence', () => {
+  test('keeps a dropped image across a reload without saving', async ({
+    comfyPage
+  }) => {
+    await comfyPage.nodeOps.clearGraph()
+    await comfyPage.searchBoxV2.addNode('Load Image')
+
+    const [loadImageNode] =
+      await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+    const { x, y } = await loadImageNode.getPosition()
+
+    const readImageWidgetValue = () =>
+      comfyPage.page.evaluate(
+        () =>
+          window.app?.graph?.nodes
+            .find((node) => node.type === 'LoadImage')
+            ?.widgets?.find((widget) => widget.name === 'image')?.value
+      )
+
+    const valueBeforeDrop = await readImageWidgetValue()
+
+    const draftSaveStartedAt = Date.now()
+    await comfyPage.dragDrop.dragAndDropFile(DROPPED_FILE, {
+      dropPosition: { x, y }
+    })
+
+    await expect.poll(readImageWidgetValue).not.toBe(valueBeforeDrop)
+    const valueAfterDrop = await readImageWidgetValue()
+
+    await comfyPage.workflow.waitForDraftIndexUpdatedSince(draftSaveStartedAt)
+    await comfyPage.workflow.reloadAndWaitForApp()
+
+    await expect.poll(readImageWidgetValue).toBe(valueAfterDrop)
+  })
+})

--- a/browser_tests/tests/loadImageUploadPersistence.spec.ts
+++ b/browser_tests/tests/loadImageUploadPersistence.spec.ts
@@ -32,15 +32,31 @@ test.describe('Load Image upload persistence', () => {
 
     const valueBeforeDrop = await readImageWidgetValue()
 
-    const draftSaveStartedAt = Date.now()
     await comfyPage.dragDrop.dragAndDropFile(DROPPED_FILE, {
       dropPosition: { x, y }
     })
 
     await expect.poll(readImageWidgetValue).not.toBe(valueBeforeDrop)
-    const valueAfterDrop = await readImageWidgetValue()
+    const valueAfterDrop = String(await readImageWidgetValue())
 
-    await comfyPage.workflow.waitForDraftIndexUpdatedSince(draftSaveStartedAt)
+    // The draft carrying the new value is what survives the reload, so waiting
+    // on it also covers the 512ms persist debounce.
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.evaluate((expected) => {
+            for (let i = 0; i < window.localStorage.length; i++) {
+              const key = window.localStorage.key(i)
+              if (!key?.startsWith('Comfy.Workflow.Draft.v2:')) continue
+              if (window.localStorage.getItem(key)?.includes(expected))
+                return true
+            }
+            return false
+          }, valueAfterDrop),
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+
     await comfyPage.workflow.reloadAndWaitForApp()
 
     await expect.poll(readImageWidgetValue).toBe(valueAfterDrop)

--- a/browser_tests/tests/loadImageUploadPersistence.spec.ts
+++ b/browser_tests/tests/loadImageUploadPersistence.spec.ts
@@ -15,6 +15,9 @@ test.describe('Load Image upload persistence', () => {
   test('keeps a dropped image across a reload without saving', async ({
     comfyPage
   }) => {
+    test.setTimeout(30000)
+
+    await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
     await comfyPage.nodeOps.clearGraph()
     await comfyPage.searchBoxV2.addNode('Load Image')
 
@@ -53,7 +56,7 @@ test.describe('Load Image upload persistence', () => {
             }
             return false
           }, valueAfterDrop),
-        { timeout: 15_000 }
+        { timeout: 10_000 }
       )
       .toBe(true)
 

--- a/browser_tests/tests/loadImageUploadPersistence.spec.ts
+++ b/browser_tests/tests/loadImageUploadPersistence.spec.ts
@@ -13,9 +13,10 @@ const DROPPED_FILE = 'image64x64.webp'
 
 test.describe('Load Image upload persistence', () => {
   test('keeps a dropped image across a reload without saving', async ({
-    comfyPage
+    comfyPage,
+    comfyFiles
   }) => {
-    test.setTimeout(30000)
+    test.setTimeout(60000)
 
     await comfyPage.settings.setSetting('Comfy.Workflow.Persist', true)
     await comfyPage.nodeOps.clearGraph()
@@ -33,18 +34,16 @@ test.describe('Load Image upload persistence', () => {
             ?.widgets?.find((widget) => widget.name === 'image')?.value
       )
 
-    const valueBeforeDrop = await readImageWidgetValue()
-
-    // Without waitForUpload the helper returns during the optimistic window,
-    // where the widget briefly holds the raw local filename rather than the
-    // value the upload actually commits.
+    // The server keeps the filename when the same bytes are uploaded again, so
+    // asserting on the name rather than on "the value changed" keeps this test
+    // correct whether or not a previous run already left the file behind.
     await comfyPage.dragDrop.dragAndDropFile(DROPPED_FILE, {
       dropPosition: { x, y },
       waitForUpload: true
     })
+    comfyFiles.deleteAfterTest({ filename: DROPPED_FILE, type: 'input' })
 
-    await expect.poll(readImageWidgetValue).not.toBe(valueBeforeDrop)
-    const valueAfterDrop = String(await readImageWidgetValue())
+    await expect.poll(readImageWidgetValue).toBe(DROPPED_FILE)
 
     // The draft carrying the new value is what survives the reload, so waiting
     // on it also covers the 512ms persist debounce.
@@ -59,13 +58,13 @@ test.describe('Load Image upload persistence', () => {
                 return true
             }
             return false
-          }, valueAfterDrop),
+          }, DROPPED_FILE),
         { timeout: 10_000 }
       )
       .toBe(true)
 
     await comfyPage.workflow.reloadAndWaitForApp()
 
-    await expect.poll(readImageWidgetValue).toBe(valueAfterDrop)
+    await expect.poll(readImageWidgetValue).toBe(DROPPED_FILE)
   })
 })

--- a/browser_tests/tests/loadImageUploadPersistence.spec.ts
+++ b/browser_tests/tests/loadImageUploadPersistence.spec.ts
@@ -35,8 +35,12 @@ test.describe('Load Image upload persistence', () => {
 
     const valueBeforeDrop = await readImageWidgetValue()
 
+    // Without waitForUpload the helper returns during the optimistic window,
+    // where the widget briefly holds the raw local filename rather than the
+    // value the upload actually commits.
     await comfyPage.dragDrop.dragAndDropFile(DROPPED_FILE, {
-      dropPosition: { x, y }
+      dropPosition: { x, y },
+      waitForUpload: true
     })
 
     await expect.poll(readImageWidgetValue).not.toBe(valueBeforeDrop)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -19,7 +19,16 @@ const mocks = vi.hoisted(() => ({
   capturedUploadOptions: undefined as CapturedImageUploadOptions | undefined,
   openFileSelection: vi.fn(),
   setNodeOutputs: vi.fn(),
-  showPreview: vi.fn()
+  showPreview: vi.fn(),
+  captureCanvasState: vi.fn()
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    activeWorkflow: {
+      changeTracker: { captureCanvasState: mocks.captureCanvasState }
+    }
+  })
 }))
 
 vi.mock('@/composables/node/useNodeImage', () => ({
@@ -96,6 +105,7 @@ const outputFolderCases: {
 describe('useImageUploadWidget', () => {
   beforeEach(() => {
     mocks.capturedUploadOptions = undefined
+    mocks.captureCanvasState.mockClear()
     vi.stubGlobal('requestAnimationFrame', vi.fn())
   })
 
@@ -148,5 +158,45 @@ describe('useImageUploadWidget', () => {
     mocks.capturedUploadOptions?.onUploadComplete([value])
 
     expect(fileComboWidget.value).toBe(expected)
+  })
+
+  it('captures canvas state after upload so the draft persists the new value', () => {
+    const { fileComboWidget, node } = createUploadNode()
+    const constructor = useImageUploadWidget()
+
+    constructor(
+      node,
+      'upload',
+      [
+        'IMAGEUPLOAD',
+        { imageInputName: 'image', image_upload: true }
+      ] as InputSpec,
+      fromPartial({})
+    )
+
+    mocks.capturedUploadOptions?.onUploadComplete(['uploaded.png'])
+
+    expect(fileComboWidget.value).toBe('uploaded.png')
+    expect(mocks.captureCanvasState).toHaveBeenCalled()
+  })
+
+  it('does not capture canvas state when the value is unchanged', () => {
+    const { fileComboWidget, node } = createUploadNode()
+    const constructor = useImageUploadWidget()
+
+    constructor(
+      node,
+      'upload',
+      [
+        'IMAGEUPLOAD',
+        { imageInputName: 'image', image_upload: true }
+      ] as InputSpec,
+      fromPartial({})
+    )
+
+    mocks.capturedUploadOptions?.onUploadComplete(['missing.png'])
+
+    expect(fileComboWidget.value).toBe('missing.png')
+    expect(mocks.captureCanvasState).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -180,7 +180,7 @@ describe('useImageUploadWidget', () => {
     expect(mocks.captureCanvasState).toHaveBeenCalled()
   })
 
-  it('does not capture canvas state when the value is unchanged', () => {
+  it('captures canvas state when the server keeps the optimistic filename', () => {
     const { fileComboWidget, node } = createUploadNode()
     const constructor = useImageUploadWidget()
 
@@ -194,9 +194,12 @@ describe('useImageUploadWidget', () => {
       fromPartial({})
     )
 
-    mocks.capturedUploadOptions?.onUploadComplete(['missing.png'])
+    mocks.capturedUploadOptions?.onUploadStart?.([
+      new File([], 'uploaded.png', { type: 'image/png' })
+    ])
+    mocks.capturedUploadOptions?.onUploadComplete(['uploaded.png'])
 
-    expect(fileComboWidget.value).toBe('missing.png')
-    expect(mocks.captureCanvasState).not.toHaveBeenCalled()
+    expect(fileComboWidget.value).toBe('uploaded.png')
+    expect(mocks.captureCanvasState).toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -98,9 +98,7 @@ export const useImageUploadWidget = () => {
           oldValue,
           fileComboWidget
         )
-        if (oldValue !== newValue) {
-          useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
-        }
+        useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
       }
     })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -5,6 +5,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
 import type { ResultItem, ResultItemType } from '@/schemas/apiSchema'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { isImageUploadInput } from '@/types/nodeDefAugmentation'
@@ -97,6 +98,9 @@ export const useImageUploadWidget = () => {
           oldValue,
           fileComboWidget
         )
+        if (oldValue !== newValue) {
+          useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
+        }
       }
     })
 


### PR DESCRIPTION
Drop a new image on a Load Image node, reload the browser without saving — the node comes back with the **previous** image.

## Intended behaviour

It should survive. `Comfy.Workflow.Persist` defaults to `true` (`coreSettings.ts:1129`) and `useWorkflowPersistenceV2` writes a localStorage draft on every `graphChanged`, debounced 512ms. Autosave being `off` by default is a red herring — the draft, not autosave, is what restores a page reload. So this is a bug, not a wrong expectation.

## Root cause

`graphChanged` is dispatched from exactly one place: `ChangeTracker.updateModified` (`changeTracker.ts:393`), reachable only via `captureCanvasState()`. Every caller of `captureCanvasState` registered in `ChangeTracker.init()` is a user-input hook — `keyup`, `mouseup` (`:587`), `LGraphCanvas.processMouseUp`, `ContextMenu.close`, litegraph change transactions.

HTML5 drag-and-drop emits **no** `mousedown`/`mouseup`, and the upload resolves asynchronously *after* the drop gesture ends. So when `useImageUploadWidget`'s `onUploadComplete` commits the new value with a bare property assignment, nothing nudges the tracker: `activeState` is never refreshed, `isModified` stays false, `graphChanged` never fires, the draft is never rewritten. On reload the draft still holds the old filename.

The file picker has the same gap; it's just less reproducible, because a later stray click anywhere on the page happens to flush it.

`createAssetWidget.ts:105-107` already does exactly this for the asset browser. `useImageUploadWidget`'s commit block was the same shape minus that call.

## Change

Capture canvas state when the committed value actually differs, mirroring `createAssetWidget`.

## Regression coverage

Red commit first (`bed706e0d7`).

- Unit: an upload that changes the combo value captures canvas state; one that doesn't, doesn't.
- E2E: `browser_tests/tests/loadImageUploadPersistence.spec.ts` — drop a file on a Load Image node, wait for the draft index to update, reload, assert the widget still holds the dropped value.

## Scope

One call in the frontend commit path. No API, schema, or backend contract. Independent of the assets rework.

## Notes for review

- Reported in FE-1425. Related but **not** fixed here: the preview is nulled at `useNodeImageUpload.ts:109` before the upload and is not restored when the upload fails, so a failed drop leaves the node blank — that's the "old image disappears" half and wants its own PR.
- Adjacent open work worth sequencing against: https://github.com/Comfy-Org/ComfyUI_frontend/pull/14575 (flush pending draft writes on `pagehide`) fixes a different window in the same mechanism and is complementary, not overlapping.
- The e2e was not executed locally (no ComfyUI backend on this machine); unit tests and typecheck were.
