### PR TITLE
test: remove redundant mock cleanup

### DIFF
--- a/apps/website/src/utils/cloudNodes.build.test.ts
+++ b/apps/website/src/utils/cloudNodes.build.test.ts
@@ -35,8 +35,6 @@ describe('loadPacksForBuild', () => {
   const savedVercelEnv = process.env.VERCEL_ENV
 
   beforeEach(() => {
-    fetchCloudNodesMock.mockReset()
-    reportCloudNodesOutcomeMock.mockReset()
     delete process.env.VERCEL_ENV
   })
 

--- a/apps/website/src/utils/cloudNodes.test.ts
+++ b/apps/website/src/utils/cloudNodes.test.ts
@@ -94,9 +94,7 @@ describe('fetchCloudNodesForBuild', () => {
 
   beforeEach(() => {
     resetCloudNodesFetcherForTests()
-    fetchRegistryPacksWithNodesMock.mockReset()
     fetchRegistryPacksWithNodesMock.mockResolvedValue(new Map())
-    sanitizeCallSpy.mockReset()
     delete process.env.WEBSITE_CLOUD_API_KEY
   })
 

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -4,7 +4,7 @@
  * Confirm* sections carry their own). Catches accidental reverts of the
  * Phase 6 renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 
@@ -18,10 +18,6 @@ import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
 import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 
 describe('showConfirmDialog Reka renderer opt-in', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-  })
-
   it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
     showConfirmDialog()
 

--- a/src/components/dialog/content/signin/ApiKeyForm.test.ts
+++ b/src/components/dialog/content/signin/ApiKeyForm.test.ts
@@ -58,7 +58,6 @@ const i18n = createI18n({
 
 describe('ApiKeyForm', () => {
   beforeEach(() => {
-    mockStoreApiKey.mockReset()
     mockLoadingRef.value = false
   })
 

--- a/src/components/dialog/content/signin/SignInForm.test.ts
+++ b/src/components/dialog/content/signin/SignInForm.test.ts
@@ -61,8 +61,6 @@ const loginButtonText = enMessages.auth.login.loginButton
 
 describe('SignInForm', () => {
   beforeEach(() => {
-    mockSendPasswordReset.mockReset()
-    mockToastAdd.mockReset()
     mockLoadingRef.value = false
   })
 

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -108,7 +108,6 @@ describe('SignUpForm', () => {
     mockTurnstileEnabled.value = false
     mockTurnstileToken.value = ''
     mockTurnstileUnavailable.value = false
-    mockReset.mockClear()
     emitTurnstileToken = undefined
     emitTurnstileUnavailable = undefined
   })

--- a/src/components/error/ErrorOverlay.test.ts
+++ b/src/components/error/ErrorOverlay.test.ts
@@ -125,11 +125,9 @@ describe('ErrorOverlay', () => {
     mockErrorGroups.missingModelGroups.value = []
     mockErrorGroups.missingMediaGroups.value = []
     mockErrorGroups.swapNodeGroups.value = []
-    mockOpenPanel.mockClear()
     mockCanvasStore.linearMode = false
     mockCanvasStore.canvas = null
     mockCanvasStore.currentGraph = null
-    mockCanvasStore.updateSelectedItems.mockClear()
   })
 
   it('renders a single overlay message without list markup', async () => {

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -120,7 +120,6 @@ describe('HelpCenterMenuContent feedback item', () => {
     distribution.isCloud = false
     distribution.isDesktop = false
     distribution.isNightly = false
-    commandStoreExecute.mockReset()
     openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
   })
 

--- a/src/components/load3d/Load3DScene.test.ts
+++ b/src/components/load3d/Load3DScene.test.ts
@@ -74,9 +74,6 @@ describe('Load3DScene', () => {
   beforeEach(() => {
     dragState.isDragging = ref(false)
     dragState.dragMessage = ref('')
-    dragState.handleDragOver.mockReset()
-    dragState.handleDragLeave.mockReset()
-    dragState.handleDrop.mockReset()
     dragState.capturedOptions = null
   })
 

--- a/src/components/load3d/controls/HDRIControls.test.ts
+++ b/src/components/load3d/controls/HDRIControls.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- hidden file input has no role/label, queried by selector */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -67,10 +67,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('HDRIControls', () => {
-  beforeEach(() => {
-    addAlert.mockClear()
-  })
-
   afterEach(() => {
     document.body.innerHTML = ''
   })

--- a/src/components/load3d/controls/ViewerControls.test.ts
+++ b/src/components/load3d/controls/ViewerControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ViewerControls from '@/components/load3d/controls/ViewerControls.vue'
@@ -37,11 +37,6 @@ const i18n = createI18n({
 const mockNode = createMockLGraphNode({ id: 'node-1' })
 
 describe('ViewerControls', () => {
-  beforeEach(() => {
-    showDialog.mockClear()
-    handleViewerClose.mockClear()
-  })
-
   it('renders the open-in-viewer button labeled by the localized aria-label', () => {
     render(ViewerControls, {
       props: { node: mockNode },

--- a/src/components/queue/JobHistoryActionsMenu.test.ts
+++ b/src/components/queue/JobHistoryActionsMenu.test.ts
@@ -65,9 +65,6 @@ const renderMenu = () =>
 describe('JobHistoryActionsMenu', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    popoverCloseSpy.mockClear()
-    mockSetSetting.mockClear()
-    mockSetMany.mockClear()
     mockSidebarTabStore.activeSidebarTabId = null
     mockGetSetting.mockImplementation((key: string) =>
       key === 'Comfy.Queue.QPOV2' || key === 'Comfy.Queue.ShowRunProgressBar'

--- a/src/components/queue/QueueOverlayHeader.test.ts
+++ b/src/components/queue/QueueOverlayHeader.test.ts
@@ -72,9 +72,6 @@ const renderHeader = (props = {}) =>
 describe('QueueOverlayHeader', () => {
   beforeEach(() => {
     i18n.global.locale.value = 'en'
-    popoverCloseSpy.mockClear()
-    mockSetSetting.mockClear()
-    mockSetMany.mockClear()
     mockSidebarTabStore.activeSidebarTabId = null
     mockGetSetting.mockImplementation((key: string) =>
       key === 'Comfy.Queue.QPOV2' ? true : undefined

--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -143,8 +143,6 @@ function renderCard(
 
 describe('MissingNodeCard', () => {
   beforeEach(() => {
-    mockApplyChanges.mockClear()
-    mockIsPackInstalled.mockReset()
     mockIsPackInstalled.mockReturnValue(false)
     mockIsCloud.value = false
     mockShouldShowManagerButtons.value = false

--- a/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
+++ b/src/components/rightSidePanel/errors/MissingPackGroupRow.test.ts
@@ -127,9 +127,6 @@ function renderRow(
 
 describe('MissingPackGroupRow', () => {
   beforeEach(() => {
-    mockInstallAllPacks.mockClear()
-    mockOpenManager.mockClear()
-    mockIsPackInstalled.mockReset()
     mockIsPackInstalled.mockReturnValue(false)
     mockShouldShowManagerButtons.value = false
     mockIsInstalling.value = false

--- a/src/components/rightSidePanel/errors/useErrorActions.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorActions.test.ts
@@ -39,9 +39,6 @@ describe('useErrorActions', () => {
       trackUiButtonClicked: mocks.trackUiButtonClicked,
       trackHelpResourceClicked: mocks.trackHelpResourceClicked
     }
-    mocks.trackUiButtonClicked.mockReset()
-    mocks.trackHelpResourceClicked.mockReset()
-    mocks.execute.mockReset()
     windowOpenSpy = vi
       .spyOn(window, 'open')
       .mockImplementation(() => null as unknown as Window)

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -216,7 +216,6 @@ describe('useErrorGroups', () => {
     setActivePinia(createPinia())
     mockIsCloud.value = false
     vi.mocked(isLGraphNode).mockReturnValue(false)
-    vi.mocked(getNodeByExecutionId).mockReset()
   })
 
   describe('missingPackGroups', () => {

--- a/src/components/rightSidePanel/errors/useErrorReport.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorReport.test.ts
@@ -115,10 +115,6 @@ describe('useErrorReport', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
-    mocks.getLogs.mockReset()
-    mocks.serialize.mockReset()
-    mocks.refetchSystemStats.mockReset()
-    mocks.generateErrorReport.mockReset()
     storeState.systemStats = null
     storeState.isLoading = false
     const store = await getStore()

--- a/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.test.ts
@@ -135,11 +135,6 @@ function createHostWithPromotedModel(): {
 
 describe('SectionWidgets', () => {
   beforeEach(() => {
-    setDirty.mockClear()
-    getNodeById.mockReset()
-    animateToBounds.mockClear()
-    mockGetInputSpecForWidget.mockReset()
-    mockTrackUiButtonClicked.mockClear()
     selectedItems.length = 0
   })
 

--- a/src/components/rightSidePanel/rightSidePanelTabTelemetry.test.ts
+++ b/src/components/rightSidePanel/rightSidePanelTabTelemetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const { mockTrackUiButtonClicked } = vi.hoisted(() => ({
   mockTrackUiButtonClicked: vi.fn()
@@ -13,10 +13,6 @@ vi.mock('@/platform/telemetry', () => ({
 import { trackRightSidePanelTabOpened } from './rightSidePanelTabTelemetry'
 
 describe('trackRightSidePanelTabOpened', () => {
-  beforeEach(() => {
-    mockTrackUiButtonClicked.mockClear()
-  })
-
   it('tracks opening the settings tab', () => {
     trackRightSidePanelTabOpened('settings')
 

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -127,7 +127,6 @@ describe('NodeSearchBoxPopover', () => {
   }
 
   beforeEach(() => {
-    addNodeOnGraph.mockReset()
     addNodeOnGraph.mockReturnValue(null)
   })
 

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTabV2.test.ts
@@ -91,7 +91,6 @@ const i18n = createI18n({
 
 describe('NodeLibrarySidebarTabV2', () => {
   beforeEach(() => {
-    hoisted.mockSearchNode.mockReset()
     hoisted.mockSearchNode.mockReturnValue([])
   })
 

--- a/src/components/topbar/WorkflowTab.test.ts
+++ b/src/components/topbar/WorkflowTab.test.ts
@@ -208,10 +208,6 @@ describe('WorkflowTab - workflow status indicator', () => {
 })
 
 describe('WorkflowTab - close button', () => {
-  beforeEach(() => {
-    mockCloseWorkflow.mockClear()
-  })
-
   it('delegates close to workflow service with the tab workflow', async () => {
     renderTab()
     const user = userEvent.setup()

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -141,7 +141,6 @@ describe('WorkflowTabs feedback button', () => {
     distribution.isDesktop = false
     distribution.isNightly = false
     tabBarLayout.value = 'Default'
-    openFeedbackDialog.mockReset()
   })
 
   it('opens the feedback dialog tagged with topbar source when clicked', async () => {

--- a/src/components/videoEdit/WidgetVideoEdit.test.ts
+++ b/src/components/videoEdit/WidgetVideoEdit.test.ts
@@ -146,8 +146,6 @@ describe('WidgetVideoEdit', () => {
     recorded.props = undefined
     mocks.resolvedSource = undefined
     mocks.filmstripError.value = null
-    mocks.filmstripRetry.mockClear()
-    mocks.getNodeByLocatorId.mockReset()
   })
 
   it('resolves the source from the host node when no locator is present', () => {

--- a/src/composables/billing/useLegacyBilling.test.ts
+++ b/src/composables/billing/useLegacyBilling.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useLegacyBilling } from './useLegacyBilling'
 
@@ -31,10 +31,6 @@ vi.mock('@/stores/authStore', () => ({
 }))
 
 describe('useLegacyBilling', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   describe('resubscribe', () => {
     it('performs the checkout via the unwrapped subscribeDirect', async () => {
       mockSubscribeDirect.mockResolvedValue(undefined)

--- a/src/composables/graph/useArrangeSession.test.ts
+++ b/src/composables/graph/useArrangeSession.test.ts
@@ -20,7 +20,6 @@ describe('useArrangeSession', () => {
   let nextHandle: number
 
   beforeEach(() => {
-    mockArrangeNodes.mockReset()
     frameCallbacks = []
     nextHandle = 1
     vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(

--- a/src/composables/useCopy.test.ts
+++ b/src/composables/useCopy.test.ts
@@ -67,7 +67,6 @@ function readSerializedClipboardMetadata(dataTransfer: DataTransfer): string {
 describe('useCopy', () => {
   beforeEach(() => {
     copyMocks.copyHandler = undefined
-    copyMocks.canvas.copyToClipboard.mockReset()
   })
 
   it('should write large serialized node data to clipboard metadata', () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -389,9 +389,6 @@ describe('useCoreCommands', () => {
 
     beforeEach(() => {
       app.canvas.selectedItems = new Set()
-      vi.mocked(app.canvas.copyToClipboard).mockClear()
-      vi.mocked(app.canvas.pasteFromClipboard).mockClear()
-      vi.mocked(app.canvas.selectItems).mockClear()
     })
 
     it('should copy selected items when selection exists', async () => {

--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -103,7 +103,6 @@ describe('useCurveEditor', () => {
   beforeEach(() => {
     ensureMatrixTransformPolyfill()
     harness = undefined
-    mockCreateInterpolator.mockClear()
   })
 
   afterEach(() => {

--- a/src/composables/useNodeHelpContent.test.ts
+++ b/src/composables/useNodeHelpContent.test.ts
@@ -70,7 +70,6 @@ describe('useNodeHelpContent', () => {
   const mockFetch = vi.fn()
 
   beforeEach(() => {
-    mockFetch.mockReset()
     vi.stubGlobal('fetch', mockFetch)
   })
 

--- a/src/composables/useRunButtonTelemetry.test.ts
+++ b/src/composables/useRunButtonTelemetry.test.ts
@@ -45,7 +45,6 @@ import {
 
 describe('useRunButtonTelemetry', () => {
   beforeEach(() => {
-    state.telemetry.trackRunButton.mockClear()
     state.mode.value = 'graph'
     state.isAppMode.value = false
     state.executionContextError = null

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { promotedInputWidget } from '@/core/graph/subgraph/promotedInputWidget'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -294,10 +294,6 @@ describe('getPromotableWidgets', () => {
 })
 
 describe('promoteRecommendedWidgets', () => {
-  beforeEach(() => {
-    updatePreviewsMock.mockReset()
-  })
-
   it('promotes recommended value widgets through linked subgraph inputs', () => {
     const subgraph = createTestSubgraph()
     const subgraphNode = createTestSubgraphNode(subgraph)
@@ -406,10 +402,6 @@ describe('promoteRecommendedWidgets', () => {
 })
 
 describe('autoExposeKnownPreviewNodes', () => {
-  beforeEach(() => {
-    updatePreviewsMock.mockReset()
-  })
-
   it('auto-exposes previews when host has no persisted previewExposures property', () => {
     const subgraph = createTestSubgraph()
     const subgraphNode = createTestSubgraphNode(subgraph)

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -30,8 +30,6 @@ vi.mock('@/platform/support/feedbackDialog', () => ({
 describe('cloudFeedbackTopbarButton', () => {
   beforeEach(() => {
     vi.resetModules()
-    registerExtension.mockReset()
-    openFeedbackDialog.mockReset()
   })
 
   function getRegisteredButtons(): ActionBarButton[] {

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -357,10 +357,6 @@ describe('parseAnnotatedFilename', () => {
 })
 
 describe('Load3DConfiguration.loadSceneConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('returns the persisted Scene Config when present, ignoring settings', () => {
     const stored: SceneConfig = {
       showGrid: false,
@@ -394,10 +390,6 @@ describe('Load3DConfiguration.loadSceneConfig', () => {
 })
 
 describe('Load3DConfiguration.loadCameraConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('returns the persisted Camera Config when present', () => {
     const stored: CameraConfig = {
       cameraType: 'orthographic',
@@ -423,10 +415,6 @@ describe('Load3DConfiguration.loadCameraConfig', () => {
 })
 
 describe('Load3DConfiguration.loadLightConfig', () => {
-  beforeEach(() => {
-    settingsGetMock.mockReset()
-  })
-
   it('falls back to settings with default hdri when nothing is persisted', () => {
     stubSettings({ 'Comfy.Load3D.LightIntensity': 4 })
 
@@ -511,7 +499,6 @@ describe('Load3DConfiguration.configure forwards persisted + settings to load3d'
   }
 
   beforeEach(() => {
-    settingsGetMock.mockReset()
     load3d = makeLoad3dMock()
     vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'model.glb'])
     vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view')

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -1145,14 +1145,6 @@ describe('Load3d', () => {
   })
 
   describe('exportModel', () => {
-    beforeEach(() => {
-      cloneSkinnedMock.mockReset()
-      exportGLBMock.mockReset()
-      exportOBJMock.mockReset()
-      exportSTLMock.mockReset()
-      exportFBXMock.mockReset()
-    })
-
     function setupForExport(overrides: {
       currentModel: THREE.Object3D | null
       originalModel?: THREE.Object3D | null

--- a/src/extensions/core/load3d/ModelAdapter.test.ts
+++ b/src/extensions/core/load3d/ModelAdapter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { api } from '@/scripts/api'
 
@@ -28,10 +28,6 @@ describe('DEFAULT_MODEL_CAPABILITIES', () => {
 
 describe('fetchModelData', () => {
   const mockFetchApi = vi.mocked(api.fetchApi)
-
-  beforeEach(() => {
-    mockFetchApi.mockReset()
-  })
 
   it('returns the arrayBuffer on a successful response', async () => {
     const buf = new ArrayBuffer(8)

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -64,10 +64,6 @@ function makeContext(
 }
 
 describe('PointCloudModelAdapter', () => {
-  beforeEach(() => {
-    mockSettingGet.mockReset()
-  })
-
   describe('identity', () => {
     it('handles the ply extension', () => {
       const adapter = new PointCloudModelAdapter()

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -50,10 +50,6 @@ function makeContext(): ModelLoadContext {
 
 describe('SplatModelAdapter', () => {
   beforeEach(() => {
-    splatMeshSpies.ctor.mockClear()
-    splatMeshSpies.dispose.mockClear()
-    splatMeshSpies.getBoundingBox.mockClear()
-    splatMeshSpies.updateWorldMatrix.mockClear()
     vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
       new ArrayBuffer(8)
     )

--- a/src/lib/litegraph/src/LGraphNode.namedValuesShadowDiff.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.namedValuesShadowDiff.test.ts
@@ -49,8 +49,6 @@ describe('LGraphNode configure named values shadow diff', () => {
   let node: LGraphNode
 
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     node = new LGraphNode('TestNode')
     node.addWidget('number', 'steps', 0, null, {})
     node.addWidget('number', 'seed', 0, null, {})

--- a/src/lib/litegraph/src/utils/namedValuesShadowDiffTelemetry.test.ts
+++ b/src/lib/litegraph/src/utils/namedValuesShadowDiffTelemetry.test.ts
@@ -33,8 +33,6 @@ function fakeNode(className: string, hooks: NodeHooks = {}): LGraphNode {
 
 describe('reportNamedValuesShadowDiff', () => {
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     getCnrIdFromNode.mockReset().mockReturnValue(undefined)
   })
 
@@ -97,8 +95,6 @@ describe('reportNamedValuesShadowDiff', () => {
 
 describe('named values shadow diff load aggregation', () => {
   beforeEach(() => {
-    trackNamedValuesShadowDiffMismatch.mockClear()
-    trackNamedValuesShadowDiffSummary.mockClear()
     getCnrIdFromNode.mockReset().mockReturnValue(undefined)
   })
 

--- a/src/platform/assets/components/ActiveMediaAssetCard.test.ts
+++ b/src/platform/assets/components/ActiveMediaAssetCard.test.ts
@@ -77,8 +77,6 @@ describe('ActiveJobCard', () => {
   beforeEach(() => {
     mockCanCancelJob.value = false
     mockCanDeleteJob.value = false
-    mockRunCancelJob.mockReset()
-    mockRunDeleteJob.mockReset()
   })
 
   it('displays percentage and progress bar when job is running', () => {

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -300,11 +300,8 @@ describe('useMediaAssetActions', () => {
     mockIsCloud.value = false
     litegraphServiceMock.addNodeOnGraph.mockImplementation(createLoadImageNode)
     litegraphServiceMock.getCanvasCenter.mockReturnValue([100, 100])
-    mockGetOutputAssetMetadata.mockReset()
     mockGetOutputAssetMetadata.mockReturnValue(null)
-    mockGetAssetType.mockReset()
     mockGetAssetType.mockReturnValue('input')
-    mockResolveOutputAssetItems.mockReset()
     mockResolveOutputAssetItems.mockResolvedValue([])
   })
 
@@ -859,8 +856,6 @@ describe('useMediaAssetActions', () => {
   describe('downloadAssets - cloud zip filters', () => {
     beforeEach(() => {
       mockIsCloud.value = true
-      mockCreateAssetExport.mockClear()
-      mockTrackExport.mockClear()
       mockGetAssetType.mockReturnValue('output')
       mockGetOutputAssetMetadata.mockImplementation(
         (meta: Record<string, unknown> | undefined) =>
@@ -1034,7 +1029,6 @@ describe('useMediaAssetActions', () => {
   describe('downloadAssets - export toast file count', () => {
     beforeEach(() => {
       mockIsCloud.value = true
-      mockCreateAssetExport.mockClear()
       mockGetAssetType.mockReturnValue('output')
       mockGetOutputAssetMetadata.mockImplementation(
         (meta: Record<string, unknown> | undefined) =>
@@ -1124,11 +1118,6 @@ describe('useMediaAssetActions', () => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('input')
       mockDeleteAsset.mockResolvedValue(undefined)
-      mockInvalidateModelsForCategory.mockClear()
-      mockSetAssetDeleting.mockClear()
-      mockUpdateHistory.mockClear()
-      mockUpdateInputs.mockClear()
-      mockHasCategory.mockClear()
       // By default, hasCategory returns true for model categories
       mockHasCategory.mockImplementation(
         (tag: string) => tag === 'checkpoints' || tag === 'loras'
@@ -1233,7 +1222,6 @@ describe('useMediaAssetActions', () => {
     beforeEach(() => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('output')
-      mockShowDialog.mockReset()
     })
 
     it('should show user_metadata display names instead of hash filenames', () => {
@@ -1319,7 +1307,6 @@ describe('useMediaAssetActions', () => {
     beforeEach(() => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('input')
-      mockDeleteAsset.mockReset()
       mockShowDialog.mockImplementation(
         (opts: {
           props: {

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -32,7 +32,6 @@ describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     seedMediaNodeDefs()
-    mockScanNodeMediaCandidates.mockReset()
     mockScanNodeMediaCandidates.mockReturnValue([])
   })
 

--- a/src/platform/auth/session/useSessionCookie.test.ts
+++ b/src/platform/auth/session/useSessionCookie.test.ts
@@ -30,8 +30,6 @@ vi.mock('@/scripts/api', () => ({
 describe('useSessionCookie', () => {
   beforeEach(() => {
     vi.resetModules()
-    mockGetIdToken.mockReset()
-    mockGetAuthHeader.mockReset()
     mockAuthState.currentUser = { uid: 'user-a' }
     globalThis.fetch = vi.fn()
   })

--- a/src/platform/auth/unified/remintRetry.test.ts
+++ b/src/platform/auth/unified/remintRetry.test.ts
@@ -43,8 +43,6 @@ describe('fetchWithUnifiedRemint', () => {
   let mockFetch: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    mockRemint.mockReset()
-    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
     mockFetch = vi.fn()
     vi.stubGlobal('fetch', mockFetch)
@@ -292,8 +290,6 @@ describe('fetchWithUnifiedRemint', () => {
 
 describe('attachUnifiedRemintInterceptor', () => {
   beforeEach(() => {
-    mockRemint.mockReset()
-    mockTrackUnifiedAuthRetry.mockReset()
     flagState.unifiedCloudAuthEnabled = true
   })
 

--- a/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
+++ b/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
@@ -45,7 +45,6 @@ function mountRedirect() {
 describe('useOAuthPostLoginRedirect', () => {
   beforeEach(() => {
     sessionStorage.clear()
-    routerPush.mockClear()
     createSessionOrThrow.mockReset().mockResolvedValue(undefined)
   })
 

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { getSurveyCompletedStatus } from './auth'
 
@@ -34,10 +34,6 @@ function mockResponse({
 }
 
 describe('getSurveyCompletedStatus', () => {
-  beforeEach(() => {
-    fetchApi.mockReset()
-  })
-
   test('200 with non-empty value → true', async () => {
     fetchApi.mockResolvedValueOnce(
       mockResponse({ ok: true, status: 200, body: { value: { q1: 'a' } } })

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -131,7 +131,6 @@ describe('installDesktopLoginRedemption', () => {
     sessionStorage.clear()
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockFetch.mockReset()
     mockConfirm.mockResolvedValue(true)
     mockUserGetIdToken.mockResolvedValue('firebase-id-token')
     mockAuthStore = reactive({

--- a/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
+++ b/src/platform/cloud/subscription/components/FreeTierQuota.test.ts
@@ -41,7 +41,6 @@ describe('FreeTierQuota', () => {
   beforeEach(() => {
     mockIsFreeTier.value = true
     mockAvailable.value = 3
-    mockShowSubscriptionDialog.mockClear()
   })
 
   it('hides the displayed quota when the user leaves the free tier', async () => {

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -245,9 +245,7 @@ describe('PricingTable', () => {
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
     mockUserId.value = 'user-123'
-    mockAccessBillingPortal.mockReset()
     mockAccessBillingPortal.mockResolvedValue(true)
-    mockTrackBeginCheckout.mockReset()
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,

--- a/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
+++ b/src/platform/cloud/subscription/composables/useBillingPlans.test.ts
@@ -39,7 +39,6 @@ describe('useBillingPlans', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    mockGetBillingPlans.mockReset()
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -195,11 +195,6 @@ describe('useSubscription', () => {
 
     mockLocalStorage.__reset()
     mockIsLoggedIn.value = false
-    mockTelemetry.trackSubscription.mockReset()
-    mockTelemetry.trackMonthlySubscriptionSucceeded.mockReset()
-    mockTelemetry.trackMonthlySubscriptionCancelled.mockReset()
-    mockTelemetry.trackBillingEvent.mockReset()
-    mockAccessBillingPortal.mockReset()
     mockAccessBillingPortal.mockResolvedValue(true)
     mockUserId.value = 'user-123'
     mockIsCloud.value = true

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -47,7 +47,6 @@ describe('useSubscriptionCancellationWatcher', () => {
   }
 
   beforeEach(() => {
-    trackMonthlySubscriptionCancelled.mockReset()
     subscriptionStatus.value = { ...baseStatus }
     isActive.value = true
     shouldWatch = true

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -187,7 +187,6 @@ describe('MissingModelRow', () => {
     mockIsDesktop.value = false
     mockRootGraph.value = null
     mockApiListeners.clear()
-    mockGetNodeByExecutionId.mockReset()
     mockUploadContext.resolver = undefined
     mockUploadCallbacks.onUploadSuccess = undefined
     mockFetchModelMetadata.mockResolvedValue({

--- a/src/platform/nodeReplacement/nodeReplacementStore.test.ts
+++ b/src/platform/nodeReplacement/nodeReplacementStore.test.ts
@@ -209,10 +209,6 @@ describe('useNodeReplacementStore', () => {
       ]
     }
 
-    beforeEach(() => {
-      vi.mocked(fetchNodeReplacements).mockReset()
-    })
-
     it('should fetch and assign replacements on successful load', async () => {
       vi.mocked(fetchNodeReplacements).mockResolvedValue(mockReplacements)
       store = createStore()

--- a/src/platform/remote/comfyui/useQueuePolling.test.ts
+++ b/src/platform/remote/comfyui/useQueuePolling.test.ts
@@ -41,7 +41,6 @@ describe('useQueuePolling', () => {
   beforeEach(() => {
     store.activeJobsCount = 0
     store.isLoading = false
-    store.update.mockReset()
   })
 
   it('does not call update on creation', () => {

--- a/src/platform/settings/components/SettingDialog.test.ts
+++ b/src/platform/settings/components/SettingDialog.test.ts
@@ -88,7 +88,6 @@ beforeEach(() => {
   searchMocks.matchedNavItemKeys = ref(new Set<string>())
   searchMocks.searchQuery = ref('')
   searchMocks.searchResultsCategories = ref(new Set<string>())
-  mockFetchBalance.mockReset()
 })
 
 it('falls back when the active navigation item becomes unavailable', async () => {

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -37,7 +37,6 @@ import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDi
 
 describe('useSettingsDialog', () => {
   beforeEach(() => {
-    showDialog.mockReset()
     isCloudRef.value = false
   })
 

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -83,7 +83,6 @@ describe('ErrorPanelSurveyCta', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    mockOpen.mockReset()
 
     mockIsNightly.value = true
     mockIsCloud.value = false

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -32,7 +32,6 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    trackFeatureUsed.mockReset()
     setActivePinia(createPinia())
     store = useFakeExecutionErrorStore()
   })

--- a/src/platform/surveys/useSurveyFeatureTracking.test.ts
+++ b/src/platform/surveys/useSurveyFeatureTracking.test.ts
@@ -11,7 +11,6 @@ vi.mock('./surveyRegistry', () => ({
 describe('useSurveyFeatureTracking', () => {
   beforeEach(() => {
     vi.resetModules()
-    getSurveyConfig.mockReset()
   })
 
   it('tracks usage when config is enabled', async () => {

--- a/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
+++ b/src/platform/telemetry/nodeAdded/installNodeAddedTelemetry.test.ts
@@ -22,7 +22,6 @@ function fakeNode(type: string): LGraphNode {
 
 describe('installNodeAddedTelemetry', () => {
   beforeEach(() => {
-    trackNodeAdded.mockClear()
     ChangeTracker.isLoadingGraph = false
   })
 

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.test.ts
@@ -62,9 +62,6 @@ function toUint8Array(data: BufferSource): Uint8Array {
 
 describe('ImpactTelemetryProvider', () => {
   beforeEach(() => {
-    mockCaptureCheckoutAttributionFromSearch.mockReset()
-    mockUseApiKeyAuthStore.mockReset()
-    mockUseAuthStore.mockReset()
     mockApiKeyAuthStore.isAuthenticated = false
     mockApiKeyAuthStore.currentUser = null
     mockAuthStore.currentUser = null

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
@@ -10,7 +10,6 @@ const state = vi.hoisted(() => ({
 
 describe('HostTelemetrySink', () => {
   beforeEach(() => {
-    state.capture.mockClear()
     window.__comfyDesktop2 = {
       isRemote: () => false,
       Telemetry: {

--- a/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
+++ b/src/platform/telemetry/searchQuery/useSearchQueryTracking.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { EffectScope, Ref } from 'vue'
 import { effectScope, ref } from 'vue'
 
@@ -29,10 +29,6 @@ describe('useSearchQueryTracking', () => {
     scopes.push(scope)
     return scope
   }
-
-  beforeEach(() => {
-    hoisted.trackSearchQuery.mockClear()
-  })
 
   afterEach(() => {
     scopes.forEach((s) => s.stop())

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -939,7 +939,6 @@ describe('useWorkflowService', () => {
       service = useWorkflowService()
       vi.spyOn(workflowStore, 'saveWorkflow').mockResolvedValue()
       vi.spyOn(workflowStore, 'renameWorkflow').mockResolvedValue()
-      mockTrackWorkflowSaved.mockClear()
       app.rootGraph.extra = {}
     })
 

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -190,7 +190,6 @@ describe('useWorkflowPersistenceV2', () => {
     mocks.state.graphChangedHandler = null
     mocks.state.currentGraph = { initial: true }
     mocks.serializeMock.mockImplementation(() => mocks.state.currentGraph)
-    mocks.loadGraphDataMock.mockReset()
     mocks.apiMock.clientId = 'test-client'
     mocks.apiMock.initialClientId = 'test-client'
     mocks.apiMock.addEventListener.mockImplementation(
@@ -201,9 +200,6 @@ describe('useWorkflowPersistenceV2', () => {
       }
     )
     mocks.apiMock.removeEventListener.mockImplementation(() => {})
-    openWorkflowMock.mockReset()
-    loadBlankWorkflowMock.mockReset()
-    commandStoreMocks.execute.mockReset()
     routeMocks.query = {}
     preservedQueryMocks.payloads = {}
   })

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
@@ -151,8 +151,6 @@ describe('ShareWorkflowDialogContent', () => {
   const onClose = vi.fn()
 
   beforeEach(() => {
-    mockPublishWorkflow.mockReset()
-    mockGetShareableAssets.mockReset()
     mockWorkflowStore.activeWorkflow = {
       path: 'workflows/test.json',
       directory: 'workflows',

--- a/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateWorkflows.test.ts
@@ -70,7 +70,6 @@ describe('useTemplateWorkflows', () => {
 
   beforeEach(() => {
     mockIsCloud.value = true
-    mockTrackTemplate.mockClear()
 
     mockWorkflowTemplatesStore = {
       isLoaded: false,

--- a/src/platform/workspace/composables/useAutoPageSize.test.ts
+++ b/src/platform/workspace/composables/useAutoPageSize.test.ts
@@ -65,8 +65,6 @@ function runInScope(container: Ref<HTMLElement | null>, min?: number) {
 describe('useAutoPageSize', () => {
   beforeEach(() => {
     resizeObserverState.callback = null
-    resizeObserverState.observe.mockClear()
-    resizeObserverState.disconnect.mockClear()
   })
 
   it('fits as many whole rows as the container height allows', () => {

--- a/src/platform/workspace/composables/useBillingBanner.test.ts
+++ b/src/platform/workspace/composables/useBillingBanner.test.ts
@@ -74,8 +74,6 @@ describe('useBillingBanner', () => {
     b.subscription.value = { hasFunds: true }
     mocks.billingControlEnabled!.value = true
     mocks.v1PaymentRecovery!.value = true
-    b.fetchStatus.mockClear()
-    b.fetchBalance.mockClear()
   })
 
   it('suppresses the banner entirely when billing control is rolled back', async () => {

--- a/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
+++ b/src/platform/workspace/stores/partnerNodeGovernanceStore.test.ts
@@ -77,7 +77,6 @@ describe('partnerNodeGovernanceStore', () => {
   let store: ReturnType<typeof usePartnerNodeGovernanceStore> | undefined
 
   beforeEach(() => {
-    mockUpdatePartnerNodePolicy.mockReset()
     mockFlags.partnerNodeGovernanceEnabled = true
     mockGetPartnerProviders.mockResolvedValue(providers)
     mockGetPartnerNodePolicy.mockResolvedValue(null)

--- a/src/renderer/core/layout/sync/useLayoutSync.test.ts
+++ b/src/renderer/core/layout/sync/useLayoutSync.test.ts
@@ -55,10 +55,8 @@ describe('useLayoutSync', () => {
   beforeEach(() => {
     testState.listener = null
     testState.layoutByNodeId.clear()
-    testState.unsubscribe.mockReset()
     testState.rafCallback = null
     testState.microtaskCallback = null
-    testState.cancelAnimationFrame.mockReset()
 
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       testState.rafCallback = cb

--- a/src/renderer/extensions/compositor/composables/compositorSave.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSave.test.ts
@@ -69,7 +69,6 @@ function widgetValue(widget: IBaseWidget): CompositorLayerState {
 const cacheNode = { id: toNodeId(7) } as unknown as LGraphNode
 
 beforeEach(() => {
-  vi.clearAllMocks()
   clearCompositorLayers(cacheNode)
 })
 

--- a/src/renderer/extensions/compositor/composables/compositorSession.test.ts
+++ b/src/renderer/extensions/compositor/composables/compositorSession.test.ts
@@ -56,7 +56,6 @@ const fallbackName = (i: number) => `Layer ${i + 1}`
 
 describe('loadCompositorSession', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     getCompositorLayers.mockReturnValue([])
     resolveInitialLayerState.mockReturnValue(null)
   })

--- a/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorEditor.test.ts
@@ -32,7 +32,6 @@ describe('useCompositorEditor', () => {
   const node = { id: toNodeId(1) } as unknown as LGraphNode
 
   beforeEach(() => {
-    vi.clearAllMocks()
     clearCompositorLayers(node)
   })
 

--- a/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
+++ b/src/renderer/extensions/compositor/composables/useCompositorPsdDownload.test.ts
@@ -47,7 +47,6 @@ const node = { id: toNodeId(5) } as unknown as LGraphNode
 
 describe('useCompositorPsdDownload', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     loadCompositorSession.mockResolvedValue(0)
     buildSessionPsdBlob.mockResolvedValue(new Blob(['psd']))
   })

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -103,7 +103,6 @@ function loadTemplate(templateId: keyof typeof TOUR_ROLE_PINS): LGraph {
 describe('firstRunTourSteps', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    disposals.spy.mockClear()
   })
 
   afterEach(() => {

--- a/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
+++ b/src/renderer/extensions/layerEditor/components/LayerEditorContent.test.ts
@@ -135,7 +135,6 @@ async function waitForAutoSaveStart() {
 
 describe('LayerEditorContent', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     session.canUndo.value = false
     session.loadImages.mockResolvedValue(0)
     loadCompositorSession.mockResolvedValue(0)

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
@@ -17,10 +17,6 @@ vi.mock('@/stores/nodeOutputStore', () => ({
 }))
 
 describe('useLayerEditor', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('does nothing without a node', () => {
     useLayerEditor().openLayerEditor(null as unknown as LGraphNode)
     expect(showDialog).not.toHaveBeenCalled()

--- a/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
+++ b/src/renderer/extensions/layerEditor/composables/useLayerEditorExport.test.ts
@@ -54,7 +54,6 @@ function stubContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
 const origGetContext = HTMLCanvasElement.prototype.getContext
 
 beforeEach(() => {
-  vi.clearAllMocks()
   registerBuiltinKinds()
   HTMLCanvasElement.prototype.getContext = function (
     this: HTMLCanvasElement,

--- a/src/renderer/extensions/linearMode/LinearRunErrorWarning.test.ts
+++ b/src/renderer/extensions/linearMode/LinearRunErrorWarning.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import LinearRunErrorWarning from '@/renderer/extensions/linearMode/LinearRunErrorWarning.vue'
 import { LINEAR_RUN_ERROR_WARNING_DESCRIPTION_ID } from '@/renderer/extensions/linearMode/linearRunErrorWarningIds'
@@ -49,10 +49,6 @@ function renderWarning() {
 }
 
 describe('LinearRunErrorWarning', () => {
-  beforeEach(() => {
-    mocks.viewErrorsInGraph.mockReset()
-  })
-
   it('shows the current error overlay title and message without a close action', () => {
     renderWarning()
 

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -165,8 +165,6 @@ describe(useOutputHistory, () => {
     pendingTasksRef.value = []
     resolvedOutputsCacheRef.clear()
     jobDetailResults.clear()
-    selectAsLatestFn.mockReset()
-    resolveIfReadyFn.mockReset()
   })
 
   describe('sessionMedia filtering', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -236,9 +236,6 @@ describe('useMinimap', () => {
   }
 
   beforeEach(() => {
-    mockPause.mockClear()
-    mockResume.mockClear()
-
     mockContext2D = createMockCanvas2DContext()
 
     moduleMockCanvasElement = createMockMinimapCanvas({

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -130,7 +130,6 @@ describe('useSlotElementTracking', () => {
     })
     mockGraph._nodes = [{ id: 1 }]
     mockCanvasState.canvas = {}
-    mockClientPosToCanvasPos.mockClear()
   })
 
   it.for([

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -245,8 +245,6 @@ describe('useSlotLinkInteraction auto-pan', () => {
     }
     mockDs.offset = [0, 0]
     mockDs.scale = 1
-    mockSetDirty.mockClear()
-    mockAdapter.beginFromOutput.mockClear()
     mockLinkConnector.state.snapLinksPos = null
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -160,13 +160,6 @@ describe('useVueNodeResizeTracking', () => {
   beforeEach(() => {
     testState.linearMode = false
     testState.nodeLayouts.clear()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.setSource.mockReset()
-    testState.syncNodeSlotLayoutsFromDOM.mockReset()
-    testState.scheduleSlotLayoutSync.mockReset()
-    resizeObserverState.observe.mockReset()
-    resizeObserverState.unobserve.mockReset()
-    resizeObserverState.disconnect.mockReset()
   })
 
   it('skips repeated no-op resize entries after first measurement', () => {

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -135,17 +135,10 @@ describe('useNodeDrag', () => {
     testState.selectedNodeIds = ref(new Set<NodeId>())
     testState.selectedItems = ref<unknown[]>([])
     testState.nodeLayouts.clear()
-    testState.mutationFns.setSource.mockReset()
-    testState.mutationFns.moveNode.mockReset()
-    testState.mutationFns.batchMoveNodes.mockReset()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.nodeSnap.shouldSnap.mockReset()
     testState.nodeSnap.shouldSnap.mockReturnValue(false)
-    testState.nodeSnap.applySnapToPosition.mockReset()
     testState.nodeSnap.applySnapToPosition.mockImplementation(
       (pos: { x: number; y: number }) => pos
     )
-    testState.cancelAnimationFrame.mockReset()
     testState.requestAnimationFrameCallback = null
     testState.capturedOnPan.current = null
     testState.capturedAutoPanInstance.current = null
@@ -252,17 +245,10 @@ describe('useNodeDrag auto-pan', () => {
       position: { x: 300, y: 400 },
       size: { width: 200, height: 100 }
     })
-    testState.mutationFns.setSource.mockReset()
-    testState.mutationFns.moveNode.mockReset()
-    testState.mutationFns.batchMoveNodes.mockReset()
-    testState.batchUpdateNodeBounds.mockReset()
-    testState.nodeSnap.shouldSnap.mockReset()
     testState.nodeSnap.shouldSnap.mockReturnValue(false)
-    testState.nodeSnap.applySnapToPosition.mockReset()
     testState.nodeSnap.applySnapToPosition.mockImplementation(
       (pos: { x: number; y: number }) => pos
     )
-    testState.cancelAnimationFrame.mockReset()
     testState.requestAnimationFrameCallback = null
     testState.capturedOnPan.current = null
     testState.capturedAutoPanInstance.current = null

--- a/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/ValueControlPopover.test.ts
@@ -77,7 +77,6 @@ function renderPopover(modelValue: ControlOptions = 'randomize') {
 
 describe('ValueControlPopover', () => {
   beforeEach(() => {
-    mockGet.mockReset()
     mockGet.mockReturnValue('after')
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -34,9 +34,6 @@ import { createMockWidget } from './widgetTestUtils'
 
 describe('WidgetDOM', () => {
   beforeEach(() => {
-    canvasMocks.canvas.graph.getNodeById.mockReset()
-    resolveMock.mockReset()
-    isDOMWidgetMock.mockReset()
     isDOMWidgetMock.mockReturnValue(true)
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -134,21 +134,12 @@ describe('WidgetRecordAudio', () => {
     recorder.isRecording.value = false
     recorder.recordedURL.value = null
     recorder.mediaRecorder.value = null
-    recorder.startRecording.mockClear()
-    recorder.stopRecording.mockClear()
-    recorder.dispose.mockClear()
 
     playback.isPlaying.value = false
     playback.audioElementKey.value = 0
     playback.playbackTimerInterval.value = null
-    playback.play.mockClear()
-    playback.stop.mockClear()
 
     waveform.waveformBars.value = []
-
-    useAudioRecorderMock.mockClear()
-    useAudioPlaybackMock.mockClear()
-    useAudioWaveformMock.mockClear()
 
     appMock.app.canvas.graph.getNodeById.mockReset().mockReturnValue(null)
     isDOMWidgetMock.mockReset().mockReturnValue(false)

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -139,13 +139,10 @@ const i18n = createI18n({
 describe('WidgetSelectDropdown', () => {
   beforeEach(() => {
     mockMediaAssets.media.value = []
-    mockCheckState.mockClear()
     mockAssetsData.items = []
     mockItemsRef.value = []
     mockSelectedSetRef.value = new Set()
     mockFilterSelectedRef.value = 'all'
-    mockUpdateSelectedItems.mockClear()
-    mockHandleFilesUpdate.mockClear()
   })
 
   function renderComponent(

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextPreview.test.ts
@@ -2,7 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -93,11 +93,6 @@ function renderPreview(
 }
 
 describe('WidgetTextPreview', () => {
-  beforeEach(() => {
-    downloadFileMock.mockClear()
-    copyMock.mockClear()
-  })
-
   it('renders plaintext in a textarea by default', () => {
     renderPreview('# not rendered')
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
@@ -192,10 +192,6 @@ describe('WidgetTextarea Value Binding', () => {
     })
   })
   describe('Copy Button Behavior', () => {
-    beforeEach(() => {
-      mockCopyToClipboard.mockClear()
-    })
-
     it('hides copy button when not read-only', async () => {
       const widget = createTextareaWidget('test')
       renderComponent(widget, 'test')

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -148,10 +148,6 @@ async function openPopover(user: TestUser, triggerName: string) {
 }
 
 describe('FormDropdownMenuActions', () => {
-  beforeEach(() => {
-    popoverHide.mockClear()
-  })
-
   describe('Search', () => {
     it('binds search input to v-model on initial render', () => {
       renderMenu({ searchQuery: 'seed' })

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuFilter.test.ts
@@ -76,7 +76,6 @@ describe('FormDropdownMenuFilter', () => {
   beforeEach(() => {
     const upload = getUploadMock()
     upload.isUploadButtonEnabled.value = false
-    upload.showUploadDialog.mockReset()
   })
 
   describe('Filter options', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
@@ -82,7 +82,6 @@ async function flushPromises() {
 describe('FormDropdownMenuItem', () => {
   beforeEach(() => {
     intersectionCallbacks.length = 0
-    mockFindServerPreviewUrl.mockReset()
     mockIsAssetPreviewSupported.mockReset().mockReturnValue(true)
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/audio/useAudioRecorder.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/audio/useAudioRecorder.test.ts
@@ -48,7 +48,6 @@ describe('useAudioRecorder', () => {
     vi.stubGlobal('navigator', {
       mediaDevices: { getUserMedia: mockGetUserMedia }
     })
-    MockMediaRecorder.mockClear()
     mockGetUserMedia.mockResolvedValue(createMockStream())
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRemoteWidget.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { api } from '@/scripts/api'
@@ -106,15 +106,6 @@ async function getResolvedValue(hook: ReturnType<typeof useRemoteWidget>) {
 }
 
 describe('useRemoteWidget', () => {
-  beforeEach(() => {
-    // Reset mocks
-    vi.mocked(axios.get).mockReset()
-    // Reset cache between tests
-    vi.spyOn(Map.prototype, 'get').mockClear()
-    vi.spyOn(Map.prototype, 'set').mockClear()
-    vi.spyOn(Map.prototype, 'delete').mockClear()
-  })
-
   describe('initialization', () => {
     it('should create hook with default values', () => {
       const hook = useRemoteWidget(createMockOptions())

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -1,6 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { computed, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
@@ -44,10 +44,6 @@ function createItems(...names: string[]): FormDropdownItem[] {
 }
 
 describe('useWidgetSelectActions', () => {
-  beforeEach(() => {
-    mockCaptureCanvasState.mockClear()
-  })
-
   describe('updateSelectedItems', () => {
     it('sets modelValue to the selected item name', () => {
       const modelValue = ref<string | undefined>('img_001.png')

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -130,7 +130,6 @@ describe('display label behavior', () => {
 describe('useWidgetSelectItems', () => {
   beforeEach(() => {
     mockMediaAssets = createMockMediaAssets()
-    mockResolveOutputAssetItems.mockReset()
     mockAssetsData.items = []
   })
 

--- a/src/renderer/three/RendererView.test.ts
+++ b/src/renderer/three/RendererView.test.ts
@@ -30,7 +30,6 @@ vi.mock('three', async (importOriginal) => {
 const drawImage = vi.fn()
 
 beforeEach(() => {
-  drawImage.mockClear()
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
     drawImage,
     globalCompositeOperation: 'source-over'

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -216,14 +216,12 @@ function omitOptionalSubgraphCollections(state: ComfyWorkflowJSON) {
 
 describe('ChangeTracker', () => {
   beforeEach(() => {
-    vi.mocked(api.dispatchCustomEvent).mockReset()
     resetSubgraphFixtureState()
     nodeIdCounter = 0
     ChangeTracker.isLoadingGraph = false
     ChangeTracker.resetCheckStateWarningForTest()
     mockWorkflowStore.activeWorkflow = null
     mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
-    vi.mocked(app.rootGraph.serialize).mockReset()
     mockCanvasState(createState())
     useQueueSettingsStore().mode = 'change'
     app.ui.autoQueueEnabled = false

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -48,8 +48,6 @@ describe('ComfyUI file input', () => {
         unobserve = vi.fn()
       }
     )
-    mockApp.handleFile.mockReset()
-    mockApp.showErrorOnFileLoad.mockReset()
   })
 
   afterEach(() => {

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -3,7 +3,7 @@
  * Reka-migrated dialog, the dialog stack item must carry `renderer: 'reka'`.
  * Catches accidental reverts of the Reka renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 
@@ -35,10 +35,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 import { useDialogService } from '@/services/dialogService'
 
 describe('dialogService Reka renderer opt-in', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-  })
-
   it("prompt() sets renderer 'reka' and size 'md'", () => {
     void useDialogService().prompt({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -29,8 +29,6 @@ describe('useNewUserService', () => {
 
   beforeEach(() => {
     mockSettingStore.settingValues = {}
-    mockSettingStore.get.mockReset()
-    mockSettingStore.set.mockReset()
 
     service = useNewUserService()
     service.reset()

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -222,7 +222,6 @@ describe('useAuthStore', () => {
     store = useAuthStore()
 
     // Reset and set up getIdToken mock
-    mockUser.getIdToken.mockReset()
     mockUser.getIdToken.mockResolvedValue('mock-id-token')
 
     // Default: no API key auth

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -187,9 +187,6 @@ describe('useExecutionStore - NodeLocatorId conversions', () => {
 
   beforeEach(() => {
     // Reset mock implementations
-    mockNodeIdToNodeLocatorId.mockReset()
-    mockNodeLocatorIdToNodeExecutionId.mockReset()
-    mockExecutionIdToCurrentId.mockReset()
 
     store = useExecutionStore()
   })
@@ -272,10 +269,6 @@ describe('useExecutionStore - nodeLocationProgressStates caching', () => {
   let store: ReturnType<typeof useExecutionStore>
 
   beforeEach(() => {
-    mockNodeIdToNodeLocatorId.mockReset()
-    mockNodeLocatorIdToNodeExecutionId.mockReset()
-    mockExecutionIdToCurrentId.mockReset()
-
     store = useExecutionStore()
   })
 
@@ -1469,7 +1462,6 @@ describe('useExecutionStore - RAF batching', () => {
   }
 
   beforeEach(() => {
-    vi.clearAllMocks()
     store = useExecutionStore()
     store.bindExecutionEvents()
   })

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -59,8 +59,6 @@ describe('FE-230 regression — workflow-load missing-media flagging must not wi
     setActivePinia(createPinia())
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
-    mockRemoveNodeOutputs.mockReset()
-    mockGetNodeByExecutionId.mockReset()
   })
 
   it('does not clear node.imgs when verification flags a Load Image as missing on workflow load (e.g. mask-editor saved value)', async () => {

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -91,9 +91,6 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
     mockCanvas.ds.offset = [0, 0]
     mockCanvas.ds.state.scale = 1
     mockCanvas.ds.state.offset = [0, 0]
-    mockSetDirty.mockClear()
-    mockFitView.mockClear()
-    mockRequestSlotSyncAll.mockClear()
   })
 
   describe('cache key isolation', () => {

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -14,7 +14,6 @@ vi.mock('@/scripts/api', () => ({
 describe('userStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    getUserConfig.mockReset()
   })
 
   describe('initialize', () => {

--- a/src/stores/workspace/sidebarTabStore.test.ts
+++ b/src/stores/workspace/sidebarTabStore.test.ts
@@ -105,10 +105,6 @@ vi.mock('@/platform/workflow/management/composables/useAppsSidebarTab', () => ({
 
 describe('useSidebarTabStore', () => {
   beforeEach(() => {
-    mockGetSetting.mockReset()
-    mockRegisterCommand.mockClear()
-    mockRegisterCommands.mockClear()
-    mockBrowseModelAssets.mockClear()
     registeredCommands.length = 0
     commandStoreCommands.length = 0
   })

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 
 import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
@@ -91,10 +91,6 @@ describe('createNode', () => {
       graph_mouse: [100, 200]
     })
   }
-
-  beforeEach(() => {
-    mockBringNodeToFront.mockClear()
-  })
 
   it('returns null when name is empty', async () => {
     const result = await createNode(makeCanvas(new LGraph()), '')

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.test.ts
@@ -77,8 +77,6 @@ const PackVersionSelectorPopoverStub = {
 
 describe('PackVersionBadge', () => {
   beforeEach(() => {
-    mockToggle.mockReset()
-    mockHide.mockReset()
     mockIsPackEnabled.mockReturnValue(true)
   })
 

--- a/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
+++ b/src/workbench/extensions/manager/components/manager/PackVersionSelectorPopover.test.ts
@@ -91,7 +91,6 @@ const waitForPromises = async () => {
 
 describe('PackVersionSelectorPopover', () => {
   beforeEach(() => {
-    mockGetPackVersions.mockReset()
     mockInstallPack.mockReset().mockResolvedValue(undefined)
     mockCheckNodeCompatibility
       .mockReset()

--- a/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
+++ b/src/workbench/extensions/manager/components/manager/button/PackEnableToggle.test.ts
@@ -96,7 +96,6 @@ describe('PackEnableToggle', () => {
   const user = userEvent.setup()
 
   beforeEach(() => {
-    mockIsPackEnabled.mockReset()
     mockEnablePack.mockReset().mockResolvedValue(undefined)
     mockDisablePack.mockReset().mockResolvedValue(undefined)
     mockGetConflictsForPackageByID.mockReset().mockReturnValue(undefined)

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCardFooter.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -51,11 +51,6 @@ const mockNodePack = {
 }
 
 describe('PackCardFooter', () => {
-  beforeEach(() => {
-    mockIsPackInstalled.mockReset()
-    mockCheckNodeCompatibility.mockReset()
-  })
-
   function renderComponent(props = {}) {
     const i18n = createI18n({
       legacy: false,

--- a/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
@@ -4,7 +4,7 @@
  * max-width × 80vh, expanding at 3000px). Catches accidental reverts of the
  * Phase 4 renderer flip.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
@@ -17,11 +17,6 @@ import { ManagerTab } from '@/workbench/extensions/manager/types/comfyManagerTyp
 import { useManagerDialog } from '@/workbench/extensions/manager/composables/useManagerDialog'
 
 describe('useManagerDialog', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-    closeDialog.mockReset()
-  })
-
   it("show() opens the Reka renderer with size 'full' and Manager content sizing", () => {
     useManagerDialog().show()
     const [args] = showDialog.mock.calls[0]

--- a/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
@@ -10,11 +10,6 @@ vi.mock('@/stores/dialogStore', () => ({
 import { useManagerSurveyDialog } from '@/workbench/extensions/manager/composables/useManagerSurveyDialog'
 
 describe('useManagerSurveyDialog', () => {
-  beforeEach(() => {
-    showDialog.mockReset()
-    closeDialog.mockReset()
-  })
-
   it('show() opens the survey dialog under its own key via the Reka layout renderer', () => {
     useManagerSurveyDialog().show()
     const [args] = showDialog.mock.calls[0]


### PR DESCRIPTION
## Summary

- remove standalone `mockReset()`, `mockClear()`, and `vi.clearAllMocks()` calls from `beforeEach` hooks
- rely on the existing Vitest `mockReset` and `restoreMocks` configuration
- preserve configured chains and cleanup outside `beforeEach`

Stacked on #15057.

## Results

- removed 249 redundant cleanup statements across 120 files
- removed 29 empty hooks and 21 unused lifecycle imports
- retained all mock calls that install return values or implementations

## Verification

- root unit suite: 1,159 files passed; 15,897 tests passed, 8 skipped
- affected website tests: 17 passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:website`
- formatting and commit hooks