### PR TITLE
test: exclude the impact-add-queue emitters and ledger their victim

### DIFF
--- a/browser_tests/fixtures/customNode/autoRun.ts
+++ b/browser_tests/fixtures/customNode/autoRun.ts
@@ -179,6 +179,13 @@ export const AUTO_RUN_ALLOWED_FAILURES: Record<
   string,
   Record<string, { outcomes: Array<string | RegExp>; reason: string }>
 > = {
+  'ComfyUI-Impact-Pack': {
+    ImpactSelectNthItemOfAnyList: {
+      outcomes: ['VALIDATION_FAIL'],
+      reason:
+        'victim, not cause: a background impact-add-queue app.queuePrompt from a queue-control node holds app.processingQueue and the harness submission returns bare false (failed run 31545300324, passed run 31537458068 on the identical commit); tolerated while the emitters sit in AUTO_RUN_EXCLUDE'
+    }
+  },
   'ComfyUI-Upscaler-Tensorrt': {
     LoadUpscalerTensorrtModel: {
       outcomes: ['TIMEOUT'],

--- a/browser_tests/tests/customNodes/allNodes.spec.ts
+++ b/browser_tests/tests/customNodes/allNodes.spec.ts
@@ -108,10 +108,10 @@ const AUTO_RUN_EXCLUDE: Record<string, Record<string, string>> = {
       'remote-control widget node; its executing signal flip-flops between PASS and PARTIAL run-to-run (same class as ImpactRemoteBoolean)',
     ImpactSchedulerAdapter:
       'executing signal flip-flops between PASS and PARTIAL run-to-run (same class as essentials TransitionMask+)',
+    ImpactQueueTrigger:
+      'queue-control node: backend execution emits impact-add-queue whenever its mode widget is on (the default), and the pack JS answers with a background app.queuePrompt whose re-entrancy refusal (app.processingQueue) then pins a bare VALIDATION_FAIL on whichever node the harness submits next',
     ImpactQueueTriggerCountdown:
-      'pack JS hooks the queue at submit time; client-side queuePrompt transiently refuses even through the retry, flip-flopping between PASS and VALIDATION_FAIL',
-    ImpactSelectNthItemOfAnyList:
-      'pack JS hooks the queue at submit time; client-side queuePrompt transiently refuses even through the retry, flip-flopping between PASS and VALIDATION_FAIL (same class as ImpactQueueTriggerCountdown; failed run 31545300324 and passed run 31537458068 on the same commit)',
+      'queue-control node: backend execution emits impact-add-queue while counting, and the pack JS answers with a background app.queuePrompt whose re-entrancy refusal poisons the next harness submission (same emitter chain as ImpactQueueTrigger; the pack installs no submit-time queue hook)',
     ImageReceiver:
       'environment-variable execution: av.error.InvalidDataError decoding its default image on macOS, clean on Linux CI'
   },

--- a/browser_tests/tests/customNodes/allNodes.spec.ts
+++ b/browser_tests/tests/customNodes/allNodes.spec.ts
@@ -110,6 +110,8 @@ const AUTO_RUN_EXCLUDE: Record<string, Record<string, string>> = {
       'executing signal flip-flops between PASS and PARTIAL run-to-run (same class as essentials TransitionMask+)',
     ImpactQueueTriggerCountdown:
       'pack JS hooks the queue at submit time; client-side queuePrompt transiently refuses even through the retry, flip-flopping between PASS and VALIDATION_FAIL',
+    ImpactSelectNthItemOfAnyList:
+      'pack JS hooks the queue at submit time; client-side queuePrompt transiently refuses even through the retry, flip-flopping between PASS and VALIDATION_FAIL (same class as ImpactQueueTriggerCountdown; failed run 31545300324 and passed run 31537458068 on the same commit)',
     ImageReceiver:
       'environment-variable execution: av.error.InvalidDataError decoding its default image on macOS, clean on Linux CI'
   },


### PR DESCRIPTION
## Summary

The bare `VALIDATION_FAIL` flip-flop is a queue race with a verified source chain - not a submit-time hook, and not a pack defect of the failing node. The emitters are excluded as the cause; the victim keeps executing under an allowed-failure entry.

## Changes

- **What**:
  - `ImpactQueueTrigger` joins `AUTO_RUN_EXCLUDE`: its backend execution emits `impact-add-queue` whenever its mode widget is on - **the default** (`modules/impact/logics.py`, `doit`); Impact's JS answers with a background `app.queuePrompt(0, 1)` (`js/common.js:113`); the frontend re-entrancy guard (`app.ts:1640`, `if (this.processingQueue) return false`) then refuses the harness's next submission with **no POST** - the bare-`VALIDATION_FAIL` signature - pinning the failure on whichever node queues next, through the 250ms retry when the background submission is still processing.
  - `ImpactQueueTriggerCountdown`'s inherited reason text is corrected: the pack installs **no** `queuePrompt`/`beforeQueued`/`graphToPrompt` hook anywhere in its JS; its real mechanism is the same backend-emit chain.
  - `ImpactSelectNthItemOfAnyList` - the victim, not the cause - moves from `AUTO_RUN_EXCLUDE` to `AUTO_RUN_ALLOWED_FAILURES` (`outcomes: ['VALIDATION_FAIL']`): it keeps executing every run with full coverage, the bare refusal is tolerated while the emitters sit excluded, and no stale-entry alarm fires on passing runs.

## Review Focus

- Evidence: S9 failed with exactly this node in [run 31545300324](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31545300324) and passed in [run 31537458068](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31537458068) on the identical commit; every mechanism link above is cited to pinned pack source or frontend source, addressing https://github.com/Comfy-Org/ComfyUI_frontend/pull/15073#discussion_r3762802465.
- A candidate follow-up outside this PR: the harness could wait for `app.processingQueue` to clear before submitting, closing this race class for every pack at the source.