### PR TITLE
test: clear session storage before each test

### DIFF
--- a/src/platform/cloud/oauth/oauthState.test.ts
+++ b/src/platform/cloud/oauth/oauthState.test.ts
@@ -8,7 +8,6 @@ import {
 
 describe('oauthState', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearOAuthRequestId()
   })
 

--- a/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
+++ b/src/platform/cloud/oauth/useOAuthPostLoginRedirect.test.ts
@@ -44,7 +44,6 @@ function mountRedirect() {
 
 describe('useOAuthPostLoginRedirect', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     createSessionOrThrow.mockReset().mockResolvedValue(undefined)
   })
 

--- a/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginRedemption.test.ts
@@ -128,7 +128,6 @@ async function setup(
 describe('installDesktopLoginRedemption', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
     vi.stubGlobal('fetch', mockFetch)
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockConfirm.mockResolvedValue(true)

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -117,12 +117,6 @@ describe('useSubscriptionDialog', () => {
     mockIsTeamPlan.value = false
     mockCurrentPlanSlug.value = null
     mockCanManageSubscription.value = true
-
-    try {
-      sessionStorage.clear()
-    } catch {
-      // noop
-    }
   })
 
   describe('showPricingTable', () => {

--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -13,7 +13,6 @@ const NAMESPACE = PRESERVED_QUERY_NAMESPACES.TEMPLATE
 
 describe('preservedQueryManager', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearPreservedQuery(NAMESPACE)
   })
 

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -40,7 +40,6 @@ function createTestRouter(
 
 describe('installPreservedQueryTracker', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     clearPreservedQuery(STRIPPED_NAMESPACE)
     clearPreservedQuery(SECOND_STRIPPED_NAMESPACE)
     clearPreservedQuery(PLAIN_NAMESPACE)

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { nextTick } from 'vue'
 
@@ -97,7 +97,6 @@ describe('useWorkflowStore', () => {
   }
 
   beforeEach(() => {
-    sessionStorage.clear()
     store = useWorkflowStore()
     bookmarkStore = useWorkflowBookmarkStore()
 
@@ -109,10 +108,6 @@ describe('useWorkflowStore', () => {
     vi.mocked(api.storeUserData).mockResolvedValue({
       status: 200
     } as Response)
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   describe('syncWorkflows', () => {

--- a/src/platform/workflow/persistence/base/storageIO.test.ts
+++ b/src/platform/workflow/persistence/base/storageIO.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DraftIndexV2, DraftPayloadV2 } from './draftTypes'
 import {
@@ -21,12 +21,7 @@ import {
 
 describe('storageIO', () => {
   beforeEach(() => {
-    sessionStorage.clear()
     vi.resetModules()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   describe('index operations', () => {

--- a/src/platform/workflow/persistence/base/storageKeys.test.ts
+++ b/src/platform/workflow/persistence/base/storageKeys.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 describe('storageKeys', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
   })
 
   describe('getWorkspaceId', () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.test.ts
@@ -184,7 +184,6 @@ describe('useWorkflowPersistenceV2', () => {
   }> = []
 
   beforeEach(() => {
-    sessionStorage.clear()
     settingMocks.persistRef!.value = true
     settingMocks.values = {}
     mocks.state.graphChangedHandler = null

--- a/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowTabState.test.ts
@@ -10,7 +10,6 @@ vi.mock('@/scripts/api', () => ({
 describe('useWorkflowTabState', () => {
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
   })
 
   describe('activePath', () => {

--- a/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
+++ b/src/platform/workflow/persistence/migration/migrateV1toV2.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { hashPath } from '../base/hashUtil'
 import { readOpenPaths } from '../base/storageIO'
@@ -14,11 +14,6 @@ describe('migrateV1toV2', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
   })
 
   function setV1Data(

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.fsm.test.ts
@@ -3,7 +3,7 @@ import type { Command } from 'fast-check'
 
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_DRAFTS } from '../base/draftTypes'
 import { useWorkflowDraftStoreV2 } from './workflowDraftStoreV2'
@@ -301,14 +301,6 @@ class StoreResetCommand implements Command<PersistenceModel, PersistenceReal> {
 // ── Test Suite ──────────────────────────────────────────────────────
 
 describe('workflowDraftStoreV2 FSM', () => {
-  beforeEach(() => {
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
-  })
-
   // 33+ unique paths to exceed MAX_DRAFTS (32) and exercise LRU eviction
   const pathPool = fc.constantFrom(
     ...Array.from({ length: 35 }, (_, i) => `workflows/${i}.json`)

--- a/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
+++ b/src/platform/workflow/persistence/stores/workflowDraftStoreV2.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MAX_DRAFTS } from '../base/draftTypes'
 import { StorageKeys } from '../base/storageKeys'
@@ -18,14 +18,6 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 describe('workflowDraftStoreV2', () => {
-  beforeEach(() => {
-    sessionStorage.clear()
-  })
-
-  afterEach(() => {
-    sessionStorage.clear()
-  })
-
   describe('saveDraft', () => {
     it('saves draft to localStorage with separate payload', () => {
       const store = useWorkflowDraftStoreV2()

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
@@ -23,7 +23,6 @@ const invalidShareQueries: Array<{ name: string; query: LocationQuery }> = [
 describe('shareAuthAttribution', () => {
   beforeEach(() => {
     clearPreservedQuery(SHARE_AUTH_NAMESPACE)
-    sessionStorage.clear()
   })
 
   it('preserves a valid share id for logged-out users', () => {

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -158,7 +158,6 @@ function expectCleanupBeforeContextAndReload(): void {
 describe('useTeamWorkspaceStore', () => {
   beforeEach(() => {
     vi.stubGlobal('localStorage', mockLocalStorage)
-    sessionStorage.clear()
     mockCurrentUser.userEmail.value = null
 
     // Reset workspaceAuthStore mock state

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -108,7 +108,6 @@ describe('useWorkspaceAuthStore', () => {
     })
     setActivePinia(createPinia())
     vi.useFakeTimers({ shouldAdvanceTime: false })
-    sessionStorage.clear()
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }
     mockEnsureSessionCookie.mockResolvedValue(undefined)

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -427,12 +427,10 @@ describe('API Feature Flags', () => {
    */
   describe('characterization: resolution with no override present', () => {
     beforeEach(() => {
-      sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
 
     afterEach(() => {
-      sessionStorage.clear()
       window.history.replaceState({}, '', '/')
     })
 

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -30,13 +30,11 @@ describe('api.getServerFeature session override outside component setup', () => 
     mockDistribution.isCloud = true
     mockCurrentUser.value = { email: 'dev@comfy.org', emailVerified: true }
     api.serverFeatureFlags.value = {}
-    sessionStorage.clear()
   })
 
   afterEach(() => {
     window.history.replaceState({}, '', '/')
     api.serverFeatureFlags.value = {}
-    sessionStorage.clear()
     vi.restoreAllMocks()
   })
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -174,7 +174,6 @@ describe('useAuthStore', () => {
 
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch)
-    sessionStorage.clear()
     clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
     mockFeatureFlags.unifiedCloudAuthEnabled = false

--- a/src/utils/sessionFeatureFlagOverride.test.ts
+++ b/src/utils/sessionFeatureFlagOverride.test.ts
@@ -28,7 +28,6 @@ describe('getSessionOverride', () => {
   beforeEach(() => {
     mockDistribution.isCloud = true
     mockCurrentUser.value = COMFY_EMPLOYEE
-    sessionStorage.clear()
   })
 
   afterEach(() => {

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
   globalThis.localStorage?.clear()
+  globalThis.sessionStorage?.clear()
   vi.useFakeTimers()
 })
 


### PR DESCRIPTION
## Summary

- clear `sessionStorage` from the shared Vitest `beforeEach` setup
- remove 28 redundant lifecycle cleanup calls across 21 suites
- preserve the fast-check iteration reset that isolates generated runs within one test

Stacked on #15072.

## Verification

- affected suites: 21 files passed; 581 tests passed
- root unit suite: 1,159 files passed; 15,897 tests passed, 8 skipped
- `pnpm lint`
- `pnpm typecheck`
- formatting and commit hooks