### PR TITLE
test: remove redundant real Pinia setup

### DIFF
--- a/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
+++ b/src/components/bottomPanel/tabs/shortcuts/EssentialsPanel.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ComfyCommandImpl } from '@/stores/commandStore'
 
@@ -50,10 +49,6 @@ vi.mock('@/stores/commandStore', () => ({
 }))
 
 describe('EssentialsPanel', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('should render ShortcutsList with essentials commands', async () => {
     const { default: EssentialsPanel } =
       await import('@/components/bottomPanel/tabs/shortcuts/EssentialsPanel.vue')

--- a/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
+++ b/src/components/boundingBoxes/WidgetBoundingBoxes.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access, testing-library/prefer-user-event */
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -98,7 +97,6 @@ const lastBoxes = (emitted: () => Record<string, unknown[][]>) => {
 }
 
 beforeEach(() => {
-  setActivePinia(createPinia())
   appState.node = {
     widgets: [
       { name: 'width', value: 512 },

--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -99,7 +98,6 @@ const i18n = createI18n({
 
 describe('BuilderFooterToolbar', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockState.mode = 'builder:inputs'
     mockHasOutputs.value = true
     mockActiveWorkflow.value = { isTemporary: true, initialMode: 'app' }

--- a/src/components/dialog/content/ConfirmationDialogContent.test.ts
+++ b/src/components/dialog/content/ConfirmationDialogContent.test.ts
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
@@ -35,10 +34,6 @@ const i18n = createI18n({
 })
 
 describe('ConfirmationDialogContent', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function renderComponent(props: Partial<Props> = {}) {
     const user = userEvent.setup()
     render(ConfirmationDialogContent, {

--- a/src/components/dialog/content/PromptDialogContent.test.ts
+++ b/src/components/dialog/content/PromptDialogContent.test.ts
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
@@ -19,10 +18,6 @@ const i18n = createI18n({
 })
 
 describe('PromptDialogContent', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function renderComponent(props: Partial<Props> = {}) {
     const user = userEvent.setup()
     render(PromptDialogContent, {

--- a/src/components/graph/selectionToolbox/BypassButton.test.ts
+++ b/src/components/graph/selectionToolbox/BypassButton.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -41,7 +40,6 @@ describe('BypassButton', () => {
   })
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     commandStore = useCommandStore()
   })

--- a/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
@@ -1,7 +1,6 @@
 import type { Mock } from 'vitest'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Tooltip from 'primevue/tooltip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -95,7 +94,6 @@ describe('ColorPickerButton', () => {
   })
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     workflowStore = useWorkflowStore()
 

--- a/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
+++ b/src/components/rightSidePanel/errors/swapNodeGroups.test.ts
@@ -1,7 +1,6 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { nextTick, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
@@ -74,10 +73,6 @@ function makeMissingNodeType(
 }
 
 describe('swapNodeGroups computed', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   function getSwapNodeGroups(nodeTypes: MissingNodeType[]) {
     useMissingNodesErrorStore().surfaceMissingNodes(nodeTypes)
 

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -213,7 +212,6 @@ function createErrorGroups() {
 
 describe('useErrorGroups', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockIsCloud.value = false
     vi.mocked(isLGraphNode).mockReturnValue(false)
   })

--- a/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/EssentialNodeCard.test.ts
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -74,7 +73,6 @@ const UNRESOLVED_TILE: EssentialTile = {
 
 describe('EssentialNodeCard', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     useNodeDefStore().updateNodeDefs([createNodeDef('LoadImage')])
   })
 

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -1,5 +1,4 @@
 import { FirebaseError } from 'firebase/app'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -137,7 +136,6 @@ beforeEach(() => {
 
 describe('useAuthActions.purchaseCreditsDirect', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockBillingState.canAccessSubscriptionFeatures = true
   })
 
@@ -181,7 +179,6 @@ describe('useAuthActions.purchaseCreditsDirect', () => {
 
 describe('useAuthActions.logout', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockDistributionState.isCloud = true
     mockWorkflowStore.modifiedWorkflows = []
   })
@@ -339,7 +336,6 @@ describe('useAuthActions.logout', () => {
 
 describe('useAuthActions auth flow error telemetry', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockWorkflowStore.modifiedWorkflows = []
   })
 
@@ -416,10 +412,6 @@ describe('useAuthActions auth flow error telemetry', () => {
 })
 
 describe('useAuthActions.reportError', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('shows the friendly message for a known Firebase auth code', () => {
     const { reportError } = useAuthActions()
 

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -173,7 +172,6 @@ vi.mock('@/platform/workspace/api/workspaceApi', () => ({
 
 describe('useBillingContext', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockIsPersonal.value = true
     mockBillingRail.value = undefined
     mockSetWorkspaceBillingRail.mockImplementation(

--- a/src/composables/boundingBoxes/useBoundingBoxes.test.ts
+++ b/src/composables/boundingBoxes/useBoundingBoxes.test.ts
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ref, ShallowRef } from 'vue'
 import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
@@ -175,7 +174,6 @@ function makeConnectedNode(): MockNode {
 }
 
 beforeEach(() => {
-  setActivePinia(createPinia())
   appState.node = makeNode()
   outputState.outputs = undefined
   if (outputState.nodeOutputs) outputState.nodeOutputs.value = {}

--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -101,7 +100,6 @@ describe('useSelectedLiteGraphItems', () => {
   let mockCanvas: { selectedItems: Set<Positionable> }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
     mockApp.canvas.selected_nodes = null
 

--- a/src/composables/canvas/useSelectionToolboxPosition.test.ts
+++ b/src/composables/canvas/useSelectionToolboxPosition.test.ts
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, h, markRaw, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -30,7 +29,6 @@ describe('useSelectionToolboxPosition', () => {
   let canvasStore: ReturnType<typeof useCanvasStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     canvasStore = useCanvasStore()
   })
 

--- a/src/composables/graph/useGroupMenuOptions.test.ts
+++ b/src/composables/graph/useGroupMenuOptions.test.ts
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useGroupMenuOptions } from '@/composables/graph/useGroupMenuOptions'
 import { LGraphCanvas, LGraphGroup } from '@/lib/litegraph/src/litegraph'
@@ -23,10 +22,6 @@ const i18n = createI18n({
 })
 
 describe('useGroupMenuOptions.getGroupColorOptions', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('applies the same colour as the circle-swatch picker (LGraphCanvas.node_colors groupcolor)', () => {
     const group = new LGraphGroup('Test Group')
     const canvasStore = useCanvasStore()

--- a/src/composables/graph/useNodeMenuOptions.test.ts
+++ b/src/composables/graph/useNodeMenuOptions.test.ts
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useNodeMenuOptions } from '@/composables/graph/useNodeMenuOptions'
 import type { Positionable } from '@/lib/litegraph/src/litegraph'
@@ -70,10 +69,6 @@ const getBypassLabel = (selected: LGraphNode[]): string => {
 }
 
 describe('useNodeMenuOptions.getBypassOption', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('labels as "Bypass" when no node is bypassed', () => {
     expect(getBypassLabel([nodeWithMode(LGraphEventMode.ALWAYS, 1)])).toBe(
       'contextMenu.Bypass'

--- a/src/composables/queue/useResultGallery.test.ts
+++ b/src/composables/queue/useResultGallery.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { useResultGallery } from '@/composables/queue/useResultGallery'
 import type { JobListItem as JobListViewItem } from '@/composables/queue/useJobList'
@@ -59,10 +58,6 @@ const createJobViewItem = (
   }) as JobListViewItem
 
 describe('useResultGallery', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('collects only previewable outputs and preserves their order', async () => {
     const previewable = [createResultItem('p-1'), createResultItem('p-2')]
     const nonPreviewable = createResultItem('skip-me', false)

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -306,9 +305,6 @@ describe('useCoreCommands', () => {
     vi.mocked(app.refreshComboInNodes).mockResolvedValue(undefined)
     mockModelStoreRefresh.mockResolvedValue(undefined)
     mockMissingModelStoreRefresh.mockResolvedValue(undefined)
-
-    // Set up Pinia
-    setActivePinia(createPinia())
 
     // Reset app state
     app.canvas.subgraph = undefined

--- a/src/composables/useNewMenuItemIndicator.test.ts
+++ b/src/composables/useNewMenuItemIndicator.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNewMenuItemIndicator } from '@/composables/useNewMenuItemIndicator'
@@ -26,7 +25,6 @@ function createItems(...ids: string[]): WorkflowMenuItem[] {
 
 describe('useNewMenuItemIndicator', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSettingStore.get.mockReturnValue([])
   })
 

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -64,7 +63,6 @@ vi.mock('@/platform/telemetry/searchQuery/useSearchQueryTracking', () => ({
 
 describe('useTemplateFiltering', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     vi.stubGlobal('__DISTRIBUTION__', 'localhost')
     mockSystemStatsStore.systemStats.system.os = 'linux'
   })

--- a/src/composables/useViewErrorsInGraph.test.ts
+++ b/src/composables/useViewErrorsInGraph.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -59,7 +58,6 @@ function createSelectedCanvas() {
 
 describe('useViewErrorsInGraph', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     apiMock.getSettings.mockResolvedValue({})
     apiMock.storeSetting.mockResolvedValue(undefined)
     apiMock.storeSettings.mockResolvedValue(undefined)

--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -112,7 +111,6 @@ function findItem(items: MenuItems, label: string): WorkflowMenuAction {
 
 describe('useWorkflowActionsMenu', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockBookmarkStore.isBookmarked.mockReturnValue(false)
     mockSubgraphStore.isSubgraphBlueprint.mockReturnValue(false)
     mockMenuItemStore.hasSeenLinear = false

--- a/src/platform/assets/components/AssetCard.test.ts
+++ b/src/platform/assets/components/AssetCard.test.ts
@@ -1,7 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
 import { render, screen } from '@testing-library/vue'
-import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
@@ -67,7 +66,6 @@ function createDisplayAsset(
 }
 
 function renderCard(asset: AssetDisplayItem) {
-  setActivePinia(createPinia())
   const i18n = createI18n({
     legacy: false,
     locale: 'en',

--- a/src/platform/assets/composables/useAssetBrowser.perf.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.perf.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
@@ -38,10 +37,6 @@ function makeAsset(index: number): AssetItem {
 }
 
 describe('useAssetBrowser - filter tab switching perf (FE-229)', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('does not re-transform every asset on each filter tab switch', async () => {
     const assets = Array.from({ length: ASSET_COUNT }, (_, i) => makeAsset(i))
     const filenameSpy = vi.spyOn(assetMetadataUtils, 'getAssetFilename')

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -38,7 +37,6 @@ vi.mock('@/composables/useFeatureFlags', () => ({
 
 describe('useAssetBrowser', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockSupportsModelTypeTags.value = false
   })
 

--- a/src/platform/assets/composables/useAssetSelection.property.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.property.test.ts
@@ -41,7 +41,6 @@ function arbAssets(minLength = 1, maxLength = 20): fc.Arbitrary<AssetItem[]> {
 
 describe('useAssetSelection properties', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShiftKey.value = false
     mockCtrlKey.value = false
     mockMetaKey.value = false

--- a/src/platform/assets/composables/useAssetSelection.test.ts
+++ b/src/platform/assets/composables/useAssetSelection.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -44,7 +43,6 @@ function createMockAssets(count: number): AssetItem[] {
 
 describe('useAssetSelection', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShiftKey.value = false
     mockCtrlKey.value = false
     mockMetaKey.value = false

--- a/src/platform/assets/composables/useAssetSelectionStore.test.ts
+++ b/src/platform/assets/composables/useAssetSelectionStore.test.ts
@@ -1,13 +1,8 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { useAssetSelectionStore } from './useAssetSelectionStore'
 
 describe('useAssetSelectionStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('addToSelection', () => {
     it('adds an asset ID to the selection', () => {
       const store = useAssetSelectionStore()

--- a/src/platform/assets/composables/useMediaAssetFiltering.test.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.test.ts
@@ -1,7 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { effectScope, ref } from 'vue'
 
 import { useMediaAssetFiltering } from '@/platform/assets/composables/useMediaAssetFiltering'
@@ -43,10 +42,6 @@ function ids(assets: AssetItem[]): string[] {
 }
 
 describe('useMediaAssetFiltering', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('media-type filter', () => {
     it('returns all assets when no filters are selected', () => {
       const assets = ref<AssetItem[]>([

--- a/src/platform/assets/composables/useMediaAssetGalleryStore.test.ts
+++ b/src/platform/assets/composables/useMediaAssetGalleryStore.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ResultItemImpl } from '@/stores/queueStore'
@@ -20,7 +19,6 @@ describe('useMediaAssetGalleryStore', () => {
         url: ''
       })
     })
-    setActivePinia(createPinia())
   })
 
   describe('openSingle', () => {

--- a/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
+++ b/src/platform/assets/utils/markDeletedAssetsAsMissingMedia.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
@@ -30,7 +29,6 @@ function makeGraph(nodes: unknown[]): LGraph {
 
 describe('FE-230 markDeletedAssetsAsMissingMedia', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     seedMediaNodeDefs()
     mockScanNodeMediaCandidates.mockReturnValue([])
   })

--- a/src/platform/keybindings/keybindingService.dialog.test.ts
+++ b/src/platform/keybindings/keybindingService.dialog.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { markRaw, reactive } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -46,8 +45,6 @@ describe('keybindingService - dialog gate', () => {
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     const commandStore = useCommandStore()
     mockCommandExecute = vi.fn()
     commandStore.execute = mockCommandExecute

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -50,8 +50,6 @@ describe('keybindingService - Escape key handling', () => {
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     const commandStore = useCommandStore()
     mockCommandExecute = vi.fn()
     commandStore.execute = mockCommandExecute

--- a/src/platform/missingMedia/missingMediaStore.test.ts
+++ b/src/platform/missingMedia/missingMediaStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
@@ -39,10 +38,6 @@ function makeCandidate(
 }
 
 describe('useMissingMediaStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('starts with no missing media', () => {
     const store = useMissingMediaStore()
     expect(store.missingMediaCandidates).toBeNull()

--- a/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import type { App } from 'vue'
@@ -121,7 +120,6 @@ describe('useMissingModelInteractions', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockDownloadList.mockImplementation(
       (): Array<{ taskId: string; status: string }> => []
     )

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeExecutionId } from '@/types/nodeIdentification'
@@ -58,7 +57,6 @@ function makeModelCandidate(
 
 describe('missingModelStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockNodeLocatorIdToNodeExecutionId.mockImplementation(
       (nodeLocatorId: string) => nodeLocatorId
     )

--- a/src/platform/nodeReplacement/missingNodeScan.test.ts
+++ b/src/platform/nodeReplacement/missingNodeScan.test.ts
@@ -1,5 +1,4 @@
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -77,7 +76,6 @@ function getMissingNodesError(
 
 describe('scanMissingNodes (via rescanAndSurfaceMissingNodes)', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     // Reset registered_node_types
     const reg = LiteGraph.registered_node_types as Record<string, unknown>
     for (const key of Object.keys(reg)) {

--- a/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
+++ b/src/platform/nodeReplacement/missingNodesErrorStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { MissingNodeType } from '@/types/comfy'
 
@@ -22,10 +21,6 @@ vi.mock('@/platform/settings/settingStore', () => ({
 import { useMissingNodesErrorStore } from './missingNodesErrorStore'
 
 describe('missingNodesErrorStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('setMissingNodeTypes', () => {
     it('sets missingNodesError with provided types', () => {
       const store = useMissingNodesErrorStore()

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1,6 +1,5 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
@@ -169,10 +168,6 @@ function makeMissingNodeType(
 }
 
 describe('useNodeReplacement', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('replaceNodesInPlace', () => {
     it('should return empty array when no placeholders exist', () => {
       const graph = createMockGraph([])

--- a/src/platform/secrets/components/SecretsPanel.test.ts
+++ b/src/platform/secrets/components/SecretsPanel.test.ts
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -87,7 +86,6 @@ const i18n = createI18n({
 })
 
 function renderPanel() {
-  setActivePinia(createPinia())
   return render(SecretsPanel, {
     global: {
       plugins: [i18n],

--- a/src/platform/settings/composables/useSettingSearch.test.ts
+++ b/src/platform/settings/composables/useSettingSearch.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -35,8 +34,6 @@ describe('useSettingSearch', () => {
   let mockSettings: Record<string, MockSettingParams>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
-
     // Mock settings data
     mockSettings = {
       'Category.Setting1': {

--- a/src/platform/surveys/openTypeformDialog.test.ts
+++ b/src/platform/surveys/openTypeformDialog.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useDialogStore } from '@/stores/dialogStore'
 
@@ -7,10 +6,6 @@ import TypeformDialogContent from './TypeformDialogContent.vue'
 import { openTypeformDialog } from './openTypeformDialog'
 
 describe('openTypeformDialog', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('opens the form embed in a Reka dialog with the given id and hidden fields', () => {
     const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, defineStore, setActivePinia } from 'pinia'
+import { defineStore } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 
@@ -32,7 +32,6 @@ describe('useErrorSurveyTracking', () => {
   }
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     store = useFakeExecutionErrorStore()
   })
 

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -84,10 +83,6 @@ vi.mock('vue', async () => {
 })
 
 describe('useFrontendVersionMismatchWarning', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('should not show warning when there is no version mismatch', () => {
     const toastStore = useToastStore()
     const versionStore = useVersionCompatibilityStore()

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -1,4 +1,4 @@
-import { createPinia, setActivePinia, storeToRefs } from 'pinia'
+import { storeToRefs } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -106,7 +106,6 @@ describe('useWorkspaceAuthStore', () => {
       reload: mockReload,
       origin: 'http://localhost'
     })
-    setActivePinia(createPinia())
     vi.useFakeTimers({ shouldAdvanceTime: false })
     mockUnifiedCloudAuthEnabled.value = false
     mockCurrentUser.value = { uid: 'user-a' }

--- a/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
+++ b/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -26,7 +25,6 @@ describe('useWorkflowThumbnail', () => {
   let workflowStore: ReturnType<typeof useWorkflowStore>
 
   beforeEach(() => {
-    setActivePinia(createPinia())
     workflowStore = useWorkflowStore()
 
     // Clear any existing thumbnails from previous tests BEFORE mocking

--- a/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/heuristicRoles.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -101,8 +100,6 @@ function addExposedPrompt(root: LGraph, portName: string) {
 }
 
 describe('heuristicRoles', () => {
-  beforeEach(() => setActivePinia(createPinia()))
-
   it('takes the prompt wired to positive when negative comes first', () => {
     const graph = createTestRootGraph()
     addWiredSink(graph)

--- a/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
+++ b/src/renderer/extensions/firstRunTour/roles/resolveTourRoles.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -44,8 +43,6 @@ function addHostedSubgraph(root: LGraph, parent: LGraph | Subgraph = root) {
 }
 
 describe('resolveTourRoles', () => {
-  beforeEach(() => setActivePinia(createPinia()))
-
   it('spotlights a prompt pinned inside a subgraph through its root-graph host', () => {
     const root = createTestRootGraph()
     const { subgraph, host } = addHostedSubgraph(root)

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { DragAndScale } from '@/lib/litegraph/src/DragAndScale'
@@ -101,10 +100,6 @@ function loadTemplate(templateId: keyof typeof TOUR_ROLE_PINS): LGraph {
 }
 
 describe('firstRunTourSteps', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   afterEach(() => {
     releaseFirstRunTargets()
     clearCoachmarks()

--- a/src/renderer/extensions/linearMode/linearOutputStore.test.ts
+++ b/src/renderer/extensions/linearMode/linearOutputStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -104,7 +103,6 @@ function makeExecutedDetail(
 
 describe('linearOutputStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     activeJobIdRef.value = null
     previewsRef.value = {}
     isAppModeRef.value = true

--- a/src/renderer/extensions/linearMode/useOutputHistory.test.ts
+++ b/src/renderer/extensions/linearMode/useOutputHistory.test.ts
@@ -1,6 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
@@ -152,7 +151,6 @@ function makeResult(filename: string, nodeId: string = '1'): ResultItemImpl {
 
 describe(useOutputHistory, () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mediaRef.value = []
     pendingResolveRef.value = new Set()
     inProgressItemsRef.value = []

--- a/src/renderer/extensions/vueNodes/widgets/composables/useDismissOnCanvasGesture.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useDismissOnCanvasGesture.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { effectScope, nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -28,7 +27,6 @@ function nextFrame() {
 
 describe('useDismissOnCanvasGesture', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     panCanvasTo(0, 0)
   })
 

--- a/src/renderer/glsl/glslPreviewStoreContract.test.ts
+++ b/src/renderer/glsl/glslPreviewStoreContract.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, shallowRef } from 'vue'
 
@@ -101,7 +100,6 @@ function createGLSLNode(nodeId: number): LGraphNode {
 
 describe('GLSL live preview reads the shader written by the customtext widget', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     for (const key of Object.keys(nodeOutputs)) delete nodeOutputs[key]
   })
 

--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -1,5 +1,4 @@
 import { fromAny } from '@total-typescript/shoehorn'
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, ref, shallowRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
@@ -129,7 +128,6 @@ function wrapNode(
 
 describe('useGLSLPreview', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockRendererFactory.lastConfig.value = undefined
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:test')
     globalThis.URL.revokeObjectURL = vi.fn()

--- a/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.promotedRead.test.ts
@@ -1,6 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { computed } from 'vue'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { CurveData } from '@/components/curve/types'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -60,10 +59,6 @@ function runUniforms(sources: UniformSources) {
 }
 
 describe('useGLSLUniforms reads promoted widget values from the host key', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('curveValues reflects the edited host curve, not the stale interior curve', () => {
     const staleCurve: CurveData = {
       points: [

--- a/src/stores/executionErrorStore.test.ts
+++ b/src/stores/executionErrorStore.test.ts
@@ -53,10 +53,6 @@ function mockGraphReady(rootGraph: typeof app.rootGraph) {
 }
 
 describe('executionErrorStore — node error operations', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('clearSimpleNodeErrors', () => {
     it('does nothing if lastNodeErrors is null', () => {
       const store = useExecutionErrorStore()
@@ -628,7 +624,6 @@ describe('executionErrorStore — node error operations', () => {
 
 describe('surfaceMissingModels — silent option', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShowErrorsTab.value = true
   })
 
@@ -696,7 +691,6 @@ describe('surfaceMissingModels — silent option', () => {
 
 describe('surfaceMissingMedia — silent option', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockShowErrorsTab.value = true
   })
 
@@ -763,10 +757,6 @@ describe('surfaceMissingMedia — silent option', () => {
 })
 
 describe('recordNodeErrors', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('normalizes an empty error record to null', () => {
     const store = useExecutionErrorStore()
 
@@ -785,10 +775,6 @@ describe('recordNodeErrors', () => {
 })
 
 describe('hasMissingError', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it.for([
     {
       type: 'nodes',

--- a/src/stores/jobPreviewStore.test.ts
+++ b/src/stores/jobPreviewStore.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -23,7 +22,6 @@ vi.mock('@/utils/objectUrlUtil', () => ({
 
 describe('jobPreviewStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     previewMethodRef.value = 'latent2rgb'
   })
 

--- a/src/stores/missingMediaPreviewRegression.test.ts
+++ b/src/stores/missingMediaPreviewRegression.test.ts
@@ -1,4 +1,3 @@
-import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -56,7 +55,6 @@ function makeNodeWithPreview(id: number): LGraphNode {
 
 describe('FE-230 regression — workflow-load missing-media flagging must not wipe node previews', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
     mockApp.isGraphReady = true
     mockApp.rootGraph = { nodes: [], _nodes: [] } as unknown as LGraph
   })

--- a/src/stores/userStore.test.ts
+++ b/src/stores/userStore.test.ts
@@ -1,5 +1,4 @@
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { useUserStore } from './userStore'
 
@@ -12,10 +11,6 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 describe('userStore', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   describe('initialize', () => {
     it('fetches user config on first call', async () => {
       getUserConfig.mockResolvedValue({})


### PR DESCRIPTION
## Summary

- rely on the fresh global `createTestingPinia({ stubActions: false })` for ordinary test boundaries
- remove 67 redundant `setActivePinia(createPinia())` calls across 60 files
- retain within-test resets used by fast-check, keybinding state isolation, and a helper that deliberately creates independent stores

Stacked on #15074.

## Verification

- partitioned targeted suites: 984 tests passed
- root unit suite: 1,159 files passed; 15,897 tests passed, 8 skipped
- `pnpm lint`
- `pnpm typecheck`
- formatting and commit hooks