### PR TITLE
test: clear the document body before each test

### DIFF
--- a/src/components/graph/SelectionRectangle.test.ts
+++ b/src/components/graph/SelectionRectangle.test.ts
@@ -50,7 +50,6 @@ describe('SelectionRectangle', () => {
   afterEach(() => {
     rafCallbacks.length = 0
     mockCanvas.value = null
-    document.body.replaceChildren()
   })
 
   it('clips the rectangle to the canvas panel when dragged over the sidebar', async () => {

--- a/src/components/honeyToast/HoneyToast.test.ts
+++ b/src/components/honeyToast/HoneyToast.test.ts
@@ -1,15 +1,11 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 
 import HoneyToast from './HoneyToast.vue'
 
 describe('HoneyToast', () => {
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
   function renderComponent(
     props: { visible: boolean; expanded?: boolean } = { visible: true }
   ) {

--- a/src/components/load3d/controls/ExportControls.test.ts
+++ b/src/components/load3d/controls/ExportControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import ExportControls from '@/components/load3d/controls/ExportControls.vue'
@@ -28,10 +28,6 @@ function renderComponent(
 }
 
 describe('ExportControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   it('renders the trigger button without exposing the format list initially', () => {
     renderComponent()
 

--- a/src/components/load3d/controls/HDRIControls.test.ts
+++ b/src/components/load3d/controls/HDRIControls.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-container, testing-library/no-node-access -- hidden file input has no role/label, queried by selector */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -67,10 +67,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('HDRIControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('initial render', () => {
     it('renders the upload button when no HDRI is loaded', () => {
       renderComponent()

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -94,10 +94,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('LightControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('material mode gating', () => {
     it('renders the intensity control when materialMode is original', () => {
       renderComponent({ materialMode: 'original' })

--- a/src/components/load3d/controls/ModelControls.test.ts
+++ b/src/components/load3d/controls/ModelControls.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -77,10 +77,6 @@ function renderComponent(opts: RenderOpts = {}) {
 }
 
 describe('ModelControls', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   describe('up direction', () => {
     it('renders the up-direction trigger and opens the popup with all 7 directions', async () => {
       const { user } = renderComponent()

--- a/src/components/load3d/controls/PopupSlider.test.ts
+++ b/src/components/load3d/controls/PopupSlider.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
@@ -55,10 +55,6 @@ function renderComponent(
 }
 
 describe('PopupSlider', () => {
-  afterEach(() => {
-    document.body.innerHTML = ''
-  })
-
   it('keeps the slider hidden from the accessibility tree until the trigger is clicked', () => {
     renderComponent({ tooltipText: 'FOV' })
 

--- a/src/components/maskeditor/BrushCursor.test.ts
+++ b/src/components/maskeditor/BrushCursor.test.ts
@@ -41,7 +41,6 @@ const getGradientEl = (): HTMLElement =>
 
 describe('BrushCursor', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     mockStore = initialMock()
   })
 

--- a/src/components/queue/job/JobContextMenu.test.ts
+++ b/src/components/queue/job/JobContextMenu.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 
 import JobContextMenu from '@/components/queue/job/JobContextMenu.vue'
@@ -115,10 +115,6 @@ async function openMenu(
   await nextTick()
   return trigger
 }
-
-afterEach(() => {
-  document.body.innerHTML = ''
-})
 
 describe('JobContextMenu', () => {
   it('passes disabled state to action buttons', async () => {

--- a/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
+++ b/src/components/sidebar/tabs/queue/MediaLightbox.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -96,10 +96,6 @@ describe('MediaLightbox', () => {
       id: '3'
     }
   ]
-
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
 
   const renderGallery = (props = {}) => {
     const onUpdateActiveIndex = vi.fn()

--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -44,7 +44,6 @@ describe('useKeyboard', () => {
   let keyboard: ReturnType<typeof useKeyboard>
 
   beforeEach(() => {
-    document.body.innerHTML = ''
     keyboard = useKeyboard()
     keyboard.addListeners()
   })

--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -107,7 +107,6 @@ describe('useCurveEditor', () => {
 
   afterEach(() => {
     harness?.unmount()
-    document.body.innerHTML = ''
   })
 
   describe('curvePath', () => {

--- a/src/composables/useDismissableOverlay.test.ts
+++ b/src/composables/useDismissableOverlay.test.ts
@@ -45,7 +45,6 @@ describe('useDismissableOverlay', () => {
   afterEach(() => {
     scope?.stop()
     scope = undefined
-    document.body.innerHTML = ''
   })
 
   it('dismisses on outside pointerdown', () => {

--- a/src/composables/usePopoverSizing.test.ts
+++ b/src/composables/usePopoverSizing.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { effectScope } from 'vue'
 import type { EffectScope } from 'vue'
 
@@ -22,14 +22,9 @@ describe('usePrimeVueOverlayChildStyle', () => {
     return composable
   }
 
-  beforeEach(() => {
-    document.body.innerHTML = ''
-  })
-
   afterEach(() => {
     scope?.stop()
     scope = undefined
-    document.body.innerHTML = ''
   })
 
   it('preserves existing stacking when there is no PrimeVue parent overlay', () => {

--- a/src/composables/useRangeEditor.test.ts
+++ b/src/composables/useRangeEditor.test.ts
@@ -115,7 +115,6 @@ describe('useRangeEditor', () => {
 
   afterEach(() => {
     harness?.unmount()
-    document.body.innerHTML = ''
   })
 
   it('does nothing when trackRef is null', () => {

--- a/src/platform/assets/components/MediaAssetContextMenu.test.ts
+++ b/src/platform/assets/components/MediaAssetContextMenu.test.ts
@@ -143,7 +143,6 @@ async function showMenu(container: Element): Promise<HTMLElement> {
 afterEach(() => {
   capturedRef = null
   capturedMenu.model = []
-  document.body.innerHTML = ''
 })
 
 type MenuItemWithCommand = MenuItem & {

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -60,7 +60,6 @@ describe('TourSpotlight interactive and masked steps', () => {
   afterEach(() => {
     cleanup()
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('keeps the blocking scrim and no hit region on a plain step', () => {

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -53,7 +53,6 @@ describe('TourSpotlight', () => {
   afterEach(() => {
     cleanup()
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('renders the spotlight and card for a step', () => {

--- a/src/platform/onboarding/coachmarkRegistry.test.ts
+++ b/src/platform/onboarding/coachmarkRegistry.test.ts
@@ -35,7 +35,6 @@ describe('coachmarkRegistry', () => {
 describe('targetMounted', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   it('is true once a laid-out element is registered', () => {
@@ -64,7 +63,6 @@ describe('targetMounted', () => {
 describe('waitForTarget', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   /** Lets the poll sample once, and the resulting promise settle. */

--- a/src/platform/onboarding/useCoachmarkTarget.test.ts
+++ b/src/platform/onboarding/useCoachmarkTarget.test.ts
@@ -20,7 +20,6 @@ function step(coachId: CoachId): SpotlightStep {
 describe('useCoachmarkTarget', () => {
   afterEach(() => {
     clearCoachmarks()
-    document.body.replaceChildren()
   })
 
   function setup(coachId: CoachId) {

--- a/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
+++ b/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
@@ -52,7 +52,6 @@ function createAdapter() {
 
 describe('resolveSlotTargetCandidate', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     layoutStore.initializeFromLiteGraph([])
     useSlotLinkDragUIState().clearCompatible()
   })

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -87,7 +87,6 @@ describe('GettingStartedScreen', () => {
 
   afterEach(() => {
     cleanup()
-    document.body.replaceChildren()
   })
 
   async function pickFirstTemplate() {

--- a/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/firstRunTourDefinition.test.ts
@@ -103,7 +103,6 @@ describe('firstRunTourSteps', () => {
   afterEach(() => {
     releaseFirstRunTargets()
     clearCoachmarks()
-    document.body.replaceChildren()
     appState.graph = undefined
     runState.value = 'idle'
     framings.length = 0

--- a/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
+++ b/src/renderer/extensions/firstRunTour/tour/useFirstRunTourController.test.ts
@@ -245,7 +245,6 @@ describe('useFirstRunTourController', () => {
   afterEach(() => {
     controllerScope?.stop()
     controllerScope = undefined
-    document.body.innerHTML = ''
     setViewportWidth(1280)
   })
 

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -110,7 +110,6 @@ async function mountAndRegisterSlot(type: 'input' | 'output') {
 
 describe('useSlotElementTracking', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
     layoutStore.initializeFromLiteGraph([])
     layoutStore.applyOperation({
       type: 'createNode',

--- a/src/scripts/ui.test.ts
+++ b/src/scripts/ui.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ComfyUI } from './ui'
 
@@ -48,10 +48,6 @@ describe('ComfyUI file input', () => {
         unobserve = vi.fn()
       }
     )
-  })
-
-  afterEach(() => {
-    document.body.replaceChildren()
   })
 
   it('reports rejected imports and resets the selected file', async () => {

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
+  globalThis.document?.body.replaceChildren()
   globalThis.localStorage?.clear()
   globalThis.sessionStorage?.clear()
   vi.useFakeTimers()


### PR DESCRIPTION
## Summary

- clear `document.body` from the shared Vitest `beforeEach`
- remove 28 redundant lifecycle body resets across 26 suites
- preserve DOM replacement performed as part of website test behavior

Stacked on #15075.

## Verification

- affected suites: 26 files, 272 tests passed
- root suite: 1,159 files, 15,897 tests passed, 8 skipped
- website suite: 41 files, 387 tests passed
- lint, typecheck, formatting, and commit hooks