### PR TITLE
ci: cache the core gate's setup - pip wheels and pinned pack trees

### DIFF
--- a/.github/actions/setup-comfyui-server/action.yaml
+++ b/.github/actions/setup-comfyui-server/action.yaml
@@ -41,11 +41,6 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-        # Caches pip's wheel cache (~/.cache/pip) keyed on the requirements
-        # hash - the CPU torch stack is the dominant download. A miss changes
-        # nothing: every install below still runs; hits just skip downloads.
-        cache: 'pip'
-        cache-dependency-path: ComfyUI/requirements.txt
 
     - name: Install Python requirements
       shell: bash

--- a/.github/actions/setup-comfyui-server/action.yaml
+++ b/.github/actions/setup-comfyui-server/action.yaml
@@ -41,6 +41,11 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
+        # Caches pip's wheel cache (~/.cache/pip) keyed on the requirements
+        # hash - the CPU torch stack is the dominant download. A miss changes
+        # nothing: every install below still runs; hits just skip downloads.
+        cache: 'pip'
+        cache-dependency-path: ComfyUI/requirements.txt
 
     - name: Install Python requirements
       shell: bash

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -130,11 +130,12 @@ jobs:
       # reuses every other pack. The per-pack .pin marker is the integrity
       # check - a stale or partial entry re-clones.
       - name: Restore manifest pack cache
+        id: pack-cache
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/cn-packs
-          key: cn-packs-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
-          restore-keys: cn-packs-
+          key: cn-packs-v2-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
+          restore-keys: cn-packs-v2-
 
       # Install every pack the manifest declares (DRY: a new pack row installs
       # itself here, no workflow change). A clone or dependency failure fails the
@@ -142,6 +143,7 @@ jobs:
       # gate failure, not something to paper over. The `jq | while` pipe hides
       # failures in a subshell, so read into an array and loop with `set -e`.
       - name: Install manifest custom nodes
+        id: install
         shell: bash
         run: |
           set -euo pipefail
@@ -175,38 +177,56 @@ jobs:
             fi
             dir="ComfyUI/custom_nodes/$pack"
             cache_dir="$HOME/.cache/cn-packs/$pack"
-            if [ -f "$cache_dir/.pin" ] && [ "$(cat "$cache_dir/.pin")" = "$pin" ]; then
+            # The pin marker is a SIBLING of the tree, never inside it - a
+            # pack legitimately shipping a top-level .pin must install
+            # identically on cached and fresh runs.
+            if [ -f "$cache_dir.pin" ] && [ "$(cat "$cache_dir.pin")" = "$pin" ]; then
               echo "::group::restore $pack from cache ($pin)"
               cp -R "$cache_dir" "$dir"
-              rm -f "$dir/.pin"
             else
               echo "::group::install $pack"
               git clone --depth 1 "$repo" "$dir"
               git -C "$dir" fetch --depth 1 origin "$pin"
               git -C "$dir" checkout "$pin"
               # Repopulate the cache entry: tree without .git (nothing after
-              # this point reads pack git state), pin recorded for the
-              # integrity check above.
-              rm -rf "$cache_dir"
+              # this point reads pack git state), pin written LAST so a
+              # truncated copy fails the integrity check above.
+              rm -rf "$cache_dir" "$cache_dir.pin"
               mkdir -p "$(dirname "$cache_dir")"
               cp -R "$dir" "$cache_dir"
               rm -rf "$cache_dir/.git"
-              printf '%s' "$pin" > "$cache_dir/.pin"
+              printf '%s' "$pin" > "$cache_dir.pin"
             fi
             if [ -f "$dir/requirements.txt" ]; then
               pip install -r "$dir/requirements.txt" -c /tmp/torch-constraints.txt
             fi
             echo "::endgroup::"
           done
+          # Prune entries for packs no longer in the manifest: the prefix
+          # fallback restores old entries and the save re-tars the whole
+          # directory, so without this the entry grows monotonically and
+          # eats the repo's shared cache budget.
+          if [ -d "$HOME/.cache/cn-packs" ]; then
+            current=$(jq -r '.[].pack' "$manifest")
+            for entry in "$HOME/.cache/cn-packs"/*; do
+              name=$(basename "$entry" .pin)
+              grep -qxF "$name" <<<"$current" || rm -rf "$entry"
+            done
+          fi
 
-      # Exact-key save: unchanged manifest finds its key already present and
-      # skips; any pin bump writes a fresh entry.
+      # Save only when this run rebuilt entries. An exact-key restore means
+      # the stored tree is already current - actions/cache/save re-tars and
+      # uploads unconditionally and only then hits the duplicate-key
+      # rejection, so skipping here is what actually avoids the cost. Gating
+      # on the INSTALL step (not the job) still saves when the suite fails,
+      # while a failed or cancelled install can never freeze a partial tree
+      # under the immutable key.
       - name: Save manifest pack cache
-        if: always()
+        if: always() && steps.install.outcome == 'success' && steps.pack-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: ~/.cache/cn-packs
-          key: cn-packs-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
+          key: cn-packs-v2-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
 
       # The VHS run-tier workflow reads input/plain_video.mp4.
       - name: Stage run-tier assets

--- a/.github/workflows/ci-tests-custom-nodes.yaml
+++ b/.github/workflows/ci-tests-custom-nodes.yaml
@@ -124,6 +124,18 @@ jobs:
           # pinned.
           comfyui_ref: ${{ inputs.comfyui_ref || 'b08e6cf35fac50d3ca8470dffb3f9a1fbb7187d2' }}
 
+      # Pack sources are SHA-pinned, so their content is fully determined by
+      # the manifest: cache the checked-out trees (sans .git) and restore by
+      # manifest hash, with a prefix fallback so a single-pack pin bump still
+      # reuses every other pack. The per-pack .pin marker is the integrity
+      # check - a stale or partial entry re-clones.
+      - name: Restore manifest pack cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/cn-packs
+          key: cn-packs-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
+          restore-keys: cn-packs-
+
       # Install every pack the manifest declares (DRY: a new pack row installs
       # itself here, no workflow change). A clone or dependency failure fails the
       # job - if a pack can't be installed, its coverage can't run, and that is a
@@ -162,15 +174,39 @@ jobs:
               echo "::error::$pack: pin must be a full commit SHA (got '$pin')"; exit 1
             fi
             dir="ComfyUI/custom_nodes/$pack"
-            echo "::group::install $pack"
-            git clone --depth 1 "$repo" "$dir"
-            git -C "$dir" fetch --depth 1 origin "$pin"
-            git -C "$dir" checkout "$pin"
+            cache_dir="$HOME/.cache/cn-packs/$pack"
+            if [ -f "$cache_dir/.pin" ] && [ "$(cat "$cache_dir/.pin")" = "$pin" ]; then
+              echo "::group::restore $pack from cache ($pin)"
+              cp -R "$cache_dir" "$dir"
+              rm -f "$dir/.pin"
+            else
+              echo "::group::install $pack"
+              git clone --depth 1 "$repo" "$dir"
+              git -C "$dir" fetch --depth 1 origin "$pin"
+              git -C "$dir" checkout "$pin"
+              # Repopulate the cache entry: tree without .git (nothing after
+              # this point reads pack git state), pin recorded for the
+              # integrity check above.
+              rm -rf "$cache_dir"
+              mkdir -p "$(dirname "$cache_dir")"
+              cp -R "$dir" "$cache_dir"
+              rm -rf "$cache_dir/.git"
+              printf '%s' "$pin" > "$cache_dir/.pin"
+            fi
             if [ -f "$dir/requirements.txt" ]; then
               pip install -r "$dir/requirements.txt" -c /tmp/torch-constraints.txt
             fi
             echo "::endgroup::"
           done
+
+      # Exact-key save: unchanged manifest finds its key already present and
+      # skips; any pin bump writes a fresh entry.
+      - name: Save manifest pack cache
+        if: always()
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/cn-packs
+          key: cn-packs-${{ hashFiles('browser_tests/fixtures/data/customNodeManifest.core.json') }}
 
       # The VHS run-tier workflow reads input/plain_video.mp4.
       - name: Stage run-tier assets


### PR DESCRIPTION
## Summary

The core gate's suite runs in 10-16m but setup adds ~12-16m; this caches the pinned pack trees - the half of the original proposal the measurements and review supported. (The pip-cache half was removed: its key froze on the pinned requirements hash while torch floats, and live measurement showed it wall-clock neutral.)

## Changes

- **What**: the manifest packs are fully determined by their SHA pins, so their checked-out trees (sans `.git`) cache under `cn-packs-v2-<manifest hash>` with a prefix fallback - a single-pin bump still reuses every other pack. Hardened per review:
  - Save gates on the **install step's** outcome (`always() && steps.install.outcome == 'success'`): a suite failure still saves a complete tree; a failed or cancelled install can never freeze a partial one under the immutable key.
  - Save skips entirely on an exact-key restore (`cache-hit != 'true'`): `actions/cache/save` re-tars and uploads unconditionally before the server's duplicate-key rejection, so the steady-state green run now costs nothing.
  - Entries prune to the current manifest's pack set before saving - no monotonic growth into the repo's shared 10GB budget.
  - The integrity marker is a **sibling** `$cache_dir.pin` written last: restored trees are byte-identical to fresh checkouts, truncated copies fail the check, and a pack shipping its own top-level `.pin` installs identically either way.
  - Cache misses take exactly the pre-change install path; pack `requirements.txt` installs run on every path so a dependency break still fails the gate loudly.

## Review Focus

- v1-key validation (populate [31549672781](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31549672781) / restore [31550313207](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/31550313207)): all six `restore <pack> from cache` lines in the logs, install step 100s -> 77s. A fresh populate+restore pair on the v2 schema will be dispatched and linked here.