### PR TITLE
test: centralize Testing Library cleanup

### DIFF
--- a/apps/website/src/components/pricing/CloudPricingSection.test.ts
+++ b/apps/website/src/components/pricing/CloudPricingSection.test.ts
@@ -1,12 +1,8 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import CloudPricingSection from './CloudPricingSection.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 function isBefore(first: Element, second: Element) {
   return Boolean(

--- a/apps/website/src/components/pricing/PricingFreeBanner.test.ts
+++ b/apps/website/src/components/pricing/PricingFreeBanner.test.ts
@@ -1,13 +1,9 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 
 import PricingFreeBanner from './PricingFreeBanner.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 type BannerProps = ComponentProps<typeof PricingFreeBanner>
 

--- a/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
+++ b/apps/website/src/components/product/local/MobileDownloadEmailForm.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import userEvent from '@testing-library/user-event'
-import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import MobileDownloadEmailForm from './MobileDownloadEmailForm.vue'
 
@@ -33,10 +33,6 @@ describe('MobileDownloadEmailForm', () => {
   beforeEach(() => {
     hoisted.isEnabled = true
     hoisted.isMobileUa = true
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders nothing when the write key is not configured', () => {

--- a/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchHeroCtaButtons.test.ts
@@ -1,12 +1,8 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import ModelLaunchHeroCtaButtons from './ModelLaunchHeroCtaButtons.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 describe('ModelLaunchHeroCtaButtons', () => {
   it('renders only the primary CTA when no secondary CTA is given', () => {

--- a/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
+++ b/apps/website/src/templates/model-launch/ModelLaunchPricingSection.test.ts
@@ -1,13 +1,9 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import { minimaxPage } from '../../data/minimax'
 import ModelLaunchPricingSection from './ModelLaunchPricingSection.vue'
-
-afterEach(() => {
-  cleanup()
-})
 
 // The live /minimax config, so a refactor of the shared banner cannot quietly
 // change what that page ships. `pricing` is optional on a launch page, so fail

--- a/apps/website/src/test/setup.ts
+++ b/apps/website/src/test/setup.ts
@@ -1,0 +1,4 @@
+import { cleanup } from '@testing-library/vue'
+import { afterEach } from 'vitest'
+
+afterEach(cleanup)

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -18,6 +18,6 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
     globals: false,
-    setupFiles: ['../../vitest.timer.setup.ts']
+    setupFiles: ['../../vitest.timer.setup.ts', './src/test/setup.ts']
   }
 })

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -1,7 +1,7 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -103,10 +103,6 @@ function mountDialog() {
 }
 
 describe('GlobalDialog renderer branching', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders the Reka branch when renderer is omitted (default)', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -171,10 +167,6 @@ describe('GlobalDialog renderer branching', () => {
 })
 
 describe('GlobalDialog Reka parity with PrimeVue', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('omits the close button when closable is false', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -358,10 +350,6 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
 })
 
 describe('GlobalDialog Reka overlay scrim', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('renders a backdrop scrim for modal Reka dialogs', async () => {
     mountDialog()
     const store = useDialogStore()
@@ -476,10 +464,6 @@ describe('GlobalDialog Reka overlay scrim', () => {
 })
 
 describe('GlobalDialog Reka focus-outside binding', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   // Reka's DismissableLayer fires focus-outside off a real focus transition
   // (blur inside the layer, then focusin on the new target), so drive the
   // mounted binding by moving focus to a fresh element outside the dialog

--- a/src/components/graph/NodeTooltip.test.ts
+++ b/src/components/graph/NodeTooltip.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { nextTick } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -174,7 +174,6 @@ describe('NodeTooltip', () => {
 
   afterEach(() => {
     mergeOutputTooltipMessage(null)
-    cleanup()
   })
 
   it('shows input slot JSON tooltips without i18n placeholder errors', async () => {

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
@@ -125,7 +125,6 @@ describe('HelpCenterMenuContent feedback item', () => {
 
   afterEach(() => {
     openSpy.mockRestore()
-    cleanup()
   })
 
   it('opens the Typeform survey tagged with help-center source on Cloud', async () => {
@@ -178,7 +177,6 @@ describe('HelpCenterMenuContent system status item', () => {
 
   afterEach(() => {
     openSpy.mockRestore()
-    cleanup()
   })
 
   it('opens the status page on Cloud', async () => {

--- a/src/platform/onboarding/CoachmarkCard.test.ts
+++ b/src/platform/onboarding/CoachmarkCard.test.ts
@@ -1,10 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 
 import CoachmarkCard from './CoachmarkCard.vue'
-
-afterEach(cleanup)
 
 describe('CoachmarkCard', () => {
   it('renders the title, message and subtitle', () => {

--- a/src/platform/onboarding/CoachmarkLanding.test.ts
+++ b/src/platform/onboarding/CoachmarkLanding.test.ts
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -27,8 +27,6 @@ function renderLanding() {
 }
 
 describe('CoachmarkLanding', () => {
-  afterEach(cleanup)
-
   it('renders a modal backdrop behind the landing card', async () => {
     renderLanding()
     expect(await screen.findByTestId('coach-landing-overlay')).toBeTruthy()

--- a/src/platform/onboarding/TourOverlay.test.ts
+++ b/src/platform/onboarding/TourOverlay.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, reactive, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -74,8 +74,6 @@ describe('TourOverlay', () => {
     s = makeTourState()
     vi.mocked(useOnboardingTourStore).mockReturnValue(fromPartial(reactive(s)))
   })
-
-  afterEach(cleanup)
 
   it('renders nothing when no tour step is active', () => {
     renderOverlay()

--- a/src/platform/onboarding/TourSpotlight.interactive.test.ts
+++ b/src/platform/onboarding/TourSpotlight.interactive.test.ts
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
@@ -58,7 +58,6 @@ function renderSpotlight(
 
 describe('TourSpotlight interactive and masked steps', () => {
   afterEach(() => {
-    cleanup()
     clearCoachmarks()
   })
 

--- a/src/platform/onboarding/TourSpotlight.test.ts
+++ b/src/platform/onboarding/TourSpotlight.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -51,7 +51,6 @@ function renderSpotlight(
 
 describe('TourSpotlight', () => {
   afterEach(() => {
-    cleanup()
     clearCoachmarks()
   })
 

--- a/src/platform/onboarding/vCoachmark.test.ts
+++ b/src/platform/onboarding/vCoachmark.test.ts
@@ -1,5 +1,5 @@
-import { cleanup, render } from '@testing-library/vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { render } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref, withDirectives } from 'vue'
 
 import { coachmarkElements } from './coachmarkRegistry'
@@ -31,8 +31,6 @@ function mountHost(initial: CoachId | null) {
 }
 
 describe('vCoachmark', () => {
-  afterEach(cleanup)
-
   it('registers the element and mirrors the id to data-coach-id on mount', () => {
     const { getByTestId } = mountHost('app-run-button')
     const host = getByTestId('host')

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -1,7 +1,7 @@
 import { ZIndex } from '@primeuix/utils/zindex'
-import { cleanup, render, screen } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -59,10 +59,6 @@ const i18n = createI18n({
 })
 
 describe('SecretFormDialog z-index stacking', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   let openModalZIndex: number
 
   beforeEach(() => {

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
@@ -114,10 +114,6 @@ describe('SubscriptionSuccessWorkspace', () => {
     mockPendingInvites.length = 0
     mockMaxSeats.value = 73
     mockOccupiedSeats.value = 1
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('renders the all-set heading and plan price', () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,6 +1,6 @@
-import { cleanup, render, screen, within } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Slots } from 'vue'
 import { computed, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -18,8 +18,6 @@ const mockMemberMenuItems = vi.fn(() => [])
 const mockShowTeamPlans = vi.fn()
 const mockToggleSort = vi.fn()
 const mockHandleInviteMember = vi.fn()
-
-afterEach(cleanup)
 
 const {
   mockMembers,

--- a/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
+++ b/src/renderer/extensions/firstRunTour/gettingStarted/GettingStartedScreen.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen, waitFor } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -83,10 +83,6 @@ describe('GettingStartedScreen', () => {
     mocks.loadCatalog.mockResolvedValue(undefined)
     mocks.beginTour.mockResolvedValue(true)
     mocks.loadingTemplateId.value = null
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   async function pickFirstTemplate() {

--- a/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
+++ b/src/renderer/extensions/firstRunTour/nudge/FirstRunTourNudge.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
-import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -68,10 +68,6 @@ describe('FirstRunTourNudge', () => {
     mocks.nudgeArmed.value = false
     mocks.tourWasCompleted.value = true
     mocks.openDialogs.value = []
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   it('shows a nudge that came due before it mounted', async () => {


### PR DESCRIPTION
## Summary

- rely on Vue Testing Library's built-in auto-cleanup in the root Vitest project
- add scoped website cleanup because that project runs with `globals: false`
- remove 23 redundant lifecycle cleanup registrations
- preserve mid-test cleanup used before rerendering

Stacked on #15082.

## Verification

- affected root suites: 14 files, 160 tests passed
- root suite: 1,159 files, 15,897 tests passed, 8 skipped
- website suite: 41 files, 387 tests passed
- root and website typechecks, lint, formatting, and commit hooks