### PR TITLE
test: reset browser history before each unit test

### DIFF
--- a/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
+++ b/src/platform/telemetry/utils/__tests__/checkoutAttribution.test.ts
@@ -15,7 +15,6 @@ describe('getCheckoutAttribution', () => {
     window.ire = undefined
     window.rewardful = undefined
     window.Rewardful = undefined
-    window.history.pushState({}, '', '/')
   })
 
   it('reads GA identity and URL attribution, and prefers generated click id', async () => {

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -66,7 +66,6 @@ describe(useWorkflowShareService, () => {
 
   beforeEach(() => {
     mockApp.rootGraph = {}
-    window.history.replaceState({}, '', '/')
   })
 
   it('returns unpublished status for unknown workflow', async () => {

--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -426,14 +426,6 @@ describe('API Feature Flags', () => {
    * how server values, falsy values, nested paths or defaults resolve.
    */
   describe('characterization: resolution with no override present', () => {
-    beforeEach(() => {
-      window.history.replaceState({}, '', '/')
-    })
-
-    afterEach(() => {
-      window.history.replaceState({}, '', '/')
-    })
-
     it('returns the server value verbatim', () => {
       api.serverFeatureFlags.value = { some_flag: 'server_value' }
 

--- a/src/scripts/api.sessionOverride.test.ts
+++ b/src/scripts/api.sessionOverride.test.ts
@@ -33,7 +33,6 @@ describe('api.getServerFeature session override outside component setup', () => 
   })
 
   afterEach(() => {
-    window.history.replaceState({}, '', '/')
     api.serverFeatureFlags.value = {}
     vi.restoreAllMocks()
   })

--- a/src/utils/sessionFeatureFlagOverride.test.ts
+++ b/src/utils/sessionFeatureFlagOverride.test.ts
@@ -31,7 +31,6 @@ describe('getSessionOverride', () => {
   })
 
   afterEach(() => {
-    window.history.replaceState({}, '', '/')
     vi.restoreAllMocks()
   })
 

--- a/vitest.timer.setup.ts
+++ b/vitest.timer.setup.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
   globalThis.document?.body.replaceChildren()
+  globalThis.window?.history.replaceState({}, '', '/')
   globalThis.localStorage?.clear()
   globalThis.sessionStorage?.clear()
   vi.useFakeTimers()


### PR DESCRIPTION
## Summary

Reset browser history to `/` in the shared Vitest `beforeEach`, preventing URL state from leaking between unit tests.

## Changes

- **What**: Adds one guarded global history reset and removes five suite-local lifecycle resets across five files (11 net lines removed).

## Review Focus

This is a stacked experiment on #15084. Please verify that resetting only the URL, while preserving `history.state` as an empty object, is the expected universal baseline. URL mutations that are test inputs remain local to their tests.

## Validation

- 5 affected files: 96 tests passed
- Full root suite: 1,159 files passed; 15,897 tests passed; 8 skipped
- `pnpm typecheck`
- lint-staged hooks and formatting